### PR TITLE
Do triggerLoadOfLibraries() only in glibc environment

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -475,7 +475,9 @@ void mainthread()
    secPollParseResolveConf();
 
    if(!::arg()["chroot"].empty()) {
+#ifdef __GLIBC__
      triggerLoadOfLibraries();
+#endif
      if(::arg().mustDo("master") || ::arg().mustDo("slave"))
         gethostbyname("a.root-servers.net"); // this forces all lookup libraries to be loaded
      Utility::dropGroupPrivs(newuid, newgid);


### PR DESCRIPTION
The workaround of preloading libgcc_s.so.1 to memory by creating a dummy
thread from #1907 makes pdns fail to run in musl libc environment with
`setuid` and `chroot` enabled at the same time. musl libc [implements
set\*id calls AS-safe](http://git.musl-libc.org/cgit/musl/commit/?id=78a8ef47c4d92b7680c52a85f80a81e29da86bb9)
by reading `/proc/self/task` to get information of all threads. And
since most users `chroot` to an empty directory for security reason,
`setuid` cannot find `/proc/self/task` in the new root.

I've started [a discussion thread on musl's mailing list](http://www.openwall.com/lists/musl/2016/04/01/15),
however, until the Linux kernel provides truly atomic set\*id calls,
which is a really tough task according to Rich Felker, there seems no
easy way to keep set\*id AS-safe without using `/proc/self/task`.

Since #1907 is an issue of glibc, I think it is rather safe to do the
fix only in glibc environment, and as a consequence mitigate the
combinational use of `pthread`, `chroot`, and `setuid` in musl libc
environment.