### PR TITLE
Memory allocating with new[] should be freed with delete[]

### DIFF
--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -391,7 +391,7 @@ struct StackMallocTest
   void operator()() const
   {
     char *buffer= new char[200000];
-    delete buffer;
+    delete[] buffer;
   }
 
 };


### PR DESCRIPTION
Candidate for the lamest first bugfix award.
