### PR TITLE
Use an automake variable for server building

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,10 @@
-SUBDIRS=modules codedocs @programdescend@
-DIST_SUBDIRS=modules codedocs pdns
-EXTRA_DIST=README INSTALL NOTICE debian pdns.spec \
+SUBDIRS = modules codedocs
+
+if WITH_PDNS_SERVER
+  SUBDIRS += pdns
+endif
+
+EXTRA_DIST=README INSTALL NOTICE debian pdns.spec  \
 codedocs/doxygen.conf contrib/powerdns.solaris.init.d \
 contrib/systemd-pdns.service contrib/systemd-pdns-recursor.service \
 bootstrap build-scripts/semistaticg++ pdns/docs/dnstcpbench.1 \

--- a/configure.ac
+++ b/configure.ac
@@ -236,12 +236,7 @@ AC_ARG_ENABLE([pdns-server],
   [enable_pdns_server=yes]
 )
 AC_MSG_RESULT([$enable_pdns_server])
-
-AS_IF([test "x$enable_pdns_server" = "xyes"],
-  [programdescend=pdns]
-)
-
-AC_SUBST(programdescend)
+AM_CONDITIONAL([WITH_PDNS_SERVER],[test "x$enable_pdns_server" != "xno"])
 
 AC_ARG_ENABLE([gcc-skip-locking],
   [AS_HELP_STRING([--enable-gcc-skip-locking],[if we should forcefully skip gcc locking @<:@default=no@:>@])],


### PR DESCRIPTION
Since automake knows all possible values of this variable
up front, it can determine what goes into DIST_SUBDIRS
automagically.
