### PR TITLE
Fixed return to master problem

### DIFF
--- a/debian-pdns/pdns.postinst
+++ b/debian-pdns/pdns.postinst
@@ -10,7 +10,7 @@ update_init() {
 
 
 update_pdns() {
-	if [ -n "$2" ] ; then
+	if [ -z "$2" ] ; then
 		invoke-rc.d pdns start
 	else
 		invoke-rc.d pdns restart

--- a/debian-pdns/rules
+++ b/debian-pdns/rules
@@ -50,8 +50,7 @@ build-static stamp-build-static:
 		--sysconfdir=/etc/powerdns \
 		--infodir='$${datadir}/info' \
 		--mandir='$${datadir}/man' \
-		--with-pgsql-lib=/opt/postgresql/lib --with-pgsql-includes=/opt/postgresql/include \
-		--with-modules="bind gmysql gpgsql pipe gsqlite3 lua geo tinydns mydns opendbx remote random" \
+		--with-modules="bind gmysql pipe gsqlite3 lua geo tinydns mydns opendbx remote random" \
 		--with-dynmodules="" \
 		--enable-botan1.10 \
 		--enable-static-binaries \

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -462,7 +462,7 @@ struct SlaveSenderReceiver
 
   Identifier send(DomainNotificationInfo& dni)
   {
-    //random_shuffle(dni.di.masters.begin(), dni.di.masters.end());
+    random_shuffle(dni.di.masters.begin(), dni.di.masters.end());
     try {
       ComboAddress remote(*dni.di.masters.begin());
       if (dni.localaddr.sin4.sin_family == 0) {
@@ -508,10 +508,14 @@ void CommunicatorClass::addSlaveCheckRequest(const DomainInfo& di, const ComboAd
   DomainInfo ours = di;
   ours.backend = 0;
   string remote_address = remote.toString();
-  for (vector<string>::iterator it = ours.masters.begin();it!=ours.masters.end();++it) {
+
+  // When adding a check, if the remote addr from whcih notification was
+  // received is a master, clear all other masters so we can be sure the
+  // query goes to that one.
+  for (vector<string>::iterator it = ours.masters.begin(); it != ours.masters.end(); ++it) {
     if (*it == remote_address) {
 	ours.masters.erase(it);
-        ours.masters.insert(ours.masters.begin(), remote_address);
+        ours.masters.push_back(remote_address);
         break;
     } 
   }


### PR DESCRIPTION
We found out that when notifying from a master, the pdns chooses his return address either randomly or by the first master defined (depending on the bind), this is problematic in case you can't promise to update the masters list every time a master fails (like in our case).

For that, we have fixed the slave communicator code to always return to the master who notified him in that case.

This was compiled and tested.