### PR TITLE
regression tests: Use environment vars to determine program location

### DIFF
--- a/build-scripts/test-auth
+++ b/build-scripts/test-auth
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+set -x
+export PDNS=/usr/sbin/pdns_server
+export PDNS2=$PDNS
+export SDIG=/usr/bin/sdig
+export NSEC3DIG=/usr/bin/nsec3dig
+export SAXFR=/usr/bin/saxfr
+export ZONE2SQL=/usr/bin/zone2sql
+export PDNSSEC=/usr/bin/pdnssec
+export PDNSCONTROL=/usr/bin/pdns_control
+
+MODULES=""
+
+for dir in /usr/lib/x86_64-linux-gnu/pdns /usr/lib64/pdns; do
+  if [ -d $dir ]; then
+    MODULES=$dir
+    break
+  fi
+done
+[ -z $MODULES ] && echo "No module directory found" >&2 && exit 1
+
+# Symlink the modules on the system
+cd regression-tests/modules
+for backend in *.so; do
+  ln -sf $MODULES/$backend $backend
+done
+
+cd ..
+
+export geoipregion=oc geoipregionip=1.2.3.4
+./timestamp ./start-test-stop 5300 bind-both
+./timestamp ./start-test-stop 5300 bind-dnssec-both
+./timestamp ./start-test-stop 5300 bind-dnssec-pkcs11
+./timestamp ./start-test-stop 5300 bind-dnssec-nsec3-both
+./timestamp ./start-test-stop 5300 bind-dnssec-nsec3-optout-both
+./timestamp ./start-test-stop 5300 bind-dnssec-nsec3-narrow
+./timestamp ./start-test-stop 5300 bind-hybrid-nsec3
+./timestamp ./start-test-stop 5300 geoipbackend
+./timestamp ./start-test-stop 5300 geoipbackend-nsec3-narrow
+./timestamp ./start-test-stop 5300 gmysql-nodnssec-both
+./timestamp ./start-test-stop 5300 gmysql-both
+./timestamp ./start-test-stop 5300 gmysql-nsec3-both
+./timestamp ./start-test-stop 5300 gmysql-nsec3-optout-both
+./timestamp ./start-test-stop 5300 gmysql-nsec3-narrow
+./timestamp ./start-test-stop 5300 gpgsql-nodnssec-both
+./timestamp ./start-test-stop 5300 gpgsql-both
+./timestamp ./start-test-stop 5300 gpgsql-nsec3-both
+./timestamp ./start-test-stop 5300 gpgsql-nsec3-optout-both
+./timestamp ./start-test-stop 5300 gpgsql-nsec3-narrow
+./timestamp ./start-test-stop 5300 gsqlite3-nodnssec-both
+./timestamp ./start-test-stop 5300 gsqlite3-both
+./timestamp ./start-test-stop 5300 gsqlite3-nsec3-both
+./timestamp ./start-test-stop 5300 gsqlite3-nsec3-optout-both
+./timestamp ./start-test-stop 5300 gsqlite3-nsec3-narrow
+#DNSName - ./timestamp ./start-test-stop 5300 lmdb-nodnssec
+./timestamp ./start-test-stop 5300 mydns
+./timestamp ./start-test-stop 5300 opendbx-sqlite3
+./timestamp timeout 120s ./start-test-stop 5300 remotebackend-pipe
+./timestamp timeout 120s ./start-test-stop 5300 remotebackend-pipe-dnssec
+./timestamp timeout 120s ./start-test-stop 5300 remotebackend-unix
+./timestamp timeout 120s ./start-test-stop 5300 remotebackend-unix-dnssec
+./timestamp timeout 120s ./start-test-stop 5300 remotebackend-http
+./timestamp timeout 120s ./start-test-stop 5300 remotebackend-http-dnssec
+./timestamp timeout 120s ./start-test-stop 5300 remotebackend-zeromq
+./timestamp timeout 120s ./start-test-stop 5300 remotebackend-zeromq-dnssec
+./timestamp ./start-test-stop 5300 tinydns
+
+cd ../regression-tests.nobackend/
+
+# The package builds define other dirs, so the distconf test fails, so skip it
+touch pdnsconfdist/skip
+
+./runtests
+test ! -s ./failed_tests

--- a/regression-tests.nobackend/counters/command
+++ b/regression-tests.nobackend/counters/command
@@ -6,25 +6,25 @@ port=5600
 
 rm -f pdns*.pid
 
-../pdns/pdns_server --daemon=no --local-ipv6=::1 --local-address=127.0.0.1 \
+$PDNS --daemon=no --local-ipv6=::1 --local-address=127.0.0.1 \
   --local-port=$port --socket-dir=./ --no-shuffle --launch=random --no-config \
   --module-dir=../regression-tests/modules &
 
 sleep 2
 
-../pdns/sdig 127.0.0.1 $port random.example.com A >&2 >/dev/null
-../pdns/sdig 127.0.0.1 $port example.com SOA >&2 >/dev/null
+$SDIG 127.0.0.1 $port random.example.com A >&2 >/dev/null
+$SDIG 127.0.0.1 $port example.com SOA >&2 >/dev/null
 
-../pdns/sdig 127.0.0.1 $port random.example.com A tcp >&2 >/dev/null
-../pdns/sdig 127.0.0.1 $port example.com SOA tcp >&2 >/dev/null
+$SDIG 127.0.0.1 $port random.example.com A tcp >&2 >/dev/null
+$SDIG 127.0.0.1 $port example.com SOA tcp >&2 >/dev/null
 
