### PR TITLE
Correct name of libcrypto in ax_check_openssl.m4

### DIFF
--- a/m4/ax_check_openssl.m4
+++ b/m4/ax_check_openssl.m4
@@ -53,7 +53,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
             # then use that information and don't search ssldirs
             AC_PATH_PROG([PKG_CONFIG], [pkg-config])
             if test x"$PKG_CONFIG" != x""; then
-                OPENSSL_LDFLAGS=`$PKG_CONFIG libcryptol --libs-only-L 2>/dev/null`
+                OPENSSL_LDFLAGS=`$PKG_CONFIG libcrypto --libs-only-L 2>/dev/null`
                 if test $? = 0; then
                     OPENSSL_LIBS=`$PKG_CONFIG libcrypto --libs-only-l 2>/dev/null`
                     OPENSSL_INCLUDES=`$PKG_CONFIG libcrypto --cflags-only-I 2>/dev/null`


### PR DESCRIPTION
Introduced by 85aa638bc42a5a12e0b30b82bb334bba44036e6d