### PR TITLE
recursor: Require = in forward-zones

### DIFF
--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -320,9 +320,11 @@ SyncRes::domainmap_t* parseAuthAndForwards()
   const char *option_names[3]={"auth-zones", "forward-zones", "forward-zones-recurse"};
   for(int n=0; n < 3 ; ++n ) {
     parts.clear();
-    stringtok(parts, ::arg()[option_names[n]], ",\t\n\r");
+    stringtok(parts, ::arg()[option_names[n]], " ,\t\n\r");
     for(parts_t::const_iterator iter = parts.begin(); iter != parts.end(); ++iter) {
       SyncRes::AuthDomain ad;
+      if ((*iter).find('=') == string::npos)
+        throw PDNSException("Error parsing '" + *iter + "', missing =");
       pair<string,string> headers=splitField(*iter, '=');
       trim(headers.first);
       trim(headers.second);


### PR DESCRIPTION
Fixes #3956 in 3.7.x