### PR TITLE
Add support for TCP timeouts and limit the number of retries on downs…

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -133,6 +133,24 @@ To change the QPS for a server:
 > getServer(0):setQPS(1000)
 ```
 
+TCP timeouts
+------------
+
+By default, a 2 seconds timeout is enforced on the TCP connection from the client,
+meaning that a connection will be closed if the query can't be read in less than 2s
+or if the answer can't be sent in less than 2s. This can be configured with:
+```
+> setTCPRecvTimeout(5)
+> setTCPSendTimeout(5)
+```
+
+The same kind of timeouts is enforced on the TCP connections to the downstream servers.
+The default value of 30s can be modified by passing the `tcpRecvTimeout` and `tcpSendTimeout`
+parameters to `newServer`:
+```
+newServer {address="192.0.2.1", tcpRecvTimeout=10, tcpSendTimeout=10}
+```
+
 Webserver
 ---------
 To visually interact with dnsdist, try adding:
@@ -544,7 +562,7 @@ Here are all functions:
    * `errlog(string)`: log at level error
  * Server related:
    * `newServer("ip:port")`: instantiate a new downstream server with default settings
-   * `newServer({address="ip:port", qps=1000, order=1, weight=10, pool="abuse"})`: instantiate
+   * `newServer({address="ip:port", qps=1000, order=1, weight=10, pool="abuse", retries=5, tcpSendTimeout=30, tcpRecvTimeout=30})`: instantiate
      a server with additional parameters
    * `showServers()`: output all servers
    * `getServer(n)`: returns server with index n 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -152,6 +152,18 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			  ret->weight=boost::lexical_cast<int>(boost::get<string>(vars["weight"]));
 			}
 
+			if(vars.count("retries")) {
+			  ret->retries=boost::lexical_cast<int>(boost::get<string>(vars["retries"]));
+			}
+
+			if(vars.count("tcpSendTimeout")) {
+			  ret->tcpSendTimeout=boost::lexical_cast<int>(boost::get<string>(vars["tcpSendTimeout"]));
+			}
+
+			if(vars.count("tcpRecvTimeout")) {
+			  ret->tcpRecvTimeout=boost::lexical_cast<int>(boost::get<string>(vars["tcpRecvTimeout"]));
+			}
+
 			if(g_launchWork) {
 			  g_launchWork->push_back([ret]() {
 			      ret->tid = move(thread(responderThread, ret));
@@ -814,6 +826,9 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
        g_outputBuffer="Crypto failed..\n";
      }});
 
+  g_lua.writeFunction("setTCPRecvTimeout", [](int timeout) { g_tcpRecvTimeout=timeout; });
+
+  g_lua.writeFunction("setTCPSendTimeout", [](int timeout) { g_tcpSendTimeout=timeout; });
   
   std::ifstream ifs(config);
   if(!ifs) 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -103,6 +103,9 @@ Rings g_rings;
 
 GlobalStateHolder<servers_t> g_dstates;
 
+int g_tcpRecvTimeout{2};
+int g_tcpSendTimeout{2};
+
 bool g_truncateTC{1};
 void truncateTC(const char* packet, unsigned int* len)
 try

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -246,6 +246,9 @@ struct DownstreamState
   double latencyUsec{0.0};
   int order{1};
   int weight{1};
+  int tcpRecvTimeout{30};
+  int tcpSendTimeout{30};
+  uint16_t retries{5};
   StopWatch sw;
   set<string> pools;
   enum class Availability { Up, Down, Auto} availability{Availability::Auto};
@@ -323,6 +326,8 @@ extern ComboAddress g_serverControl; // not changed during runtime
 extern std::vector<std::pair<ComboAddress, bool>> g_locals; // not changed at runtime (we hope XXX)
 extern std::string g_key; // in theory needs locking
 extern bool g_truncateTC;
+extern int g_tcpRecvTimeout;
+extern int g_tcpSendTimeout;
 struct dnsheader;
 
 void controlThread(int fd, ComboAddress local);

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -151,6 +151,8 @@ vstringtok (Container &container, string const &in,
 int writen2(int fd, const void *buf, size_t count);
 inline int writen2(int fd, const std::string &s) { return writen2(fd, s.data(), s.size()); }
 int readn2(int fd, void* buffer, unsigned int len);
+int readn2WithTimeout(int fd, void* buffer, size_t len, int timeout);
+int writen2WithTimeout(int fd, const void * buffer, size_t len, int timeout);
 
 const string toLower(const string &upper);
 const string toLowerCanonic(const string &upper);


### PR DESCRIPTION
…tream server

The TCP timeouts default to 30s in both sides (client and server), for receiving
and sending data. For now we use SO_RCVTIMEO and SO_SNDTIMEO, we might need to
use select() instead for some platforms.

We now only retry 5 times if the downstream server keeps failing on us.