### PR TITLE
Change SOA-EDIT-API to work like SOA-EDIT-DNSUPDATE

### DIFF
--- a/docs/markdown/authoritative/upgrading.md
+++ b/docs/markdown/authoritative/upgrading.md
@@ -2,6 +2,11 @@ Before proceeding, it is advised to check the release notes for your PDNS versio
 
 **WARNING**: Version 3.X of the PowerDNS Authoritative Server is a major upgrade if you are coming from 2.9.x. Please follow **all** instructions.
 
+# 3.4.X to HEAD
+
+## API
+Incompatible change: `SOA-EDIT-API` now follows `SOA-EDIT-DNSUPDATE` instead of `SOA-EDIT` (incl. the fact that it now has a default value of `DEFAULT`). You must update your existing `SOA-EDIT-API` metadata (set `SOA-EDIT` to your previous `SOA-EDIT-API` value, and `SOA-EDIT-API` to `SOA-EDIT` to keep the old behaviour).
+
 # 3.4.2 to 3.4.3
 No breaking changes.
 

--- a/docs/markdown/httpapi/api_spec.md
+++ b/docs/markdown/httpapi/api_spec.md
@@ -336,7 +336,8 @@ zone_collection
 
 * `soa_edit_api` MAY be set. If it is set, on changes to the contents of
   a zone made through the API, the SOA record will be edited according to
-  the SOA-EDIT-API rules. (Which are the same as the SOA-EDIT rules.)
+  the SOA-EDIT-API rules. (Which are the same as the SOA-EDIT-DNSUPDATE rules.)
+  If not set at all during zone creation, defaults to `DEFAULT`.
   **Note**: Authoritative only.
 
 * `account` MAY be set. It's value is defined by local policy.

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -167,8 +167,12 @@ private:
 };
 
 class DNSPacket;
-uint32_t calculateEditSOA(SOAData sd, const string& kind);
 uint32_t localtime_format_YYYYMMDDSS(time_t t, uint32_t seq);
+// for SOA-EDIT
+uint32_t calculateEditSOA(SOAData sd, const string& kind);
 bool editSOA(DNSSECKeeper& dk, const string& qname, DNSPacket* dp);
 bool editSOARecord(DNSResourceRecord& rr, const string& kind);
+// for SOA-EDIT-DNSUPDATE/API
+uint32_t calculateIncreaseSOA(SOAData sd, const string& increaseKind, const string& editKind);
+bool increaseSOARecord(DNSResourceRecord& rr, const string& increaseKind, const string& editKind);
 #endif

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -961,39 +961,14 @@ void PacketHandler::increaseSerial(const string &msgPrefix, const DomainInfo *di
       vector<string> soaEditSetting;
       B.getDomainMetadata(di->zone, "SOA-EDIT", soaEditSetting);
       if (soaEditSetting.empty()) {
-        L<<Logger::Error<<msgPrefix<<"Using "<<soaEdit2136<<" for SOA-EDIT-DNSUPDATE increase on DNS update, but SOA-EDIT is not set for domain. Using DEFAULT for SOA-EDIT-DNSUPDATE"<<endl;
+        L<<Logger::Error<<msgPrefix<<"Using "<<soaEdit2136<<" for SOA-EDIT-DNSUPDATE increase on DNS update, but SOA-EDIT is not set for domain \""<< di->zone <<"\". Using DEFAULT for SOA-EDIT-DNSUPDATE"<<endl;
         soaEdit2136 = "DEFAULT";
       } else
         soaEdit = soaEditSetting[0];
     }
   }
 
-
-  if (pdns_iequals(soaEdit2136, "INCREASE"))
-    soa2Update.serial++;
-  else if (pdns_iequals(soaEdit2136, "SOA-EDIT-INCREASE")) {
-    uint32_t newSer = calculateEditSOA(soa2Update, soaEdit);
-    if (newSer <= soa2Update.serial)
-      soa2Update.serial++;
-    else
-      soa2Update.serial = newSer;
-  } else if (pdns_iequals(soaEdit2136, "SOA-EDIT"))
-    soa2Update.serial = calculateEditSOA(soa2Update, soaEdit);
-  else if (pdns_iequals(soaEdit2136, "EPOCH"))
-    soa2Update.serial = time(0);
-  else {
-    time_t now = time(0);
-    struct tm tm;
-    localtime_r(&now, &tm);
-    boost::format fmt("%04d%02d%02d%02d");
-    string newserdate=(fmt % (tm.tm_year+1900) % (tm.tm_mon +1 )% tm.tm_mday % 1).str();
-    uint32_t newser = atol(newserdate.c_str());
-    if (newser <= soa2Update.serial)
-      soa2Update.serial++;
-    else
-      soa2Update.serial = newser;
-  }
-
+  calculateIncreaseSOA(soa2Update, soaEdit2136, soaEdit);
 
   newRec.content = serializeSOAData(soa2Update);
   vector<DNSResourceRecord> rrset;

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -968,7 +968,7 @@ void PacketHandler::increaseSerial(const string &msgPrefix, const DomainInfo *di
     }
   }
 
