### PR TITLE
Add configure options to build dnsdist with various sanitizers

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I pdns $(LUA_CFLAGS) $(YAHTTP_CFLAGS) $(BOOST_CPPFLAGS) -I$(CURDIR)/ext/mbedtls/include -O3 -Wall -pthread -DSYSCONFDIR=\"${sysconfdir}\"
+AM_CPPFLAGS = -I pdns $(LUA_CFLAGS) $(YAHTTP_CFLAGS) $(BOOST_CPPFLAGS) $(SANITIZER_FLAGS) -I$(CURDIR)/ext/mbedtls/include -O3 -Wall -pthread -DSYSCONFDIR=\"${sysconfdir}\"
 
 ACLOCAL_AMFLAGS = -I m4
 
@@ -67,5 +67,6 @@ dnsdist_LDADD = \
 	$(READLINE_LIBS) \
 	$(RT_LIBS) \
 	$(YAHTTP_LIBS) \
-	$(LIBSODIUM_LIBS)
+	$(LIBSODIUM_LIBS) \
+	$(SANITIZER_FLAGS)
 

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -33,6 +33,8 @@ AS_IF([test "x$enable_hardening" != "xno"], [
   AC_LD_RELRO
 ])
 
+PDNS_ENABLE_SANITIZERS
+
 LDFLAGS="$RELRO_LDFLAGS $LDFLAGS"
 
 AS_IF([test "x$static" != "xyes"], [

--- a/pdns/dnsdistdist/m4/pdns_enable_sanitizers.m4
+++ b/pdns/dnsdistdist/m4/pdns_enable_sanitizers.m4
@@ -1,0 +1,1 @@
+../../../m4/pdns_enable_sanitizers.m4


### PR DESCRIPTION
It makes it really easy to enable ASAN, LSAN, MSAN, TSAN, or
USBSAN on a custom build, to track issues.