### PR TITLE
Fix 2 warnings found with Clang 3.5

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -595,8 +595,8 @@ bool checkForCorrectTSIG(const DNSPacket* q, DNSBackend* B, string* keyname, str
 
   q->getTSIGDetails(trc, keyname, &message);
   uint64_t now = time(0);
-  if(abs(trc->d_time - now) > trc->d_fudge) {
-    L<<Logger::Error<<"Packet for '"<<q->qdomain<<"' denied: TSIG (key '"<<*keyname<<"') time delta "<< abs(trc->d_time - now)<<" > 'fudge' "<<trc->d_fudge<<endl;
+  if(trc->d_time - now > trc->d_fudge) {
+    L<<Logger::Error<<"Packet for '"<<q->qdomain<<"' denied: TSIG (key '"<<*keyname<<"') time delta "<< trc->d_time - now <<" > 'fudge' "<<trc->d_fudge<<endl;
     return false;
   }
 


### PR DESCRIPTION
dnspacket.cc:599:105: fatal error: taking the absolute value of unsigned type 'unsigned long' has no effect [-Wabsolute-value]
    L<<Logger::Error<<"Packet for '"<<q->qdomain<<"' denied: TSIG (key '"<<_keyname<<"') time delta "<< abs(trc->d_time - now)<<" > 'fudge' "<<trc->d_fudge<<endl;
                                                                                                        ^
dnspacket.cc:599:105: note: remove the call to 'abs' since unsigned values cannot be negative
    L<<Logger::Error<<"Packet for '"<<q->qdomain<<"' denied: TSIG (key '"<<_keyname<<"') time delta "<< abs(trc->d_time - now)<<" > 'fudge' "<<trc->d_fudge<<endl;
                                                                                                        ^~~
