### PR TITLE
Fix zone2{sql,json} exit codes

### DIFF
--- a/pdns/backends/bind/zone2json.cc
+++ b/pdns/backends/bind/zone2json.cc
@@ -122,10 +122,10 @@ ArgvMap &arg()
 
 
 int main(int argc, char **argv)
+try
 {
   vector<string> lines;
 
-  try {
     reportAllTypes();
     reportFancyTypes();
 #if __GNUC__ >= 3
@@ -232,21 +232,19 @@ int main(int argc, char **argv)
       num_domainsdone=1;
     }
     cerr<<num_domainsdone<<" domains were fully parsed, containing "<<g_numRecords<<" records\n";
-    
-  }
-  catch(PDNSException &ae) {
-    cerr<<"\nFatal error: "<<ae.reason<<endl;
-    return 0;
-  }
-  catch(std::exception &e) {
-    cerr<<"died because of STL error: "<<e.what()<<endl;
-    exit(0);
-  }
-  catch(...) {
-    cerr<<"died because of unknown exception"<<endl;
-    exit(0);
-  }
-  
-  return 1;
 
+  return 0;
+    
+}
+catch(PDNSException &ae) {
+  cerr<<"\nFatal error: "<<ae.reason<<endl;
+  return 1;
+}
+catch(std::exception &e) {
+  cerr<<"\ndied because of STL error: "<<e.what()<<endl;
+  return 1;
+}
+catch(...) {
+  cerr<<"\ndied because of unknown exception"<<endl;
+  return 1;
 }

--- a/pdns/backends/bind/zone2sql.cc
+++ b/pdns/backends/bind/zone2sql.cc
@@ -241,8 +241,8 @@ ArgvMap &arg()
 
 
 int main(int argc, char **argv)
+try
 {
-  try {
     reportAllTypes();
     reportFancyTypes();
 #if __GNUC__ >= 3
@@ -379,26 +379,23 @@ int main(int argc, char **argv)
     }
     cerr<<num_domainsdone<<" domains were fully parsed, containing "<<g_numRecords<<" records\n";
     
-  }
-  catch(PDNSException &ae) {
-    cerr<<"\nFatal error: "<<ae.reason<<endl;
-    return 0;
-  }
-  catch(std::exception &e) {
-    cerr<<"died because of STL error: "<<e.what()<<endl;
-    exit(0);
-  }
-  catch(...) {
-    cerr<<"died because of unknown exception"<<endl;
-    exit(0);
-  }
-  
   if(::arg().mustDo("transactions") && g_intransaction) {
     if(g_mode != SQLITE)
       cout<<"COMMIT WORK;"<<endl;
     else
       cout<<"COMMIT;"<<endl;
   }
+  return 0;
+}
+catch(PDNSException &ae) {
+  cerr<<"\nFatal error: "<<ae.reason<<endl;
   return 1;
-
+}
+catch(std::exception &e) {
+  cerr<<"\ndied because of STL error: "<<e.what()<<endl;
+  return 1;
+}
+catch(...) {
+  cerr<<"\ndied because of unknown exception"<<endl;
+  return 1;
 }


### PR DESCRIPTION
To be consistent with general practice, fix zone2{sql,json} to exit with:
- 0 on success
- 1 on error

This also moves the catch block after the last line of main, so a
"theoretically" possible exception in ::arg().mustDo would get caught.
(Also, one level less of indent!)
