### PR TITLE
API: dot correctness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -288,7 +288,7 @@ script:
 
   ### api ###
   - cd regression-tests.api
-  #DNSName: - ./runtests authoritative
+  - ./runtests authoritative
   #DNSName: - ./runtests recursor
   - cd ..
 

--- a/docs/markdown/httpapi/README.md
+++ b/docs/markdown/httpapi/README.md
@@ -33,27 +33,27 @@ After restarting `pdns_server`, the following examples should start working:
     curl -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones | jq .
     
     # Create new zone "example.org" with nameservers ns1.example.org, ns2.example.org
-    curl -X POST --data '{"name":"example.org", "kind": "Native", "masters": [], "nameservers": ["ns1.example.org", "ns2.example.org"]}' -v -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones | jq .
+    curl -X POST --data '{"name":"example.org.", "kind": "Native", "masters": [], "nameservers": ["ns1.example.org.", "ns2.example.org."]}' -v -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones | jq .
     
     # Show the new zone
-    curl -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones/example.org | jq .
+    curl -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones/example.org. | jq .
     
     # Add a new record to the new zone (would replace any existing test.example.org/A records)
-    curl -X PATCH --data '{"rrsets": [ {"name": "test.example.org", "type": "A", "changetype": "REPLACE", "records": [ {"content": "192.0.5.4", "disabled": false, "name": "test.example.org", "ttl": 86400, "type": "A" } ] } ] }' -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones/example.org | jq .
+    curl -X PATCH --data '{"rrsets": [ {"name": "test.example.org.", "type": "A", "changetype": "REPLACE", "records": [ {"content": "192.0.5.4", "disabled": false, "name": "test.example.org.", "ttl": 86400, "type": "A" } ] } ] }' -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones/example.org. | jq .
 
     # Combined replacement of multiple RRsets
     curl -X PATCH --data '{"rrsets": [
-      {"name": "test1.example.org",
+      {"name": "test1.example.org.",
        "type": "A",
        "changetype": "REPLACE",
-       "records": [ {"content": "192.0.2.5", "disabled": false, "name": "test.example.org", "ttl": 86400, "type": "A" } ]
+       "records": [ {"content": "192.0.2.5", "disabled": false, "name": "test1.example.org.", "ttl": 86400, "type": "A" } ]
       },
-      {"name": "test2.example.org",
+      {"name": "test2.example.org.",
        "type": "AAAA",
        "changetype": "REPLACE",
-       "records": [ {"content": "2001:db8::6/32", "disabled": false, "name": "test.example.org", "ttl": 86400, "type": "AAAA" } ]
+       "records": [ {"content": "2001:db8::6/32", "disabled": false, "name": "test2.example.org.", "ttl": 86400, "type": "AAAA" } ]
       }
-      ] }' -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones/example.org | jq .
+      ] }' -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones/example.org. | jq .
 
 `jq` is a highly recommended tool for pretty-printing JSON. If you don't have
 `jq`, try `json_pp` or `python -mjson.tool` instead.
@@ -95,3 +95,107 @@ Additional help
 ---------------
 
 For additional help, come to the `#powerdns` IRC channel on `irc.oftc.net`.
