### PR TITLE
travis: snip remotebackend output on success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ script:
  - cd ../regression-tests.nobackend/
  - ./runtests
  - test ! -s ./failed_tests
- - cat /tmp/remotebackend.txt.* | sort
+ - test ! -s ./failed_tests || (cat /tmp/remotebackend.txt.* | sort)
 notifications:
   irc:
     channels:


### PR DESCRIPTION
If the remotebackend tests worked, cut out the debug output.
