### PR TITLE
in this commit, we remove d_qtype from the DNSRecordContent base clas…

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -32,12 +32,12 @@ class UnknownRecordContent : public DNSRecordContent
 {
 public:
   UnknownRecordContent(const DNSRecord& dr, PacketReader& pr) 
-    : DNSRecordContent(dr.d_type), d_dr(dr)
+    : d_dr(dr)
   {
     pr.copyRecord(d_record, dr.d_clen);
   }
 
-  UnknownRecordContent(const string& zone) : DNSRecordContent(0)
+  UnknownRecordContent(const string& zone) 
   {
     // parse the input
     vector<string> parts;
@@ -74,6 +74,11 @@ public:
   void toPacket(DNSPacketWriter& pw)
   {
     pw.xfrBlob(string(d_record.begin(),d_record.end()));
+  }
+
+  uint16_t getType() const override 
+  {
+    return d_dr.d_type;
   }
 private:
   DNSRecord d_dr;

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -179,7 +179,7 @@ public:
     if(lowerCase)
       pw.setLowercase(true);
 
-    pw.startRecord(qname, d_qtype);
+    pw.startRecord(qname, this->getType());
     this->toPacket(pw);
     pw.commit();
     
@@ -234,19 +234,7 @@ public:
     return iter->second;
   }
 
-  explicit DNSRecordContent(uint16_t type) : d_qtype(type)
-  {
-  }
-  
-  
-  DNSRecordContent& operator=(const DNSRecordContent& orig) 
-  {
-    const_cast<uint16_t&>(d_qtype) = orig.d_qtype; // **COUGH**
-    return *this;
-  }
-
-  
-  const uint16_t d_qtype;
+  virtual uint16_t getType() const = 0;
 
 protected:
   typedef std::map<std::pair<uint16_t, uint16_t>, makerfunc_t* > typemap_t;

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -91,17 +91,17 @@ DNSResourceRecord::DNSResourceRecord(const DNSRecord &p) {
 
 boilerplate_conv(A, QType::A, conv.xfrIP(d_ip));
 
-ARecordContent::ARecordContent(uint32_t ip) : DNSRecordContent(QType::A)
+ARecordContent::ARecordContent(uint32_t ip) 
 {
   d_ip = ip;
 }
 
-ARecordContent::ARecordContent(const ComboAddress& ca) : DNSRecordContent(QType::A)
+ARecordContent::ARecordContent(const ComboAddress& ca) 
 {
   d_ip = ca.sin4.sin_addr.s_addr;
 }
 
-AAAARecordContent::AAAARecordContent(const ComboAddress& ca) : DNSRecordContent(QType::AAAA)
+AAAARecordContent::AAAARecordContent(const ComboAddress& ca) 
 {
   d_ip6.assign((const char*)ca.sin6.sin6_addr.s6_addr, 16);
 }
@@ -189,7 +189,7 @@ boilerplate_conv(TSIG, QType::TSIG,
                  if (size>0) conv.xfrBlobNoSpaces(d_otherData, size);
                  );
 
-MXRecordContent::MXRecordContent(uint16_t preference, const DNSName& mxname) : DNSRecordContent(QType::MX), d_preference(preference), d_mxname(mxname)
+MXRecordContent::MXRecordContent(uint16_t preference, const DNSName& mxname):  d_preference(preference), d_mxname(mxname)
 {
 }
 
@@ -256,7 +256,7 @@ boilerplate_conv(NAPTR, QType::NAPTR,
 
 
 SRVRecordContent::SRVRecordContent(uint16_t preference, uint16_t weight, uint16_t port, const DNSName& target) 
-: DNSRecordContent(QType::SRV), d_weight(weight), d_port(port), d_target(target), d_preference(preference)
+: d_weight(weight), d_port(port), d_target(target), d_preference(preference)
 {}
 
 boilerplate_conv(SRV, QType::SRV, 
@@ -265,7 +265,7 @@ boilerplate_conv(SRV, QType::SRV,
                  )
 
 SOARecordContent::SOARecordContent(const DNSName& mname, const DNSName& rname, const struct soatimes& st) 
-: DNSRecordContent(QType::SOA), d_mname(mname), d_rname(rname)
+: d_mname(mname), d_rname(rname)
 {
   d_st=st;
 }
@@ -308,7 +308,7 @@ boilerplate_conv(OPENPGPKEY, 61,
                  )
 
 #undef DS
-DSRecordContent::DSRecordContent() : DNSRecordContent(43) {}
+DSRecordContent::DSRecordContent() {}
 boilerplate_conv(DS, 43, 
                  conv.xfr16BitInt(d_tag); 
                  conv.xfr8BitInt(d_algorithm); 
@@ -316,7 +316,7 @@ boilerplate_conv(DS, 43,
                  conv.xfrHexBlob(d_digest, true); // keep reading across spaces
                  )
 
-CDSRecordContent::CDSRecordContent() : DNSRecordContent(59) {}
+CDSRecordContent::CDSRecordContent() {}
 boilerplate_conv(CDS, 59, 
                  conv.xfr16BitInt(d_tag); 
                  conv.xfr8BitInt(d_algorithm); 
@@ -324,7 +324,7 @@ boilerplate_conv(CDS, 59,
                  conv.xfrHexBlob(d_digest, true); // keep reading across spaces
                  )
 
-DLVRecordContent::DLVRecordContent() : DNSRecordContent(32769) {}
+DLVRecordContent::DLVRecordContent() {}
 boilerplate_conv(DLV,32769 , 
                  conv.xfr16BitInt(d_tag); 
                  conv.xfr8BitInt(d_algorithm); 
@@ -351,7 +351,7 @@ boilerplate_conv(RRSIG, 46,
                  conv.xfrBlob(d_signature);
                  )
                  
-RRSIGRecordContent::RRSIGRecordContent() : DNSRecordContent(46) {}
+RRSIGRecordContent::RRSIGRecordContent() {}
 
 boilerplate_conv(DNSKEY, 48, 
                  conv.xfr16BitInt(d_flags); 
@@ -359,7 +359,7 @@ boilerplate_conv(DNSKEY, 48,
                  conv.xfr8BitInt(d_algorithm); 
                  conv.xfrBlob(d_key);
                  )
-DNSKEYRecordContent::DNSKEYRecordContent() : DNSRecordContent(48) {}
+DNSKEYRecordContent::DNSKEYRecordContent() {}
 
 boilerplate_conv(CDNSKEY, 60, 
                  conv.xfr16BitInt(d_flags); 
@@ -367,14 +367,14 @@ boilerplate_conv(CDNSKEY, 60,
                  conv.xfr8BitInt(d_algorithm); 
                  conv.xfrBlob(d_key);
                  )
-CDNSKEYRecordContent::CDNSKEYRecordContent() : DNSRecordContent(60) {}
+CDNSKEYRecordContent::CDNSKEYRecordContent() {}
 
 boilerplate_conv(RKEY, 57, 
                  conv.xfr16BitInt(d_flags); 
                  conv.xfr8BitInt(d_protocol); 
                  conv.xfrBlob(d_key);
                  )
-RKEYRecordContent::RKEYRecordContent() : DNSRecordContent(57) {}
+RKEYRecordContent::RKEYRecordContent() {}
 
 /* EUI48 start */
 void EUI48RecordContent::report(void) 
@@ -474,7 +474,7 @@ boilerplate_conv(TKEY, QType::TKEY,
                  conv.xfr16BitInt(d_othersize);
                  if (d_othersize>0) conv.xfrBlobNoSpaces(d_other, d_othersize);
                  )
-TKEYRecordContent::TKEYRecordContent() : DNSRecordContent(QType::TKEY) { d_othersize = 0; } // fix CID#1288932
+TKEYRecordContent::TKEYRecordContent() { d_othersize = 0; } // fix CID#1288932
 
 uint16_t DNSKEYRecordContent::getTag()
 {

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -39,6 +39,7 @@
   static DNSRecordContent* make(const string& zonedata);                                         \
   string getZoneRepresentation() const;                                                          \
   void toPacket(DNSPacketWriter& pw);                                                            \
+  uint16_t getType() const override { return QType::RNAME; }                                   \
   template<class Convertor> void xfrPacket(Convertor& conv);                             
 
 class NAPTRRecordContent : public DNSRecordContent
@@ -142,7 +143,7 @@ class TSIGRecordContent : public DNSRecordContent
 {
 public:
   includeboilerplate(TSIG)
-  TSIGRecordContent() : DNSRecordContent(QType::TSIG) {}
+  TSIGRecordContent() {}
 
   uint16_t d_origID;
   uint16_t d_fudge;
@@ -180,7 +181,7 @@ class NSRecordContent : public DNSRecordContent
 {
 public:
   includeboilerplate(NS)
-  explicit NSRecordContent(const DNSName& content) : DNSRecordContent(QType::NS), d_content(content){}
+  explicit NSRecordContent(const DNSName& content) : d_content(content){}
   DNSName getNS() const { return d_content; } 
 private:
   DNSName d_content;
@@ -445,7 +446,7 @@ class NSECRecordContent : public DNSRecordContent
 {
 public:
   static void report(void);
-  NSECRecordContent() : DNSRecordContent(47)
+  NSECRecordContent()
   {}
   NSECRecordContent(const string& content, const string& zone=""); //FIXME400: DNSName& zone?
 
@@ -453,6 +454,10 @@ public:
   static DNSRecordContent* make(const string& content);
   string getZoneRepresentation() const;
   void toPacket(DNSPacketWriter& pw);
+  uint16_t getType() const override
+  {
+    return QType::NSEC;
+  }
   DNSName d_next;
   std::set<uint16_t> d_set;
 private:
@@ -462,7 +467,7 @@ class NSEC3RecordContent : public DNSRecordContent
 {
 public:
   static void report(void);
-  NSEC3RecordContent() : DNSRecordContent(50)
+  NSEC3RecordContent() 
   {}
   NSEC3RecordContent(const string& content, const string& zone=""); //FIXME400: DNSName& zone?
 
@@ -479,6 +484,12 @@ public:
   uint8_t d_saltlength;
   uint8_t d_nexthashlength;
 
+  uint16_t getType() const override
+  {
+    return QType::NSEC3;
+  }
+
+
 private:
 };
 
@@ -487,7 +498,7 @@ class NSEC3PARAMRecordContent : public DNSRecordContent
 {
 public:
   static void report(void);
-  NSEC3PARAMRecordContent() : DNSRecordContent(51)
+  NSEC3PARAMRecordContent()
   {}
   NSEC3PARAMRecordContent(const string& content, const string& zone=""); // FIXME400: DNSName& zone?
 
@@ -495,6 +506,11 @@ public:
   static DNSRecordContent* make(const string& content);
   string getZoneRepresentation() const;
   void toPacket(DNSPacketWriter& pw);
+
+  uint16_t getType() const override
+  {
+    return QType::NSEC3PARAM;
+  }
 
 
   uint8_t d_algorithm, d_flags;
@@ -508,7 +524,7 @@ class LOCRecordContent : public DNSRecordContent
 {
 public:
   static void report(void);
-  LOCRecordContent() : DNSRecordContent(QType::LOC)
+  LOCRecordContent() 
   {}
   LOCRecordContent(const string& content, const string& zone="");
 
@@ -519,7 +535,11 @@ public:
 
   uint8_t d_version, d_size, d_horizpre, d_vertpre;
   uint32_t d_latitude, d_longitude, d_altitude;
-  
+  uint16_t getType() const override
+  {
+    return QType::LOC;
+  }
+
 private:
 };
 
@@ -528,7 +548,7 @@ class WKSRecordContent : public DNSRecordContent
 {
 public:
   static void report(void);
-  WKSRecordContent() : DNSRecordContent(QType::WKS)
+  WKSRecordContent() 
   {}
   WKSRecordContent(const string& content, const string& zone=""); // FIXME400: DNSName& zone?
 
@@ -545,12 +565,13 @@ private:
 class EUI48RecordContent : public DNSRecordContent 
 {
 public:
-  EUI48RecordContent() : DNSRecordContent(QType::EUI48) {};
+  EUI48RecordContent() {};
   static void report(void);
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& zone); // FIXME400: DNSName& zone?
   void toPacket(DNSPacketWriter& pw);
   string getZoneRepresentation() const;
+  uint16_t getType() const override { return QType::EUI48; }
 private:
  // storage for the bytes
  uint8_t d_eui48[6]; 
@@ -559,12 +580,13 @@ private:
 class EUI64RecordContent : public DNSRecordContent
 {
 public:
-  EUI64RecordContent() : DNSRecordContent(QType::EUI64) {};
+  EUI64RecordContent() {};
   static void report(void);
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& zone); // FIXME400: DNSName& zone?
   void toPacket(DNSPacketWriter& pw);
   string getZoneRepresentation() const;
+  uint16_t getType() const override { return QType::EUI64; }
 private:
  // storage for the bytes
  uint8_t d_eui64[8];
@@ -597,7 +619,7 @@ RNAME##RecordContent::DNSRecordContent* RNAME##RecordContent::make(const DNSReco
   return new RNAME##RecordContent(dr, pr);                                                         \
 }                                                                                                  \
                                                                                                    \
-RNAME##RecordContent::RNAME##RecordContent(const DNSRecord& dr, PacketReader& pr) : DNSRecordContent(RTYPE) \
+RNAME##RecordContent::RNAME##RecordContent(const DNSRecord& dr, PacketReader& pr)                  \
 {                                                                                                  \
   doRecordCheck(dr);                                                                               \
   xfrPacket(pr);                                                                                   \
@@ -624,7 +646,7 @@ void RNAME##RecordContent::unreport(void)                                       
   unregist(254, RTYPE);                                                                            \
 }                                                                                                  \
                                                                                                    \
-RNAME##RecordContent::RNAME##RecordContent(const string& zoneData) : DNSRecordContent(RTYPE)       \
+RNAME##RecordContent::RNAME##RecordContent(const string& zoneData)                                 \
 {                                                                                                  \
   try {                                                                                            \
     RecordTextReader rtr(zoneData);                                                                \

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -13,7 +13,7 @@ DNSRecordContent* NSECRecordContent::make(const string& content)
   return new NSECRecordContent(content);
 }
 
-NSECRecordContent::NSECRecordContent(const string& content, const string& zone) : DNSRecordContent(47)
+NSECRecordContent::NSECRecordContent(const string& content, const string& zone) 
 {
   RecordTextReader rtr(content, zone);
   rtr.xfrName(d_next);
@@ -120,7 +120,7 @@ DNSRecordContent* NSEC3RecordContent::make(const string& content)
   return new NSEC3RecordContent(content);
 }
 
-NSEC3RecordContent::NSEC3RecordContent(const string& content, const string& zone) : DNSRecordContent(50)
+NSEC3RecordContent::NSEC3RecordContent(const string& content, const string& zone)
 {
   RecordTextReader rtr(content, zone);
   rtr.xfr8BitInt(d_algorithm);
@@ -257,7 +257,7 @@ DNSRecordContent* NSEC3PARAMRecordContent::make(const string& content)
   return new NSEC3PARAMRecordContent(content);
 }
 
-NSEC3PARAMRecordContent::NSEC3PARAMRecordContent(const string& content, const string& zone) : DNSRecordContent(51)
+NSEC3PARAMRecordContent::NSEC3PARAMRecordContent(const string& content, const string& zone) 
 {
   RecordTextReader rtr(content, zone);
   rtr.xfr8BitInt(d_algorithm); 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -683,7 +683,7 @@ void startDoResolve(void *p)
     case DNSFilterEngine::PolicyKind::Custom:
       res=RCode::NoError;
       spoofed.d_name=dc->d_mdp.d_qname;
-      spoofed.d_type=dfepol.d_custom->d_qtype;
+      spoofed.d_type=dfepol.d_custom->getType();
       spoofed.d_ttl = 1234;
       spoofed.d_class = 1;
       spoofed.d_content = dfepol.d_custom;
@@ -742,7 +742,7 @@ void startDoResolve(void *p)
       case DNSFilterEngine::PolicyKind::Custom:
 	res=RCode::NoError;
 	spoofed.d_name=dc->d_mdp.d_qname;
-	spoofed.d_type=dfepol.d_custom->d_qtype;
+	spoofed.d_type=dfepol.d_custom->getType();
 	spoofed.d_ttl = 1234;
 	spoofed.d_class = 1;
 	spoofed.d_content = dfepol.d_custom;
@@ -2093,7 +2093,6 @@ void  parseEDNSSubnetWhitelist(const std::string& wlist)
 
 int serviceMain(int argc, char*argv[])
 {
-
   L.setName(s_programname);
   L.setLoglevel((Logger::Urgency)(6)); // info and up
 

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -81,7 +81,7 @@ public:
 #undef DS
   enum typeenum : uint16_t {A=1, NS=2, CNAME=5, SOA=6, MR=9, WKS=11, PTR=12, HINFO=13, MINFO=14, MX=15, TXT=16, RP=17, AFSDB=18, SIG=24, KEY=25, AAAA=28, LOC=29, SRV=33, NAPTR=35, KX=36,
 		 CERT=37, A6=38, DNAME=39, OPT=41, DS=43, SSHFP=44, IPSECKEY=45, RRSIG=46, NSEC=47, DNSKEY=48, DHCID=49, NSEC3=50, NSEC3PARAM=51,
-		 TLSA=52, CDS=59, CDNSKEY=60, OPENPGPKEY=61, SPF=99, EUI48=108, EUI64=109, TKEY=249, TSIG=250, IXFR=251, AXFR=252, MAILB=253, MAILA=254, ANY=255, ADDR=259,
+      TLSA=52, RKEY=57, CDS=59, CDNSKEY=60, OPENPGPKEY=61, SPF=99, EUI48=108, EUI64=109, TKEY=249, TSIG=250, IXFR=251, AXFR=252, MAILB=253, MAILA=254, ANY=255, ADDR=259,
 		 ALIAS=260, DLV=32769};
   typedef pair<string,uint16_t> namenum;
   static vector<namenum> names;
@@ -153,6 +153,7 @@ private:
       qtype_insert("NSEC3", 50);
       qtype_insert("NSEC3PARAM", 51);
       qtype_insert("TLSA", 52);
+      qtype_insert("RKEY", 57);
       qtype_insert("CDS", 59);
       qtype_insert("CDNSKEY", 60);
       qtype_insert("OPENPGPKEY", 61);

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -189,7 +189,7 @@ LOCRecordContent::DNSRecordContent* LOCRecordContent::make(const DNSRecord &dr, 
   return ret;
 }
 
-LOCRecordContent::LOCRecordContent(const string& content, const string& zone) : DNSRecordContent(QType::LOC)
+LOCRecordContent::LOCRecordContent(const string& content, const string& zone) 
 {
   // 51 59 00.000 N 5 55 00.000 E 4.00m 1.00m 10000.00m 10.00m
   // convert this to d_version, d_size, d_horiz/vertpre, d_latitude, d_longitude, d_altitude


### PR DESCRIPTION
…s. This slims down all derived types, but impossibly also appears to slim down our IPv6 class to the actual mininum of 16 bytes. Unsure how this is possible. Perhaps "emtpy base class optimization"? The base is now indeed empty.