### PR TITLE
Disable protobuf detection in packages

### DIFF
--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -171,6 +171,7 @@ export CPPFLAGS="-DLDAP_DEPRECATED"
 	--with-lua \
 	--with-dynmodules='%{backends} random' \
 	--enable-tools \
+	--without-protobuf \
 	--enable-remotebackend-http \
 	--enable-unit-tests
 
@@ -438,6 +439,7 @@ export CPPFLAGS="-DLDAP_DEPRECATED"
 	--with-lua \
 	--with-dynmodules='%{backends} random' \
 	--enable-tools \
+	--without-protobuf \
 	--enable-unit-tests \
 	--enable-systemd
 
@@ -693,6 +695,7 @@ export CPPFLAGS="-DLDAP_DEPRECATED"
 	--with-lua \
 	--with-dynmodules='%{backends} random' \
 	--enable-tools \
+	--without-protobuf \
 	--enable-unit-tests \
 	--enable-systemd
 

--- a/build-scripts/build-dnsdist-rpm
+++ b/build-scripts/build-dnsdist-rpm
@@ -104,6 +104,7 @@ ${SETUP}
 %build
 %configure \
   --sysconfdir=/etc/dnsdist \
+  --without-protobuf \
   ${INIT_CONFIGURE}
   ${SODIUM_CONFIGURE}
 

--- a/build-scripts/build-recursor-rpm
+++ b/build-scripts/build-recursor-rpm
@@ -142,6 +142,7 @@ package if you need a dns cache for your network.
 	--disable-static \
 	--disable-dependency-tracking \
 	--disable-silent-rules \
+	--without-protobuf \
 	--enable-unit-tests
 
 make %{?_smp_mflags}
@@ -233,6 +234,7 @@ package if you need a dns cache for your network.
 	--disable-dependency-tracking \
 	--disable-silent-rules \
 	--enable-unit-tests \
+	--without-protobuf \
 	--enable-systemd
 
 make %{?_smp_mflags}

--- a/build-scripts/debian-authoritative/rules
+++ b/build-scripts/debian-authoritative/rules
@@ -49,6 +49,7 @@ override_dh_auto_configure:
 		--with-pgsql-includes=`pg_config --includedir` \
 		--enable-botan1.10 \
 		--enable-tools \
+		--without-protobuf \
 		--enable-unit-tests \
 		$(ENABLE_SYSTEMD)
 

--- a/build-scripts/debian-dnsdist/rules
+++ b/build-scripts/debian-dnsdist/rules
@@ -46,6 +46,7 @@ override_dh_auto_configure:
 	  --infodir=\$${prefix}/share/info \
 	  --libdir='$${prefix}/lib/$(DEB_HOST_MULTIARCH)' \
 	  --libexecdir='$${prefix}/lib' \
+	  --without-protobuf \
 	  $(ENABLE_SYSTEMD) \
 	  $(ENABLE_LIBSODIUM)
 

--- a/build-scripts/debian-recursor/rules
+++ b/build-scripts/debian-recursor/rules
@@ -46,6 +46,7 @@ override_dh_auto_configure:
 		--libdir='$${prefix}/lib/$(DEB_HOST_MULTIARCH)' \
 		--libexecdir='$${prefix}/lib' \
 		--enable-unit-tests \
+		--without-protobuf \
 		$(ENABLE_SYSTEMD)
 
 override_dh_auto_install:


### PR DESCRIPTION
So that we do not accidently link against it. A PR where we do enable protobuf support in packages will follow.