### PR TITLE
Readd exec_prefix to pdns.init.in

### DIFF
--- a/pdns/pdns.init.in
+++ b/pdns/pdns.init.in
@@ -16,6 +16,7 @@
 
 set -e
 
+exec_prefix=@exec_prefix@
 BINARYPATH=@bindir@
 SBINARYPATH=@sbindir@
 SOCKETPATH=@socketdir@


### PR DESCRIPTION
automake doesn't completely expand variables like @bindir@, so we need
to keep ${exec_prefix} in there.

Fixes #2204