### PR TITLE
Stop pretending UeberBackend is a normal DNSBackend

### DIFF
--- a/docs/markdown/appendix/backend-writers-guide.md
+++ b/docs/markdown/appendix/backend-writers-guide.md
@@ -190,7 +190,7 @@ Please note that a RandomBackend is actually in most PDNS releases. By default i
 #### `void lookup(const QType &qtype, const string &qdomain, DNSPacket *pkt=0, int zoneId=-1)`
 This function is used to initiate a straight lookup for a record of name 'qdomain' and type 'qtype'. A QType can be converted into an integer by invoking its `getCode()` method and into a string with the `getCode()`.
 
-The original question may or may not be passed in the pointer p. If it is, you can retrieve (from 1.99.11 onwards) information about who asked the question with the `getRemote(DNSPacket *)` method. Alternatively, `bool getRemote(struct sockaddr *sa, socklen_t *len)` is available.
+The original question may or may not be passed in the pointer pkt. If it is, you can retrieve information about who asked the question with the `pkt->getRemote()` method.
 
 Note that **qdomain** can be of any case and that your backend should make sure it is in effect case insensitive. Furthermore, the case of the original question should be retained in answers returned by `get()`!
 

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -344,7 +344,6 @@ void Bind2Backend::getAllDomains(vector<DomainInfo> *domains, bool include_disab
   }
  
   BOOST_FOREACH(DomainInfo &di, *domains) {
-    soadata.db=(DNSBackend *)-1; // makes getSOA() skip the cache. 
     this->getSOA(di.zone, soadata);
     di.serial=soadata.serial;
   }
@@ -373,7 +372,6 @@ void Bind2Backend::getUnfreshSlaveInfos(vector<DomainInfo> *unfreshDomains)
     SOAData soadata;
     soadata.refresh=0;
     soadata.serial=0;
-    soadata.db=(DNSBackend *)-1; // not sure if this is useful, inhibits any caches that might be around
     try {
       getSOA(sd.zone,soadata); // we might not *have* a SOA yet
     }

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -876,6 +876,7 @@ testrunner_SOURCES = \
 	bindparser.yy \
 	dns.cc \
 	dns_random.cc \
+	dnsbackend.cc \
 	dnslabeltext.cc \
 	dnspacket.cc \
 	dnsparser.cc \
@@ -910,15 +911,18 @@ testrunner_SOURCES = \
 	test-sha_hh.cc \
 	packetcache.cc \
 	unix_utility.cc \
+	ueberbackend.cc \
 	zoneparser-tng.cc zoneparser-tng.hh
 
 testrunner_LDFLAGS = \
 	$(AM_LDFLAGS) \
-	$(BOOST_UNIT_TEST_FRAMEWORK_LDFLAGS)
+	$(BOOST_UNIT_TEST_FRAMEWORK_LDFLAGS) \
+	$(BOOST_SERIALIZATION_LDFLAGS)
 
 testrunner_LDADD = \
 	$(POLARSSL_LIBS) \
-	$(BOOST_UNIT_TEST_FRAMEWORK_LIBS)
+	$(BOOST_UNIT_TEST_FRAMEWORK_LIBS) \
+	$(BOOST_SERIALIZATION_LIBS)
 
 if PKCS11
 testrunner_SOURCES += pkcs11signers.cc pkcs11signers.hh

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -181,7 +181,7 @@ public:
   bool notifyDomain(const string &domain);
 private:
   void makeNotifySockets();
-  void queueNotifyDomain(const string &domain, DNSBackend *B);
+  void queueNotifyDomain(const string &domain, UeberBackend *B);
   int d_nsock4, d_nsock6;
   map<pair<string,string>,time_t>d_holes;
   pthread_mutex_t d_holelock;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -315,11 +315,11 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const std::string& zone, boost::tri
     }
   }    
   keyset_t retkeyset, allkeyset;
-  vector<UeberBackend::KeyData> dbkeyset;
+  vector<DNSBackend::KeyData> dbkeyset;
   
   d_keymetadb->getDomainKeys(zone, 0, dbkeyset);
   
-  BOOST_FOREACH(UeberBackend::KeyData& kd, dbkeyset) 
+  BOOST_FOREACH(DNSBackend::KeyData& kd, dbkeyset)
   {
     DNSSECPrivateKey dpk;
 
@@ -363,7 +363,7 @@ bool DNSSECKeeper::secureZone(const std::string& name, int algorithm, int size)
   return addKey(name, true, algorithm, size);
 }
 
