### PR TITLE
Ship the notify tool in the pdns-tools deb

### DIFF
--- a/build-scripts/debian-authoritative/pdns-tools.install
+++ b/build-scripts/debian-authoritative/pdns-tools.install
@@ -6,6 +6,7 @@ usr/bin/dnsscope
 usr/bin/dnstcpbench
 usr/bin/dnswasher
 usr/bin/ixplore
+usr/bin/notify
 usr/bin/nsec3dig
 usr/bin/saxfr
 usr/bin/sdig

--- a/build-scripts/test-auth
+++ b/build-scripts/test-auth
@@ -19,6 +19,7 @@ export PDNS=/usr/sbin/pdns_server
 export PDNS2=$PDNS
 export SDIG=/usr/bin/sdig
 export NSEC3DIG=/usr/bin/nsec3dig
+export NOTIFY=/usr/bin/notify
 export SAXFR=/usr/bin/saxfr
 export ZONE2SQL=/usr/bin/zone2sql
 export PDNSUTIL=/usr/bin/pdnsutil

--- a/regression-tests.nobackend/supermaster-signed/command
+++ b/regression-tests.nobackend/supermaster-signed/command
@@ -2,17 +2,11 @@
 set -e
 set -x
 
-PDNS=${PDNS:-../pdns/pdns_server}
-PDNS2=${PDNS2:-../pdns/pdns_server}
-
 ALGORITHM=${ALGORITHM:="hmac-md5"}
 KEY=${KEY:="kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys="}
 if [ "$RUNWRAPPER" = "" ]; then
   RUNWRAPPER="authbind"
 fi
-MAKE=${MAKE:-make}
-
-$MAKE -C ../pdns notify > /dev/null
 
 export ALGORITHM
 export KEY
@@ -24,8 +18,7 @@ trap "kill_process 2" EXIT INT TERM
 
 tosql ()
 {
-        ${MAKE} -C ../pdns zone2sql > /dev/null
-        ../pdns/zone2sql --transactions --$1 --named-conf=./named.conf
+        ${ZONE2SQL} --transactions --$1 --named-conf=./named.conf
 }
 
 prepare()
@@ -73,17 +66,17 @@ EOF
 UPDATE domains SET type = 'MASTER', notified_serial = NULL;
 EOF
 	# setup tsig keys
-        ../pdns/pdnsutil --config-name=gsqlite3-master --config-dir=. import-tsig-key tsig.com $ALGORITHM "$KEY"
-	../pdns/pdnsutil --config-name=gsqlite3-slave --config-dir=. import-tsig-key tsig.com $ALGORITHM "$KEY"
-	../pdns/zone2sql --transactions --gsqlite --zone=zones/example.com --zone-name=example.com | sqlite3 slave.db
+        $PDNSUTIL --config-name=gsqlite3-master --config-dir=. import-tsig-key tsig.com $ALGORITHM "$KEY"
+	$PDNSUTIL --config-name=gsqlite3-slave --config-dir=. import-tsig-key tsig.com $ALGORITHM "$KEY"
+	$ZONE2SQL --transactions --gsqlite --zone=zones/example.com --zone-name=example.com | sqlite3 slave.db
 	# setup supermaster
 	sqlite3 slave.db <<EOF
 UPDATE domains SET type = 'SLAVE', master = '127.0.0.1' WHERE name = 'example.com';
 EOF
 	# setup metadata on master
-        ../pdns/pdnsutil --config-name=gsqlite3-master --config-dir=. set-meta example.com TSIG-ALLOW-AXFR tsig.com
-	../pdns/pdnsutil --config-name=gsqlite3-master --config-dir=. set-meta test.com TSIG-ALLOW-AXFR tsig.com
-        ../pdns/pdnsutil --config-name=gsqlite3-slave --config-dir=. set-meta example.com AXFR-MASTER-TSIG tsig.com
+        $PDNSUTIL --config-name=gsqlite3-master --config-dir=. set-meta example.com TSIG-ALLOW-AXFR tsig.com
+	$PDNSUTIL --config-name=gsqlite3-master --config-dir=. set-meta test.com TSIG-ALLOW-AXFR tsig.com
+        $PDNSUTIL --config-name=gsqlite3-slave --config-dir=. set-meta example.com AXFR-MASTER-TSIG tsig.com
 	# i suppose we are done here...
 }
 
