### PR TITLE
Do not divide timeout twice

### DIFF
--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -388,7 +388,7 @@ int HTTPConnector::recv_message(rapidjson::Document &output) {
 
     try {
       t0 = time((time_t*)NULL);
-      while(arl.ready() == false && (labs(time((time_t*)NULL) - t0) <= timeout/1000)) {
+      while(arl.ready() == false && (labs(time((time_t*)NULL) - t0) <= timeout)) {
         rd = d_socket->readWithTimeout(buffer, sizeof(buffer), timeout);
         if (rd==0) 
           throw NetworkError("EOF while reading");


### PR DESCRIPTION
Fixes bug reported by @jpmens where replies timeout too fast even when timeout is increased.