### PR TITLE
Fix trailing dot issues in pdnssec check-zone

### DIFF
--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -77,7 +77,7 @@ public:
   enum Place : uint8_t {QUESTION=0, ANSWER=1, AUTHORITY=2, ADDITIONAL=3}; //!< Type describing the positioning of a DNSResourceRecord within, say, a DNSPacket
 
   void setContent(const string& content);
-  string getZoneRepresentation() const;
+  string getZoneRepresentation(bool noDot=false) const;
 
   // data
   DNSName qname; //!< the name of this record, for example: www.powerdns.com

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -41,6 +41,7 @@ public:
 
   std::string toString(const std::string& separator=".", const bool trailing=true) const;              //!< Our human-friendly, escaped, representation
   std::string toStringNoDot() const { return toString(".", false); }
+  std::string toStringRootDot() const { if(isRoot()) return "."; else return toString(".", false); }
   std::string toDNSString() const;           //!< Our representation in DNS native format
   void appendRawLabel(const std::string& str); //!< Append this unescaped label
   void appendRawLabel(const char* start, unsigned int length); //!< Append this unescaped label

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -59,7 +59,7 @@ public:
     d_record.insert(d_record.end(), out.begin(), out.end());
   }
 
-  string getZoneRepresentation() const override
+  string getZoneRepresentation(bool noDot) const override
   {
     ostringstream str;
     str<<"\\# "<<(unsigned int)d_record.size()<<" ";

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -120,7 +120,7 @@ public:
   }
 
 
-  void xfrName(DNSName &name, bool compress=false)
+  void xfrName(DNSName &name, bool compress=false, bool noDot=false)
   {
     name=getName();
   }
@@ -165,7 +165,7 @@ public:
   static DNSRecordContent* mastermake(uint16_t qtype, uint16_t qclass, const string& zone);
   static std::unique_ptr<DNSRecordContent> makeunique(uint16_t qtype, uint16_t qclass, const string& content);
 
-  virtual std::string getZoneRepresentation() const = 0;
+  virtual std::string getZoneRepresentation(bool noDot=false) const = 0;
   virtual ~DNSRecordContent() {}
   virtual void toPacket(DNSPacketWriter& pw)=0;
   virtual string serialize(const DNSName& qname, bool canonic=false, bool lowerCase=false) // it would rock if this were const, but it is too hard

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -120,9 +120,9 @@ public:
   }
 
 
-  void xfrName(DNSName &label, bool compress=false)
+  void xfrName(DNSName &name, bool compress=false)
   {
-    label=getName();
+    name=getName();
   }
 
   void xfrText(string &text, bool multi=false)

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -42,15 +42,18 @@ void DNSResourceRecord::setContent(const string &cont) {
   }
 }
 
