### PR TITLE
dnsdist: Lock the Lua context before executing a LuaAction

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -22,6 +22,7 @@ public:
 
   Action operator()(DNSQuestion* dq, string* ruleresult) const override
   {
+    std::lock_guard<std::mutex> lock(g_luamutex);
     auto ret = d_func(dq);
     if(ruleresult)
       *ruleresult=std::get<1>(ret);


### PR DESCRIPTION
Otherwise the stack of the Lua context might get corrupted
whenever another Lua function (blockfilter, policy, maintenance or
another LuaAction) is simultaneously called from another thread.

We might be able to use a separate execution stack via
createThread()/lua_newthread(), but if I understand correctly how
it works, we would need to be sure that the Lua function called
does not access the global state at all, which is probably too
restrictive.

This should fix #3374, #3375, #3376, #3377, #3378, #3379, #3383,
and hopefully the random travis failures in our regression tests.