### PR TITLE
dnsdist: Drop queries with no question (qdcount == 0)

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -202,6 +202,17 @@ void* tcpClientThread(int pipefd)
           qlen = decryptedQueryLen;
         }
 #endif
+        struct dnsheader* dh = (struct dnsheader*) query;
+
+        if(dh->qr) {   // don't respond to responses
+          g_stats.nonCompliantQueries++;
+          goto drop;
+        }
+
+        if(dh->qdcount == 0) {
+          g_stats.emptyQueries++;
+          goto drop;
+        }
 
 	uint16_t qtype;
 	unsigned int consumed = 0;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -601,6 +601,11 @@ try
 	continue;
       }
 
+      if(dh->qdcount == 0) {
+        g_stats.emptyQueries++;
+        continue;
+      }
+
       if (dh->rd) {
         g_stats.rdQueries++;
       }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -42,6 +42,7 @@ struct DNSDistStats
   stat_t queries{0};
   stat_t nonCompliantQueries{0};
   stat_t rdQueries{0};
+  stat_t emptyQueries{0};
   stat_t aclDrops{0};
   stat_t blockFilter{0};
   stat_t dynBlocked{0};
@@ -73,6 +74,7 @@ struct DNSDistStats
     {"real-memory-usage", getRealMemoryUsage},
     {"noncompliant-queries", &nonCompliantQueries},
     {"rdqueries", &rdQueries},
+    {"empty-queries", &emptyQueries},
     {"cpu-user-msec", getCPUTimeUser},
     {"cpu-sys-msec", getCPUTimeSystem},
     {"fd-usage", getOpenFileDescriptors}, {"dyn-blocked", &dynBlocked}, 


### PR DESCRIPTION
Added a counter for these dropped queries, `emptyQueries` too.
This might be an issue for DNS cookies some day, as it uses
query with no question [1].
Additionnaly drops queries with QR set over TCP too to be
consistent with UDP.
This might close #3290.

[1]: https://tools.ietf.org/html/draft-ietf-dnsop-cookies-09#section-5.4