### PR TITLE
dnsdist: Replace the Lua params with a DNSQuestion `dq` object

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -131,7 +131,7 @@ void* tcpClientThread(int pipefd)
   /* we get launched with a pipe on which we receive file descriptors from clients that we own
      from that point on */
      
-  typedef std::function<bool(ComboAddress, DNSName, uint16_t, dnsheader*)> blockfilter_t;
+  typedef std::function<bool(const DNSQuestion*)> blockfilter_t;
   blockfilter_t blockFilter = 0;
   
   {
@@ -182,8 +182,7 @@ void* tcpClientThread(int pipefd)
         size_t querySize = qlen <= 4096 ? qlen + 512 : qlen;
         char queryBuffer[querySize];
         const char* query = queryBuffer;
-        uint16_t queryLen = qlen;
-        readn2WithTimeout(ci.fd, queryBuffer, queryLen, g_tcpRecvTimeout);
+        readn2WithTimeout(ci.fd, queryBuffer, qlen, g_tcpRecvTimeout);
 #ifdef HAVE_DNSCRYPT
         std::shared_ptr<DnsCryptQuery> dnsCryptQuery = 0;
 
@@ -191,7 +190,7 @@ void* tcpClientThread(int pipefd)
           dnsCryptQuery = std::make_shared<DnsCryptQuery>();
           uint16_t decryptedQueryLen = 0;
           vector<uint8_t> response;
-          bool decrypted = handleDnsCryptQuery(ci.cs->dnscryptCtx, queryBuffer, queryLen, dnsCryptQuery, &decryptedQueryLen, true, response);
+          bool decrypted = handleDnsCryptQuery(ci.cs->dnscryptCtx, queryBuffer, qlen, dnsCryptQuery, &decryptedQueryLen, true, response);
 
           if (!decrypted) {
             if (response.size() > 0) {
@@ -200,23 +199,23 @@ void* tcpClientThread(int pipefd)
             }
             break;
           }
-          queryLen = decryptedQueryLen;
+          qlen = decryptedQueryLen;
         }
 #endif
 
 	uint16_t qtype;
 	unsigned int consumed = 0;
-	DNSName qname(query, queryLen, sizeof(dnsheader), false, &qtype, 0, &consumed);
+	DNSName qname(query, qlen, sizeof(dnsheader), false, &qtype, 0, &consumed);
+	DNSQuestion dq(&qname, qtype, &ci.cs->local, &ci.remote, (dnsheader*)query, querySize, qlen, true);
 	string ruleresult;
-	struct dnsheader* dh =(dnsheader*)query;
-	const uint16_t * flags = getFlagsFromDNSHeader(dh);
+	const uint16_t * flags = getFlagsFromDNSHeader(dq.dh);
 	uint16_t origFlags = *flags;
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 
 	{
 	  WriteLock wl(&g_rings.queryLock);
-	  g_rings.queryRing.push_back({now,ci.remote,qname,queryLen,qtype,*dh});
+	  g_rings.queryRing.push_back({now,ci.remote,qname,dq.len,dq.qtype,*dq.dh});
 	}
 
 	g_stats.queries++;
@@ -233,27 +232,27 @@ void* tcpClientThread(int pipefd)
 	  }
 	}
 
