### PR TITLE
WIP: Add support for id.server requests following RFC 4892

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -122,7 +122,7 @@ void declareArguments()
   ::arg().set("negquery-cache-ttl","Seconds to store negative query results in the QueryCache")="60";
   ::arg().set("query-cache-ttl","Seconds to store query results in the QueryCache")="20";
   ::arg().set("soa-minimum-ttl","Default SOA minimum ttl")="3600";
-  ::arg().set("server-id", "Returned when queried for 'server.id' TXT or NSID, defaults to hostname")="";
+  ::arg().set("server-id", "Returned when queried for 'server.id' TXT or NSID, defaults to hostname  - valid options: anonymous, disabled or custom")="");
   ::arg().set("soa-refresh-default","Default SOA refresh")="10800";
   ::arg().set("soa-retry-default","Default SOA retry")="3600";
   ::arg().set("soa-expire-default","Default SOA expire")="604800";

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -286,7 +286,10 @@ void DNSPacket::wrapup()
   
   DNSPacketWriter::optvect_t opts;
   if(d_wantsnsid) {
-    opts.push_back(make_pair(3, ::arg()["server-id"]));
+    const static string mode_server_id=::arg()["server-id"];
+    if(mode_server_id != "anonymous" && mode_server_id != "disabled") {
+      opts.push_back(make_pair(3, mode_server_id));
+    }
   }
 
   if(!d_ednsping.empty()) {

--- a/pdns/pdns.conf-dist
+++ b/pdns/pdns.conf-dist
@@ -325,7 +325,7 @@
 # send-root-referral=no
 
 #################################
-# server-id	Returned when queried for 'server.id' TXT or NSID, defaults to hostname
+# server-id	Returned when queried for 'server.id' TXT or NSID, defaults to hostname - valid options: anonymous, disabled or custom
 #
 # server-id=
 


### PR DESCRIPTION
Follow up as a pull request on https://github.com/PowerDNS/pdns/issues/215.

This is a slightly reworked patch from the one in the comments on that issue.
