### PR TITLE
Remove the send-root-referral option

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -647,16 +647,6 @@ If set, recursive queries will be handed to the recursor specified here. See
 
 Number of AXFR slave threads to start.
 
-## `send-root-referral`
-* Boolean or `lean`
-* Default: no
-
-if set, PowerDNS will send out old-fashioned root-referrals when queried for
-domains for which it is not authoritative. Wastes some bandwidth but may solve
-incoming query floods if domains are delegated to you for which you are not
-authoritative, but which are queried by broken recursors. It is possible to
-specify 'lean' root referrals, which waste less bandwidth.
-
 ## `setgid`
 * String
 

--- a/modules/luabackend/test/pdns
+++ b/modules/luabackend/test/pdns
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 ../../../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./  \
---no-shuffle --launch=lua --send-root-referral --loglevel=9 \
+--no-shuffle --launch=lua --loglevel=9 \
 --config-dir=./ --cache-ttl=0 --negquery-cache-ttl=0 --query-cache-ttl=0 --recursive-cache-ttl=0

--- a/modules/tinydnsbackend/generate-data.sh
+++ b/modules/tinydnsbackend/generate-data.sh
@@ -20,7 +20,7 @@ done
 cd ../../regression-tests
 ../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./ \
   --no-shuffle --launch=bind --bind-config=../regression-tests/named.conf \
-  --query-logging --send-root-referral --loglevel=0 \
+  --query-logging --loglevel=0 \
   --cache-ttl=0 --no-config --local-address=127.0.0.1 \
   --bind-ignore-broken-records=yes --module-dir=modules &
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -119,7 +119,6 @@ void declareArguments()
   ::arg().setSwitch("master","Act as a master")="no";
   ::arg().setSwitch("disable-axfr-rectify","Disable the rectify step during an outgoing AXFR. Only required for regression testing.")="no";
   ::arg().setSwitch("guardian","Run within a guardian process")="no";
-  ::arg().setSwitch("send-root-referral","Send out old-fashioned root-referral instead of ServFail in case of no authority")="no";
   ::arg().setSwitch("prevent-self-notification","Don't send notifications to what we think is ourself")="yes";
   ::arg().setSwitch("webserver","Start a webserver for monitoring")="no"; 
   ::arg().setSwitch("webserver-print-arguments","If the webserver should print arguments")="no"; 

--- a/pdns/pdns.conf-dist
+++ b/pdns/pdns.conf-dist
@@ -410,11 +410,6 @@
 # security-poll-suffix=secpoll.powerdns.com.
 
 #################################
-# send-root-referral	Send out old-fashioned root-referral instead of ServFail in case of no authority
-#
-# send-root-referral=no
-
-#################################
 # server-id	Returned when queried for 'server.id' TXT or NSID, defaults to hostname - disabled or custom
 #
 # server-id=

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -350,39 +350,6 @@ vector<uint8_t> makeEmptyQuery()
   return  packet;
 }
 
-
-vector<uint8_t> makeRootReferral()
-{
-  vector<uint8_t> packet;
-  DNSPacketWriter pw(packet, DNSName("outpost.ds9a.nl"), QType::SOA);
-
-  // nobody reads what we output, but it appears to be the magic that shuts some nameservers up
-  static const char*ips[]={"198.41.0.4", "192.228.79.201", "192.33.4.12", "199.7.91.13", "192.203.230.10", "192.5.5.241", "192.112.36.4", "198.97.190.53", 
-                     "192.36.148.17","192.58.128.30", "193.0.14.129", "199.7.83.42", "202.12.27.33"};
-  static char templ[40];
-  strncpy(templ,"a.root-servers.net", sizeof(templ) - 1);
-  
-  
-  for(char c='a';c<='m';++c) {
-    *templ=c;
-    pw.startRecord(DNSName(), QType::NS, 3600, 1, DNSResourceRecord::AUTHORITY);
-    DNSRecordContent* drc = DNSRecordContent::mastermake(QType::NS, 1, templ);
-    drc->toPacket(pw);
-    delete drc;
-  }
-
-  for(char c='a';c<='m';++c) {
-    *templ=c;
-    pw.startRecord(DNSName(), QType::A, 3600, 1, DNSResourceRecord::ADDITIONAL);
-    DNSRecordContent* drc = DNSRecordContent::mastermake(QType::A, 1, ips[c-'a']);
-    drc->toPacket(pw);
-    delete drc;
-  }
-  pw.commit();
-  return  packet;
-
-}
-
 vector<uint8_t> makeTypicalReferral()
 {
   vector<uint8_t> packet;
@@ -412,22 +379,6 @@ vector<uint8_t> makeTypicalReferral()
   pw.commit();
   return  packet;
 }
