### PR TITLE
JSON API: strip trailing dots when creating zones

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -379,6 +379,11 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     if(zonename.empty())
       throw ApiException("Zone name empty");
 
+    // strip any trailing dots
+    while (zonename.substr(zonename.size()-1) == ".") {
+      zonename.resize(zonename.size()-1);
+    }
+
     string kind = stringFromJson(document, "kind");
 
     bool exists = B.getDomainInfo(zonename, di);

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -50,6 +50,12 @@ class AuthZones(ApiTestCase):
                 self.assertEquals(data[k], payload[k])
         self.assertEquals(data['comments'], [])
 
+    def test_CreateZoneTrailingDot(self):
+        # Trailing dots should not end up in the zone name.
+        basename = unique_zone_name()
+        payload, data = self.create_zone(name=basename+'.')
+        self.assertEquals(data['name'], basename)
+
     def test_CreateZoneWithSymbols(self):
         payload, data = self.create_zone(name='foo/bar.'+unique_zone_name())
         name = payload['name']


### PR DESCRIPTION
Otherwise we end up with example.org. in the DB, when it should have been
example.org .
