### PR TITLE
Make sure yahttp is linked into remotebackend

### DIFF
--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -4,6 +4,7 @@ AM_CPPFLAGS=$(THREADFLAGS) $(BOOST_CPPFLAGS) -I../../pdns/ext/rapidjson/include 
 #       install .lib/libremotebackend.so.0.0.0 @libdir@
 #endif
 
+SUBDIRS=../../pdns/ext/yahttp
 EXTRA_DIST=OBJECTFILES OBJECTLIBS testrunner.sh unittest_http.rb unittest_json.rb unittest_pipe.rb unittest_zeromq.rb unittest_post.rb unittest.rb Gemfile Gemfile.lock
 EXTRA_PROGRAMS=test_remotebackend_pipe test_remotebackend_unix test_remotebackend_http test_remotebackend_post test_remotebackend_json test_remotebackend_zeromq
 EXTRA_LTLIBRARIES=libtestremotebackend.la
@@ -16,7 +17,7 @@ pkglib_LTLIBRARIES = libremotebackend.la
 libremotebackend_la_SOURCES=remotebackend.hh remotebackend.cc unixconnector.cc httpconnector.cc pipeconnector.cc zmqconnector.cc
 
 libremotebackend_la_LDFLAGS=-module -avoid-version
-libremotebackend_la_LIBADD=$(LIBZMQ_LIBS) 
+libremotebackend_la_LIBADD=$(LIBZMQ_LIBS) ../../pdns/ext/yahttp/yahttp/libyahttp.la
 
 if UNIT_TESTS
 TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message REMOTEBACKEND_ZEROMQ=$(REMOTEBACKEND_ZEROMQ) ./testrunner.sh 


### PR DESCRIPTION
Make sure that the yahttp directory is built first.

Adding the archive causes the linker to do this:
libtool: link: g++  -fPIC -DPIC -shared -nostdlib /usr/lib/gcc/x86_64-redhat-linux/4.9.1/../../../../lib64/crti.o /usr/lib/gcc/x86_64-redhat-linux/4.9.1/crtbeginS.o  .libs/remotebackend.o .libs/unixconnector.o .libs/httpconnector.o .libs/pipeconnector.o .libs/zmqconnector.o  -Wl,--whole-archive ../../pdns/ext/yahttp/yahttp/.libs/libyahttp.a -Wl,--no-whole-archive  -lrt -L/usr/lib/gcc/x86_64-redhat-linux/4.9.1 -L/usr/lib/gcc/x86_64-redhat-linux/4.9.1/../../../../lib64 -L/lib/../lib64 -L/usr/lib/../lib64 -L/usr/lib/gcc/x86_64-redhat-linux/4.9.1/../../.. -lstdc++ -lm -lc -lgcc_s /usr/lib/gcc/x86_64-redhat-linux/4.9.1/crtendS.o /usr/lib/gcc/x86_64-redhat-linux/4.9.1/../../../../lib64/crtn.o  -O2 -Wl,-z -Wl,relro -Wl,-z -Wl,now   -Wl,-soname -Wl,libremotebackend.so -o .libs/libremotebackend.so

Note the --whole-archive stuff.

Fixes #1732