-../pdns/sdig ::1 $port random.example.com A >&2 >/dev/null
-../pdns/sdig ::1 $port random.example.com A tcp >&2 >/dev/null
+$SDIG ::1 $port random.example.com A >&2 >/dev/null
+$SDIG ::1 $port random.example.com A tcp >&2 >/dev/null
 
-../pdns/sdig ::1 $port example.com SOA >&2 >/dev/null
-../pdns/sdig ::1 $port example.com SOA tcp >&2 >/dev/null
+$SDIG ::1 $port example.com SOA >&2 >/dev/null
+$SDIG ::1 $port example.com SOA tcp >&2 >/dev/null
 
-../pdns/pdns_control --config-name= --no-config --socket-dir=./ 'show *' | \
+$PDNSCONTROL --config-name= --no-config --socket-dir=./ 'show *' | \
   tr ',' '\n'| grep -v -E '(user-msec|sys-msec|uptime|udp-noport-errors|udp-in-errors|udp-recvbuf-errors|udp-sndbuf-errors|-hit|-miss)' | LC_ALL=C sort
 
 kill $(cat pdns*.pid)

--- a/regression-tests.nobackend/edns-packet-cache/command
+++ b/regression-tests.nobackend/edns-packet-cache/command
@@ -9,7 +9,7 @@ bindwait ()
 	loopcount=0
 	while [ $loopcount -lt 20 ]; do
 		sleep 1
