### PR TITLE
Fix linkage of RemoteLoader::RemoteLoader

### DIFF
--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -892,15 +892,17 @@ class RemoteBackendFactory : public BackendFactory
 
 class RemoteLoader
 {
-   public:
-      RemoteLoader()
-      {
-#ifdef REMOTEBACKEND_HTTP
-         curl_global_init(CURL_GLOBAL_ALL);
-#endif
-         BackendMakers().report(new RemoteBackendFactory);
-         L<<Logger::Notice<<kBackendId<<" This is the remotebackend version "VERSION" ("__DATE__", "__TIME__") reporting"<<endl;
-      }
+public:
+    RemoteLoader();
 };
+
+
+RemoteLoader::RemoteLoader() {
+#ifdef REMOTEBACKEND_HTTP
+    curl_global_init(CURL_GLOBAL_ALL);
+#endif
+    BackendMakers().report(new RemoteBackendFactory);
+    L<<Logger::Notice<<kBackendId<<" This is the remotebackend version "VERSION" ("__DATE__", "__TIME__") reporting"<<endl;
+}
 
 static RemoteLoader remoteloader;


### PR DESCRIPTION
Yep, moving the class def (without function bodies!) into a header file would be nicer, but I didn't care.
