### PR TITLE
Use token label in PKCS#11 instead of slot ID

### DIFF
--- a/docs/markdown/authoritative/dnssec.md
+++ b/docs/markdown/authoritative/dnssec.md
@@ -281,6 +281,8 @@ For further details, please see [the `pdnssec`](#pdnssec) documentation.
 
 # PKCS\#11 support
 **Note**: This feature is experimental, and not ready for production. Use at your own risk!
+**Note**: As of version 4.0, slot IDs are deprecated, and you are expected to use slot label instead
+
 To enable it, compile PowerDNS Authoritative Server using --enable-experimental-pkcs11 flag on configure. This requires you to have p11-kit libraries and headers.
 
 You can also log on to the tokens after starting server, in this case you need to edit your PKCS#11 cryptokey record and remove PIN or set it empty. PIN is required
@@ -314,10 +316,10 @@ Instructions on how to setup SoftHSM to work with the feature after compilation 
     sudo pkcs11-tool --module=/home/cmouse/softhsm/lib/softhsm/libsofthsm.so -l -p some-pin -k --key-type RSA:2048 -a zone-ksk|zone-zsk --slot-index slot-number
     ```
 
--   Assign the keys using
+-   Assign the keys using (note that token label is not necessarely same as object label, see p11-kit -l)
 
     ```
-    pdnssec hsm assign zone rsasha256 ksk|zsk softhsm slot-id pin zone-ksk|zsk
+    pdnssec hsm assign zone rsasha256 ksk|zsk softhsm token-label pin zone-ksk|zsk
     ```
 
 -   Verify that everything worked, you should see valid data there
@@ -388,7 +390,7 @@ Instructions on how to use CryptAS [`Athena IDProtect Key USB Token V2J`](http:/
 -   Assign the keys using
 
     ```
-    pdnssec hsm assign zone rsasha256 ksk|zsk softhsm slot-id pin zone-ksk|zsk
+    pdnssec hsm assign zone rsasha256 ksk|zsk athena IDProtect#0A50123456789 pin zone-ksk|zsk
     ```
 
 -   Verify that everything worked, you should see valid data there.

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -72,8 +72,7 @@ DNSCryptoKeyEngine* DNSCryptoKeyEngine::makeFromISCString(DNSKEYRecordContent& d
       pkcs11=true;
       continue;
     } else if (pdns_iequals(key,"slot")) {
-      int slot = atoi(value.c_str());
-      stormap["slot"]=lexical_cast<string>(slot);
+      stormap["slot"]=value;
       continue;
     }  else if (pdns_iequals(key,"label")) {
       stormap["label"]=value;

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -372,7 +372,7 @@ string DLPolicy(const vector<string>&parts, Utility::pid_t ppid)
 }
 
 #ifdef HAVE_P11KIT1
-extern bool PKCS11ModuleSlotLogin(const std::string& module, int slot, const std::string& pin);
+extern bool PKCS11ModuleSlotLogin(const std::string& module, const string& tokenId, const std::string& pin);
 #endif
 
 string DLTokenLogin(const vector<string>&parts, Utility::pid_t ppid)
@@ -384,7 +384,7 @@ string DLTokenLogin(const vector<string>&parts, Utility::pid_t ppid)
     return "invalid number of parameters, needs 4, got " + boost::lexical_cast<string>(parts.size());
   }
 
-  if (PKCS11ModuleSlotLogin(parts[1], boost::lexical_cast<int>(parts[2]), parts[3])) {
+  if (PKCS11ModuleSlotLogin(parts[1], parts[2], parts[3])) {
     return "logged in";
   } else {
     return "could not log in, check logs";

--- a/pdns/pdnssec.cc
+++ b/pdns/pdnssec.cc
@@ -2228,7 +2228,7 @@ try
       std::vector<DNSBackend::KeyData> keys;
 
       if (cmds.size() < 9) {
-        std::cout << "Usage: pdnssec hsm assign zone algorithm ksk|zsk module slot pin label" << std::endl;
+        std::cout << "Usage: pdnssec hsm assign zone algorithm ksk|zsk module token pin label" << std::endl;
         return 1;
       }
 

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -211,6 +211,7 @@ class Pkcs11Slot {
         L<<Logger::Error<< msg << endl;
       }
     }
+
   public:
     Pkcs11Slot(CK_FUNCTION_LIST* functions, const CK_SLOT_ID& slot) {
       CK_TOKEN_INFO tokenInfo;
@@ -259,7 +260,8 @@ class Pkcs11Slot {
 
     pthread_mutex_t *m() { return &d_m; }
 
-    static std::shared_ptr<Pkcs11Slot> GetSlot(const std::string& module, const CK_SLOT_ID& slotId);
+    static std::shared_ptr<Pkcs11Slot> GetSlot(const std::string& module, const string& tokenId);
+    static CK_RV HuntSlot(const string& tokenId, CK_SLOT_ID &slotId, _CK_SLOT_INFO* info, CK_FUNCTION_LIST* functions);
 };
 
 class Pkcs11Token {
@@ -615,17 +617,65 @@ class Pkcs11Token {
       return d_bits;
     }
 
-    static std::shared_ptr<Pkcs11Token> GetToken(const std::string& module, const CK_SLOT_ID& slotId, const std::string& label);
+    static std::shared_ptr<Pkcs11Token> GetToken(const std::string& module, const string& tokenId, const std::string& label);
 };
 
 static std::map<std::string, std::shared_ptr<Pkcs11Slot> > pkcs11_slots;
 static std::map<std::string, std::shared_ptr<Pkcs11Token> > pkcs11_tokens;
 
-std::shared_ptr<Pkcs11Slot> Pkcs11Slot::GetSlot(const std::string& module, const CK_SLOT_ID& slotId) {
+CK_RV Pkcs11Slot::HuntSlot(const string& tokenId, CK_SLOT_ID &slotId, _CK_SLOT_INFO* info, CK_FUNCTION_LIST* functions)
+{
+  CK_RV err;
+  unsigned long slots;
+  _CK_TOKEN_INFO tinfo;
+
+  // go thru all slots
+  // this is required by certain tokens, otherwise C_GetSlotInfo will not return a token
+  err = functions->C_GetSlotList(CK_FALSE, NULL_PTR, &slots);
+  if (err) {
+    L<<Logger::Warning<<"C_GetSlotList(CK_FALSE, NULL_PTR, &slots) = " << err << std::endl;
+    return err;
+  }
+
+  // iterate all slots
+  for(slotId=0;slotId<slots;slotId++) {
+    if ((err = functions->C_GetSlotInfo(slotId, info))) {
+      L<<Logger::Warning<<"C_GetSlotList("<<slotId<<", info) = " << err << std::endl;
+      return err;
+    }
+    if ((err = functions->C_GetTokenInfo(slotId, &tinfo))) {
+      L<<Logger::Warning<<"C_GetSlotList("<<slotId<<", &tinfo) = " << err << std::endl;
+      return err;
+    }
+    std::string slotName;
+    slotName.assign(reinterpret_cast<char*>(tinfo.label), 32);
+    // trim it
+    boost::trim(slotName);
+    if (boost::iequals(slotName, tokenId)) {
+      return 0;
+    }
+  }
+
+  // see if we can find it with slotId
+  try {
+    slotId = boost::lexical_cast<int>(tokenId);
+    if ((err = functions->C_GetSlotInfo(slotId, info))) {
+      L<<Logger::Warning<<"C_GetSlotList("<<slotId<<", info) = " << err << std::endl;
+      return err;
+    }
+    L<<Logger::Warning<<"Specifying PKCS#11 token by SLOT ID is deprecated and should not be used"<<std::endl;
+    return 0;
+  } catch (...) {
+    return CK_UNAVAILABLE_INFORMATION;
+  }
+  return CK_UNAVAILABLE_INFORMATION;
+}
+
+std::shared_ptr<Pkcs11Slot> Pkcs11Slot::GetSlot(const std::string& module, const string& tokenId) {
   // see if we can find module
   std::string sidx = module;
   sidx.append("|");
-  sidx.append(boost::lexical_cast<std::string>(slotId));
+  sidx.append(tokenId);
   std::map<std::string, std::shared_ptr<Pkcs11Slot> >::iterator slotIter;
   CK_RV err;
   CK_FUNCTION_LIST* functions;
@@ -645,15 +695,10 @@ std::shared_ptr<Pkcs11Slot> Pkcs11Slot::GetSlot(const std::string& module, const
 
   // try to locate a slot
    _CK_SLOT_INFO info;
-  unsigned long slots;
+  CK_SLOT_ID slotId;
 
-  // this is required by certain tokens, otherwise C_GetSlotInfo will not return a token
-  err = functions->C_GetSlotList(CK_FALSE, NULL_PTR, &slots);
-  if (err)
-    L<<Logger::Warning<<"C_GetSlotList(CK_FALSE, NULL_PTR, &slots) = " << err << std::endl;
-
-  if ((err = functions->C_GetSlotInfo(slotId, &info))) {
-    throw PDNSException(std::string("Cannot find PKCS#11 slot ") + boost::lexical_cast<std::string>(slotId) + std::string(" on module ") + module + std::string(": error code ") + boost::lexical_cast<std::string>(err));
+  if ((err = Pkcs11Slot::HuntSlot(tokenId, slotId, &info, functions))) {
+    throw PDNSException(std::string("Cannot find PKCS#11 token ") + tokenId + std::string(" on module ") + module + std::string(": error code ") + boost::lexical_cast<std::string>(err));
   }
 
   // store slot
@@ -662,17 +707,17 @@ std::shared_ptr<Pkcs11Slot> Pkcs11Slot::GetSlot(const std::string& module, const
   return pkcs11_slots[sidx];
 }
 
-std::shared_ptr<Pkcs11Token> Pkcs11Token::GetToken(const std::string& module, const CK_SLOT_ID& slotId, const std::string& label) {
+std::shared_ptr<Pkcs11Token> Pkcs11Token::GetToken(const std::string& module, const string& tokenId, const std::string& label) {
   // see if we can find module
   std::string tidx = module;
   tidx.append("|");
-  tidx.append(boost::lexical_cast<std::string>(slotId));
+  tidx.append(boost::lexical_cast<std::string>(tokenId));
   tidx.append("|");
   tidx.append(label);
   std::map<std::string, std::shared_ptr<Pkcs11Token> >::iterator tokenIter;
   if ((tokenIter = pkcs11_tokens.find(tidx)) != pkcs11_tokens.end()) return tokenIter->second;
 
-  std::shared_ptr<Pkcs11Slot> slot = Pkcs11Slot::GetSlot(module, slotId);
+  std::shared_ptr<Pkcs11Slot> slot = Pkcs11Slot::GetSlot(module, tokenId);
   pkcs11_tokens[tidx] = std::make_shared<Pkcs11Token>(slot, label);
   return pkcs11_tokens[tidx];
 }
@@ -690,10 +735,10 @@ Pkcs11Token::Pkcs11Token(const std::shared_ptr<Pkcs11Slot>& slot, const std::str
 Pkcs11Token::~Pkcs11Token() {
 }
 
-bool PKCS11ModuleSlotLogin(const std::string& module, int slotId, const std::string& pin)
+bool PKCS11ModuleSlotLogin(const std::string& module, const string& tokenId, const std::string& pin)
 {
   std::shared_ptr<Pkcs11Slot> slot;
-  slot = Pkcs11Slot::GetSlot(module, slotId);
+  slot = Pkcs11Slot::GetSlot(module, tokenId);
   if (slot->LoggedIn()) return true; // no point failing
   return slot->Login(pin);
 }
@@ -896,7 +941,8 @@ DNSCryptoKeyEngine::storvector_t PKCS11DNSCryptoKeyEngine::convertToISCVector() 
 void PKCS11DNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, stormap_t& stormap) {
   drc.d_algorithm = atoi(stormap["algorithm"].c_str());
   d_module = stormap["engine"];
-  d_slot_id = atoi(stormap["slot"].c_str());
+  d_slot_id = stormap["slot"];
+  boost::trim(d_slot_id);
   d_pin = stormap["pin"];
   d_label = stormap["label"];
   // validate parameters

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -932,7 +932,7 @@ DNSCryptoKeyEngine::storvector_t PKCS11DNSCryptoKeyEngine::convertToISCVector() 
   boost::assign::push_back(storvect)
    (make_pair("Algorithm", boost::lexical_cast<std::string>(d_algorithm)))
    (make_pair("Engine", d_module))
-   (make_pair("Slot", boost::lexical_cast<std::string>(d_slot_id)))
+   (make_pair("Slot", d_slot_id))
    (make_pair("PIN", d_pin))
    (make_pair("Label", d_label));
   return storvect;

--- a/pdns/pkcs11signers.hh
+++ b/pdns/pkcs11signers.hh
@@ -5,7 +5,7 @@ class PKCS11DNSCryptoKeyEngine : public DNSCryptoKeyEngine
 {
   protected:
     std::string d_module;
-    unsigned long d_slot_id;
+    std::string d_slot_id;
     std::string d_pin;
     std::string d_label;
 
@@ -44,6 +44,6 @@ class PKCS11DNSCryptoKeyEngine : public DNSCryptoKeyEngine
     static DNSCryptoKeyEngine* maker(unsigned int algorithm);
 };
 
-bool PKCS11ModuleSlotLogin(const std::string& module, int slot, const std::string& pin);
+bool PKCS11ModuleSlotLogin(const std::string& module, const string& tokenId, const std::string& pin);
 
 #endif /* PDNS_PKCS11SIGNERS_HH */

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -87,13 +87,13 @@ securezone ()
                     slot=$((slot+1))
                   fi
                   sudo softhsm --init-token --slot $slot --label label$slot --pin 123$slot --so-pin 123$slot 
-                  kid=`$PDNSSEC --config-dir=. $configname hsm assign $zone rsasha256 ksk softhsm $slot 123$slot label$slot 2>&1 | grep softhsm | awk '{ print $NF }'` 
+                  kid=`$PDNSSEC --config-dir=. $configname hsm assign $zone rsasha256 ksk softhsm label$slot 123$slot label$slot 2>&1 | grep softhsm | awk '{ print $NF }'`
 # keep this until #1413 is merged
                   kid=`$PDNSSEC --config-dir=. $configname show-zone $zone | grep 'ID =.*KSK' | awk '{ print $3 }'`
                   $PDNSSEC --config-dir=. $configname hsm create-key $zone $kid
                   slot=$((slot+1))
                   sudo softhsm --init-token --slot $slot --label label$slot --pin 123$slot --so-pin 123$slot
-                  kid=`$PDNSSEC --config-dir=. $configname hsm assign $zone rsasha256 zsk softhsm $slot 123$slot label$slot 2>&1 | grep softhsm | awk '{ print $NF }'`
+                  kid=`$PDNSSEC --config-dir=. $configname hsm assign $zone rsasha256 zsk softhsm label$slot 123$slot label$slot 2>&1 | grep softhsm | awk '{ print $NF }'`
                   kid=`$PDNSSEC --config-dir=. $configname show-zone $zone | grep 'ID =.*ZSK' | awk '{ print $3 }'`
                   $PDNSSEC --config-dir=. $configname hsm create-key $zone $kid
                 else


### PR DESCRIPTION
SoftHSM2 at least does not retain slot ID order if you add more slots, so we need to use token label instead to make sure we open the same token each time. Contains backwards compability with token slots IDs to prevent breakage.