### PR TITLE
Small fixes reported by coverity

### DIFF
--- a/pdns/delaypipe.cc
+++ b/pdns/delaypipe.cc
@@ -30,8 +30,10 @@ template<class T>
 void ObjectPipe<T>::write(T& t)
 {
   auto ptr = new T(t);
-  if(::write(d_fds[1], &ptr, sizeof(ptr)) != sizeof(ptr))
+  if(::write(d_fds[1], &ptr, sizeof(ptr)) != sizeof(ptr)) {
+    delete ptr;
     unixDie("write");
+  }
 }
 
 template<class T>

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -498,8 +498,6 @@ public:
   string d_salt;
   string d_nexthash;
   std::set<uint16_t> d_set;
-  uint8_t d_saltlength;
-  uint8_t d_nexthashlength;
 
   uint16_t getType() const override
   {
@@ -533,7 +531,6 @@ public:
   uint8_t d_algorithm, d_flags;
   uint16_t d_iterations;
   string d_salt;
-  uint8_t d_saltlength;
 };
 
 

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -282,9 +282,9 @@ NSEC3PARAMRecordContent::DNSRecordContent* NSEC3PARAMRecordContent::make(const D
   pr.xfr8BitInt(ret->d_algorithm); 
         pr.xfr8BitInt(ret->d_flags); 
         pr.xfr16BitInt(ret->d_iterations); 
-  pr.xfr8BitInt(ret->d_saltlength);
-  pr.xfrHexBlob(ret->d_salt);
- 
+  uint8_t len;
+  pr.xfr8BitInt(len);
+  pr.xfrHexBlob(ret->d_salt, len);
   return ret;
 }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -188,7 +188,7 @@ struct DNSComboWriter {
   ComboAddress d_remote, d_local;
   bool d_tcp;
   int d_socket;
-  int d_tag;
+  int d_tag{0};
   string d_query;
   shared_ptr<TCPConnection> d_tcpConnection;
   vector<pair<uint16_t, string> > d_ednsOpts;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -283,6 +283,9 @@ bool SyncRes::doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSR
 void SyncRes::doEDNSDumpAndClose(int fd)
 {
   FILE* fp=fdopen(fd, "w");
+  if (!fp) {
+    return;
+  }
   fprintf(fp,"IP Address\tMode\tMode last updated at\n");
   for(const auto& eds : t_sstorage->ednsstatus) {
     fprintf(fp, "%s\t%d\t%s", eds.first.toString().c_str(), (int)eds.second.mode, ctime(&eds.second.modeSetAt));


### PR DESCRIPTION
I would appreciate any comment, especially regarding the NSEC3*RecordContent changes. The removed fields don't seem to be used, but I'm really not familiar with this code and thus might very well be missing something.