### PR TITLE
Rename manpages target to all-manpages

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -37,7 +37,7 @@ endif
 EXTRA_DIST = manpages \
 	markdown
 
-.PHONY: html manpages
+.PHONY: html all-manpages
 html: html/index.html
 
 html/index.html: process-md.sh mkdocs.yml markdown/** markdown/*/** manpages/*
@@ -51,7 +51,7 @@ html/index.html: process-md.sh mkdocs.yml markdown/** markdown/*/** manpages/*
 html.tar.bz2: html
 	tar cjf html.tar.bz2 html/
 
-manpages: $(MANPAGES_TARGET_ALL)
+all-manpages: $(MANPAGES_TARGET_ALL)
 
 if HAVE_PANDOC
 $(MANPAGES_TARGET_ALL): %: manpages/%.md


### PR DESCRIPTION
manpages was both a directory and a .PHONY target.
This caused make distcheck to trigger the rule
for this target and build all the manpages instead
of only the ones needed. The unneeded manpages were left
in the build root after a distclean:

ERROR: files left in build directory after distclean:
./docs/dnsdist.1
./docs/pdns_recursor.1
./docs/rec_control.1
Makefile:824: recipe for target 'distcleancheck' failed
make[1]: *** [distcleancheck] Error 1
make[1]: Leaving directory '/home/ruben/src/pdns/pdns-git/_build/sub'
Makefile:751: recipe for target 'distcheck' failed
make: *** [distcheck] Error 1

Always ship all the markdown for the manpages in the tarball
but don't trigger the rule to generate all the files.

After this change, we can run
make distcheck DISTCHECK_CONFIGURE_FLAGS=--disable-dependency-tracking