### PR TITLE
On testing with large numbers of unknown domains the send-root-referral

### DIFF
--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -109,6 +109,7 @@ private:
   bool d_doRecursion;
   bool d_logDNSDetails;
   bool d_doIPv6AdditionalProcessing;
+  int d_sendRootReferral;
   AuthLua* d_pdl;
 
   UeberBackend B; // every thread an own instance


### PR DESCRIPTION
argument query amounted to quite a high proportion of CPU time. This will cache
it to reduce this overhead as is already done with a number of variables.
