### PR TITLE
modules: use libtool object files - real object file might be in a .libs subdir

### DIFF
--- a/modules/db2backend/OBJECTFILES
+++ b/modules/db2backend/OBJECTFILES
@@ -1,1 +1,1 @@
-DB2Backend.o
+DB2Backend.lo

--- a/modules/geobackend/OBJECTFILES
+++ b/modules/geobackend/OBJECTFILES
@@ -1,1 +1,1 @@
-geobackend.o ippreftree.o
+geobackend.lo ippreftree.lo

--- a/modules/gmysqlbackend/OBJECTFILES
+++ b/modules/gmysqlbackend/OBJECTFILES
@@ -1,1 +1,1 @@
-gmysqlbackend.o smysql.o
+gmysqlbackend.lo smysql.lo

--- a/modules/goraclebackend/OBJECTFILES
+++ b/modules/goraclebackend/OBJECTFILES
@@ -1,1 +1,1 @@
-goraclebackend.o soracle.o
+goraclebackend.lo soracle.lo

--- a/modules/gpgsqlbackend/OBJECTFILES
+++ b/modules/gpgsqlbackend/OBJECTFILES
@@ -1,1 +1,1 @@
-gpgsqlbackend.o spgsql.o
+gpgsqlbackend.lo spgsql.lo

--- a/modules/gsqlite3backend/OBJECTFILES
+++ b/modules/gsqlite3backend/OBJECTFILES
@@ -1,1 +1,1 @@
-gsqlite3backend.o
+gsqlite3backend.lo

--- a/modules/ldapbackend/OBJECTFILES
+++ b/modules/ldapbackend/OBJECTFILES
@@ -1,1 +1,1 @@
-ldapbackend.o powerldap.o
+ldapbackend.lo powerldap.lo

--- a/modules/luabackend/OBJECTFILES
+++ b/modules/luabackend/OBJECTFILES
@@ -1,1 +1,1 @@
-luabackend.o minimal.o reload.o lua_functions.o master.o private.o slave.o supermaster.o dnssec.o
+luabackend.lo minimal.lo reload.lo lua_functions.lo master.lo private.lo slave.lo supermaster.lo dnssec.lo

--- a/modules/mydnsbackend/OBJECTFILES
+++ b/modules/mydnsbackend/OBJECTFILES
@@ -1,1 +1,1 @@
-mydnsbackend.o 
+mydnsbackend.lo

--- a/modules/opendbxbackend/OBJECTFILES
+++ b/modules/opendbxbackend/OBJECTFILES
@@ -1,1 +1,1 @@
-odbxbackend.o odbxprivate.o
+odbxbackend.lo odbxprivate.lo

--- a/modules/oraclebackend/OBJECTFILES
+++ b/modules/oraclebackend/OBJECTFILES
@@ -1,1 +1,1 @@
-oraclebackend.o
+oraclebackend.lo

--- a/modules/pipebackend/OBJECTFILES
+++ b/modules/pipebackend/OBJECTFILES
@@ -1,1 +1,1 @@
-coprocess.o pipebackend.o
+coprocess.lo pipebackend.lo

--- a/modules/randombackend/OBJECTFILES
+++ b/modules/randombackend/OBJECTFILES
@@ -1,1 +1,1 @@
-randombackend.o
+randombackend.lo

--- a/modules/remotebackend/OBJECTFILES
+++ b/modules/remotebackend/OBJECTFILES
@@ -1,1 +1,1 @@
-remotebackend.o unixconnector.o httpconnector.o pipeconnector.o
+remotebackend.lo unixconnector.lo httpconnector.lo pipeconnector.lo

--- a/modules/tinydnsbackend/OBJECTFILES
+++ b/modules/tinydnsbackend/OBJECTFILES
@@ -1,1 +1,1 @@
-tinydnsbackend.o cdb.o
+tinydnsbackend.lo cdb.lo

--- a/modules/xdbbackend/OBJECTFILES
+++ b/modules/xdbbackend/OBJECTFILES
@@ -1,1 +1,1 @@
-xdbbackend.o xtdb.o
+xdbbackend.lo xtdb.lo


### PR DESCRIPTION
Build failed with:

```
g++-4.8: error: ../modules/gpgsqlbackend/gpgsqlbackend.o: No such file or directory
g++-4.8: error: ../modules/gpgsqlbackend/spgsql.o: No such file or directory
```

Searching object files through the libtool object files instead worked.
