### PR TITLE
Fix out of tree builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -329,6 +329,9 @@ done
 
 AC_SUBST(LIBS)
 
+AC_SUBST([AM_CPPFLAGS], ['-I$(top_builddir) -I$(top_srcdir)'])
+AC_SUBST([AM_CXXFLAGS], ['-I$(top_builddir) -I$(top_srcdir)'])
+
 export moduledirs moduleobjects modulelibs
 
 AC_CONFIG_FILES([

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS=-DSYSCONFDIR=\"@sysconfdir@\" -DPKGLIBDIR=\"$(pkglibdir)\" -DLOCALSTATEDIR=\"@socketdir@\" @THREADFLAGS@ $(LUA_CFLAGS) $(SQLITE3_CFLAGS) $(POLARSSL_CFLAGS) -Iext/rapidjson/include -Iext/yahttp
+AM_CXXFLAGS += -DSYSCONFDIR=\"@sysconfdir@\" -DPKGLIBDIR=\"$(pkglibdir)\" -DLOCALSTATEDIR=\"@socketdir@\" @THREADFLAGS@ $(LUA_CFLAGS) $(SQLITE3_CFLAGS) $(POLARSSL_CFLAGS) -I$(top_srcdir)/pdns/ext/rapidjson/include -I$(top_srcdir)/pdns/ext/yahttp
 
 YAHTTP_LIBS = -Lext/yahttp/yahttp -lyahttp
 


### PR DESCRIPTION
When building out of tree, we need
to look for headers in the source dir.

This fixes out of tree builds and make distcheck.

This will resolve in some duplicate and unused
include paths, I'll clean those up in followup patches.
