### PR TITLE
GSQL: use lazy prepared statements

### DIFF
--- a/modules/godbcbackend/sodbc.hh
+++ b/modules/godbcbackend/sodbc.hh
@@ -24,7 +24,7 @@ private:
   SQLHDBC   m_connection;   //!< Database connection handle.
   SQLHENV   m_environment;  //!< Database environment handle
 
-
+  void testResult(SQLRETURN result, SQLSMALLINT type, SQLHANDLE handle, const std::string & message);
 
 public:
   //! Default constructor.

--- a/modules/goraclebackend/soracle.cc
+++ b/modules/goraclebackend/soracle.cc
@@ -347,9 +347,9 @@ private:
         throw SSqlException("Cannot prepare statement (1): " + d_query + string(": ") + OCIErrStr());
       }
       d_init = true;
-    } else d_init = false;
-
-
+    } else {
+      d_init = false;
+    }
 
     d_bind = new struct obind[d_parnum];
     memset(d_bind, 0, sizeof(struct obind)*d_parnum);
@@ -370,6 +370,7 @@ private:
         throw SSqlException("Cannot prepare statement (3): " + d_query + string(": ") + OCIErrStr());
       }
     }
+
     d_prepared = true;
   }
 

--- a/modules/goraclebackend/soracle.cc
+++ b/modules/goraclebackend/soracle.cc
@@ -489,7 +489,7 @@ SOracle::~SOracle()
 }
 
 void SOracle::startTransaction() {
-  std::string cmd = "SET TRANSACTION NAME 'tx_" + std::to_string(s_txid++) + "'";
+  std::string cmd = "SET TRANSACTION NAME 'pdns_" + std::to_string(s_txid++) + "'";
   execute(cmd);
 }
 

--- a/modules/goraclebackend/soracle.cc
+++ b/modules/goraclebackend/soracle.cc
@@ -44,11 +44,11 @@ public:
     d_stmt_key[d_stmt_keysize] = 0;
   }
 
