### PR TITLE
Add support for binding non-local addresses on linux

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -58,6 +58,7 @@ void declareArguments()
   ::arg().setSwitch("local-address-nonexist-fail","Fail to start if one or more of the local-address's do not exist on this server")="yes";
   ::arg().set("local-ipv6","Local IP address to which we bind")="";
   ::arg().setSwitch("reuseport","Enable higher performance on compliant kernels by using SO_REUSEPORT allowing each receiver thread to open its own socket")="no";
+  ::arg().setSwitch("local-bind-transparent", "Enable binding to non-local addresses by using the IP_TRANSPARENT socket option")="no";
   ::arg().setSwitch("local-ipv6-nonexist-fail","Fail to start if one or more of the local-ipv6 addresses do not exist on this server")="yes";
   ::arg().set("query-local-address","Source IP address for sending queries")="0.0.0.0";
   ::arg().set("query-local-address6","Source IPv6 address for sending queries")="::";

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -123,6 +123,11 @@ void UDPNameserver::bindIPv4()
           d_can_reuseport = false;
 #endif
 
+#ifdef IP_TRANSPARENT
+    if( ::arg().mustDo("local-bind-transparent") )
+        setsockopt(s, IPPROTO_IP, IP_TRANSPARENT, &one, sizeof(one));
+#endif
+
     locala=ComboAddress(localname, ::arg().asNum("local-port"));
     if(locala.sin4.sin_family != AF_INET) 
       throw PDNSException("Attempting to bind IPv4 socket to IPv6 address");
@@ -221,6 +226,11 @@ void UDPNameserver::bindIPv6()
     if( d_can_reuseport )
         if( setsockopt(s, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) )
           d_can_reuseport = false;
+#endif
+
+#ifdef IP_TRANSPARENT
+    if( ::arg().mustDo("local-bind-transparent") )
+        setsockopt(s, IPPROTO_IP, IP_TRANSPARENT, &one, sizeof(one));
 #endif
 
     if( !d_additional_socket )

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2243,6 +2243,7 @@ int main(int argc, char **argv)
     ::arg().set("no-shuffle","Don't change")="off";
     ::arg().set("local-port","port to listen on")="53";
     ::arg().set("local-address","IP addresses to listen on, separated by spaces or commas. Also accepts ports.")="127.0.0.1";
+    ::arg().setSwitch("local-bind-transparent", "Enable binding to non-local addresses by using the IP_TRANSPARENT socket option")="no";
     ::arg().set("trace","if we should output heaps of logging. set to 'fail' to only log failing domains")="off";
     ::arg().set("daemon","Operate as a daemon")="yes";
     ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1125,6 +1125,11 @@ void makeTCPServerSockets()
     }
 #endif
 
+#ifdef IP_TRANSPARENT
+    if( ::arg().mustDo("local-bind-transparent") )
+        setsockopt(fd, IPPROTO_IP, IP_TRANSPARENT, &tmp, sizeof(tmp));
+#endif
+
     sin.sin4.sin_port = htons(st.port);
     int socklen=sin.sin4.sin_family==AF_INET ? sizeof(sin.sin4) : sizeof(sin.sin6);
     if (::bind(fd, (struct sockaddr *)&sin, socklen )<0) 
@@ -1146,6 +1151,7 @@ void makeTCPServerSockets()
 
 void makeUDPServerSockets()
 {
+  int one=1;
   vector<string>locals;
   stringtok(locals,::arg()["local-address"]," ,");
 
@@ -1174,7 +1180,6 @@ void makeUDPServerSockets()
     setSocketTimestamps(fd);
 
     if(IsAnyAddress(sin)) {
-      int one=1;
       setsockopt(fd, IPPROTO_IP, GEN_IP_PKTINFO, &one, sizeof(one));     // linux supports this, so why not - might fail on other systems
       setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &one, sizeof(one)); 
       if(sin.sin6.sin6_family == AF_INET6 && setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one)) < 0) {
@@ -1182,6 +1187,11 @@ void makeUDPServerSockets()
       }
 
     }
+
+#ifdef IP_TRANSPARENT
+    if( ::arg().mustDo("local-bind-transparent") )
+        setsockopt(fd, IPPROTO_IP, IP_TRANSPARENT, &one, sizeof(one));
+#endif
 
     Utility::setCloseOnExec(fd);
 


### PR DESCRIPTION
Binding to floating ip-addresses is desirable when using common failover strategies (vrrp, keepalived).
Linux has a special socket option to allow binding to addresses that are not local to the host.

This adds support for the socket option, with a new config option (disabled by default)