### PR TITLE
dnsdist: Check response validity over TCP, more cache fixes

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -734,6 +734,12 @@ A reference to the cache affected to a specific pool can be retrieved with:
 getPool("poolname"):getCache()
 ```
 
+And removed with:
+
+```
+getPool("poolname"):unsetCache()
+```
+
 Cache usage stats (hits, misses, deferred inserts and lookups, collisions)
 can be displayed by using the `printStats()` method:
 
@@ -1073,6 +1079,7 @@ instantiate a server with additional parameters
  * ServerPool related:
     * `getCache()`: return the current packet cache, if any
     * `setCache(PacketCache)`: set the cache for this pool
+    * `unsetCache()`: remove the packet cache from this pool
  * PacketCache related:
     * `expunge(n)`: remove entries from the cache, leaving at most `n` entries
     * `expungeByName(DNSName [, qtype=ANY])`: remove entries matching the supplied DNSName and type from the cache

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -530,6 +530,9 @@ void moreLua(bool client)
         pool->packetCache = cache;
     });
     g_lua.registerFunction("getCache", &ServerPool::getCache);
+    g_lua.registerFunction<void(std::shared_ptr<ServerPool>::*)()>("unsetCache", [](std::shared_ptr<ServerPool> pool) {
+        pool->packetCache = nullptr;
+    });
 
     g_lua.writeFunction("newPacketCache", [client](size_t maxEntries, boost::optional<uint32_t> maxTTL, boost::optional<uint32_t> minTTL, boost::optional<uint32_t> servFailTTL, boost::optional<uint32_t> staleTTL) {
         return std::make_shared<DNSDistPacketCache>(maxEntries, maxTTL ? *maxTTL : 86400, minTTL ? *minTTL : 60, servFailTTL ? *servFailTTL : 60, staleTTL ? *staleTTL : 60);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -220,7 +220,9 @@ void* responderThread(std::shared_ptr<DownstreamState> state)
 
     if(g_fixupCase) {
       string realname = ids->qname.toDNSString();
-      memcpy(packet+12, realname.c_str(), realname.length());
+      if (responseLen >= (sizeof(dnsheader) + realname.length())) {
+        memcpy(packet+12, realname.c_str(), realname.length());
+      }
     }
 
     if(dh->tc && g_truncateTC) {

--- a/regression-tests.dnsdist/test_Basics.py
+++ b/regression-tests.dnsdist/test_Basics.py
@@ -309,6 +309,12 @@ class TestBasics(DNSDistTest):
         receivedQuery.id = query.id
         self.assertEquals(query, receivedQuery)
 
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, unrelatedResponse)
+        self.assertTrue(receivedQuery)
+        self.assertEquals(receivedResponse, None)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add `unsetCache()` to remove the cache from a pool
- Check the response size before caching it, and make no
assumption when getting it from the cache
- Check that the response is larger than sizeof(dnsheader) over
TCP too
- Check that the response matches the query over TCP too, because
we reuse downstream connections