### PR TITLE
Implement subcommand printing all KSK DS records in pdnsutil

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1721,11 +1721,19 @@ bool exportZoneDS(DNSSECKeeper& dk, const DNSName& zone)
     return true;
   }
 
+  bool has_ksks = false;
+  for (const auto &key: keys) {
+    if (key.d_flags == 257) {
+      has_ksks = true;
+      break;
+    }
+  }
+
   sort(keys.begin(),keys.end());
   reverse(keys.begin(),keys.end());
   for(const auto& key : keys) {
-    if (key.d_flags != 257) {
-      // only KSKs are printed
+    if (key.d_flags != 257 || !has_ksks) {
+      // if there are any, print only KSKs
       continue;
     }
 


### PR DESCRIPTION
The subcommands prints all KSK DS records of the given zone to stdout. Diagnostics are exclusively printed to stderr, and if the zone is not secured this is fatal.

Merge this -or- #4007 