+
+
+Examples (Authoritative Server)
+===============================
+
+Show zone information and records
+---------------------------------
+
+    curl -H 'X-API-Key: changeme' \
+        http://127.0.0.1:8081/api/v1/servers/localhost/zones/example.org. | jq .
+
+Response:
+
+    {
+      "id": "example.org.",
+      "url": "api/v1/servers/localhost/zones/example.org.",
+      "name": "example.org.",
+      "kind": "Master",
+      "dnssec": false,
+      "account": "",
+      "masters": [],
+      "serial": 2015120401,
+      "notified_serial": 0,
+      "last_check": 0,
+      "soa_edit_api": "",
+      "soa_edit": "",
+      "records": [
+        {
+          "name": "example.org.",
+          "type": "NS",
+          "ttl": 86400,
+          "disabled": false,
+          "content": "ns1.example.org."
+        },
+        {
+          "name": "example.org.",
+          "type": "NS",
+          "ttl": 86400,
+          "disabled": false,
+          "content": "ns2.powerdns.com."
+        },
+        {
+          "name": "example.org.",
+          "type": "SOA",
+          "ttl": 86400,
+          "disabled": false,
+          "content": "ns1.example.org. hostmaster.example.org. 2015120401 10800 15 604800 10800"
+        },
+        {
+          "name": "ns1.example.org.",
+          "type": "A",
+          "ttl": 86400,
+          "disabled": false,
+          "content": "192.168.0.1"
+        },
+        {
+          "name": "www.example.org.",
+          "type": "A",
+          "ttl": 86400,
+          "disabled": false,
+          "content": "192.168.0.2"
+        }
+      ],
+      "comments": []
+    }
+
+
+Replace ns1.example.org
+-----------------------
+
+Based on the example.org zone above, replace the ns1.example.org A record with
+192.0.2.5:
+
+    curl -X PATCH --data '{"rrsets": [{
+      "name": "ns1.example.org.",
+      "type": "A",
+      "changetype": "REPLACE",
+      "records": [ {
+        "content": "192.0.2.5",
+        "disabled": false,
+        "name": "ns1.example.org.",
+        "ttl": 86400,
+        "type": "A"
+      }]
+    }]}' -H 'X-API-Key: changeme' \
+    http://127.0.0.1:8081/api/v1/servers/localhost/zones/example.org. | jq .
+
+Response:
+
+    {
+      "id": "example.org.",
+      ...
+      "records": [
+        {
+          "name": "ns1.example.org.",
+          "type": "A",
+          "ttl": 86400,
+          "disabled": false,
+          "content": "192.0.2.5"
+        },
+        ...
+      ],
+      ...
+    }

--- a/docs/markdown/httpapi/api_spec.md
+++ b/docs/markdown/httpapi/api_spec.md
@@ -216,7 +216,7 @@ depend on the credentials you have supplied.
 
 
 URL: /api/v1/servers
--------------
+--------------------
 
 Collection access.
 
@@ -228,7 +228,7 @@ Allowed REST methods:
 
 
 URL: /api/v1/servers/:server\_id
--------------------------
+--------------------------------
 
 Returns a single server_resource.
 
@@ -249,7 +249,7 @@ config\_setting\_resource
 
 
 URL: /api/v1/servers/:server\_id/config
---------------------------------
+---------------------------------------
 
 Collection access.
 
@@ -263,7 +263,7 @@ Creates a new config setting. This is useful for creating configuration for new 
 
 
 URL: /api/v1/servers/:server\_id/config/:config\_setting\_name
--------------------------------------------------------
+--------------------------------------------------------------
 
 Allowed REST methods: `GET`, `PUT`
 
@@ -385,7 +385,7 @@ When creating a slave zone, it is recommended to not set any of
 
 
 URL: /api/v1/servers/:server\_id/zones
--------------------------------
+--------------------------------------
 
 Allowed REST methods: `GET`, `POST`
 
@@ -406,7 +406,7 @@ rules before storing it. (Also applies to custom SOA records.)
 **TODO**: `dnssec`, `nsec3narrow`, `nsec3param`, `presigned` are not yet implemented.
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_id
------------------------------------------
+------------------------------------------------
 
 Allowed methods: `GET`, `PUT`, `DELETE`, `PATCH`.
 
@@ -496,7 +496,7 @@ Changing `name` renames the zone, as expected.
 
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_id/notify
-------------------------------------------------
+-------------------------------------------------------
 
 Allowed methods: `PUT`
 
@@ -511,7 +511,7 @@ Clients MUST NOT send a body.
 
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_id/axfr-retrieve
--------------------------------------------------------
+--------------------------------------------------------------
 
 Allowed methods: `PUT`
 
@@ -536,7 +536,7 @@ Not supported for recursors.
 
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_id/check
------------------------------------------------
+------------------------------------------------------
 
 Allowed methods: `GET`
 
@@ -575,7 +575,7 @@ metadata.
 
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/metadata
-----------------------------------------------------
+-----------------------------------------------------------
 
 Collection access.
 
@@ -584,7 +584,7 @@ Allowed methods: `GET`, `POST`
 **TODO**: Not yet implemented.
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/metadata/:metadata\_kind
---------------------------------------------------------------------
+---------------------------------------------------------------------------
 
 Allowed methods: `GET`, `PUT`, `DELETE`
 
