### PR TITLE
Fix xml to warning

### DIFF
--- a/pdns/docs/dnstcpbench.1.txt
+++ b/pdns/docs/dnstcpbench.1.txt
@@ -1,6 +1,5 @@
 DNSTCPBENCH(1)
 ==============
-bert hubert <bert.hubert@netherlabs.nl>
 
 NAME
 ----


### PR DESCRIPTION
 This also dos2unix'es dnstcpbench.1.txt and fixes the manpage so it
 only contains a single AUTHOR section
