### PR TITLE
dnsdist: Catch WrongTypeException in client mode

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -355,6 +355,10 @@ try
         throw;
       }
     }
+    catch(const LuaContext::WrongTypeException& e) {
+      response = "Command returned an object we can't print: " +std::string(e.what()) + "\n";
+      // tried to return something we don't understand
+    }
     catch(const LuaContext::ExecutionErrorException& e) {
       response = "Error: " + string(e.what()) + ": ";
       try {


### PR DESCRIPTION
Closes #3839.