### PR TITLE
API (Auth): fix hosting of root zone

### DIFF
--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -262,7 +262,7 @@ string apiZoneIdToName(const string& id) {
   zonename = ss.str();
 
   // strip trailing dot
-  if (zonename.substr(zonename.size()-1) == ".") {
+  if (zonename.size() > 0 && zonename.substr(zonename.size()-1) == ".") {
     zonename.resize(zonename.size()-1);
   }
   return zonename;
@@ -285,14 +285,14 @@ string apiZoneNameToId(const string& name) {
   string id = ss.str();
 
   // add trailing dot
-  if (id.substr(id.size()-1) != ".") {
+  if (id.size() == 0 || id.substr(id.size()-1) != ".") {
     id += ".";
   }
 
   // special handling for the root zone, as a dot on it's own doesn't work
   // everywhere.
   if (id == ".") {
-    id = (boost::format("=%02x") % (int)('.')).str();
+    id = (boost::format("=%02X") % (int)('.')).str();
   }
   return id;
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -601,17 +601,14 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     Document document;
     req->json(document);
     string zonename = stringFromJson(document, "name");
-    string dotsuffix = "." + zonename;
-    string zonestring = stringFromJson(document, "zone", "");
 
-    // TODO: better validation of zonename
-    if(zonename.empty())
-      throw ApiException("Zone name empty");
-
-    // strip any trailing dots
-    while (zonename.substr(zonename.size()-1) == ".") {
+    // strip trailing dot (from spec PoV this is wrong, but be nice to clients)
+    if (zonename.size() > 0 && zonename.substr(zonename.size()-1) == ".") {
       zonename.resize(zonename.size()-1);
     }
+
+    string dotsuffix = "." + zonename;
+    string zonestring = stringFromJson(document, "zone", "");
 
     bool exists = B.getDomainInfo(zonename, di);
     if(exists)


### PR DESCRIPTION
As discovered by @jpmens in #2216, the API could not create the root
zone, and listing zones would also fail when the root zone was present.

This corrects those bugs, plus another that prevented reading the root
zone, and adds a small API test set for the root zone.

Fixes #2216.