### PR TITLE
Fix building rec and dnsdist with LuaJIT

### DIFF
--- a/m4/pdns_with_luajit.m4
+++ b/m4/pdns_with_luajit.m4
@@ -14,7 +14,10 @@ AC_DEFUN([PDNS_WITH_LUAJIT],[
       [LUAJITPC=""]
     )
     AS_IF([test "x$LUAJITPC" = "x"], [
-      AC_MSG_ERROR([LuaJIT not found])]
+      AC_MSG_ERROR([LuaJIT not found])],
+      [AC_CHECK_HEADER([lua.hpp], [ have_lua_hpp=y ])
+        AM_CONDITIONAL([HAVE_LUA_HPP], [ test x"$have_lua_hpp" = "xy" ])
+      ]
     )
   ])
 


### PR DESCRIPTION
The HAVE_LUA_HPP macro was not defined when LuaJIT was used.