### PR TITLE
Support building recursor on GNU/kFreeBSD and GNU/Hurd

### DIFF
--- a/pdns/Makefile-recursor
+++ b/pdns/Makefile-recursor
@@ -33,6 +33,12 @@ all: message version_generated.h build
 
 # OS specific instructions
 -include sysdeps/$(shell uname).inc
+ifeq ($(shell uname),GNU/kFreeBSD)
+	-include sysdeps/FreeBSD.inc
+endif
+ifeq ($(shell uname),GNU/Hurd)
+	-include sysdeps/Linux.inc
+endif
 
 ifeq ($(LUA), 1)
 	LUALIBS=$(LUA_LIBS_CONFIG)

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -6,7 +6,7 @@
 #include <boost/lexical_cast.hpp>
 #include "syncres.hh"
 #include <sys/types.h>
-#ifdef __FreeBSD__ 
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 #include <sys/event.h>
 #endif
 #include <sys/time.h>


### PR DESCRIPTION
Based on Debian patches by Matthijs Möhlmann matthijs@cacholong.nl.

Please also merge this into Recursor 3.6.0.
