### PR TITLE
Some fixes for lua backend for Lua version >= 5.2

### DIFF
--- a/modules/luabackend/minimal.cc
+++ b/modules/luabackend/minimal.cc
@@ -68,7 +68,7 @@ bool LUABackend::list(const DNSName &target, int domain_id, bool include_disable
     lua_rawgeti(lua, LUA_REGISTRYINDEX, f_lua_list);
 
     lua_pushstring(lua, target.toString().c_str());
-    lua_pushnumber(lua, domain_id);
+    lua_pushinteger(lua, domain_id);
 
     if(lua_pcall(lua, 2, 1, f_lua_exec_error) != 0) {
 	string e = backend_name + lua_tostring(lua, -1);
@@ -102,7 +102,7 @@ void LUABackend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *p, 
 //    lua_pushnumber(lua, qtype.getCode());
     lua_pushstring(lua, qtype.getName().c_str());
     lua_pushstring(lua, qname.toString().       c_str());
-    lua_pushnumber(lua, domain_id);
+    lua_pushinteger(lua, domain_id);
 
     if(lua_pcall(lua, 3, 0, f_lua_exec_error) != 0) {
 	string e = backend_name + lua_tostring(lua, -1);


### PR DESCRIPTION
Fix importing of standard libraries for Lua version >= 5.2
Change some lua_pushnumbers to lua_pushinteger because Lua 5.3 has native integers.
(so that domain_id is 1234 instead of 1234.0 in the debug logging)