### PR TITLE
Detect cdb on OSX

### DIFF
--- a/m4/pdns_check_cdb.m4
+++ b/m4/pdns_check_cdb.m4
@@ -1,7 +1,13 @@
 AC_DEFUN([PDNS_CHECK_CDB],[
   PKG_CHECK_MODULES([CDB], [libcdb],
-    [HAVE_CDB=yes],
-    [AC_MSG_ERROR([Could not find libcdb/tinycdb])]
+    [],
+    [AC_CHECK_HEADERS([cdb.h],
+      [AC_CHECK_LIB([cdb], [cdb_find],
+        [CDB_LIBS="-lcdb"],
+        [AC_MSG_ERROR([Could not find libcdb])]
+      )],
+      [AC_MSG_ERROR([Could not find cdb])]
+    )]
   )
   AC_SUBST(CDB_LIBS)
   AC_SUBST(CDB_CFLAGS)


### PR DESCRIPTION
cdb from homebrew doesn't ship a .pc file
so detect it the old-fashioned way.
