### PR TITLE
dnsdist: Add a simple Packet Cache

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -1,0 +1,254 @@
+#include "dolog.hh"
+#include "dnsdist-cache.hh"
+#include "dnsparser.hh"
+
+DNSDistPacketCache::DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL, uint32_t minTTL): d_maxEntries(maxEntries), d_maxTTL(maxTTL), d_minTTL(minTTL)
+{
+  pthread_rwlock_init(&d_lock, 0);
+  /* we reserve maxEntries + 1 to avoid rehashing from occuring
+     when we get to maxEntries, as it means a load factor of 1 */
+  d_map.reserve(maxEntries + 1);
+}
+
+DNSDistPacketCache::~DNSDistPacketCache()
+{
+  WriteLock l(&d_lock);
+}
+
+bool DNSDistPacketCache::cachedValueMatches(const CacheValue& cachedValue, const DNSName& qname, uint16_t qtype, uint16_t qclass)
+{
+  if (cachedValue.qname != qname || cachedValue.qtype != qtype || cachedValue.qclass != qclass)
+    return false;
+  return true;
+}
+
+void DNSDistPacketCache::insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen)
+{
+  if (responseLen == 0)
+    return;
+
+  uint32_t minTTL = getMinTTL(response, responseLen);
+  if (minTTL > d_maxTTL)
+    minTTL = d_maxTTL;
+
+  if (minTTL < d_minTTL)
+    return;
+
+  {
+    TryReadLock r(&d_lock);
+    if (!r.gotIt()) {
+      d_deferredInserts++;
+      return;
+    }
+    if (d_map.size() >= d_maxEntries) {
+      return;
+    }
+  }
+
+  const time_t now = time(NULL);
+  std::unordered_map<uint32_t,CacheValue>::iterator it;
+  bool result;
+  time_t newValidity = now + minTTL;
+  CacheValue newValue;
+  newValue.qname = qname;
+  newValue.qtype = qtype;
+  newValue.qclass = qclass;
+  newValue.len = responseLen;
+  newValue.validity = newValidity;
+  newValue.added = now;
+  newValue.value = std::string(response, responseLen);
+
+  {
+    TryWriteLock w(&d_lock);
+
+    if (!w.gotIt()) {
+      d_deferredInserts++;
+      return;
+    }
+
+    tie(it, result) = d_map.insert({key, newValue});
+
+    if (result) {
+      return;
+    }
+
+    /* in case of collision, don't override the existing entry
+       except if it has expired */
+    CacheValue& value = it->second;
+    bool wasExpired = value.validity <= now;
+
+    if (!wasExpired && !cachedValueMatches(value, qname, qtype, qclass)) {
+      d_insertCollisions++;
+      return;
+    }
+
+    /* if the existing entry had a longer TTD, keep it */
+    if (newValidity <= value.validity)
+      return;
+
+    value = newValue;
+  }
+}
+
+bool DNSDistPacketCache::get(const unsigned char* query, uint16_t queryLen, const DNSName& qname, uint16_t qtype, uint16_t qclass, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, uint32_t* keyOut, bool skipAging)
+{
+  uint32_t key = getKey(qname, consumed, query, queryLen);
+  if (keyOut)
+    *keyOut = key;
+
+  time_t now = time(NULL);
+  time_t age;
+  {
+    TryReadLock r(&d_lock);
+    if (!r.gotIt()) {
+      d_deferredLookups++;
+      return false;
+    }
+
+    std::unordered_map<uint32_t,CacheValue>::const_iterator it = d_map.find(key);
+    if (it == d_map.end()) {
+      d_misses++;
+      return false;
+    }
+
+    const CacheValue& value = it->second;
+    if (value.validity < now) {
+      d_misses++;
+      return false;
+    }
+
+    if (*responseLen < value.len) {
+      return false;
+    }
+
+    /* check for collision */
+    if (!cachedValueMatches(value, qname, qtype, qclass)) {
+      d_misses++;
+      d_lookupCollisions++;
+      return false;
+    }
+
+    string dnsQName(qname.toDNSString());
+    memcpy(response, &queryId, sizeof(queryId));
+    memcpy(response + sizeof(queryId), value.value.c_str() + sizeof(queryId), sizeof(dnsheader) - sizeof(queryId));
+    memcpy(response + sizeof(dnsheader), dnsQName.c_str(), dnsQName.length());
+    memcpy(response + sizeof(dnsheader) + dnsQName.length(), value.value.c_str() + sizeof(dnsheader) + dnsQName.length(), value.value.length() - (sizeof(dnsheader) + dnsQName.length()));
+    *responseLen = value.len;
+    age = now - value.added;
+  }
+
+  if (!skipAging)
+    ageDNSPacket(response, *responseLen, age);
+  d_hits++;
+  return true;
+}
+
+void DNSDistPacketCache::purge(size_t upTo)
+{
+  time_t now = time(NULL);
+  WriteLock w(&d_lock);
+  if (upTo <= d_map.size())
+    return;
+
+  size_t toRemove = d_map.size() - upTo;
+  for(auto it = d_map.begin(); toRemove > 0 && it != d_map.end(); ) {
+    const CacheValue& value = it->second;
+
+    if (value.validity < now) {
+        it = d_map.erase(it);
+        --toRemove;
+    } else {
+      ++it;
+    }
+  }
+}
+
+void DNSDistPacketCache::expunge(const DNSName& name, uint16_t qtype)
+{
+  WriteLock w(&d_lock);
+
+  for(auto it = d_map.begin(); it != d_map.end(); ) {
+    const CacheValue& value = it->second;
+    uint16_t cqtype = 0;
+    uint16_t cqclass = 0;
+    DNSName cqname(value.value.c_str(), value.len, sizeof(dnsheader), false, &cqtype, &cqclass, nullptr);
+
+    if (cqname == name && (qtype == QType::ANY || qtype == cqtype)) {
+        it = d_map.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+bool DNSDistPacketCache::isFull()
+{
+    ReadLock r(&d_lock);
+    return (d_map.size() >= d_maxEntries);
+}
+
+uint32_t DNSDistPacketCache::getMinTTL(const char* packet, uint16_t length)
+{
+  const struct dnsheader* dh = (const struct dnsheader*) packet;
+  uint32_t result = std::numeric_limits<uint32_t>::max();
+  vector<uint8_t> content(length - sizeof(dnsheader));
+  copy(packet + sizeof(dnsheader), packet + length, content.begin());
+  PacketReader pr(content);
+  size_t idx = 0;
+  DNSName rrname;
+  uint16_t qdcount = ntohs(dh->qdcount);
+  uint16_t ancount = ntohs(dh->ancount);
+  uint16_t nscount = ntohs(dh->nscount);
+  uint16_t arcount = ntohs(dh->arcount);
+  uint16_t rrtype;
+  uint16_t rrclass;
+  struct dnsrecordheader ah;
+
+  /* consume qd */
+  for(idx = 0; idx < qdcount; idx++) {
+    rrname = pr.getName();
+    rrtype = pr.get16BitInt();
+    rrclass = pr.get16BitInt();
+    (void) rrtype;
+    (void) rrclass;
+  }
+
+  /* consume AN and NS */
+  for (idx = 0; idx < ancount + nscount; idx++) {
+    rrname = pr.getName();
+    pr.getDnsrecordheader(ah);
+    pr.d_pos += ah.d_clen;
+    if (result > ah.d_ttl)
+      result = ah.d_ttl;
+  }
+
+  /* consume AR, watch for OPT */
+  for (idx = 0; idx < arcount; idx++) {
+    rrname = pr.getName();
+    pr.getDnsrecordheader(ah);
+    pr.d_pos += ah.d_clen;
+    if (ah.d_type == QType::OPT) {
+      continue;
+    }
+    if (result > ah.d_ttl)
+      result = ah.d_ttl;
+  }
+  return result;
+}
+
+uint32_t DNSDistPacketCache::getKey(const DNSName& qname, uint16_t consumed, const unsigned char* packet, uint16_t packetLen)
+{
+  uint32_t result = 0;
+  /* skip the query ID */
+  result = burtle(packet + 2, sizeof(dnsheader) - 2, result);
+  string lc(qname.toDNSStringLC());
+  result = burtle((const unsigned char*) lc.c_str(), lc.length(), result);
+  result = burtle(packet + sizeof(dnsheader) + consumed, packetLen - (sizeof(dnsheader) + consumed), result);
+  return result;
+}
+
+string DNSDistPacketCache::toString()
+{
+  ReadLock r(&d_lock);
+  return std::to_string(d_map.size()) + "/" + std::to_string(d_maxEntries);
+}

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <atomic>
+#include <unordered_map>
+#include "lock.hh"
+
+class DNSDistPacketCache : boost::noncopyable
+{
+public:
+  DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL=86400, uint32_t minTTL=60);
+  ~DNSDistPacketCache();
+
+  void insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen);
+  bool get(const unsigned char* query, uint16_t queryLen, const DNSName& qname, uint16_t qtype, uint16_t qclass, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, uint32_t* keyOut, bool skipAging=false);
+  void purge(size_t upTo=0);
+  void expunge(const DNSName& name, uint16_t qtype=QType::ANY);
+  bool isFull();
+  string toString();
+  uint64_t getSize() const { return d_map.size(); };
+  uint64_t getHits() const { return d_hits; };
+  uint64_t getMisses() const { return d_misses; };
+  uint64_t getDeferredLookups() const { return d_deferredLookups; };
+  uint64_t getDeferredInserts() const { return d_deferredInserts; };
+  uint64_t getLookupCollisions() const { return d_lookupCollisions; };
+  uint64_t getInsertCollisions() const { return d_insertCollisions; };
+
+  static uint32_t getMinTTL(const char* packet, uint16_t length);
+
+private:
+
+  struct CacheValue
+  {
+    time_t getTTD() const { return validity; }
+    std::string value;
+    DNSName qname;
+    uint16_t qtype{0};
+    uint16_t qclass{0};
+    time_t added{0};
+    time_t validity{0};
+    uint16_t len{0};
+  };
+
+  static uint32_t getKey(const DNSName& qname, uint16_t consumed, const unsigned char* packet, uint16_t packetLen);
+  static bool cachedValueMatches(const CacheValue& cachedValue, const DNSName& qname, uint16_t qtype, uint16_t qclass);
+
+  pthread_rwlock_t d_lock;
+  std::unordered_map<uint32_t,CacheValue> d_map;
+  std::atomic<uint64_t> d_deferredLookups{0};
+  std::atomic<uint64_t> d_deferredInserts{0};
+  std::atomic<uint64_t> d_hits{0};
+  std::atomic<uint64_t> d_misses{0};
+  std::atomic<uint64_t> d_insertCollisions{0};
+  std::atomic<uint64_t> d_lookupCollisions{0};
+  size_t d_maxEntries;
+  uint32_t d_maxTTL;
+  uint32_t d_minTTL;
+};

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -44,6 +44,7 @@ dnsdist_SOURCES = \
 	dns.cc dns.hh \
 	dnscrypt.cc dnscrypt.hh \
 	dnsdist.cc dnsdist.hh \
+	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-carbon.cc \
 	dnsdist-console.cc \
 	dnsdist-dnscrypt.cc \
@@ -94,8 +95,10 @@ testrunner_SOURCES = \
 	dns.hh \
 	test-base64_cc.cc \
 	test-dnsdist_cc.cc \
+	test-dnsdistpacketcache_cc.cc \
 	test-dnscrypt_cc.cc \
 	dnsdist.hh \
+	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
 	dnscrypt.cc dnscrypt.hh \
 	dnslabeltext.cc \

--- a/pdns/dnsdistdist/dnsdist-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-cache.cc
@@ -1,0 +1,1 @@
+../dnsdist-cache.cc

--- a/pdns/dnsdistdist/dnsdist-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-cache.hh
@@ -1,0 +1,1 @@
+../dnsdist-cache.hh

--- a/pdns/dnsdistdist/test-dnsdistpacketcache_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistpacketcache_cc.cc
@@ -1,0 +1,1 @@
+../test-dnsdistpacketcache_cc.cc

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -344,6 +344,7 @@ private:
 
 string simpleCompress(const string& label, const string& root="");
 void simpleExpandTo(const string& label, unsigned int frompos, string& ret);
+void ageDNSPacket(char* packet, size_t length, uint32_t seconds);
 void ageDNSPacket(std::string& packet, uint32_t seconds);
 
 template<typename T>

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -646,3 +646,17 @@ public:
     return "set cd=1";
   }
 };
