### PR TITLE
Recursor: Add dnssec=process-no-validate option

### DIFF
--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -176,8 +176,8 @@ supervisor that handles logging (like systemd). **Note**: do not use this settin
 in combination with [`daemon`](#daemon) as all logging will disappear.
 
 ## `dnssec`
-* One of `off`, `process`, `log-fail`, `validate`, String
-* Default: `off` (**note**: was `process` until 4.0.0-alpha2)
+* One of `off`, `process-no-validate`, `process`, `log-fail`, `validate`, String
+* Default: `process-no-validate` (**note**: was `process` until 4.0.0-alpha2)
 * Available since: 4.0.0
 
 Set the mode for DNSSEC processing:
@@ -187,9 +187,14 @@ No DNSSEC processing whatsoever. Ignore DO-bits in queries, don't request any
 DNSSEC information from authoritative servers. This behaviour is similar to
 PowerDNS Recursor pre-4.0.
 
-### `process`
+### `process-no-validate`
 Respond with DNSSEC records to clients that ask for it, set the DO bit on all
 outgoing queries. Don't do any validation.
+
+### `process`
+Respond with DNSSEC records to clients that ask for it, set the DO bit on all
+outgoing queries. Do validation for clients that request it (by means of the AD-
+bit in the query).
 
 ### `log-fail`
 Similar behaviour to `process`, but validate RRSIGs on responses and log bogus

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -960,7 +960,7 @@ void startDoResolve(void *p)
           }
 
           // Does the query or validation mode sending out a SERVFAIL on validation errors?
-          if(!pw.getHeader()->cd && (g_dnssecmode == DNSSECMode::ValidateAll || (dc->d_mdp.d_header.ad && g_dnssecmode != DNSSECMode::Off))) {
+          if(!pw.getHeader()->cd && (g_dnssecmode == DNSSECMode::ValidateAll || dc->d_mdp.d_header.ad)) {
             if(sr.doLog()) {
               L<<Logger::Warning<<"Sending out SERVFAIL for "<<dc->d_mdp.d_qname<<" because recursor or query demands it for Bogus results"<<endl;
             }
@@ -2523,6 +2523,8 @@ int serviceMain(int argc, char*argv[])
 
   if(::arg()["dnssec"]=="off") 
     g_dnssecmode=DNSSECMode::Off;
+  else if(::arg()["dnssec"]=="process-no-validate")
+    g_dnssecmode=DNSSECMode::ProcessNoValidate;
   else if(::arg()["dnssec"]=="process") 
     g_dnssecmode=DNSSECMode::Process;
   else if(::arg()["dnssec"]=="validate")
@@ -2855,7 +2857,7 @@ int main(int argc, char **argv)
     ::arg().set("local-address","IP addresses to listen on, separated by spaces or commas. Also accepts ports.")="127.0.0.1";
     ::arg().setSwitch("non-local-bind", "Enable binding to non-local addresses by using FREEBIND / BINDANY socket options")="no";
     ::arg().set("trace","if we should output heaps of logging. set to 'fail' to only log failing domains")="off";
-    ::arg().set("dnssec", "DNSSEC mode: off/process (default)/log-fail/validate")="process";
+    ::arg().set("dnssec", "DNSSEC mode: off/process-no-validate (default)/process/log-fail/validate")="process-no-validate";
     ::arg().set("daemon","Operate as a daemon")="no";
     ::arg().setSwitch("write-pid","Write a PID file")="yes";
     ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -975,8 +975,6 @@ void startDoResolve(void *p)
         }
       }
 
-
-
       if(ret.size()) {
         orderAndShuffle(ret);
 	if(auto sl = luaconfsLocal->sortlist.getOrderCmp(dc->d_remote)) {
@@ -2521,14 +2519,14 @@ int serviceMain(int argc, char*argv[])
   setupDelegationOnly();
   g_outgoingEDNSBufsize=::arg().asNum("edns-outgoing-bufsize");
 
-  if(::arg()["dnssec"]=="off") 
+  if(::arg()["dnssec"]=="off")
     g_dnssecmode=DNSSECMode::Off;
   else if(::arg()["dnssec"]=="process-no-validate")
     g_dnssecmode=DNSSECMode::ProcessNoValidate;
-  else if(::arg()["dnssec"]=="process") 
+  else if(::arg()["dnssec"]=="process")
     g_dnssecmode=DNSSECMode::Process;
   else if(::arg()["dnssec"]=="validate")
-    g_dnssecmode=DNSSECMode::ValidateAll; 
+    g_dnssecmode=DNSSECMode::ValidateAll;
   else if(::arg()["dnssec"]=="log-fail")
     g_dnssecmode=DNSSECMode::ValidateForLog;
   else {

--- a/pdns/validate-recursor.cc
+++ b/pdns/validate-recursor.cc
@@ -3,7 +3,7 @@
 #include "syncres.hh"
 #include "logger.hh"
 
-DNSSECMode g_dnssecmode{DNSSECMode::Process};
+DNSSECMode g_dnssecmode{DNSSECMode::ProcessNoValidate};
 
 #define LOG(x) if(g_dnssecLOG) { L <<Logger::Warning << x; }
 

--- a/pdns/validate-recursor.hh
+++ b/pdns/validate-recursor.hh
@@ -6,10 +6,11 @@
 vState validateRecords(const vector<DNSRecord>& recs);
 
 /* Off: 3.x behaviour, we do no DNSSEC, no EDNS
-   Process: we gather DNSSEC records on all queries, of you do do=1, we'll validate for you (unless you set cd=1)
+   ProcessNoValidate: we gather DNSSEC records on all queries, but we will never validate
+   Process: we gather DNSSEC records on all queries, if you do ad=1, we'll validate for you (unless you set cd=1)
    ValidateForLog: Process + validate all answers, but only log failures
    ValidateAll: DNSSEC issue -> servfail
 */
 
-enum class DNSSECMode { Off, Process, ValidateForLog, ValidateAll };
+enum class DNSSECMode { Off, Process, ProcessNoValidate, ValidateForLog, ValidateAll };
 extern DNSSECMode g_dnssecmode;


### PR DESCRIPTION
This option turns the recursor into a "Security-Aware Recursive Name Server" (RFC 4033 §2), meaning it will pass on RRSIGs and NSEC(3)s but will not validate, even when the client requests it. This is similar to e.g. unbound without the validator enabled.