### PR TITLE
Remove unused tests from configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,18 +87,11 @@ if test "$WITH_SQLITE3" != "no"; then
   fi
 fi
 
-dnl Checks for header files.
-AC_HEADER_STDC
-AC_CHECK_HEADERS(fcntl.h  getopt.h limits.h strings.h sys/time.h syslog.h unistd.h)
-
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T
-AC_HEADER_TIME
-AC_STRUCT_TM
 
 dnl Checks for library functions.
-AC_TYPE_SIGNAL
-AC_CHECK_FUNCS(gethostname gettimeofday mkdir mktime select socket strerror strcasestr)
+AC_CHECK_FUNCS(strcasestr)
 
 # Check for libdl
 


### PR DESCRIPTION
No code ever uses the HAVE_\* macros for these. Also, code can't use them, because the recursor Makefile doesn't support them.
