### PR TITLE
Ask RPM not to replace /etc/sysconfig/dnsdist by default

### DIFF
--- a/build-scripts/build-dnsdist-rpm
+++ b/build-scripts/build-dnsdist-rpm
@@ -113,7 +113,7 @@ ${DEFAULTS_INSTALL}
 %doc README.md
 %dir %{_sysconfdir}/dnsdist
 ${INIT_FILES}
-${DEFAULTS_FILES}
+%config(noreplace) ${DEFAULTS_FILES}
 
 EOF
 


### PR DESCRIPTION
The RHEL/CentOS RPM packages have an issue where `/etc/sysconfig/dnsdist` is overwritten every time the package is updated.

Per http://www-uxsup.csx.cam.ac.uk/~jw35/docs/rpm_config.html the most appropriate descriptor on the file is %config(noreplace).