### PR TITLE
fixes a crash in BIND backend NSEC code - but needs more work

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -940,7 +940,8 @@ bool Bind2Backend::findBeforeAndAfterUnhashed(BB2DomainInfo& bbd, const DNSName&
         break;
       }
     }
-    after = (iter)->qname.labelReverse().toString(" ",false);
+    if(iter != records->end())
+      after = (iter)->qname.labelReverse().toString(" ",false);
   }
 
   // cerr<<"Before: '"<<before<<"', after: '"<<after<<"'\n";


### PR DESCRIPTION
The function findBeforeAndAfterUnhashed() is weakly defined, and I'm not sure what it is supposed to do. I'm pretty sure it doesn't do it though. In addition, in many other places it looks like it might dereference an end() iterator or simply march past the end or beginning even. 