### PR TITLE
Trim variable names

### DIFF
--- a/pdns/arguments.cc
+++ b/pdns/arguments.cc
@@ -326,6 +326,8 @@ void ArgvMap::parseOne(const string &arg, const string &parseOnly, bool lax)
   }
   else // command
     d_cmds.push_back(arg);
+ 
+  boost::trim(var);
 
   if(var!="" && (parseOnly.empty() || var==parseOnly)) {
     pos=val.find_first_not_of(" \t");  // strip leading whitespace


### PR DESCRIPTION
Fixes issue where space in variable name before = the space becomes part of the variable name.

example

```
allow-2136-from = 0.0.0.0/0
May 04 21:13:09 Fatal error: Trying to set unknown parameter 'allow-2136-from '
```
