### PR TITLE
Squash 2 compiler warnings in ws-auth.cc

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -530,7 +530,7 @@ static void apiZoneCryptokeys(HttpRequest* req, HttpResponse* resp) {
     throw ApiException("Only GET is implemented");
 
   bool inquireSingleKey = false;
-  int inquireKeyId;
+  unsigned int inquireKeyId = 0;
   if (req->parameters.count("key_id")) {
     inquireSingleKey = true;
     inquireKeyId = std::stoi(req->parameters["key_id"]);


### PR DESCRIPTION
Use the correct datatype and initialize. Closes #3832