### PR TITLE
dnsdist: Filter on opcode, records count/type, trailing data

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -332,6 +332,10 @@ Rules have selectors and actions. Current selectors are:
  * RE2Rule on query name (optional)
  * Packet requests DNSSEC processing
  * Query received over UDP or TCP
+ * Opcode (OpcodeRule)
+ * Number of entries in a given section (RecordsCountRule)
+ * Number of entries of a specific type in a given section (RecordsTypeCountRule)
+ * Presence of trailing data (TrailingDataRule)
 
 Special rules are:
 
@@ -383,13 +387,17 @@ A DNS rule can be:
  * a MaxQPSRule
  * a NetmaskGroupRule
  * a NotRule
+ * an OpcodeRule
  * an OrRule
  * a QClassRule
  * a QTypeRule
  * a RegexRule
  * a RE2Rule
+ * a RecordsCountRule
+ * a RecordsTypeCountRule
  * a SuffixMatchNodeRule
  * a TCPRule
+ * a TrailingDataRule
 
 Some specific actions do not stop the processing when they match, contrary to all other actions:
 
@@ -1072,11 +1080,16 @@ instantiate a server with additional parameters
     * `NetmaskGroupRule()`: matches traffic from the specified network range
     * `NotRule()`: matches if the sub-rule does not match
     * `OrRule()`: matches if at least one of the sub-rules matches
+    * `OpcodeRule()`: matches queries with the specified opcode
     * `QClassRule(qclass)`: matches queries with the specified qclass (numeric)
     * `QTypeRule(qtype)`: matches queries with the specified qtype
     * `RegexRule(regex)`: matches the query name against the supplied regex
+    * `RecordsCountRule(section, minCount, maxCount)`: matches if there is at least `minCount` and at most `maxCount` records in the `section` section
+    * `RecordsTypeCountRule(section, type, minCount, maxCount)`: matches if there is at least `minCount` and at most `maxCount` records of type `type` in the `section` section
+    * `RE2Rule(regex)`: matches the query name against the supplied regex using the RE2 engine
     * `SuffixMatchNodeRule(smn, [quiet-bool])`: matches based on a group of domain suffixes for rapid testing of membership. Pass `true` as second parameter to prevent listing of all domains matched.
     * `TCPRule(tcp)`: matches question received over TCP if `tcp` is true, over UDP otherwise
+    * `TrailingDataRule()`: matches if the query has trailing data
  * Rule management related:
     * `getAction(num)`: returns the Action associate with rule 'num'.
     * `showRules()`: show all defined rules (Pool, Block, QPS, addAnyTCRule)
@@ -1192,6 +1205,7 @@ instantiate a server with additional parameters
         * member `dh`: DNSHeader
         * member `len`: the question length
         * member `localaddr`: ComboAddress of the local bind this question was received on
+        * member `opcode`: the question opcode
         * member `qname`: DNSName of this question
         * member `qclass`: QClass (as an unsigned integer) of this question
         * member `qtype`: QType (as an unsigned integer) of this question

--- a/pdns/dnsdistconf.lua
+++ b/pdns/dnsdistconf.lua
@@ -1,4 +1,3 @@
-
 -- listen for console connection with the given secret key
 controlSocket("0.0.0.0")
 setKey("MXNeLFWHUe4363BBKrY06cAsH8NWNb+Se2eXU5+Bb74=")
@@ -167,10 +166,10 @@ end
 -- addAction(AndRule({QTypeRule("ANY"), TCPRule(true)}), TCAction())
 
 -- return 'not implemented' for qtype != A over UDP
--- addAction(AndRule({NotRule(QTypeRule("A")), TCPRule(false)}), RCodeAction(4))
+-- addAction(AndRule({NotRule(QTypeRule("A")), TCPRule(false)}), RCodeAction(dnsdist.NOTIMPL))
 
 -- return 'not implemented' for qtype == A OR received over UDP
