### PR TITLE
Add --with-luajit configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,11 @@ AC_DEFINE([_GNU_SOURCE], [1],
   [Define _GNU_SOURCE so that we get all necessary prototypes]
 )
 
-PDNS_WITH_LUA
+PDNS_WITH_LUAJIT
+AS_IF([test "x$with_luajit" = "xno"], [
+  PDNS_WITH_LUA
+])
+
 AX_CXX_COMPILE_STDCXX_11(,optional)
 AM_CONDITIONAL([CXX2011],[test "$HAVE_CXX11" = "1"])
 

--- a/m4/pdns_with_luajit.m4
+++ b/m4/pdns_with_luajit.m4
@@ -1,0 +1,18 @@
+AC_DEFUN([PDNS_WITH_LUAJIT],[
+  AC_MSG_CHECKING([whether we will be linking in LuaJIT])
+  AC_ARG_WITH([luajit],
+    [AS_HELP_STRING([--with-luajit], [build LuaJIT bindings @<:@default=auto@:>@])],
+    [with_luajit=$withval],
+    [with_luajit=no]
+  )
+  AC_MSG_RESULT([$with_luajit])
+
+  AS_IF([test "x$with_luajit" = "xyes"], [
+    PKG_CHECK_MODULES([LUA], [luajit],
+      [AC_DEFINE([HAVE_LUA], [1], [Define to 1 if you have LuaJIT])],
+      [AC_MSG_ERROR([LuaJIT not found])]
+    )
+  ])
+
+  AM_CONDITIONAL([LUA], [test "x$with_luajit" = "xyes"])
+])


### PR DESCRIPTION
For now we don't do autodetection and you'll need
to explicitly enable it. If it is enabled, we check
for LuaJIT and not for Lua.