### PR TITLE
detect gcc 4.9 in configure

### DIFF
--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -1110,6 +1110,7 @@ if test x$boost_cv_inc_path != xno; then
   # I'm not sure about my test for `il' (be careful: Intel's ICC pre-defines
   # the same defines as GCC's).
   for i in \
+    _BOOST_gcc_test(4, 9) \
     _BOOST_gcc_test(4, 8) \
     _BOOST_gcc_test(4, 7) \
     _BOOST_gcc_test(4, 6) \


### PR DESCRIPTION
and silence warning: checking for the toolset name used by Boost for g++... configure: WARNING: could not figure out which toolset name to use for g++
