### PR TITLE
Ship auth tarballs as tar.bz2, just like recursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Source code is available on GitHub:
     $ git clone https://github.com/PowerDNS/pdns.git
     
 This repository contains the sources both for the PowerDNS Recursor and for PowerDNS Authoritative Server,
-and both can be built from this repository. Both are released separately as .tar.gz, .deb and .rpm however!
+and both can be built from this repository. Both are released separately as .tar.bz2, .deb and .rpm however!
 
 COMPILING Authoritative Server
 ------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 
-AM_INIT_AUTOMAKE([foreign tar-ustar -Wno-portability subdir-objects no-dependencies])
+AM_INIT_AUTOMAKE([foreign dist-bzip2 tar-ustar -Wno-portability subdir-objects no-dependencies])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_CANONICAL_HOST

--- a/pdns/docs/pdns.xml
+++ b/pdns/docs/pdns.xml
@@ -17196,7 +17196,7 @@ This setting will make PowerDNS renotify the slaves after an AXFR is *received* 
 	    <para>
 	      A: Start out with stating what you think should be happening. Quite often, wrong expectations are the actual problem. 
 	      Furthermore, which database backend you use, your operating system, which version of PowerDNS you use and where you 
-	      got it from (RPM, .DEB, tar.gz). If you compiled it yourself, what were the ./configure parameters.
+	      got it from (RPM, .DEB, tar.bz2). If you compiled it yourself, what were the ./configure parameters.
 	    </para>
 	    <para>
 	      If at *all* possible, supply the actual name of your domain and the IP address of your server(s).


### PR DESCRIPTION
Fixes #1480
