### PR TITLE
dnsdist: Add reuseport support, maxOutstanding -> 10240, document perf tuning

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -805,8 +805,8 @@ Here are all functions:
     * `setACL({netmask, netmask})`: replace the ACL set with these netmasks. Use `setACL({})` to reset the list, meaning no one can use us
     * `showACL()`: show our ACL set
  * Network related:
-    * `addLocal(netmask, [false])`: add to addresses we listen on. Second optional parameter sets TCP/IP or not.
-    * `setLocal(netmask, [false])`: reset list of addresses we listen on to this address. Second optional parameter sets TCP/IP or not.
+    * `addLocal(netmask, [false], [false])`: add to addresses we listen on. Second optional parameter sets TCP/IP or not. Third optional parameter sets SO_REUSEPORT when available.
+    * `setLocal(netmask, [false], [false])`: reset list of addresses we listen on to this address. Second optional parameter sets TCP/IP or not. Third optional parameter sets SO_REUSEPORT when available.
  * Blocking related:
     * `addDomainBlock(domain)`: block queries within this domain
  * Carbon/Graphite/Metronome statistics related:
@@ -1008,7 +1008,7 @@ instantiate a server with additional parameters
     * `setMaxUDPOutstanding(n)`: set the maximum number of outstanding UDP queries to a given backend server. This can only be set at configuration time
     * `setCacheCleaningDelay(n)`: set the interval in seconds between two runs of the cache cleaning algorithm, removing expired entries
  * DNSCrypt related:
-    * `addDNSCryptBind("127.0.0.1:8443", "provider name", "/path/to/resolver.cert", "/path/to/resolver.key"):` listen to incoming DNSCrypt queries on 127.0.0.1 port 8443, with a provider name of "provider name", using a resolver certificate and associated key stored respectively in the `resolver.cert` and `resolver.key` files
+    * `addDNSCryptBind("127.0.0.1:8443", "provider name", "/path/to/resolver.cert", "/path/to/resolver.key", [false]):` listen to incoming DNSCrypt queries on 127.0.0.1 port 8443, with a provider name of "provider name", using a resolver certificate and associated key stored respectively in the `resolver.cert` and `resolver.key` files. The last optional parameter sets SO_REUSEPORT when available
     * `generateDNSCryptProviderKeys("/path/to/providerPublic.key", "/path/to/providerPrivate.key"):` generate a new provider keypair
     * `generateDNSCryptCertificate("/path/to/providerPrivate.key", "/path/to/resolver.cert", "/path/to/resolver.key", serial, validFrom, validUntil):` generate a new resolver private key and related certificate, valid from the `validFrom` timestamp until the `validUntil` one, signed with the provider private key
     * `printDNSCryptProviderFingerprint("/path/to/providerPublic.key")`: display the fingerprint of the provided resolver public key

--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -10,7 +10,7 @@ interface.
 
 Compiling
 ---------
-`dnsdist` depends on boost, Lua or luajit and a pretty recent C++
+`dnsdist` depends on boost, Lua or LuaJIT and a pretty recent C++
 compiler (g++ 4.8 or higher, clang 3.5 or higher). It can optionally use libsodium
 for encrypted communications with its client.
 
@@ -351,6 +351,7 @@ A DNS rule can be:
  * a TCPRule
 
 Some specific actions do not stop the processing when they match, contrary to all other actions:
+
  * Delay
  * Disable Validation
  * Log
