### PR TITLE
fix branch snapshot build detection in build-scripts/make-jenkins-version

### DIFF
--- a/build-scripts/make-jenkins-version
+++ b/build-scripts/make-jenkins-version
@@ -40,7 +40,7 @@ then
 	if [ "$product" = "$BUILDING_PRODUCT" ]
 	then
 		expected_tag=${product}-${version} # ex: "rec-3.5.1"
-		git_tag=$(git describe --match "${expected_tag}*" 2>/dev/null)
+		git_tag=$(git describe --exact-match --match "${expected_tag}*" 2>/dev/null)
 		if [ -z "$git_tag" ]
 		then
 			# snapshot build:


### PR DESCRIPTION
Should fix version numbers on rel branches for commits that don't exactly match a tag.
