### PR TITLE
dnsdist: packet cache enhancements 

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -712,14 +712,15 @@ The first step is to define a cache, then to assign that cache to the chosen poo
 the default one being represented by the empty string:
 
 ```
-pc = newPacketCache(10000, 86400, 600)
+pc = newPacketCache(10000, 86400, 600, 60)
 getPool(""):setCache(pc)
 ```
 
 The first parameter is the maximum number of entries stored in the cache, the
 second one, optional, is the maximum lifetime of an entry in the cache, in seconds,
-and the last one, optional too, is the minimum TTL an entry should have to be considered
-for insertion in the cache.
+the third one, optional too, is the minimum TTL an entry should have to be considered
+for insertion in the cache, and the last one, still optional, is the TTL used for a
+Server Failure response.
 
 
 Performance tuning
@@ -1035,7 +1036,7 @@ instantiate a server with additional parameters
     * `expunge(n)`: remove entries from the cache, leaving at most `n` entries
     * `expungeByName(DNSName [, qtype=ANY])`: remove entries matching the supplied DNSName and type from the cache
     * `isFull()`: return true if the cache has reached the maximum number of entries
-    * `newPacketCache(maxEntries, maxTTL=86400, minTTL=60)`: return a new PacketCache
+    * `newPacketCache(maxEntries[, maxTTL=86400, minTTL=60, servFailTTL=60])`: return a new PacketCache
     * `printStats()`: print the cache stats (hits, misses, deferred lookups and deferred inserts)
     * `purgeExpired(n)`: remove expired entries from the cache until there is at most `n` entries remaining in the cache
     * `toString()`: return the number of entries in the Packet Cache, and the maximum number of entries

--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -712,15 +712,56 @@ The first step is to define a cache, then to assign that cache to the chosen poo
 the default one being represented by the empty string:
 
 ```
-pc = newPacketCache(10000, 86400, 600, 60)
+pc = newPacketCache(10000, 86400, 600, 60, 60)
 getPool(""):setCache(pc)
 ```
 
-The first parameter is the maximum number of entries stored in the cache, the
-second one, optional, is the maximum lifetime of an entry in the cache, in seconds,
-the third one, optional too, is the minimum TTL an entry should have to be considered
-for insertion in the cache, and the last one, still optional, is the TTL used for a
-Server Failure response.
+The first parameter is the maximum number of entries stored in the cache, and is the
+only one required. All the others parameters are optional and in seconds.
+The second one is the maximum lifetime of an entry in the cache, the third one is
+the minimum TTL an entry should have to be considered for insertion in the cache,
+the fourth one is the TTL used for a Server Failure response. The last one is the
+TTL that will be used when a stale cache entry is returned.
+
+The `setStaleCacheEntriesTTL(n)` directive can be used to allow `dnsdist` to use
+expired entries from the cache when no backend is available. Only entries that have
+expired for less than `n` seconds will be used, and the returned TTL can be set
+when creating a new cache with `newPacketCache()`.
+
+A reference to the cache affected to a specific pool can be retrieved with:
+
+```
+getPool("poolname"):getCache()
+```
+
+Cache usage stats (hits, misses, deferred inserts and lookups, collisions)
+can be displayed by using the `printStats()` method:
+
+```
+getPool("poolname"):getCache():printStats()
+```
+
+Expired cached entries can be removed from a cache using the `purgeExpired(n)`
+method, which will remove expired entries from the cache until at least `n`
+entries remain in the cache. For example, to remove all expired entries:
+
+```
+getPool("poolname"):getCache():purgeExpired(0)
+```
+
+Specific entries can also be removed using the `expungeByName(DNSName [, qtype=ANY])`
+method.
+
+```
+getPool("poolname"):getCache():expungeByName(newDNSName("powerdns.com"), dnsdist.A)
+```
+
+Finally, the `expunge(n)` method will remove all entries until at most `n`
+entries remain in the cache:
+
+```
+getPool("poolname"):getCache():expunge(0)
+```
 
 
 Performance tuning
@@ -1036,7 +1077,7 @@ instantiate a server with additional parameters
     * `expunge(n)`: remove entries from the cache, leaving at most `n` entries
     * `expungeByName(DNSName [, qtype=ANY])`: remove entries matching the supplied DNSName and type from the cache
     * `isFull()`: return true if the cache has reached the maximum number of entries
