### PR TITLE
DNSName class should not have a C string constructor.

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -12,7 +12,7 @@
    a primitive is nextLabel()
 */
 
-DNSName::DNSName(const char* p)
+DNSName::DNSName(const std::string& p)
 {
   auto labels = segmentDNSName(p);
   for(const auto& e : labels)

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -24,8 +24,8 @@ class DNSName
 {
 public:
   DNSName() {}                 //!< Constructs the root name
-  DNSName(const char* p);      //!< Constructs from a human formatted, escaped presentation
-  DNSName(const std::string& str) : DNSName(str.c_str()) {}   //!< Constructs from a human formatted, escaped presentation
+  DNSName(const char* p);      //!< Constructs from C strings of unknown length and string literals. *** ONLY DEFINED IN test-dnsname_cc.cc, see test_embedded_nulls ***
+  DNSName(const std::string& str);   //!< Constructs from a human formatted, escaped presentation
   DNSName(const char* p, int len, int offset, bool uncompress, uint16_t* qtype=0, uint16_t* qclass=0, unsigned int* consumed=0); //!< Construct from a DNS Packet, taking the first question
   
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name?

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -400,10 +400,6 @@ BOOST_AUTO_TEST_CASE(test_name_length_too_long) { // 256 char name
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_embedded_nulls) {
-  BOOST_CHECK (!(DNSName ("www.google.com.\x00sub.mydomain.com.") == DNSName("www.google.com.")));
-}
-
 
 BOOST_AUTO_TEST_CASE(test_invalid_label_length) { // Invalid label length in qname
 

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -400,6 +400,10 @@ BOOST_AUTO_TEST_CASE(test_name_length_too_long) { // 256 char name
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_embedded_nulls) {
+  BOOST_CHECK (!(DNSName ("www.google.com.\x00sub.mydomain.com.") == DNSName("www.google.com.")));
+}
+
 
 BOOST_AUTO_TEST_CASE(test_invalid_label_length) { // Invalid label length in qname
 

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -9,6 +9,9 @@
 using namespace boost;
 using std::string;
 
+DNSName::DNSName(const char* s): DNSName(std::string(s)) {
+}
+
 BOOST_AUTO_TEST_SUITE(dnsname_cc)
 
 BOOST_AUTO_TEST_CASE(test_basic) {
@@ -400,6 +403,10 @@ BOOST_AUTO_TEST_CASE(test_name_length_too_long) { // 256 char name
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_embedded_nulls) {
+  char const s[] = "www.google.com.\x00mydomain.com";
+  BOOST_CHECK_THROW (DNSName (std::string(s, sizeof(s) - 1)), std::runtime_error);
+}
 
 BOOST_AUTO_TEST_CASE(test_invalid_label_length) { // Invalid label length in qname
 


### PR DESCRIPTION
DNSName currently has a constructor that takes an arbitrary char*. This constructor is currently unused outside of the unit tests. This is good, but its presence is inherently risky because null termination is ambiguous wrt names containing embedded null bytes. 

Note that simply deleting the constructor is not advisable, since the (std::string) constructor will also accept a char\*. This pull request adds 3 commits, one to add a test case that demonstrates the risk, and 2 which remove it again and move the definition of the offending constructor  to the test suite itself. This guarantees anyone attempting to construct a DNSName from a char* will get a link error.