### PR TITLE
doc update make clear also-notify does override only-notify

### DIFF
--- a/pdns/docs/pdns.xml
+++ b/pdns/docs/pdns.xml
@@ -16156,7 +16156,8 @@ To enable a Lua script for a particular slave zone, determine the domain_id for 
 	  <term>also-notify=...</term>
 	  <listitem>
 	    <para>
-	      When notifying a domain, also notify these nameservers. Example: <command>also-notify=192.168.0.1, 10.0.0.1</command>.
+	      When notifying a domain, also notify these nameservers. Example: <command>also-notify=192.168.0.1, 10.0.0.1</command>. The IP adresses listed in <command>
+	      also-notify</command> always receive a notification. Even if they do not mach the list in <command>only-notify</command>.
 	    </para>
 	  </listitem>
 	</varlistentry>


### PR DESCRIPTION
```
also-notify=1.1.1.1
only-notify=
```

result in "notify-explicit=1.1.1.1" behaviour 

closes #1340
