### PR TITLE
Encode symbols in zone names for REST API URLs

### DIFF
--- a/pdns/ws-api.hh
+++ b/pdns/ws-api.hh
@@ -31,5 +31,9 @@ void apiServerConfig(HttpRequest* req, HttpResponse* resp);
 void apiServerSearchLog(HttpRequest* req, HttpResponse* resp);
 void apiServerStatistics(HttpRequest* req, HttpResponse* resp);
 
+// helpers
+string apiZoneIdToName(const string& id);
+string apiZoneNameToId(const string& name);
+
 // To be provided by product code.
 void productServerStatisticsFetch(std::map<string,string>& out);

--- a/pdns/ws-auth.hh
+++ b/pdns/ws-auth.hh
@@ -25,14 +25,6 @@
 #include <map>
 #include <time.h>
 #include <pthread.h>
-#include <sstream>
-#include <iomanip>
-#include <unistd.h>
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif // HAVE_CONFIG_H
-
 #include "misc.hh"
 #include "namespaces.hh"
 

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -41,16 +41,25 @@ class Servers(ApiTestCase):
             if k in payload:
                 self.assertEquals(data[k], payload[k])
 
-    @unittest.expectedFailure
     def test_CreateZoneWithSymbols(self):
         payload, data = self.create_zone(name='foo/bar.'+unique_zone_name())
         name = payload['name']
-        expected_id = name.replace('/', '\\047')
+        expected_id = (name.replace('/', '=47')) + '.'
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial'):
             self.assertIn(k, data)
             if k in payload:
                 self.assertEquals(data[k], payload[k])
         self.assertEquals(data['id'], expected_id)
+
+    def test_GetZoneWithSymbols(self):
+        payload, data = self.create_zone(name='foo/bar.'+unique_zone_name())
+        name = payload['name']
+        zone_id = (name.replace('/', '=47')) + '.'
+        r = self.session.get(self.url("/servers/localhost/zones/" + zone_id))
+        for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial'):
+            self.assertIn(k, data)
+            if k in payload:
+                self.assertEquals(data[k], payload[k])
 
     def test_GetZone(self):
         r = self.session.get(self.url("/servers/localhost/zones"))


### PR DESCRIPTION
Examples: foo/bar.org, as well as the root zone.
