### PR TITLE
Various fixes from clang static analyzer, coverity and cppcheck

### DIFF
--- a/modules/godbcbackend/sodbc.cc
+++ b/modules/godbcbackend/sodbc.cc
@@ -53,6 +53,8 @@ public:
     d_dolog = dolog;
     d_residx = 0;
     d_paridx = 0;
+    d_result = SQL_NO_DATA;
+    m_columncount = 0;
 
     // Allocate statement handle.
     result = SQLAllocHandle( SQL_HANDLE_STMT, d_conn, &d_statement );
@@ -232,7 +234,6 @@ public:
 private:
   string d_query;
   bool d_dolog;
-  bool d_havenextrow;
   int d_residx;
   size_t d_paridx,d_parnum;
   SQLRETURN d_result;

--- a/modules/luabackend/luabackend.hh
+++ b/modules/luabackend/luabackend.hh
@@ -97,7 +97,7 @@ public:
 private:
 
     pthread_t backend_pid;
-    unsigned int backend_count;
+    unsigned int backend_count{0};
 
     int f_lua_exec_error;
 

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -96,6 +96,7 @@ void CoWrapper::receive(string &line)
 PipeBackend::PipeBackend(const string &suffix)
 {
    d_disavow=false;
+   d_regex=nullptr;
    signal(SIGCHLD, SIG_IGN);
    setArgPrefix("pipe"+suffix);
    try {

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -191,7 +191,7 @@ try
     sockets.push_back(sock);
   }
   new thread(recvThread, &sockets);
-  int qps=atoi(argv[3]);
+  int qps;
 
   ofstream plot("plot");
   for(qps=qpsstart;;qps *= 1.1) {

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -136,7 +136,7 @@ void BackendMakerClass::load_all()
 
 void BackendMakerClass::load(const string &module)
 {
-  int res;
+  bool res;
 
   if(module.find(".")==string::npos)
     res=UeberBackend::loadmodule(arg()["module-dir"]+"/lib"+module+"backend.so");

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -144,15 +144,15 @@ public:
   includeboilerplate(TSIG)
   TSIGRecordContent() {}
 
-  uint16_t d_origID;
-  uint16_t d_fudge;
+  uint16_t d_origID{0};
+  uint16_t d_fudge{0};
 
   DNSName d_algoName;
   string d_mac;
   string d_otherData;
-  uint64_t d_time;
+  uint64_t d_time{0};
   //  uint16_t d_macSize;
-  uint16_t d_eRcode;
+  uint16_t d_eRcode{0};
   // uint16_t d_otherLen
 };
 
@@ -281,9 +281,9 @@ public:
   uint16_t getTag() const;
   uint16_t getTag();
 
-  uint16_t d_flags;
-  uint8_t d_protocol;
-  uint8_t d_algorithm;
+  uint16_t d_flags{0};
+  uint8_t d_protocol{0};
+  uint8_t d_algorithm{0};
   string d_key;
   bool operator<(const DNSKEYRecordContent& rhs) const
   {
@@ -299,9 +299,9 @@ public:
   includeboilerplate(CDNSKEY)
   uint16_t getTag();
 
-  uint16_t d_flags;
-  uint8_t d_protocol;
-  uint8_t d_algorithm;
+  uint16_t d_flags{0};
+  uint8_t d_protocol{0};
+  uint8_t d_algorithm{0};
   string d_key;
 };
 
@@ -322,8 +322,8 @@ public:
 
   includeboilerplate(DS)
 
-  uint16_t d_tag;
-  uint8_t d_algorithm, d_digesttype;
+  uint16_t d_tag{0};
+  uint8_t d_algorithm{0}, d_digesttype{0};
   string d_digest;
 };
 
@@ -333,8 +333,8 @@ public:
   CDSRecordContent();
   includeboilerplate(CDS)
 
-  uint16_t d_tag;
-  uint8_t d_algorithm, d_digesttype;
+  uint16_t d_tag{0};
+  uint8_t d_algorithm{0}, d_digesttype{0};
   string d_digest;
 };
 
@@ -344,8 +344,8 @@ public:
   DLVRecordContent();
   includeboilerplate(DLV)
 
-  uint16_t d_tag;
-  uint8_t d_algorithm, d_digesttype;
+  uint16_t d_tag{0};
+  uint8_t d_algorithm{0}, d_digesttype{0};
   string d_digest;
 };
 
@@ -419,12 +419,12 @@ public:
   RRSIGRecordContent(); 
   includeboilerplate(RRSIG)
 
-  uint16_t d_type;
-  uint16_t d_tag;
+  uint16_t d_type{0};
+  uint16_t d_tag{0};
   DNSName d_signer;
   string d_signature;
