### PR TITLE
Increase MySQL client timeouts from 10 seconds

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -337,7 +337,7 @@ SMySQL::SMySQL(const string &database, const string &host, uint16_t port, const 
 #endif
 
 #if MYSQL_VERSION_ID >= 50100
-    unsigned int timeout = 10;
+    unsigned int timeout = 180;
     mysql_options(&d_db, MYSQL_OPT_READ_TIMEOUT, &timeout);
     mysql_options(&d_db, MYSQL_OPT_WRITE_TIMEOUT, &timeout);
 #endif


### PR DESCRIPTION
If a single SQL query runs for 10 seconds or more, the connection is killed from the client side.

This could happen when slaving domains with a huge amount of rows - as all existing rows will be deleted in a DELETE statement at the beginning of the transaction, before re-populating the rows again.

With MySQL warnings enabled, MySQL server will log the following:
"[Warning] Aborted connection <id> to db: '<database>' user: '<user>' host: <host>' (Unknown error)"
... while powerdns (at least in 3.4.1) will log:
"Database failed to start transaction: Failed to execute mysql_query, perhaps connection died? Err=1: Lost connection to MySQL server during query" - none of which make it obvious why the query failed.

Having a configurable timeout is obviously a better alternative, but as a temporary workaround, changing the timeout to a couple of minutes should hopefully minimise the risk in most situations.