### PR TITLE
0MQ remotebackend requires remote backend itself

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,7 +183,6 @@ PDNS_ENABLE_BOTAN
 PDNS_ENABLE_PKCS11
 PDNS_WITH_CRYPTOPP
 PDNS_ENABLE_ED25519
-PDNS_ENABLE_REMOTEBACKEND_ZEROMQ
 
 AS_IF([test "x$static" != "xno"], [
   LDFLAGS="-all-static $LDFLAGS"
@@ -264,6 +263,9 @@ for a in $modules $dynmodules; do
     opendbx)
       PDNS_CHECK_OPENDBX
       ;;
+    remote)
+      have_remotebackend=yes
+      ;;
     tinydns)
       PDNS_CHECK_CDB
       ;;
@@ -280,6 +282,8 @@ for a in $modules $dynmodules; do
       ;;
   esac
 done
+
+PDNS_ENABLE_REMOTEBACKEND_ZEROMQ
 
 AM_CONDITIONAL([ORACLE],[test "x$needoracle" = "xyes"])
 

--- a/m4/pdns_enable_remotebackend_zeromq.m4
+++ b/m4/pdns_enable_remotebackend_zeromq.m4
@@ -12,27 +12,34 @@ AC_DEFUN([PDNS_ENABLE_REMOTEBACKEND_ZEROMQ],[
 
   AM_CONDITIONAL([REMOTEBACKEND_ZEROMQ],[test "x$enable_remotebackend_zeromq" != "xno"])
   AC_SUBST(REMOTEBACKEND_ZEROMQ)
+
   AS_IF([test "x$enable_remotebackend_zeromq" != "xno"],
-    [PKG_CHECK_MODULES([LIBZMQ], [libzmq],
-      [
-        AC_DEFINE([HAVE_LIBZMQ], [1], [Define to 1 if you have libzmq])
-        AC_DEFINE([REMOTEBACKEND_ZEROMQ], [1], [Define to 1 if you have the ZeroMQ connector])
-        REMOTEBACKEND_ZEROMQ=yes
+    [
+      AS_IF([test "x$have_remotebackend" == "xyes"],
+        [
+          PKG_CHECK_MODULES([LIBZMQ], [libzmq],
+            [
+              AC_DEFINE([HAVE_LIBZMQ], [1], [Define to 1 if you have libzmq])
+              AC_DEFINE([REMOTEBACKEND_ZEROMQ], [1], [Define to 1 if you have the ZeroMQ connector])
+              REMOTEBACKEND_ZEROMQ=yes
+            ],
+            [AC_MSG_ERROR([Could not find libzmq])]
+          )
 
-      ],
-      [AC_MSG_ERROR([Could not find libzmq])]
-    )]
-
-    old_CXXFLAGS="$CXXFLAGS"
-    old_LDFLAGS="$LDFLAGS"
-    CXXFLAGS="$CFLAGS $LIBZMQ_CFLAGS"
-    LDFLAGS="$LDFLAGS $LIBZMQ_LIBS"
-    AC_CHECK_LIB([zmq], [zmq_msg_send],
-      [
-        AC_DEFINE([HAVE_ZMQ_MSG_SEND], [1], [Define to 1 if the ZeroMQ 3.x or greater API is available])
-      ])
-    CXXFLAGS="$old_CXXFLAGS"
-    LDFLAGS="$old_LDFLAGS"
+          old_CXXFLAGS="$CXXFLAGS"
+          old_LDFLAGS="$LDFLAGS"
+          CXXFLAGS="$CFLAGS $LIBZMQ_CFLAGS"
+          LDFLAGS="$LDFLAGS $LIBZMQ_LIBS"
+          AC_CHECK_LIB([zmq], [zmq_msg_send],
+            [
+              AC_DEFINE([HAVE_ZMQ_MSG_SEND], [1], [Define to 1 if the ZeroMQ 3.x or greater API is available])
+            ]
+          )
+          CXXFLAGS="$old_CXXFLAGS"
+          LDFLAGS="$old_LDFLAGS"
+        ],
+        [AC_MSG_ERROR([remotebackend \"zeromq\" selected but the \"remote\" backend itself is not selected. Please add \"remote\" to your modules or dynmodules list and re-run configure!])]
+      )
+    ]
   )
 ])
-


### PR DESCRIPTION
If you enable the 0MQ remotebackend with `--enable-remotebackend-zeromq` but don't have *remote* in `--with-modules` or `--with-dynmodules`, we actual won't build the 0MQ remotebacked, because it requires the *remote* backend itself.

This could lead to confusion, especially for package maintainers, when you enabled the 0MQ backend and everything builds without any errors but you cannot use the 0MQ remotebackend and you wonders why..

With this PR we will show the following error message to the user in this case:
```
checking whether to enable ZeroMQ connector in remotebackend... yes
configure: error: remotebackend "0MQ" selected but the "remote" backend itself is not selected. Please add "remote" to your modules or dynmodules list and re-run configure!
```