### PR TITLE
Don't link to zlib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,8 +91,6 @@ dnl Checks for library functions.
 AC_CHECK_FUNCS([strcasestr])
 
 # Check for libdl
-LIBS="$LIBS -lz"
-
 my_save_LIBS="$LIBS"
 LIBS=""
 AC_CHECK_LIB(dl,dlopen)


### PR DESCRIPTION
The bindbackend dropped support for
compressed zones in 2007

Fixes #1614
