### PR TITLE
Allow building with OpenSSL in place of mbedtls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,7 @@ script:
   - CFLAGS='-O1' CXXFLAGS='-O1' ./configure
     --with-dynmodules='bind gmysql geoip gpgsql gsqlite3 ldap lua mydns opendbx pipe random remote tinydns'
     --with-modules=''
+    --without-mbedtls
     --with-sqlite3
     --enable-libsodium
     --enable-experimental-pkcs11

--- a/build-scripts/dist-recursor
+++ b/build-scripts/dist-recursor
@@ -31,7 +31,7 @@ INCLUDES="iputils.hh arguments.hh base64.hh zoneparser-tng.hh \
 rcpgenerator.hh lock.hh dnswriter.hh  dnsrecords.hh dnsparser.hh utility.hh \
 recursor_cache.hh rec_channel.hh qtype.hh misc.hh dns.hh syncres.hh \
 sstuff.hh mtasker.hh mtasker.cc lwres.hh logger.hh pdnsexception.hh \
-mplexer.hh pubsuffix.hh mbedtlscompat.hh \
+mplexer.hh pubsuffix.hh opensslsigners.hh \
 dns_random.hh lua-recursor4.hh namespaces.hh \
 recpacketcache.hh base32.hh cachecleaner.hh json.hh version.hh \
 ws-recursor.hh ws-api.hh secpoll-recursor.hh \
@@ -50,7 +50,7 @@ devpollmplexer.cc recpacketcache.cc dns.cc reczones.cc base32.cc nsecrecords.cc 
 dnslabeltext.cc json.cc ws-recursor.cc ws-api.cc version.cc dns_random.cc \
 responsestats.cc webserver.cc rec-carbon.cc secpoll-recursor.cc dnsname.cc \
 filterpo.cc rpzloader.cc ixfr.cc dnssecinfra.cc gss_context.cc resolver.cc \
-ednssubnet.cc validate.cc validate-recursor.cc mbedtlssigners.cc rec-lua-conf.cc \
+ednssubnet.cc validate.cc validate-recursor.cc opensslsigners.cc rec-lua-conf.cc \
 sortlist.cc"
 
 curl https://publicsuffix.org/list/public_suffix_list.dat > effective_tld_names.dat
@@ -68,16 +68,9 @@ cat >>$DIRNAME/config.h <<EOF
 #define VERSION "$VERSION"
 #define DIST_HOST "$DIST_HOST"
 #define HAVE_BOOST 1
-#define HAVE_MBEDTLS2 1
+#define HAVE_OPENSSL 1
 EOF
-mkdir -p $DIRNAME/ext/mbedtls/include/mbedtls
-cp -a ../ext/mbedtls/include/mbedtls/{config.h,check_config.h,aes.h,ripemd160.h,sha1.h,md.h,md5.h,sha256.h,sha512.h,ecp.h,ecdsa.h,md_internal.h} ../ext/mbedtls/include/mbedtls/base64.h ../ext/mbedtls/include/mbedtls/platform.h ../ext/mbedtls/include/mbedtls/version.h $DIRNAME/ext/mbedtls/include/mbedtls
-cp -a ../ext/mbedtls/include/mbedtls/{entropy.h,ctr_drbg.h,hmac_drbg.h,rsa.h,ecp.h,bignum.h,oid.h,asn1.h,asn1write.h,pk.h,ecdsa.h,cipher.h,x509.h} $DIRNAME/ext/mbedtls/include/mbedtls
-cp -a ../ext/mbedtls/include/mbedtls/{bn_mul.h,config.h,entropy_poll.h,timing.h} $DIRNAME/ext/mbedtls/include/mbedtls
-
-mkdir -p $DIRNAME/ext/mbedtls/library
-cp -a ../ext/mbedtls/library/{aes.c,base64.c,md.c,md_wrap.c,md5.c,sha1.c,sha256.c,sha512.c,ripemd160.c} $DIRNAME/ext/mbedtls/library
-cp -a ../ext/mbedtls/library/{rsa.c,bignum.c,oid.c,asn1parse.c,ctr_drbg.c,entropy.c,entropy_poll.c,timing.c,ecp.c,ecdsa.c,ecp_curves.c,hmac_drbg.c,asn1write.c} $DIRNAME/ext/mbedtls/library
+mkdir -p $DIRNAME/ext
 
 cp -a ../ext/yahttp/ $DIRNAME/ext/yahttp
 cp -a ../ext/json11/ $DIRNAME/ext/json11

