### PR TITLE
Allow comments in the forward-zones-file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ before_script:
     unbound-host
     validns
     default-jre
+    jq
   - cd ..
   - wget http://www.verisignlabs.com/dnssec-tools/packages/jdnssec-tools-0.12.tar.gz
   - sudo tar xfz jdnssec-tools-0.12.tar.gz --strip-components=1 -C /

--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -268,11 +268,12 @@ setting is intended to forward queries to authoritative servers.
 
 Same as [`forward-zones`](#forward-zones), parsed from a file. Only 1 zone is
 allowed per line, specified as follows: `example.org=203.0.113.210, 192.0.2.4:5300`.
-No comments are allowed.
 
 Since version 3.2, zones prefixed with a '+' are forwarded with the
 recursion-desired bit set to one, for which see ['forward-zones-recurse'](#forward-zones-recurse).
 Default behaviour without '+' is as with [`forward-zones`](#forward-zones).
+
+Comments are allowed since version 4.0.0. Everything behind '#' is ignored.
 
 ## `forward-zones-recurse`
 * 'zonename=IP' pairs, comma separated

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -449,8 +449,12 @@ SyncRes::domainmap_t* parseAuthAndForwards()
     int linenum=0;
     uint64_t before = newMap->size();
     while(linenum++, stringfgets(fp.get(), line)) {
+      trim(line);
+      if (line[0] == '#') // Comment line, skip to the next line
+        continue;
       string domain, instructions;
       tie(domain, instructions)=splitField(line, '=');
+      instructions = splitField(instructions, '#').first; // Remove EOL comments
       trim(domain);
       trim(instructions);
       if(domain.empty() && instructions.empty()) { // empty line

--- a/regression-tests.recursor/comments-in-forward-zones-file/command
+++ b/regression-tests.recursor/comments-in-forward-zones-file/command
@@ -1,0 +1,2 @@
+#!/bin/sh
+curl -s -H 'X-API-Key: secret' 127.0.0.1:8082/api/v1/servers/localhost/zones | jq '.[] | select(.kind=="Forwarded")'

--- a/regression-tests.recursor/comments-in-forward-zones-file/description
+++ b/regression-tests.recursor/comments-in-forward-zones-file/description
@@ -1,0 +1,1 @@
+Check if the comments in the forward-zones-file are indeed ignored

--- a/regression-tests.recursor/comments-in-forward-zones-file/expected_result
+++ b/regression-tests.recursor/comments-in-forward-zones-file/expected_result
@@ -1,0 +1,20 @@
+{
+  "id": "forward-zones-test2.non-existing.powerdns.com.",
+  "url": "/api/v1/servers/localhost/zones/forward-zones-test2.non-existing.powerdns.com.",
+  "name": "forward-zones-test2.non-existing.powerdns.com.",
+  "kind": "Forwarded",
+  "servers": [
+    "8.8.8.8:53"
+  ],
+  "recursion_desired": false
+}
+{
+  "id": "forward-zones-test.non-existing.powerdns.com.",
+  "url": "/api/v1/servers/localhost/zones/forward-zones-test.non-existing.powerdns.com.",
+  "name": "forward-zones-test.non-existing.powerdns.com.",
+  "kind": "Forwarded",
+  "servers": [
+    "8.8.8.8:53"
+  ],
+  "recursion_desired": false
+}

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -450,7 +450,18 @@ EOF
     ln -s ../run-auth $dir/run
 done
 
+cat > recursor-service/forward-zones-file << EOF
+# Some comment that should be ignored
+forward-zones-test.non-existing.powerdns.com=8.8.8.8
+forward-zones-test2.non-existing.powerdns.com=8.8.8.8# This comment should be ignored as well
+EOF
+
 cat > recursor-service/recursor.conf <<EOF
+webserver=yes
+api-key=secret
+api-readonly=yes
+forward-zones-file=$(pwd)/recursor-service/forward-zones-file
+
 socket-dir=$(pwd)/recursor-serviceS
 auth-zones=global.box.answer-cname-in-local.example.net=$(pwd)/recursor-service/global.box.answer-cname-in-local.example.net.zone,auth-zone.example.net=$(pwd)/recursor-service/auth-zone.example.net.zone,another-auth-zone.example.net=$(pwd)/recursor-service/another-auth-zone.example.net.zone
 


### PR DESCRIPTION
  * Closes #2430
  * Lines starting with a '#' get skipped.
  * Everything after a '#' symbol on a line is ignored
  * Document this change