### PR TITLE
respect OPENSSL_LDFLAGS

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -226,6 +226,7 @@ endif
 
 if OPENSSL
 pdns_server_SOURCES += opensslsigners.cc opensslsigners.hh
+pdns_server_LDFLAGS += $(OPENSSL_LDFLAGS)
 pdns_server_LDADD += $(OPENSSL_LIBS)
 endif
 
@@ -326,6 +327,7 @@ endif
 
 if OPENSSL
 pdnsutil_SOURCES += opensslsigners.cc
+pdnsutil_LDFLAGS += $(OPENSSL_LDFLAGS)
 pdnsutil_LDADD += $(OPENSSL_LIBS)
 endif
 


### PR DESCRIPTION
This makes it possible to build against 'brew' OpenSSL on OSX (which is 20 times faster than stock 10.10 openssl for ECDSA)