### PR TITLE
Rename setting json-interface to api

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -54,18 +54,26 @@ always receive a notification. Even if they do not match the list in
 Answer questions for the ANY and RRSIG types on UDP with a truncated packet that
 refers the remote server to TCP. Useful for mitigating reflection attacks.
 
-## `api-readonly`
+## `api`
 * Boolean
 * Default: no
-* Available since: 3.4
+* Available since: 4.0
 
-Disallow data modification through the json API when set.
+Enable/disable the [REST API](../httpapi/README.md). Must also enable `webserver`
+to use the API.
 
 ## `api-key`
 * String
-* Available since: 3.4.1
+* Available since: 4.0
 
-api-key REST API Static authentication key (required for API use)
+Static pre-shared authentication key for access to the REST API.
+
+## `api-readonly`
+* Boolean
+* Default: no
+* Available since: 4.0
+
+Disallow data modification through the REST API when set.
 
 ## `cache-ttl`
 * Integer
@@ -281,12 +289,6 @@ Enables EDNS subnet processing, for backends that support it.
 * Default: /dev/urandom
 
 Entropy source file to use.
-
-## `json-interface`
-* Boolean
-* Default: no
-
-Enable/disable the [JSON API](../httpapi/README.md).
 
 ## `forward-dnsupdates`
 * Boolean
@@ -770,7 +772,7 @@ this response to a custom value as well.
 * Boolean
 * Default: no
 
-Start a webserver for monitoring. See
+Start a webserver for monitoring (and REST API if enabled). See
 ["Performance Monitoring"](../common/logging.md#performance-monitoring).
 
 ## `webserver-address`

--- a/docs/markdown/httpapi/README.md
+++ b/docs/markdown/httpapi/README.md
@@ -22,7 +22,7 @@ PostgreSQL or SQLite3).
 
 Then configure as follows:
 
-    json-interface=yes
+    api=yes
     api-key=changeme
     webserver=yes
 

--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -47,26 +47,30 @@ remote server to TCP. Useful for mitigating ANY reflection attacks.
 ## `api-config-dir`
 * Path
 * Default: unset
+* Available since: 4.0
 
 Directory where the REST API stores its configuration and zones.
 
 ## `api-key`
 * String
 * Default: unset
+* Available since: 4.0
 
 Static pre-shared authentication key for access to the REST API.
 
 ## `api-readonly`
 * Boolean
 * Default: no
+* Available since: 4.0
 
-Whether or not the JSON API is read only.
+Disallow data modification through the REST API when set.
 
 ## `api-logfile`
 * Path
 * Default: unset
+* Available since: 4.0
 
-Location of the logs from the JSON parser.
+Location of the server logfile (used by the REST API).
 
 ## `auth-can-lower-ttl`
 * Boolean
@@ -190,7 +194,7 @@ waiting for enough entropy to arrive.
 * Boolean
 * Default: no
 
-Start the webserver for monitoring.
+Start the webserver (for REST API).
 
 ## `webserver-address`
 * IP Addresses, separated by spaces

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -71,10 +71,10 @@ void declareArguments()
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";
 
   ::arg().set("retrieval-threads", "Number of AXFR-retrieval threads for slave operation")="2";
-  ::arg().setSwitch("json-interface", "If the webserver should serve JSON data")="no";
-  ::arg().setSwitch("api-readonly", "If the JSON API should disallow data modification")="no";
-  ::arg().set("api-key", "REST API Static authentication key (required for API use)")="";
-  ::arg().set("api-logfile", "Filename of the log file for JSON parser" )= "/var/log/pdns.log";
+  ::arg().setSwitch("api", "Enable/disable the REST API")="no";
+  ::arg().set("api-key", "Static pre-shared authentication key for access to the REST API")="";
+  ::arg().set("api-logfile", "Location of the server logfile (used by the REST API)")="/var/log/pdns.log";
+  ::arg().setSwitch("api-readonly", "Disallow data modification through the REST API when set")="no";
   ::arg().setSwitch("dname-processing", "If we should support DNAME records")="no";
 
   ::arg().setCmd("help","Provide a helpful message");
@@ -544,7 +544,3 @@ void mainthread()
   
   L<<Logger::Error<<"Mainthread exiting - should never happen"<<endl;
 }
-
-
-
-

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2515,10 +2515,10 @@ int main(int argc, char **argv)
     ::arg().set("processes", "Launch this number of processes (EXPERIMENTAL, DO NOT CHANGE)")="1";
     ::arg().set("config-name","Name of this virtual configuration - will rename the binary image")="";
     ::arg().set("api-config-dir", "Directory where REST API stores config and zones") = "";
-    ::arg().set("api-key", "REST API Static authentication key (required for API use)") = "";
-    ::arg().set("api-logfile", "Filename of the log file for JSON parser" )= "/var/log/pdns.log";
-    ::arg().set("api-readonly", "If the JSON API should disallow data modification") = "no";
-    ::arg().setSwitch("webserver", "Start a webserver for monitoring") = "no";
+    ::arg().set("api-key", "Static pre-shared authentication key for access to the REST API") = "";
+    ::arg().set("api-logfile", "Location of the server logfile (used by the REST API)") = "/var/log/pdns.log";
+    ::arg().set("api-readonly", "Disallow data modification through the REST API when set") = "no";
+    ::arg().setSwitch("webserver", "Start a webserver (for REST API)") = "no";
     ::arg().set("webserver-address", "IP Address of webserver to listen on") = "127.0.0.1";
     ::arg().set("webserver-port", "Port of webserver to listen on") = "8082";
     ::arg().set("webserver-password", "Password required for accessing the webserver") = "";

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1225,7 +1225,7 @@ void AuthWebServer::cssfunction(HttpRequest* req, HttpResponse* resp)
 void AuthWebServer::webThread()
 {
   try {
-    if(::arg().mustDo("json-interface")) {
+    if(::arg().mustDo("api")) {
       d_ws->registerApiHandler("/api/v1/servers/localhost/config", &apiServerConfig);
       d_ws->registerApiHandler("/api/v1/servers/localhost/flush-cache", &apiServerFlushCache);
       d_ws->registerApiHandler("/api/v1/servers/localhost/search-log", &apiServerSearchLog);

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -78,7 +78,7 @@ if daemon == 'authoritative':
         tf.seek(0, os.SEEK_SET)  # rewind
         subprocess.check_call(["sqlite3", SQLITE_DB], stdin=tf)
 
-    pdnscmd = ("../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./ --module-dir=../regression-tests/modules --no-shuffle --launch=gsqlite3 --gsqlite3-dnssec --send-root-referral --dnsupdate=yes --cache-ttl=0 --no-config --gsqlite3-dnssec=on --gsqlite3-database="+SQLITE_DB+" --json-interface=yes --webserver=yes --webserver-port="+WEBPORT+" --webserver-address=127.0.0.1 --webserver-password=something --api-key="+APIKEY).split()
+    pdnscmd = ("../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./ --module-dir=../regression-tests/modules --no-shuffle --launch=gsqlite3 --gsqlite3-dnssec --send-root-referral --dnsupdate=yes --cache-ttl=0 --no-config --gsqlite3-dnssec=on --gsqlite3-database="+SQLITE_DB+" --api=yes --webserver=yes --webserver-port="+WEBPORT+" --webserver-address=127.0.0.1 --webserver-password=something --api-key="+APIKEY).split()
 
 else:
     conf_dir = 'rec-conf.d'


### PR DESCRIPTION
Plus:
* Mark settings as available since 4.0, as before they were
called experimental-...
* Sync setting descriptions between auth and recursor.

Fixes #2995