### PR TITLE
dnsdist: Do not create socket/thread for fake DS in client mode

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -306,15 +306,17 @@ void* responderThread(std::shared_ptr<DownstreamState> state)
 
 DownstreamState::DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf_): remote(remote_), sourceAddr(sourceAddr_), sourceItf(sourceItf_)
 {
-  fd = SSocket(remote.sin4.sin_family, SOCK_DGRAM, 0);
-  if (!IsAnyAddress(sourceAddr)) {
-    SSetsockopt(fd, SOL_SOCKET, SO_REUSEADDR, 1);
-    SBind(fd, sourceAddr);
+  if (!IsAnyAddress(remote)) {
+    fd = SSocket(remote.sin4.sin_family, SOCK_DGRAM, 0);
+    if (!IsAnyAddress(sourceAddr)) {
+      SSetsockopt(fd, SOL_SOCKET, SO_REUSEADDR, 1);
+      SBind(fd, sourceAddr);
+    }
+    SConnect(fd, remote);
+    idStates.resize(g_maxOutstanding);
+    sw.start();
+    infolog("Added downstream server %s", remote.toStringWithPort());
   }
-  SConnect(fd, remote);
-  idStates.resize(g_maxOutstanding);
-  sw.start();
-  infolog("Added downstream server %s", remote.toStringWithPort());
 }
 
 std::mutex g_luamutex;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -286,7 +286,7 @@ struct DownstreamState
       close(fd);
   }
 
-  int fd;            
+  int fd{-1};
   std::thread tid;
   ComboAddress remote;
   QPSLimiter qps;


### PR DESCRIPTION
While parsing the configuration in client mode, we create a fake
DownstreamState for each newServer() call, because we need it to
return a valid DownstreamState object. Unfortunately this leads
to the creation of a socket for 0.0.0.0, and a subsequent
connection attempt.
We now detect that the address does not make sense in this context
and do not create the associated socket.
Closes #3257.