### PR TITLE
dnsdist: Fix the Drop action over UDP

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -746,6 +746,10 @@ try
         }
       }
 
+      if (action == DNSAction::Action::Drop) {
+        continue;
+      }
+
       if(dq.dh->qr) { // something turned it into a response
         char* response = query;
         uint16_t responseLen = dq.len;

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -41,6 +41,7 @@ class DNSDistTest(unittest.TestCase):
     mySMN = newSuffixMatchNode()
     mySMN:add(newDNSName("nameAndQtype.tests.powerdns.com."))
     addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(4))
+    addAction(makeRule("drop.test.powerdns.com."), DropAction())
     block=newDNSName("powerdns.org.")
     function blockFilter(dq)
         if(dq.qname:isPartOf(block))

--- a/regression-tests.dnsdist/test_Basics.py
+++ b/regression-tests.dnsdist/test_Basics.py
@@ -6,6 +6,22 @@ from dnsdisttests import DNSDistTest
 
 class TestBasics(DNSDistTest):
 
+    def testDropped(self):
+        """
+        Basics: Dropped query
+
+        Send an A query for drop.test.powerdns.com. domain,
+        which is dropped by configuration. We expect
+        no response.
+        """
+        name = 'drop.test.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, None)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, None)
+
     def testBlockedA(self):
         """
         Basics: Blocked A query


### PR DESCRIPTION
I broke the Drop action over UDP in commit
1a2a4e68b6368361981cf525e0c5cad3b63c3788 and somehow we did not
have any regression tests actually testing it.
Reported by @rygl 