@@ -622,7 +622,7 @@ both mutually exclusive.
 
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/cryptokeys
-------------------------------------------------------
+-------------------------------------------------------------
 
 Allowed methods: `GET`, `POST`
 
@@ -649,7 +649,7 @@ numeric id, see
 [http://rtfm.powerdns.com/pdnsutil.html](http://rtfm.powerdns.com/pdnsutil.html)
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/cryptokeys/:cryptokey\_id
----------------------------------------------------------------------
+----------------------------------------------------------------------------
 
 Allowed methods: `GET`, `PUT`, `DELETE`
 
@@ -676,7 +676,7 @@ Logging & Statistics
 ====================
 
 URL: /api/v1/servers/:server\_id/search-log?q=:search\_term
-----------------------------------------------------
+-----------------------------------------------------------
 
 Allowed methods: `GET` (Query)
 
@@ -690,7 +690,7 @@ Query the log, filtered by `:search_term`. Response body:
     ]
 
 URL: /api/v1/servers/:server\_id/statistics
-------------------------------------
+-------------------------------------------
 
 Allowed methods: `GET` (Query)
 
@@ -712,7 +712,7 @@ Values are returned as strings.
 
 
 URL: /api/v1/servers/:server\_id/trace
--------------------------------
+--------------------------------------
 
 **TODO**: Not yet implemented.
 
@@ -742,7 +742,7 @@ Retrieve query tracing log and current config. Response body:
 
 
 URL: /api/v1/servers/:server\_id/failures
-----------------------------------
+-----------------------------------------
 
 **TODO**: Not yet implemented.
 
@@ -879,7 +879,7 @@ Clears recursively all cached data ("plain" DNS + DNSSEC)
 **TODO**: should this be stored? (for history)
 
 URL: /api/v1/servers/:server\_id/overrides
-----------------------------------
+------------------------------------------
 
 **TODO**: Not yet implemented.
 
@@ -888,7 +888,7 @@ Collection access.
 Allowed Methods: `GET`, `POST`
 
 URL: /api/v1/servers/:server\_id/overrides/:override\_id
--------------------------------------------------
+--------------------------------------------------------
 
 **TODO**: Not yet implemented.
 

--- a/docs/markdown/httpapi/api_spec.md
+++ b/docs/markdown/httpapi/api_spec.md
@@ -315,6 +315,10 @@ zone_collection
   Opaque zone id (string), assigned by the Server. Do not interpret.
   Guaranteed to be safe for embedding in URLs.
 
+* `name`
+  Zone name, always including the trailing dot. Example: `example.org.`
+  Note: Before 4.0.0, zone names were taken/given without the trailing dot.
+
 * `kind`
   Authoritative: `<kind>`: `Native`, `Master` or `Slave`
   Recursor: `<kind>`: `Native`, or `Forwarded`
@@ -351,7 +355,9 @@ zone_collection
   **Note**: Authoritative only.
 
 * `nameservers` MAY be sent in client bodies during creation, and MUST
-  NOT be sent by the server. Simple list of strings of nameserver names.
+  NOT be sent by the server. Simple list of strings of nameserver names,
+  including the trailing dot. Note: Before 4.0.0, names were taken without
+  the trailing dot.
   **Note**: Authoritative only. Not required for slave zones.
 
 * `servers`: list of forwarded-to servers, including port.
@@ -460,7 +466,7 @@ Client body for PATCH:
 Having `type` inside an RR differ from `type` at the RRset level is an error.
 
 * `name`
-  Full name of the RRset to modify. (Example: `foo.example.org`)
+  Full name of the RRset to modify. (Example: `foo.example.org.`)
 
 * `type`
   Type of the RRset to modify. (Example: `AAAA`)
@@ -505,7 +511,7 @@ Allowed methods: `PUT`
 
 Send a DNS NOTIFY to all slaves.
 
-Fails when zone kind is not `Master` or `Slave`, or `master` and `slave` are 
+Fails when zone kind is not `Master` or `Slave`, or `master` and `slave` are
 disabled in pdns configuration. Only works for `Slave` if renotify is on.
 
 Not supported for recursors.
