### PR TITLE
Support multiple results set in gMySQL and gPGSql

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -144,18 +144,21 @@ public:
       throw SSqlException("Could not execute mysql statement: " + d_query + string(": ") + error);
     }
 
+    // MySQL documentation says you can call this safely for all queries
+    if ((err = mysql_stmt_store_result(d_stmt))) {
+      string error(mysql_stmt_error(d_stmt));
+      throw SSqlException("Could not store mysql statement: " + d_query + string(": ") + error);
+    }
+
     if ((d_fnum = static_cast<int>(mysql_stmt_field_count(d_stmt)))>0) {
       // prepare for result
-      if ((err = mysql_stmt_store_result(d_stmt))) {
-        string error(mysql_stmt_error(d_stmt));
-        throw SSqlException("Could not store mysql statement: " + d_query + string(": ") + error);
-      }
       d_resnum = mysql_stmt_num_rows(d_stmt);
       
       if (d_resnum>0 && d_res_bind == NULL) {
+        MYSQL_RES* meta = mysql_stmt_result_metadata(d_stmt);
+        d_fnum = static_cast<int>(mysql_num_fields(meta)); // ensure correct number of fields
         d_res_bind = new MYSQL_BIND[d_fnum];
         memset(d_res_bind, 0, sizeof(MYSQL_BIND)*d_fnum);
-        MYSQL_RES* meta = mysql_stmt_result_metadata(d_stmt);
         MYSQL_FIELD* fields = mysql_fetch_fields(meta);
 
         for(int i = 0; i < d_fnum; i++) {
@@ -187,7 +190,7 @@ public:
   SSqlStatement* nextRow(row_t& row) {
     int err;
     row.clear();
-    if (d_residx >= d_resnum) return this;
+    if (!hasNextRow()) return this;
 
     if ((err =mysql_stmt_fetch(d_stmt))) {
       if (err != MYSQL_DATA_TRUNCATED) {
@@ -211,6 +214,29 @@ public:
     }
 
     d_residx++;
+#if MYSQL_VERSION_ID >= 50500
+    if (d_residx >= d_resnum) {
+      mysql_stmt_free_result(d_stmt);
+      while(!mysql_stmt_next_result(d_stmt)) {
+        if ((err = mysql_stmt_store_result(d_stmt))) {
+          string error(mysql_stmt_error(d_stmt));
+          throw PDNSException("Could not store mysql statement: " + d_query + string(": ") + error);
+        }
+        d_resnum = mysql_stmt_num_rows(d_stmt);
+        // XXX: For some reason mysql_stmt_result_metadata returns NULL here, so we cannot
+        // ensure row field count matches first result set.
+        if (d_resnum>0) { // ignore empty result set
+          if ((err = mysql_stmt_bind_result(d_stmt, d_res_bind))) {
+            string error(mysql_stmt_error(d_stmt));
+            throw SSqlException("Could not bind parameters to mysql statement: " + d_query + string(": ") + error);
+          }
+          d_residx = 0;
+          break;
+        }
+        mysql_stmt_free_result(d_stmt);
+      }
+    }
+#endif
     return this; 
   }
 
@@ -229,7 +255,15 @@ public:
 
   SSqlStatement* reset() {
     if (!d_stmt) return this;
-
+    int err;
+    mysql_stmt_free_result(d_stmt);
+    while((err = mysql_stmt_next_result(d_stmt)) == 0) {
+      mysql_stmt_free_result(d_stmt);
+    }
+    if (err>0) {
+      string error(mysql_stmt_error(d_stmt));
+      throw SSqlException("Could not get next result from mysql statement: " + d_query + string(": ") + error);
+    }
     mysql_stmt_reset(d_stmt);
     if (d_req_bind) {
       for(int i=0;i<d_parnum;i++) {

--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -16,12 +16,12 @@
 class SPgSQLStatement: public SSqlStatement
 {
 public:
-  SPgSQLStatement(const string& query, bool dolog, int nparams, PGconn* db) {
+  SPgSQLStatement(const string& query, bool dolog, int nparams, SPgSQL* db) {
     struct timeval tv;
 
     d_query = query;
     d_dolog = dolog;
-    d_db = db;
+    d_parent = db;
 
     // prepare a statement
     gettimeofday(&tv,NULL);
@@ -29,7 +29,7 @@ public:
 
     d_nparams = nparams;
  
-    PGresult* res = PQprepare(d_db, d_stmt.c_str(), d_query.c_str(), d_nparams, NULL);
+    PGresult* res = PQprepare(d_db(), d_stmt.c_str(), d_query.c_str(), d_nparams, NULL);
     ExecStatusType status = PQresultStatus(res);
     string errmsg(PQresultErrorMessage(res));
     PQclear(res);
@@ -37,9 +37,11 @@ public:
       throw SSqlException("Fatal error during prepare: " + d_query + string(": ") + errmsg);
     } 
     paramValues=NULL;
-    d_paridx=d_residx=d_resnum=0;
+    d_cur_set=0;d_paridx=d_residx=d_resnum=0;
     paramLengths=NULL;
     d_res=NULL;
+    d_res_set=NULL;
+    d_do_commit=false;
   }
 
   SSqlStatement* bind(const string& name, bool value) { return bind(name, string(value ? "t" : "f")); }
@@ -65,17 +67,50 @@ public:
     if (d_dolog) {
       L<<Logger::Warning<<"Query: "<<d_query<<endl;
     }
-    d_res = PQexecPrepared(d_db, d_stmt.c_str(), d_nparams, paramValues, paramLengths, NULL, 0);
-    ExecStatusType status = PQresultStatus(d_res);
-    string errmsg(PQresultErrorMessage(d_res));
+    if (!d_parent->in_trx()) {
+      PQexec(d_db(),"BEGIN");
+      d_do_commit = true;
+    } else d_do_commit = false;
+    d_res_set = PQexecPrepared(d_db(), d_stmt.c_str(), d_nparams, paramValues, paramLengths, NULL, 0);
+    ExecStatusType status = PQresultStatus(d_res_set);
+    string errmsg(PQresultErrorMessage(d_res_set));
     if (status != PGRES_COMMAND_OK && status != PGRES_TUPLES_OK && status != PGRES_NONFATAL_ERROR) {
-      string errmsg(PQresultErrorMessage(d_res));
-      PQclear(d_res);
+      string errmsg(PQresultErrorMessage(d_res_set));
+      PQclear(d_res_set);
       d_res = NULL;
       throw SSqlException("Fatal error during query: " + d_query + string(": ") + errmsg);
     }
-    d_resnum = PQntuples(d_res);
+    d_cur_set = 0;
+    nextResult();
     return this;
+  }
+
+  void nextResult() {
+    if (d_res_set == NULL) return; // no refcursor
+    if (d_cur_set >= PQntuples(d_res_set)) {
+      PQclear(d_res_set);
+      d_res_set = NULL;
+      return;
+    }
+    // this code handles refcursors if they are returned
+    // by stored procedures. you can return more than one
+    // if you return SETOF refcursor.
+    if (PQftype(d_res_set, 0) == 1790) { // REFCURSOR
+      string portal = string(PQgetvalue(d_res_set, d_cur_set++, 0));
+      string cmd = string("FETCH ALL FROM \"") + portal + string("\"");
+      // execute FETCH
+      if (d_dolog)
+         L<<Logger::Warning<<"Query: "<<cmd<<endl;
+      d_res = PQexec(d_db(),cmd.c_str());
+      d_resnum = PQntuples(d_res);
+      d_fnum = PQnfields(d_res);
+      d_residx = 0;
+    } else {
+      d_res = d_res_set;
+      d_res_set = NULL;
+      d_resnum = PQntuples(d_res);
+      d_fnum = PQnfields(d_res);
+    }
   }
 
   bool hasNextRow() 
@@ -99,6 +134,7 @@ public:
     if (d_residx >= d_resnum) {
       PQclear(d_res);
       d_res = NULL;
+      nextResult();
     }
     return this;
   }
@@ -114,8 +150,15 @@ public:
 
   SSqlStatement* reset() {
      int i;
+     if (!d_parent->in_trx() && d_do_commit) {
+       PQexec(d_db(),"COMMIT");
+     }
+     d_do_commit = false;
      if (d_res) 
        PQclear(d_res);
+     if (d_res_set)
+       PQclear(d_res_set);
+     d_res_set = NULL;
      d_res = NULL;
      d_paridx = d_residx = d_resnum = 0;
      if (paramValues) 
@@ -134,6 +177,10 @@ public:
     reset();
   }
 private:
+  PGconn* d_db() {
+    return d_parent->db();
+  }
+
   void allocate() {
      if (paramValues != NULL) return;
      paramValues = new char*[d_nparams];
@@ -144,7 +191,8 @@ private:
 
   string d_query;
   string d_stmt;
-  PGconn *d_db;
+  SPgSQL *d_parent;
+  PGresult *d_res_set;
   PGresult *d_res;
   bool d_dolog;
   int d_nparams;
@@ -153,6 +201,9 @@ private:
   int *paramLengths;
   int d_residx;
   int d_resnum;
+  int d_fnum;
+  int d_cur_set;
+  bool d_do_commit;
 };
 
 bool SPgSQL::s_dolog;
@@ -161,6 +212,7 @@ SPgSQL::SPgSQL(const string &database, const string &host, const string& port, c
                const string &password)
 {
   d_db=0;
+  d_in_trx = false;
   d_connectstr="";
 
   if (!database.empty())
@@ -225,17 +277,20 @@ void SPgSQL::execute(const string& query)
 
 SSqlStatement* SPgSQL::prepare(const string& query, int nparams) 
 {
-  return new SPgSQLStatement(query, s_dolog, nparams, d_db);
+  return new SPgSQLStatement(query, s_dolog, nparams, this);
 }
 
 void SPgSQL::startTransaction() {
   execute("begin");
+  d_in_trx = true;
 }
 
 void SPgSQL::commit() {
   execute("commit");
+  d_in_trx = false;
 }
 
 void SPgSQL::rollback() {
   execute("rollback");
+  d_in_trx = false;
 }

--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -96,8 +96,10 @@ public:
     // by stored procedures. you can return more than one
     // if you return SETOF refcursor.
     if (PQftype(d_res_set, 0) == 1790) { // REFCURSOR
-      string portal = string(PQgetvalue(d_res_set, d_cur_set++, 0));
-      string cmd = string("FETCH ALL FROM \"") + portal + string("\"");
+      char *val = PQgetvalue(d_res_set, d_cur_set++, 0);
+      char *portal =  PQescapeIdentifier(d_db(), val, strlen(val));
+      string cmd = string("FETCH ALL FROM \"") + string(portal) + string("\"");
+      PQfreemem(portal);
       // execute FETCH
       if (d_dolog)
          L<<Logger::Warning<<"Query: "<<cmd<<endl;

--- a/modules/gpgsqlbackend/spgsql.hh
+++ b/modules/gpgsqlbackend/spgsql.hh
@@ -23,11 +23,15 @@ public:
   void rollback();
   void commit();
 
+  PGconn* db() { return d_db; }
+  bool in_trx() { return d_in_trx; }
+
 private:
-  PGconn* d_db; 
+  PGconn* d_db;
   string d_connectstr;
   string d_connectlogstr;
   static bool s_dolog;
+  bool d_in_trx;
 };
       
 #endif /* SPGSQL_HH */


### PR DESCRIPTION
Add result set support for gmysql and gpgsql. Allows use of stored procedures in these backends. Goracle would require quite a lot of effort to do this (at least I could not find any sensible way forward).