-  SSqlStatement* bind(const string& name, bool value) 
-  {  
+  SSqlStatement* bind(const string& name, bool value)
+  {
     return bind(name, (int)value);
   }
-  SSqlStatement* bind(const string& name, int value) 
+  SSqlStatement* bind(const string& name, int value)
   {
     if (d_paridx >= d_parnum)
      throw SSqlException("Attempt to bind more parameters than query has: " + d_query);
@@ -87,7 +87,7 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bind(const string& name, unsigned long value) 
+  SSqlStatement* bind(const string& name, unsigned long value)
   {
     if (d_paridx >= d_parnum)
      throw SSqlException("Attempt to bind more parameters than query has: " + d_query);
@@ -126,7 +126,7 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bind(const string& name, const std::string& value) 
+  SSqlStatement* bind(const string& name, const std::string& value)
   {
     if (d_paridx >= d_parnum)
      throw SSqlException("Attempt to bind more parameters than query has: " + d_query);
@@ -141,8 +141,8 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bindNull(const string& name) 
-  { 
+  SSqlStatement* bindNull(const string& name)
+  {
     if (d_paridx >= d_parnum)
      throw SSqlException("Attempt to bind more parameters than query has: " + d_query);
     prepareStatement();
@@ -154,12 +154,12 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* execute() 
+  SSqlStatement* execute()
   {
     if (d_query.size() == 0) return this; // do not execute empty queries
     prepareStatement();
 
-    if (d_dolog) 
+    if (d_dolog)
       L<<Logger::Warning<<"Query: "<<d_query<<endl;
     ub2 fntype;
     ub4 iters;
@@ -175,16 +175,16 @@ public:
       throw SSqlException("Cannot execute statement: " + d_query + string(": ") + OCIErrStr());
     }
 
-    d_resnum = d_residx = 0; 
+    d_resnum = d_residx = 0;
 
     if (fntype == OCI_STMT_SELECT) {
       ub4 o_fnum;
       ub4 o_resnum;
 
       // figure out what the result looks like
-      if (OCIAttrGet(d_stmt, OCI_HTYPE_STMT, (dvoid*)&o_resnum, 0, OCI_ATTR_ROW_COUNT, d_err)) 
-        throw SSqlException("Cannot get statement result row count: " + d_query + string(": ") + OCIErrStr()); // this returns 0 
-      if (OCIAttrGet(d_stmt, OCI_HTYPE_STMT, (dvoid*)&o_fnum, 0, OCI_ATTR_PARAM_COUNT, d_err)) 
+      if (OCIAttrGet(d_stmt, OCI_HTYPE_STMT, (dvoid*)&o_resnum, 0, OCI_ATTR_ROW_COUNT, d_err))
+        throw SSqlException("Cannot get statement result row count: " + d_query + string(": ") + OCIErrStr()); // this returns 0
+      if (OCIAttrGet(d_stmt, OCI_HTYPE_STMT, (dvoid*)&o_fnum, 0, OCI_ATTR_PARAM_COUNT, d_err))
         throw SSqlException("Cannot get statement result column count: " + d_query + string(": ") + OCIErrStr());
 
       d_residx = 0;
@@ -205,7 +205,7 @@ public:
           if (OCIAttrGet(parms, OCI_DTYPE_PARAM, (dvoid*)&(d_res[i].colsize), 0, OCI_ATTR_DATA_SIZE, d_err) != OCI_SUCCESS) {
             throw SSqlException("Cannot get statement result column information: " + d_query + string(": ") + OCIErrStr());
           }
-          
+
           if (d_res[i].colsize == 0) {
             if (OCIAttrGet(parms, OCI_DTYPE_PARAM, (dvoid*)&o_attrtype, 0, OCI_ATTR_DATA_TYPE, d_err) != OCI_SUCCESS) {
               throw SSqlException("Cannot get statement result column information: " + d_query + string(": ") + OCIErrStr());
@@ -226,7 +226,7 @@ public:
 
       if (d_fnum > 0) {
         for(int i=0;i<d_fnum;i++) {
-          if (OCIDefineByPos(d_stmt, &(d_res[i].handle), d_err, i+1, d_res[i].content, d_res[i].colsize+1, SQLT_STR, (dvoid*)&(d_res[i].ind), NULL, NULL, OCI_DEFAULT)) 
+          if (OCIDefineByPos(d_stmt, &(d_res[i].handle), d_err, i+1, d_res[i].content, d_res[i].colsize+1, SQLT_STR, (dvoid*)&(d_res[i].ind), NULL, NULL, OCI_DEFAULT))
             throw SSqlException("Cannot bind result column: " + d_query + string(": ") + OCIErrStr());
         }
       }
@@ -237,7 +237,7 @@ public:
     return this;
   }
 
-  string OCIErrStr() 
+  string OCIErrStr()
   {
     string mReason = "ORA-UNKNOWN";
     if (d_err != NULL) {
@@ -314,7 +314,7 @@ public:
     }
     d_bind = new struct obind[d_parnum];
     memset(d_bind, 0, sizeof(struct obind)*d_parnum);
-  
+
     if (d_release_stmt) {
       if (OCIStmtRelease(d_stmt, d_err, (text*)d_stmt_key, d_stmt_keysize, OCI_DEFAULT) != OCI_SUCCESS)
         throw SSqlException("Could not release statement: " + d_query + string(": ") + OCIErrStr());
@@ -451,7 +451,7 @@ SOracle::SOracle(const string &database,
     throw sPerrorException("OCIHandleAlloc(errorHandle)" + string(": ") + getOracleError());
   }
 
-  err = OCILogon2(d_environmentHandle, d_errorHandle, &d_serviceContextHandle, (OraText*)user.c_str(), user.size(), 
+  err = OCILogon2(d_environmentHandle, d_errorHandle, &d_serviceContextHandle, (OraText*)user.c_str(), user.size(),
                  (OraText*) password.c_str(),  strlen(password.c_str()), (OraText*) database.c_str(), strlen(database.c_str()), OCI_LOGON2_STMTCACHE);
   // increase statement cache to 100
   if (err) {

--- a/modules/goraclebackend/soracle.cc
+++ b/modules/goraclebackend/soracle.cc
@@ -344,7 +344,7 @@ private:
       if (OCIStmtPrepare2(d_svcctx, &d_stmt, d_err, (text*)d_query.c_str(), d_query.size(),
           NULL, 0, OCI_NTV_SYNTAX, OCI_DEFAULT) != OCI_SUCCESS) {
         // failed.
-        throw SSqlException("Cannot prepare statement (1): " + d_query + string(": ") + OCIErrStr());
+        throw SSqlException("Cannot prepare statement: " + d_query + string(": ") + OCIErrStr());
       }
       d_init = true;
     } else {
@@ -362,12 +362,12 @@ private:
     if (d_query.size()==0) return;
     if (d_init == false) {
       if (OCIStmtPrepare2(d_svcctx, &d_stmt, d_err, (text*)d_query.c_str(), d_query.size(), NULL, 0, OCI_NTV_SYNTAX, OCI_DEFAULT) != OCI_SUCCESS) {
-        throw SSqlException("Cannot prepare statement (2): " + d_query + string(": ") + OCIErrStr());
+        throw SSqlException("Cannot prepare statement: " + d_query + string(": ") + OCIErrStr());
       }
       d_init = true;
     } else {
       if (OCIStmtPrepare2(d_svcctx, &d_stmt, d_err, (text*)d_query.c_str(), d_query.size(), d_stmt_key, d_stmt_keysize, OCI_NTV_SYNTAX, OCI_DEFAULT) != OCI_SUCCESS) {
-        throw SSqlException("Cannot prepare statement (3): " + d_query + string(": ") + OCIErrStr());
+        throw SSqlException("Cannot prepare statement: " + d_query + string(": ") + OCIErrStr());
       }
     }
 

--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -1,4 +1,4 @@
-/* Copyright 2003 - 2005 Netherlabs BV, bert.hubert@netherlabs.nl. See LICENSE 
+/* Copyright 2003 - 2005 Netherlabs BV, bert.hubert@netherlabs.nl. See LICENSE
    for more information. */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -104,7 +104,7 @@ public:
     }
   }
 
-  bool hasNextRow() 
+  bool hasNextRow()
   {
     return d_residx<d_resnum;
   }
@@ -149,15 +149,15 @@ public:
        PQclear(res);
      }
      d_do_commit = false;
-     if (d_res) 
+     if (d_res)
        PQclear(d_res);
      if (d_res_set)
        PQclear(d_res_set);
      d_res_set = NULL;
      d_res = NULL;
      d_paridx = d_residx = d_resnum = 0;
-     if (paramValues) 
-       for(i=0;i<d_nparams;i++) 
+     if (paramValues)
+       for(i=0;i<d_nparams;i++)
          if (paramValues[i]) delete [] paramValues[i];
      delete [] paramValues;
      paramValues = NULL;
@@ -235,7 +235,7 @@ private:
 
 bool SPgSQL::s_dolog;
 
-SPgSQL::SPgSQL(const string &database, const string &host, const string& port, const string &user, 
+SPgSQL::SPgSQL(const string &database, const string &host, const string& port, const string &user,
                const string &password)
 {
   d_db=0;
@@ -260,7 +260,7 @@ SPgSQL::SPgSQL(const string &database, const string &host, const string& port, c
     d_connectlogstr+=" password=<HIDDEN>";
     d_connectstr+=" password="+password;
   }
-  
+
   d_db=PQconnectdb(d_connectstr.c_str());
 
   if (!d_db || PQstatus(d_db)==CONNECTION_BAD) {
@@ -291,7 +291,7 @@ SSqlException SPgSQL::sPerrorException(const string &reason)
   return SSqlException(reason+string(": ")+(d_db ? PQerrorMessage(d_db) : "no connection"));
 }
 
-void SPgSQL::execute(const string& query) 
+void SPgSQL::execute(const string& query)
 {
   PGresult* res = PQexec(d_db, query.c_str());
   ExecStatusType status = PQresultStatus(res);
@@ -302,7 +302,7 @@ void SPgSQL::execute(const string& query)
   }
 }
 
-SSqlStatement* SPgSQL::prepare(const string& query, int nparams) 
+SSqlStatement* SPgSQL::prepare(const string& query, int nparams)
 {
   return new SPgSQLStatement(query, s_dolog, nparams, this);
 }

--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -17,31 +17,11 @@ class SPgSQLStatement: public SSqlStatement
 {
 public:
   SPgSQLStatement(const string& query, bool dolog, int nparams, SPgSQL* db) {
-    struct timeval tv;
-
     d_query = query;
     d_dolog = dolog;
     d_parent = db;
-
-    // prepare a statement
-    gettimeofday(&tv,NULL);
-    this->d_stmt = string("stmt") + std::to_string(tv.tv_sec) + std::to_string(tv.tv_usec);
-
+    d_prepared = false;
     d_nparams = nparams;
- 
-    PGresult* res = PQprepare(d_db(), d_stmt.c_str(), d_query.c_str(), d_nparams, NULL);
-    ExecStatusType status = PQresultStatus(res);
-    string errmsg(PQresultErrorMessage(res));
-    PQclear(res);
-    if (status != PGRES_COMMAND_OK && status != PGRES_TUPLES_OK && status != PGRES_NONFATAL_ERROR) {
-      throw SSqlException("Fatal error during prepare: " + d_query + string(": ") + errmsg);
-    } 
-    paramValues=NULL;
-    d_cur_set=d_paridx=d_residx=d_resnum=d_fnum=0;
-    paramLengths=NULL;
-    d_res=NULL;
-    d_res_set=NULL;
-    d_do_commit=false;
   }
 
   SSqlStatement* bind(const string& name, bool value) { return bind(name, string(value ? "t" : "f")); }
@@ -52,9 +32,12 @@ public:
   SSqlStatement* bind(const string& name, long long value) { return bind(name, std::to_string(value)); }
   SSqlStatement* bind(const string& name, unsigned long long value) { return bind(name, std::to_string(value)); }
   SSqlStatement* bind(const string& name, const std::string& value) {
+    prepareStatement();
     allocate();
-    if (d_paridx>=d_nparams) 
+    if (d_paridx>=d_nparams) {
+      releaseStatement();
       throw SSqlException("Attempt to bind more parameters than query has: " + d_query);
+    }
     paramValues[d_paridx] = new char[value.size()+1];
     memset(paramValues[d_paridx], 0, sizeof(char)*(value.size()+1));
     value.copy(paramValues[d_paridx], value.size());
@@ -62,8 +45,9 @@ public:
     d_paridx++;
     return this;
   }
-  SSqlStatement* bindNull(const string& name) { d_paridx++; return this; } // these are set null in allocate()
+  SSqlStatement* bindNull(const string& name) { prepareStatement(); d_paridx++; return this; } // these are set null in allocate()
   SSqlStatement* execute() {
+    prepareStatement();
     if (d_dolog) {
       L<<Logger::Warning<<"Query: "<<d_query<<endl;
     }
@@ -76,8 +60,7 @@ public:
     string errmsg(PQresultErrorMessage(d_res_set));
     if (status != PGRES_COMMAND_OK && status != PGRES_TUPLES_OK && status != PGRES_NONFATAL_ERROR) {
       string errmsg(PQresultErrorMessage(d_res_set));
-      PQclear(d_res_set);
-      d_res_set = NULL;
+      releaseStatement();
       throw SSqlException("Fatal error during query: " + d_query + string(": ") + errmsg);
     }
     d_cur_set = 0;
@@ -162,7 +145,8 @@ public:
   SSqlStatement* reset() {
      int i;
      if (!d_parent->in_trx() && d_do_commit) {
-       PQexec(d_db(),"COMMIT");
+       PGresult *res = PQexec(d_db(),"COMMIT");
+       PQclear(res);
      }
      d_do_commit = false;
      if (d_res) 
@@ -185,11 +169,42 @@ public:
   const std::string& getQuery() { return d_query; }
 
   ~SPgSQLStatement() {
-    reset();
+    releaseStatement();
   }
 private:
   PGconn* d_db() {
     return d_parent->db();
+  }
+
+  void releaseStatement() {
+    d_prepared = false;
+    reset();
+    string cmd = string("DEALLOCATE " + d_stmt);
+    PGresult *res = PQexec(d_db(), cmd.c_str());
+    PQclear(res);
+  }
+
+  void prepareStatement() {
+    struct timeval tv;
+    if (d_prepared) return;
+    // prepare a statement
+    gettimeofday(&tv,NULL);
+    this->d_stmt = string("stmt") + std::to_string(tv.tv_sec) + std::to_string(tv.tv_usec);
+    PGresult* res = PQprepare(d_db(), d_stmt.c_str(), d_query.c_str(), d_nparams, NULL);
+    ExecStatusType status = PQresultStatus(res);
+    string errmsg(PQresultErrorMessage(res));
+    PQclear(res);
+    if (status != PGRES_COMMAND_OK && status != PGRES_TUPLES_OK && status != PGRES_NONFATAL_ERROR) {
+      releaseStatement();
+      throw SSqlException("Fatal error during prepare: " + d_query + string(": ") + errmsg);
+    }
+    paramValues=NULL;
+    d_cur_set=d_paridx=d_residx=d_resnum=d_fnum=0;
+    paramLengths=NULL;
+    d_res=NULL;
+    d_res_set=NULL;
+    d_do_commit=false;
+    d_prepared = true;
   }
 
   void allocate() {
@@ -206,6 +221,7 @@ private:
   PGresult *d_res_set;
   PGresult *d_res;
   bool d_dolog;
+  bool d_prepared;
   int d_nparams;
   int d_paridx;
   char **paramValues;

--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -22,6 +22,11 @@ public:
     d_parent = db;
     d_prepared = false;
     d_nparams = nparams;
+    d_res = NULL;
+    d_res_set = NULL;
+    paramValues = NULL;
+    paramLengths = NULL;
+    d_do_commit = false;
   }
 
   SSqlStatement* bind(const string& name, bool value) { return bind(name, string(value ? "t" : "f")); }

--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -9,7 +9,6 @@ After=network-online.target mysqld.service postgresql.service slapd.service
 Type=notify
 ExecStart=@sbindir@/pdns_server --guardian=no --daemon=no --disable-syslog --write-pid=no
 Restart=on-failure
-StartLimitInterval=0
 PrivateTmp=true
 PrivateDevices=true
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_CHOWN CAP_SYS_CHROOT

--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -20,7 +20,7 @@
 /*
 ** Set all the parameters in the compiled SQL statement to NULL.
 *
-* copied from sqlite 3.3.6 // cmouse 
+* copied from sqlite 3.3.6 // cmouse
 */
 int pdns_sqlite3_clear_bindings(sqlite3_stmt *pStmt){
   int i;
@@ -31,7 +31,7 @@ int pdns_sqlite3_clear_bindings(sqlite3_stmt *pStmt){
   return rc;
 }
 
-class SSQLite3Statement: public SSqlStatement 
+class SSQLite3Statement: public SSqlStatement
 {
 public:
   SSQLite3Statement(SSQLite3 *db, bool dolog, const string& query) : d_prepared(false)
@@ -47,7 +47,7 @@ public:
     string zName = string(":")+name;
     prepareStatement();
     return sqlite3_bind_parameter_index(d_stmt, zName.c_str());
-    // XXX: support @ and $?    
+    // XXX: support @ and $?
   }
 
   SSqlStatement* bind(const string& name, bool value) { int idx = name2idx(name); if (idx>0) { sqlite3_bind_int(d_stmt, idx, value ? 1 : 0); }; return this; }
@@ -89,7 +89,7 @@ public:
         row.push_back("");
       } else {
         const char *pData = (const char*) sqlite3_column_text(d_stmt, i);
-        row.push_back(string(pData, sqlite3_column_bytes(d_stmt, i))); 
+        row.push_back(string(pData, sqlite3_column_bytes(d_stmt, i)));
       }
     }
     d_rc = sqlite3_step(d_stmt);
@@ -175,7 +175,7 @@ SSQLite3::SSQLite3( const std::string & database, bool creat )
 }
 
 void SSQLite3::setLog(bool state)
-{ 
+{
   m_dolog=state;
 }
 

--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -34,25 +34,18 @@ int pdns_sqlite3_clear_bindings(sqlite3_stmt *pStmt){
 class SSQLite3Statement: public SSqlStatement 
 {
 public:
-  SSQLite3Statement(SSQLite3 *db, bool dolog, const string& query) 
+  SSQLite3Statement(SSQLite3 *db, bool dolog, const string& query) : d_prepared(false)
   {
-    const char *pTail;
     this->d_query = query;
     this->d_dolog = dolog;
+    d_stmt = NULL;
     d_rc = 0;
     d_db = db;
-#if SQLITE_VERSION_NUMBER >= 3003009
-    if (sqlite3_prepare_v2(d_db->db(), query.c_str(), -1, &d_stmt, &pTail ) != SQLITE_OK)
-#else
-    if (sqlite3_prepare(d_db->db(), query.c_str(), -1, &d_stmt, &pTail ) != SQLITE_OK)
-#endif
-      throw SSqlException(string("Unable to compile SQLite statement : '")+query+"': "+sqlite3_errmsg(d_db->db()));
-    if (pTail && strlen(pTail)>0)
-      L<<Logger::Warning<<"Sqlite3 command partially processed. Unprocessed part: "<<pTail<<endl;
   }
 
   int name2idx(const string& name) {
     string zName = string(":")+name;
+    prepareStatement();
     return sqlite3_bind_parameter_index(d_stmt, zName.c_str());
     // XXX: support @ and $?    
   }
@@ -68,6 +61,7 @@ public:
   SSqlStatement* bindNull(const string& name) { int idx = name2idx(name); if (idx>0) { sqlite3_bind_null(d_stmt, idx); }; return this; }
 
   SSqlStatement* execute() {
+    prepareStatement();
     if (d_dolog)
       L<<Logger::Warning<< "Query: " << d_query << endl;
     int attempts = d_db->inTransaction(); // try only once
@@ -75,7 +69,8 @@ public:
 
     if (d_rc != SQLITE_ROW && d_rc != SQLITE_DONE) {
       // failed.
-      if (d_rc == SQLITE_CANTOPEN) 
+      releaseStatement();
+      if (d_rc == SQLITE_CANTOPEN)
         throw SSqlException(string("CANTOPEN error in sqlite3, often caused by unwritable sqlite3 db *directory*: ")+string(sqlite3_errmsg(d_db->db())));
       throw SSqlException(string("Error while retrieving SQLite query results: ")+string(sqlite3_errmsg(d_db->db())));
     }
@@ -123,8 +118,7 @@ public:
 
   ~SSQLite3Statement() {
     // deallocate if necessary
-    if (d_stmt) 
-      sqlite3_finalize(d_stmt);
+    releaseStatement();
   }
 
   const string& getQuery() { return d_query; };
@@ -134,6 +128,32 @@ private:
   SSQLite3* d_db;
   int d_rc;
   bool d_dolog;
+  bool d_prepared;
+
+  void prepareStatement() {
+    const char *pTail;
+
+    if (d_prepared) return;
+#if SQLITE_VERSION_NUMBER >= 3003009
+    if (sqlite3_prepare_v2(d_db->db(), d_query.c_str(), -1, &d_stmt, &pTail ) != SQLITE_OK)
+#else
+    if (sqlite3_prepare(d_db->db(), d_query.c_str(), -1, &d_stmt, &pTail ) != SQLITE_OK)
+#endif
+    {
+      releaseStatement();
+      throw SSqlException(string("Unable to compile SQLite statement : '")+d_query+"': "+sqlite3_errmsg(d_db->db()));
+    }
+    if (pTail && strlen(pTail)>0)
+      L<<Logger::Warning<<"Sqlite3 command partially processed. Unprocessed part: "<<pTail<<endl;
+    d_prepared = true;
+  }
+
+  void releaseStatement() {
+    if (d_stmt)
+      sqlite3_finalize(d_stmt);
+    d_stmt = NULL;
+    d_prepared = false;
+  }
 };
 
 // Constructor.


### PR DESCRIPTION
Change GSQL drives to defer statement initialization to happen when they are actually needed.