### PR TITLE
lua-auth.cc: Fix compiler warning

### DIFF
--- a/pdns/lua-auth.cc
+++ b/pdns/lua-auth.cc
@@ -347,7 +347,7 @@ string AuthLua::policycmd(const vector<string>&parts) {
     return "no policycmd function in policy script";
   }
 
-  for(int i=1; i<parts.size(); i++)
+  for(uint i=1; i<parts.size(); i++)
     lua_pushstring(d_lua, parts[i].c_str());
 
   if(lua_pcall(d_lua, parts.size()-1, 1, 0)) {


### PR DESCRIPTION
```
lua-auth.cc: In member function ‘string AuthLua::policycmd(const std::vector<std::basic_string<char> >&)’:
lua-auth.cc:350:17: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for(int i=1; i<parts.size(); i++)
```

