### PR TITLE
Implement IXFR-based slaving for Authoritative, fix duplicate AXFRs

### DIFF
--- a/docs/markdown/authoritative/domainmetadata.md
+++ b/docs/markdown/authoritative/domainmetadata.md
@@ -25,7 +25,7 @@ insert into domainmetadata (domain_id, kind, content) values (7,'ALLOW-AXFR-FROM
 To dissallow all IP's, except those explicitly allowed by domainmetadata records, add `allow-axfr-ips=` to `pdns.conf`.
 
 ## AXFR-SOURCE
-The IP address to use as a source address for sending AXFR requests.
+The IP address to use as a source address for sending AXFR and IXFR requests.
 
 ## ALLOW-DNSUPDATE-FROM, TSIG-ALLOW-DNSUPDATE, FORWARD-DNSUPDATE, SOA-EDIT-DNSUPDATE
 See the documentation on [Dynamic DNS update](dnsupdate.md)
@@ -44,6 +44,9 @@ Allow this GSS principal to perform AXFR retrieval. Most commonly it is
 
 ## GSS-ACCEPTOR-PRINCIPAL
 Use this principal for accepting GSS context. (See [GSS-TSIG support](tsig.md#gss-tsig-support)).
+
+## IXFR
+If set to 1, attempt IXFR when retrieving zone updates. Otherwise IXFR is not attempted.
 
 ## LUA-AXFR-SCRIPT
 Script to be used to edit incoming AXFRs, see [Modifying a slave zone using a script](modes-of-operation.md#modifying-a-slave-zone-using-a-script).

--- a/docs/markdown/authoritative/modes-of-operation.md
+++ b/docs/markdown/authoritative/modes-of-operation.md
@@ -85,7 +85,26 @@ PowerDNS supports multiple masters. For the BIND backend, the native BIND
 configuration language suffices to specify multiple masters, for SQL based backends,
 list all master servers separated by commas in the 'master' field of the domains table.
 
-Since version 4.0.0, PowerDNS requires that masters sign their notifications. During transition and interoperation with other nameservers, you can use options **allow-unsigned-notify** to permit unsigned notifications. For 4.0.0 this is turned off by default, but it might be turned on permanently in future releases.
+Since version 4.0.0, PowerDNS requires that masters sign their
+notifications.  During transition and interoperation with other nameservers,
+you can use options **allow-unsigned-notify** to permit unsigned
+notifications.  For 4.0.0 this is turned off by default, but it might be
+turned on permanently in future releases.
+
+## IXFR: incremental zone transfers
+If the 'IXFR' zone metadata item is set to 1 for a zone, PowerDNS will attempt to retrieve
+zone updates via IXFR. 
+
+As of 4.0.0, if a slave zone changes from non-DNSSEC to DNSSEC, an IXFR
+update will not set the PRESIGNED flag.  In addition, a change in NSEC3 mode
+will also not be picked up.  
+
+In such cases, make sure to delete the zone contents to force a fresh retrieval. 
+
+Finally, IXFR updates that "plug" Empty Non Terminals do not yet remove ENT
+records.  A 'pdnsutil rectify-zone' may be required.
+
+PowerDNS itself is currently only able to retrieve updates via IXFR. It can not serve IXFR updates.
 
 ## Supermaster: automatic provisioning of slaves
 PowerDNS can recognize so called 'supermasters'. A supermaster is a host which is

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -165,6 +165,7 @@ pdns_server_SOURCES = \
 	ednssubnet.cc ednssubnet.hh \
 	gss_context.cc gss_context.hh \
 	iputils.cc iputils.hh \
+	ixfr.cc ixfr.hh \
 	json.cc json.hh \
 	lock.hh \
 	logger.cc logger.hh \

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -52,7 +52,7 @@ void CommunicatorClass::retrievalLoopThread(void)
       sr=d_suckdomains.front();
       d_suckdomains.pop_front();
     }
-    suck(sr.domain, sr.master, sr.currentSerial ? &sr.currentSerial : 0);
+    suck(sr.domain, sr.master);
   }
 }
 

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -37,8 +37,7 @@
 #include "arguments.hh"
 #include "packetcache.hh"
 
-// #include "namespaces.hh"
-
+// there can be MANY OF THESE
 void CommunicatorClass::retrievalLoopThread(void)
 {
   for(;;) {

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -52,7 +52,7 @@ void CommunicatorClass::retrievalLoopThread(void)
       sr=d_suckdomains.front();
       d_suckdomains.pop_front();
     }
-    suck(sr.domain,sr.master);
+    suck(sr.domain, sr.master, sr.currentSerial ? &sr.currentSerial : 0);
   }
 }
 

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -1,6 +1,6 @@
 /*
     PowerDNS Versatile Database Driven Nameserver
-    Copyright (C) 2002-2010  PowerDNS.COM BV
+    Copyright (C) 2002-2016  PowerDNS.COM BV
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2
@@ -31,6 +31,7 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
+#include <boost/scoped_ptr.hpp>
 using namespace boost::multi_index;
 
 #include <unistd.h>
@@ -140,6 +141,8 @@ private:
 
 };
 
+struct ZoneStatus;
+
 /** this class contains a thread that communicates with other nameserver and does housekeeping.
     Initially, it is notified only of zones that need to be pulled in because they have been updated. */
 
