### PR TITLE
dist-tar cleanup / fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,6 @@ EXTRA_DIST = \
 	README \
 	.version \
 	build-aux/gen-version \
-	build-scripts/semistaticg++ \
 	codedocs/doxygen.conf \
 	contrib/powerdns.solaris.init.d \
 	contrib/systemd-pdns-recursor.service \

--- a/ext/incbin/UNLICENSE
+++ b/ext/incbin/UNLICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -47,7 +47,6 @@ EXTRA_DIST = \
 	bindparser.h \
 	named.conf.parsertest \
 	pdns.conf-dist \
-	dnsdistdist/html \
 	delaypipe.hh delaypipe.cc
 
 BUILT_SOURCES = \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -20,6 +20,7 @@ EXTRA_DIST=dnslabeltext.rl \
 	   delaypipe.cc delaypipe.hh \
 	   html \
 	   dnsdist.1 \
+	   dnsdist.1.md \
 	   .version \
 	   contrib
 

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -22,7 +22,8 @@ EXTRA_DIST=dnslabeltext.rl \
 	   dnsdist.1 \
 	   dnsdist.1.md \
 	   .version \
-	   contrib
+	   contrib \
+	   build-aux/gen-version
 
 if UNIT_TESTS
 bin_PROGRAMS = dnsdist testrunner

--- a/pdns/dnsdistdist/dnsdist.1.md
+++ b/pdns/dnsdistdist/dnsdist.1.md
@@ -1,0 +1,1 @@
+../../docs/manpages/dnsdist.1.md

--- a/pdns/dnsdistdist/ext/incbin/UNLICENSE
+++ b/pdns/dnsdistdist/ext/incbin/UNLICENSE
@@ -1,0 +1,1 @@
+../../../../ext/incbin/UNLICENSE


### PR DESCRIPTION
Basically change set of files in the auth and dnsdist tarballs.
Mostly the low-hanging fruit from #3118.