### PR TITLE
Fix the forward zones in the recursor

### DIFF
--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -460,7 +460,7 @@ public:
 
 private:
   struct GetBestNSAnswer;
-  int doResolveAt(set<DNSName> nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret,
+  int doResolveAt(map<DNSName, pair<ComboAddress, bool> > &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret,
         	  int depth, set<GetBestNSAnswer>&beenthere);
   int doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int depth, set<GetBestNSAnswer>& beenthere);
   bool doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int depth, int &res);
@@ -468,9 +468,9 @@ private:
   bool doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int depth, int &res);
   bool doCacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int depth, int &res);
   void getBestNSFromCache(const DNSName &qname, const QType &qtype, vector<DNSRecord>&bestns, bool* flawedNSSet, int depth, set<GetBestNSAnswer>& beenthere);
-  DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, set<DNSName>& nsset, bool* flawedNSSet, int depth, set<GetBestNSAnswer>&beenthere);
+  DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, map<DNSName, pair<ComboAddress, bool> >& nsset, bool* flawedNSSet, int depth, set<GetBestNSAnswer>&beenthere);
 
-  inline vector<DNSName> shuffleInSpeedOrder(set<DNSName> &nameservers, const string &prefix);
+  inline vector<DNSName> shuffleInSpeedOrder(map<DNSName, pair<ComboAddress, bool> > &nameservers, const string &prefix);
   bool moreSpecificThan(const DNSName& a, const DNSName &b);
   vector<ComboAddress> getAddrs(const DNSName &qname, int depth, set<GetBestNSAnswer>& beenthere);
 private:

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -33,6 +33,12 @@ BOOST_AUTO_TEST_CASE(test_ComboAddress) {
   
   withport = ComboAddress("[::]:5300", 53);
   BOOST_CHECK_EQUAL(withport.sin4.sin_port, htons(5300));
+
+  // Verify that 2 'empty' ComboAddresses are equal, used in syncres.hh to
+  // signal auth-zones
+  ComboAddress a = ComboAddress();
+  ComboAddress b = ComboAddress();
+  BOOST_CHECK(a == b);
 }
 
 BOOST_AUTO_TEST_CASE(test_ComboAddressTruncate) {


### PR DESCRIPTION
In the pre-DNSName era, when dns-native names were passed as strings, we
overloaded the NS-name for a forward or auth zone. e.g. an empty string
meant 'this is an auth zone' and '+203.0.113.1' meant 'forward to 203.0.113.1
with the RD bit set'. With DNSNames, this is impossible (yay!).

In this commit, the set of strings (and later DNSNames), is replaced by
a map where a DNSName is the key and the value is a pair of a
ComboAddress and a boolean.

A non-empty DNSName: This is a normal NS, recurse as usual (the pair is
ignored).

An empty DNSName and empty ComboAddress: We are auth for this zone,
check the auth store for an answer.

An empty DNSName and non-empty ComboAddress: The query must be forwarded
to the ComboAddress specified and the boolean in the pair tells us the
value of the RD bit in the query we need to send.