### PR TITLE
Check for lua.hpp when using luajit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,7 @@ PDNS_WITH_LUAJIT
 AS_IF([test "x$with_luajit" = "xno"], [
   PDNS_WITH_LUA
 ])
+PDNS_CHECK_LUA_HPP
 
 AX_CXX_COMPILE_STDCXX_11
 

--- a/m4/pdns_check_lua_hpp.m4
+++ b/m4/pdns_check_lua_hpp.m4
@@ -1,0 +1,8 @@
+AC_DEFUN([PDNS_CHECK_LUA_HPP],[
+  AC_REQUIRE([PDNS_WITH_LUA])
+  AC_REQUIRE([PDNS_WITH_LUAJIT])
+  AS_IF([test "x$LUAPC" != "x" -o "x$LUAJITPC" != "x" ], [
+    AC_CHECK_HEADER([lua.hpp], [ have_lua_hpp=y ])
+  ])
+  AM_CONDITIONAL([HAVE_LUA_HPP], [ test x"$have_lua_hpp" = "xy" ])
+])

--- a/m4/pdns_with_lua.m4
+++ b/m4/pdns_with_lua.m4
@@ -28,10 +28,8 @@ AC_DEFUN([PDNS_WITH_LUA],[
       AS_IF([test "x$with_lua" = "xyes"],
         [AC_MSG_ERROR([cannot find lua])],
         [AC_MSG_RESULT([not found])]
-      )],
-      [AC_MSG_RESULT([$LUAPC])
-       AC_CHECK_HEADER([lua.hpp], [ have_lua_hpp=y ])
-       AM_CONDITIONAL([HAVE_LUA_HPP], [ test x"$have_lua_hpp" = "xy" ])
+      )],[
+        AC_MSG_RESULT([$LUAPC])
       ])
     ])
   AM_CONDITIONAL([LUA], [test "x$with_lua" = "xyes"])

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -48,6 +48,7 @@ AS_IF([test "x$with_luajit" = "xno"], [
 AS_IF([test "x$LUAPC" = "x" -a "x$LUAJITPC" = "x"], [
   AC_MSG_ERROR([Neither Lua nor LuaJIT found, Lua support is not optional])
 ])
+PDNS_CHECK_LUA_HPP
 
 AX_CXX_COMPILE_STDCXX_11([ext], [mandatory])
 

--- a/pdns/dnsdistdist/m4/pdns_check_lua_hpp.m4
+++ b/pdns/dnsdistdist/m4/pdns_check_lua_hpp.m4
@@ -1,0 +1,1 @@
+../../../m4/pdns_check_lua_hpp.m4

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -89,6 +89,7 @@ PDNS_WITH_LUAJIT
 AS_IF([test "x$with_luajit" = "xno"], [
   PDNS_WITH_LUA
 ])
+PDNS_CHECK_LUA_HPP
 
 PDNS_ENABLE_VERBOSE_LOGGING
 

--- a/pdns/recursordist/m4/pdns_check_lua_hpp.m4
+++ b/pdns/recursordist/m4/pdns_check_lua_hpp.m4
@@ -1,0 +1,1 @@
+../../../m4/pdns_check_lua_hpp.m4


### PR DESCRIPTION
configure would throw an error when no luajit or no lua at all was found.