### PR TITLE
dnsdist: Fix TCP clients threads vector and counters initialization

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -853,8 +853,8 @@ void* maintThread()
   for(;;) {
     sleep(interval);
 
-    if(g_tcpclientthreads.d_queued > 1 && g_tcpclientthreads.d_numthreads < g_maxTCPClientThreads)
-      g_tcpclientthreads.addTCPClientThread();
+    if(g_tcpclientthreads->d_queued > 1 && g_tcpclientthreads->d_numthreads < g_maxTCPClientThreads)
+      g_tcpclientthreads->addTCPClientThread();
 
     for(auto& dss : g_dstates.getCopy()) { // this points to the actual shared_ptrs!
       if(dss->availability==DownstreamState::Availability::Auto) {
@@ -1264,6 +1264,8 @@ try
 
   /* this need to be done _after_ dropping privileges */
   g_delay = new DelayPipe<DelayedPacket>();
+
+  g_tcpclientthreads = std::make_shared<TCPClientCollection>(g_maxTCPClientThreads);
 
   for(auto& t : todo)
     t();

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -258,16 +258,16 @@ struct ClientState
 
 class TCPClientCollection {
   std::vector<int> d_tcpclientthreads;
-  std::atomic<uint64_t> d_pos;
+  std::atomic<uint64_t> d_pos{0};
 public:
-  std::atomic<uint64_t> d_queued, d_numthreads;
+  std::atomic<uint64_t> d_queued{0}, d_numthreads{0};
 
-  TCPClientCollection()
+  TCPClientCollection(size_t maxThreads)
   {
-    d_tcpclientthreads.reserve(1024);
+    d_tcpclientthreads.reserve(maxThreads);
   }
 
-  int getThread() 
+  int getThread()
   {
     int pos = d_pos++;
     ++d_queued;
@@ -276,7 +276,7 @@ public:
   void addTCPClientThread();
 };
 
-extern TCPClientCollection g_tcpclientthreads;
+extern std::shared_ptr<TCPClientCollection> g_tcpclientthreads;
 
 struct DownstreamState
 {


### PR DESCRIPTION
By tracking the FD leak reported in #3300, I observed that:
* we could create up to g_maxTCPClientThreads TCP threads,
but the corresponding vector size was hardcoded at 1024
(which the default for g_maxTCPClientThreads)
* the counters were not explicitly initialized

This commit fixes that and adds some additional checks to make
sure we don't add more TCP client threads, as that could lead to
a race if the vector is resized.