-    * `newPacketCache(maxEntries[, maxTTL=86400, minTTL=60, servFailTTL=60])`: return a new PacketCache
+    * `newPacketCache(maxEntries[, maxTTL=86400, minTTL=60, servFailTTL=60, stateTTL=60])`: return a new PacketCache
     * `printStats()`: print the cache stats (hits, misses, deferred lookups and deferred inserts)
     * `purgeExpired(n)`: remove expired entries from the cache until there is at most `n` entries remaining in the cache
     * `toString()`: return the number of entries in the Packet Cache, and the maximum number of entries
@@ -1091,6 +1132,7 @@ instantiate a server with additional parameters
     * `setMaxTCPClientThreads(n)`: set the maximum of TCP client threads, handling TCP connections
     * `setMaxUDPOutstanding(n)`: set the maximum number of outstanding UDP queries to a given backend server. This can only be set at configuration time and defaults to 10240
     * `setCacheCleaningDelay(n)`: set the interval in seconds between two runs of the cache cleaning algorithm, removing expired entries
+    * `setStaleCacheEntriesTTL(n)`: allows using cache entries expired for at most `n` seconds when no backend available to answer for a query
  * DNSCrypt related:
     * `addDNSCryptBind("127.0.0.1:8443", "provider name", "/path/to/resolver.cert", "/path/to/resolver.key", [false]):` listen to incoming DNSCrypt queries on 127.0.0.1 port 8443, with a provider name of "provider name", using a resolver certificate and associated key stored respectively in the `resolver.cert` and `resolver.key` files. The last optional parameter sets SO_REUSEPORT when available
     * `generateDNSCryptProviderKeys("/path/to/providerPublic.key", "/path/to/providerPrivate.key"):` generate a new provider keypair

--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1032,11 +1032,12 @@ instantiate a server with additional parameters
     * `getCache()`: return the current packet cache, if any
     * `setCache(PacketCache)`: set the cache for this pool
  * PacketCache related:
-    * `expungeByName(DNSName)`: remove entries matching the supplied DNSName from the cache
+    * `expunge(n)`: remove entries from the cache, leaving at most `n` entries
+    * `expungeByName(DNSName [, qtype=ANY])`: remove entries matching the supplied DNSName and type from the cache
     * `isFull()`: return true if the cache has reached the maximum number of entries
     * `newPacketCache(maxEntries, maxTTL=86400, minTTL=60)`: return a new PacketCache
     * `printStats()`: print the cache stats (hits, misses, deferred lookups and deferred inserts)
-    * `purge()`: remove entries from the cache until it the number of entries is lower than the maximum, starting with expired ones.
+    * `purgeExpired(n)`: remove expired entries from the cache until there is at most `n` entries remaining in the cache
     * `toString()`: return the number of entries in the Packet Cache, and the maximum number of entries
  * Advanced functions for writing your own policies and hooks
     * ComboAddress related:

--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -1,8 +1,9 @@
+#include "dnsdist.hh"
 #include "dolog.hh"
-#include "dnsdist-cache.hh"
 #include "dnsparser.hh"
+#include "dnsdist-cache.hh"
 
