### PR TITLE
pdns_control cycle only works in guardian mode

### DIFF
--- a/pdns/docs/pdns_control.8
+++ b/pdns/docs/pdns_control.8
@@ -47,7 +47,7 @@ Show the content of the cache.
 Retrieve the current configuration.
 .TP
 .B cycle
-Restart the nameserver so it reloads its configuration.
+Restart the nameserver so it reloads its configuration. Only works when you are running in guardian mode.
 .TP
 .B help
 Show summary of options.


### PR DESCRIPTION
Fixes #483
