### PR TITLE
auth: Handle `read()` returning 0 in RemoteBackend's unix connector

### DIFF
--- a/modules/remotebackend/unixconnector.cc
+++ b/modules/remotebackend/unixconnector.cc
@@ -89,7 +89,7 @@ ssize_t UnixsocketConnector::read(std::string &data) {
   // just try again later...
   if (nread==-1 && errno == EAGAIN) return 0;
 
-  if (nread==-1) {
+  if (nread==-1 || nread==0) {
     connected = false;
     close(fd);
     return -1;


### PR DESCRIPTION
Otherwise it looks like we may loop in `recv_message()` until the
timeout is reached if the other end closes the connection:
* `waitForData()` will return immediately
* `read()` will keep returning 0