### PR TITLE
auth: Fix reading invalid iterator in fillZone()

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -381,7 +381,7 @@ static void fillZone(const DNSName& zonename, HttpResponse* resp) {
   auto cit = comments.begin();
 
   while (rit != records.end() || cit != comments.end()) {
-    if (cit == comments.end() || cit->qname.toString() < rit->qname.toString() || cit->qtype < rit->qtype) {
+    if (cit == comments.end() || (rit != records.end() && (cit->qname.toString() < rit->qname.toString() || cit->qtype < rit->qtype))) {
       current_qname = rit->qname;
       current_qtype = rit->qtype;
       ttl = rit->ttl;


### PR DESCRIPTION
Reported by coverity:
```
CID 1353069 (#1 of 1): Using invalid iterator (INVALIDATE_ITERATOR)

19. deref_iterator: Dereferencing iterator rit though it is already
past the end of its container.
```