### PR TITLE
Limit the maximum length of a qname

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -494,6 +494,8 @@ void PacketReader::getLabelFromContent(const vector<uint8_t>& content, uint16_t&
       }
       ret.append(1,'.');
     }
+    if (ret.length() > 1024)
+      throw MOADNSException("Total name too long");
   }
 }
 


### PR DESCRIPTION
This problem is non-existent with DNSName. But for now make sure we don't use too many resources when parsing a broken packet.