### PR TITLE
Add more restrictions to pdns systemd unit file

### DIFF
--- a/contrib/systemd-pdns.service
+++ b/contrib/systemd-pdns.service
@@ -11,6 +11,12 @@ ExecStop=/usr/bin/pdns_control quit
 Restart=on-failure
 RestartSec=2
 PrivateTmp=true
+PrivateDevices=true
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We already did for the recursor, now do the same for auth.