### PR TITLE
Cap packetcache-servfail-ttl to packetcache-ttl

### DIFF
--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -559,6 +559,9 @@ the original TTL specified.
 * Available since: 3.2
 
 Maximum number of seconds to cache a 'server failure' answer in the packet cache.
+From 4.0.0 onward, this settings maximum is capped to [`packetcache-ttl`](#packetcache-ttl).
+i.e. setting `packetcache-ttl=15` and keeping `packetcache-servfail-ttl` at the
+default will lower `packetcache-servfail-ttl` to `15`.
 
 ## `pdns-distributes-queries`
 * Boolean

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2566,7 +2566,9 @@ int serviceMain(int argc, char*argv[])
   SyncRes::s_maxnegttl=::arg().asNum("max-negative-ttl");
   SyncRes::s_maxcachettl=::arg().asNum("max-cache-ttl");
   SyncRes::s_packetcachettl=::arg().asNum("packetcache-ttl");
-  SyncRes::s_packetcacheservfailttl=::arg().asNum("packetcache-servfail-ttl");
+  // Cap the packetcache-servfail-ttl to the packetcache-ttl
+  uint32_t packetCacheServFailTTL = ::arg().asNum("packetcache-servfail-ttl");
+  SyncRes::s_packetcacheservfailttl=(packetCacheServFailTTL > SyncRes::s_packetcachettl) ? SyncRes::s_packetcachettl : packetCacheServFailTTL;
   SyncRes::s_serverdownmaxfails=::arg().asNum("server-down-max-fails");
   SyncRes::s_serverdownthrottletime=::arg().asNum("server-down-throttle-time");
   SyncRes::s_serverID=::arg()["server-id"];


### PR DESCRIPTION
This prevents surprises when packetcache-ttl is set to 0, but servfails
are still served from the cache. Closes #3738.