### PR TITLE
Use the inet data type for supermasters.ip on postgrsql.

### DIFF
--- a/pdns/no-dnssec.schema.pgsql.sql
+++ b/pdns/no-dnssec.schema.pgsql.sql
@@ -30,7 +30,7 @@ CREATE INDEX nametype_index ON records(name,type);
 CREATE INDEX domain_id ON records(domain_id);
 
 create table supermasters (
-          ip VARCHAR(64) NOT NULL,
+          ip INET NOT NULL,
           nameserver VARCHAR(255) NOT NULL,
           account VARCHAR(40) DEFAULT NULL
 );


### PR DESCRIPTION
Use pgsql’s inet data type for v4 and v6 IP addresses in the
supermasters table.

The guarantees that the address will fit, that the queries will
return the addresses in canonical format, and correctness in that
nothing other than an IP address can be stored in that column.

Signed-off-by: James Cloos cloos@jhcloos.com
