### PR TITLE
Avoid busy waiting in unixconnector.cc by adding waitForData at the right place

### DIFF
--- a/modules/remotebackend/unixconnector.cc
+++ b/modules/remotebackend/unixconnector.cc
@@ -56,6 +56,14 @@ int UnixsocketConnector::recv_message(rapidjson::Document &output) {
   s_output = "";       
 
   while((t.tv_sec - t0.tv_sec)*1000 + (t.tv_usec - t0.tv_usec)/1000 < this->timeout) { 
+    int avail = waitForData(this->fd, 0, this->timeout * 500); // use half the timeout as poll timeout
+    if (avail < 0) // poll error
+      return -1;
+    if (avail == 0) { // timeout
+      gettimeofday(&t, NULL);
+      continue;
+    }
+
     std::string temp;
     temp.clear();
 


### PR DESCRIPTION
imho this is a better fix than pull #2283, because that one will still loop with a 1 ms timeout,