### PR TITLE
dnsdist: initialize the uptime variable on startup

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -13,10 +13,10 @@
 #include "htmlfiles.h"
 #include "base64.hh"
 
+static time_t s_start=time(0);
 static int uptimeOfProcess()
 {
-  static time_t start=time(0);
-  return time(0) - start;
+  return time(0) - s_start;
 }
 
 


### PR DESCRIPTION
Similar to the fix for PowerDNS itself in 22f1199cbca9676eed263d6fd06169a1b7a2d182