### PR TITLE
Use gmtime instead of localtime when generating SOA serials

### DIFF
--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -168,7 +168,7 @@ private:
 
 class DNSPacket;
 uint32_t calculateEditSOA(SOAData sd, const string& kind);
-uint32_t localtime_format_YYYYMMDDSS(time_t t, uint32_t seq);
+uint32_t gmtime_format_YYYYMMDDSS(time_t t, uint32_t seq);
 bool editSOA(DNSSECKeeper& dk, const string& qname, DNSPacket* dp);
 bool editSOARecord(DNSResourceRecord& rr, const string& kind);
 #endif

--- a/pdns/pdnssec.cc
+++ b/pdns/pdnssec.cc
@@ -602,7 +602,7 @@ int increaseSerial(const string& zone, DNSSECKeeper &dk)
     sd.serial++;
   }
   else if(pdns_iequals(soaEditKind,"INCEPTION-INCREMENT")) {
-    uint32_t today_serial = localtime_format_YYYYMMDDSS(time(NULL), 1);
+    uint32_t today_serial = gmtime_format_YYYYMMDDSS(time(NULL), 1);
 
     if (sd.serial < today_serial) {
       sd.serial = today_serial;

--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -25,10 +25,10 @@
 #include "namespaces.hh"
 #include <boost/foreach.hpp>
 
-uint32_t localtime_format_YYYYMMDDSS(time_t t, uint32_t seq)
+uint32_t gmtime_format_YYYYMMDDSS(time_t t, uint32_t seq)
 {
   struct tm tm;
-  localtime_r(&t, &tm);
+  gmtime_r(&t, &tm);
   return
       (uint32_t)(tm.tm_year+1900) * 1000000u
     + (uint32_t)(tm.tm_mon + 1) * 10000u
@@ -63,12 +63,12 @@ bool editSOARecord(DNSResourceRecord& rr, const string& kind) {
 uint32_t calculateEditSOA(SOAData sd, const string& kind) {
   if(pdns_iequals(kind,"INCEPTION")) {
     time_t inception = getStartOfWeek();
-    return localtime_format_YYYYMMDDSS(inception, 1);
+    return gmtime_format_YYYYMMDDSS(inception, 1);
   }
   else if(pdns_iequals(kind,"INCEPTION-INCREMENT")) {
     time_t inception = getStartOfWeek();
-    uint32_t inception_serial = localtime_format_YYYYMMDDSS(inception, 1);
-    uint32_t dont_increment_after = localtime_format_YYYYMMDDSS(inception + 2*86400, 99);
+    uint32_t inception_serial = gmtime_format_YYYYMMDDSS(inception, 1);
+    uint32_t dont_increment_after = gmtime_format_YYYYMMDDSS(inception + 2*86400, 99);
 
     if(sd.serial < inception_serial - 1) { /* less than <inceptionday>00 */
       return inception_serial; /* return <inceptionday>01   (skipping <inceptionday>00 as possible value) */


### PR DESCRIPTION
closes #1339

Conflicts:
	pdns/dnsseckeeper.hh

This is just a rebased version of https://github.com/abh/pdns/commit/e5f92e2a77b1d8a459b50ea7ec6098687cf594b8 -- the older commit is what I've been using successfully in production; this version I haven't had a chance to try.