### PR TITLE
Use an explit rule to turn ragel into C++

### DIFF
--- a/pdns/Makefile-recursor
+++ b/pdns/Makefile-recursor
@@ -66,7 +66,7 @@ LDFLAGS += $(PROFILEFLAGS) $(STATICFLAGS)
 CXXFLAGS += -DSYSCONFDIR='"$(SYSCONFDIR)"' -DLOCALSTATEDIR='"$(LOCALSTATEDIR)"'
 CFLAGS += -DSYSCONFDIR='"$(SYSCONFDIR)"' -DLOCALSTATEDIR='"$(LOCALSTATEDIR)"'
 
-%.cc: %.rl
+dnslabeltext.cc: dnslabeltext.rl
 	ragel $< -o $@
 
 # Version


### PR DESCRIPTION
The implicit rule causes Make to search for a .rl
file for each .cc file