### PR TITLE
replace broken mailto: markdown links with static html

### DIFF
--- a/docs/markdown/authoritative/backend-ldap.md
+++ b/docs/markdown/authoritative/backend-ldap.md
@@ -1,5 +1,5 @@
 # LDAP backend
-**Warning**: As of PowerDNS Authoritative Server 3.0, the LDAP backend is unmaintained. While care will be taken that this backend still compiles, this backend is known to have problems in version 3.0 and beyond! Please contact <a href="mailto:powerdns.support@netherlabs.nl">powerdns.support@netherlabs.nl</a> or visit [www.powerdns.com](http://www.powerdns.com) to rectify this situation.
+**Warning**: As of PowerDNS Authoritative Server 3.0, the LDAP backend is unmaintained. While care will be taken that this backend still compiles, this backend is known to have problems in version 3.0 and beyond! Please contact <a href="mailto:powerdns.support@powerdns.com">powerdns.support@powerdns.com</a> or visit [www.powerdns.com](http://www.powerdns.com) to rectify this situation.
 
 **Warning**: Grégory Oestreicher has forked the LDAP backend shortly before our 3.2 release. Please visit his [repository](http://repo.or.cz/w/pdns-ldap-backend.git) for the latest code.
 

--- a/docs/markdown/authoritative/backend-ldap.md
+++ b/docs/markdown/authoritative/backend-ldap.md
@@ -1,5 +1,5 @@
 # LDAP backend
-**Warning**: As of PowerDNS Authoritative Server 3.0, the LDAP backend is unmaintained. While care will be taken that this backend still compiles, this backend is known to have problems in version 3.0 and beyond! Please contact powerdns.support@netherlabs.nl or visit www.powerdns.com to rectify this situation.
+**Warning**: As of PowerDNS Authoritative Server 3.0, the LDAP backend is unmaintained. While care will be taken that this backend still compiles, this backend is known to have problems in version 3.0 and beyond! Please contact <a href="mailto:powerdns.support@netherlabs.nl">powerdns.support@netherlabs.nl</a> or visit [www.powerdns.com](http://www.powerdns.com) to rectify this situation.
 
 **Warning**: Grégory Oestreicher has forked the LDAP backend shortly before our 3.2 release. Please visit his [repository](http://repo.or.cz/w/pdns-ldap-backend.git) for the latest code.
 

--- a/docs/markdown/authoritative/upgrading.md
+++ b/docs/markdown/authoritative/upgrading.md
@@ -263,7 +263,7 @@ The 3.0 release of the PowerDNS Authoritative Server is significantly different 
 
 **Warning**: Version 3.0 of the PowerDNS Authoritative Server is the biggest change in PowerDNS history. In some senses, this means that it behaves somewhat like a '1.0' version. We advise operators to carefully perform the upgrade process from 2.9.x, and if possible test on a copy of the database beforehand.
 
-In addition, it may also be useful to have a support agreement in place during such upgrades. For first class and rapid support, please contact <a href="mailto:powerdns-support@netherlabs.nl">powerdns-support@netherlabs.nl</a>, or see [www.powerdns.com](http://www.powerdns.com). Alternatively, the [PowerDNS Community](http://wiki.powerdns.com) can be very helpful too.
+In addition, it may also be useful to have a support agreement in place during such upgrades. For first class and rapid support, please contact <a href="mailto:powerdns.support@powerdns.com">powerdns.support@powerdns.com</a>, or see [www.powerdns.com](http://www.powerdns.com). Alternatively, the [PowerDNS Community](http://wiki.powerdns.com) can be very helpful too.
 
 With similar settings, version 3.0 will most likely use a lot more memory than 2.9. This is due to the new DNSSEC key & signature caches, but also because the database query cache will now store multiple row answers, which it did not do previously. Memory use can be brought down again by tuning the cache-ttl settings.
 

--- a/docs/markdown/authoritative/upgrading.md
+++ b/docs/markdown/authoritative/upgrading.md
@@ -263,7 +263,7 @@ The 3.0 release of the PowerDNS Authoritative Server is significantly different 
 
 **Warning**: Version 3.0 of the PowerDNS Authoritative Server is the biggest change in PowerDNS history. In some senses, this means that it behaves somewhat like a '1.0' version. We advise operators to carefully perform the upgrade process from 2.9.x, and if possible test on a copy of the database beforehand.
 
-In addition, it may also be useful to have a support agreement in place during such upgrades. For first class and rapid support, please contact [powerdns-support@netherlabs.nl](mailto:powerdns-support@netherlabs.nl), or see [www.powerdns.com](http://www.powerdns.com). Alternatively, the [PowerDNS Community](http://wiki.powerdns.com) can be very helpful too.
+In addition, it may also be useful to have a support agreement in place during such upgrades. For first class and rapid support, please contact <a href="mailto:powerdns-support@netherlabs.nl">powerdns-support@netherlabs.nl</a>, or see [www.powerdns.com](http://www.powerdns.com). Alternatively, the [PowerDNS Community](http://wiki.powerdns.com) can be very helpful too.
 
 With similar settings, version 3.0 will most likely use a lot more memory than 2.9. This is due to the new DNSSEC key & signature caches, but also because the database query cache will now store multiple row answers, which it did not do previously. Memory use can be brought down again by tuning the cache-ttl settings.
 

--- a/docs/markdown/common/support.md
+++ b/docs/markdown/common/support.md
@@ -4,7 +4,7 @@ community or from its authors. You may also help others (please do).
 
 The PowerDNS company provides free support on the public mailing lists, and can
 help or support you in private as well. For first class and rapid support,
-please contact <a href="mailto:powerdns-support@netherlabs.nl">powerdns-support@netherlabs.nl</a>
+please contact <a href="mailto:powerdns.support@powerdns.com">powerdns.support@powerdns.com</a>
 , or see [www.powerdns.com](http://www.powerdns.com).
 
 More information about the PowerDNS community, and its mailing lists, can be

--- a/docs/markdown/common/support.md
+++ b/docs/markdown/common/support.md
@@ -4,7 +4,7 @@ community or from its authors. You may also help others (please do).
 
 The PowerDNS company provides free support on the public mailing lists, and can
 help or support you in private as well. For first class and rapid support,
-please contact [powerdns-support@netherlabs.nl](mailto:powerdns-support@netherlabs.nl)
+please contact <a href="mailto:powerdns-support@netherlabs.nl">powerdns-support@netherlabs.nl</a>
 , or see [www.powerdns.com](http://www.powerdns.com).
 
 More information about the PowerDNS community, and its mailing lists, can be
@@ -40,4 +40,4 @@ Before posting, read all FAQs.
 
 ## My information is confidential, must I send it to the mailing list?
 If you desire privacy, please consider entering a support relationship with us,
-in which case we invite you to contact `<powerdns.support.sales@netherlabs.eu>`.
+in which case we invite you to contact <a href="mailto:powerdns.support.sales@netherlabs.eu">powerdns.support.sales@netherlabs.eu</a>.

--- a/docs/markdown/security/index.md
+++ b/docs/markdown/security/index.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-If you have a security problem to report, please email us at both `<security@netherlabs.nl>` and `<ahu@ds9a.nl>`. Please do not mail security issues to public lists, nor file a ticket, unless we do not get back to you in a timely manner. We fully credit reporters of security issues, and respond quickly, but please allow us a reasonable timeframe to coordinate a response.
+If you have a security problem to report, please email us at both <a href="mailto:security@netherlabs.nl">security@netherlabs.nl</a> and <a href="mailto:ahu@ds9a.nl">ahu@ds9a.nl</a>. Please do not mail security issues to public lists, nor file a ticket, unless we do not get back to you in a timely manner. We fully credit reporters of security issues, and respond quickly, but please allow us a reasonable timeframe to coordinate a response.
 
 We remind PowerDNS users that under the terms of the GNU General Public License, PowerDNS comes with ABSOLUTELY NO WARRANTY. This license is included in this documentation.
 


### PR DESCRIPTION
attempt at fixing #2158 . it looks like mkdocs is pretty determined in creating broken markdown mailto: links. I've tried various versions, and they all either mess up the display or add relative path junk to the link

```
foo@bar.com
<foo@bar.com>
<mailto:foo@bar.com>
[foo@bar.com]
[mailto:foo@bar.com]
[foo@bar.com](mailto:foo@bar.com)
```

static html is maybe a bit ugly but does the trick