### PR TITLE
Add option to disable the stdout log timestamp

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -266,6 +266,13 @@ Do not allow zone transfers.
 Disable the rectify step during an outgoing AXFR. Only required for regression
 testing.
 
+## `disable-log-timestamp`
+* Boolean
+* Default: no
+
+When set to 'yes', don't timestamp log messages sent to stdout. Set this to true
+if process supervisor adds timestamps itself.
+
 ## `disable-syslog`
 * Boolean
 * Default: no

--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -159,6 +159,13 @@ Operate in the background.
 
 Which domains we only accept delegations from (a Verisign special).
 
+## `disable-log-timestamp`
+* Boolean
+* Default: no
+
+When set to 'yes', don't timestamp log messages sent to stdout. Set this to true
+if process supervisor adds timestamps itself.
+
 ## `disable-packetcache`
 * Boolean
 * Default: no

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -92,6 +92,7 @@ void declareArguments()
   ::arg().set("version-string","PowerDNS version in packets - full, anonymous, powerdns or custom")="full"; 
   ::arg().set("control-console","Debugging switch - don't use")="no"; // but I know you will!
   ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";
+  ::arg().set("disable-log-timestamp","Disable adding the timestamp to logs sent to stdout")="no";
   ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
   ::arg().set("default-soa-name","name to insert in the SOA record if none set in the backend")="a.misconfigured.powerdns.server";
   ::arg().set("default-soa-mail","mail address to insert in the SOA record if none set in the backend")="";

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -47,14 +47,17 @@ void Logger::log(const string &msg, Urgency u)
 #ifndef RECURSOR
   bool mustAccount(false);
 #endif
-  struct tm tm;
-  time_t t;
-  time(&t);
-  tm=*localtime(&t);
-
   if(u<=consoleUrgency) {
     char buffer[50];
-    strftime(buffer,sizeof(buffer),"%b %d %H:%M:%S ", &tm);
+    buffer[0] = '\0';
+    if(!d_disableTimeStamp) {
+      struct tm tm;
+      time_t t;
+      time(&t);
+      tm=*localtime(&t);
+
+      strftime(buffer,sizeof(buffer),"%b %d %H:%M:%S ", &tm);
+    }
     static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
     Lock l(&m); // the C++-2011 spec says we need this, and OSX actually does
     clog << string(buffer) + msg <<endl;

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -61,6 +61,10 @@ public:
     d_disableSyslog = d;
   }
 
+  void disableTimeStamp(bool d) {
+    d_disableTimeStamp = d;
+  }
+
   //! Log to a file.
   void toFile( const string & filename );
   
@@ -108,6 +112,7 @@ private:
   Urgency consoleUrgency;
   bool opened;
   bool d_disableSyslog;
+  bool d_disableTimeStamp;
   static pthread_once_t s_once;
   static pthread_key_t s_loggerKey;
 };

--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -7,7 +7,7 @@ After=network-online.target mysqld.service postgresql.service slapd.service
 
 [Service]
 Type=notify
-ExecStart=@sbindir@/pdns_server --guardian=no --daemon=no --disable-syslog --write-pid=no
+ExecStart=@sbindir@/pdns_server --guardian=no --daemon=no --disable-syslog --disable-log-timestamp --write-pid=no
 Restart=on-failure
 RestartSec=1
 StartLimitInterval=0

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2483,7 +2483,7 @@ int serviceMain(int argc, char*argv[])
   L.setName(s_programname);
   L.setLoglevel((Logger::Urgency)(6)); // info and up
 
