### PR TITLE
5-arg version of getAuth is only for backend modules not for UeberBacken...

### DIFF
--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -115,6 +115,11 @@ public:
 
   void lookup(const QType &, const string &qdomain, DNSPacket *pkt_p=0,  int zoneId=-1);
 
+  /* 5-arg version is only valid for backends and should never be called directly */
+  virtual bool getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId, const int best_match_len) {
+    throw PDNSException("5-arg version of getAuth should not be called in UeberBackend");
+  }
+
   bool getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId);
   bool getSOA(const string &domain, SOAData &sd, DNSPacket *p=0);
   bool list(const string &target, int domain_id);


### PR DESCRIPTION
...d. Should fix clang warning For powerdns/pdns#1130
