### PR TITLE
secpoll: Replace ~ with _, too

### DIFF
--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -131,6 +131,7 @@ void doSecPoll(bool first)
     query+='.';
 
   boost::replace_all(query, "+", "_");
+  boost::replace_all(query, "~", "_");
 
   vector<DNSResourceRecord> ret;
 

--- a/pdns/secpoll-recursor.cc
+++ b/pdns/secpoll-recursor.cc
@@ -29,6 +29,7 @@ void doSecPoll(time_t* last_secpoll)
     query+='.';
 
   boost::replace_all(query, "+", "_");
+  boost::replace_all(query, "~", "_");
 
   int res=sr.beginResolve(query, QType(QType::TXT), 1, ret);
   if(!res && !ret.empty()) {


### PR DESCRIPTION
Debian backports versions use '~' in the version number.
