### PR TITLE
logging socket file name when using gmysql-socket instead of gmysql-host

### DIFF
--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -29,7 +29,7 @@ gMySQLBackend::gMySQLBackend(const string &mode, const string &suffix)  : GSQLBa
     L<<Logger::Error<<mode<<" Connection failed: "<<e.txtReason()<<endl;
     throw PDNSException("Unable to launch "+mode+" connection: "+e.txtReason());
   }
-  L<<Logger::Info<<mode<<" Connection successful. Connected to database '"<<getArg("dbname")<<"' on '"<<(getArg("socket").empty() ? getArg("host") : getArg("socket"))<<"'."<<endl;
+  L<<Logger::Info<<mode<<" Connection successful. Connected to database '"<<getArg("dbname")<<"' on '"<<(getArg("host").empty() ? getArg("socket") : getArg("host"))<<"'."<<endl;
 }
 
 class gMySQLFactory : public BackendFactory


### PR DESCRIPTION
Avoid logging empty host name when using `gmysql-socket`.  Such as this

``` shell
Mar 20 18:48:02 gmysql Connection successful. Connected to database 'powerdns' on ''.
```
