### PR TITLE
Fix comparison between signed and unsigned by using uint32_t for incepti...

### DIFF
--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -80,7 +80,7 @@ uint32_t calculateEditSOA(SOAData sd, const string& kind) {
     return time(0);
   }
   else if(pdns_iequals(kind,"INCEPTION-EPOCH")) {
-    time_t inception = getStartOfWeek();
+    uint32_t inception = getStartOfWeek();
     if (sd.serial < inception)
       return inception;
   }


### PR DESCRIPTION
...on on INCEPTION-EPOCH. 

Fixes warning on some platforms. 
