### PR TITLE
[WIP] honour direct RRSIG queries

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -60,6 +60,7 @@ DNSPacket::DNSPacket()
   d_wantsnsid=false;
   d_haveednssubnet = false;
   d_dnssecOk=false;
+  d_doFakeRRSIG=false;
   d_ednsversion=0;
   d_ednsrcode=0;
   memset(&d, 0, sizeof(d));
@@ -115,6 +116,7 @@ DNSPacket::DNSPacket(const DNSPacket &orig)
   d_ednsversion = orig.d_ednsversion;
   d_ednsrcode = orig.d_ednsrcode;
   d_dnssecOk = orig.d_dnssecOk;
+  d_doFakeRRSIG = orig.d_doFakeRRSIG;
   d_rrs=orig.d_rrs;
   
   d_tsigkeyname = orig.d_tsigkeyname;
@@ -317,6 +319,8 @@ void DNSPacket::wrapup()
     try {
       uint8_t maxScopeMask=0;
       for(pos=d_rrs.begin(); pos < d_rrs.end(); ++pos) {
+        if(d_doFakeRRSIG && pos->qtype.getCode()!=QType::RRSIG)
+          continue;
         // cerr<<"during wrapup, content=["<<pos->content<<"]"<<endl;
         maxScopeMask = max(maxScopeMask, pos->scopeMask);
 
@@ -414,6 +418,7 @@ DNSPacket *DNSPacket::replyPacket() const
   r->d_ednsping = d_ednsping;
   r->d_wantsnsid = d_wantsnsid;
   r->d_dnssecOk = d_dnssecOk;
+  r->d_doFakeRRSIG = d_doFakeRRSIG;
   r->d_eso = d_eso;
   r->d_haveednssubnet = d_haveednssubnet;
   r->d_haveednssection = d_haveednssection;
@@ -549,6 +554,7 @@ try
 
   d_wantsnsid=false;
   d_dnssecOk=false;
+  d_doFakeRRSIG=false;
   d_ednsping.clear();
   d_havetsig = mdp.getTSIGPos();
   d_haveednssubnet = false;

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -159,6 +159,7 @@ public:
   bool d_tcp;
   bool d_dnssecOk;
   bool d_havetsig;
+  bool d_doFakeRRSIG;
 
   bool getTSIGDetails(TSIGRecordContent* tr, DNSName* keyname, string* message) const;
   void setTSIGDetails(const TSIGRecordContent& tr, const DNSName& keyname, const string& secret, const string& previous, bool timersonly=false);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1075,7 +1075,7 @@ bool PacketHandler::tryReferral(DNSPacket *p, DNSPacket*r, SOAData& sd, const DN
 
 void PacketHandler::completeANYRecords(DNSPacket *p, DNSPacket*r, SOAData& sd, const DNSName &target)
 {
-  if(!p->d_dnssecOk)
+  if(!p->d_dnssecOk && !r->d_doFakeRRSIG)
     return; // Don't send dnssec info to non validating resolvers.
 
   if(!d_dk.isSecuredZone(sd.qname))
@@ -1375,8 +1375,7 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
     // this TRUMPS a cname!
     if(p->qtype.getCode() == QType::RRSIG) {
       L<<Logger::Info<<"Direct RRSIG query for "<<target<<" from "<<p->getRemote()<<endl;
-      r->setRcode(RCode::NotImp);
-      goto sendit;
+      r->d_doFakeRRSIG = true;
     }
 
     DLOG(L<<"Checking for referrals first, unless this is a DS query"<<endl);
@@ -1393,13 +1392,13 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
     
     while(B.get(rr)) {
       //cerr<<"got content: ["<<rr.content<<"]"<<endl;
-      if (p->qtype.getCode() == QType::ANY && !p->d_dnssecOk && (rr.qtype.getCode() == QType:: DNSKEY || rr.qtype.getCode() == QType::NSEC3PARAM))
+      if (p->qtype.getCode() == QType::ANY && !p->d_dnssecOk && !r->d_doFakeRRSIG && (rr.qtype.getCode() == QType:: DNSKEY || rr.qtype.getCode() == QType::NSEC3PARAM))
         continue; // Don't send dnssec info to non validating resolvers.
       if (rr.qtype.getCode() == QType::RRSIG) // RRSIGS are added later any way.
         continue; // TODO: this actually means addRRSig should check if the RRSig is already there
 
       // cerr<<"Auth: "<<rr.auth<<", "<<(rr.qtype == p->qtype)<<", "<<rr.qtype.getName()<<endl;
-      if((p->qtype.getCode() == QType::ANY || rr.qtype == p->qtype) && rr.auth) 
+      if((p->qtype.getCode() == QType::ANY || rr.qtype == p->qtype || r->d_doFakeRRSIG) && rr.auth) 
         weDone=1;
       // the line below fakes 'unauth NS' for delegations for non-DNSSEC backends.
       if((rr.qtype == p->qtype && !rr.auth) || (rr.qtype.getCode() == QType::NS && (!rr.auth || !(sd.qname==rr.qname))))
@@ -1497,14 +1496,14 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
     else if(weDone) {
       bool haveRecords = false;
       for(const auto& rr: rrset) {
-        if((p->qtype.getCode() == QType::ANY || rr.qtype == p->qtype) && rr.qtype.getCode() && rr.auth) {
+        if((p->qtype.getCode() == QType::ANY || rr.qtype == p->qtype || r->d_doFakeRRSIG) && rr.qtype.getCode() && rr.auth) {
           r->addRecord(rr);
           haveRecords = true;
         }
       }
 
       if (haveRecords) {
-        if(p->qtype.getCode() == QType::ANY)
+        if(p->qtype.getCode() == QType::ANY || r->d_doFakeRRSIG)
           completeANYRecords(p, r, sd, target);
       }
       else
@@ -1542,7 +1541,7 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
         break;
       }
     }
-    if(p->d_dnssecOk)
+    if(p->d_dnssecOk || r->d_doFakeRRSIG)
       addRRSigs(d_dk, B, authSet, r->getRRS());
       
     r->wrapup(); // needed for inserting in cache


### PR DESCRIPTION
This makes it possible to enable DNSSEC for .fi domains.

TODO:
- [ ] hide behind an ACL? (allow-rrsig-queries-from)
- [ ] figure out Ficora client IPs so we can give the ACL a good default
- [ ] document
- [ ] add tests
- [ ] maybe rename `d_doFakeRRSIG`, I named it when I hoped to get away with actual obviously fake RRSIGs
- [ ] fix `[2016-02-13 16:05:43] Feb 13 16:05:43 Exception: DNSPacketWriter::commit() called without startRecord ever having been called, but a record` as reported on travis during the existing `direct-rrsig` test

Review welcome!
