### PR TITLE
Inform that log-failed-updates has been removed since 3.4.0

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -458,6 +458,13 @@ Tell PowerDNS to log all incoming DNS queries. This will lead to a lot of
 logging! Only enable for debugging! Set [`loglevel`](#loglevel) to at least 5
 to see the logs.
 
+## `log-failed-updates`
+* Boolean
+* Default: no
+* Removed in: 3.4.0
+
+If PowerDNS should log failed update requests.
+
 ## `lua-prequery-script`
 * Path
 


### PR DESCRIPTION
We know that `lazy-recursion` has been removed in 3.2.
It's also important to inform that `log-failed-updates` has been removed since 3.4.0.

 - I'm not sure that the default was `no`.
 - [In here](https://github.com/PowerDNS/pdns/blob/master/docs/markdown/authoritative/upgrading.md#31-to-32), I see:

> Some configuration settings (that did not do anything, anyway) have been removed. You need to remove them from your configuration to start pdns_server. They are: lazy-recursion, use-logfile, logfile.

 - Should I add another commit in the [*3.3.1 to 3.4.0* chapter](https://github.com/PowerDNS/pdns/blob/master/docs/markdown/authoritative/upgrading.md#331-to-340) to inform that:

> `log-failed-updates`setting has been removed. You need to remove it from your configuration to start pdns_server.

 