### PR TITLE
refactor doResolve out of secpoll

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -186,6 +186,7 @@ pdns_server_SOURCES = \
 	sillyrecords.cc \
 	slavecommunicator.cc \
 	statbag.cc statbag.hh \
+	stubresolver.cc stubresolver.hh \
 	tcpreceiver.cc tcpreceiver.hh \
 	tkey.cc \
 	ueberbackend.cc ueberbackend.hh \

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -472,7 +472,7 @@ void mainthread()
    DNSPacket::s_udpTruncationThreshold = std::max(512, ::arg().asNum("udp-truncation-threshold"));
    DNSPacket::s_doEDNSSubnetProcessing = ::arg().mustDo("edns-subnet-processing");
 
-   secPollParseResolveConf();
+   stubParseResolveConf();
 
    if(!::arg()["chroot"].empty()) {
      triggerLoadOfLibraries();

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -14,6 +14,7 @@
 #include "dns_random.hh"
 #include "namespaces.hh"
 #include "statbag.hh"
+#include "stubresolver.hh"
 #include <stdint.h>
 #ifndef PACKAGEVERSION
 #define PACKAGEVERSION getPDNSVersion()
@@ -23,107 +24,6 @@ string g_security_message;
 
 extern StatBag S;
 
-// s_secpollresolvers contains the ComboAddresses that are used to resolve the
-// secpoll status of PowerDNS
-static vector<ComboAddress> s_secpollresolvers;
-
-/** Parse /etc/resolv.conf and add the nameservers to the vector
- * s_secpollresolvers.
- */
-void secPollParseResolveConf()
-{
-  ifstream ifs("/etc/resolv.conf");
-  if(!ifs)
-    return;
-
-  string line;
-  while(std::getline(ifs, line)) {
-    boost::trim_right_if(line, is_any_of(" \r\n\x1a"));
-    boost::trim_left(line); // leading spaces, let's be nice
-
-    string::size_type tpos = line.find_first_of(";#");
-    if(tpos != string::npos)
-      line.resize(tpos);
-
-    if(boost::starts_with(line, "nameserver ") || boost::starts_with(line, "nameserver\t")) {
-      vector<string> parts;
-      stringtok(parts, line, " \t,"); // be REALLY nice
-      for(vector<string>::const_iterator iter = parts.begin()+1; iter != parts.end(); ++iter) {
-        try {
-          s_secpollresolvers.push_back(ComboAddress(*iter, 53));
-        }
-        catch(...)
-        {
-        }
-      }
-    }
-  }
-  // Last resort, add 127.0.0.1
-  if(s_secpollresolvers.empty()) {
-    s_secpollresolvers.push_back(ComboAddress("127.0.0.1", 53));
-  }
-}
-
-int doResolve(const string& qname, uint16_t qtype, vector<DNSResourceRecord>& ret)
-{
-  vector<uint8_t> packet;
-
-  DNSPacketWriter pw(packet, DNSName(qname), qtype);
-  pw.getHeader()->id=dns_random(0xffff);
-  pw.getHeader()->rd=1;
-  if (s_secpollresolvers.empty()) {
-    L<<Logger::Warning<<"No recursors set, secpoll impossible."<<endl;
-    return RCode::ServFail;
-  }
-
-  string msg ="Doing secpoll, using resolvers: ";
-  for (const auto& server : s_secpollresolvers) {
-    msg += server.toString() + ", ";
-  }
-  L<<Logger::Debug<<msg.substr(0, msg.length() - 2)<<endl;
-
-  for(ComboAddress& dest :  s_secpollresolvers) {
-    Socket sock(dest.sin4.sin_family, SOCK_DGRAM);
-    sock.setNonBlocking();
-    sock.sendTo(string(packet.begin(), packet.end()), dest);
-
-    string reply;
-
-    waitForData(sock.getHandle(), 2, 0);
-    try {
-    retry:
-      sock.recvFrom(reply, dest);
-      if(reply.size() > sizeof(struct dnsheader)) {
-        struct dnsheader d;
-        memcpy(&d, reply.c_str(), sizeof(d));
-        if(d.id != pw.getHeader()->id)
-          goto retry;
-      }
-    }
-    catch(...) {
-      continue;
-    }
-    MOADNSParser mdp(reply);
-    if(mdp.d_header.rcode == RCode::ServFail)
-      continue;
-
-
-    for(MOADNSParser::answers_t::const_iterator i=mdp.d_answers.begin(); i!=mdp.d_answers.end(); ++i) {
-      if(i->first.d_place == 1 && i->first.d_type==qtype) {
-        DNSResourceRecord rr;
-        rr.qname = i->first.d_name;
-        rr.qtype = QType(i->first.d_type);
-        rr.content = i->first.d_content->getZoneRepresentation();
-        rr.ttl=i->first.d_ttl;
-        ret.push_back(rr);
-      }
-    }
-    L<<Logger::Debug<<"Secpoll got answered by "<<dest.toString()<<endl;
-    return mdp.d_header.rcode;
-  }
-  return RCode::ServFail;
-}
-
 /** Do an actual secpoll for the current version
  * @param first bool that tells if this is the first secpoll run since startup
  */
@@ -131,9 +31,6 @@ void doSecPoll(bool first)
 {
   if(::arg()["security-poll-suffix"].empty())
     return;
-
-  if(::arg().mustDo("recursor") && first)
-    s_secpollresolvers.push_back(ComboAddress(::arg()["recursor"], 53));
 
   struct timeval now;
   gettimeofday(&now, 0);

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -109,7 +109,7 @@ int doResolve(const string& qname, uint16_t qtype, vector<DNSResourceRecord>& re
 
 
     for(MOADNSParser::answers_t::const_iterator i=mdp.d_answers.begin(); i!=mdp.d_answers.end(); ++i) {
-      if(i->first.d_place == 1 && i->first.d_type==QType::TXT) {
+      if(i->first.d_place == 1 && i->first.d_type==qtype) {
         DNSResourceRecord rr;
         rr.qname = i->first.d_name;
         rr.qtype = QType(i->first.d_type);

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -46,7 +46,7 @@ void doSecPoll(bool first)
 
   vector<DNSResourceRecord> ret;
 
-  int res=doResolve(query, QType::TXT, ret);
+  int res=stubDoResolve(query, QType::TXT, ret);
 
   int security_status=0;
 

--- a/pdns/secpoll-auth.hh
+++ b/pdns/secpoll-auth.hh
@@ -2,9 +2,9 @@
 #define PDNS_SECPOLL_AUTH_HH
 #include <time.h>
 #include "namespaces.hh"
+#include "stubresolver.hh"
 
 void doSecPoll(bool first);
-void secPollParseResolveConf();
 extern std::string g_security_message;
 
 #endif

--- a/pdns/stubresolver.cc
+++ b/pdns/stubresolver.cc
@@ -1,0 +1,121 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "logger.hh"
+#include "arguments.hh"
+#include "version.hh"
+#include "misc.hh"
+
+#include "sstuff.hh"
+#include "dnswriter.hh"
+#include "dns_random.hh"
+#include "namespaces.hh"
+#include "statbag.hh"
+#include "stubresolver.hh"
+
+// s_secpollresolvers contains the ComboAddresses that are used to resolve the
+// secpoll status of PowerDNS
+static vector<ComboAddress> s_secpollresolvers;
+
+/** Parse /etc/resolv.conf and add the nameservers to the vector
+ * s_secpollresolvers.
+ */
+void secPollParseResolveConf()
+{
+  ifstream ifs("/etc/resolv.conf");
+  if(!ifs)
+    return;
+
+  string line;
+  while(std::getline(ifs, line)) {
+    boost::trim_right_if(line, is_any_of(" \r\n\x1a"));
+    boost::trim_left(line); // leading spaces, let's be nice
+
+    string::size_type tpos = line.find_first_of(";#");
+    if(tpos != string::npos)
+      line.resize(tpos);
+
+    if(boost::starts_with(line, "nameserver ") || boost::starts_with(line, "nameserver\t")) {
+      vector<string> parts;
+      stringtok(parts, line, " \t,"); // be REALLY nice
+      for(vector<string>::const_iterator iter = parts.begin()+1; iter != parts.end(); ++iter) {
+        try {
+          s_secpollresolvers.push_back(ComboAddress(*iter, 53));
+        }
+        catch(...)
+        {
+        }
+      }
+    }
+  }
+
+  if(::arg().mustDo("recursor"))
+    s_secpollresolvers.push_back(ComboAddress(::arg()["recursor"], 53));
+
+  // Last resort, add 127.0.0.1
+  if(s_secpollresolvers.empty()) {
+    s_secpollresolvers.push_back(ComboAddress("127.0.0.1", 53));
+  }
+}
+
+// s_secpollresolvers contains the ComboAddresses that are used to resolve the
+int doResolve(const string& qname, uint16_t qtype, vector<DNSResourceRecord>& ret)
+{
+  vector<uint8_t> packet;
+
+  DNSPacketWriter pw(packet, DNSName(qname), qtype);
+  pw.getHeader()->id=dns_random(0xffff);
+  pw.getHeader()->rd=1;
+  if (s_secpollresolvers.empty()) {
+    L<<Logger::Warning<<"No recursors set, secpoll impossible."<<endl;
+    return RCode::ServFail;
+  }
+
+  string msg ="Doing secpoll, using resolvers: ";
+  for (const auto& server : s_secpollresolvers) {
+    msg += server.toString() + ", ";
+  }
+  L<<Logger::Debug<<msg.substr(0, msg.length() - 2)<<endl;
+
+  for(ComboAddress& dest :  s_secpollresolvers) {
+    Socket sock(dest.sin4.sin_family, SOCK_DGRAM);
+    sock.setNonBlocking();
+    sock.sendTo(string(packet.begin(), packet.end()), dest);
+
+    string reply;
+
+    waitForData(sock.getHandle(), 2, 0);
+    try {
+    retry:
+      sock.recvFrom(reply, dest);
+      if(reply.size() > sizeof(struct dnsheader)) {
+        struct dnsheader d;
+        memcpy(&d, reply.c_str(), sizeof(d));
+        if(d.id != pw.getHeader()->id)
+          goto retry;
+      }
+    }
+    catch(...) {
+      continue;
+    }
+    MOADNSParser mdp(reply);
+    if(mdp.d_header.rcode == RCode::ServFail)
+      continue;
+
+
+    for(MOADNSParser::answers_t::const_iterator i=mdp.d_answers.begin(); i!=mdp.d_answers.end(); ++i) {
+      if(i->first.d_place == 1 && i->first.d_type==qtype) {
+        DNSResourceRecord rr;
+        rr.qname = i->first.d_name;
+        rr.qtype = QType(i->first.d_type);
+        rr.content = i->first.d_content->getZoneRepresentation();
+        rr.ttl=i->first.d_ttl;
+        ret.push_back(rr);
+      }
+    }
+    L<<Logger::Debug<<"Secpoll got answered by "<<dest.toString()<<endl;
+    return mdp.d_header.rcode;
+  }
+  return RCode::ServFail;
+}

--- a/pdns/stubresolver.hh
+++ b/pdns/stubresolver.hh
@@ -2,5 +2,5 @@
 #include "namespaces.hh"
 #include "dnsparser.hh"
 
-void secPollParseResolveConf();
-int doResolve(const string& qname, uint16_t qtype, vector<DNSResourceRecord>& ret);
+void stubParseResolveConf();
+int stubDoResolve(const string& qname, uint16_t qtype, vector<DNSResourceRecord>& ret);

--- a/pdns/stubresolver.hh
+++ b/pdns/stubresolver.hh
@@ -1,0 +1,6 @@
+#pragma once
+#include "namespaces.hh"
+#include "dnsparser.hh"
+
+void secPollParseResolveConf();
+int doResolve(const string& qname, uint16_t qtype, vector<DNSResourceRecord>& ret);


### PR DESCRIPTION
This is in preparation for switching #3733 from `FindNS` to `(stub)DoResolve`