### PR TITLE
Secure and Rectify Zones When they are Created or Modified Through API Calls (POST/PATCH)

### DIFF
--- a/docs/http-api/endpoint-zones.rst
+++ b/docs/http-api/endpoint-zones.rst
@@ -20,7 +20,7 @@ Zones endpoint
   These default values can be overridden by supplying a custom SOA record in the records list.
   If ``soa_edit_api`` is set, the SOA record is edited according to the SOA-EDIT-API rules before storing it (also applies to custom SOA records).
 
-  **TODO**: ``dnssec``, ``nsec3narrow``, ``nsec3param``, ``presigned`` are not yet implemented.
+  **TODO**: ``presigned`` is not yet implemented.
 
 .. http:get:: /api/v1/servers/:server_id/zones/:zone_id
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -286,11 +286,19 @@ bool DNSSECKeeper::getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* 
   return true;
 }
 
-bool DNSSECKeeper::setNSEC3PARAM(const DNSName& zname, const NSEC3PARAMRecordContent& ns3p, const bool& narrow)
+bool DNSSECKeeper::checkNSEC3PARAM(const NSEC3PARAMRecordContent& ns3p)
 {
   static int maxNSEC3Iterations=::arg().asNum("max-nsec3-iterations");
   if (ns3p.d_iterations > maxNSEC3Iterations)
-    throw runtime_error("Can't set NSEC3PARAM for zone '"+zname.toString()+"': number of NSEC3 iterations is above 'max-nsec3-iterations'");
+    return false;
+
+  return true;
+}
+
+bool DNSSECKeeper::setNSEC3PARAM(const DNSName& zname, const NSEC3PARAMRecordContent& ns3p, const bool& narrow)
+{
+  if (!checkNSEC3PARAM(ns3p))
+    throw runtime_error("NSEC3PARAMs provided for zone '"+zname.toString()+"' are invalid. Check if the number of NSEC3 iterations is above 'max-nsec3-iterations'");
 
   if (ns3p.d_algorithm != 1)
     throw runtime_error("Invalid hash algorithm for NSEC3: '"+std::to_string(ns3p.d_algorithm)+"' for zone '"+zname.toString()+"'. The only valid value is '1'");

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -627,6 +627,7 @@ bool DNSSECKeeper::rectifyZone(UeberBackend& B, const DNSName& zone)
   bool isOptOut=(haveNSEC3 && ns3pr.d_flags);
 
   bool realrr=true;
+  bool doent=true;
   uint32_t maxent = ::arg().asNum("max-ent-entries");
 
   dononterm:;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -649,25 +649,25 @@ bool DNSSECKeeper::rectifyZone(UeberBackend& B, const DNSName& zone)
     if(haveNSEC3) // NSEC3
     {
       if(!narrow && (realrr || !isOptOut || nonterm.find(qname)->second))
-        ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname))) + zone;
+        ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname)));
       else if(!realrr)
         auth=false;
     }
     else if (realrr) // NSEC
-      ordername=qname;
+      ordername=qname.makeRelative(zone);
 
-    sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, auth);
+    sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, auth);
 
     if(realrr)
     {
       if (dsnames.count(qname))
-        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, true, QType::DS);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, true, QType::DS);
       if (!auth || nsset.count(qname)) {
         ordername.clear();
         if(isOptOut)
-          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, false, QType::NS);
-        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, false, QType::A);
-        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, false, QType::AAAA);
+          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::NS);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::A);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::AAAA);
       }
 
       if(doent)
@@ -707,7 +707,7 @@ bool DNSSECKeeper::rectifyZone(UeberBackend& B, const DNSName& zone)
     //cerr<<"Total: "<<nonterm.size()<<" Insert: "<<insnonterm.size()<<" Delete: "<<delnonterm.size()<<endl;
     if(!insnonterm.empty() || !delnonterm.empty() || !doent)
     {
-      sd.db->updateEmptyNonTerminals(sd.domain_id, zone, insnonterm, delnonterm, !doent);
+      sd.db->updateEmptyNonTerminals(sd.domain_id, insnonterm, delnonterm, !doent);
     }
     if(doent)
     {

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -38,6 +38,7 @@
 #include "base64.hh"
 #include "cachecleaner.hh"
 #include "arguments.hh"
+#include "base32.hh"
 
 
 using namespace boost::assign;
@@ -574,4 +575,141 @@ void DNSSECKeeper::cleanup()
     }
     s_last_prune=time(0);
   }
