### PR TITLE
Pls discuss: Teeaction: send copy of query to second nameserver, sponge responses

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -447,6 +447,29 @@ clients to fall back to TCP/IP.
 
 To turn this per IP or range limit into a global limit, use NotRule(MaxQPSRule(5000)) instead of MaxQPSIPRule.
 
+TeeAction
+---------
+This action sends off a copy of a UDP query to another server, and keeps statistics
+on the responses received. Sample use:
+
+```
+> addAction(AllRule(), TeeAction("192.168.1.54"))
+> getAction(0):printStats()
+refuseds	0
+nxdomains	0
+noerrors	0
+servfails	0
+recv-errors	0
+tcp-drops	0
+responses	0
+other-rcode	0
+send-errors	0
+queries	0
+```
+
+It is also possible to share a TeeAction between several rules. Statistics
+will be combined in that case.
+
 Lua actions in rules
 --------------------
 While we can pass every packet through the `blockFilter()` functions, it is also
@@ -1037,6 +1060,7 @@ instantiate a server with additional parameters
     * `SuffixMatchNodeRule()`: matches based on a group of domain suffixes for rapid testing of membership
     * `TCPRule(tcp)`: matches question received over TCP if `tcp` is true, over UDP otherwise
  * Rule management related:
+    * `getAction(num)`: returns the Action associate with rule 'num'.
     * `showRules()`: show all defined rules (Pool, Block, QPS, addAnyTCRule)
     * `rmRule(n)`: remove rule n
     * `mvRule(from, to)`: move rule 'from' to a position where it is in front of 'to'. 'to' can be one larger than the largest rule,
