### PR TITLE
rec: Log protobuf messages for cache hits. Add policy tags in gettag()

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -138,6 +138,7 @@ would require packet parsing, which is what we are trying to prevent with `ipfil
 The `gettag` function is invoked when `dq.tag` is called on a dq object or when
 the Recursor attempts to discover in which packetcache an answer is available.
 This function must return an integer, which is the tag number of the packetcache.
+In addition to this integer, this function can return a table of policy tags.
 
 The tagged packetcache can e.g. be used to answer queries from cache that have
 e.g. been filtered for certain IPs (this logic should be implemented in the

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -44,7 +44,7 @@ bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& loca
   return false;
 }
 
-int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype)
+int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags)
 {
   return 0;
 }
@@ -480,10 +480,21 @@ bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& loca
   return false; // don't block
 }
 
-int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype)
+int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags)
 {
-  if(d_gettag)
-    return d_gettag(remote, ednssubnet, local, qname, qtype);
+  if(d_gettag) {
+    auto ret = d_gettag(remote, ednssubnet, local, qname, qtype);
+
+    if (policyTags) {
+      const auto& tags = std::get<1>(ret);
+      if (tags) {
+        for (const auto& tag : *tags) {
+          policyTags->push_back(tag.second);
+        }
+      }
+    }
+    return std::get<0>(ret);
+  }
   return 0;
 }
 

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -30,9 +30,9 @@ public:
   bool preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret);
   bool ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader&);
 
-  int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& query, uint16_t qtype);
+  int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& query, uint16_t qtype, std::vector<std::string>* policyTags);
 
-  typedef std::function<int(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t)> gettag_t;
+  typedef std::function<std::tuple<int,boost::optional<std::unordered_map<int,string> > >(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t)> gettag_t;
   gettag_t d_gettag; // public so you can query if we have this hooked
 
 private:

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -12,6 +12,15 @@
 #include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#ifdef HAVE_PROTOBUF
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include "dnsmessage.pb.h"
+#endif
+
 
 using namespace ::boost::multi_index;
 
@@ -26,6 +35,10 @@ public:
   RecursorPacketCache();
   bool getResponsePacket(unsigned int tag, const std::string& queryPacket, time_t now, std::string* responsePacket, uint32_t* age);
   void insertResponsePacket(unsigned int tag, const DNSName& qname, uint16_t qtype, const std::string& queryPacket, const std::string& responsePacket, time_t now, uint32_t ttd);
+#ifdef HAVE_PROTOBUF
+  bool getResponsePacket(unsigned int tag, const std::string& queryPacket, time_t now, std::string* responsePacket, uint32_t* age, PBDNSMessage* protobufMessage);
+  void insertResponsePacket(unsigned int tag, const DNSName& qname, uint16_t qtype, const std::string& queryPacket, const std::string& responsePacket, time_t now, uint32_t ttd, const PBDNSMessage* protobufMessage);
+#endif
   void doPruneTo(unsigned int maxSize=250000);
   uint64_t doDump(int fd);
   int doWipePacketCache(const DNSName& name, uint16_t qtype=0xffff, bool subtree=false);
@@ -45,6 +58,9 @@ private:
     DNSName d_name;
     uint16_t d_type;
     mutable std::string d_packet; // "I know what I am doing"
+#ifdef HAVE_PROTOBUF
+    mutable PBDNSMessage d_protobufMessage;
+#endif
     uint32_t d_qhash;
     uint32_t d_tag;
     inline bool operator<(const struct Entry& rhs) const;


### PR DESCRIPTION
`gettag()` can now return an optional policy tags table in addition to
the existing `tag` integer.
Question and response protobuf messages are now sent even on cache hits.
When protobuf logging is enabled, the protobuf response message is
added to the cache and retrieved together with the response.