### PR TITLE
Only link botan with -lrt and -lgmp on Linux

### DIFF
--- a/m4/pdns_enable_botan.m4
+++ b/m4/pdns_enable_botan.m4
@@ -22,6 +22,9 @@ AC_DEFUN([PDNS_ENABLE_BOTAN],[
       [AC_DEFINE([HAVE_BOTAN110],[1],[Define to 1 if you have botan 1.10])],
       [AC_MSG_ERROR([Could not find botan 1.10])]
     )]
+    [AS_CASE([$host_os], [linux*],
+      [BOTAN110_LIBS="$BOTAN110_LIBS -lgmp -lrt"]
+    )]
   )
 
   AS_IF([test "x$enable_botan18" != "xno"], [
@@ -29,5 +32,11 @@ AC_DEFUN([PDNS_ENABLE_BOTAN],[
       [AC_DEFINE([HAVE_BOTAN18], [1], [Define to 1 if you have botan 1.10])],
       [AC_MSG_ERROR([Could not find botan 1.8])]
     )]
+    [AS_CASE([$host_os], [linux*],
+      [BOTAN18_LIBS="$BOTAN18_LIBS -lgmp"]
+    )]
   )
+
+  AC_SUBST([BOTAN110_LIBS])
+  AC_SUBST([BOTAN18_LIBS])
 ])

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -199,12 +199,12 @@ pdns_server_LDADD = \
 
 if BOTAN110
 pdns_server_SOURCES += botan110signers.cc botansigners.cc
-pdns_server_LDADD += $(BOTAN110_LIBS) -lgmp -lrt
+pdns_server_LDADD += $(BOTAN110_LIBS)
 endif
 
 if BOTAN18
 pdns_server_SOURCES += botan18signers.cc botansigners.cc
-pdns_server_LDADD += $(BOTAN18_LIBS) -lgmp
+pdns_server_LDADD += $(BOTAN18_LIBS)
 endif
 
 if CRYPTOPP
@@ -288,7 +288,7 @@ pdnssec_LDADD = \
 
 if BOTAN110
 pdnssec_SOURCES += botan110signers.cc botansigners.cc
-pdnssec_LDADD += $(BOTAN110_LIBS) -lgmp -lrt
+pdnssec_LDADD += $(BOTAN110_LIBS)
 endif
 
 if BOTAN18


### PR DESCRIPTION
This fixes #1909

We still need to find a way to do
this only for static builds.
