### PR TITLE
Fix header path during VPATH build

### DIFF
--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS += \
-	-I../../pdns/ext/rapidjson/include \
+	-I$(top_srcdir)/pdns/ext/rapidjson/include \
 	$(YAHTTP_CFLAGS) \
 	$(POLARSSL_CFLAGS) \
 	$(LIBZMQ_CFLAGS)


### PR DESCRIPTION
/bin/sh ../../libtool  --tag=CXX   --mode=compile g++ -DHAVE_CONFIG_H
-I. -I../../../modules/remotebackend -I../..  -I../.. -I../../..
-pthread -I/usr/include -I../../pdns/ext/rapidjson/include
-I../../../pdns/ext/yahttp -I../../../pdns/ext/polarssl/include/
-fPIE -DPIE -D_FORTIFY_SOURCE=2 --param ssp-buffer-size=4
-fstack-protector -Wall -g -O2 -c -o remotebackend.lo
../../../modules/remotebackend/remotebackend.cc
libtool: compile:  g++ -DHAVE_CONFIG_H -I.
-I../../../modules/remotebackend -I../.. -I../.. -I../../.. -pthread
-I/usr/include -I../../pdns/ext/rapidjson/include
-I../../../pdns/ext/yahttp -I../../../pdns/ext/polarssl/include/ -DPIE
-D_FORTIFY_SOURCE=2 --param ssp-buffer-size=4 -fstack-protector -Wall -g
-O2 -c ../../../modules/remotebackend/remotebackend.cc  -fPIC -DPIC -o
.libs/remotebackend.o
In file included from
../../../modules/remotebackend/remotebackend.hh:9:0,
                 from ../../../modules/remotebackend/remotebackend.cc:1:
../../../pdns/json.hh:27:32: fatal error: rapidjson/document.h: No such
file or directory
 #include "rapidjson/document.h"
                                ^
compilation terminated.