### PR TITLE
Fix parsing of invalid DNS names

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -197,10 +197,17 @@ uint32_t DNSDistPacketCache::getKey(const DNSName& qname, uint16_t consumed, con
 {
   uint32_t result = 0;
   /* skip the query ID */
+  if (packetLen < sizeof(dnsheader))
+    throw std::range_error("Computing packet cache key for an invalid packet size");
   result = burtle(packet + 2, sizeof(dnsheader) - 2, result);
   string lc(qname.toDNSStringLC());
   result = burtle((const unsigned char*) lc.c_str(), lc.length(), result);
-  result = burtle(packet + sizeof(dnsheader) + consumed, packetLen - (sizeof(dnsheader) + consumed), result);
+  if (packetLen < sizeof(dnsheader) + consumed) {
+    throw std::range_error("Computing packet cache key for an invalid packet");
+  }
+  if (packetLen > ((sizeof(dnsheader) + consumed))) {
+    result = burtle(packet + sizeof(dnsheader) + consumed, packetLen - (sizeof(dnsheader) + consumed), result);
+  }
   result = burtle((const unsigned char*) &tcp, sizeof(tcp), result);
   return result;
 }

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -81,8 +81,8 @@ void DNSName::packetParser(const char* qpos, int len, int offset, bool uncompres
   if (offset >= len)
     throw std::range_error("Trying to read past the end of the buffer ("+std::to_string(offset)+ " >= "+std::to_string(len)+")");
 
-  pos += offset;
   const unsigned char* end = pos + len;
+  pos += offset;
   while((labellen=*pos++) && pos < end) { // "scan and copy"
     if(labellen & 0xc0) {
       if(!uncompress)

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -256,6 +256,15 @@ BOOST_AUTO_TEST_CASE(test_PacketParse) {
   DNSPacketWriter dpw1(packet, DNSName("."), QType::AAAA);
   DNSName p((char*)&packet[0], packet.size(), 12, false);
   BOOST_CHECK_EQUAL(p, root);
+  unsigned char* buffer=&packet[0];
+  /* set invalid label len:
+     - packet.size() == 17 (sizeof(dnsheader) + 1 + 2 + 2)
+     - label len < packet.size() but
+     - offset is 12, label len of 15 should be rejected
+     because offset + 15 >= packet.size()
+  */
+  buffer[sizeof(dnsheader)] = 15;
+  BOOST_CHECK_THROW(DNSName((char*)&packet[0], packet.size(), 12, false), std::range_error);
 }
 
 


### PR DESCRIPTION
Two things:
- Fix DNSName::packetParser `end` computation
- Add defensive checks in dnsdist packet cache