### PR TITLE
Fix JSON API to return an object for /config/allow-from

### DIFF
--- a/regression-tests.api/test_RecursorConfig.py
+++ b/regression-tests.api/test_RecursorConfig.py
@@ -12,11 +12,11 @@ class RecursorConfig(ApiTestCase):
         self.assertSuccessJson(r)
 
     def test_ConfigAllowFromReplace(self):
-        payload = ["127.0.0.1"]
+        payload = {'value': ["127.0.0.1"]}
         r = self.session.put(
             self.url("/servers/localhost/config/allow-from"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
         self.assertSuccessJson(r)
         data = r.json()
-        self.assertEquals("127.0.0.1/32", data[0])
+        self.assertEquals("127.0.0.1/32", data["value"][0])


### PR DESCRIPTION
Can't return arrays for stuff that isn't a collection.
