### PR TITLE
Make the string parameter to testCrypto() optional

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -505,6 +505,10 @@ Then start `dnsdist` as a daemon, and then connect to it:
 > 
 ```
 
+Please note that, without libsodium support, 'makeKey()' will return
+setKey("plaintext") and the communication between the client and the
+server will not be encrypted.
+
 ACL, who can use dnsdist
 ------------------------
 For safety reasons, by default only private networks can use dnsdist, see below

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -876,9 +876,18 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
     });
 
   
-  g_lua.writeFunction("testCrypto", [](string testmsg)
+  g_lua.writeFunction("testCrypto", [](boost::optional<string> optTestMsg)
    {
      try {
+       string testmsg;
+
+       if (optTestMsg) {
+         testmsg = *optTestMsg;
+       }
+       else {
+         testmsg = "testStringForCryptoTests";
+       }
+
        SodiumNonce sn, sn2;
        sn.init();
        sn2=sn;


### PR DESCRIPTION
The documentation does not mention it and I don't think it makes
sense to require one.
Document the fact that makeKey() does return setKey('plaintext')
without libsodium support.
Reported by Charles-Henri Bruyand.