### PR TITLE
Add --version and --help to all the tools

### DIFF
--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -254,6 +254,7 @@ fi
 %{_mandir}/man1/dnsscope.1.gz
 %{_mandir}/man1/dnstcpbench.1.gz
 %{_mandir}/man1/dnswasher.1.gz
+%{_mandir}/man1/dumresp.1.gz
 %{_mandir}/man1/ixplore.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz
@@ -527,6 +528,7 @@ exit 0
 %{_mandir}/man1/dnsscope.1.gz
 %{_mandir}/man1/dnstcpbench.1.gz
 %{_mandir}/man1/dnswasher.1.gz
+%{_mandir}/man1/dumresp.1.gz
 %{_mandir}/man1/ixplore.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz
@@ -783,6 +785,7 @@ exit 0
 %{_mandir}/man1/dnsscope.1.gz
 %{_mandir}/man1/dnstcpbench.1.gz
 %{_mandir}/man1/dnswasher.1.gz
+%{_mandir}/man1/dumresp.1.gz
 %{_mandir}/man1/ixplore.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz

--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -256,6 +256,7 @@ fi
 %{_mandir}/man1/dnswasher.1.gz
 %{_mandir}/man1/dumresp.1.gz
 %{_mandir}/man1/ixplore.1.gz
+%{_mandir}/man1/notify.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz
 %{_mandir}/man1/sdig.1.gz
@@ -530,6 +531,7 @@ exit 0
 %{_mandir}/man1/dnswasher.1.gz
 %{_mandir}/man1/dumresp.1.gz
 %{_mandir}/man1/ixplore.1.gz
+%{_mandir}/man1/notify.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz
 %{_mandir}/man1/sdig.1.gz
@@ -787,6 +789,7 @@ exit 0
 %{_mandir}/man1/dnswasher.1.gz
 %{_mandir}/man1/dumresp.1.gz
 %{_mandir}/man1/ixplore.1.gz
+%{_mandir}/man1/notify.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz
 %{_mandir}/man1/sdig.1.gz

--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -257,6 +257,7 @@ fi
 %{_mandir}/man1/dumresp.1.gz
 %{_mandir}/man1/ixplore.1.gz
 %{_mandir}/man1/notify.1.gz
+%{_mandir}/man1/nproxy.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz
 %{_mandir}/man1/sdig.1.gz
@@ -532,6 +533,7 @@ exit 0
 %{_mandir}/man1/dumresp.1.gz
 %{_mandir}/man1/ixplore.1.gz
 %{_mandir}/man1/notify.1.gz
+%{_mandir}/man1/nproxy.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz
 %{_mandir}/man1/sdig.1.gz
@@ -790,6 +792,7 @@ exit 0
 %{_mandir}/man1/dumresp.1.gz
 %{_mandir}/man1/ixplore.1.gz
 %{_mandir}/man1/notify.1.gz
+%{_mandir}/man1/nproxy.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz
 %{_mandir}/man1/sdig.1.gz

--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -246,6 +246,7 @@ fi
 %{_bindir}/nsec3dig
 %{_bindir}/saxfr
 %{_bindir}/sdig
+%{_mandir}/man1/calidns.1.gz
 %{_mandir}/man1/dnsbulktest.1.gz
 %{_mandir}/man1/dnsgram.1.gz
 %{_mandir}/man1/dnsreplay.1.gz
@@ -518,6 +519,7 @@ exit 0
 %{_bindir}/nsec3dig
 %{_bindir}/saxfr
 %{_bindir}/sdig
+%{_mandir}/man1/calidns.1.gz
 %{_mandir}/man1/dnsbulktest.1.gz
 %{_mandir}/man1/dnsgram.1.gz
 %{_mandir}/man1/dnsreplay.1.gz
@@ -773,6 +775,7 @@ exit 0
 %{_bindir}/nsec3dig
 %{_bindir}/saxfr
 %{_bindir}/sdig
+%{_mandir}/man1/calidns.1.gz
 %{_mandir}/man1/dnsbulktest.1.gz
 %{_mandir}/man1/dnsgram.1.gz
 %{_mandir}/man1/dnsreplay.1.gz

--- a/build-scripts/debian-authoritative/pdns-tools.install
+++ b/build-scripts/debian-authoritative/pdns-tools.install
@@ -1,3 +1,4 @@
+usr/bin/calidns
 usr/bin/dnsbulktest
 usr/bin/dnsgram
 usr/bin/dnsreplay

--- a/build-scripts/debian-authoritative/pdns-tools.install
+++ b/build-scripts/debian-authoritative/pdns-tools.install
@@ -6,6 +6,7 @@ usr/bin/dnsscan
 usr/bin/dnsscope
 usr/bin/dnstcpbench
 usr/bin/dnswasher
+usr/bin/dumresp
 usr/bin/ixplore
 usr/bin/notify
 usr/bin/nsec3dig

