### PR TITLE
dnsdist: Refactor query/response handling code (UDP/TCP)

### DIFF
--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -381,6 +381,7 @@ struct DNSQuestion
   bool skipCache{false};
 };
 
+typedef std::function<bool(const DNSQuestion*)> blockfilter_t;
 template <class T> using NumberedVector = std::vector<std::pair<unsigned int, T> >;
 
 void* responderThread(std::shared_ptr<DownstreamState> state);
@@ -507,6 +508,7 @@ bool getLuaNoSideEffect(); // set if there were only explicit declarations of _n
 void resetLuaSideEffect(); // reset to indeterminate state
 
 bool responseContentMatches(const char* response, const uint16_t responseLen, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote);
+bool processQuery(LocalStateHolder<NetmaskTree<DynBlock> >& localDynBlock, LocalStateHolder<vector<pair<std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction> > > >& localRulactions, blockfilter_t blockFilter, DNSQuestion& dq, const ComboAddress& remote, string& poolname, int* delayMsec, const struct timespec& now);
 bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded,
 #ifdef HAVE_DNSCRYPT
                    std::shared_ptr<DnsCryptQuery> dnsCryptQuery,

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -506,6 +506,13 @@ void setLuaSideEffect();   // set to report a side effect, cancelling all _no_ s
 bool getLuaNoSideEffect(); // set if there were only explicit declarations of _no_ side effect
 void resetLuaSideEffect(); // reset to indeterminate state
 
+bool responseContentMatches(const char* response, const uint16_t responseLen, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote);
+bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded,
+#ifdef HAVE_DNSCRYPT
+                   std::shared_ptr<DnsCryptQuery> dnsCryptQuery,
+#endif
+                   std::vector<uint8_t>& rewrittenResponse);
+
 #ifdef HAVE_DNSCRYPT
 extern std::vector<std::tuple<ComboAddress,DnsCryptContext,bool>> g_dnsCryptLocals;
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -509,14 +509,12 @@ void resetLuaSideEffect(); // reset to indeterminate state
 
 bool responseContentMatches(const char* response, const uint16_t responseLen, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote);
 bool processQuery(LocalStateHolder<NetmaskTree<DynBlock> >& localDynBlock, LocalStateHolder<vector<pair<std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction> > > >& localRulactions, blockfilter_t blockFilter, DNSQuestion& dq, const ComboAddress& remote, string& poolname, int* delayMsec, const struct timespec& now);
-bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded,
-#ifdef HAVE_DNSCRYPT
-                   std::shared_ptr<DnsCryptQuery> dnsCryptQuery,
-#endif
-                   std::vector<uint8_t>& rewrittenResponse);
+bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom);
+void restoreFlags(struct dnsheader* dh, uint16_t origFlags);
 
 #ifdef HAVE_DNSCRYPT
 extern std::vector<std::tuple<ComboAddress,DnsCryptContext,bool>> g_dnsCryptLocals;
 
 int handleDnsCryptQuery(DnsCryptContext* ctx, char* packet, uint16_t len, std::shared_ptr<DnsCryptQuery>& query, uint16_t* decryptedQueryLen, bool tcp, std::vector<uint8_t>& reponse);
+bool encryptResponse(char* response, uint16_t* responseLen, size_t responseSize, bool tcp, std::shared_ptr<DnsCryptQuery> dnsCryptQuery);
 #endif

--- a/regression-tests.dnsdist/test_DNSCrypt.py
+++ b/regression-tests.dnsdist/test_DNSCrypt.py
@@ -128,6 +128,7 @@ class TestDNSCryptWithCache(DNSDistTest):
         """
         DNSCrypt: encrypted A query served from cache
         """
+        misses = 0
         client = dnscrypt.DNSCryptClient(self._providerName, self._providerFingerprint, "127.0.0.1", 8443)
         name = 'cacheda.dnscrypt.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
@@ -152,6 +153,7 @@ class TestDNSCryptWithCache(DNSDistTest):
         receivedQuery.id = query.id
         self.assertEquals(query, receivedQuery)
         self.assertEquals(response, receivedResponse)
+        misses += 1
 
         # second query should get a cached response
         data = client.query(query.to_wire())
