### PR TITLE
some more FAQ additions

### DIFF
--- a/pdns/docs/markdown/common/support.md
+++ b/pdns/docs/markdown/common/support.md
@@ -1,0 +1,43 @@
+# Getting support, free and paid FAQ
+PowerDNS is an open source program so you may get help from the PowerDNS users'
+community or from its authors. You may also help others (please do).
+
+The PowerDNS company provides free support on the public mailing lists, and can
+help or support you in private as well. For first class and rapid support,
+please contact powerdns-support@netherlabs.nl, or see
+[www.powerdns.com](http://www.powerdns.com).
+
+More information about the PowerDNS community, and its mailing lists, can be
+found on [its Wiki](http://wiki.powerdns.com). On the wiki, you will also find
+information on how to file bugs.
+
+Below, please find a list of common questions asked on our public mailing lists.
+
+## Help!
+Please try harder :-) Specifically, before people will be able to help you,
+they need to know a lot about your system. If you list more details, chances are
+you'll get better answers.
+
+## I have a question, what details should I supply?
+Start out with stating what you think should be happening. Quite often, wrong
+expectations are the actual problem. Furthermore, which database backend you
+use, your operating system, which version of PowerDNS you use and where you got
+it from (RPM, .DEB, tar.bz2). If you compiled it yourself, what were the
+./configure parameters.
+
+If at **all** possible, supply the actual name of your domain and the IP address
+of your server(s).
+
+## Where should I send my question?
+To a mailing list. Please email the authors directly only if you previously
+entered a support contract with them, or are considering doing so. For mailing
+list details, see [the mailing lists page](http://mailman.powerdns.com/mailman/admin/).
+
+Questions about using PowerDNS should be sent to the pdns-users list, questions
+about compiler errors or feature requests to pdns-dev.
+
+Before posting, read all FAQs.
+
+## My information is confidential, must I send it to the mailing list?
+If you desire privacy, please consider entering a support relationship with us,
+in which case we invite you to contact `<powerdns.support.sales@netherlabs.eu>`.

--- a/pdns/docs/markdown/index.md
+++ b/pdns/docs/markdown/index.md
@@ -1,5 +1,8 @@
-# PowerDNS Nameserver
+> It is a book about a Spanish guy called Manual. You should read it.
 
+>       -- Dilbert
+
+# PowerDNS Nameserver
 There are two PowerDNS nameserver products: the [Authoritative Server](authoritative/index.md) and the [Recursor](recursor/index.md). While most other nameservers fully combine these functions, PowerDNS offers them separately, but can mix both authoritative and recursive usage seamlessly.
 The Authoritative Server will answer questions about domains it knows about, but will not go out on the net to resolve queries about other domains. However, it can use a recursing backend to provide that functionality. Depending on your needs, this backend can either be the PowerDNS recursor or an external one.
 When the Authoritative Server answers a question, it comes out of the database, and can be trusted as being authoritative. There is no way to pollute the cache or to confuse the daemon.
@@ -19,11 +22,17 @@ Finally, PowerDNS is able to give a lot of statistics on its operation which
 is both helpful in determining the scalability of an installation as well as
 for spotting problems.
 
+# Getting help
+There are several ways of getting help:
+
+* [The pretty .com website](www.powerdns.com) for commercial support
+* This documentation
+  * [Getting support](common/support.md)
+* [The mailing lists](https://www.powerdns.com/mailing-lists.html)
+  * 
+* \#powerdns on [irc.oftc.net](irc://irc.oftc.net/#powerdns)
+
 # About this document
 If you are reading this document from disk, you may want to check <http://doc.powerdns.com> for updates.
 
 To add to the PowerDNS documentation, or to fix mistakes, head to [Documentation details](appendix/documentation.md).
-
-> It is a book about a Spanish guy called Manual. You should read it.  
-
->       -- Dilbert

--- a/pdns/docs/mkdocs.yml
+++ b/pdns/docs/mkdocs.yml
@@ -9,6 +9,7 @@ pages:
   - [types.md, 'PowerDNS Server', 'Supported DNS Record Types']
   - [common/logging.md, 'PowerDNS Server', 'Logging and Performance Monitoring']
   - [common/security.md, 'PowerDNS Server', 'Security settings & considerations']
+  - [common/support.md, 'PowerDNS Server', 'Getting support']
   - [httpapi/README.md, 'PowerDNS Server', 'HTTP API - Introduction']
 #  - [httpapi/intro.md, 'PowerDNS Server', 'HTTP API - Discussion']
   - [httpapi/api_spec.md, 'PowerDNS Server', 'HTTP API - API Specification']


### PR DESCRIPTION
Port a missing section of the FAQ (about getting help) to the new docs. Also, move the inspirational quote to the top (where it belongs).