--- a/build-scripts/debian-authoritative/pdns-tools.install
+++ b/build-scripts/debian-authoritative/pdns-tools.install
@@ -9,6 +9,7 @@ usr/bin/dnswasher
 usr/bin/dumresp
 usr/bin/ixplore
 usr/bin/notify
+usr/bin/nproxy
 usr/bin/nsec3dig
 usr/bin/saxfr
 usr/bin/sdig

--- a/build-scripts/debian-authoritative/pdns-tools.manpages
+++ b/build-scripts/debian-authoritative/pdns-tools.manpages
@@ -12,3 +12,4 @@ debian/tmp/usr/share/man/man1/notify.1
 debian/tmp/usr/share/man/man1/nproxy.1
 debian/tmp/usr/share/man/man1/nsec3dig.1
 debian/tmp/usr/share/man/man1/saxfr.1
+debian/tmp/usr/share/man/man1/sdig.1

--- a/build-scripts/debian-authoritative/pdns-tools.manpages
+++ b/build-scripts/debian-authoritative/pdns-tools.manpages
@@ -9,5 +9,6 @@ debian/tmp/usr/share/man/man1/dnswasher.1
 debian/tmp/usr/share/man/man1/dumresp.1
 debian/tmp/usr/share/man/man1/ixplore.1
 debian/tmp/usr/share/man/man1/notify.1
+debian/tmp/usr/share/man/man1/nproxy.1
 debian/tmp/usr/share/man/man1/nsec3dig.1
 debian/tmp/usr/share/man/man1/saxfr.1

--- a/build-scripts/debian-authoritative/pdns-tools.manpages
+++ b/build-scripts/debian-authoritative/pdns-tools.manpages
@@ -6,6 +6,7 @@ debian/tmp/usr/share/man/man1/dnsscan.1
 debian/tmp/usr/share/man/man1/dnsscope.1
 debian/tmp/usr/share/man/man1/dnstcpbench.1
 debian/tmp/usr/share/man/man1/dnswasher.1
+debian/tmp/usr/share/man/man1/dumresp.1
 debian/tmp/usr/share/man/man1/ixplore.1
 debian/tmp/usr/share/man/man1/nsec3dig.1
 debian/tmp/usr/share/man/man1/saxfr.1

--- a/build-scripts/debian-authoritative/pdns-tools.manpages
+++ b/build-scripts/debian-authoritative/pdns-tools.manpages
@@ -1,3 +1,4 @@
+debian/tmp/usr/share/man/man1/calidns.1
 debian/tmp/usr/share/man/man1/dnsbulktest.1
 debian/tmp/usr/share/man/man1/dnsgram.1
 debian/tmp/usr/share/man/man1/dnsreplay.1

--- a/build-scripts/debian-authoritative/pdns-tools.manpages
+++ b/build-scripts/debian-authoritative/pdns-tools.manpages
@@ -8,5 +8,6 @@ debian/tmp/usr/share/man/man1/dnstcpbench.1
 debian/tmp/usr/share/man/man1/dnswasher.1
 debian/tmp/usr/share/man/man1/dumresp.1
 debian/tmp/usr/share/man/man1/ixplore.1
+debian/tmp/usr/share/man/man1/notify.1
 debian/tmp/usr/share/man/man1/nsec3dig.1
 debian/tmp/usr/share/man/man1/saxfr.1

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -13,6 +13,7 @@ MANPAGES_TARGET_TOOLS = calidns.1 \
 	dnsscope.1 \
 	dnstcpbench.1 \
 	dnswasher.1 \
+	dumresp.1 \
 	ixplore.1 \
 	nsec3dig.1 \
 	saxfr.1 \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -16,6 +16,7 @@ MANPAGES_TARGET_TOOLS = calidns.1 \
 	dumresp.1 \
 	ixplore.1 \
 	notify.1 \
+	nproxy.1 \
 	nsec3dig.1 \
 	saxfr.1 \
 	sdig.1

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -5,7 +5,8 @@ MANPAGES_TARGET_AUTH = pdns_server.1 \
 	zone2ldap.1 \
 	zone2sql.1
 
-MANPAGES_TARGET_TOOLS = dnsbulktest.1 \
+MANPAGES_TARGET_TOOLS = calidns.1 \
+	dnsbulktest.1 \
 	dnsgram.1 \
 	dnsreplay.1 \
 	dnsscan.1 \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -15,6 +15,7 @@ MANPAGES_TARGET_TOOLS = calidns.1 \
 	dnswasher.1 \
 	dumresp.1 \
 	ixplore.1 \
+	notify.1 \
 	nsec3dig.1 \
 	saxfr.1 \
 	sdig.1

