### PR TITLE
Add SLES 12 support to the build-auth-rpm script

### DIFF
--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -36,14 +36,23 @@ fi
 # Some setups need rpmbuild in a 'special' env
 RPMBUILD_COMMAND='rpmbuild -bb pdns.spec'
 
+if [ -r /etc/os-release ]; then
+  OLDVERSION=$VERSION
+  source /etc/os-release
+  OS="${NAME} ${VERSION}"
+  VERSION=$OLDVERSION
+fi
+
 if [ -f /etc/redhat-release ]; then
   OS="$(cat /etc/redhat-release)"
-  case "$OS" in
+fi
+
+case "$OS" in
 #    Fedora\ *\ 21*)
 #      ;;
-    CentOS\ *\ 6*)
-      RPMBUILD_COMMAND="scl enable devtoolset-2 -- ${RPMBUILD_COMMAND}"
-      cat > pdns.spec << EOF
+  CentOS\ *\ 6*)
+    RPMBUILD_COMMAND="scl enable devtoolset-2 -- ${RPMBUILD_COMMAND}"
+    cat > pdns.spec << EOF
 %global backends %{nil}
 
 Name: pdns
@@ -277,9 +286,9 @@ fi
 %doc pdns/bind-dnssec.schema.sqlite3.sql
 %{_libdir}/%{name}/libgsqlite3backend.so
 EOF
-      ;;
-    CentOS\ Linux\ *\ 7*)
-      cat > pdns.spec << EOF
+    ;;
+  CentOS\ Linux\ *\ 7*)
+    cat > pdns.spec << EOF
 %global _hardened_build 1
 %global backends %{nil}
 
@@ -559,12 +568,257 @@ exit 0
 %{_libdir}/%{name}/libgsqlite3backend.so
 EOF
       ;;