-bool DNSSECKeeper::getPreRRSIGs(DNSBackend& db, const std::string& signer, const std::string& qname,
+bool DNSSECKeeper::getPreRRSIGs(UeberBackend& db, const std::string& signer, const std::string& qname,
         const std::string& wildcardname, const QType& qtype,
         DNSPacketWriter::Place signPlace, vector<DNSResourceRecord>& rrsigs, uint32_t signTTL)
 {

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -381,8 +381,7 @@ bool DNSSECKeeper::getPreRRSIGs(UeberBackend& db, const std::string& signer, con
 
   // cerr<<"Doing DB lookup for precomputed RRSIGs for '"<<(wildcardname.empty() ? qname : wildcardname)<<"'"<<endl;
         SOAData sd;
-        sd.db=(DNSBackend *)-1; // force uncached answer
-        if(!db.getSOA(signer, sd)) {
+        if(!db.getSOAUncached(signer, sd)) {
                 DLOG(L<<"Could not get SOA for domain"<<endl);
                 return false;
         }

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -30,7 +30,7 @@
 #include "dnspacket.hh"
 #include "dns.hh"
 
-bool DNSBackend::getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId, const int best_match_len)
+bool DNSBackend::getAuth(DNSPacket *p, SOAData *sd, const string &target, const int best_match_len)
 {
   bool found=false;
   string subdomain(target);
@@ -40,8 +40,6 @@ bool DNSBackend::getAuth(DNSPacket *p, SOAData *sd, const string &target, int *z
 
     if( this->getSOA( subdomain, *sd, p ) ) {
       sd->qname = subdomain;
-      if(zoneId)
-        *zoneId = sd->domain_id;
 
       if(p->qtype.getCode() == QType::DS && pdns_iequals(subdomain, target)) {
         // Found authoritative zone but look for parent zone with 'DS' record.
@@ -364,7 +362,7 @@ bool _add_to_negcache( const string &zone ) {
     return false;
 }
 
-inline int DNSReversedBackend::_getAuth(DNSPacket *p, SOAData *soa, const string &inZone, int *zoneId, const string &querykey, const int best_match_len) {
+inline int DNSReversedBackend::_getAuth(DNSPacket *p, SOAData *soa, const string &inZone, const string &querykey, const int best_match_len) {
     static int negqueryttl=::arg().asNum("negquery-cache-ttl");
 
     DLOG(L<<Logger::Error<<"SOA Query: " <<querykey<<endl);
@@ -410,8 +408,6 @@ inline int DNSReversedBackend::_getAuth(DNSPacket *p, SOAData *soa, const string
         /* all the keys are reversed. rather than reversing them again it is
          * presumably quicker to just substring the zone down to size */
         soa->qname = inZone.substr( inZone.length() - foundkey.length(), string::npos );
-        if(zoneId)
-            *zoneId = soa->domain_id;
 
         DLOG(L<<Logger::Error<<"Successfully got record: " <<foundkey << " : " << querykey.substr( 0, foundkey.length() ) << " : " << soa->qname<<endl);
 
@@ -421,12 +417,12 @@ inline int DNSReversedBackend::_getAuth(DNSPacket *p, SOAData *soa, const string
     return GET_AUTH_NEG_CACHE;
 }
 
-bool DNSReversedBackend::getAuth(DNSPacket *p, SOAData *soa, const string &inZone, int *zoneId, const int best_match_len) {
+bool DNSReversedBackend::getAuth(DNSPacket *p, SOAData *soa, const string &inZone, const int best_match_len) {
     // Reverse the lowercased query string
     string zone = toLower(inZone);
     string querykey = labelReverse(zone);
 
-    int ret = _getAuth( p, soa, inZone, zoneId, querykey, best_match_len );
+    int ret = _getAuth( p, soa, inZone, querykey, best_match_len );
 
     /* If this is disabled then we would just cache the tree structure not the
      * leaves which should give the best performance and a nice small negcache

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -30,20 +30,6 @@
 #include "dnspacket.hh"
 #include "dns.hh"
 
-string DNSBackend::getRemote(DNSPacket *p)
-{
-  return p->getRemote();
-}
-
-bool DNSBackend::getRemote(DNSPacket *p, struct sockaddr *sa, Utility::socklen_t *len)
-{
-  if(p->d_remote.getSocklen() < *len)
-    return false;
-  *len=p->d_remote.getSocklen();
-  memcpy(sa,&p->d_remote,*len);
-  return true;
-}
-
 bool DNSBackend::getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId, const int best_match_len)
 {
   bool found=false;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -162,7 +162,7 @@ public:
   virtual void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) { }
 
   /** Determines if we are authoritative for a zone, and at what level */
-  virtual bool getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId, const int best_match_len);
+  virtual bool getAuth(DNSPacket *p, SOAData *sd, const string &target, const int best_match_len);
 
   struct KeyData {
     unsigned int id;
@@ -400,14 +400,14 @@ class DNSReversedBackend : public DNSBackend {
         virtual bool getAuthZone( string &rev_zone ) { return false; };  // Must be overridden
 
         /* Once the record has been found, this will be called to get the data
-         * associated with the record so the backend can set up soa and zoneId
-         * respectively.  soa->qname does not need to be set. Return false if
+         * associated with the record so the backend can set up soa.
+         * soa->qname does not need to be set. Return false if
          * there is a problem getting the data.
          * */
         virtual bool getAuthData( SOAData &soa, DNSPacket *p=0) { return false; };  // Must be overridden
 
-        bool getAuth(DNSPacket *p, SOAData *soa, const string &inZone, int *zoneId, const int best_match_len);
-        inline int _getAuth(DNSPacket *p, SOAData *soa, const string &inZone, int *zoneId, const string &querykey, const int best_match_len);
+        bool getAuth(DNSPacket *p, SOAData *soa, const string &inZone, const int best_match_len);
+        inline int _getAuth(DNSPacket *p, SOAData *soa, const string &inZone, const string &querykey, const int best_match_len);
 
         /* Only called for stuff like signing or AXFR transfers */
         bool _getSOA(const string &rev_zone, SOAData &soa, DNSPacket *p);

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -378,8 +378,6 @@ protected:
   bool mustDo(const string &key);
   const string &getArg(const string &key);
   int getArgAsNum(const string &key);
-  string getRemote(DNSPacket *p);
-  bool getRemote(DNSPacket *p, struct sockaddr *in, Utility::socklen_t *len);
 
 private:
   string d_prefix;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -90,7 +90,7 @@ struct TSIGKey {
 
 class DNSPacket;
 
-//! This virtual base class defines the interface for backends for the ahudns. 
+//! This virtual base class defines the interface for backends for the ahudns.
 /** To create a backend, inherit from this class and implement functions for all virtual methods.
     Methods should not throw an exception if they are sure they did not find the requested data. However,
     if an error occurred which prevented them temporarily from performing a lockup, they should throw a DBException,

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -589,7 +589,7 @@ void DNSPacket::commitD()
   d_rawpacket.replace(0,12,(char *)&d,12); // copy in d
 }
 
-bool checkForCorrectTSIG(const DNSPacket* q, DNSBackend* B, string* keyname, string* secret, TSIGRecordContent* trc)
+bool checkForCorrectTSIG(const DNSPacket* q, UeberBackend* B, string* keyname, string* secret, TSIGRecordContent* trc)
 {
   string message;
 

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -60,7 +60,7 @@
  #endif // HAVE_CONFIG_H
 
 
-class DNSBackend;
+class UeberBackend;
 class DNSSECKeeper;
 
 //! This class represents DNS packets, either received or to be sent.
@@ -179,6 +179,6 @@ private:
 };
 
 
-bool checkForCorrectTSIG(const DNSPacket* q, DNSBackend* B, string* keyname, string* secret, TSIGRecordContent* trc);
+bool checkForCorrectTSIG(const DNSPacket* q, UeberBackend* B, string* keyname, string* secret, TSIGRecordContent* trc);
 
 #endif

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -7,6 +7,7 @@
 #include <vector>
 #include <map>
 #include "misc.hh"
+#include "ueberbackend.hh"
 
 // rules of the road: Algorithm must be set in 'make' for each KeyEngine, and will NEVER change!
 
@@ -119,7 +120,7 @@ struct DNSSECPrivateKey;
 
 void fillOutRRSIG(DNSSECPrivateKey& dpk, const std::string& signQName, RRSIGRecordContent& rrc, vector<shared_ptr<DNSRecordContent> >& toSign);
 uint32_t getStartOfWeek();
-void addSignature(DNSSECKeeper& dk, DNSBackend& db, const std::string& signer, const std::string signQName, const std::string& wildcardname, uint16_t signQType, uint32_t signTTL, DNSPacketWriter::Place signPlace, 
+void addSignature(DNSSECKeeper& dk, UeberBackend& db, const std::string& signer, const std::string signQName, const std::string& wildcardname, uint16_t signQType, uint32_t signTTL, DNSPacketWriter::Place signPlace,
   vector<shared_ptr<DNSRecordContent> >& toSign, vector<DNSResourceRecord>& outsigned, uint32_t origTTL);
 int getRRSIGsForRRSET(DNSSECKeeper& dk, const std::string& signer, const std::string signQName, uint16_t signQType, uint32_t signTTL,
   vector<shared_ptr<DNSRecordContent> >& toSign, vector<RRSIGRecordContent> &rrc);
@@ -127,7 +128,7 @@ int getRRSIGsForRRSET(DNSSECKeeper& dk, const std::string& signer, const std::st
 std::string hashQNameWithSalt(unsigned int times, const std::string& salt, const std::string& qname);
 void decodeDERIntegerSequence(const std::string& input, vector<string>& output);
 class DNSPacket;
-void addRRSigs(DNSSECKeeper& dk, DNSBackend& db, const std::set<string, CIStringCompare>& authMap, vector<DNSResourceRecord>& rrs);
+void addRRSigs(DNSSECKeeper& dk, UeberBackend& db, const std::set<string, CIStringCompare>& authMap, vector<DNSResourceRecord>& rrs);
 
 typedef enum { TSIG_MD5, TSIG_SHA1, TSIG_SHA224, TSIG_SHA256, TSIG_SHA384, TSIG_SHA512 } TSIGHashEnum;
 

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -86,7 +86,7 @@ public:
   bool unsetNSEC3PARAM(const std::string& zname);
   void clearAllCaches();
   void clearCaches(const std::string& name);
-  bool getPreRRSIGs(DNSBackend& db, const std::string& signer, const std::string& qname, const std::string& wildcardname, const QType& qtype, DNSPacketWriter::Place, vector<DNSResourceRecord>& rrsigs, uint32_t signTTL);
+  bool getPreRRSIGs(UeberBackend& db, const std::string& signer, const std::string& qname, const std::string& wildcardname, const QType& qtype, DNSPacketWriter::Place, vector<DNSResourceRecord>& rrsigs, uint32_t signTTL);
   bool isPresigned(const std::string& zname);
   bool setPresigned(const std::string& zname);
   bool unsetPresigned(const std::string& zname);

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -86,7 +86,7 @@ int getRRSIGsForRRSET(DNSSECKeeper& dk, const std::string& signer, const std::st
 }
 
 // this is the entrypoint from DNSPacket
-void addSignature(DNSSECKeeper& dk, DNSBackend& db, const std::string& signer, const std::string signQName, const std::string& wildcardname, uint16_t signQType, 
+void addSignature(DNSSECKeeper& dk, UeberBackend& db, const std::string& signer, const std::string signQName, const std::string& wildcardname, uint16_t signQType,
   uint32_t signTTL, DNSPacketWriter::Place signPlace, 
   vector<shared_ptr<DNSRecordContent> >& toSign, vector<DNSResourceRecord>& outsigned, uint32_t origTTL)
 {
@@ -196,7 +196,7 @@ static bool getBestAuthFromSet(const set<string, CIStringCompare>& authSet, cons
   return false;
 }
 
-void addRRSigs(DNSSECKeeper& dk, DNSBackend& db, const set<string, CIStringCompare>& authSet, vector<DNSResourceRecord>& rrs)
+void addRRSigs(DNSSECKeeper& dk, UeberBackend& db, const set<string, CIStringCompare>& authSet, vector<DNSResourceRecord>& rrs)
 {
   stable_sort(rrs.begin(), rrs.end(), rrsigncomp);
   

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -40,7 +40,7 @@
 #include "namespaces.hh"
 
 
-void CommunicatorClass::queueNotifyDomain(const string &domain, DNSBackend *B)
+void CommunicatorClass::queueNotifyDomain(const string &domain, UeberBackend *B)
 {
   bool hasQueuedItem=false;
   set<string> nsset, ips;
@@ -124,7 +124,7 @@ void CommunicatorClass::masterUpdateCheck(PacketHandler *P)
   if(!::arg().mustDo("master"))
     return; 
 
-  UeberBackend *B=dynamic_cast<UeberBackend *>(P->getBackend());
+  UeberBackend *B=P->getBackend();
   vector<DomainInfo> cmdomains;
   B->getUpdatedMasters(&cmdomains);
   

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -986,8 +986,7 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
   *shouldRecurse=false;
   DNSResourceRecord rr;
   SOAData sd;
-  sd.db=0;
-  
+
   string subdomain="";
   string soa;
   int retargetcount=0;
@@ -1116,7 +1115,7 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
       return r;
     }
     
-    if(!B.getAuth(p, &sd, target, 0)) {
+    if(!B.getAuth(p, &sd, target)) {
       DLOG(L<<Logger::Error<<"We have no authority over zone '"<<target<<"'"<<endl);
       if(r->d.ra) {
         DLOG(L<<Logger::Error<<"Recursion is available for this remote, doing that"<<endl);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -80,7 +80,7 @@ PacketHandler::PacketHandler():B(s_programname)
 
 }
 
-DNSBackend *PacketHandler::getBackend()
+UeberBackend *PacketHandler::getBackend()
 {
   return &B;
 }
@@ -410,7 +410,7 @@ void PacketHandler::emitNSEC(const std::string& begin, const std::string& end, c
   r->addRecord(rr);
 }
 
-void emitNSEC3(DNSBackend& B, const NSEC3PARAMRecordContent& ns3prc, const SOAData& sd, const std::string& unhashed, const std::string& begin, const std::string& end, const std::string& toNSEC3, DNSPacket *r, int mode)
+void emitNSEC3(UeberBackend& B, const NSEC3PARAMRecordContent& ns3prc, const SOAData& sd, const std::string& unhashed, const std::string& begin, const std::string& end, const std::string& toNSEC3, DNSPacket *r, int mode)
 {
   // cerr<<"We should emit NSEC3 '"<<toBase32Hex(begin)<<"' - ('"<<toNSEC3<<"') - '"<<toBase32Hex(end)<<"' (unhashed: '"<<unhashed<<"')"<<endl;
   NSEC3RecordContent n3rc;

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -544,8 +544,7 @@ void PacketHandler::addNSEC3(DNSPacket *p, DNSPacket *r, const string& target, c
   DLOG(L<<"addNSEC3() mode="<<mode<<" auth="<<auth<<" target="<<target<<" wildcard="<<wildcard<<endl);
 
   SOAData sd;
-  sd.db = (DNSBackend*)-1; // force uncached answer
-  if(!B.getSOA(auth, sd)) {
+  if(!B.getSOAUncached(auth, sd)) {
     DLOG(L<<"Could not get SOA for domain");
     return;
   }
@@ -638,8 +637,7 @@ void PacketHandler::addNSEC(DNSPacket *p, DNSPacket *r, const string& target, co
   DLOG(L<<"addNSEC() mode="<<mode<<" auth="<<auth<<" target="<<target<<" wildcard="<<wildcard<<endl);
 
   SOAData sd;
-  sd.db=(DNSBackend *)-1; // force uncached answer
-  if(!B.getSOA(auth, sd)) {
+  if(!B.getSOAUncached(auth, sd)) {
     DLOG(L<<"Could not get SOA for domain"<<endl);
     return;
   }

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -61,7 +61,7 @@ public:
   static int numRunning(){return s_count;}; //!< Returns the number of running PacketHandlers. Called by Distributor
  
   void soaMagic(DNSResourceRecord *rr);
-  DNSBackend *getBackend();
+  UeberBackend *getBackend();
 
   int trySuperMasterSynchronous(DNSPacket *p);
 

--- a/pdns/pdnssec.cc
+++ b/pdns/pdnssec.cc
@@ -184,9 +184,8 @@ bool rectifyZone(DNSSECKeeper& dk, const std::string& zone)
   UeberBackend B("default");
   bool doTransaction=true; // but see above
   SOAData sd;
-  sd.db = (DNSBackend*)-1;
 
-  if(!B.getSOA(zone, sd)) {
+  if(!B.getSOAUncached(zone, sd)) {
     cerr<<"No SOA known for '"<<zone<<"', is such a zone in the database?"<<endl;
     return false;
   }
@@ -401,8 +400,7 @@ void rectifyAllZones(DNSSECKeeper &dk)
 int checkZone(DNSSECKeeper &dk, UeberBackend &B, const std::string& zone)
 {
   SOAData sd;
-  sd.db=(DNSBackend*)-1;
-  if(!B.getSOA(zone, sd)) {
+  if(!B.getSOAUncached(zone, sd)) {
     cout<<"[error] No SOA record present, or active, in zone '"<<zone<<"'"<<endl;
     cout<<"Checked 0 records of '"<<zone<<"', 1 errors, 0 warnings."<<endl;
     return 1;
@@ -613,8 +611,7 @@ int increaseSerial(const string& zone, DNSSECKeeper &dk)
 {
   UeberBackend B("default");
   SOAData sd;
-  sd.db=(DNSBackend*)-1;
-  if(!B.getSOA(zone, sd)) {
+  if(!B.getSOAUncached(zone, sd)) {
     cout<<"No SOA for zone '"<<zone<<"'"<<endl;
     return -1;
   }

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -71,7 +71,7 @@ void CommunicatorClass::suck(const string &domain,const string &remote)
   di.backend=0;
   bool transaction=false;
   try {
-    UeberBackend *B=dynamic_cast<UeberBackend *>(P.getBackend());  // copy of the same UeberBackend
+    UeberBackend *B=P.getBackend();  // copy of the same UeberBackend
     DNSSECKeeper dk (B); // reuse our UeberBackend copy for DNSSECKeeper
 
     if(!B->getDomainInfo(domain, di) || !di.backend) { // di.backend and B are mostly identical
@@ -519,7 +519,7 @@ void CommunicatorClass::addTrySuperMasterRequest(DNSPacket *p)
 
 void CommunicatorClass::slaveRefresh(PacketHandler *P)
 {
-  UeberBackend *B=dynamic_cast<UeberBackend *>(P->getBackend());
+  UeberBackend *B=P->getBackend();
   vector<DomainInfo> rdomains;
   vector<DomainNotificationInfo> sdomains; // the bool is for 'presigned'
   vector<DNSPacket> trysuperdomains;

--- a/pdns/testrunner.cc
+++ b/pdns/testrunner.cc
@@ -2,4 +2,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE unit
 
+#include "packetcache.hh"
+PacketCache PC;
+
 #include <boost/test/unit_test.hpp>

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -54,7 +54,6 @@ vector<UeberBackend *>UeberBackend::instances;
 pthread_mutex_t UeberBackend::instances_lock=PTHREAD_MUTEX_INITIALIZER;
 
 sem_t UeberBackend::d_dynserialize;
-string UeberBackend::s_status;
 
 // initially we are blocked
 bool UeberBackend::d_go=false;
@@ -397,11 +396,6 @@ bool UeberBackend::superMasterBackend(const string &ip, const string &domain, co
     if((*i)->superMasterBackend(ip, domain, nsset, nameserver, account, db))
       return true;
   return false;
-}
-
-void UeberBackend::setStatus(const string &st)
-{
-  s_status=st;
 }
 
 UeberBackend::UeberBackend(const string &pname)

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -419,12 +419,6 @@ UeberBackend::UeberBackend(const string &pname)
   backends=BackendMakers().all(pname=="key-only");
 }
 
-void UeberBackend::die()
-{
-  cleanup();
-  stale=true;
-}
-
 void del(DNSBackend* d)
 {
   delete d;

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -108,7 +108,7 @@ bool UeberBackend::createDomain(const string &domain)
   return false;
 }
 
-int UeberBackend::addDomainKey(const string& name, const KeyData& key)
+int UeberBackend::addDomainKey(const string& name, const DNSBackend::KeyData& key)
 {
   int ret;
   BOOST_FOREACH(DNSBackend* db, backends) {
@@ -117,7 +117,7 @@ int UeberBackend::addDomainKey(const string& name, const KeyData& key)
   }
   return -1;
 }
-bool UeberBackend::getDomainKeys(const string& name, unsigned int kind, std::vector<KeyData>& keys)
+bool UeberBackend::getDomainKeys(const string& name, unsigned int kind, std::vector<DNSBackend::KeyData>& keys)
 {
   BOOST_FOREACH(DNSBackend* db, backends) {
     if(db->getDomainKeys(name, kind, keys))

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -60,8 +60,6 @@ bool UeberBackend::d_go=false;
 pthread_mutex_t  UeberBackend::d_mut = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t UeberBackend::d_cond = PTHREAD_COND_INITIALIZER;
 
-int UeberBackend::s_s=-1; // ?
-
 #ifdef NEED_RTLD_NOW
 #define RTLD_NOW RTLD_LAZY
 #endif

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -271,7 +271,7 @@ void UeberBackend::getUpdatedMasters(vector<DomainInfo>* domains)
   }
 }
 
-bool UeberBackend::getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId)
+bool UeberBackend::getAuth(DNSPacket *p, SOAData *sd, const string &target)
 {
   int best_match_len = -1;
   bool from_cache = false;  // Was this result fetched from the cache?
@@ -312,7 +312,7 @@ bool UeberBackend::getAuth(DNSPacket *p, SOAData *sd, const string &target, int 
   }
 
   for(vector<DNSBackend *>::const_iterator i=backends.begin(); i!=backends.end();++i)
-    if((*i)->getAuth(p, sd, target, zoneId, best_match_len)) {
+    if((*i)->getAuth(p, sd, target, best_match_len)) {
         best_match_len = sd->qname.length();
         from_cache = false;
 

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -43,8 +43,6 @@
 
 #include "namespaces.hh"
 
-class BackendReporter;
-
 /** This is a very magic backend that allows us to load modules dynamically,
     and query them in order. This is persistent over all UeberBackend instantiations
     across multiple threads. 
@@ -60,11 +58,6 @@ public:
   typedef DNSBackend *BackendMaker(); //!< typedef for functions returning pointers to new backends
 
   bool superMasterBackend(const string &ip, const string &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db);
-
-  /** contains BackendReporter objects, which contain maker functions and information about
-      weather a module has already been reported to existing instances of the UeberBackend
-  */
-//  static vector<BackendReporter>backendmakers;
 
   /** Tracks all created UeberBackend instances for us. We use this vector to notify
       existing threads of new modules 
@@ -170,23 +163,6 @@ private:
   
   bool stale;
   int domain_id;
-};
-
-
-/** Class used to report new backends. It stores a maker function, and a flag that indicates that 
-    this module has been reported */
-class BackendReporter
-{
-public:
-  BackendReporter(UeberBackend::BackendMaker *p)
-  {
-    maker=p;
-    reported=false;
-  };
-  map<string,string>d_parameters;
-  UeberBackend::BackendMaker *maker; //!< function to make this backend
-  bool reported; //!< if this backend has been reported to running UeberBackend threads 
-private:
 };
 
 #endif

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -119,8 +119,6 @@ public:
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false);
 
   static DNSBackend *maker(const map<string,string> &);
-  static void closeDynListener();
-  static void setStatus(const string &st);
   void getUnfreshSlaveInfos(vector<DomainInfo>* domains);
   void getUpdatedMasters(vector<DomainInfo>* domains);
   bool getDomainInfo(const string &domain, DomainInfo &di);
@@ -173,7 +171,6 @@ private:
   static sem_t d_dynserialize;
   static bool d_go;
   static int s_s;
-  static string s_status; 
   int d_ancount;
   
   bool stale;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -52,7 +52,7 @@ class BackendReporter;
     The UeberBackend is transparent for exceptions, which should fall straight through.
 */
 
-class UeberBackend : public DNSBackend, public boost::noncopyable
+class UeberBackend : public boost::noncopyable
 {
 public:
   UeberBackend(const string &pname="default");
@@ -113,11 +113,6 @@ public:
 
   void lookup(const QType &, const string &qdomain, DNSPacket *pkt_p=0,  int zoneId=-1);
 
-  /* 5-arg version is only valid for backends and should never be called directly */
-  virtual bool getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId, const int best_match_len) {
-    throw PDNSException("5-arg version of getAuth should not be called in UeberBackend");
-  }
-
   bool getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId);
   bool getSOA(const string &domain, SOAData &sd, DNSPacket *p=0);
   bool list(const string &target, int domain_id, bool include_disabled=false);
@@ -132,8 +127,8 @@ public:
   bool getDomainInfo(const string &domain, DomainInfo &di);
   bool createDomain(const string &domain);
   
-  int addDomainKey(const string& name, const KeyData& key);
-  bool getDomainKeys(const string& name, unsigned int kind, std::vector<KeyData>& keys);
+  int addDomainKey(const string& name, const DNSBackend::KeyData& key);
+  bool getDomainKeys(const string& name, unsigned int kind, std::vector<DNSBackend::KeyData>& keys);
   bool getAllDomainMetadata(const string& name, std::map<std::string, std::vector<std::string> >& meta);
   bool getDomainMetadata(const string& name, const std::string& kind, std::vector<std::string>& meta);
   bool setDomainMetadata(const string& name, const std::string& kind, const std::vector<std::string>& meta);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -170,7 +170,6 @@ private:
   static pthread_cond_t d_cond;
   static sem_t d_dynserialize;
   static bool d_go;
-  static int s_s;
   int d_ancount;
   
   bool stale;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -102,7 +102,7 @@ public:
 
   void lookup(const QType &, const string &qdomain, DNSPacket *pkt_p=0,  int zoneId=-1);
 
-  bool getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId);
+  bool getAuth(DNSPacket *p, SOAData *sd, const string &target);
   bool getSOA(const string &domain, SOAData &sd, DNSPacket *p=0);
   bool getSOAUncached(const string &domain, SOAData &sd, DNSPacket *p=0);  // same, but ignores cache
   bool list(const string &target, int domain_id, bool include_disabled=false);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -104,6 +104,7 @@ public:
 
   bool getAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId);
   bool getSOA(const string &domain, SOAData &sd, DNSPacket *p=0);
+  bool getSOAUncached(const string &domain, SOAData &sd, DNSPacket *p=0);  // same, but ignores cache
   bool list(const string &target, int domain_id, bool include_disabled=false);
   bool get(DNSResourceRecord &r);
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -83,7 +83,6 @@ public:
       new modules are loaded */
   vector<DNSBackend*> backends; 
 
-  void die();
   void cleanup();
 
   //! the very magic handle for UeberBackend questions

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -74,9 +74,6 @@ public:
 
   static bool loadmodule(const string &name);
 
-  /** Thread function that listens on our unix domain socket for commands, for example
-      instructions to load new modules */
-  static void *DynListener(void *);
   static void go(void);
 
   /** This contains all registered backends. The DynListener modifies this list for us when

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -148,7 +148,6 @@ public:
 private:
   unsigned int d_cache_ttl, d_negcache_ttl;
 
-  DNSResourceRecord lastrr;
   pthread_t tid;
   handle d_handle;
   bool d_negcached;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -414,7 +414,7 @@ static void gatherRecords(const Value& container, vector<DNSResourceRecord>& new
         DNSPacket fakePacket;
         SOAData sd;
         fakePacket.qtype = QType::PTR;
-        if (!B.getAuth(&fakePacket, &sd, ptr.qname, 0))
+        if (!B.getAuth(&fakePacket, &sd, ptr.qname))
           throw ApiException("Could not find domain for PTR '"+ptr.qname+"' requested for '"+ptr.content+"'");
 
         ptr.domain_id = sd.domain_id;
@@ -1049,7 +1049,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
     sd.db = (DNSBackend *)-1;  // getAuth() cache bypass
     fakePacket.qtype = QType::PTR;
 
-    if (!B.getAuth(&fakePacket, &sd, rr.qname, 0))
+    if (!B.getAuth(&fakePacket, &sd, rr.qname))
       throw ApiException("Could not find domain for PTR '"+rr.qname+"' requested for '"+rr.content+"' (while saving)");
 
     sd.db->startTransaction(rr.qname);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1046,7 +1046,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
   BOOST_FOREACH(const DNSResourceRecord& rr, new_ptrs) {
     DNSPacket fakePacket;
     SOAData sd;
-    sd.db = (DNSBackend *)-1;
+    sd.db = (DNSBackend *)-1;  // getAuth() cache bypass
     fakePacket.qtype = QType::PTR;
 
     if (!B.getAuth(&fakePacket, &sd, rr.qname, 0))


### PR DESCRIPTION
Makes it clear who calls what where.

Plus remove unused stuff from UeberBackend, and cleanup getSOA.