### PR TITLE
Add support for compiler LTO in dnsdist

### DIFF
--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -33,11 +33,23 @@ AS_IF([test "x$enable_hardening" != "xno"], [
   AC_LD_RELRO
 ])
 
+AC_MSG_CHECKING([whether we will enable compiler LTO])
+AC_ARG_ENABLE([lto],
+  [AS_HELP_STRING([--disable-lto],[disable compiler link-time optimizations @<:@default=no@:>@])],
+  [enable_lto=$enableval],
+  [enable_lto=yes]
+)
+AC_MSG_RESULT([$enable_lto])
+
+AS_IF([test "x$enable_lto" != "xno"], [
+  AC_CC_LTO
+])
+
 LDFLAGS="$RELRO_LDFLAGS $LDFLAGS"
 
 AS_IF([test "x$static" != "xyes"], [
-  CFLAGS="$PIE_CFLAGS $CFLAGS"
-  CXXFLAGS="$PIE_CFLAGS $CXXFLAGS"
+  CFLAGS="$PIE_CFLAGS $LTO_CFLAGS $CFLAGS"
+  CXXFLAGS="$PIE_CFLAGS $LTO_CFLAGS $CXXFLAGS"
   PROGRAM_LDFLAGS="$PIE_LDFLAGS $PROGRAM_LDFLAGS"
 ])
 AC_SUBST([PROGRAM_LDFLAGS])

--- a/pdns/dnsdistdist/m4/pdns_lto.m4
+++ b/pdns/dnsdistdist/m4/pdns_lto.m4
@@ -1,0 +1,19 @@
+dnl Check for support for LTO 
+
+AC_DEFUN([AC_CC_LTO],[
+    AC_REQUIRE([gl_UNKNOWN_WARNINGS_ARE_ERRORS])
+    LTO_CFLAGS=
+    OLD_CXXFLAGS=$CXXFLAGS
+    CXXFLAGS="-flto"
+    gl_COMPILER_OPTION_IF([-flto], [
+       LTO_CFLAGS="-flto"
+       ], [
+          ],
+          [AC_LANG_PROGRAM([[
+#include <pthread.h>
+__thread unsigned int t_id;
+            ]], [[t_id = 1;]])]
+        )
+    CXXFLAGS=$OLD_CXXFLAGS
+    AC_SUBST([LTO_CFLAGS])
+])


### PR DESCRIPTION
GCC and clang are capable, in recent versions, of doing
inter-procedural optimizations across different compilation
units:

https://gcc.gnu.org/wiki/LinkTimeOptimization

This comes at the cost of an increase of RAM and CPU usage during
the build.