-		done=$( (../pdns/pdns_control --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
+		done=$( ($PDNSCONTROL --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
 		if [ $done = $domcount ]
 			then
 			return
@@ -24,20 +24,20 @@ bindwait ()
 port=5501
 rm -f pdns*.pid
 
-../pdns/pdns_server --daemon=no --local-port=$port --socket-dir=./          \
+$PDNS --daemon=no --local-port=$port --socket-dir=./          \
 	--no-shuffle --launch=bind --bind-config=edns-packet-cache/named.conf   \
 	--send-root-referral --cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
 bindwait
 	
 # prime cache without EDNS
-../pdns/sdig 127.0.0.1 5501 minimal.com SOA | LC_ALL=C sort
+$SDIG 127.0.0.1 5501 minimal.com SOA | LC_ALL=C sort
 # expect EDNS in identical query with EDNS
-SDIGBUFSIZE=512 ../pdns/sdig 127.0.0.1 5501 minimal.com SOA | LC_ALL=C sort
+SDIGBUFSIZE=512 $SDIG 127.0.0.1 5501 minimal.com SOA | LC_ALL=C sort
 
 # prime cache with EDNS
-SDIGBUFSIZE=512 ../pdns/sdig 127.0.0.1 5501 minimal.com NS | LC_ALL=C sort
+SDIGBUFSIZE=512 $SDIG 127.0.0.1 5501 minimal.com NS | LC_ALL=C sort
 # expect no EDNS in identical query without EDNS
-../pdns/sdig 127.0.0.1 5501 minimal.com NS | LC_ALL=C sort
+$SDIG 127.0.0.1 5501 minimal.com NS | LC_ALL=C sort
 
 kill $(cat pdns*.pid)
 rm pdns*.pid

--- a/regression-tests.nobackend/edns1/command
+++ b/regression-tests.nobackend/edns1/command
@@ -12,7 +12,7 @@ bindwait ()
         loopcount=0
         while [ $loopcount -lt 20 ]; do
                 sleep 1
-                done=$( (../pdns/pdns_control --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
+                done=$( ($PDNSCONTROL --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
                 if [ $done = $domcount ]
                         then
                         return
@@ -24,7 +24,7 @@ bindwait ()
         fi
 }
 
-$RUNWRAPPER ../pdns/pdns_server --daemon=no --local-port=$port --socket-dir=./          \
+$RUNWRAPPER $PDNS --daemon=no --local-port=$port --socket-dir=./          \
         --no-shuffle --launch=bind --bind-config=edns-packet-cache/named.conf   \
         --send-root-referral --cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
 bindwait

--- a/regression-tests.nobackend/lua-policy/command
+++ b/regression-tests.nobackend/lua-policy/command
@@ -9,7 +9,7 @@ bindwait ()
 	loopcount=0
 	while [ $loopcount -lt 20 ]; do
 		sleep 1
-		done=$( (../pdns/pdns_control --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
+		done=$( ($PDNSCONTROL --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
 		if [ $done = $domcount ]
 			then
 			return
@@ -24,19 +24,19 @@ bindwait ()
 port=5501
 rm -f pdns*.pid
 
-../pdns/pdns_server --daemon=no --local-port=$port --socket-dir=./          \
+$PDNS --daemon=no --local-port=$port --socket-dir=./          \
 	--no-shuffle --launch=bind --bind-config=lua-policy/named.conf   \
 	--experimental-lua-policy-script=lua-policy/policy.lua \
 	--send-root-referral --cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
 bindwait
 
 # plain SOA query
-../pdns/sdig 127.0.0.1 5501 minimal.com SOA | LC_ALL=C sort
+$SDIG 127.0.0.1 5501 minimal.com SOA | LC_ALL=C sort
 # expect DROP, so timeout
-timeout 3 ../pdns/sdig 127.0.0.1 5501 drop.minimal.com SOA || ret=$?
+timeout 3 $SDIG 127.0.0.1 5501 drop.minimal.com SOA || ret=$?
 echo timeout/sdig return value: $ret
 # expect TRUNCATE
-../pdns/sdig 127.0.0.1 5501 truncate.minimal.com SOA
+$SDIG 127.0.0.1 5501 truncate.minimal.com SOA
 
 kill $(cat pdns*.pid)
 rm pdns*.pid

--- a/regression-tests.nobackend/pdnsconfdist/command
+++ b/regression-tests.nobackend/pdnsconfdist/command
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-diff -u ../pdns/pdns.conf-dist <(../pdns/pdns_server --config)
+diff -u ../pdns/pdns.conf-dist <($PDNS --config)

--- a/regression-tests.nobackend/soa-edit/command
+++ b/regression-tests.nobackend/soa-edit/command
@@ -9,7 +9,7 @@ bindwait ()
 	loopcount=0
 	while [ $loopcount -lt 20 ]; do
 		sleep 1
-		done=$( (../pdns/pdns_control --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
+		done=$( ($PDNSCONTROL --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
 		if [ $done = $domcount ]
 			then
 			return
@@ -29,14 +29,14 @@ rm -f soa-edit/bind-dnssec.db
 now=$(date +%s)
 delta=$((now-1418860790)) # Wed Dec 17 23:59:50 2014 UTC
  
-../pdns/pdnssec --config-dir=soa-edit create-bind-db soa-edit/bind-dnssec.db
-../pdns/pdnssec --config-dir soa-edit/ set-meta minimal.com SOA-EDIT INCREMENT-WEEKS
-faketime -m -f -$delta ../pdns/pdns_server --config-dir=soa-edit &
+$PDNSSEC --config-dir=soa-edit create-bind-db soa-edit/bind-dnssec.db
+$PDNSSEC --config-dir soa-edit/ set-meta minimal.com SOA-EDIT INCREMENT-WEEKS
+faketime -m -f -$delta $PDNS --config-dir=soa-edit &
 bindwait
 
-../pdns/sdig 127.0.0.1 $port minimal.com SOA | LC_ALL=C sort
+$SDIG 127.0.0.1 $port minimal.com SOA | LC_ALL=C sort
 sleep 15
-../pdns/sdig 127.0.0.1 $port minimal.com SOA | LC_ALL=C sort
+$SDIG 127.0.0.1 $port minimal.com SOA | LC_ALL=C sort
 	
 kill $(cat pdns*.pid)
 rm pdns*.pid

--- a/regression-tests.recursor/cleandig
+++ b/regression-tests.recursor/cleandig
@@ -1,2 +1,2 @@
 #!/bin/sh
-../pdns/sdig $nameserver $port $1 $2 recurse | LC_ALL=C sort
+$SDIG $nameserver $port $1 $2 recurse | LC_ALL=C sort

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -2,6 +2,9 @@
 set -e
 set -x
 
+export PDNS=${PDNS:-../../../pdns/pdns_server}
+export PDNSRECURSOR=${PDNSRECURSOR:-../../../pdns/pdns_recursor}
+
 . ./vars
 
 if [ -z "$PREFIX" ]

--- a/regression-tests.recursor/vars.sample
+++ b/regression-tests.recursor/vars.sample
@@ -1,3 +1,3 @@
 PREFIX=10.0.3
-AUTHRUN="exec authbind ../../../pdns/pdns_server --config-dir=. > logfile 2>&1"
-RECRUN="exec authbind ../../../pdns/pdns_recursor --config-dir=. --socket-dir=. --daemon=no --trace=yes --dont-query= --local-address=$PREFIX.9 --hint-file=hintfile --packetcache-ttl=0 --max-cache-ttl=15 --threads=1 > logfile 2>&1"
+AUTHRUN="exec authbind ${PDNS} --config-dir=. > logfile 2>&1"
+RECRUN="exec authbind ${PDNSRECURSOR} --config-dir=. --socket-dir=. --daemon=no --trace=yes --dont-query= --local-address=$PREFIX.9 --hint-file=hintfile --packetcache-ttl=0 --max-cache-ttl=15 --threads=1 > logfile 2>&1"

--- a/regression-tests/backends/bind-master
+++ b/regression-tests/backends/bind-master
@@ -48,7 +48,7 @@ gmysql-dnssec
 __EOF__
 		else
 			echo "bind-dnssec-db=./dnssec.sqlite3" >> pdns-bind.conf
-			../pdns/pdnssec --config-dir=. --config-name=bind create-bind-db dnssec.sqlite3
+			$PDNSSEC --config-dir=. --config-name=bind create-bind-db dnssec.sqlite3
 		fi
 
 		for zone in $(grep 'zone ' named.conf  | cut -f2 -d\")
@@ -61,10 +61,10 @@ __EOF__
 			securezone $zone bind
 			if [ $context = bind-dnssec-nsec3 ] || [ $context = bind-dnssec-nsec3-optout ] || [ $context = bind-hybrid-nsec3 ]
 			then
-				../pdns/pdnssec --config-dir=. --config-name=bind set-nsec3 $zone "1 $optout 1 abcd" 2>&1
+				$PDNSSEC --config-dir=. --config-name=bind set-nsec3 $zone "1 $optout 1 abcd" 2>&1
 			elif [ $context = bind-dnssec-nsec3-narrow ]
 			then
-				../pdns/pdnssec --config-dir=. --config-name=bind set-nsec3 $zone '1 1 1 abcd' narrow 2>&1
+				$PDNSSEC --config-dir=. --config-name=bind set-nsec3 $zone '1 1 1 abcd' narrow 2>&1
 			fi
 		done
 
@@ -85,8 +85,8 @@ __EOF__
 			skipreasons="nodyndns"
 		fi
 
-		../pdns/pdnssec --config-dir=. --config-name=bind import-tsig-key test $ALGORITHM $KEY
-		../pdns/pdnssec --config-dir=. --config-name=bind activate-tsig-key tsig.com test master
+		$PDNSSEC --config-dir=. --config-name=bind import-tsig-key test $ALGORITHM $KEY
+		$PDNSSEC --config-dir=. --config-name=bind activate-tsig-key tsig.com test master
 
 		$RUNWRAPPER $PDNS --daemon=no --local-port=$port --config-dir=. \
 			--config-name=bind --socket-dir=./ --no-shuffle \

--- a/regression-tests/backends/bind-slave
+++ b/regression-tests/backends/bind-slave
@@ -8,7 +8,7 @@
 
 	rm -f dnssec-slave.sqlite3
 
-	../pdns/pdnssec --config-dir=. create-bind-db dnssec-slave.sqlite3
+	$PDNSSEC --config-dir=. create-bind-db dnssec-slave.sqlite3
 
 	set +e
 	echo $skipreasons | grep -q nodnssec

--- a/regression-tests/backends/geoip-master
+++ b/regression-tests/backends/geoip-master
@@ -65,7 +65,7 @@ EOF
 		if [ "$geoipdosec" = "yes" ]
 		then
 			echo "$geoipkeydir" >> pdns-geoip.conf
-			../pdns/pdnssec --config-dir=. --config-name=geoip secure-zone geo.example.com
+			$PDNSSEC --config-dir=. --config-name=geoip secure-zone geo.example.com
 			geoipkeydir="--geoip-dnssec-keydir=$testsdir/geosec"
 		fi
 

--- a/regression-tests/backends/gmysql-slave
+++ b/regression-tests/backends/gmysql-slave
@@ -31,11 +31,11 @@ __EOF__
 			"$GMYSQL2DB" -e "INSERT INTO domains (name, type, master) VALUES('$zone','SLAVE','127.0.0.1:$port')"
 	done
 
-	../pdns/pdnssec --config-dir=. --config-name=gmysql2 import-tsig-key test $ALGORITHM $KEY
-	../pdns/pdnssec --config-dir=. --config-name=gmysql2 activate-tsig-key tsig.com test slave
+	$PDNSSEC --config-dir=. --config-name=gmysql2 import-tsig-key test $ALGORITHM $KEY
+	$PDNSSEC --config-dir=. --config-name=gmysql2 activate-tsig-key tsig.com test slave
 	if [[ $skipreasons != *nolua* ]]
 	then
-		../pdns/pdnssec --config-dir=. --config-name=gmysql2 set-meta stest.com AXFR-SOURCE 127.0.0.2
+		$PDNSSEC --config-dir=. --config-name=gmysql2 set-meta stest.com AXFR-SOURCE 127.0.0.2
 	fi
 
 	port=$((port+100))

--- a/regression-tests/backends/goracle-slave
+++ b/regression-tests/backends/goracle-slave
@@ -30,11 +30,11 @@ __EOF__
 		echo "INSERT INTO domains (id, name, type, master) VALUES(domains_id_sequence.nextval, '$zone', 'SLAVE', '127.0.0.1:$port');" | sqlplus -S $GORACLE2USER/$GORACLE2PASSWD@xe >> goracle2.log
 	done
 
-	../pdns/pdnssec --config-dir=. --config-name=goracle2 import-tsig-key test $ALGORITHM $KEY
-	../pdns/pdnssec --config-dir=. --config-name=goracle2 activate-tsig-key tsig.com test slave
+	$PDNSSEC --config-dir=. --config-name=goracle2 import-tsig-key test $ALGORITHM $KEY
+	$PDNSSEC --config-dir=. --config-name=goracle2 activate-tsig-key tsig.com test slave
 	if [[ $skipreasons != *nolua* ]]
 	then
-		../pdns/pdnssec --config-dir=. --config-name=goracle2 set-meta stest.com AXFR-SOURCE 127.0.0.2
+		$PDNSSEC --config-dir=. --config-name=goracle2 set-meta stest.com AXFR-SOURCE 127.0.0.2
 	fi
 
 	port=$((port+100))

--- a/regression-tests/backends/gpgsql-slave
+++ b/regression-tests/backends/gpgsql-slave
@@ -24,11 +24,11 @@ __EOF__
 		-c "INSERT INTO domains (name, type, master) VALUES('$zone','SLAVE','127.0.0.1:$port')"
 	done
 
-	../pdns/pdnssec --config-dir=. --config-name=gpgsql2 import-tsig-key test $ALGORITHM $KEY
-	../pdns/pdnssec --config-dir=. --config-name=gpgsql2 activate-tsig-key tsig.com test slave
+	$PDNSSEC --config-dir=. --config-name=gpgsql2 import-tsig-key test $ALGORITHM $KEY
+	$PDNSSEC --config-dir=. --config-name=gpgsql2 activate-tsig-key tsig.com test slave
 	if [[ $skipreasons != *nolua* ]]
 	then
-		../pdns/pdnssec --config-dir=. --config-name=gpgsql2 set-meta stest.com AXFR-SOURCE 127.0.0.2
+		$PDNSSEC --config-dir=. --config-name=gpgsql2 set-meta stest.com AXFR-SOURCE 127.0.0.2
 	fi
 
 	port=$((port+100))

--- a/regression-tests/backends/gsql-common
+++ b/regression-tests/backends/gsql-common
@@ -14,19 +14,19 @@ gsql-master()
 		then
 			if [ $context = ${backend}-nsec3 ] || [ $context = ${backend}-nsec3-optout ]
 			then
-				../pdns/pdnssec --config-dir=. --config-name=$backend set-nsec3 $zone "1 $optout 1 abcd" 2>&1
+				$PDNSSEC --config-dir=. --config-name=$backend set-nsec3 $zone "1 $optout 1 abcd" 2>&1
 			elif [ $context = ${backend}-nsec3-narrow ]
 			then
-				../pdns/pdnssec --config-dir=. --config-name=$backend set-nsec3 $zone '1 1 1 abcd' narrow 2>&1
+				$PDNSSEC --config-dir=. --config-name=$backend set-nsec3 $zone '1 1 1 abcd' narrow 2>&1
 			fi
 			securezone $zone ${backend}
 		else
-			../pdns/pdnssec --config-dir=. --config-name=$backend rectify-zone $zone 2>&1
+			$PDNSSEC --config-dir=. --config-name=$backend rectify-zone $zone 2>&1
 		fi
 	done
 
-	../pdns/pdnssec --config-dir=. --config-name=$backend import-tsig-key test $ALGORITHM $KEY
-	../pdns/pdnssec --config-dir=. --config-name=$backend activate-tsig-key tsig.com test master
+	$PDNSSEC --config-dir=. --config-name=$backend import-tsig-key test $ALGORITHM $KEY
+	$PDNSSEC --config-dir=. --config-name=$backend activate-tsig-key tsig.com test master
 
 	$RUNWRAPPER $PDNS --daemon=no --local-port=$port --config-dir=. \
 		--config-name=$backend --socket-dir=./ --no-shuffle \

--- a/regression-tests/backends/gsqlite3-slave
+++ b/regression-tests/backends/gsqlite3-slave
@@ -19,11 +19,11 @@ __EOF__
 		sqlite3 pdns.sqlite32 "INSERT INTO domains (name, type, master) VALUES('$zone','SLAVE','127.0.0.1:$port');"
 	done
 
-	../pdns/pdnssec --config-dir=. --config-name=gsqlite32 import-tsig-key test $ALGORITHM $KEY
-	../pdns/pdnssec --config-dir=. --config-name=gsqlite32 activate-tsig-key tsig.com test slave
+	$PDNSSEC --config-dir=. --config-name=gsqlite32 import-tsig-key test $ALGORITHM $KEY
+	$PDNSSEC --config-dir=. --config-name=gsqlite32 activate-tsig-key tsig.com test slave
 	if [[ $skipreasons != *nolua* ]]
 	then
-		../pdns/pdnssec --config-dir=. --config-name=gsqlite32 set-meta stest.com AXFR-SOURCE 127.0.0.2
+		$PDNSSEC --config-dir=. --config-name=gsqlite32 set-meta stest.com AXFR-SOURCE 127.0.0.2
 	fi
 
 	port=$((port+100))

--- a/regression-tests/backends/lmdb-master
+++ b/regression-tests/backends/lmdb-master
@@ -23,7 +23,7 @@ case $context in
 
 			for zone in $(grep 'zone ' named.conf  | cut -f2 -d\")
 			do
-				../pdns/saxfr 127.0.0.1 $port $zone showdetails showflags > zones/$zone.signed
+				$SAXFR 127.0.0.1 $port $zone showdetails showflags > zones/$zone.signed
 
 				echo "" >> named-lmdb.conf
 				echo "zone \"${zone}\" {" >> named-lmdb.conf

--- a/regression-tests/backends/oracle-master
+++ b/regression-tests/backends/oracle-master
@@ -35,7 +35,7 @@ __EOF__
 				securezone $zone oracle
 				if [ $context = oracle-nsec3 ]
 				then
-					../pdns/pdnssec --config-dir=. --config-name=oracle set-nsec3 $zone "1 0 1 abcd" 2>&1
+					$PDNSSEC --config-dir=. --config-name=oracle set-nsec3 $zone "1 0 1 abcd" 2>&1
 				fi
 			done
 		fi
@@ -43,8 +43,8 @@ __EOF__
 		echo "TRUNCATE TABLE records;" | sqlplus -S $ORACLEUSER/$ORACLEPASSWD@xe >> oracle.log
 		../pdns/zone2sql --oracle | grep -v 'INSERT INTO Zones' | sqlplus -S $ORACLEUSER/$ORACLEPASSWD@xe >> oracle.log
 
-		../pdns/pdnssec --config-dir=. --config-name=oracle import-tsig-key test $ALGORITHM $KEY
-		../pdns/pdnssec --config-dir=. --config-name=oracle activate-tsig-key tsig.com test master
+		$PDNSSEC --config-dir=. --config-name=oracle import-tsig-key test $ALGORITHM $KEY
+		$PDNSSEC --config-dir=. --config-name=oracle activate-tsig-key tsig.com test master
 
 		$RUNWRAPPER $PDNS --daemon=no --local-port=$port --config-dir=. \
 			--config-name=oracle --socket-dir=./ --no-shuffle \

--- a/regression-tests/backends/oracle-slave
+++ b/regression-tests/backends/oracle-slave
@@ -26,14 +26,14 @@ __EOF__
 		echo "INSERT ALL INTO zones (id, name, type) VALUES (zones_id_seq.nextval, name, 'SLAVE') INTO zonemasters (zone_id, master) VALUES (zones_id_seq.nextval, master) SELECT '$zone' AS name, '127.0.0.1:$port' AS master FROM dual;" | sqlplus -S $ORACLE2USER/$ORACLE2PASSWD@xe >> oracle2.log
 	done
 
-	../pdns/pdnssec --config-dir=. --config-name=oracle2 import-tsig-key test $ALGORITHM $KEY
-	../pdns/pdnssec --config-dir=. --config-name=oracle2 activate-tsig-key tsig.com test slave
+	$PDNSSEC --config-dir=. --config-name=oracle2 import-tsig-key test $ALGORITHM $KEY
+	$PDNSSEC --config-dir=. --config-name=oracle2 activate-tsig-key tsig.com test slave
 
 	set +e
 	echo $skipreasons | grep -q nolua
 	if [ $? -ne 0 ]
 	then
-		../pdns/pdnssec --config-dir=. --config-name=oracle2 set-meta stest.com AXFR-SOURCE 127.0.0.2
+		$PDNSSEC --config-dir=. --config-name=oracle2 set-meta stest.com AXFR-SOURCE 127.0.0.2
 	fi
 	set -e
 

--- a/regression-tests/backends/remote-master
+++ b/regression-tests/backends/remote-master
@@ -90,19 +90,19 @@ EOF
 		if [ "$remotedosec" = "yes" ]
 		then
 			echo "remote-dnssec=yes" >> pdns-remote.conf
-			../pdns/pdnssec --config-dir=. --config-name=remote secure-zone example.com
-			../pdns/pdnssec --config-dir=. --config-name=remote secure-zone up.example.com
+			$PDNSSEC --config-dir=. --config-name=remote secure-zone example.com
+			$PDNSSEC --config-dir=. --config-name=remote secure-zone up.example.com
 
-			./gsql_feed_ds.pl up.example.com example.com "../pdns/pdnssec --config-dir=. --config-name=remote" "sqlite3 $testsdir/remote.sqlite3"
+			./gsql_feed_ds.pl up.example.com example.com "$PDNSSEC --config-dir=. --config-name=remote" "sqlite3 $testsdir/remote.sqlite3"
 
 			if [ "$remotesec" = "nsec3" ]
 			then
-				../pdns/pdnssec --config-dir=. --config-name=remote set-nsec3 example.com
-				../pdns/pdnssec --config-dir=. --config-name=remote set-nsec3 up.example.com
+				$PDNSSEC --config-dir=. --config-name=remote set-nsec3 example.com
+				$PDNSSEC --config-dir=. --config-name=remote set-nsec3 up.example.com
 			fi
 
 			# add DS records into list-all-records
-                        ../pdns/pdnssec --config-dir=. --config-name=remote show-zone up.example.com | gawk '{ if ($1=="DS") { printf "up.example.com.		120	IN	DS	" $6 " " $7 " " $8 " " substr(toupper($9),0,56); if (length($9)>56) { print " " substr(toupper($9),57) } else { print "" } } }' > $testsdir/list-all-records/expected_dnssec_part2
+                        $PDNSSEC --config-dir=. --config-name=remote show-zone up.example.com | gawk '{ if ($1=="DS") { printf "up.example.com.		120	IN	DS	" $6 " " $7 " " $8 " " substr(toupper($9),0,56); if (length($9)>56) { print " " substr(toupper($9),57) } else { print "" } } }' > $testsdir/list-all-records/expected_dnssec_part2
 			cat $testsdir/list-all-records/expected_dnssec_part1 $testsdir/list-all-records/expected_dnssec_part2 $testsdir/list-all-records/expected_dnssec_part3 > $testsdir/list-all-records/expected_result.dnssec 
 			cp -f $testsdir/list-all-records/expected_result.dnssec $testsdir/list-all-records/expected_result.nsec3
 		fi

--- a/regression-tests/cleandig
+++ b/regression-tests/cleandig
@@ -3,12 +3,12 @@ if [ ! -e ${testsdir}/${testname}/use.drill ]
 then
 	if [ "$2" != "AXFR" ]
 	then
-		../pdns/sdig $nameserver $port "$1" $2 $3 $4 $5 | LC_ALL=C sort
+		$SDIG $nameserver $port "$1" $2 $3 $4 $5 | LC_ALL=C sort
 	else
-		../pdns/saxfr $nameserver $port "$1" $3 $4 | LC_ALL=C sort
+		$SAXFR $nameserver $port "$1" $3 $4 | LC_ALL=C sort
 	fi
 fi
-../pdns/nsec3dig $nameserver $port "$1" $2 > ${testsdir}/${testname}/nsec3dig.out 2>&1
+$NSEC3DIG $nameserver $port "$1" $2 > ${testsdir}/${testname}/nsec3dig.out 2>&1
 if [ ! -e ${testsdir}/${testname}/skip-drill ]
 then
 	if [ ! -s trustedkeys ]

--- a/regression-tests/getserial
+++ b/regression-tests/getserial
@@ -1,2 +1,2 @@
 #!/bin/sh
-../pdns/sdig $nameserver $port $1 SOA | LC_ALL=C sort | grep ^0 | cut -d ' ' -f 3
+$SDIG $nameserver $port $1 SOA | LC_ALL=C sort | grep ^0 | cut -d ' ' -f 3

--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -2,10 +2,24 @@
 PATH=.:$PATH:/usr/sbin
 MAKE=${MAKE:-make}
 
+export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
+export PDNS2=${PDNS2:-${PWD}/../pdns/pdns_server}
+export PDNSRECURSOR=${PDNSRECURSOR:-${PWD}/../pdns_recursor}
+export SDIG=${SDIG:-${PWD}/../pdns/sdig}
+export NSEC3DIG=${NSEC3DIG:-${PWD}/../pdns/nsec3dig}
+export SAXFR=${SAXFR:-${PWD}/../pdns/saxfr}
+export ZONE2SQL=${ZONE2SQL:-${PWD}/../pdns/zone2sql}
+export PDNSSEC=${PDNSSEC:-${PWD}/../pdns/pdnssec}
+export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
+
 spectest=$1
 [ -z $spectest ] && spectest=""
 
-${MAKE} -C ../pdns sdig nsec3dig saxfr || exit 1
+for prog in $SDIG $SAXFR $NSEC3DIG; do
+  if `echo $prog | grep -q '../pdns'`; then
+    ${MAKE} -C ../pdns ${prog##../pdns/} || exit
+  fi
+done
 
 rm -f test-results failed_tests passed_tests skipped_tests ${testsdir}/*/real_result ${testsdir}/*/diff ${testsdir}/*/*.out ${testsdir}/*/start ${testsdir}/*/step.*
 

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -2,8 +2,16 @@
 set -e
 set -x
 
-PDNS=${PDNS:-../pdns/pdns_server}
-PDNS2=${PDNS2:-../pdns/pdns_server}
+export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
+export PDNS2=${PDNS2:-${PWD}/../pdns/pdns_server}
+export PDNSRECURSOR=${PDNSRECURSOR:-${PWD}/../pdns_recursor}
+export SDIG=${SDIG:-${PWD}/../pdns/sdig}
+export NSEC3DIG=${NSEC3DIG:-${PWD}/../pdns/nsec3dig}
+export SAXFR=${SAXFR:-${PWD}/../pdns/saxfr}
+export ZONE2SQL=${ZONE2SQL:-${PWD}/../pdns/zone2sql}
+export PDNSSEC=${PDNSSEC:-${PWD}/../pdns/pdnssec}
+export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
+
 
 ALGORITHM=${ALGORITHM:="hmac-md5"}
 KEY=${KEY:="kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys="}
@@ -17,8 +25,10 @@ trap "kill_process 2" EXIT INT TERM
 
 tosql ()
 {
-	${MAKE} -C ../pdns zone2sql > /dev/null
-	../pdns/zone2sql --transactions --$1 --named-conf=./named.conf
+	if echo $ZONE2SQL | grep -q '../pdns'; then
+		${MAKE} -C ../pdns zone2sql > /dev/null
+	fi
+	$ZONE2SQL --transactions --$1 --named-conf=./named.conf
 }
 
 bindwait ()
@@ -26,7 +36,7 @@ bindwait ()
 	check_process
 	configname=$1
 	domcount=$(grep -c ^zone named.conf)
-	if [ ! -x ../pdns/pdns_control ]
+	if [ ! -x $PDNSCONTROL ]
 	then
 		echo "No pdns_control found"
 		exit
@@ -36,7 +46,7 @@ bindwait ()
 	while [ $loopcount -lt 20 ]
 	do
 		sleep 5
-		done=$( (../pdns/pdns_control --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
+		done=$( ($PDNSCONTROL --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
 		if [ $done = $domcount ]
 		then
 			return
@@ -61,11 +71,11 @@ securezone ()
 	fi
 	if [ "${zone: 0:16}" = "secure-delegated" ]
 	then
-		../pdns/pdnssec --config-dir=. $configname import-zone-key $zone $zone.private ksk 2>&1
-		../pdns/pdnssec --config-dir=. $configname add-zone-key $zone 1024 zsk 2>&1
-		keyid=`../pdns/pdnssec --config-dir=. $configname show-zone $zone | grep ZSK | cut -d' ' -f3`
-		../pdns/pdnssec --config-dir=. $configname activate-zone-key $zone $keyid 2>&1
-		../pdns/pdnssec --config-dir=. $configname rectify-zone $zone 2>&1
+		$PDNSSEC --config-dir=. $configname import-zone-key $zone $zone.private ksk 2>&1
+		$PDNSSEC --config-dir=. $configname add-zone-key $zone 1024 zsk 2>&1
+		keyid=`$PDNSSEC --config-dir=. $configname show-zone $zone | grep ZSK | cut -d' ' -f3`
+		$PDNSSEC --config-dir=. $configname activate-zone-key $zone $keyid 2>&1
+		$PDNSSEC --config-dir=. $configname rectify-zone $zone 2>&1
 	else
 		# check if PKCS#11 should be used
 		if [ "$pkcs11" -eq 1 ]; then
@@ -75,17 +85,17 @@ securezone ()
                     slot=$((slot+1))
                   fi
                   sudo softhsm --init-token --slot $slot --label label$slot --pin 123$slot --so-pin 123$slot 
-                  kid=`../pdns/pdnssec --config-dir=. $configname hsm assign $zone rsasha256 ksk softhsm $slot 123$slot label$slot 2>&1 | grep softhsm | awk '{ print $NF }'` 
+                  kid=`$PDNSSEC --config-dir=. $configname hsm assign $zone rsasha256 ksk softhsm $slot 123$slot label$slot 2>&1 | grep softhsm | awk '{ print $NF }'` 
 # keep this until #1413 is merged
-                  kid=`../pdns/pdnssec --config-dir=. $configname show-zone $zone | grep 'ID =.*KSK' | awk '{ print $3 }'`
-                  ../pdns/pdnssec --config-dir=. $configname hsm create-key $zone $kid
+                  kid=`$PDNSSEC --config-dir=. $configname show-zone $zone | grep 'ID =.*KSK' | awk '{ print $3 }'`
+                  $PDNSSEC --config-dir=. $configname hsm create-key $zone $kid
                   slot=$((slot+1))
                   sudo softhsm --init-token --slot $slot --label label$slot --pin 123$slot --so-pin 123$slot
-                  kid=`../pdns/pdnssec --config-dir=. $configname hsm assign $zone rsasha256 zsk softhsm $slot 123$slot label$slot 2>&1 | grep softhsm | awk '{ print $NF }'`
-                  kid=`../pdns/pdnssec --config-dir=. $configname show-zone $zone | grep 'ID =.*ZSK' | awk '{ print $3 }'`
-                  ../pdns/pdnssec --config-dir=. $configname hsm create-key $zone $kid
+                  kid=`$PDNSSEC --config-dir=. $configname hsm assign $zone rsasha256 zsk softhsm $slot 123$slot label$slot 2>&1 | grep softhsm | awk '{ print $NF }'`
+                  kid=`$PDNSSEC --config-dir=. $configname show-zone $zone | grep 'ID =.*ZSK' | awk '{ print $3 }'`
+                  $PDNSSEC --config-dir=. $configname hsm create-key $zone $kid
                 else
-                  ../pdns/pdnssec --config-dir=. $configname secure-zone $zone 2>&1
+                  $PDNSSEC --config-dir=. $configname secure-zone $zone 2>&1
                 fi
 	fi
 }
@@ -219,7 +229,12 @@ __EOF__
 	exit
 fi
 
-${MAKE} -C ../pdns sdig saxfr nsec3dig || exit
+for prog in $SDIG $SAXFR $NSEC3DIG; do
+  if `echo $prog | grep -q '../pdns'`; then
+    ${MAKE} -C ../pdns ${prog##../pdns/} || exit
+  fi
+done
+
 # Copy original zones because the test might modify them (well only the dyndns stuff, but let's make this work for others as well)
 for zone in $(grep 'zone ' named.conf  | cut -f2 -d\")
 do

--- a/regression-tests/tests/bind-add-zone/command
+++ b/regression-tests/tests/bind-add-zone/command
@@ -6,10 +6,10 @@ fi
 
 cleandig ns1.addzone.com A
 cleandig ns1.test.com A
-../pdns/pdns_control --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com zones/addzone.com
-../pdns/pdns_control --config-name=bind --socket-dir=. --no-config purge addzone.com
+$PDNSCONTROL --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com zones/addzone.com
+$PDNSCONTROL --config-name=bind --socket-dir=. --no-config purge addzone.com
 sleep 1
-../pdns/pdns_control --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com zones/addzone.com
+$PDNSCONTROL --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com zones/addzone.com
 sleep 1
 cleandig ns1.addzone.com A
 cleandig ns1.test.com A

--- a/regression-tests/tests/bind-add-zone/stress/addzones.sh
+++ b/regression-tests/tests/bind-add-zone/stress/addzones.sh
@@ -3,8 +3,8 @@
 for f in $(seq 1 $AMOUNT); do
     f=addzone$f.com
     dig ns1.$f @localhost -p $port > /dev/null 2>&1
-    ../pdns/pdns_control --config-dir=. bind-add-zone $f $TMP/$f
-    ../pdns/pdns_control --config-dir=. purge $f
+    $PDNSCONTROL --config-dir=. bind-add-zone $f $TMP/$f
+    $PDNSCONTROL --config-dir=. purge $f
     sleep 0.5;
     dig ns1.$f @localhost -p $port > /dev/null 2>&1
 

--- a/regression-tests/tests/bind-add-zone/stress/run.sh
+++ b/regression-tests/tests/bind-add-zone/stress/run.sh
@@ -24,7 +24,7 @@ bindwait ()
 	check_process
 	configname=$1
 	domcount=$(grep -c zone named.conf)
-	if [ ! -x ../pdns/pdns_control ]; then
+	if [ ! -x $PDNSCONTROL ]; then
 		echo "No pdns_control found"
 		exit 1
 	fi
@@ -32,7 +32,7 @@ bindwait ()
 
 	while [ $loopcount -lt 20 ]; do
 		sleep 10
-		done=$( (../pdns/pdns_control --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
+		done=$( ($PDNSCONTROL --config-name=$configname --socket-dir=. --no-config bind-domain-status || true) | grep -c 'parsed into memory' || true )
 		if [ $done = $domcount ]; then
 			return
 		fi


### PR DESCRIPTION
This will allow us to run the regression tests on installed PowerDNS packages (e.g. our automatically generated packages).