### PR TITLE
Handle missing Lua when lua backend is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -291,6 +291,14 @@ for a in $modules $dynmodules; do
     geoip)
       PDNS_CHECK_GEOIP
       ;;
+    lua)
+      AS_IF([test "x$with_lua" = "xno"],
+        AC_MSG_ERROR([Lua backend needs lua, run ./configure --with-lua])
+      )
+      AS_IF([test "x$LUAPC" = "x"],
+        AC_MSG_ERROR([Lua backend needs lua but we cannot find it])
+      )
+      ;;
   esac
 done
 


### PR DESCRIPTION
The first case handles ./configure --with-modules='lua' --with-lua=no.
I don't know who would do such a thing, but better handle it in
./configure than bailing out later with a compiler error.

The second case handles ./configure --with-modules=lua when you don't have
Lua installed, which I actually observed since I assumed enabling the
lua backend would be enough, and I did't have the lua headers on my
system.

Fixes #1618
