### PR TITLE
API: Fix set-ptr to honor SOA-EDIT-API

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -759,6 +759,8 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
 
     di.backend->commitTransaction();
 
+    storeChangedPTRs(B, new_ptrs);
+
     fillZone(zonename, resp);
     resp->status = 201;
     return;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -737,6 +737,11 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     if(!B.getDomainInfo(zonename, di))
       throw ApiException("Creating domain '"+zonename.toString()+"' failed: lookup of domain ID failed");
 
+    // updateDomainSettingsFromDocument does NOT fill out the default we've established above.
+    if (!soa_edit_api_kind.empty()) {
+      di.backend->setDomainMetadataOne(zonename, "SOA-EDIT-API", soa_edit_api_kind);
+    }
+
     di.backend->startTransaction(zonename, di.id);
 
     for(auto rr : new_records) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -618,7 +618,7 @@ static void gatherRecordsFromZone(const std::string& zonestring, vector<DNSResou
 
 static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
   UeberBackend B;
-  DNSSECKeeper dk;
+  DNSSECKeeper dk(&B);
   if (req->method == "POST" && !::arg().mustDo("api-readonly")) {
     DomainInfo di;
     auto document = req->json();

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -133,6 +133,11 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             if k in payload:
                 self.assertEquals(data[k], payload[k])
 
+    def test_create_zone_default_soa_edit_api(self):
+        name, payload, data = self.create_zone()
+        print data
+        self.assertEquals(data['soa_edit_api'], 'DEFAULT')
+
     def test_create_zone_with_records(self):
         name = unique_zone_name()
         rrset = {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -960,7 +960,40 @@ fred   IN  A      192.168.0.4
         self.assertEquals(serverset['records'], rrset2['records'])
         self.assertEquals(serverset['comments'], rrset['comments'])
 
-    def test_zone_auto_ptr_ipv4(self):
+    def test_zone_auto_ptr_ipv4_create(self):
+        revzone = '4.2.192.in-addr.arpa.'
+        _, _, revzonedata = self.create_zone(name=revzone)
+        name = unique_zone_name()
+        rrset = {
+            "name": name,
+            "type": "A",
+            "ttl": 3600,
+            "records": [{
+                "content": "192.2.4.44",
+                "disabled": False,
+                "set-ptr": True,
+            }],
+        }
+        name, payload, data = self.create_zone(name=name, rrsets=[rrset])
+        del rrset['records'][0]['set-ptr']
+        self.assertEquals(get_rrset(data, name, 'A')['records'], rrset['records'])
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + revzone)).json()
+        revsets = [s for s in r['rrsets'] if s['type'] == 'PTR']
+        print revsets
+        self.assertEquals(revsets, [{
+            u'name': u'44.4.2.192.in-addr.arpa.',
+            u'ttl': 3600,
+            u'type': u'PTR',
+            u'comments': [],
+            u'records': [{
+                u'content': name,
+                u'disabled': False,
+            }],
+        }])
+        # with SOA-EDIT-API DEFAULT on the revzone, the serial should now be higher.
+        self.assertGreater(r['serial'], revzonedata['serial'])
+
+    def test_zone_auto_ptr_ipv4_update(self):
         revzone = '0.2.192.in-addr.arpa.'
         _, _, revzonedata = self.create_zone(name=revzone)
         name, payload, zone = self.create_zone()
@@ -999,7 +1032,7 @@ fred   IN  A      192.168.0.4
         # with SOA-EDIT-API DEFAULT on the revzone, the serial should now be higher.
         self.assertGreater(r['serial'], revzonedata['serial'])
 
-    def test_zone_auto_ptr_ipv6(self):
+    def test_zone_auto_ptr_ipv6_update(self):
         # 2001:DB8::bb:aa
         revzone = '8.b.d.0.1.0.0.2.ip6.arpa.'
         _, _, revzonedata = self.create_zone(name=revzone)


### PR DESCRIPTION
Fixes #3654, plus:
- SOA-EDIT-API did not default to DEFAULT.
- set-ptr did not work when creating a zone
