### PR TITLE
dnsdist: Remove ECS option from response's OPT RR when necessary

### DIFF
--- a/pdns/dnsdist-ecs.hh
+++ b/pdns/dnsdist-ecs.hh
@@ -1,6 +1,8 @@
 #pragma once
 
 int rewriteResponseWithoutEDNS(const char * packet, size_t len, vector<uint8_t>& newContent);
-int locateEDNSOptRR(const char * packet, size_t len, const char ** optStart, size_t * optLen, bool * last);
-void handleEDNSClientSubnet(char * packet, size_t packetSize, unsigned int consumed, uint16_t * len, string& largerPacket, bool * ednsAdded, const ComboAddress& remote);
+int locateEDNSOptRR(char * packet, size_t len, char ** optStart, size_t * optLen, bool * last);
+void handleEDNSClientSubnet(char * packet, size_t packetSize, unsigned int consumed, uint16_t * len, string& largerPacket, bool* ednsAdded, bool* ecsAdded, const ComboAddress& remote);
 void generateOptRR(const std::string& optRData, string& res);
+int removeEDNSOptionFromOPT(char* optStart, size_t* optLen, const uint16_t optionCodeToRemove);
+int rewriteResponseWithoutEDNSOption(const char * packet, const size_t len, const uint16_t optionCodeToSkip, vector<uint8_t>& newContent);

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -224,6 +224,7 @@ struct IDState
   uint16_t origFlags;                                         // 2
   int delayMsec;
   bool ednsAdded{false};
+  bool ecsAdded{false};
   bool skipCache{false};
 };
 
@@ -530,7 +531,7 @@ void resetLuaSideEffect(); // reset to indeterminate state
 bool responseContentMatches(const char* response, const uint16_t responseLen, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote);
 bool processQuery(LocalStateHolder<NetmaskTree<DynBlock> >& localDynBlock, LocalStateHolder<vector<pair<std::shared_ptr<DNSRule>, std::shared_ptr<DNSAction> > > >& localRulactions, blockfilter_t blockFilter, DNSQuestion& dq, string& poolname, int* delayMsec, const struct timespec& now);
 bool processResponse(LocalStateHolder<vector<pair<std::shared_ptr<DNSRule>, std::shared_ptr<DNSResponseAction> > > >& localRespRulactions, DNSQuestion& dq);
-bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom);
+bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom);
 void restoreFlags(struct dnsheader* dh, uint16_t origFlags);
 
 #ifdef HAVE_DNSCRYPT

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -68,6 +68,7 @@ dnsdist_SOURCES = \
 	dnswriter.cc dnswriter.hh \
 	dolog.hh \
 	ednsoptions.cc ednsoptions.hh \
+	ednscookies.cc ednscookies.hh \
 	ednssubnet.cc ednssubnet.hh \
 	iputils.cc iputils.hh \
 	lock.hh \
@@ -128,6 +129,7 @@ testrunner_SOURCES = \
 	dnswriter.cc dnswriter.hh \
 	dolog.hh \
 	ednsoptions.cc ednsoptions.hh \
+	ednscookies.cc ednscookies.hh \
 	ednssubnet.cc ednssubnet.hh \
 	iputils.cc iputils.hh \
 	misc.cc misc.hh \

--- a/pdns/dnsdistdist/ednscookies.cc
+++ b/pdns/dnsdistdist/ednscookies.cc
@@ -1,0 +1,1 @@
+../ednscookies.cc

--- a/pdns/dnsdistdist/ednscookies.hh
+++ b/pdns/dnsdistdist/ednscookies.hh
@@ -1,0 +1,1 @@
+../ednscookies.hh

