### PR TITLE
Fix building on OSX again

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,9 @@ linux*)
   THREADFLAGS="-pthread"
   ;;
 darwin*)
+  AC_DEFINE([_XOPEN_SOURCE], [1],
+    [Define _XOPEN_SOURCE for getcontext]
+  )
   CXXFLAGS="-D__APPLE_USE_RFC_3542 $CXXFLAGS"
   AM_CONDITIONAL([OS_MACOSX], true)
   ;;


### PR DESCRIPTION
In file included from selectmplexer.cc:6:
In file included from ./syncres.hh:22:
In file included from ./mtasker.hh:26:
/usr/include/ucontext.h:43:2: error: The deprecated ucontext routines require _XOPEN_SOURCE to be defined
 ^
In file included from selectmplexer.cc:6:
In file included from ./syncres.hh:22:
In file included from ./mtasker.hh:113:
./mtasker.cc:272:3: error: use of undeclared identifier 'getcontext'
  getcontext(uc);
  ^
2 errors generated.
make[4]: **\* [selectmplexer.o] Error 1
make[3]: **\* [all-recursive] Error 1
make[2]: **\* [all] Error 2
make[1]: **\* [all-recursive] Error 1
make: **\* [all] Error 2
