### PR TITLE
Properly lock lmdb database, fixes #1954

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -47,7 +47,7 @@ private:
     void needReload();
     inline bool get_finished();
     static int s_reloadcount;
-    static pthread_mutex_t s_initlock;
+    static pthread_rwlock_t s_initlock;
 
 public:
     LMDBBackend(const string &suffix="");


### PR DESCRIPTION
The LMDB database needs to be reloaded without allowing requests, so
we use readwrite lock to ensure that this cannot happen.