### PR TITLE
read ALLOW-AXFR-FROM from the backend with the metadata

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -428,7 +428,7 @@ bool TCPNameserver::canDoAXFR(shared_ptr<DNSPacket> q)
     // cerr<<"got backend and SOA"<<endl;
     DNSBackend *B=sd.db;
     vector<string> acl;
-    B->getDomainMetadata(q->qdomain, "ALLOW-AXFR-FROM", acl);
+    s_P->getBackend()->getDomainMetadata(q->qdomain, "ALLOW-AXFR-FROM", acl);
     for (vector<string>::const_iterator i = acl.begin(); i != acl.end(); ++i) {
       // cerr<<"matching against "<<*i<<endl;
       if(pdns_iequals(*i, "AUTO-NS")) {


### PR DESCRIPTION
http://mailman.powerdns.com/pipermail/pdns-users/2014-October/010950.html
