### PR TITLE
Check the length of TCP queries in dnsdist

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -146,7 +146,12 @@ void* tcpClientThread(int pipefd)
       for(;;) {      
         if(!getNonBlockingMsgLen(ci.fd, &qlen, g_tcpRecvTimeout))
           break;
-        
+
+        if (qlen < sizeof(dnsheader)) {
+          g_stats.nonCompliantQueries++;
+          break;
+        }
+
         char query[qlen];
         readn2WithTimeout(ci.fd, query, qlen, g_tcpRecvTimeout);
 	uint16_t qtype;


### PR DESCRIPTION
There is no point in trying to parse queries whose length
is < sizeof(dnsheader).