### PR TITLE
Enable subdir-objects for automake-1.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_INIT([pdns], [git])
 dnl AC_SUBST([DIST_HOST], [TO_BE_PATCHED])
 dnl End patch area.
 AC_CONFIG_SRCDIR([pdns/receiver.cc])
-AM_INIT_AUTOMAKE([foreign tar-ustar -Wno-portability])
+AM_INIT_AUTOMAKE([foreign tar-ustar -Wno-portability subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CANONICAL_HOST
 LT_INIT


### PR DESCRIPTION
Fixes warnings about source files in subdirectories, without having
this option enabled.

Appears to work on Travis, which likely has automake 1.11. Can't vouch for even older versions.
(Also I don't 100% understand what this option changes.)
