### PR TITLE
use hostname -f || hostname consistently

### DIFF
--- a/build-scripts/set-version-auth
+++ b/build-scripts/set-version-auth
@@ -4,7 +4,7 @@ DEB_VERSION=$2
 RPM_VERSION=$3
 [ -z "$VERSION" -o -z "$DEB_VERSION" -o -z "$RPM_VERSION" ] && exit 1
 
-DIST_HOST="$(id -u -n)@$(hostname -f)"
+DIST_HOST="$(id -u -n)@$(hostname -f || hostname)"
 
 sed -r "s/Version: (.*)/Version: $RPM_VERSION/" -i pdns.spec
 sed -r "s/AC_INIT\(\[pdns\],(.*)/AC_INIT([pdns], [$VERSION])/" -i configure.ac

--- a/build-scripts/set-version-recursor
+++ b/build-scripts/set-version-recursor
@@ -7,7 +7,7 @@ DEB_VERSION=$2
 RPM_VERSION=$3
 [ -z "$VERSION" -o -z "$DEB_VERSION" -o -z "$RPM_VERSION" ] && exit 1
 
-DIST_HOST="$(id -u -n)@$(hostname -f)"
+DIST_HOST="$(id -u -n)@$(hostname -f || hostname)"
 
 sed -r "s/^VERSION=(.*)/VERSION=$VERSION/" -i pdns/dist-recursor
 sed -r "s/^DIST_HOST=(.*)/DIST_HOST=$DIST_HOST/" -i pdns/dist-recursor


### PR DESCRIPTION
Other places use this idiom, too. Linux and FreeBSD have -f. NetBSD, OpenBSD and OpenSolaris (and others?) don't.