### PR TITLE
RFC2136: Support autoserial

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -946,8 +946,13 @@ void PacketHandler::increaseSerial(const string &msgPrefix, const DomainInfo *di
   }
   SOAData soa2Update;
   fillSOAData(rec.content, soa2Update);
-  int oldSerial = soa2Update.serial;
 
+  // No change of the serial required if the zone is using
+  // the autoserial feature (#2066)
+  if (soa2Update.serial == 0)
+    return;
+
+  int oldSerial = soa2Update.serial;
   vector<string> soaEdit2136Setting;
   B.getDomainMetadata(di->zone, "SOA-EDIT-DNSUPDATE", soaEdit2136Setting);
   string soaEdit2136 = "DEFAULT";


### PR DESCRIPTION
Please merge these patches.

They introduce triggers that will automatically keep up the change_date column of the database when a row is inserted or updated and will update change_date of the SOA record if a record is deleted from the database.

If the autoserial feature is in use, all changes to the zone will leave the serial in the content field of the SOA record untouched if it is zero. PowerDNS will automatically replace that accordingly with the timestamp of the most recently changed record (fixes #2066).