@@ -447,6 +448,7 @@ end
 ```
 
 Valid return values for `LuaAction` functions are:
+
  * DNSAction.Allow: let the query pass, skipping other rules
  * DNSAction.Delay: delay the response for the specified milliseconds (UDP-only), continue to the next rule
  * DNSAction.Drop: drop the query
@@ -704,7 +706,6 @@ fe80::/10
 
 Caching
 -------
-
 `dnsdist` implements a simple but effective packet cache, not enabled by default.
 It is enabled per-pool, but the same cache can be shared between several pools.
 The first step is to define a cache, then to assign that cache to the chosen pool,
@@ -719,6 +720,86 @@ The first parameter is the maximum number of entries stored in the cache, the
 second one, optional, is the maximum lifetime of an entry in the cache, in seconds,
 and the last one, optional too, is the minimum TTL an entry should have to be considered
 for insertion in the cache.
+
+
+Performance tuning
+------------------
+First, a few words about `dnsdist` architecture:
+
+ * Each local bind has its own thread listening for incoming UDP queries
+ * and its own thread listening for incoming TCP connections,
+ dispatching them right away to a pool of threads
+ * Each backend has its own thread listening for UDP responses
+ * A maintenance thread calls the `maintenance()` Lua function every second
+ if any, and is responsible for cleaning the cache
+ * A health check thread checks the backends availability
+ * A control thread handles console connections
+ * A carbon thread exports statistics to a carbon server if needed
+ * One or more webserver threads handle queries to the internal webserver
+
+The maximum number of threads in the TCP pool is controlled by the
+`setMaxTCPClientThreads()` directive, and defaults to 10. This number can be
+increased to handle a large number of simultaneous TCP connections.
+
+When dispatching UDP queries to backend servers, `dnsdist` keeps track of at
+most `n` outstanding queries for each backend. This number `n` can be tuned by
+the `setMaxUDPOutstanding()` directive, defaulting to 10240, with a maximum
+value of 65535. Large installations are advised to increase the default value
+at the cost of a slightly increased memory usage.
+
+Most of the query processing is done in C++ for maximum performance,
+but some operations are executed in Lua for maximum flexibility:
+
+ * the `blockfilter()` function
+ * rules added by `addLuaAction()`
+ * server selection policies defined via `setServerPolicyLua()` or `newServerPolicy()`
+
+While Lua is fast, its use should be restricted to the strict necessary in order
+to achieve maximum performance, it might be worth considering using LuaJIT instead
+of Lua. When Lua inspection is needed, the best course of action is to restrict
+the queries sent to Lua inspection by using `addLuaAction()` instead of inspecting
+all queries in the `blockfilter()` function.
+
+`dnsdist` design choices mean that the processing of UDP queries is done by only
+one thread per local bind. This is great to keep lock contention to a low level,
+but might not be optimal for setups using a lot of processing power, caused for
+example by a large number of complicated rules. To be able to use more CPU cores
+for UDP queries processing, it is possible to use the `reuseport` parameter of
+the `addLocal()` and `setLocal()` directives to be able to add several identical
+local binds to `dnsdist`:
+
+```
+addLocal("192.0.2.1:53", true, true)
+addLocal("192.0.2.1:53", true, true)
+addLocal("192.0.2.1:53", true, true)
+addLocal("192.0.2.1:53", true, true)
+```
+
+`dnsdist` will then add four identical local binds as if they were different IPs
+or ports, start four threads to handle incoming queries and let the kernel load
+balance those randomly to the threads, thus using four CPU cores for rules
+processing. Note that this require SO_REUSEPORT support in the underlying
+operating system (added for example in Linux 3.9).
+Please also be aware that doing so will increase lock contention and might not
+therefore scale linearly. This is especially true for Lua-intensive setups,
+because Lua processing in `dnsdist` is serialized by an unique lock for all
+threads.
+
+Another possibility is to use the reuseport option to run several `dnsdist`
+processes in parallel on the same host, thus avoiding the lock contention issue
+at the cost of having to deal with the fact that the different processes will
+not share informations, like statistics or DDoS offenders.
+
+The UDP threads handling the responses from the backends do not use a lot of CPU,
+but if needed it is also possible to add the same backend several times to the
+`dnsdist` configuration to distribute the load over several responder threads.
+
+```
+newServer({address="192.0.2.127:53", name="Backend1"})
+newServer({address="192.0.2.127:53", name="Backend2"})
+newServer({address="192.0.2.127:53", name="Backend3"})
+newServer({address="192.0.2.127:53", name="Backend4"})
+```
 
 
 Carbon/Graphite/Metronome
@@ -1005,7 +1086,7 @@ instantiate a server with additional parameters
     * `setTCPRecvTimeout(n)`: set the read timeout on TCP connections from the client, in seconds
     * `setTCPSendTimeout(n)`: set the write timeout on TCP connections from the client, in seconds
     * `setMaxTCPClientThreads(n)`: set the maximum of TCP client threads, handling TCP connections
-    * `setMaxUDPOutstanding(n)`: set the maximum number of outstanding UDP queries to a given backend server. This can only be set at configuration time
+    * `setMaxUDPOutstanding(n)`: set the maximum number of outstanding UDP queries to a given backend server. This can only be set at configuration time and defaults to 10240
     * `setCacheCleaningDelay(n)`: set the interval in seconds between two runs of the cache cleaning algorithm, removing expired entries
  * DNSCrypt related:
     * `addDNSCryptBind("127.0.0.1:8443", "provider name", "/path/to/resolver.cert", "/path/to/resolver.key", [false]):` listen to incoming DNSCrypt queries on 127.0.0.1 port 8443, with a provider name of "provider name", using a resolver certificate and associated key stored respectively in the `resolver.cert` and `resolver.key` files. The last optional parameter sets SO_REUSEPORT when available

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -436,7 +436,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       g_ACL.modify([domain](NetmaskGroup& nmg) { nmg.addMask(domain); });
     });
 
-  g_lua.writeFunction("setLocal", [client](const std::string& addr, boost::optional<bool> doTCP) {
+  g_lua.writeFunction("setLocal", [client](const std::string& addr, boost::optional<bool> doTCP, boost::optional<bool> reusePort) {
       setLuaSideEffect();
       if(client)
 	return;
@@ -447,14 +447,14 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       try {
 	ComboAddress loc(addr, 53);
 	g_locals.clear();
-	g_locals.push_back({loc, doTCP ? *doTCP : true}); /// only works pre-startup, so no sync necessary
+	g_locals.push_back(std::make_tuple(loc, doTCP ? *doTCP : true, reusePort ? *reusePort : false)); /// only works pre-startup, so no sync necessary
       }
       catch(std::exception& e) {
 	g_outputBuffer="Error: "+string(e.what())+"\n";
       }
     });
 
-  g_lua.writeFunction("addLocal", [client](const std::string& addr, boost::optional<bool> doTCP) {
+  g_lua.writeFunction("addLocal", [client](const std::string& addr, boost::optional<bool> doTCP, boost::optional<bool> reusePort) {
       setLuaSideEffect();
       if(client)
 	return;
@@ -464,7 +464,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       }
       try {
 	ComboAddress loc(addr, 53);
-	g_locals.push_back({loc, doTCP ? *doTCP : true}); /// only works pre-startup, so no sync necessary
+	g_locals.push_back(std::make_tuple(loc, doTCP ? *doTCP : true, reusePort ? *reusePort : false)); /// only works pre-startup, so no sync necessary
       }
       catch(std::exception& e) {
 	g_outputBuffer="Error: "+string(e.what())+"\n";

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -206,7 +206,7 @@ static void connectionThread(int sock, ComboAddress remote, string password)
       string localaddresses;
       for(const auto& loc : g_locals) {
         if(!localaddresses.empty()) localaddresses += ", ";
-        localaddresses += loc.first.toStringWithPort();
+        localaddresses += std::get<0>(loc).toStringWithPort();
       }
  
       Json my_json = Json::object {

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -65,9 +65,9 @@ bool g_verboseHealthChecks{false};
 
 GlobalStateHolder<NetmaskGroup> g_ACL;
 string g_outputBuffer;
-vector<std::pair<ComboAddress, bool>> g_locals;
+vector<std::tuple<ComboAddress, bool, bool>> g_locals;
 #ifdef HAVE_DNSCRYPT
-std::vector<std::pair<ComboAddress,DnsCryptContext>> g_dnsCryptLocals;
+std::vector<std::tuple<ComboAddress,DnsCryptContext,bool>> g_dnsCryptLocals;
 #endif
 vector<ClientState *> g_frontends;
 GlobalStateHolder<pools_t> g_pools;
@@ -1339,11 +1339,11 @@ try
   if(g_cmdLine.locals.size()) {
     g_locals.clear();
     for(auto loc : g_cmdLine.locals)
-      g_locals.push_back({ComboAddress(loc, 53), true});
+      g_locals.push_back(std::make_tuple(ComboAddress(loc, 53), true, false));
   }
   
   if(g_locals.empty())
-    g_locals.push_back({ComboAddress("127.0.0.1", 53), true});
+    g_locals.push_back(std::make_tuple(ComboAddress("127.0.0.1", 53), true, false));
   
 
   g_configurationDone = true;
@@ -1351,25 +1351,30 @@ try
   vector<ClientState*> toLaunch;
   for(const auto& local : g_locals) {
     ClientState* cs = new ClientState;
-    cs->local= local.first;
+    cs->local= std::get<0>(local);
     cs->udpFD = SSocket(cs->local.sin4.sin_family, SOCK_DGRAM, 0);
     if(cs->local.sin4.sin_family == AF_INET6) {
       SSetsockopt(cs->udpFD, IPPROTO_IPV6, IPV6_V6ONLY, 1);
     }
     //if(g_vm.count("bind-non-local"))
-    bindAny(local.first.sin4.sin_family, cs->udpFD);
+    bindAny(cs->local.sin4.sin_family, cs->udpFD);
 
     //    if (!setSocketTimestamps(cs->udpFD))
     //      L<<Logger::Warning<<"Unable to enable timestamp reporting for socket"<<endl;
 
 
-    if(IsAnyAddress(local.first)) {
+    if(IsAnyAddress(cs->local)) {
       int one=1;
       setsockopt(cs->udpFD, IPPROTO_IP, GEN_IP_PKTINFO, &one, sizeof(one));     // linux supports this, so why not - might fail on other systems
 #ifdef IPV6_RECVPKTINFO
       setsockopt(cs->udpFD, IPPROTO_IPV6, IPV6_RECVPKTINFO, &one, sizeof(one));
 #endif
     }
+#ifdef SO_REUSEPORT
+    if (std::get<2>(local)) {
+      SSetsockopt(cs->udpFD, SOL_SOCKET, SO_REUSEPORT, 1);
+    }
+#endif
 
     SBind(cs->udpFD, cs->local);
     toLaunch.push_back(cs);
@@ -1377,12 +1382,12 @@ try
   }
 
   for(const auto& local : g_locals) {
-    if(!local.second) { // no TCP/IP
-      warnlog("Not providing TCP/IP service on local address '%s'", local.first.toStringWithPort());
+    if(!std::get<1>(local)) { // no TCP/IP
+      warnlog("Not providing TCP/IP service on local address '%s'", std::get<0>(local).toStringWithPort());
       continue;
     }
     ClientState* cs = new ClientState;
-    cs->local= local.first;
+    cs->local= std::get<0>(local);
 
     cs->tcpFD = SSocket(cs->local.sin4.sin_family, SOCK_STREAM, 0);
 
@@ -1393,6 +1398,11 @@ try
     if(cs->local.sin4.sin_family == AF_INET6) {
       SSetsockopt(cs->tcpFD, IPPROTO_IPV6, IPV6_V6ONLY, 1);
     }
+#ifdef SO_REUSEPORT
+    if (std::get<2>(local)) {
+      SSetsockopt(cs->tcpFD, SOL_SOCKET, SO_REUSEPORT, 1);
+    }
+#endif
     //    if(g_vm.count("bind-non-local"))
       bindAny(cs->local.sin4.sin_family, cs->tcpFD);
     SBind(cs->tcpFD, cs->local);
@@ -1406,8 +1416,8 @@ try
 #ifdef HAVE_DNSCRYPT
   for(auto& dcLocal : g_dnsCryptLocals) {
     ClientState* cs = new ClientState;
-    cs->local = dcLocal.first;
-    cs->dnscryptCtx = &dcLocal.second;
+    cs->local = std::get<0>(dcLocal);
+    cs->dnscryptCtx = &(std::get<1>(dcLocal));
     cs->udpFD = SSocket(cs->local.sin4.sin_family, SOCK_DGRAM, 0);
     if(cs->local.sin4.sin_family == AF_INET6) {
       SSetsockopt(cs->udpFD, IPPROTO_IPV6, IPV6_V6ONLY, 1);
@@ -1425,12 +1435,17 @@ try
     g_frontends.push_back(cs);
 
     cs = new ClientState;
-    cs->local = dcLocal.first;
-    cs->dnscryptCtx = &dcLocal.second;
+    cs->local = std::get<0>(dcLocal);
+    cs->dnscryptCtx = &(std::get<1>(dcLocal));
     cs->tcpFD = SSocket(cs->local.sin4.sin_family, SOCK_STREAM, 0);
     SSetsockopt(cs->tcpFD, SOL_SOCKET, SO_REUSEADDR, 1);
 #ifdef TCP_DEFER_ACCEPT
     SSetsockopt(cs->tcpFD, SOL_TCP,TCP_DEFER_ACCEPT, 1);
+#endif
+#ifdef SO_REUSEPORT
+    if (std::get<2>(dcLocal)) {
+      SSetsockopt(cs->tcpFD, SOL_SOCKET, SO_REUSEPORT, 1);
+    }
 #endif
     if(cs->local.sin4.sin_family == AF_INET6) {
       SSetsockopt(cs->tcpFD, IPPROTO_IPV6, IPV6_V6ONLY, 1);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -59,7 +59,7 @@ using std::thread;
 bool g_verbose;
 
 struct DNSDistStats g_stats;
-uint16_t g_maxOutstanding;
+uint16_t g_maxOutstanding{10240};
 bool g_console;
 bool g_verboseHealthChecks{false};
 
@@ -1308,8 +1308,6 @@ try
   for(auto p = argv; *p; ++p) {
     g_cmdLine.remotes.push_back(*p);
   }
-
-  g_maxOutstanding = 1024;
 
   ServerPolicy leastOutstandingPol{"leastOutstanding", leastOutstanding};
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -454,7 +454,7 @@ extern GlobalStateHolder<NetmaskGroup> g_ACL;
 
 extern ComboAddress g_serverControl; // not changed during runtime
 
-extern std::vector<std::pair<ComboAddress, bool>> g_locals; // not changed at runtime (we hope XXX)
+extern std::vector<std::tuple<ComboAddress, bool, bool>> g_locals; // not changed at runtime (we hope XXX)
 extern vector<ClientState*> g_frontends;
 extern std::string g_key; // in theory needs locking
 extern bool g_truncateTC;
@@ -505,7 +505,7 @@ bool getLuaNoSideEffect(); // set if there were only explicit declarations of _n
 void resetLuaSideEffect(); // reset to indeterminate state
 
 #ifdef HAVE_DNSCRYPT
-extern std::vector<std::pair<ComboAddress,DnsCryptContext>> g_dnsCryptLocals;
+extern std::vector<std::tuple<ComboAddress,DnsCryptContext,bool>> g_dnsCryptLocals;
 
 int handleDnsCryptQuery(DnsCryptContext* ctx, char* packet, uint16_t len, std::shared_ptr<DnsCryptQuery>& query, uint16_t* decryptedQueryLen, bool tcp, std::vector<uint8_t>& reponse);
 #endif


### PR DESCRIPTION
If set to true, this parameter sets SO_REUSEPORT on platforms
supporting for this option, allowing multiple servers to
bind to the same port.
The same parameter is also added to addDNSCryptBind().