### PR TITLE
correct overloading of feedRecord

### DIFF
--- a/modules/luabackend/luabackend.hh
+++ b/modules/luabackend/luabackend.hh
@@ -56,7 +56,7 @@ public:
     bool startTransaction(const string &qname, int id);
     bool commitTransaction();
     bool abortTransaction();
-    bool feedRecord(const DNSResourceRecord &rr);
+    bool feedRecord(const DNSResourceRecord &rr, string *ordername=0);
 
 
 //  SUPERMASTER BACKEND

--- a/modules/luabackend/slave.cc
+++ b/modules/luabackend/slave.cc
@@ -26,7 +26,7 @@
    virtual bool startTransaction(const string &qname, int id);
    virtual bool commitTransaction();
    virtual bool abortTransaction();
-   virtual bool feedRecord(const DNSResourceRecord &rr);
+   virtual bool feedRecord(const DNSResourceRecord &rr, string* ordername=0);
 
    virtual bool getDomainInfo(const string &domain, DomainInfo &di);
    virtual bool isMaster(const string &name, const string &ip);
@@ -129,7 +129,7 @@ bool LUABackend::abortTransaction() {
     return ok;
 }
 
-bool LUABackend::feedRecord(const DNSResourceRecord &rr) {
+bool LUABackend::feedRecord(const DNSResourceRecord &rr, string *ordername) {
 
     if (f_lua_feedrecord == 0)
         return false;

--- a/modules/opendbxbackend/odbxbackend.cc
+++ b/modules/opendbxbackend/odbxbackend.cc
@@ -645,7 +645,7 @@ bool OdbxBackend::createSlaveDomain( const string& ip, const string& domain, con
 
 
 
-bool OdbxBackend::feedRecord( const DNSResourceRecord& rr )
+bool OdbxBackend::feedRecord( const DNSResourceRecord& rr, string *ordername )
 {
         try
         {

--- a/modules/opendbxbackend/odbxbackend.hh
+++ b/modules/opendbxbackend/odbxbackend.hh
@@ -86,7 +86,7 @@ public:
 
         bool isMaster( const string& domain, const string& ip );
         bool getDomainInfo( const string& domain, DomainInfo& di );
-        bool feedRecord( const DNSResourceRecord& rr );
+        bool feedRecord( const DNSResourceRecord& rr, string *ordername=0 );
         bool createSlaveDomain( const string& ip, const string& domain, const string& account );
         bool superMasterBackend( const string& ip, const string& domain, const vector<DNSResourceRecord>& nsset, string* account, DNSBackend** ddb );
 

--- a/modules/oraclebackend/oraclebackend.cc
+++ b/modules/oraclebackend/oraclebackend.cc
@@ -1058,7 +1058,7 @@ OracleBackend::startTransaction (const string &domain, int zoneId)
 }
 
 bool
-OracleBackend::feedRecord (const DNSResourceRecord &rr)
+OracleBackend::feedRecord (const DNSResourceRecord &rr, string *ordername)
 {
   sword rc;
   OCIStmt *stmt;

--- a/modules/oraclebackend/oraclebackend.hh
+++ b/modules/oraclebackend/oraclebackend.hh
@@ -69,7 +69,7 @@ public:
   void setNotified(uint32_t zoneId, uint32_t serial);
   bool list(const string &domain, int zoneId);
   bool startTransaction(const string &domain, int zoneId);
-  bool feedRecord(const DNSResourceRecord &rr);
+  bool feedRecord(const DNSResourceRecord &rr, string* ordername);
   bool commitTransaction();
   bool abortTransaction();
   bool superMasterBackend(const string &ip, const string &domain,

--- a/pdns/docs/pdns.xml
+++ b/pdns/docs/pdns.xml
@@ -22386,7 +22386,7 @@ static RandomLoader randomloader;
 	   virtual bool startTransaction(const string &amp;qname, int id);
 	   virtual bool commitTransaction();
 	   virtual bool abortTransaction();
-	   virtual bool feedRecord(const DNSResourceRecord &amp;rr);
+	   virtual bool feedRecord(const DNSResourceRecord &amp;rr, string *ordername=0);
 	   virtual void getUnfreshSlaveInfos(vector&lt;DomainInfo&gt;* domains);
 	   virtual void setFresh(uint32_t id);
            /* ... */
@@ -22467,7 +22467,7 @@ static RandomLoader randomloader;
 	    </listitem>
 	  </varlistentry>
 	  <varlistentry>
-	    <term>bool feedRecord(const DNSResourceRecord &amp;rr)</term>
+	    <term>bool feedRecord(const DNSResourceRecord &amp;rr, string *ordername)</term>
 	    <listitem>
 	      <para>
 		Insert this record.
@@ -22613,7 +22613,7 @@ public:
   virtual bool startTransaction(const string &amp;qname, int id);
   virtual bool commitTransaction();
   virtual bool abortTransaction();
-  virtual bool feedRecord(const DNSResourceRecord &amp;rr);
+  virtual bool feedRecord(const DNSResourceRecord &amp;rr, string *ordername);
   virtual bool replaceRRSet(uint32_t domain_id, const string&amp; qname, const QType&amp; qt, const vector&lt;DNSResourceRecord&gt;&amp; rrset)
   virtual bool listSubZone(const string &amp;zone, int domain_id);
   /* ... */
@@ -22647,7 +22647,7 @@ public:
 	    </listitem>
 	  </varlistentry>
           <varlistentry>
-	    <term>virtual bool feedRecord(const DNSResourceRecord &amp;rr);</term>
+	    <term>virtual bool feedRecord(const DNSResourceRecord &amp;rr, string *ordername);</term>
 	    <listitem>
 	      <para>See <xref linkend="rw-backends" />. Please keep in mind that the zone is not empty because <function>startTransaction()</function> was called different.</para>
 	    </listitem>


### PR DESCRIPTION
G++ 4.8 does not warn about this, but clearly an overload with the
wrong signature will not work when called through a base class pointer.
(clang++ 3.3 produces a diagnostic.)
