### PR TITLE
Add notify-type option to disable implicit notifications

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -106,7 +106,8 @@ void declareArguments()
   ::arg().set("launch","Which backends to launch and order to query them in")="";
   ::arg().setSwitch("disable-axfr","Disable zonetransfers but do allow TCP queries")="no";
   ::arg().set("allow-axfr-ips","Allow zonetransfers only to these subnets")="127.0.0.0/8,::1";
-  ::arg().set("only-notify", "Only send AXFR NOTIFY to these IP addresses or netmasks")="0.0.0.0/0,::/0";
+  ::arg().set("notify-type", "Defines NOTIFY generation - either 'default' (implicit und explicit) or 'explicit' (also-notify)")="default";
+  ::arg().set("only-notify", "Send implicit (triggered by NS records) NOTIFYs only to these IP addresses or netmasks")="0.0.0.0/0,::/0";
   ::arg().set("also-notify", "When notifying a domain, also notify these nameservers")="";
   ::arg().set("allow-notify-from","Allow AXFR NOTIFY from these IP ranges. If empty, drop all incoming notifies.")="0.0.0.0/0,::/0";
   ::arg().set("slave-cycle-interval","Schedule slave freshness checks once every .. seconds")="60";

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -261,8 +261,8 @@ string DLNotifyHostHandler(const vector<string>&parts, Utility::pid_t ppid)
   ostringstream os;
   if(parts.size()!=3)
     return "syntax: notify-host domain ip";
-  if(!::arg().mustDo("master"))
-      return "PowerDNS not configured as master";
+  if(!::arg().mustDo("master") && !::arg().mustDo("slave-renotify"))
+      return "PowerDNS not configured as master or slave with re-notifications";
 
   DNSName domain;
   try {
@@ -289,8 +289,8 @@ string DLNotifyHandler(const vector<string>&parts, Utility::pid_t ppid)
   UeberBackend B;
   if(parts.size()!=2)
     return "syntax: notify domain";
-  if(!::arg().mustDo("master"))
-      return "PowerDNS not configured as master";
+  if(!::arg().mustDo("master") && !::arg().mustDo("slave-renotify"))
+      return "PowerDNS not configured as master or slave with re-notifications";
   L<<Logger::Warning<<"Notification request for domain '"<<parts[1]<<"' received from operator"<<endl;
 
   if (parts[1] == "*") {


### PR DESCRIPTION
For outgoing slaved zones PDNS automatically notifies all the
host in the zones NS records. This is often not needed and imposes
external dependencies as PDNS will try to resolve every hostname
of the NS records.

Using notify-type=explicit disables this implicit notifications
and only send notifications to targets specified with also-notify
or ALSO-NOTIFY metadata.

Further the log warning was canged to info as it may be common to not have any explicit notifications and having implicit slaves disabled.