### PR TITLE
Bugfix for issue 444

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -332,10 +332,14 @@ bool PacketHandler::getBestWildcard(DNSPacket *p, SOAData& sd, const string &tar
   bool haveSomething=false;
 
   wildcard=subdomain;
-  while ( chopOff( subdomain ) && !haveSomething ) {
-    B.lookup(QType(QType::ANY), "*."+subdomain, p, sd.domain_id);
+  while( chopOff( subdomain ) && !haveSomething )  {
+    if (subdomain.empty()) {
+      B.lookup(QType(QType::ANY), "*", p, sd.domain_id); 
+    } else {
+      B.lookup(QType(QType::ANY), "*."+subdomain, p, sd.domain_id);
+    }
     while(B.get(rr)) {
-      if(rr.qtype == p->qtype ||rr.qtype.getCode() == QType::CNAME || (p->qtype.getCode() == QType::ANY && rr.qtype.getCode() != QType::RRSIG))
+      if(rr.qtype == p->qtype || rr.qtype.getCode() == QType::CNAME || (p->qtype.getCode() == QType::ANY && rr.qtype.getCode() != QType::RRSIG))
         ret->push_back(rr);
       wildcard="*."+subdomain;
       haveSomething=true;


### PR DESCRIPTION
This fixes issue #444

Tested with this zone:

<pre>
mysql> select * from records where domain_id=6;
+-------+-----------+------+------+----------------------------------------------------------------------+------+------+-------------+----------------------------------+------+
| id    | domain_id | name | type | content                                                              | ttl  | prio | change_date | ordername                        | auth |
+-------+-----------+------+------+----------------------------------------------------------------------+------+------+-------------+----------------------------------+------+
| 20209 |         6 |      | SOA  | ns1.example.com. ahu.example.com. 2000081501 28800 7200 604800 86400 |  120 |    0 |        NULL | 09lo11rs63u9b3d538a86ijvqcqt9312 |    1 |
| 20210 |         6 | *    | NS   | ns1.example.com                                                      |  120 |    0 |        NULL | 09lo11rs63u9b3d538a86ijvqcqt9312 |    1 |
| 20211 |         6 | *    | NS   | ns2.example.com                                                      |  120 |    0 |        NULL | 09lo11rs63u9b3d538a86ijvqcqt9312 |    1 |
| 20222 |         6 | *    | A    | 192.168.1.1                                                          |  120 | NULL |        NULL | NULL                             | NULL |
+-------+-----------+------+------+----------------------------------------------------------------------+------+------+-------------+----------------------------------+------+
</pre>


Which results in:

<pre>
May 07 22:57:33 gmysql Connection successful
May 07 22:57:33 Done launching threads, ready to distribute questions
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where type='SOA' and name='www.google.com'
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where type='SOA' and name='google.com'
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where type='SOA' and name='com'
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where type='SOA' and name=''
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where type='NS' and name='www.google.com' and domain_id=6
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where type='NS' and name='google.com' and domain_id=6
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where type='NS' and name='com' and domain_id=6
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where name='www.google.com' and domain_id=6
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where name='*.google.com' and domain_id=6
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where name='google.com' and domain_id=6
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where name='*.com' and domain_id=6
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where name='com' and domain_id=6
May 07 22:57:35 Query: select content,ttl,prio,type,domain_id,name, auth from records where name='*' and domain_id=6

</pre>
