### PR TITLE
JSON API: uppercase types

### DIFF
--- a/pdns/qtype.cc
+++ b/pdns/qtype.cc
@@ -79,19 +79,20 @@ QType &QType::operator=(uint16_t n)
 
 int QType::chartocode(const char *p)
 {
-  static QType qt;
+  string P = toUpper(p);
   vector<namenum>::iterator pos;
+
   for(pos=names.begin(); pos < names.end(); ++pos)
-    if(pos->first == p)
+    if(pos->first == P)
       return pos->second;
-  
+
   if(*p=='#') {
     return atoi(p+1);
   }
 
-  if(boost::starts_with(p, "TYPE"))
+  if(boost::starts_with(P, "TYPE"))
     return atoi(p+4);
-    
+
   return 0;
 }
 

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -95,13 +95,14 @@ class AuthZones(ApiTestCase):
         comments = [
             {
                 'name': name,
-                'type': 'SOA',
+                'type': 'soa',  # test uppercasing of type, too.
                 'account': 'test1',
                 'content': 'blah blah',
                 'modified_at': 11112,
             }
         ]
         payload, data = self.create_zone(name=name, comments=comments)
+        comments[0]['type'] = comments[0]['type'].upper()
         # check our comment has appeared
         self.assertEquals(data['comments'], comments)
 
@@ -110,13 +111,14 @@ class AuthZones(ApiTestCase):
         records = [
             {
                 "name": name,
-                "type": "SOA",
+                'type': 'soa',  # test uppercasing of type, too.
                 "ttl": 3600,
                 "content": "ns1.example.net testmaster@example.net 10 10800 3600 604800 3600",
                 "disabled": False
             }
         ]
         payload, data = self.create_zone(name=name, records=records)
+        records[0]['type'] = records[0]['type'].upper()
         self.assertEquals([r for r in data['records'] if r['type'] == records[0]['type']], records)
 
     def test_create_zone_trailing_dot(self):
@@ -449,7 +451,7 @@ fred   IN  A      192.168.0.4
         rrset = {
             'changetype': 'replace',
             'name': name,
-            'type': 'NS',
+            'type': 'ns',
             'records': [
                 {
                     "name": name,
@@ -475,6 +477,7 @@ fred   IN  A      192.168.0.4
         self.assert_success_json(r)
         # verify that (only) the new record is there
         r = self.session.get(self.url("/servers/localhost/zones/" + name))
+        rrset['type'] = rrset['type'].upper()
         data = r.json()['records']
         recs = [rec for rec in data if rec['type'] == rrset['type'] and rec['name'] == rrset['name']]
         self.assertEquals(recs, rrset['records'])


### PR DESCRIPTION
We never promised that types can be in lowercase, but given we're
interpreting them as TYPE0 instead of flat-out failing, let's be nicer.