-  if(!::arg()["logging-facility"].empty()) {
+  if(!::arg().mustDo("disable-syslog") && !::arg()["logging-facility"].empty()) {
     int val=logFacilityToLOG(::arg().asNum("logging-facility") );
     if(val >= 0)
       theL().setFacility(val);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2482,7 +2482,6 @@ int serviceMain(int argc, char*argv[])
 {
   L.setName(s_programname);
   L.setLoglevel((Logger::Urgency)(6)); // info and up
-  L.disableSyslog(::arg().mustDo("disable-syslog"));
 
   if(!::arg()["logging-facility"].empty()) {
     int val=logFacilityToLOG(::arg().asNum("logging-facility") );
@@ -2877,6 +2876,7 @@ int main(int argc, char **argv)
     ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";
     ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
     ::arg().set("log-common-errors","If we should log rather common errors")="no";
+    ::arg().set("disable-log-timestamp","Disable adding the timestamp to logs sent to stdout")="no";
     ::arg().set("chroot","switch to chroot jail")="";
     ::arg().set("setgid","If set, change group id to this gid for more security")="";
     ::arg().set("setuid","If set, change user id to this uid for more security")="";
@@ -2962,7 +2962,10 @@ int main(int argc, char **argv)
     ::arg().setCmd("version","Print version string");
     ::arg().setCmd("config","Output blank configuration");
     L.toConsole(Logger::Info);
+
     ::arg().laxParse(argc,argv); // do a lax parse
+    L.disableSyslog(::arg().mustDo("disable-syslog"));
+    L.disableTimeStamp(::arg().mustDo("disable-log-timestamp"));
 
     string configname=::arg()["config-dir"]+"/recursor.conf";
     if(::arg()["config-name"]!="") {

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -440,6 +440,9 @@ int main(int argc, char **argv)
     UNIX_declareArguments();
 
     ::arg().laxParse(argc,argv); // do a lax parse
+    // ensure we pick up logging preferences from the cmdline early
+    L.disableSyslog(::arg().mustDo("disable-syslog"));
+    L.disableTimeStamp(::arg().mustDo("disable-log-timestamp"));
     
     if(::arg().mustDo("version")) {
       showProductVersion();
@@ -459,7 +462,10 @@ int main(int argc, char **argv)
       ::arg().laxFile(configname.c_str());
     
     ::arg().laxParse(argc,argv); // reparse so the commandline still wins
-    if(!::arg()["logging-facility"].empty()) {
+    L.disableSyslog(::arg().mustDo("disable-syslog"));
+    L.disableTimeStamp(::arg().mustDo("disable-log-timestamp"));
+
+    if(!::arg().mustDo("disable-syslog") && !::arg()["logging-facility"].empty()) {
       int val=logFacilityToLOG(::arg().asNum("logging-facility") );
       if(val >= 0)
         theL().setFacility(val);
@@ -468,7 +474,6 @@ int main(int argc, char **argv)
     }
 
     L.setLoglevel((Logger::Urgency)(::arg().asNum("loglevel")));
-    L.disableSyslog(::arg().mustDo("disable-syslog"));
     L.toConsole((Logger::Urgency)(::arg().asNum("loglevel")));  
 
     if(::arg().mustDo("help") || ::arg().mustDo("config")) {

--- a/pdns/recursordist/pdns-recursor.service.in
+++ b/pdns/recursordist/pdns-recursor.service.in
@@ -8,7 +8,7 @@ After=network-online.target
 
 [Service]
 Type=notify
-ExecStart=@sbindir@/pdns_recursor --daemon=no --write-pid=no --disable-syslog
+ExecStart=@sbindir@/pdns_recursor --daemon=no --write-pid=no --disable-syslog --disable-log-timestamp
 Restart=on-failure
 StartLimitInterval=0
 PrivateTmp=true

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -425,7 +425,8 @@ distributor-threads=1""".format(confdir=confdir,
         recursorcmd = [os.environ['PDNSRECURSOR'],
                        '--config-dir=%s' % confdir,
                        '--local-port=%s' % port,
-                       '--security-poll-suffix=']
+                       '--security-poll-suffix=',
+                       '--disable-log-timestamp']
         print(' '.join(recursorcmd))
 
         logFile = os.path.join(confdir, 'recursor.log')


### PR DESCRIPTION
And add it to the unit files. This fixes the "double timestamps" issue.