### PR TITLE
dnsdist: Add an option to log as text. Display filename in showRules

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -840,7 +840,7 @@ instantiate a server with additional parameters
     * `DelayAction()`: delay the response by the specified amount of milliseconds (UDP-only)
     * `DisableValidationAction()`: set the CD bit in the question, let it go through
     * `DropAction()`: drop these packets
-    * `LogAction()`: Log a line for each query, to the specified file if any, to the console (require verbose) otherwise
+    * `LogAction([filename], [binary])`: Log a line for each query, to the specified file if any, to the console (require verbose) otherwise. When logging to a file, the `binary` optional parameter specifies whether we log in binary form (default) or in textual form
     * `NoRecurseAction()`: strip RD bit from the question, let it go through
     * `PoolAction()`: set the packet into the specified pool
     * `QPSPoolAction()`: set the packet into the specified pool only if it does not exceed the specified QPS limits

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -619,8 +619,8 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       return std::shared_ptr<DNSAction>(new DisableValidationAction);
     });
 
-  g_lua.writeFunction("LogAction", [](const std::string& fname) {
-      return std::shared_ptr<DNSAction>(new LogAction(fname));
+  g_lua.writeFunction("LogAction", [](const std::string& fname, boost::optional<bool> binary) {
+      return std::shared_ptr<DNSAction>(new LogAction(fname, binary ? *binary : true));
     });
 
   g_lua.writeFunction("RCodeAction", [](int rcode) {

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -589,7 +589,7 @@ public:
   LogAction() : d_fp(0)
   {
   }
-  LogAction(const std::string& str) : d_fname(str)
+  LogAction(const std::string& str, bool binary=true) : d_fname(str), d_binary(binary)
   {
     if(str.empty())
       return;
@@ -608,19 +608,28 @@ public:
       vinfolog("Packet from %s for %s %s with id %d", dq->remote->toStringWithPort(), dq->qname->toString(), QType(dq->qtype).getName(), dq->dh->id);
     }
     else {
-      string out = dq->qname->toDNSString();
-      fwrite(out.c_str(), 1, out.size(), d_fp);
-      fwrite((void*)&dq->qtype, 1, 2, d_fp);
+      if(d_binary) {
+        string out = dq->qname->toDNSString();
+        fwrite(out.c_str(), 1, out.size(), d_fp);
+        fwrite((void*)&dq->qtype, 1, 2, d_fp);
+      }
+      else {
+        fprintf(d_fp, "Packet from %s for %s %s with id %d\n", dq->remote->toStringWithPort().c_str(), dq->qname->toString().c_str(), QType(dq->qtype).getName().c_str(), dq->dh->id);
+      }
     }
     return Action::None;
   }
   string toString() const override
   {
+    if (!d_fname.empty()) {
+      return "log to " + d_fname;
+    }
     return "log";
   }
 private:
   string d_fname;
   FILE* d_fp{0};
+  bool d_binary{true};
 };
 
 


### PR DESCRIPTION
LogAction() could log to the console in text mode or to a file in
binary mode. This commit adds an option to log to a file in text
mode.
When logging to a file, we now display the file name in
showRules().