### PR TITLE
Allow not stripping of binaries in recursor's make install

### DIFF
--- a/pdns/Makefile-recursor
+++ b/pdns/Makefile-recursor
@@ -7,6 +7,7 @@ OPTFLAGS?=-O3
 CXXFLAGS:= $(CXXFLAGS) -Iext/rapidjson/include -I$(CURDIR)/ext/polarssl-1.3.2/include -Wall $(OPTFLAGS) $(PROFILEFLAGS) $(ARCHFLAGS) -pthread -Iext/yahttp
 CFLAGS:=$(CFLAGS) -Wall $(OPTFLAGS) $(PROFILEFLAGS) $(ARCHFLAGS) -I$(CURDIR)/ext/polarssl-1.3.2/include -pthread
 LDFLAGS:=$(LDFLAGS) $(ARCHFLAGS) -pthread
+STRIP_BINARIES?=1
 
 LINKCC=$(CXX)
 CC?=gcc
@@ -96,10 +97,14 @@ basic_checks:
 install: build-stamp
 	-mkdir -p $(DESTDIR)/$(SBINDIR)
 	mv pdns_recursor $(DESTDIR)/$(SBINDIR)
+ifeq ($(STRIP_BINARIES), 1)
 	strip $(DESTDIR)/$(SBINDIR)/pdns_recursor
+endif
 	mkdir -p $(DESTDIR)/$(BINDIR)
 	mv rec_control $(DESTDIR)/$(BINDIR)
+ifeq ($(STRIP_BINARIES), 1)
 	strip $(DESTDIR)/$(BINDIR)/rec_control
+endif
 	-mkdir -p $(DESTDIR)/$(SYSCONFDIR)
 	$(DESTDIR)/$(SBINDIR)/pdns_recursor --config > $(DESTDIR)/$(SYSCONFDIR)/recursor.conf-dist
 	-mkdir -p $(DESTDIR)/usr/share/man/man1


### PR DESCRIPTION
Debian needs this (and currently carries a local patch). Please also merge to Recursor 3.6.0.
