### PR TITLE
Add counter for ignored packets to recursor statistics.

### DIFF
--- a/docs/markdown/recursor/stats.md
+++ b/docs/markdown/recursor/stats.md
@@ -30,6 +30,7 @@ The `rec_control get` command can be used to query the following statistics, eit
 * `edns-ping-matches`: number of servers that sent a valid EDNS PING response
 * `edns-ping-mismatches`: number of servers that sent an invalid EDNS PING response
 * `failed-host-entries`: number of servers that failed to resolve
+* `ignored-packets`: counts the number of non-query packets received on server sockets that should only get query packets
 * `ipv6-outqueries`: number of outgoing queries over IPv6
 * `ipv6-questions`: counts all end-user initiated queries with the RD bit set, received over IPv6 UDP
 * `malloc-bytes`: returns the number of bytes allocated by the process (broken, always returns 0)

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1040,11 +1040,13 @@ void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       dc->setRemote(&conn->d_remote);
       if(dc->d_mdp.d_header.qr) {
         delete dc;
+        g_stats.ignoredCount++;
         L<<Logger::Error<<"Ignoring answer from TCP client "<< conn->d_remote.toString() <<" on server socket!"<<endl;
         return;
       }
       if(dc->d_mdp.d_header.opcode) {
         delete dc;
+        g_stats.ignoredCount++;
         L<<Logger::Error<<"Ignoring non-query opcode from TCP client "<< conn->d_remote.toString() <<" on server socket!"<<endl;
         return;
       }
@@ -1229,10 +1231,12 @@ void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       dnsheader* dh=(dnsheader*)data;
 
       if(dh->qr) {
+        g_stats.ignoredCount++;
         if(g_logCommonErrors)
           L<<Logger::Error<<"Ignoring answer from "<<fromaddr.toString()<<" on server socket!"<<endl;
       }
       else if(dh->opcode) {
+        g_stats.ignoredCount++;
         if(g_logCommonErrors)
           L<<Logger::Error<<"Ignoring non-query opcode "<<dh->opcode<<" from "<<fromaddr.toString()<<" on server socket!"<<endl;
       }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -571,6 +571,7 @@ RecursorControlParser::RecursorControlParser()
   addGetStat("policy-drops", &g_stats.policyDrops);
   addGetStat("no-packet-error", &g_stats.noPacketError);
   addGetStat("dlg-only-drops", &SyncRes::s_nodelegated);
+  addGetStat("ignored-packets", &g_stats.ignoredCount);
   addGetStat("max-mthread-stack", &g_stats.maxMThreadStackUsage);
   
   addGetStat("negcache-entries", boost::bind(getNegCacheSize));

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -593,6 +593,7 @@ struct RecursorStats
   uint64_t noPingOutQueries, noEdnsOutQueries;
   uint64_t packetCacheHits;
   uint64_t noPacketError;
+  uint64_t ignoredCount;
   time_t startupTime;
   unsigned int maxMThreadStackUsage;
 };


### PR DESCRIPTION
Turns out recursor can be kept rather busy dealing with packets that will not show up anywhere.

Noticed while doing some flood-tests where the packets happened to have the response bit set.
Was considering adding this to "unexpected-packets" but that metric is used for another purpose. And it's technically not a "client-parse-error" .. so, adding "ignored-packets" to count these.

Unfortunately I pushed to master before, hence reopening this the right way (hopefully).