### PR TITLE
API: clean up cryptokeys resource

### DIFF
--- a/docs/markdown/httpapi/api_spec.md
+++ b/docs/markdown/httpapi/api_spec.md
@@ -648,7 +648,7 @@ cryptokey\_resource
       "active": <bool>,
       "keytype": <keytype>,
       "dnskey": <string>,
-      "content": <string>,
+      "privatekey": <string>,
       "ds": [ <ds>,
               <ds>,
               .... ]
@@ -659,12 +659,13 @@ cryptokey\_resource
 
 `id`: read-only.
 
-`keytype`: `<keytype>` is one of the following: `ksk` or `zsk`, and they are
-both mutually exclusive.
+`keytype`: `<keytype>` is one of the following: `ksk`, `zsk`, `csk`.
 
 `dnskey`: the DNSKEY for this key
 
 `ds`: an array with all DSes for this key
+
+`privatekey`: private key data (in ISC format).
 
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/cryptokeys
@@ -674,7 +675,7 @@ Allowed methods: `GET`, `POST`
 
 #### GET
 
-Returns all public data about cryptokeys, but not `content`.
+Returns all public data about cryptokeys, but not `privatekey`.
 
 #### POST
 
@@ -700,7 +701,7 @@ Allowed methods: `GET`, `PUT`, `DELETE`
 
 #### GET
 
-Returns all public data about cryptokeys, including `content`, with all the private data. An array is returned, even though a single key is requested.
+Returns all public data about cryptokeys, including `privatekey`.
 
 #### PUT
 


### PR DESCRIPTION
Treat domain not found as a normal not found; treat all keys
absent for single resource request as a normal not found;
return an object instead of a single-valued list for single
resource requests and rename "content" to "privatekey"
and don't re-read the key from the backend.

Also share UeberBackend with DNSSECKeeper to avoid extra
backend connection.

Unfortunately, without support for creating keys, no tests are possible.