@@ -860,7 +866,7 @@ override\_type
       "type": "Override",
       "id": <int>,
       "override": "replace",
-      "domain": "www.cnn.com",
+      "domain": "www.cnn.com.",
       "rrtype": "AAAA",
       "values": ["203.0.113.4", "203.0.113..2"],
       "until": <timestamp>,
@@ -873,7 +879,7 @@ override\_type
       "type": "Override",
       "id": <int>,
       "override": "purge",
-      "domain": "example.net",
+      "domain": "example.net.",
       "created": <timestamp>
     }
 

--- a/docs/markdown/httpapi/api_spec.md
+++ b/docs/markdown/httpapi/api_spec.md
@@ -8,8 +8,8 @@ Design Goals
 
 * Discovery endpoint
 * Unified API Scheme for Daemons & Console.
-  Think of the Console Server as a proxy for all your pdns deployments.
-* Have API docs (this!) for other consumers
+  Think of the Console Server as a proxy for all your PowerDNS deployments.
+* Have API documentation (this!) for other consumers
 
 Data format
 -----------
@@ -190,7 +190,8 @@ Servers
 server_resource
 ---------------
 
-Example with server `"localhost"`, which is the only server returned by pdns.
+Example with server `"localhost"`, which is the only server returned by
+pdns\_server or pdns\_recursor.
 
 pdnsmgrd and pdnscontrol MUST NOT return “localhost”, but SHOULD return
 other servers.
@@ -205,8 +206,8 @@ other servers.
       "zones_url": "/api/v1/servers/localhost/zones{/zone}",
     }
 
-Note: On a pdns server, the servers collection is read-only, and the only
-allowed returned server is read-only as well.
+Note: On a pdns\_server or pdns\_recursor, the servers collection is read-only,
+and the only allowed returned server is read-only as well.
 On a pdnscontrol server, the servers collection is read-write, and the
 returned server resources are read-write as well. Write permissions may
 depend on the credentials you have supplied.
@@ -222,7 +223,8 @@ Collection access.
 
 Allowed REST methods:
 
-* pdns: `GET`
+* pdns\_server: `GET`
+* pdns\_recursor: `GET`
 * pdnsmgrd: `GET`
 * pdnscontrol: `GET`, `PUT`, `POST`, `DELETE`
 
@@ -332,7 +334,8 @@ zone_collection
   **TODO**: `dnssec`, `nsec3narrow`, `nsec3param`, `presigned` are not yet implemented.
 
 * `soa_edit` MAY be set to change the `SOA-EDIT` zone setting. See
-  http://doc.powerdns.com/html/domainmetadata.html for more information.
+  [the `SOA-EDIT` documentation](../authoritative/domainmetadata.md#soa-edit)
+  for more information.
   **Note**: Authoritative only.
 
 * `soa_edit_api` MAY be set. If it is set, on changes to the contents of
@@ -374,7 +377,7 @@ implemented.
 Changes made through the Zones API will always yield valid zone data,
 and the zone will be properly "rectified" (**TODO**: not yet
 implemented). If changes are made through other means (e.g. direct
-database access), this is not guranteed to be true and clients SHOULD
+database access), this is not guaranteed to be true and clients SHOULD
 trigger rectify.
 
 Backends might implement additional features (by coincidence or not).
@@ -396,7 +399,7 @@ Creates a new domain.
 * `dnssec`, `nsec3narrow`, `presigned` default to `false`.
 * The server MUST create a SOA record. The created SOA record SHOULD have
 serial set to the value given as `serial` (or 0 if missing), use the
-nameserver name, email, TTL values as specified in the pdns configuration
+nameserver name, email, TTL values as specified in the PowerDNS configuration
 (`default-soa-name`, `default-soa-mail`, etc).
 These default values can be overridden by supplying a custom SOA record in
 the records list.
@@ -464,7 +467,7 @@ Having `type` inside an RR differ from `type` at the RRset level is an error.
 
 * `changetype`
   Must be `REPLACE` or `DELETE`.
