### PR TITLE
JSON API: provide flush-cache, notify, axfr-receive

### DIFF
--- a/pdns/docs/httpapi/api_spec.md
+++ b/pdns/docs/httpapi/api_spec.md
@@ -49,6 +49,12 @@ For interactions that do not directly map onto CRUD, we use these:
 * GET: Query. Success reply: `200 OK`
 * PUT: Action/Execute. Success reply: `200 OK`
 
+Action/Execute methods return a JSON body of this format:
+
+    {
+      "message": "result message"
+    }
+
 
 Authentication
 --------------
@@ -477,8 +483,6 @@ Not supported for recursors.
 
 Clients MUST NOT send a body.
 
-**TODO**: Not yet implemented.
-
 
 URL: /servers/:server\_id/zones/:zone\_id/axfr-retrieve
 -------------------------------------------------------
@@ -494,7 +498,6 @@ Not supported for recursors.
 
 Clients MUST NOT send a body.
 
-**TODO**: Not yet implemented.
 
 URL: /servers/:server\_id/zones/:zone\_id/check
 -----------------------------------------------

--- a/pdns/json.cc
+++ b/pdns/json.cc
@@ -1,3 +1,24 @@
+/*
+    Copyright (C) 2002 - 2015  PowerDNS.COM BV
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation
+
+    Additionally, the license of this program contains a special
+    exception which allows to distribute the program in binary form when
+    it is linked against OpenSSL.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
 #include "json.hh"
 #include "namespaces.hh"
 #include "misc.hh"
@@ -117,5 +138,16 @@ string returnJsonError(const string& error)
   doc.SetObject();
   Value jerror(error.c_str(), doc.GetAllocator()); // copy
   doc.AddMember("error", jerror, doc.GetAllocator());
+  return makeStringFromDocument(doc);
+}
+
+/* success response */
+string returnJsonMessage(const string& message)
+{
+  Document doc;
+  doc.SetObject();
+  Value jmessage;
+  jmessage.SetString(message.c_str());
+  doc.AddMember("result", jmessage, doc.GetAllocator());
   return makeStringFromDocument(doc);
 }

--- a/pdns/json.hh
+++ b/pdns/json.hh
@@ -28,6 +28,7 @@
 
 std::string returnJsonObject(const std::map<std::string, std::string>& items);
 std::string returnJsonError(const std::string& error);
+std::string returnJsonMessage(const std::string& message);
 std::string makeStringFromDocument(const rapidjson::Document& doc);
 int intFromJson(const rapidjson::Value& container, const char* key);
 int intFromJson(const rapidjson::Value& container, const char* key, const int default_value);

--- a/regression-tests.api/test_Servers.py
+++ b/regression-tests.api/test_Servers.py
@@ -41,3 +41,16 @@ class Servers(ApiTestCase):
         self.assert_success_json(r)
         data = dict([(r['name'], r['value']) for r in r.json()])
         self.assertIn('uptime', data)
+
+    def test_flush_cache(self):
+        r = self.session.put(self.url("/servers/localhost/flush-cache?domain=example.org."))
+        self.assert_success_json(r)
+        data = r.json()
+        self.assertIn('count', data)
+
+    def test_flush_complete_cache(self):
+        r = self.session.put(self.url("/servers/localhost/flush-cache"))
+        self.assert_success_json(r)
+        data = r.json()
+        self.assertIn('count', data)
+        self.assertEqual(data['result'], 'Flushed cache.')

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -180,6 +180,25 @@ class AuthZones(ApiTestCase):
         r = self.session.delete(self.url("/servers/localhost/zones/" + data['id']))
         r.raise_for_status()
 
+    def test_retrieve_slave_zone(self):
+        payload, data = self.create_zone(kind='Slave', nameservers=None, masters=['127.0.0.2'])
+        print "payload:", payload
+        print "data:", data
+        r = self.session.put(self.url("/servers/localhost/zones/" + data['id'] + "/axfr-retrieve"))
+        data = r.json()
+        print "status for axfr-retrieve:", data
+        self.assertEqual(data['result'], u'Added retrieval request for \'' + payload['name'] +
+                         '\' from master 127.0.0.2')
+
+    def test_notify_master_zone(self):
+        payload, data = self.create_zone(kind='Master')
+        print "payload:", payload
+        print "data:", data
+        r = self.session.put(self.url("/servers/localhost/zones/" + data['id'] + "/notify"))
+        data = r.json()
+        print "status for notify:", data
+        self.assertEqual(data['result'], 'Notification queued')
+
     def test_get_zone_with_symbols(self):
         payload, data = self.create_zone(name='foo/bar.'+unique_zone_name())
         name = payload['name']


### PR DESCRIPTION
pdnscontrol used to send pdns/rec-control commands for those through
the jsonstat command tunnel, but jsonstat (on Auth at least) doesn't
do X-API-Key, so that functionality was broken.

Also removes jsonstat from Auth completely.

Cherry-pick conflicts:
	pdns/ws-recursor.cc (kept jsonstat as is)