### PR TITLE
GeoIP backend features & fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ script:
  - touch tests/verify-dnssec-zone/allow-missing
  - touch tests/verify-dnssec-zone/skip.nsec3 # some (travis) tools in this test are unable to handle nsec3 zones
  - touch tests/verify-dnssec-zone/skip.optout
- - export geoipregion=aus geoipregionip=1.2.3.4
+ - export geoipregion=oc geoipregionip=1.2.3.4
  - ./timestamp ./start-test-stop 5300 bind-both
  - ./timestamp ./start-test-stop 5300 bind-dnssec-both
  - ./timestamp ./start-test-stop 5300 bind-dnssec-pkcs11

--- a/docs/markdown/authoritative/backend-geoip.md
+++ b/docs/markdown/authoritative/backend-geoip.md
@@ -9,9 +9,7 @@
 |Autoserial|No|
 |DNSSEC|Yes|
 
-The GeoIP backend can be used to distribute queries globally using an MaxMind IP-address/country mapping table, currently avaible for debian and ubuntu for free. Other formats are not yet supported but will be in the future. The only format supported at the moment is country listing.
-
-This allows visitors to be sent to a server close to them, with no appreciable delay, as would otherwise be incurred with a protocol level redirect. Additionally, the Geo Backend can be used to provide service over several clusters, any of which can be taken out of use easily, for example for maintenance purposes.
+This backend allows visitors to be sent to a server closer to them, with no appreciable delay, as would otherwise be incurred with a protocol level redirect. Additionally, the Geo Backend can be used to provide service over several clusters, any of which can be taken out of use easily, for example for maintenance purposes. This backend can utilize EDNS Client Subnet extension for decision making, if provided in query and you have turned on (edns-subnet-processing)[settings.md#edns-subnet-processing].
 
 ## Prerequisites
 To compile the backend, you need libyaml-cpp 0.5 or later and libgeoip.
@@ -22,10 +20,13 @@ You must have geoip database available. As of writing, on debian/ubuntu systems,
 These are the configuration file parameters that are available for the GeoIP backend. geoip-zones-files is the only thing you must set, if the defaults suite you.
 
 ### `geoip-database-file`
-Specifies the full path of the data file for IPv4 to use. You can use [geoip-cvs-to-dat](https://github.com/dankamongmen/sprezzos-world/blob/master/packaging/geoip/debian/src/geoip-csv-to-dat.cpp) to generate your own.
+Before 4.0.0. Specifies the full path of the data file for IPv4 to use.
 
 ### `geoip-database-file6`
-Specifies the full path of the data file for IPv6 to use.
+Before 4.0.0. Specifies the full path of the data file for IPv6 to use.
+
+### `geoip-database-files`
+After 4.0.0. Comma, tab or space separated list of files to open. You can use [geoip-cvs-to-dat](https://github.com/dankamongmen/sprezzos-world/blob/master/packaging/geoip/debian/src/geoip-csv-to-dat.cpp) to generate your own.
 
 ### `geoip-database-cache`
 Specifies the kind of caching that is done on the database. This is one of
@@ -40,6 +41,8 @@ Specifies the full path of a directory that will contain DNSSEC keys. This optio
 
 ## Zonefile format
 Zone configuration file uses YAML syntax. Here is simple example. Note that the ‐ before certain keys is part of the syntax.
+
+Before 4.0.0:
 
 ```
 domains:
@@ -57,11 +60,34 @@ domains:
       - aaaa: 2001:DB8::12:34DE:3
   services:
     service.geo.example.com: '%co.%cn.service.geo.example.com'
+```
+
+From 4.0.0:
+
+```
+domains:
+- domain: geo.example.com
+  ttl: 30
+  records:
+    geo.example.com:
+      - soa: ns1.example.com hostmaster.example.com 2014090125 7200 3600 1209600 3600
+      - ns: ns1.example.com
+      - ns: ns2.example.com
+      - mx: 10 mx.example.com
+    fin.eu.service.geo.example.com:
+      - a: 198.51.100.221
+      - txt: hello world
+      - aaaa: 2001:DB8::12:34DE:3
+  services:
+# syntax 1
+    service.geo.example.com: '%co.%cn.service.geo.example.com'
+# syntax 2
+    service.geo.example.com: [ '%co.%cn.service.geo.example.com', '%cn.service.geo.example.com']
 # alternative syntax
   services:
-    service.geo.example.com: '%co.%cn.service.geo.example.com'
-      default: '%co.%cn.service.geo.example.com'
-      127.0.0.0/8: 'localhost.service.geo.example.com'   
+    service.geo.example.com:
+      default: [ '%co.%cn.service.geo.example.com', '%cn.service.geo.example.com' ]
+      10.0.0.0/8: 'internal.service.geo.example.com'
 ```
 
 ### Keys explained
@@ -70,6 +96,8 @@ domains:
 * **ttl**: TTL value for all records
 * **records**: Put fully qualified name as subkey, under which you must define at least soa: key. Note that this is an array of records, so ‐ is needed for the values.
 * **services**: Defines one or more services for querying. The format supports following placeholders, %% = %, %co = 3-letter country, %cn = continent, %af = v4 or v6. There are also other specifiers that will only work with suitable database and currently are untested. These are %re = region, %na = Name (such as, organisation), %ci = City. 
-* Since of 4.0, you can also use additional specifiers. These are %hh = hour, %dd = day, %mo = month, %mos = month as short string, %wd = weekday (as number), %wds weekday as short string. 
-* Since of 4.0, scopeMask is set to most specific value, in case of date/time modifiers it will be 32 or 128, but with the others it is set to what geoip says it used for matching.
-You can add per-network overrides for format, they will be formatted with the same placeholders as default. Default is short-hand for adding 0.0.0.0/0 and ::/0. Default is default when only string is given for service name.
+* From 4.0.0, you can also use %as = ASn
+* From 4.0.0, you can also use additional specifiers. These are %hh = hour, %dd = day, %mo = month, %mos = month as short string, %wd = weekday (as number), %wds weekday as short string. 
+* From 4.0.0, scopeMask is set to most specific value, in case of date/time modifiers it will be 32 or 128, but with the others it is set to what geoip says it used for matching.
+* From 4.0.0, You can add per-network overrides for format, they will be formatted with the same placeholders as default. Default is short-hand for adding 0.0.0.0/0 and ::/0. Default is default when only string is given for service name.
+* From 4.0.0, You can use array to specify return values, works only if you have those records specified. It matches the format results to your records, and if it finds match that is used. Otherwise the last is returned.

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -20,10 +20,13 @@
 #include "pdns/dnsbackend.hh"
 #include "pdns/lock.hh"
 
+struct geoip_deleter;
+
 class GeoIPDomain;
 
 class GeoIPBackend: public DNSBackend {
 public:
+  typedef pair<int,unique_ptr<GeoIP,geoip_deleter> > geoip_file_t;
   GeoIPBackend(const std::string& suffix="");
   ~GeoIPBackend();
 
@@ -45,7 +48,7 @@ public:
   virtual bool deactivateDomainKey(const DNSName& name, unsigned int id);
 
   enum GeoIPQueryAttribute {
-    Afi,
+    ASn,
     City,
     Continent,
     Country,
@@ -59,8 +62,19 @@ private:
   void initialize();
   void ip2geo(const GeoIPDomain& dom, const string& qname, const string& ip);
   string queryGeoIP(const string &ip, bool v6, GeoIPQueryAttribute attribute, GeoIPLookup* gl);
+  bool queryCountry(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryCountryV6(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryContinent(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryContinentV6(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryName(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryNameV6(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryASnum(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryASnumV6(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryRegion(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryRegionV6(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryCity(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
+  bool queryCityV6(string &ret, GeoIPLookup* gl, const string &ip, const geoip_file_t& gi);
   string format2str(string format, const string& ip, bool v6, GeoIPLookup* gl);
-  int d_dbmode;
   bool d_dnssec; 
   bool hasDNSSECkey(const DNSName& name);
 

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -636,3 +636,9 @@ const T& defTer(const T& a, const T& b)
 {
   return a ? a : b;
 }
+
+template<typename P, typename T>
+T valueOrEmpty(const P val) {
+  if (!val) return T{};
+  return T(val);
+}

--- a/regression-tests/backends/geoip-master
+++ b/regression-tests/backends/geoip-master
@@ -60,6 +60,7 @@ EOF
 module-dir=./modules
 launch=geoip
 geoip-zones-file=$testsdir/geo.yaml
+geoip-database-files=/usr/share/GeoIP/GeoIP.dat
 EOF
 
 		if [ "$geoipdosec" = "yes" ]
@@ -73,7 +74,8 @@ EOF
 			--no-shuffle --launch=geoip \
 			--cache-ttl=$cachettl --experimental-dname-processing --no-config \
 			--distributor-threads=1 \
-                        --geoip-zones-file=$testsdir/geo.yaml --module-dir=./modules \
+                        --geoip-zones-file=$testsdir/geo.yaml --geoip-database-files=/usr/share/GeoIP/GeoIP.dat \
+                        --module-dir=./modules \
 			$geoipkeydir &
 		;;
 


### PR DESCRIPTION
Use --geoip-database-files to open one or more files. Allows also running without database. Thank you for @tuxis-ie for AS number support.

Changes:
- you can now load geoip backend w/o database at all, useful for purposes where you only need to support few networks
- support AS numbers
- supports multiple database files, and it keeps on looking until it gets non-unknown result, or databases run out
- still reloadable (you can reload config & databases with pdns_control reload)
- queryGeoIP has been split into parts
- Adds support for multiple formats per service, closes #2757