### PR TITLE
Don't eat exceptions in GSQLBackend::get, include these as errors in …

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1055,7 +1055,6 @@ bool GSQLBackend::get(DNSResourceRecord &r)
   // L << "GSQLBackend get() was called for "<<qtype.getName() << " record: ";
   SSqlStatement::row_t row;
 
-skiprow:
   if(d_query_stmt->hasNextRow()) {
     try {
       d_query_stmt->nextRow(row);
@@ -1065,8 +1064,8 @@ skiprow:
     }
     try {
       extractRecord(row, r);
-    } catch (...) {
-      goto skiprow;
+    } catch (std::exception &e) {
+      throw PDNSException("Exception '"+string(e.what())+"' occured for row: "+boost::algorithm::join(row, " | "));
     }
     return true;
   }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -448,8 +448,20 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
   vector<DNSResourceRecord> records;
   if(!suppliedrecords) {
     sd.db->list(zone, sd.domain_id, g_verbose);
-    while(sd.db->get(rr)) {
-      records.push_back(rr);
+
+    bool more=true;
+    while(more) {
+      try
+      {
+        more=sd.db->get(rr);
+        records.push_back(rr);
+      }
+      catch (PDNSException& e)
+      {
+        cout<<"[Error] Error from backend: "<<e.reason<<endl;
+        numerrors++;
+        numrecords++;
+      }
     }
   }
   else 


### PR DESCRIPTION
Don't eat exceptions in GSQLBackend::get, include these as errors in pdnsutil check-zone.

An example of a problem that was otherwise silently ignored was a record with owner name `toolongxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.example.com` (too long label).
