### PR TITLE
secpoll: Add 3.4.5/3.7.3 data for Debian

### DIFF
--- a/docs/secpoll.zone
+++ b/docs/secpoll.zone
@@ -18,18 +18,22 @@ auth-3.4.1-3.debian.security-status                     60 IN TXT "3 Upgrade now
 auth-3.4.1-4.debian.security-status                     60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"
 auth-3.4.4-1.debian.security-status                     60 IN TXT "1 OK"
 auth-3.4.4-2.debian.security-status                     60 IN TXT "1 OK"
+auth-3.4.5-1.debian.security-status                     60 IN TXT "1 OK"
 
 auth-3.4.1-3_bpo70_1.debian.security-status             60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"
 auth-3.4.1-4_bpo70_1.debian.security-status             60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"
 auth-3.4.4-2_bpo7_1.debian.security-status              60 IN TXT "1 OK"
+auth-3.4.5-1_bpo7_1.debian.security-status              60 IN TXT "1 OK"
 
 auth-3.4.1-4_deb8u1.debian.security-status              60 IN TXT "1 OK"
 
 auth-3.4.4-2_bpo8_1.debian.security-status              60 IN TXT "1 OK"
+auth-3.4.5-1_bpo8_1.debian.security-status              60 IN TXT "1 OK"
 
 ; Auth Ubuntu
 auth-3.4.1-3.ubuntu.security-status                     60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"
 auth-3.4.1-4.ubuntu.security-status                     60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"
+auth-3.4.5-1.ubuntu.security-status                     60 IN TXT "1 OK"
 
 ; Auth Raspbian
 auth-3.4.1-3.raspbian.security-status                   60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"
@@ -65,12 +69,18 @@ recursor-3.7.2-1.debian.security-status                 60 IN TXT "1 OK"
 recursor-3.7.2-1_bpo8_1.debian.security-status          60 IN TXT "1 OK"
 recursor-3.7.2-1_bpo7_1.debian.security-status          60 IN TXT "1 OK"
 
+recursor-3.7.3-1.debian.security-status                 60 IN TXT "1 OK"
+recursor-3.7.3-1_bpo8_1.debian.security-status          60 IN TXT "1 OK"
+recursor-3.7.3-1_bpo7_1.debian.security-status          60 IN TXT "1 OK"
+
 ; Recursor Raspbian
 recursor-3.6.2-2.raspbian.security-status               60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"
 recursor-3.6.2-2_bpo70_2.raspbian.security-status       60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"
 
 ; Recursor Ubuntu
 recursor-3.6.2-2.ubuntu.security-status                 60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"
+recursor-3.7.2-1.ubuntu.security-status                 60 IN TXT "1 OK"
+recursor-3.7.3-1.ubuntu.security-status                 60 IN TXT "1 OK"
 
 ; Recursor Fedora, EL
 recursor-3.6.2-1.fc19.fedora.security-status            60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/md/security/powerdns-advisory-2015-01/"


### PR DESCRIPTION
sid versions are in the queue already; backports may or may not come.
The Ubuntu versions are taken from packages.ubuntu.com, but the older
(actually current) versions are missing, because it's hard to tell
how they report themselves without installing them.