### PR TITLE
fix: do not escape tabs in txt records

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -413,7 +413,7 @@ static string txtEscape(const string &name)
   char ebuf[5];
 
   for(string::const_iterator i=name.begin();i!=name.end();++i) {
-    if((unsigned char) *i > 127 || (unsigned char) *i < 32) {
+    if(((unsigned char) *i > 127 || (unsigned char) *i < 32) && (unsigned char) *i != 9) {
       snprintf(ebuf, sizeof(ebuf), "\\%03u", (unsigned char)*i);
       ret += ebuf;
     }


### PR DESCRIPTION
I use pdns as a slave to a bind9 server. I have several zones with txt records, which contain among other characters some tabulators. When pdns writes the zone on disc, all the tabs are replaced with string "\009". I believe this should not happen.
