### PR TITLE
CDS and CDNSKEY support

### DIFF
--- a/docs/manpages/pdnssec.1.md
+++ b/docs/manpages/pdnssec.1.md
@@ -88,24 +88,17 @@ remove-zone-key *ZONE* *KEY-ID*
 set-nsec3 *ZONE* '*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*' [**narrow**]
 :    Sets NSEC3 parameters for this zone. The quoted parameters are 4 values
      that are used for the the NSEC3PARAM record and decide how NSEC3 records
-     are created. The NSEC3 parameters must be quoted on the command line.
-
-     *HASH-ALGORITHM* must be 1 (SHA-1).
-
+     are created. The NSEC3 parameters must be quoted on the command line.<br><br>
+     *HASH-ALGORITHM* must be 1 (SHA-1).<br><br>
      Setting *FLAGS* to 1 enables NSEC3 opt-out operation. Only do this if you
-     know you need it.
-
+     know you need it.<br><br>
      For *ITERATIONS*, please consult RFC 5155, section 10.3. And be aware
-     that a high number might overload validating resolvers.
-
-     The *SALT* is a hexadecimal string encoding the bits for the salt.
-
+     that a high number might overload validating resolvers.<br><br>
+     The *SALT* is a hexadecimal string encoding the bits for the salt.<br><br>
      Setting **narrow** will make PowerDNS send out "white lies" about the next
      secure record. Instead of looking it up in the database, it will send out
-     the hash + 1 as the next secure record.
-
-     A sample commandline is: "pdnssec set-nsec3 powerdnssec.org '1 1 1 ab' narrow".
-
+     the hash + 1 as the next secure record. <br><br>
+     A sample commandline is: "pdnssec set-nsec3 powerdnssec.org '1 1 1 ab' narrow".<br><br>
      **WARNING**: If running in RSASHA1 mode (algorithm 5 or 7), switching from
      NSEC to NSEC3 will require a DS update in the parent zone.
 
@@ -113,6 +106,20 @@ unset-nsec3 *ZONE*
 :    Converts *ZONE* to NSEC operations. **WARNING**: If running in RSASHA1 mode
      (algorithm 5 or 7), switching from NSEC to NSEC3 will require a DS update
      at the parent zone!
+
+set-publish-cds *ZONE* [*DIGESTALGOS*]
+:    Set *ZONE* to respond to queries for its CDS records. the optional argument
+     *DIGESTALGOS* should be a comma-separated list of DS algorithms to use. By
+     default, this is 1,2 (SHA1 and SHA2-256).
+
+set-publish-cdnskey *ZONE*
+:    Set *ZONE* to publish CDNSKEY records.
+
+unset-publish-cds *ZONE*
+:    Set *ZONE* to stop responding to queries for its CDS records.
+
+unset-publish-cdnskey *ZONE*
+:    Set *ZONE* to stop publishing CDNSKEY records.
 
 ## TSIG RELATED COMMANDS
 These commands manipulate TSIG key information in the database. Some commands

--- a/docs/markdown/authoritative/dnssec.md
+++ b/docs/markdown/authoritative/dnssec.md
@@ -204,40 +204,7 @@ Precisely speaking, the time period used is always from the start of the previou
 # `pdnssec`
 `pdnssec` is a powerful command that is the operator-friendly gateway into PowerDNSSEC configuration. Behind the scenes, `pdnssec` manipulates a PowerDNS backend database, which also means that for many databases, `pdnssec` can be run remotely, and can configure key material on different servers.
 
