### PR TITLE
Add oustanding queries and send errors stats to the carbon export.

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -64,6 +64,8 @@ try
         str<<base<<"queries" << ' ' << s->queries.load() << " " << now << "\r\n";
         str<<base<<"drops" << ' ' << s->reuseds.load() << " " << now << "\r\n";
         str<<base<<"latency" << ' ' << s->latencyUsec/1000.0 << " " << now << "\r\n";
+        str<<base<<"senderrors" << ' ' << s->sendErrors.load() << " " << now << "\r\n";
+        str<<base<<"outstanding" << ' ' << s->outstanding.load() << " " << now << "\r\n";
       }
       const string msg = str.str();
 


### PR DESCRIPTION
I really have no idea why I didn't include those last time, it just makes sense to have them.