### PR TITLE
Add a 'dnssec' field in the zonelist

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -303,7 +303,7 @@ static void fillZone(const string& zonename, HttpResponse* resp) {
   doc.AddMember("name", di.zone.c_str(), doc.GetAllocator());
   doc.AddMember("type", "Zone", doc.GetAllocator());
   doc.AddMember("kind", di.getKindString(), doc.GetAllocator());
-  doc.AddMember("dnssec", dk.isSecuredZone(di.zone.c_str()), doc.GetAllocator());
+  doc.AddMember("dnssec", dk.isSecuredZone(di.zone), doc.GetAllocator());
   string soa_edit_api;
   di.backend->getDomainMetadataOne(zonename, "SOA-EDIT-API", soa_edit_api);
   doc.AddMember("soa_edit_api", soa_edit_api.c_str(), doc.GetAllocator());
@@ -688,7 +688,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     jdi.AddMember("url", jurl, doc.GetAllocator());
     jdi.AddMember("name", di.zone.c_str(), doc.GetAllocator());
     jdi.AddMember("kind", di.getKindString(), doc.GetAllocator());
-    jdi.AddMember("dnssec", dk.isSecuredZone(di.zone.c_str()), doc.GetAllocator());
+    jdi.AddMember("dnssec", dk.isSecuredZone(di.zone), doc.GetAllocator());
     Value masters;
     masters.SetArray();
     BOOST_FOREACH(const string& master, di.masters) {


### PR DESCRIPTION
So we do not need to fetch the whole zone to find out if we have dnssec.
