### PR TITLE
OSX doesn't know which side of the egg it should crack.

### DIFF
--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -257,8 +257,7 @@ struct dnsheader {
         unsigned        ad: 1;          /* authentic data from named */
         unsigned        cd: 1;          /* checking disabled by resolver */
         unsigned        rcode :4;       /* response code */
-#endif
-#if BYTE_ORDER == LITTLE_ENDIAN || BYTE_ORDER == PDP_ENDIAN
+#elif BYTE_ORDER == LITTLE_ENDIAN || BYTE_ORDER == PDP_ENDIAN
                         /* fields in third byte */
         unsigned        rd :1;          /* recursion desired */
         unsigned        tc :1;          /* truncated message */


### PR DESCRIPTION
My guess is that this is because can provide universal binaries.
We'll need to look into that later, but for now, at least choose
one of them and not both ;)
