### PR TITLE
API: return status 204 on successful delete

### DIFF
--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -119,6 +119,11 @@ static void apiWrapper(boost::function<void(HttpRequest*,HttpResponse*)> handler
     return;
   }
 
+  if (resp->status == 204) {
+    // No Content -> no Content-Type.
+    resp->headers.erase("Content-Type");
+  }
+
   if(!callback.empty()) {
     resp->body = callback + "(" + resp->body + ");";
   }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -649,6 +649,7 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
 
     // empty body on success
     resp->body = "";
+    resp->status = 204; // No Content: declare that the zone is gone now
     return;
   } else if (req->method == "PATCH" && !::arg().mustDo("experimental-api-readonly")) {
     patchZone(req, resp);

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -355,6 +355,7 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp)
     reloadAuthAndForwards();
     // empty body on success
     resp->body = "";
+    resp->status = 204; // No Content: declare that the zone is gone now
   } else if(req->method == "GET") {
     fillZone(zonename, resp);
   } else {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -520,6 +520,13 @@ class AuthZones(ApiTestCase):
         self.assertEquals(r.status_code, 422)
         self.assertIn('out of zone', r.json()['error'])
 
+    def test_zone_delete(self):
+        payload, zone = self.create_zone()
+        name = payload['name']
+        r = self.session.delete(self.url("/servers/localhost/zones/" + name))
+        self.assertEquals(r.status_code, 204)
+        self.assertNotIn('Content-Type', r.headers)
+
     def test_zone_comment_create(self):
         payload, zone = self.create_zone()
         name = payload['name']
@@ -815,6 +822,13 @@ class RecursorZones(ApiTestCase):
         data = r.json()
         for k in payload.keys():
             self.assertEquals(data[k], payload[k])
+
+    def test_zone_delete(self):
+        payload, zone = self.create_zone(kind='Native')
+        name = payload['name']
+        r = self.session.delete(self.url("/servers/localhost/zones/" + name))
+        self.assertEquals(r.status_code, 204)
+        self.assertNotIn('Content-Type', r.headers)
 
     def test_search_rr_exact_zone(self):
         name = unique_zone_name() + '.'


### PR DESCRIPTION
204 No Content is meant to indicate that the data (zone) is now gone.

Also add tests to make sure DELETE works.

Fixes #1422.
