### PR TITLE
rework automatic build versioning

### DIFF
--- a/build-scripts/jenkins-driver
+++ b/build-scripts/jenkins-driver
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [ "${PDNS_TAG}" != 'HEAD' ]
+then
+	git checkout $PDNS_TAG
+        export GIT_BRANCH=unknown
+        export GIT_COMMIT=$(git rev-parse $PDNS_TAG)
+fi
+
+eval $(build-scripts/make-jenkins-version)
+
+build-scripts/set-version-auth $SOURCE_VERSION $DEB_VERSION $RPM_VERSION
+build-scripts/set-version-recursor $SOURCE_VERSION $DEB_VERSION $RPM_VERSION

--- a/build-scripts/make-jenkins-version
+++ b/build-scripts/make-jenkins-version
@@ -1,9 +1,69 @@
-#!/bin/sh
-GIT_BRANCH=$(echo ${GIT_BRANCH} | sed 's!^origin/!!')
+#!/usr/bin/env bash
+
+# input variables:
+#  GIT_BRANCH
+#  GIT_COMMIT
+#  BUILD_NUMBER
+#  BUILDING_PRODUCT (ex: "rec" or "auth")
+
+# eat origin/ off branch name
+GIT_BRANCH=${GIT_BRANCH#origin/}
+date=$(date +%Y%m%d)
+git_id=$(git rev-parse --short $GIT_COMMIT)
+source_branch="$(echo ${GIT_BRANCH} | tr ' /' -)"
+deb_branch="$(echo ${GIT_BRANCH} | tr ' /-' .)"
+rpm_branch="$(echo ${GIT_BRANCH} | tr ' /-' _)"
+# dbg: date, build, gitid
+source_dbg=${date}-${BUILD_NUMBER}-${git_id}
+deb_dbg=${date}.${BUILD_NUMBER}.${git_id}
+rpm_dbg=${date}_${BUILD_NUMBER}_${git_id}
+
+is_release_build=0
+
 if [ $GIT_BRANCH = master ]
 then
-	echo $(date +%Y%m%d).${BUILD_NUMBER}.$(git rev-parse --short $GIT_COMMIT)
+	source_version=git-${source_dbg}
+	deb_version=0.0.${deb_dbg}
+	rpm_version=0.0.${rpm_dbg}
+elif [[ $GIT_BRANCH = rel/* ]]
+then
+	# on release branch
+	product_version=${GIT_BRANCH#rel/}
+	product=${product_version%-*} # ex: "rec" or "auth"
+	version=${product_version#*-} # ex: "3.5.1"
+	if [ "$product" = "$BUILDING_PRODUCT" ]
+	then
+		expected_tag=${product}-${version} # ex: "rec-3.5.1"
+		git_tag=$(git describe --match "${expected_tag}*" 2>/dev/null)
+		if [ -z "$git_tag" ]
+		then
+			# snapshot build:
+			# prepend the target product version.
+			source_version=${version}-snapshot-${date}-${BUILD_NUMBER}-${git_id}
+			deb_version=${version}~snapshot${date}.${BUILD_NUMBER}.${git_id}
+			rpm_version=${version}snapshot${date}_${BUILD_NUMBER}_${git_id}
+		else
+			# rcX or release build:
+			# use the tag as the real version number.
+			source_version=${git_tag#${product}-}
+			deb_version=${source_version}
+			rpm_version="$(echo ${source_version} | sed -e 's/-//' )"
+			is_release_build=1
+                fi
+        else
+                # building auth on recursor release branch, or v.v.
+		source_version=git-unknown-${source_dbg}
+		deb_version=0.0~unknown.${deb_dbg}
+		rpm_version=0.0unknown_${rpm_dbg}
+        fi
 else
-	branch="$(echo ${GIT_BRANCH} | tr ' /-' _)"
-	echo $(date +%Y%m%d).${branch}_${BUILD_NUMBER}.$(git rev-parse --short $GIT_COMMIT)
+        # must be a test branch
+        source_version=git-${source_branch}-${source_dbg}
+	deb_version=0.0~${deb_branch}.${deb_dbg}
+	rpm_version=0.0.${rpm_branch}_${rpm_dbg}
 fi
+
+echo SOURCE_VERSION=$source_version
+echo DEB_VERSION=$deb_version
+echo RPM_VERSION=$rpm_version
+echo IS_RELEASE_BUILD=$is_release_build

--- a/build-scripts/set-version-auth
+++ b/build-scripts/set-version-auth
@@ -1,7 +1,9 @@
 #!/bin/bash 
 VERSION=$1
-[ -z "$VERSION" ] && exit
+DEB_VERSION=$2
+RPM_VERSION=$3
+[ -z "$VERSION" -o -z "$DEB_VERSION" -o -z "$RPM_VERSION" ] && exit 1
 
-ssed -r "s/Version: (.*)/Version: \\1.$VERSION/" -i pdns.spec
-ssed -r "s/AC_INIT\\(\\[pdns\\],\\[(.*)\\]\\)/AC_INIT\([pdns],[\\1.$VERSION\])/" -i configure.ac
-ssed -r "1 s/^pdns \\(([^)]*)-([0-9.])\\)/pdns \\(\\1.$VERSION-\\2\\)/" -i debian-pdns/changelog
+ssed -r "s/Version: (.*)/Version: $RPM_VERSION/" -i pdns.spec
+ssed -r "s/AC_INIT\\(\\[pdns\\],\\[(.*)\\]\\)/AC_INIT\([pdns],[$VERSION\])/" -i configure.ac
+ssed -r "1 s/^pdns \\(([^)]*)-([0-9.])\\)/pdns \\($DEB_VERSION-\\2\\)/" -i debian-pdns/changelog

--- a/build-scripts/set-version-recursor
+++ b/build-scripts/set-version-recursor
@@ -1,6 +1,8 @@
-#!/bin/bash 
+#!/bin/bash
 VERSION=$1
-[ -z "$VERSION" ] && exit
+DEB_VERSION=$2
+RPM_VERSION=$3
+[ -z "$VERSION" -o -z "$DEB_VERSION" -o -z "$RPM_VERSION" ] && exit 1
 
-ssed -r "s/^VERSION=(.*)/VERSION=\\1.$VERSION/" -i pdns/dist-recursor
-ssed -r "s/Version: (.*)/Version: \\1.$VERSION/" -i pdns/pdns-recursor.spec
+ssed -r "s/^VERSION=(.*)/VERSION=$VERSION/" -i pdns/dist-recursor
+ssed -r "s/Version: (.*)/Version: $RPM_VERSION/" -i pdns/pdns-recursor.spec


### PR DESCRIPTION
Very tentative, and I assumed a few things along the way.

Versions for master and feature branches are really TBD, but how you like them is something you need to figure out.

I think the deb and rpm versions should work, the deb versions should also compare properly.

Big TODO: I have no idea how you're actually calling this script from Jenkins and I changed the output, so integrating this back is something to figure out as well.
## Examples

On feature branch:

```
% BUILD_NUMBER=4666 GIT_BRANCH=foo/bar GIT_COMMIT=11be5cb5af5437af2783ea5041dbd298c1f941ff ./build-scripts/make-jenkins-version
SOURCE_VERSION=git-foo-bar-20130430-4666-11be5cb
DEB_VERSION=0.0~foo.bar.20130430.4666.11be5cb
RPM_VERSION=0.0.foo_bar_20130430_4666_11be5cb
```

On master:

```
% BUILD_NUMBER=4666 GIT_BRANCH=master GIT_COMMIT=11be5cb5af5437af2783ea5041dbd298c1f941ff ./build-scripts/make-jenkins-version
SOURCE_VERSION=git-20130430-4666-11be5cb
DEB_VERSION=0.0.20130430.4666.11be5cb
RPM_VERSION=0.0.20130430_4666_11be5cb
```

On rel/rec-3.5.1:

```
% BUILD_NUMBER=4666 GIT_BRANCH=rel/rec-3.5.1 GIT_COMMIT=11be5cb5af5437af2783ea5041dbd298c1f941ff ./build-scripts/make-jenkins-version
SOURCE_VERSION=3.5.1-snapshot-20130430-4666-11be5cb
DEB_VERSION=3.5.1~snapshot20130430.4666.11be5cb
RPM_VERSION=3.5.1.snapshot20130430_4666_11be5cb
```

On rel/rec-3.5.1 with an rc tag:

```
git tag -m 'rc release' rec-3.5.1-rc2
% BUILD_NUMBER=4666 GIT_BRANCH=rel/rec-3.5.1 GIT_COMMIT=11be5cb5af5437af2783ea5041dbd298c1f941ff ./build-scripts/make-jenkins-version
SOURCE_VERSION=3.5.1-rc2
DEB_VERSION=3.5.1-rc2
RPM_VERSION=3.5.1-rc2
```

On rel/rec-3.5.1 with the final release tag:

```
% git tag -m 'release' rec-3.5.1
% BUILD_NUMBER=4666 GIT_BRANCH=rel/rec-3.5.1 GIT_COMMIT=11be5cb5af5437af2783ea5041dbd298c1f941ff ./build-scripts/make-jenkins-version
SOURCE_VERSION=3.5.1
DEB_VERSION=3.5.1
RPM_VERSION=3.5.1
```
