### PR TITLE
Bump minimum required Autoconf version to 2.64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.61])
+AC_PREREQ([2.64])
 
 AC_INIT([pdns], m4_esyscmd_s(build-aux/gen-version))
 


### PR DESCRIPTION
m4_esyscmd_s doesn't exist before that.