### PR TITLE
Dnsdist node: infrastructure for querying recent traffic

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -153,7 +153,8 @@ void doConsole()
             boost::variant<
               string, 
               shared_ptr<DownstreamState>,
-              std::unordered_map<string, double>
+              std::unordered_map<string, double>,
+              std::vector<pair<unsigned int, std::unordered_map<string, string> > >
               >
             >
           >(withReturn ? ("return "+line) : line);
@@ -171,6 +172,20 @@ void doConsole()
             for(const auto& v : *um)
               o[v.first]=v.second;
             Json out = o;
+            cout<<out.dump()<<endl;
+          }
+          else if(const auto um = boost::get<std::vector<pair<unsigned int, std::unordered_map<string, string> > >>(&*ret)) {
+            cerr<<"So.. "<<um->size()<<endl;
+            using namespace json11;
+
+            Json::array a;
+            for(auto& e : *um) {
+              Json::object o;
+              o["qname"]=e.second["qname"];
+              o["rcode"]=e.second["rcode"];
+              a.push_back(o);
+            }
+            Json out=a;
             cout<<out.dump()<<endl;
           }
         }

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -153,8 +153,7 @@ void doConsole()
             boost::variant<
               string, 
               shared_ptr<DownstreamState>,
-              std::unordered_map<string, double>,
-              std::vector<pair<unsigned int, std::unordered_map<string, string> > >
+              std::unordered_map<string, double>
               >
             >
           >(withReturn ? ("return "+line) : line);
@@ -172,20 +171,6 @@ void doConsole()
             for(const auto& v : *um)
               o[v.first]=v.second;
             Json out = o;
-            cout<<out.dump()<<endl;
-          }
-          else if(const auto um = boost::get<std::vector<pair<unsigned int, std::unordered_map<string, string> > >>(&*ret)) {
-            cerr<<"So.. "<<um->size()<<endl;
-            using namespace json11;
-
-            Json::array a;
-            for(auto& e : *um) {
-              Json::object o;
-              o["qname"]=e.second["qname"];
-              o["rcode"]=e.second["rcode"];
-              a.push_back(o);
-            }
-            Json out=a;
             cout<<out.dump()<<endl;
           }
         }

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -67,28 +67,9 @@ void statNodeRespRing(statvisitor_t visitor)
     root.submit(c.name, c.dh.rcode, c.requestor);
   }
   StatNode::Stat node;
-  try {
-    root.visit([&visitor](const StatNode* node, const StatNode::Stat& self, const StatNode::Stat& children) {
-        visitor(*node, self, children);}
-      , node);  
-  }
-  catch(const LuaContext::ExecutionErrorException& e) {
-    std::cerr << e.what(); 
-    try {
-      std::rethrow_if_nested(e);
-      std::cerr << std::endl;
-    } catch(const std::exception& e) {
-      // e is the exception that was thrown from inside the lambda
-      std::cerr << ": " << e.what() << std::endl;      
-    }
-    catch(const PDNSException& e) {
-      // e is the exception that was thrown from inside the lambda
-      std::cerr << ": " << e.reason << std::endl;      
-    }
-  }
-  catch(std::exception& e) {
-    cerr<<"error: "<<e.what()<<endl;
-  }
+
+  root.visit([&visitor](const StatNode* node, const StatNode::Stat& self, const StatNode::Stat& children) {
+      visitor(*node, self, children);},  node);  
 
 }
 

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -165,6 +165,7 @@ void* tcpClientThread(int pipefd)
   auto localRulactions = g_rulactions.getLocal();
   auto localRespRulactions = g_resprulactions.getLocal();
   auto localDynBlockNMG = g_dynblockNMG.getLocal();
+  auto localDynBlockSMT = g_dynblockSMT.getLocal();
   auto localPools = g_pools.getLocal();
 #ifdef HAVE_PROTOBUF
   boost::uuids::random_generator uuidGenerator;
@@ -267,7 +268,7 @@ void* tcpClientThread(int pipefd)
 	struct timespec now;
 	gettime(&now);
 
-	if (!processQuery(localDynBlockNMG, localRulactions, blockFilter, dq, poolname, &delayMsec, now)) {
+	if (!processQuery(localDynBlockNMG, localDynBlockSMT, localRulactions, blockFilter, dq, poolname, &delayMsec, now)) {
 	  goto drop;
 	}
 

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -185,6 +185,22 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
             obj.insert({e->first.toString(), thing});
           }
         }
+
+        auto slow2 = g_dynblockSMT.getCopy();
+        slow2.visit([&now,&obj](const SuffixMatchTree<DynBlock>& node) {
+            if(now <node.d_value.until) {
+              string dom("empty");
+              if(!node.d_value.domain.empty())
+                dom = node.d_value.domain.toString();
+              Json::object thing{{"reason", node.d_value.reason}, {"seconds", (double)(node.d_value.until.tv_sec - now.tv_sec)},
+							     {"blocks", (double)node.d_value.blocks} };
+
+              obj.insert({dom, thing});
+          }
+        });
+
+
+
         Json my_json = obj;
         resp.body=my_json.dump();
         resp.headers["Content-Type"] = "application/json";

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -93,6 +93,7 @@ dnsdist_SOURCES = \
 	sholder.hh \
 	sodcrypto.cc sodcrypto.hh \
 	sstuff.hh \
+	statnode.cc statnode.hh \
 	ext/luawrapper/include/LuaContext.hpp \
 	ext/json11/json11.cpp \
 	ext/json11/json11.hpp \

--- a/pdns/dnsdistdist/statnode.cc
+++ b/pdns/dnsdistdist/statnode.cc
@@ -1,0 +1,1 @@
+../statnode.cc

--- a/pdns/dnsdistdist/statnode.hh
+++ b/pdns/dnsdistdist/statnode.hh
@@ -1,0 +1,1 @@
+../statnode.hh


### PR DESCRIPTION
With this PR, it becomes possible to build a tree of traffic in the ringbuffers. This tree can then be visited to make policy. The API is expected to remain fluid for a bit. 