### PR TITLE
Introducing Linux Socket Filters to recursor listening sockets

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -86,6 +86,9 @@ extern SortList g_sortlist;
 #include "statbag.hh"
 StatBag S;
 #endif
+#ifdef SO_ATTACH_FILTER
+#include <linux/filter.h>
+#endif
 
 __thread FDMultiplexer* t_fdm;
 __thread unsigned int t_id;
@@ -1370,6 +1373,39 @@ void makeUDPServerSockets()
     }
     if (!setSocketTimestamps(fd))
       L<<Logger::Warning<<"Unable to enable timestamp reporting for socket"<<endl;
+
+#ifdef SO_ATTACH_FILTER
+    // Linux Socket Filtering
+    //
+    // As we are using SOCK_DGRAM sockets we are matching on UDP datagrams; note the
+    // different offsets (eg "ether[0:2]" = UDP source port).
+
+    // Accept only UDP datagrams that pass the following rules:
+    // dgram length >24, QR=0, OpCode=0, AA=?, TC=0, RD=?, QDCount=1, ANCount=0
+    //
+    // PCAP: 'ether[4:2]>24 and (ether[10]|5=5) and ether[12:2]=1 and ether[14:2]=0'
+
+    struct sock_filter lsf_code[] = {
+      { 0x28, 0, 0, 0x00000004 }, // (000) ldh      [4]
+      { 0x25, 0, 8, 0x00000018 }, // (001) jgt      #0x18            jt 2    jf 10
+      { 0x30, 0, 0, 0x0000000a }, // (002) ldb      [10]
+      { 0x44, 0, 0, 0x00000005 }, // (003) or       #0x5
+      { 0x15, 0, 5, 0x00000005 }, // (004) jeq      #0x5             jt 5    jf 10
+      { 0x28, 0, 0, 0x0000000c }, // (005) ldh      [12]
+      { 0x15, 0, 3, 0x00000001 }, // (006) jeq      #0x1             jt 7    jf 10
+      { 0x28, 0, 0, 0x0000000e }, // (007) ldh      [14]
+      { 0x15, 0, 1, 0x00000000 }, // (008) jeq      #0x0             jt 9    jf 10
+      { 0x6, 0, 0, 0x0000ffff },  // (009) ret      #65535
+      { 0x6, 0, 0, 0x00000000 },  // (010) ret      #0
+    };
+
+    struct sock_fprog lsf;
+    lsf.len = (sizeof(lsf_code) / sizeof((lsf_code)[0]));
+    lsf.filter = lsf_code;
+
+    if(setsockopt(fd, SOL_SOCKET, SO_ATTACH_FILTER, &lsf, sizeof(lsf)) < 0)
+      L<<Logger::Warning<<"Failed to attach LSF filter to socket, continuing anyhow: "<<strerror(errno)<<endl;
+#endif
 
     if(IsAnyAddress(sin)) {
       setsockopt(fd, IPPROTO_IP, GEN_IP_PKTINFO, &one, sizeof(one));     // linux supports this, so why not - might fail on other systems


### PR DESCRIPTION
Using LSF recursor can instruct the kernel what it wants to receive on its listening sockets. This can be used to shift the burden of handling certain unwanted packets to the kernel that can usually deal with that way better than an userspace process.

This code uses LSF to add a very basic packet size check to recursor. It could be enhanced easily to include further DNS packet checks. Downside of that is that dropped packets will not appear anywhere within recursor, so won't show up in statistics.
This is not as fast as blocking traffic via netfilter so it can't really replace any existing netfilter or network based protections. I'd see it as an additional security layer, or in cases where netfilter can't be used.
While this is Linux-specific similar socket filtering could most likely be added using BPF on some other supported OS (e.g. BSD).

For a quick verification on the difference between stock pdns-recursor and this code one could use tools such as hping3 in flood mode with different packet sizes and watch CPU usage.

I'd like to put this up for discussion as this technique seems to be rather useful to me. I've tested it for a bit but can't guarantee that it won't cause recursor to explode or cause other undesired side-effects.