### PR TITLE
Fix out-of-zone-additional-processing documentation

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -507,12 +507,15 @@ or ALSO-NOTIFY metadata always receive AXFR NOTIFY.
 
 ## `out-of-zone-additional-processing`
 * Boolean
-* Default: no
+* Default: yes
 
 Do out of zone additional processing. This means that if a malicious user adds a
 '.com' zone to your server, it is not used for other domains and will not
 contaminate answers. Do not enable this setting if you run a public DNS service
 with untrusted users.
+
+The docs had previously indicated that the default was "no", but the default has
+been "yes" since 2005.
 
 ## `pipebackend-abi-version`
 * Integer


### PR DESCRIPTION
Docs indicate that it defaults to "no", while it actually
defaults to "yes"