### PR TITLE
re-dist dnsrecords.hh

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -142,7 +142,7 @@ pdns_server_SOURCES = \
 	dnspacket.cc dnspacket.hh \
 	dnsparser.cc \
 	dnsproxy.cc dnsproxy.hh \
-	dnsrecords.cc \
+	dnsrecords.cc dnsrecords.hh \
 	dnssecinfra.cc dnssecinfra.hh \
 	dnsseckeeper.hh \
 	dnssecsigner.cc \


### PR DESCRIPTION
@mind04 reported this file was missing from our dist balls since #3373. This PR fixes that. I confirmed locally that after this, a dist tarball will build.