### PR TITLE
no systemd kill signals required, pdns_control take care of this

### DIFF
--- a/contrib/systemd-pdns.service
+++ b/contrib/systemd-pdns.service
@@ -6,6 +6,7 @@ After=network.target mysqld.service postgresql.service slapd.service
 Type=forking
 ExecStart=/usr/sbin/pdns_server --daemon
 ExecStop=/usr/bin/pdns_control quit
+KillMode=none
 Restart=on-failure
 RestartSec=2
 PrivateTmp=true


### PR DESCRIPTION
fixes #1640
