### PR TITLE
Improve compatibility for old compilers & libs in MTasker

### DIFF
--- a/pdns/mtasker_context.cc
+++ b/pdns/mtasker_context.cc
@@ -1,0 +1,10 @@
+#include <boost/version.hpp>
+
+/* Boost Context was introduced in 1.51 (Aug 2012), but it's probably not worth
+ * supporting it because there was an immediate API break in 1.52 (Nov 2012)
+ */
+#if BOOST_VERSION <= 105100
+#include "mtasker_ucontext.cc"
+#else
+#include "mtasker_fcontext.cc"
+#endif

--- a/pdns/mtasker_ucontext.cc
+++ b/pdns/mtasker_ucontext.cc
@@ -61,14 +61,14 @@ pdns_ucontext_t::pdns_ucontext_t() {
 }
 
 pdns_ucontext_t::~pdns_ucontext_t() {
-    delete static_cast<::ucontext_t*>(uc_mcontext);
+    delete static_cast<ucontext_t*>(uc_mcontext);
 }
 
 void
 pdns_swapcontext
 (pdns_ucontext_t& __restrict octx, pdns_ucontext_t const& __restrict ctx) {
-    if (::swapcontext (static_cast<::ucontext*>(octx.uc_mcontext),
-                       static_cast<::ucontext*>(ctx.uc_mcontext))) {
+    if (::swapcontext (static_cast<ucontext*>(octx.uc_mcontext),
+                       static_cast<ucontext*>(ctx.uc_mcontext))) {
         throw_errno ("swapcontext() failed");
     }
     if (ctx.exception) {
@@ -82,8 +82,8 @@ pdns_makecontext
     assert (ctx.uc_link);
     assert (ctx.uc_stack.size());
 
-    auto const mcp = static_cast<::ucontext*>(ctx.uc_mcontext);
-    auto const next = static_cast<::ucontext*>(ctx.uc_link->uc_mcontext);
+    auto const mcp = static_cast<ucontext*>(ctx.uc_mcontext);
+    auto const next = static_cast<ucontext*>(ctx.uc_link->uc_mcontext);
     if (::getcontext (mcp)) {
         throw_errno ("getcontext() failed");
     }

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -85,7 +85,7 @@ pdns_recursor_SOURCES = \
 	misc.hh misc.cc \
 	mplexer.hh \
 	mtasker.hh \
-	mtasker_context.hh mtasker_fcontext.cc \
+	mtasker_context.hh mtasker_context.cc \
 	namespaces.hh \
 	nsecrecords.cc \
 	opensslsigners.cc opensslsigners.hh \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -86,7 +86,7 @@ pdns_recursor_SOURCES = \
 	misc.hh misc.cc \
 	mplexer.hh \
 	mtasker.hh \
-	mtasker_context.hh mtasker_context.cc \
+	mtasker_context.cc mtasker_context.hh \
 	namespaces.hh \
 	nsecrecords.cc \
 	opensslsigners.cc opensslsigners.hh \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -44,6 +44,7 @@ EXTRA_DIST = \
 	kqueuemplexer.cc \
 	malloctrace.cc malloctrace.hh \
 	mtasker.cc \
+	mtasker_fcontext.cc mtasker_ucontext.cc \
 	opensslsigners.hh opensslsigners.cc \
 	pdns_recursor.1.md \
 	portsmplexer.cc \

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -33,8 +33,26 @@ AC_PROG_LIBTOOL
 
 PDNS_CHECK_OS
 
+AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
+    AC_MSG_CHECKING([for Boost version >= 1.52])
+    AC_PREPROC_IFELSE([AC_LANG_SOURCE([[
+#include <boost/version.hpp>
+#if BOOST_VERSION <= 105100
+#error
+#endif
+    ]])], [
+        AC_MSG_RESULT([yes])
+        AC_MSG_NOTICE([MTasker will use the Boost Context library for context switching])
+        BOOST_CONTEXT
+    ], [
+        AC_MSG_RESULT([no])
+        AC_MSG_NOTICE([MTasker will use System V contexts for context switching])
+    ])
+])
+
 BOOST_REQUIRE([1.35])
-BOOST_CONTEXT()
+PDNS_SELECT_CONTEXT_IMPL
+
 PDNS_ENABLE_REPRODUCIBLE
 
 PDNS_WITH_LUAJIT

--- a/pdns/recursordist/mtasker_context.cc
+++ b/pdns/recursordist/mtasker_context.cc
@@ -1,0 +1,1 @@
+../mtasker_context.cc


### PR DESCRIPTION
Fixes MTasker (recursor) build against GCC 4.7 and Boost versions <= 1.51. With respect to the latter we fallback automagically to System V context switching.

Tested against the following:
- Debian Wheezy (GCC 4.7, Boost 1.49)
- Debian Jessie (GCC 4.9, Boost 1.55)
- Arch Linux (GCC 5.3, Boost 1.60)