### PR TITLE
Update Makefile.am: do not swallow curl errors

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1115,7 +1115,7 @@ curl_verbose = $(curl_verbose_$(V))
 curl_verbose_ = $(curl_verbose_$(AM_DEFAULT_VERBOSITY))
 curl_verbose_0 = @echo "  CURL    " $@;
 $(srcdir)/effective_tld_names.dat:
-	$(curl_verbose)if ! curl -s https://publicsuffix.org/list/public_suffix_list.dat > $@; then rm -f $@; exit 1; fi
+	$(curl_verbose)if ! curl -s -S https://publicsuffix.org/list/public_suffix_list.dat > $@; then rm -f $@; exit 1; fi
 
 pubsuffix.cc: $(srcdir)/effective_tld_names.dat
 	$(AM_V_GEN)./mkpubsuffixcc

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -187,7 +187,7 @@ curl_verbose = $(curl_verbose_$(V))
 curl_verbose_ = $(curl_verbose_$(AM_DEFAULT_VERBOSITY))
 curl_verbose_0 = @echo "  CURL    " $@;
 $(srcdir)/effective_tld_names.dat:
-	$(curl_verbose)if ! curl -s https://publicsuffix.org/list/public_suffix_list.dat > $@; then rm -f $@; exit 1; fi
+	$(curl_verbose)if ! curl -s -S https://publicsuffix.org/list/public_suffix_list.dat > $@; then rm -f $@; exit 1; fi
 
 pubsuffix.cc: $(srcdir)/effective_tld_names.dat
 	$(AM_V_GEN)./mkpubsuffixcc


### PR DESCRIPTION
The versions of Makefile.am execute 'curl -s' when fetching public_suffix_list.dat. However, if an error occurs during the retrieval of the URL, curl will swallow that error and silently fail. This PR adds the '-S' option, which will report details of an error, should one occur.

(In my case, the problem was caused by a transparent HTTPS proxy which was MITM'ing my connections using certificates that were generated on-the-fly. However, the root of those automatically-generated certificates was not in my machine's certificate store, which made curl fail silently)