### PR TITLE
limit long version strings to 63 characters and catch exceptions in secpoll

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -440,7 +440,10 @@ void mainthread()
    DNSPacket::s_udpTruncationThreshold = std::max(512, ::arg().asNum("udp-truncation-threshold"));
    DNSPacket::s_doEDNSSubnetProcessing = ::arg().mustDo("edns-subnet-processing");
 
-   doSecPoll(true); // this must be BEFORE chroot
+   try {
+     doSecPoll(true); // this must be BEFORE chroot
+   }
+   catch(...) {}
 
    if(!::arg()["chroot"].empty()) {  
      triggerLoadOfLibraries();

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1317,7 +1317,10 @@ try
     }
 
     if(now.tv_sec - last_secpoll >= 3600) {
-      doSecPoll(&last_secpoll);
+      try {
+        doSecPoll(&last_secpoll);
+      }
+      catch(...) {}
     }
   }
 }

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -124,7 +124,8 @@ void doSecPoll(bool first)
   struct timeval now;
   gettimeofday(&now, 0);
 
-  string query = "auth-" + string(PACKAGEVERSION) +".security-status."+::arg()["security-poll-suffix"];
+  string version = "auth-" + string(PACKAGEVERSION);
+  string query = version.substr(0, 63) +".security-status."+::arg()["security-poll-suffix"];
 
   if(*query.rbegin()!='.')
     query+='.';

--- a/pdns/secpoll-recursor.cc
+++ b/pdns/secpoll-recursor.cc
@@ -23,7 +23,8 @@ void doSecPoll(time_t* last_secpoll)
   
   vector<DNSResourceRecord> ret;
 
-  string query = "recursor-" +string(PACKAGEVERSION)+ ".security-status."+::arg()["security-poll-suffix"];
+  string version = "recursor-" +string(PACKAGEVERSION);
+  string query = version.substr(0, 63)+ ".security-status."+::arg()["security-poll-suffix"];
 
   if(*query.rbegin()!='.')
     query+='.';


### PR DESCRIPTION
fixes #2063 