### PR TITLE
systemd starting dnsdist too early

### DIFF
--- a/pdns/dnsdistdist/contrib/dnsdist.service
+++ b/pdns/dnsdistdist/contrib/dnsdist.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=dnsdist
-After=syslog.target
+After=network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/dnsdist


### PR DESCRIPTION
dnsdist was starting too early and had to be restarted after the network came up.  This was only tested on Centos