### PR TITLE
Don't create PIE executables for semistatic builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -345,9 +345,13 @@ for a in $dynmodules; do
   moduledirs="$moduledirs ${a}backend"
 done
 
-CFLAGS="$PIE_CFLAGS $CFLAGS"
-CXXFLAGS="$PIE_CFLAGS $CXXFLAGS"
-LDFLAGS="$PIE_LDFLAGS $RELRO_LDFLAGS $LDFLAGS"
+LDFLAGS="$RELRO_LDFLAGS $LDFLAGS"
+
+AS_IF([test "x$static" != "xyes"], [
+  CFLAGS="$PIE_CFLAGS $CFLAGS"
+  CXXFLAGS="$PIE_CFLAGS $CXXFLAGS"
+  LDFLAGS="$PIE_LDFLAGS $LDFLAGS"
+])
 
 AC_SUBST(LIBS)
 


### PR DESCRIPTION
Otherwise this happens:

/bin/bash ../libtool  --tag=CXX   --mode=link /var/lib/jenkins/jobs/auth-git-semistatic-rpm-amd64/workspace/pdns-git-20150106-5355-20d9693/build-scripts/semistaticg++ -DSYSCONFDIR=\"/etc/powerdns\" -DPKGLIBDIR=\"/usr/lib/pdns\" -DLOCALSTATEDIR=\"/var/run\" -fPIE -DPIE -D_FORTIFY_SOURCE=2 --param ssp-buffer-size=4 -fstack-protector -Wall -g -O2 -pthread -pie -Wl,-z -Wl,relro -Wl,-z -Wl,now -L/opt/postgresql/lib -Wl,-rpath,/opt/postgresql/lib -lpq -all-static  -o pdns_control arguments.o dynloader.o dynmessenger.o logger.o misc.o qtype.o statbag.o unix_utility.o  -lcrypt
libtool: link: /var/lib/jenkins/jobs/auth-git-semistatic-rpm-amd64/workspace/pdns-git-20150106-5355-20d9693/build-scripts/semistaticg++ -DSYSCONFDIR=\"/etc/powerdns\" -DPKGLIBDIR=\"/usr/lib/pdns\" -DLOCALSTATEDIR=\"/var/run\" -fPIE -DPIE -D_FORTIFY_SOURCE=2 --param ssp-buffer-size=4 -fstack-protector -Wall -g -O2 -pthread -pie -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-rpath -Wl,/opt/postgresql/lib -static -o pdns_control arguments.o dynloader.o dynmessenger.o logger.o misc.o qtype.o statbag.o unix_utility.o  -L/opt/postgresql/lib -lpq -lcrypt -pthread
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/4.7/libstdc++.a(compatibility.o): relocation R_X86_64_32 against `_ZTIN10__cxxabiv115__forced_unwindE' can not be used when making a shared object; recompile with -fPIC
/usr/lib/gcc/x86_64-linux-gnu/4.7/libstdc++.a: could not read symbols: Bad value
collect2: error: ld returned 1 exit status

(cherry picked from commit 62e6530a76a2accd997a287172e087ed46d03cf8)

Conflicts:
	configure.ac