### PR TITLE
Use ssize_t for the result of send() to DS in dnsdist UDP thread

### DIFF
--- a/pdns/dnsdist-ecs.cc
+++ b/pdns/dnsdist-ecs.cc
@@ -337,7 +337,6 @@ void handleEDNSClientSubnet(char * const packet, const size_t packetSize, const 
 {
   assert(packet != NULL);
   assert(len != NULL);
-  assert(*len >= 0);
   assert(consumed <= (size_t) *len);
   assert(ednsAdded != NULL);
   char * optRRStart = NULL;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -480,7 +480,7 @@ try
 
   for(;;) {
     try {
-      int ret = recvmsg(cs->udpFD, &msgh, 0);
+      ssize_t ret = recvmsg(cs->udpFD, &msgh, 0);
 
       cs->queries++;
       g_stats.queries++;
@@ -638,14 +638,14 @@ try
       }
       
       if (largerQuery.empty()) {
-        len = send(ss->fd, packet, len, 0);
+        ret = send(ss->fd, packet, len, 0);
       }
       else {
-        len = send(ss->fd, largerQuery.c_str(), largerQuery.size(), 0);
+        ret = send(ss->fd, largerQuery.c_str(), largerQuery.size(), 0);
         largerQuery.clear();
       }
       
-      if(len < 0) {
+      if(ret < 0) {
 	ss->sendErrors++;
 	g_stats.downstreamSendErrors++;
       }


### PR DESCRIPTION
Otherwise we cannot detect error sending query to DS.
Remove useless assert() since len has been changed to uint16t_t.
Found by @cmouse.