### PR TITLE
Check that the C++ compiler actually works.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,12 +18,16 @@ AC_C_BIGENDIAN
 : ${CXXFLAGS="-Wall -O2"}
 
 AC_PROG_CC
-AC_PROG_CXX
 AM_PROG_CC_C_O
 AC_PROG_YACC
 AM_PROG_LEX
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
+
+AC_PROG_CXX
+AS_IF([test "x$CXX" = "xno" || test "x$CXX:x$GXX" = "xg++:x"],
+  AC_MSG_ERROR([no C++ compiler found])
+)
 
 AC_LANG([C++])
 


### PR DESCRIPTION
AC_PROG_CXX still sets CXX, even if it doesn't
find a working C++ compiler:

http://osdir.com/ml/bug-autoconf-gnu/2010-05/msg00002.html

This causes the Boost checks to fail.

If AC_PROG_CXX finds a working compiler, it sets the GXX shell
variable. Test for this.

Fixes #1178
