### PR TITLE
dnsdist: Fix str-only server not being added to the default pool

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -841,6 +841,8 @@ instantiate a server with additional parameters
     * `rmServer(server)`: remove this server object
  * Server member functions:
     * `addPool(pool)`: add this server to that pool
+    * `getName()`: return the server name if any
+    * `getNameWithAddr()`: return a string containing the server name if any plus the server address and port
     * `getOutstanding()`: this *returns* the number of outstanding queries (doesn't print it!)
     * `rmPool(pool)`: remove server from that pool
     * `setQPS(n)`: set the QPS setting to n
@@ -850,6 +852,7 @@ instantiate a server with additional parameters
     * `isUp()`: if this server is available
  * Server member data:
     * `upStatus`: if `dnsdist` considers this server available (overridden by `setDown()` and `setUp()`)
+    * `name`: name of the server
     * `order`: order of this server in order-based server selection policies
     * `weight`: weight of this server in weighted server selection policies
  * Rule related:

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -170,6 +170,10 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 
 			    });
 
+			  auto localPools = g_pools.getCopy();
+			  addServerToPool(localPools, "", ret);
+			  g_pools.setState(localPools);
+
 			  if(g_launchWork) {
 			    g_launchWork->push_back([ret]() {
 				ret->tid = move(thread(responderThread, ret));
@@ -911,9 +915,12 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   g_lua.registerFunction("setDown", &DownstreamState::setDown);
   g_lua.registerFunction("setUp", &DownstreamState::setUp);
   g_lua.registerFunction("setAuto", &DownstreamState::setAuto);
+  g_lua.registerFunction("getName", &DownstreamState::getName);
+  g_lua.registerFunction("getNameWithAddr", &DownstreamState::getNameWithAddr);
   g_lua.registerMember("upStatus", &DownstreamState::upStatus);
   g_lua.registerMember("weight", &DownstreamState::weight);
   g_lua.registerMember("order", &DownstreamState::order);
+  g_lua.registerMember("name", &DownstreamState::name);
   
   g_lua.writeFunction("infolog", [](const string& arg) {
       infolog("%s", arg);

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -759,6 +759,7 @@ class TestAdvancedQClass(DNSDistTest):
         self.assertEquals(query, receivedQuery)
         self.assertEquals(response, receivedResponse)
 
+
 class TestAdvancedNonTerminalRule(DNSDistTest):
 
     _config_template = """
@@ -784,7 +785,7 @@ class TestAdvancedNonTerminalRule(DNSDistTest):
                                     3600,
                                     dns.rdataclass.IN,
                                     dns.rdatatype.A,
-                                    '192.2.0.1')
+                                    '192.0.2.1')
         response.answer.append(rrset)
 
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
@@ -799,4 +800,38 @@ class TestAdvancedNonTerminalRule(DNSDistTest):
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
         self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+class TestAdvancedStringOnlyServer(DNSDistTest):
+
+    _config_template = """
+    newServer("127.0.0.1:%s")
+    """
+
+    def testAdvancedStringOnlyServer(self):
+        """
+        Advanced: "string-only" server is placed in the default pool
+        """
+        name = 'string-only-server.advanced.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '192.0.2.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
         self.assertEquals(response, receivedResponse)


### PR DESCRIPTION
As reported by @pieterlexis, server defined with the "string-only"
syntax were not correctly added to the default pool. This should
fix #3456.
In addition to that, this commit adds some Lua bindings for server
objects:
- member functions `getName()` and `getNameWithAddr()`
- member data `name`