### PR TITLE
Rename PUBLISH_* to PUBLISH-* domainmetadata

### DIFF
--- a/docs/markdown/authoritative/domainmetadata.md
+++ b/docs/markdown/authoritative/domainmetadata.md
@@ -63,12 +63,12 @@ records in the zone. However, if you import a presigned zone using `zone2sql` or
 PowerDNS will not be able to correctly serve the zone if the imported data is
 bogus or incomplete. Also see `set-presigned` in [`pdnsutil`](dnssec.md#pdnsutil).
 
-## PUBLISH_CDNSKEY, PUBLISH_CDS
+## PUBLISH-CDNSKEY, PUBLISH-CDS
 Whether to publish CDNSKEY and/or CDS recording defined in [RFC 7344](https://tools.ietf.org/html/rfc7344).
 
-To publish CDNSKEY records of the KSKs for the zone, set `PUBLISH_CDNSKEY` to `1`.
+To publish CDNSKEY records of the KSKs for the zone, set `PUBLISH-CDNSKEY` to `1`.
 
-To publish CDS records for the KSKs in the zone, set `PUBLISH_CDS` to a comma-
+To publish CDS records for the KSKs in the zone, set `PUBLISH-CDS` to a comma-
 separated list of [signature algorithm numbers](http://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml#ds-rr-types-1).
 
 This metadata can also be set using the [`pdnsutil`](dnssec.md#pdnsutil) options

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -326,7 +326,7 @@ bool DNSSECKeeper::setPublishCDS(const DNSName& zname, const string& digestAlgos
   clearCaches(zname);
   vector<string> meta;
   meta.push_back(digestAlgos);
-  return d_keymetadb->setDomainMetadata(zname, "PUBLISH_CDS", meta);
+  return d_keymetadb->setDomainMetadata(zname, "PUBLISH-CDS", meta);
 }
 
 /**
@@ -338,7 +338,7 @@ bool DNSSECKeeper::setPublishCDS(const DNSName& zname, const string& digestAlgos
 bool DNSSECKeeper::unsetPublishCDS(const DNSName& zname)
 {
   clearCaches(zname);
-  return d_keymetadb->setDomainMetadata(zname, "PUBLISH_CDS", vector<string>());
+  return d_keymetadb->setDomainMetadata(zname, "PUBLISH-CDS", vector<string>());
 }
 
 /**
@@ -352,7 +352,7 @@ bool DNSSECKeeper::setPublishCDNSKEY(const DNSName& zname)
   clearCaches(zname);
   vector<string> meta;
   meta.push_back("1");
-  return d_keymetadb->setDomainMetadata(zname, "PUBLISH_CDNSKEY", meta);
+  return d_keymetadb->setDomainMetadata(zname, "PUBLISH-CDNSKEY", meta);
 }
 
 /**
@@ -364,7 +364,7 @@ bool DNSSECKeeper::setPublishCDNSKEY(const DNSName& zname)
 bool DNSSECKeeper::unsetPublishCDNSKEY(const DNSName& zname)
 {
   clearCaches(zname);
-  return d_keymetadb->setDomainMetadata(zname, "PUBLISH_CDNSKEY", vector<string>());
+  return d_keymetadb->setDomainMetadata(zname, "PUBLISH-CDNSKEY", vector<string>());
 }
 
 /**

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -96,7 +96,7 @@ PacketHandler::~PacketHandler()
 bool PacketHandler::addCDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 {
   string publishCDNSKEY;
-  d_dk.getFromMeta(p->qdomain, "PUBLISH_CDNSKEY", publishCDNSKEY);
+  d_dk.getFromMeta(p->qdomain, "PUBLISH-CDNSKEY", publishCDNSKEY);
   if (publishCDNSKEY != "1")
     return false;
 
@@ -177,7 +177,7 @@ bool PacketHandler::addDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 bool PacketHandler::addCDS(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 {
   string publishCDS;
-  d_dk.getFromMeta(p->qdomain, "PUBLISH_CDS", publishCDS);
+  d_dk.getFromMeta(p->qdomain, "PUBLISH-CDS", publishCDS);
   if (publishCDS.empty())
     return false;
 
@@ -448,11 +448,11 @@ void PacketHandler::emitNSEC(DNSPacket *r, const SOAData& sd, const DNSName& nam
     nrc.d_set.insert(QType::SOA); // 1dfd8ad SOA can live outside the records table
     nrc.d_set.insert(QType::DNSKEY);
     string publishCDNSKEY;
-    d_dk.getFromMeta(name, "PUBLISH_CDNSKEY", publishCDNSKEY);
+    d_dk.getFromMeta(name, "PUBLISH-CDNSKEY", publishCDNSKEY);
     if (publishCDNSKEY == "1")
       nrc.d_set.insert(QType::CDNSKEY);
     string publishCDS;
-    d_dk.getFromMeta(name, "PUBLISH_CDS", publishCDS);
+    d_dk.getFromMeta(name, "PUBLISH-CDS", publishCDS);
     if (! publishCDS.empty())
       nrc.d_set.insert(QType::CDS);
   }
@@ -492,11 +492,11 @@ void PacketHandler::emitNSEC3(DNSPacket *r, const SOAData& sd, const NSEC3PARAMR
       n3rc.d_set.insert(QType::NSEC3PARAM);
       n3rc.d_set.insert(QType::DNSKEY);
       string publishCDNSKEY;
-      d_dk.getFromMeta(name, "PUBLISH_CDNSKEY", publishCDNSKEY);
+      d_dk.getFromMeta(name, "PUBLISH-CDNSKEY", publishCDNSKEY);
       if (publishCDNSKEY == "1")
         n3rc.d_set.insert(QType::CDNSKEY);
       string publishCDS;
-      d_dk.getFromMeta(name, "PUBLISH_CDS", publishCDS);
+      d_dk.getFromMeta(name, "PUBLISH-CDS", publishCDS);
       if (! publishCDS.empty())
         n3rc.d_set.insert(QType::CDS);
     }

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -654,8 +654,8 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   rr.auth = 1; // please sign!
 
   string publishCDNSKEY, publishCDS;
-  dk.getFromMeta(q->qdomain, "PUBLISH_CDNSKEY", publishCDNSKEY);
-  dk.getFromMeta(q->qdomain, "PUBLISH_CDS", publishCDS);
+  dk.getFromMeta(q->qdomain, "PUBLISH-CDNSKEY", publishCDNSKEY);
+  dk.getFromMeta(q->qdomain, "PUBLISH-CDS", publishCDS);
   vector<DNSResourceRecord> cds, cdnskey;
   DNSSECKeeper::keyset_t entryPoints = dk.getEntryPoints(q->qdomain);
   set<uint32_t> entryPointIds;


### PR DESCRIPTION
For consistency with all other domainmetadata settings names.