### PR TITLE
API: test "correct" capitalization of key header

### DIFF
--- a/regression-tests.api/test_helper.py
+++ b/regression-tests.api/test_helper.py
@@ -15,7 +15,7 @@ class ApiTestCase(unittest.TestCase):
         self.server_port = int(os.environ.get('WEBPORT', '5580'))
         self.server_url = 'http://%s:%s/' % (self.server_address, self.server_port)
         self.session = requests.Session()
-        self.session.headers = {'x-api-key': os.environ.get('APIKEY', 'changeme-key')}
+        self.session.headers = {'X-API-Key': os.environ.get('APIKEY', 'changeme-key')}
 
     def url(self, relative_url):
         return urlparse.urljoin(self.server_url, relative_url)


### PR DESCRIPTION
Test what we document, not what the code checks for.