--- a/docs/manpages/calidns.1.md
+++ b/docs/manpages/calidns.1.md
@@ -1,0 +1,31 @@
+% CALIDNS(1)
+% PowerDNS.com BV
+% April 2016
+
+# NAME
+**calidns** - A DNS recursor testing tool
+
+# SYNOPSIS
+**calidns** *QUERY_FILE* *DESTINATION* *INITIAL_QPS* *HITRATE*
+
+# DESCRIPTION
+**calidns** reads queries from *QUERY_FILE* and sends them as a recursive query to
+*DESTINATION* (an IPv4 or IPv6 address, optionally with a port number), starting
+at INITIAL_QPS queries per second and aims to have a cache hitrate of *HITRATE*
+percent.
+
+It will then try to determine the maximum amount of queries per second the recursor
+can handle with the aforementioned *HITRATE*.
+
+# QUERY_FILE format
+The format of the *QUERY_FILE* is very simple, it should contain "QNAME<space>QTYPE"
+tuples, one per line. For example:
+
+powerdns.com A
+powerdns.com AAAA
+google.com A
+
+This is similar to Alexa top 1 million list.
+
+# OPTIONS
+None

--- a/docs/manpages/dnsbulktest.1.md
+++ b/docs/manpages/dnsbulktest.1.md
@@ -25,3 +25,6 @@ domain names from STDIN in the alexa topX format and outputs statistics on STDOU
 
 --envoutput, -e
 :    Write results on STDOUT as shell environment variables
+
+--version
+:    Display the version of dnsbulktest

--- a/docs/manpages/dumresp.1.md
+++ b/docs/manpages/dumresp.1.md
@@ -1,0 +1,21 @@
+% DUMRESP(1)
+% PowerDNS.com BV
+% April 2016
+
+# NAME
+**dumresp** - A dumb DNS responder
+
+# SYNOPSIS
+ **dumresp** *LOCAL-ADDRESS* *LOCAL-PORT* *NUMBER-OF-PROCESSES*
+
+# DESCRIPTION
+**dumresp** accepts DNS packets on *LOCAL-ADDRESS*:*LOCAL-PORT* and simply replies
+with the same query, with the QR bit set. When *NUMBER-OF-PROCESSES* is set to
+anything but 1, **dumresp** will spawn *NUMBER-OF-PROCESSES* forks and use the
+SO_REUSEPORT option to bind to the port.
+
+# OPTIONS
+None
+
+# SEE ALSO
+socket(7)

--- a/docs/manpages/notify.1.md
+++ b/docs/manpages/notify.1.md
@@ -1,0 +1,16 @@
+% NOTIFY(1)
+% PowerDNS.com BV
+% April 2016
+
+# NAME
+**notify** - A simple DNS NOTIFY sender
+
+# SYNOPSIS
+**notify** *IP_ADDRESS*[:*PORT*] *DOMAIN*
+
+# DESCRIPTION
+**notify** sends a DNS NOTIFY message to *IP_ADDRESS*, by default on port 53, for
+*DOMAIN* and prints the remote nameserver's response.
+
+# OPTIONS
+None

