### PR TITLE
Add a warning about this being the docs for 4.X

### DIFF
--- a/docs/markdown/theme/content.html
+++ b/docs/markdown/theme/content.html
@@ -6,4 +6,6 @@
 </div>
 {% endif %}
 
+<span class="alert alert-danger">This document is about PowerDNS 4.X. If you have PowerDNS 3.X, please see the <a href="/3">PowerDNS 3.X documentation</a></span><br>
+
 {{ content }}


### PR DESCRIPTION
This adds this a-subtle alert to every page:

![This huge warning](http://i.imgur.com/tU94Qjp.png)