### PR TITLE
recursor: when replacing an expired entry, move it to the back

### DIFF
--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -92,6 +92,13 @@ void RecursorPacketCache::insertResponsePacket(const std::string& responsePacket
   packetCache_t::iterator iter = d_packetCache.find(e);
   
   if(iter != d_packetCache.end()) {
+    if (iter->d_ttd <= now) {
+      /* entry had expired, a cache miss might have
+         moved it to the front, and we don't want to
+         get expunged just right now */
+      moveCacheItemToBack(d_packetCache, iter);
+    }
+
     iter->d_packet = responsePacket;
     iter->d_ttd = now + ttl;
     iter->d_creation = now;


### PR DESCRIPTION
If we did a lookup earlier and found the entry to be expired,
we moved it to the front of the expunge queue. If we don't move
it to the back, and the next cache purging operation occurs before
a cache hit using this entry, it's very likely to get expunged.