@@ -213,7 +206,7 @@ INSERT INTO supermasters (ip,nameserver,account) VALUES('127.0.0.1','ns1.example
 EOF
 
 # send notifications
-../pdns/pdns_control --config-dir=. --config-name=gsqlite3-master --socket-dir=. notify test.com
+$PDNSCONTROL --config-dir=. --config-name=gsqlite3-master --socket-dir=. notify test.com
 sleep 2
 
 # hopefully notifications have gone thru
@@ -232,6 +225,6 @@ for domain in test.com; do
 done
 
 # ensure unsigned notifications are refused
-../pdns/notify 127.0.0.2:53 test.com 2>&1
+$NOTIFY 127.0.0.2:53 test.com 2>&1
 
 kill_process 0

--- a/regression-tests.nobackend/supermaster-unsigned/command
+++ b/regression-tests.nobackend/supermaster-unsigned/command
@@ -2,24 +2,18 @@
 set -e
 set -x
 
-PDNS=${PDNS:-../pdns/pdns_server}
-PDNS2=${PDNS2:-../pdns/pdns_server}
 if [ "$RUNWRAPPER" = "" ]; then
   RUNWRAPPER="authbind"
 fi
-MAKE=${MAKE:-make}
 
 port=$1
 [ -z "$port" ] && port=53
 
 trap "kill_process 2" EXIT INT TERM
 
-$MAKE -C ../pdns notify > /dev/null
-
 tosql ()
 {
-        ${MAKE} -C ../pdns zone2sql > /dev/null
-        ../pdns/zone2sql --transactions --$1 --named-conf=./named.conf
+        $ZONE2SQL --transactions --$1 --named-conf=./named.conf
 }
 
 prepare()
@@ -66,14 +60,14 @@ EOF
 	sqlite3 master.db <<EOF
 UPDATE domains SET type = 'MASTER', notified_serial = NULL;
 EOF
-	../pdns/zone2sql --transactions --gsqlite --zone=zones/example.com --zone-name=example.com | sqlite3 slave.db
+	$ZONE2SQL --transactions --gsqlite --zone=zones/example.com --zone-name=example.com | sqlite3 slave.db
 	# setup supermaster
 	sqlite3 slave.db <<EOF
 UPDATE domains SET type = 'SLAVE', master = '127.0.0.1' WHERE name = 'example.com';
 EOF
 	# setup metadata on master
-        ../pdns/pdnsutil --config-name=gsqlite3-master --config-dir=. set-meta example.com ALLOW-AXFR-FROM 127.0.0.2
-        ../pdns/pdnsutil --config-name=gsqlite3-master --config-dir=. set-meta test.com ALLOW-AXFR-FROM 127.0.0.2
+        $PDNSUTIL --config-name=gsqlite3-master --config-dir=. set-meta example.com ALLOW-AXFR-FROM 127.0.0.2
+        $PDNSUTIL --config-name=gsqlite3-master --config-dir=. set-meta test.com ALLOW-AXFR-FROM 127.0.0.2
 	# i suppose we are done here...
 }
 
@@ -203,7 +197,7 @@ INSERT INTO supermasters (ip,nameserver,account) VALUES('127.0.0.1','ns1.example
 EOF
 
 # send notifications
-../pdns/pdns_control --config-dir=. --config-name=gsqlite3-master --socket-dir=. notify test.com
+$PDNSCONTROL --config-dir=. --config-name=gsqlite3-master --socket-dir=. notify test.com
 sleep 2
 
 # hopefully notifications have gone thru

--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -6,6 +6,7 @@ export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
 export PDNS2=${PDNS2:-${PWD}/../pdns/pdns_server}
 export PDNSRECURSOR=${PDNSRECURSOR:-${PWD}/../pdns_recursor}
 export SDIG=${SDIG:-${PWD}/../pdns/sdig}
+export NOTIFY=${NOTIFY:-${PWD}/../pdns/notify}
 export NSEC3DIG=${NSEC3DIG:-${PWD}/../pdns/nsec3dig}
 export SAXFR=${SAXFR:-${PWD}/../pdns/saxfr}
 export ZONE2SQL=${ZONE2SQL:-${PWD}/../pdns/zone2sql}
@@ -16,7 +17,7 @@ export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
 spectest=$1
 [ -z $spectest ] && spectest=""
 
-for prog in $SDIG $SAXFR $NSEC3DIG; do
+for prog in $SDIG $SAXFR $NOTIFY $NSEC3DIG; do
   if `echo $prog | grep -q '../pdns'`; then
     ${MAKE} -C ../pdns ${prog##*../pdns/} || exit
   fi

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -8,6 +8,7 @@ export PDNS=${PDNS:-${PWD}/../pdns/pdns_server}
 export PDNS2=${PDNS2:-${PWD}/../pdns/pdns_server}
 export PDNSRECURSOR=${PDNSRECURSOR:-${PWD}/../pdns_recursor}
 export SDIG=${SDIG:-${PWD}/../pdns/sdig}
+export NOTIFY=${NOTIFY:-${PWD}/../pdns/notify}
 export NSEC3DIG=${NSEC3DIG:-${PWD}/../pdns/nsec3dig}
 export SAXFR=${SAXFR:-${PWD}/../pdns/saxfr}
 export ZONE2SQL=${ZONE2SQL:-${PWD}/../pdns/zone2sql}
@@ -235,7 +236,7 @@ __EOF__
 	exit
 fi
 
-for prog in $SDIG $SAXFR $NSEC3DIG; do
+for prog in $SDIG $SAXFR $NOTIFY $NSEC3DIG; do
   if `echo $prog | grep -q '../pdns'`; then
     ${MAKE} -C ../pdns ${prog##*../pdns/} || exit
   fi


### PR DESCRIPTION
This commit fixes our testsuite on buildbot. However, the `pdns-tools` package now conflicts with `ruby-notify`, as they both ship `/usr/bin/notify`. See also #3447 