### PR TITLE
Restore old gsql backend behaviour

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -38,7 +38,7 @@
 #include <boost/format.hpp>
 #include <boost/scoped_ptr.hpp>
 
-#define ASSERT_ROW_COLUMNS(query, row, num) { if (row.size() != num) { throw DBException(std::string(query) + " returned wrong number of columns, expected "  #num  ", got " + std::to_string(row.size())); } }
+#define ASSERT_ROW_COLUMNS(query, row, num) { if (row.size() != num) { throw PDNSException(std::string(query) + " returned wrong number of columns, expected "  #num  ", got " + std::to_string(row.size())); } }
 
 GSQLBackend::GSQLBackend(const string &mode, const string &suffix)
 {
@@ -197,7 +197,7 @@ void GSQLBackend::setNotified(uint32_t domain_id, uint32_t serial)
       reset();
   }
   catch(SSqlException &e) {
-    throw DBException("GSQLBackend unable to refresh domain_id "+itoa(domain_id)+": "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to refresh domain_id "+itoa(domain_id)+": "+e.txtReason());
   }
 }
 
@@ -211,7 +211,7 @@ void GSQLBackend::setFresh(uint32_t domain_id)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to refresh domain_id "+itoa(domain_id)+": "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to refresh domain_id "+itoa(domain_id)+": "+e.txtReason());
   }
 }
 
@@ -227,7 +227,7 @@ bool GSQLBackend::isMaster(const DNSName &domain, const string &ip)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to retrieve list of master domains: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to retrieve list of master domains: "+e.txtReason());
   }
 
   if(!d_result.empty()) {
@@ -260,7 +260,7 @@ bool GSQLBackend::setMaster(const DNSName &domain, const string &ip)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to set master of domain \""+domain.toString()+"\": "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to set master of domain \""+domain.toString()+"\": "+e.txtReason());
   }
   return true;
 }
@@ -277,7 +277,7 @@ bool GSQLBackend::setKind(const DNSName &domain, const DomainInfo::DomainKind ki
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to set kind of domain \""+domain.toString()+"\": "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to set kind of domain \""+domain.toString()+"\": "+e.txtReason());
   }
   return true;
 }
@@ -294,7 +294,7 @@ bool GSQLBackend::setAccount(const DNSName &domain, const string &account)
             reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to set account of domain \""+domain.toString()+"\": "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to set account of domain \""+domain.toString()+"\": "+e.txtReason());
   }
   return true;
 }
@@ -313,7 +313,7 @@ bool GSQLBackend::getDomainInfo(const DNSName &domain, DomainInfo &di)
       reset();
   }
   catch(SSqlException &e) {
-    throw DBException("GSQLBackend unable to retrieve information about a domain: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to retrieve information about a domain: "+e.txtReason());
   }
 
   int numanswers=d_result.size();
@@ -363,7 +363,7 @@ void GSQLBackend::getUnfreshSlaveInfos(vector<DomainInfo> *unfreshDomains)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to retrieve list of slave domains: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to retrieve list of slave domains: "+e.txtReason());
   }
 
   vector<DomainInfo> allSlaves;
@@ -407,7 +407,7 @@ void GSQLBackend::getUpdatedMasters(vector<DomainInfo> *updatedDomains)
       reset();
   }
   catch(SSqlException &e) {
-    throw DBException("GSQLBackend unable to retrieve list of master domains: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to retrieve list of master domains: "+e.txtReason());
   }
 
   vector<DomainInfo> allMasters;
@@ -458,7 +458,7 @@ bool GSQLBackend::updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName
           reset();
       }
       catch(SSqlException &e) {
-        throw DBException("GSQLBackend unable to update ordername and auth for domain_id "+itoa(domain_id)+": "+e.txtReason());
+        throw PDNSException("GSQLBackend unable to update ordername and auth for domain_id "+itoa(domain_id)+": "+e.txtReason());
       }
     } else {
       try {
@@ -472,7 +472,7 @@ bool GSQLBackend::updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName
           reset();
       }
       catch(SSqlException &e) {
-        throw DBException("GSQLBackend unable to update ordername and auth per type for domain_id "+itoa(domain_id)+": "+e.txtReason());
+        throw PDNSException("GSQLBackend unable to update ordername and auth per type for domain_id "+itoa(domain_id)+": "+e.txtReason());
       }
     }
   } else {
@@ -486,7 +486,7 @@ bool GSQLBackend::updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName
           reset();
       }
       catch(SSqlException &e) {
-        throw DBException("GSQLBackend unable to nullify ordername and update auth for domain_id "+itoa(domain_id)+": "+e.txtReason());
+        throw PDNSException("GSQLBackend unable to nullify ordername and update auth for domain_id "+itoa(domain_id)+": "+e.txtReason());
       }
     } else {
       try {
@@ -499,7 +499,7 @@ bool GSQLBackend::updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName
           reset();
       }
       catch(SSqlException &e) {
-        throw DBException("GSQLBackend unable to nullify ordername and update auth per type for domain_id "+itoa(domain_id)+": "+e.txtReason());
+        throw PDNSException("GSQLBackend unable to nullify ordername and update auth per type for domain_id "+itoa(domain_id)+": "+e.txtReason());
       }
     }
   }
