### PR TITLE
Gracefully handle cases where IPv6 (AF_INET6) is not supported.

### DIFF
--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -206,8 +206,13 @@ void UDPNameserver::bindIPv6()
 
     s=socket(AF_INET6,SOCK_DGRAM,0);
     if(s<0) {
-      L<<Logger::Error<<"Unable to acquire UDPv6 socket: "+string(strerror(errno)) << endl;
-      throw PDNSException("Unable to acquire UDPv6 socket: "+string(strerror(errno)));
+      if( errno == EAFNOSUPPORT ) {
+        L<<Logger::Error<<"IPv6 Address Family is not supported - skipping UDPv6 bind" << endl;
+        return;
+      } else {
+        L<<Logger::Error<<"Unable to acquire a UDPv6 socket: "+string(strerror(errno)) << endl;
+        throw PDNSException("Unable to acquire a UDPv6 socket: "+string(strerror(errno)));
+      }
     }
 
     setCloseOnExec(s);

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -56,11 +56,14 @@ int makeQuerySocket(const ComboAddress& local, bool udpOrTCP)
   ComboAddress ourLocal(local);
   
   int sock=socket(ourLocal.sin4.sin_family, udpOrTCP ? SOCK_DGRAM : SOCK_STREAM, 0);
-  setCloseOnExec(sock);
   if(sock < 0) {
-    unixDie("Creating local resolver socket for "+ourLocal.toString() + ((local.sin4.sin_family == AF_INET6) ? ", does your OS miss IPv6?" : ""));
+    if(errno == EAFNOSUPPORT && local.sin4.sin_family == AF_INET6) {
+        return sock;
+    }
+    unixDie("Creating local resolver socket for "+ourLocal.toString());
   }
 
+  setCloseOnExec(sock);
   if(udpOrTCP) {
     // udp, try hard to bind an unpredictable port
     int tries=10;

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -58,7 +58,7 @@ int makeQuerySocket(const ComboAddress& local, bool udpOrTCP)
   int sock=socket(ourLocal.sin4.sin_family, udpOrTCP ? SOCK_DGRAM : SOCK_STREAM, 0);
   if(sock < 0) {
     if(errno == EAFNOSUPPORT && local.sin4.sin_family == AF_INET6) {
-        return sock;
+        return -1;
     }
     unixDie("Creating local resolver socket for "+ourLocal.toString());
   }


### PR DESCRIPTION
This fixes issue #1259 and allows a single configuration file to be used
both for IPv6 enabled and IPv6-less systems.