@@ -1059,6 +1083,7 @@ instantiate a server with additional parameters
     * `SpoofAction(ip[, ip])` or `SpoofAction({ip, ip, ..}): forge a response with the specified IPv4 (for an A query) or IPv6 (for an AAAA). If you specify multiple addresses, all that match the query type (A, AAAA or ANY) will get spoofed in
     * `SpoofCNAMEAction(cname)`: forge a response with the specified CNAME value
     * `TCAction()`: create answer to query with TC and RD bits set, to move to TCP/IP
+    * `TeeAction(remote)`: send copy of query to remote, keep stats on responses
  * Specialist rule generators
     * `addAnyTCRule()`: generate TC=1 answers to ANY queries received over UDP, moving them to TCP
     * `addDomainSpoof(domain, ip[, ip6])` or `addDomainSpoof(domain, {IP, IP, IP..})`: generate answers for A/AAAA/ANY queries using the ip parameters

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -165,16 +165,17 @@ void doConsole()
         feedConfigDelta(line);
     }
     catch(const LuaContext::ExecutionErrorException& e) {
-      std::cerr << e.what() << ": ";
+      std::cerr << e.what(); 
       try {
         std::rethrow_if_nested(e);
+        std::cerr << std::endl;
       } catch(const std::exception& e) {
         // e is the exception that was thrown from inside the lambda
-        std::cerr << e.what() << std::endl;      
+        std::cerr << ": " << e.what() << std::endl;      
       }
       catch(const PDNSException& e) {
         // e is the exception that was thrown from inside the lambda
-        std::cerr << e.reason << std::endl;      
+        std::cerr << ": " << e.reason << std::endl;      
       }
     }
     catch(const std::exception& e) {

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -583,4 +583,14 @@ void moreLua(bool client)
         return std::make_shared<RemoteLogger>(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? *maxQueuedEntries : 100, reconnectWaitTime ? *reconnectWaitTime : 1);
       });
 
+    g_lua.writeFunction("TeeAction", [](const std::string& remote) {
+        return std::shared_ptr<DNSAction>(new TeeAction(ComboAddress(remote, 53)));
+      });
+
+    g_lua.registerFunction<void(DNSAction::*)()>("printStats", [](const DNSAction& ta) {
+        auto stats = ta.getStats();
+        for(const auto& s : stats) {
+          g_outputBuffer+=s.first+"\t"+std::to_string(s.second)+"\n";
+        }
+      });
 }

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -584,13 +584,30 @@ void moreLua(bool client)
       });
 
     g_lua.writeFunction("TeeAction", [](const std::string& remote) {
+        setLuaNoSideEffect();
         return std::shared_ptr<DNSAction>(new TeeAction(ComboAddress(remote, 53)));
       });
 
     g_lua.registerFunction<void(DNSAction::*)()>("printStats", [](const DNSAction& ta) {
+        setLuaNoSideEffect();
         auto stats = ta.getStats();
         for(const auto& s : stats) {
-          g_outputBuffer+=s.first+"\t"+std::to_string(s.second)+"\n";
+          g_outputBuffer+=s.first+"\t";
+          if((uint64_t)s.second == s.second)
+            g_outputBuffer += std::to_string((uint64_t)s.second)+"\n";
+          else
+            g_outputBuffer += std::to_string(s.second)+"\n";
         }
       });
+
+    g_lua.writeFunction("getAction", [](unsigned int num) {
+        setLuaNoSideEffect();
+        auto rulactions = g_rulactions.getCopy();
+        if(num >= rulactions.size())
+          return std::shared_ptr<DNSAction>();
+        return rulactions[num].second;
+      });
+
+    g_lua.registerFunction("getStats", &DNSAction::getStats);
+
 }

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -216,9 +216,11 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
       for(const auto& a : localRules) {
 	Json::object rule{
 	  {"id", num++},
-	    {"matches", (int)a.first->d_matches},
-	      {"rule", a.first->toString()},
-		{"action", a.second->toString()} };
+	  {"matches", (int)a.first->d_matches},
+	  {"rule", a.first->toString()},
+          {"action", a.second->toString()}, 
+          {"action-stats", a.second->getStats()} 
+        };
 	rules.push_back(rule);
       }
       

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -424,6 +424,10 @@ public:
   enum class Action { Drop, Nxdomain, Spoof, Allow, HeaderModify, Pool, Delay, None};
   virtual Action operator()(DNSQuestion*, string* ruleresult) const =0;
   virtual string toString() const = 0;
+  virtual std::unordered_map<string, double> getStats() const 
+  {
+    return {{}};
+  }
 };
 
 class DNSResponseAction

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -75,7 +75,7 @@ dnsdist_SOURCES = \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dnsparser.hh dnsparser.cc \
-	dnsrulactions.hh \
+	dnsrulactions.cc dnsrulactions.hh \
 	dnswriter.cc dnswriter.hh \
 	dolog.hh \
 	ednsoptions.cc ednsoptions.hh \

--- a/pdns/dnsdistdist/dnsrulactions.cc
+++ b/pdns/dnsdistdist/dnsrulactions.cc
@@ -66,7 +66,7 @@ void TeeAction::worker()
     if(res==0)
       continue;
     res=recv(d_fd, packet, sizeof(packet), 0);
-    if(res <= 0) 
+    if(res <= (int)sizeof(struct dnsheader)) 
       d_recverrors++;
     else if(res > 0)
       d_responses++;

--- a/pdns/dnsdistdist/dnsrulactions.cc
+++ b/pdns/dnsdistdist/dnsrulactions.cc
@@ -1,0 +1,55 @@
+#include "dnsrulactions.hh"
+#include <iostream>
+
+using namespace std;
+
+TeeAction::TeeAction(const ComboAddress& ca) : d_remote(ca)
+{
+  cerr<<"Created!"<<endl;
+  d_fd=SSocket(d_remote.sin4.sin_family, SOCK_DGRAM, 0);
+  SConnect(d_fd, d_remote);
+  d_worker=std::thread(std::bind(&TeeAction::worker, this));
+  
+}
+
+TeeAction::~TeeAction()
+{
+  cerr<<"Closding down!"<<endl;
+  d_pleaseQuit=true;
+  close(d_fd);
+  d_worker.join();
+}
+
+DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) const 
+{
+  d_queries++;
+  send(d_fd, (char*)dq->dh, dq->len, 0);
+  return DNSAction::Action::None;
+}
+
+string TeeAction::toString() const
+{
+  return "tee to "+d_remote.toStringWithPort();
+}
+
+std::unordered_map<string,double> TeeAction::getStats() const
+{
+  return {{"queries", d_queries},
+      {"responses", d_responses},
+        {"socket-errors", d_errors}};
+}
+
+void TeeAction::worker()
+{
+  char packet[1500];
+  int res=0;
+  for(;;) {
+    res=recv(d_fd, packet, sizeof(packet), 0);
+    if(res < 0) 
+      d_errors++;
+    else if(res > 0)
+      d_responses++;
+    if(d_pleaseQuit)
+      break;
+  }
+}

--- a/pdns/dnsdistdist/dnsrulactions.cc
+++ b/pdns/dnsdistdist/dnsrulactions.cc
@@ -5,16 +5,14 @@ using namespace std;
 
 TeeAction::TeeAction(const ComboAddress& ca) : d_remote(ca)
 {
-  cerr<<"Created!"<<endl;
   d_fd=SSocket(d_remote.sin4.sin_family, SOCK_DGRAM, 0);
   SConnect(d_fd, d_remote);
-  d_worker=std::thread(std::bind(&TeeAction::worker, this));
-  
+  setNonBlocking(d_fd);
+  d_worker=std::thread(std::bind(&TeeAction::worker, this));  
 }
 
 TeeAction::~TeeAction()
 {
-  cerr<<"Closding down!"<<endl;
   d_pleaseQuit=true;
   close(d_fd);
   d_worker.join();
@@ -22,8 +20,13 @@ TeeAction::~TeeAction()
 
 DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) const 
 {
-  d_queries++;
-  send(d_fd, (char*)dq->dh, dq->len, 0);
+  if(dq->tcp) 
+    d_tcpdrops++;
+  else {
+    d_queries++;
+    if(send(d_fd, (char*)dq->dh, dq->len, 0) <= 0) 
+      d_senderrors++;
+  }
   return DNSAction::Action::None;
 }
 
@@ -35,21 +38,50 @@ string TeeAction::toString() const
 std::unordered_map<string,double> TeeAction::getStats() const
 {
   return {{"queries", d_queries},
-      {"responses", d_responses},
-        {"socket-errors", d_errors}};
+          {"responses", d_responses},
+          {"recv-errors", d_recverrors},
+          {"send-errors", d_senderrors},
+          {"noerrors", d_noerrors},
+          {"nxdomains", d_nxdomains},
+          {"refuseds", d_refuseds},
+          {"servfails", d_servfails},
+          {"other-rcode", d_otherrcode},
+          {"tcp-drops", d_tcpdrops}
+  };
 }
 
 void TeeAction::worker()
 {
   char packet[1500];
   int res=0;
+  struct dnsheader* dh=(struct dnsheader*)packet;
   for(;;) {
-    res=recv(d_fd, packet, sizeof(packet), 0);
-    if(res < 0) 
-      d_errors++;
-    else if(res > 0)
-      d_responses++;
+    res=waitForData(d_fd, 0, 250000);
     if(d_pleaseQuit)
       break;
+    if(res < 0) {
+      usleep(250000);
+      continue;
+    }
+    if(res==0)
+      continue;
+    res=recv(d_fd, packet, sizeof(packet), 0);
+    if(res <= 0) 
+      d_recverrors++;
+    else if(res > 0)
+      d_responses++;
+
+    if(dh->rcode == RCode::NoError)
+      d_noerrors++;
+    else if(dh->rcode == RCode::ServFail)
+      d_servfails++;
+    else if(dh->rcode == RCode::NXDomain)
+      d_nxdomains++;
+    else if(dh->rcode == RCode::Refused)
+      d_refuseds++;
+    else if(dh->rcode == RCode::FormErr)
+      d_formerrs++;
+    else if(dh->rcode == RCode::NotImp)
+      d_notimps++;
   }
 }

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -411,6 +411,28 @@ private:
 };
 
 
+class TeeAction : public DNSAction
+{
+public:
+  TeeAction(const ComboAddress& ca);
+  ~TeeAction();
+  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override;
+  string toString() const override;
+  std::unordered_map<string, double> getStats() const override;
+private:
+  ComboAddress d_remote;
+  std::thread d_worker;
+  void worker();
+
+  int d_fd;
+  unsigned long d_errors{0};
+  mutable unsigned long d_queries{0};
+  unsigned long d_responses{0};
+  std::atomic<bool> d_pleaseQuit{false};
+};
+
+
+
 class PoolAction : public DNSAction
 {
 public:

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -425,9 +425,18 @@ private:
   void worker();
 
   int d_fd;
-  unsigned long d_errors{0};
+  mutable unsigned long d_senderrors{0};
+  unsigned long d_recverrors{0};
   mutable unsigned long d_queries{0};
   unsigned long d_responses{0};
+  unsigned long d_nxdomains{0};
+  unsigned long d_servfails{0};
+  unsigned long d_refuseds{0};
+  unsigned long d_formerrs{0};
+  unsigned long d_notimps{0};
+  unsigned long d_noerrors{0};
+  mutable unsigned long d_tcpdrops{0};
+  unsigned long d_otherrcode{0};
   std::atomic<bool> d_pleaseQuit{false};
 };
 

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -425,9 +425,9 @@ private:
   void worker();
 
   int d_fd;
-  mutable unsigned long d_senderrors{0};
+  mutable std::atomic<unsigned long> d_senderrors{0};
   unsigned long d_recverrors{0};
-  mutable unsigned long d_queries{0};
+  mutable std::atomic<unsigned long> d_queries{0};
   unsigned long d_responses{0};
   unsigned long d_nxdomains{0};
   unsigned long d_servfails{0};


### PR DESCRIPTION
This adds a getStats() too all Actions which is currently empty, but could be exposed via the API so people could query it remotely. I think it makes sense like this but @rgacogne is closed in tune with the architecture of dnsdist post 1.0.0 I think. So please ponder before merging!