### PR TITLE
rec: Handle multiple EDNS0 Options in gettag

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1021,6 +1021,7 @@ testrunner_SOURCES = \
 	dnsrecords.cc \
 	dnssecinfra.cc \
 	dnswriter.cc \
+	ednsoptions.cc \
 	ednssubnet.cc \
 	gss_context.cc gss_context.hh \
 	iputils.cc \

--- a/pdns/dnsdist-ecs.hh
+++ b/pdns/dnsdist-ecs.hh
@@ -4,7 +4,3 @@ int rewriteResponseWithoutEDNS(const char * packet, size_t len, vector<uint8_t>&
 int locateEDNSOptRR(const char * packet, size_t len, const char ** optStart, size_t * optLen, bool * last);
 void handleEDNSClientSubnet(char * packet, size_t packetSize, unsigned int consumed, uint16_t * len, string& largerPacket, bool * ednsAdded, const ComboAddress& remote);
 void generateOptRR(const std::string& optRData, string& res);
-void generateEDNSOption(uint16_t optionCode, const std::string& payload, std::string& res);
-
-
-

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -443,11 +443,6 @@ enum ednsHeaderFlags {
   EDNS_HEADER_FLAG_DO = 32768
 };
 
-enum ednsOptionCodes {
-  EDNS0_OPTION_CODE_NONE = 0,
-  EDNS0_OPTION_CODE_ECS = 8,
-};
-
 extern GlobalStateHolder<CarbonConfig> g_carbon;
 extern GlobalStateHolder<ServerPolicy> g_policy;
 extern GlobalStateHolder<servers_t> g_dstates;

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -65,6 +65,7 @@ dnsdist_SOURCES = \
 	dnsrulactions.hh \
 	dnswriter.cc dnswriter.hh \
 	dolog.hh \
+	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
 	iputils.cc iputils.hh \
 	lock.hh \
@@ -115,6 +116,7 @@ testrunner_SOURCES = \
 	dnsparser.hh dnsparser.cc \
 	dnswriter.cc dnswriter.hh \
 	dolog.hh \
+	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
 	iputils.cc iputils.hh \
 	misc.cc misc.hh \

--- a/pdns/dnsdistdist/ednsoptions.cc
+++ b/pdns/dnsdistdist/ednsoptions.cc
@@ -1,0 +1,1 @@
+../ednsoptions.cc

--- a/pdns/dnsdistdist/ednsoptions.hh
+++ b/pdns/dnsdistdist/ednsoptions.hh
@@ -1,0 +1,1 @@
+../ednsoptions.hh

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -2,6 +2,7 @@
 #include "dnsdist-ecs.hh"
 #include "dnsname.hh"
 #include "dolog.hh"
+#include "ednsoptions.hh"
 
 class MaxQPSIPRule : public DNSRule
 {

--- a/pdns/ednsoptions.cc
+++ b/pdns/ednsoptions.cc
@@ -1,0 +1,56 @@
+
+#include "dns.hh"
+#include "ednsoptions.hh"
+#include "iputils.hh"
+
+/* extract a specific EDNS0 option from a pointer on the beginning rdLen of the OPT RR */
+int getEDNSOption(char* optRR, const size_t len, uint16_t wantedOption, char ** optionValue, size_t * optionValueSize)
+{
+  assert(optRR != NULL);
+  assert(optionValue != NULL);
+  assert(optionValueSize != NULL);
+  size_t pos = 0;
+  if (len < DNS_RDLENGTH_SIZE)
+    return EINVAL;
+
+  const uint16_t rdLen = (((unsigned char) optRR[pos]) * 256) + ((unsigned char) optRR[pos+1]);
+  size_t rdPos = 0;
+  pos += DNS_RDLENGTH_SIZE;
+  if ((pos + rdLen) > len) {
+    return EINVAL;
+  }
+
+  while(len >= (pos + EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE) &&
+        rdLen >= (rdPos + EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE)) {
+    const uint16_t optionCode = (((unsigned char) optRR[pos]) * 256) + ((unsigned char) optRR[pos+1]);
+    pos += EDNS_OPTION_CODE_SIZE;
+    rdPos += EDNS_OPTION_CODE_SIZE;
+    const uint16_t optionLen = (((unsigned char) optRR[pos]) * 256) + ((unsigned char) optRR[pos+1]);
+    pos += EDNS_OPTION_LENGTH_SIZE;
+    rdPos += EDNS_OPTION_LENGTH_SIZE;
+    if (optionLen > (rdLen - rdPos) || optionLen > (len - pos))
+      return EINVAL;
+
+    if (optionCode == wantedOption) {
+      *optionValue = optRR + pos - (EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE);
+      *optionValueSize = optionLen + EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE;
+      return 0;
+    }
+    else {
+      /* skip this option */
+      pos += optionLen;
+      rdPos += optionLen;
+    }
+  }
+
+  return ENOENT;
+}
+
+void generateEDNSOption(uint16_t optionCode, const std::string& payload, std::string& res)
+{
+  const uint16_t ednsOptionCode = htons(optionCode);
+  const uint16_t payloadLen = htons(payload.length());
+  res.append((const char *) &ednsOptionCode, sizeof ednsOptionCode);
+  res.append((const char *) &payloadLen, sizeof payloadLen);
+  res.append(payload);
+}

--- a/pdns/ednsoptions.hh
+++ b/pdns/ednsoptions.hh
@@ -1,0 +1,36 @@
+/*
+    PowerDNS Versatile Database Driven Nameserver
+    Copyright (C) 2011 - 2016  Netherlabs Computer Consulting BV
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2 as
+    published by the Free Software Foundation
+
+    Additionally, the license of this program contains a special
+    exception which allows to distribute the program in binary form when
+    it is linked against OpenSSL.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#ifndef PDNS_EDNSOPTIONS_HH
+#define PDNS_EDNSOPTIONS_HH
+
+#include "namespaces.hh"
+
+struct EDNSOptionCode
+{
+  enum EDNSOptionCodeEnum {NSID=3, DAU=4, DHU=6, N3U=7, ECS=8, EXPIRE=9, COOKIE=10, TCPKEEPALIVE=11, PADDING=12, CHAIN=13};
+};
+
+/* extract a specific EDNS0 option from a pointer on the beginning rdLen of the OPT RR */
+int getEDNSOption(char* optRR, size_t len, uint16_t wantedOption, char ** optionValue, size_t * optionValueSize);
+void generateEDNSOption(uint16_t optionCode, const std::string& payload, std::string& res);
+
+#endif

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -72,6 +72,7 @@ pdns_recursor_SOURCES = \
 	dnssecinfra.hh dnssecinfra.cc \
 	dnsseckeeper.hh \
 	dnswriter.cc dnswriter.hh \
+	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
 	filterpo.cc filterpo.hh \
 	gss_context.cc gss_context.hh \

--- a/pdns/recursordist/ednsoptions.cc
+++ b/pdns/recursordist/ednsoptions.cc
@@ -1,0 +1,1 @@
+../ednsoptions.cc

--- a/pdns/recursordist/ednsoptions.hh
+++ b/pdns/recursordist/ednsoptions.hh
@@ -1,0 +1,1 @@
+../ednsoptions.hh

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -32,6 +32,7 @@
 #include "dnsname.hh"
 #include "dnsparser.hh"
 #include "dnswriter.hh"
+#include "ednsoptions.hh"
 #include "ednssubnet.hh"
 #include <unistd.h>
 
@@ -164,7 +165,7 @@ BOOST_AUTO_TEST_CASE(replaceECSWithSameSize) {
   ecsOpts.source = Netmask(origRemote, g_ECSSourcePrefixV4);
   string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
   DNSPacketWriter::optvect_t opts;
-  opts.push_back(make_pair(EDNS0_OPTION_CODE_ECS, origECSOption));
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOption));
   pw.addOpt(512, 0, 0, opts);
   pw.commit();
   uint16_t len = query.size();
@@ -201,7 +202,7 @@ BOOST_AUTO_TEST_CASE(replaceECSWithSmaller) {
   ecsOpts.source = Netmask(origRemote, 32);
   string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
   DNSPacketWriter::optvect_t opts;
-  opts.push_back(make_pair(EDNS0_OPTION_CODE_ECS, origECSOption));
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOption));
   pw.addOpt(512, 0, 0, opts);
   pw.commit();
   uint16_t len = query.size();
@@ -238,7 +239,7 @@ BOOST_AUTO_TEST_CASE(replaceECSWithLarger) {
   ecsOpts.source = Netmask(origRemote, 8);
   string origECSOption = makeEDNSSubnetOptsString(ecsOpts);
   DNSPacketWriter::optvect_t opts;
-  opts.push_back(make_pair(EDNS0_OPTION_CODE_ECS, origECSOption));
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOption));
   pw.addOpt(512, 0, 0, opts);
   pw.commit();
   uint16_t len = query.size();


### PR DESCRIPTION
Refactor the handling of EDNS0 Options parsing to use the same code
in dnsdist and the recursor (packet cache and gettag).
Closes #3516.