### PR TITLE
version.cc: Add dependency on version_generated.h

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -295,6 +295,8 @@ pdns_version=$(shell test -z "$(git_version)" && echo UNKNOWN || echo "git-$(git
 dist_host=$(build_host)
 endif
 
+version.o: version_generated.h
+
 .PHONY: version_generated.h
 version_generated.h:
 	echo '#ifndef VERSION_GENERATED_H' > $@


### PR DESCRIPTION
This way 'make pdns_recursor' also (re)builds version_generated.h.

@Habbie caught this.