--- addAction(OrRule({QTypeRule("A"), TCPRule(false)}), RCodeAction(4))
+-- addAction(OrRule({QTypeRule("A"), TCPRule(false)}), RCodeAction(dnsdist.NOTIMPL))
 
 -- log all queries to a 'dndist.log' file, in text-mode (not binary)
 -- addAction(AllRule(), LogAction("dnsdist.log", false))
@@ -180,9 +179,16 @@ end
 
 -- drop all queries for the CHAOS class
 -- addAction(QClassRule(3), DropAction())
+-- addAction(QClassRule(DNSClass.CHAOS), DropAction())
+
+-- drop all queries with the UPDATE opcode
+-- addAction(OpcodeRule(DNSOpcode.Update), DropAction())
+
+-- refuse all queries not having exactly one question
+-- addAction(NotRule(RecordsCountRule(DNSSection.Question, 1, 1)), RCodeAction(dnsdist.REFUSED))
 
 -- return 'refused' for domains matching the regex evil[0-9]{4,}.powerdns.com$
--- addAction(RegexRule("evil[0-9]{4,}\\.powerdns\\.com$"), RCodeAction(5))
+-- addAction(RegexRule("evil[0-9]{4,}\\.powerdns\\.com$"), RCodeAction(dnsdist.REFUSED))
 
 -- spoof responses for A, AAAA and ANY for spoof.powerdns.com.
 -- A queries will get 192.0.2.1, AAAA 2001:DB8::1 and ANY both

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -652,14 +652,16 @@ void ageDNSPacket(char* packet, size_t length, uint32_t seconds)
     uint64_t n;
     for(n=0; n < ntohs(dh.qdcount) ; ++n) {
       dpm.skipLabel();
-      dpm.skipBytes(4); // qtype, qclass
+      /* type and class */
+      dpm.skipBytes(4);
     }
    // cerr<<"Skipped "<<n<<" questions, now parsing "<<numrecords<<" records"<<endl;
     for(n=0; n < numrecords; ++n) {
       dpm.skipLabel();
       
       uint16_t dnstype = dpm.get16BitInt();
-      /* uint16_t dnsclass = */ dpm.get16BitInt();
+      /* class */
+      dpm.skipBytes(2);
       
       if(dnstype == QType::OPT) // not aging that one with a stick
         break;
@@ -693,14 +695,15 @@ uint32_t getDNSPacketMinTTL(const char* packet, size_t length)
     const uint16_t qdcount = ntohs(dh->qdcount);
     for(size_t n = 0; n < qdcount; ++n) {
       dpm.skipLabel();
-      dpm.skipBytes(4); // qtype, qclass
+      /* type and class */
+      dpm.skipBytes(4);
     }
     const size_t numrecords = ntohs(dh->ancount) + ntohs(dh->nscount) + ntohs(dh->arcount);
     for(size_t n = 0; n < numrecords; ++n) {
       dpm.skipLabel();
-
       const uint16_t dnstype = dpm.get16BitInt();
-      /* uint16_t dnsclass = */ dpm.get16BitInt();
+      /* class */
+      dpm.skipBytes(2);
 
       if(dnstype == QType::OPT)
         break;
@@ -732,15 +735,14 @@ uint32_t getDNSPacketLength(const char* packet, size_t length)
     const uint16_t qdcount = ntohs(dh->qdcount);
     for(size_t n = 0; n < qdcount; ++n) {
       dpm.skipLabel();
-      dpm.skipBytes(4); // qtype, qclass
+      /* type and class */
+      dpm.skipBytes(4);
     }
     const size_t numrecords = ntohs(dh->ancount) + ntohs(dh->nscount) + ntohs(dh->arcount);
     for(size_t n = 0; n < numrecords; ++n) {
       dpm.skipLabel();
-
-      /* const uint16_t dnstype */ dpm.get16BitInt();
-      /* uint16_t dnsclass */ dpm.get16BitInt();
-      /* const uint32_t ttl */ dpm.get32BitInt();
+      /* type (2), class (2) and ttl (4) */
+      dpm.skipBytes(8);
       dpm.skipRData();
     }
     result = dpm.getOffset();
@@ -770,9 +772,11 @@ uint16_t getRecordsOfTypeCount(const char* packet, size_t length, uint8_t sectio
         if (dnstype == type) {
           result++;
         }
-        dpm.skipBytes(2); // qclass
+        /* class */
+        dpm.skipBytes(2);
       } else {
-        dpm.skipBytes(4); // qtype, qclass
+        /* type and class */
+        dpm.skipBytes(4);
       }
     }
     const uint16_t ancount = ntohs(dh->ancount);
@@ -783,11 +787,14 @@ uint16_t getRecordsOfTypeCount(const char* packet, size_t length, uint8_t sectio
         if (dnstype == type) {
           result++;
         }
-        dpm.skipBytes(2); // qclass
+        /* class */
+        dpm.skipBytes(2);
       } else {
-        dpm.skipBytes(4); // qtype, qclass
+        /* type and class */
+        dpm.skipBytes(4);
       }
-      /* const uint32_t ttl */ dpm.get32BitInt();
+      /* ttl */
+      dpm.skipBytes(4);
       dpm.skipRData();
     }
     const uint16_t nscount = ntohs(dh->nscount);
