### PR TITLE
Fix make distclean

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 
-AM_INIT_AUTOMAKE([foreign tar-ustar -Wno-portability subdir-objects])
+AM_INIT_AUTOMAKE([foreign tar-ustar -Wno-portability subdir-objects no-dependencies])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_CANONICAL_HOST


### PR DESCRIPTION
Both the remotebackend and bindbackend use sources from
the pdns/ directory two levels up.

When running make distclean, the automatically generated
dependencies are cleaned from the current directory.
When make next recurses into pdns/, those .deps are gone
and make fails.

http://debbugs.gnu.org/cgi/bugreport.cgi?bug=17354 describes
the same issue.

The obvious fix (apart from fixing the bug in automake) is
to either switch to non-recursive make, or create a convenience
library.

Until that hapens, disabling dependency tracking is the only
solution I see. The nice side effect is that this speeds
up one off builds tremendously.

Fixes #1232
