### PR TITLE
Fix Base64 decoding for dnsdist on big endian platforms

### DIFF
--- a/pdns/sodcrypto.cc
+++ b/pdns/sodcrypto.cc
@@ -219,9 +219,15 @@ int B64Decode(const std::string& strInput, std::string& strOutput)
     // Interpret the resulting 3 bytes...note there
     // may have been padding, so those padded bytes
     // are actually ignored.
+#if BYTE_ORDER == BIG_ENDIAN
+    strOutput += pBuf[sizeof(long)-3];
+    strOutput += pBuf[sizeof(long)-2];
+    strOutput += pBuf[sizeof(long)-1];
+#else
     strOutput += pBuf[2];
     strOutput += pBuf[1];
     strOutput += pBuf[0];
+#endif
   } // while
   if(pad)
     strOutput.resize(strOutput.length()-pad);


### PR DESCRIPTION
This PR fixes an endianess-related bug originally present in dnsdist since 1489accc using solutions provided in the past by @ahupowerdns (b969c229) and @Habbie (0c37420).