### PR TITLE
Allow virtual hosting with systemd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ EXTRA_DIST = \
 	contrib/powerdns.solaris.init.d \
 	contrib/systemd-pdns-recursor.service \
 	contrib/systemd-pdns.service \
+	contrib/systemd-pdns@.service \
 	debian \
 	pdns.spec \
 	pdns/named.conf.parsertest \

--- a/contrib/systemd-pdns@.service
+++ b/contrib/systemd-pdns@.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=PowerDNS Authoritative Server %i
+Documentation=man:pdns_server(8) man:pdns_control(8)
+Wants=network-online.target
+After=network-online.target mysqld.service postgresql.service slapd.service
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/pdns_server --daemon --config-name=%i
+Restart=on-failure
+StartLimitInterval=0
+PrivateTmp=true
+PrivateDevices=true
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/markdown/authoritative/virtual.md
+++ b/docs/markdown/authoritative/virtual.md
@@ -21,4 +21,13 @@ When you launch a virtual instance of PowerDNS, the pid-file is saved inside
 **Warning**: Be aware however that the init.d `force-stop` will kill all
 PowerDNS instances!
 
-**Warning**: For systems running systemd, virtual hosting is not yet supported.
+## Systemd
+With systemd it is as simple as calling the correct service. Assuming your
+instance is called `myinstance` and `pdns-myinstance.conf` exists, the
+following command will start the service:
+
+systemctl start pdns@myinstance
+
+Similar you can enable it at boot:
+
+systemctl enable pdns@myinstance


### PR DESCRIPTION
Note this is only tested by manually placing dns pdns@.service file in the correct directory and executing the commands documented in virtual.md. Any further integration probably needs testing but I'm not familiar enough with powerdns packaging to say anything useful about this.

I'm also unsure if it's conventional to ship both pdns.service and pdns@.service.