### PR TITLE
Updates to the info-all-master-query fixing the expected number of params

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -402,7 +402,7 @@ void GSQLBackend::getUpdatedMasters(vector<DomainInfo> *updatedDomains)
   int numanswers=d_result.size();
   for(int n=0;n<numanswers;++n) { // id,name,master,last_check,notified_serial
     DomainInfo sd;
-    ASSERT_ROW_COLUMNS("info-all-master-query", d_result[n], 5);
+    ASSERT_ROW_COLUMNS("info-all-master-query", d_result[n], 6);
     sd.id=atol(d_result[n][0].c_str());
     sd.zone= DNSName(d_result[n][1]);
     sd.last_check=atol(d_result[n][3].c_str());


### PR DESCRIPTION
Updates to the info-all-master-query fixing the expected number of params

Was getting lots of errors like this in syslog:
pdns[31471]: Exiting because communicator thread died with error: info-all-master-query returned wrong number of columns, expected 5, got 6

Looking at the query its clearly 6 fiels in the output:
modules/gmysqlbackend/gmysqlbackend.cc:    declare(suffix,"info-all-master-query","", "select id,name,master,last_check,notified_serial,type from domains where type='MASTER'");
modules/gpgsqlbackend/gpgsqlbackend.cc:    declare(suffix,"info-all-master-query","", "select id,name,master,last_check,notified_serial,type from domains where type='MASTER'");
modules/gsqlite3backend/gsqlite3backend.cc:    declare(suffix, "info-all-master-query", "", "select id,name,master,last_check,notified_serial,type from domains where type='MASTER'");
modules/goraclebackend/goraclebackend.cc:    declare(suffix, "info-all-master-query", "", "select id,name,master,last_check,notified_serial,type from domains where type='MASTER'");

