### PR TITLE
Add per-frontend stats to dnsdist

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -67,6 +67,15 @@ try
         str<<base<<"senderrors" << ' ' << s->sendErrors.load() << " " << now << "\r\n";
         str<<base<<"outstanding" << ' ' << s->outstanding.load() << " " << now << "\r\n";
       }
+      for(const auto& front : g_frontends) {
+        if (front->udpFD == -1 && front->tcpFD == -1)
+          continue;
+
+        string frontName = front->local.toStringWithPort() + (front->udpFD >= 0 ? "_udp" : "_tcp");
+        boost::replace_all(frontName, ".", "_");
+        const string base = "dnsdist." + hostname + ".main.frontends." + frontName + ".";
+        str<<base<<"queries" << ' ' << front->queries.load() << " " << now << "\r\n";
+      }
       const string msg = str.str();
 
       int ret = waitForRWData(s.getHandle(), false, 1 , 0); 

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -341,6 +341,9 @@ void* tcpAcceptorThread(void* p)
       ci = new ConnectionInfo;
       ci->fd = -1;
       ci->fd = SAccept(cs->tcpFD, remote);
+
+      g_stats.queries++;
+      cs->queries++;
       
       if(!acl->match(remote)) {
 	g_stats.aclDrops++;

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -57,6 +57,7 @@ struct ConnectionInfo
 {
   int fd;
   ComboAddress remote;
+  ClientState* cs;
 };
 
 void* tcpClientThread(int pipefd);
@@ -170,6 +171,11 @@ void* tcpClientThread(int pipefd)
 	  g_rings.queryRing.push_back({now,ci.remote,qname,qtype});
 	}
 
+	g_stats.queries++;
+	if (ci.cs) {
+	  ci.cs->queries++;
+	}
+
 	if(localDynBlockNMG->match(ci.remote)) {
 	  vinfolog("Query from %s dropped because of dynamic block", ci.remote.toStringWithPort());
 	  g_stats.dynBlocked++;
@@ -227,6 +233,8 @@ void* tcpClientThread(int pipefd)
 	if(dh->qr) { // something turned it into a response
 	  if (putNonBlockingMsgLen(ci.fd, qlen, g_tcpSendTimeout))
 	    writen2WithTimeout(ci.fd, query, rlen, g_tcpSendTimeout);
+
+	  g_stats.selfAnswered++;
 	  goto drop;
 	}
 
@@ -305,6 +313,8 @@ void* tcpClientThread(int pipefd)
 
         if (putNonBlockingMsgLen(ci.fd, rlen, ds->tcpSendTimeout))
           writen2WithTimeout(ci.fd, answerbuffer, rlen, ds->tcpSendTimeout);
+
+        g_stats.responses++;
       }
     }
     catch(...){}
@@ -339,12 +349,10 @@ void* tcpAcceptorThread(void* p)
     try {
       ci=0;
       ci = new ConnectionInfo;
+      ci->cs = cs;
       ci->fd = -1;
       ci->fd = SAccept(cs->tcpFD, remote);
 
-      g_stats.queries++;
-      cs->queries++;
-      
       if(!acl->match(remote)) {
 	g_stats.aclDrops++;
 	close(ci->fd);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -64,6 +64,7 @@ bool g_console;
 GlobalStateHolder<NetmaskGroup> g_ACL;
 string g_outputBuffer;
 vector<std::pair<ComboAddress, bool>> g_locals;
+vector<ClientState *> g_frontends;
 
 /* UDP: the grand design. Per socket we listen on for incoming queries there is one thread.
    Then we have a bunch of connected sockets for talking to downstream servers. 
@@ -441,6 +442,9 @@ try
     try {
       len = recvmsg(cs->udpFD, &msgh, 0);
 
+      cs->queries++;
+      g_stats.queries++;
+
       if(len < (int)sizeof(struct dnsheader)) {
 	g_stats.nonCompliantQueries++;
 	continue;
@@ -453,7 +457,6 @@ try
         continue;
       }
 
-      g_stats.queries++;
       if(!acl->match(remote)) {
 	vinfolog("Query from %s dropped because of ACL", remote.toStringWithPort());
 	g_stats.aclDrops++;
@@ -1272,14 +1275,15 @@ try
 
     SBind(cs->udpFD, cs->local);    
     toLaunch.push_back(cs);
+    g_frontends.push_back(cs);
   }
 
   for(const auto& local : g_locals) {
-    ClientState* cs = new ClientState;
     if(!local.second) { // no TCP/IP
       warnlog("Not providing TCP/IP service on local address '%s'", local.first.toStringWithPort());
       continue;
     }
+    ClientState* cs = new ClientState;
     cs->local= local.first;
 
     cs->tcpFD = SSocket(cs->local.sin4.sin_family, SOCK_STREAM, 0);
@@ -1298,6 +1302,7 @@ try
     warnlog("Listening on %s",cs->local.toStringWithPort());
 
     toLaunch.push_back(cs);
+    g_frontends.push_back(cs);
   }
 
   uid_t newgid=0;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -217,6 +217,7 @@ extern Rings g_rings;
 struct ClientState
 {
   ComboAddress local;
+  std::atomic<uint64_t> queries{0};
   int udpFD{-1};
   int tcpFD{-1};
 };
@@ -355,6 +356,7 @@ extern GlobalStateHolder<NetmaskGroup> g_ACL;
 extern ComboAddress g_serverControl; // not changed during runtime
 
 extern std::vector<std::pair<ComboAddress, bool>> g_locals; // not changed at runtime (we hope XXX)
+extern vector<ClientState*> g_frontends;
 extern std::string g_key; // in theory needs locking
 extern bool g_truncateTC;
 extern int g_tcpRecvTimeout;


### PR DESCRIPTION
For now, we only display the number of queries received for each
frontend, separating TCP and UDP.