+}
+
+/**
+ * Rectify the zone given using the given backend. Automatically chooses NSEC vs NSEC3 appropriately
+ */
+bool DNSSECKeeper::rectifyZone(UeberBackend& B, const DNSName& zone)
+{
+  if(isPresigned(zone)){
+    return false;
+  }
+
+  SOAData sd;
+
+  if(!B.getSOAUncached(zone, sd)) {
+    return false;
+  }
+  sd.db->list(zone, sd.domain_id);
+
+  DNSResourceRecord rr;
+  set<DNSName> qnames, nsset, dsnames, insnonterm, delnonterm;
+  map<DNSName,bool> nonterm;
+  vector<DNSResourceRecord> rrs;
+
+  while(sd.db->get(rr)) {
+    rr.qname.makeUsLowerCase();
+    if (rr.qtype.getCode())
+    {
+      rrs.push_back(rr);
+      qnames.insert(rr.qname);
+      if(rr.qtype.getCode() == QType::NS && rr.qname != zone)
+        nsset.insert(rr.qname);
+      if(rr.qtype.getCode() == QType::DS)
+        dsnames.insert(rr.qname);
+    }
+    else
+      delnonterm.insert(rr.qname);
+  }
+
+  NSEC3PARAMRecordContent ns3pr;
+  bool narrow;
+  bool haveNSEC3 = getNSEC3PARAM(zone, &ns3pr, &narrow);
+  bool isOptOut=(haveNSEC3 && ns3pr.d_flags);
+
+  bool realrr=true;
+  uint32_t maxent = ::arg().asNum("max-ent-entries");
+
+  dononterm:;
+  for (const auto& qname: qnames)
+  {
+    bool auth=true;
+    DNSName ordername;
+    auto shorter(qname);
+
+    if(realrr) {
+      do {
+        if(nsset.count(shorter)) {
+          auth=false;
+          break;
+        }
+      } while(shorter.chopOff());
+    }
+
+    if(haveNSEC3) // NSEC3
+    {
+      if(!narrow && (realrr || !isOptOut || nonterm.find(qname)->second))
+        ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname))) + zone;
+      else if(!realrr)
+        auth=false;
+    }
+    else if (realrr) // NSEC
+      ordername=qname;
+
+    sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, auth);
+
+    if(realrr)
+    {
+      if (dsnames.count(qname))
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, true, QType::DS);
+      if (!auth || nsset.count(qname)) {
+        ordername.clear();
+        if(isOptOut)
+          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, false, QType::NS);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, false, QType::A);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, false, QType::AAAA);
+      }
+
+      if(doent)
+      {
+        shorter=qname;
+        while(shorter!=zone && shorter.chopOff())
+        {
+          if(!qnames.count(shorter))
+          {
+            if(!(maxent))
+            {
+              cerr<<"Zone '"<<zone.toString()<<"' has too many empty non terminals."<<endl;
+              insnonterm.clear();
+              delnonterm.clear();
+              doent=false;
+              break;
+            }
+
+            if (!delnonterm.count(shorter) && !nonterm.count(shorter))
+              insnonterm.insert(shorter);
+            else
+              delnonterm.erase(shorter);
+
+            if (!nonterm.count(shorter)) {
+              nonterm.insert(pair<DNSName, bool>(shorter, auth));
+              --maxent;
+            } else if (auth)
+              nonterm[shorter]=true;
+          }
+        }
+      }
+    }
+  }
+
+  if(realrr)
+  {
+    //cerr<<"Total: "<<nonterm.size()<<" Insert: "<<insnonterm.size()<<" Delete: "<<delnonterm.size()<<endl;
+    if(!insnonterm.empty() || !delnonterm.empty() || !doent)
+    {
+      sd.db->updateEmptyNonTerminals(sd.domain_id, zone, insnonterm, delnonterm, !doent);
+    }
+    if(doent)
+    {
+      realrr=false;
+      qnames.clear();
+      for(const auto& nt :  nonterm){
+        qnames.insert(nt.first);
+      }
+      goto dononterm;
+    }
+  }
+
+  return true;
 }

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -182,6 +182,7 @@ public:
 
   bool getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* n3p=0, bool* narrow=0);
   bool setNSEC3PARAM(const DNSName& zname, const NSEC3PARAMRecordContent& n3p, const bool& narrow=false);
+  bool checkNSEC3PARAM(const NSEC3PARAMRecordContent& n3p);
   bool unsetNSEC3PARAM(const DNSName& zname);
   void clearAllCaches();
   void clearCaches(const DNSName& name);

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -209,6 +209,8 @@ public:
   
   void getFromMeta(const DNSName& zname, const std::string& key, std::string& value);
   void getSoaEdit(const DNSName& zname, std::string& value);
