### PR TITLE
rec: Fix the `noEdnsOutQueries` counter

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -316,8 +316,6 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
      If '3', send bare queries
   */
 
-  g_stats.noEdnsOutQueries++;
-  
   SyncRes::EDNSStatus* ednsstatus;
   ednsstatus = &t_sstorage->ednsstatus[ip]; // does this include port? 
 


### PR DESCRIPTION
It was incremented for every call to `asyncresolveWrapper()`, then
one more time for queries sent without EDNS.