### PR TITLE
WIP: Support offline KSK presigning

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -62,13 +62,13 @@ bool DNSSECKeeper::isSecuredZone(const std::string& zname)
     ReadLock l(&s_keycachelock);
     keycache_t::const_iterator iter = s_keycache.find(zname);
     if(iter != s_keycache.end() && iter->d_ttd > (unsigned int)time(0)) {
-      if(iter->d_keys.empty())
-        return false;
-      else
-        return true;
+      BOOST_FOREACH(keyset_t::value_type& val, iter->d_keys) {
+        if(val.second.keyOrZone && val.second.active) {
+          return true;
+        }
+      }
+      return false;
     }
-    else
-      ;
   }
   keyset_t keys = getKeys(zname, true); // does the cache
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -3,7 +3,7 @@
     Copyright (C) 2001 - 2012  PowerDNS.COM BV
 
     This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2 as 
+    it under the terms of the GNU General Public License version 2 as
     published by the Free Software Foundation
 
     Additionally, the license of this program contains a special
@@ -49,11 +49,11 @@ pthread_rwlock_t DNSSECKeeper::s_keycachelock = PTHREAD_RWLOCK_INITIALIZER;
 AtomicCounter DNSSECKeeper::s_ops;
 time_t DNSSECKeeper::s_last_prune;
 
