### PR TITLE
Hook up Base64 test suite to dnsdist's testrunner

### DIFF
--- a/pdns/dnsdistdist/.gitignore
+++ b/pdns/dnsdistdist/.gitignore
@@ -27,4 +27,5 @@
 /libtool
 /ltmain.sh
 /missing
+/testrunner
 /dnsdist

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -83,7 +83,8 @@ dnsdist_LDADD = \
 
 
 testrunner_SOURCES = \
-	dns.hh \
+	base64.hh dns.hh \
+	test-base64_cc.cc \
 	test-dnsdist_cc.cc dnsdist.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
 	dnslabeltext.cc \
@@ -98,6 +99,7 @@ testrunner_SOURCES = \
 	pdnsexception.hh \
 	qtype.cc qtype.hh \
 	sholder.hh \
+	sodcrypto.cc \
 	sstuff.hh \
 	testrunner.cc
 

--- a/pdns/dnsdistdist/test-base64_cc.cc
+++ b/pdns/dnsdistdist/test-base64_cc.cc
@@ -1,0 +1,1 @@
+../test-base64_cc.cc


### PR DESCRIPTION
The Base64 test suite implemented in `test-base64_cc.cc` is currently *not* executed when dnsdist is built.  This PR fixes that.

I also added `testrunner` to dnsdist's `.gitignore` in a separate commit.