-  With `DELETE`, all existing RRs matching `name` and `type` will be deleted, incl. all comments.
+  With `DELETE`, all existing RRs matching `name` and `type` will be deleted, including all comments.
   With `REPLACE`: when `records` is present, all existing RRs matching `name` and `type` will be deleted, and then new records given in `records` will be created.
   If no records are left, any existing comments will be deleted as well.
   When `comments` is present, all existing comments for the RRs matching `name` and `type` will be deleted, and then new comments given in `comments` will be created.
@@ -517,7 +520,7 @@ Allowed methods: `PUT`
 
 Retrieves the zone from the master.
 
-Fails when zone kind is not `Slave`, or `slave` is disabled in pdns
+Fails when zone kind is not `Slave`, or `slave` is disabled in PowerDNS.
 configuration.
 
 Not supported for recursors.
@@ -567,7 +570,8 @@ zone\_metadata\_resource
       ]
     }
 
-Valid values for `<metadata_kind>` are specified in <http://doc.powerdns.com/domainmetadata.html>.
+Valid values for `<metadata_kind>` are specified in
+[the `domainmetadata` documentation](../authoritative/domainmetadata.md).
 
 Clients MUST NOT modify `NSEC3PARAM`, `NSEC3NARROW` or `PRESIGNED`
 through this interface. The server SHOULD reject updates to these
@@ -618,7 +622,7 @@ both mutually exclusive.
 
 `dnskey`: the DNSKEY for this key
 
-`ds`: an array with all dses for this key
+`ds`: an array with all DSes for this key
 
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/cryptokeys
@@ -638,15 +642,14 @@ Creates a new, single cryptokey.
 
 ##### Parameters:
 
-`content`: if `null`, pdns generates a new key. In this case, the
+`content`: if `null`, the server generates a new key. In this case, the
 following additional fields MAY be supplied:
 
 * `bits`: `<int>`
 * `algo`: `<algo>`
 