--- a/pdns/ednscookies.cc
+++ b/pdns/ednscookies.cc
@@ -1,0 +1,51 @@
+/*
+    PowerDNS Versatile Database Driven Nameserver
+    Copyright (C) 2011 - 2016  Netherlabs Computer Consulting BV
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2 as
+    published by the Free Software Foundation
+
+    Additionally, the license of this program contains a special
+    exception which allows to distribute the program in binary form when
+    it is linked against OpenSSL.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include "ednscookies.hh"
+
+bool getEDNSCookiesOptFromString(const string& option, EDNSCookiesOpt* eco)
+{
+  return getEDNSCookiesOptFromString(option.c_str(), option.length(), eco);
+}
+
+bool getEDNSCookiesOptFromString(const char* option, unsigned int len, EDNSCookiesOpt* eco)
+{
+  if(len != 8 && len < 16)
+    return false;
+  eco->client = string(option, 8);
+  if (len > 8) {
+    eco->server = string(option + 8, len - 8);
+  }
+  return true;
+}
+
+string makeEDNSCookiesOptString(const EDNSCookiesOpt& eco)
+{
+  string ret;
+  if (eco.client.length() != 8)
+    return ret;
+  if (eco.server.length() != 0 && (eco.server.length() < 8 || eco.server.length() > 32))
+    return ret;
+  ret.assign(eco.client);
+  if (eco.server.length() != 0)
+    ret.append(eco.server);
+  return ret;
+}

--- a/pdns/ednscookies.hh
+++ b/pdns/ednscookies.hh
@@ -1,0 +1,36 @@
+/*
+    PowerDNS Versatile Database Driven Nameserver
+    Copyright (C) 2011 - 2016  Netherlabs Computer Consulting BV
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2 as
+    published by the Free Software Foundation
+
+    Additionally, the license of this program contains a special
+    exception which allows to distribute the program in binary form when
+    it is linked against OpenSSL.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#ifndef PDNS_EDNSCOOKIES_HH
+#define PDNS_EDNSCOOKIES_HH
+
+#include "namespaces.hh"
+
+struct EDNSCookiesOpt
+{
+  string client;
+  string server;
+};
+
+bool getEDNSCookiesOptFromString(const char* option, unsigned int len, EDNSCookiesOpt* eco);
+bool getEDNSCookiesOptFromString(const string& option, EDNSCookiesOpt* eco);
+string makeEDNSCookiesOptString(const EDNSCookiesOpt& eco);
+#endif

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -33,6 +33,7 @@
 #include "dnsparser.hh"
 #include "dnswriter.hh"
 #include "ednsoptions.hh"
+#include "ednscookies.hh"
 #include "ednssubnet.hh"
 #include <unistd.h>
 
@@ -54,7 +55,7 @@ static void validateQuery(const char * packet, size_t packetSize)
   BOOST_CHECK_EQUAL(mdp.d_header.arcount, 1);
 }
 
-static void validateResponse(const char * packet, size_t packetSize, bool hasEdns)
+static void validateResponse(const char * packet, size_t packetSize, bool hasEdns, uint8_t additionalCount=0)
 {
   MOADNSParser mdp(packet, packetSize);
 
@@ -64,13 +65,14 @@ static void validateResponse(const char * packet, size_t packetSize, bool hasEdn
   BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1);
   BOOST_CHECK_EQUAL(mdp.d_header.ancount, 1);
   BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0);
-  BOOST_CHECK_EQUAL(mdp.d_header.arcount, hasEdns ? 1 : 0);
+  BOOST_CHECK_EQUAL(mdp.d_header.arcount, (hasEdns ? 1 : 0) + additionalCount);
 }
 
 BOOST_AUTO_TEST_CASE(addECSWithoutEDNS)
 {
   string largerPacket;
   bool ednsAdded = false;
+  bool ecsAdded = false;
   ComboAddress remote;
   DNSName name("www.powerdns.com.");
 
@@ -89,10 +91,11 @@ BOOST_AUTO_TEST_CASE(addECSWithoutEDNS)
   BOOST_CHECK_EQUAL(qname, name);
   BOOST_CHECK(qtype == QType::A);
 
-  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, remote);
+  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, &ecsAdded, remote);
   BOOST_CHECK((size_t) len > query.size());
   BOOST_CHECK_EQUAL(largerPacket.size(), 0);
   BOOST_CHECK_EQUAL(ednsAdded, true);
+  BOOST_CHECK_EQUAL(ecsAdded, false);
   validateQuery(packet, len);
 
   /* not large enought packet */
@@ -102,16 +105,18 @@ BOOST_AUTO_TEST_CASE(addECSWithoutEDNS)
   BOOST_CHECK_EQUAL(qname, name);
   BOOST_CHECK(qtype == QType::A);
 
-  handleEDNSClientSubnet((char*) query.data(), query.size(), consumed, &len, largerPacket, &ednsAdded, remote);
+  handleEDNSClientSubnet((char*) query.data(), query.size(), consumed, &len, largerPacket, &ednsAdded, &ecsAdded, remote);
   BOOST_CHECK_EQUAL((size_t) len, query.size());
   BOOST_CHECK(largerPacket.size() > query.size());
   BOOST_CHECK_EQUAL(ednsAdded, true);