-The following pdnssec commands are available:
-
-* `activate-zone-key ZONE KEY-ID`: Activate a key with id KEY-ID within a zone called ZONE.
-* `add-zone-key ZONE [ksk|zsk] [bits] [rsasha1|rsasha256|rsasha512|gost|ecdsa256|ecdsa384]`: Create a new key for zone ZONE, and make it a KSK or a ZSK, with the specified algorithm.
-* `backend-cmd BACKEND CMD [CMD..]`: Send a text command to a backend for execution. GSQL backends will take SQL commands, other backends may take different things. Be careful!
-* `check-zone ZONE`: Check a zone for DNSSEC correctness. Main goals is to check if the auth flag is set correctly.
-* `check-all-zones`: Check all zones for DNSSEC correctness. Added in 3.1.
-* `deactivate-zone-key ZONE KEY-ID`: Deactivate a key with id KEY-ID within a zone called ZONE.
-* `disable-dnssec ZONE`: Deactivate all keys and unset PRESIGNED in ZONE.
-* `export-zone-dnskey ZONE KEY-ID`: Export to standard output DNSKEY and DS of key with key id KEY-ID within zone called ZONE.
-* `export-zone-key ZONE KEY-ID`: Export to standard output full (private) key with key id KEY-ID within zone called ZONE. The format used is compatible with BIND and NSD/LDNS.
-* `hash-zone-record ZONE RECORDNAME`:
-This convenience command hashes the name 'recordname' according to the NSEC3 settings of ZONE. Refuses to hash for zones with no NSEC3 settings.
-* `import-zone-key ZONE filename [ksk|zsk]`: Import from 'filename' a full (private) key for zone called ZONE. The format used is compatible with BIND and NSD/LDNS. KSK or ZSK specifies the flags this key should have on import.
-* `import-zone-key-pem ZONE filename algorithm [ksk|zsk]`: Import from 'filename' a full (private) key in PEM format for zone called ZONE, and assign it an algorithm number. KSK or ZSK specifies the flags this key should have on import. The format used is compatible with 'openssl genrsa', which is also called PEM.
-* `generate-zone-key [ksk|zsk] [algorithm] [bits]`: Generate and display a zone key. Can be used when you need to generate a key for some script backend. Does not store the key.
-* `rectify-zone ZONE [ZONE ..]`: Calculates the 'ordername' and 'auth' fields for a zone called ZONE so they comply with DNSSEC settings. Can be used to fix up migrated data. Can always safely be run, it does no harm. Multiple zones can be supplied.
-* `rectify-all-zones`: Do a rectify-zone for all the zones. Be careful when running this. Only bind and gmysql backends are supported. Added in 3.1.
-* `remove-zone-key ZONE KEY-ID`: Remove a key with id KEY-ID from a zone called ZONE.
-* `secure-zone ZONE`: Configures a zone called ZONE with reasonable DNSSEC settings. You should manually run `rectify-zone` afterwards.
-* `secure-all-zones`: Add keymaterial to all zones. You should manually run `rectify-all-zones` afterwards. The `increase-serial` option increases the SOA serial for new secured zones.
-* `set-nsec3 ZONE 'parameters' [narrow]`: Sets NSEC3 parameters for this zone. A sample command line is: `pdnssec set-nsec3 powerdnssec.org '1 0 1 ab' narrow`. The NSEC3 parameters must be quoted on the command line. **Warning**: If running in RSASHA1 mode (algorithm 5 or 7), switching from NSEC to NSEC3 will require a DS update at the parent zone! The NSEC3 fields are: 'algorithm flags iterations salt'. For 'algorithm', currently '1' is the only supported value. Setting 'flags' to 1 enables opt-out operation. Only do this if you know you need it. The salt is hexadecimal.
-* `set-presigned ZONE`: Switches zone to presigned operation, utilizing in-zone RRSIGs.
-* `show-zone ZONE`: Shows all DNSSEC related settings of a zone called ZONE.
-* `unset-nsec3 ZONE`: Converts a zone to NSEC operations. **Warning**: If running in RSASHA1 mode (algorithm 5 or 7), switching from NSEC to NSEC3 will require a DS update at the parent zone!
-* `unset-presigned ZONE`: Disables presigned operation for ZONE.
-* `import-tsig-key name algorithm key`: Imports a named TSIG key. Use enable/disable-tsig-key to map it to a zone.
-* `generate-tsig-key name algorithm`: Creates and stores a named tsig key.
-* `delete-tsig-key name`: Deletes a named TSIG key. **Warning**: Does not unmap it from zones.
-* `list-tsig-keys`: Shows all TSIG keys from all backends.
-* `activate-tsig-key zone name [master|slave]`: activate TSIG key for a zone. Use master on master server, slave on slave server.
-* `deactivate-tsig-key zone name [master|slave]`: Deactivate TSIG key for a zone. Use master on master server, slave on slave server.
-* `get-meta ZONE [kind kind..]`: Gets one or more meta items for domain ZONE. If no meta keys defined, it retrieves well known meta keys.
-* `set-meta ZONE kind [value value ..]`: Clears or sets meta for domain ZONE. You can provide one or more value(s).
+For a list of available commands, see the [manpage](../manpages/pdnssec.1.md).
 
 # DNSSEC advice & precautions
 DNSSEC is a major change in the way DNS works. Furthermore, there is a bewildering array of settings that can be configured.

--- a/docs/markdown/authoritative/domainmetadata.md
+++ b/docs/markdown/authoritative/domainmetadata.md
@@ -1,12 +1,17 @@
 # Per zone settings aka Domain Metadata
-Starting with the PowerDNS Authoritative Server 3.0, each served zone can have "metadata". Such metadata determines how this zone behaves in certain circumstances.
+Starting with the PowerDNS Authoritative Server 3.0, each served zone can have
+"metadata". Such metadata determines how this zone behaves in certain circumstances.
 
-**Warning**: Domain metadata is only available for DNSSEC capable backends! Make sure to enable the proper '-dnssec' setting to benefit, and to have performed the DNSSEC schema update.
+**Warning**: Domain metadata is only available for DNSSEC capable backends! Make
+sure to enable the proper '-dnssec' setting to benefit, and to have performed
+the DNSSEC schema update.
 
 ## ALLOW-AXFR-FROM
-Starting with the PowerDNS Authoritative Server 3.1, per-zone AXFR ACLs can be stored in the domainmetadata table.
+Starting with the PowerDNS Authoritative Server 3.1, per-zone AXFR ACLs can be
+stored in the domainmetadata table.
 
-Each ACL row can list one subnet (v4 or v6), or the magical value 'AUTO-NS' that tries to allow all potential slaves in.
+Each ACL row can list one subnet (v4 or v6), or the magical value 'AUTO-NS' that
+tries to allow all potential slaves in.
 
 Example:
 
@@ -27,10 +32,13 @@ See the documentation on [Dynamic DNS update](dnsupdate.md)
 When notifying this domain, also notify this nameserver (can occur multiple times).
 
 ## AXFR-MASTER-TSIG