+
+  bool rectifyZone(UeberBackend& B, const DNSName& zone);
 private:
 
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -150,6 +150,7 @@ bool rectifyZone(DNSSECKeeper& dk, const DNSName& zone)
 
   if(!B.getSOAUncached(zone, sd)) {
     cerr<<"No SOA known for '"<<zone.toString()<<"', is such a zone in the database?"<<endl;
+    return false;
   }
 
   NSEC3PARAMRecordContent ns3pr;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1166,7 +1166,8 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       for (auto &k_algo: k_algos) {
         int algo = DNSSECKeeper::shorthand2algorithm(k_algo);
 
-        if (!dk.addKey(zonename, true, algo, k_size, true)) {
+        int64_t id;
+        if (!dk.addKey(zonename, true, algo, id, k_size)) {
           throw ApiException("No backend was able to secure '" + zonename.toString() + "', most likely because no DNSSEC"
                              + "capable backends are loaded, or because the backends have DNSSEC disabled."
                              + "For the Generic SQL backends, set the 'gsqlite3-dnssec', 'gmysql-dnssec' or"
@@ -1177,7 +1178,8 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       for (auto &z_algo :  z_algos) {
         int algo = DNSSECKeeper::shorthand2algorithm(z_algo);
 
-        if (!dk.addKey(zonename, k_algos.empty(), algo, z_size, true)) {
+        int64_t id;
+        if (!dk.addKey(zonename, k_algos.empty(), algo, id, z_size)) {
           throw ApiException("No backend was able to secure '" + zonename.toString() + "', most likely because no DNSSEC"
                              + "capable backends are loaded, or because the backends have DNSSEC disabled."
                              + "For the Generic SQL backends, set the 'gsqlite3-dnssec', 'gmysql-dnssec' or"

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1179,7 +1179,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
         int algo = DNSSECKeeper::shorthand2algorithm(z_algo);
 
         int64_t id;
-        if (!dk.addKey(zonename, k_algos.empty(), algo, id, z_size)) {
+        if (!dk.addKey(zonename, false, algo, id, z_size)) {
           throw ApiException("No backend was able to secure '" + zonename.toString() + "', most likely because no DNSSEC"
                              + "capable backends are loaded, or because the backends have DNSSEC disabled."
                              + "For the Generic SQL backends, set the 'gsqlite3-dnssec', 'gmysql-dnssec' or"

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1194,7 +1194,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       }
     }
 
-    if (!dk.isPresigned(zonename)) {
+    if (dk.isSecuredZone(zonename) && !dk.isPresigned(zonename)) {
       if (!dk.rectifyZone(B, zonename)) {
         throw ApiException("Failed to rectify '" + zonename.toString() + "'. Check if the zone contains too many non-empty terminals.");
       }
@@ -1547,7 +1547,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
   }
 
   DNSSECKeeper dk;
-  if (!dk.isPresigned(zonename)) {
+  if (dk.isSecuredZone(zonename) && !dk.isPresigned(zonename)) {
     if (!dk.rectifyZone(B, zonename))
       throw ApiException("Failed to rectify '" + zonename.toString() + "'. Check if the zone contains too many non-empty terminals.");
   }


### PR DESCRIPTION
This PR extends existing API functionality of POST and PATCH zones by optionally sign and rectify them. To do so, the patch honors the `dnssec`, `nsec3param` and `nsec3narrow` parameters of the API request on POST and stores them. If anything goes wrong with signing or rectifying, the API throws an APIException and aborts the transaction -- the zone will not be inserted. On a PATCH, the zone is rectified again.

Technical note: the code for signing and rectifying was taken from pdnsutil. Due to the amount of code needed for rectifying, it was moved to the DNSSECKeeper to use the same code in pdnsutil and in the API.

The PR does not cause any more gmysql test cases to fail than before. Failing test cases are:

```
0dyndns-prereq-all
0dyndns-prereq-nxrrset-full
1dyndns-big-package
1dyndns-check-soa-update
1dyndns-update-add-delete
1dyndns-update-add-delete-casesensative
1dyndns-update-add-delete-cname
1dyndns-update-add-delete-ds
1dyndns-update-add-delete-mx
1dyndns-update-add-delete-wildcard
1dyndns-update-add-invalid-record
1dyndns-update-add-soa
1dyndns-update-deep-add-delete
1dyndns-update-deep-delegate
1dyndns-update-delegate
1dyndns-update-delegate-in-between
1dyndns-update-delete-add-host
1dyndns-update-delete-multi-add-host
1dyndns-update-delete-mx-prio
1dyndns-update-delete-ns
1dyndns-update-delete-parent-delegate
1dyndns-update-delete-soa
1dyndns-update-in-between
1dyndns-update-nsec3params
1dyndns-update-nsec3params-with-others
1dyndns-update-replace-a-host
1dyndns-update-replace-cname
1dyndns-update-replace-mx
1dyndns-update-srv
1dyndns-update-update-ttl
2dyndns-update-replace-soa
tsig-axfr
tsig-axfr-algorithm-mismatch
tsig-axfr-key-mismatch
tsig-ixfr
tsig-ixfr-algorithm-mismatch
tsig-ixfr-key-mismatch
```

I can edit the commit messages if desired.

Please let me know if any more editing is needed in order to pass this PR.
