### PR TITLE
gsqlbackend: fix includes

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -20,11 +20,6 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <string>
-#include <map>
-
-#include "namespaces.hh"
-
 #include "pdns/dns.hh"
 #include "pdns/dnsbackend.hh"
 #include "gsqlbackend.hh"

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -3,7 +3,7 @@
 #include "ssql.hh"
 #include "pdns/arguments.hh"
 
-#include "../../namespaces.hh"
+#include "pdns/namespaces.hh"
 
 bool isDnssecDomainMetadata (const string& name);
 


### PR DESCRIPTION
gsqlbackend.cc includes gsqlbackend.hh
so remove duplicate includes.

Fix the path to namespaces.hh as well.
