### PR TITLE
pdnsutil clearzone allows operator to remove all records of a zone but leave everything else in place

### DIFF
--- a/docs/manpages/pdnsutil.1.md
+++ b/docs/manpages/pdnsutil.1.md
@@ -154,6 +154,9 @@ check-all-zones
 check-zone *ZONE*
 :    Check zone *ZONE* for correctness.
 
+clear-zone *ZONE*
+:    Clear the records in zone *ZONE*, but leave actual domain and settings unchanged
+
 delete-zone *ZONE*:
 :    Delete the zone named *ZONE*.
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -865,6 +865,21 @@ int read1char(){
     return c;
 }
 
+int clearZone(DNSSECKeeper& dk, const DNSName &zone) {
+  UeberBackend B;
+  DomainInfo di;
+  
+  if (! B.getDomainInfo(zone, di)) {
+    cerr<<"Domain '"<<zone.toString()<<"' not found!"<<endl;
+    return 1;
+  }
+  if(!di.backend->startTransaction(zone, di.id)) {
+    cerr<<"Unable to start transaction for load of zone '"<<zone.toString()<<"'"<<endl;
+    return 1;
+  }
+  di.backend->commitTransaction();
+  return 0;
+}
 
 int editZone(DNSSECKeeper& dk, const DNSName &zone) {
   UeberBackend B;
@@ -1831,6 +1846,7 @@ try
     cerr<<"check-zone ZONE                    Check a zone for correctness"<<endl;
     cerr<<"check-all-zones [exit-on-error]    Check all zones for correctness. Set exit-on-error to exit immediately"<<endl;
     cerr<<"                                   after finding an error in a zone."<<endl;
+    cerr<<"clear-zone ZONE                    Clear all records of a zone, but keep everything else"<<endl;
     cerr<<"create-bind-db FNAME               Create DNSSEC db for BIND backend (bind-dnssec-db)"<<endl;
     cerr<<"create-zone ZONE [nsname]          Create empty zone ZONE"<<endl;
     cerr<<"deactivate-tsig-key ZONE NAME {master|slave}"<<endl;
@@ -2203,7 +2219,16 @@ seedRandom(::arg()["entropy-source"]);
 
     exit(editZone(dk, DNSName(cmds[1])));
   }
+  else if(cmds[0] == "clear-zone") {
+    if(cmds.size() != 2) {
+      cerr<<"Syntax: pdnsutil edit-zone ZONE"<<endl;
+      return 0;
+    }
+    if(cmds[1]==".")
+      cmds[1].clear();
 
+    exit(clearZone(dk, DNSName(cmds[1])));
+  }
   else if(cmds[0] == "list-keys") {
     if(cmds.size() > 2) {
       cerr<<"Syntax: pdnsutil list-keys [ZONE]"<<endl;


### PR DESCRIPTION
Used when perhaps pdns_control retrieve does not work but the records have to go away PDQ