### PR TITLE
Add api-readonly switch

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -65,6 +65,7 @@ void declareArguments()
   
   ::arg().set("retrieval-threads", "Number of AXFR-retrieval threads for slave operation")="2";
   ::arg().setSwitch("experimental-json-interface", "If the webserver should serve JSON data")="no";
+  ::arg().setSwitch("experimental-api-readonly", "If the JSON API should disallow data modification")="no";
 
   ::arg().setCmd("help","Provide a helpful message");
   ::arg().setCmd("version","Output version and compilation date");

--- a/pdns/pdns.conf-dist
+++ b/pdns/pdns.conf-dist
@@ -135,6 +135,11 @@
 # entropy-source=/dev/urandom
 
 #################################
+# experimental-api-readonly	If the JSON API should disallow data modification
+#
+# experimental-api-readonly=no
+
+#################################
 # experimental-json-interface	If the webserver should serve JSON data
 #
 # experimental-json-interface=no

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -370,7 +370,7 @@ static void apiServerZoneRRset(HttpRequest* req, HttpResponse* resp);
 
 static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
   UeberBackend B;
-  if (req->method == "POST") {
+  if (req->method == "POST" && !::arg().mustDo("experimental-api-readonly")) {
     DomainInfo di;
     Document document;
     req->json(document);
@@ -483,7 +483,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
 static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
   string zonename = apiZoneIdToName(req->path_parameters["id"]);
 
-  if(req->method == "PUT") {
+  if(req->method == "PUT" && !::arg().mustDo("experimental-api-readonly")) {
     // update domain settings
     UeberBackend B;
     DomainInfo di;
@@ -507,7 +507,7 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
     fillZone(zonename, resp);
     return;
   }
-  else if(req->method == "DELETE") {
+  else if(req->method == "DELETE" && !::arg().mustDo("experimental-api-readonly")) {
     // delete domain
     UeberBackend B;
     DomainInfo di;
@@ -520,7 +520,7 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
     // empty body on success
     resp->body = "";
     return;
-  } else if (req->method == "PATCH") {
+  } else if (req->method == "PATCH" && !::arg().mustDo("experimental-api-readonly")) {
     apiServerZoneRRset(req, resp);
     return;
   } else if (req->method == "GET") {
@@ -568,7 +568,7 @@ static void makePtr(const DNSResourceRecord& rr, DNSResourceRecord* ptr) {
 }
 
 static void apiServerZoneRRset(HttpRequest* req, HttpResponse* resp) {
-  if(req->method != "PATCH")
+  if(req->method != "PATCH" || ::arg().mustDo("experimental-api-readonly"))
     throw HttpMethodNotAllowedException();
 
   UeberBackend B;


### PR DESCRIPTION
This disables all JSON-API-level changes to backend data.

Intended use: on slave servers using NATIVE replication, where modifying the backend data would be harmful to the database replication.
