### PR TITLE
Resulting docs identical for pandoc 1.12 and 1.13

### DIFF
--- a/pdns/docs/markdown/authoritative/backend-generic-mypgsql.md
+++ b/pdns/docs/markdown/authoritative/backend-generic-mypgsql.md
@@ -30,7 +30,8 @@ In practice, great results are achieved with the 'InnoDB' tables. PowerDNS will 
 
 The default setup conforms to the following schema:
 
-```{include=../../modules/gmysqlbackend/schema.mysql.sql}
+```
+!!include=../../modules/gmysqlbackend/schema.mysql.sql
 ```
 
 `zone2sql` with the `--gmysql` flag also assumes this layout is in place.
@@ -59,7 +60,8 @@ This automates deletion of records on deletion of a domain from the domains tabl
 
 The default setup conforms to the following schema, which you should add to a PostgreSQL database.
 
-```{include=../../modules/gpgsqlbackend/schema.pgsql.sql}
+```
+!!include=../../modules/gpgsqlbackend/schema.pgsql.sql
 ```
 
 `zone2sql` with the `--gpgsql` flag also assumes this layout is in place.
@@ -73,7 +75,8 @@ With PostgreSQL, you may have to run `createdb powerdns` first and then connect 
 # Oracle specifics
 Generic Oracle support is only available since version 2.9.18. The default setup conforms to the following schema, which you should add to an Oracle database. You may need or want to add `namespace` statements.
 
-```{include=../../modules/gpgsqlbackend/schema.pgsql.sql}
+```
+!!include=../../modules/gpgsqlbackend/schema.pgsql.sql
 ```
 
 This schema contains all elements needed for master, slave and superslave operation.

--- a/pdns/docs/markdown/authoritative/backend-gsqlite.md
+++ b/pdns/docs/markdown/authoritative/backend-gsqlite.md
@@ -29,7 +29,8 @@ SQLite is included in most PowerDNS binary releases.
 ## Setting up the database
 Before you can use this backend you first have to set it up and fill it with data. The default setup conforms to the following schema:
 
-```{include=../../modules/gsqlite3backend/schema.sqlite3.sql}
+```
+!!include=../../modules/gsqlite3backend/schema.sqlite3.sql
 ```
 
 This schema contains all elements needed for master, slave and superslave operation.

--- a/pdns/docs/markdown/authoritative/backend-pipe.md
+++ b/pdns/docs/markdown/authoritative/backend-pipe.md
@@ -171,5 +171,6 @@ DATA    scopebits   auth    qname       qclass  qtype   ttl id  content
 For api-versions 1 and 2, the two new fields fall back to default values. The default value for scopebits is 0. The default for auth is 1 (meaning authoritative).
 
 ## Sample perl backend
-```{include=../../modules/pipebackend/backend.pl}
+```
+!!include=../../modules/pipebackend/backend.pl
 ```

--- a/pdns/docs/markdown/authoritative/installation.md
+++ b/pdns/docs/markdown/authoritative/installation.md
@@ -96,7 +96,8 @@ General MySQL knowledge is assumed in this chapter, please do not interpret thes
 ## Example: configuring MySQL
 Connect to MySQL as a user with sufficient privileges and issue the following commands:
 
-``` {include=../../modules/gmysqlbackend/schema.mysql.sql}
+``` 
+!!include=../../modules/gmysqlbackend/schema.mysql.sql
 ```
 
 Now we have a database and an empty table. PDNS should now be able to launch in monitor mode and display no errors:

--- a/pdns/docs/markdown/authoritative/upgrading.md
+++ b/pdns/docs/markdown/authoritative/upgrading.md
@@ -12,32 +12,38 @@ If custom queries are in use, they probably need an update.
 
 ### gmysql backend with nodnssec schema
 
-```{include=../../modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql}
+```
+!!include=../../modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql
 ```
 
 ### gmysql backend with dnssec schema
 
-```{include=../../modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql}
+```
+!!include=../../modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
 ```
 
 ### gpgsql backend with nodnssec schema
 
-```{include=../../modules/gpgsqlbackend/nodnssec-3.x_to_3.4.0_schema.pgsql.sql}
+```
+!!include=../../modules/gpgsqlbackend/nodnssec-3.x_to_3.4.0_schema.pgsql.sql
 ```
 
 ### gpgsql backend with dnssec schema:
 
-```{include=../../modules/gpgsqlbackend/dnssec-3.x_to_3.4.0_schema.pgsql.sql}
+```
+!!include=../../modules/gpgsqlbackend/dnssec-3.x_to_3.4.0_schema.pgsql.sql
 ```
 
 ### gsqlite3 backend with nodnssec schema
 
-```{include=../../modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql}
+```
+!!include=../../modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
 ```
 
 ### gsqlite3 backend with dnssec schema:
 
-```{include=../../modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql}
+```
+!!include=../../modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
 ```
 
 ### goracle backend:

--- a/pdns/docs/markdown/process-includes.py
+++ b/pdns/docs/markdown/process-includes.py
@@ -11,13 +11,12 @@ from pandocfilters import toJSONFilter, CodeBlock
 def code_include(key, value, format, meta):
     if key == 'CodeBlock':
         [[ident, classes, namevals], code] = value
-        for nameval in namevals:
-            if nameval[0] == 'include':
-                with open(nameval[1], 'rb') as content_file:
-                    content = content_file.read()
-                    content.decode('utf-8')
-                namevals.remove(nameval)
-                return CodeBlock([ident, classes, namevals], content)
+        if code.startswith('!!include='):
+            source_file = code.split('=')[1]
+            with open(source_file, 'rb') as content_file:
+                content = content_file.read()
+                content.decode('utf-8')
+            return CodeBlock([ident, classes, namevals], content)
 
 if __name__ == "__main__":
     toJSONFilter(code_include)

--- a/pdns/docs/process-md.sh
+++ b/pdns/docs/process-md.sh
@@ -7,9 +7,14 @@ pre() {
 }
 
 post() {
-  find html-new -type f -name '*.html' -exec sed -i \
-    -e 's/<table>/<table class="table-bordered">/' \
-    -e 's/\\&\(gt\|lt\)/\&\1/' \
+  # Change the following:
+  # 1. Add class="table-bordered" to tables
+  # 2. Fix &gt; and &lt; escaping fuckery
+  # 3. Fix $-sign escaping insanity
+  find html-new -type f -name '*.html' -exec perl -i -p \
+    -e 's/\<table>/<table class="table-bordered">/;' \
+    -e 's/\\&(gt|lt)/&\1/;' \
+    -e 's/\\\\/\\/g;' \
     {} +
 }
 


### PR DESCRIPTION
Several fixes:
1. Use perl instead of sed for consistent behaviour between platforms
2. Change the way we include files into the docs so the pandoc filter.
   works for both 1.12 and 1.13.
3. More escaping fixes

Closes #1919 

@Habbie could you test this on Mac OS X?