@@ -518,7 +518,7 @@ bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, const DNSName& zon
         reset();
     }
     catch (SSqlException &e) {
-      throw DBException("GSQLBackend unable to delete empty non-terminal records from domain_id "+itoa(domain_id)+": "+e.txtReason());
+      throw PDNSException("GSQLBackend unable to delete empty non-terminal records from domain_id "+itoa(domain_id)+": "+e.txtReason());
       return false;
     }
   }
@@ -533,7 +533,7 @@ bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, const DNSName& zon
           reset();
       }
       catch (SSqlException &e) {
-        throw DBException("GSQLBackend unable to delete empty non-terminal rr "+qname.toString()+" from domain_id "+itoa(domain_id)+": "+e.txtReason());
+        throw PDNSException("GSQLBackend unable to delete empty non-terminal rr "+qname.toString()+" from domain_id "+itoa(domain_id)+": "+e.txtReason());
         return false;
       }
     }
@@ -550,7 +550,7 @@ bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, const DNSName& zon
         reset();
     }
     catch (SSqlException &e) {
-      throw DBException("GSQLBackend unable to insert empty non-terminal rr "+qname.toString()+" in domain_id "+itoa(domain_id)+": "+e.txtReason());
+      throw PDNSException("GSQLBackend unable to insert empty non-terminal rr "+qname.toString()+" in domain_id "+itoa(domain_id)+": "+e.txtReason());
       return false;
     }
   }
@@ -586,7 +586,7 @@ bool GSQLBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const string& qnam
     d_afterOrderQuery_stmt->reset();
   }
   catch(SSqlException &e) {
-    throw DBException("GSQLBackend unable to find before/after (after) for domain_id "+itoa(id)+": "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to find before/after (after) for domain_id "+itoa(id)+": "+e.txtReason());
   }
 
   if(after.empty() && !qname.empty()) {
@@ -602,7 +602,7 @@ bool GSQLBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const string& qnam
       d_firstOrderQuery_stmt->reset();
     }
     catch(SSqlException &e) {
-      throw DBException("GSQLBackend unable to find before/after (first) for domain_id "+itoa(id)+": "+e.txtReason());
+      throw PDNSException("GSQLBackend unable to find before/after (first) for domain_id "+itoa(id)+": "+e.txtReason());
     }
   }
 
@@ -627,7 +627,7 @@ bool GSQLBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const string& qnam
       d_beforeOrderQuery_stmt->reset();
     }
     catch(SSqlException &e) {
-      throw DBException("GSQLBackend unable to find before/after (before) for domain_id "+itoa(id)+": "+e.txtReason());
+      throw PDNSException("GSQLBackend unable to find before/after (before) for domain_id "+itoa(id)+": "+e.txtReason());
     }
 
     if(! unhashed.empty())
@@ -653,7 +653,7 @@ bool GSQLBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const string& qnam
       d_lastOrderQuery_stmt->reset();
     }
     catch(SSqlException &e) {
-      throw DBException("GSQLBackend unable to find before/after (last) for domain_id "+itoa(id)+": "+e.txtReason());
+      throw PDNSException("GSQLBackend unable to find before/after (last) for domain_id "+itoa(id)+": "+e.txtReason());
     }
   } else {
     before=qname;
@@ -678,7 +678,7 @@ int GSQLBackend::addDomainKey(const DNSName& name, const KeyData& key)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to store key: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to store key: "+e.txtReason());
   }
   return 1; // XXX FIXME, no idea how to get the id
 }
@@ -697,7 +697,7 @@ bool GSQLBackend::activateDomainKey(const DNSName& name, unsigned int id)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to activate key: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to activate key: "+e.txtReason());
   }
   return true;
 }
@@ -716,7 +716,7 @@ bool GSQLBackend::deactivateDomainKey(const DNSName& name, unsigned int id)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to deactivate key: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to deactivate key: "+e.txtReason());
   }
   return true;
 }
