### PR TITLE
dnsdist: minor fixes reported by coverity and some cleanups

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -19,6 +19,10 @@ void doClient(ComboAddress server, const std::string& command)
 {
   cout<<"Connecting to "<<server.toStringWithPort()<<endl;
   int fd=socket(server.sin4.sin_family, SOCK_STREAM, 0);
+  if (fd < 0) {
+    cerr<<"Unable to connect to "<<server.toStringWithPort()<<endl;
+    return;
+  }
   SConnect(fd, server);
 
   SodiumNonce theirs, ours;
@@ -40,6 +44,7 @@ void doClient(ComboAddress server, const std::string& command)
     msg.assign(resp.get(), len);
     msg=sodDecryptSym(msg, g_key, theirs);
     cout<<msg<<endl;
+    close(fd);
     return; 
   }
 

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -211,7 +211,8 @@ char* my_generator(const char* text, int state)
       "showDNSCryptBinds()", "showDynBlocks()", "showResponseLatency()", "showRules()",
       "showServerPolicy()", "showServers()", "shutdown()", "SpoofAction(",
       "TCAction(", "testCrypto()", "topBandwidth(", "topClients(",
-      "topQueries(", "topResponses(", "topRule()", "truncateTC(",
+      "topQueries(", "topResponses(", "topRule()", "topSlow(",
+      "truncateTC(",
       "webserver(", "whashed", "wrandom" };
   static int s_counter=0;
   int counter=0;

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -113,7 +113,7 @@ std::unordered_map<int, vector<boost::variant<string,double>>> getGenResponses(u
     else
       ret.insert({count++, {rc.second.toString(), rc.first, 100.0*rc.first/total}});
   }
-  ret.insert({count, {"Rest", rest, 100.0*rest/total}});
+  ret.insert({count, {"Rest", rest, total > 0 ? 100.0*rest/total : 100.0}});
   return ret;
 }
 
@@ -966,7 +966,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 	else
 	  g_outputBuffer += (fmt % (count++) % rc.second.toString() % rc.first % (100.0*rc.first/total)).str();
       }
-      g_outputBuffer += (fmt % (count) % "Rest" % rest % (100.0*rest/total)).str();
+      g_outputBuffer += (fmt % (count) % "Rest" % rest % (total > 0 ? 100.0*rest/total : 100.0)).str();
     });
 
   g_lua.writeFunction("getTopQueries", [](unsigned int top, boost::optional<int> labels) {
@@ -1008,7 +1008,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 	else
 	  ret.insert({count++, {rc.second.toString(), rc.first, 100.0*rc.first/total}});
       }
-      ret.insert({count, {"Rest", rest, 100.0*rest/total}});
+      ret.insert({count, {"Rest", rest, total > 0 ? 100.0*rest/total : 100.0}});
       return ret;
 
     });

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -208,8 +208,9 @@ void moreLua()
 
     });
 
-  g_lua.writeFunction("topBandwidth", [](unsigned int top) {
+  g_lua.writeFunction("topBandwidth", [](boost::optional<unsigned int> top_) {
       setLuaNoSideEffect();
+      auto top = top_.get_value_or(10);
       auto res = g_rings.getTopBandwidth(top);
       boost::format fmt("%7d  %s\n");
       for(const auto& l : res) {

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -280,6 +280,11 @@ struct DownstreamState
 {
   DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf);
   DownstreamState(const ComboAddress& remote_): DownstreamState(remote_, ComboAddress(), 0) {}
+  ~DownstreamState()
+  {
+    if (fd >= 0)
+      close(fd);
+  }
 
   int fd;            
   std::thread tid;


### PR DESCRIPTION
Coverity fixes:
- Handle connection error in client mode
- Prevent FPE in some top* functions when no queries were processed
- Close Downstream FD in the destructor (not that we really care)
And some minor cleanups:
- Add topSlow() to the completion rules (#3188)
- Make topBandwidth() default to the top 10 clients (#3189)