### PR TITLE
Build dnsdist packages for Ubuntu Trusty

### DIFF
--- a/build-scripts/build-dnsdist-debian
+++ b/build-scripts/build-dnsdist-debian
@@ -36,4 +36,9 @@ dnsdist (${VERSION}-${RELEASE}) unstable; urgency=medium
 
 EOF
 
+. /etc/os-release
+export ID="${ID}"
+export VERSION_ID="${VERSION_ID}"
+
+fakeroot debian/rules debian/control
 fakeroot debian/rules binary

--- a/build-scripts/debian-dnsdist/control.in
+++ b/build-scripts/debian-dnsdist/control.in
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9), dh-systemd (>= 1.5), autotools-dev, libboost-dev, liblua5.2-dev, libsodium-dev
+Build-Depends: debhelper (>= 9), dh-systemd (>= 1.5), autotools-dev, libboost-dev, liblua5.2-dev @LIBSODIUMDEV@
 Standards-Version: 3.9.5
 Homepage: http://dnsdist.org
 

--- a/build-scripts/debian-dnsdist/dnsdist.upstart
+++ b/build-scripts/debian-dnsdist/dnsdist.upstart
@@ -1,0 +1,9 @@
+description "dnsdist - A powerful DNS loadbalancer"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+author "Pieter Lexis <pieter.lexis@powerdns.com>"
+
+# Keep the --supervised option when modifying this
+exec /usr/bin/dnsdist --supervised -l 127.0.0.1

--- a/build-scripts/debian-dnsdist/rules
+++ b/build-scripts/debian-dnsdist/rules
@@ -7,11 +7,28 @@
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
+ENABLE_LIBSODIUM := --enable-libsodium
+LIBSODIUM_DEV := , libsodium-dev
+DEBHELPER_WITH_SYSTEMD := --with systemd
+
+# $(ID) and $(VERSION_ID) come from the environment, source this from /etc/os-release
+ifeq ($(ID), ubuntu)
+  ifeq ($(VERSION_ID), 14.04)
+    # Disable building and depending on libsodium on Ubuntu Trusty
+    ENABLE_LIBSODIUM=
+    LIBSODIUM_DEV=
+    DEBHELPER_WITH_SYSTEMD=
+  endif
+endif
+
+debian/control: debian/control.in
+	sed -E "s!@LIBSODIUMDEV@!$(LIBSODIUM_DEV)!" $< > $@
+
 %:
 	dh $@ \
 	  --with autotools-dev \
 	  --parallel \
-	  --with systemd
+	  $(DEBHELPER_WITH_SYSTEMD)
 
 override_dh_auto_configure:
 	./configure \
@@ -23,7 +40,7 @@ override_dh_auto_configure:
 	  --infodir=\$${prefix}/share/info \
 	  --libdir='$${prefix}/lib/$(DEB_HOST_MULTIARCH)' \
 	  --libexecdir='$${prefix}/lib' \
-	  --enable-libsodium
+	  $(ENABLE_LIBSODIUM)
 
 override_dh_strip:
 	dh_strip --dbg-package=dnsdist-dbg


### PR DESCRIPTION
These changes allow us to build Ubuntu 14.04 packages of dnsdist.