### PR TITLE
Defer launch of coprocess until first question

### DIFF
--- a/modules/remotebackend/pipeconnector.cc
+++ b/modules/remotebackend/pipeconnector.cc
@@ -20,7 +20,6 @@ PipeConnector::PipeConnector(std::map<std::string,std::string> options) {
 
   d_pid = -1;
   d_fp = NULL;
-  launch();
 }
 
 PipeConnector::~PipeConnector(){


### PR DESCRIPTION
Do not launch coprocess in ctor as if that fails for some reason,
like delays, it can prevent PowerDNS from starting at all.