### PR TITLE
set AA on CNAME into referral, fixes #589

### DIFF
--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -74,7 +74,7 @@ private:
   bool addDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd);
   bool addNSEC3PARAM(DNSPacket *p, DNSPacket *r, const SOAData& sd);
   bool getTLDAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId);
-  int doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, const SOAData& sd);
+  int doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, const SOAData& sd, bool retargeted);
   bool doDNSSECProcessing(DNSPacket* p, DNSPacket *r);
   void addNSECX(DNSPacket *p, DNSPacket* r, const string &target, const string &wildcard, const std::string &auth, int mode);
   void addNSEC(DNSPacket *p, DNSPacket* r, const string &target, const string &wildcard, const std::string& auth, int mode);
@@ -94,7 +94,7 @@ private:
   vector<DNSResourceRecord> getBestReferralNS(DNSPacket *p, SOAData& sd, const string &target);
   vector<DNSResourceRecord> getBestDNAMESynth(DNSPacket *p, SOAData& sd, string &target);
   bool tryDNAME(DNSPacket *p, DNSPacket*r, SOAData& sd, string &target);
-  bool tryReferral(DNSPacket *p, DNSPacket*r, SOAData& sd, const string &target);
+  bool tryReferral(DNSPacket *p, DNSPacket*r, SOAData& sd, const string &target, bool retargeted);
 
   bool getBestWildcard(DNSPacket *p, SOAData& sd, const string &target, string &wildcard, vector<DNSResourceRecord>* ret);
   bool tryWildcard(DNSPacket *p, DNSPacket*r, SOAData& sd, string &target, string &wildcard, bool& retargeted, bool& nodata);

--- a/regression-tests/tests/cname-to-referral/expected_result
+++ b/regression-tests/tests/cname-to-referral/expected_result
@@ -1,5 +1,5 @@
 0	server1.example.com.	IN	CNAME	120	server1.france.example.com.
 1	france.example.com.	IN	NS	120	ns1.otherprovider.net.
 1	france.example.com.	IN	NS	120	ns2.otherprovider.net.
-Rcode: 0, RD: 0, QR: 1, TC: 0, AA: 0, opcode: 0
+Rcode: 0, RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='server1.example.com.', qtype=A


### PR DESCRIPTION
Not entirely happy with this, our AA logic is basically the wrong way around - we start out true and set it false in various places, while the RFC says 'set AA if the first thing you put into ANSWER is auth'.
