### PR TITLE
Ship effective_tld_names.dat in tarball

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -34,6 +34,7 @@ endif
 EXTRA_DIST = \
 	dnslabeltext.rl \
 	dnslabeltext.cc \
+	effective_tld_names.dat \
 	mtasker.cc \
 	inflighter.cc \
 	bind-dnssec.schema.sqlite3.sql \


### PR DESCRIPTION
pubsuffix.cc is generated code, so we need the source.
make[3]: *** No rule to make target '../../../pdns/effective_tld_names.dat', needed by 'pubsuffix.cc'. Stop.