### PR TITLE
zone2sql: support --zone without --zone-name

### DIFF
--- a/docs/manpages/zone2sql.1.md
+++ b/docs/manpages/zone2sql.1.md
@@ -6,7 +6,7 @@
 **zone2sql** - convert BIND zones to SQL
 
 # SYNOPSIS
-**zone2sql** {**--named-conf=***PATH*,**--zone-file=***PATH* **--zone-name=***NAME*} [*OPTIONS*]
+**zone2sql** {**--named-conf=***PATH*,**--zone-file=***PATH* [**--zone-name=***NAME*]} [*OPTIONS*]
 
 # DESCRIPTION
 **zone2sql** parses Bind named.conf files and zonefiles and outputs SQL

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -237,6 +237,11 @@ bool findAndElide(string& line, char c)
   return false;
 }
 
+DNSName ZoneParserTNG::getZoneName()
+{
+  return d_zonename;
+}
+
 string ZoneParserTNG::getLineOfFile()
 {
   if (d_zonedata.size() > 0)

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -39,6 +39,7 @@ public:
   bool get(DNSResourceRecord& rr, std::string* comment=0);
   typedef runtime_error exception;
   typedef deque<pair<string::size_type, string::size_type> > parts_t;
+  DNSName getZoneName();
   string getLineOfFile();
 private:
   bool getLine();


### PR DESCRIPTION
This *does* mean that $ORIGIN must be set in the zone file.

Closes #2838