-string DNSResourceRecord::getZoneRepresentation() const {
+string DNSResourceRecord::getZoneRepresentation(bool noDot) const {
   ostringstream ret;
   switch(qtype.getCode()) {
     case QType::SRV:
     case QType::MX:
     case QType::CNAME:
     case QType::NS:
-      if (*(content.rbegin()) != '.')
-        ret<<content<<".";
+      if (*(content.rbegin()) != '.') {
+        ret<<content;
+        if(!noDot)
+          ret<<".";
+      }
       break;
     default:
       ret<<content;
@@ -407,7 +410,7 @@ void EUI48RecordContent::toPacket(DNSPacketWriter& pw)
     string blob(d_eui48, d_eui48+6);
     pw.xfrBlob(blob); 
 }
-string EUI48RecordContent::getZoneRepresentation() const
+string EUI48RecordContent::getZoneRepresentation(bool noDot) const
 {
     char tmp[18]; 
     snprintf(tmp,18,"%02x-%02x-%02x-%02x-%02x-%02x", 
@@ -451,7 +454,7 @@ void EUI64RecordContent::toPacket(DNSPacketWriter& pw)
     string blob(d_eui64, d_eui64+8);
     pw.xfrBlob(blob);
 }
-string EUI64RecordContent::getZoneRepresentation() const
+string EUI64RecordContent::getZoneRepresentation(bool noDot) const
 {
     char tmp[24]; 
     snprintf(tmp,24,"%02x-%02x-%02x-%02x-%02x-%02x-%02x-%02x",

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -37,10 +37,10 @@
   static void unreport(void);                                                                    \
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);                          \
   static DNSRecordContent* make(const string& zonedata);                                         \
-  string getZoneRepresentation() const override;                                                 \
+  string getZoneRepresentation(bool noDot=false) const override;                                 \
   void toPacket(DNSPacketWriter& pw) override;                                                   \
   uint16_t getType() const override { return QType::RNAME; }                                   \
-  template<class Convertor> void xfrPacket(Convertor& conv);
+  template<class Convertor> void xfrPacket(Convertor& conv, bool noDot=false);
 
 class NAPTRRecordContent : public DNSRecordContent
 {
@@ -469,7 +469,7 @@ public:
 
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& content);
-  string getZoneRepresentation() const override;
+  string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
   uint16_t getType() const override
   {
@@ -490,7 +490,7 @@ public:
 
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& content);
-  string getZoneRepresentation() const override;
+  string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
 
   uint8_t d_algorithm, d_flags;
@@ -521,7 +521,7 @@ public:
 
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& content);
-  string getZoneRepresentation() const override;
+  string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
 
   uint16_t getType() const override
@@ -547,7 +547,7 @@ public:
 
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& content);
-  string getZoneRepresentation() const override;
+  string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
 
   uint8_t d_version, d_size, d_horizpre, d_vertpre;
@@ -571,7 +571,7 @@ public:
 
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& content);
-  string getZoneRepresentation() const override;
+  string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
 
   uint32_t d_ip;
@@ -586,7 +586,7 @@ public:
   static void report(void);
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& zone); // FIXME400: DNSName& zone?
-  string getZoneRepresentation() const override;
+  string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
   uint16_t getType() const override { return QType::EUI48; }
 private:
@@ -601,7 +601,7 @@ public:
   static void report(void);
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& zone); // FIXME400: DNSName& zone?
-  string getZoneRepresentation() const override;
+  string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
   uint16_t getType() const override { return QType::EUI64; }
 private:
@@ -674,10 +674,10 @@ RNAME##RecordContent::RNAME##RecordContent(const string& zoneData)              
   }        											   \
 }                                                                                                  \
                                                                                                    \
-string RNAME##RecordContent::getZoneRepresentation() const                                         \
+string RNAME##RecordContent::getZoneRepresentation(bool noDot) const                               \
 {                                                                                                  \
   string ret;                                                                                      \
-  RecordTextWriter rtw(ret);                                                                       \
+  RecordTextWriter rtw(ret, noDot);                                                                       \
   const_cast<RNAME##RecordContent*>(this)->xfrPacket(rtw);                                         \
   return ret;                                                                                      \
 }                                                                                                  
@@ -686,7 +686,7 @@ string RNAME##RecordContent::getZoneRepresentation() const                      
 #define boilerplate_conv(RNAME, TYPE, CONV)                       \
 boilerplate(RNAME, TYPE)                                          \
 template<class Convertor>                                         \
