### PR TITLE
dnsdist: Allow accessing the API with an optional API key

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -880,7 +880,7 @@ Here are all functions:
  * Practical
     * `shutdown()`: shut down `dnsdist`
     * quit or ^D: exit the console
-    * `webserver(address, password)`: launch a webserver with stats on that address with that password
+    * `webserver(address, password [, apiKey])`: launch a webserver with stats on that address with that password
  * ACL related:
     * `addACL(netmask)`: add to the ACL set who can use this server
     * `setACL({netmask, netmask})`: replace the ACL set with these netmasks. Use `setACL({})` to reset the list, meaning no one can use us

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -995,7 +995,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			g_carbon.setState(ours);
 		      });
 
-  g_lua.writeFunction("webserver", [client](const std::string& address, const std::string& password) {
+  g_lua.writeFunction("webserver", [client](const std::string& address, const std::string& password, const boost::optional<std::string> apiKey) {
       setLuaSideEffect();
       if(client)
 	return;
@@ -1005,8 +1005,8 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 	SSetsockopt(sock, SOL_SOCKET, SO_REUSEADDR, 1);
 	SBind(sock, local);
 	SListen(sock, 5);
-	auto launch=[sock, local, password]() {
-	  thread t(dnsdistWebserverThread, sock, local, password);
+	auto launch=[sock, local, password, apiKey]() {
+	  thread t(dnsdistWebserverThread, sock, local, password, apiKey ? *apiKey : "");
 	  t.detach();
 	};
 	if(g_launchWork) 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -489,7 +489,7 @@ std::shared_ptr<DownstreamState> roundrobin(const NumberedServerVector& servers,
 int getEDNSZ(const char* packet, unsigned int len);
 void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent);
 uint16_t getEDNSOptionCode(const char * packet, size_t len);
-void dnsdistWebserverThread(int sock, const ComboAddress& local, const string& password);
+void dnsdistWebserverThread(int sock, const ComboAddress& local, const string& password, const string& apiKey);
 bool getMsgLen32(int fd, uint32_t* len);
 bool putMsgLen32(int fd, uint32_t len);
 void* tcpAcceptorThread(void* p);


### PR DESCRIPTION
The API key can be specified as an additional, optional parameter
to `webserver()`. If present in a X-API-Key header, it allows
access to the API URLs:
- /api/v1/servers/localhost
- /jsonstat

Others URLs are still only allowed through basic authentication.