### PR TITLE
Stop linking with pgsql with hardcoded -lssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,15 +117,6 @@ if test "$has_RTLD_NOW" = "no"; then
 fi
 LIBS=$ac_save_LIBS
 
-# Check for libcrypt
-
-my_save_LIBS="$LIBS"
-LIBS=""
-AC_CHECK_LIB(crypt, crypt)
-LIBCRYPT=$LIBS
-LIBS="$my_save_LIBS"
-AC_SUBST(LIBCRYPT)
-
 THREADFLAGS=""
 
 case "$host_os" in
@@ -278,10 +269,6 @@ for a in $modules; do
     moduleobjects="$moduleobjects ../modules/${a}backend/$b"
   done
   modulelibs="$modulelibs `cat $srcdir/modules/${a}backend/OBJECTLIBS`"
-
-  if test ${a} = "gpgsql"; then
-    LIBS="$LIBS $LIBCRYPT"
-  fi
 done
 
 for a in $dynmodules; do

--- a/modules/gpgsqlbackend/Makefile.am
+++ b/modules/gpgsqlbackend/Makefile.am
@@ -18,4 +18,4 @@ libgpgsqlbackend_la_SOURCES = \
 	spgsql.cc spgsql.hh
 
 libgpgsqlbackend_la_LDFLAGS = -module -avoid-version
-libgpgsqlbackend_la_LIBADD = $(PGSQL_lib) -lssl $(LIBCRYPT) -lcrypto
+libgpgsqlbackend_la_LIBADD = $(PGSQL_lib)


### PR DESCRIPTION
This is only for the dynamic case, static case uses
OBJECTLIBS to do the right thing.