### PR TITLE
Fix (some) out of tree build failures

### DIFF
--- a/modules/bindbackend/Makefile.am
+++ b/modules/bindbackend/Makefile.am
@@ -18,7 +18,7 @@ libbindbackend_la_SOURCES = \
 libbindbackend_la_LDFLAGS = -module -avoid-version
 
 ../../pdns/bind-dnssec.schema.sqlite3.sql.h: ../../pdns/bind-dnssec.schema.sqlite3.sql
-	( echo 'static char sqlCreate[] __attribute__((unused))=' ; sed 's/$$/"/g' ../../pdns/bind-dnssec.schema.sqlite3.sql | sed 's/^/"/g'  ; echo ';' ) > $@
+	( echo 'static char sqlCreate[] __attribute__((unused))=' ; sed 's/$$/"/g' $< | sed 's/^/"/g'  ; echo ';' ) > $@
 
 # for bindparser.h/hh
 .hh.h:

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1015,10 +1015,10 @@ check-local:
 endif
 
 dnslabeltext.cc: dnslabeltext.rl
-	$(AM_V_GEN)$(RAGEL) dnslabeltext.rl -o dnslabeltext.cc
+	$(AM_V_GEN)$(RAGEL) $< -o dnslabeltext.cc
 
 bind-dnssec.schema.sqlite3.sql.h: bind-dnssec.schema.sqlite3.sql
-	( echo 'static char sqlCreate[] __attribute__((unused))=' ; sed 's/$$/"/g' bind-dnssec.schema.sqlite3.sql | sed 's/^/"/g'  ; echo ';' ) > $@
+	( echo 'static char sqlCreate[] __attribute__((unused))=' ; sed 's/$$/"/g' $< | sed 's/^/"/g'  ; echo ';' ) > $@
 
 # for bindparser.h/hh
 .hh.h:

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1006,7 +1006,7 @@ pdns_control_SOURCES = \
 pdns_control_LDFLAGS = $(THREADFLAGS)
 
 if UNIT_TESTS
-TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message
+TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message SRCDIR='$(srcdir)'
 TESTS=testrunner
 else
 check-local:

--- a/pdns/test-bindparser_cc.cc
+++ b/pdns/test-bindparser_cc.cc
@@ -7,15 +7,20 @@
 #include "pdnsexception.hh"
 #include <utility>
 #include <boost/foreach.hpp>
+#include <sstream>
+#include <cstdlib>
 
 using std::string;
 
 BOOST_AUTO_TEST_SUITE(bindparser_cc)
 
 BOOST_AUTO_TEST_CASE(test_parser) {
+        std::ostringstream pathbuf;
         BindParser BP;
         BOOST_CHECK_THROW( BP.parse("../regression-tests/named.confx"), PDNSException);
-        BP.parse("../pdns/named.conf.parsertest"); // indirect path because Jenkins runs us from ../regression-tests/
+        BP.setVerbose(true);
+        pathbuf << std::getenv("SRCDIR") << "/../pdns/named.conf.parsertest";
+        BP.parse(pathbuf.str());
 
         vector<BindDomainInfo> domains=BP.getDomains();
         BOOST_CHECK_EQUAL(domains.size(), 11);

--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -11,6 +11,7 @@
 #include "zoneparser-tng.hh"
 #include "dnsrecords.hh"
 #include <fstream>
+#include <cstdlib>
 
 BOOST_AUTO_TEST_SUITE(test_zoneparser_tng_cc)
 
@@ -18,10 +19,12 @@ BOOST_AUTO_TEST_CASE(test_tng_record_types) {
   reportAllTypes();
   reportFancyTypes();
 
-  ZoneParserTNG zp("../regression-tests/zones/unit.test", "unit.test");
+  std::ostringstream pathbuf;
+  pathbuf << std::getenv("SRCDIR") << "/../regression-tests/zones/unit.test";
+  ZoneParserTNG zp(pathbuf.str(), "unit.test");
   DNSResourceRecord rr;
 
-  boost::iostreams::stream<boost::iostreams::file_source> ifs("../regression-tests/zones/unit.test");
+  boost::iostreams::stream<boost::iostreams::file_source> ifs(pathbuf.str());
 
   while(zp.get(rr)) {
     // make sure these concur.


### PR DESCRIPTION
This makes this simple case work:

```
mkdir pdns-build && cd pdns-build
../pdns/configure --with-modules="gsqlite3 bind pipe"
```