### PR TITLE
fix c++2011 detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,9 +35,6 @@ AC_DEFINE([_GNU_SOURCE], [1],
   [Define _GNU_SOURCE so that we get all necessary prototypes]
 )
 
-PDNS_WITH_LUA
-AX_CXX_COMPILE_STDCXX_11(,optional)
-AM_CONDITIONAL([CXX2011],[test "$HAVE_CXX11" = "1"])
 AC_ARG_ENABLE([hardening], [
   AS_HELP_STRING([--disable-hardening, disable compiler security checks])
 ])
@@ -98,10 +95,15 @@ AC_CHECK_HEADERS(
 
 PDNS_CHECK_RAGEL
 
+PDNS_WITH_LUA
+
 BOOST_REQUIRE([1.35])
 BOOST_FOREACH
 BOOST_PROGRAM_OPTIONS([mt])
 BOOST_SERIALIZATION([mt])
+
+AX_CXX_COMPILE_STDCXX_11(,optional)
+AM_CONDITIONAL([CXX2011],[test "$HAVE_CXX11" = "1"])
 
 PDNS_ENABLE_UNIT_TESTS
 

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -39,7 +39,6 @@
 m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
   #include <thread>
   #include <boost/shared_ptr.hpp>
-  #include "pdns/ext/luawrapper/include/LuaContext.hpp"
   void test() {
   boost::shared_ptr<int> one;
   boost::shared_ptr<int> two;

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -97,7 +97,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl
       AC_CACHE_CHECK(whether $CXX supports C++11 features with $switch,
                      $cachevar,
         [ac_save_CXXFLAGS="$CXXFLAGS"
-         CXXFLAGS="$LUA_CFLAGS $CXXFLAGS $switch"
+         CXXFLAGS="$CXXFLAGS $switch"
          AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_11_testbody])],
           [eval $cachevar=yes],
           [eval $cachevar=no])
@@ -117,7 +117,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl
       AC_CACHE_CHECK(whether $CXX supports C++11 features with $switch,
                      $cachevar,
         [ac_save_CXXFLAGS="$CXXFLAGS"
-         CXXFLAGS="$CXXFLAGS $LUA_CFLAGS $switch"
+         CXXFLAGS="$CXXFLAGS $switch"
          AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_11_testbody])],
           [eval $cachevar=yes],
           [eval $cachevar=no])

--- a/pdns/.gitignore
+++ b/pdns/.gitignore
@@ -48,3 +48,5 @@ version_generated.h
 /testrunner.log
 /testrunner.trs
 /pubsuffix.cc
+/calidns
+/dumresp

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -87,7 +87,10 @@ bin_PROGRAMS += \
 	saxfr
 
 if CXX2011
-bin_PROGRAMS += dnsdist calidns dumresp
+bin_PROGRAMS += calidns dumresp
+if LUA
+bin_PROGRAMS += dnsdist
+endif
 endif
 
 endif


### PR DESCRIPTION
C++2011 detection requires boost (and \<thread\> for some reason?) Don't test before we know boost is there
Only build dnsdist if lua is available