-DNSDistPacketCache::DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL, uint32_t minTTL, uint32_t servFailTTL): d_maxEntries(maxEntries), d_maxTTL(maxTTL), d_servFailTTL(servFailTTL), d_minTTL(minTTL)
+DNSDistPacketCache::DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL, uint32_t minTTL, uint32_t servFailTTL, uint32_t staleTTL): d_maxEntries(maxEntries), d_maxTTL(maxTTL), d_servFailTTL(servFailTTL), d_minTTL(minTTL), d_staleTTL(staleTTL)
 {
   pthread_rwlock_init(&d_lock, 0);
   /* we reserve maxEntries + 1 to avoid rehashing from occuring
@@ -98,14 +99,15 @@ void DNSDistPacketCache::insert(uint32_t key, const DNSName& qname, uint16_t qty
   }
 }
 
-bool DNSDistPacketCache::get(const unsigned char* query, uint16_t queryLen, const DNSName& qname, uint16_t qtype, uint16_t qclass, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, bool tcp, uint32_t* keyOut, bool skipAging)
+bool DNSDistPacketCache::get(const DNSQuestion& dq, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, uint32_t* keyOut, uint32_t allowExpired, bool skipAging)
 {
-  uint32_t key = getKey(qname, consumed, query, queryLen, tcp);
+  uint32_t key = getKey(*dq.qname, consumed, (const unsigned char*)dq.dh, dq.len, dq.tcp);
   if (keyOut)
     *keyOut = key;
 
   time_t now = time(NULL);
   time_t age;
+  bool stale = false;
   {
     TryReadLock r(&d_lock);
     if (!r.gotIt()) {
@@ -121,8 +123,13 @@ bool DNSDistPacketCache::get(const unsigned char* query, uint16_t queryLen, cons
 
     const CacheValue& value = it->second;
     if (value.validity < now) {
-      d_misses++;
-      return false;
+      if ((value.validity + allowExpired) < now) {
+        d_misses++;
+        return false;
+      }
+      else {
+        stale = true;
+      }
     }
 
     if (*responseLen < value.len) {
@@ -130,23 +137,30 @@ bool DNSDistPacketCache::get(const unsigned char* query, uint16_t queryLen, cons
     }
 
     /* check for collision */
-    if (!cachedValueMatches(value, qname, qtype, qclass, tcp)) {
+    if (!cachedValueMatches(value, *dq.qname, dq.qtype, dq.qclass, dq.tcp)) {
       d_misses++;
       d_lookupCollisions++;
       return false;
     }
 
-    string dnsQName(qname.toDNSString());
+    string dnsQName(dq.qname->toDNSString());
     memcpy(response, &queryId, sizeof(queryId));
     memcpy(response + sizeof(queryId), value.value.c_str() + sizeof(queryId), sizeof(dnsheader) - sizeof(queryId));
     memcpy(response + sizeof(dnsheader), dnsQName.c_str(), dnsQName.length());
     memcpy(response + sizeof(dnsheader) + dnsQName.length(), value.value.c_str() + sizeof(dnsheader) + dnsQName.length(), value.value.length() - (sizeof(dnsheader) + dnsQName.length()));
     *responseLen = value.len;
-    age = now - value.added;
+    if (!stale) {
+      age = now - value.added;
+    }
+    else {
+      age = (value.validity - value.added) - d_staleTTL;
+    }
   }
 
-  if (!skipAging)
+  if (!skipAging) {
     ageDNSPacket(response, *responseLen, age);
+  }
+
   d_hits++;
   return true;
 }

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -4,14 +4,16 @@
 #include <unordered_map>
 #include "lock.hh"
 
+struct DNSQuestion;
+
 class DNSDistPacketCache : boost::noncopyable
 {
 public:
-  DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL=86400, uint32_t minTTL=60, uint32_t servFailTTL=60);
+  DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL=86400, uint32_t minTTL=60, uint32_t servFailTTL=60, uint32_t staleTTL=60);
   ~DNSDistPacketCache();
 
   void insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp, bool servFail=false);
-  bool get(const unsigned char* query, uint16_t queryLen, const DNSName& qname, uint16_t qtype, uint16_t qclass, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, bool tcp, uint32_t* keyOut, bool skipAging=false);
+  bool get(const DNSQuestion& dq, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, uint32_t* keyOut, uint32_t allowExpired=0, bool skipAging=false);
   void purgeExpired(size_t upTo=0);
   void expunge(size_t upTo=0);
   void expungeByName(const DNSName& name, uint16_t qtype=QType::ANY);
@@ -57,4 +59,5 @@ private:
   uint32_t d_maxTTL;
   uint32_t d_servFailTTL;
   uint32_t d_minTTL;
+  uint32_t d_staleTTL;
 };

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -7,10 +7,10 @@
 class DNSDistPacketCache : boost::noncopyable
 {
 public:
-  DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL=86400, uint32_t minTTL=60);
+  DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL=86400, uint32_t minTTL=60, uint32_t servFailTTL=60);
   ~DNSDistPacketCache();
 
-  void insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp);
+  void insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp, bool servFail=false);
   bool get(const unsigned char* query, uint16_t queryLen, const DNSName& qname, uint16_t qtype, uint16_t qclass, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, bool tcp, uint32_t* keyOut, bool skipAging=false);
   void purgeExpired(size_t upTo=0);
   void expunge(size_t upTo=0);
@@ -55,5 +55,6 @@ private:
   std::atomic<uint64_t> d_lookupCollisions{0};
   size_t d_maxEntries;
   uint32_t d_maxTTL;
+  uint32_t d_servFailTTL;
   uint32_t d_minTTL;
 };

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -12,8 +12,9 @@ public:
 
   void insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp);
   bool get(const unsigned char* query, uint16_t queryLen, const DNSName& qname, uint16_t qtype, uint16_t qclass, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, bool tcp, uint32_t* keyOut, bool skipAging=false);
