### PR TITLE
Link our internal libs directly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -305,7 +305,7 @@ AC_SUBST([AM_CPPFLAGS],
 )
 
 AC_SUBST([YAHTTP_CFLAGS], ['-I$(top_srcdir)/ext/yahttp'])
-AC_SUBST([YAHTTP_LIBS], ['-L$(top_builddir)/ext/yahttp/yahttp -lyahttp'])
+AC_SUBST([YAHTTP_LIBS], ['$(top_builddir)/ext/yahttp/yahttp/libyahttp.la'])
 
 CXXFLAGS="$SANITIZER_FLAGS $CXXFLAGS"
 

--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS += \
 
 AM_LDFLAGS = $(THREADFLAGS)
 
-JSON11_LIBS = -L$(top_srcdir)/ext/json11 -ljson11
+JSON11_LIBS = $(top_srcdir)/ext/json11/libjson11.la
 
 EXTRA_DIST = \
 	OBJECTFILES \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1,4 +1,4 @@
-JSON11_LIBS = -L$(top_builddir)/ext/json11 -ljson11
+JSON11_LIBS = $(top_builddir)/ext/json11/libjson11.la
 
 AM_CPPFLAGS += \
 	-I$(top_srcdir)/ext/json11 \
@@ -294,10 +294,10 @@ pdnsutil_LDFLAGS = \
 pdnsutil_LDADD = \
 	@moduleobjects@ \
 	@modulelibs@ \
-	$(LIBDL) \
-	$(BOOST_PROGRAM_OPTIONS_LIBS) \
 	$(YAHTTP_LIBS) \
 	$(JSON11_LIBS) \
+	$(LIBDL) \
+	$(BOOST_PROGRAM_OPTIONS_LIBS) \
 	$(OPENSSL_LIBS)
 
 if BOTAN110

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -16,7 +16,7 @@ PDNS_ENABLE_UNIT_TESTS
 DNSDIST_ENABLE_DNSCRYPT
 
 AC_SUBST([YAHTTP_CFLAGS], ['-I$(top_srcdir)/ext/yahttp'])
-AC_SUBST([YAHTTP_LIBS], ['-L$(top_builddir)/ext/yahttp/yahttp -lyahttp'])
+AC_SUBST([YAHTTP_LIBS], ['$(top_builddir)/ext/yahttp/yahttp/libyahttp.la'])
 
 PDNS_WITH_LUAJIT
 AS_IF([test "x$with_luajit" = "xno"], [
@@ -60,5 +60,5 @@ AC_SUBST([PROGRAM_LDFLAGS])
 AC_CONFIG_FILES([Makefile
 	ext/yahttp/Makefile
 	ext/yahttp/yahttp/Makefile])
-	
+
 AC_OUTPUT

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -1,4 +1,4 @@
-JSON11_LIBS = -L$(top_srcdir)/ext/json11 -ljson11
+JSON11_LIBS = $(top_srcdir)/ext/json11/libjson11.la
 
 AM_CPPFLAGS = $(LUA_CFLAGS) $(YAHTTP_CFLAGS) $(BOOST_CPPFLAGS) $(SANITIZER_FLAGS) -O3 -Wall -pthread -DSYSCONFDIR=\"${sysconfdir}\"
 

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -90,7 +90,7 @@ AC_SUBST([AM_CPPFLAGS],
 )
 
 AC_SUBST([YAHTTP_CFLAGS], ['-I$(top_srcdir)/ext/yahttp'])
-AC_SUBST([YAHTTP_LIBS], ['-L$(top_builddir)/ext/yahttp/yahttp -lyahttp'])
+AC_SUBST([YAHTTP_LIBS], ['$(top_builddir)/ext/yahttp/yahttp/libyahttp.la'])
 
 CXXFLAGS="$SANITIZER_FLAGS $CXXFLAGS"
 


### PR DESCRIPTION
If we don't do this and we have an external version of the same
lib installed, we risk picking that one up instead.

See #3127 for background