-Use this named TSIG key to retrieve this zone from its master (see [Provisioning signed notification and AXFR requests](modes-of-operation.md#provisioning-signed-notification-and-axfr-requests)).
+Use this named TSIG key to retrieve this zone from its master (see
+[Provisioning signed notification and AXFR requests](modes-of-operation.md#provisioning-signed-notification-and-axfr-requests)).
 
 ## GSS-ALLOW-AXFR-PRINCIPAL
-Allow this GSS principal to perform AXFR retrieval. Most commonly it is host/something@REALM, DNS/something@REALM or user@REALM. (See [GSS-TSIG support](gss-tsig.md)).
+Allow this GSS principal to perform AXFR retrieval. Most commonly it is
+`host/something@REALM`, `DNS/something@REALM` or `user@REALM`. (See
+[GSS-TSIG support](gss-tsig.md)).
 
 ## GSS-ACCEPTOR-PRINCIPAL
 Use this principal for accepting GSS context. (See [GSS-TSIG support](gss-tsig.md)).
@@ -39,18 +47,31 @@ Use this principal for accepting GSS context. (See [GSS-TSIG support](gss-tsig.m
 Script to be used to edit incoming AXFRs, see [Modifying a slave zone using a script](modes-of-operation.md#modifying-a-slave-zone-using-a-script).
 
 ## NSEC3NARROW
-Set to "1" to tell PowerDNS this zone operates in NSEC3 'narrow' mode. See `set-nsec3` for [`pdnssec`](dnssec.md#pdnssec).
+Set to "1" to tell PowerDNS this zone operates in NSEC3 'narrow' mode. See
+`set-nsec3` for [`pdnssec`](dnssec.md#pdnssec).
 
 ## NSEC3PARAM
-NSEC3 parameters of a DNSSEC zone. Will be used to synthesize the NSEC3PARAM record. If present, NSEC3 is used, if not present, zones default to NSEC. See `set-nsec3` in [`pdnssec`](dnssec.md#pdnssec). Example content: "1 0 1 ab".
+NSEC3 parameters of a DNSSEC zone. Will be used to synthesize the NSEC3PARAM
+record. If present, NSEC3 is used, if not present, zones default to NSEC. See
+`set-nsec3` in [`pdnssec`](dnssec.md#pdnssec). Example content: "1 0 1 ab".
 
 ## PRESIGNED
-This zone carries DNSSEC RRSIGs (signatures), and is presigned. PowerDNS sets this flag automatically upon incoming zone transfers (AXFR) if it detects DNSSEC records in the zone. However, if you import a presigned zone using `zone2sql` or `pdnssec load-zone` you must explicitly set the zone to be `PRESIGNED`. Note that PowerDNS will not be able to correctly serve the zone if the imported data is bogus or incomplete. Also see `set-presigned` in [`pdnssec`](dnssec.md#pdnssec).
+This zone carries DNSSEC RRSIGs (signatures), and is presigned. PowerDNS sets
+this flag automatically upon incoming zone transfers (AXFR) if it detects DNSSEC
+records in the zone. However, if you import a presigned zone using `zone2sql` or
+`pdnssec load-zone` you must explicitly set the zone to be `PRESIGNED`. Note that
+PowerDNS will not be able to correctly serve the zone if the imported data is
+bogus or incomplete. Also see `set-presigned` in [`pdnssec`](dnssec.md#pdnssec).
 
 ## SOA-EDIT
-When serving this zone, modify the SOA serial number in one of several ways. Mostly useful to get slaves to re-transfer a zone regularly to get fresh RRSIGs.
+When serving this zone, modify the SOA serial number in one of several ways.
+Mostly useful to get slaves to re-transfer a zone regularly to get fresh RRSIGs.
 
-Inception refers to the time the RRSIGs got updated in [live-signing mode](dnssec.md#records-keys-signatures-hashes-within-powerdnssec-in-online-signing-mode). This happens every week (see [Signatures](dnssec.md#signatures)). The inception time does not depend on local timezone, but some modes below will use localtime for representation.
+Inception refers to the time the RRSIGs got updated in
+[live-signing mode](dnssec.md#records-keys-signatures-hashes-within-powerdnssec-in-online-signing-mode).
+This happens every week (see [Signatures](dnssec.md#signatures)). The inception
+time does not depend on local timezone, but some modes below will use localtime
+for representation.
 
 Available modes are:
 
@@ -65,4 +86,5 @@ Available modes are:
 Allow these named TSIG keys to AXFR this zone (see [Provisioning outbound AXFR access](modes-of-operation.md#provisioning-outbound-axfr-access)).
 
 ## TSIG-ALLOW-DNSUPDATE
-This setting allows you to set the TSIG key required to do an DNS update. If GSS-TSIG is enabled, you can put kerberos principals here as well.
+This setting allows you to set the TSIG key required to do an DNS update. If
+GSS-TSIG is enabled, you can put kerberos principals here as well.

--- a/docs/markdown/authoritative/domainmetadata.md
+++ b/docs/markdown/authoritative/domainmetadata.md
@@ -63,6 +63,18 @@ records in the zone. However, if you import a presigned zone using `zone2sql` or
 PowerDNS will not be able to correctly serve the zone if the imported data is
 bogus or incomplete. Also see `set-presigned` in [`pdnssec`](dnssec.md#pdnssec).
 
+## PUBLISH_CDNSKEY, PUBLISH_CDS
+Whether to publish CDNSKEY and/or CDS recording defined in [RFC 7344](https://tools.ietf.org/html/rfc7344).
+
+To publish CDNSKEY records of the KSKs for the zone, set `PUBLISH_CDNSKEY` to `1`.
+
+To publish CDS records for the KSKs in the zone, set `PUBLISH_CDS` to a comma-
+separated list of [signature algorithm numbers](http://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml#ds-rr-types-1).
+
+This metadata can also be set using the [`pdnssec`](dnssec.md#pdnssec) options
+`set-publish-cdnskey` and `set-publish-cds`. For an example for an RFC 7344
+key rollover, see the [CDS and CDNSKEY howto](howtos.md#cds-dnskey-key-rollover).
+
 ## SOA-EDIT
 When serving this zone, modify the SOA serial number in one of several ways.
 Mostly useful to get slaves to re-transfer a zone regularly to get fresh RRSIGs.

--- a/docs/markdown/authoritative/howtos.md
+++ b/docs/markdown/authoritative/howtos.md
@@ -1,0 +1,29 @@
+# CDS & CDNSKEY Key Rollover
+If the upstream registry supports [RFC 7344](https://tools.ietf.org/html/rfc7344)
+key rollovers you can use several [`pdnssec`](dnssec.md#pdnssec) commands to do
+this rollover. This HowTo follows the rollover example from the RFCs [Appendix B](https://tools.ietf.org/html/rfc7344#appendix-B).
+
+We assume the zone name is example.com and is already DNSSEC signed.
+
+Start by adding a new KSK to the zone: `pdnssec add-zone-key example.com ksk 2048 passive`.
+The "passive" means that the key is not used to sign any ZSK records. This limits
+the size of `ANY` and DNSKEY responses.
+
+Publish the CDS records: `pdnssec set-publish-cds example.com`, these records
+will tell the parent zone to update its DS records. Now wait for the DS records
+to be updated in the parent zone.
+
+Once the DS records are updated, do the actual key-rollover: `pdnssec activate-zone-key example.com new-key-id`
+and `pdnssec deactivate-zone-key example.com old-key-id`. You can get the `new-key-id`
+and `old-key-id` by listing them through `pdnssec show-zone example.com`.
+
+After the rollover, wait *at least* until the TTL on the DNSKEY records have
+expired so validating resolvers won't mark the zone as BOGUS. When the wait is
+over, delete the old key from the zone: `pdnssec remove-zone-key example.com old-key-id`.
+This updates the CDS records to reflect only the new key.
+
+Wait for the parent to pick up on the CDS change. Once the upstream DS records
+show only the DS records for the new KSK, you may disable sending out the CDS
+responses: `pdnssec unset-pushish-cds example.com`.
+
+Done!

--- a/docs/markdown/types.md
+++ b/docs/markdown/types.md
@@ -17,6 +17,12 @@ Since 2.9.21. Specialised record type for the 'Andrew Filesystem'. Stored as: '\
 ## CERT
 Since 2.9.21. Specialised record type for storing certificates, defined in [RFC 2538](http://tools.ietf.org/html/rfc2538).
 
+## CDNSKEY
+Since 4.0.0. The CDNSKEY ([Child DNSKEY](https://tools.ietf.org/html/rfc7344#section-3.2)) type is supported.
+
+## CDS
+Since 4.0.0. The CDS ([Child DS](https://tools.ietf.org/html/rfc7344#section-3.1)) type is supported.
+
 ## CNAME
 The CNAME record specifies the canonical name of a record. It is stored plainly. Like all other records, it is not terminated by a dot. A sample might be 'webserver-01.yourcompany.com'.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -24,6 +24,7 @@ pages:
     - Domain metadata: authoritative/domainmetadata.md
     - Dynamic DNS Update: authoritative/dnsupdate.md
     - GSS-TSIG: authoritative/gss-tsig.md
+    - Various How To's: authoritative/howtos.md
     - Internals: authoritative/internals.md
     - Virtual Hosting: authoritative/virtual.md
     - Performance Tuning and Monitoring: authoritative/performance.md

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -295,6 +295,31 @@ bool DNSSECKeeper::unsetPresigned(const DNSName& zname)
   return d_keymetadb->setDomainMetadata(zname, "PRESIGNED", vector<string>());
 }
 
+/**
+ * Add domainmetadata to allow publishing CDNSKEY records.for zone zname
+ *
+ * @param zname        DNSName of the zone
+ * @return             true if the data was inserted, false otherwise
+ */
+bool DNSSECKeeper::setPublishCDNSKEY(const DNSName& zname)
+{
+  clearCaches(zname);
+  vector<string> meta;
+  meta.push_back("1");
+  return d_keymetadb->setDomainMetadata(zname, "PUBLISH_CDNSKEY", meta);
+}
+
+/**
+ * Remove domainmetadata to stop publishing CDNSKEY records for zone zname
+ *
+ * @param zname        DNSName of the zone
+ * @return             true if the operation was successful, false otherwise
+ */
+bool DNSSECKeeper::unsetPublishCDNSKEY(const DNSName& zname)
+{
+  clearCaches(zname);
+  return d_keymetadb->setDomainMetadata(zname, "PUBLISH_CDNSKEY", vector<string>());
+}
 
 DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, boost::tribool allOrKeyOrZone, bool useCache)
 {

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -296,6 +296,35 @@ bool DNSSECKeeper::unsetPresigned(const DNSName& zname)
 }
 
 /**
+ * Add domainmetadata to allow publishing CDS records for zone zname
+ *
+ * @param zname        DNSName of the zone
+ * @param digestAlgos  string with comma-separated numbers that describe the
+ *                     used digest algorithms. This is copied to the database
+ *                     verbatim
+ * @return             true if the data was inserted, false otherwise
+ */
+bool DNSSECKeeper::setPublishCDS(const DNSName& zname, const string& digestAlgos)
+{
+  clearCaches(zname);
+  vector<string> meta;
+  meta.push_back(digestAlgos);
+  return d_keymetadb->setDomainMetadata(zname, "PUBLISH_CDS", meta);
+}
+
+/**
+ * Remove domainmetadata to stop publishing CDS records for zone zname
+ *
+ * @param zname        DNSName of the zone
+ * @return             true if the operation was successful, false otherwise
+ */
+bool DNSSECKeeper::unsetPublishCDS(const DNSName& zname)
+{
+  clearCaches(zname);
+  return d_keymetadb->setDomainMetadata(zname, "PUBLISH_CDS", vector<string>());
+}
+
+/**
  * Add domainmetadata to allow publishing CDNSKEY records.for zone zname
  *
  * @param zname        DNSName of the zone

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -279,6 +279,14 @@ boilerplate_conv(DS, 43,
                  conv.xfrHexBlob(d_digest, true); // keep reading across spaces
                  )
 
+CDSRecordContent::CDSRecordContent() : DNSRecordContent(59) {}
+boilerplate_conv(CDS, 59, 
+                 conv.xfr16BitInt(d_tag); 
+                 conv.xfr8BitInt(d_algorithm); 
+                 conv.xfr8BitInt(d_digesttype); 
+                 conv.xfrHexBlob(d_digest, true); // keep reading across spaces
+                 )
+
 DLVRecordContent::DLVRecordContent() : DNSRecordContent(32769) {}
 boilerplate_conv(DLV,32769 , 
                  conv.xfr16BitInt(d_tag); 
@@ -315,6 +323,14 @@ boilerplate_conv(DNSKEY, 48,
                  conv.xfrBlob(d_key);
                  )
 DNSKEYRecordContent::DNSKEYRecordContent() : DNSRecordContent(48) {}
+
+boilerplate_conv(CDNSKEY, 60, 
+                 conv.xfr16BitInt(d_flags); 
+                 conv.xfr8BitInt(d_protocol); 
+                 conv.xfr8BitInt(d_algorithm); 
+                 conv.xfrBlob(d_key);
+                 )
+CDNSKEYRecordContent::CDNSKEYRecordContent() : DNSRecordContent(60) {}
 
 boilerplate_conv(RKEY, 57, 
                  conv.xfr16BitInt(d_flags); 
@@ -494,9 +510,11 @@ void reportOtherTypes()
    RPRecordContent::report();
    KEYRecordContent::report();
    DNSKEYRecordContent::report();
+   CDNSKEYRecordContent::report();
    RKEYRecordContent::report();
    RRSIGRecordContent::report();
    DSRecordContent::report();
+   CDSRecordContent::report();
    SSHFPRecordContent::report();
    CERTRecordContent::report();
    NSECRecordContent::report();

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -284,11 +284,35 @@ public:
   string d_key;
 };
 
+class CDNSKEYRecordContent : public DNSRecordContent
+{
+public:
+  CDNSKEYRecordContent();
+  includeboilerplate(CDNSKEY)
+  uint16_t getTag();
+
+  uint16_t d_flags;
+  uint8_t d_protocol;
+  uint8_t d_algorithm;
+  string d_key;
+};
+
 class DSRecordContent : public DNSRecordContent
 {
 public:
   DSRecordContent();
   includeboilerplate(DS)
+
+  uint16_t d_tag;
+  uint8_t d_algorithm, d_digesttype;
+  string d_digest;
+};
+
+class CDSRecordContent : public DNSRecordContent
+{
+public:
+  CDSRecordContent();
+  includeboilerplate(CDS)
 
   uint16_t d_tag;
   uint8_t d_algorithm, d_digesttype;

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -92,6 +92,8 @@ public:
   bool unsetPresigned(const DNSName& zname);
   bool setPublishCDNSKEY(const DNSName& zname);
   bool unsetPublishCDNSKEY(const DNSName& zname);
+  bool setPublishCDS(const DNSName& zname, const string& digestAlgos);
+  bool unsetPublishCDS(const DNSName& zname);
 
   bool TSIGGrantsAccess(const DNSName& zone, const DNSName& keyname);
   bool getTSIGForAccess(const DNSName& zone, const string& master, DNSName* keyname);

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -90,6 +90,8 @@ public:
   bool isPresigned(const DNSName& zname);
   bool setPresigned(const DNSName& zname);
   bool unsetPresigned(const DNSName& zname);
+  bool setPublishCDNSKEY(const DNSName& zname);
+  bool unsetPublishCDNSKEY(const DNSName& zname);
 
   bool TSIGGrantsAccess(const DNSName& zone, const DNSName& keyname);
   bool getTSIGForAccess(const DNSName& zone, const string& master, DNSName* keyname);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -214,12 +214,12 @@ bool PacketHandler::addCDS(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 
   DNSSECKeeper::keyset_t keyset = d_dk.getKeys(p->qdomain);
 
-  for(auto value : keyset) {
+  for(auto const &value : keyset) {
     if (!value.second.keyOrZone) {
       // Don't send out CDS records for ZSKs
       continue;
     }
-    for(auto digestAlgo : digestAlgos){
+    for(auto const &digestAlgo : digestAlgos){
       rr.content=makeDSFromDNSKey(p->qdomain, value.first.getDNSKEY(), lexical_cast<int>(digestAlgo)).getZoneRepresentation();
       r->addRecord(rr);
       haveOne=true;

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -71,7 +71,7 @@ private:
   int processNotify(DNSPacket *);
   void addRootReferral(DNSPacket *r);
   int doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target);
-  bool addDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd);
+  bool addDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd, bool doCDNSKEY);
   bool addNSEC3PARAM(DNSPacket *p, DNSPacket *r, const SOAData& sd);
   int doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, const SOAData& sd, bool retargeted);
   void addNSECX(DNSPacket *p, DNSPacket* r, const DNSName &target, const DNSName &wildcard, const DNSName &auth, int mode);

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -72,6 +72,7 @@ private:
   void addRootReferral(DNSPacket *r);
   int doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target);
   bool addDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd, bool doCDNSKEY);
+  bool addCDS(DNSPacket *p, DNSPacket *r, const SOAData& sd);
   bool addNSEC3PARAM(DNSPacket *p, DNSPacket *r, const SOAData& sd);
   int doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, const SOAData& sd, bool retargeted);
   void addNSECX(DNSPacket *p, DNSPacket* r, const DNSName &target, const DNSName &wildcard, const DNSName &auth, int mode);

--- a/pdns/pdnssec.cc
+++ b/pdns/pdnssec.cc
@@ -1363,11 +1363,13 @@ try
     cerr<<"secure-zone ZONE [ZONE ..]         Add KSK and two ZSKs"<<endl;
     cerr<<"set-nsec3 ZONE ['params' [narrow]] Enable NSEC3 with PARAMs. Optionally narrow"<<endl;
     cerr<<"set-presigned ZONE                 Use presigned RRSIGs from storage"<<endl;
+    cerr<<"set-publish-cdnskey ZONE           Enable sending CDNSKEY responses for ZONE"<<endl;
     cerr<<"set-meta ZONE KIND [value value ..]"<<endl;
     cerr<<"                                   Set zone metadata, optionally providing a value. Empty clears meta."<<endl;
     cerr<<"show-zone ZONE                     Show DNSSEC (public) key details about a zone"<<endl;
     cerr<<"unset-nsec3 ZONE                   Switch back to NSEC"<<endl;
     cerr<<"unset-presigned ZONE               No longer use presigned RRSIGs"<<endl;
+    cerr<<"unset-publish-cdnskey ZONE         Disable sending CDNSKEY responses for ZONE"<<endl;
     cerr<<"test-schema ZONE                   Test DB schema - will create ZONE"<<endl;
     cerr<<desc<<endl;
     return 0;
@@ -1752,6 +1754,17 @@ try
     }
     return 0;
   }
+  else if(cmds[0]=="set-publish-cdnskey") {
+    if(cmds.size() < 2) {
+      cerr<<"Syntax: pdnssec set-publish-cdnskey ZONE"<<endl;
+      return 0;
+    }
+    if (! dk.setPublishCDNSKEY(cmds[1])) {
+      cerr << "Could not set publishing for CDNSKEY records for "<< cmds[1]<<endl;
+      return 1;
+    }
+    return 0;
+  }
   else if(cmds[0]=="unset-presigned") {
     if(cmds.size() < 2) {
       cerr<<"Syntax: pdnssec unset-presigned ZONE"<<endl;
@@ -1759,6 +1772,17 @@ try
     }
     if (! dk.unsetPresigned(cmds[1])) {
       cerr << "Could not unset presigned on for " << cmds[1] << endl;
+      return 1;
+    }
+    return 0;
+  }
+  else if(cmds[0]=="unset-publish-cdnskey") {
+    if(cmds.size() < 2) {
+      cerr<<"Syntax: pdnssec unset-publish-cdnskey ZONE"<<endl;
+      return 0;
+    }
+    if (! dk.unsetPublishCDNSKEY(cmds[1])) {
+      cerr << "Could not unset publishing for CDNSKEY records for "<< cmds[1]<<endl;
       return 1;
     }
     return 0;

--- a/pdns/pdnssec.cc
+++ b/pdns/pdnssec.cc
@@ -1364,12 +1364,15 @@ try
     cerr<<"set-nsec3 ZONE ['params' [narrow]] Enable NSEC3 with PARAMs. Optionally narrow"<<endl;
     cerr<<"set-presigned ZONE                 Use presigned RRSIGs from storage"<<endl;
     cerr<<"set-publish-cdnskey ZONE           Enable sending CDNSKEY responses for ZONE"<<endl;
+    cerr<<"set-publish-cds ZONE [DIGESTALGOS] Enable sending CDS responses for ZONE, using DIGESTALGOS as signature algirithms"<<endl;
+    cerr<<"                                   DIGESTALGORITHMS should be a comma separated list of numbers, is is '1,2' by default"<<endl;
     cerr<<"set-meta ZONE KIND [value value ..]"<<endl;
     cerr<<"                                   Set zone metadata, optionally providing a value. Empty clears meta."<<endl;
     cerr<<"show-zone ZONE                     Show DNSSEC (public) key details about a zone"<<endl;
     cerr<<"unset-nsec3 ZONE                   Switch back to NSEC"<<endl;
     cerr<<"unset-presigned ZONE               No longer use presigned RRSIGs"<<endl;
     cerr<<"unset-publish-cdnskey ZONE         Disable sending CDNSKEY responses for ZONE"<<endl;
+    cerr<<"unset-publish-cds ZONE             Disable sending CDS responses for ZONE"<<endl;
     cerr<<"test-schema ZONE                   Test DB schema - will create ZONE"<<endl;
     cerr<<desc<<endl;
     return 0;
@@ -1765,6 +1768,22 @@ try
     }
     return 0;
   }
+  else if(cmds[0]=="set-publish-cds") {
+    if(cmds.size() < 2) {
+      cerr<<"Syntax: pdnssec set-publish-cds ZONE [DIGESTALGOS]"<<endl;
+      return 0;
+    }
+
+    // If DIGESTALGOS is unset
+    if(cmds.size() == 2)
+      cmds.push_back("1,2");
+
+    if (! dk.setPublishCDS(cmds[1], cmds[2])) {
+      cerr << "Could not set publishing for CDS records for "<< cmds[1]<<endl;
+      return 1;
+    }
+    return 0;
+  }
   else if(cmds[0]=="unset-presigned") {
     if(cmds.size() < 2) {
       cerr<<"Syntax: pdnssec unset-presigned ZONE"<<endl;
@@ -1783,6 +1802,17 @@ try
     }
     if (! dk.unsetPublishCDNSKEY(cmds[1])) {
       cerr << "Could not unset publishing for CDNSKEY records for "<< cmds[1]<<endl;
+      return 1;
+    }
+    return 0;
+  }
+  else if(cmds[0]=="unset-publish-cds") {
+    if(cmds.size() < 2) {
+      cerr<<"Syntax: pdnssec unset-publish-cds ZONE"<<endl;
+      return 0;
+    }
+    if (! dk.unsetPublishCDS(cmds[1])) {
+      cerr << "Could not unset publishing for CDS records for "<< cmds[1]<<endl;
       return 1;
     }
     return 0;

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -81,7 +81,8 @@ public:
 #undef DS
   enum typeenum : uint16_t {A=1, NS=2, CNAME=5, SOA=6, MR=9, WKS=11, PTR=12, HINFO=13, MINFO=14, MX=15, TXT=16, RP=17, AFSDB=18, SIG=24, KEY=25, AAAA=28, LOC=29, SRV=33, NAPTR=35, KX=36,
 		 CERT=37, A6=38, DNAME=39, OPT=41, DS=43, SSHFP=44, IPSECKEY=45, RRSIG=46, NSEC=47, DNSKEY=48, DHCID=49, NSEC3=50, NSEC3PARAM=51,
-		 TLSA=52, SPF=99, EUI48=108, EUI64=109, TKEY=249, TSIG=250, IXFR=251, AXFR=252, MAILB=253, MAILA=254, ANY=255, ADDR=259, ALIAS=260, DLV=32769};
+		 TLSA=52, CDS=59, CDNSKEY=60, SPF=99, EUI48=108, EUI64=109, TKEY=249, TSIG=250, IXFR=251, AXFR=252, MAILB=253, MAILA=254, ANY=255, ADDR=259,
+		 ALIAS=260, DLV=32769};
   typedef pair<string,uint16_t> namenum;
   static vector<namenum> names;
 
@@ -152,6 +153,8 @@ private:
       qtype_insert("NSEC3", 50);
       qtype_insert("NSEC3PARAM", 51);
       qtype_insert("TLSA", 52);
+      qtype_insert("CDS", 59);
+      qtype_insert("CDNSKEY", 60);
       qtype_insert("SPF", 99);
       qtype_insert("EUI48", 108);
       qtype_insert("EUI64", 109);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -688,7 +688,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
         rr.qtype=QType(QType::CDS);
         vector<string> digestAlgos;
         stringtok(digestAlgos, publishCDS, ", ");
-        for(auto digestAlgo : digestAlgos) {
+        for(auto const &digestAlgo : digestAlgos) {
           rr.content=makeDSFromDNSKey(target, value.first.getDNSKEY(), lexical_cast<int>(digestAlgo)).getZoneRepresentation();
           cds.push_back(rr);
         }
@@ -733,10 +733,10 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   vector<DNSResourceRecord> rrs;
 
   // Add the CDNSKEY and CDS records we created earlier
-  for (auto const rr : cds)
+  for (auto const &rr : cds)
     rrs.push_back(rr);
 
-  for (auto const rr : cdnskey)
+  for (auto const &rr : cdnskey)
     rrs.push_back(rr);
 
   while(sd.db->get(rr)) {

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -76,6 +76,8 @@ securezone ()
 		keyid=`$PDNSSEC --config-dir=. $configname show-zone $zone | grep ZSK | cut -d' ' -f3`
 		$PDNSSEC --config-dir=. $configname activate-zone-key $zone $keyid 2>&1
 		$PDNSSEC --config-dir=. $configname rectify-zone $zone 2>&1
+		$PDNSSEC --config-dir=. $configname set-publish-cds $zone 2>&1
+		$PDNSSEC --config-dir=. $configname set-publish-cdnskey $zone 2>&1
 	else
 		# check if PKCS#11 should be used
 		if [ "$pkcs11" -eq 1 ]; then

--- a/regression-tests/tests/publishing-cds-cdnskey/command
+++ b/regression-tests/tests/publishing-cds-cdnskey/command
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cleandig secure-delegated.dnssec-parent.com CDS dnssec
+cleandig secure-delegated.dnssec-parent.com CDNSKEY dnssec
+cleandig secure-delegated.dnssec-parent.com ANY dnssec tcp | grep 'CDS\|CDNSKEY' | grep -v 'NSEC'

--- a/regression-tests/tests/publishing-cds-cdnskey/description
+++ b/regression-tests/tests/publishing-cds-cdnskey/description
@@ -1,0 +1,2 @@
+Test whether we get a correct response for CDS query, a CDNSKEY query and an ANY
+query on the apex.

--- a/regression-tests/tests/publishing-cds-cdnskey/expected_result
+++ b/regression-tests/tests/publishing-cds-cdnskey/expected_result
@@ -1,0 +1,16 @@
+0	secure-delegated.dnssec-parent.com.	IN	CDS	86400	54319 8 1 a28ebe791e9cc7f4c2821131be367326ddd7434c
+0	secure-delegated.dnssec-parent.com.	IN	CDS	86400	54319 8 2 a0b9c38cd324182af0ef66830d0a0e85a1d58979c9834e18c871779e040857b7
+0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDS 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...
+2	.	IN	OPT	32768	
+Rcode: 0, RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='secure-delegated.dnssec-parent.com.', qtype=CDS
+0	secure-delegated.dnssec-parent.com.	IN	CDNSKEY	86400	257 3 8 AwEAAZd9R7SWWGqA12oG7Ls+h3b0/IAyMj/Pqn/ZuKWM/OdpxT/cn2xwLDhkdmqP/pUqAzvyFPyd4kTqrmLfbohBwA7+07pBVa4qf/jxlHivdMNUD72H+dUYqBlmhCC6l3eG+8FZi2tkdwn8kUoa9kyLMtrEaFnOd/oUQbmNvIDp+8VWv1cSnRJ8UXKdXLl0smpvC7h1K2AUiC5oGIYQTCYWwYRM1wCbb+q1fbFCdkbI7OQW/h7Pj30eLpIuz0bJj4vdKXXZHK8clSdTMAFm6rQsNDI0w7QdCgaDmTn3b6TF2UJi4eDnh7uDbSpUd1mI5XWNw4C6WrUmebFLfiry6vqdiIc=
+0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDNSKEY 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...
+2	.	IN	OPT	32768	
+Rcode: 0, RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='secure-delegated.dnssec-parent.com.', qtype=CDNSKEY
+0	secure-delegated.dnssec-parent.com.	IN	CDNSKEY	86400	257 3 8 AwEAAZd9R7SWWGqA12oG7Ls+h3b0/IAyMj/Pqn/ZuKWM/OdpxT/cn2xwLDhkdmqP/pUqAzvyFPyd4kTqrmLfbohBwA7+07pBVa4qf/jxlHivdMNUD72H+dUYqBlmhCC6l3eG+8FZi2tkdwn8kUoa9kyLMtrEaFnOd/oUQbmNvIDp+8VWv1cSnRJ8UXKdXLl0smpvC7h1K2AUiC5oGIYQTCYWwYRM1wCbb+q1fbFCdkbI7OQW/h7Pj30eLpIuz0bJj4vdKXXZHK8clSdTMAFm6rQsNDI0w7QdCgaDmTn3b6TF2UJi4eDnh7uDbSpUd1mI5XWNw4C6WrUmebFLfiry6vqdiIc=
+0	secure-delegated.dnssec-parent.com.	IN	CDS	86400	54319 8 1 a28ebe791e9cc7f4c2821131be367326ddd7434c
+0	secure-delegated.dnssec-parent.com.	IN	CDS	86400	54319 8 2 a0b9c38cd324182af0ef66830d0a0e85a1d58979c9834e18c871779e040857b7
+0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDNSKEY 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...
+0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDS 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...

--- a/regression-tests/tests/verify-dnssec-zone/command
+++ b/regression-tests/tests/verify-dnssec-zone/command
@@ -2,7 +2,7 @@
 for zone in $(grep 'zone ' named.conf  | cut -f2 -d\" | grep -v '^\(example.com\|nztest.com\)$')
 do
 	TFILE=$(mktemp tmp.XXXXXXXXXX)
-	dig axfr $zone @$nameserver -p $port | ldns-read-zone -z > $TFILE
+	drill axfr $zone @$nameserver -p $port | ldns-read-zone -z > $TFILE
 	for validator in "ldns-verify-zone -V2" validns jdnssec-verifyzone named-checkzone
 	do
 		echo --- $validator $zone


### PR DESCRIPTION
This PR adds support for the CDS and CDNSKEY ([RFC 7344](https://tools.ietf.org/html/rfc7344)) record types. Furthermore, it updates to the dnssec infra to send out these records when requested (either by a direct query or ANY on the apex (amplification yay!)).

The functionality is there, the following is missing:
- [ ] Code review
- [x] Documentation on the Domain Metadata added
- [x] Documentation on how to use the feature
- [x] How to with examples
- [x] Regression tests

Closes #2648 