@@ -735,7 +735,7 @@ bool GSQLBackend::removeDomainKey(const DNSName& name, unsigned int id)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to remove key: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to remove key: "+e.txtReason());
   }
   return true;
 }
@@ -764,7 +764,7 @@ bool GSQLBackend::getTSIGKey(const DNSName& name, DNSName* algorithm, string* co
     d_getTSIGKeyQuery_stmt->reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to retrieve named TSIG key: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to retrieve named TSIG key: "+e.txtReason());
   }
 
   return !content->empty();
@@ -781,7 +781,7 @@ bool GSQLBackend::setTSIGKey(const DNSName& name, const DNSName& algorithm, cons
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to store named TSIG key: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to store named TSIG key: "+e.txtReason());
   }
   return true;
 }
@@ -795,7 +795,7 @@ bool GSQLBackend::deleteTSIGKey(const DNSName& name)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to store named TSIG key: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to store named TSIG key: "+e.txtReason());
   }
   return true;
 }
@@ -825,7 +825,7 @@ bool GSQLBackend::getTSIGKeys(std::vector< struct TSIGKey > &keys)
     d_getTSIGKeysQuery_stmt->reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to retrieve TSIG keys: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to retrieve TSIG keys: "+e.txtReason());
   }
 
   return keys.empty();
@@ -861,7 +861,7 @@ bool GSQLBackend::getDomainKeys(const DNSName& name, unsigned int kind, std::vec
     d_ListDomainKeysQuery_stmt->reset();    
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to list keys: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to list keys: "+e.txtReason());
   }
 
   return true;
@@ -898,7 +898,7 @@ bool GSQLBackend::getAllDomainMetadata(const DNSName& name, std::map<std::string
     d_GetAllDomainMetadataQuery_stmt->reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to list metadata: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to list metadata: "+e.txtReason());
   }
 
   return true;
@@ -927,7 +927,7 @@ bool GSQLBackend::getDomainMetadata(const DNSName& name, const std::string& kind
     d_GetDomainMetadataQuery_stmt->reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to list metadata: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to list metadata: "+e.txtReason());
   }
 
   return true;
@@ -957,7 +957,7 @@ bool GSQLBackend::setDomainMetadata(const DNSName& name, const std::string& kind
     }
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to store metadata key: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to store metadata key: "+e.txtReason());
   }
   
   return true;
@@ -1001,7 +1001,7 @@ void GSQLBackend::lookup(const QType &qtype,const DNSName &qname, DNSPacket *pkt
       execute();
   }
   catch(SSqlException &e) {
-    throw DBException("GSQLBackend lookup query: "+e.txtReason());
+    throw PDNSException("GSQLBackend lookup query:"+e.txtReason());
   }
 
   d_qname=qname;
@@ -1022,7 +1022,7 @@ bool GSQLBackend::list(const DNSName &target, int domain_id, bool include_disabl
       execute();
   }
   catch(SSqlException &e) {
-    throw DBException("GSQLBackend list query: "+e.txtReason());
+    throw PDNSException("GSQLBackend list query: "+e.txtReason());
   }
 
   d_qname.clear();
@@ -1044,7 +1044,7 @@ bool GSQLBackend::listSubZone(const DNSName &zone, int domain_id) {
       execute();      
   }
   catch(SSqlException &e) {
-    throw DBException("GSQLBackend listSubZone query: "+e.txtReason());
+    throw PDNSException("GSQLBackend listSubZone query: "+e.txtReason());
   }
   d_qname.clear();
   return true;
@@ -1061,7 +1061,7 @@ skiprow:
       d_query_stmt->nextRow(row);
       ASSERT_ROW_COLUMNS(d_query_name, row, 8);
     } catch (SSqlException &e) {
-      throw DBException("GSQLBackend get: "+e.txtReason());
+      throw PDNSException("GSQLBackend get: "+e.txtReason());
     }
     try {
       extractRecord(row, r);
@@ -1074,7 +1074,7 @@ skiprow:
   try {
     d_query_stmt->reset();
   } catch (SSqlException &e) {
-      throw DBException("GSQLBackend get: "+e.txtReason());
+      throw PDNSException("GSQLBackend get: "+e.txtReason());
   }
   d_query_stmt = NULL;
   return false;
@@ -1093,7 +1093,7 @@ bool GSQLBackend::superMasterBackend(const string &ip, const DNSName &domain, co
         reset();
     }
     catch (SSqlException &e) {
-      throw DBException("GSQLBackend unable to search for a domain: "+e.txtReason());
+      throw PDNSException("GSQLBackend unable to search for a domain: "+e.txtReason());
     }
     if(!d_result.empty()) {
       ASSERT_ROW_COLUMNS("supermaster-query", d_result[0], 1);
@@ -1118,7 +1118,7 @@ bool GSQLBackend::createDomain(const DNSName &domain, const string &type, const 
       reset();
   }
   catch(SSqlException &e) {
-    throw DBException("Database error trying to insert new domain '"+domain.toString()+"': "+ e.txtReason());
+    throw PDNSException("Database error trying to insert new domain '"+domain.toString()+"': "+ e.txtReason());
   }
   return true;
 }
@@ -1150,7 +1150,7 @@ bool GSQLBackend::createSlaveDomain(const string &ip, const DNSName &domain, con
     createDomain(domain, "SLAVE", masters, account);
   }
   catch(SSqlException &e) {
-    throw DBException("Database error trying to insert new slave domain '"+domain.toString()+"': "+ e.txtReason());
+    throw PDNSException("Database error trying to insert new slave domain '"+domain.toString()+"': "+ e.txtReason());
   }
   return true;
 }
