### PR TITLE
pdns_control bind-add-zone check for zonefile

### DIFF
--- a/docs/manpages/pdns_control.1.md
+++ b/docs/manpages/pdns_control.1.md
@@ -3,7 +3,7 @@
 % December 2002
 
 # NAME
-**pdns_control** - Contreol the PowerDNS nameserver
+**pdns_control** - Control the PowerDNS nameserver
 
 # SYNOPSIS
 **pdns_control** [*OPTION*]... *COMMAND*
@@ -38,6 +38,21 @@
 
 
 # COMMANDS
+bind-add-zone *DOMAIN* *FILENAME*
+:    When using the bindbackend, add a zone. This zone is added in-memory and served
+     immediately. Note that this does not add the zone to the bind-config file.
+     *FILENAME* must be an absolute path.
+
+bind-domain-status [*DOMAIN*...]
+:    When using the bindbackend, list status of all domains. Optionally, append
+     *DOMAIN*s to get the status of specific zones.
+
+bind-list-rejects
+:    When using the bindbackend, get a list of all rejected domains.
+
+bind-reload-now *DOMAIN* [*DOMAIN*...]
+:    When using the bindbackend, immediately reload *DOMAIN* from disk.
+
 ccounts
 :    Show the content of the cache.
 

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -576,6 +576,14 @@ string Bind2Backend::DLAddDomainHandler(const vector<string>&parts, Utility::pid
   BB2DomainInfo bbd;
   if(safeGetBBDomainInfo(domainname, &bbd))
     return "Already loaded";
+
+  if (!boost::starts_with(filename, "/") && ::arg()["chroot"].empty())
+    return "Unable to load zone " + domainname.toStringRootDot() + " from " + filename + " as the filename is not absolute.";
+
+  struct stat buf;
+  if (stat(filename.c_str(), &buf) != 0)
+    return "Unable to load zone " + domainname.toStringRootDot() + " from " + filename + ": " + strerror(errno);
+
   Bind2Backend bb2; // createdomainentry needs access to our configuration
   bbd=bb2.createDomainEntry(domainname, filename);
   bbd.d_filename=filename;

--- a/regression-tests/tests/bind-add-zone/command
+++ b/regression-tests/tests/bind-add-zone/command
@@ -6,10 +6,10 @@ fi
 
 cleandig ns1.addzone.com A
 cleandig ns1.test.com A
-$PDNSCONTROL --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com zones/addzone.com
+$PDNSCONTROL --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com ${PWD}/zones/addzone.com
 $PDNSCONTROL --config-name=bind --socket-dir=. --no-config purge addzone.com
 sleep 1
-$PDNSCONTROL --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com zones/addzone.com
+$PDNSCONTROL --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com ${PWD}/zones/addzone.com
 sleep 1
 cleandig ns1.addzone.com A
 cleandig ns1.test.com A

--- a/regression-tests/tests/bind-add-zone/command
+++ b/regression-tests/tests/bind-add-zone/command
@@ -6,7 +6,7 @@ fi
 
 cleandig ns1.addzone.com A
 cleandig ns1.test.com A
-$PDNSCONTROL --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com ${PWD}/zones/addzone.com
+$PDNSCONTROL --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com ${PWD}/zones/addzone.com >/dev/null 2>&1
 $PDNSCONTROL --config-name=bind --socket-dir=. --no-config purge addzone.com
 sleep 1
 $PDNSCONTROL --config-name=bind --socket-dir=. --no-config bind-add-zone addzone.com ${PWD}/zones/addzone.com

--- a/regression-tests/tests/bind-add-zone/expected_result.bind
+++ b/regression-tests/tests/bind-add-zone/expected_result.bind
@@ -3,7 +3,6 @@ Reply to question for qname='ns1.addzone.com.', qtype=A
 0	ns1.test.com.	IN	A	3600	1.1.1.1
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='ns1.test.com.', qtype=A
-Loaded zone addzone.com from zones/addzone.com
 1
 Already loaded
 0	ns1.addzone.com.	IN	A	3600	1.1.1.5


### PR DESCRIPTION
We now check if we can access the zonefile before we add a zone to the
bindbackend via `pdns_control bind-add-zone`. By sheer luck, this
function worked on relative names (names were relative to the PWD of the
pdns_server process), so we now force the use of absolute names (unless
we are chrooted). Closes #3078

Update the pdns_control(1) manpage with the bind commands.