-
-
-
-struct RootRefTest
-{
-  string getName() const
-  {
-    return "write rootreferral";
-  }
-
-  void operator()() const
-  {
-    vector<uint8_t> packet=makeRootReferral();
-  }
-
-};
 
 struct StackMallocTest
 {
@@ -732,12 +683,6 @@ try
   doRun(B64DecodeTest());
 
   doRun(StackMallocTest());
-
-  vector<uint8_t> packet = makeRootReferral();
-  doRun(ParsePacketBareTest(packet, "root-referral"));
-  doRun(ParsePacketTest(packet, "root-referral"));
-
-  doRun(RootRefTest());
 
   doRun(EmptyQueryTest());
   doRun(TypicalRefTest());

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -98,7 +98,7 @@ if daemon == 'authoritative':
         named_conf.write(AUTH_CONF_TPL)
 
     subprocess.check_call(["../pdns/pdnsutil", "--config-dir=.", "secure-zone", "powerdnssec.org"])
-    pdnscmd = ("../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./ --no-shuffle --send-root-referral --dnsupdate=yes --cache-ttl=0 --config-dir=. --api=yes --webserver=yes --webserver-port="+WEBPORT+" --webserver-address=127.0.0.1 --webserver-password=something --api-key="+APIKEY).split()
+    pdnscmd = ("../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./ --no-shuffle --dnsupdate=yes --cache-ttl=0 --config-dir=. --api=yes --webserver=yes --webserver-port="+WEBPORT+" --webserver-address=127.0.0.1 --webserver-password=something --api-key="+APIKEY).split()
 
 else:
     conf_dir = 'rec-conf.d'

--- a/regression-tests.nobackend/edns-packet-cache/command
+++ b/regression-tests.nobackend/edns-packet-cache/command
@@ -28,7 +28,7 @@ rm -f pdns*.pid
 
 $PDNS --daemon=no --local-port=$port --socket-dir=./          \
 	--no-shuffle --launch=bind --bind-config=edns-packet-cache/named.conf   \
-	--send-root-referral --cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
+	--cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
 bindwait
 	
 # prime cache without EDNS

--- a/regression-tests.nobackend/edns1/command
+++ b/regression-tests.nobackend/edns1/command
@@ -26,7 +26,7 @@ bindwait ()
 
 $RUNWRAPPER $PDNS --daemon=no --local-port=$port --socket-dir=./          \
         --no-shuffle --launch=bind --bind-config=edns-packet-cache/named.conf   \
-        --send-root-referral --cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
+        --cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
 bindwait
 
 timeout 5 ./edns1/test-edns.py

--- a/regression-tests.nobackend/lua-policy/command
+++ b/regression-tests.nobackend/lua-policy/command
@@ -29,7 +29,7 @@ rm -f pdns*.pid
 $PDNS --daemon=no --local-port=$port --socket-dir=./          \
 	--no-shuffle --launch=bind --bind-config=lua-policy/named.conf   \
 	--experimental-lua-policy-script=lua-policy/policy.lua \
-	--send-root-referral --cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
+	--cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
 bindwait
 
 # plain SOA query

--- a/regression-tests.nobackend/negcache-tests-dotted-cname/command
+++ b/regression-tests.nobackend/negcache-tests-dotted-cname/command
@@ -10,7 +10,7 @@ rm -f pdns*.pid
 $PDNS --daemon=no --local-port=$port --socket-dir=./          \
 	--no-shuffle --launch=bind,pipe --bind-config=negcache-tests-dotted-cname/named.conf   \
 	--pipe-command=negcache-tests-dotted-cname/pipe.py \
-	--send-root-referral --cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
+	--cache-ttl=60 --no-config --module-dir=../regression-tests/modules &
 
 sleep 3
 

--- a/regression-tests.nobackend/soa-edit/pdns.conf
+++ b/regression-tests.nobackend/soa-edit/pdns.conf
@@ -2,7 +2,6 @@ daemon=no
 local-port=5502
 socket-dir=./
 no-shuffle
-send-root-referral
 cache-ttl=0
 query-cache-ttl=0
 module-dir=../regression-tests/modules

--- a/regression-tests.nobackend/supermaster-signed/command
+++ b/regression-tests.nobackend/supermaster-signed/command
@@ -84,7 +84,7 @@ start_master()
 {
         $RUNWRAPPER $PDNS --daemon=no --local-port=$port --config-dir=. --module-dir=../regression-tests/modules \
                 --config-name=gsqlite3-master --socket-dir=./ --no-shuffle \
-                --send-root-referral --master=yes --local-address=127.0.0.1 --local-ipv6='' \
+                --master=yes --local-address=127.0.0.1 --local-ipv6='' \
                 --query-local-address=127.0.0.1 --cache-ttl=$cachettl --dname-processing --allow-axfr-ips= &
 }
 
@@ -94,7 +94,7 @@ start_slave()
 
         $RUNWRAPPER $PDNS2 --daemon=no --local-port=$slaveport --config-dir=. --module-dir=../regression-tests/modules \
                 --config-name=gsqlite3-slave --socket-dir=./ --no-shuffle --local-address=127.0.0.2 --local-ipv6='' \
-                --send-root-referral --slave --retrieval-threads=4 --slave=yes --query-local-address=127.0.0.2 \
+                --slave --retrieval-threads=4 --slave=yes --query-local-address=127.0.0.2 \
                 --slave-cycle-interval=300 --allow-unsigned-notify=no --allow-unsigned-supermaster=no &
 }
 