-Where `<algo>` is one of the supported key algos in lowercase OR the
-numeric id, see
-[http://rtfm.powerdns.com/pdnsutil.html](http://rtfm.powerdns.com/pdnsutil.html)
+Where `<algo>` is one of the supported key algorithms in lowercase OR the
+numeric id, see [`the list`](../authoritative/dnssec.md#supported-algorithms).
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/cryptokeys/:cryptokey\_id
 ----------------------------------------------------------------------------
@@ -655,7 +658,7 @@ Allowed methods: `GET`, `PUT`, `DELETE`
 
 #### GET
 
-Returns all public data about cryptokeys, including `content`, with all the private data. An array is returned, eventhough a single key is requested.
+Returns all public data about cryptokeys, including `content`, with all the private data. An array is returned, even though a single key is requested.
 
 #### PUT
 
@@ -824,11 +827,11 @@ Where `<failure_code>` is one of these:
 
   + `refused`
 
-    All auth nameservers that have been tried responded with refused.
+    All auth nameservers that have been tried responded with REFUSED.
 
   + `servfail`
 
-    All auth nameservers that have been tried responded with servfail.
+    All auth nameservers that have been tried responded with SERVFAIL.
 
   + **TODO**: further failures
 

--- a/pdns/json.cc
+++ b/pdns/json.cc
@@ -90,6 +90,27 @@ string stringFromJson(const Value& container, const char* key, const string& def
   }
 }
 
+DNSName dnsnameFromJson(const rapidjson::Value& container, const char* key)
+{
+  if (!container.IsObject()) {
+    throw JsonException("Container was not an object.");
+  }
+  const Value& val = container[key];
+  if (val.IsString()) {
+    string name = val.GetString();
+    if (!isCanonical(name)) {
+      throw JsonException("DNS Name '" + name + "' is not canonical");
+    }
+    try {
+      return DNSName(name);
+    } catch (...) {
+      throw JsonException("Unable to parse DNS Name '" + name + "'");
+    }
+  } else {
+    throw JsonException("Key '" + string(key) + "' not present or not a String");
+  }
+}
+
 bool boolFromJson(const rapidjson::Value& container, const char* key)
 {
   if (!container.IsObject()) {

--- a/pdns/json.hh
+++ b/pdns/json.hh
@@ -25,6 +25,7 @@
 #include <map>
 #include <stdexcept>
 #include "rapidjson/document.h"
+#include "dnsname.hh"
 
 std::string returnJsonObject(const std::map<std::string, std::string>& items);
 std::string returnJsonError(const std::string& error);
@@ -34,6 +35,7 @@ int intFromJson(const rapidjson::Value& container, const char* key);
 int intFromJson(const rapidjson::Value& container, const char* key, const int default_value);
 std::string stringFromJson(const rapidjson::Value& container, const char* key);
 std::string stringFromJson(const rapidjson::Value& container, const char* key, const std::string& default_value);
+DNSName dnsnameFromJson(const rapidjson::Value& container, const char* key);
 bool boolFromJson(const rapidjson::Value& container, const char* key);
 bool boolFromJson(const rapidjson::Value& container, const char* key, const bool default_value);
 

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -148,7 +148,7 @@ void CommunicatorClass::masterUpdateCheck(PacketHandler *P)
   
   for(vector<DomainInfo>::const_iterator i=cmdomains.begin();i!=cmdomains.end();++i) {
     extern PacketCache PC;
-    PC.purge(i->zone.toString()); // fixes cvstrac ticket #30
+    PC.purgeExact(i->zone);
     queueNotifyDomain(i->zone,P->getBackend());
     i->backend->setNotified(i->id,i->serial); 
   }
@@ -262,4 +262,3 @@ void CommunicatorClass::notify(const DNSName &domain, const string &ip)
   d_nq.add(domain, ip);
   d_any_sem.post();
 }
-

--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -71,6 +71,7 @@ public:
   void cleanup(); //!< force the cache to preen itself from expired packets
   int purge();
   int purge(const std::string& match); // could be $ terminated. Is not a dnsname!
+  int purgeExact(const DNSName& qname); // no wildcard matching here
 
   map<char,int> getCounts();
 private:
@@ -149,4 +150,3 @@ private:
 
 
 #endif /* PACKETCACHE_HH */
-

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -261,7 +261,11 @@ DNSName apiZoneIdToName(const string& id) {
 
   zonename = ss.str();
 
-  return DNSName(zonename);
+  try {
+    return DNSName(zonename);
+  } catch (...) {
+    throw ApiException("Unable to parse DNS Name '" + zonename + "'");
+  }
 }
 
 string apiZoneNameToId(const DNSName& dname) {
@@ -292,4 +296,9 @@ string apiZoneNameToId(const DNSName& dname) {
     id = (boost::format("=%02X") % (int)('.')).str();
   }
   return id;
+}
+
+void apiCheckNameAllowedCharacters(const string& label) {
+  if (label.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_/.-") != std::string::npos)
+    throw ApiException("Label '"+label+"' contains unsupported characters");
 }

--- a/pdns/ws-api.hh
+++ b/pdns/ws-api.hh
@@ -37,6 +37,7 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp);
 // helpers
 DNSName apiZoneIdToName(const string& id);
 string apiZoneNameToId(const DNSName& name);
+void apiCheckNameAllowedCharacters(const string& label);
 
 // To be provided by product code.
 void productServerStatisticsFetch(std::map<string,string>& out);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1052,7 +1052,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
   di.backend->commitTransaction();
 
   extern PacketCache PC;
-  PC.purge(zonename.toString()); // XXX DNSName pain - this seems the wrong way round!
+  PC.purgeExact(zonename);
 
   // now the PTRs
   for(const DNSResourceRecord& rr :  new_ptrs) {
@@ -1070,7 +1070,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
       throw ApiException("PTR-Hosting backend for "+rr.qname.toString()+"/"+rr.qtype.getName()+" does not support editing records.");
     }
     sd.db->commitTransaction();
-    PC.purge(rr.qname.toString());
+    PC.purgeExact(rr.qname);
   }
 
   // success

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -187,10 +187,8 @@ static void doCreateZone(const Value& document)
     throw ApiException("Config Option \"api-config-dir\" must be set");
   }
 
-  if(stringFromJson(document, "name").empty())
-    throw ApiException("Zone name empty");
-  
-  DNSName zonename(stringFromJson(document, "name"));
+  DNSName zonename = dnsnameFromJson(document, "name");
+  apiCheckNameAllowedCharacters(zonename.toString());
 
   string singleIPTarget = stringFromJson(document, "single_target_ip", "");
   string kind = toUpper(stringFromJson(document, "kind"));
