### PR TITLE
Make sure the DelayPipe thread is the last member initialized

### DIFF
--- a/pdns/delaypipe.hh
+++ b/pdns/delaypipe.hh
@@ -38,7 +38,6 @@ public:
   void submit(T& t, int msec); //!< don't try for more than 4294 msec
 
 private:
-  std::thread d_thread;
   void worker();
   struct Combo
   {
@@ -60,6 +59,7 @@ private:
   };
   std::multimap<struct timespec, T, tscomp> d_work;
   void gettime(struct timespec* ts);
+  std::thread d_thread;
 };
 
 #include "delaypipe.cc"


### PR DESCRIPTION
Otherwise the new thread might start running and access
uninitialized members like d_pipe or d_work.
On my host, running dnsdist in gdb without this modification
results in a SIGSEGV at delaypipe.cc:141.