### PR TITLE
Dnsdist: Show INFO logs in default verbosity mode

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -80,7 +80,7 @@ try
 
       int ret = waitForRWData(s.getHandle(), false, 1 , 0); 
       if(ret <= 0 ) {
-	infolog("Unable to write data to carbon server on %s: %s", localCarbon->server.toStringWithPort(), (ret<0 ? strerror(errno) : "Timeout"));
+	vinfolog("Unable to write data to carbon server on %s: %s", localCarbon->server.toStringWithPort(), (ret<0 ? strerror(errno) : "Timeout"));
 	continue;
       }
       s.setBlocking();

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -38,7 +38,7 @@ bool compareAuthorization(YaHTTP::Request& req, const string &expected_password)
 static void connectionThread(int sock, ComboAddress remote, string password)
 {
   using namespace json11;
-  infolog("Webserver handling connection from %s", remote.toStringWithPort());
+  vinfolog("Webserver handling connection from %s", remote.toStringWithPort());
   FILE* fp=0;
   fp=fdopen(sock, "r");
   try {

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -429,7 +429,7 @@ public:
   DNSAction::Action operator()(const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh, uint16_t& len, string* ruleresult) const override
   {
     if(!d_fp) 
-      infolog("Packet from %s for %s %s with id %d", remote.toStringWithPort(), qname.toString(), QType(qtype).getName(), dh->id);
+      vinfolog("Packet from %s for %s %s with id %d", remote.toStringWithPort(), qname.toString(), QType(qtype).getName(), dh->id);
     else {
       string out = qname.toDNSString();
       fwrite(out.c_str(), 1, out.size(), d_fp);

--- a/pdns/dolog.hh
+++ b/pdns/dolog.hh
@@ -10,12 +10,13 @@
 
    Usage: 
           string address="localhost";
+          vinfolog("Got TCP connection from %s", remote);
           infolog("Bound to %s port %d", address, port);
           warnlog("Query took %d milliseconds", 1232.4); // yes, %d
           errlog("Unable to bind to %s: %s", ca.toStringWithPort(), strerr(errno));
 
    If bool g_console is true, will log to stdout. Will syslog in any case with LOG_INFO,
-   LOG_WARNING, LOG_ERR respectively. If g_verbose=false, infolog is a noop.
+   LOG_WARNING, LOG_ERR respectively. If g_verbose=false, vinfolog is a noop.
    More generically, dolog(someiostream, "Hello %s", stream) will log to someiostream
 
    This will happily print a string to %d! Doesn't do further format processing.
@@ -64,8 +65,7 @@ void genlog(int level, const char* s, Args... args)
 template<typename... Args>
 void infolog(const char* s, Args... args)
 {
-  if(g_verbose)
-    genlog(LOG_INFO, s, args...);
+  genlog(LOG_INFO, s, args...);
 }
 
 template<typename... Args>


### PR DESCRIPTION
Currently there is no way to get `info` level messages on the console without also getting spammed with `debug` level logs. This is because `infolog()` messages are not shown until one enables verbose mode with the `-v` flag.
Most people would like to be able to see info messages without the debug messages.

This PR makes the following changes:

* Display infolog() messages in default verbosity mode (without `-v` flag)
* Fix log-level for a log message that would spam the console every second during a session to the webserver "Webserver handling connection from..."