### PR TITLE
Migrate existing DNSSEC tables to InnoDB

### DIFF
--- a/modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
+++ b/modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
@@ -12,6 +12,9 @@ ALTER TABLE supermasters MODIFY ip VARCHAR(64) NOT NULL;
 ALTER TABLE supermasters ADD PRIMARY KEY(ip, nameserver);
 ALTER TABLE domainmetadata MODIFY kind VARCHAR(32);
 ALTER TABLE tsigkeys MODIFY algorithm VARCHAR(50);
+ALTER TABLE domainmetadata ENGINE=InnoDB;
+ALTER TABLE cryptokeys ENGINE=InnoDB;
+ALTER TABLE tsigkeys ENGINE=InnoDB;
 
 DROP INDEX domainmetaidindex ON domainmetadata;
 CREATE INDEX domainmetadata_idx ON domainmetadata (domain_id, kind);


### PR DESCRIPTION
We should migrate all existing DNSSEC tables (domainmetadata, cryptokeys, tsigkeys) to engine InnoDB.
