### PR TITLE
[wip] LuaJIT raises a 'user data' error, but not an std::exception

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1345,10 +1345,13 @@ private:
                     // an exception_ptr was pushed on the stack
                     // rethrowing it with an additional ExecutionErrorException
                     try {
-                        std::rethrow_exception(readTopAndPop<std::exception_ptr>(state, std::move(errorCode)));
+                        if (const auto exp = readTopAndPop<std::exception_ptr>(state, std::move(errorCode))) {
+                            std::rethrow_exception(exp);
+                        }
                     } catch(...) {
                         std::throw_with_nested(ExecutionErrorException{"Exception thrown by a callback function called by Lua"});
                     }
+                    throw ExecutionErrorException{"Unknown Lua error"};
                 }
             }
         }


### PR DESCRIPTION
Related to #3716, where an invalid configuration raises "Fatal error: invalid key to 'next'" with Lua but crashes with LuaJIT. This is probably not the best fix, but my journey into LuaJIT ends here, at least for now. Comments welcome!
