### PR TITLE
dnsdist: Fix Lua Spoof PR not being compatible w/ the DNSQuestion one

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -274,7 +274,7 @@ void* tcpClientThread(int pipefd)
 	  break;
 	  
 	case DNSAction::Action::Spoof:
-	  spoofResponseFromString(ci.remote, qname, qtype, dh, queryLen, querySize, ruleresult);
+	  spoofResponseFromString(dq, ruleresult);
 	  /* fall-through */;
 	case DNSAction::Action::HeaderModify:
 	  break;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -482,17 +482,17 @@ int getEDNSZ(const char* packet, unsigned int len)
   return 0x100 * (*z) + *(z+1);
 }
 
-void spoofResponseFromString(const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh, uint16_t& len, uint16_t querySize, const string& spoofContent)
+void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent)
 {
   string result;
   try {
     ComboAddress spoofAddr(spoofContent);
     SpoofAction sa(spoofAddr);
-    sa(remote, qname, qtype, dh, len, querySize, &result);
+    sa(&dq, &result);
   }
   catch(PDNSException &e) {
     SpoofAction sa(spoofContent);
-    sa(remote, qname, qtype, dh, len, querySize, &result);
+    sa(&dq, &result);
   }
 }
 
@@ -662,7 +662,7 @@ try
 	pool=ruleresult;
 	break;
       case DNSAction::Action::Spoof:
-	spoofResponseFromString(remote, qname, qtype, dh, len, querySize, ruleresult);
+	spoofResponseFromString(dq, ruleresult);
 	/* fall-through */;
       case DNSAction::Action::HeaderModify:
 	break;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -454,7 +454,7 @@ std::shared_ptr<DownstreamState> wrandom(const NumberedServerVector& servers, co
 std::shared_ptr<DownstreamState> whashed(const NumberedServerVector& servers, const DNSQuestion* dq);
 std::shared_ptr<DownstreamState> roundrobin(const NumberedServerVector& servers, const DNSQuestion* dq);
 int getEDNSZ(const char* packet, unsigned int len);
-void spoofResponseFromString(const ComboAddress& remote, const DNSName& qname, uint16_t qtype, dnsheader* dh, uint16_t& len, uint16_t querySize, const string& spoofContent);
+void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent);
 uint16_t getEDNSOptionCode(const char * packet, size_t len);
 void dnsdistWebserverThread(int sock, const ComboAddress& local, const string& password);
 bool getMsgLen32(int fd, uint32_t* len);

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -549,18 +549,18 @@ class TestAdvancedDelay(DNSDistTest):
 class TestAdvancedLuaSpoof(DNSDistTest):
 
     _config_template = """
-    function spoof1rule(remote, qname, qtype, dh, len)
-        if(qtype==1) -- A
+    function spoof1rule(dq)
+        if(dq.qtype==1) -- A
         then
                 return DNSAction.Spoof, "192.0.2.1"
-        elseif(qtype == 28) -- AAAA
+        elseif(dq.qtype == 28) -- AAAA
         then
                 return DNSAction.Spoof, "2001:DB8::1"
         else
                 return DNSAction.None, ""
         end
     end
-    function spoof2rule(remote, qname, qtype, dh, len)
+    function spoof2rule(dq)
         return DNSAction.Spoof, "spoofedcname.tests.powerdns.com."
     end
     addLuaAction("luaspoof1.tests.powerdns.com.", spoof1rule)


### PR DESCRIPTION
PR #3241 did not take PR #3233 into account, my bad.