-void RNAME##RecordContent::xfrPacket(Convertor& conv)             \
+void RNAME##RecordContent::xfrPacket(Convertor& conv, bool noDot) \
 {                                                                 \
   CONV;                                                           \
   if (conv.eof() == false) throw MOADNSException("All data was not consumed"); \

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -203,7 +203,7 @@ DNSPacketWriter::lmap_t::iterator find(DNSPacketWriter::lmap_t& nmap, const DNSN
 // }
 
 // this is the absolute hottest function in the pdns recursor
-void DNSPacketWriter::xfrName(const DNSName& name, bool compress)
+void DNSPacketWriter::xfrName(const DNSName& name, bool compress, bool)
 {
   //cerr<<"xfrName: name=["<<name.toString()<<"] compress="<<compress<<endl;
   // string label = d_lowerCase ? toLower(Label) : Label;

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -86,7 +86,7 @@ public:
 
   void xfr8BitInt(uint8_t val);
 
-  void xfrName(const DNSName& label, bool compress=false);
+  void xfrName(const DNSName& label, bool compress=false, bool noDot=false);
   void xfrText(const string& text, bool multi=false);
   void xfrBlob(const string& blob, int len=-1);
   void xfrBlobNoSpaces(const string& blob, int len=-1);

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -94,7 +94,7 @@ NSECRecordContent::DNSRecordContent* NSECRecordContent::make(const DNSRecord &dr
   return ret;
 }
 
-string NSECRecordContent::getZoneRepresentation() const
+string NSECRecordContent::getZoneRepresentation(bool noDot) const
 {
   string ret;
   RecordTextWriter rtw(ret);
@@ -227,7 +227,7 @@ NSEC3RecordContent::DNSRecordContent* NSEC3RecordContent::make(const DNSRecord &
   return ret;
 }
 
-string NSEC3RecordContent::getZoneRepresentation() const
+string NSEC3RecordContent::getZoneRepresentation(bool noDot) const
 {
   string ret;
   RecordTextWriter rtw(ret);
@@ -288,7 +288,7 @@ NSEC3PARAMRecordContent::DNSRecordContent* NSEC3PARAMRecordContent::make(const D
   return ret;
 }
 
-string NSEC3PARAMRecordContent::getZoneRepresentation() const
+string NSEC3PARAMRecordContent::getZoneRepresentation(bool noDot) const
 {
   string ret;
   RecordTextWriter rtw(ret);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -478,7 +478,7 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone)
     try {
       shared_ptr<DNSRecordContent> drc(DNSRecordContent::mastermake(rr.qtype.getCode(), 1, rr.content));
       string tmp=drc->serialize(rr.qname);
-      tmp = drc->getZoneRepresentation();
+      tmp = drc->getZoneRepresentation(true);
       if (rr.qtype.getCode() != QType::AAAA) {
         if (!pdns_iequals(tmp, rr.content)) {
           cout<<"[Warning] Parsed and original record content are not equal: "<<rr.qname.toString()<<" IN " <<rr.qtype.getName()<< " '" << rr.content<<"' (Content parsed as '"<<tmp<<"')"<<endl;

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -188,7 +188,7 @@ void RecordTextReader::xfr8BitInt(uint8_t &val)
 }
 
 // this code should leave all the escapes around 
-void RecordTextReader::xfrName(DNSName& val, bool) 
+void RecordTextReader::xfrName(DNSName& val, bool, bool)
 {
   skipSpaces();
   string sval;
@@ -398,9 +398,10 @@ void RecordTextReader::skipSpaces()
 }
 
 
-RecordTextWriter::RecordTextWriter(string& str) : d_string(str)
+RecordTextWriter::RecordTextWriter(string& str, bool noDot) : d_string(str)
 {
   d_string.clear();
+  d_nodot=noDot;
 }
 
 void RecordTextWriter::xfr48BitInt(const uint64_t& val)
@@ -503,12 +504,21 @@ void RecordTextWriter::xfr8BitInt(const uint8_t& val)
 }
 
 // should not mess with the escapes
-void RecordTextWriter::xfrName(const DNSName& val, bool)
+void RecordTextWriter::xfrName(const DNSName& val, bool, bool noDot)
 {
   if(!d_string.empty())
     d_string.append(1,' ');
   
-  d_string+=val.toString();
+  if(d_nodot) {
+    if(val.isRoot())
+      d_string+=".";
+    else
+      d_string+=val.toStringNoDot();
+  }
+  else
+  {
+    d_string+=val.toString();
+  }
 }
 
 void RecordTextWriter::xfrBlobNoSpaces(const string& val, int size)

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -510,10 +510,7 @@ void RecordTextWriter::xfrName(const DNSName& val, bool, bool noDot)
     d_string.append(1,' ');
   
   if(d_nodot) {
-    if(val.isRoot())
-      d_string+=".";
-    else
-      d_string+=val.toStringNoDot();
+    d_string+=val.toStringRootDot();
   }
   else
   {

--- a/pdns/rcpgenerator.hh
+++ b/pdns/rcpgenerator.hh
@@ -52,7 +52,7 @@ public:
   void xfrIP6(std::string& val);
   void xfrTime(uint32_t& val);
 
-  void xfrName(DNSName& val, bool compress=false);
+  void xfrName(DNSName& val, bool compress=false, bool noDot=false);
   void xfrText(string& val, bool multi=false);
   void xfrHexBlob(string& val, bool keepReading=false);
   void xfrBase32HexBlob(string& val);
@@ -72,7 +72,7 @@ private:
 class RecordTextWriter
 {
 public:
-  RecordTextWriter(string& str);
+  RecordTextWriter(string& str, bool noDot=false);
   void xfr48BitInt(const uint64_t& val);
   void xfr32BitInt(const uint32_t& val);
   void xfr16BitInt(const uint16_t& val);
@@ -83,7 +83,7 @@ public:
   void xfrBase32HexBlob(const string& val);
 
   void xfrType(const uint16_t& val);
-  void xfrName(const DNSName& val, bool compress=false);
+  void xfrName(const DNSName& val, bool compress=false, bool noDot=false);
   void xfrText(const string& val, bool multi=false);
   void xfrBlobNoSpaces(const string& val, int len=-1);
   void xfrBlob(const string& val, int len=-1);
@@ -91,5 +91,6 @@ public:
   bool eof() { return true; };
 private:
   string& d_string;
+  bool d_nodot;
 };
 #endif

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -290,7 +290,7 @@ LOCRecordContent::LOCRecordContent(const string& content, const string& zone)
 }
 
 
-string LOCRecordContent::getZoneRepresentation() const
+string LOCRecordContent::getZoneRepresentation(bool noDot) const
 {
   // convert d_version, d_size, d_horiz/vertpre, d_latitude, d_longitude, d_altitude to:
   // 51 59 00.000 N 5 55 00.000 E 4.00m 1.00m 10000.00m 10.00m

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -372,7 +372,7 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
   trim(rr.content);
 
   if(equals(rr.content, "@"))
-    rr.content=d_zonename.toStringNoDot();
+    rr.content=d_zonename.toStringRootDot();
 
   if(findAndElide(rr.content, '(')) {      // have found a ( and elided it
     if(!findAndElide(rr.content, ')')) {
@@ -395,7 +395,7 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
     stringtok(recparts, rr.content);
     if(recparts.size()==2) {
       if (recparts[1]!=".")
-        recparts[1] = toCanonic(d_zonename, recparts[1]).toStringNoDot();
+        recparts[1] = toCanonic(d_zonename, recparts[1]).toStringRootDot();
       rr.content=recparts[0]+" "+recparts[1];
     }
     break;
@@ -403,8 +403,8 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
   case QType::RP:
     stringtok(recparts, rr.content);
     if(recparts.size()==2) {
-      recparts[0] = toCanonic(d_zonename, recparts[0]).toStringNoDot();
-      recparts[1] = toCanonic(d_zonename, recparts[1]).toStringNoDot();
+      recparts[0] = toCanonic(d_zonename, recparts[0]).toStringRootDot();
+      recparts[1] = toCanonic(d_zonename, recparts[1]).toStringRootDot();
       rr.content=recparts[0]+" "+recparts[1];
     }
     break;
@@ -413,7 +413,7 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
     stringtok(recparts, rr.content);
     if(recparts.size()==4) {
       if(recparts[3]!=".")
-        recparts[3] = toCanonic(d_zonename, recparts[3]).toStringNoDot();
+        recparts[3] = toCanonic(d_zonename, recparts[3]).toStringRootDot();
       rr.content=recparts[0]+" "+recparts[1]+" "+recparts[2]+" "+recparts[3];
     }
     break;
@@ -424,14 +424,14 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
   case QType::DNAME:
   case QType::PTR:
   case QType::AFSDB:
-    rr.content=toCanonic(d_zonename, rr.content).toStringNoDot();
+    rr.content=toCanonic(d_zonename, rr.content).toStringRootDot();
     break;
 
   case QType::SOA:
     stringtok(recparts, rr.content);
     if(recparts.size() > 1) {
-      recparts[0]=toCanonic(d_zonename, recparts[0]).toStringNoDot();
-      recparts[1]=toCanonic(d_zonename, recparts[1]).toStringNoDot();
+      recparts[0]=toCanonic(d_zonename, recparts[0]).toStringRootDot();
+      recparts[1]=toCanonic(d_zonename, recparts[1]).toStringRootDot();
     }
     rr.content.clear();
     for(string::size_type n = 0; n < recparts.size(); ++n) {


### PR DESCRIPTION
plus make sure 'root' entries turn into single dots, instead of sometimes being empty strings.