### PR TITLE
remotebackend Documentation Update

### DIFF
--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -74,7 +74,7 @@ remote-connection-string=zeromq:endpoint=ipc:///tmp/tmp.sock
 
 # API
 ## Queries
-Unix, Pipe and ZeroMQ connectors send JSON formatted string to the remote end. Each JSON query has two sections, 'method' and 'parameters'.
+Unix, Pipe and ZeroMQ connectors send JSON formatted strings to the remote end. Each JSON query has two sections, 'method' and 'parameters'.
 
 HTTP connector calls methods based on URL and has parameters in the query string. Most calls are GET; see the methods listing for details. You can change this with post and post\_json attributes.
 

--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -13,7 +13,7 @@
 
 \* If provided by the responder (your script).
 
-This backend provides unix socket, pipe, http and ZeroMQ remoting for powerdns. You should think this as normal RPC thin client, which converts native C++ calls into JSON/RPC and passes them to you via connector.
+This backend provides Unix socket, Pipe, HTTP and ZeroMQ remoting for powerdns. You should think this as normal RPC thin client, which converts native C++ calls into JSON/RPC and passes them to you via connector.
 
 ## Important notices
 Please do not use remotebackend shipped before version 3.3. This version has severe bug that can crash the entire process.

--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -13,7 +13,7 @@
 
 \* If provided by the responder (your script).
 
-This backend provides unix socket / pipe / http remoting for powerdns. You should think this as normal RPC thin client, which converts native C++ calls into JSON/RPC and passes them to you via connector.
+This backend provides unix socket, pipe, http and ZeroMQ remoting for powerdns. You should think this as normal RPC thin client, which converts native C++ calls into JSON/RPC and passes them to you via connector.
 
 ## Important notices
 Please do not use remotebackend shipped before version 3.3. This version has severe bug that can crash the entire process.

--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -1081,7 +1081,7 @@ Content-Type: text/javascript; charset=utf-8
 ```
 
 # Examples
-## Scenario: SOA lookup via pipe or unix connector
+## Scenario: SOA lookup via pipe, unix or zeromq connector
 Query:
 ```
 { 

--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -74,7 +74,7 @@ remote-connection-string=zeromq:endpoint=ipc:///tmp/tmp.sock
 
 # API
 ## Queries
-Unix and Pipe connector sends JSON formatted string to the remote end. Each JSON query has two sections, 'method' and 'parameters'.
+Unix, Pipe and ZeroMQ connectors send JSON formatted string to the remote end. Each JSON query has two sections, 'method' and 'parameters'.
 
 HTTP connector calls methods based on URL and has parameters in the query string. Most calls are GET; see the methods listing for details. You can change this with post and post\_json attributes.
 


### PR DESCRIPTION
Making it clearer that ZeroMQ backend uses the same JSON format as the pipe and unix backends.