### PR TITLE
dnsdist: Make PoolAction() stop the rule processing again

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -356,7 +356,6 @@ Some specific actions do not stop the processing when they match, contrary to al
  * Log
  * MacAddr
  * No Recurse
- * Route to a pool
  * and of course None
 
 A convenience function `makeRule()` is supplied which will make a NetmaskGroupRule for you or a SuffixMatchNodeRule
@@ -454,7 +453,7 @@ Valid return values for `LuaAction` functions are:
  * DNSAction.HeaderModify: indicate that the query has been turned into a response
  * DNSAction.None: continue to the next rule
  * DNSAction.Nxdomain: return a response with a NXDomain rcode
- * DNSAction.Pool: use the specified pool to forward this query, continue to the next rule
+ * DNSAction.Pool: use the specified pool to forward this query
  * DNSAction.Spoof: spoof the response using the supplied IPv4 (A), IPv6 (AAAA) or string (CNAME) value
 
 DNSSEC

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -297,10 +297,11 @@ void* tcpClientThread(int pipefd)
             case DNSAction::Action::HeaderModify:
               done = true;
               break;
-            /* non-terminal actions follow */
             case DNSAction::Action::Pool:
               poolname=ruleresult;
+              done = true;
               break;
+            /* non-terminal actions follow */
             case DNSAction::Action::Delay:
             case DNSAction::Action::None:
               break;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -752,10 +752,11 @@ try
           case DNSAction::Action::HeaderModify:
             done = true;
             break;
-          /* non-terminal actions follow */
           case DNSAction::Action::Pool:
             poolname=ruleresult;
+            done = true;
             break;
+          /* non-terminal actions follow */
           case DNSAction::Action::Delay:
             delayMsec = static_cast<int>(pdns_stou(ruleresult)); // sorry
             break;


### PR DESCRIPTION
It could clearly be confusing, and can easily be done by
ordering rules correctly anyway.
Thanks @rygl for the very valuable feedback.