### PR TITLE
dnsdist: Prevent dangling TCP fd in case setupTCPDownstream() fails

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -358,6 +358,8 @@ void* tcpClientThread(int pipefd)
         if(!sendNonBlockingMsgLen(dsock, dq.len, ds->tcpSendTimeout, ds->remote, ds->sourceAddr, ds->sourceItf)) {
 	  vinfolog("Downstream connection to %s died on us, getting a new one!", ds->getName());
           close(dsock);
+          dsock=-1;
+          sockets.erase(ds->remote);
           sockets[ds->remote]=dsock=setupTCPDownstream(ds);
           downstream_failures++;
           goto retry;
@@ -374,6 +376,8 @@ void* tcpClientThread(int pipefd)
         catch(const runtime_error& e) {
           vinfolog("Downstream connection to %s died on us, getting a new one!", ds->getName());
           close(dsock);
+          dsock=-1;
+          sockets.erase(ds->remote);
           sockets[ds->remote]=dsock=setupTCPDownstream(ds);
           downstream_failures++;
           goto retry;
@@ -382,6 +386,8 @@ void* tcpClientThread(int pipefd)
         if(!getNonBlockingMsgLen(dsock, &rlen, ds->tcpRecvTimeout)) {
 	  vinfolog("Downstream connection to %s died on us phase 2, getting a new one!", ds->getName());
           close(dsock);
+          dsock=-1;
+          sockets.erase(ds->remote);
           sockets[ds->remote]=dsock=setupTCPDownstream(ds);
           downstream_failures++;
           goto retry;


### PR DESCRIPTION
Remove the closed socket descriptor from the `sockets` map.
Otherwise, if an exception occurs in `setupTCPDownstream()`, we might
try to use it and close it again later, not knowing it has been
reassigned to another socket or, worse, to a TCP acceptor pipe.
This might fix #3560.