### PR TITLE
HTTP server: fix requests that are larger than 1024bytes

### DIFF
--- a/pdns/ext/yahttp/yahttp/reqresp.cpp
+++ b/pdns/ext/yahttp/yahttp/reqresp.cpp
@@ -222,6 +222,10 @@ namespace YaHTTP {
 
     if (chunk_size!=0) return false; // need more data
 
+    if (!chunked && bodybuf.str().size() < maxbody) {
+      return false; // need more data
+    }
+
     bodybuf.flush();
     request->body = bodybuf.str();
     bodybuf.str("");


### PR DESCRIPTION
This fixes PowerDNS/pdnscontrol#29
