### PR TITLE
dnsdist: Fix coverity/clang static analyzer warnings

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -760,7 +760,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 	return;
       ComboAddress local(address);
       try {
-	int sock = socket(local.sin4.sin_family, SOCK_STREAM, 0);
+	int sock = SSocket(local.sin4.sin_family, SOCK_STREAM, 0);
 	SSetsockopt(sock, SOL_SOCKET, SO_REUSEADDR, 1);
 	SBind(sock, local);
 	SListen(sock, 5);
@@ -788,7 +788,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       }
       
       try {
-	int sock = socket(local.sin4.sin_family, SOCK_STREAM, 0);
+	int sock = SSocket(local.sin4.sin_family, SOCK_STREAM, 0);
 	SSetsockopt(sock, SOL_SOCKET, SO_REUSEADDR, 1);
 	SBind(sock, local);
 	SListen(sock, 5);

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -166,7 +166,7 @@ void moreLua()
                            int actualSeconds = seconds ? *seconds : 10;
 			   until.tv_sec += actualSeconds; 
 			   for(const auto& capair : m) {
-			     unsigned int count;
+			     unsigned int count = 0;
 			     if(auto got = slow.lookup(Netmask(capair.first))) {
 			       if(until < got->second.until) // had a longer policy
 				 continue;

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -118,5 +118,6 @@ testrunner_LDFLAGS = \
 testrunner_LDADD = \
 	$(BOOST_UNIT_TEST_FRAMEWORK_LIBS) \
 	$(LIBSODIUM_LIBS) \
-	$(RT_LIBS)
+	$(RT_LIBS) \
+	$(SANITIZER_FLAGS)
 

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -443,7 +443,7 @@ public:
   }
 private:
   string d_fname;
-  FILE* d_fp;
+  FILE* d_fp{0};
 };
 
 


### PR DESCRIPTION
Fix building the unit tests with sanitizers enabled.
Coverity complained about d_fp in LogAction not being initialized
when constructed from a string, and about negative values from
socket() not being handled.
Clang static analyzer complained about the count var in
addDynBlocks not being initialized in some cases.