### PR TITLE
Fix chroot() issues

### DIFF
--- a/docs/manpages/rec_control.1.md
+++ b/docs/manpages/rec_control.1.md
@@ -10,7 +10,7 @@ rec_control - control pdns_recursor
 
 DESCRIPTION
 -----------
-rec_control(1) allows the operator to control a running instance
+**rec_control** allows the operator to control a running instance
 of the pdns_recursor.
 
 The commands that can be passed to the recursor are described on
@@ -29,8 +29,11 @@ To dump the cache to disk, execute:
 --help
 :    provide this helpful message.
 
+--config-dir=*PATH*
+:    Directory where the recursor.conf lives.
+
 --socket-dir=*PATH*
-:    Where the controlsocket will live.
+:    Where the controlsocket will live, please use **--config-dir** instead.
 
 --socket-pid=*PID*
 :    When running in SMP mode, pid of **pdns_recursor** to control.

--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -114,6 +114,13 @@ If sending carbon updates, this is the interval between them in seconds. See
 If set, chroot to this directory for more security. See
 ["Security settings & considerations"](../common/security.md).
 
+Make sure that `/dev/log` is available from within the chroot. Logging will
+silently fail over time otherwise (on logrotate).
+
+When setting `chroot`, all other paths in the config (except for
+[`config-dir`](#config-dir) and [`module-dir`](#module-dir)) set in the configuration
+are relative to the new root.
+
 ## `config-dir`
 * Path
 

--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -123,6 +123,12 @@ If set, chroot to this directory for more security. See [Security](../common/sec
 Make sure that `/dev/log` is available from within the chroot. Logging will
 silently fail over time otherwise (on logrotate).
 
+When using `chroot`, all other paths (except for [`config-dir`](#config-dir) set
+in the configuration are relative to the new root.
+
+When using `chroot` and the API ([`webserver`](#webserver)), [`api-readonly`](#api-readonly)
+must be set and [`api-config-dir`](#api-config-dir) unset.
+
 ## `client-tcp-timeout`
 * Integer
 * Default: 2
@@ -606,6 +612,8 @@ Use only a single socket for outgoing queries.
 
 Where to store the control socket and pidfile. The default depends on
 `LOCALSTATEDIR` during compile-time (usually `/var/run` or `/run`).
+
+When using [`chroot`](#chroot) the default becomes to `/`.
 
 ## `socket-owner`, `socket-group`, `socket-mode`
 Owner, group and mode of the controlsocket. Owner and group can be specified by

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -472,7 +472,7 @@ void mainthread()
 
    secPollParseResolveConf();
 
-   if(!::arg()["chroot"].empty()) {  
+   if(!::arg()["chroot"].empty()) {
      triggerLoadOfLibraries();
      if(::arg().mustDo("master") || ::arg().mustDo("slave"))
         gethostbyname("a.root-servers.net"); // this forces all lookup libraries to be loaded

--- a/pdns/dynlistener.cc
+++ b/pdns/dynlistener.cc
@@ -177,7 +177,16 @@ DynListener::DynListener(const string &progname)
   d_s=-1;
 
   if(!progname.empty()) {
-    string socketname=arg()["socket-dir"]+"/";
+    string socketname = ::arg()["socket-dir"];
+    if (::arg()["socket-dir"].empty()) {
+      if (::arg()["chroot"].empty())
+        socketname = LOCALSTATEDIR;
+      else
+        socketname = ::arg()["chroot"];
+    } else if (!::arg()["socket-dir"].empty() && !::arg()["chroot"].empty()) {
+      socketname = ::arg()["chroot"] + ::arg()["socket-dir"];
+    }
+    socketname += "/";
     cleanSlashes(socketname);
     
     if(!mkdir(socketname.c_str(),0700)) // make /var directory, if needed

--- a/pdns/pdns.conf-dist
+++ b/pdns/pdns.conf-dist
@@ -460,9 +460,9 @@
 # soa-retry-default=3600
 
 #################################
-# socket-dir	Where the controlsocket will live
+# socket-dir	Where the controlsocket will live, /var/run when unset and not chrooted
 #
-# socket-dir=/var/run
+# socket-dir=
 
 #################################
 # tcp-control-address	If set, PowerDNS can be controlled over TCP on this address

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -935,6 +935,11 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
   }
 
   if(cmd=="reload-acls") {
+    if(!::arg()["chroot"].empty()) {
+      L<<Logger::Error<<"Unable to reload ACL when chroot()'ed, requested via control channel"<<endl;
+      return "Unable to reload ACL when chroot()'ed, please restart\n";
+    }
+
     try {
       parseACLs();
     } 
@@ -983,6 +988,10 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
   }
 
   if(cmd=="reload-zones") {
+    if(!::arg()["chroot"].empty()) {
+      L<<Logger::Error<<"Unable to reload zones and forwards when chroot()'ed, requested via control channel"<<endl;
+      return "Unable to reload zones and forwards when chroot()'ed, please restart\n";
+    }
     return reloadAuthAndForwards();
   }
 

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -133,7 +133,17 @@ static void writePid(void)
   if(!::arg().mustDo("write-pid"))
     return;
 
-  string fname=::arg()["socket-dir"]+"/"+s_programname+".pid";
+  string fname=::arg()["socket-dir"];
+  if (::arg()["socket-dir"].empty()) {
+    if (::arg()["chroot"].empty())
+      fname = LOCALSTATEDIR;
+    else
+      fname = ::arg()["chroot"] + "/";
+  } else if (!::arg()["socket-dir"].empty() && !::arg()["chroot"].empty()) {
+    fname = ::arg()["chroot"] + ::arg()["socket-dir"];
+  }
+
+  fname += + "/" + s_programname + ".pid";
   ofstream of(fname.c_str());
   if(of)
     of<<getpid()<<endl;
@@ -347,7 +357,7 @@ static void UNIX_declareArguments()
 {
   ::arg().set("config-dir","Location of configuration directory (pdns.conf)")=SYSCONFDIR;
   ::arg().set("config-name","Name of this virtual configuration - will rename the binary image")="";
-  ::arg().set("socket-dir","Where the controlsocket will live")=LOCALSTATEDIR;
+  ::arg().set("socket-dir",string("Where the controlsocket will live, ")+LOCALSTATEDIR+" when unset and not chrooted" )="";
   ::arg().set("module-dir","Default directory for modules")=PKGLIBDIR;
   ::arg().set("chroot","If set, chroot to this directory for more security")="";
   ::arg().set("logging-facility","Log under a specific facility")="";


### PR DESCRIPTION
We now create the sockets and pid-files inside the chroot. The *_control
tools also know about the chroot and act accordingly.

Closes #191
Closes #148