### PR TITLE
Api zone import

### DIFF
--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -41,6 +41,16 @@ ZoneParserTNG::ZoneParserTNG(const string& fname, const string& zname, const str
   stackFile(fname);
 }
 
+ZoneParserTNG::ZoneParserTNG(const vector<string> zonedata, const string& zname):
+                                                                        d_zonename(zname), d_defaultttl(3600), 
+                                                                        d_havedollarttl(false)
+{
+  d_zonename = toCanonic("", d_zonename);
+  d_zonedata = zonedata;
+  d_zonedataline = d_zonedata.begin();
+  d_fromfile = false;
+}
+
 void ZoneParserTNG::stackFile(const std::string& fname)
 {
   FILE *fp=fopen(fname.c_str(), "r");
@@ -49,6 +59,7 @@ void ZoneParserTNG::stackFile(const std::string& fname)
 
   filestate fs(fp, fname);
   d_filestates.push(fs);
+  d_fromfile = true;
 }
 
 ZoneParserTNG::~ZoneParserTNG()
@@ -226,6 +237,9 @@ bool findAndElide(string& line, char c)
 
 string ZoneParserTNG::getLineOfFile()
 {
+  if (d_zonedata.size() > 0)
+    return "on line "+lexical_cast<string>(std::distance(d_zonedata.begin(), d_zonedataline))+" of given string";
+
   return "on line "+lexical_cast<string>(d_filestates.top().d_lineno)+" of file '"+d_filestates.top().d_filename+"'";
 }
 
@@ -256,7 +270,7 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
       d_defaultttl=makeTTLFromZone(trim_right_copy_if(makeString(d_line, parts[1]), is_any_of(";")));
       d_havedollarttl=true;
     }
-    else if(pdns_iequals(command,"$INCLUDE") && parts.size() > 1) {
+    else if(pdns_iequals(command,"$INCLUDE") && parts.size() > 1 && d_fromfile) {
       string fname=unquotify(makeString(d_line, parts[1]));
       if(!fname.empty() && fname[0]!='/' && !d_reldir.empty())
         fname=d_reldir+"/"+fname;
@@ -442,6 +456,14 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
 
 bool ZoneParserTNG::getLine()
 {
+  if (d_zonedata.size() > 0) {
+    if (d_zonedataline != d_zonedata.end()) {
+      d_line = *d_zonedataline;
+      d_zonedataline++;
+      return true;
+    }
+    return false;
+  }
   while(!d_filestates.empty()) {
     if(stringfgets(d_filestates.top().d_fp, d_line)) {
       d_filestates.top().d_lineno++;

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -33,6 +33,7 @@ class ZoneParserTNG
 {
 public:
   ZoneParserTNG(const string& fname, const string& zname="", const string& reldir="");
+  ZoneParserTNG(const vector<string> zonedata, const string& zname);
 
   ~ZoneParserTNG();
   bool get(DNSResourceRecord& rr, std::string* comment=0);
@@ -48,8 +49,11 @@ private:
   string d_line;
   string d_prevqname;
   string d_zonename;
+  vector<string> d_zonedata;
+  vector<string>::iterator d_zonedataline;
   int d_defaultttl;
   bool d_havedollarttl;
+  bool d_fromfile;
   uint32_t d_templatecounter, d_templatestop, d_templatestep;
   string d_templateline;
   parts_t d_templateparts;


### PR DESCRIPTION
Allows an API user to import a zone as a string. Uses zoneparser, so should be able to understand AXFR-output, or BIND..
