### PR TITLE
auth: Don't fail if `socat` exits at the end of remote backend unix tests

### DIFF
--- a/modules/remotebackend/testrunner.sh
+++ b/modules/remotebackend/testrunner.sh
@@ -186,9 +186,8 @@ function stop_unix() {
   fi
 
   if ! kill -0 ${socat_pid} 2>/dev/null; then
-    # should never happen - did the test crashed the service?
-    echo >&2 "ERROR: Unable to stop \"UNIX socket\" test service: service (${socat_pid}) not running"
-    exit 69
+    # might very well happen, since socat will stop after getting EOF
+    return 0
   fi
 
   kill -TERM ${socat_pid}


### PR DESCRIPTION
Every time I managed to reproduce that failure we sometimes get on travis, I have:

```
*** No errors detected
2016/06/24 17:28:00 socat[28022] E write(4, 0x6f33a0, 1): Broken pipe
ERROR: Unable to stop "UNIX socket" test service: service (28022) not running
```

And that actually might make sense because `socat` is going to exit as soon as it gets an EOF, which will happen when the`remotebackend_unix.test` process stops. We would then be in a race to stop the `socat` process before it stops existing.