### PR TITLE
dnsdist: Add `sourceBindAny` to allow a nonlocal address as source

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -202,6 +202,12 @@ The supported values for `source` are:
 
 Specifying the interface name is only supported on system having IP_PKTINFO.
 
+The `sourceBindAny` boolean parameter can be used to select a source address
+that does not exist on the host yet.
+
+```
+newServer({address="192.0.2.1", source="192.0.2.127", sourceBindAny=true})
+```
 
 Configuration management
 ------------------------
@@ -1040,7 +1046,7 @@ Here are all functions:
     * `setVerboseHealthChecks(bool)`: set whether health check errors will be logged
  * Server related:
     * `newServer("ip:port")`: instantiate a new downstream server with default settings
-    * `newServer({address="ip:port", qps=1000, order=1, weight=10, pool="abuse", retries=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName="a.root-servers.net.", checkType="A", maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source="address|interface name|address@interface"})`:
+    * `newServer({address="ip:port", qps=1000, order=1, weight=10, pool="abuse", retries=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName="a.root-servers.net.", checkType="A", maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source="address|interface name|address@interface", sourceBindAny=false})`:
 instantiate a server with additional parameters
     * `showServers()`: output all servers
     * `getServer(n)`: returns server with index n 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -156,6 +156,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			}
 			ComboAddress sourceAddr;
 			unsigned int sourceItf = 0;
+			bool sourceBindAny = false;
 			if(auto address = boost::get<string>(&pvars)) {
 			  std::shared_ptr<DownstreamState> ret;
 			  try {
@@ -241,9 +242,13 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			  }
 			}
 
+			if(vars.count("sourceBindAny")) {
+			  sourceBindAny = boost::get<bool>(vars["sourceBindAny"]);
+			}
+
 			std::shared_ptr<DownstreamState> ret;
 			try {
-			  ret=std::make_shared<DownstreamState>(ComboAddress(boost::get<string>(vars["address"]), 53), sourceAddr, sourceItf);
+			  ret=std::make_shared<DownstreamState>(ComboAddress(boost::get<string>(vars["address"]), 53), sourceAddr, sourceItf, sourceBindAny);
 			}
 			catch(std::exception& e) {
 			  g_outputBuffer="Error creating new server: "+string(e.what());

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -454,12 +454,40 @@ void* responderThread(std::shared_ptr<DownstreamState> state)
   return 0;
 }
 
-DownstreamState::DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf_): remote(remote_), sourceAddr(sourceAddr_), sourceItf(sourceItf_)
+static void bindAny(int af, int sock)
+{
+  int one = 1;
+
+#ifdef IP_FREEBIND
+  if (setsockopt(sock, IPPROTO_IP, IP_FREEBIND, &one, sizeof(one)) < 0)
+    warnlog("Warning: IP_FREEBIND setsockopt failed: %s", strerror(errno));
+#endif
+
+#ifdef IP_BINDANY
+  if (af == AF_INET)
+    if (setsockopt(sock, IPPROTO_IP, IP_BINDANY, &one, sizeof(one)) < 0)
+      warnlog("Warning: IP_BINDANY setsockopt failed: %s", strerror(errno));
+#endif
+#ifdef IPV6_BINDANY
+  if (af == AF_INET6)
+    if (setsockopt(sock, IPPROTO_IPV6, IPV6_BINDANY, &one, sizeof(one)) < 0)
+      warnlog("Warning: IPV6_BINDANY setsockopt failed: %s", strerror(errno));
+#endif
+#ifdef SO_BINDANY
+  if (setsockopt(sock, SOL_SOCKET, SO_BINDANY, &one, sizeof(one)) < 0)
+    warnlog("Warning: SO_BINDANY setsockopt failed: %s", strerror(errno));
+#endif
+}
+
+DownstreamState::DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf_, bool sourceBindAny_): remote(remote_), sourceAddr(sourceAddr_), sourceItf(sourceItf_), sourceBindAny(sourceBindAny_)
 {
   if (!IsAnyAddress(remote)) {
     fd = SSocket(remote.sin4.sin_family, SOCK_DGRAM, 0);
     if (!IsAnyAddress(sourceAddr)) {
       SSetsockopt(fd, SOL_SOCKET, SO_REUSEADDR, 1);
+      if (sourceBindAny) {
+        bindAny(sourceAddr.sin4.sin_family, fd);
+      }
       SBind(fd, sourceAddr);
     }
     SConnect(fd, remote);
@@ -1083,6 +1111,9 @@ try
   sock.setNonBlocking();
   if (!IsAnyAddress(ds.sourceAddr)) {
     sock.setReuseAddr();
+    if (ds.sourceBindAny) {
+      bindAny(ds.sourceAddr.sin4.sin_family, sock.getHandle());
+    }
     sock.bind(ds.sourceAddr);
   }
   sock.connect(ds.remote);
@@ -1275,33 +1306,6 @@ catch(std::exception& e)
 {
   close(fd);
   errlog("Control connection died: %s", e.what());
-}
-
-
-
-static void bindAny(int af, int sock)
-{
-  int one = 1;
-
-#ifdef IP_FREEBIND
-  if (setsockopt(sock, IPPROTO_IP, IP_FREEBIND, &one, sizeof(one)) < 0)
-    warnlog("Warning: IP_FREEBIND setsockopt failed: %s", strerror(errno));
-#endif
-
-#ifdef IP_BINDANY
-  if (af == AF_INET)
-    if (setsockopt(sock, IPPROTO_IP, IP_BINDANY, &one, sizeof(one)) < 0)
-      warnlog("Warning: IP_BINDANY setsockopt failed: %s", strerror(errno));
-#endif
-#ifdef IPV6_BINDANY
-  if (af == AF_INET6)
-    if (setsockopt(sock, IPPROTO_IPV6, IPV6_BINDANY, &one, sizeof(one)) < 0)
-      warnlog("Warning: IPV6_BINDANY setsockopt failed: %s", strerror(errno));
-#endif
-#ifdef SO_BINDANY
-  if (setsockopt(sock, SOL_SOCKET, SO_BINDANY, &one, sizeof(one)) < 0)
-    warnlog("Warning: SO_BINDANY setsockopt failed: %s", strerror(errno));
-#endif
 }
 
 static void dropGroupPrivs(gid_t gid)

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -301,8 +301,8 @@ extern std::shared_ptr<TCPClientCollection> g_tcpclientthreads;
 
 struct DownstreamState
 {
-  DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf);
-  DownstreamState(const ComboAddress& remote_): DownstreamState(remote_, ComboAddress(), 0) {}
+  DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf, bool sourceBindAny);
+  DownstreamState(const ComboAddress& remote_): DownstreamState(remote_, ComboAddress(), 0, false) {}
   ~DownstreamState()
   {
     if (fd >= 0)
@@ -345,6 +345,7 @@ struct DownstreamState
   bool mustResolve{false};
   bool upStatus{false};
   bool useECS{false};
+  bool sourceBindAny{false};
   bool isUp() const
   {
     if(availability == Availability::Down)


### PR DESCRIPTION
It allows specifying a source address to reach this backend that might not exist yet
on the host but will later, for example in HA setups.