### PR TITLE
Use mysql_real_escape_string

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -140,12 +140,11 @@ bool SMySQL::getRow(row_t &row)
 
 string SMySQL::escape(const string &name)
 {
+  char *tmp = new char[name.size()*2+1];
+  unsigned long len;
+  len = mysql_real_escape_string(&d_db, tmp, name.c_str(), name.size());
   string a;
-
-  for(string::const_iterator i=name.begin();i!=name.end();++i) {
-    if(*i=='\'' || *i=='\\')
-      a+='\\';
-    a+=*i;
-  }
+  a.assign(tmp, len);
+  delete [] tmp;
   return a;
 }


### PR DESCRIPTION
The string in from is encoded to an escaped SQL string, taking into account the current character set of the connection. The result is placed in to and a terminating null byte is appended. Characters encoded are NUL (ASCII 0), “\n”, “\r”, “\”, “'”, “"”, and Control-Z (see Section 8.1, “Literal Values”).