@@ -798,11 +805,14 @@ uint16_t getRecordsOfTypeCount(const char* packet, size_t length, uint8_t sectio
         if (dnstype == type) {
           result++;
         }
-        dpm.skipBytes(2); // qclass
+        /* class */
+        dpm.skipBytes(2);
       } else {
-        dpm.skipBytes(4); // qtype, qclass
+        /* type and class */
+        dpm.skipBytes(4);
       }
-      /* const uint32_t ttl */ dpm.get32BitInt();
+      /* ttl */
+      dpm.skipBytes(4);
       dpm.skipRData();
     }
     const uint16_t arcount = ntohs(dh->arcount);
@@ -813,11 +823,14 @@ uint16_t getRecordsOfTypeCount(const char* packet, size_t length, uint8_t sectio
         if (dnstype == type) {
           result++;
         }
-        dpm.skipBytes(2); // qclass
+        /* class */
+        dpm.skipBytes(2);
       } else {
-        dpm.skipBytes(4); // qtype, qclass
+        /* type and class */
+        dpm.skipBytes(4);
       }
-      /* const uint32_t ttl */ dpm.get32BitInt();
+      /* ttl */
+      dpm.skipBytes(4);
       dpm.skipRData();
     }
   }

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -617,6 +617,10 @@ public:
     tmp = htonl(tmp);
     memcpy(d_packet + d_offset-4, (const char*)&tmp, sizeof(tmp));
   }