--- a/m4/pdns_with_system_mbedtls.m4
+++ b/m4/pdns_with_system_mbedtls.m4
@@ -1,61 +1,86 @@
 AC_DEFUN([PDNS_WITH_SYSTEM_MBEDTLS],[
+  AC_ARG_WITH([mbedtls],
+    [AS_HELP_STRING([--with-mbedtls], [use mbed TLS @<:@default=yes@:>@])]
+  )
   AC_ARG_WITH([system-mbedtls],
-    [AS_HELP_STRING([--with-system-mbedtls], [use system mbedt TLS @<:@default=no@:>@])],
+    [AS_HELP_STRING([--with-system-mbedtls], [use system mbed TLS @<:@default=no@:>@])],
     [],
     [with_system_mbedtls=no],
   )
 
-  MBEDTLS_SUBDIR=mbedtls
-  MBEDTLS_CFLAGS=-I\$\(top_srcdir\)/ext/$MBEDTLS_SUBDIR/include/
-  MBEDTLS_LIBS="-L\$(top_builddir)/ext/$MBEDTLS_SUBDIR/library/ -lmbedtls"
-
-  AS_IF([test "x$with_system_mbedtls" = "xyes"],[
-    OLD_LIBS=$LIBS
-    LIBS=""
-    AC_SEARCH_LIBS([mbedtls_sha1], [mbedcrypto],[
-      MBEDTLS_LIBS=$LIBS
-      have_system_mbedtls=yes
-      have_mbedtls_v2=yes
-    ],[
-      have_mbedtls_v2=no
-      AC_SEARCH_LIBS([sha1_hmac], [mbedtls polarssl],[
+  AC_MSG_CHECKING([if we should build with mbedtls])
+  AS_IF([test "x$with_mbedtls" != "xno"],[
+    AC_MSG_RESULT([yes])
+    have_mbedtls=yes
+    MBEDTLS_SUBDIR=mbedtls
+    MBEDTLS_CFLAGS=-I\$\(top_srcdir\)/ext/$MBEDTLS_SUBDIR/include/
+    MBEDTLS_LIBS="-L\$(top_builddir)/ext/$MBEDTLS_SUBDIR/library/ -lmbedtls"
+    AS_IF([test "x$with_system_mbedtls" = "xyes"],[
+      OLD_LIBS=$LIBS
+      LIBS=""
+      AC_SEARCH_LIBS([mbedtls_sha1], [mbedcrypto],[
         MBEDTLS_LIBS=$LIBS
-        AC_MSG_CHECKING([for mbed TLS/PolarSSL version >= 1.3.0])
-        AC_COMPILE_IFELSE([
-          AC_LANG_PROGRAM(
-            [[#include <polarssl/version.h>]],
-            [[
-              #if POLARSSL_VERSION_NUMBER < 0x01030000
-              #error invalid version
-              #endif
-            ]]
-          )],
-          [have_system_mbedtls=yes],
+        have_system_mbedtls=yes
+        have_mbedtls_v2=yes
+      ],[
+        have_mbedtls_v2=no
+        AC_SEARCH_LIBS([sha1_hmac], [mbedtls polarssl],[
+          MBEDTLS_LIBS=$LIBS
+          AC_MSG_CHECKING([for mbed TLS/PolarSSL version >= 1.3.0])
+          AC_COMPILE_IFELSE([
+            AC_LANG_PROGRAM(
+              [[#include <polarssl/version.h>]],
+              [[
+                #if POLARSSL_VERSION_NUMBER < 0x01030000
+                #error invalid version
+                #endif
+              ]]
+            )],
+            [have_system_mbedtls=yes],
+            [have_system_mbedtls=no]
+          )
+          AC_MSG_RESULT([$have_system_mbedtls])
+          ],
           [have_system_mbedtls=no]
         )
-        AC_MSG_RESULT([$have_system_mbedtls])
-        ],
-        [have_system_mbedtls=no]
-      )
+      ])
+      LIBS=$OLD_LIBS
+    ],[
+      have_system_mbedtls=no
+      have_mbedtls_v2=yes
     ])
-    LIBS=$OLD_LIBS
-  ],[
-    have_system_mbedtls=no
-    have_mbedtls_v2=yes
-  ])
 
-  AS_IF([test "x$have_system_mbedtls" = "xyes"],[
-    MBEDTLS_CFLAGS=
-    MBEDTLS_SUBDIR=
-    AC_DEFINE([MBEDTLS_SYSTEM], [1], [Defined if system mbed TLS is used])
+    AS_IF([test "x$have_system_mbedtls" = "xyes"],[
+      MBEDTLS_CFLAGS=
+      MBEDTLS_SUBDIR=
+      AC_DEFINE([MBEDTLS_SYSTEM], [1], [Defined if system mbed TLS is used])
+    ],[
+      AS_IF([test "x$with_system_mbedtls" = "xyes"],[
+        AC_MSG_ERROR([use of system mbed TLS requested but not found])
+      ])
+    ])
   ],[
+    AC_MSG_RESULT([no])
+    have_system_mbedtls=no
+    have_mbedtls_v2=no
+    have_mbedtls=no
+    MBEDTLS_SUBDIR=
+    MBEDTLS_CFLAGS=
+    MBEDTLS_LIBS=
     AS_IF([test "x$with_system_mbedtls" = "xyes"],[
-      AC_MSG_ERROR([use of system mbedtls requested but not found])]
-    )]
-  )
+      AC_MSG_ERROR([use of system mbed TLS requested but mbed TLS disabled])
+    ])
+  ])
 
   AS_IF([test "x$have_mbedtls_v2" = "xyes"],[
     AC_DEFINE([HAVE_MBEDTLS2], [1], [Defined if mbed TLS version 2.x.x is used])
+  ])
+
+  AS_IF([test "x$have_mbedtls" = "xyes"],[
+    AC_DEFINE([HAVE_MBEDTLS], [1], [Defined if mbed TLS is used])
+	AM_CONDITIONAL([MBEDTLS], [true])
+  ],[
+	AM_CONDITIONAL([MBEDTLS], [false])
   ])
 
   AC_SUBST(MBEDTLS_CFLAGS)

--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -2,6 +2,7 @@ AM_CPPFLAGS += \
 	-I$(top_srcdir)/ext/rapidjson/include \
 	$(YAHTTP_CFLAGS) \
 	$(MBEDTLS_CFLAGS) \
+	$(OPENSSL_CFLAGS) \
 	$(LIBZMQ_CFLAGS)
 
 AM_LDFLAGS = $(THREADFLAGS)
@@ -129,6 +130,7 @@ libtestremotebackend_la_CPPFLAGS = $(AM_CPPFLAGS)
 libtestremotebackend_la_LIBADD = \
 	$(YAHTTP_LIBS) \
 	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS) \
 	$(BOOST_UNIT_TEST_FRAMEWORK_LIBS) \
 	$(BOOST_SERIALIZATION_LIBS) \
 	$(BOOST_PROGRAM_OPTIONS_LIBS) \

--- a/pdns/Makefile-recursor
+++ b/pdns/Makefile-recursor
@@ -4,8 +4,8 @@ BINDIR=/usr/bin/
 SYSCONFDIR=/etc/powerdns/
 LOCALSTATEDIR=/var/run/
 OPTFLAGS?=-O3
-CXXFLAGS:= $(CXXFLAGS) -I$(CURDIR)/ext/mbedtls/include -I$(CURDIR)/ext/json11 -Wall @CF_PIE@ @CF_FORTIFY@ @CF_STACK@ $(OPTFLAGS) $(PROFILEFLAGS) $(ARCHFLAGS) -pthread -Iext/yahttp -DHAVE_CONFIG_H
-CFLAGS:=$(CFLAGS) -Wall $(OPTFLAGS) @CF_PIE@ @CF_FORTIFY@ @CF_STACK@ $(PROFILEFLAGS) $(ARCHFLAGS) -I$(CURDIR)/ext/mbedtls/include -pthread -DHAVE_CONFIG_H
+CXXFLAGS:= $(CXXFLAGS) -I$(CURDIR)/ext/json11 -Wall @CF_PIE@ @CF_FORTIFY@ @CF_STACK@ $(OPTFLAGS) $(PROFILEFLAGS) $(ARCHFLAGS) -pthread -Iext/yahttp -DHAVE_CONFIG_H
+CFLAGS:=$(CFLAGS) -Wall $(OPTFLAGS) @CF_PIE@ @CF_FORTIFY@ @CF_STACK@ $(PROFILEFLAGS) $(ARCHFLAGS) -pthread -DHAVE_CONFIG_H
 LDFLAGS:=$(LDFLAGS) $(ARCHFLAGS) -pthread @LD_RELRO@ @CF_STACK@ @LD_PIE@
 STRIP_BINARIES?=1
 
@@ -20,22 +20,14 @@ PDNS_RECURSOR_OBJECTS=syncres.o misc.o unix_utility.o qtype.o logger.o \
 arguments.o lwres.o pdns_recursor.o recursor_cache.o dnsparser.o \
 dnswriter.o dnsrecords.o rcpgenerator.o base64.o zoneparser-tng.o \
 rec_channel.o rec_channel_rec.o selectmplexer.o sillyrecords.o \
-dns_random.o pubsuffix.o ext/mbedtls/library/aes.o ext/mbedtls/library/base64.o dnslabeltext.o \
-ext/mbedtls/library/md5.o ext/mbedtls/library/sha1.o ext/mbedtls/library/sha256.o  \
-ext/mbedtls/library/sha512.o ext/mbedtls/library/md.o ext/mbedtls/library/md_wrap.o \
-ext/mbedtls/library/ripemd160.o ext/mbedtls/library/rsa.o \
-ext/mbedtls/library/ecdsa.o ext/mbedtls/library/ecp.o ext/mbedtls/library/ecp_curves.o \
-ext/mbedtls/library/hmac_drbg.o ext/mbedtls/library/asn1write.o \
-ext/mbedtls/library/bignum.o ext/mbedtls/library/oid.o ext/mbedtls/library/asn1parse.o  \
-ext/mbedtls/library/ctr_drbg.o ext/mbedtls/library/entropy.o ext/mbedtls/library/entropy_poll.o\
-ext/mbedtls/library/timing.o \
+dns_random.o pubsuffix.o dnslabeltext.o \
 ext/json11/json11.o \
 lua-recursor4.o randomhelper.o recpacketcache.o dns.o \
 reczones.o base32.o nsecrecords.o json.o ws-recursor.o ws-api.o \
 version.o responsestats.o webserver.o ext/yahttp/yahttp/reqresp.o ext/yahttp/yahttp/router.o \
 rec-carbon.o secpoll-recursor.o iputils.o dnsname.o \
 rpzloader.o filterpo.o resolver.o ixfr.o dnssecinfra.o gss_context.o \
-ednssubnet.o validate.o validate-recursor.o mbedtlssigners.o \
+ednssubnet.o validate.o validate-recursor.o opensslsigners.o \
 rec-lua-conf.o sortlist.o
 
 REC_CONTROL_OBJECTS=rec_channel.o rec_control.o arguments.o misc.o \
@@ -74,6 +66,7 @@ endif
 
 
 LDFLAGS += $(PROFILEFLAGS) $(STATICFLAGS)
+LDFLAGS += -lcrypto
 
 CXXFLAGS += -DSYSCONFDIR='"$(SYSCONFDIR)"' -DLOCALSTATEDIR='"$(LOCALSTATEDIR)"'
 CFLAGS += -DSYSCONFDIR='"$(SYSCONFDIR)"' -DLOCALSTATEDIR='"$(LOCALSTATEDIR)"'

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -162,7 +162,6 @@ pdns_server_SOURCES = \
 	lua-auth.cc lua-auth.hh \
 	lua-pdns.cc lua-pdns.hh lua-iputils.cc \
 	mastercommunicator.cc \
-	mbedtlscompat.hh \
 	md5.hh \
 	misc.cc misc.hh \
 	nameserver.cc nameserver.hh \
@@ -171,7 +170,6 @@ pdns_server_SOURCES = \
 	packetcache.cc packetcache.hh \
 	packethandler.cc packethandler.hh \
 	pdnsexception.hh \
-	mbedtlssigners.cc \
 	qtype.cc qtype.hh \
 	randomhelper.cc \
 	rcpgenerator.cc \
@@ -206,7 +204,6 @@ pdns_server_LDADD = \
 	@moduleobjects@ \
 	@modulelibs@ \
 	$(LIBDL) \
-	$(MBEDTLS_LIBS) \
 	$(YAHTTP_LIBS) \
 	$(JSON11_LIBS)
 
@@ -223,6 +220,11 @@ endif
 if LIBSODIUM
 pdns_server_SOURCES += sodiumsigners.cc
 pdns_server_LDADD += $(LIBSODIUM_LIBS)
+endif
+
+if MBEDTLS
+pdns_server_SOURCES += mbedtlssigners.cc mbedtlscompat.hh
+pdns_server_LDADD += $(MBEDTLS_LIBS)
 endif
 
 if OPENSSL
@@ -280,12 +282,10 @@ pdnsutil_SOURCES = \
         iputils.cc iputils.hh \
 	json.cc \
 	logger.cc \
-	mbedtlscompat.hh \
 	misc.cc misc.hh \
 	nsecrecords.cc \
 	packetcache.cc \
 	pdnsutil.cc \
-	mbedtlssigners.cc \
 	qtype.cc \
 	randomhelper.cc \
 	rcpgenerator.cc rcpgenerator.hh \
@@ -307,7 +307,6 @@ pdnsutil_LDADD = \
 	@moduleobjects@ \
 	@modulelibs@ \
 	$(LIBDL) \
-	$(MBEDTLS_LIBS) \
 	$(BOOST_PROGRAM_OPTIONS_LIBS) \
 	$(YAHTTP_LIBS) \
 	$(JSON11_LIBS)
@@ -325,6 +324,11 @@ endif
 if LIBSODIUM
 pdnsutil_SOURCES += sodiumsigners.cc
 pdnsutil_LDADD += $(LIBSODIUM_LIBS)
+endif
+
+if MBEDTLS
+pdnsutil_SOURCES += mbedtlssigners.cc mbedtlscompat.hh
+pdnsutil_LDADD += $(MBEDTLS_LIBS)
 endif
 
 if OPENSSL
@@ -378,7 +382,8 @@ zone2sql_SOURCES = \
 	zone2sql.cc \
 	zoneparser-tng.cc
 
-zone2sql_LDADD = $(MBEDTLS_LIBS) $(JSON11_LIBS)
+zone2sql_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS) $(JSON11_LIBS)
+zone2sql_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 zone2json_SOURCES = \
 	arguments.cc \
@@ -404,7 +409,8 @@ zone2json_SOURCES = \
 	zone2json.cc \
 	zoneparser-tng.cc
 
-zone2json_LDADD = $(MBEDTLS_LIBS) $(JSON11_LIBS)
+zone2json_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS) $(JSON11_LIBS)
+zone2json_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 # pkglib_LTLIBRARIES = iputils.la
 # iputils_la_SOURCES = lua-iputils.cc
@@ -439,7 +445,8 @@ zone2ldap_SOURCES = \
 	zone2ldap.cc \
 	zoneparser-tng.cc
 
-zone2ldap_LDADD = $(MBEDTLS_LIBS)
+zone2ldap_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS)
+zone2ldap_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 sdig_SOURCES = \
 	base32.cc \
@@ -463,7 +470,8 @@ sdig_SOURCES = \
 	statbag.cc \
 	unix_utility.cc
 
-sdig_LDADD = $(MBEDTLS_LIBS)
+sdig_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS)
+sdig_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 calidns_SOURCES = \
 	base32.cc \
@@ -486,8 +494,8 @@ calidns_SOURCES = \
 	statbag.cc \
 	unix_utility.cc
 
-calidns_LDADD = $(MBEDTLS_LIBS)
-calidns_LDFLAGS=$(THREADFLAGS) 
+calidns_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS)
+calidns_LDFLAGS = $(AM_LDFLAGS) $(THREADFLAGS) $(OPENSSL_LDFLAGS)
 
 dumresp_SOURCES = \
 	dnslabeltext.cc \
@@ -531,7 +539,8 @@ saxfr_SOURCES = \
 	statbag.cc \
 	unix_utility.cc
 
-saxfr_LDADD = $(MBEDTLS_LIBS)
+saxfr_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS)
+saxfr_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 if PKCS11
 saxfr_SOURCES += pkcs11signers.cc pkcs11signers.hh