--- a/regression-tests.nobackend/supermaster-unsigned/command
+++ b/regression-tests.nobackend/supermaster-unsigned/command
@@ -75,7 +75,7 @@ start_master()
 {
         $RUNWRAPPER $PDNS --daemon=no --local-port=$port --config-dir=. --module-dir=../regression-tests/modules \
                 --config-name=gsqlite3-master --socket-dir=./ --no-shuffle \
-                --send-root-referral --master=yes --local-address=127.0.0.1 --local-ipv6= \
+                --master=yes --local-address=127.0.0.1 --local-ipv6= \
                 --query-local-address=127.0.0.1 --cache-ttl=$cachettl --dname-processing --allow-axfr-ips= &
 }
 
@@ -85,7 +85,7 @@ start_slave()
 
         $RUNWRAPPER $PDNS2 --daemon=no --local-port=$slaveport --config-dir=. --module-dir=../regression-tests/modules \
                 --config-name=gsqlite3-slave --socket-dir=./ --no-shuffle --local-address=127.0.0.2 --local-ipv6= \
-                --send-root-referral --slave --retrieval-threads=4 --slave=yes --query-local-address=127.0.0.2 \
+                --slave --retrieval-threads=4 --slave=yes --query-local-address=127.0.0.2 \
                 --slave-cycle-interval=300 --dname-processing &
 }
 

--- a/regression-tests/README.md
+++ b/regression-tests/README.md
@@ -81,7 +81,7 @@ Run PowerDNS as (to test gmysql):
 ```
 $ ../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./  \
 --no-shuffle --launch=gmysql --gmysql-dbname=pdnstest --gmysql-user=root \
---fancy-records --query-logging --send-root-referral --loglevel=9 \
+--fancy-records --query-logging --loglevel=9 \
 --cache-ttl=0 --no-config
 ```
 
@@ -89,7 +89,7 @@ or (to test bind, without DNSSEC):
 ```
 $ ../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./  \
 --no-shuffle --launch=bind --bind-config=./named.conf                \
---fancy-records --query-logging --send-root-referral --loglevel=9    \
+--fancy-records --query-logging --loglevel=9    \
 --cache-ttl=0 --no-config
 ```
 
@@ -99,7 +99,7 @@ or (to test bind with DNSSEC):
 $ ./bind-dnssec-setup
 $ ../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./  \
 --no-shuffle --launch=bind --bind-config=./named.conf                \
---query-logging --send-root-referral --loglevel=9                    \
+--query-logging --loglevel=9                    \
 --cache-ttl=0 --no-config
 ```
 
@@ -115,7 +115,7 @@ echo 'analyze;' | sqlite3 powerdns.sqlite3
 $ ../pdns/pdns_server --daemon=no --local-port=5300 --socket-dir=./  \
 --no-shuffle --launch=gsqlite3 \
 --gsqlite3-database=./powerdns.sqlite3 --gsqlite3-dnssec             \
---query-logging --send-root-referral --loglevel=9                    \
+--query-logging --loglevel=9                    \
 --cache-ttl=0 --no-config
 ```
 

--- a/regression-tests/tests/bind-add-zone/stress/run.sh
+++ b/regression-tests/tests/bind-add-zone/stress/run.sh
@@ -90,8 +90,7 @@ grep '^host' example.com | grep -e 'IN\s*A' | \
 
 $PDNS --daemon=no --local-port=$port --socket-dir=./ \
       --no-shuffle --launch=bind --bind-config=./named.conf \
-      --fancy-records --send-root-referral \
-      --cache-ttl=0 --no-config &
+      --fancy-records --cache-ttl=0 --no-config &
 bindwait
 
 DNSPERF=$DNSPERF port=$port ./add-zone/stress/dnsperf.sh &


### PR DESCRIPTION
This was already disabled and is wrong and bad:
https://www.dns-oarc.net/oarc/articles/upward-referrals-considered-harmful