@@ -1185,7 +1185,7 @@ bool GSQLBackend::deleteDomain(const DNSName &domain)
       reset();
   }
   catch(SSqlException &e) {
-    throw DBException("Database error trying to delete domain '"+domain.toString()+"': "+ e.txtReason());
+    throw PDNSException("Database error trying to delete domain '"+domain.toString()+"': "+ e.txtReason());
   }
   return true;
 }
@@ -1236,7 +1236,7 @@ void GSQLBackend::getAllDomains(vector<DomainInfo> *domains, bool include_disabl
     d_getAllDomainsQuery_stmt->reset();
   }
   catch (SSqlException &e) {
-    throw DBException("Database error trying to retrieve all domains: " + e.txtReason());
+    throw PDNSException("Database error trying to retrieve all domains:" + e.txtReason());
   }
 }
 
@@ -1261,7 +1261,7 @@ bool GSQLBackend::replaceRRSet(uint32_t domain_id, const DNSName& qname, const Q
     }
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to delete RRSet: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to delete RRSet: "+e.txtReason());
   }
 
   if (rrset.empty()) {
@@ -1274,7 +1274,7 @@ bool GSQLBackend::replaceRRSet(uint32_t domain_id, const DNSName& qname, const Q
         reset();
     }
     catch (SSqlException &e) {
-      throw DBException("GSQLBackend unable to delete comment: "+e.txtReason());
+      throw PDNSException("GSQLBackend unable to delete comment: "+e.txtReason());
     }
   }
   for(const auto& rr: rrset) {
@@ -1322,7 +1322,7 @@ bool GSQLBackend::feedRecord(const DNSResourceRecord &r, string *ordername)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to feed record: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to feed record: "+e.txtReason());
   }
   return true; // XXX FIXME this API should not return 'true' I think -ahu 
 }
@@ -1342,7 +1342,7 @@ bool GSQLBackend::feedEnts(int domain_id, map<DNSName,bool>& nonterm)
         reset();
     }
     catch (SSqlException &e) {
-      throw DBException("GSQLBackend unable to feed empty non-terminal: "+e.txtReason());
+      throw PDNSException("GSQLBackend unable to feed empty non-terminal: "+e.txtReason());
     }
   }
   return true;
@@ -1375,7 +1375,7 @@ bool GSQLBackend::feedEnts3(int domain_id, const DNSName &domain, map<DNSName,bo
         reset();
     }
     catch (SSqlException &e) {
-      throw DBException("GSQLBackend unable to feed empty non-terminal: "+e.txtReason());
+      throw PDNSException("GSQLBackend unable to feed empty non-terminal: "+e.txtReason());
     }
   }
   return true;
@@ -1395,7 +1395,7 @@ bool GSQLBackend::startTransaction(const DNSName &domain, int domain_id)
     }
   }
   catch (SSqlException &e) {
-    throw DBException("Database failed to start transaction: "+e.txtReason());
+    throw PDNSException("Database failed to start transaction: "+e.txtReason());
   }
 
   return true;
@@ -1407,7 +1407,7 @@ bool GSQLBackend::commitTransaction()
     d_db->commit();
   }
   catch (SSqlException &e) {
-    throw DBException("Database failed to commit transaction: "+e.txtReason());
+    throw PDNSException("Database failed to commit transaction: "+e.txtReason());
   }
   return true;
 }
@@ -1418,7 +1418,7 @@ bool GSQLBackend::abortTransaction()
     d_db->rollback();
   }
   catch(SSqlException &e) {
-    throw DBException("Database failed to abort transaction: "+string(e.txtReason()));
+    throw PDNSException("Database failed to abort transaction: "+string(e.txtReason()));
   }
   return true;
 }
