### PR TITLE
API: Consolidate zone update plus SOA-EDIT-API

### DIFF
--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -136,7 +136,25 @@ public:
   // the DNSSEC related (getDomainMetadata has broader uses too)
   virtual bool getAllDomainMetadata(const string& name, std::map<std::string, std::vector<std::string> >& meta) { return false; };
   virtual bool getDomainMetadata(const string& name, const std::string& kind, std::vector<std::string>& meta) { return false; }
+  virtual bool getDomainMetadataOne(const string& name, const std::string& kind, std::string& value)
+  {
+    std::vector<std::string> meta;
+    if (getDomainMetadata(name, kind, meta)) {
+      if(!meta.empty()) {
+        value = *meta.begin();
+        return true;
+      }
+    }
+    return false;
+  }
+
   virtual bool setDomainMetadata(const string& name, const std::string& kind, const std::vector<std::string>& meta) {return false;}
+  virtual bool setDomainMetadataOne(const string& name, const std::string& kind, const std::string& value)
+  {
+    const std::vector<std::string> meta(1, value);
+    return setDomainMetadata(name, kind, meta);
+  }
+
 
   virtual void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) { }
 

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -170,4 +170,5 @@ class DNSPacket;
 uint32_t calculateEditSOA(SOAData sd, const string& kind);
 uint32_t localtime_format_YYYYMMDDSS(time_t t, uint32_t seq);
 bool editSOA(DNSSECKeeper& dk, const string& qname, DNSPacket* dp);
+bool editSOARecord(DNSResourceRecord& rr, const string& kind);
 #endif

--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -43,18 +43,22 @@ bool editSOA(DNSSECKeeper& dk, const string& qname, DNSPacket* dp)
     if(rr.qtype.getCode() == QType::SOA && pdns_iequals(rr.qname,qname)) {
       string kind;
       dk.getFromMeta(qname, "SOA-EDIT", kind);
-      if(kind.empty())
-        return false;
-      SOAData sd;
-      fillSOAData(rr.content, sd);
-      sd.serial = calculateEditSOA(sd, kind);
-      rr.content = serializeSOAData(sd);      
-      return true;
+      return editSOARecord(rr, kind);
     }
   }
   return false;
 }
 
+bool editSOARecord(DNSResourceRecord& rr, const string& kind) {
+  if(kind.empty())
+    return false;
+
+  SOAData sd;
+  fillSOAData(rr.content, sd);
+  sd.serial = calculateEditSOA(sd, kind);
+  rr.content = serializeSOAData(sd);
+  return true;
+}
 
 uint32_t calculateEditSOA(SOAData sd, const string& kind) {
   if(pdns_iequals(kind,"INCEPTION")) {

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -79,7 +79,7 @@ if daemon == 'authoritative':
         tf.seek(0, os.SEEK_SET)  # rewind
         subprocess.check_call(["sqlite3", SQLITE_DB], stdin=tf)
 
-    pdnscmd = ("../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./ --no-shuffle --launch=gsqlite3 --gsqlite3-dnssec --send-root-referral --allow-2136-from=127.0.0.0/8 --experimental-rfc2136=yes --cache-ttl=0 --no-config --gsqlite3-database="+SQLITE_DB+" --experimental-json-interface=yes --webserver=yes --webserver-port="+WEBPORT+" --webserver-address=127.0.0.1 --query-logging  --webserver-password="+WEBPASSWORD).split()
+    pdnscmd = ("../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./ --no-shuffle --launch=gsqlite3 --gsqlite3-dnssec --send-root-referral --allow-2136-from=127.0.0.0/8 --experimental-rfc2136=yes --cache-ttl=0 --no-config --gsqlite3-dnssec=on --gsqlite3-database="+SQLITE_DB+" --experimental-json-interface=yes --webserver=yes --webserver-port="+WEBPORT+" --webserver-address=127.0.0.1 --query-logging  --webserver-password="+WEBPASSWORD).split()
 
 else:
     conf_dir = 'rec-conf.d'


### PR DESCRIPTION
PATCH /api/:server/zone/:zone/rrset has been replaced with PATCH /api/:server/zone/:zone, which supports multiple RRsets at once.

Also introduces SOA-EDIT-API, a new setting that triggers on change of records through the API.
