### PR TITLE
Use PDNSException in place of ZoneParserTNG::exception

### DIFF
--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -122,7 +122,7 @@ unsigned int ZoneParserTNG::makeTTLFromZone(const string& str)
       break;
 
     default:
-      throw ZoneParserTNG::exception("Unable to parse time specification '"+str+"' "+getLineOfFile());
+      throw PDNSException("Unable to parse time specification '"+str+"' "+getLineOfFile());
     }
   return val;
 }


### PR DESCRIPTION
As a follow up to #1538