@@ -570,7 +579,8 @@ ixplore_SOURCES = \
 	statbag.cc \
 	unix_utility.cc zoneparser-tng.cc
 
-ixplore_LDADD = $(MBEDTLS_LIBS)
+ixplore_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS)
+ixplore_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 if PKCS11
 ixplore_SOURCES += pkcs11signers.cc pkcs11signers.hh
@@ -604,10 +614,12 @@ dnstcpbench_SOURCES = \
 
 dnstcpbench_LDFLAGS = \
 	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS) \
 	$(BOOST_PROGRAM_OPTIONS_LDFLAGS)
 
 dnstcpbench_LDADD = \
 	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS) \
 	$(BOOST_PROGRAM_OPTIONS_LIBS)
 
 nsec3dig_SOURCES = \
@@ -632,7 +644,8 @@ nsec3dig_SOURCES = \
 	statbag.cc \
 	unix_utility.cc
 
-nsec3dig_LDADD = $(MBEDTLS_LIBS)
+nsec3dig_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS)
+nsec3dig_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 if PKCS11
 nsec3dig_SOURCES += pkcs11signers.cc pkcs11signers.hh
@@ -657,7 +670,6 @@ toysdig_SOURCES = \
 	gss_context.cc gss_context.hh \
 	logger.cc \
 	mbedtlscompat.hh \
