### PR TITLE
dnsdist: Implement DNSAction.Spoof. Support IPv6-only SpoofAction

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -428,7 +428,7 @@ Valid return values for `LuaAction` functions are:
  * DNSAction.None: continue to the next rule
  * DNSAction.Nxdomain: return a response with a NXDomain rcode
  * DNSAction.Pool: use the specified pool to forward this query
- * DNSAction.Spoof: currently not implemented, see addDomainSpoof() and SpoofAction()
+ * DNSAction.Spoof: spoof the response using the supplied IPv4 (A), IPv6 (AAAA) or string (CNAME) value
 
 DNSSEC
 ------
@@ -828,12 +828,12 @@ instantiate a server with additional parameters
    * `QPSPoolAction()`: set the packet into the specified pool only if it does not exceed the specified QPS limits
    * `QPSAction()`: drop these packets if the QPS limits are exceeded
    * `RCodeAction()`: reply immediatly by turning the query into a response with the specified rcode
-   * `SpoofAction()`: forge a response with the specified IPv4 (for an A query). If you specify both an IPv4 and an IPv6, IPv4 will be used for A and IPv6 for an AAAA
+   * `SpoofAction()`: forge a response with the specified IPv4 (for an A query) or IPv6 (for an AAAA). If you specify two addresses, the first one should be an IPv4 and will be used for A, the second an IPv6 for an AAAA
    * `SpoofCNAMEAction()`: forge a response with the specified CNAME value
    * `TCAction()`: create answer to query with TC and RD bits set, to move to TCP/IP
  * Specialist rule generators
    * `addAnyTCRule()`: generate TC=1 answers to ANY queries, moving them to TCP
-   * `addDomainSpoof(domain, ip[, ip6])`: generate answers for A queries using the ip parameter. If ip6 is supplied, generate answers for AAAA queries too
+   * `addDomainSpoof(domain, ip[, ip6])`: generate answers for A queries using the ip parameter (AAAA if ip is an IPv6). If ip6 is supplied, generate answers for AAAA queries too
    * `addDomainCNAMESpoof(domain, cname)`: generate CNAME answers for queries using the specified value
    * `addDisableValidationRule(domain)`: set the CD flags to 1 for all queries matching the specified domain
    * `addNoRecurseRule(domain)`: clear the RD flag for all queries matching the specified domain

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -275,7 +275,8 @@ void* tcpClientThread(int pipefd)
 	  break;
 	  
 	case DNSAction::Action::Spoof:
-	  ;
+	  spoofResponseFromString(ci.remote, qname, qtype, dh, queryLen, querySize, ruleresult);
+	  /* fall-through */;
 	case DNSAction::Action::HeaderModify:
 	  break;
 	case DNSAction::Action::Allow:

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -440,6 +440,7 @@ std::shared_ptr<DownstreamState> wrandom(const NumberedServerVector& servers, co
 std::shared_ptr<DownstreamState> whashed(const NumberedServerVector& servers, const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh);
 std::shared_ptr<DownstreamState> roundrobin(const NumberedServerVector& servers, const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh);
 int getEDNSZ(const char* packet, unsigned int len);
+void spoofResponseFromString(const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh, uint16_t& len, uint16_t querySize, const string& spoofContent);
 uint16_t getEDNSOptionCode(const char * packet, size_t len);
 void dnsdistWebserverThread(int sock, const ComboAddress& local, const string& password);
 bool getMsgLen32(int fd, uint32_t* len);

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -356,7 +356,16 @@ public:
 class SpoofAction : public DNSAction
 {
 public:
-  SpoofAction(const ComboAddress& a) : d_a(a) { d_aaaa.sin4.sin_family = 0;}
+  SpoofAction(const ComboAddress& a)
+  {
+    if (a.sin4.sin_family == AF_INET) {
+      d_a = a;
+      d_aaaa.sin4.sin_family = 0;
+    } else {
+      d_a.sin4.sin_family = 0;
+      d_aaaa = a;
+    }
+  }
   SpoofAction(const ComboAddress& a, const ComboAddress& aaaa) : d_a(a), d_aaaa(aaaa) {}
   SpoofAction(const string& cname): d_cname(cname) { d_a.sin4.sin_family = 0; d_aaaa.sin4.sin_family = 0; }
   DNSAction::Action operator()(const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh, uint16_t& len, uint16_t bufferSize, string* ruleresult) const override


### PR DESCRIPTION
DNSAction.Spoof can be used to return a spoofed response from
a Lua rule. It supports an IPv4 (A), IPv6 (AAAA) or a DNSName
(CNAME).
SpoofAction() can be used IPv6-only, by passing a IPv6 as the
first parameter. It now supports spoofing IPv4-only, IPv6-only,
IPv4 and IPv6, and CNAME.
Closes #3064.