### PR TITLE
SOA-EDIT: fix INCEPTION-INCREMENT handling

### DIFF
--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -62,10 +62,11 @@ uint32_t calculateEditSoa(SOAData sd, const string& kind) {
     uint32_t inception_serial = localtime_format_YYYYMMDDSS(inception, 1);
     uint32_t dont_increment_after = localtime_format_YYYYMMDDSS(inception + 2*86400, 99);
 
-    if(sd.serial <= dont_increment_after)
-      return (sd.serial + 2); /* "day00" and "day01" are reserved for inception increasing, so increment sd.serial by two */
-    else if(sd.serial < inception_serial) 
-      return inception_serial;
+    if(sd.serial < inception_serial - 1) { /* less than <inceptionday>00 */
+      return inception_serial; /* return <inceptionday>01   (skipping <inceptionday>00 as possible value) */
+    } else if(sd.serial <= dont_increment_after) { /* >= <inceptionday>00 but <= <inceptionday+2>99 */
+      return (sd.serial + 2); /* "<inceptionday>00" and "<inceptionday>01" are reserved for inception increasing, so increment sd.serial by two */
+    }
   }
   else if(pdns_iequals(kind,"INCEPTION-WEEK")) {
     time_t inception = getStartOfWeek();


### PR DESCRIPTION
Now that I installed 3.3 from debian experimental I realized that the logic is broken... My test zone has SOA 2013050801 in the db, and pdns returned 2013050803 - which is way too small, it should be something like 2013070901.

Please review the logic before merging :)
It should use inception day as serial if the backend serial is before inception day; it should increment by two if the backend serial is between inception day and two days later, and do nothing if backend serial is more than two days later.

It would be nice to have test cases for SOA-EDIT stuff; but it seems this would be a major change in the test handling. I think it would require different zones for the different SOA-EDIT values to test, somehow setting the SOA-EDIT values in the dnssec.sqlite3 (? I'm not sure how the bind/dnssec stuff is working), and generating zones with SOA values based on the current time. Or mocking the time() function to some static value with LD_PRELOAD or similar :)
