### PR TITLE
Make linkchecker less chatty

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -48,13 +48,8 @@ endif
 
 if HAVE_LINKCHECKER
 check-links: html
-	linkchecker --anchors \
-	  --ignore-url=.eot$ \
-	  --ignore-url=\.svg \
-	  --ignore-url=mailto \
-	  --ignore-url=.ttf$ \
-	  --ignore-url=woff$ \
-	  html/index.html
+	./checklinks.sh
+
 endif
 
 clean:

--- a/docs/checklinks.sh
+++ b/docs/checklinks.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+OUTPUT=$(linkchecker \
+  --anchors \
+  --ignore-url=.eot$ \
+  --ignore-url=\.svg \
+  --ignore-url=mailto \
+  --ignore-url=.ttf$ \
+  --ignore-url=woff$ \
+  html/index.html 2>&1)
+
+if [ $? -ne 0 ]; then
+  echo "Errors in links detected, log follows:"
+  echo "$OUTPUT"
+  exit 1
+else
+  echo "Links OK!"
+  exit 0
+fi
+


### PR DESCRIPTION
```
$ make check-links
mkdir -p doc-build
rsync -a --delete markdown/. doc-build/.
./process-md.sh pre
mkdocs build --clean
Cleaning site directory
Building documentation to directory: html
./process-md.sh post
./checklinks.sh
Links OK!
```