### PR TITLE
dnsdist: Don't parse DNS names when caching responses

### DIFF
--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -346,6 +346,7 @@ string simpleCompress(const string& label, const string& root="");
 void simpleExpandTo(const string& label, unsigned int frompos, string& ret);
 void ageDNSPacket(char* packet, size_t length, uint32_t seconds);
 void ageDNSPacket(std::string& packet, uint32_t seconds);
+uint32_t getDNSPacketMinTTL(const char* packet, size_t length);
 
 template<typename T>
 std::shared_ptr<T> getRR(const DNSRecord& dr)


### PR DESCRIPTION
Fix a crash reported by @rygl:

terminate called after throwing an instance of 'std::out_of_range'
what():  dnsname issue: Found a forward reference during label decompression