### PR TITLE
Bring pdnssec algs inline with pdnssec source

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -115,13 +115,12 @@ Must be one of:
 * dsa
 * ecc
 * rsasha1
-* dsa-nsec3-sha1
-* rsasha1-nsec3-sha1
 * rsasha256
 * rsasha512
 * ecc-gost
-* ecdsap256sha256
-* ecdsap384sha384
+* ecdsa256 (ECDSA P-256 with SHA256)
+* ecdsa384 (ECDSA P-384 with SHA384)
+* ed25519
 
 ## `default-ksk-size`
 * Integer
@@ -159,13 +158,12 @@ Must be one of:
 * dsa
 * ecc
 * rsasha1
-* dsa-nsec3-sha1
-* rsasha1-nsec3-sha1
 * rsasha256
 * rsasha512
 * ecc-gost
-* ecdsap256sha256
-* ecdsap384sha384
+* ecdsa256 (ECDSA P-256 with SHA256)
+* ecdsa384 (ECDSA P-384 with SHA384)
+* ed25519
 
 ## `default-zsk-size`
 * Integer


### PR DESCRIPTION
* Changed the algorithms to be inline with shorthand2algorithm()
  from pdns/pdnssec.c
* Might need to clarify what the other algorithms are, too