### PR TITLE
move make from runtest to start-test-stop

### DIFF
--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -1,8 +1,6 @@
 #!/bin/bash
 PATH=.:$PATH
 
-make -C ../pdns sdig nsec3dig || exit 1
-
 rm -f test-results failed_tests passed_tests skipped_tests ${testsdir}/*/real_result ${testsdir}/*/diff ${testsdir}/*/*.out
 
 passed=0

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -58,6 +58,8 @@ __EOF__
 	exit 1
 fi
 
+make -C ../pdns sdig nsec3dig || exit 1
+
 rm -f pdns*.pid
 
 presigned=no


### PR DESCRIPTION
This prevent a endless loop if pdnssec is not present (build failed). 
