### PR TITLE
optimize only-notify logic

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -572,9 +572,18 @@ This is the server ID that will be returned on an EDNS NSID query.
 * IP Ranges, separated by commas or whitespace
 * Default: 0.0.0.0/0, ::/0
 
-Only send AXFR NOTIFY to these IP addresses or netmasks. The default is to
-notify the world. The IP addresses or netmasks in [`also-notify`](#also-notify)
-or ALSO-NOTIFY metadata always receive AXFR NOTIFY.
+For type=MASTER zones (or SLAVE zones with slave-renotify enabled) PowerDNS
+automatically sends NOTIFYs to the name servers specified in the NS records.
+By specifying networks/mask as whitelist, the targets can be limited. The default 
+is to notify the world. To completely disable these NOTIFYs set only-notify to an
+empty value. The IP addresses or netmasks in [`also-notify`](#also-notify)
+or ALSO-NOTIFY metadata always receive AXFR NOTIFY. 
+
+Note: Even if NOTIFYs are limited by a netmask, PowerDNS first has to resolve all the
+hostnames to get IP addresses. Thus, PowerDNS relies on DNS. If the respective
+authoritative name servers are slow, PowerDNS becomes slow too. To avoid this, set
+only-notify to an empty value and specify the notification targets with ALSO-NOTIFY
+and also-notify.
 
 ## `out-of-zone-additional-processing`
 * Boolean

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -80,6 +80,9 @@ void CommunicatorClass::go()
     L<<Logger::Error<<"Unparseable IP in only-notify. Error: "<<e.reason<<endl;
     exit(1);
   }
+  if ( !d_onlyNotify.size() ) {
+    L<<Logger::Warning<<"WARNING: only-notify is empty. Thus, automatic NOTIFYs to slave name servers will be disabled!"<<endl;
+  }
 
   vector<string> parts;
   stringtok(parts, ::arg()["also-notify"], ", \t");

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -185,7 +185,7 @@ public:
   bool notifyDomain(const DNSName &domain);
 private:
   void makeNotifySockets();
-  void queueNotifyDomain(const DNSName &domain, UeberBackend *B);
+  void queueNotifyDomain(const DNSName &domain, UeberBackend *B, DomainInfo::DomainKind);
   int d_nsock4, d_nsock6;
   map<pair<DNSName,string>,time_t>d_holes;
   pthread_mutex_t d_holelock;

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -49,30 +49,32 @@ void CommunicatorClass::queueNotifyDomain(const DNSName &domain, UeberBackend *B
   DNSResourceRecord rr;
   FindNS fns;
 
-  B->lookup(QType(QType::NS),domain);
-  while(B->get(rr))
-    nsset.insert(rr.content);
+  if (d_onlyNotify.size()) {
+    B->lookup(QType(QType::NS),domain);
+    while(B->get(rr))
+      nsset.insert(rr.content);
 
-  for(set<string>::const_iterator j=nsset.begin();j!=nsset.end();++j) {
-    vector<string> nsips=fns.lookup(DNSName(*j), B);
-    if(nsips.empty())
-      L<<Logger::Warning<<"Unable to queue notification of domain '"<<domain<<"': nameservers do not resolve!"<<endl;
-    else
-      for(vector<string>::const_iterator k=nsips.begin();k!=nsips.end();++k) {
-        const ComboAddress caIp(*k, 53);
-        if(!d_preventSelfNotification || !AddressIsUs(caIp)) {
-          if(!d_onlyNotify.match(&caIp))
-            L<<Logger::Info<<"Skipped notification of domain '"<<domain<<"' to "<<*j<<" because it does not match only-notify."<<endl;
-          else
-            ips.insert(caIp.toStringWithPort());
+    for(set<string>::const_iterator j=nsset.begin();j!=nsset.end();++j) {
+      vector<string> nsips=fns.lookup(DNSName(*j), B);
+      if(nsips.empty())
+        L<<Logger::Warning<<"Unable to queue notification of domain '"<<domain<<"': nameservers do not resolve!"<<endl;
+      else
+        for(vector<string>::const_iterator k=nsips.begin();k!=nsips.end();++k) {
+          const ComboAddress caIp(*k, 53);
+          if(!d_preventSelfNotification || !AddressIsUs(caIp)) {
+            if(!d_onlyNotify.match(&caIp))
+              L<<Logger::Info<<"Skipped notification of domain '"<<domain<<"' to "<<*j<<" because it does not match only-notify."<<endl;
+            else
+              ips.insert(caIp.toStringWithPort());
+          }
         }
-      }
-  }
+    }
 
-  for(set<string>::const_iterator j=ips.begin();j!=ips.end();++j) {
-    L<<Logger::Warning<<"Queued notification of domain '"<<domain<<"' to "<<*j<<endl;
-    d_nq.add(domain,*j);
-    hasQueuedItem=true;
+    for(set<string>::const_iterator j=ips.begin();j!=ips.end();++j) {
+      L<<Logger::Warning<<"Queued notification of domain '"<<domain<<"' to "<<*j<<endl;
+      d_nq.add(domain,*j);
+      hasQueuedItem=true;
+    }
   }
 
   set<string> alsoNotify(d_alsoNotify);
@@ -93,7 +95,7 @@ void CommunicatorClass::queueNotifyDomain(const DNSName &domain, UeberBackend *B
     }
   }
 
-  if (!hasQueuedItem)
+  if (!hasQueuedItem && d_onlyNotify.size())
     L<<Logger::Warning<<"Request to queue notification for domain '"<<domain<<"' was processed, but no valid nameservers or ALSO-NOTIFYs found. Not notifying!"<<endl;
 }
 


### PR DESCRIPTION
do not execute the NS-records NOTIFY logic if the only-notify "whitelist"
is empty, as a target will never match an empty whitelist.
