### PR TITLE
Do not check slave domain freshness unless slave=yes

### DIFF
--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -521,6 +521,9 @@ void CommunicatorClass::addTrySuperMasterRequest(DNSPacket *p)
 
 void CommunicatorClass::slaveRefresh(PacketHandler *P)
 {
+  // not unless we are slave
+  if (!::arg().mustDo("slave")) return;
+
   UeberBackend *B=dynamic_cast<UeberBackend *>(P->getBackend());
   vector<DomainInfo> rdomains;
   vector<DomainNotificationInfo> sdomains; // the bool is for 'presigned'


### PR DESCRIPTION
Before this, the code would perform initial AXFR from master(s) for slave domains on nameserver with slave=no.