### PR TITLE
Add support for OPENPGPKEY RRTYPE.

### DIFF
--- a/docs/markdown/types.md
+++ b/docs/markdown/types.md
@@ -54,7 +54,7 @@ Nameserver record. Specifies nameservers for a domain. Stored plainly: 'ns1.powe
 Since 2.9.21. The NSEC DNSSEC record type is fully supported, as described in [RFC 3757](http://tools.ietf.org/html/rfc3757). Before 3.0 PowerDNS didn't do any DNSSEC processing, since 3.0 PowerDNS is able to fully process DNSSEC. This can be done with [`pdnssec`](authoritative/dnssec.md#pdnssec "'pdnssec' for PowerDNSSEC command & control").
 
 ## OPENPGPKEY
-Since 3.0. The OPENPGPKEY record, specified in [RFC TBD](https://tools.ietf.org/html/draft-ietf-dane-openpgpkey-02), is used to bind OpenPGP certificates to email addresses.
+Since 3.0. The OPENPGPKEY records, specified in [RFC TBD](https://tools.ietf.org/html/draft-ietf-dane-openpgpkey-02), are used to bind OpenPGP certificates to email addresses.
 
 ## PTR
 Reverse pointer, used to specify the host name belonging to an IP or IPv6 address. Name is stored plainly: 'www.powerdns.com'. As always, no terminating dot.
@@ -96,7 +96,7 @@ Since 2.9.21. The SSHFP record type, used for storing Secure Shell (SSH) fingerp
 SRV records can be used to encode the location and port of services on a domain name. When encoding, the priority field is used to encode the priority. For example, '\_ldap.\_tcp.dc.\_msdcs.conaxis.ch SRV 0 100 389 mars.conaxis.ch' would be encoded with 0 in the priority field and '100 389 mars.conaxis.ch' in the content field.
 
 ## TLSA
-Since 3.0. The TLSA record, specified in [RFC 6698](http://tools.ietf.org/html/rfc6698), are used to bind SSL/TLS certificate to named hosts and ports.
+Since 3.0. The TLSA records, specified in [RFC 6698](http://tools.ietf.org/html/rfc6698), are used to bind SSL/TLS certificate to named hosts and ports.
 
 ## TXT
 The TXT field can be used to attach textual data to a domain. Text is stored plainly.

--- a/docs/markdown/types.md
+++ b/docs/markdown/types.md
@@ -54,7 +54,7 @@ Nameserver record. Specifies nameservers for a domain. Stored plainly: 'ns1.powe
 Since 2.9.21. The NSEC DNSSEC record type is fully supported, as described in [RFC 3757](http://tools.ietf.org/html/rfc3757). Before 3.0 PowerDNS didn't do any DNSSEC processing, since 3.0 PowerDNS is able to fully process DNSSEC. This can be done with [`pdnssec`](authoritative/dnssec.md#pdnssec "'pdnssec' for PowerDNSSEC command & control").
 
 ## OPENPGPKEY
-Since 3.0. The OPENPGPKEY record, specified in [RFC TBD](https://tools.ietf.org/id/draft-ietf-dane-openpgpkey-02.html), are used to bind OpenPGP certificates to email addresses.
+Since 3.0. The OPENPGPKEY record, specified in [RFC TBD](https://tools.ietf.org/html/draft-ietf-dane-openpgpkey-02), is used to bind OpenPGP certificates to email addresses.
 
 ## PTR
 Reverse pointer, used to specify the host name belonging to an IP or IPv6 address. Name is stored plainly: 'www.powerdns.com'. As always, no terminating dot.

--- a/docs/markdown/types.md
+++ b/docs/markdown/types.md
@@ -53,6 +53,9 @@ Nameserver record. Specifies nameservers for a domain. Stored plainly: 'ns1.powe
 ## NSEC
 Since 2.9.21. The NSEC DNSSEC record type is fully supported, as described in [RFC 3757](http://tools.ietf.org/html/rfc3757). Before 3.0 PowerDNS didn't do any DNSSEC processing, since 3.0 PowerDNS is able to fully process DNSSEC. This can be done with [`pdnssec`](authoritative/dnssec.md#pdnssec "'pdnssec' for PowerDNSSEC command & control").
 
+## OPENPGPKEY
+Since 3.0. The OPENPGPKEY record, specified in [RFC TBD](https://tools.ietf.org/id/draft-ietf-dane-openpgpkey-02.html), are used to bind OpenPGP certificates to email addresses.
+
 ## PTR
 Reverse pointer, used to specify the host name belonging to an IP or IPv6 address. Name is stored plainly: 'www.powerdns.com'. As always, no terminating dot.
 

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -273,6 +273,10 @@ boilerplate_conv(TLSA, 52,
                  conv.xfrHexBlob(d_cert, true);
                  )                 
                  
+boilerplate_conv(OPENPGPKEY, 61,
+                 conv.xfrHexBlob(d_cert, true);
+                 )
+
 #undef DS
 DSRecordContent::DSRecordContent() : DNSRecordContent(43) {}
 boilerplate_conv(DS, 43, 
@@ -492,6 +496,7 @@ void reportOtherTypes()
    NSEC3RecordContent::report();
    NSEC3PARAMRecordContent::report();
    TLSARecordContent::report();
+   OPENPGPKEYRecordContent::report();
    DLVRecordContent::report();
    DNSRecordContent::regist(QClass::ANY, QType::TSIG, &TSIGRecordContent::make, &TSIGRecordContent::make, "TSIG");
    //TSIGRecordContent::report();

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -356,6 +356,15 @@ private:
   string d_cert;
 };
 
+class OPENPGPKEYRecordContent : public OPENPGPKEYRecordContent
+{
+public:
+  includeboilerplate(OPENPGPKEY)
+
+private:
+  string d_cert;
+};
+
 
 class RRSIGRecordContent : public DNSRecordContent
 {

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -82,7 +82,7 @@ public:
 #undef DS
   enum typeenum {A=1, NS=2, CNAME=5, SOA=6, MR=9, WKS=11, PTR=12, HINFO=13, MINFO=14, MX=15, TXT=16, RP=17, AFSDB=18, SIG=24, KEY=25, AAAA=28, LOC=29, SRV=33, NAPTR=35, KX=36,
 		 CERT=37, A6=38, DNAME=39, OPT=41, DS=43, SSHFP=44, IPSECKEY=45, RRSIG=46, NSEC=47, DNSKEY=48, DHCID=49, NSEC3=50, NSEC3PARAM=51,
-		 TLSA=52, SPF=99, EUI48=108, EUI64=109, TSIG=250, IXFR=251, AXFR=252, MAILB=253, MAILA=254, ANY=255, ADDR=259, ALIAS=260, DLV=32769} types;
+		 TLSA=52, OPENPGPKEY=61, SPF=99, EUI48=108, EUI64=109, TSIG=250, IXFR=251, AXFR=252, MAILB=253, MAILA=254, ANY=255, ADDR=259, ALIAS=260, DLV=32769} types;
   typedef pair<string,uint16_t> namenum;
   static vector<namenum> names;
 
@@ -153,6 +153,7 @@ private:
       qtype_insert("NSEC3", 50);
       qtype_insert("NSEC3PARAM", 51);
       qtype_insert("TLSA", 52);
+      qtype_insert("OPENPGPKEY", 61);
       qtype_insert("SPF", 99);
       qtype_insert("EUI48", 108);
       qtype_insert("EUI64", 109);


### PR DESCRIPTION
OPENPGPKEY is defined in draft-ietf-dane-openpgpkey.

The IANA has assigned RRTYPE 61.

Its content is a single binary blob, its presentation is a single hex blob.

Signed-off-by: James Cloos <cloos@jhcloos.com>