### PR TITLE
Fixed issue #3602 by adding a tracking to who the notifyier is

### DIFF
--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -507,6 +507,15 @@ void CommunicatorClass::addSlaveCheckRequest(const DomainInfo& di, const ComboAd
   Lock l(&d_lock);
   DomainInfo ours = di;
   ours.backend = 0;
+  string remote_address = remote.toString();
+  for (vector<string>::iterator it = ours.masters.begin();it!=ours.masters.end();++it) {
+    if (*it == remote_address) {
+	ours.masters.erase(it);
+        ours.masters.insert(ours.masters.begin(), remote_address);
+        break;
+    } 
+  }
+  d_tocheck.erase(di);
   d_tocheck.insert(ours);
   d_any_sem.post(); // kick the loop!
 }
@@ -633,8 +642,10 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
   typedef DomainNotificationInfo val_t;
   BOOST_FOREACH(val_t& val, sdomains) {
     DomainInfo& di(val.di);
+    DomaintInfo tempdi;
     // might've come from the packethandler
-    if(!di.backend && !B->getDomainInfo(di.zone, di)) {
+    // Please do not overwrite received DI just to make sure it exists in backend.
+    if(!di.backend && !B->getDomainInfo(di.zone, tempdi)) {
         L<<Logger::Warning<<"Ignore domain "<< di.zone<<" since it has been removed from our backend"<<endl;
         continue;
     }


### PR DESCRIPTION
This is a fix I've created for the ticket I've opened.

The idea is that when adding a new slave check in the slave communicator, the domain info moves the requester to be the first master on its list. Later on, there is a small fix of using "GetDomainInfo" just to check if the domain info exists in the backend, so it'll not overwrite our new order of masters list.

This change is only local for the current suck request.