### PR TITLE
we need unistd.h here

### DIFF
--- a/pdns/randomhelper.cc
+++ b/pdns/randomhelper.cc
@@ -6,6 +6,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include "dns_random.hh"                     
 
 void seedRandom(const string& source)


### PR DESCRIPTION
This used to compile in 3.4.4 on OpenBSD. Presumably some code shuffling broke this.