### PR TITLE
Add 2 missing options

### DIFF
--- a/pdns/docs/pdns_server.8
+++ b/pdns/docs/pdns_server.8
@@ -20,6 +20,12 @@ of the inner \fBpdns_server\fR instance. It is also this guardian that
 Run the server in a special monitor mode. This enables detailed logging
 and exposes the raw control socket.
 .TP
+.B \-\-launch=\fI<backend>\fR
+Set the backend to use, you can set multiple backends like this: \-\-launch=bind,gmysql
+.TP
+.B \-\-config
+Export the default configuration, if no backend is specified a config without a backend configured is provided
+.TP
 .B \-\-loglevel=\fI<level>\fR
 Set the logging level.
 .SH FILES


### PR DESCRIPTION
The man page for pdns_server is atleast missing 2 options. This should add them to the man page. The problem was reported on IRC by Dettorer (Paul Hervot).
