### PR TITLE
we need errno.h here

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -21,6 +21,7 @@
 */
 #ifndef MISC_HH
 #define MISC_HH
+#include <errno.h>
 #include <inttypes.h>
 #include <cstring>
 #include <cstdio>


### PR DESCRIPTION
This used to compile in 3.4.4 on OpenBSD. Presumably some code shuffling broke this.