--- a/docs/manpages/nproxy.1.md
+++ b/docs/manpages/nproxy.1.md
@@ -1,0 +1,54 @@
+% NPROXY(1)
+% PowerDNS.com BV
+% April 2016
+
+# NAME
+**nproxy** - DNS notification proxy
+
+# SYNOPSIS
+nproxy --powerdns-address *ADDRESS* [*OPTION*]... *ADDRESS*...
+
+# DESCRIPTION
+**nproxy** is a simple daemon that reads DNS NOTIFY queries on one address and
+forwards them to an 'inner' nameserver that will process the notification.
+
+Its usecase is e.g. a private authoritative server inside a NAT or firewalled LAN
+where **nproxy** is deployed in the DMZ.
+
+The PowerDNS Authoritative Server has the trusted-notification-proxy option that
+should be set to the address set with *--origin-address* to accept these proxied
+notifications.
+
+**nproxy** also has a health-check option built in. A query for 'pdns.nproxy.'
+with QType 'TXT' will be responded to with an answer of "OK" (inside the TXT record.
+When the query is for an A-record, '1.2.3.4.' is returned.
+
+# OPTIONS
+--powerdns-address *ADDRESS*
+:    IP address of the PowerDNS server to forward the notifications to.
+
+--chroot *PATH*
+:    chroot to *PATH* for additional security.
+
+--setuid *UID*
+:    setuid to this numerical *UID*.
+
+--setgid *GID*
+:    setgid to this numerical *GID*.
+
+--origin-address *ADDRESS*
+:    Set the source of the notifications sent to PowerDNS to *ADDRESS*. By default,
+     the best matching address (kernel's choice) is used.
+
+--listen-address *ADDRESS*
+:    IP addresses to listen on.
+
+--listen-port *PORT*
+:    Source port to listen on, 53 by default.
+
+-d,--daemon *ARG*
+:    Set *ARG* to 0 to disable running in the background.
+
+-v,--verbose
+:     Be verbose
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -97,6 +97,7 @@ pages:
     - 'Manpage: dnsscope.1': manpages/dnsscope.1.md
     - 'Manpage: dnstcpbench.1': manpages/dnstcpbench.1.md
     - 'Manpage: dnswasher.1': manpages/dnswasher.1.md
+    - 'Manpage: notify.1': manpages/notify.1.md
     - 'Manpage: nsec3dig.1': manpages/nsec3dig.1.md
     - 'Manpage: saxfr.1': manpages/saxfr.1.md
     - 'Manpage: sdig.1': manpages/sdig.1.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -98,6 +98,7 @@ pages:
     - 'Manpage: dnstcpbench.1': manpages/dnstcpbench.1.md
     - 'Manpage: dnswasher.1': manpages/dnswasher.1.md
     - 'Manpage: notify.1': manpages/notify.1.md
+    - 'Manpage: nproxy.1': manpages/nproxy.1.md
     - 'Manpage: nsec3dig.1': manpages/nsec3dig.1.md
     - 'Manpage: saxfr.1': manpages/saxfr.1.md
     - 'Manpage: sdig.1': manpages/sdig.1.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -97,6 +97,7 @@ pages:
     - 'Manpage: dnsscope.1': manpages/dnsscope.1.md
     - 'Manpage: dnstcpbench.1': manpages/dnstcpbench.1.md
     - 'Manpage: dnswasher.1': manpages/dnswasher.1.md
+    - 'Manpage: ixplore.1': manpages/ixplore.1.md
     - 'Manpage: notify.1': manpages/notify.1.md
     - 'Manpage: nproxy.1': manpages/nproxy.1.md
     - 'Manpage: nsec3dig.1': manpages/nsec3dig.1.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -89,6 +89,7 @@ pages:
     - Documentation details: appendix/documentation.md
     - Compiling PowerDNS: appendix/compiling-powerdns.md
     - DNS Analysis Tools: tools/analysis.md
+    - 'Manpage: calidns.1': manpages/calidns.1.md
     - 'Manpage: dnsbulktest.1': manpages/dnsbulktest.1.md
     - 'Manpage: dnsgram.1': manpages/dnsgram.1.md
     - 'Manpage: dnsreplay.1': manpages/dnsreplay.1.md

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -125,6 +125,9 @@ void sendPackets(const vector<Socket*>* sockets, const vector<vector<uint8_t>* >
   }
 }
 
+void usage() {
+  cerr<<"Syntax: calidns QUERY_FILE DESTINATION INITIAL_QPS HITRATE"<<endl;
+}
 
 /*
   New plan. Set cache hit percentage, which we achieve on a per second basis.
@@ -156,10 +159,27 @@ try
   struct sched_param param;
   param.sched_priority=99;
 
-  if(argc != 5) {
-    cerr<<"Syntax: calidns file-with-queries destination qps-start hitperc"<<endl;
+  if (argc == 1 || (argc > 1 && argc <5)) {
+    for(int i = 1; i<argc; i++) {
+      string opt(argv[i]);
+
+      if(opt == "--help") {
+        usage();
+        exit(EXIT_SUCCESS);
+      }
+
+      if(opt == "--version") {
+        cerr<<"calidns "<<VERSION<<endl;
+        exit(EXIT_SUCCESS);
+      }
+    }
+
+    usage();
+    if (argc == 1)
+      exit(EXIT_SUCCESS);
     exit(EXIT_FAILURE);
   }
+
   if(sched_setscheduler(0, SCHED_FIFO, &param) < 0)
     cerr<<"Unable to set SCHED_FIFO: "<<strerror(errno)<<endl;
 

--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -188,6 +188,11 @@ struct SendReceive
   unsigned int d_receiveds, d_receiveerrors, d_senderrors;
 };
 
+void usage(po::options_description &desc) {
+  cerr << "Usage: dnsbulktest [OPTION].. IPADDRESS PORTNUMBER [LIMIT]"<<endl;
+  cerr << desc << "\n";
+}
+
 int main(int argc, char** argv)
 try
 {
@@ -197,6 +202,7 @@ try
     ("quiet,q", "be quiet about individual queries")
     ("type,t",  po::value<string>()->default_value("A"), "What type to query for")
     ("envoutput,e", "write report in shell environment format")
+    ("version", "show the version number")
   ;
 
   po::options_description alloptions;
@@ -216,15 +222,18 @@ try
   po::notify(g_vm);
 
   if (g_vm.count("help")) {
-    cerr << "Usage: dnsbulktest [--options] ip-address portnumber [limit]"<<endl;
-    cerr << desc << "\n";
+    usage(desc);
     return EXIT_SUCCESS;
   }
-  
+
+  if (g_vm.count("version")) {
+    cerr<<"dnsbulktest "<<VERSION<<endl;
+    return EXIT_SUCCESS;
+  }
+
   if(!g_vm.count("portnumber")) {
     cerr<<"Fatal, need to specify ip-address and portnumber"<<endl;
-    cerr << "Usage: dnsbulktest [--options] ip-address portnumber [limit]"<<endl;
-    cerr << desc << "\n";
+    usage(desc);
     return EXIT_FAILURE;
   }
 

--- a/pdns/dnsgram.cc
+++ b/pdns/dnsgram.cc
@@ -79,10 +79,31 @@ void makeReport(const struct pdns_timeval& tv)
   g_skipped=0;
 }
 
+void usage() {
+  cerr<<"syntax: dnsgram INFILE..."<<endl;
+}
 
 int main(int argc, char** argv)
 try
 {
+  // Parse possible options
+  if (argc == 1) {
+    usage();
+    return EXIT_SUCCESS;
+  }
+
+  for(int n=1 ; n < argc; ++n) {
+    if ((string) argv[n] == "--help") {
+      usage();
+      return EXIT_SUCCESS;
+    }
+
+    if ((string) argv[n] == "--version") {
+      cerr<<"dnsgram "<<VERSION<<endl;
+      return EXIT_SUCCESS;
+    }
+  }
+
   reportAllTypes();
   for(int n=1 ; n < argc; ++n) {
     cout<<argv[n]<<endl;

--- a/pdns/dnspcap.cc
+++ b/pdns/dnspcap.cc
@@ -11,7 +11,7 @@ PcapPacketReader::PcapPacketReader(const string& fname) : d_fname(fname)
 {
   d_fp=fopen(fname.c_str(),"r");
   if(!d_fp)
-    unixDie("Unable to open file");
+    unixDie("Unable to open file " + fname);
   
   int flags=fcntl(fileno(d_fp),F_GETFL,0);
   fcntl(fileno(d_fp), F_SETFL,flags&(~O_NONBLOCK)); // bsd needs this in stdin (??)

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -670,12 +670,18 @@ bool sendPacketFromPR(PcapPacketReader& pr, const ComboAddress& remote, int stam
   return sent;
 }
 
+void usage(po::options_description &desc) {
+  cerr << "Usage: dnsreplay [OPTIONS] FILENAME [IP-ADDRESS] [PORT]"<<endl;
+  cerr << desc << "\n";
+}
+
 int main(int argc, char** argv)
 try
 {
   po::options_description desc("Allowed options");
   desc.add_options()
     ("help,h", "produce help message")
+    ("version", "show version number")
     ("packet-limit", po::value<uint32_t>()->default_value(0), "stop after this many packets")
     ("quiet", po::value<bool>()->default_value(true), "don't be too noisy")
     ("recursive", po::value<bool>()->default_value(true), "look at recursion desired packets, or not (defaults true)")
@@ -703,15 +709,18 @@ try
   reportAllTypes();
 
   if (g_vm.count("help")) {
-    cerr << "Usage: dnsreplay [--options] filename [ip-address] [port]"<<endl;
-    cerr << desc << "\n";
+    usage(desc);
     return EXIT_SUCCESS;
   }
-  
+
+  if (g_vm.count("version")) {
+    cerr<<"dnsreplay "<<VERSION<<endl;
+    return EXIT_SUCCESS;
+  }
+
   if(!g_vm.count("pcap-source")) {
     cerr<<"Fatal, need to specify at least a PCAP source file"<<endl;
-    cerr << "Usage: dnsreplay [--options] filename [ip-address] [port]"<<endl;
-    cerr << desc << "\n";
+    usage(desc);
     return EXIT_FAILURE;
   }
 

--- a/pdns/dnsscan.cc
+++ b/pdns/dnsscan.cc
@@ -25,6 +25,10 @@ using namespace ::boost::multi_index;
 #include "namespaces.hh"
 StatBag S;
 
+void usage() {
+  cerr<<"syntax: dnsscan INFILE ..."<<endl;
+}
+
 int main(int argc, char** argv)
 try
 {
@@ -37,8 +41,20 @@ try
   */
 
   if(argc<2) {
-    cerr<<"Syntax: dnsscan file1 [file2 ..] "<<endl;
-    exit(1);
+    usage();
+    exit(EXIT_SUCCESS);
+  }
+
+  for(int n=1; n < argc; ++n) {
+    if ((string) argv[n] == "--help") {
+      usage();
+      return EXIT_SUCCESS;
+    }
+
+    if ((string) argv[n] == "--version") {
+      cerr<<"dnsscan "<<VERSION<<endl;
+      return EXIT_SUCCESS;
+    }
   }
 
   unsigned int counts[256];

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -257,6 +257,7 @@ try
   po::options_description desc("Allowed options"), hidden, alloptions;
   desc.add_options()
     ("help,h", "produce help message")
+    ("version", "print version number")
     ("rd", po::value<bool>(), "If set to true, only process RD packets, to false only non-RD, unset: both")
     ("ipv4", po::value<bool>()->default_value(true), "Process IPv4 packets")
     ("ipv6", po::value<bool>()->default_value(true), "Process IPv6 packets")
@@ -279,10 +280,16 @@ try
   vector<string> files;
   if(g_vm.count("files")) 
     files = g_vm["files"].as<vector<string> >(); 
+
+  if(g_vm.count("version")) {
+    cerr<<"dnsscope "<<VERSION<<endl;
+    exit(0);
+  }
+
   if(files.empty() || g_vm.count("help")) {
     cerr<<"Syntax: dnsscope filename.pcap"<<endl;
     cout << desc << endl;
-    exit(1);
+    exit(0);
   }
 
   StatNode root;

--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -184,12 +184,19 @@ static void* worker(void*)
   return 0;
 }
 
