### PR TITLE
Die on fatal error 3.4.7

### DIFF
--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -248,8 +248,7 @@ template<class Answer, class Question, class Backend>void *MultiThreadDistributo
         a->setRcode(RCode::ServFail);
         S.inc("servfail-packets");
         S.ringAccount("servfail-queries",q->qdomain);
-
-	delete QD->Q;
+        delete q;
 	must_die = true;
       }
       catch(...) {
@@ -258,6 +257,7 @@ template<class Answer, class Question, class Backend>void *MultiThreadDistributo
         a->setRcode(RCode::ServFail);
         S.inc("servfail-packets");
         S.ringAccount("servfail-queries",q->qdomain);
+        delete q;
       }
 
       AnswerData<Answer> AD;

--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -195,6 +195,7 @@ template<class Answer, class Question, class Backend>void *MultiThreadDistributo
 {
   pthread_detach(pthread_self());
   try {
+    bool must_die = false;
     Backend *b=new Backend(); // this will answer our questions
     MultiThreadDistributor *us=static_cast<MultiThreadDistributor *>(p);
     int qcount;
@@ -206,7 +207,6 @@ template<class Answer, class Question, class Backend>void *MultiThreadDistributo
     // ick ick ick!
     static int overloadQueueLength=::arg().asNum("overload-queue-length");
     for(;;) {
-      bool must_die = false;
       ++(us->d_idle_threads);
 
       us->numquestions.getValue( &qcount );

--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -195,7 +195,6 @@ template<class Answer, class Question, class Backend>void *MultiThreadDistributo
 {
   pthread_detach(pthread_self());
   try {
-    bool must_die = false;
     Backend *b=new Backend(); // this will answer our questions
     MultiThreadDistributor *us=static_cast<MultiThreadDistributor *>(p);
     int qcount;
@@ -207,6 +206,7 @@ template<class Answer, class Question, class Backend>void *MultiThreadDistributo
     // ick ick ick!
     static int overloadQueueLength=::arg().asNum("overload-queue-length");
     for(;;) {
+      bool must_die = false;
       ++(us->d_idle_threads);
 
       us->numquestions.getValue( &qcount );


### PR DESCRIPTION
Repair incorrect changes in f1ad3c5 that made pdns not die on fatal error. It is desirable here to die instead of continue.