@@ -191,13 +194,15 @@ private:
   pthread_mutex_t d_holelock;
   void launchRetrievalThreads();
   void suck(const DNSName &domain, const string &remote);
-  void ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote);
+  void ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, boost::scoped_ptr<AuthLua>& pdl,
+                ZoneStatus& zs, vector<DNSRecord>* axfr);
 
   void slaveRefresh(PacketHandler *P);
   void masterUpdateCheck(PacketHandler *P);
   pthread_mutex_t d_lock;
   
   UniQueue d_suckdomains;
+  set<DNSName> d_inprogress;
   
   Semaphore d_suck_sem;
   Semaphore d_any_sem;
@@ -210,6 +215,21 @@ private:
   bool d_havepriosuckrequest;
   bool d_masterschanged, d_slaveschanged;
   bool d_preventSelfNotification;
+
+  struct RemoveSentinel
+  {
+    explicit RemoveSentinel(const DNSName& dn, CommunicatorClass* cc) : d_dn(dn), d_cc(cc)
+    {}
+    
+    ~RemoveSentinel()
+    {
+      Lock l(&d_cc->d_lock);
+      d_cc->d_inprogress.erase(d_dn);
+    }
+    DNSName d_dn;
+    CommunicatorClass* d_cc;
+};
+
 };
 
 // class that one day might be more than a function to help you get IP addresses for a nameserver

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -46,6 +46,7 @@ struct SuckRequest
 {
   DNSName domain;
   string master;
+  uint32_t currentSerial;
   bool operator<(const SuckRequest& b) const
   {
     return tie(domain, master) < tie(b.domain, b.master);
@@ -164,7 +165,7 @@ public:
   
   void drillHole(const DNSName &domain, const string &ip);
   bool justNotified(const DNSName &domain, const string &ip);
-  void addSuckRequest(const DNSName &domain, const string &master);
+  void addSuckRequest(const DNSName &domain, const string &master, uint32_t curser);
   void addSlaveCheckRequest(const DomainInfo& di, const ComboAddress& remote);
   void addTrySuperMasterRequest(DNSPacket *p);
   void notify(const DNSName &domain, const string &ip);
@@ -190,7 +191,9 @@ private:
   map<pair<DNSName,string>,time_t>d_holes;
   pthread_mutex_t d_holelock;
   void launchRetrievalThreads();
-  void suck(const DNSName &domain, const string &remote);
+  void suck(const DNSName &domain, const string &remote, uint32_t* curser);
+  void ixfrSuck(const DNSName &domain, const string &remote, uint32_t curser);
+
   void slaveRefresh(PacketHandler *P);
   void masterUpdateCheck(PacketHandler *P);
   pthread_mutex_t d_lock;

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -46,7 +46,6 @@ struct SuckRequest
 {
   DNSName domain;
   string master;
-  uint32_t currentSerial;
   bool operator<(const SuckRequest& b) const
   {
     return tie(domain, master) < tie(b.domain, b.master);
@@ -165,7 +164,7 @@ public:
   
   void drillHole(const DNSName &domain, const string &ip);
   bool justNotified(const DNSName &domain, const string &ip);
-  void addSuckRequest(const DNSName &domain, const string &master, uint32_t curser);
+  void addSuckRequest(const DNSName &domain, const string &master);
   void addSlaveCheckRequest(const DomainInfo& di, const ComboAddress& remote);
   void addTrySuperMasterRequest(DNSPacket *p);
   void notify(const DNSName &domain, const string &ip);
@@ -191,8 +190,8 @@ private:
   map<pair<DNSName,string>,time_t>d_holes;
   pthread_mutex_t d_holelock;
   void launchRetrievalThreads();
-  void suck(const DNSName &domain, const string &remote, uint32_t* curser);
-  void ixfrSuck(const DNSName &domain, const string &remote, uint32_t curser);
+  void suck(const DNSName &domain, const string &remote);
+  void ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote);
 
   void slaveRefresh(PacketHandler *P);
   void masterUpdateCheck(PacketHandler *P);

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -251,7 +251,7 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
     return "Domain '"+domain.toString()+"' is not a slave domain (or has no master defined)";
 
   random_shuffle(di.masters.begin(), di.masters.end());
-  Communicator.addSuckRequest(domain, di.masters.front(), 0); // we don't know serial
+  Communicator.addSuckRequest(domain, di.masters.front()); 
   return "Added retrieval request for '"+domain.toString()+"' from master "+di.masters.front();
 }
 

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -251,7 +251,7 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
     return "Domain '"+domain.toString()+"' is not a slave domain (or has no master defined)";
 
   random_shuffle(di.masters.begin(), di.masters.end());
-  Communicator.addSuckRequest(domain, di.masters.front());
+  Communicator.addSuckRequest(domain, di.masters.front(), 0); // we don't know serial
   return "Added retrieval request for '"+domain.toString()+"' from master "+di.masters.front();
 }
 

--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -5,8 +5,9 @@
 #include "dnssecinfra.hh"
 
 
-// if you the remove,add pairs always remove a SOA and add a new one. If you get an empty remove, it means you got an AXFR!
-vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAddress& master, const DNSName& zone, const DNSRecord& oursr, const TSIGTriplet& tt)
+// Returns pairs of "remove & add" vectors. If you get an empty remove, it means you got an AXFR!
+vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAddress& master, const DNSName& zone, const DNSRecord& oursr, 
+                                                                   const TSIGTriplet& tt, const ComboAddress* laddr)
 {
   vector<pair<vector<DNSRecord>, vector<DNSRecord> > >  ret;
   vector<uint8_t> packet;
@@ -39,8 +40,8 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
 
   Socket s(master.sin4.sin_family, SOCK_STREAM);
   //  cout<<"going to connect"<<endl;
-  ComboAddress local("2001:470:1f15:86f:4413:6149:48d1:16a3", 0);
-  s.bind(local);
+  if(laddr)
+    s.bind(*laddr);
   s.connect(master);
   //  cout<<"Connected"<<endl;
   s.writen(msg);

--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -39,6 +39,8 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
 
   Socket s(master.sin4.sin_family, SOCK_STREAM);
   //  cout<<"going to connect"<<endl;
+  ComboAddress local("2001:470:1f15:86f:4413:6149:48d1:16a3", 0);
+  s.bind(local);
   s.connect(master);
   //  cout<<"Connected"<<endl;
   s.writen(msg);

--- a/pdns/ixfr.hh
+++ b/pdns/ixfr.hh
@@ -2,5 +2,6 @@
 #include "iputils.hh"
 #include "dnsparser.hh"
 
-vector<pair<vector<DNSRecord>, vector<DNSRecord> > >   getIXFRDeltas(const ComboAddress& master, const DNSName& zone, const DNSRecord& sr,
-                                                                     const TSIGTriplet& tt=TSIGTriplet());
+vector<pair<vector<DNSRecord>, vector<DNSRecord> > >   getIXFRDeltas(const ComboAddress& master, const DNSName& zone, 
+                                                                     const DNSRecord& sr, const TSIGTriplet& tt=TSIGTriplet(),
+                                                                     const ComboAddress* laddr=0);

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -189,7 +189,7 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
     zs.ns3pr = NSEC3PARAMRecordContent(rr.content);
     zs.isDnssecZone = zs.isNSEC3 = true;
     zs.isNarrow = false;
-  
+    break;
   case QType::NSEC3: {
     NSEC3RecordContent ns3rc(rr.content);
     if (firstNSEC3) {
@@ -202,16 +202,17 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
       DNSName hashPart = DNSName(toLower(rr.qname.makeRelative(domain).toString()));
       zs.secured.insert(hashPart);
     }
+    break;
   }
   
   case QType::NSEC: 
     zs.isDnssecZone = zs.isPresigned = true;
-  
+    break;
   
   case QType::NS: 
     if(rr.qname!=domain)
       zs.nsset.insert(rr.qname);
-  
+    break;
   }
 
   zs.qnames.insert(rr.qname);
