### PR TITLE
fix ext/json11 link directory

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1,4 +1,4 @@
-JSON11_LIBS = -L$(top_srcdir)/ext/json11 -ljson11
+JSON11_LIBS = -L$(top_builddir)/ext/json11 -ljson11
 
 AM_CPPFLAGS += \
 	-I$(top_srcdir)/ext/json11 \


### PR DESCRIPTION
otherwise building in a separate directory doesn't work (`mkdir build; cd build; ../configure; make`)