### PR TITLE
Auth API: fix missing abortTransaction() in error case

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1086,6 +1086,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
 
     sd.db->startTransaction(rr.qname);
     if (!sd.db->replaceRRSet(sd.domain_id, rr.qname, rr.qtype, vector<DNSResourceRecord>(1, rr))) {
+      sd.db->abortTransaction();
       throw ApiException("PTR-Hosting backend for "+rr.qname+"/"+rr.qtype.getName()+" does not support editing records.");
     }
     sd.db->commitTransaction();


### PR DESCRIPTION
Noticed by Aki Tuomi.
(cherry picked from commit d0f4bb3825281f6acb84477d6879cc494ffa1aaa)