### PR TITLE
to ask for help is not an error

### DIFF
--- a/pdns/dynloader.cc
+++ b/pdns/dynloader.cc
@@ -70,9 +70,9 @@ int main(int argc, char **argv)
   ::arg().laxParse(argc,argv);
 
   if(::arg().mustDo("help")) {
-    cerr<<"syntax:"<<endl<<endl;
-    cerr<<::arg().helpstring(::arg()["help"])<<endl;
-    exit(99);
+    cout<<"syntax:"<<endl<<endl;
+    cout<<::arg().helpstring(::arg()["help"])<<endl;
+    exit(0);
   }
 
   const vector<string>commands=::arg().getCommands();

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2185,9 +2185,9 @@ int main(int argc, char **argv)
     ::arg().set("delegation-only")=toLower(::arg()["delegation-only"]);
 
     if(::arg().mustDo("help")) {
-      cerr<<"syntax:"<<endl<<endl;
-      cerr<<::arg().helpstring(::arg()["help"])<<endl;
-      exit(99);
+      cout<<"syntax:"<<endl<<endl;
+      cout<<::arg().helpstring(::arg()["help"])<<endl;
+      exit(0);
     }
     if(::arg().mustDo("version")) {
       showProductVersion();

--- a/pdns/pdnssec.cc
+++ b/pdns/pdnssec.cc
@@ -118,9 +118,9 @@ void loadMainConfig(const std::string& configdir)
   //::arg().laxParse(argc,argv);
 
   if(::arg().mustDo("help")) {
-    cerr<<"syntax:"<<endl<<endl;
-    cerr<<::arg().helpstring(::arg()["help"])<<endl;
-    exit(99);
+    cout<<"syntax:"<<endl<<endl;
+    cout<<::arg().helpstring(::arg()["help"])<<endl;
+    exit(0);
   }
 
   if(::arg()["config-name"]!="") 

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -49,7 +49,13 @@ static void initArguments(int argc, char** argv)
   arg().setCmd("help","Provide this helpful message");
 
   arg().laxParse(argc,argv);  
-  if(arg().getCommands().empty() || arg().mustDo("help")) {
+  if(arg().mustDo("help")) {
+    cout<<"syntax: rec_control [options] command, options as below: "<<endl<<endl;
+    cout<<arg().helpstring(arg()["help"])<<endl;
+    exit(0);
+  }
+
+  if(arg().getCommands().empty()) {
     cerr<<"syntax: rec_control [options] command, options as below: "<<endl<<endl;
     cerr<<arg().helpstring(arg()["help"])<<endl;
     exit(99);

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -509,9 +509,9 @@ int main(int argc, char **argv)
     }
     
     if(::arg().mustDo("help")) {
-      cerr<<"syntax:"<<endl<<endl;
-      cerr<<::arg().helpstring(::arg()["help"])<<endl;
-      exit(99);
+      cout<<"syntax:"<<endl<<endl;
+      cout<<::arg().helpstring(::arg()["help"])<<endl;
+      exit(0);
     }
     
     if(::arg().mustDo("config")) {

--- a/pdns/zone2json.cc
+++ b/pdns/zone2json.cc
@@ -155,7 +155,13 @@ try
 
     ::arg().parse(argc, argv);
   
-    if(argc<2 || ::arg().mustDo("help")) {
+    if(::arg().mustDo("help")) {
+      cout<<"syntax:"<<endl<<endl;
+      cout<<::arg().helpstring()<<endl;
+      exit(0);
+    }
+
+    if(argc<2) {
       cerr<<"syntax:"<<endl<<endl;
       cerr<<::arg().helpstring()<<endl;
       exit(1);

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -169,7 +169,14 @@ int main( int argc, char* argv[] )
 
                 args.parse( argc, argv );
 
-                if( argc < 2 || args.mustDo( "help" ) )
+                if( args.mustDo( "help" ) )
+                {
+                        cout << "Syntax:" << endl << endl;
+                        cout << args.helpstring() << endl;
+                        exit( 0 );
+                }
+
+                if( argc < 2 )
                 {
                         cerr << "Syntax:" << endl << endl;
                         cerr << args.helpstring() << endl;

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -291,7 +291,13 @@ try
 
     ::arg().parse(argc, argv);
   
-    if(argc<2 || ::arg().mustDo("help")) {
+    if(::arg().mustDo("help")) {
+      cout<<"syntax:"<<endl<<endl;
+      cout<<::arg().helpstring()<<endl;
+      exit(0);
+    }
+
+    if(argc<2) {
       cerr<<"syntax:"<<endl<<endl;
       cerr<<::arg().helpstring()<<endl;
       exit(1);


### PR DESCRIPTION
The --hep pages are huge lists meanwhile. They do not fit on one page. `... --help | less` does not work. So I always must write `... --help 2>&1 | less` to browse the list. But why not write the help to `cout` instead of `cerr` if I explicit ask for help?
