### PR TITLE
Log nice error messages when creating a socket fails

### DIFF
--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -105,8 +105,10 @@ void UDPNameserver::bindIPv4()
 
     s=socket(AF_INET,SOCK_DGRAM,0);
 
-    if(s<0)
+    if(s<0) {
+      L<<Logger::Error<<"Unable to acquire a UDP socket: "+string(strerror(errno)) << endl;
       throw PDNSException("Unable to acquire a UDP socket: "+string(strerror(errno)));
+    }
   
     Utility::setCloseOnExec(s);
   
@@ -197,8 +199,10 @@ void UDPNameserver::bindIPv6()
     string localname(*i);
 
     s=socket(AF_INET6,SOCK_DGRAM,0);
-    if(s<0)
+    if(s<0) {
+      L<<Logger::Error<<"Unable to acquire a UDPv6 socket: "+string(strerror(errno)) << endl;
       throw PDNSException("Unable to acquire a UDPv6 socket: "+string(strerror(errno)));
+    }
 
     Utility::setCloseOnExec(s);
     if(!Utility::setNonBlocking(s))


### PR DESCRIPTION
Just spent quite a while trying to debug why a certain server test case didn't start. It was because I was exceeding the number of allowed FD's however powerdns was just dumping. If it had logged these error messages it would have been a lot quicker to debug! For some reason the PDNSException is not being properly handled when it occurs (terminate called recursively) so the below is a nice simple workaround to ensure that something at least hits the logs.

Mark
