### PR TITLE
Prevent launching similarly named backend

### DIFF
--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -134,6 +134,10 @@ void BackendMakerClass::launch(const string &instr)
   vector<string> parts;
   stringtok(parts,instr,", ");
 
+  for (const auto part : parts)
+    if (count(parts.begin(), parts.end(), part) > 1)
+      throw ArgException("Refusing to launch multiple backends with the same name '" + part + "', verify all 'launch' statements in your configuration");
+
   for(vector<string>::const_iterator i=parts.begin();i!=parts.end();++i) {
     const string &part=*i;
 


### PR DESCRIPTION
This catches configuration bugs (mostly when includes are used) where a
line `launch=backend` and a line `launch+=backend` occur in the sum of
the configuration.

Closes #3615