### PR TITLE
support clock_gettime for platforms that require -lrt

### DIFF
--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -139,7 +139,8 @@ pdns_recursor_LDADD = \
 	$(JSON11_LIBS) \
 	$(OPENSSL_LIBS) \
 	$(BOOST_CONTEXT_LIBS) \
-	$(SYSTEMD_LIBS)
+	$(SYSTEMD_LIBS) \
+	$(RT_LIBS)
 
 pdns_recursor_LDFLAGS = $(AM_LDFLAGS) \
 	$(OPENSSL_LDFLAGS)


### PR DESCRIPTION
Like el6