### PR TITLE
rec: Fix a memory leak in DNSSEC validation

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -103,8 +103,10 @@ void validateWithKeySet(const cspmap_t& rrsets, cspmap_t& validated, const keyse
 	bool isValid = false;
 	try {
 	  unsigned int now=time(0);
-	  if(signature->d_siginception < now && signature->d_sigexpire > now)
-	    isValid = DNSCryptoKeyEngine::makeFromPublicKeyString(l.d_algorithm, l.d_key)->verify(msg, signature->d_signature);
+	  if(signature->d_siginception < now && signature->d_sigexpire > now) {
+	    std::shared_ptr<DNSCryptoKeyEngine> dke = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromPublicKeyString(l.d_algorithm, l.d_key));
+	    isValid = dke->verify(msg, signature->d_signature);
+	  }
 	  else {
 	    LOG("signature is expired/not yet valid"<<endl);
           }
@@ -273,8 +275,10 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
           bool isValid = false;
 	  try {
 	    unsigned int now = time(0);
-	    if(i->d_siginception < now && i->d_sigexpire > now)
-	      isValid = DNSCryptoKeyEngine::makeFromPublicKeyString(j.d_algorithm, j.d_key)->verify(msg, i->d_signature);
+	    if(i->d_siginception < now && i->d_sigexpire > now) {
+	      std::shared_ptr<DNSCryptoKeyEngine> dke = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromPublicKeyString(j.d_algorithm, j.d_key));
+	      isValid = dke->verify(msg, i->d_signature);
+	    }
 	  }
 	  catch(std::exception& e) {
 	    //	    cerr<<"Could not make a validator for signature: "<<e.what()<<endl;


### PR DESCRIPTION
`DNSCryptoKeyEngine::makeFromPublicKeyString()` returns a naked
pointer to a new object.