### PR TITLE
Bulk test: change results filename

### DIFF
--- a/build-scripts/test-recursor-bulk
+++ b/build-scripts/test-recursor-bulk
@@ -35,7 +35,7 @@ version=$($PDNSRECURSOR --version 2>&1 | awk '/PowerDNS Recursor/ { print $6 }')
 for IPv6 in 0 1; do
   for CSV in $(ls *.csv); do
     for domains in $numdomains; do
-      export context="${version}.v6:${IPv6}.csv:${CSV%%.*}"
+      export context="${version}_v6:${IPv6}_csv:${CSV%%.*}"
       export IPv6
       export CSV
       RECURSOR=$PDNSRECURSOR THRESHOLD=0 TRACE=no time ./recursor-test 5401 $domains || EXIT=1

--- a/regression-tests/bulktest-to-json.py
+++ b/regression-tests/bulktest-to-json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import glob, json
 
 varnames = set()
@@ -6,7 +6,7 @@ statnames = set()
 runs = list()
 
 for fname in glob.glob('testresults-*.xml'):
-	info = fname[12:-4].split('.')
+	info = fname[12:-4].split('_')
 	tag = info.pop(0)
 	vars = dict(s.split(':') for s in info)
 	vars['tag'] = tag


### PR DESCRIPTION
The use of dots in the version caused havoc, use '_' to separate fields
containing test information.