### PR TITLE
Stop checking for size_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,9 +104,6 @@ PDNS_CHECK_PANDOC
 PDNS_CHECK_MKDOCS
 PDNS_CHECK_LINKCHECKER
 
-dnl Checks for typedefs, structures, and compiler characteristics.
-AC_TYPE_SIZE_T
-
 dnl Checks for library functions.
 AC_CHECK_FUNCS_ONCE([strcasestr localtime_r])
 


### PR DESCRIPTION
We use it all over the place unconditionally.