### PR TITLE
Use LONG_MIN instead of LLONG_MIN to check strotl() return value

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1007,7 +1007,7 @@ static uid_t strToUID(const string &str)
     char * endptr = 0;
     long int val = strtol(cstr, &endptr, 10);
 
-    if (((val == LONG_MAX || val == LLONG_MIN) && errno == ERANGE) || endptr == cstr || val <= 0) {
+    if (((val == LONG_MAX || val == LONG_MIN) && errno == ERANGE) || endptr == cstr || val <= 0) {
       warnlog("Warning: Unable to parse user ID %s", cstr);
     }
     else {
@@ -1031,7 +1031,7 @@ static gid_t strToGID(const string &str)
     char * endptr = 0;
     long int val = strtol(cstr, &endptr, 10);
 
-    if (((val == LONG_MAX || val == LLONG_MIN) && errno == ERANGE) || endptr == cstr || val <= 0) {
+    if (((val == LONG_MAX || val == LONG_MIN) && errno == ERANGE) || endptr == cstr || val <= 0) {
       warnlog("Warning: Unable to parse group ID %s", cstr);
     }
     else {


### PR DESCRIPTION
This typo cause this part of the check to always fail on arch where
sizeof(long long) != sizeof(long), ie != 64 bits. This is not too
bad here as we check later if the value is > 0 anyway.