### PR TITLE
Add consistency checks to segmentDNSNameRaw()

### DIFF
--- a/pdns/dnslabeltext.rl
+++ b/pdns/dnslabeltext.rl
@@ -111,6 +111,9 @@ DNSName::string_t segmentDNSNameRaw(const char* realinput)
         unsigned int lenpos=0;
         %%{
                 action labelEnd { 
+                        if (labellen < 0 || labellen > 63) {
+                          throw runtime_error("Unable to parse DNS name '"+string(realinput)+"': invalid label length "+std::to_string(labellen));
+                        }
                         ret[lenpos]=labellen;
                         labellen=0;
                 }

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -201,6 +201,9 @@ bool DNSName::isPartOf(const DNSName& parent) const
       }
       return true;
     }
+    if (*us < 0) {
+      throw std::out_of_range("negative label length in dnsname");
+    }
   }
   return false;
 }

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -51,8 +51,12 @@ DNSName::DNSName(const char* p)
       }
       d_storage.append(1, (char)0);
     }
-    else
+    else {
       d_storage=segmentDNSNameRaw(p); 
+      if(d_storage.size() > 255) {
+        throw std::range_error("name too long");
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This fixes most issues found by fuzzing rpzLoadFile() with American Fuzzy Lop.
Also throw on negative label length in `DNSName::isPartOf()`, just in case.