### PR TITLE
Fix segfault in zone2lmdb

### DIFF
--- a/pdns/zone2lmdb.cc
+++ b/pdns/zone2lmdb.cc
@@ -241,6 +241,8 @@ try
 
   int count=0;
 
+  openDB();
+
   if(zonefile.empty()) {
     BindParser BP;
     BP.setVerbose(::arg().mustDo("verbose"));
@@ -261,7 +263,6 @@ try
     int tick=numdomains/100;
 
     cout <<"[";
-    openDB();
     for(vector<BindDomainInfo>::const_iterator i=domains.begin(); i!=domains.end(); ++i) {
       if(i->type!="master" && i->type!="slave") {
         cerr<<" Warning! Skipping '"<<i->type<<"' zone '"<<i->name<<"'"<<endl;


### PR DESCRIPTION
```
$ ./pdns/zone2lmdb --zone=./regression-tests.recursor/configs/10.0.3.10/example.net.zone
ASAN:SIGSEGV
=================================================================
==25526==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000000c
(pc 0x7fe8b57a4d50 bp 0x7ffedb062f90 sp 0x7ffedb061d58 T0)
    #0 0x7fe8b57a4d4f  (/lib64/liblmdb.so.0.0.0+0x4d4f)
    #1 0x7fe8b6c4c1aa in emitData(std::__cxx11::basic_string<char,
std::char_traits<char>, std::allocator<char> >, ZoneParserTNG&)
/home/ruben/src/pdns/pdns/zone2lmdb.cc:99
    #2 0x7fe8b6c4f301 in main /home/ruben/src/pdns/pdns/zone2lmdb.cc:295
    #3 0x7fe8b493b83f in __libc_start_main (/lib64/libc.so.6+0x2083f)
    #4 0x7fe8b6b6ef88 in _start
(/home/ruben/src/pdns/pdns/zone2lmdb+0x27f88)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV ??:0 ??
==25526==ABORTING

```