-	mbedtlssigners.cc \
 	misc.cc misc.hh \
 	nsecrecords.cc \
 	qtype.cc \
@@ -671,7 +683,9 @@ toysdig_SOURCES = \
 	validate.cc validate.hh
 
 
-toysdig_LDADD = $(MBEDTLS_LIBS)
+toysdig_LDFLAGS = $(AM_LDFLAGS)
+toysdig_LDADD =
+
 if GSS_TSIG
 toysdig_LDADD += $(GSS_LIBS)
 endif
@@ -684,6 +698,17 @@ endif
 if PKCS11
 toysdig_SOURCES += pkcs11signers.cc pkcs11signers.hh
 toysdig_LDADD += $(P11KIT1_LIBS)
+endif
+
+if MBEDTLS
+toysdig_SOURCES += mbedtlssigners.cc mbedtlscompat.hh
+toysdig_LDADD += $(MBEDTLS_LIBS)
+endif
+
+if OPENSSL
+toysdig_SOURCES += opensslsigners.cc opensslsigners.hh
+toysdig_LDADD += $(OPENSSL_LIBS)
+toysdig_LDFLAGS += $(OPENSSL_LDFLAGS)
 endif
 
 
@@ -714,7 +739,8 @@ tsig_tests_SOURCES = \
 	tsig-tests.cc \
 	unix_utility.cc
 
-tsig_tests_LDADD = $(MBEDTLS_LIBS)
+tsig_tests_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS)
+tsig_tests_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 if PKCS11
 tsig_tests_SOURCES += pkcs11signers.cc pkcs11signers.hh
@@ -724,6 +750,7 @@ endif
 if GSS_TSIG
 tsig_tests_LDADD += $(GSS_LIBS)
 endif
+
 speedtest_SOURCES = \
 	base32.cc \
 	base64.cc base64.hh \
@@ -743,7 +770,8 @@ speedtest_SOURCES = \
 	statbag.cc \
 	unix_utility.cc
 
-speedtest_LDADD = $(MBEDTLS_LIBS) \
+speedtest_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
+speedtest_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS) \
 	$(RT_LIBS)
 
 dnswasher_SOURCES = \
@@ -780,10 +808,12 @@ dnsbulktest_SOURCES = \
 
 dnsbulktest_LDFLAGS = \
 	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS) \
 	$(BOOST_PROGRAM_OPTIONS_LDFLAGS)
 
 dnsbulktest_LDADD = \
 	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS) \
 	$(BOOST_PROGRAM_OPTIONS_LIBS)
 
 dnsscan_SOURCES = \
@@ -808,7 +838,11 @@ dnsscan_SOURCES = \
 	unix_utility.cc \
 	utility.hh
 
-dnsscan_LDADD = $(MBEDTLS_LIBS)
+dnsscan_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS)
+
+dnsscan_LDADD = $(MBEDTLS_LIBS) $(OPENSSL_LIBS)
 
 dnsreplay_SOURCES = \
 	anadns.hh \
