### PR TITLE
Catch DNSName build errors in dynhandler

### DIFF
--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -264,6 +264,13 @@ string DLNotifyHostHandler(const vector<string>&parts, Utility::pid_t ppid)
   if(!::arg().mustDo("master"))
       return "PowerDNS not configured as master";
 
+  DNSName domain;
+  try {
+    domain = DNSName(parts[1]);
+  } catch (...) {
+    return "Failed to parse domain as valid DNS name";
+  }
+
   try {
     ComboAddress ca(parts[2]);
   } catch(...)
@@ -271,8 +278,8 @@ string DLNotifyHostHandler(const vector<string>&parts, Utility::pid_t ppid)
     return "Unable to convert '"+parts[2]+"' to an IP address";
   }
   
-  L<<Logger::Warning<<"Notification request to host "<<parts[2]<<" for domain '"<<parts[1]<<"' received from operator"<<endl;
-  Communicator.notify(DNSName(parts[1]), parts[2]);
+  L<<Logger::Warning<<"Notification request to host "<<parts[2]<<" for domain '"<<domain<<"' received from operator"<<endl;
+  Communicator.notify(domain, parts[2]);
   return "Added to queue";
 }
 

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -235,18 +235,24 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
   if(parts.size()!=2)
     return "syntax: retrieve domain";
 
-  const string& domain=parts[1];
+  DNSName domain;
+  try {
+    domain = DNSName(parts[1]);
+  } catch (...) {
+    return "Failed to parse domain as valid DNS name";
+  }
+
   DomainInfo di;
   UeberBackend B;
-  if(!B.getDomainInfo(DNSName(domain), di))
-    return "Domain '"+domain+"' unknown";
+  if(!B.getDomainInfo(domain, di))
+    return "Domain '"+domain.toString()+"' unknown";
   
   if(di.masters.empty())
-    return "Domain '"+domain+"' is not a slave domain (or has no master defined)";
+    return "Domain '"+domain.toString()+"' is not a slave domain (or has no master defined)";
 
   random_shuffle(di.masters.begin(), di.masters.end());
-  Communicator.addSuckRequest(DNSName(domain), di.masters.front());
-  return "Added retrieval request for '"+domain+"' from master "+di.masters.front();
+  Communicator.addSuckRequest(domain, di.masters.front());
+  return "Added retrieval request for '"+domain.toString()+"' from master "+di.masters.front();
 }
 
 string DLNotifyHostHandler(const vector<string>&parts, Utility::pid_t ppid)

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -270,9 +270,6 @@ string DLNotifyHostHandler(const vector<string>&parts, Utility::pid_t ppid)
   return "Added to queue";
 }
 
-// XXX DNSName pain - if you pass us something that is not DNS,  you'll get an exception here, which you never got before
-// and I bet we don't report it well to the user...
-
 string DLNotifyHandler(const vector<string>&parts, Utility::pid_t ppid)
 {
   extern CommunicatorClass Communicator;
@@ -301,6 +298,12 @@ string DLNotifyHandler(const vector<string>&parts, Utility::pid_t ppid)
       return itoa(notified)+" out of "+itoa(total)+" zones added to queue - see log";
     return "Added "+itoa(total)+" MASTER zones to queue";
   } else {
+    DNSName domain;
+    try {
+      domain = DNSName(parts[1]);
+    } catch (...) {
+      return "Failed to parse domain as valid DNS name";
+    }
     if(!Communicator.notifyDomain(DNSName(parts[1])))
       return "Failed to add to the queue - see log";
     return "Added to queue";


### PR DESCRIPTION
Without this, calling "notify \\1" (or similar) results in a syslog message and a hanging pdns_control.