### PR TITLE
Show DNSSEC keys for slaved zone

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1153,11 +1153,20 @@ bool showZone(DNSSECKeeper& dk, const DNSName& zone)
     cout << "keys: "<<endl;
     sort(keys.begin(),keys.end());
     reverse(keys.begin(),keys.end());
+    bool shown=false;
     for(const auto& key : keys) {
       string algname;
       algorithm2name(key.d_algorithm,algname);
-      cout << "tag = " << key.getTag() << ", algo = "<<(int)key.d_algorithm<<endl;
-      cout << (key.d_flags == 257 ? "KSK" : "ZSK") << " DNSKEY = " << key.getZoneRepresentation() << "; ( " + algname + " ) " <<endl;
+      int bits;
+      if (key.d_key[0] == 0)
+        bits = *(uint16_t*)(key.d_key.c_str()+1);
+      else
+        bits = *(uint8_t*)key.d_key.c_str();
+      bits = (key.d_key.size() - (bits+1))*8;
+      cout << (key.d_flags == 257 ? "KSK" : "ZSK") << ", tag = " << key.getTag() << ", algo = "<<(int)key.d_algorithm << ", bits = " << bits << endl;
+      cout << "DNSKEY = " <<zone.toString()<<" IN DNSKEY "<< key.getZoneRepresentation() << "; ( " + algname + " ) " <<endl;
+      if (shown) continue;
+      shown=true;
       cout<<"DS = "<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, 1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;
       cout<<"DS = "<<zone.toString()<<" IN DS "<<makeDSFromDNSKey(zone, key, 2).getZoneRepresentation() << " ; ( SHA256 digest )" << endl;
       try {


### PR DESCRIPTION
Example output

```
Zone uses following TSIG key(s): mythnet
Zone is presigned
Zone has NSEC semantics
keys:
tag = 16141, algo = 8
KSK DNSKEY = 257 3 8 AwEAAdVmUT6ldZ4Y2HklBdhvh08NW0t9Rwqx8TPxIaWorZ51AAIeiih7bGWAkKukLIzPF1bzxALSs5gTJJfBi59UDRH0MAgTPqq/VQyt0TWh7crBVntWlQqoODEtURDeE2S+ZIVmTY/vUncvLX5Ijtz7ENvIAxItfLJ9RpnNwpl26HC1o2WJQwjeGEGylTwF3iDiuRmB3LwSpjXLhHnWpHX6SnrkYUiQclHsGfgXC7nXkD4xOKtPz7bx7dGnKnhR85KitZ26UtWscGFIvmlRV4+bfMsg66t+tObxp2IZs3b05J4GPFT0t2F7kJgV7PdVQvm3rS8oOjJ/0/w7LVh7SooXO60=; ( RSASHA256 )
DS = mythnet.org. IN DS 16141 8 1 9b9aa8f7bcc0b9b96b49b8044a1b695ab8e56e67 ; ( SHA1 digest )
DS = mythnet.org. IN DS 16141 8 2 8b90eaba5c17637be110018d6e81550941e4f63588bae7271300368f422657dc ; ( SHA256 digest )
DS = mythnet.org. IN DS 16141 8 4 ff6e50907586083fd14a3a4c992c987a78dd6b10e5c18a9cd2fca6e9d56642a6da95c661cd0b4d121c94841caffa2c22 ; ( SHA-384 digest )
tag = 44614, algo = 8
ZSK DNSKEY = 256 3 8 AwEAAcVH8v1T0L4mr+5f7rmqFVCrSoLrl3jD7H7sz5OSrCUwbyz2lzyVZZcDkGT/YcpQSE2/TT7h7YAo3rSUCPMT6WQnKKEOl8G++OsqQ32A7MIgmPMHQNMQYqUKFdaVEZkoE8Bt9P0hJNM9WpfBUkC13+8Inj8kIBgJdnEv8ca9/wXH; ( RSASHA256 )
DS = mythnet.org. IN DS 44614 8 1 fc16e652e5fc1e0c1e3d85098c8a6ed64f7ea036 ; ( SHA1 digest )
DS = mythnet.org. IN DS 44614 8 2 2346c2a4b44bdf0daba4d5a8b2857071efaef0a0736270f2c8c6046615f4231a ; ( SHA256 digest )
DS = mythnet.org. IN DS 44614 8 4 9af6711ddfb265eec05258fc54e327271b8a1d6dee18a19e3d47de7ac6cbb7d779d2cc4c249ad5720a820730175e101b ; ( SHA-384 digest )
```