### PR TITLE
Allow setting maxOustanding and maxTCPClientThreads in configuration

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -671,6 +671,11 @@ instantiate a server with additional parameters
      * newSuffixMatchNode(): returns a new SuffixMatchNode
      * member `check(DNSName)`: returns true if DNSName is matched by this group
      * member `add(DNSName)`: add this DNSName to the node
+ * Tuning related:
+   * setTCPRecvTimeout(n): set the read timeout on TCP connections from the client, in seconds.
+   * setTCPSendTimeout(n): set the write timeout on TCP connections from the client, in seconds.
+   * setMaxTCPClientThreads(n): set the maximum of TCP client threads, handling TCP connections.
+   * setMaxUDPOutstanding(n): set the maximum number of outstanding UDP queries to a given backend server. This can only be set at configuration time.
 
 All hooks
 ---------

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -897,6 +897,16 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 
   g_lua.writeFunction("setTCPSendTimeout", [](int timeout) { g_tcpSendTimeout=timeout; });
 
+  g_lua.writeFunction("setMaxUDPOutstanding", [](uint16_t max) {
+      if (!g_configurationDone) {
+        g_maxOutstanding = max;
+      } else {
+        g_outputBuffer="Max UDP outstanding cannot be altered at runtime!\n";
+      }
+    });
+
+  g_lua.writeFunction("setMaxTCPClientThreads", [](uint64_t max) { g_maxTCPClientThreads = max; });
+
   g_lua.writeFunction("dumpStats", [] {
       vector<string> leftcolumn, rightcolumn;
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -361,6 +361,9 @@ extern std::string g_key; // in theory needs locking
 extern bool g_truncateTC;
 extern int g_tcpRecvTimeout;
 extern int g_tcpSendTimeout;
+extern uint16_t g_maxOutstanding;
+extern std::atomic<bool> g_configurationDone;
+extern std::atomic<uint64_t> g_maxTCPClientThreads;
 struct dnsheader;
 
 void controlThread(int fd, ComboAddress local);


### PR DESCRIPTION
This commit adds the setMaxTCPClientThreads() and
setMaxUDPOutstanding() directives.
These controls, respectively, the maximum number of TCP threads
handling client connections and the maximum number of oustanding
UDP queries to a given backend server.
setMaxUDPOutstanding() is only usable at configuration-time, and
not at runtime.