### PR TITLE
dnsdist: Document toString() aliases. Add TCPRule. Make AnyTCRule set TC only over UDP

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -895,11 +895,14 @@ instantiate a server with additional parameters
      * `newCA(address)`: return a new ComboAddress
      * `getPort()`: return the port number
      * `tostring()`: return in human-friendly format
+     * `toString()`: alias for `tostring()`
      * `tostringWithPort()`: return in human-friendly format, with port number
+     * `toStringWithPort()`: alias for `tostringWithPort()`
    * DNSName related:
      * `newDNSName(name)`: make a DNSName based on this .-terminated name
      * member `isPartOf(dnsname)`: is this dnsname part of that dnsname
      * member `tostring()`: return as a human friendly . terminated string
+     * member `toString()`: alias for `tostring()`
    * DNSQuestion related:
      * member `dh`: DNSHeader
      * member `len`: the question length

--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -301,6 +301,7 @@ Rules have selectors and actions. Current selectors are:
  * QType (QTypeRule)
  * RegexRule on query name
  * Packet requests DNSSEC processing
+ * Query received over UDP or TCP
 
 A special rule is `AndRule{rule1, rule2}`, which only matches if all of its subrules match.
 
@@ -336,6 +337,7 @@ A DNS rule can be:
  * a QTypeRule
  * a RegexRule
  * a SuffixMatchNodeRule
+ * a TCPRule
 
 A convenience function `makeRule()` is supplied which will make a NetmaskGroupRule for you or a SuffixMatchNodeRule
 depending on how you call it. `makeRule("0.0.0.0/0")` will for example match all IPv4 traffic, `makeRule{"be","nl","lu"}` will
@@ -354,7 +356,8 @@ the exact definition of `blockFilter()` is at the end of this document.
 
 ANY or whatever to TC
 ---------------------
-The `blockFilter()` also gets passed read/writable copy of the DNS Header.
+The `blockFilter()` also gets passed read/writable copy of the DNS Header,
+via `dq.dh`.
 If you invoke setQR(1) on that, `dnsdist` knows you turned the packet into
 a response, and will send the answer directly to the original client.
 
@@ -815,6 +818,7 @@ instantiate a server with additional parameters
    * `QTypeRule(qtype)`: matches queries with the specified qtype
    * `RegexRule(regex)`: matches the query name against the supplied regex
    * `SuffixMatchNodeRule()`: matches based on a group of domain suffixes for rapid testing of membership
+   * `TCPRule(tcp)`: matches question received over TCP if `tcp` is true, over UDP otherwise
  * Rule management related:
    * `showRules()`: show all defined rules (Pool, Block, QPS, addAnyTCRule)
    * `rmRule(n)`: remove rule n
@@ -836,7 +840,7 @@ instantiate a server with additional parameters
    * `SpoofCNAMEAction()`: forge a response with the specified CNAME value
    * `TCAction()`: create answer to query with TC and RD bits set, to move to TCP/IP
  * Specialist rule generators
-   * `addAnyTCRule()`: generate TC=1 answers to ANY queries, moving them to TCP
+   * `addAnyTCRule()`: generate TC=1 answers to ANY queries received over UDP, moving them to TCP
    * `addDomainSpoof(domain, ip[, ip6])`: generate answers for A queries using the ip parameter (AAAA if ip is an IPv6). If ip6 is supplied, generate answers for AAAA queries too
    * `addDomainCNAMESpoof(domain, cname)`: generate CNAME answers for queries using the specified value
    * `addDisableValidationRule(domain)`: set the CD flags to 1 for all queries matching the specified domain

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -312,10 +312,14 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 		      } );
 
   g_lua.writeFunction("makeRule", makeRule);
+
   g_lua.writeFunction("addAnyTCRule", []() {
       setLuaSideEffect();
       auto rules=g_rulactions.getCopy();
-      rules.push_back({ std::make_shared<QTypeRule>(0xff), std::make_shared<TCAction>()});
+      std::vector<pair<int, shared_ptr<DNSRule> >> v;
+      v.push_back({1, std::make_shared<QTypeRule>(0xff)});
+      v.push_back({2, std::make_shared<TCPRule>(false)});
+      rules.push_back({ std::shared_ptr<DNSRule>(new AndRule(v)), std::make_shared<TCAction>()});
       g_rulactions.setState(rules);
     });
 
@@ -699,6 +703,9 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       return std::shared_ptr<DNSRule>(new AndRule(a));
     });
 
+  g_lua.writeFunction("TCPRule", [](bool tcp) {
+      return std::shared_ptr<DNSRule>(new TCPRule(tcp));
+    });
 
   g_lua.writeFunction("addAction", [](luadnsrule_t var, std::shared_ptr<DNSAction> ea) 
 		      {

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -211,6 +211,24 @@ private:
   uint16_t d_qtype;
 };
 
+class TCPRule : public DNSRule
+{
+public:
+  TCPRule(bool tcp): d_tcp(tcp)
+  {
+  }
+  bool matches(const DNSQuestion* dq) const override
+  {
+    return dq->tcp == d_tcp;
+  }
+  string toString() const override
+  {
+    return (d_tcp ? "TCP" : "UDP");
+  }
+private:
+  bool d_tcp;
+};
+
 class DropAction : public DNSAction
 {
 public:

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -157,6 +157,7 @@ class DNSDistTest(unittest.TestCase):
             if not answered:
                 # unexpected query, or health check
                 response = dns.message.make_response(request)
+                rrset = None
                 if request.question[0].rdclass == dns.rdataclass.IN:
                     if request.question[0].rdtype == dns.rdatatype.A:
                         rrset = dns.rrset.from_text(request.question[0].name,
@@ -211,6 +212,7 @@ class DNSDistTest(unittest.TestCase):
             if not answered:
                 # unexpected query, or health check
                 response = dns.message.make_response(request)
+                rrset = None
                 if request.question[0].rdclass == dns.rdataclass.IN:
                     if request.question[0].rdtype == dns.rdatatype.A:
                         rrset = dns.rrset.from_text(request.question[0].name,


### PR DESCRIPTION
- For maximum compatibility with PowerDNS Lua scripts, I have recently added toString() and toStringWithPort() aliases, but forgot to document them
- Add TCPRule() to be able to match queries based on the protocol they were received over
- Make addAnyTCRule set TC=1 for ANY queries received on UDP, but not on TCP, as suggested by Greg on the dnsdist mailing-list (thanks!)
