### PR TITLE
Fix SIGSEGV from stack overflow during outgoing AXFR on MUSL C library

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1188,17 +1188,24 @@ void TCPNameserver::thread()
           }
           else {
             pthread_t tid;
+            pthread_attr_t tattr;
+
             d_connectionroom_sem->wait(); // blocks if no connections are available
+
+            /* setting a new size */
+            pthread_attr_init(&tattr);
+            pthread_attr_setstacksize(&tattr, PTHREAD_STACK_MIN + 100000);
 
             int room;
             d_connectionroom_sem->getValue( &room);
             if(room<1)
               L<<Logger::Warning<<Logger::NTLog<<"Limit of simultaneous TCP connections reached - raise max-tcp-connections"<<endl;
 
-            if(pthread_create(&tid, 0, &doConnection, reinterpret_cast<void*>(fd))) {
+            if(pthread_create(&tid, &tattr, &doConnection, reinterpret_cast<void*>(fd))) {
               L<<Logger::Error<<"Error creating thread: "<<stringerror()<<endl;
               d_connectionroom_sem->post();
             }
+            pthread_attr_destroy(&tattr);
           }
         }
       }


### PR DESCRIPTION
* Fixes #2056
* PTHREAD_STACK_MIN + 100000 was found by analysing the stack size

Discussion is under #2062, I managed to break my git by deleting my repo (oops)