### PR TITLE
Fix Boost component library detection on ARM64 etc.

### DIFF
--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -328,14 +328,14 @@ CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
 AC_CACHE_CHECK([for the Boost $1 library], [Boost_lib],
                [_BOOST_FIND_LIBS($@)])
 case $Boost_lib in #(
-  (no) _AC_MSG_LOG_CONFTEST
-    AC_MSG_ERROR([cannot find the flags to link with Boost $1])
+  (yes) _AC_MSG_LOG_CONFTEST
+    AC_DEFINE(AS_TR_CPP([HAVE_BOOST_$1]), [1], [Defined if the Boost $1 library is available])dnl
+    AC_SUBST(AS_TR_CPP([BOOST_$1_LDFLAGS]), [$Boost_lib_LDFLAGS])dnl
+    AC_SUBST(AS_TR_CPP([BOOST_$1_LDPATH]), [$Boost_lib_LDPATH])dnl
+    AC_SUBST([BOOST_LDPATH], [$Boost_lib_LDPATH])dnl
+    AC_SUBST(AS_TR_CPP([BOOST_$1_LIBS]), [$Boost_lib_LIBS])dnl
     ;;
 esac
-AC_SUBST(AS_TR_CPP([BOOST_$1_LDFLAGS]), [$Boost_lib_LDFLAGS])dnl
-AC_SUBST(AS_TR_CPP([BOOST_$1_LDPATH]), [$Boost_lib_LDPATH])dnl
-AC_SUBST([BOOST_LDPATH], [$Boost_lib_LDPATH])dnl
-AC_SUBST(AS_TR_CPP([BOOST_$1_LIBS]), [$Boost_lib_LIBS])dnl
 CPPFLAGS=$boost_save_CPPFLAGS
 AS_VAR_POPDEF([Boost_lib])dnl
 AS_VAR_POPDEF([Boost_lib_LDFLAGS])dnl

--- a/pdns/mtasker_context.cc
+++ b/pdns/mtasker_context.cc
@@ -1,4 +1,6 @@
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
 
 #if defined(HAVE_BOOST_CONTEXT)
 #include "mtasker_fcontext.cc"

--- a/pdns/mtasker_context.cc
+++ b/pdns/mtasker_context.cc
@@ -1,10 +1,7 @@
-#include <boost/version.hpp>
+#include "config.h"
 
-/* Boost Context was introduced in 1.51 (Aug 2012), but it's probably not worth
- * supporting it because there was an immediate API break in 1.52 (Nov 2012)
- */
-#if BOOST_VERSION <= 105100
-#include "mtasker_ucontext.cc"
-#else
+#if defined(HAVE_BOOST_CONTEXT)
 #include "mtasker_fcontext.cc"
+#else
+#include "mtasker_ucontext.cc"
 #endif

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -47,7 +47,7 @@ AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
       LDFLAGS="$LDFLAGS $BOOST_THREAD_LDFLAGS"
     fi
     AC_MSG_NOTICE([checking whether the Boost context library actually links...])
-    BOOST_FIND_LIB([context], [], [boost/context/fcontext.hpp], [[]])
+    BOOST_FIND_LIB([context], [$1], [boost/context/fcontext.hpp], [[]])
     case $boost_cv_lib_context in
       (yes)
         AC_MSG_NOTICE([MTasker will use the Boost context library for context switching])

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -33,21 +33,34 @@ AC_PROG_LIBTOOL
 
 PDNS_CHECK_OS
 
+# Boost Context was introduced in 1.51 (Aug 2012), but there was an immediate
+# API break in 1.52 (Nov 2012), so we only support that, and later.
+
 AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
-    AC_MSG_CHECKING([for Boost version >= 1.52])
-    AC_PREPROC_IFELSE([AC_LANG_SOURCE([[
-#include <boost/version.hpp>
-#if BOOST_VERSION <= 105100
-#error
-#endif
-    ]])], [
-        AC_MSG_RESULT([yes])
-        AC_MSG_NOTICE([MTasker will use the Boost Context library for context switching])
-        BOOST_CONTEXT
-    ], [
-        AC_MSG_RESULT([no])
-        AC_MSG_NOTICE([MTasker will use System V contexts for context switching])
-    ])
+  AC_MSG_CHECKING([whether Boost is new enough to use the context library...])
+  if test $boost_major_version -ge 152; then
+    AC_MSG_RESULT([yes])
+    if test $boost_major_version -ge 157; then
+      BOOST_THREAD([$1])
+      m4_pattern_allow([^BOOST_THREAD_(LIBS|LDFLAGS)$])dnl
+      LIBS="$LIBS $BOOST_THREAD_LIBS"
+      LDFLAGS="$LDFLAGS $BOOST_THREAD_LDFLAGS"
+    fi
+    AC_MSG_NOTICE([checking whether the Boost context library actually links...])
+    BOOST_FIND_LIB([context], [], [boost/context/fcontext.hpp], [[]])
+    case $boost_cv_lib_context in
+      (yes)
+        AC_MSG_NOTICE([MTasker will use the Boost context library for context switching])
+        ;;
+      *)
+        AC_MSG_NOTICE([Boost context library is missing])
+        AC_MSG_NOTICE([MTasker will use System V ucontexts for context switching])
+        ;;
+    esac
+  else
+    AC_MSG_RESULT([no])
+    AC_MSG_NOTICE([MTasker will use System V ucontexts for context switching])
+  fi
 ])
 
 BOOST_REQUIRE([1.35])


### PR DESCRIPTION
On some platforms the Boost context headers are being shipped on architectures where the library can't be built. Here we patch boost.m4 to set HAVE_BOOST_<component> definitions based on whether the library actually exists.

This should also fix #3536 by avoiding the context/all.hpp header check.