### PR TITLE
Fix personblurp warnings.

### DIFF
--- a/pdns/docs/pdns_recursor.1.txt
+++ b/pdns/docs/pdns_recursor.1.txt
@@ -1,7 +1,5 @@
 PDNS_RECURSOR(1)
 ================
-bert hubert <bert.hubert@netherlabs.nl>
-v3.0, 22 March 2008
 
 NAME
 ----
@@ -172,6 +170,7 @@ None known. File new ones at http://wiki.powerdns.com.
 AUTHOR
 ------
 Written by PowerDNS.COM BV, bert hubert, <bert.hubert@netherlabs.nl>
+v3.0, 22 March 2008
 
 RESOURCES
 ---------

--- a/pdns/docs/rec_control.1.txt
+++ b/pdns/docs/rec_control.1.txt
@@ -1,7 +1,5 @@
 REC_CONTROL(1)
 ==============
-bert hubert <bert.hubert@netherlabs.nl>
-v3.0, 19 April 2006
 
 NAME
 ----
@@ -131,6 +129,7 @@ None known. File new ones at https://github.com/PowerDNS/pdns/issues.
 AUTHOR
 ------
 Written by PowerDNS.COM BV, bert hubert, <bert.hubert@netherlabs.nl>
+v3.0, 19 April 2006
 
 RESOURCES
 ---------


### PR DESCRIPTION
As a continuation of #1596, fix warnings about personblurps in 2 more manpages (and dos2unix these files).
