### PR TITLE
disable sqlite3 foreign keys by default

### DIFF
--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -24,18 +24,20 @@
 // Connects to the database.
 gSQLite3Backend::gSQLite3Backend( const std::string & mode, const std::string & suffix ) : GSQLBackend( mode, suffix )
 {
-  try 
+  try
   {
-    SSQLite3 *ptr = new SSQLite3( getArg( "database" ));    
+    SSQLite3 *ptr = new SSQLite3( getArg( "database" ));
     setDB( ptr);
     if(!getArg("pragma-synchronous").empty()) {
       SSQLite3::result_t res;
       ptr->doQuery("PRAGMA synchronous="+getArg("pragma-synchronous"), res);
     }
-    SSQLite3::result_t res;
-    ptr->doQuery("PRAGMA foreign_keys = 1", res);
-  }  
-  catch( SSqlException & e ) 
+    if(mustDo("pragma-foreign-keys")) {
+      SSQLite3::result_t res;
+      ptr->doQuery("PRAGMA foreign_keys = ON", res);
+    }
+  }
+  catch( SSqlException & e )
   {
     L << Logger::Error << mode << ": connection failed: " << e.txtReason() << std::endl;
     throw PDNSException( "Unable to launch " + mode + " connection: " + e.txtReason());
@@ -59,6 +61,7 @@ public:
   {
     declare( suffix, "database", "Filename of the SQLite3 database", "powerdns.sqlite" );
     declare( suffix, "pragma-synchronous", "Set this to 0 for blazing speed", "" );
+    declare( suffix, "pragma-foreign-keys", "Enable foreign key constraints", "no" );
 
     declare(suffix, "dnssec", "Enable DNSSEC processing","no");
 

--- a/pdns/docs/markdown/authoritative/backend-gsqlite.md
+++ b/pdns/docs/markdown/authoritative/backend-gsqlite.md
@@ -39,6 +39,21 @@ After you have created the database you probably want to fill it with data. If y
 
 To communicate with a SQLite database, use either the 'sqlite' or 'sqlite3' program, and feed it SQL.
 
+## Configuration Parameters
+These are the configuration file parameters that are available for the gsqlite3 backend.
+
+### `(gsqlite3)-database`
+Filename of the SQLite3 database.
+
+### `(gsqlite3)-pragma-synchronous`
+Set this to 0 for blazing speed.
+
+### `(gsqlite3)-pragma-foreign-keys`
+Enable foreign key constraints.
+
+### `(gsqlite3)-dnssec`
+Enable DNSSEC processing.
+
 ## Using the SQLite backend
 The last thing you need to do is telling PowerDNS to use the SQLite backend.
 


### PR DESCRIPTION
if we need foreign keys in pdns, we are doing something wrong.