+  BOOST_CHECK_EQUAL(ecsAdded, false);
   validateQuery(largerPacket.c_str(), largerPacket.size());
 }
 
 BOOST_AUTO_TEST_CASE(addECSWithEDNSNoECS) {
   string largerPacket;
   bool ednsAdded = false;
+  bool ecsAdded = false;
   ComboAddress remote;
   DNSName name("www.powerdns.com.");
 
@@ -132,10 +137,11 @@ BOOST_AUTO_TEST_CASE(addECSWithEDNSNoECS) {
   BOOST_CHECK_EQUAL(qname, name);
   BOOST_CHECK(qtype == QType::A);
 
-  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, remote);
+  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, &ecsAdded, remote);
   BOOST_CHECK((size_t) len > query.size());
   BOOST_CHECK_EQUAL(largerPacket.size(), 0);
   BOOST_CHECK_EQUAL(ednsAdded, false);
+  BOOST_CHECK_EQUAL(ecsAdded, true);
   validateQuery(packet, len);
 
   /* not large enought packet */
@@ -145,16 +151,18 @@ BOOST_AUTO_TEST_CASE(addECSWithEDNSNoECS) {
   BOOST_CHECK_EQUAL(qname, name);
   BOOST_CHECK(qtype == QType::A);
 
-  handleEDNSClientSubnet((char*) query.data(), query.size(), consumed, &len, largerPacket, &ednsAdded, remote);
+  handleEDNSClientSubnet((char*) query.data(), query.size(), consumed, &len, largerPacket, &ednsAdded, &ecsAdded, remote);
   BOOST_CHECK_EQUAL((size_t) len, query.size());
   BOOST_CHECK(largerPacket.size() > query.size());
   BOOST_CHECK_EQUAL(ednsAdded, false);
+  BOOST_CHECK_EQUAL(ecsAdded, true);
   validateQuery(largerPacket.c_str(), largerPacket.size());
 }
 
 BOOST_AUTO_TEST_CASE(replaceECSWithSameSize) {
   string largerPacket;
   bool ednsAdded = false;
+  bool ecsAdded = false;
   ComboAddress remote("192.168.1.25");
   DNSName name("www.powerdns.com.");
   ComboAddress origRemote("127.0.0.1");
@@ -182,16 +190,18 @@ BOOST_AUTO_TEST_CASE(replaceECSWithSameSize) {
   BOOST_CHECK(qtype == QType::A);
 
   g_ECSOverride = true;
-  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, remote);
+  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, &ecsAdded, remote);
   BOOST_CHECK_EQUAL((size_t) len, query.size());
   BOOST_CHECK_EQUAL(largerPacket.size(), 0);
   BOOST_CHECK_EQUAL(ednsAdded, false);
+  BOOST_CHECK_EQUAL(ecsAdded, false);
   validateQuery(packet, len);
 }
 
 BOOST_AUTO_TEST_CASE(replaceECSWithSmaller) {
   string largerPacket;
   bool ednsAdded = false;
+  bool ecsAdded = false;
   ComboAddress remote("192.168.1.25");
   DNSName name("www.powerdns.com.");
   ComboAddress origRemote("127.0.0.1");
@@ -219,16 +229,18 @@ BOOST_AUTO_TEST_CASE(replaceECSWithSmaller) {
   BOOST_CHECK(qtype == QType::A);
 
   g_ECSOverride = true;
-  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, remote);
+  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, &ecsAdded, remote);
   BOOST_CHECK((size_t) len < query.size());
   BOOST_CHECK_EQUAL(largerPacket.size(), 0);
   BOOST_CHECK_EQUAL(ednsAdded, false);
