### PR TITLE
Fix compiling mydns module without gmysql module

### DIFF
--- a/modules/mydnsbackend/OBJECTLIBS
+++ b/modules/mydnsbackend/OBJECTLIBS
@@ -1,1 +1,1 @@
-$(MYSQL_lib)
+../modules/gmysqlbackend/smysql.lo $(MYSQL_lib)


### PR DESCRIPTION
This fixes the last case in #544:
https://github.com/PowerDNS/pdns/issues/544#issuecomment-32457187

It's still a dirty hack, and we should pull the parts that mydns
and gmysql have in comming into a common library.