@@ -834,10 +868,12 @@ dnsreplay_SOURCES = \
 
 dnsreplay_LDFLAGS = \
 	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS) \
 	$(BOOST_PROGRAM_OPTIONS_LDFLAGS)
 
 dnsreplay_LDADD = \
 	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS) \
 	$(BOOST_PROGRAM_OPTIONS_LIBS)
 
 nproxy_SOURCES = \
@@ -863,10 +899,12 @@ nproxy_SOURCES = \
 
 nproxy_LDFLAGS = \
 	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS) \
 	$(BOOST_PROGRAM_OPTIONS_LDFLAGS)
 
 nproxy_LDADD = \
 	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS) \
 	$(BOOST_PROGRAM_OPTIONS_LIBS)
 
 notify_SOURCES = \
@@ -893,10 +931,12 @@ notify_SOURCES = \
 
 notify_LDFLAGS = \
 	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS) \
 	$(BOOST_PROGRAM_OPTIONS_LDFLAGS)
 
 notify_LDADD = \
 	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS) \
 	$(BOOST_PROGRAM_OPTIONS_LIBS)
 
 dnsscope_SOURCES = \
@@ -924,10 +964,12 @@ dnsscope_SOURCES = \
 
 dnsscope_LDFLAGS = \
 	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS) \
 	$(BOOST_PROGRAM_OPTIONS_LDFLAGS)
 
 dnsscope_LDADD = \
 	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS) \
 	$(BOOST_PROGRAM_OPTIONS_LIBS)
 
 dnsgram_SOURCES = \
@@ -951,7 +993,13 @@ dnsgram_SOURCES = \
 	unix_utility.cc \
 	utility.hh
 
-dnsgram_LDADD = $(MBEDTLS_LIBS)
+dnsgram_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS)
+
+dnsgram_LDADD = \
+	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS)
 
 dnsdemog_SOURCES = \
 	base32.cc \
@@ -974,7 +1022,13 @@ dnsdemog_SOURCES = \
 	unix_utility.cc \
 	utility.hh
 
-dnsdemog_LDADD = $(MBEDTLS_LIBS)
+dnsdemog_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS)
+
+dnsdemog_LDADD = \
+	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS)
 
 rec_control_SOURCES = \
 	arguments.cc arguments.hh \
@@ -1046,10 +1100,12 @@ testrunner_SOURCES = \
 
 testrunner_LDFLAGS = \
 	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS) \
 	$(BOOST_UNIT_TEST_FRAMEWORK_LDFLAGS) 
 
 testrunner_LDADD = \
 	$(MBEDTLS_LIBS) \
+	$(OPENSSL_LIBS) \
 	$(BOOST_UNIT_TEST_FRAMEWORK_LIBS) \
 	$(RT_LIBS) \
 	$(LIBDL)
@@ -1082,7 +1138,6 @@ pdns_recursor_SOURCES = \
 	lua-recursor4.cc lua-recursor4.hh \
 	lwres.cc lwres.hh \
 	mbedtlscompat.hh \
-	mbedtlssigners.cc \
 	misc.cc \
 	mtasker.hh \
 	nsecrecords.cc \
@@ -1118,9 +1173,10 @@ pdns_recursor_SOURCES = \
 	zoneparser-tng.cc zoneparser-tng.hh
 
 pdns_recursor_LDADD = \
-	$(MBEDTLS_LIBS) \
 	$(YAHTTP_LIBS) \
 	$(JSON11_LIBS)
+
+pdns_recursor_LDFLAGS = $(AM_LDFLAGS)
 
 if PKCS11
 pdns_recursor_SOURCES += pkcs11signers.cc pkcs11signers.hh
@@ -1132,8 +1188,16 @@ pdns_recursor_SOURCES += botan110signers.cc botansigners.cc
 pdns_recursor_LDADD += $(BOTAN110_LIBS)
 endif
 
+if MBEDTLS
+pdns_recursor_SOURCES += mbedtlssigners.cc mbedtlscompat.hh
+pdns_recursor_LDADD += $(MBEDTLS_LIBS)
+endif
 
-pdns_recursor_LDFLAGS = $(AM_LDFLAGS)
+if OPENSSL
+pdns_recursor_SOURCES += opensslsigners.cc opensslsigners.hh
+pdns_recursor_LDADD += $(OPENSSL_LIBS)
+pdns_recursor_LDFLAGS += $(OPENSSL_LDFLAGS)
+endif
 
 if MALLOC_TRACE
 pdns_recursor_SOURCES += malloctrace.cc malloctrace.hh 
@@ -1209,14 +1273,16 @@ nodist_dnsdist_SOURCES = \
 	../ext/json11/json11.cpp
 
 dnsdist_LDFLAGS = \
-	$(AM_LDFLAGS) 
+	$(AM_LDFLAGS) \
+	$(OPENSSL_LDFLAGS)
 
 dnsdist_LDADD = \
 	$(LUA_LIBS) \
 	$(LIBEDIT_LIBS) \
 	$(RT_LIBS) \
 	$(YAHTTP_LIBS) \