@@ -163,3 +165,7 @@ class TestDNSCryptWithCache(DNSDistTest):
         self.assertEquals(receivedQuery, None)
         self.assertTrue(receivedResponse)
         self.assertEquals(response, receivedResponse)
+        total = 0
+        for key in self._responsesCounter:
+            total += self._responsesCounter[key]
+        self.assertEquals(total, misses)

--- a/regression-tests.dnsdist/test_DNSCrypt.py
+++ b/regression-tests.dnsdist/test_DNSCrypt.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import time
-import unittest
 import dns
 import dns.message
 from dnsdisttests import DNSDistTest
@@ -43,11 +42,24 @@ class TestDNSCrypt(DNSDistTest):
                                     3600,
                                     dns.rdataclass.IN,
                                     dns.rdatatype.A,
-                                    '127.0.0.1')
+                                    '192.2.0.1')
         response.answer.append(rrset)
 
         self._toResponderQueue.put(response)
         data = client.query(query.to_wire())
+        receivedResponse = dns.message.from_wire(data)
+        receivedQuery = None
+        if not self._fromResponderQueue.empty():
+            receivedQuery = self._fromResponderQueue.get(query)
+
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        self._toResponderQueue.put(response)
+        data = client.query(query.to_wire(), tcp=True)
         receivedResponse = dns.message.from_wire(data)
         receivedQuery = None
         if not self._fromResponderQueue.empty():
@@ -95,6 +107,59 @@ class TestDNSCrypt(DNSDistTest):
         self.assertTrue(len(receivedResponse.authority) == 0)
         self.assertTrue(len(receivedResponse.additional) == 0)
 
-if __name__ == '__main__':
-    unittest.main()
-    exit(0)
+class TestDNSCryptWithCache(DNSDistTest):
+    _dnsDistPortDNSCrypt = 8443
+    _providerFingerprint = 'E1D7:2108:9A59:BF8D:F101:16FA:ED5E:EA6A:9F6C:C78F:7F91:AF6B:027E:62F4:69C3:B1AA'
+    _providerName = "2.provider.name"
+    _resolverCertificateSerial = 42
+    # valid from 60s ago until 2h from now
+    _resolverCertificateValidFrom = time.time() - 60
+    _resolverCertificateValidUntil = time.time() + 7200
+    _config_params = ['_resolverCertificateSerial', '_resolverCertificateValidFrom', '_resolverCertificateValidUntil', '_dnsDistPortDNSCrypt', '_providerName', '_testServerPort']
+    _config_template = """
+    generateDNSCryptCertificate("DNSCryptProviderPrivate.key", "DNSCryptResolver.cert", "DNSCryptResolver.key", %d, %d, %d)
+    addDNSCryptBind("127.0.0.1:%d", "%s", "DNSCryptResolver.cert", "DNSCryptResolver.key")
+    pc = newPacketCache(5, 86400, 1)
+    getPool(""):setCache(pc)
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testCachedSimpleA(self):
+        """
+        DNSCrypt: encrypted A query served from cache
+        """
+        client = dnscrypt.DNSCryptClient(self._providerName, self._providerFingerprint, "127.0.0.1", 8443)
+        name = 'cacheda.dnscrypt.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '192.2.0.1')
+        response.answer.append(rrset)
+
+        # first query to fill the cache
+        self._toResponderQueue.put(response)
+        data = client.query(query.to_wire())
+        receivedResponse = dns.message.from_wire(data)
+        receivedQuery = None
+        if not self._fromResponderQueue.empty():
+            receivedQuery = self._fromResponderQueue.get(query)
+
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        # second query should get a cached response
+        data = client.query(query.to_wire())
+        receivedResponse = dns.message.from_wire(data)
+        receivedQuery = None
+        if not self._fromResponderQueue.empty():
+            receivedQuery = self._fromResponderQueue.get(query)
+
+        self.assertEquals(receivedQuery, None)
+        self.assertTrue(receivedResponse)
+        self.assertEquals(response, receivedResponse)


### PR DESCRIPTION
Merge the UDP/TCP code handling:

* dynamic blocks
* blockfilter
* rules
* response consistency check
* response fixup (removing EDNS if needed, restoring flags, restoring case)

This fixes an issue with DNSCrypt, where cached responses were not
being encrypted, and make the counters more consistent between UDP and TCP.