### PR TITLE
Prevent SIGFPE in wrandom routine - Fixes Issue #2794

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -262,6 +262,11 @@ shared_ptr<DownstreamState> wrandom(const NumberedServerVector& servers, const C
 
     }
   }
+
+  // Catch poss & sum are empty to avoid SIGFPE
+  if(poss.empty())
+    return shared_ptr<DownstreamState>();
+
   int r = random() % sum;
   auto p = upper_bound(poss.begin(), poss.end(),r, [](int r, const decltype(poss)::value_type& a) { return  r < a.first;});
   if(p==poss.end())


### PR DESCRIPTION
When a selected pool is empty (no servers in the default pool) or all servers in
the pool are marked as down, a Floating Point Exception will trigger as the
situation isn't caught.

(Since mentioning it in the commit doesn't trigger it... Issue #2794)