### PR TITLE
Stringify preprocessor string

### DIFF
--- a/pdns/version.cc
+++ b/pdns/version.cc
@@ -115,7 +115,11 @@ void showBuildConfiguration()
   theL()<<Logger::Warning<<"Built-in PolarSSL: "<<POLARSSL_VERSION_STRING<<endl;
 #endif
 #ifdef PDNS_CONFIG_ARGS
-  theL()<<Logger::Warning<<"Configured with: "<<PDNS_CONFIG_ARGS<<endl;
+#define double_escape(s) #s
+#define escape_quotes(s) double_escape(s)
+  theL()<<Logger::Warning<<"Configured with: "<<escape_quotes(PDNS_CONFIG_ARGS)<<endl;
+#undef escape_quotes
+#undef double_escape
 #endif
 }
 


### PR DESCRIPTION
When compiling with something like './configure
CXXFLAGS=-DPACKAGEVERSION="1.2.3"', we fail with
"../config.h:162:792: error: too many decimal points in number"

This happens because the string as defined in config.h
has embedded double quotes. Escape them.