### PR TITLE
when generating message for signature (validation), no longer lowerca…

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -365,7 +365,8 @@ string getMessageForRRSET(const DNSName& qname, const RRSIGRecordContent& rrc, v
     toHash.append((char*)&tmp, 2);
     uint32_t ttl=htonl(rrc.d_originalttl);
     toHash.append((char*)&ttl, 4);
-    string rdata=add->serialize(DNSName("."), true, true); 
+    // for NSEC signatures, we should not lowercase the rdata section
+    string rdata=add->serialize(DNSName("."), true, (add->getType() == QType::NSEC) ? false : true);  // RFC 6840, 5.1
     tmp=htons(rdata.length());
     toHash.append((char*)&tmp, 2);
     toHash.append(rdata);

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -79,7 +79,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
 
   string ping;
   bool weWantEDNSSubnet=false;
-  if(EDNS0Level && !doTCP) {
+  if(EDNS0Level) { 
     DNSPacketWriter::optvect_t opts;
     if(srcmask) {
       EDNSSubnetOpts eo;

--- a/pdns/validate-recursor.cc
+++ b/pdns/validate-recursor.cc
@@ -52,6 +52,9 @@ vState validateRecords(const vector<DNSRecord>& recs)
         if(state == NTA)
           return Insecure;
         LOG("! state = "<<vStates[state]<<", now have "<<keys.size()<<" keys"<<endl);
+        for(const auto& k : keys) {
+          LOG("Key: "<<k.getZoneRepresentation()<< " {tag="<<k.getTag()<<"}"<<endl);
+        }
         // this sort of charges on and 'state' ends up as the last thing to have been checked
         // maybe not the right idea
       }
@@ -90,9 +93,9 @@ vState validateRecords(const vector<DNSRecord>& recs)
 #endif
   //  cerr<<"Input to validate: "<<endl;
   for(const auto& csp : cspmap) {
-    LOG(csp.first.first<<"|"<<csp.first.second<<" with "<<csp.second.signatures.size()<<" signatures"<<endl);
+    LOG(csp.first.first<<"|"<<DNSRecordContent::NumberToType(csp.first.second)<<" with "<<csp.second.signatures.size()<<" signatures"<<endl);
     if(!csp.second.signatures.empty() && !validrrsets.count(csp.first)) {
-      LOG("Lacks signature, must have one"<<endl);
+      LOG("Lacks signature, must have one, signatures: "<<csp.second.signatures.size()<<", valid rrsets: "<<validrrsets.count(csp.first)<<endl);
       return Bogus;
     }
   }


### PR DESCRIPTION
…se NSEC rdata, in accordance with RFC 6840, paragraph 5.1. This changes both auth and recursor behaviour, except I think we never consciously sign NSEC records with user generated content. We might lowercase it before we attempt to anyhow.