### PR TITLE
Automake doesn't support wildcards

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS=modules codedocs @programdescend@
 DIST_SUBDIRS=modules codedocs pdns pdns/ext/rapidjson
-EXTRA_DIST=README INSTALL NOTICE debian-pdns/* pdns.spec  \
+EXTRA_DIST=README INSTALL NOTICE debian-pdns pdns.spec  \
 codedocs/doxygen.conf contrib/powerdns.solaris.init.d \
 contrib/systemd-pdns.service contrib/systemd-pdns-recursor.service \
 bootstrap build-scripts/semistaticg++ pdns/docs/dnstcpbench.1 \


### PR DESCRIPTION
And this makes distuninstallcheck fail.
