### PR TITLE
Implement subcommand printing all KSK DS records in pdnsutil (by adapting showZone)

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1567,7 +1567,8 @@ bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = false)
   }
 
   if(!dk.isSecuredZone(zone)) {
-    cerr<<"Zone is not actively secured"<<endl;
+    auto &outstream = (exportDS ? cerr : cout);
+    outstream << "Zone is not actively secured" << endl;
     if (exportDS) {
       // it does not make sense to proceed here, and it might be useful
       // for scripts to know that something is odd here


### PR DESCRIPTION
The subcommands prints all KSK DS records of the given zone to stdout. Diagnostics are exclusively printed to stderr, and if the zone is not secured this is fatal.

This is a different approach to the same thing as #4005. Only one of the two should be merged.
