### PR TITLE
Update gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /Makefile.in
 /aclocal.m4
 /autom4te.cache
+/config.cache
 /config.guess
 /config.h
 /config.h.in
@@ -14,6 +15,7 @@
 /mkinstalldirs
 /stamp-h
 /stamp-h1
+/test-driver
 /ylwrap
 *.la
 *.lo

--- a/pdns/backends/bind/.gitignore
+++ b/pdns/backends/bind/.gitignore
@@ -6,6 +6,7 @@
 /bindlexer.c
 /bindparser.cc
 /bindparser.h
+/bindparser.hh
 /bindparser.output
 /dnslabeltext.cc
 /bind-dnssec.schema.sqlite3.sql.h


### PR DESCRIPTION
- config.cache is configure's cache (if used)
- test-driver is a new autotools script
- bindparser.hh is an intermediate file (gets copied to bindparser.h)