+  BOOST_CHECK_EQUAL(ecsAdded, false);
   validateQuery(packet, len);
 }
 
 BOOST_AUTO_TEST_CASE(replaceECSWithLarger) {
   string largerPacket;
   bool ednsAdded = false;
+  bool ecsAdded = false;
   ComboAddress remote("192.168.1.25");
   DNSName name("www.powerdns.com.");
   ComboAddress origRemote("127.0.0.1");
@@ -256,10 +268,11 @@ BOOST_AUTO_TEST_CASE(replaceECSWithLarger) {
   BOOST_CHECK(qtype == QType::A);
 
   g_ECSOverride = true;
-  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, remote);
+  handleEDNSClientSubnet(packet, sizeof packet, consumed, &len, largerPacket, &ednsAdded, &ecsAdded, remote);
   BOOST_CHECK((size_t) len > query.size());
   BOOST_CHECK_EQUAL(largerPacket.size(), 0);
   BOOST_CHECK_EQUAL(ednsAdded, false);
+  BOOST_CHECK_EQUAL(ecsAdded, false);
   validateQuery(packet, len);
 
   /* not large enought packet */
@@ -270,14 +283,15 @@ BOOST_AUTO_TEST_CASE(replaceECSWithLarger) {
   BOOST_CHECK(qtype == QType::A);
 
   g_ECSOverride = true;
-  handleEDNSClientSubnet((char*) query.data(), query.size(), consumed, &len, largerPacket, &ednsAdded, remote);
+  handleEDNSClientSubnet((char*) query.data(), query.size(), consumed, &len, largerPacket, &ednsAdded, &ecsAdded, remote);
   BOOST_CHECK_EQUAL((size_t) len, query.size());
   BOOST_CHECK(largerPacket.size() > query.size());
   BOOST_CHECK_EQUAL(ednsAdded, false);
+  BOOST_CHECK_EQUAL(ecsAdded, false);
   validateQuery(largerPacket.c_str(), largerPacket.size());
 }
 
-BOOST_AUTO_TEST_CASE(removeEDNS) {
+BOOST_AUTO_TEST_CASE(removeEDNSWhenFirst) {
   DNSName name("www.powerdns.com.");
 
   vector<uint8_t> response;
@@ -285,6 +299,71 @@ BOOST_AUTO_TEST_CASE(removeEDNS) {
   pw.getHeader()->qr = 1;
   pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
   pw.xfr32BitInt(0x01020304);
+  pw.addOpt(512, 0, 0);
+  pw.commit();
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  vector<uint8_t> newResponse;
+  int res = rewriteResponseWithoutEDNS((const char *) response.data(), response.size(), newResponse);
+  BOOST_CHECK_EQUAL(res, 0);
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) newResponse.data(), newResponse.size(), sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+  size_t const ednsOptRRSize = sizeof(struct dnsrecordheader) + 1 /* root in OPT RR */;
+  BOOST_CHECK_EQUAL(newResponse.size(), response.size() - ednsOptRRSize);
+
+  validateResponse((const char *) newResponse.data(), newResponse.size(), false, 1);
+}
+
+BOOST_AUTO_TEST_CASE(removeEDNSWhenIntermediary) {
+  DNSName name("www.powerdns.com.");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.startRecord(DNSName("other.powerdns.com."), QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+  pw.addOpt(512, 0, 0);
+  pw.commit();
+  pw.startRecord(DNSName("yetanother.powerdns.com."), QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  vector<uint8_t> newResponse;
+  int res = rewriteResponseWithoutEDNS((const char *) response.data(), response.size(), newResponse);
+  BOOST_CHECK_EQUAL(res, 0);
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) newResponse.data(), newResponse.size(), sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+  size_t const ednsOptRRSize = sizeof(struct dnsrecordheader) + 1 /* root in OPT RR */;
+  BOOST_CHECK_EQUAL(newResponse.size(), response.size() - ednsOptRRSize);
+
+  validateResponse((const char *) newResponse.data(), newResponse.size(), false, 2);
+}
+
+BOOST_AUTO_TEST_CASE(removeEDNSWhenLast) {
+  DNSName name("www.powerdns.com.");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+  pw.startRecord(DNSName("other.powerdns.com."), QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
   pw.addOpt(512, 0, 0);
   pw.commit();
 
@@ -301,7 +380,379 @@ BOOST_AUTO_TEST_CASE(removeEDNS) {
   size_t const ednsOptRRSize = sizeof(struct dnsrecordheader) + 1 /* root in OPT RR */;
   BOOST_CHECK_EQUAL(newResponse.size(), response.size() - ednsOptRRSize);
 
-  validateResponse((const char *) newResponse.data(), newResponse.size(), false);
+  validateResponse((const char *) newResponse.data(), newResponse.size(), false, 1);
+}
+
+BOOST_AUTO_TEST_CASE(removeECSWhenOnlyOption) {
+  DNSName name("www.powerdns.com.");
+  ComboAddress origRemote("127.0.0.1");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.source = Netmask(origRemote, g_ECSSourcePrefixV4);
+  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  DNSPacketWriter::optvect_t opts;
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOptionStr));
+  pw.addOpt(512, 0, 0, opts);
+  pw.commit();
+
+  char * optStart = NULL;
+  size_t optLen = 0;
+  bool last = false;
+
+  int res = locateEDNSOptRR((char *) response.data(), response.size(), &optStart, &optLen, &last);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(last, true);
+
+  size_t responseLen = response.size();
+  size_t existingOptLen = optLen;
+  BOOST_CHECK(existingOptLen < responseLen);
+  res = removeEDNSOptionFromOPT(optStart, &optLen, EDNSOptionCode::ECS);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(optLen, existingOptLen - (origECSOptionStr.size() + 4));
+  responseLen -= (existingOptLen - optLen);
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) response.data(), responseLen, sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+
+  validateResponse((const char *) response.data(), responseLen, true, 1);
+}
+
+BOOST_AUTO_TEST_CASE(removeECSWhenFirstOption) {
+  DNSName name("www.powerdns.com.");
+  ComboAddress origRemote("127.0.0.1");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.source = Netmask(origRemote, g_ECSSourcePrefixV4);
+  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  EDNSCookiesOpt cookiesOpt;
+  cookiesOpt.client = string("deadbeef");
+  cookiesOpt.server = string("deadbeef");
+  string cookiesOptionStr = makeEDNSCookiesOptString(cookiesOpt);
+  DNSPacketWriter::optvect_t opts;
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOptionStr));
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr));
+  pw.addOpt(512, 0, 0, opts);
+  pw.commit();
+
+  char * optStart = NULL;
+  size_t optLen = 0;
+  bool last = false;
+
+  int res = locateEDNSOptRR((char *) response.data(), response.size(), &optStart, &optLen, &last);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(last, true);
+
+  size_t responseLen = response.size();
+  size_t existingOptLen = optLen;
+  BOOST_CHECK(existingOptLen < responseLen);
+  res = removeEDNSOptionFromOPT(optStart, &optLen, EDNSOptionCode::ECS);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(optLen, existingOptLen - (origECSOptionStr.size() + 4));
+  responseLen -= (existingOptLen - optLen);
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) response.data(), responseLen, sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+
+  validateResponse((const char *) response.data(), responseLen, true, 1);
+}
+
+BOOST_AUTO_TEST_CASE(removeECSWhenIntermediaryOption) {
+  DNSName name("www.powerdns.com.");
+  ComboAddress origRemote("127.0.0.1");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.source = Netmask(origRemote, g_ECSSourcePrefixV4);
+  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+
+  EDNSCookiesOpt cookiesOpt;
+  cookiesOpt.client = string("deadbeef");
+  cookiesOpt.server = string("deadbeef");
+  string cookiesOptionStr1 = makeEDNSCookiesOptString(cookiesOpt);
+  string cookiesOptionStr2 = makeEDNSCookiesOptString(cookiesOpt);
+
+  DNSPacketWriter::optvect_t opts;
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr1));
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOptionStr));
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr2));
+  pw.addOpt(512, 0, 0, opts);
+  pw.commit();
+
+  char * optStart = NULL;
+  size_t optLen = 0;
+  bool last = false;
+
+  int res = locateEDNSOptRR((char *) response.data(), response.size(), &optStart, &optLen, &last);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(last, true);
+
+  size_t responseLen = response.size();
+  size_t existingOptLen = optLen;
+  BOOST_CHECK(existingOptLen < responseLen);
+  res = removeEDNSOptionFromOPT(optStart, &optLen, EDNSOptionCode::ECS);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(optLen, existingOptLen - (origECSOptionStr.size() + 4));
+  responseLen -= (existingOptLen - optLen);
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) response.data(), responseLen, sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+
+  validateResponse((const char *) response.data(), responseLen, true, 1);
+}
+
+BOOST_AUTO_TEST_CASE(removeECSWhenLastOption) {
+  DNSName name("www.powerdns.com.");
+  ComboAddress origRemote("127.0.0.1");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  EDNSCookiesOpt cookiesOpt;
+  cookiesOpt.client = string("deadbeef");
+  cookiesOpt.server = string("deadbeef");
+  string cookiesOptionStr = makeEDNSCookiesOptString(cookiesOpt);
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.source = Netmask(origRemote, g_ECSSourcePrefixV4);
+  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  DNSPacketWriter::optvect_t opts;
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr));
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOptionStr));
+  pw.addOpt(512, 0, 0, opts);
+  pw.commit();
+
+  char * optStart = NULL;
+  size_t optLen = 0;
+  bool last = false;
+
+  int res = locateEDNSOptRR((char *) response.data(), response.size(), &optStart, &optLen, &last);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(last, true);
+
+  size_t responseLen = response.size();
+  size_t existingOptLen = optLen;
+  BOOST_CHECK(existingOptLen < responseLen);
+  res = removeEDNSOptionFromOPT(optStart, &optLen, EDNSOptionCode::ECS);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(optLen, existingOptLen - (origECSOptionStr.size() + 4));
+  responseLen -= (existingOptLen - optLen);
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) response.data(), responseLen, sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+
+  validateResponse((const char *) response.data(), responseLen, true, 1);
+}
+
+BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenOnlyOption) {
+  DNSName name("www.powerdns.com.");
+  ComboAddress origRemote("127.0.0.1");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.source = Netmask(origRemote, g_ECSSourcePrefixV4);
+  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  DNSPacketWriter::optvect_t opts;
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOptionStr));
+  pw.addOpt(512, 0, 0, opts);
+  pw.commit();
+
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  vector<uint8_t> newResponse;
+  int res = rewriteResponseWithoutEDNSOption((const char *) response.data(), response.size(), EDNSOptionCode::ECS, newResponse);
+  BOOST_CHECK_EQUAL(res, 0);
+
+  BOOST_CHECK_EQUAL(newResponse.size(), response.size() - (origECSOptionStr.size() + 4));
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) newResponse.data(), newResponse.size(), sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+
+  validateResponse((const char *) newResponse.data(), newResponse.size(), true, 1);
+}
+
+BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenFirstOption) {
+  DNSName name("www.powerdns.com.");
+  ComboAddress origRemote("127.0.0.1");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.source = Netmask(origRemote, g_ECSSourcePrefixV4);
+  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  EDNSCookiesOpt cookiesOpt;
+  cookiesOpt.client = string("deadbeef");
+  cookiesOpt.server = string("deadbeef");
+  string cookiesOptionStr = makeEDNSCookiesOptString(cookiesOpt);
+  DNSPacketWriter::optvect_t opts;
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOptionStr));
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr));
+  pw.addOpt(512, 0, 0, opts);
+  pw.commit();
+
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  vector<uint8_t> newResponse;
+  int res = rewriteResponseWithoutEDNSOption((const char *) response.data(), response.size(), EDNSOptionCode::ECS, newResponse);
+  BOOST_CHECK_EQUAL(res, 0);
+
+  BOOST_CHECK_EQUAL(newResponse.size(), response.size() - (origECSOptionStr.size() + 4));
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) newResponse.data(), newResponse.size(), sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+
+  validateResponse((const char *) newResponse.data(), newResponse.size(), true, 1);
+}
+
+BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenIntermediaryOption) {
+  DNSName name("www.powerdns.com.");
+  ComboAddress origRemote("127.0.0.1");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.source = Netmask(origRemote, g_ECSSourcePrefixV4);
+  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  EDNSCookiesOpt cookiesOpt;
+  cookiesOpt.client = string("deadbeef");
+  cookiesOpt.server = string("deadbeef");
+  string cookiesOptionStr1 = makeEDNSCookiesOptString(cookiesOpt);
+  string cookiesOptionStr2 = makeEDNSCookiesOptString(cookiesOpt);
+  DNSPacketWriter::optvect_t opts;
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr1));
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOptionStr));
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr2));
+  pw.addOpt(512, 0, 0, opts);
+  pw.commit();
+
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  vector<uint8_t> newResponse;
+  int res = rewriteResponseWithoutEDNSOption((const char *) response.data(), response.size(), EDNSOptionCode::ECS, newResponse);
+  BOOST_CHECK_EQUAL(res, 0);
+
+  BOOST_CHECK_EQUAL(newResponse.size(), response.size() - (origECSOptionStr.size() + 4));
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) newResponse.data(), newResponse.size(), sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+
+  validateResponse((const char *) newResponse.data(), newResponse.size(), true, 1);
+}
+
+BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenLastOption) {
+  DNSName name("www.powerdns.com.");
+  ComboAddress origRemote("127.0.0.1");
+
+  vector<uint8_t> response;
+  DNSPacketWriter pw(response, name, QType::A, QClass::IN, 0);
+  pw.getHeader()->qr = 1;
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER, true);
+  pw.xfr32BitInt(0x01020304);
+
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.source = Netmask(origRemote, g_ECSSourcePrefixV4);
+  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  EDNSCookiesOpt cookiesOpt;
+  cookiesOpt.client = string("deadbeef");
+  cookiesOpt.server = string("deadbeef");
+  string cookiesOptionStr = makeEDNSCookiesOptString(cookiesOpt);
+  DNSPacketWriter::optvect_t opts;
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr));
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOptionStr));
+  pw.addOpt(512, 0, 0, opts);
+  pw.commit();
+
+  pw.startRecord(name, QType::A, 3600, QClass::IN, DNSResourceRecord::ADDITIONAL, true);
+  pw.xfr32BitInt(0x01020304);
+  pw.commit();
+
+  vector<uint8_t> newResponse;
+  int res = rewriteResponseWithoutEDNSOption((const char *) response.data(), response.size(), EDNSOptionCode::ECS, newResponse);
+  BOOST_CHECK_EQUAL(res, 0);
+
+  BOOST_CHECK_EQUAL(newResponse.size(), response.size() - (origECSOptionStr.size() + 4));
+
+  unsigned int consumed = 0;
+  uint16_t qtype;
+  DNSName qname((const char*) newResponse.data(), newResponse.size(), sizeof(dnsheader), false, &qtype, NULL, &consumed);
+  BOOST_CHECK_EQUAL(qname, name);
+  BOOST_CHECK(qtype == QType::A);
+
+  validateResponse((const char *) newResponse.data(), newResponse.size(), true, 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/regression-tests.dnsdist/clientsubnetoption.py
+++ b/regression-tests.dnsdist/clientsubnetoption.py
@@ -141,7 +141,7 @@ class ClientSubnetOption(dns.edns.Option):
         test = test[-(mask_bits // 8):]
 
         format = "!HBB%ds" % (mask_bits // 8)
-        data = struct.pack(format, self.family, self.mask, 0, test)
+        data = struct.pack(format, self.family, self.mask, self.scope, test)
         file.write(data)
 
     def from_wire(cls, otype, wire, current, olen):

--- a/regression-tests.dnsdist/cookiesoption.py
+++ b/regression-tests.dnsdist/cookiesoption.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python2
+
+import dns
+import dns.edns
+import dns.flags
+import dns.message
+import dns.query
+
+class CookiesOption(dns.edns.Option):
+    """Implementation of draft-ietf-dnsop-cookies-09.
+    """
+
+    def __init__(self, client, server):
+        super(CookiesOption, self).__init__(10)
+
+        if len(client) != 8:
+            raise Exception('invalid client cookie length')
+
+        if server is not None and len(server) != 0 and (len(server) < 8 or len(server) > 32):
+            raise Exception('invalid server cookie length')
+
+        self.client = client
+        self.server = server
+
+    def to_wire(self, file):
+        """Create EDNS packet as definied in draft-ietf-dnsop-cookies-09."""
+
+        file.write(self.client)
+        if self.server and len(self.server) > 0:
+            file.write(self.server)
+
+    def from_wire(cls, otype, wire, current, olen):
+        """Read EDNS packet as defined in draft-ietf-dnsop-cookies-09.
+
+        Returns:
+            An instance of CookiesOption based on the EDNS packet
+        """
+
+        data = wire[current:current + olen]
+        if len(data) != 8 and (len(data) < 16 or len(data) > 40):
+            raise Exception('Invalid EDNS Cookies option')
+
+        client = data[:8]
+        if len(data) > 8:
+            server = data[8:]
+        else:
+            server = None
+
+        return cls(client, server)
+
+    from_wire = classmethod(from_wire)
+
+    def __repr__(self):
+        return '%s(%s, %s)' % (
+            self.__class__.__name__,
+            self.client,
+            self.server
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, CookiesOption):
+            return False
+        if self.client != other.client:
+            return False
+        if self.server != other.server:
+            return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+dns.edns._type_to_class[0x000A] = CookiesOption
+


### PR DESCRIPTION
If we added an ECS option to a query already having EDNS,
we need to remove the ECS option sent back by the server if any,
otherwise this might confuse the original client.

Closes #3515.