-  calculateIncreaseSOA(soa2Update, soaEdit2136, soaEdit);
+  soa2Update.serial = calculateIncreaseSOA(soa2Update, soaEdit2136, soaEdit);
 
   newRec.content = serializeSOAData(soa2Update);
   vector<DNSResourceRecord> rrset;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -626,8 +626,15 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       throw ApiException("Nameservers list must be given (but can be empty if NS records are supplied)");
 
     string soa_edit_api_kind;
-    if (document["soa_edit_api"].IsString())
+    if (document["soa_edit_api"].IsString()) {
       soa_edit_api_kind = document["soa_edit_api"].GetString();
+    }
+    else {
+      soa_edit_api_kind = "DEFAULT";
+    }
+    string soa_edit_kind;
+    if (document["soa_edit"].IsString())
+      soa_edit_kind = document["soa_edit"].GetString();
 
     // if records/comments are given, load and check them
     bool have_soa = false;
@@ -651,7 +658,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
 
       if (rr.qtype.getCode() == QType::SOA && pdns_iequals(rr.qname, zonename)) {
         have_soa = true;
-        editSOARecord(rr, soa_edit_api_kind);
+        increaseSOARecord(rr, soa_edit_api_kind, soa_edit_kind);
       }
     }
 
@@ -680,7 +687,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
 
       rr.content = serializeSOAData(sd);
       rr.qtype = "SOA";
-      editSOARecord(rr, soa_edit_api_kind);
+      increaseSOARecord(rr, soa_edit_api_kind, soa_edit_kind);
       new_records.push_back(rr);
     }
 
@@ -948,7 +955,9 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
 
   try {
     string soa_edit_api_kind;
+    string soa_edit_kind;
     di.backend->getDomainMetadataOne(zonename, "SOA-EDIT-API", soa_edit_api_kind);
+    di.backend->getDomainMetadataOne(zonename, "SOA-EDIT", soa_edit_kind);
     bool soa_edit_done = false;
 
     for(SizeType rrsetIdx = 0; rrsetIdx < rrsets.Size(); ++rrsetIdx) {
@@ -982,7 +991,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
             throw ApiException("Record "+rr.qname+"/"+rr.qtype.getName()+" "+rr.content+": Record wrongly bundled with RRset " + qname + "/" + qtype.getName());
 
           if (rr.qtype.getCode() == QType::SOA && pdns_iequals(rr.qname, zonename)) {
-            soa_edit_done = editSOARecord(rr, soa_edit_api_kind);
+            soa_edit_done = increaseSOARecord(rr, soa_edit_api_kind, soa_edit_kind);
           }
         }
 
@@ -1025,7 +1034,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
       rr.domain_id = di.id;
       rr.auth = 1;
       rr.ttl = sd.ttl;
-      editSOARecord(rr, soa_edit_api_kind);
+      increaseSOARecord(rr, soa_edit_api_kind, soa_edit_kind);
 
       if (!di.backend->replaceRRSet(di.id, rr.qname, rr.qtype, vector<DNSResourceRecord>(1, rr))) {
         throw ApiException("Hosting backend does not support editing records.");

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -50,7 +50,8 @@ class AuthZonesHelperMixin(object):
 class AuthZones(ApiTestCase, AuthZonesHelperMixin):
 
     def test_create_zone(self):
-        payload, data = self.create_zone(serial=22)
+        # soa_edit_api has a default, override with empty for this test
+        payload, data = self.create_zone(serial=22, soa_edit_api='')
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'soa_edit_api', 'soa_edit', 'account'):
             self.assertIn(k, data)
             if k in payload:
@@ -389,7 +390,7 @@ fred   IN  A      192.168.0.4
             self.assertEquals(counter[et], 0)
 
     def test_export_zone_json(self):
-        payload, zone = self.create_zone(nameservers=['ns1.foo.com', 'ns2.foo.com'])
+        payload, zone = self.create_zone(nameservers=['ns1.foo.com', 'ns2.foo.com'], soa_edit_api='')
         name = payload['name']
         # export it
         r = self.session.get(
@@ -406,7 +407,7 @@ fred   IN  A      192.168.0.4
         self.assertEquals(data['zone'].strip().split('\n'), expected_data)
 
     def test_export_zone_text(self):
-        payload, zone = self.create_zone(nameservers=['ns1.foo.com', 'ns2.foo.com'])
+        payload, zone = self.create_zone(nameservers=['ns1.foo.com', 'ns2.foo.com'], soa_edit_api='')
         name = payload['name']
         # export it
         r = self.session.get(
@@ -1015,7 +1016,7 @@ class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):
         self.session.delete(self.url("/servers/localhost/zones/=2E"))
 
     def test_create_zone(self):
-        payload, data = self.create_zone(name='', serial=22)
+        payload, data = self.create_zone(name='', serial=22, soa_edit_api='')
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'soa_edit_api', 'soa_edit', 'account'):
             self.assertIn(k, data)
             if k in payload:


### PR DESCRIPTION
The SOA-EDIT-DNSUPDATE behaviour makes for a better ruleset for
incremental updates, like they are done via the API.

Also SOA-EDIT-API now defaults to DEFAULT, if it's not given at all
during zone creation (over the API).

Fixes #2173.