-  void purge(size_t upTo=0);
-  void expunge(const DNSName& name, uint16_t qtype=QType::ANY);
+  void purgeExpired(size_t upTo=0);
+  void expunge(size_t upTo=0);
+  void expungeByName(const DNSName& name, uint16_t qtype=QType::ANY);
   bool isFull();
   string toString();
   uint64_t getSize() const { return d_map.size(); };

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -531,8 +531,8 @@ void moreLua(bool client)
     });
     g_lua.registerFunction("getCache", &ServerPool::getCache);
 
-    g_lua.writeFunction("newPacketCache", [client](size_t maxEntries, boost::optional<uint32_t> maxTTL, boost::optional<uint32_t> minTTL, boost::optional<uint32_t> servFailTTL) {
-        return std::make_shared<DNSDistPacketCache>(maxEntries, maxTTL ? *maxTTL : 86400, minTTL ? *minTTL : 60, servFailTTL ? *servFailTTL : 60);
+    g_lua.writeFunction("newPacketCache", [client](size_t maxEntries, boost::optional<uint32_t> maxTTL, boost::optional<uint32_t> minTTL, boost::optional<uint32_t> servFailTTL, boost::optional<uint32_t> staleTTL) {
+        return std::make_shared<DNSDistPacketCache>(maxEntries, maxTTL ? *maxTTL : 86400, minTTL ? *minTTL : 60, servFailTTL ? *servFailTTL : 60, staleTTL ? *staleTTL : 60);
       });
     g_lua.registerFunction("toString", &DNSDistPacketCache::toString);
     g_lua.registerFunction("isFull", &DNSDistPacketCache::isFull);
@@ -561,4 +561,5 @@ void moreLua(bool client)
       });
 
     g_lua.writeFunction("setVerboseHealthChecks", [](bool verbose) { g_verboseHealthChecks=verbose; });
+    g_lua.writeFunction("setStaleCacheEntriesTTL", [](uint32_t ttl) { g_staleCacheEntriesTTL = ttl; });
 }

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -536,9 +536,10 @@ void moreLua(bool client)
       });
     g_lua.registerFunction("toString", &DNSDistPacketCache::toString);
     g_lua.registerFunction("isFull", &DNSDistPacketCache::isFull);
-    g_lua.registerFunction("purge", &DNSDistPacketCache::purge);
+    g_lua.registerFunction("purgeExpired", &DNSDistPacketCache::purgeExpired);
+    g_lua.registerFunction("expunge", &DNSDistPacketCache::expunge);
     g_lua.registerFunction<void(std::shared_ptr<DNSDistPacketCache>::*)(const DNSName& dname, boost::optional<uint16_t> qtype)>("expungeByName", [](std::shared_ptr<DNSDistPacketCache> cache, const DNSName& dname, boost::optional<uint16_t> qtype) {
-        cache->expunge(dname, qtype ? *qtype : QType::ANY);
+        cache->expungeByName(dname, qtype ? *qtype : QType::ANY);
       });
     g_lua.registerFunction<void(std::shared_ptr<DNSDistPacketCache>::*)()>("printStats", [](const std::shared_ptr<DNSDistPacketCache> cache) {
         g_outputBuffer="Hits: " + std::to_string(cache->getHits()) + "\n";

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -531,8 +531,8 @@ void moreLua(bool client)
     });
     g_lua.registerFunction("getCache", &ServerPool::getCache);
 
