### PR TITLE
auth: Don't build dnsbulktest and dnstcpbench if boost is too old

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,10 @@ PDNS_CHECK_RAGEL
 PDNS_CHECK_CLOCK_GETTIME
 
 BOOST_REQUIRE([1.35])
+# Boost accumulators, as used by dnsbulktest and dnstcpbench, need 1.48+
+# to be compatible with C++11
+AM_CONDITIONAL([HAVE_BOOST_GE_148], [test "$boost_major_version" -ge 148])
+
 BOOST_PROGRAM_OPTIONS([mt])
 PDNS_ENABLE_UNIT_TESTS
 PDNS_ENABLE_REPRODUCIBLE

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -78,12 +78,10 @@ bin_PROGRAMS = \
 
 if TOOLS
 bin_PROGRAMS += \
-	dnsbulktest \
 	dnsgram \
 	dnsreplay \
 	dnsscan \
 	dnsscope \
-	dnstcpbench \
 	dnswasher \
 	dumresp \
 	notify \
@@ -96,6 +94,12 @@ bin_PROGRAMS += \
 
 if HAVE_RECVMMSG
 bin_PROGRAMS += calidns
+endif
+
+if HAVE_BOOST_GE_148
+bin_PROGRAMS += \
+	dnsbulktest \
+	dnstcpbench
 endif
 
 endif


### PR DESCRIPTION
Second attempt, this time not building the offending programs at all if boost is tool old.
Comments welcome, especially since I'm still not skilled at this autoconf stuff, and I had a hard time finding how to get the detected boost version in there, so I might not be doing it the right way.