### PR TITLE
Rec: Don't fail configure on missing fcontext.hpp

### DIFF
--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -54,7 +54,9 @@ AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
       LDFLAGS="$LDFLAGS $BOOST_THREAD_LDFLAGS"
     fi
     AC_MSG_NOTICE([checking whether the Boost context library actually links...])
-    BOOST_FIND_LIB([context], [$1], [boost/context/fcontext.hpp], [[]])
+    BOOST_FIND_HEADER([boost/context/fcontext.hpp], [ : ], [
+      BOOST_FIND_LIB([context], [$1], [boost/context/fcontext.hpp], [[]])
+    ])
     case $boost_cv_lib_context in
       (yes)
         AC_MSG_NOTICE([MTasker will use the Boost context library for context switching])


### PR DESCRIPTION
Fall back to System V ucontexts:

with fcontext.hpp renamed to fcontext.hpp.bak:
```
configure: checking whether the Boost context library actually links...
checking boost/context/fcontext.hpp usability... no
checking boost/context/fcontext.hpp presence... no
checking for boost/context/fcontext.hpp... no
configure: Boost context library is missing
configure: MTasker will use System V ucontexts for context switching
```

with fcontext.hpp available:
```
checking boost/context/fcontext.hpp usability... yes
checking boost/context/fcontext.hpp presence... yes
checking for boost/context/fcontext.hpp... yes
checking for boost/context/fcontext.hpp... (cached) yes
checking for the Boost context library... (cached) yes
configure: MTasker will use the Boost context library for context switching
```

Fixes #4014