### PR TITLE
Fix my pdnsutil check-all-zones fix

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1570,7 +1570,7 @@ seedRandom(::arg()["entropy-source"]);
     dbBench(cmds.size() > 1 ? cmds[1] : "");
   }
   else if (cmds[0] == "check-all-zones") {
-    bool exitOnError = ((cmds.size() > 2 ? cmds[1] : "") == "exit-on-error");
+    bool exitOnError = ((cmds.size() >= 2 ? cmds[1] : "") == "exit-on-error");
     exit(checkAllZones(dk, exitOnError));
   }
   else if (cmds[0] == "list-all-zones") {


### PR DESCRIPTION
Which entirely disabled exit-on-error.

Noticed by @stbuehler.
