### PR TITLE
devpollmplexer is leaky

### DIFF
--- a/pdns/devpollmplexer.cc
+++ b/pdns/devpollmplexer.cc
@@ -102,11 +102,15 @@ int DevPollFDMultiplexer::run(struct timeval* now)
   int ret=ioctl(d_devpollfd, DP_POLL, &dvp); 
   gettimeofday(now,0); // MANDATORY!
   
-  if(ret < 0 && errno!=EINTR)
+  if(ret < 0 && errno!=EINTR) {
+    delete[] dvp.dp_fds;
     throw FDMultiplexerException("/dev/poll returned error: "+stringerror());
+  }
 
-  if(ret < 1) // thanks AB!
+  if(ret < 1) { // thanks AB!
+    delete[] dvp.dp_fds;
     return 0;
+  }
 
   d_inrun=true;
   for(int n=0; n < ret; ++n) {


### PR DESCRIPTION
See #3001 

With this patch, I don't see any leaks after about ~31kq.  Note however, that a leak is still possible if any of the callbacks throw an exception.