### PR TITLE
Check NSEC3PARAMRecordContent pointer before dereferencing it.

### DIFF
--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -167,11 +167,13 @@ bool Bind2Backend::getNSEC3PARAM(const DNSName& name, NSEC3PARAMRecordContent* n
     NSEC3PARAMRecordContent* tmp=dynamic_cast<NSEC3PARAMRecordContent*>(DNSRecordContent::mastermake(QType::NSEC3PARAM, 1, value));
     *ns3p = *tmp;
     delete tmp;
+
+    if (ns3p->d_iterations > maxNSEC3Iterations) {
+      ns3p->d_iterations = maxNSEC3Iterations;
+      L<<Logger::Error<<"Number of NSEC3 iterations for zone '"<<name.toString()<<"' is above 'max-nsec3-iterations'. Value adjsted to: "<<maxNSEC3Iterations<<endl;
+    }
   }
-  if (ns3p->d_iterations > maxNSEC3Iterations) {
-    ns3p->d_iterations = maxNSEC3Iterations;
-    L<<Logger::Error<<"Number of NSEC3 iterations for zone '"<<name.toString()<<"' is above 'max-nsec3-iterations'. Value adjsted to: "<<maxNSEC3Iterations<<endl;
-  }
+
   return true;
 }
 


### PR DESCRIPTION
Bind2Backend::getNSEC3PARAM() does not seem to be called with a NULL
NSEC3PARAMRecordContent pointer, but better safe than sorry.