-	$(LIBSODIUM_LIBS)
+	$(LIBSODIUM_LIBS) \
+	$(OPENSSL_LIBS)
 
 htmlfiles.h: $(srcdir)/dnsdistdist/html/*
 	$(srcdir)/dnsdistdist/incfiles $(srcdir)/dnsdistdist > $@

--- a/pdns/base64.cc
+++ b/pdns/base64.cc
@@ -5,9 +5,12 @@
 #include <boost/scoped_array.hpp>
 #ifdef HAVE_MBEDTLS2
 #include <mbedtls/base64.h>
-#else
+#elif defined(HAVE_MBEDTLS)
 #include <polarssl/base64.h>
 #include "mbedtlscompat.hh"
+#elif defined(HAVE_OPENSSL)
+#include <openssl/bio.h>
+#include <openssl/evp.h>
 #endif
 
 int B64Decode(const std::string& src, std::string& dst)
@@ -19,7 +22,21 @@ int B64Decode(const std::string& src, std::string& dst)
   size_t dlen = ( src.length() * 6 + 7 ) / 8 ;
   size_t olen = 0;
   boost::scoped_array<unsigned char> d( new unsigned char[dlen] );
+#ifdef HAVE_MBEDTLS
   if ( mbedtls_base64_decode( d.get(), dlen, &olen, (const unsigned char*) src.c_str(), src.length() ) == 0 ) {
+#elif defined(HAVE_OPENSSL)
+  BIO *bio, *b64;
+  bio = BIO_new(BIO_s_mem());
+  BIO_write(bio, src.c_str(), src.length());
+  b64 = BIO_new(BIO_f_base64());
+  bio = BIO_push(b64, bio);
+  BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
+  olen = BIO_read(b64, d.get(), dlen);
+  BIO_free_all(bio);
+  if (olen > 0) {
+#else
+#error "No base64 implementation found"
+#endif
     dst = std::string( (const char*) d.get(), olen );
     return 0;
   }
@@ -29,11 +46,50 @@ int B64Decode(const std::string& src, std::string& dst)
 std::string Base64Encode (const std::string& src)
 {
   if (!src.empty()) {
-    size_t dlen = ( ( ( src.length() + 2 ) / 3 ) * 4 ) + 1;
     size_t olen = 0;
+#ifdef HAVE_MBEDTLS
+    size_t dlen = ( ( ( src.length() + 2 ) / 3 ) * 4 ) + 1;
     boost::scoped_array<unsigned char> dst( new unsigned char[dlen] );
     if( mbedtls_base64_encode( dst.get(), dlen, &olen, (const unsigned char*) src.c_str(), src.length() ) == 0 )
       return std::string( (const char*) dst.get(), olen );
+#elif defined(HAVE_OPENSSL)
+    BIO *bio, *b64;
+    b64 = BIO_new(BIO_f_base64());
+    bio = BIO_new(BIO_s_mem());
+    bio = BIO_push(b64, bio);
+    BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
+    BIO_write(bio, src.c_str(), src.length());
+    BIO_flush(bio);
+    char* pp;
+    std::string out;
+    olen = BIO_get_mem_data(bio, &pp);
+    if (olen > 0) {
+      out = std::string(pp, olen);
+    }
+    BIO_free_all(bio);
+    return out;
+#else
+#error "No base64 implementation found"
+#endif
   }
   return "";
 }
+
+#if 0
+#include <iostream>
+int main() {
+  std::string in = "PowerDNS Test String 1";
+  std::string out = Base64Encode(in);
+  std::cout << out << std::endl;
+  if (out != "UG93ZXJETlMgVGVzdCBTdHJpbmcgMQ==") {
+    std::cerr << "output did not match expected data" << std::endl;
+  }
+  std::string roundtrip;
+  B64Decode(out, roundtrip);
+  std::cout << roundtrip << std::endl;
+  if (roundtrip != in) {
+    std::cerr << "roundtripped data did not match input data" << std::endl;
+  }
+  return 0;
+}
+#endif

--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -1,11 +1,13 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#ifdef HAVE_MBEDTLS2
+#if HAVE_MBEDTLS2
 #include <mbedtls/aes.h>
-#else
+#elif HAVE_MBEDTLS
 #include <polarssl/aes.h>
 #include "mbedtlscompat.hh"
+#elif HAVE_OPENSSL
+#include <openssl/aes.h>
 #endif
 #include <iostream>
 #include <cstdlib>
@@ -14,22 +16,35 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <limits>
+#include <stdexcept>
 #include <stdint.h>
 #include "dns_random.hh"
 
 using namespace std;
 
+#ifdef HAVE_MBEDTLS
 static mbedtls_aes_context g_ctx;
+static size_t g_offset;
+#elif defined(HAVE_OPENSSL)
+static AES_KEY aes_key;
+static unsigned int g_offset;
+#endif
 static unsigned char g_counter[16], g_stream[16];
 static uint32_t g_in;
-static size_t g_offset;
 
 static bool g_initialized;
 
 void dns_random_init(const char data[16])
 {
   g_offset = 0;
+  memset(&g_stream, 0, sizeof(g_stream));
+#if HAVE_MBEDTLS
   mbedtls_aes_setkey_enc(&g_ctx, (const unsigned char*)data, 128);
+#elif HAVE_OPENSSL
+  if (AES_set_encrypt_key((const unsigned char*)data, 128, &aes_key) < 0) {
+    throw std::runtime_error("AES_set_encrypt_key failed");
+  }
+#endif
 
   struct timeval now;
   gettimeofday(&now, 0);
@@ -47,7 +62,13 @@ unsigned int dns_random(unsigned int n)
   if(!g_initialized)
     abort();
   uint32_t out;
+#ifdef HAVE_MBEDTLS
   mbedtls_aes_crypt_ctr(&g_ctx, sizeof(g_in), &g_offset, g_counter, (unsigned char*) &g_stream, (unsigned char*) &g_in, (unsigned char*) &out);
+#elif defined(HAVE_OPENSSL)
+  AES_ctr128_encrypt((const unsigned char*)&g_in, (unsigned char*) &out, sizeof(g_in), &aes_key, g_counter, g_stream, &g_offset);
+#else
+#error "No dns_random implementation found"
+#endif
   return out % n;
 }
 

--- a/pdns/mbedtlssigners.cc
+++ b/pdns/mbedtlssigners.cc
@@ -7,17 +7,20 @@
 #include <mbedtls/ecdsa.h>
 #include <mbedtls/rsa.h>
 #include <mbedtls/base64.h>
+#include <mbedtls/sha1.h>
+#include <mbedtls/sha256.h>
 #else
 #include <polarssl/entropy.h>
 #include <polarssl/ctr_drbg.h>
 #include <polarssl/ecdsa.h>
 #include <polarssl/rsa.h>
 #include <polarssl/base64.h>
+#include <polarssl/sha1.h>
+#include <polarssl/sha256.h>
 #include "mbedtlscompat.hh"
 #endif
 #include <boost/assign/std/vector.hpp> // for 'operator+=()'
 
-#include "sha.hh"
 #include "dnssecinfra.hh"
 using namespace boost::assign;
 

--- a/pdns/md5.hh
+++ b/pdns/md5.hh
@@ -5,15 +5,23 @@
 #include <stdint.h>
 #ifdef HAVE_MBEDTLS2
 #include <mbedtls/md5.h>
-#else
+#elif defined(HAVE_MBEDTLS)
 #include <polarssl/md5.h>
 #include "mbedtlscompat.hh"
+#elif HAVE_OPENSSL
+#include <openssl/md5.h>
 #endif
 
 inline std::string pdns_md5sum(const std::string& input)
 {
   unsigned char result[16] = {0};
+#ifdef HAVE_MBEDTLS
   mbedtls_md5(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result);
+#elif defined(HAVE_OPENSSL)
+  MD5(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result);
+#else
+#error "No md5 implementation found"
+#endif
   return std::string(result, result + sizeof result);
 }
 

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -830,29 +830,19 @@ std::string PKCS11DNSCryptoKeyEngine::hash(const std::string& msg) const {
     // FINE! I'll do this myself, then, shall I?
     switch(d_algorithm) {
     case 5: {
-      SHA1Summer sha;
-      sha.feed(msg);
-      return sha.get();
+      return pdns_sha1sum(msg);
     }
     case 8: {
-      SHA256Summer sha;
-      sha.feed(msg);
-      return sha.get();
+      return pdns_sha256sum(msg);
     }
     case 10: {
-      SHA512Summer sha;
-      sha.feed(msg);
-      return sha.get();
+      return pdns_sha512sum(msg);
     }
     case 13: {
-      SHA256Summer sha;
-      sha.feed(msg);
-      return sha.get();
+      return pdns_sha256sum(msg);
     }
     case 14: {
-      SHA384Summer sha;
-      sha.feed(msg);
-      return sha.get();
+      return pdns_sha384sum(msg);
     }
     };
   };

--- a/pdns/sha.hh
+++ b/pdns/sha.hh
@@ -7,87 +7,67 @@
 #include <mbedtls/sha1.h>
 #include <mbedtls/sha256.h>
 #include <mbedtls/sha512.h>
-#else
+#elif defined(HAVE_MBEDTLS)
 #include <polarssl/sha1.h>
 #include <polarssl/sha256.h>
 #include <polarssl/sha512.h>
 #include "mbedtlscompat.hh"
+#elif defined(HAVE_OPENSSL)
+#include <openssl/sha.h>
+#else
+#error "No SHA implementation found"
 #endif
 
-class SHA1Summer
+inline std::string pdns_sha1sum(const std::string& input)
 {
-public:
-   SHA1Summer() { mbedtls_sha1_starts(&d_context); };
-   void feed(const std::string &str) { feed(str.c_str(), str.length()); };
-   void feed(const char *ptr, size_t len) { mbedtls_sha1_update(&d_context, reinterpret_cast<const unsigned char*>(ptr), len); };
-   const std::string get() const {
-     mbedtls_sha1_context ctx2;
-     unsigned char result[20] = {0};
-     ctx2=d_context;
-     mbedtls_sha1_finish(&ctx2, result);
-     return std::string(result, result + sizeof result);
-   };
-   SHA1Summer(const SHA1Summer&) = delete;
-   SHA1Summer& operator=(const SHA1Summer&) = delete;
-private:
-   mbedtls_sha1_context d_context;
-};
+  unsigned char result[20] = {0};
+#ifdef HAVE_MBEDTLS
+  mbedtls_sha1(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result);
+#elif defined(HAVE_OPENSSL)
+  SHA1(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result);
+#else
+#error "No sha1 implementation found"
+#endif
+  return std::string(result, result + sizeof result);
+}
 
-class SHA256Summer
+inline std::string pdns_sha256sum(const std::string& input)
 {
-public:
-   SHA256Summer() { mbedtls_sha256_starts(&d_context, 0); };
-   void feed(const std::string &str) { feed(str.c_str(), str.length()); };
-   void feed(const char *ptr, size_t len) { mbedtls_sha256_update(&d_context, reinterpret_cast<const unsigned char*>(ptr), len); };
-   const std::string get() const {
-     mbedtls_sha256_context ctx2;
-     unsigned char result[32] = {0};
-     ctx2=d_context;
-     mbedtls_sha256_finish(&ctx2, result);
-     return std::string(result, result + 32);
-   };
-   SHA256Summer(const SHA256Summer&) = delete;
-   SHA256Summer& operator=(const SHA256Summer&) = delete;
-private:
-   mbedtls_sha256_context d_context;
-};
+  unsigned char result[32] = {0};
+#ifdef HAVE_MBEDTLS
+  mbedtls_sha256(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result, 0);
+#elif defined(HAVE_OPENSSL)
+  SHA256(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result);
+#else
+#error "No sha256 implementation found"
+#endif
+  return std::string(result, result + sizeof result);
+}
 
-class SHA384Summer
+inline std::string pdns_sha384sum(const std::string& input)
 {
-public:
-   SHA384Summer() { mbedtls_sha512_starts(&d_context, 1); };
-   void feed(const std::string &str) { feed(str.c_str(), str.length()); };
-   void feed(const char *ptr, size_t len) { mbedtls_sha512_update(&d_context, reinterpret_cast<const unsigned char*>(ptr), len); };
-   const std::string get() const {
-     mbedtls_sha512_context ctx2;
-     unsigned char result[64] = {0};
-     ctx2 = d_context;
-     mbedtls_sha512_finish(&ctx2, result);
-     return std::string(result, result + 48);
-   };
-   SHA384Summer(const SHA384Summer&) = delete;
-   SHA384Summer& operator=(const SHA384Summer&) = delete;
-private:
-   mbedtls_sha512_context d_context;
-};
+  unsigned char result[48] = {0};
+#ifdef HAVE_MBEDTLS
+  mbedtls_sha512(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result, 1);
+#elif defined(HAVE_OPENSSL)
+  SHA384(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result);
+#else
+#error "No sha384 implementation found"
+#endif
+  return std::string(result, result + sizeof result);
+}
 
-class SHA512Summer
+inline std::string pdns_sha512sum(const std::string& input)
 {
-public:
-   SHA512Summer() { mbedtls_sha512_starts(&d_context, 0); };
-   void feed(const std::string &str) { feed(str.c_str(), str.length()); };
-   void feed(const char *ptr, size_t len) { mbedtls_sha512_update(&d_context, reinterpret_cast<const unsigned char*>(ptr), len); };
-   const std::string get() const {
-     mbedtls_sha512_context ctx2;
-     unsigned char result[64] = {0};
-     ctx2=d_context;
-     mbedtls_sha512_finish(&ctx2, result);
-     return std::string(result, result + sizeof result);
-   };
-   SHA512Summer(const SHA512Summer&) = delete;
-   SHA512Summer& operator=(const SHA512Summer&) = delete;
-private:
-   mbedtls_sha512_context d_context;
-};
+  unsigned char result[64] = {0};
+#ifdef HAVE_MBEDTLS
+  mbedtls_sha512(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result, 0);
+#elif defined(HAVE_OPENSSL)
+  SHA512(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result);
+#else
+#error "No sha512 implementation found"
+#endif
+  return std::string(result, result + sizeof result);
+}
 
 #endif /* sha.hh */

