### PR TITLE
Fix automake warnings for remotebackend testsuite

### DIFF
--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -52,7 +52,6 @@ if REMOTEBACKEND_ZEROMQ
 libremotebackend_la_LIBADD += $(LIBZMQ_LIBS)
 endif
 
-if UNIT_TESTS
 TESTS_ENVIRONMENT = \
 	BOOST_TEST_LOG_LEVEL=message; \
 	export BOOST_TEST_LOG_LEVEL; \
@@ -62,14 +61,6 @@ TESTS_ENVIRONMENT = \
 TEST_EXTENSIONS = .test
 
 TEST_LOG_COMPILER = $(abs_srcdir)/testrunner.sh
-
-TESTS = \
-	remotebackend_pipe.test \
-	remotebackend_unix.test \
-	remotebackend_http.test \
-	remotebackend_post.test \
-	remotebackend_json.test \
-	remotebackend_zeromq.test
 
 RECHECK_LOGS = \
 	$(TEST_LOGS) \
@@ -85,6 +76,16 @@ RECHECK_LOGS = \
 remotebackend_post.log: remotebackend_http.log
 
 remotebackend_json.log: remotebackend_http.log remotebackend_post.log
+
+if UNIT_TESTS
+TESTS = \
+	remotebackend_pipe.test \
+	remotebackend_unix.test \
+	remotebackend_http.test \
+	remotebackend_post.test \
+	remotebackend_json.test \
+	remotebackend_zeromq.test
+
 endif
 
 BUILT_SOURCES = ../../pdns/dnslabeltext.cc


### PR DESCRIPTION
Define RECHECK_LOGS and TEST_EXTENSIONS outside of the UNIT_TESTS
conditional

Fixes the following warnings:
/usr/share/automake-1.14/am/check.am: warning: RECHECK_LOGS was already defined in condition UNIT_TESTS, which is included in condition TRUE ...

modules/remotebackend/Makefile.am:74: ... 'RECHECK_LOGS' previously defined here

modules/remotebackend/Makefile.am:62: warning: 'TEST_EXTENSIONS' cannot have conditional contents