### PR TITLE
Remove hardcoded -lresolv, -lnsl and -lsocket

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,15 +40,15 @@ AC_CC_PARAM_SSP_BUFFER_SIZE([4])
 AC_CC_D_FORTIFY_SOURCE
 
 AC_CHECK_FUNC([socket], [], [
- AC_CHECK_LIB([socket], [socket], [LIBS="-lsocket $LIBS"])
+  AC_CHECK_LIB([socket], [socket], [LIBS="-lsocket $LIBS"])
 ])
 
 AC_CHECK_FUNC([gethostent], [], [
- AC_CHECK_LIB([nsl], [gethostent], [LIBS="-lnsl $LIBS"])
+  AC_CHECK_LIB([nsl], [gethostent], [LIBS="-lnsl $LIBS"])
 ])
 
 AC_CHECK_FUNC([inet_aton], [], [
- AC_CHECK_LIB([resolv], [inet_aton], [LIBS="-lresolv $LIBS"])
+  AC_CHECK_LIB([resolv], [inet_aton], [LIBS="-lresolv $LIBS"])
 ])
 
 m4_ifndef([LT_INIT],[

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,10 @@ AC_CHECK_FUNC([gethostent], [], [
  AC_CHECK_LIB([nsl], [gethostent], [LIBS="-lnsl $LIBS"])
 ])
 
+AC_CHECK_FUNC([inet_aton], [], [
+ AC_CHECK_LIB([resolv], [inet_aton], [LIBS="-lresolv $LIBS"])
+])
+
 m4_ifndef([LT_INIT],[
 AC_PROG_LIBTOOL([disable-static])
 ],[

--- a/configure.ac
+++ b/configure.ac
@@ -39,17 +39,9 @@ AC_CC_STACK_PROTECTOR
 AC_CC_PARAM_SSP_BUFFER_SIZE([4])
 AC_CC_D_FORTIFY_SOURCE
 
-AC_CHECK_FUNC([socket], [], [
-  AC_CHECK_LIB([socket], [socket], [LIBS="-lsocket $LIBS"])
-])
-
-AC_CHECK_FUNC([gethostent], [], [
-  AC_CHECK_LIB([nsl], [gethostent], [LIBS="-lnsl $LIBS"])
-])
-
-AC_CHECK_FUNC([inet_aton], [], [
-  AC_CHECK_LIB([resolv], [inet_aton], [LIBS="-lresolv $LIBS"])
-])
+AC_SEARCH_LIBS([socket], [socket])
+AC_SEARCH_LIBS([gethostent], [nsl])
+AC_SEARCH_LIBS([inet_aton], [resolv])
 
 m4_ifndef([LT_INIT],[
 AC_PROG_LIBTOOL([disable-static])

--- a/configure.ac
+++ b/configure.ac
@@ -145,13 +145,13 @@ THREADFLAGS=""
 
 case "$host_os" in
 solaris2.10)
-  LIBS="-lposix4 -lresolv -lnsl -lsocket -lpthread -lrt $LIBS"
+  LIBS="-lposix4 -lpthread -lrt $LIBS"
   CXXFLAGS="-D_REENTRANT $CXXFLAGS"
   ;;
 solaris2.8 | solaris2.9 )
   AC_DEFINE(NEED_POSIX_TYPEDEF,,[If POSIX typedefs need to be defined])
   AC_DEFINE(NEED_INET_NTOP_PROTO,,[If your OS is so broken that it needs an additional prototype])
-  LIBS="-lposix4 -lresolv -lnsl -lsocket -lpthread $LIBS"
+  LIBS="-lposix4 -lpthread $LIBS"
   CXXFLAGS="-D_REENTRANT $CXXFLAGS"
   ;;
 linux*)
@@ -300,17 +300,6 @@ for a in $modules; do
 
   if test ${a} = "gpgsql"; then
     LIBS="$LIBS $LIBCRYPT"
-
-    case "$host_os" in
-      freebsd*)
-        ;;
-      darwin*)
-        modulelibs="$modulelibs -lresolv"
-        ;;
-      *)
-        modulelibs="$modulelibs -lresolv -lnsl"
-        ;;
-    esac
   fi
 done
 


### PR DESCRIPTION
We already check for the functions we need in libnsl
and libsocket, and I assume we don't need libresolv

Should fix #1967