### PR TITLE
polarssl: fix path to headers for VPATH builds

### DIFF
--- a/pdns/ext/polarssl-1.3.2/library/Makefile.am
+++ b/pdns/ext/polarssl-1.3.2/library/Makefile.am
@@ -1,4 +1,4 @@
 noinst_LTLIBRARIES=libpolarssl.la
 libpolarssl_la_SOURCES=aes.c arc4.c asn1parse.c asn1write.c base64.c bignum.c blowfish.c camellia.c certs.c cipher.c cipher_wrap.c ctr_drbg.c debug.c des.c dhm.c ecdh.c ecdsa.c ecp.c entropy.c entropy_poll.c error.c gcm.c havege.c md2.c md4.c md5.c md.c md_wrap.c memory_buffer_alloc.c memory.c net.c oid.c padlock.c pbkdf2.c pem.c pk.c pkcs11.c pkcs12.c pkcs5.c pkparse.c pk_wrap.c pkwrite.c rsa.c sha1.c sha256.c sha512.c ssl_cache.c ssl_ciphersuites.c ssl_cli.c ssl_srv.c ssl_tls.c threading.c timing.c version.c x509.c x509_create.c x509_crl.c x509_crt.c x509_csr.c x509write_crt.c x509write_csr.c xtea.c
 
-libpolarssl_la_CPPFLAGS=-I../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement
+libpolarssl_la_CPPFLAGS=-I$(srcdir)/../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement


### PR DESCRIPTION
When doing an out of tree build we need to look for headers
relative to the source directory, not the current directory.