+  SLES\ 12*)
+    cat > pdns.spec << EOF
+%global _hardened_build 1
+%global backends %{nil}
+
+Name: pdns
+Version: ${VERSION}
+Release: ${RELEASE}
+Summary: A modern, advanced and high performance authoritative-only nameserver
+Group: System Environment/Daemons
+License: GPLv2
+URL: http://powerdns.com
+Source: ../pdns-${TARBALLVERSION}.tar.bz2
+
+%{?systemd_requires}
+
+BuildRequires: boost-devel
+BuildRequires: lua-devel
+BuildRequires: bison
+BuildRequires: openssl-devel
+BuildRequires: systemd-rpm-macros
+Provides: powerdns = %{version}-%{release}
+%global backends %{backends} bind
+
+%description
+The PowerDNS Nameserver is a modern, advanced and high performance
+authoritative-only nameserver. It is written from scratch and conforms
+to all relevant DNS standards documents.
+Furthermore, PowerDNS interfaces with almost any database.
+
+%package tools
+Summary: Extra tools for %{name}
+Group: System Environment/Daemons
+
+%description tools
+This package contains the extra tools for %{name}
+
+%package backend-mysql
+Summary: MySQL backend for %{name}
+Group: System Environment/Daemons
+Requires: %{name}%{?_isa} = %{version}-%{release}
+BuildRequires: mysql-devel
+%global backends %{backends} gmysql
+
+%description backend-mysql
+This package contains the gmysql backend for %{name}
+
+%package backend-odbc
+Summary: UnixODBC backend for %{name}
+Group: System Environment/Daemons
+Requires: %{name}%{?_isa} = %{version}-%{release}
+BuildRequires: unixODBC-devel
+%global backends %{backends} godbc
+
+%description backend-odbc
+This package contains the godbc backend for %{name}
+
+%package backend-pipe
+Summary: Pipe backend for %{name}
+Group: System Environment/Daemons
+Requires: %{name}%{?_isa} = %{version}-%{release}
+%global backends %{backends} pipe
+
+%description backend-pipe
+This package contains the pipe backend for %{name}
+
+%package backend-remote
+Summary: Remote backend for %{name}
+Group: System Environment/Daemons
+Requires: %{name}%{?_isa} = %{version}-%{release}
+%global backends %{backends} remote
+
+%description backend-remote
+This package contains the remote backend for %{name}
+
+%package backend-ldap
+Summary: LDAP backend for %{name}
+Group: System Environment/Daemons
+Requires: %{name}%{?_isa} = %{version}-%{release}
+BuildRequires: openldap2-devel
+%global backends %{backends} ldap
+
+%description backend-ldap
+This package contains the LDAP backend for %{name}
+
+%package backend-lua
+Summary: Lua backend for %{name}
+Group: System Environment/Daemons
+Requires: %{name}%{?_isa} = %{version}-%{release}
+%global backends %{backends} lua
+
+%description backend-lua
+This package contains the lua backend for %{name}
+
+%package backend-sqlite
+Summary: SQLite backend for %{name}
+Group: System Environment/Daemons
+Requires: %{name}%{?_isa} = %{version}-%{release}
+BuildRequires: sqlite-devel
+%global backends %{backends} gsqlite3
+
+%description backend-sqlite
+This package contains the SQLite backend for %{name}
+
+%prep
+%setup -q -n %{name}-${TARBALLVERSION}
+
+%build
+export CPPFLAGS="-DLDAP_DEPRECATED"
+
+%configure \
+	--sysconfdir=%{_sysconfdir}/%{name} \
+	--disable-static \
+	--disable-dependency-tracking \
+	--disable-silent-rules \
+	--with-modules='' \
+	--with-lua \
+	--with-dynmodules='%{backends} random' \
+	--enable-tools \
+	--enable-unit-tests
+
+make %{?_smp_mflags}
+
+%install
+make install DESTDIR=%{buildroot}
+
+%{__rm} -f %{buildroot}%{_libdir}/%{name}/*.la
+%{__rm} -rf %{buildroot}/usr/share/doc
+%{buildroot}/usr/sbin/pdns_server --no-config --config | sed \
+  -e 's!# config-dir=.*!config-dir=%{_sysconfdir}%{name}!' \
+  -e 's!# daemon=.*!daemon=yes!' \
+  -e 's!# guardian=.*!guardian=yes!' \
+  -e 's!# launch=.*!&\\nlaunch=!' \
+  -e 's!# setgid=.*!setgid=pdns!' \
+  -e 's!# setuid=.*!setuid=pdns!' \
+  > %{buildroot}%{_sysconfdir}/%{name}/pdns.conf
+%{__rm} %{buildroot}%{_sysconfdir}/%{name}/pdns.conf-dist
+
+chmod 600 %{buildroot}%{_sysconfdir}/%{name}/pdns.conf
+
+# rename zone2ldap to pdns-zone2ldap (#1193116)
+%{__mv} %{buildroot}/%{_bindir}/zone2ldap %{buildroot}/%{_bindir}/pdns-zone2ldap
+%{__mv} %{buildroot}/%{_mandir}/man1/zone2ldap.1 %{buildroot}/%{_mandir}/man1/pdns-zone2ldap.1
+
+# install systemd unit file
+%{__install} -D -p -m 644 contrib/systemd-pdns.service %{buildroot}%{_unitdir}/%{name}.service
+
+%check
+make %{?_smp_mflags} -C pdns check
+
+%pre
+getent group pdns >/dev/null || groupadd -r pdns
+getent passwd pdns >/dev/null || \
+	useradd -r -g pdns -d / -s /sbin/nologin \
+	-c "PowerDNS user" pdns
+exit 0
+
+%service_add_pre pdns.service
+
+%post
+%service_add_post pdns.service
+
+%preun
+%service_del_preun pdns.service
+
+%postun
+%service_del_postun pdns.service
+
+%files
+%doc COPYING README
+%{_bindir}/pdns_control
+%{_bindir}/pdnsutil
+%{_bindir}/pdns-zone2ldap
+%{_bindir}/zone2sql
+%{_bindir}/zone2json
+%{_sbindir}/pdns_server
+%{_libdir}/%{name}/libbindbackend.so
+%{_mandir}/man1/pdns_control.1.gz
+%{_mandir}/man1/pdns_server.1.gz
+%{_mandir}/man1/zone2sql.1.gz
+%{_mandir}/man1/zone2json.1.gz
+%{_mandir}/man1/pdns-zone2ldap.1.gz
+%{_mandir}/man1/pdnsutil.1.gz
+%{_unitdir}/pdns.service
+%dir %{_libdir}/%{name}/
+%{_libdir}/%{name}/librandombackend.so
+%dir %{_sysconfdir}/%{name}/
+%config(noreplace) %{_sysconfdir}/%{name}/pdns.conf
+
+%files tools
+%{_bindir}/calidns
+%{_bindir}/dnsbulktest
+%{_bindir}/dnsgram
+%{_bindir}/dnsreplay
+%{_bindir}/dnsscan
+%{_bindir}/dnsscope
+%{_bindir}/dnstcpbench
+%{_bindir}/dnswasher
+%{_bindir}/dumresp
+%{_bindir}/ixplore
+%{_bindir}/notify
+%{_bindir}/nproxy
+%{_bindir}/nsec3dig
+%{_bindir}/saxfr
+%{_bindir}/sdig
+%{_mandir}/man1/dnsbulktest.1.gz
+%{_mandir}/man1/dnsgram.1.gz
+%{_mandir}/man1/dnsreplay.1.gz
+%{_mandir}/man1/dnsscan.1.gz
+%{_mandir}/man1/dnsscope.1.gz
+%{_mandir}/man1/dnstcpbench.1.gz
+%{_mandir}/man1/dnswasher.1.gz
+%{_mandir}/man1/ixplore.1.gz
+%{_mandir}/man1/nsec3dig.1.gz
+%{_mandir}/man1/saxfr.1.gz
+%{_mandir}/man1/sdig.1.gz
+
+%files backend-mysql
+%doc modules/gmysqlbackend/schema.mysql.sql
+%doc modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
+%doc modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql
+%{_libdir}/%{name}/libgmysqlbackend.so
+
+%files backend-odbc
+%doc modules/godbcbackend/schema.mssql.sql
+%{_libdir}/%{name}/libgodbcbackend.so
+
+%files backend-pipe
+%{_libdir}/%{name}/libpipebackend.so
+
+%files backend-remote
+%{_libdir}/%{name}/libremotebackend.so
+
+%files backend-ldap
+%{_libdir}/%{name}/libldapbackend.so
+
+%files backend-lua
+%{_libdir}/%{name}/libluabackend.so
+
+%files backend-sqlite
+%doc modules/gsqlite3backend/schema.sqlite3.sql
+%doc modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
+%doc modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
+%{_libdir}/%{name}/libgsqlite3backend.so
+EOF
+      ;;
     *)
       echo "No support for $OS (yet?)"
       exit 1
       ;;
   esac
-fi
 
 ${RPMBUILD_COMMAND}
 


### PR DESCRIPTION
No postgresql and tinydns backends, there is no tinycdb in SLES and the pg_config returns an unusable path according to configure (needs investigation, but it not a prio).