### PR TITLE
Drop truncated UDP messages caused by a small buffer

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -439,6 +439,13 @@ try
 	continue;
       }
 
+      if (msgh.msg_flags & MSG_TRUNC) {
+        /* message was too large for our buffer */
+        vinfolog("Dropping message too large for our buffer");
+        g_stats.nonCompliantQueries++;
+        continue;
+      }
+
       g_stats.queries++;
       if(!acl->match(remote)) {
 	vinfolog("Query from %s dropped because of ACL", remote.toStringWithPort());


### PR DESCRIPTION
When we receive a message too large for our buffer, recvmsg() will
truncate the content to fit to the buffer and set the MSG_TRUNC flag.
There is no point in trying to parse this message because we will
choke during the parsing anyway.