### PR TITLE
Remove duplicate -rdynamic flag

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -187,8 +187,7 @@ pdns_server_SOURCES = \
 pdns_server_LDFLAGS = \
 	$(DYNLINKFLAGS) \
 	$(THREADFLAGS) \
-	$(BOOST_SERIALIZATION_LDFLAGS) \
-	-rdynamic
+	$(BOOST_SERIALIZATION_LDFLAGS)
 
 pdns_server_LDADD = \
 	@moduleobjects@ \


### PR DESCRIPTION
We already set it in DYNLINKFLAGS, except for
Solaris where it's not needed.
