### PR TITLE
Fix various crashes

### DIFF
--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -80,10 +80,16 @@ DNSFilterEngine::Policy DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& 
   for(const auto& r : records) {
     if(r.d_place != DNSResourceRecord::ANSWER) 
       continue;
-    if(r.d_type == QType::A) 
-      ca = std::dynamic_pointer_cast<ARecordContent>(r.d_content)->getCA();
-    else if(r.d_type == QType::AAAA) 
-      ca = std::dynamic_pointer_cast<AAAARecordContent>(r.d_content)->getCA();
+    if(r.d_type == QType::A) {
+      if (auto rec = getRR<ARecordContent>(r)) {
+        ca = rec->getCA();
+      }
+    }
+    else if(r.d_type == QType::AAAA) {
+      if (auto rec = getRR<AAAARecordContent>(r)) {
+        ca = rec->getCA();
+      }
+    }
     else
       continue;
 

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -319,7 +319,7 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, const std::
 
     sleep(refresh);
     
-    L<<Logger::Info<<"Getting IXFR deltas for "<<zone<<" from "<<master.toStringWithPort()<<", our serial: "<<std::dynamic_pointer_cast<SOARecordContent>(dr.d_content)->d_st.serial<<endl;
+    L<<Logger::Info<<"Getting IXFR deltas for "<<zone<<" from "<<master.toStringWithPort()<<", our serial: "<<getRR<SOARecordContent>(dr)->d_st.serial<<endl;
     vector<pair<vector<DNSRecord>, vector<DNSRecord> > > deltas;
     try {
       deltas = getIXFRDeltas(master, zone, dr, tt);
@@ -343,8 +343,8 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, const std::
       for(const auto& rr : remove) { // should always contain the SOA
 	totremove++;
 	if(rr.d_type == QType::SOA) {
-	  auto oldsr = std::dynamic_pointer_cast<SOARecordContent>(rr.d_content);
-	  if(oldsr->d_st.serial == oursr->d_st.serial) {
+	  auto oldsr = getRR<SOARecordContent>(rr);
+	  if(oldsr && oldsr->d_st.serial == oursr->d_st.serial) {
 	    //	    cout<<"Got good removal of SOA serial "<<oldsr->d_st.serial<<endl;
 	  }
 	  else
@@ -359,9 +359,11 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, const std::
       for(const auto& rr : add) { // should always contain the new SOA
 	totadd++;
 	if(rr.d_type == QType::SOA) {
-	  auto newsr = std::dynamic_pointer_cast<SOARecordContent>(rr.d_content);
+	  auto newsr = getRR<SOARecordContent>(rr);
 	  //	  L<<Logger::Info<<"New SOA serial for "<<zone<<": "<<newsr->d_st.serial<<endl;
-	  oursr = newsr;
+	  if (newsr) {
+	    oursr = newsr;
+	  }
 	}
 	else {
 	  L<<Logger::Info<<"Had addition of "<<rr.d_name<<endl;

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -23,8 +23,16 @@ void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, const std::
 
   DNSFilterEngine::Policy pol{DNSFilterEngine::PolicyKind::NoAction, nullptr, polName, 0};
 
+  if(dr.d_class != QClass::IN) {
+    return;
+  }
+
   if(dr.d_type == QType::CNAME) {
-    auto target=std::dynamic_pointer_cast<CNAMERecordContent>(dr.d_content)->getTarget();
+    auto crc = getRR<CNAMERecordContent>(dr);
+    if (!crc) {
+      return;
+    }
+    auto target=crc->getTarget();
     if(defpol) {
       pol=*defpol;
     }
@@ -118,7 +126,7 @@ shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const
 
       dr.d_name.makeUsRelative(zone);
       if(dr.d_type==QType::SOA) {
-	sr = std::dynamic_pointer_cast<SOARecordContent>(dr.d_content);
+	sr = getRR<SOARecordContent>(dr);
 	continue;
       }
 

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -137,6 +137,9 @@ latlon2ul(const char **latlonstrptr, int *which)
     break;
   }
 
+  if (!*cp)
+    return 0;
+
   cp++;                   /* skip the hemisphere */
   
   while (*cp && !isspace(*cp))   /* if any trailing garbage */

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -150,7 +150,9 @@ cspmap_t harvestCSPFromRecs(const vector<DNSRecord>& recs)
     
     if(rec.d_type == QType::RRSIG) {
       auto rrc = getRR<RRSIGRecordContent>(rec);
-      cspmap[{rec.d_name,rrc->d_type}].signatures.push_back(getRR<RRSIGRecordContent>(rec));
+      if (rrc) {
+        cspmap[{rec.d_name,rrc->d_type}].signatures.push_back(rrc);
+      }
     }
     else {
       cspmap[{rec.d_name, rec.d_type}].records.push_back(rec.d_content);
@@ -200,19 +202,21 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
       if(rec.d_type == QType::RRSIG)
       {
         auto rrc=getRR<RRSIGRecordContent> (rec);
-        if(rrc->d_type != QType::DNSKEY)
+        if(rrc && rrc->d_type != QType::DNSKEY)
           continue;
         sigs.push_back(*rrc);
       }
       else if(rec.d_type == QType::DNSKEY)
       {
         auto drc=getRR<DNSKEYRecordContent> (rec);
-        tkeys.insert(*drc);
-	//	cerr<<"Inserting key with tag "<<drc->getTag()<<": "<<drc->getZoneRepresentation()<<endl;
-	dotNode("DNSKEY", qname, std::to_string(drc->getTag()), (boost::format("tag=%d, algo=%d") % drc->getTag() % static_cast<int>(drc->d_algorithm)).str());
+        if(drc) {
+          tkeys.insert(*drc);
+          //	cerr<<"Inserting key with tag "<<drc->getTag()<<": "<<drc->getZoneRepresentation()<<endl;
+          dotNode("DNSKEY", qname, std::to_string(drc->getTag()), (boost::format("tag=%d, algo=%d") % drc->getTag() % static_cast<int>(drc->d_algorithm)).str());
 
-        toSign.push_back(rec.d_content);
-        toSignTags.push_back(drc->getTag());
+          toSign.push_back(rec.d_content);
+          toSignTags.push_back(drc->getTag());
+        }
       }
     }
     //    cerr<<"got "<<tkeys.size()<<" keys and "<<sigs.size()<<" sigs from server"<<endl;
@@ -339,10 +343,12 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
             for(const auto& r : v.second.records) {
               LOG("\t"<<r->getZoneRepresentation()<<endl);
               auto nsec = std::dynamic_pointer_cast<NSECRecordContent>(r);
-              if(v.first.first == qname && !nsec->d_set.count(QType::DS))
-                return Insecure;
-              else {
-                LOG("Did not deny existence of DS, "<<v.first.first<<"?="<<qname<<", "<<nsec->d_set.count(QType::DS)<<endl);
+              if(nsec) {
+                if(v.first.first == qname && !nsec->d_set.count(QType::DS))
+                  return Insecure;
+                else {
+                  LOG("Did not deny existence of DS, "<<v.first.first<<"?="<<qname<<", "<<nsec->d_set.count(QType::DS)<<endl);
+                }
               }
             }
 
@@ -354,11 +360,13 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
         for(auto j=cspiter->second.records.cbegin(); j!=cspiter->second.records.cend(); j++)
         {
           const auto dsrc=std::dynamic_pointer_cast<DSRecordContent>(*j);
-          dsmap.insert(make_pair(dsrc->d_tag, *dsrc));
-          // dotEdge(keyqname,
-          //         "DNSKEY", keyqname, ,
-          //         "DS", qname, std::to_string(dsrc.d_tag));
-          // cout<<"    "<<dotEscape("DNSKEY "+keyqname)<<" -> "<<dotEscape("DS "+qname)<<";"<<endl;
+          if(dsrc) {
+            dsmap.insert(make_pair(dsrc->d_tag, *dsrc));
+            // dotEdge(keyqname,
+            //         "DNSKEY", keyqname, ,
+            //         "DS", qname, std::to_string(dsrc.d_tag));
+            // cout<<"    "<<dotEscape("DNSKEY "+keyqname)<<" -> "<<dotEscape("DS "+qname)<<";"<<endl;
+          }
         }
       }
       if(!dsmap.size()) {

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -250,6 +250,9 @@ string ZoneParserTNG::getLineOfFile()
   if (d_zonedata.size() > 0)
     return "on line "+std::to_string(std::distance(d_zonedata.begin(), d_zonedataline))+" of given string";
 
+  if (d_filestates.empty())
+    return "";
+
   return "on line "+std::to_string(d_filestates.top().d_lineno)+" of file '"+d_filestates.top().d_filename+"'";
 }
 


### PR DESCRIPTION
* rec chokes on non-IN records from auths / RPZ
* off-by-one read in `latlon2ul()`
* NULL-deref on parsing error in ZoneParserTNG
Found with American Fuzzy Lop and Address Sanitizer.