--- a/pdns/test-sha_hh.cc
+++ b/pdns/test-sha_hh.cc
@@ -20,51 +20,43 @@ BOOST_AUTO_TEST_SUITE(test_sha_hh)
 typedef boost::tuple<const std::string, const std::string> case_t;
 typedef std::vector<case_t> cases_t;
 
-BOOST_AUTO_TEST_CASE(test_sha1summer) {
+BOOST_AUTO_TEST_CASE(test_sha1) {
    cases_t cases = list_of
       (case_t("abc", "a9 99 3e 36 47 06 81 6a ba 3e 25 71 78 50 c2 6c 9c d0 d8 9d "))
       (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "84 98 3e 44 1c 3b d2 6e ba ae 4a a1 f9 51 29 e5 e5 46 70 f1 "));
    
    for(case_t& val :  cases) {
-      SHA1Summer s;
-      s.feed(val.get<0>());
-      BOOST_CHECK_EQUAL(makeHexDump(s.get()), val.get<1>());
+      BOOST_CHECK_EQUAL(makeHexDump(pdns_sha1sum(val.get<0>())), val.get<1>());
    }
 }
 
-BOOST_AUTO_TEST_CASE(test_sha256summer) {
+BOOST_AUTO_TEST_CASE(test_sha256) {
    cases_t cases = list_of 
       (case_t("abc", "ba 78 16 bf 8f 01 cf ea 41 41 40 de 5d ae 22 23 b0 03 61 a3 96 17 7a 9c b4 10 ff 61 f2 00 15 ad ")) 
       (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "24 8d 6a 61 d2 06 38 b8 e5 c0 26 93 0c 3e 60 39 a3 3c e4 59 64 ff 21 67 f6 ec ed d4 19 db 06 c1 ")); 
 
    for(case_t& val :  cases) { 
-      SHA256Summer s; 
-      s.feed(val.get<0>()); 
-      BOOST_CHECK_EQUAL(makeHexDump(s.get()), val.get<1>()); 
+      BOOST_CHECK_EQUAL(makeHexDump(pdns_sha256sum(val.get<0>())), val.get<1>());
    } 
 }
 
