### PR TITLE
Implement %as for geoip-backend

### DIFF
--- a/docs/markdown/authoritative/backend-geoip.md
+++ b/docs/markdown/authoritative/backend-geoip.md
@@ -70,6 +70,7 @@ domains:
 * **ttl**: TTL value for all records
 * **records**: Put fully qualified name as subkey, under which you must define at least soa: key. Note that this is an array of records, so ‐ is needed for the values.
 * **services**: Defines one or more services for querying. The format supports following placeholders, %% = %, %co = 3-letter country, %cn = continent, %af = v4 or v6. There are also other specifiers that will only work with suitable database and currently are untested. These are %re = region, %na = Name (such as, organisation), %ci = City. 
+* As of 4.0, you can also use %as = ASn
 * Since of 4.0, you can also use additional specifiers. These are %hh = hour, %dd = day, %mo = month, %mos = month as short string, %wd = weekday (as number), %wds weekday as short string. 
 * Since of 4.0, scopeMask is set to most specific value, in case of date/time modifiers it will be 32 or 128, but with the others it is set to what geoip says it used for matching.
 You can add per-network overrides for format, they will be formatted with the same placeholders as default. Default is short-hand for adding 0.0.0.0/0 and ::/0. Default is default when only string is given for service name.

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -308,6 +308,7 @@ string GeoIPBackend::queryGeoIP(const string &ip, bool v6, GeoIPQueryAttribute a
   GeoIPRegion *gir = NULL;
   GeoIPRecord *gir2 = NULL;
   int id;
+  vector<string> asnr;
 
   if (v6 && s_gi6) {
     if (attribute == Afi) {
@@ -315,6 +316,16 @@ string GeoIPBackend::queryGeoIP(const string &ip, bool v6, GeoIPQueryAttribute a
     } else if (d_dbmode == GEOIP_ISP_EDITION_V6 || d_dbmode == GEOIP_ORG_EDITION_V6) {
       if (attribute == Name) {
         val = GeoIP_name_by_addr_v6_gl(s_gi6, ip.c_str(), gl);
+      }
+    } else if (d_dbmode == GEOIP_ASNUM_EDITION_V6) {
+      if (attribute == ASn) {
+        val = GeoIP_name_by_addr_v6_gl(s_gi6, ip.c_str(), gl);
+        if (val) {
+          stringtok(asnr, val);
+          if(asnr.size()>0) {
+            val = asnr[0].c_str();
+          }
+        }
       }
     } else if (d_dbmode == GEOIP_COUNTRY_EDITION_V6 ||
         d_dbmode == GEOIP_LARGE_COUNTRY_EDITION_V6 ||
@@ -362,6 +373,16 @@ string GeoIPBackend::queryGeoIP(const string &ip, bool v6, GeoIPQueryAttribute a
     } else if (d_dbmode == GEOIP_ISP_EDITION || d_dbmode == GEOIP_ORG_EDITION) {
       if (attribute == Name) {
         val = GeoIP_name_by_addr_v6_gl(s_gi, ip.c_str(), gl);
+      }
+    } else if (d_dbmode == GEOIP_ASNUM_EDITION) {
+      if (attribute == ASn) {
+        val = GeoIP_name_by_addr_gl(s_gi, ip.c_str(), gl);
+        if (val) {
+          stringtok(asnr, val);
+          if(asnr.size()>0) {
+            val = asnr[0].c_str();
+          }
+        }
       }
     } else if (d_dbmode == GEOIP_COUNTRY_EDITION ||
         d_dbmode == GEOIP_LARGE_COUNTRY_EDITION) {
@@ -430,6 +451,8 @@ string GeoIPBackend::format2str(string format, const string& ip, bool v6, GeoIPL
       rep = queryGeoIP(ip, v6, Country, &tmp_gl);
     } else if (!format.compare(cur,3,"%af")) {
       rep = queryGeoIP(ip, v6, Afi, &tmp_gl);
+    } else if (!format.compare(cur,3,"%as")) {
+      rep = queryGeoIP(ip, v6, ASn, &tmp_gl);
     } else if (!format.compare(cur,3,"%re")) {
       rep = queryGeoIP(ip, v6, Region, &tmp_gl);
     } else if (!format.compare(cur,3,"%na")) {

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -46,6 +46,7 @@ public:
 
   enum GeoIPQueryAttribute {
     Afi,
+    ASn,
     City,
     Continent,
     Country,


### PR DESCRIPTION
... which translates to the clients AS-number. Also, fix the documentation for geoip-backend.

This PR needs PR #2907 to be merged first, as this patch uses that code already.