### PR TITLE
Add a `disable-syslog` option

### DIFF
--- a/docs/manpages/dnsdist.1.md
+++ b/docs/manpages/dnsdist.1.md
@@ -81,6 +81,10 @@ Server for example is often mentioned.
 :    Run in foreground, but do not spawn a console. Use this switch to run
      dnsdist inside a supervisor (use with e.g. systemd and daemontools).
 
+--disable-syslog
+:    Disable logging to syslog. Use this when running inside a supervisor that
+     handles logging (like systemd). Do not use in combination with **--daemon**.
+
 -p,--pidfile *FILE*
 :    Write a pidfile to *FILE*, works only with **--daemon**.
 

--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -259,6 +259,14 @@ Do not allow zone transfers.
 Disable the rectify step during an outgoing AXFR. Only required for regression
 testing.
 
+## `disable-syslog`
+* Boolean
+* Default: no
+
+Do not log to syslog, only to stdout. Use this setting when running inside a
+supervisor that handles logging (like systemd). **Note**: do not use this setting
+in combination with [`daemon`](#daemon) as all logging will disappear.
+
 ## `disable-tcp`
 * Boolean
 * Default: no

--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -167,6 +167,14 @@ Which domains we only accept delegations from (a Verisign special).
 Turn off the packet cache. Useful when running with Lua scripts that can not be
 cached.
 
+## `disable-syslog`
+* Boolean
+* Default: no
+
+Do not log to syslog, only to stdout. Use this setting when running inside a
+supervisor that handles logging (like systemd). **Note**: do not use this setting
+in combination with [`daemon`](#daemon) as all logging will disappear.
+
 ## `dnssec`
 * One of `off`, `process`, `log-fail`, `validate`, String
 * Default: `off` (**note**: was `process` until 4.0.0-alpha2)

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -88,6 +88,7 @@ void declareArguments()
   ::arg().set("version-string","PowerDNS version in packets - full, anonymous, powerdns or custom")="full"; 
   ::arg().set("control-console","Debugging switch - don't use")="no"; // but I know you will!
   ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";
+  ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
   ::arg().set("default-soa-name","name to insert in the SOA record if none set in the backend")="a.misconfigured.powerdns.server";
   ::arg().set("default-soa-mail","mail address to insert in the SOA record if none set in the backend")="";
   ::arg().set("distributor-threads","Default number of Distributor (backend) threads to start")="3";

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -63,6 +63,7 @@ uint16_t g_maxOutstanding{10240};
 bool g_console;
 bool g_verboseHealthChecks{false};
 uint32_t g_staleCacheEntriesTTL{0};
+bool g_syslog{true};
 
 GlobalStateHolder<NetmaskGroup> g_ACL;
 string g_outputBuffer;
@@ -1257,6 +1258,7 @@ try
     {"daemon", 0, 0, 'd'},
     {"pidfile",  required_argument, 0, 'p'},
     {"supervised", 0, 0, 's'},
+    {"disable-syslog", 0, 0, 2},
     {"uid",  required_argument, 0, 'u'},
     {"verbose", 0, 0, 'v'},
     {"version", 0, 0, 'V'},
@@ -1276,6 +1278,9 @@ try
     switch(c) {
     case 1:
       g_cmdLine.checkConfig=true;
+      break;
+    case 2:
+      g_syslog=false;
       break;
     case 'C':
       g_cmdLine.config=optarg;
@@ -1316,6 +1321,8 @@ try
       cout<<"-l,--local address    Listen on this local address\n";
       cout<<"--supervised          Don't open a console, I'm supervised\n";
       cout<<"                        (use with e.g. systemd and daemontools)\n";
+      cout<<"--disable-syslog      Don't log to syslog, only to stdout\n";
+      cout<<"                        (use with e.g. systemd)\n";
       cout<<"-p,--pidfile file     Write a pidfile, works only with --daemon\n";
       cout<<"-u,--uid uid          Change the process user ID after binding sockets\n";
       cout<<"-v,--verbose          Enable verbose mode\n";

--- a/pdns/dolog.hh
+++ b/pdns/dolog.hh
@@ -48,13 +48,15 @@ void dolog(std::ostream& os, const char* s, T value, Args... args)
 
 extern bool g_console;
 extern bool g_verbose;
+extern bool g_syslog;
 
 template<typename... Args>
 void genlog(int level, const char* s, Args... args)
 {
   std::ostringstream str;
   dolog(str, s, args...);
-  syslog(level, "%s", str.str().c_str());
+  if(g_syslog)
+    syslog(level, "%s", str.str().c_str());
   if(g_console) 
     std::cout<<str.str()<<std::endl;
 }

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -56,7 +56,7 @@ void Logger::log(const string &msg, Urgency u)
     Lock l(&m); // the C++-2011 spec says we need this, and OSX actually does
     clog << string(buffer) + msg <<endl;
   }
-  if( u <= d_loglevel ) {
+  if( u <= d_loglevel && !d_disableSyslog ) {
 #ifndef RECURSOR
     S.ringAccount("logmessages",msg);
 #endif

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -56,6 +56,10 @@ public:
   void toConsole(Urgency);
   void setLoglevel( Urgency );
 
+  void disableSyslog(bool d) {
+    d_disableSyslog = d;
+  }
+
   //! Log to a file.
   void toFile( const string & filename );
   
@@ -102,6 +106,7 @@ private:
   Urgency d_loglevel;
   Urgency consoleUrgency;
   bool opened;
+  bool d_disableSyslog;
   static pthread_once_t s_once;
   static pthread_key_t s_loggerKey;
 };

--- a/pdns/pdns.conf-dist
+++ b/pdns/pdns.conf-dist
@@ -165,6 +165,11 @@
 # disable-axfr-rectify=no
 
 #################################
+# disable-syslog	Disable logging to syslog, useful when running inside a supervisor that logs stdout
+#
+# disable-syslog=no
+
+#################################
 # disable-tcp	Do not listen to TCP queries
 #
 # disable-tcp=no

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2265,6 +2265,7 @@ int serviceMain(int argc, char*argv[])
 {
   L.setName(s_programname);
   L.setLoglevel((Logger::Urgency)(6)); // info and up
+  L.disableSyslog(::arg().mustDo("disable-syslog"));
 
   if(!::arg()["logging-facility"].empty()) {
     int val=logFacilityToLOG(::arg().asNum("logging-facility") );
@@ -2636,6 +2637,7 @@ int main(int argc, char **argv)
     ::arg().set("daemon","Operate as a daemon")="no";
     ::arg().setSwitch("write-pid","Write a PID file")="yes";
     ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";
+    ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
     ::arg().set("log-common-errors","If we should log rather common errors")="yes";
     ::arg().set("chroot","switch to chroot jail")="";
     ::arg().set("setgid","If set, change group id to this gid for more security")="";

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -468,6 +468,7 @@ int main(int argc, char **argv)
     }
 
     L.setLoglevel((Logger::Urgency)(::arg().asNum("loglevel")));
+    L.disableSyslog(::arg().mustDo("disable-syslog"));
     L.toConsole((Logger::Urgency)(::arg().asNum("loglevel")));  
 
     if(::arg().mustDo("help") || ::arg().mustDo("config")) {

--- a/pdns/test-dnscrypt_cc.cc
+++ b/pdns/test-dnscrypt_cc.cc
@@ -34,6 +34,7 @@
 
 bool g_verbose{true};
 bool g_console{true};
+bool g_syslog{true};
 
 BOOST_AUTO_TEST_SUITE(dnscrypt_cc)
 

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -39,6 +39,7 @@
 BOOST_AUTO_TEST_SUITE(dnsdist_cc)
 
 bool g_console{true};
+bool g_syslog{true};
 bool g_verbose{true};
 
 static void validateQuery(const char * packet, size_t packetSize)


### PR DESCRIPTION
This allows running PowerDNS/dnsdist in systemd with `Type=simple` without the double loggin issue.

Closes #1607