### PR TITLE
Don't remove .la files after installation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,10 +31,3 @@ install-exec-local:
 	@echo "***********************************************************"
 
 
-# remove .la files. We don't need them, because we use dlopen, not libltdl.
-# If we ever switch to libltdl (to support dynamic loading on OSX, perhaps)
-# remove this hook.
-install-exec-hook:
-	find $(DESTDIR)$(pkglibdir) -type f -name \*.la -delete
-
-


### PR DESCRIPTION
libtool needs the .la files to determine which .so
files need to be removed during make uninstall.
