### PR TITLE
Fix dnsdist console client sending empty lines

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -60,6 +60,10 @@ void doClient(ComboAddress server, const std::string& command)
     if(line=="quit")
       break;
 
+    /* no need to send an empty line to the server */
+    if(line.empty())
+      continue;
+
     string response;
     string msg=sodEncryptSym(line, g_key, ours);
     putMsgLen32(fd, msg.length());
@@ -207,6 +211,14 @@ try
     uint32_t len;
     if(!getMsgLen32(fd, &len))
       break;
+
+    if (len == 0) {
+      /* just ACK an empty message
+         with an empty response */
+      putMsgLen32(fd, 0);
+      continue;
+    }
+
     boost::scoped_array<char> msg(new char[len]);
     readn2(fd, msg.get(), len);
     


### PR DESCRIPTION
There is no point for the console client to send empty lines to the
server. Just in case, fix the server to not abort the connection
when receiving such empty lines.
Reported by @gryphius as a follow-up on #3015.