### PR TITLE
Fix building tools on OSX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ linux*)
   THREADFLAGS="-pthread"
   ;;
 darwin*)
-  CXXFLAGS="-D__APPLE_USE_RFC_3542 $CXXFLAGS"
+  CXXFLAGS="-D__APPLE_USE_RFC_3542 -D_XOPEN_SOURCE $CXXFLAGS"
   ;;
 *)
   LDFLAGS="-pthread $LDFLAGS"


### PR DESCRIPTION
Triggered by running ./configure --enable-tools

Turns the error

In file included from selectmplexer.cc:6:
In file included from ./syncres.hh:22:
In file included from ./mtasker.hh:26:
/usr/include/ucontext.h:43:2: error: The deprecated ucontext routines require _XOPEN_SOURCE to be defined
^
In file included from selectmplexer.cc:6:
In file included from ./syncres.hh:22:
In file included from ./mtasker.hh:113:
./mtasker.cc:272:3: error: use of undeclared identifier 'getcontext'
getcontext(uc);
^
2 errors generated.
make[4]: *** [selectmplexer.o] Error 1
make[3]: *** [all-recursive] Error 1
make[2]: *** [all] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2

into a warning:

In file included from ./mtasker.hh:113:
./mtasker.cc:272:3: warning: 'getcontext' is deprecated: first deprecated in OS X 10.6 [-Wdeprecated-declarations]
  getcontext(uc);
  ^
/usr/include/ucontext.h:37:6: note: 'getcontext' has been explicitly marked deprecated here
int  getcontext(ucontext_t *) __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_5, __MAC_10_6, __IPHONE_2_0, __IPHONE_2_0);
     ^
1 warning generated.