### PR TITLE
Remotebackend patch createSlaveDomain

### DIFF
--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -695,7 +695,7 @@ Creates new domain. This method is called when NOTIFY is received and you are su
 
 Mandatory: No
 Parameters: ip, domain
-Optional parameters: account
+Optional parameters: nameserver, account
 Reply: true for success, false for failure
 
 #### Example JSON/RPC

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -730,6 +730,7 @@ bool RemoteBackend::createSlaveDomain(const string &ip, const string &domain, co
    parameters.SetObject();
    JSON_ADD_MEMBER(parameters, "ip", ip.c_str(), query.GetAllocator());
    JSON_ADD_MEMBER(parameters, "domain", domain.c_str(), query.GetAllocator());
+   JSON_ADD_MEMBER(parameters, "nameserver", nameserver.c_str(), query.GetAllocator());
    JSON_ADD_MEMBER(parameters, "account", account.c_str(), query.GetAllocator());
    query.AddMember("parameters", parameters, query.GetAllocator());
 


### PR DESCRIPTION
Adds missing nameserver parameter to createSlaveDomain call.