### PR TITLE
Sets d_server to NULL on failed initialization

### DIFF
--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -258,6 +258,7 @@ WebServer::WebServer(const string &listenaddress, int port, const string &passwo
   }
   catch(SessionException &e) {
     L<<Logger::Error<<"Fatal error in webserver: "<<e.reason<<endl;
+    d_server = NULL;
   }
 }
 


### PR DESCRIPTION
Fixes bug where powerdns process can crash if webserver fails to bind to address. 
