### PR TITLE
if_ether.h is in netinet/ not net/ on OpenBSD

### DIFF
--- a/pdns/dnspcap.hh
+++ b/pdns/dnspcap.hh
@@ -10,9 +10,12 @@
 #include <netinet/in_systm.h>
 #include <netinet/ip.h>
 #include <netinet/udp.h>
-#if defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__NetBSD__)
 #include <net/if.h>
 #include <net/if_ether.h>
+#elif defined (__OpenBSD__)
+#include <net/if.h>
+#include <netinet/if_ether.h>
 #elif defined (__SVR4) && defined (__sun)
 #include <sys/ethernet.h>
 #else


### PR DESCRIPTION
Issue 522 was not correctly fixed.
