### PR TITLE
Magicnumberfix

### DIFF
--- a/pdns/lua-pdns.cc
+++ b/pdns/lua-pdns.cc
@@ -299,9 +299,9 @@ PowerDNSLua::PowerDNSLua(const std::string& fname)
   // set syslog codes used by Logger/enum Urgency
   pushSyslogSecurityLevelTable(d_lua);
   lua_setfield(d_lua, -2, "loglevels");
-  lua_pushnumber(d_lua, RecursorBehavior::PASS);
+  lua_pushnumber(d_lua, RecursorBehaviour::PASS);
   lua_setfield(d_lua, -2, "PASS");
-  lua_pushnumber(d_lua, RecursorBehavior::DROP);
+  lua_pushnumber(d_lua, RecursorBehaviour::DROP);
   lua_setfield(d_lua, -2, "DROP");
 
   lua_setglobal(d_lua, "pdns");

--- a/pdns/lua-pdns.hh
+++ b/pdns/lua-pdns.hh
@@ -30,8 +30,8 @@ protected: // FIXME?
   bool d_variable;  
   ComboAddress d_local;
 };
-// this enum creates constants to track the pdns_recursor behavior when returned from the Lua call 
-namespace RecursorBehavior { enum returnTypes{PASS=-1,DROP=-2}; };
+// this enum creates constants to track the pdns_recursor behaviour when returned from the Lua call 
+namespace RecursorBehaviour { enum returnTypes { PASS=-1, DROP=-2 }; };
 void pushResourceRecordsTable(lua_State* lua, const vector<DNSResourceRecord>& records);
 void popResourceRecordsTable(lua_State *lua, const string &query, vector<DNSResourceRecord>& ret);
 void pushSyslogSecurityLevelTable(lua_State *lua);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -563,12 +563,12 @@ void startDoResolve(void *p)
       }
     }
     
-    if(res == RecursorBehavior::DROP) {
+    if(res == RecursorBehaviour::DROP) {
       delete dc;
       dc=0;
       return;
     }  
-    if(tracedQuery || res == RecursorBehavior::PASS || res == RCode::ServFail || pw.getHeader()->rcode == RCode::ServFail)
+    if(tracedQuery || res == RecursorBehaviour::PASS || res == RCode::ServFail || pw.getHeader()->rcode == RCode::ServFail)
     {
       string trace(sr.getTrace());
       if(!trace.empty()) {
@@ -581,7 +581,7 @@ void startDoResolve(void *p)
       }
     }
 
-    if(res == RecursorBehavior::PASS) {
+    if(res == RecursorBehaviour::PASS) {
       pw.getHeader()->rcode=RCode::ServFail;
       // no commit here, because no record
       g_stats.servFails++;


### PR DESCRIPTION
Last PR had a rebase oops, so set this one up in separate branch. 

Fixes magic number usage in lua-pdns, and sets up a namespace & enum for recursor behavior. This can pave the way for configuration options in pdns_recursor when interacting with lua from the cpp side
