### PR TITLE
RFC: Use Metadata Cache for all operation

### DIFF
--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -122,20 +122,6 @@ private:
     mutable keys_t d_keys;
   };
   
-  struct METACacheEntry
-  {
-    uint32_t getTTD() const
-    {
-      return d_ttd;
-    }
-  
-    string d_domain;
-    unsigned int d_ttd;
-  
-    mutable std::string d_key, d_value;
-  };
-  
-  
   typedef multi_index_container<
     KeyCacheEntry,
     indexed_by<
@@ -143,24 +129,10 @@ private:
       sequenced<>
     >
   > keycache_t;
-  typedef multi_index_container<
-    METACacheEntry,
-    indexed_by<
-      ordered_unique<
-        composite_key< 
-          METACacheEntry, 
-          member<METACacheEntry, std::string, &METACacheEntry::d_domain> ,
-          member<METACacheEntry, std::string, &METACacheEntry::d_key>
-        >, composite_key_compare<CIStringCompare, CIStringCompare> >,
-      sequenced<>
-    >
-  > metacache_t;
 
   void cleanup();
 
   static keycache_t s_keycache;
-  static metacache_t s_metacache;
-  static pthread_rwlock_t s_metacachelock;
   static pthread_rwlock_t s_keycachelock;
   static AtomicCounter s_ops;
   static time_t s_last_prune;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -138,6 +138,8 @@ public:
   bool getDomainKeys(const string& name, unsigned int kind, std::vector<KeyData>& keys);
   bool getDomainMetadata(const string& name, const std::string& kind, std::vector<std::string>& meta);
   bool setDomainMetadata(const string& name, const std::string& kind, const std::vector<std::string>& meta);
+  void clearMetadataCacheAllDomains();
+  void clearMetadataCache(const std::string& name);
 
   bool removeDomainKey(const string& name, unsigned int id);
   bool activateDomainKey(const string& name, unsigned int id);
@@ -191,6 +193,40 @@ private:
   
   bool stale;
   int domain_id;
+
+  // Metadata Cache
+  struct MetaCacheEntry
+  {
+    uint32_t getTTD() const
+    {
+      return d_ttd;
+    }
+
+    string d_domain;
+    unsigned int d_ttd;
+
+    mutable std::string d_kind;
+    mutable std::vector<std::string> d_values;
+  };
+
+  typedef multi_index_container<
+    MetaCacheEntry,
+    indexed_by<
+      ordered_unique<
+        composite_key<
+          MetaCacheEntry,
+          member<MetaCacheEntry, std::string, &MetaCacheEntry::d_domain> ,
+          member<MetaCacheEntry, std::string, &MetaCacheEntry::d_kind>
+        >, composite_key_compare<CIStringCompare, CIStringCompare> >,
+      sequenced<>
+    >
+  > metacache_t;
+
+  static metacache_t s_metacache;
+  static pthread_rwlock_t s_metacachelock;
+  static time_t s_metacache_last_prune;
+  static AtomicCounter s_metacache_ops;
+  void cleanupMetaCache();
 };
 
 


### PR DESCRIPTION
Move metadata cache from DNSSECKeeper to UeberBackend.
DNSSECKeeper::clearCaches, clearAllCaches forwards to UeberBackend.

Important changes:
- UeberBackend got yet another cache.
- UeberBackend::setDomainMetadata will now clear the metadata cache.
- reload, rediscover will now clear the metadata cache.
- In DNSSECKeeper the ops counter was shared across both caches,
  and across more operations. I have changed the required number of
  ops (before triggering cleanup) in UeberBackend to a tenth of the
  DNSSECKeeper value, but this is just a wild guess.

Note that this is mostly cut and paste coding, and little to no
testing has been done.
