### PR TITLE
Be consistent in the usage of timeout in the remote backend's httpconnector.

### DIFF
--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -401,7 +401,7 @@ int HTTPConnector::recv_message(rapidjson::Document &output) {
 
     try {
       t0 = time((time_t*)NULL);
-      while(arl.ready() == false && (labs(time((time_t*)NULL) - t0) <= timeout/1000)) {
+      while(arl.ready() == false && (labs(time((time_t*)NULL) - t0) <= timeout)) {
         rd = d_socket->readWithTimeout(buffer, sizeof(buffer), timeout);
         if (rd==0) 
           throw NetworkError("EOF while reading");


### PR DESCRIPTION
The `timeout` configuration option for the remotebackend is provided in milliseconds in the httpconnector, this is immediately converted (and stored) as seconds.

For all write operations, the `timeout` is used without modification, however the read operation in `recv_message` again divides the `timeout` by 1000. This is inconsistent with the usage of `time`, which returns seconds since the UNIX epoch.

The bug created by this is that HTTP requests from the remotebackend must be responded to extremely quickly (practically instantaneously with the default 2 second timeout).

After this change the same timeout is used appropriately for both read and write.

Please let me know if there are any questions. Thanks!