-bool DNSSECKeeper::isSecuredZone(const std::string& zone) 
+bool DNSSECKeeper::isSecuredZone(const std::string& zone)
 {
   if(isPresigned(zone))
     return true;
-  
+
   if(!((++s_ops) % 100000)) {
     cleanup();
   }
@@ -61,17 +61,17 @@ bool DNSSECKeeper::isSecuredZone(const std::string& zone)
   {
     ReadLock l(&s_keycachelock);
     keycache_t::const_iterator iter = s_keycache.find(zone);
-    if(iter != s_keycache.end() && iter->d_ttd > (unsigned int)time(0)) { 
+    if(iter != s_keycache.end() && iter->d_ttd > (unsigned int)time(0)) {
       if(iter->d_keys.empty())
         return false;
       else
         return true;
     }
     else
-      ; 
-  }  
+      ;
+  }
   keyset_t keys = getKeys(zone, true); // does the cache
-  
+
   BOOST_FOREACH(keyset_t::value_type& val, keys) {
     if(val.second.active) {
       return true;
@@ -124,7 +124,7 @@ void DNSSECKeeper::clearCaches(const std::string& name)
 {
   {
     WriteLock l(&s_keycachelock);
-    s_keycache.erase(name); 
+    s_keycache.erase(name);
   }
   WriteLock l(&s_metacachelock);
   pair<metacache_t::iterator, metacache_t::iterator> range = s_metacache.equal_range(name);
@@ -152,24 +152,24 @@ static bool keyCompareByKindAndID(const DNSSECKeeper::keyset_t::value_type& a, c
 }
 
 DNSSECPrivateKey DNSSECKeeper::getKeyById(const std::string& zname, unsigned int id)
-{  
+{
   vector<DNSBackend::KeyData> keys;
   d_keymetadb->getDomainKeys(zname, 0, keys);
   BOOST_FOREACH(const DNSBackend::KeyData& kd, keys) {
-    if(kd.id != id) 
+    if(kd.id != id)
       continue;
-    
+
     DNSSECPrivateKey dpk;
     DNSKEYRecordContent dkrc;
     dpk.setKey(shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content)));
     dpk.d_flags = kd.flags;
     dpk.d_algorithm = dkrc.d_algorithm;
-    
+
     if(dpk.d_algorithm == 5 && getNSEC3PARAM(zname)) {
       dpk.d_algorithm += 2;
     }
-    
-    return dpk;    
+
+    return dpk;
   }
   throw runtime_error("Can't find a key with id "+lexical_cast<string>(id)+" for zone '"+zname+"'");
 }
@@ -204,8 +204,8 @@ void DNSSECKeeper::getFromMeta(const std::string& zname, const std::string& key,
   }
 
   {
-    ReadLock l(&s_metacachelock); 
-    
+    ReadLock l(&s_metacachelock);
+
     metacache_t::const_iterator iter = s_metacache.find(tie(zname, key));
     if(iter != s_metacache.end() && iter->d_ttd > now) {
       value = iter->d_value;
@@ -216,13 +216,13 @@ void DNSSECKeeper::getFromMeta(const std::string& zname, const std::string& key,
   d_keymetadb->getDomainMetadata(zname, key, meta);
   if(!meta.empty())
     value=*meta.begin();
-    
+
   METACacheEntry nce;
   nce.d_domain=zname;
   nce.d_ttd = now+60;
   nce.d_key= key;
   nce.d_value = value;
-  { 
+  {
     WriteLock l(&s_metacachelock);
     replacing_insert(s_metacache, nce);
   }
@@ -235,7 +235,7 @@ bool DNSSECKeeper::getNSEC3PARAM(const std::string& zname, NSEC3PARAMRecordConte
   if(value.empty()) { // "no NSEC3"
     return false;
   }
-     
+
   if(ns3p) {
     NSEC3PARAMRecordContent* tmp=dynamic_cast<NSEC3PARAMRecordContent*>(DNSRecordContent::mastermake(QType::NSEC3PARAM, 1, value));
     *ns3p = *tmp;
@@ -256,10 +256,10 @@ bool DNSSECKeeper::setNSEC3PARAM(const std::string& zname, const NSEC3PARAMRecor
   meta.push_back(descr);
   if (d_keymetadb->setDomainMetadata(zname, "NSEC3PARAM", meta)) {
     meta.clear();
-    
+
     if(narrow)
       meta.push_back("1");
-    
+
     return d_keymetadb->setDomainMetadata(zname, "NSEC3NARROW", meta);
   }
   return false;
@@ -287,7 +287,7 @@ bool DNSSECKeeper::unsetPresigned(const std::string& zname)
 }
 
 
-DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const std::string& zone, boost::tribool allOrKeyOrZone) 
+DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const std::string& zone, boost::tribool allOrKeyOrZone)
 {
   unsigned int now = time(0);
 
@@ -298,8 +298,8 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const std::string& zone, boost::tri
   {
     ReadLock l(&s_keycachelock);
     keycache_t::const_iterator iter = s_keycache.find(zone);
-      
-    if(iter != s_keycache.end() && iter->d_ttd > now) { 
+
+    if(iter != s_keycache.end() && iter->d_ttd > now) {
       keyset_t ret;
       BOOST_FOREACH(const keyset_t::value_type& value, iter->d_keys) {
         if(boost::indeterminate(allOrKeyOrZone) || allOrKeyOrZone == value.second.keyOrZone)
@@ -307,38 +307,38 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const std::string& zone, boost::tri
       }
       return ret;
     }
-  }    
+  }
   keyset_t retkeyset, allkeyset;
   vector<UeberBackend::KeyData> dbkeyset;
-  
+
   d_keymetadb->getDomainKeys(zone, 0, dbkeyset);
-  
-  BOOST_FOREACH(UeberBackend::KeyData& kd, dbkeyset) 
+
+  BOOST_FOREACH(UeberBackend::KeyData& kd, dbkeyset)
   {
     DNSSECPrivateKey dpk;
 
     DNSKEYRecordContent dkrc;
-    
+
     dpk.setKey(shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content)));
-    
+
     dpk.d_flags = kd.flags;
     dpk.d_algorithm = dkrc.d_algorithm;
     if(dpk.d_algorithm == 5 && getNSEC3PARAM(zone))
       dpk.d_algorithm+=2;
-    
+
     KeyMetaData kmd;
 
     kmd.active = kd.active;
     kmd.keyOrZone = (kd.flags == 257);
     kmd.id = kd.id;
-    
+
     if(boost::indeterminate(allOrKeyOrZone) || allOrKeyOrZone == kmd.keyOrZone)
       retkeyset.push_back(make_pair(dpk, kmd));
     allkeyset.push_back(make_pair(dpk, kmd));
   }
   sort(retkeyset.begin(), retkeyset.end(), keyCompareByKindAndID);
   sort(allkeyset.begin(), allkeyset.end(), keyCompareByKindAndID);
-  
+
   KeyCacheEntry kce;
   kce.d_domain=zone;
   kce.d_keys = allkeyset;
@@ -347,7 +347,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const std::string& zone, boost::tri
     WriteLock l(&s_keycachelock);
     replacing_insert(s_keycache, kce);
   }
-  
+
   return retkeyset;
 }
 
@@ -357,42 +357,42 @@ bool DNSSECKeeper::secureZone(const std::string& name, int algorithm, int size)
   return addKey(name, true, algorithm, size);
 }
 
-bool DNSSECKeeper::getPreRRSIGs(DNSBackend& db, const std::string& signer, const std::string& qname, 
-        const std::string& wildcardname, const QType& qtype, 
-        DNSPacketWriter::Place signPlace, vector<DNSResourceRecord>& rrsigs, uint32_t signTTL)
+bool DNSSECKeeper::getPreRRSIGs(DNSBackend& db, const std::string& signer, const std::string& qname,
+  const std::string& wildcardname, const QType& qtype,
+  DNSPacketWriter::Place signPlace, vector<DNSResourceRecord>& rrsigs, uint32_t signTTL)
 {
   // cerr<<"Doing DB lookup for precomputed RRSIGs for '"<<(wildcardname.empty() ? qname : wildcardname)<<"'"<<endl;
-        SOAData sd;
-        sd.db=(DNSBackend *)-1; // force uncached answer
-        if(!db.getSOA(signer, sd)) {
-                DLOG(L<<"Could not get SOA for domain"<<endl);
-                return false;
-        }
-        db.lookup(QType(QType::RRSIG), wildcardname.empty() ? qname : wildcardname, NULL, sd.domain_id);
-        DNSResourceRecord rr;
-        while(db.get(rr)) { 
-                // cerr<<"Considering for '"<<qtype.getName()<<"' RRSIG '"<<rr.content<<"'\n";
-                vector<string> parts;
-                stringtok(parts, rr.content);
-                if(parts[0] == qtype.getName() && pdns_iequals(parts[7], signer+".")) {
-                        // cerr<<"Got it"<<endl;
-                        if (!wildcardname.empty())
-                                rr.qname = qname;
-                        rr.d_place = (DNSResourceRecord::Place)signPlace;
-                        rr.ttl = signTTL;
-                        rrsigs.push_back(rr);
-                }
-                else ; // cerr<<"Skipping!"<<endl;
-        }
-        return true;
+  SOAData sd;
+  sd.db=(DNSBackend *)-1; // force uncached answer
+  if(!db.getSOA(signer, sd)) {
+    DLOG(L<<"Could not get SOA for domain"<<endl);
+    return false;
+  }
+  db.lookup(QType(QType::RRSIG), wildcardname.empty() ? qname : wildcardname, NULL, sd.domain_id);
+  DNSResourceRecord rr;
+  while(db.get(rr)) {
+    // cerr<<"Considering for '"<<qtype.getName()<<"' RRSIG '"<<rr.content<<"'\n";
+    vector<string> parts;
+    stringtok(parts, rr.content);
+    if(parts[0] == qtype.getName() && pdns_iequals(parts[7], signer+".")) {
+      // cerr<<"Got it"<<endl;
+      if (!wildcardname.empty())
+        rr.qname = qname;
+      rr.d_place = (DNSResourceRecord::Place)signPlace;
+      rr.ttl = signTTL;
+      rrsigs.push_back(rr);
+    }
+    else ; // cerr<<"Skipping!"<<endl;
+  }
+  return true;
 }
 
 bool DNSSECKeeper::TSIGGrantsAccess(const string& zone, const string& keyname, const string& algorithm)
 {
   vector<string> allowed;
-  
+
   d_keymetadb->getDomainMetadata(zone, "TSIG-ALLOW-AXFR", allowed);
-  
+
   BOOST_FOREACH(const string& dbkey, allowed) {
     if(pdns_iequals(dbkey, keyname))
       return true;
@@ -405,7 +405,7 @@ bool DNSSECKeeper::getTSIGForAccess(const string& zone, const string& master, st
   vector<string> keynames;
   d_keymetadb->getDomainMetadata(zone, "AXFR-MASTER-TSIG", keynames);
   keyname->clear();
-  
+
   // XXX FIXME this should check for a specific master!
   BOOST_FOREACH(const string& dbkey, keynames) {
     *keyname=dbkey;

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -44,7 +44,7 @@ public:
   {
     unsigned int id;
     bool active;
-    bool keyOrZone;
+    bool keyOrZone; /* true: KSK, false: ZSK */
     string fname;
   };
   typedef std::pair<DNSSECPrivateKey, KeyMetaData> keymeta_t;
@@ -119,6 +119,7 @@ private:
     string d_domain;
     unsigned int d_ttd;
     mutable keys_t d_keys;
+    bool d_isSecure; /* whether any active KSK is present */
   };
 
   struct METACacheEntry
@@ -156,6 +157,7 @@ private:
   > metacache_t;
 
   void cleanup();
+  KeyCacheEntry getKeyCacheEntry(const std::string& zone);
 
   static keycache_t s_keycache;
   static metacache_t s_metacache;

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -68,17 +68,17 @@ public:
     if(d_ourDB)
       delete d_keymetadb;
   }
-  bool isSecuredZone(const std::string& zone);
+  bool isSecuredZone(const std::string& zname);
 
-  keyset_t getKeys(const std::string& zone, boost::tribool allOrKeyOrZone = boost::indeterminate);
-  DNSSECPrivateKey getKeyById(const std::string& zone, unsigned int id);
+  keyset_t getKeys(const std::string& zname, boost::tribool allOrKeyOrZone = boost::indeterminate);
+  DNSSECPrivateKey getKeyById(const std::string& zname, unsigned int id);
   bool addKey(const std::string& zname, bool keyOrZone, int algorithm=5, int bits=0, bool active=true);
   bool addKey(const std::string& zname, const DNSSECPrivateKey& dpk, bool active=true);
   bool removeKey(const std::string& zname, unsigned int id);
   bool activateKey(const std::string& zname, unsigned int id);
   bool deactivateKey(const std::string& zname, unsigned int id);
 
-  bool secureZone(const std::string& fname, int algorithm, int size);
+  bool secureZone(const std::string& zname, int algorithm, int size);
 
   bool getNSEC3PARAM(const std::string& zname, NSEC3PARAMRecordContent* n3p=0, bool* narrow=0);
   bool setNSEC3PARAM(const std::string& zname, const NSEC3PARAMRecordContent& n3p, const bool& narrow=false);
@@ -90,8 +90,8 @@ public:
   bool setPresigned(const std::string& zname);
   bool unsetPresigned(const std::string& zname);
 
-  bool TSIGGrantsAccess(const string& zone, const string& keyname, const string& algorithm);
-  bool getTSIGForAccess(const string& zone, const string& master, string* keyname);
+  bool TSIGGrantsAccess(const string& zname, const string& keyname, const string& algorithm);
+  bool getTSIGForAccess(const string& zname, const string& master, string* keyname);
 
   void startTransaction()
   {

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -69,6 +69,8 @@ public:
       delete d_keymetadb;
   }
   bool isSecuredZone(const std::string& zname);
+  /* not presigned, has active ZSK but no active KSK - assume DNSKEYs (including a KSK from backend) are presigned offline with KSK */
+  bool isKskOffline(const std::string& zname);
 
   keyset_t getKeys(const std::string& zname, boost::tribool allOrKeyOrZone = boost::indeterminate);
   DNSSECPrivateKey getKeyById(const std::string& zname, unsigned int id);
@@ -119,7 +121,8 @@ private:
     string d_domain;
     unsigned int d_ttd;
     mutable keys_t d_keys;
-    bool d_isSecure; /* whether any active KSK is present */
+    bool d_isSecure; /* whether any active KSK or ZSK is present */
+    bool d_haveActiveKSK; /* whether any active KSK is present */
   };
 
   struct METACacheEntry

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -5,7 +5,7 @@
     Copyright (C) 2002-2011  PowerDNS.COM BV
 
     This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2 as 
+    it under the terms of the GNU General Public License version 2 as
     published by the Free Software Foundation
 
     Additionally, the license of this program contains a special
@@ -47,7 +47,7 @@ public:
     bool keyOrZone;
     string fname;
   };
-  typedef std::pair<DNSSECPrivateKey, KeyMetaData> keymeta_t; 
+  typedef std::pair<DNSSECPrivateKey, KeyMetaData> keymeta_t;
   typedef std::vector<keymeta_t > keyset_t;
 
 private:
@@ -57,20 +57,19 @@ private:
 public:
   DNSSECKeeper() : d_keymetadb( new UeberBackend("key-only")), d_ourDB(true)
   {
-    
   }
-  
+
   DNSSECKeeper(UeberBackend* db) : d_keymetadb(db), d_ourDB(false)
   {
   }
-  
+
   ~DNSSECKeeper()
   {
     if(d_ourDB)
       delete d_keymetadb;
   }
   bool isSecuredZone(const std::string& zone);
-  
+
   keyset_t getKeys(const std::string& zone, boost::tribool allOrKeyOrZone = boost::indeterminate);
   DNSSECPrivateKey getKeyById(const std::string& zone, unsigned int id);
   bool addKey(const std::string& zname, bool keyOrZone, int algorithm=5, int bits=0, bool active=true);
@@ -93,49 +92,49 @@ public:
 
   bool TSIGGrantsAccess(const string& zone, const string& keyname, const string& algorithm);
   bool getTSIGForAccess(const string& zone, const string& master, string* keyname);
-  
+
   void startTransaction()
   {
     (*d_keymetadb->backends.begin())->startTransaction("", -1);
   }
-  
+
   void commitTransaction()
   {
     (*d_keymetadb->backends.begin())->commitTransaction();
   }
-  
+
   void getFromMeta(const std::string& zname, const std::string& key, std::string& value);
 private:
 
-  
+
   struct KeyCacheEntry
   {
     typedef vector<DNSSECKeeper::keymeta_t> keys_t;
-  
+
     uint32_t getTTD() const
     {
       return d_ttd;
     }
-  
+
     string d_domain;
     unsigned int d_ttd;
     mutable keys_t d_keys;
   };
-  
+
   struct METACacheEntry
   {
     uint32_t getTTD() const
     {
       return d_ttd;
     }
-  
+
     string d_domain;
     unsigned int d_ttd;
-  
+
     mutable std::string d_key, d_value;
   };
-  
-  
+
+
   typedef multi_index_container<
     KeyCacheEntry,
     indexed_by<
@@ -147,8 +146,8 @@ private:
     METACacheEntry,
     indexed_by<
       ordered_unique<
-        composite_key< 
-          METACacheEntry, 
+        composite_key<
+          METACacheEntry,
           member<METACacheEntry, std::string, &METACacheEntry::d_domain> ,
           member<METACacheEntry, std::string, &METACacheEntry::d_key>
         >, composite_key_compare<CIStringCompare, CIStringCompare> >,

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -92,6 +92,10 @@ void addSignature(DNSSECKeeper& dk, DNSBackend& db, const std::string& signer, c
     //cerr<<"Doing presignatures"<<endl;
     dk.getPreRRSIGs(db, signer, signQName, wildcardname, QType(signQType), signPlace, outsigned, origTTL); // does it all
   }
+  else if (signQType == QType::DNSKEY && dk.isKskOffline(signer)) {
+    //cerr<<"Doing offline KSK presignatures for RRSIG DNSKEY"<<endl;
+    dk.getPreRRSIGs(db, signer, signQName, wildcardname, QType(signQType), signPlace, outsigned, origTTL); // does it all
+  }
   else {
     if(getRRSIGsForRRSET(dk, signer, wildcardname.empty() ? signQName : wildcardname, signQType, signTTL, toSign, rrcs, signQType == QType::DNSKEY) < 0)  {
       // cerr<<"Error signing a record!"<<endl;

--- a/pdns/docs/pdns.xml
+++ b/pdns/docs/pdns.xml
@@ -13046,6 +13046,30 @@ $ pdnssec rectify-zone powerdnssec.org
       that all DNSSEC-related fields are set correctly.
     </para>
   </section>
+  <section id="dnssec-ksk-offline"><title>PowerDNSSEC KSK Pre-signed records</title>
+    <para>
+      In this mode the DNSKEY records (KSK and ZSK) are pre-signed offline with the KSK key(s); the KSK private key(s)
+      must not be available in PowerDNS. The ZSK private key(s) must be available to sign all other records live.
+      This means the zone records must include the DNSKEY KSK record(s) and the RRSIG record(s) for all DNSKEY
+      records (KSK and ZSK) signed with the KSK(s).
+    </para>
+    <para>
+      This mode is activated automatically if an active ZSK is present but no active KSK; it will operate similar to
+      the simplest mode described above, but it will use RRSIG from the zone instead of signing the DNSKEY RRset live.
+    </para>
+    <para>
+      This allows you to store the KSK in a more secure environment than the ZSK. If you loose the ZSK, it can only
+      be abused as long as the offline signature with the KSK is valid and the delegation to the KSK is valid.
+    </para>
+    <para>
+      If the offline signature isn't valid for a long time you can replace a lost ZSK without replacing the KSK
+      and therefore without updating the delegation.
+    </para>
+    <para>
+      Similar to pre-signed records you need a system in place that ensures the offline signature is updated
+      regularly.
+    </para>
+  </section>
   <section id="dnssec-bind"><title>PowerDNSSEC BIND-mode operation</title>
   <para>
   	Starting with PowerDNS 3.1, the bindbackend can manage keys in an SQLite3 database without launching

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -87,7 +87,7 @@ private:
   void emitNSEC3(const NSEC3PARAMRecordContent &ns3rc, const SOAData& sd, const std::string& unhashed, const std::string& begin, const std::string& end, const std::string& toNSEC3, DNSPacket *r, int mode);
   int processUpdate(DNSPacket *p);
   int forwardPacket(const string &msgPrefix, DNSPacket *p, DomainInfo *di);
-  uint performUpdate(const string &msgPrefix, const DNSRecord *rr, DomainInfo *di, bool isPresigned, bool* narrow, bool* haveNSEC3, NSEC3PARAMRecordContent *ns3pr, bool *updatedSerial);
+  uint performUpdate(const string &msgPrefix, const DNSRecord *rr, DomainInfo *di, bool isPresigned, bool isKskOffline, bool* narrow, bool* haveNSEC3, NSEC3PARAMRecordContent *ns3pr, bool *updatedSerial);
   int checkUpdatePrescan(const DNSRecord *rr);
   int checkUpdatePrerequisites(const DNSRecord *rr, DomainInfo *di);
   void increaseSerial(const string &msgPrefix, const DomainInfo *di, bool haveNSEC3, bool narrow, const NSEC3PARAMRecordContent *ns3pr);

--- a/pdns/pdnssec.cc
+++ b/pdns/pdnssec.cc
@@ -461,7 +461,7 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const std::string& zone)
       }
     } else {
       if (rr.qtype.getCode() == QType::RRSIG) {
-        if(presigned) {
+        if(!presigned) {
           cout<<"[Error] RRSIG found at '"<<rr.qname<<"' in non-presigned zone. These do not belong in the database."<<endl;
           numerrors++;
           continue;

--- a/pdns/pdnssec.cc
+++ b/pdns/pdnssec.cc
@@ -343,6 +343,8 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const std::string& zone)
     return -1;
   }
   bool presigned=dk.isPresigned(zone);
+  bool kskOffline=dk.isKskOffline(zone);
+  bool dnskey_rrsig=false,dnskey_ksk=false;
   sd.db->list(zone, sd.domain_id);
   DNSResourceRecord rr;
   uint64_t numrecords=0, numerrors=0, numwarnings=0;
@@ -461,7 +463,18 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const std::string& zone)
       }
     } else {
       if (rr.qtype.getCode() == QType::RRSIG) {
-        if(!presigned) {
+        if(kskOffline) {
+          RRSIGRecordContent rrc(rr.content);
+          if (rrc.d_type != QType::DNSKEY) {
+            cout<<"[Error] RRSIG (not for DNSKEY) found at '"<<rr.qname<<"' in offline KSK zone. These do not belong in the database."<<endl;
+            numerrors++;
+            continue;
+          } else {
+            dnskey_rrsig = true;
+          }
+        }
+        else if (!presigned)
+        {
           cout<<"[Error] RRSIG found at '"<<rr.qname<<"' in non-presigned zone. These do not belong in the database."<<endl;
           numerrors++;
           continue;
@@ -479,7 +492,18 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const std::string& zone)
 
     if(!presigned && rr.qtype.getCode() == QType::DNSKEY)
     {
-      if(::arg().mustDo("experimental-direct-dnskey"))
+      if (kskOffline) {
+        DNSKEYRecordContent drc(rr.content);
+        if(rr.ttl != sd.default_ttl)
+        {
+          cout<<"[Error] DNSKEY TTL of "<<rr.ttl<<" at '"<<rr.qname<<"' differs from SOA default of "<<sd.default_ttl<<endl;
+          numerrors++;
+        }
+        if (drc.d_flags == 257) {
+          dnskey_ksk = true;
+        }
+      }
+      else if(::arg().mustDo("experimental-direct-dnskey"))
       {
         if(rr.ttl != sd.default_ttl)
         {
@@ -516,6 +540,15 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const std::string& zone)
       cout<<"[Error] Following record is auth=0, run pdnssec rectify-zone?: "<<rr.qname<<" IN " <<rr.qtype.getName()<< " " << rr.content<<endl;
       numerrors++;
     }
+  }
+
+  if (kskOffline && !dnskey_rrsig) {
+    cout<<"[Error] Zone is supposed to have RRSIG DNSKEY (offline KSK signing)\n";
+    numerrors++;
+  }
+  if (kskOffline && !dnskey_ksk) {
+    cout<<"[Error] Zone is supposed to have KSK DNSKEY (offline KSK signing)\n";
+    numerrors++;
   }
 
   for(set<string>::const_iterator i = cnames.begin(); i != cnames.end(); i++) {
@@ -768,6 +801,9 @@ bool showZone(DNSSECKeeper& dk, const std::string& zone)
   }
   
   cout <<"Zone is " << (dk.isPresigned(zone) ? "" : "not ") << "presigned"<<endl;
+  if (dk.isKskOffline(zone)) {
+    cout<<"No active KSK: DNSKEYs in zone are supposed to be presigned with a KSK"<<endl;
+  }
 
   if(keyset.empty())  {
     cerr << "No keys for zone '"<<zone<<"'."<<endl;
@@ -784,7 +820,7 @@ bool showZone(DNSSECKeeper& dk, const std::string& zone)
       algorithm2name(value.first.d_algorithm, algname);
       cout<<"ID = "<<value.second.id<<" ("<<(value.second.keyOrZone ? "KSK" : "ZSK")<<"), tag = "<<value.first.getDNSKEY().getTag();
       cout<<", algo = "<<(int)value.first.d_algorithm<<", bits = "<<value.first.getKey()->getBits()<<"\tActive: "<<value.second.active<< " ( " + algname + " ) "<<endl;
-      if(value.second.keyOrZone || ::arg().mustDo("experimental-direct-dnskey"))
+      if(value.second.keyOrZone || dk.isKskOffline(zone) || ::arg().mustDo("experimental-direct-dnskey"))
         cout<<(value.second.keyOrZone ? "KSK" : "ZSK")<<" DNSKEY = "<<zone<<" IN DNSKEY "<< value.first.getDNSKEY().getZoneRepresentation() << " ; ( "  + algname + " )" << endl;
       if(value.second.keyOrZone) {
         cout<<"DS = "<<zone<<" IN DS "<<makeDSFromDNSKey(zone, value.first.getDNSKEY(), 1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;


### PR DESCRIPTION
Todo:
- [ ] review
- [x] no breaking of current tests
- [ ] test cases
- [x] documentation
- [ ] make configurable and default-off

(The ``DLOG`` code was removed)
~~I added logging in some places:~~

  ~~``if (kskOffline) DLOG(L<<Logger::Warning<<"TTL from backend DNSKEY record in '"<<p->qdomain<<"' didn't match SOA default TTL, fixing"<<endl);``~~

~~Maybe this is a bad idea, as it will trigger on every query on a broken zone.. is there a better way?~~