### PR TITLE
Disable dependency tracking in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
  - p11-kit -l # ensure it's ok
 script:
  - ./bootstrap
- - ./configure --with-dynmodules='bind geo geoip gmysql gpgsql gsqlite3 mydns tinydns remote random opendbx ldap lmdb lua' --with-modules='' --enable-unit-tests --enable-tools --enable-remotebackend-zeromq --enable-experimental-pkcs11 --disable-silent-rules
+ - ./configure --with-dynmodules='bind geo geoip gmysql gpgsql gsqlite3 mydns tinydns remote random opendbx ldap lmdb lua' --with-modules='' --enable-unit-tests --enable-tools --enable-remotebackend-zeromq --enable-experimental-pkcs11 --disable-silent-rules --disable-dependency-tracking
  - make -k dist
  - make -k -j 4
  - make -k install DESTDIR=/tmp/pdns-install-dir


### PR DESCRIPTION
Since we don't reuse the results we have no use for it.
Speeds up the build and makes the build output more readable.