-  uint32_t d_originalttl, d_sigexpire, d_siginception;
-  uint8_t d_algorithm, d_labels;
+  uint32_t d_originalttl{0}, d_sigexpire{0}, d_siginception{0};
+  uint8_t d_algorithm{0}, d_labels{0};
 };
 
 //namespace {
@@ -443,8 +443,8 @@ class RKEYRecordContent : public DNSRecordContent
 public:
   RKEYRecordContent();
   includeboilerplate(RKEY)
-  uint16_t d_flags;
-  uint8_t d_protocol, d_algorithm;
+  uint16_t d_flags{0};
+  uint8_t d_protocol{0}, d_algorithm{0};
   string d_key;
 };
 
@@ -493,8 +493,8 @@ public:
   string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
 
-  uint8_t d_algorithm, d_flags;
-  uint16_t d_iterations;
+  uint8_t d_algorithm{0}, d_flags{0};
+  uint16_t d_iterations{0};
   string d_salt;
   string d_nexthash;
   std::set<uint16_t> d_set;
@@ -528,8 +528,8 @@ public:
   }
 
 
-  uint8_t d_algorithm, d_flags;
-  uint16_t d_iterations;
+  uint8_t d_algorithm{0}, d_flags{0};
+  uint16_t d_iterations{0};
   string d_salt;
 };
 
@@ -547,8 +547,8 @@ public:
   string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
 
-  uint8_t d_version, d_size, d_horizpre, d_vertpre;
-  uint32_t d_latitude, d_longitude, d_altitude;
+  uint8_t d_version{0}, d_size{0}, d_horizpre{0}, d_vertpre{0};
+  uint32_t d_latitude{0}, d_longitude{0}, d_altitude{0};
   uint16_t getType() const override
   {
     return QType::LOC;
@@ -571,7 +571,7 @@ public:
   string getZoneRepresentation(bool noDot=false) const override;
   void toPacket(DNSPacketWriter& pw) override;
 
-  uint32_t d_ip;
+  uint32_t d_ip{0};
   std::bitset<65535> d_services;
 private:
 };
@@ -613,17 +613,17 @@ public:
   includeboilerplate(TKEY)
 
   // storage for the bytes
-  uint16_t d_othersize;
-  uint16_t d_mode;
-  uint32_t d_inception;
-  uint32_t d_expiration;
+  uint16_t d_othersize{0};
+  uint16_t d_mode{0};
+  uint32_t d_inception{0};
+  uint32_t d_expiration{0};
 
   DNSName d_algo;
   string d_key;
   string d_other;
 
-  uint16_t d_error;
-  uint16_t d_keysize;
+  uint16_t d_error{0};
+  uint16_t d_keysize{0};
 private:
 };
 

--- a/pdns/dynloader.cc
+++ b/pdns/dynloader.cc
@@ -176,6 +176,10 @@ int main(int argc, char **argv)
     cerr<<"Fatal error: "<<ae.reason<<endl;
     return 1;
   }
+  catch(const std::runtime_error& e) {
+    cerr<<"Runtime error: "<<e.what()<<endl;
+    return 2;
+  }
   return 0;
 }
 

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -101,6 +101,7 @@ Logger::Logger(const string &n, int facility)
   flags=LOG_PID|LOG_NDELAY;
   d_facility=facility;
   d_loglevel=Logger::None;
+  d_disableSyslog=false;
   consoleUrgency=Error;
   name=n;
 

--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -60,10 +60,10 @@ public:
   LWResult() : d_usec(0) {}
 
   vector<DNSRecord> d_records;
-  int d_rcode;
-  bool d_aabit, d_tcbit;
-  uint32_t d_usec;
-  bool d_haveEDNS;
+  int d_rcode{0};
+  bool d_aabit{false}, d_tcbit{false};
+  uint32_t d_usec{0};
+  bool d_haveEDNS{false};
 };
 
 int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res);

--- a/pdns/mtasker.hh
+++ b/pdns/mtasker.hh
@@ -99,9 +99,8 @@ public:
       This limit applies solely to the stack, the heap is not limited in any way. If threads need to allocate a lot of data,
       the use of new/delete is suggested. 
    */
-  MTasker(size_t stacksize=8192) : d_stacksize(stacksize)
+  MTasker(size_t stacksize=8192) : d_tid(0), d_maxtid(0), d_stacksize(stacksize), d_waitstatus(Error)
   {
-    d_maxtid=0;
   }
 
   typedef void tfunc_t(void *); //!< type of the pointer that starts a thread 

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -108,7 +108,6 @@ private:
   bool d_logDNSDetails;
   bool d_doIPv6AdditionalProcessing;
   bool d_doDNAME;
