### PR TITLE
log name/qtype when sending out servfail

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -137,6 +137,23 @@ std::string DNSName::toString(const std::string& separator, const bool trailing)
   return ret.substr(0, ret.size()-!trailing);
 }
 
+std::string DNSName::toLogString() const
+{
+  if (empty()) {
+    return "(empty)";
+  }
+
+ if(isRoot())
+    return ".";
+
+  std::string ret;
+  for(const auto& s : getRawLabels()) {
+    ret+= escapeLabel(s) + ".";
+  }
+
+  return ret;
+}
+
 std::string DNSName::toDNSString() const
 {
   if (empty())

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -52,6 +52,7 @@ public:
   bool operator!=(const DNSName& other) const { return !(*this == other); }
 
   std::string toString(const std::string& separator=".", const bool trailing=true) const;              //!< Our human-friendly, escaped, representation
+  std::string toLogString() const; //!< like plain toString, but returns (empty) on empty names
   std::string toStringNoDot() const { return toString(".", false); }
   std::string toStringRootDot() const { if(isRoot()) return "."; else return toString(".", false); }
   std::string toDNSString() const;           //!< Our representation in DNS native format

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1562,7 +1562,7 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
     throw; // we WANT to die at this point
   }
   catch(std::exception &e) {
-    L<<Logger::Error<<"Exception building answer packet ("<<e.what()<<") sending out servfail"<<endl;
+    L<<Logger::Error<<"Exception building answer packet for "<<p->qdomain.toLogString()<<"/"<<p->qtype.getName()<<" ("<<e.what()<<") sending out servfail"<<endl;
     delete r;
     r=p->replyPacket(); // generate an empty reply packet
     r->setRcode(RCode::ServFail);


### PR DESCRIPTION
Should we check for 'empty qname' to avoid generating another exception? Should we log client? query ID?