### PR TITLE
recursor: Move replaced cached entries to the back

### DIFF
--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -126,6 +126,7 @@ void RecursorPacketCache::insertResponsePacket(unsigned int tag, const DNSName& 
     DNSName respname(iter->d_packet.c_str(), iter->d_packet.length(), sizeof(dnsheader), false, 0, 0, 0);
     if(qname != respname)
       continue;
+    moveCacheItemToBack(d_packetCache, iter);
     iter->d_packet = responsePacket;
     iter->d_ttd = now + ttl;
     iter->d_creation = now;

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -127,10 +127,12 @@ void MemRecursorCache::replace(time_t now, const DNSName &qname, const QType& qt
   d_cachecachevalid=false;
 
   cache_t::iterator stored;
+  bool isNew = false;
   auto key=boost::make_tuple(qname, qt.getCode(), ednsmask ? *ednsmask : Netmask());
   stored=d_cache.find(key);
   if(stored == d_cache.end()) {
     stored=d_cache.insert(CacheEntry(key,CacheEntry::records_t(), auth)).first;
+    isNew = true;
   }
 
   uint32_t maxTTD=UINT_MAX;
@@ -174,6 +176,9 @@ void MemRecursorCache::replace(time_t now, const DNSName &qname, const QType& qt
     // there was code here that did things with TTL and auth. Unsure if it was good. XXX
   }
 
+  if (!isNew) {
+    moveCacheItemToBack(d_cache, stored);
+  }
   d_cache.replace(stored, ce);
 }
 


### PR DESCRIPTION
When we replace an existing entry, it keeps its existing place in
the expunge queue, while new entries are inserted to the back and
hits are moved to the back.
Moving replaced entries to the back of the queue is more fair and
so probably more efficient, as it would increase the likelihood of
expunging unused expired entries from the cache.