### PR TITLE
Dnsdist: include <sys/endian.h> on FreeBSD

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -79,6 +79,10 @@
 
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#endif
+
 union ComboAddress {
   struct sockaddr_in sin4;
   struct sockaddr_in6 sin6;


### PR DESCRIPTION
Fixes:
In file included from dnsdist.hh:6:0,
                 from dnsdist.cc:23:
iputils.hh: In member function 'NetmaskTree<T>::node_type& NetmaskTree<T>::insert(const key_type&)':
iputils.hh:532:73: error: there are no arguments to 'be32toh' that depend on a template parameter, so a declaration of 'be32toh' must be available [-fpermissive]
       std::bitset<32> addr(be32toh(key.getNetwork().sin4.sin_addr.s_addr));
                                                                         ^

When building with g++