### PR TITLE
PacketHandler: Share UeberBackend with DNSSECKeeper

### DIFF
--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -231,8 +231,8 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
 
   const string& domain=parts[1];
   DomainInfo di;
-  PacketHandler P;
-  if(!P.getBackend()->getDomainInfo(domain, di))
+  UeberBackend B;
+  if(!B.getDomainInfo(domain, di))
     return "Domain '"+domain+"' unknown";
   
   if(di.masters.empty())
@@ -300,11 +300,11 @@ string DLNotifyHandler(const vector<string>&parts, Utility::pid_t ppid)
 
 string DLRediscoverHandler(const vector<string>&parts, Utility::pid_t ppid)
 {
-  PacketHandler P;
+  UeberBackend B;
   try {
     L<<Logger::Error<<"Rediscovery was requested"<<endl;
     string status="Ok";
-    P.getBackend()->rediscover(&status);
+    B.rediscover(&status);
     return status;
   }
   catch(PDNSException &ae) {
@@ -315,8 +315,8 @@ string DLRediscoverHandler(const vector<string>&parts, Utility::pid_t ppid)
 
 string DLReloadHandler(const vector<string>&parts, Utility::pid_t ppid)
 {
-  PacketHandler P;
-  P.getBackend()->reload();
+  UeberBackend B;
+  B.reload();
   L<<Logger::Error<<"Reload was requested"<<endl;
   return "Ok";
 }

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -99,12 +99,12 @@ void CommunicatorClass::queueNotifyDomain(const string &domain, UeberBackend *B)
 bool CommunicatorClass::notifyDomain(const string &domain)
 {
   DomainInfo di;
-  PacketHandler P;
-  if(!P.getBackend()->getDomainInfo(domain, di)) {
+  UeberBackend B;
+  if(!B.getDomainInfo(domain, di)) {
     L<<Logger::Error<<"No such domain '"<<domain<<"' in our database"<<endl;
     return false;
   }
-  queueNotifyDomain(domain, P.getBackend());
+  queueNotifyDomain(domain, &B);
   // call backend and tell them we sent out the notification - even though that is premature    
   di.backend->setNotified(di.id, di.serial);
 

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -58,7 +58,7 @@ enum root_referral {
     FULL_ROOT_REFERRAL
 };
 
-PacketHandler::PacketHandler():B(s_programname)
+PacketHandler::PacketHandler():B(s_programname), d_dk(&B)
 {
   ++s_count;
   d_doDNAME=::arg().mustDo("experimental-dname-processing");

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -111,7 +111,7 @@ private:
   AuthLua* d_pdl;
 
   UeberBackend B; // every thread an own instance
-  DNSSECKeeper d_dk; // same, might even share B?
+  DNSSECKeeper d_dk; // B is shared with DNSSECKeeper
 };
 void emitNSEC3(DNSBackend& B, const NSEC3PARAMRecordContent& ns3prc, const SOAData& sd, const std::string& unhashed, const std::string& begin, const std::string& end, const std::string& toNSEC3, DNSPacket *r, int mode);
 bool getNSEC3Hashes(bool narrow, DNSBackend* db, int id, const std::string& hashed, bool decrement, string& unhashed, string& before, string& after, int mode=0);

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -108,6 +108,5 @@ private:
   UeberBackend B; // every thread an own instance
   DNSSECKeeper d_dk; // B is shared with DNSSECKeeper
 };
-void emitNSEC3(DNSBackend& B, const NSEC3PARAMRecordContent& ns3prc, const SOAData& sd, const std::string& unhashed, const std::string& begin, const std::string& end, const std::string& toNSEC3, DNSPacket *r, int mode);
 bool getNSEC3Hashes(bool narrow, DNSBackend* db, int id, const std::string& hashed, bool decrement, string& unhashed, string& before, string& after, int mode=0);
 #endif /* PACKETHANDLER */

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -60,7 +60,6 @@ public:
   ~PacketHandler(); // defined in packethandler.cc, and does --count
   static int numRunning(){return s_count;}; //!< Returns the number of running PacketHandlers. Called by Distributor
  
-  void soaMagic(DNSResourceRecord *rr);
   UeberBackend *getBackend();
 
   int trySuperMasterSynchronous(DNSPacket *p);
@@ -69,13 +68,10 @@ private:
   int trySuperMaster(DNSPacket *p);
   int processNotify(DNSPacket *);
   void addRootReferral(DNSPacket *r);
-  int makeCanonic(DNSPacket *p, DNSPacket *r, string &target);
   int doChaosRequest(DNSPacket *p, DNSPacket *r, string &target);
   bool addDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd);
   bool addNSEC3PARAM(DNSPacket *p, DNSPacket *r, const SOAData& sd);
-  bool getTLDAuth(DNSPacket *p, SOAData *sd, const string &target, int *zoneId);
   int doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, const SOAData& sd, bool retargeted);
-  bool doDNSSECProcessing(DNSPacket* p, DNSPacket *r);
   void addNSECX(DNSPacket *p, DNSPacket* r, const string &target, const string &wildcard, const std::string &auth, int mode);
   void addNSEC(DNSPacket *p, DNSPacket* r, const string &target, const string &wildcard, const std::string& auth, int mode);
   void addNSEC3(DNSPacket *p, DNSPacket* r, const string &target, const string &wildcard, const std::string& auth, const NSEC3PARAMRecordContent& nsec3param, bool narrow, int mode);
@@ -88,7 +84,6 @@ private:
   int checkUpdatePrerequisites(const DNSRecord *rr, DomainInfo *di);
   void increaseSerial(const string &msgPrefix, const DomainInfo *di, bool haveNSEC3, bool narrow, const NSEC3PARAMRecordContent *ns3pr);
 
-  void synthesiseRRSIGs(DNSPacket* p, DNSPacket* r);
   void makeNXDomain(DNSPacket* p, DNSPacket* r, const std::string& target, const std::string& wildcard, SOAData& sd);
   void makeNOError(DNSPacket* p, DNSPacket* r, const std::string& target, const std::string& wildcard, SOAData& sd, int mode);
   vector<DNSResourceRecord> getBestReferralNS(DNSPacket *p, SOAData& sd, const string &target);

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -65,16 +65,15 @@ void CommunicatorClass::addSuckRequest(const string &domain, const string &maste
 void CommunicatorClass::suck(const string &domain,const string &remote)
 {
   L<<Logger::Error<<"Initiating transfer of '"<<domain<<"' from remote '"<<remote<<"'"<<endl;
-  PacketHandler P; // fresh UeberBackend
+  UeberBackend B; // fresh UeberBackend
 
   DomainInfo di;
   di.backend=0;
   bool transaction=false;
   try {
-    UeberBackend *B=P.getBackend();  // copy of the same UeberBackend
-    DNSSECKeeper dk (B); // reuse our UeberBackend copy for DNSSECKeeper
+    DNSSECKeeper dk (&B); // reuse our UeberBackend copy for DNSSECKeeper
 
-    if(!B->getDomainInfo(domain, di) || !di.backend) { // di.backend and B are mostly identical
+    if(!B.getDomainInfo(domain, di) || !di.backend) { // di.backend and B are mostly identical
       L<<Logger::Error<<"Can't determine backend for domain '"<<domain<<"'"<<endl;
       return;
     }
@@ -84,7 +83,7 @@ void CommunicatorClass::suck(const string &domain,const string &remote)
     string tsigkeyname, tsigalgorithm, tsigsecret;
     if(dk.getTSIGForAccess(domain, remote, &tsigkeyname)) {
       string tsigsecret64;
-      if(B->getTSIGKey(tsigkeyname, &tsigalgorithm, &tsigsecret64)) {
+      if(B.getTSIGKey(tsigkeyname, &tsigalgorithm, &tsigsecret64)) {
         B64Decode(tsigsecret64, tsigsecret);
       } else {
         L<<Logger::Error<<"TSIG key '"<<tsigkeyname<<"' for domain '"<<domain<<"' not found"<<endl;
@@ -95,7 +94,7 @@ void CommunicatorClass::suck(const string &domain,const string &remote)
 
     scoped_ptr<AuthLua> pdl;
     vector<string> scripts;
-    if(B->getDomainMetadata(domain, "LUA-AXFR-SCRIPT", scripts) && !scripts.empty()) {
+    if(B.getDomainMetadata(domain, "LUA-AXFR-SCRIPT", scripts) && !scripts.empty()) {
       try {
         pdl.reset(new AuthLua(scripts[0]));
         L<<Logger::Info<<"Loaded Lua script '"<<scripts[0]<<"' to edit the incoming AXFR of '"<<domain<<"'"<<endl;
@@ -108,7 +107,7 @@ void CommunicatorClass::suck(const string &domain,const string &remote)
 
     vector<string> localaddr;
     ComboAddress laddr;
-    if(B->getDomainMetadata(domain, "AXFR-SOURCE", localaddr) && !localaddr.empty()) {
+    if(B.getDomainMetadata(domain, "AXFR-SOURCE", localaddr) && !localaddr.empty()) {
       try {
         laddr = ComboAddress(localaddr[0]);
         L<<Logger::Info<<"AXFR source for domain '"<<domain<<"' set to "<<localaddr[0]<<endl;


### PR DESCRIPTION
Reduces number of backend instances by 50%, very relevant for setups
that have backends with huge startup/runtime cost.

(Plus related cleanup.)
