### PR TITLE
Check for different boost versions

### DIFF
--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -15,12 +15,21 @@ PDNS_CHECK_LIBSODIUM
 DNSDIST_CHECK_RAGEL
 PDNS_CHECK_LIBEDIT
 PDNS_CHECK_CLOCK_GETTIME
-BOOST_REQUIRE([1.35])
+
+boost_required_version=1.35
+
+PDNS_WITH_PROTOBUF
+AS_IF([test "x$PROTOBUF_LIBS" != "x" -a x"$PROTOC" != "x"],
+  # The protobuf code needs boost::uuid, which is available from 1.42 onward
+  [boost_required_version=1.42]
+)
+
+BOOST_REQUIRE([$boost_required_version])
 BOOST_FOREACH
+
 PDNS_ENABLE_UNIT_TESTS
 PDNS_CHECK_RE2
 DNSDIST_ENABLE_DNSCRYPT
-PDNS_WITH_PROTOBUF
 
 AX_AVAILABLE_SYSTEMD
 AM_CONDITIONAL([HAVE_SYSTEMD], [ test x"$systemd" = "xy" ])

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -71,7 +71,15 @@ AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
 
 PDNS_CHECK_CLOCK_GETTIME
 
-BOOST_REQUIRE([1.35])
+boost_required_version=1.35
+
+PDNS_WITH_PROTOBUF
+AS_IF([test "x$PROTOBUF_LIBS" != "x" -a x"$PROTOC" != "x"],
+  # The protobuf code needs boost::uuid, which is available from 1.42 onward
+  [boost_required_version=1.42]
+)
+
+BOOST_REQUIRE([$boost_required_version])
 PDNS_SELECT_CONTEXT_IMPL
 
 PDNS_ENABLE_REPRODUCIBLE
@@ -121,7 +129,6 @@ AS_IF([test "x$enable_hardening" != "xno"], [
 
 PDNS_ENABLE_SANITIZERS
 PDNS_ENABLE_MALLOC_TRACE
-PDNS_WITH_PROTOBUF
 AX_AVAILABLE_SYSTEMD
 AM_CONDITIONAL([HAVE_SYSTEMD], [ test x"$systemd" = "xy" ])
 PDNS_CHECK_PANDOC


### PR DESCRIPTION
Enabling protobuf support means we need boost 1.42 (for boost::uuid), this PR ensures configure tests for this.