@@ -345,7 +346,7 @@ void CommunicatorClass::suck(const DNSName &domain, const string &remote)
         L<<Logger::Error<<"Failed to load AXFR source '"<<localaddr[0]<<"' for incoming AXFR of '"<<domain<<"': "<<e.what()<<endl;
         return;
       }
-    } else {
+    } else { // should use global query-local-addr here! XXX
       laddr.sin4.sin_family = 0;
     }
 

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -189,7 +189,7 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
     zs.ns3pr = NSEC3PARAMRecordContent(rr.content);
     zs.isDnssecZone = zs.isNSEC3 = true;
     zs.isNarrow = false;
-    break;
+    return false;
   case QType::NSEC3: {
     NSEC3RecordContent ns3rc(rr.content);
     if (firstNSEC3) {
@@ -202,12 +202,12 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
       DNSName hashPart = DNSName(toLower(rr.qname.makeRelative(domain).toString()));
       zs.secured.insert(hashPart);
     }
-    break;
+    return false;
   }
   
   case QType::NSEC: 
     zs.isDnssecZone = zs.isPresigned = true;
-    break;
+    return false;
   
   case QType::NS: 
     if(rr.qname!=domain)

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -261,7 +261,8 @@ vector<DNSResourceRecord> doAxfr(const ComboAddress& raddr, const DNSName& domai
       }
 
       for(DNSResourceRecord& rr :  out) {
-        processRecordForZS(domain, firstNSEC3, rr, zs);
+        if(!processRecordForZS(domain, firstNSEC3, rr, zs))
+          continue;
         if(rr.qtype.getCode() == QType::SOA) {
           if(soa_received)
             continue; //skip the last SOA
@@ -381,7 +382,8 @@ void CommunicatorClass::suck(const DNSName &domain, const string &remote)
             DNSResourceRecord rr(dr);
             rr.qname += domain;
             rr.domain_id = zs.domain_id;
-            processRecordForZS(domain, firstNSEC3, rr, zs);
+            if(!processRecordForZS(domain, firstNSEC3, rr, zs))
+              continue;
             if(dr.d_type == QType::SOA) {
               auto sd = getRR<SOARecordContent>(dr);
               zs.soa_serial = sd->d_st.serial;

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -140,7 +140,7 @@ public:
   void connect(const ComboAddress &ep)
   {
     if(::connect(d_socket,(struct sockaddr *)&ep, ep.getSocklen()) < 0 && errno != EINPROGRESS)
-      throw NetworkError("While connecting: "+string(strerror(errno)));
+      throw NetworkError("While connecting to "+ep.toStringWithPort()+": "+string(strerror(errno)));
   }
 
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -870,7 +870,7 @@ static void apiServerZoneAxfrRetrieve(HttpRequest* req, HttpResponse* resp) {
     throw ApiException("Domain '"+zonename.toString()+"' is not a slave domain (or has no master defined)");
 
   random_shuffle(di.masters.begin(), di.masters.end());
-  Communicator.addSuckRequest(zonename, di.masters.front());
+  Communicator.addSuckRequest(zonename, di.masters.front(), 0);
   resp->setSuccessResult("Added retrieval request for '"+zonename.toString()+"' from master "+di.masters.front());
 }
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -870,7 +870,7 @@ static void apiServerZoneAxfrRetrieve(HttpRequest* req, HttpResponse* resp) {
     throw ApiException("Domain '"+zonename.toString()+"' is not a slave domain (or has no master defined)");
 
   random_shuffle(di.masters.begin(), di.masters.end());
-  Communicator.addSuckRequest(zonename, di.masters.front(), 0);
+  Communicator.addSuckRequest(zonename, di.masters.front());
   resp->setSuccessResult("Added retrieval request for '"+zonename.toString()+"' from master "+di.masters.front());
 }
 


### PR DESCRIPTION
With this PR, we gain the conditional ability to slave a domain over IXFR, with some documented limitations mostly involving DNSSEC. 

At this late stage in 4.0.0 development, this change sadly also impacted regular AXFR but this could not be avoided. For starters, the old AXFR logic would happily launch two AXFR-attempts simultaneously, which messed with our ability to actually test IXFR. 

Secondly, the AXFR code performs a LOT of analysis on zones to filter records and determine zone status, an this logic had to be abstracted to also be available for IXFR. 

This PR passes all the regression tests, but I estimate (without proof) that it will inconvenience at least some users. I feel this is offset however by cleaning up the embarrassing double-AXFR situation, which must have been hurting other people!