-    g_lua.writeFunction("newPacketCache", [client](size_t maxEntries, boost::optional<uint32_t> maxTTL, boost::optional<uint32_t> minTTL) {
-        return std::make_shared<DNSDistPacketCache>(maxEntries, maxTTL ? *maxTTL : 86400, minTTL ? *minTTL : 60);
+    g_lua.writeFunction("newPacketCache", [client](size_t maxEntries, boost::optional<uint32_t> maxTTL, boost::optional<uint32_t> minTTL, boost::optional<uint32_t> servFailTTL) {
+        return std::make_shared<DNSDistPacketCache>(maxEntries, maxTTL ? *maxTTL : 86400, minTTL ? *minTTL : 60, servFailTTL ? *servFailTTL : 60);
       });
     g_lua.registerFunction("toString", &DNSDistPacketCache::toString);
     g_lua.registerFunction("isFull", &DNSDistPacketCache::isFull);

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -330,12 +330,8 @@ void* tcpClientThread(int pipefd)
 	  ds = localPolicy->policy(serverPool->servers, &dq);
 	  packetCache = serverPool->packetCache;
 	}
-	if(!ds) {
-	  g_stats.noPolicy++;
-	  break;
-	}
 
-        if (ds->useECS) {
+        if (ds && ds->useECS) {
           uint16_t newLen = dq.len;
           handleEDNSClientSubnet(queryBuffer, dq.size, consumed, &newLen, largerQuery, &ednsAdded, ci.remote);
           if (largerQuery.empty() == false) {
@@ -351,7 +347,8 @@ void* tcpClientThread(int pipefd)
         if (packetCache && !dq.skipCache) {
           char cachedResponse[4096];
           uint16_t cachedResponseSize = sizeof cachedResponse;
-          if (packetCache->get((unsigned char*) query, dq.len, *dq.qname, dq.qtype, dq.qclass, consumed, dq.dh->id, cachedResponse, &cachedResponseSize, true, &cacheKey)) {
+          uint32_t allowExpired = ds ? 0 : g_staleCacheEntriesTTL;
+          if (packetCache->get(dq, consumed, dq.dh->id, cachedResponse, &cachedResponseSize, &cacheKey, allowExpired)) {
             if (putNonBlockingMsgLen(ci.fd, cachedResponseSize, g_tcpSendTimeout))
               writen2WithTimeout(ci.fd, cachedResponse, cachedResponseSize, g_tcpSendTimeout);
             g_stats.cacheHits++;
@@ -359,6 +356,11 @@ void* tcpClientThread(int pipefd)
           }
           g_stats.cacheMisses++;
         }
+
+	if(!ds) {
+	  g_stats.noPolicy++;
+	  break;
+	}
 
 	int dsock;
 	if(sockets.count(ds->remote) == 0) {

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -479,7 +479,7 @@ void* tcpClientThread(int pipefd)
 	}
 
 	if (packetCache && !dq.skipCache) {
-	  packetCache->insert(cacheKey, qname, qtype, qclass, response, responseLen, true);
+	  packetCache->insert(cacheKey, qname, qtype, qclass, response, responseLen, true, dh->rcode == RCode::ServFail);
 	}
 
 #ifdef HAVE_DNSCRYPT

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1035,7 +1035,7 @@ void* maintThread()
           packetCache = entry.second->packetCache;
         }
         if (packetCache) {
-          packetCache->purge();
+          packetCache->purgeExpired();
         }
       }
       counter = 0;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -264,7 +264,7 @@ void* responderThread(std::shared_ptr<DownstreamState> state)
     g_stats.responses++;
 
     if (ids->packetCache && !ids->skipCache) {
-      ids->packetCache->insert(ids->cacheKey, qname, qtype, qclass, response, responseLen, false);
+      ids->packetCache->insert(ids->cacheKey, qname, qtype, qclass, response, responseLen, false, dh->rcode == RCode::ServFail);
     }
 
 #ifdef HAVE_DNSCRYPT

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -13,6 +13,7 @@
 #include "sholder.hh"
 #include "dnscrypt.hh"
 #include "dnsdist-cache.hh"
+
 void* carbonDumpThread();
 uint64_t uptimeOfProcess(const std::string& str);
 
@@ -469,6 +470,7 @@ extern uint16_t g_ECSSourcePrefixV4;
 extern uint16_t g_ECSSourcePrefixV6;
 extern bool g_ECSOverride;
 extern bool g_verboseHealthChecks;
+extern uint32_t g_staleCacheEntriesTTL;
 
 struct dnsheader;
 

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
       uint32_t key = 0;
       bool found = PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), 0, responseBuf, &responseBufSize, false, &key);
       if (found == true) {
-        PC.expunge(a);
+        PC.expungeByName(a);
         deleted++;
       }
     }

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -3,9 +3,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "dnsdist.hh"
 #include "iputils.hh"
-#include "dnsdist-cache.hh"
 #include "dnswriter.hh"
+#include "dnsdist-cache.hh"
 
 BOOST_AUTO_TEST_SUITE(dnsdistpacketcache_cc)
 
@@ -16,6 +17,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
 
   size_t counter=0;
   size_t skipped=0;
