### PR TITLE
configure: Add base check for dynmodules parameter to prevent impossible build attempts due to invalid values

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -299,12 +299,19 @@ PDNS_CHECK_SQLITE3
 AM_CONDITIONAL([SQLITE3], [test "x$needsqlite3" = "xyes"])
 
 for a in $modules; do
-  moduledirs="$moduledirs ${a}backend"
+  AC_MSG_CHECKING([whether we can build module "${a}"])
+  if [[ -d "$srcdir/modules/${a}backend" ]]; then
+    AC_MSG_RESULT([yes])
+    moduledirs="$moduledirs ${a}backend"
 
-  for b in `cat $srcdir/modules/${a}backend/OBJECTFILES`; do
-    moduleobjects="$moduleobjects ../modules/${a}backend/$b"
-  done
-  modulelibs="$modulelibs `cat $srcdir/modules/${a}backend/OBJECTLIBS`"
+    for b in `cat $srcdir/modules/${a}backend/OBJECTFILES`; do
+      moduleobjects="$moduleobjects ../modules/${a}backend/$b"
+    done
+    modulelibs="$modulelibs `cat $srcdir/modules/${a}backend/OBJECTLIBS`"
+  else
+    AC_MSG_RESULT([no])
+    AC_MSG_ERROR([Do not know how to build module "$a", "$srcdir/modules/${a}backend" doesn't exist! Please review --with-modules parameter for supported values.])
+  fi
 done
 
 for a in $dynmodules; do

--- a/configure.ac
+++ b/configure.ac
@@ -308,7 +308,14 @@ for a in $modules; do
 done
 
 for a in $dynmodules; do
-  moduledirs="$moduledirs ${a}backend"
+  AC_MSG_CHECKING([whether we can build dynamic module "${a}"])
+  if [[ -d "$srcdir/modules/${a}backend" ]]; then
+    AC_MSG_RESULT([yes])
+    moduledirs="$moduledirs ${a}backend"
+  else
+    AC_MSG_RESULT([no])
+    AC_MSG_ERROR([Do not know how to build module "$a", "$srcdir/modules/${a}backend" doesn't exist! Please review --with-dynmodules parameter for supported values.])
+  fi
 done
 
 LDFLAGS="$RELRO_LDFLAGS $LDFLAGS"


### PR DESCRIPTION
We didn't validate dynmodules parameter values which allows build failures like

> [...]
> Making all in geobackend
> /bin/sh: line 20: cd: geobackend: No such file or directory
> Makefile:499: recipe for target 'all-recursive' failed
> make[2]: *** [all-recursive] Error 1

which happens for example if a dynamic module was removed (or the user just passed an
invalid value).

Now we will do a base check by checking for the existence of the module's source dir.
This will allow us to catch errors like that and show a meaningful error message if
necessary.

Reference: https://github.com/PowerDNS/pdns/issues/3171