### PR TITLE
make documentation align with code

### DIFF
--- a/docs/markdown/authoritative/backend-tinydns.md
+++ b/docs/markdown/authoritative/backend-tinydns.md
@@ -38,7 +38,7 @@ The `tinydns-data` program can create data.cdb files that have bad/corrupt RDATA
 
 ### `tinydns-locations`
 * Boolean
-* Default: no
+* Default: yes
 Enable or Disable location support in the backend. Changing the value to 'no' will make the backend ignore the locations. This then returns all records. When the setting is changed to 'no' an AXFR will also return all the records. With the setting on 'yes' an AXFR will only return records without a location.
 
 ## Location and Timestamp support


### PR DESCRIPTION
The documentation says 'locations' is disabled by default but the [code enables it by default](https://github.com/PowerDNS/pdns/blob/bb310f41bef9bbbfab2337c15e5ea280322acbae/modules/tinydnsbackend/tinydnsbackend.cc#L314)

The 'locations' option in tinydns does split horizon. If someone has location
records, they probably want them to be used by default and not have all records
returned.