### PR TITLE
docs: Remove PING from pipebackend

### DIFF
--- a/docs/markdown/authoritative/backend-pipe.md
+++ b/docs/markdown/authoritative/backend-pipe.md
@@ -165,7 +165,7 @@ DATA    scopebits   auth    qname       qclass  qtype   ttl id  content
 
 `scopebits` indicates how many bits from the subnet provided in the question (originally from edns-subnet) were used in determining this answer. This can aid caching (although PowerDNS does not currently use this value). The `auth` field indicates whether this response is authoritative; this is for DNSSEC. In the `auth` field, use 0 for non-authoritative or 1 for authoritative.
 
-For api-versions 1 and 2, the two new fields fall back to default values. The default value for scopebits is 0. The default for auth is 1 (meaning authoritative).
+For abi-versions 1 and 2, the two new fields fall back to default values. The default value for scopebits is 0. The default for auth is 1 (meaning authoritative).
 
 ## Sample perl backend
 ```

--- a/docs/markdown/authoritative/backend-pipe.md
+++ b/docs/markdown/authoritative/backend-pipe.md
@@ -70,12 +70,7 @@ Questions come in over a file descriptor, by default standard input. Answers are
 ## Handshake
 PowerDNS sends out `HELO\t1`, indicating that it wants to speak the protocol as defined in this document, version 1. For abi-version 2 or 3, PowerDNS sends `HELO\t2` or `HELO\t3`. A PowerDNS Coprocess must then send out a banner, prefixed by `OK\t`, indicating it launched successfully. If it does not support the indicated version, it should respond with `FAIL`, but not exit. Suggested behaviour is to try and read a further line, and wait to be terminated.
 
-### Questions
-Questions come in three forms and are prefixed by a tag indicating the type:
-
-* `Q`: Regular queries
-* `AXFR`: List requests, which mean that an entire zone should be listed
-* `PING`: Check if the coprocess is functioning
+### `Q`: Regular queries for data
 
 The question format, for type Q questions:
 
@@ -101,6 +96,8 @@ Type is the tag above, `qname` is the domain the question is about. `qclass` is 
 `edns-subnet-address` is the actual client subnet as provided via edns-subnet support. Note that for the SOA query that precedes an AXFR, edns-subnet is always set to 0.0.0.0/0.
 
 **Note**: Queries for wildcard names should be answered literally, without expansion. So, if a backend gets a question for "*.powerdns.com", it should only answer with data if there is an actual "*.powerdns.com" name
+
+### `AXFR`: List an entire zone
 
 AXFR-queries look like this:
 

--- a/docs/markdown/authoritative/backend-pipe.md
+++ b/docs/markdown/authoritative/backend-pipe.md
@@ -52,9 +52,9 @@ If not set the default pipebackend-abi-version is 1. When set to 2, the local-ip
 Included with the PDNS distribution is the example.pl backend which has knowledge of the example.com zone, just like the BindBackend. To install both, add the following to your `pdns.conf`:
 
 ```
-          launch=pipe,bind
-          bind-example-zones
-          pipe-command=location/of/backend.pl
+launch=pipe,bind
+bind-example-zones
+pipe-command=location/of/backend.pl
 ```
 
 Please adjust the [`pipe-command`](#pipe-command) statement to the location of the unpacked PDNS distribution. If your backend is slow, raise [`pipe-timeout`](#pipe-timeout) from its default of 2000ms. Now launch PDNS in monitor mode, and perform some queries. Note the difference with the earlier experiment where only the BindBackend was loaded. The PipeBackend is launched first and thus gets queried first. The sample backend.pl script knows about:
@@ -102,10 +102,10 @@ Type is the tag above, `qname` is the domain the question is about. `qclass` is 
 AXFR-queries look like this:
 
 ```
-AXFR    id  zoneName
+AXFR    id  zone-name
 ```
 
-The id is gathered from the answer to a SOA query. ZoneName is given in ABI version 4.
+The `id` is gathered from the answer to a SOA query. `zone-name` is given in ABI version 4.
 
 ### Answers
 Each answer starts with a tag, possibly followed by a TAB and more data.


### PR DESCRIPTION
PING is never sent by pipebackend, so don't have it in the docs.