-        if (dh->rd) {
+        if (dq.dh->rd) {
           g_stats.rdQueries++;
         }
 
         if(blockFilter) {
 	  std::lock_guard<std::mutex> lock(g_luamutex);
 	
-	  if(blockFilter(ci.remote, qname, qtype, dh)) {
+	  if(blockFilter(&dq)) {
 	    g_stats.blockFilter++;
 	    goto drop;
           }
-          if(dh->tc && dh->qr) { // don't truncate on TCP/IP!
-            dh->tc=false;        // maybe we should just pass blockFilter the TCP status
-            dh->qr=false;
+          if(dq.dh->tc && dq.dh->qr) { // don't truncate on TCP/IP!
+            dq.dh->tc=false;        // maybe we should just pass blockFilter the TCP status
+            dq.dh->qr=false;
           }
         }
 	
 	DNSAction::Action action=DNSAction::Action::None;
 	for(const auto& lr : *localRulactions) {
-	  if(lr.first->matches(ci.remote, qname, qtype, dh, queryLen)) {
-	    action=(*lr.second)(ci.remote, qname, qtype, dh, queryLen, querySize, &ruleresult);
+	  if(lr.first->matches(&dq)) {
+	    action=(*lr.second)(&dq, &ruleresult);
 	    if(action != DNSAction::Action::None) {
 	      lr.first->d_matches++;
 	      break;
@@ -266,8 +265,8 @@ void* tcpClientThread(int pipefd)
 	  goto drop;
 
 	case DNSAction::Action::Nxdomain:
-	  dh->rcode = RCode::NXDomain;
-	  dh->qr=true;
+	  dq.dh->rcode = RCode::NXDomain;
+	  dq.dh->qr=true;
 	  g_stats.ruleNXDomain++;
 	  break;
 	case DNSAction::Action::Pool: 
@@ -284,9 +283,9 @@ void* tcpClientThread(int pipefd)
 	  break;
 	}
 	
-	if(dh->qr) { // something turned it into a response
-	  if (putNonBlockingMsgLen(ci.fd, queryLen, g_tcpSendTimeout))
-	    writen2WithTimeout(ci.fd, query, queryLen, g_tcpSendTimeout);
+	if(dq.dh->qr) { // something turned it into a response
+	  if (putNonBlockingMsgLen(ci.fd, dq.len, g_tcpSendTimeout))
+	    writen2WithTimeout(ci.fd, query, dq.len, g_tcpSendTimeout);
 
 	  g_stats.selfAnswered++;
 	  goto drop;
@@ -294,7 +293,7 @@ void* tcpClientThread(int pipefd)
 
 	{
 	  std::lock_guard<std::mutex> lock(g_luamutex);
-	  ds = localPolicy->policy(getDownstreamCandidates(g_dstates.getCopy(), pool), ci.remote, qname, qtype, dh);
+	  ds = localPolicy->policy(getDownstreamCandidates(g_dstates.getCopy(), pool), &dq);
 	}
 	int dsock;
 	if(!ds) {
@@ -303,14 +302,14 @@ void* tcpClientThread(int pipefd)
 	}
 
         if (ds->useECS) {
-          uint16_t newLen = queryLen;
-          handleEDNSClientSubnet(queryBuffer, querySize, consumed, &newLen, largerQuery, &ednsAdded, ci.remote);
+          uint16_t newLen = dq.len;
+          handleEDNSClientSubnet(queryBuffer, dq.size, consumed, &newLen, largerQuery, &ednsAdded, ci.remote);
           if (largerQuery.empty() == false) {
             query = largerQuery.c_str();
-            queryLen = largerQuery.size();
-            querySize = largerQuery.size();
+            dq.len = largerQuery.size();
+            dq.size = largerQuery.size();
           } else {
-            queryLen = newLen;
+            dq.len = newLen;
           }
         }
 
@@ -323,7 +322,7 @@ void* tcpClientThread(int pipefd)
         ds->queries++;
         ds->outstanding++;
 
-	if(qtype == QType::AXFR || qtype == QType::IXFR)  // XXX fixme we really need to do better
+	if(dq.qtype == QType::AXFR || dq.qtype == QType::IXFR)  // XXX fixme we really need to do better
 	  break;
 
         uint16_t downstream_failures=0;
@@ -340,7 +339,7 @@ void* tcpClientThread(int pipefd)
           break;
         }
 
-        if(!sendNonBlockingMsgLen(dsock, queryLen, ds->tcpSendTimeout, ds->remote, ds->sourceAddr, ds->sourceItf)) {
+        if(!sendNonBlockingMsgLen(dsock, dq.len, ds->tcpSendTimeout, ds->remote, ds->sourceAddr, ds->sourceItf)) {
 	  vinfolog("Downstream connection to %s died on us, getting a new one!", ds->getName());
           close(dsock);
           sockets[ds->remote]=dsock=setupTCPDownstream(ds);
@@ -350,10 +349,10 @@ void* tcpClientThread(int pipefd)
 
         try {
           if (ds->sourceItf == 0) {
-            writen2WithTimeout(dsock, query, queryLen, ds->tcpSendTimeout);
+            writen2WithTimeout(dsock, query, dq.len, ds->tcpSendTimeout);
           }
           else {
-            sendMsgWithTimeout(dsock, query, queryLen, ds->tcpSendTimeout, ds->remote, ds->sourceAddr, ds->sourceItf);
+            sendMsgWithTimeout(dsock, query, dq.len, ds->tcpSendTimeout, ds->remote, ds->sourceAddr, ds->sourceItf);
           }
         }
         catch(const runtime_error& e) {
@@ -455,7 +454,7 @@ void* tcpClientThread(int pipefd)
         unsigned int udiff = 1000000.0*DiffTime(now,answertime);
         {
           std::lock_guard<std::mutex> lock(g_rings.respMutex);
-          g_rings.respRing.push_back({answertime,  ci.remote, qname, qtype, (unsigned int)udiff, (unsigned int)responseLen, *dh, ds->remote});
+          g_rings.respRing.push_back({answertime,  ci.remote, qname, dq.qtype, (unsigned int)udiff, (unsigned int)responseLen, *dq.dh, ds->remote});
         }
 
         largerQuery.clear();

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -322,17 +322,17 @@ LuaContext g_lua;
 
 GlobalStateHolder<ServerPolicy> g_policy;
 
-shared_ptr<DownstreamState> firstAvailable(const NumberedServerVector& servers, const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh)
+shared_ptr<DownstreamState> firstAvailable(const NumberedServerVector& servers, const DNSQuestion* dq)
 {
   for(auto& d : servers) {
     if(d.second->isUp() && d.second->qps.check())
       return d.second;
   }
-  return leastOutstanding(servers, remote, qname, qtype, dh);
+  return leastOutstanding(servers, dq);
 }
 
 // get server with least outstanding queries, and within those, with the lowest order, and within those: the fastest
-shared_ptr<DownstreamState> leastOutstanding(const NumberedServerVector& servers, const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh)
+shared_ptr<DownstreamState> leastOutstanding(const NumberedServerVector& servers, const DNSQuestion* dq)
 {
   vector<pair<tuple<int,int,double>, shared_ptr<DownstreamState>>> poss;
   /* so you might wonder, why do we go through this trouble? The data on which we sort could change during the sort,
@@ -349,7 +349,7 @@ shared_ptr<DownstreamState> leastOutstanding(const NumberedServerVector& servers
   return poss.begin()->second;
 }
 
-shared_ptr<DownstreamState> valrandom(unsigned int val, const NumberedServerVector& servers, const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh)
+shared_ptr<DownstreamState> valrandom(unsigned int val, const NumberedServerVector& servers, const DNSQuestion* dq)
 {
   vector<pair<int, shared_ptr<DownstreamState>>> poss;
   int sum=0;
@@ -371,19 +371,19 @@ shared_ptr<DownstreamState> valrandom(unsigned int val, const NumberedServerVect
   return p->second;
 }
 
-shared_ptr<DownstreamState> wrandom(const NumberedServerVector& servers, const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh)
+shared_ptr<DownstreamState> wrandom(const NumberedServerVector& servers, const DNSQuestion* dq)
 {
-  return valrandom(random(), servers, remote, qname, qtype, dh);
+  return valrandom(random(), servers, dq);
 }
 
 static uint32_t g_hashperturb;
-shared_ptr<DownstreamState> whashed(const NumberedServerVector& servers, const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh)
+shared_ptr<DownstreamState> whashed(const NumberedServerVector& servers, const DNSQuestion* dq)
 {
-  return valrandom(qname.hash(g_hashperturb), servers, remote, qname, qtype, dh);
+  return valrandom(dq->qname->hash(g_hashperturb), servers, dq);
 }
 
 
-shared_ptr<DownstreamState> roundrobin(const NumberedServerVector& servers, const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh)
+shared_ptr<DownstreamState> roundrobin(const NumberedServerVector& servers, const DNSQuestion* dq)
 {
   NumberedServerVector poss;
 
@@ -506,7 +506,7 @@ try
   string largerQuery;
   uint16_t qtype;
 
-  typedef std::function<bool(ComboAddress, DNSName, uint16_t, dnsheader*)> blockfilter_t;
+  typedef std::function<bool(DNSQuestion*)> blockfilter_t;
   blockfilter_t blockFilter = 0;
   {
     std::lock_guard<std::mutex> lock(g_luamutex);
@@ -532,7 +532,6 @@ try
       std::shared_ptr<DnsCryptQuery> dnsCryptQuery = 0;
 #endif
       char* query = packet;
-      size_t querySize = sizeof(packet);
       ssize_t ret = recvmsg(cs->udpFD, &msgh, 0);
 
       cs->queries++;
@@ -556,8 +555,7 @@ try
 	continue;
       }
 
-      uint16_t len = ret;
-
+      uint16_t len = (uint16_t) ret;
 #ifdef HAVE_DNSCRYPT
       if (cs->dnscryptCtx) {
         vector<uint8_t> response;
@@ -595,11 +593,14 @@ try
       const uint16_t origFlags = *flags;
       unsigned int consumed = 0;
       DNSName qname(query, len, sizeof(dnsheader), false, &qtype, NULL, &consumed);
+
+      DNSQuestion dq(&qname, qtype, &cs->local, &remote, dh, sizeof(packet), len, false);
+
       struct timespec now;
       clock_gettime(CLOCK_MONOTONIC, &now);
       {
         WriteLock wl(&g_rings.queryLock);
-        g_rings.queryRing.push_back({now,remote,qname,len,qtype,*dh});
+        g_rings.queryRing.push_back({now,remote,qname,dq.len,dq.qtype,*dq.dh});
       }
 
       if(auto got=localDynBlock->lookup(remote)) {
@@ -614,7 +615,7 @@ try
       if(blockFilter) {
 	std::lock_guard<std::mutex> lock(g_luamutex);
 	
-	if(blockFilter(remote, qname, qtype, dh)) {
+	if(blockFilter(&dq)) {
 	  g_stats.blockFilter++;
 	  continue;
 	}
@@ -625,8 +626,8 @@ try
       string pool;
 
       for(const auto& lr : *localRulactions) {
-	if(lr.first->matches(remote, qname, qtype, dh, len)) {
-	  action=(*lr.second)(remote, qname, qtype, dh, len, querySize, &ruleresult);
+	if(lr.first->matches(&dq)) {
+	  action=(*lr.second)(&dq, &ruleresult);
 	  if(action != DNSAction::Action::None) {
 	    lr.first->d_matches++;
 	    break;
@@ -639,8 +640,8 @@ try
 	g_stats.ruleDrop++;
 	continue;
       case DNSAction::Action::Nxdomain:
-	dh->rcode = RCode::NXDomain;
-	dh->qr=true;
+	dq.dh->rcode = RCode::NXDomain;
+	dq.dh->qr=true;
 	g_stats.ruleNXDomain++;
 	break;
       case DNSAction::Action::Pool: 
@@ -658,11 +659,11 @@ try
 	break;
       }
 
-      if(dh->qr) { // something turned it into a response
+      if(dq.dh->qr) { // something turned it into a response
         char* response = query;
-        uint16_t responseLen = len;
+        uint16_t responseLen = dq.len;
 #ifdef HAVE_DNSCRYPT
-        uint16_t responseSize = querySize;
+        uint16_t responseSize = dq.size;
 #endif
         g_stats.selfAnswered++;
 
@@ -694,7 +695,7 @@ try
       auto policy=localPolicy->policy;
       {
 	std::lock_guard<std::mutex> lock(g_luamutex);
-	ss = policy(candidates, remote, qname, qtype, dh).get();
+	ss = policy(candidates, &dq).get();
       }
 
       if(!ss) {
@@ -720,7 +721,7 @@ try
       ids->origRemote = remote;
       ids->sentTime.start();
       ids->qname = qname;
-      ids->qtype = qtype;
+      ids->qtype = dq.qtype;
       ids->origDest.sin4.sin_family=0;
       ids->delayMsec = delayMsec;
       ids->origFlags = origFlags;
@@ -733,11 +734,11 @@ try
       dh->id = idOffset;
 
       if (ss->useECS) {
-        handleEDNSClientSubnet(query, querySize, consumed, &len, largerQuery, &(ids->ednsAdded), remote);
+        handleEDNSClientSubnet(query, dq.size, consumed, &dq.len, largerQuery, &(ids->ednsAdded), remote);
       }
 
       if (largerQuery.empty()) {
-        ret = udpClientSendRequestToBackend(ss, ss->fd, query, len);
+        ret = udpClientSendRequestToBackend(ss, ss->fd, query, dq.len);
       }
       else {
         ret = udpClientSendRequestToBackend(ss, ss->fd, largerQuery.c_str(), largerQuery.size());

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -41,8 +41,8 @@ class DNSDistTest(unittest.TestCase):
     mySMN:add(newDNSName("nameAndQtype.tests.powerdns.com."))
     addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(4))
     block=newDNSName("powerdns.org.")
-    function blockFilter(remote, qname, qtype, dh)
-        if(qname:isPartOf(block))
+    function blockFilter(dq)
+        if(dq.qname:isPartOf(block))
         then
             print("Blocking *.powerdns.org")
             return true

--- a/regression-tests.dnsdist/test_EdnsClientSubnet.py
+++ b/regression-tests.dnsdist/test_EdnsClientSubnet.py
@@ -17,8 +17,8 @@ class TestEdnsClientSubnetNoOverride(DNSDistTest):
     _config_template = """
     truncateTC(true)
     block=newDNSName("powerdns.org.")
-    function blockFilter(remote, qname, qtype, dh)
-        if(qname:isPartOf(block))
+    function blockFilter(dq)
+        if(dq.qname:isPartOf(block))
         then
             print("Blocking *.powerdns.org")
             return true
@@ -152,8 +152,8 @@ class TestEdnsClientSubnetOverride(DNSDistTest):
     _config_template = """
     truncateTC(true)
     block=newDNSName("powerdns.org.")
-    function blockFilter(remote, qname, qtype, dh)
-        if(qname:isPartOf(block))
+    function blockFilter(dq)
+        if(dq.qname:isPartOf(block))
         then
             print("Blocking *.powerdns.org")
             return true


### PR DESCRIPTION
In order to:
1. Be able to add functions/member without breaking the API
2. Being as compatible as possible with the PowerDNS Lua API

To limit the parsing/copy to a minimum, this DNSQuestion differs
from the PowerDNS one. Most Lua members are properly wrapped,
but it currently lacks some advanced functions like `getRecords()`
or `setRecords()`, that we might add later.
In addition to the existing `tostring()`, this commit adds
`toString()` ones to match the PowerDNS syntax.

LuaWrapper is supposed to support read-only members, where you
only define the getter and no setter, but I can't find the right
syntax for that to work, so for now the setter are present for
read-only members, and just do nothing.