### PR TITLE
Catch PDNSException in Signingpiper::helperWorker to avoid abort

### DIFF
--- a/pdns/signingpipe.cc
+++ b/pdns/signingpipe.cc
@@ -62,6 +62,9 @@ try
   shs.d_csp->worker(shs.d_id, shs.d_fd);
   return 0;
 }
+catch(PDNSException& pe) {
+  L<<Logger::Error<<"Signing thread died with error "<<pe.reason<<endl;
+}
 catch(std::exception& e) {
   L<<Logger::Error<<"Signing thread died with error "<<e.what()<<endl;
   return 0;


### PR DESCRIPTION
Fixes crash when zone is being reloaded and signingpipe attempts to get SOA record. This causes DBException to be thrown in bind backend and crashes the process with signal 6. Thank you for @afics for debugging this issue. 
