### PR TITLE
m4_esyscmd_s only exists in Autoconf 2.64 or newer

### DIFF
--- a/build-aux/gen-version
+++ b/build-aux/gen-version
@@ -35,4 +35,4 @@ elif [ -f .version ]; then
   VERSION="$(cat .version)"
 fi
 
-echo $VERSION
+printf $VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.61])
 
-AC_INIT([pdns], m4_esyscmd_s(build-aux/gen-version))
+AC_INIT([pdns], m4_esyscmd(build-aux/gen-version))
 
 AC_CONFIG_SRCDIR([pdns/receiver.cc])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Since we like to be able to keep building on RHEL6, which
has autoconf 2.61, use the older m4_esyscmd macro and strip
the newline in the version ourself.

Resolves #3471

Fixes the following error:
$ autoreconf -vif
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, `build-aux'.
libtoolize: copying file `build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
libtoolize: copying file `m4/libtool.m4'
libtoolize: copying file `m4/ltoptions.m4'
libtoolize: copying file `m4/ltsugar.m4'
libtoolize: copying file `m4/ltversion.m4'
libtoolize: copying file `m4/lt~obsolete.m4'
autoreconf: running: /usr/bin/autoconf --force
configure.ac:3: error: possibly undefined macro: m4_esyscmd_s
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1