-  int d_sendRootReferral;
   AuthLua* d_pdl;
 
   UeberBackend B; // every thread an own instance

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1150,7 +1150,9 @@ void makeControlChannelSocket(int processNum=-1)
   // do mode change if socket-mode is given
   if(!::arg().isEmpty("socket-mode")) {
     mode_t sockmode=::arg().asMode("socket-mode");
-    chmod(sockname.c_str(), sockmode);
+    if(chmod(sockname.c_str(), sockmode) < 0) {
+      unixDie("Failed to chmod control socket");
+    }
   }
 }
 

--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -21,6 +21,7 @@ RecursorControlChannel::RecursorControlChannel()
 {
   d_fd=-1;
   *d_local.sun_path=0;
+  d_local.sun_family=0;
 }
 
 RecursorControlChannel::~RecursorControlChannel() 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -1,6 +1,6 @@
 JSON11_LIBS = $(top_srcdir)/ext/json11/libjson11.la
 
-AM_CPPFLAGS = $(LUA_CFLAGS) $(YAHTTP_CFLAGS) $(BOOST_CPPFLAGS) $(SANITIZER_FLAGS) -O3 -Wall -pthread -DSYSCONFDIR=\"${sysconfdir}\"
+AM_CPPFLAGS = $(LUA_CFLAGS) $(YAHTTP_CFLAGS) $(BOOST_CPPFLAGS) $(BOTAN110_CFLAGS) $(SANITIZER_FLAGS) -O3 -Wall -pthread -DSYSCONFDIR=\"${sysconfdir}\"
 
 AM_CPPFLAGS += \
 	-I$(top_srcdir)/ext/json11 \

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -596,6 +596,10 @@ int PacketHandler::forwardPacket(const string &msgPrefix, DNSPacket *p, DomainIn
     else
       local = ComboAddress("::");
     int sock = makeQuerySocket(local, false); // create TCP socket. RFC2136 section 6.2 seems to be ok with this.
+    if(sock < 0) {
+      L<<Logger::Error<<msgPrefix<<"Error creating socket: "<<stringerror()<<endl;
+      continue;
+    }
 
     if( connect(sock, (struct sockaddr*)&remote, remote.getSocklen()) < 0 ) {
       L<<Logger::Error<<msgPrefix<<"Failed to connect to "<<remote.toStringWithPort()<<": "<<stringerror()<<endl;

--- a/pdns/toysdig.cc
+++ b/pdns/toysdig.cc
@@ -60,8 +60,10 @@ public:
     int numread;
     while(n<len) {
       numread=d_rsock.read(creply+n, len-n);
-      if(numread<0)
+      if(numread<0) {
+        delete[] creply;
         throw PDNSException("tcp read failed: "+std::string(strerror(errno)));
+      }
       n+=numread;
     }
 

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -209,10 +209,8 @@ static void *WebServerConnectionThreadStart(void *p) {
   return NULL;
 }
 
-HttpResponse WebServer::handleRequest(HttpRequest req)
+void WebServer::handleRequest(HttpRequest& req, HttpResponse& resp)
 {
-  HttpResponse resp;
-
   // set default headers
   resp.headers["Content-Type"] = "text/html; charset=utf-8";
 
@@ -286,8 +284,6 @@ HttpResponse WebServer::handleRequest(HttpRequest req)
   } else {
     resp.headers["Content-Length"] = std::to_string(resp.body.size());
   }
-
-  return resp;
 }
 
 void WebServer::serveConnection(Socket *client)
@@ -316,7 +312,8 @@ try {
     // request stays incomplete
   }
 
-  HttpResponse resp = WebServer::handleRequest(req);
+  HttpResponse resp;
+  WebServer::handleRequest(req, resp);
   ostringstream ss;
   resp.write(ss);
   string reply = ss.str();

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -141,7 +141,7 @@ public:
   void go();
 
   void serveConnection(Socket *client);
-  HttpResponse handleRequest(HttpRequest request);
+  void handleRequest(HttpRequest& request, HttpResponse& resp);
 
   typedef boost::function<void(HttpRequest* req, HttpResponse* resp)> HandlerFunction;
   void registerApiHandler(const string& url, HandlerFunction handler);

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -584,7 +584,8 @@ void AsyncWebServer::serveConnection(Socket *client)
     // request stays incomplete
   }
 
-  HttpResponse resp = handleRequest(req);
+  HttpResponse resp;
+  handleRequest(req, resp);
   ostringstream ss;
   resp.write(ss);
   data = ss.str();


### PR DESCRIPTION
Most of them are simply about making sure that members are
properly initialized by all constructors, especially if there is a
default one. The initialization cost should be fairly small, and I
expect that turning a random failure into a deterministic one is
worth it.