### PR TITLE
Always include polarssl in dist

### DIFF
--- a/pdns/ext/Makefile.am
+++ b/pdns/ext/Makefile.am
@@ -1,1 +1,2 @@
 SUBDIRS=$(POLARSSL_SUBDIR) yahttp rapidjson
+DIST_SUBDIRS=polarssl-1.3.2 yahttp rapidjson


### PR DESCRIPTION
This is necessary since POLARSSL_SUBDIR
can be empty when configuring --with-system-polarssl, running
make distdir and building an rpm from that distdir afterwards.