+  ComboAddress remote;
   try {
     for(counter = 0; counter < 100000; ++counter) {
       DNSName a=DNSName("hello ")+DNSName(std::to_string(counter));
@@ -39,12 +41,13 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
       char responseBuf[4096];
       uint16_t responseBufSize = sizeof(responseBuf);
       uint32_t key = 0;
-      bool found = PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), 0, responseBuf, &responseBufSize, false, &key);
+      DNSQuestion dq(&a, QType::A, QClass::IN, &remote, &remote, (struct dnsheader*) query.data(), query.size(), query.size(), false);
+      bool found = PC.get(dq, a.wirelength(), 0, responseBuf, &responseBufSize, &key);
       BOOST_CHECK_EQUAL(found, false);
 
       PC.insert(key, a, QType::A, QClass::IN, (const char*) response.data(), responseLen, false);
 
-      found = PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), pwR.getHeader()->id, responseBuf, &responseBufSize, false, &key, true);
+      found = PC.get(dq, a.wirelength(), pwR.getHeader()->id, responseBuf, &responseBufSize, &key, 0, true);
       if (found == true) {
         BOOST_CHECK_EQUAL(responseBufSize, responseLen);
         int match = memcmp(responseBuf, response.data(), responseLen);
@@ -68,7 +71,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
       char responseBuf[4096];
       uint16_t responseBufSize = sizeof(responseBuf);
       uint32_t key = 0;
-      bool found = PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), 0, responseBuf, &responseBufSize, false, &key);
+      DNSQuestion dq(&a, QType::A, QClass::IN, &remote, &remote, (struct dnsheader*) query.data(), query.size(), query.size(), false);
+      bool found = PC.get(dq, a.wirelength(), 0, responseBuf, &responseBufSize, &key);
       if (found == true) {
         PC.expungeByName(a);
         deleted++;
@@ -88,7 +92,8 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
       uint32_t key = 0;
       char response[4096];
       uint16_t responseSize = sizeof(response);
-      if(PC.get(query.data(), len, a, QType::A, QClass::IN, a.wirelength(), pwQ.getHeader()->id, response, &responseSize, false, &key)) {
+      DNSQuestion dq(&a, QType::A, QClass::IN, &remote, &remote, (struct dnsheader*) query.data(), len, query.size(), false);
+      if(PC.get(dq, a.wirelength(), pwQ.getHeader()->id, response, &responseSize, &key)) {
 	matches++;
       }
     }
@@ -105,6 +110,7 @@ static DNSDistPacketCache PC(500000);
 static void *threadMangler(void* a)
 {
   try {
+    ComboAddress remote;
     unsigned int offset=(unsigned int)(unsigned long)a;
     for(unsigned int counter=0; counter < 100000; ++counter) {
       DNSName a=DNSName("hello ")+DNSName(std::to_string(counter+offset));
@@ -126,7 +132,8 @@ static void *threadMangler(void* a)
       char responseBuf[4096];
       uint16_t responseBufSize = sizeof(responseBuf);
       uint32_t key = 0;
-      PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), 0, responseBuf, &responseBufSize, false, &key);
+      DNSQuestion dq(&a, QType::A, QClass::IN, &remote, &remote, (struct dnsheader*) query.data(), query.size(), query.size(), false);
+      PC.get(dq, a.wirelength(), 0, responseBuf, &responseBufSize, &key);
 
       PC.insert(key, a, QType::A, QClass::IN, (const char*) response.data(), responseLen, false);
     }
@@ -146,6 +153,7 @@ static void *threadReader(void* a)
   {
     unsigned int offset=(unsigned int)(unsigned long)a;
     vector<DNSResourceRecord> entry;
+    ComboAddress remote;
     for(unsigned int counter=0; counter < 100000; ++counter) {
       DNSName a=DNSName("hello ")+DNSName(std::to_string(counter+offset));
       vector<uint8_t> query;
@@ -155,7 +163,8 @@ static void *threadReader(void* a)
       char responseBuf[4096];
       uint16_t responseBufSize = sizeof(responseBuf);
       uint32_t key = 0;
-      bool found = PC.get((const unsigned char*) query.data(), query.size(), a, QType::A, QClass::IN, a.wirelength(), 0, responseBuf, &responseBufSize, false, &key);
+      DNSQuestion dq(&a, QType::A, QClass::IN, &remote, &remote, (struct dnsheader*) query.data(), query.size(), query.size(), false);
+      bool found = PC.get(dq, a.wirelength(), 0, responseBuf, &responseBufSize, &key);
       if (!found) {
 	g_missing++;
       }


### PR DESCRIPTION
- Add some cache cleaning options and fix the existing ones
- Add a specific TTL for ServFail responses
- Allow the use of stale cache entries if there is no backend available
- Document the whole thing
- Add regression tests
- As a bonus, we now have access to the dnsdist console in the regression tests