### PR TITLE
auth: Disable dnsbulktest and dnstcpbench when boost is too old

### DIFF
--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -1,10 +1,15 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 104400
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/array.hpp>
 #include <boost/accumulators/statistics.hpp>
 #include <boost/program_options.hpp>
+#endif
+
 #include "inflighter.cc"
 #include <deque>
 #include "namespaces.hh"
@@ -13,13 +18,15 @@
 #include "misc.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
+StatBag S;
 
+
+#if BOOST_VERSION >= 104400
 using namespace boost::accumulators;
 namespace po = boost::program_options;
 
 po::variables_map g_vm;
 
-StatBag S;
 
 bool g_quiet=false;
 bool g_envoutput=false;
@@ -341,3 +348,10 @@ catch(PDNSException& pe)
   cerr<<"Fatal error: "<<pe.reason<<endl;
   exit(EXIT_FAILURE);
 }
+#else /* BOOST_VERSION */
+int main(int argc, char** argv)
+{
+  std::cerr<<"dnsbulktest requires boost >= 1.44.\n"<<std::endl;
+  return(EXIT_FAILURE);
+}
+#endif /* BOOST_VERSION */

--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -22,11 +22,18 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 104400
+#include <boost/array.hpp>
+#include <boost/program_options.hpp>
+
 #include <boost/accumulators/statistics/median.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
 #include <boost/accumulators/accumulators.hpp>
 
 #include <boost/accumulators/statistics.hpp>
+#endif
 
 #include "dnsparser.hh"
 #include "sstuff.hh"
@@ -35,11 +42,11 @@
 #include "dnsrecords.hh"
 #include "statbag.hh"
 #include <netinet/tcp.h>
-#include <boost/array.hpp>
-#include <boost/program_options.hpp>
 
 
 StatBag S;
+
+#if BOOST_VERSION >= 104400
 namespace po = boost::program_options;
 
 po::variables_map g_vm;
@@ -312,3 +319,10 @@ catch(std::exception &e)
 {
   cerr<<"Fatal: "<<e.what()<<endl;
 }
+#else /* BOOST_VERSION */
+int main(int argc, char** argv)
+{
+  std::cerr<<"dnstcpbench requires boost >= 1.44.\n"<<std::endl;
+  return(EXIT_FAILURE);
+}
+#endif /* BOOST_VERSION */


### PR DESCRIPTION
An other option would have been to remove the corresponding targets from the Makefile if boost is too old, but comparing version in the Makefile seemed wrong.
