### PR TITLE
Cleanup paths in pdns-recursor.init.d

### DIFF
--- a/pdns/pdns-recursor.init.d
+++ b/pdns/pdns-recursor.init.d
@@ -10,9 +10,8 @@
 # chkconfig: - 80 75
 # description: pdns_recursor is a versatile high performance recursing nameserver
 
-prefix=/usr/
-BINARYPATH=/usr/bin/
-SBINARYPATH=/usr/sbin/
+BINARYPATH=/usr/bin
+SBINARYPATH=/usr/sbin
 SOCKETPATH=/var/run
 
 pdns_server=$SBINARYPATH/pdns_recursor


### PR DESCRIPTION
prefix was unused, the others had a trailing slash, leading to process
command lines like "/usr/sbin//pdns_recursor".