+
+class SkipCacheAction : public DNSAction
+{
+public:
+  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  {
+    dq->skipCache = true;
+    return Action::None;
+  }
+  string toString() const override
+  {
+    return "skip cache";
+  }
+};

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -1,0 +1,197 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include "iputils.hh"
+#include "dnsdist-cache.hh"
+#include "dnswriter.hh"
+
+BOOST_AUTO_TEST_SUITE(dnsdistpacketcache_cc)
+
+BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
+  const size_t maxEntries = 150000;
+  DNSDistPacketCache PC(maxEntries, 86400, 1);
+  BOOST_CHECK_EQUAL(PC.getSize(), 0);
+
+  size_t counter=0;
+  size_t skipped=0;
+  try {
+    for(counter = 0; counter < 100000; ++counter) {
+      DNSName a=DNSName("hello ")+DNSName(std::to_string(counter));
+      BOOST_CHECK_EQUAL(DNSName(a.toString()), a);
+
+      vector<uint8_t> query;
+      DNSPacketWriter pwQ(query, a, QType::A, QClass::IN, 0);
+      pwQ.getHeader()->rd = 1;
+
+      vector<uint8_t> response;
+      DNSPacketWriter pwR(response, a, QType::A, QClass::IN, 0);
+      pwR.getHeader()->rd = 1;
+      pwR.getHeader()->ra = 1;
+      pwR.getHeader()->qr = 1;
+      pwR.getHeader()->id = pwQ.getHeader()->id;
+      pwR.startRecord(a, QType::A, 100, QClass::IN, DNSResourceRecord::ANSWER);
+      pwR.xfr32BitInt(0x01020304);
+      pwR.commit();
+      uint16_t responseLen = response.size();
+
+      char responseBuf[4096];
+      uint16_t responseBufSize = sizeof(responseBuf);
+      uint32_t key = 0;
+      bool found = PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), 0, responseBuf, &responseBufSize, &key);
+      BOOST_CHECK_EQUAL(found, false);
+
+      PC.insert(key, a, QType::A, QClass::IN, (const char*) response.data(), responseLen);
+
+      found = PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), pwR.getHeader()->id, responseBuf, &responseBufSize, &key, true);
+      if (found == true) {
+        BOOST_CHECK_EQUAL(responseBufSize, responseLen);
+        int match = memcmp(responseBuf, response.data(), responseLen);
+        BOOST_CHECK_EQUAL(match, 0);
+      }
+      else {
+        skipped++;
+      }
+    }
+
+    BOOST_CHECK_EQUAL(skipped, PC.getInsertCollisions());
+    BOOST_CHECK_EQUAL(PC.getSize(), counter - skipped);
+
+    size_t deleted=0;
+    size_t delcounter=0;
+    for(delcounter=0; delcounter < counter/1000; ++delcounter) {
+      DNSName a=DNSName("hello ")+DNSName(std::to_string(delcounter));
+      vector<uint8_t> query;
+      DNSPacketWriter pwQ(query, a, QType::A, QClass::IN, 0);
+      pwQ.getHeader()->rd = 1;
+      char responseBuf[4096];
+      uint16_t responseBufSize = sizeof(responseBuf);
+      uint32_t key = 0;
+      bool found = PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), 0, responseBuf, &responseBufSize, &key);
+      if (found == true) {
+        PC.expunge(a);
+        deleted++;
+      }
+    }
+    BOOST_CHECK_EQUAL(PC.getSize(), counter - skipped - deleted);
+
+    size_t matches=0;
+    vector<DNSResourceRecord> entry;
+    size_t expected=counter-skipped-deleted;
+    for(; delcounter < counter; ++delcounter) {
+      DNSName a(DNSName("hello ")+DNSName(std::to_string(delcounter)));
+      vector<uint8_t> query;
+      DNSPacketWriter pwQ(query, a, QType::A, QClass::IN, 0);
+      pwQ.getHeader()->rd = 1;
+      uint16_t len = query.size();
+      uint32_t key = 0;
+      char response[4096];
+      uint16_t responseSize = sizeof(response);
+      if(PC.get(query.data(), len, a, QType::A, QClass::IN, a.wirelength(), pwQ.getHeader()->id, response, &responseSize, &key)) {
+	matches++;
+      }
+    }
+    BOOST_CHECK_EQUAL(matches, expected);
+  }
+  catch(PDNSException& e) {
+    cerr<<"Had error: "<<e.reason<<endl;
+    throw;
+  }
+}
+
+static DNSDistPacketCache PC(500000);
+
+static void *threadMangler(void* a)
+{
+  try {
+    unsigned int offset=(unsigned int)(unsigned long)a;
+    for(unsigned int counter=0; counter < 100000; ++counter) {
+      DNSName a=DNSName("hello ")+DNSName(std::to_string(counter+offset));
+      vector<uint8_t> query;
+      DNSPacketWriter pwQ(query, a, QType::A, QClass::IN, 0);
+      pwQ.getHeader()->rd = 1;
+
+      vector<uint8_t> response;
+      DNSPacketWriter pwR(response, a, QType::A, QClass::IN, 0);
+      pwR.getHeader()->rd = 1;
+      pwR.getHeader()->ra = 1;
+      pwR.getHeader()->qr = 1;
+      pwR.getHeader()->id = pwQ.getHeader()->id;
+      pwR.startRecord(a, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER);
+      pwR.xfr32BitInt(0x01020304);
+      pwR.commit();
+      uint16_t responseLen = response.size();
+
+      char responseBuf[4096];
+      uint16_t responseBufSize = sizeof(responseBuf);
+      uint32_t key = 0;
+      PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), 0, responseBuf, &responseBufSize, &key);
+
+      PC.insert(key, a, QType::A, QClass::IN, (const char*) response.data(), responseLen);
+    }
+  }
+  catch(PDNSException& e) {
+    cerr<<"Had error: "<<e.reason<<endl;
+    throw;
+  }
+  return 0;
+}
+
+AtomicCounter g_missing;
+
+static void *threadReader(void* a)
+{
+  try
+  {
+    unsigned int offset=(unsigned int)(unsigned long)a;
+    vector<DNSResourceRecord> entry;
+    for(unsigned int counter=0; counter < 100000; ++counter) {
+      DNSName a=DNSName("hello ")+DNSName(std::to_string(counter+offset));
+      vector<uint8_t> query;
+      DNSPacketWriter pwQ(query, a, QType::A, QClass::IN, 0);
+      pwQ.getHeader()->rd = 1;
+
+      char responseBuf[4096];
+      uint16_t responseBufSize = sizeof(responseBuf);
+      uint32_t key = 0;
+      bool found = PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), 0, responseBuf, &responseBufSize, &key);
+      if (!found) {
+	g_missing++;
+      }
+    }
+  }
+  catch(PDNSException& e) {
+    cerr<<"Had error in threadReader: "<<e.reason<<endl;
+    throw;
+  }
+  return 0;
+}
+
+BOOST_AUTO_TEST_CASE(test_PacketCacheThreaded) {
+  try {
+    pthread_t tid[4];
+    for(int i=0; i < 4; ++i)
+      pthread_create(&tid[i], 0, threadMangler, (void*)(i*1000000UL));
+    void* res;
+    for(int i=0; i < 4 ; ++i)
+      pthread_join(tid[i], &res);
+
+    BOOST_CHECK_EQUAL(PC.getSize() + PC.getDeferredInserts() + PC.getInsertCollisions(), 400000);
+    BOOST_CHECK_SMALL(1.0*PC.getInsertCollisions(), 10000.0);
+
+    for(int i=0; i < 4; ++i)
+      pthread_create(&tid[i], 0, threadReader, (void*)(i*1000000UL));
+    for(int i=0; i < 4 ; ++i)
+      pthread_join(tid[i], &res);
+
+    BOOST_CHECK((PC.getDeferredInserts() + PC.getDeferredLookups() + PC.getInsertCollisions()) >= g_missing);
+  }
+  catch(PDNSException& e) {
+    cerr<<"Had error: "<<e.reason<<endl;
+    throw;
+  }
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -864,3 +864,325 @@ class TestAdvancedOr(DNSDistTest):
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
         receivedResponse.id = expectedResponse.id
         self.assertEquals(receivedResponse, expectedResponse)
+
+class TestAdvancedCaching(DNSDistTest):
+
+    _config_template = """
+    pc = newPacketCache(5, 86400, 1)
+    getPool(""):setCache(pc)
+    addAction(makeRule("nocache.tests.powerdns.com."), SkipCacheAction())
+    newServer{address="127.0.0.1:%s"}
+    """
+    def testCached(self):
+        """
+        Advanced: Served from cache
+
+        dnsdist is configured to cache entries, we are sending several
+        identical requests and checking that the backend only receive
+        the first one.
+        """
+        numberOfQueries = 10
+        name = 'cached.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AAAA', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.AAAA,
+                                    '::1')
+        response.answer.append(rrset)
+
+        # first query to fill the cache
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        receivedResponse.id = response.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(receivedResponse, response)
+
+        for idx in range(numberOfQueries):
+            (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+            receivedResponse.id = response.id
+            self.assertEquals(receivedResponse, response)
+
+            (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+            receivedResponse.id = response.id
+            self.assertEquals(receivedResponse, response)
+
+        total = 0
+        for key in TestAdvancedCaching._responsesCounter:
+            total += TestAdvancedCaching._responsesCounter[key]
+
+        self.assertEquals(total, 1)
+
+    def testSkipCache(self):
+        """
+        Advanced: SkipCacheAction
+
+        dnsdist is configured to not cache entries for nocache.tests.powerdns.com.
+         we are sending several requests and checking that the backend get them all.
+        """
+        name = 'nocache.tests.powerdns.com.'
+        numberOfQueries = 10
+        query = dns.message.make_query(name, 'AAAA', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.AAAA,
+                                    '::1')
+        response.answer.append(rrset)
+
+        for idx in range(numberOfQueries):
+            (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            receivedResponse.id = response.id
+            self.assertEquals(query, receivedQuery)
+            self.assertEquals(receivedResponse, response)
+
+            (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            receivedResponse.id = response.id
+            self.assertEquals(query, receivedQuery)
+            self.assertEquals(receivedResponse, response)
+
+        for key in TestAdvancedCaching._responsesCounter:
+            value = TestAdvancedCaching._responsesCounter[key]
+            self.assertEquals(value, numberOfQueries)
+
+    def testCacheExpiration(self):
+        """
+        Advanced: Cache expiration
+
+        dnsdist is configured to cache entries, we are sending one request
+        (cache miss) with a very short TTL, checking that the next requests
+        are cached. Then we wait for the TTL to expire, check that the
+        next request is a miss but the following one a hit.
+        """
+        ttl = 2
+        misses = 0
+        name = 'cacheexpiration.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AAAA', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    ttl,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.AAAA,
+                                    '::1')
+        response.answer.append(rrset)
+
+        # first query to fill the cache
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        receivedResponse.id = response.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(receivedResponse, response)
+        misses += 1
+
+        # next queries should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        receivedResponse.id = response.id
+        self.assertEquals(receivedResponse, response)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        receivedResponse.id = response.id
+        self.assertEquals(receivedResponse, response)
+
+        # now we wait a bit for the cache entry to expire
+        time.sleep(ttl + 1)
+
+        # next query should be a miss, fill the cache again
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        receivedResponse.id = response.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(receivedResponse, response)
+        misses += 1
+
+        # following queries should hit the cache again
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        receivedResponse.id = response.id
+        self.assertEquals(receivedResponse, response)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        receivedResponse.id = response.id
+        self.assertEquals(receivedResponse, response)
+
+        total = 0
+        for key in TestAdvancedCaching._responsesCounter:
+            total += TestAdvancedCaching._responsesCounter[key]
+
+        self.assertEquals(total, misses)
+
+    def testCacheDecreaseTTL(self):
+        """
+        Advanced: Cache decreases TTL
+
+        dnsdist is configured to cache entries, we are sending one request
+        (cache miss) and verify that the cache hits have a decreasing TTL.
+        """
+        ttl = 600
+        misses = 0
+        name = 'cachedecreasettl.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AAAA', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    ttl,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.AAAA,
+                                    '::1')
+        response.answer.append(rrset)
+
+        # first query to fill the cache
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        receivedResponse.id = response.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(receivedResponse, response)
+        misses += 1
+
+        # next queries should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        receivedResponse.id = response.id
+        self.assertEquals(receivedResponse, response)
+        for an in receivedResponse.answer:
+            self.assertTrue(an.ttl <= ttl)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        receivedResponse.id = response.id
+        self.assertEquals(receivedResponse, response)
+        for an in receivedResponse.answer:
+            self.assertTrue(an.ttl <= ttl)
+
+        # now we wait a bit for the TTL to decrease
+        time.sleep(1)
+
+        # next queries should hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        receivedResponse.id = response.id
+        self.assertEquals(receivedResponse, response)
+        for an in receivedResponse.answer:
+            self.assertTrue(an.ttl < ttl)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        receivedResponse.id = response.id
+        self.assertEquals(receivedResponse, response)
+        for an in receivedResponse.answer:
+            self.assertTrue(an.ttl < ttl)
+
+        total = 0
+        for key in TestAdvancedCaching._responsesCounter:
+            total += TestAdvancedCaching._responsesCounter[key]
+
+        self.assertEquals(total, misses)
+
+    def testCacheDifferentCase(self):
+        """
+        Advanced: Cache matches different case
+
+        dnsdist is configured to cache entries, we are sending one request
+        (cache miss) and verify that the same one with a different case
+        matches.
+        """
+        ttl = 600
+        name = 'cachedifferentcase.tests.powerdns.com.'
+        differentCaseName = 'CacheDifferentCASE.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AAAA', 'IN')
+        differentCaseQuery = dns.message.make_query(differentCaseName, 'AAAA', 'IN')
+        response = dns.message.make_response(query)
+        differentCaseResponse = dns.message.make_response(differentCaseQuery)
+        rrset = dns.rrset.from_text(name,
+                                    ttl,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.AAAA,
+                                    '::1')
+        response.answer.append(rrset)
+        differentCaseResponse.answer.append(rrset)
+
+        # first query to fill the cache
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        receivedResponse.id = response.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(receivedResponse, response)
+
+        # different case query should still hit the cache
+        (_, receivedResponse) = self.sendUDPQuery(differentCaseQuery, response=None, useQueue=False)
+        receivedResponse.id = differentCaseResponse.id
+        self.assertEquals(receivedResponse, differentCaseResponse)
+
+        (_, receivedResponse) = self.sendTCPQuery(differentCaseQuery, response=None, useQueue=False)
+        receivedResponse.id = differentCaseResponse.id
+        self.assertEquals(receivedResponse, differentCaseResponse)
+
+class TestAdvancedCachingWithExistingEDNS(DNSDistTest):
+
+    _config_template = """
+    pc = newPacketCache(5, 86400, 1)
+    getPool(""):setCache(pc)
+    newServer{address="127.0.0.1:%s"}
+    """
+    def testCacheWithEDNS(self):
+        """
+        Advanced: Cache should not match different EDNS value
+
+        dnsdist is configured to cache entries, we are sending one request
+        (cache miss) and verify that the same one with a different EDNS UDP
+        Payload size is not served from the cache.
+        """
+        misses = 0
+        name = 'cachedifferentedns.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=512)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        receivedResponse.id = response.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+        misses += 1
+
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        receivedResponse.id = response.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+        misses += 1
+
+        total = 0
+        for key in TestAdvancedCaching._responsesCounter:
+            total += TestAdvancedCaching._responsesCounter[key]
+
+        self.assertEquals(total, misses)


### PR DESCRIPTION
Per-pool Packet Cache, using the whole query packet minus the id
has hashing key, to prevent issue related to:
* EDNS Payload size
* ECS
* DNSSEC

The packet cache is not enabled by default, and can be skipped
for specific queries using SkipCacheAction.
It's a per-pool cache, in case you have different responses, but
you can use the same cache for several pools if you want to.

We cache the whole response and age the TTLs when fetching the
response from the cache.

This commit also refactors a bit the way server pools are handled
to be able to have a per-pool cache, and to avoid scanning all
servers when looking for the ones in a given pool.

It is using a fixed-size unordered_map to prevent rehashing. It
is not very efficient with regard to cache cleaning, but I really
would like to use only a ReadLock on the fastpath, and using a
multi index container and moving cache entries to the back / front
on hit / miss would prevent that.

Health checks are moved to a different thread, to prevent them from
being impacted by the cache cleaning operation being slow.