### PR TITLE
Drop unused <history.h> include

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -1,7 +1,6 @@
 #include "dnsdist.hh"
 #include "sodcrypto.hh"
 #include <readline.h>
-#include <history.h>
 #include <fstream>
 #include "dolog.hh"
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -28,7 +28,6 @@
 #include <limits>
 #include "dolog.hh"
 #include <readline.h>
-#include <history.h>
 #include "dnsname.hh"
 #include "dnswriter.hh"
 #include "base64.hh"


### PR DESCRIPTION
Not needed for libedit, and the compat symlink apparently is a
Debian-only thing, breaking the build on Fedora.