### PR TITLE
Log the arguments passed to ./configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,12 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 
+AC_SUBST([pdns_configure_args],["$ac_configure_args"])
+AC_DEFINE_UNQUOTED([PDNS_CONFIG_ARGS],
+  ["$pdns_configure_args"],
+  [pdns configure arguments]
+)
+
 AM_INIT_AUTOMAKE([foreign dist-bzip2 no-dist-gzip tar-ustar -Wno-portability subdir-objects parallel-tests 1.11])
 AM_SILENT_RULES([yes])
 
@@ -360,6 +366,8 @@ AC_OUTPUT
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([Configuration summary])
 AC_MSG_NOTICE([=====================])
+AC_MSG_NOTICE([])
+AC_MSG_NOTICE([Configured with:$pdns_configure_args])
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([Modules: $modules])
 AC_MSG_NOTICE([Dynamic Modules: $dynmodules])

--- a/pdns/version.cc
+++ b/pdns/version.cc
@@ -114,6 +114,9 @@ void showBuildConfiguration()
 #ifndef POLARSSL_SYSTEM
   theL()<<Logger::Warning<<"Built-in PolarSSL: "<<POLARSSL_VERSION_STRING<<endl;
 #endif
+#ifdef PDNS_CONFIG_ARGS
+  theL()<<Logger::Warning<<"Configured with: "<<PDNS_CONFIG_ARGS<<endl;
+#endif
 }
 
 string fullVersionString()


### PR DESCRIPTION
And show them in the output of pdns_server --version:

configure:
configure: Configuration summary
configure: =====================
configure:
configure: Configured with: --enable-unit-tests --with-modules=bind gsqlite3 --with-dynmodules=lmdb --with-system-polarssl --disable-dependency-tracking --enable-tsan CXXFLAGS=-O0 -Wall -ggdb
configure:
configure: Modules: bind gsqlite3
configure: Dynamic Modules: lmdb
configure:
configure: With ZeroMQ connector for remotebackend: no
configure:
configure: CC: gcc
configure: CXX: g++
configure: LD: /usr/bin/ld -m elf_x86_64
configure: CFLAGS: -fPIE -DPIE --param ssp-buffer-size=4
-fstack-protector -Wall -g -O2
configure: CPPFLAGS:
configure: CXXFLAGS: -fsanitize=thread  -fPIE -DPIE --param
ssp-buffer-size=4 -fstack-protector -O0 -Wall -ggdb -std=gnu++11
configure: LDFLAGS: -Wl,-z -Wl,relro -Wl,-z -Wl,now
configure:
configure: BOOST_CPPFLAGS:
configure:
configure: SQLite3 support: no
configure: Lua support: yes
configure: C++2011 support: yes
configure:

Feb 25 18:07:34 PowerDNS Authoritative Server git-rec-3.7.0-180-g06ae3174df69+ (ruben@wodan) (C) 2001-2015 PowerDNS.COM BV
Feb 25 18:07:34 Using 64-bits mode. Built on 20150225173213 by ruben@wodan, gcc 5.0.0 20150217 (Red Hat 5.0.0-0.15).
Feb 25 18:07:34 PowerDNS comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it according to the terms of the GPL version 2.
Feb 25 18:07:34 Features: lua
Feb 25 18:07:34 Built-in modules: bind gsqlite3
Feb 25 18:07:34 Configured with: --enable-unit-tests --with-modules=bind gsqlite3 --with-dynmodules=lmdb --with-system-polarssl --disable-dependency-tracking --enable-tsan CXXFLAGS=-O0 -Wall -ggdb