-BOOST_AUTO_TEST_CASE(test_sha384summer) {
+BOOST_AUTO_TEST_CASE(test_sha384) {
    cases_t cases = list_of 
       (case_t("abc", "cb 00 75 3f 45 a3 5e 8b b5 a0 3d 69 9a c6 50 07 27 2c 32 ab 0e de d1 63 1a 8b 60 5a 43 ff 5b ed 80 86 07 2b a1 e7 cc 23 58 ba ec a1 34 c8 25 a7 ")) 
       (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "33 91 fd dd fc 8d c7 39 37 07 a6 5b 1b 47 09 39 7c f8 b1 d1 62 af 05 ab fe 8f 45 0d e5 f3 6b c6 b0 45 5a 85 20 bc 4e 6f 5f e9 5b 1f e3 c8 45 2b ")); 
 
    for(case_t& val :  cases) { 
-      SHA384Summer s; 
-      s.feed(val.get<0>()); 
-      BOOST_CHECK_EQUAL(makeHexDump(s.get()), val.get<1>()); 
+      BOOST_CHECK_EQUAL(makeHexDump(pdns_sha384sum(val.get<0>())), val.get<1>());
    } 
 }
 
-BOOST_AUTO_TEST_CASE(test_sha512summer) {
+BOOST_AUTO_TEST_CASE(test_sha512) {
    cases_t cases = list_of 
       (case_t("abc", "dd af 35 a1 93 61 7a ba cc 41 73 49 ae 20 41 31 12 e6 fa 4e 89 a9 7e a2 0a 9e ee e6 4b 55 d3 9a 21 92 99 2a 27 4f c1 a8 36 ba 3c 23 a3 fe eb bd 45 4d 44 23 64 3c e8 0e 2a 9a c9 4f a5 4c a4 9f ")) 
       (case_t("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "20 4a 8f c6 dd a8 2f 0a 0c ed 7b eb 8e 08 a4 16 57 c1 6e f4 68 b2 28 a8 27 9b e3 31 a7 03 c3 35 96 fd 15 c1 3b 1b 07 f9 aa 1d 3b ea 57 78 9c a0 31 ad 85 c7 a7 1d d7 03 54 ec 63 12 38 ca 34 45 ")); 
 
    for(case_t& val :  cases) { 
-      SHA512Summer s; 
-      s.feed(val.get<0>()); 
-      BOOST_CHECK_EQUAL(makeHexDump(s.get()), val.get<1>()); 
+      BOOST_CHECK_EQUAL(makeHexDump(pdns_sha512sum(val.get<0>())), val.get<1>());
    } 
 }
 

--- a/pdns/version.cc
+++ b/pdns/version.cc
@@ -27,7 +27,7 @@
 #include "version.hh"
 #ifdef HAVE_MBEDTLS2
 #include <mbedtls/version.h>
-#else
+#elif defined(HAVE_MBEDTLS)
 #include <polarssl/version.h>
 #include "mbedtlscompat.hh"
 #endif
@@ -99,6 +99,9 @@ void showBuildConfiguration()
 #ifdef HAVE_LIBSODIUM
     "sodium " <<
 #endif
+#ifdef HAVE_MBEDTLS
+    "mbedtls " <<
+#endif
 #ifdef HAVE_OPENSSL
     "openssl " <<
 #endif
@@ -119,7 +122,7 @@ void showBuildConfiguration()
   // Auth only
   theL()<<Logger::Warning<<"Built-in modules: "<<PDNS_MODULES<<endl;
 #endif
-#ifndef MBEDTLS_SYSTEM
+#if defined(HAVE_MBEDTLS) && !defined(MBEDTLS_SYSTEM)
   theL()<<Logger::Warning<<"Built-in mbed TLS: "<<MBEDTLS_VERSION_STRING<<endl;
 #endif
 #ifdef PDNS_CONFIG_ARGS


### PR DESCRIPTION
For everything where mbedtls is used, so all the hashing, randomness, etc.

Meant to fix #3117.