### PR TITLE
Remotebackend: Add getAllDomains call

### DIFF
--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -1052,6 +1052,38 @@ Content-Type: text/javascript; charset=utf-8
 {"result":"PONG"}
 ```
 
+### `getAllDomains`
+Get DomainInfo records for all domains in your backend.
+
+* Mandatory: no
+* Parameters: include_disabled
+* Reply: array of DomainInfo
+
+#### Example JSON/RPC
+Query:
+```
+{"method": "getAllDomains", "parameters": {"include_disabled": true}}
+```
+
+Response:
+```
+{"result":[{"id":1,"zone":"unit.test.","masters":["10.0.0.1"],"notified_serial":2,"serial":2,"last_check":1464693331,"kind":"native"}]}
+```
+
+#### Example HTTP/RPC
+Query:
+```
+GET /dnsapi/getAllDomains?includeDisabled=true
+```
+
+Response:
+```
+HTTP/1.1 200 OK
+Content-Type: text/javascript; charset=utf-8
+Content-Length: 135
+{"result":[{"id":1,"zone":"unit.test.","masters":["10.0.0.1"],"notified_serial":2,"serial":2,"last_check":1464693331,"kind":"native"}]}
+```
+
 ### `searchRecords`
 Can be used to search records from the backend. This is used by web api.
 

--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -221,6 +221,9 @@ void HTTPConnector::restful_requestbuilder(const std::string &method, const Json
         req.GET()["pattern"] = parameters["pattern"].string_value();
         req.GET()["maxResults"] = std::to_string(parameters["maxResults"].int_value());
         verb = "GET";
+   } else if (method == "getAllDomains") {
+        req.GET()["includeDisabled"] = (parameters["include_disabled"].bool_value()?"true":"false");
+        verb = "GET";
     } else {
         // perform normal get
         verb = "GET";

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -167,6 +167,7 @@ class RemoteBackend : public DNSBackend
   virtual string directBackendCmd(const string& querystr);
   virtual bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result);
   virtual bool searchComments(const string &pattern, int maxResults, vector<Comment>& result);
+  virtual void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false);
 
   static DNSBackend *maker();
 
@@ -198,5 +199,7 @@ class RemoteBackend : public DNSBackend
       } catch (JsonException) {};
       throw JsonException("Json value not convertible to boolean");
     };
+
+    void parseDomainInfo(const json11::Json &obj, DomainInfo &di);
 };
 #endif

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -193,6 +193,21 @@ BOOST_AUTO_TEST_CASE(test_method_getDomainInfo) {
    BOOST_CHECK_EQUAL(di.backend, be);
 }
 
+BOOST_AUTO_TEST_CASE(test_method_getAllDomains) {
+   DomainInfo di;
+   BOOST_TEST_MESSAGE("Testing getAllDomains method");
+   vector<DomainInfo> result;
+
+   be->getAllDomains(&result, true);
+
+   di = result[0];
+   BOOST_CHECK_EQUAL(di.zone.toString(), "unit.test.");
+   BOOST_CHECK_EQUAL(di.serial, 2);
+   BOOST_CHECK_EQUAL(di.notified_serial, 2);
+   BOOST_CHECK_EQUAL(di.kind, DomainInfo::Native);
+   BOOST_CHECK_EQUAL(di.backend, be);
+}
+
 BOOST_AUTO_TEST_CASE(test_method_isMaster) {
    BOOST_TEST_MESSAGE("Testing isMaster method");
    BOOST_CHECK(be->isMaster(DNSName("ns1.unit.test."), "10.0.0.1"));

--- a/modules/remotebackend/unittest.rb
+++ b/modules/remotebackend/unittest.rb
@@ -253,5 +253,9 @@ class Handler
    def do_directbackendcmd(args)
      [args["query"]]
    end
+
+   def do_getalldomains(args)
+     [do_getdomaininfo({'name'=>'unit.test.'})]
+   end
 end
 


### PR DESCRIPTION
Implements missing getAllDomains call which is needed if remotebackend is used as master backend.