### PR TITLE
pdns_control: don't open socket in /tmp

### DIFF
--- a/pdns/dynloader.cc
+++ b/pdns/dynloader.cc
@@ -55,7 +55,6 @@ StatBag S;
 int main(int argc, char **argv)
 {
   string s_programname="pdns";
-  string localdir;
 
   ::arg().set("config-dir","Location of configuration directory (pdns.conf)")=SYSCONFDIR;
   ::arg().set("socket-dir","Where the controlsocket will live")=LOCALSTATEDIR;
@@ -96,16 +95,11 @@ int main(int argc, char **argv)
   string socketname=::arg()["socket-dir"]+"/"+s_programname+".controlsocket";
   cleanSlashes(socketname);
   
-  if(::arg()["chroot"].empty())
-    localdir="/tmp";
-  else
-    localdir=dirname(strdup(socketname.c_str()));
-
   try {
     string command=commands[0];
     shared_ptr<DynMessenger> D;
     if(::arg()["remote-address"].empty())
-      D=shared_ptr<DynMessenger>(new DynMessenger(localdir,socketname));
+      D=shared_ptr<DynMessenger>(new DynMessenger(socketname));
     else {
       uint16_t port;
       try {

--- a/pdns/dynmessenger.cc
+++ b/pdns/dynmessenger.cc
@@ -28,8 +28,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-DynMessenger::DynMessenger(const string &localdir,
-    const string &fname,
+DynMessenger::DynMessenger(const string &fname,
     int timeout_sec,
     int timeout_usec)
 {
@@ -40,25 +39,7 @@ DynMessenger::DynMessenger(const string &localdir,
     throw PDNSException(string("socket")+strerror(errno));
   }
 
-  string localname=localdir;
-
-  localname+="/lsockXXXXXX";
-  if (makeUNsockaddr(localname, &d_local))
-    throw PDNSException("Unable to bind to local temporary file, path '"+localname+"' is not a valid UNIX socket path.");
-
-  if(mkstemp(d_local.sun_path)<0)
-    throw PDNSException("Unable to generate local temporary file: "+stringerror());
-  
-  unlink(d_local.sun_path);
-
   try {
-    if(bind(d_s, (sockaddr*)&d_local,sizeof(d_local))<0)
-      throw PDNSException("Unable to bind to local temporary file: "+stringerror());
-
-    // make sure that pdns can reply!
-    if(chmod(d_local.sun_path,0666)<0)
-      throw PDNSException("Unable to chmod local temporary file: "+stringerror());
-
     if(makeUNsockaddr(fname, &d_remote))
       throw PDNSException("Unable to connect to remote '"+fname+"': Path is not a valid UNIX socket path.");
 
@@ -82,7 +63,6 @@ DynMessenger::DynMessenger(const string &localdir,
   } catch(...) {
     close(d_s);
     d_s=-1;
-    unlink(d_local.sun_path);
     throw;
   }
 }
@@ -92,7 +72,6 @@ DynMessenger::DynMessenger(const ComboAddress& remote,
     int timeout_sec,
     int timeout_usec)
 {
-  *d_local.sun_path=0;
   d_s=socket(AF_INET, SOCK_STREAM,0);
   Utility::setCloseOnExec(d_s);
  
@@ -131,8 +110,6 @@ DynMessenger::~DynMessenger()
 {
   if (d_s > 0)
     close(d_s);
-  if(*d_local.sun_path && unlink(d_local.sun_path)<0)
-    cerr<<"Warning: unable to unlink local unix domain endpoint: "<<strerror(errno)<<endl;
 }   
 
 int DynMessenger::send(const string &msg) const

--- a/pdns/dynmessenger.hh
+++ b/pdns/dynmessenger.hh
@@ -40,7 +40,6 @@ class DynMessenger
 {
   int d_s;
 
-  struct sockaddr_un d_local; // our local address
   struct sockaddr_un d_remote; // our remote address
 
   DynMessenger(const DynMessenger &); // NOT IMPLEMENTED
@@ -48,8 +47,7 @@ class DynMessenger
 public:
   // CREATORS
 
-  DynMessenger(const string &ldir,
-    const string &filename,
+  DynMessenger(const string &filename,
     int timeout_sec = 7,
     int timeout_usec = 0);  //!< Create a DynMessenger sending to this file
 


### PR DESCRIPTION
pdns_control opened a socket in /tmp to receive
responses on from pdns. However, since the control
socket pdns_control connects to is a SOCK_STREAM socket
there's no need to do this anymore.

Fixes #2221