### PR TITLE
Minor fixes to make coverity happier

### DIFF
--- a/pdns/dynmessenger.cc
+++ b/pdns/dynmessenger.cc
@@ -119,10 +119,7 @@ DynMessenger::~DynMessenger()
 int DynMessenger::send(const string &msg) const
 {
   try {
-    if(writen2(d_s, msg+"\n") < 0) { // sue me
-      perror("sendto");
-      return -1;
-    }
+    writen2(d_s, msg+"\n");
     return 0;
   } catch(std::runtime_error& e) {
     if (errno == EAGAIN)

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1005,14 +1005,14 @@ bool setSocketTimestamps(int fd)
   return true; // we pretend this happened.
 }
 
-void setTCPNoDelay(int sock)
+bool setTCPNoDelay(int sock)
 {
   int flag = 1;
-  setsockopt(sock,            /* socket affected */
-             IPPROTO_TCP,     /* set option at TCP level */
-             TCP_NODELAY,     /* name of option */
-             (char *) &flag,  /* the cast is historical cruft */
-             sizeof(flag));    /* length of option value */
+  return setsockopt(sock,            /* socket affected */
+                    IPPROTO_TCP,     /* set option at TCP level */
+                    TCP_NODELAY,     /* name of option */
+                    (char *) &flag,  /* the cast is historical cruft */
+                    sizeof(flag)) == 0;    /* length of option value */
 }
 
 

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -596,7 +596,7 @@ bool setBlocking( int sock );
 
 //! Sets the socket into non-blocking mode.
 bool setNonBlocking( int sock );
-void setTCPNoDelay(int sock);
+bool setTCPNoDelay(int sock);
 bool isNonBlocking(int sock);
 int closesocket(int fd);
 bool setCloseOnExec(int sock);


### PR DESCRIPTION
* Return false if `setsockopt()` failed in `setTCPNoDelay()`
* `writen2()` returns a size_t or throws an exception
* dnsdist: In verbose mode, warn if `sendto()`/`sendfromto()` failed
