### PR TITLE
Fix zero-sized response in dnsdist client without libsodium

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -65,16 +65,21 @@ void doClient(ComboAddress server, const std::string& command)
     putMsgLen32(fd, msg.length());
     writen2(fd, msg);
     uint32_t len;
-    if(!getMsgLen32(fd, &len) || len == 0) {
+    if(!getMsgLen32(fd, &len)) {
       cout << "Connection closed by the server." << endl;
       break;
     }
 
-    boost::scoped_array<char> resp(new char[len]);
-    readn2(fd, resp.get(), len);
-    msg.assign(resp.get(), len);
-    msg=sodDecryptSym(msg, g_key, theirs);
-    cout<<msg<<endl;
+    if (len > 0) {
+      boost::scoped_array<char> resp(new char[len]);
+      readn2(fd, resp.get(), len);
+      msg.assign(resp.get(), len);
+      msg=sodDecryptSym(msg, g_key, theirs);
+      cout<<msg<<endl;
+    }
+    else {
+      cout<<endl;
+    }
   }
 }
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -289,6 +289,10 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   g_lua.writeFunction("setLocal", [client](const std::string& addr, boost::optional<bool> doTCP) {
       if(client)
 	return;
+      if (g_configurationDone) {
+        g_outputBuffer="setLocal cannot be used at runtime!\n";
+        return;
+      }
       try {
 	ComboAddress loc(addr, 53);
 	g_locals.clear();
@@ -302,6 +306,10 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   g_lua.writeFunction("addLocal", [client](const std::string& addr, boost::optional<bool> doTCP) {
       if(client)
 	return;
+      if (g_configurationDone) {
+        g_outputBuffer="addLocal cannot be used at runtime!\n";
+        return;
+      }
       try {
 	ComboAddress loc(addr, 53);
 	g_locals.push_back({loc, doTCP ? *doTCP : true}); /// only works pre-startup, so no sync necessary


### PR DESCRIPTION
Without libsodium support, we do actually get zero-sized response
(no padding).
Reported by @gryphius in issue #3015.