### PR TITLE
ZoneParser: Throw PDNSException on too many SOA data elements

### DIFF
--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -433,6 +433,8 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
 
   case QType::SOA:
     stringtok(recparts, rr.content);
+    if(recparts.size() > 7)
+      throw PDNSException("SOA record contents for "+rr.qname.toString()+" contains too many parts");
     if(recparts.size() > 1) {
       recparts[0]=toCanonic(d_zonename, recparts[0]).toStringRootDot();
       recparts[1]=toCanonic(d_zonename, recparts[1]).toStringRootDot();


### PR DESCRIPTION
This gives a better error than just "Fatal Error: stoul" for `zone2sql` and in the log when parsing the zone.