### PR TITLE
Policy lua script null handling fixes

### DIFF
--- a/pdns/lua-auth.cc
+++ b/pdns/lua-auth.cc
@@ -172,7 +172,10 @@ static int ldp_getWild(lua_State *L) {
 
 static int ldp_getZone(lua_State *L) {
   DNSPacket *p=ldp_checkDNSPacket(L);
-  lua_pushstring(L, p->qdomainzone.toString().c_str());
+  if(p->qdomainzone.empty())
+    lua_pushnil(L);
+  else
+    lua_pushstring(L, p->qdomainzone.toString().c_str());
   return 1;
 }
 

--- a/pdns/policy-example-rrl.lua
+++ b/pdns/policy-example-rrl.lua
@@ -85,7 +85,7 @@ function police (req, resp, isTcp)
 		reqsize = req:getSize()
 		respsize = resp:getSize()
 		rcode = resp:getRcode()
-		print ("< ", qname, qtype, remote, "wild: "..(wild or "EMPTY"), "zone: "..zone, reqsize.."/"..respsize, rcode, isTcp )
+		print ("< ", qname, qtype, remote, "wild: "..(wild or "EMPTY"), "zone: "..(zone or "EMPTY"), reqsize.."/"..respsize, rcode, isTcp )
 		if isTcp then return pdns.PASS end
 
 		-- mywindow[1][1] = mywindow[1][1]+1
@@ -100,7 +100,7 @@ function police (req, resp, isTcp)
 			imputedname = wild
 		elseif rcode == pdns.NXDOMAIN or errorstatus
 		then
-			imputedname = zone
+			imputedname = zone or "EMPTY"
 		end
 		token = mask(remote).."/"..imputedname.."/"..tostring(errorstatus)
 		submit(mywindow[1], token) -- FIXME: only submit when doing PASS/TRUNCATE?

--- a/pdns/policy-example-rrl.lua
+++ b/pdns/policy-example-rrl.lua
@@ -85,7 +85,7 @@ function police (req, resp, isTcp)
 		reqsize = req:getSize()
 		respsize = resp:getSize()
 		rcode = resp:getRcode()
-		print ("< ", qname, qtype, remote, "wild: "..wild, "zone: "..zone, reqsize.."/"..respsize, rcode, isTcp )
+		print ("< ", qname, qtype, remote, "wild: "..(wild or "EMPTY"), "zone: "..zone, reqsize.."/"..respsize, rcode, isTcp )
 		if isTcp then return pdns.PASS end
 
 		-- mywindow[1][1] = mywindow[1][1]+1
@@ -95,7 +95,7 @@ function police (req, resp, isTcp)
 		imputedname = qname
 		errorstatus = (rcode == pdns.REFUSED or rcode == pdns.FORMERR or rcode == pdns.SERVFAIL or rcode == pdns.NOTIMP)
 
-		if wild:len() > 0
+		if wild
 		then
 			imputedname = wild
 		elseif rcode == pdns.NXDOMAIN or errorstatus


### PR DESCRIPTION
Fixes null handling problems in the `experimental-lua-policy-script` functionality and RRL script.

A follow-up of sorts to https://github.com/PowerDNS/pdns/pull/3258