+  uint32_t getOffset() const
+  {
+    return d_offset;
+  }
 private:
   void moveOffset(uint16_t by)
   {
@@ -705,6 +709,115 @@ uint32_t getDNSPacketMinTTL(const char* packet, size_t length)
       if (result > ttl)
         result = ttl;
 
+      dpm.skipRData();
+    }
+  }
+  catch(...)
+  {
+  }
+  return result;
+}
+
+uint32_t getDNSPacketLength(const char* packet, size_t length)
+{
+  uint32_t result = length;
+  if(length < sizeof(dnsheader)) {
+    return result;
+  }
+  try
+  {
+    const dnsheader* dh = (const dnsheader*) packet;
+    DNSPacketMangler dpm(const_cast<char*>(packet), length);
+
+    const uint16_t qdcount = ntohs(dh->qdcount);
+    for(size_t n = 0; n < qdcount; ++n) {
+      dpm.skipLabel();
+      dpm.skipBytes(4); // qtype, qclass
+    }
+    const size_t numrecords = ntohs(dh->ancount) + ntohs(dh->nscount) + ntohs(dh->arcount);
+    for(size_t n = 0; n < numrecords; ++n) {
+      dpm.skipLabel();
+
+      /* const uint16_t dnstype */ dpm.get16BitInt();
+      /* uint16_t dnsclass */ dpm.get16BitInt();
+      /* const uint32_t ttl */ dpm.get32BitInt();
+      dpm.skipRData();
+    }
+    result = dpm.getOffset();
+  }
+  catch(...)
+  {
+  }
+  return result;
+}
+
+uint16_t getRecordsOfTypeCount(const char* packet, size_t length, uint8_t section, uint16_t type)
+{
+  uint16_t result = 0;
+  if(length < sizeof(dnsheader)) {
+    return result;
+  }
+  try
+  {
+    const dnsheader* dh = (const dnsheader*) packet;
+    DNSPacketMangler dpm(const_cast<char*>(packet), length);
+
+    const uint16_t qdcount = ntohs(dh->qdcount);
+    for(size_t n = 0; n < qdcount; ++n) {
+      dpm.skipLabel();
+      if (section == 0) {
+        uint16_t dnstype = dpm.get16BitInt();
+        if (dnstype == type) {
+          result++;
+        }
+        dpm.skipBytes(2); // qclass
+      } else {
+        dpm.skipBytes(4); // qtype, qclass
+      }
+    }
+    const uint16_t ancount = ntohs(dh->ancount);
+    for(size_t n = 0; n < ancount; ++n) {
+      dpm.skipLabel();
+      if (section == 1) {
+        uint16_t dnstype = dpm.get16BitInt();
+        if (dnstype == type) {
+          result++;
+        }
+        dpm.skipBytes(2); // qclass
+      } else {
+        dpm.skipBytes(4); // qtype, qclass
+      }
+      /* const uint32_t ttl */ dpm.get32BitInt();
+      dpm.skipRData();
+    }
+    const uint16_t nscount = ntohs(dh->nscount);
+    for(size_t n = 0; n < nscount; ++n) {
+      dpm.skipLabel();
+      if (section == 2) {
+        uint16_t dnstype = dpm.get16BitInt();
+        if (dnstype == type) {
+          result++;
+        }
+        dpm.skipBytes(2); // qclass
+      } else {
+        dpm.skipBytes(4); // qtype, qclass
+      }
+      /* const uint32_t ttl */ dpm.get32BitInt();
+      dpm.skipRData();
+    }
+    const uint16_t arcount = ntohs(dh->arcount);
+    for(size_t n = 0; n < arcount; ++n) {
+      dpm.skipLabel();
+      if (section == 3) {
+        uint16_t dnstype = dpm.get16BitInt();
+        if (dnstype == type) {
+          result++;
+        }
+        dpm.skipBytes(2); // qclass
+      } else {
+        dpm.skipBytes(4); // qtype, qclass
+      }
+      /* const uint32_t ttl */ dpm.get32BitInt();
       dpm.skipRData();
     }
   }

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -381,6 +381,8 @@ string simpleCompress(const string& label, const string& root="");
 void ageDNSPacket(char* packet, size_t length, uint32_t seconds);
 void ageDNSPacket(std::string& packet, uint32_t seconds);
 uint32_t getDNSPacketMinTTL(const char* packet, size_t length);
+uint32_t getDNSPacketLength(const char* packet, size_t length);
+uint16_t getRecordsOfTypeCount(const char* packet, size_t length, uint8_t section, uint16_t type);
 
 template<typename T>
 std::shared_ptr<T> getRR(const DNSRecord& dr)

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -144,14 +144,15 @@ class DNSDistTest(unittest.TestCase):
         return response
 
     @classmethod
-    def UDPResponder(cls, port):
+    def UDPResponder(cls, port, ignoreTrailing=False):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         sock.bind(("127.0.0.1", port))
         while True:
             data, addr = sock.recvfrom(4096)
-            request = dns.message.from_wire(data)
+            request = dns.message.from_wire(data, ignore_trailing=ignoreTrailing)
             response = cls._getResponse(request)
+
             if not response:
                 continue
 
@@ -161,7 +162,7 @@ class DNSDistTest(unittest.TestCase):
         sock.close()
 
     @classmethod
-    def TCPResponder(cls, port):
+    def TCPResponder(cls, port, ignoreTrailing=False):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         try:
@@ -177,8 +178,9 @@ class DNSDistTest(unittest.TestCase):
             data = conn.recv(2)
             (datalen,) = struct.unpack("!H", data)
             data = conn.recv(datalen)
-            request = dns.message.from_wire(data)
+            request = dns.message.from_wire(data, ignore_trailing=ignoreTrailing)
             response = cls._getResponse(request)
+
             if not response:
                 continue
 
@@ -189,7 +191,7 @@ class DNSDistTest(unittest.TestCase):
         sock.close()
 
     @classmethod
-    def sendUDPQuery(cls, query, response, useQueue=True, timeout=2.0):
+    def sendUDPQuery(cls, query, response, useQueue=True, timeout=2.0, rawQuery=False):
         if useQueue:
             cls._toResponderQueue.put(response, True, timeout)
 
@@ -197,7 +199,9 @@ class DNSDistTest(unittest.TestCase):
             cls._sock.settimeout(timeout)
 
         try:
-            cls._sock.send(query.to_wire())
+            if not rawQuery:
+                query = query.to_wire()
+            cls._sock.send(query)
             data = cls._sock.recv(4096)
         except socket.timeout:
             data = None
@@ -214,7 +218,7 @@ class DNSDistTest(unittest.TestCase):
         return (receivedQuery, message)
 
     @classmethod
-    def sendTCPQuery(cls, query, response, useQueue=True, timeout=2.0):
+    def sendTCPQuery(cls, query, response, useQueue=True, timeout=2.0, rawQuery=False):
         if useQueue:
             cls._toResponderQueue.put(response, True, timeout)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -224,7 +228,11 @@ class DNSDistTest(unittest.TestCase):
         sock.connect(("127.0.0.1", cls._dnsDistPort))
 
         try:
-            wire = query.to_wire()
+            if not rawQuery:
+                wire = query.to_wire()
+            else:
+                wire = query
+
             sock.send(struct.pack("!H", len(wire)))
             sock.send(wire)
             data = sock.recv(2)

--- a/regression-tests.dnsdist/test_Basics.py
+++ b/regression-tests.dnsdist/test_Basics.py
@@ -10,10 +10,10 @@ class TestBasics(DNSDistTest):
     newServer{address="127.0.0.1:%s"}
     truncateTC(true)
     addAnyTCRule()
-    addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(5))
+    addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(dnsdist.REFUSED))
     mySMN = newSuffixMatchNode()
     mySMN:add(newDNSName("nameAndQtype.tests.powerdns.com."))
