### PR TITLE
web: Fix HEAD body and Content-Length

### DIFF
--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -215,6 +215,12 @@ HttpResponse WebServer::handleRequest(HttpRequest req)
   resp.headers["Server"] = "PowerDNS/"VERSION;
   resp.headers["Connection"] = "close";
 
+  if (req.method == "HEAD") {
+    resp.body = "";
+  } else {
+    resp.headers["Content-Length"] = lexical_cast<string>(resp.body.size());
+  }
+
   return resp;
 }
 


### PR DESCRIPTION
For HEAD requests, we MUST throw away the body, for all other
requests we SHOULD return a Content-Length.
