### PR TITLE
pdns-recursor.init: remove --control-console

### DIFF
--- a/pdns/pdns-recursor.init.d
+++ b/pdns/pdns-recursor.init.d
@@ -90,9 +90,9 @@ case "$1" in
 		then 
 			echo "already running"
 		else
-			$pdns_server --daemon=no --quiet=no --control-console --loglevel=9
+			$pdns_server --daemon=no --quiet=no --loglevel=9
 		fi 
-	;;		
+	;;
 
 	*)
 	echo pdns [start\|stop\|force-reload\|restart\|status\|monitor]


### PR DESCRIPTION
Remove --control-console from `monitor` subcommand. That's a leftover
from the Authoritative init script.

Fixes #2310.