-    addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(4))
+    addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(dnsdist.NOTIMP))
     addAction(makeRule("drop.test.powerdns.com."), DropAction())
     block=newDNSName("powerdns.org.")
     function blockFilter(dq)

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -2,9 +2,8 @@
 import Queue
 import threading
 import socket
+import sys
 import time
-import unittest
-import dns
 from dnsdisttests import DNSDistTest
 
 class TestCarbon(DNSDistTest):

--- a/regression-tests.dnsdist/test_CheckConfig.py
+++ b/regression-tests.dnsdist/test_CheckConfig.py
@@ -2,7 +2,6 @@
 import unittest
 import os
 import subprocess
-import sys
 import time
 
 class TestCheckConfig(unittest.TestCase):
@@ -35,10 +34,10 @@ class TestCheckConfig(unittest.TestCase):
             newServer{address="127.0.0.1:53"}
             truncateTC(true)
             addAnyTCRule()
-            addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(5))
+            addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(dnsdist.REFUSED))
             mySMN = newSuffixMatchNode()
             mySMN:add(newDNSName("nameAndQtype.tests.powerdns.com."))
-            addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(4))
+            addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(dnsdist.NOTIMP))
             addAction(makeRule("drop.test.powerdns.com."), DropAction())
             block=newDNSName("powerdns.org.")
             function blockFilter(dq)

--- a/regression-tests.dnsdist/test_EdnsClientSubnet.py
+++ b/regression-tests.dnsdist/test_EdnsClientSubnet.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import unittest
 import dns
 import clientsubnetoption
 import cookiesoption

