### PR TITLE
Fix documentation around lack of HTTPS support in the remote backend.

### DIFF
--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -59,7 +59,7 @@ HTTP connector tries to do RESTful requests to your server. See examples. You ca
 
 URL should not end with /, and url-suffix is optional, but if you define it, it's up to you to write the ".php" or ".json". Lack of dot causes lack of dot in URL. Timeout is divided by 1000 because libcurl only supports seconds, but this is given in milliseconds for consistency with other connectors.
 
-HTTPS is not supported. HTTP Authentication is not supported.
+HTTPS is not supported, [stunnel](https://www.stunnel.org) is the suggested workaround. HTTP Authentication is not supported.
 
 ### ZeroMQ connector
 parameters: endpoint, timeout (default 2000ms)

--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -49,7 +49,7 @@ remote-connection-string=pipe:command=/path/to/executable,timeout=2000
 ```
 
 ### HTTP connector
-parameters: url, url-suffix, post, post\_json, cafile, capath, timeout (default 2000)
+parameters: url, url-suffix, post, post\_json, timeout (default 2000)
 
 ```
 remote-connection-string=http:url=http://localhost:63636/dns,url-suffix=.php
@@ -59,7 +59,7 @@ HTTP connector tries to do RESTful requests to your server. See examples. You ca
 
 URL should not end with /, and url-suffix is optional, but if you define it, it's up to you to write the ".php" or ".json". Lack of dot causes lack of dot in URL. Timeout is divided by 1000 because libcurl only supports seconds, but this is given in milliseconds for consistency with other connectors.
 
-You can use HTTPS requests. If cafile and capath is left empty, remote SSL certificate is not checked. HTTP Authentication is not supported. SSL support requires that your cURL is compiled with it.
+HTTPS is not supported. HTTP Authentication is not supported.
 
 ### ZeroMQ connector
 parameters: endpoint, timeout (default 2000ms)

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -76,8 +76,6 @@ class HTTPConnector: public Connector {
     int timeout;
     bool d_post; 
     bool d_post_json;
-    std::string d_capath;
-    std::string d_cafile;
     bool json2string(const rapidjson::Value &input, std::string &output);
     void restful_requestbuilder(const std::string &method, const rapidjson::Value &parameters, YaHTTP::Request& req);
     void post_requestbuilder(const rapidjson::Document &input, YaHTTP::Request& req);


### PR DESCRIPTION
I spent a while trying to figure out why things were not working when using HTTPS and specifying empty `cafile`/`capath`s. Turns out this just isn't supported anymore. This commit updates the documentation to be consistent with the code, namely that HTTPS is not supported.

Additionally, removes two parameters on the `HttpConnector` object that are unused due to 527f007409d5779155713a935561706e7f60dad6 and 1d0cc63227f1c7d0b15f873a2088c39ff354f73c.

(If anyone else comes across this searching for a solution: I ended up using [stunnel](https://www.stunnel.org/) for HTTPS support.)