### PR TITLE
fix broken pipebackend

### DIFF
--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -35,7 +35,7 @@ CoWrapper::CoWrapper(const string &command, int timeout)
    d_cp=0;
    d_command=command;
    d_timeout=timeout;
-   d_abiVersion = ::arg().asNum("pipebackend-abi-version");
+   d_abiVersion = ::arg().asNum("pipe-abi-version");
    launch(); // let exceptions fall through - if initial launch fails, we want to die
    // I think
 }
@@ -128,11 +128,11 @@ void PipeBackend::lookup(const QType& qtype,const DNSName& qname, DNSPacket *pkt
             realRemote = pkt_p->getRealRemote();
             remoteIP = pkt_p->getRemote();
          }
-         // pipebackend-abi-version = 1
+         // pipe-abi-version = 1
          // type    qname           qclass  qtype   id      remote-ip-address
          query<<"Q\t"<<qname.toStringNoDot()<<"\tIN\t"<<qtype.getName()<<"\t"<<zoneId<<"\t"<<remoteIP;
 
-         // add the local-ip-address if pipebackend-abi-version is set to 2
+         // add the local-ip-address if pipe-abi-version is set to 2
          if (d_abiVersion >= 2)
             query<<"\t"<<localIP;
          if(d_abiVersion >= 3)

--- a/pdns/pdnssec.cc
+++ b/pdns/pdnssec.cc
@@ -117,7 +117,7 @@ static int shorthand2algorithm(const string &algorithm)
 void loadMainConfig(const std::string& configdir)
 {
   ::arg().set("config-dir","Location of configuration directory (pdns.conf)")=configdir;
-  ::arg().set("pipebackend-abi-version","Version of the pipe backend ABI")="1";
+  ::arg().set("pipe-abi-version","Version of the pipe backend ABI")="1";
   ::arg().set("default-ttl","Seconds a result is valid if not set otherwise")="3600";
   ::arg().set("launch","Which backends to launch");
   ::arg().set("dnssec","if we should do dnssec")="true";


### PR DESCRIPTION
It seems https://github.com/PowerDNS/pdns/commit/df73fb315 broke the pipebackend. This change fixes it for me.

The pipebackend fails because of naming mismatch in setting "abi-version":
```
$ pdns/pdns_server --local-port=5300 --socket-dir=. --daemon=no --launch=pipe --pipe-command=./pipe.pl --pipe-abi-version=1
...
Nov 23 11:03:20 [PIPEBackend] Fatal argument error: Undefined but needed argument: 'pipebackend-abi-version'
Nov 23 11:03:20 Caught an exception instantiating a backend: Undefined but needed argument: 'pipebackend-abi-version'
Nov 23 11:03:20 Cleaning up
Nov 23 11:03:20 TCP server is unable to launch backends - will try again when questions come in: Undefined but needed argument: 'pipebackend-abi-version'
Nov 23 11:03:20 About to create 3 backend threads for UDP
Nov 23 11:03:20 [PIPEBackend] Fatal argument error: Undefined but needed argument: 'pipebackend-abi-version'
Nov 23 11:03:20 Caught an exception instantiating a backend: Undefined but needed argument: 'pipebackend-abi-version'
Nov 23 11:03:20 Cleaning up
Nov 23 11:03:20 Distributor caught fatal exception: Undefined but needed argument: 'pipebackend-abi-version'
terminate called after throwing an instance of 'PDNSException'
Nov 23 11:03:20 Got a signal 6, attempting to print trace: 
Nov 23 11:03:20 pdns/pdns_server(+0x1b7424) [0xb7593424]
Nov 23 11:03:20 [0xb73bd400]
Nov 23 11:03:20 [0xb73bd424]
Nov 23 11:03:20 /lib/i386-linux-gnu/i686/cmov/libc.so.6(gsignal+0x51) [0xb7038661]
Nov 23 11:03:20 /lib/i386-linux-gnu/i686/cmov/libc.so.6(abort+0x182) [0xb703ba92]
Nov 23 11:03:20 /usr/lib/i386-linux-gnu/libstdc++.so.6(_ZN9__gnu_cxx27__verbose_terminate_handlerEv+0x14d) [0xb722128d]
Nov 23 11:03:20 /lib/i386-linux-gnu/i686/cmov/libc.so.6(+0x162400) [0xb7170400]
Nov 23 11:03:20 /lib/i386-linux-gnu/i686/cmov/libc.so.6(+0x1623f8) [0xb71703f8]
Nov 23 11:03:20 [0xb8a67108]
Nov 23 11:03:20 [0x7231]
```