--- a/regression-tests.dnsdist/test_RecordsCount.py
+++ b/regression-tests.dnsdist/test_RecordsCount.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+import copy
+import os
+import dns
+from dnsdisttests import DNSDistTest
+
+class TestRecordsCountOnlyOneAR(DNSDistTest):
+
+    _config_template = """
+    addAction(NotRule(RecordsCountRule(DNSSection.Additional, 1, 1)), RCodeAction(dnsdist.REFUSED))
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testRecordsCountRefuseEmptyAR(self):
+        """
+        RecordsCount: Refuse arcount == 0
+
+        Send a query to "refuseemptyar.recordscount.tests.powerdns.com.",
+        check that we are getting a REFUSED response.
+        """
+        name = 'refuseemptyar.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+    def testRecordsCountAllowOneAR(self):
+        """
+        RecordsCount: Allow arcount == 1
+
+        Send a query to "allowonear.recordscount.tests.powerdns.com.",
+        check that we are getting a valid response.
+        """
+        name = 'allowonear.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
+        response = dns.message.make_response(query)
+        response.answer.append(dns.rrset.from_text(name,
+                                                   3600,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.A,
+                                                   '127.0.0.1'))
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+    def testRecordsCountRefuseTwoAR(self):
+        """
+        RecordsCount: Refuse arcount > 1
+
+        Send a query to "refusetwoar.recordscount.tests.powerdns.com.",
+        check that we are getting a REFUSED response.
+        """
+        name = 'refusetwoar.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
+        query.additional.append(dns.rrset.from_text(name,
+                                                    3600,
+                                                    dns.rdataclass.IN,
+                                                    dns.rdatatype.A,
+                                                    '127.0.0.1'))
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+class TestRecordsCountMoreThanOneLessThanFour(DNSDistTest):
+
+    _config_template = """
+    addAction(RecordsCountRule(DNSSection.Answer, 2, 3), AllowAction())
+    addAction(AllRule(), RCodeAction(dnsdist.REFUSED))
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testRecordsCountRefuseOneAN(self):
+        """
+        RecordsCount: Refuse ancount == 0
+
+        Send a query to "refusenoan.recordscount.tests.powerdns.com.",
+        check that we are getting a REFUSED response.
+        """
+        name = 'refusenoan.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+    def testRecordsCountAllowTwoAN(self):
+        """
+        RecordsCount: Allow ancount == 2
+
+        Send a query to "allowtwoan.recordscount.tests.powerdns.com.",
+        check that we are getting a valid response.
+        """
+        name = 'allowtwoan.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
+        rrset = dns.rrset.from_text_list(name,
+                                         3600,
+                                         dns.rdataclass.IN,
+                                         dns.rdatatype.A,
+                                         ['127.0.0.1', '127.0.0.2'])
+        query.answer.append(rrset)
+        response = dns.message.make_response(query)
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+    def testRecordsCountRefuseFourAN(self):
+        """
+        RecordsCount: Refuse ancount > 3
+
+        Send a query to "refusefouran.recordscount.tests.powerdns.com.",
+        check that we are getting a REFUSED response.
+        """
+        name = 'refusefouran.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
+        rrset = dns.rrset.from_text_list(name,
+                                         3600,
+                                         dns.rdataclass.IN,
+                                         dns.rdatatype.A,
+                                         ['127.0.0.1', '127.0.0.2', '127.0.0.3', '127.0.0.4'])
+        query.answer.append(rrset)
+
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+        expectedResponse.answer.append(rrset)
+
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+class TestRecordsCountNothingInNS(DNSDistTest):
+
+    _config_template = """
+    addAction(RecordsCountRule(DNSSection.Authority, 0, 0), AllowAction())
+    addAction(AllRule(), RCodeAction(dnsdist.REFUSED))
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testRecordsCountRefuseNS(self):
+        """
+        RecordsCount: Refuse nscount != 0
+
+        Send a query to "refusens.recordscount.tests.powerdns.com.",
+        check that we are getting a REFUSED response.
+        """
+        name = 'refusens.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.NS,
+                                    'ns.tests.powerdns.com.')
+        query.authority.append(rrset)
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+        expectedResponse.authority.append(rrset)
+
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+
+    def testRecordsCountAllowEmptyNS(self):
+        """
+        RecordsCount: Allow nscount == 0
+
+        Send a query to "allowns.recordscount.tests.powerdns.com.",
+        check that we are getting a valid response.
+        """
+        name = 'allowns.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        response.answer.append(dns.rrset.from_text(name,
+                                                   3600,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.A,
+                                                   '127.0.0.1'))
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+class TestRecordsCountNoOPTInAR(DNSDistTest):
+
+    _config_template = """
+    addAction(NotRule(RecordsTypeCountRule(DNSSection.Additional, dnsdist.OPT, 0, 0)), RCodeAction(dnsdist.REFUSED))
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testRecordsCountRefuseOPTinAR(self):
+        """
+        RecordsTypeCount: Refuse OPT in AR
+
+        Send a query to "refuseoptinar.recordscount.tests.powerdns.com.",
+        check that we are getting a REFUSED response.
+        """
+        name = 'refuseoptinar.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True)
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+    def testRecordsCountAllowNoOPTInAR(self):
+        """
+        RecordsTypeCount: Allow no OPT in AR
+
+        Send a query to "allownooptinar.recordscount.tests.powerdns.com.",
+        check that we are getting a valid response.
+        """
+        name = 'allowwnooptinar.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        response.answer.append(dns.rrset.from_text(name,
+                                                   3600,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.A,
+                                                   '127.0.0.1'))
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)