+void usage(po::options_description &desc) {
+  cerr<<"Syntax: dnstcpbench REMOTE [PORT] < QUERIES"<<endl;
+  cerr<<"Where QUERIES is one query per line, format: qname qtype, just 1 space"<<endl;
+  cerr<<desc<<endl;
+}
+
 int main(int argc, char** argv)
 try
 {
   po::options_description desc("Allowed options"), hidden, alloptions;
   desc.add_options()
     ("help,h", "produce help message")
+    ("version", "print version number")
     ("verbose,v", "be verbose")
     ("udp-first,u", "try UDP first")
     ("file,f", po::value<string>(), "source file - if not specified, defaults to stdin")
@@ -208,9 +215,14 @@ try
 
   po::store(po::command_line_parser(argc, argv).options(alloptions).positional(p).run(), g_vm);
   po::notify(g_vm);
-  
+
+  if(g_vm.count("version")) {
+    cerr<<"dnstcpbench "<<VERSION<<endl;
+    exit(EXIT_SUCCESS);
+  }
+
   if(g_vm.count("help")) {
-    cout << desc<<endl;
+    usage(desc);
     exit(EXIT_SUCCESS);
   }
   g_tcpNoDelay = g_vm["tcp-no-delay"].as<bool>();
@@ -222,9 +234,7 @@ try
   reportAllTypes();
 
   if(g_vm["remote-host"].empty()) {
-    cerr<<"Syntax: tcpbench remote [port] < queries"<<endl;
-    cerr<<"Where queries is one query per line, format: qname qtype, just 1 space"<<endl;
-    cerr<<desc<<endl;
+    usage(desc);
     exit(EXIT_FAILURE);
   }
 

--- a/pdns/dnswasher.cc
+++ b/pdns/dnswasher.cc
@@ -60,13 +60,30 @@ private:
   uint32_t d_counter;
 };
 
