### PR TITLE
Add compatibility with selinux to the systemd unit file

### DIFF
--- a/contrib/systemd-pdns.service
+++ b/contrib/systemd-pdns.service
@@ -12,10 +12,6 @@ StartLimitInterval=0
 PrivateTmp=true
 PrivateDevices=true
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID
-NoNewPrivileges=true
-# ProtectSystem=full will disallow write access to /etc and /usr, possibly
-# not being able to write slaved-zones into sqlite3 or zonefiles.
-ProtectSystem=full
 ProtectHome=true
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 


### PR DESCRIPTION
PowerDNS auth fails to start with "NoNewPrivileges=true" if selinux is set to enforcing.
See: https://bugzilla.redhat.com/show_bug.cgi?id=1305522

ProtectSystem=full caused also selinux related warnings:
type=AVC msg=audit(1456267226.894:458): avc:  denied  { mounton } for  pid=3776 comm="(s_server)" path="/etc" dev="dm-0" ino=134217857 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=dir permissive=0

I suggest to disable both settings by default.