### PR TITLE
pdns: Fix build on OSX

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -3,7 +3,8 @@ JSON11_LIBS = $(top_builddir)/ext/json11/libjson11.la
 AM_CPPFLAGS += \
 	-I$(top_srcdir)/ext/json11 \
 	$(YAHTTP_CFLAGS) \
-	$(LIBEDIT_CFLAGS)
+	$(LIBEDIT_CFLAGS) \
+	$(OPENSSL_INCLUDES)
 
 AM_CXXFLAGS = \
 	-DSYSCONFDIR=\"$(sysconfdir)\" \


### PR DESCRIPTION
Using OpenSSL from Homebrew, by doing
./configure --with-openssl=/Users/ruben/homebrew/Cellar/openssl/1.0.2g

Results in:

Making all in pdns
/Library/Developer/CommandLineTools/usr/bin/make  all-am
  CXX      base64.o
base64.cc:7:10: fatal error: 'openssl/bio.h' file not found
         ^
1 error generated.