### PR TITLE
Relax constraints accepting answers from forwarders

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1342,7 +1342,7 @@ int SyncRes::doResolveAt(set<DNSName> nameservers, DNSName auth, bool flawedNSSe
 
         return RCode::NXDomain;
       }
-      if(nsset.empty() && !lwr.d_rcode && (negindic || lwr.d_aabit)) {
+      if(nsset.empty() && !lwr.d_rcode && (negindic || lwr.d_aabit || sendRDQuery)) {
         LOG(prefix<<qname.toString()<<": status=noerror, other types may exist, but we are done "<<(negindic ? "(have negative SOA) " : "")<<(lwr.d_aabit ? "(have aa bit) " : "")<<endl);
 	addNXNSECS(ret, lwr.d_records);
         return 0;


### PR DESCRIPTION
This patch relaxes our constraints on accepting answers from forwarders,
who can' t be expected to always set an AA bit for us, especially not
when asking for recursion.

Closes #2841