### PR TITLE
Fix tabs handling in TXT records.

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -443,7 +443,7 @@ static string txtEscape(const string &name)
   char ebuf[5];
 
   for(string::const_iterator i=name.begin();i!=name.end();++i) {
-    if((unsigned char) *i > 127 || (unsigned char) *i < 32) {
+    if((unsigned char) *i > 127 || ((unsigned char) *i < 32 && (unsigned char) *i != 9)) {
       snprintf(ebuf, sizeof(ebuf), "\\%03u", (unsigned char)*i);
       ret += ebuf;
     }


### PR DESCRIPTION
Update txtEscape() in PacketReader to omit also tabs, as they are printable
characters. In fact, tabs are put equivalent to spaces in RFC 1464.