--- a/regression-tests.dnsdist/test_Trailing.py
+++ b/regression-tests.dnsdist/test_Trailing.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+import threading
+import dns
+from dnsdisttests import DNSDistTest
+
+class TestTrailing(DNSDistTest):
+
+    # this test suite uses a different responder port
+    # because, contrary to the other ones, its
+    # responders allow trailing data and we don't want
+    # to mix things up.
+    _testServerPort = 5360
+    _config_template = """
+    newServer{address="127.0.0.1:%s"}
+    addAction(AndRule({QTypeRule(dnsdist.AAAA), TrailingDataRule()}), DropAction())
+    """
+    @classmethod
+    def startResponders(cls):
+        print("Launching responders..")
+
+        cls._UDPResponder = threading.Thread(name='UDP Responder', target=cls.UDPResponder, args=[cls._testServerPort, True])
+        cls._UDPResponder.setDaemon(True)
+        cls._UDPResponder.start()
+        cls._TCPResponder = threading.Thread(name='TCP Responder', target=cls.TCPResponder, args=[cls._testServerPort, True])
+        cls._TCPResponder.setDaemon(True)
+        cls._TCPResponder.start()
+
+    def testTrailingAllowed(self):
+        """
+        Trailing: Allowed
+
+        """
+        name = 'allowed.trailing.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        raw = query.to_wire()
+        raw = raw + 'A'* 20
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(raw, response, rawQuery=True)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(raw, response, rawQuery=True)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+    def testTrailingDropped(self):
+        """
+        Trailing: dropped
+
+        """
+        name = 'dropped.trailing.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AAAA', 'IN')
+
+        raw = query.to_wire()
+        raw = raw + 'A'* 20
+
+        (_, receivedResponse) = self.sendUDPQuery(raw, response=None, rawQuery=True)
+        self.assertEquals(receivedResponse, None)
+        (_, receivedResponse) = self.sendTCPQuery(raw, response=None, rawQuery=True)
+        self.assertEquals(receivedResponse, None)


### PR DESCRIPTION
* Add `OpcodeRule()` to filter on opcode + DNSOpcode.* Lua values
* Add `TrailingDataRule()` to filter queries with trailing data
* Add `RecordsCountRule(section, minCount, maxCount)` to match on
the number of records in a given section
* Add `RecordsTypeCountRule(section, type, minCount, maxCount)` to
match on the number of records of type `type` in a given section
* Add DNSSection.* Lua values
* Add DNSClass.* Lua values