### PR TITLE
VARCHAR(255) is too long

### DIFF
--- a/modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
+++ b/modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
@@ -19,7 +19,7 @@ CREATE INDEX domainmetadata_idx ON domainmetadata (domain_id, kind);
 CREATE TABLE comments (
   id                    INT AUTO_INCREMENT,
   domain_id             INT NOT NULL,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) NOT NULL,

--- a/modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql
+++ b/modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql
@@ -49,7 +49,7 @@ CREATE UNIQUE INDEX namealgoindex ON tsigkeys(name, algorithm);
 CREATE TABLE comments (
   id                    INT AUTO_INCREMENT,
   domain_id             INT NOT NULL,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) NOT NULL,

--- a/modules/gmysqlbackend/schema.mysql.sql
+++ b/modules/gmysqlbackend/schema.mysql.sql
@@ -1,6 +1,6 @@
 CREATE TABLE domains (
   id                    INT AUTO_INCREMENT,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   master                VARCHAR(128) DEFAULT NULL,
   last_check            INT DEFAULT NULL,
   type                  VARCHAR(6) NOT NULL,
@@ -15,7 +15,7 @@ CREATE UNIQUE INDEX name_index ON domains(name);
 CREATE TABLE records (
   id                    INT AUTO_INCREMENT,
   domain_id             INT DEFAULT NULL,
-  name                  VARCHAR(255) DEFAULT NULL,
+  name                  VARCHAR(253) DEFAULT NULL,
   type                  VARCHAR(10) DEFAULT NULL,
   content               VARCHAR(64000) DEFAULT NULL,
   ttl                   INT DEFAULT NULL,
@@ -43,7 +43,7 @@ CREATE TABLE supermasters (
 CREATE TABLE comments (
   id                    INT AUTO_INCREMENT,
   domain_id             INT NOT NULL,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) NOT NULL,

--- a/modules/goraclebackend/schema.goracle.sql
+++ b/modules/goraclebackend/schema.goracle.sql
@@ -1,6 +1,6 @@
 CREATE TABLE domains (
   id              INTEGER NOT NULL,
-  name            VARCHAR2(255) NOT NULL,
+  name            VARCHAR2(253) NOT NULL,
   master          VARCHAR2(128) DEFAULT NULL,
   last_check      INTEGER DEFAULT NULL,
   type            VARCHAR2(6) NOT NULL,
@@ -16,7 +16,7 @@ CREATE INDEX domains$name ON domains (name);
 CREATE TABLE records (
   id              INTEGER NOT NULL,
   domain_id       INTEGER DEFAULT NULL REFERENCES domains (id) ON DELETE CASCADE,
-  name            VARCHAR2(255) DEFAULT NULL,
+  name            VARCHAR2(253) DEFAULT NULL,
   type            VARCHAR2(10) DEFAULT NULL,
   content         VARCHAR2(4000) DEFAULT NULL,
   ttl             INTEGER DEFAULT NULL,
@@ -45,7 +45,7 @@ CREATE TABLE supermasters (
 CREATE TABLE comments (
   id              INTEGER NOT NULL,
   domain_id       INTEGER NOT NULL REFERENCES domains (id) ON DELETE CASCADE,
-  name            VARCHAR2(255) NOT NULL,
+  name            VARCHAR2(253) NOT NULL,
   type            VARCHAR2(10) NOT NULL,
   modified_at     INTEGER NOT NULL,
   account         VARCHAR2(40) NOT NULL,

--- a/modules/gpgsqlbackend/dnssec-3.x_to_3.4.0_schema.pgsql.sql
+++ b/modules/gpgsqlbackend/dnssec-3.x_to_3.4.0_schema.pgsql.sql
@@ -18,7 +18,7 @@ DROP INDEX IF EXISTS orderindex;
 CREATE TABLE comments (
   id                    SERIAL PRIMARY KEY,
   domain_id             INT NOT NULL,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) DEFAULT NULL,

--- a/modules/gpgsqlbackend/nodnssec-3.x_to_3.4.0_schema.pgsql.sql
+++ b/modules/gpgsqlbackend/nodnssec-3.x_to_3.4.0_schema.pgsql.sql
@@ -47,7 +47,7 @@ CREATE UNIQUE INDEX namealgoindex ON tsigkeys(name, algorithm);
 CREATE TABLE comments (
   id                    SERIAL PRIMARY KEY,
   domain_id             INT NOT NULL,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) DEFAULT NULL,

--- a/modules/gpgsqlbackend/schema.pgsql.sql
+++ b/modules/gpgsqlbackend/schema.pgsql.sql
@@ -1,6 +1,6 @@
 CREATE TABLE domains (
   id                    SERIAL PRIMARY KEY,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   master                VARCHAR(128) DEFAULT NULL,
   last_check            INT DEFAULT NULL,
   type                  VARCHAR(6) NOT NULL,
@@ -15,7 +15,7 @@ CREATE UNIQUE INDEX name_index ON domains(name);
 CREATE TABLE records (
   id                    SERIAL PRIMARY KEY,
   domain_id             INT DEFAULT NULL,
-  name                  VARCHAR(255) DEFAULT NULL,
+  name                  VARCHAR(253) DEFAULT NULL,
   type                  VARCHAR(10) DEFAULT NULL,
   content               VARCHAR(65535) DEFAULT NULL,
   ttl                   INT DEFAULT NULL,
@@ -47,7 +47,7 @@ CREATE TABLE supermasters (
 CREATE TABLE comments (
   id                    SERIAL PRIMARY KEY,
   domain_id             INT NOT NULL,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) DEFAULT NULL,

--- a/modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
+++ b/modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
@@ -1,7 +1,7 @@
 CREATE TABLE comments (
   id                    INTEGER PRIMARY KEY,
   domain_id             INTEGER NOT NULL,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) DEFAULT NULL,
@@ -33,7 +33,7 @@ BEGIN TRANSACTION;
   CREATE TABLE records (
     id                  INTEGER PRIMARY KEY,
     domain_id           INTEGER DEFAULT NULL,
-    name                VARCHAR(255) DEFAULT NULL,
+    name                VARCHAR(253) DEFAULT NULL,
     type                VARCHAR(10) DEFAULT NULL,
     content             VARCHAR(65535) DEFAULT NULL,
     ttl                 INTEGER DEFAULT NULL,

--- a/modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
+++ b/modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
@@ -39,7 +39,7 @@ CREATE UNIQUE INDEX namealgoindex ON tsigkeys(name, algorithm);
 CREATE TABLE comments (
   id                    INTEGER PRIMARY KEY,
   domain_id             INTEGER NOT NULL,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) DEFAULT NULL,

--- a/modules/gsqlite3backend/schema.sqlite3.sql
+++ b/modules/gsqlite3backend/schema.sqlite3.sql
@@ -1,6 +1,6 @@
 CREATE TABLE domains (
   id                    INTEGER PRIMARY KEY,
-  name                  VARCHAR(255) NOT NULL COLLATE NOCASE,
+  name                  VARCHAR(253) NOT NULL COLLATE NOCASE,
   master                VARCHAR(128) DEFAULT NULL,
   last_check            INTEGER DEFAULT NULL,
   type                  VARCHAR(6) NOT NULL,
@@ -14,7 +14,7 @@ CREATE UNIQUE INDEX name_index ON domains(name);
 CREATE TABLE records (
   id                    INTEGER PRIMARY KEY,
   domain_id             INTEGER DEFAULT NULL,
-  name                  VARCHAR(255) DEFAULT NULL,
+  name                  VARCHAR(253) DEFAULT NULL,
   type                  VARCHAR(10) DEFAULT NULL,
   content               VARCHAR(65535) DEFAULT NULL,
   ttl                   INTEGER DEFAULT NULL,
@@ -43,7 +43,7 @@ CREATE UNIQUE INDEX ip_nameserver_pk ON supermasters(ip, nameserver);
 CREATE TABLE comments (
   id                    INTEGER PRIMARY KEY,
   domain_id             INTEGER NOT NULL,
-  name                  VARCHAR(255) NOT NULL,
+  name                  VARCHAR(253) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
   account               VARCHAR(40) DEFAULT NULL,


### PR DESCRIPTION
Per §3.1:

Domains are up to 255 octets, composed of labels.
Labels are up to 63 octets, including a preceding length octet.
The label for the root is null, i.e. a zero byte for zero length.

With the initial label in the domain taking one octet for length, and the final root label taking another octet, a domain may contain at most only 253 octets.
