### PR TITLE
Remote backend doc example change (types)

### DIFF
--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -230,7 +230,7 @@ Query:
 
 Response:
 ```
-{"result":{"PRESIGNED":["NO"]}}
+{"result":{"PRESIGNED":["0"]}}
 ```
 
 #### Example HTTP/RPC
@@ -244,7 +244,7 @@ Response:
 HTTP/1.1 200 OK
 Content-Type: text/javascript; charset=utf-8
 
-{"result":{"PRESIGNED":["NO"]}}
+{"result":{"PRESIGNED":["0"]}}
 ```
 
 ### `getDomainMetadata`
@@ -262,7 +262,7 @@ Query:
 
 Response:
 ```
-{"result":["NO"]}
+{"result":["0"]}
 ```
 
 #### Example HTTP/RPC
@@ -276,7 +276,7 @@ Response:
 HTTP/1.1 200 OK
 Content-Type: text/javascript; charset=utf-8
 
-{"result":["NO"]}
+{"result":["0"]}
 ```
 
 ### `setDomainMetadata`


### PR DESCRIPTION
Modify the examples for `getDomainMetadata`, since the `"YES"` value does not currently seems to be parsed correctly by the remote backend.
`"1"` is correctly parsed as a boolean true