### PR TITLE
Update pdns auth init script so it works on wheezy

### DIFF
--- a/pdns/pdns.in
+++ b/pdns/pdns.in
@@ -6,12 +6,12 @@
 # Provides:          pdns
 # Required-Start:    $remote_fs $network $syslog
 # Required-Stop:     $remote_fs $network $syslog
-# Should-Start:      $all
-# Should-Stop:       
+# Should-Start:
+# Should-Stop:
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Start/stop PowerDNS authoritative server
-# Description:       Start/stop PowerDNS authoritative server
+# Short-Description: PowerDNS authoritative server
+# Description:       PowerDNS authoritative server
 ### END INIT INFO
 
 set -e


### PR DESCRIPTION
insserv would complain:
insserv: There is a loop at service pdns if started
insserv: There is a loop between service pdns and mountall if started
insserv: There is a loop between service pdns and mountall-bootclean if started
insserv: Starting rsync depends on pdns and therefore on system facility `$all' which can not be true!

Please also put this into 3.3.
