### PR TITLE
Don't automatically set the QR flag in case of HeaderModify

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -256,7 +256,6 @@ void* tcpClientThread(int pipefd)
 	case DNSAction::Action::Spoof:
 	  ;
 	case DNSAction::Action::HeaderModify:
-	  dh->qr=true;
 	  break;
 	case DNSAction::Action::Allow:
 	case DNSAction::Action::None:

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -633,7 +633,6 @@ try
       case DNSAction::Action::Spoof:
 	;
       case DNSAction::Action::HeaderModify:
-	dh->qr=true;
 	break;
       case DNSAction::Action::Delay:
 	delayMsec = static_cast<int>(pdns_stou(ruleresult)); // sorry


### PR DESCRIPTION
Some actions are actually altering the query and not turning it
into an answer (NoRecurse, DisableValidation).
All the actions that do turn it into an answer are already setting
the QR flag themselves.