### PR TITLE
Check that offset < len in DNSName::packetParser.

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -41,6 +41,10 @@ void DNSName::packetParser(const char* qpos, int len, int offset, bool uncompres
   const unsigned char* pos=(const unsigned char*)qpos;
   unsigned char labellen;
   const unsigned char *opos = pos;
+
+  if (offset >= len)
+    throw std::range_error("Trying to read past the end of the buffer");
+
   pos += offset;
   const unsigned char* end = pos + len;
   while((labellen=*pos++) && pos < end) { // "scan and copy"


### PR DESCRIPTION
If DNSName::packetParser() is called with offset >= len,
we do pos = qpos + offset, then labellen=*pos++ before
checking that pos is not after qpos + len, leading to
a potential out-of-bound read.