@@ -281,7 +279,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp)
     Document document;
     req->json(document);
 
-    DNSName zonename(stringFromJson(document, "name"));
+    DNSName zonename = dnsnameFromJson(document, "name");
 
     auto iter = t_sstorage->domainmap->find(zonename);
     if (iter != t_sstorage->domainmap->end())
@@ -342,7 +340,7 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp)
     doDeleteZone(zonename);
     doCreateZone(document);
     reloadAuthAndForwards();
-    fillZone(DNSName(stringFromJson(document, "name")), resp);
+    fillZone(dnsnameFromJson(document, "name"), resp);
   }
   else if(req->method == "DELETE" && !::arg().mustDo("api-readonly")) {
     if (!doDeleteZone(zonename)) {

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -118,7 +118,7 @@ print "Running tests..."
 rc = 0
 test_env = {}
 test_env.update(os.environ)
-test_env.update({'WEBPORT': WEBPORT, 'APIKEY': APIKEY, 'DAEMON': daemon})
+test_env.update({'WEBPORT': WEBPORT, 'APIKEY': APIKEY, 'DAEMON': daemon, 'SQLITE_DB': SQLITE_DB})
 
 try:
     print ""

--- a/regression-tests.api/test_helper.py
+++ b/regression-tests.api/test_helper.py
@@ -1,10 +1,13 @@
 from datetime import datetime
+from pprint import pprint
 import os
 import requests
 import urlparse
 import unittest
+import sqlite3
 
 DAEMON = os.environ.get('DAEMON', 'authoritative')
+SQLITE_DB = os.environ.get('SQLITE_DB', 'pdns.sqlite3')
 
 
 class ApiTestCase(unittest.TestCase):
@@ -30,7 +33,7 @@ class ApiTestCase(unittest.TestCase):
 
 
 def unique_zone_name():
-    return 'test-' + datetime.now().strftime('%d%H%S%M%f') + '.org'
+    return 'test-' + datetime.now().strftime('%d%H%S%M%f') + '.org.'
 
 
 def is_auth():
@@ -39,3 +42,42 @@ def is_auth():
 
 def is_recursor():
     return DAEMON == 'recursor'
+
+
+def eq_zone_dict(rrsets, expected):
+    data_got = {}
+    data_expected = {}
+    for type_, expected_records in expected.iteritems():
+        type_ = str(type_)
+        uses_name = any(['name' in expected_record for expected_record in expected_records])
+        # minify + convert received data
+        data_got[type_] = set((str(rec['name']) if uses_name else '@', str(rec['content']))
+                              for rec in rrsets if rec['type'] == type_)
+        # minify expected data
+        data_expected[type_] = set((str(rec['name']) if uses_name else '@', str(rec['content']))
+                                   for rec in expected_records)
+
+    print "eq_zone_dict: got:"
+    pprint(data_got)
+    print "eq_zone_dict: expected:"
+    pprint(data_expected)
+
+    assert data_got == data_expected, "%r != %r" % (data_got, data_expected)
+
+
+def get_auth_db():
+    """Return Connection to Authoritative backend DB."""
+    return sqlite3.Connection(SQLITE_DB)
+
+
+def get_db_records(zonename, qtype):
+    with get_auth_db() as db:
+        rows = db.execute("""
+            SELECT name, type, content, ttl
+            FROM records
+            WHERE type = ? AND domain_id = (
+                SELECT id FROM domains WHERE name = ?
+            )""", (qtype, zonename.rstrip('.'))).fetchall()
+        recs = [{'name': row[0], 'type': row[1], 'content': row[2], 'ttl': row[3]} for row in rows]
+        print "DB Records:", recs
+        return recs


### PR DESCRIPTION
From and to API consumers we'll now always require/send names (and
content) with dots. To the backend, we'll always require/send without
dots. Some API tests now check the data written to the sqlite DB, too.

Incoming names are now checked against a restricted list of chars,
fixing #1437. The double dot case is taken care of by DNSName (and
we'll no longer report an ISE if DNSName parsing fails - we make
sure to parse all names in a try/except).

Cleanup leftovers from pre-DNSName times.

Turn auth api tests back on in travis.