### PR TITLE
implement pdnsutil create-zone zone nsname, add-record, delete-rrset, replace-rrset

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -985,10 +985,10 @@ int addOrReplaceRecord(bool addOrReplace, const vector<string>& cmds) {
   rr.auth = 1;
   rr.domain_id = di.id;
   rr.qname = name;
-
+  DNSResourceRecord oldrr;
   if(addOrReplace) { // the 'add' case
     B.lookup(rr.qtype, rr.qname, 0, di.id);
-    DNSResourceRecord oldrr;
+
     while(B.get(oldrr)) 
       newrrs.push_back(oldrr);
   }
@@ -1011,8 +1011,8 @@ int addOrReplaceRecord(bool addOrReplace, const vector<string>& cmds) {
   bool found=false;
   if(rr.qtype.getCode() == QType::CNAME) { // this will save us SO many questions
 
-    while(B.get(rr)) {
-      if(addOrReplace || rr.qtype.getCode() != QType::CNAME) // the replace case is ok if we replace one CNAME by the other
+    while(B.get(oldrr)) {
+      if(addOrReplace || oldrr.qtype.getCode() != QType::CNAME) // the replace case is ok if we replace one CNAME by the other
         found=true;
     }
     if(found) {
@@ -1021,8 +1021,8 @@ int addOrReplaceRecord(bool addOrReplace, const vector<string>& cmds) {
     }
   }
   else {
-    while(B.get(rr)) {
-      if(rr.qtype.getCode() == QType::CNAME)
+    while(B.get(oldrr)) {
+      if(oldrr.qtype.getCode() == QType::CNAME)
         found=true;
     }
     if(found) {


### PR DESCRIPTION
Now, it may be that this is not the best API. And this is the time to let me know :-) Open issue is: if we do @-expansion in the 'record name' field, why not in the content field? Within the time available, it looks iffy that we can do a good job there. But perhaps we have to. Alternatively, we don't expand the @ in the record name field either.
```
$ pdnsutil create-zone ds9a.nl ns1.powerdns.com
Creating empty zone 'ds9a.nl.'
Also adding one NS record

$ pdnsutil add-record ds9a.nl @ A 1.2.3.4
$ pdnsutil add-record ds9a.nl "*" CNAME ds9a.nl
$ pdnsutil list-zone ds9a.nl
*.ds9a.nl.      3600    IN      CNAME   ds9a.nl.
ds9a.nl.        3600    IN      A       1.2.3.4 
ds9a.nl.        3600    IN      SOA     ns1.powerdns.com hostmaster.ds9a.nl 1 10800 3600 604800 3600
$ pdnsutil replace-rrset ds9a.nl @ A 3.3.3.3 4.4.4.4
$ pdnsutil list-zone ds9a.nl
*.ds9a.nl.      3600    IN      CNAME   ds9a.nl.
ds9a.nl.        3600    IN      A       3.3.3.3 
ds9a.nl.        3600    IN      A       4.4.4.4 
ds9a.nl.        3600    IN      SOA     ns1.powerdns.com hostmaster.ds9a.nl 1 10800 3600 604800 3600

$ pdnsutil add-record ds9a.nl @ AAAA :::1
Error: Parsing record content (try 'pdnsutil check-zone'): while parsing IPv6 address: ':::1' is invalid
$ pdnsutil add-record ds9a.nl @ AAAA ::1

$ pdnsutil list-zone ds9a.nl
*.ds9a.nl.      3600    IN      CNAME   ds9a.nl.
ds9a.nl.        3600    IN      AAAA    ::1
ds9a.nl.        3600    IN      SOA     ns1.powerdns.com hostmaster.ds9a.nl 1 10800 3600 604800 3600
```