+void usage() {
+  cerr<<"Syntax: dnswasher INFILE OUTFILE"<<endl;
+}
+
 int main(int argc, char** argv)
 try
 {
+  for (int i = 1; i < argc; i++) {
+    if ((string) argv[i] == "--help") {
+      usage();
+      exit(EXIT_SUCCESS);
+    }
+
+    if ((string) argv[i] == "--version") {
+      cerr<<"dnswasher "<<VERSION<<endl;
+      exit(EXIT_SUCCESS);
+    }
+  }
+
   if(argc!=3) {
-    cerr<<"Syntax: dnswasher infile outfile\n";
+    usage();
     exit(1);
   }
+
   PcapPacketReader pr(argv[1]);
   PcapPacketWriter pw(argv[2], pr);
   IPObfuscator ipo;

--- a/pdns/dumresp.cc
+++ b/pdns/dumresp.cc
@@ -21,14 +21,29 @@ void printStatus()
   }
 }
 
+void usage() {
+  cerr<<"Syntax: dumresp LOCAL-ADDRESS LOCAL-PORT NUMBER-OF-PROCESSES"<<endl;
+}
+
 int main(int argc, char** argv)
 try
 {
-  if(argc != 4) {
-    cerr<<"Syntax: dumresp local-address local-port number-of-processes "<<endl;
-    exit(EXIT_FAILURE);
+  for(int i = 1; i < argc; i++) {
+    if((string) argv[i] == "--help"){
+      usage();
+      return(EXIT_SUCCESS);
+    }
+
+    if((string) argv[i] == "--version"){
+      cerr<<"dumresp "<<VERSION<<endl;
+      return(EXIT_SUCCESS);
+    }
   }
 
+  if(argc != 4) {
+    usage();
+    exit(EXIT_FAILURE);
+  }
 
   auto ptr = mmap(NULL, sizeof(std::atomic<uint64_t>), PROT_READ | PROT_WRITE,
 		  MAP_SHARED | MAP_ANONYMOUS, -1, 0);

--- a/pdns/ixplore.cc
+++ b/pdns/ixplore.cc
@@ -176,14 +176,30 @@ void loadZoneFromDisk(records_t& records, const string& fname, const DNSName& zo
   }
 }
 
+void usage() {
+  cerr<<"Syntax: ixplore diff ZONE BEFORE_FILE AFTER_FILE"<<endl;
+  cerr<<"Syntax: ixplore track IP-ADDRESS PORT ZONE DIRECTORY [TSIGKEY TSIGALGO TSIGSECRET]"<<endl;
+}
+
 int main(int argc, char** argv)
 try
 {
+  for(int n=1 ; n < argc; ++n) {
+    if ((string) argv[n] == "--help") {
+      usage();
+      return EXIT_SUCCESS;
+    }
+
+    if ((string) argv[n] == "--version") {
+      cerr<<"ixplore "<<VERSION<<endl;
+      return EXIT_SUCCESS;
+    }
+  }
+
   reportAllTypes();
   string command;
   if(argc < 5 || (command=argv[1], (command!="diff" && command !="track"))) {
-    cerr<<"Syntax: ixplore diff zone file1 file2"<<endl;
-    cerr<<"Syntax: ixplore track IP-address port zone directory [tsigkey tsigalgo tsigsecret]"<<endl;
+    usage();
     exit(EXIT_FAILURE);
   }
   if(command=="diff") {

--- a/pdns/notify.cc
+++ b/pdns/notify.cc
@@ -31,11 +31,28 @@ ArgvMap &arg()
   return arg;
 }
 
+void usage() {
+  cerr<<"Syntax: notify IP_ADDRESS[:PORT] DOMAIN"<<endl;
+}
+
 int main(int argc, char** argv)
 try
 {
+
+  for(int n=1 ; n < argc; ++n) {
+    if ((string) argv[n] == "--help") {
+      usage();
+      return EXIT_SUCCESS;
+    }
+
+    if ((string) argv[n] == "--version") {
+      cerr<<"notify "<<VERSION<<endl;
+      return EXIT_SUCCESS;
+    }
+  }
+
   if(argc!=3) {
-    cerr<<"Syntax: notify ip:port domain"<<endl;
+    usage();
     exit(1);
   }
 

--- a/pdns/nproxy.cc
+++ b/pdns/nproxy.cc
@@ -182,6 +182,11 @@ void expireOldNotifications()
 
 void daemonize(int null_fd);
 
+void usage(po::options_description &desc) {
+  cerr<<"nproxy"<<endl;
+  cerr<<desc<<endl;
+}
+
 int main(int argc, char** argv)
 try
 {
@@ -191,6 +196,7 @@ try
   po::options_description desc("Allowed options");
   desc.add_options()
     ("help,h", "produce help message")
+    ("version", "print the version")
     ("powerdns-address", po::value<string>(), "IP address of PowerDNS server")
     ("chroot", po::value<string>(), "chroot to this directory for additional security")
     ("setuid", po::value<int>(), "setuid to this numerical user id")
@@ -205,12 +211,18 @@ try
   po::notify(g_vm);
 
   if (g_vm.count("help")) {
-    cerr << desc << "\n";
+    usage(desc);
+    return EXIT_SUCCESS;
+  }
+
+  if (g_vm.count("version")) {
+    cerr << "nproxy " << VERSION << endl;
     return EXIT_SUCCESS;
   }
 
   if(!g_vm.count("powerdns-address")) {
-    cerr<<"Mandatory setting 'powerdns-address' unset:\n"<<desc<<endl;
+    cerr<<"Mandatory setting 'powerdns-address' unset:\n"<<endl;
+    usage(desc);
     return EXIT_FAILURE;
   }
 

--- a/pdns/nsec3dig.cc
+++ b/pdns/nsec3dig.cc
@@ -58,6 +58,11 @@ void proveOrDeny(const nsec3set &nsec3s, const DNSName &qname, const string &sal
   }
 }
 
+void usage() {
+  cerr<<"nsec3dig"<<endl;
+  cerr<<"Syntax: nsec3dig IP-ADDRESS PORT QUESTION QUESTION-TYPE [recurse]\n";
+}
+
 int main(int argc, char** argv)
 try
 {
@@ -65,8 +70,20 @@ try
 
   reportAllTypes();
 
+  for (int i = 1; i < argc; i++) {
+    if ((string) argv[i] == "--help") {
+      usage();
+      return EXIT_SUCCESS;
+    }
+
+    if ((string) argv[i] == "--version") {
+      cerr<<"nsec3dig "<<VERSION<<endl;
+      return EXIT_SUCCESS;
+    }
+  }
+
   if(argc < 5) {
-    cerr<<"Syntax: nsec3dig IP-address port question question-type [recurse]\n";
+    usage();
     exit(EXIT_FAILURE);
   }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2980,7 +2980,7 @@ int main(int argc, char **argv)
     if(::arg().mustDo("version")) {
       showProductVersion();
       showBuildConfiguration();
-      exit(99);
+      exit(0);
     }
 
     Logger::Urgency logUrgency = (Logger::Urgency)::arg().asNum("loglevel");

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1861,6 +1861,7 @@ try
   po::options_description desc("Allowed options");
   desc.add_options()
     ("help,h", "produce help message")
+    ("version", "show version")
     ("verbose,v", "be verbose")
     ("force", "force an action")
     ("config-name", po::value<string>()->default_value(""), "virtual configuration name")
@@ -1874,10 +1875,15 @@ try
 
   vector<string> cmds;
 
-  if(g_vm.count("commands")) 
+  if(g_vm.count("commands"))
     cmds = g_vm["commands"].as<vector<string> >();
 
   g_verbose = g_vm.count("verbose");
+
+  if (g_vm.count("version")) {
+    cout<<"pdnsutil "<<VERSION<<endl;
+    return 0;
+  }
 
   if(cmds.empty() || g_vm.count("help") || cmds[0] == "help") {
     cout<<"Usage: \npdnsutil [options] <command> [params ..]\n"<<endl;

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -50,6 +50,7 @@ static void initArguments(int argc, char** argv)
   arg().set("timeout", "Number of seconds to wait for the recursor to respond")="5";
   arg().set("config-name","Name of this virtual configuration - will rename the binary image")="";
   arg().setCmd("help","Provide this helpful message");
+  arg().setCmd("version","Show the version of this program");
 
   arg().laxParse(argc,argv);  
   if(arg().mustDo("help") || arg().getCommands().empty()) {
@@ -57,6 +58,11 @@ static void initArguments(int argc, char** argv)
     cout<<arg().helpstring(arg()["help"])<<endl;
     cout<<"In addition, 'rec_control help' can be used to retrieve a list\nof available commands from PowerDNS"<<endl;
     exit(arg().mustDo("help") ? 0 : 99);
+  }
+
+  if(arg().mustDo("version")) {
+    cout<<"rec_control version "<<VERSION<<endl;
+    exit(0);
   }
 
   string configname=::arg()["config-dir"]+"/recursor.conf";

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -21,6 +21,11 @@ string ttl(uint32_t ttl)
     return std::to_string(ttl);
 }
 
+void usage() {
+  cerr<<"sdig"<<endl;
+  cerr<<"Syntax: sdig IP-ADDRESS PORT QUESTION QUESTION-TYPE [dnssec] [recurse] [showflags] [hidesoadetails] [hidettl] [tcp] [ednssubnet SUBNET]"<<endl;
+}
+
 int main(int argc, char** argv)
 try
 {
@@ -31,12 +36,25 @@ try
   bool hidesoadetails=false;
   boost::optional<Netmask> ednsnm;
 
-  reportAllTypes();
+
+  for(int i=1; i<argc; i++) {
+    if ((string) argv[i] == "--help") {
+      usage();
+      exit(EXIT_SUCCESS);
+    }
+
+    if ((string) argv[i] == "--version") {
+      cerr<<"sdig "<<VERSION<<endl;
+      exit(EXIT_SUCCESS);
+    }
+  }
 
   if(argc < 5) {
-    cerr<<"Syntax: sdig IP-address port question question-type [dnssec] [recurse] [showflags] [hidesoadetails] [hidettl] [tcp] [ednssubnet SUBNET]\n";
+    usage();
     exit(EXIT_FAILURE);
   }
+
+  reportAllTypes();
 
   if (argc > 5) {
     for(int i=5; i<argc; i++) {

--- a/pdns/zone2json.cc
+++ b/pdns/zone2json.cc
@@ -111,6 +111,7 @@ try
     ::arg().set("soa-expire-default","Do not change")="0";
 
     ::arg().setCmd("help","Provide a helpful message");
+    ::arg().setCmd("version","Print the version");
 
     S.declare("logmessages");
 
@@ -118,7 +119,12 @@ try
     string zonefile="";
 
     ::arg().parse(argc, argv);
-  
+
+    if(::arg().mustDo("version")){
+      cerr<<"zone2json "<<VERSION<<endl;
+      exit(0);
+    }
+
     if(::arg().mustDo("help")) {
       cout<<"syntax:"<<endl<<endl;
       cout<<::arg().helpstring()<<endl;

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -152,6 +152,7 @@ int main( int argc, char* argv[] )
 #endif
                 reportAllTypes();
                 args.setCmd( "help", "Provide a helpful message" );
+                args.setCmd( "version", "Print the version" );
                 args.setSwitch( "verbose", "Verbose comments on operation" ) = "no";
                 args.setSwitch( "resume", "Continue after errors" ) = "no";
                 args.setSwitch( "dnsttl", "Add dnsttl attribute to every entry" ) = "no";
@@ -162,6 +163,11 @@ int main( int argc, char* argv[] )
                 args.set( "layout", "How to arrange entries in the directory (simple or as tree)" ) = "simple";
 
                 args.parse( argc, argv );
+
+                if(args.mustDo("version")) {
+                  cerr<<"zone2ldap "<<VERSION<<endl;
+                  exit(0);
+                }
 
                 if( args.mustDo( "help" ) )
                 {

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -292,6 +292,7 @@ try
     ::arg().set("soa-expire-default","Do not change")="0";
 
     ::arg().setCmd("help","Provide a helpful message");
+    ::arg().setCmd("version","Print the version");
 
     S.declare("logmessages");
 
@@ -299,6 +300,11 @@ try
     string zonefile="";
 
     ::arg().parse(argc, argv);
+
+    if(::arg().mustDo("version")) {
+      cerr<<"zone2sql "<<VERSION<<endl;
+      exit(0);
+    }
   
     if(::arg().mustDo("help")) {
       cout<<"syntax:"<<endl<<endl;


### PR DESCRIPTION
closes #270. This also hooks up missing manpages to the documentation website. For some reason the linkchecker fails on travis with:
```
This program requires Python requests 2.2.0 or later.
```

locally, the links are checked just fine though :).