### PR TITLE
dnsdist: Under threshold, QPS action should return None, not Allow

### DIFF
--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -365,7 +365,7 @@ public:
   DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
   {
     if(d_qps.check())
-      return Action::Allow;
+      return Action::None;
     else
       return Action::Drop;
   }


### PR DESCRIPTION
Otherwise we skip the remaining rules.
Closes #3638.