### PR TITLE
Fix the testrunner (unbreak master make check)

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -996,6 +996,7 @@ testrunner_SOURCES = \
 	qtype.cc \
 	rcpgenerator.cc \
 	responsestats.cc \
+	responsestats-auth.cc \
 	sillyrecords.cc \
 	statbag.cc \
 	test-arguments_cc.cc \


### PR DESCRIPTION
It was broken because a source was missing. That wasn't caught because
travis didn't retest #2638