### PR TITLE
Clean pdns_hw test binary and version_generated.h

### DIFF
--- a/pdns/Makefile-recursor
+++ b/pdns/Makefile-recursor
@@ -110,7 +110,7 @@ clean: binclean
 	-rm -f dep *~ *.gcda *.gcno optional/*.gcda optional/*.gcno
 
 binclean:
-	-rm -f *.o  pdns_recursor rec_control optional/*.o build-stamp ext/polarssl-1.3.2/library/*.o ext/yahttp/yahttp/*.o
+	-rm -f *.o pdns_hw pdns_recursor rec_control optional/*.o build-stamp ext/polarssl-1.3.2/library/*.o ext/yahttp/yahttp/*.o version_generated.h
 
 dep:
 	$(CXX) $(CXXFLAGS) -MM -MG *.cc *.hh > $@


### PR DESCRIPTION
Based on a Debian patch which removes pdns_hw.

Please also merge this into Recursor 3.6.0.
