### PR TITLE
RFC2136 to ignore serial update when using autoserial

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -948,6 +948,11 @@ void PacketHandler::increaseSerial(const string &msgPrefix, const DomainInfo *di
   fillSOAData(rec.content, soa2Update);
   int oldSerial = soa2Update.serial;
 
+  if (oldSerial == 0) { // using Autoserial, leave the serial alone.
+    L<<Logger::Notice<<msgPrefix<<"AutoSerial being used, not updating SOA serial."<<endl;
+    return;
+  }
+
   vector<string> soaEdit2136Setting;
   B.getDomainMetadata(di->zone, "SOA-EDIT-DNSUPDATE", soaEdit2136Setting);
   string soaEdit2136 = "DEFAULT";


### PR DESCRIPTION
Fixes #2066


There are unfortunately no tests that use autoserial, so to make this pull request a bit better, a autoserial test would be needed and also checked against RFC2136