### PR TITLE
dnsdist: change message returned by testCrypto() if compiled without libsodium

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1034,6 +1034,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   g_lua.writeFunction("testCrypto", [](boost::optional<string> optTestMsg)
    {
      setLuaNoSideEffect();
+#ifdef HAVE_LIBSODIUM
      try {
        string testmsg;
 
@@ -1064,7 +1065,11 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
      }
      catch(...) {
        g_outputBuffer="Crypto failed..\n";
-     }});
+     }
+#else
+     g_outputBuffer="Crypto not available.\n";
+#endif
+   });
 
   g_lua.writeFunction("setTCPRecvTimeout", [](int timeout) { g_tcpRecvTimeout=timeout; });
 


### PR DESCRIPTION
Currently when dnsdist is compiled without libsodium support, calling `testCrypto()` succeeds with the message *"Everything is ok!"*, even though "crypto" is then done by [dummy functions](https://github.com/PowerDNS/pdns/blob/8fbf9032f1eadb764dae3e6043faba77d91c69a7/pdns/sodcrypto.cc#L38-L45) which simply return the original plaintext.

This PR makes `testCrypto()` return a different message when dnsdist is compiled without libsodium support, to avoid user confusion.