### PR TITLE
Fix make check warning

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -353,8 +353,9 @@ if UNIT_TESTS
 TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message
 TESTS=testrunner
 else
-check:
+check-local:
 	@echo "Unit tests are not enabled"
+	@echo "Run ./configure --enable-unit-tests"
 endif
 
 dnslabeltext.cc: dnslabeltext.rl


### PR DESCRIPTION
Making check in pdns
Makefile:2163: warning: overriding commands for target `check'
Makefile:2023: warning: ignoring old commands for target`check'
Unit tests are not enabled

Automake doesn't like the check target to
be overridden:
http://lists.gnu.org/archive/html/automake/2011-09/msg00028.html
