### PR TITLE
Fix typo

### DIFF
--- a/docs/markdown/changelog.md.raw
+++ b/docs/markdown/changelog.md.raw
@@ -148,7 +148,7 @@ Bugs fixed:
   a6414fdce9b0ec32c340d1f2eea2254f3fedc1c1
 - Timestamps used for dropping packets were occasionaly wrong 183eb8774e4bc2569f06d5894fec65740f4b70b6 and 4c4765c104bacc146533217bcc843efb244a8086 
   (RC2) with thanks to Winfried for debugging.
-- In RC1, our new DoS protection measures would crash the Recursor if too many root sersvers were unreachable.
+- In RC1, our new DoS protection measures would crash the Recursor if too many root servers were unreachable.
   6a6fb05ad81c519b4002ed1db00f3ed9b7bce6b4. Debugging and testing by Fusl.
 
  


### PR DESCRIPTION
Fix a typo as noticed on http://blog.powerdns.com/2015/02/12/powerdns-recursor-3-7-1-released/