### PR TITLE
Show built-in features in --version output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -269,6 +269,11 @@ then
         AC_DEFINE(HAVE_BOTAN18,1,[If we have botan 1.8])
 fi
 
+if test "x$enable_cryptopp" = "xyes"
+then
+        AC_DEFINE(HAVE_CRYPTOPP,1,[If we have cryptopp])
+fi
+
 AC_ARG_ENABLE(remotebackend_http, AC_HELP_STRING([--enable-remotebackend-http],[enable HTTP connector for remotebackend]),[enable_remotebackend_http=yes], [enable_remotebackend_http=no])
 AC_MSG_CHECKING(whether to enable http connector in remotebackend)
 AC_MSG_RESULT($enable_remotebackend_http)
@@ -327,6 +332,7 @@ AC_ARG_WITH(socketdir, AC_HELP_STRING([--with-socketdir],[where the controlsocke
 AC_SUBST(moduledirs)
 AC_SUBST(moduleobjects)
 AC_SUBST(modulelibs)
+AC_DEFINE_UNQUOTED(PDNS_MODULES,"$modules", [Built-in modules])
 
 AC_MSG_CHECKING(whether we will be building the server)
 AC_ARG_ENABLE(pdns-server,

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2115,6 +2115,7 @@ int main(int argc, char **argv)
     }
     if(::arg().mustDo("version")) {
       showProductVersion();
+      showBuildConfiguration();
       exit(99);
     }
 

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -425,6 +425,7 @@ int main(int argc, char **argv)
     
     if(::arg().mustDo("version")) {
       showProductVersion();
+      showBuildConfiguration();
       exit(99);
     }
 

--- a/pdns/version.cc
+++ b/pdns/version.cc
@@ -46,6 +46,37 @@ void showProductVersion()
     "according to the terms of the GPL version 2." << endl;
 }
 
+void showBuildConfiguration()
+{
+  theL()<<Logger::Warning<<"Features: "<<
+#ifdef HAVE_BOTAN110
+    "botan1.10 " <<
+#endif
+#ifdef HAVE_BOTAN18
+    "botan1.8" <<
+#endif
+#ifdef HAVE_CRYPTOPP
+    "cryptopp " <<
+#endif
+#ifdef HAVE_LIBDL
+    "libdl " <<
+#endif
+#ifdef HAVE_LUA
+    "lua " <<
+#endif
+#ifdef REMOTEBACKEND_HTTP
+    "remotebackend-http" <<
+#endif
+#ifdef VERBOSELOG
+    "verboselog" <<
+#endif
+    endl;
+#ifdef PDNS_MODULES
+  // Auth only
+  theL()<<Logger::Warning<<"Built-in modules: "<<PDNS_MODULES<<endl;
+#endif
+}
+
 string fullVersionString()
 {
   ostringstream s;

--- a/pdns/version.hh
+++ b/pdns/version.hh
@@ -22,6 +22,7 @@
 
 string compilerVersion();
 void showProductVersion();
+void showBuildConfiguration();
 string fullVersionString();
 void versionSetProduct(string product);
 


### PR DESCRIPTION
Example:

```
Aug 24 21:54:12 PowerDNS Authoritative Server git-auth-3.3-513-gcd91689+ (ch@nq.home.zeha.at) (C) 2001-2013 PowerDNS.COM BV
Aug 24 21:54:12 Using 64-bits mode. Built on 20130824215356 by ch@nq.home.zeha.at, gcc 4.8.1.
Aug 24 21:54:12 PowerDNS comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it according to the terms of the GPL version 2.
Aug 24 21:54:12 Features: libdl lua 
Aug 24 21:54:12 Built-in modules: gsqlite3 ldap opendbx
```

Partially addresses #958.