@@ -1464,7 +1464,7 @@ bool GSQLBackend::listComments(const uint32_t domain_id)
       execute();
   }
   catch(SSqlException &e) {
-    throw DBException("GSQLBackend list comments query: "+e.txtReason());
+    throw PDNSException("GSQLBackend list comments query: "+e.txtReason());
   }
 
   return true;
@@ -1479,7 +1479,7 @@ bool GSQLBackend::getComment(Comment& comment)
       try {
         d_query_stmt->reset();
       } catch(SSqlException &e) {
-        throw DBException("GSQLBackend comment get: "+e.txtReason());
+        throw PDNSException("GSQLBackend comment get: "+e.txtReason());
       }
       d_query_stmt = NULL;
       return false;
@@ -1489,7 +1489,7 @@ bool GSQLBackend::getComment(Comment& comment)
       d_query_stmt->nextRow(row);
       ASSERT_ROW_COLUMNS(d_query_name, row, 6);
     } catch(SSqlException &e) {
-      throw DBException("GSQLBackend comment get: "+e.txtReason());
+      throw PDNSException("GSQLBackend comment get: "+e.txtReason());
     }
     try {
       extractComment(row, comment);
@@ -1514,7 +1514,7 @@ void GSQLBackend::feedComment(const Comment& comment)
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to feed comment: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to feed comment: "+e.txtReason());
   }
 }
 
@@ -1529,7 +1529,7 @@ bool GSQLBackend::replaceComments(const uint32_t domain_id, const DNSName& qname
       reset();
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to delete comment: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to delete comment: "+e.txtReason());
   }
 
   for(const auto& comment: comments) {
@@ -1560,7 +1560,7 @@ string GSQLBackend::directBackendCmd(const string &query)
    return out.str();
  }
  catch (SSqlException &e) {
-   throw DBException("GSQLBackend unable to execute query: "+e.txtReason());
+   throw PDNSException("GSQLBackend unable to execute query: "+e.txtReason());
  }
 }
 
@@ -1605,7 +1605,7 @@ bool GSQLBackend::searchRecords(const string &pattern, int maxResults, vector<DN
     return true;
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to execute query: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to execute query: "+e.txtReason());
   }
 
   return false;
@@ -1637,7 +1637,7 @@ bool GSQLBackend::searchComments(const string &pattern, int maxResults, vector<C
     return true;
   }
   catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to execute query: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to execute query: "+e.txtReason());
   }
 
   return false;
@@ -1701,7 +1701,7 @@ bool GSQLBackend::isOurDomain(const DNSName *zone, int domain_id) {
       return true;
     }
   } catch (SSqlException &e) {
-    throw DBException("GSQLBackend unable to verify ownership of domain: "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to verify ownership of domain: "+e.txtReason());
   }
 
   return false;

--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -202,8 +202,6 @@ template<class Answer, class Question, class Backend>void *MultiThreadDistributo
         S.ringAccount("servfail-queries",QD->Q->qdomain.toString());
 
 	delete QD->Q;
-	QD->callback(a);
-	throw;
       }
       catch(...) {
         L<<Logger::Error<<"Caught unknown exception in Distributor thread "<<(long)pthread_self()<<endl;
@@ -225,7 +223,6 @@ template<class Answer, class Question, class Backend>void *MultiThreadDistributo
   }
   catch(const PDNSException &AE) {
     L<<Logger::Error<<"Distributor caught fatal exception: "<<AE.reason<<endl;
-    throw;
   }
   catch(...) {
     L<<Logger::Error<<"Caught an unknown exception when creating backend, probably"<<endl;
@@ -247,8 +244,6 @@ template<class Answer, class Question, class Backend>int SingleThreadDistributor
     a->setRcode(RCode::ServFail);
     S.inc("servfail-packets");
     S.ringAccount("servfail-queries",q->qdomain.toString());
-    callback(a);
-    throw;
   }
   catch(...) {
     L<<Logger::Error<<"Caught unknown exception in Distributor thread "<<(unsigned long)pthread_self()<<endl;

--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -203,7 +203,6 @@ template<class Answer, class Question, class Backend>void *MultiThreadDistributo
 
 	delete QD->Q;
 	QD->callback(a);
-	// do NOT remove this. We want to die on PDNSException
 	throw;
       }
       catch(...) {


### PR DESCRIPTION
this pull restores the ability to recover from database failures in gsql backends

fixes #3624
fixes #3535
fixes #3583 (failed constraint may never lead to a crash)
