### PR TITLE
rec: Don't duplicate the policy name, use a shared_ptr instead

### DIFF
--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -42,7 +42,7 @@ bool findNamedPolicy(const map<DNSName, DNSFilterEngine::Policy>& polmap, const 
 DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const DNSName& qname) const
 {
   //  cout<<"Got question for nameserver name "<<qname<<endl;
-  Policy pol{PolicyKind::NoAction, nullptr, "", 0};
+  Policy pol{PolicyKind::NoAction, nullptr, nullptr, 0};
   for(const auto& z : d_zones) {
     if(findNamedPolicy(z.propolName, qname, pol)) {
       //      cerr<<"Had a hit on the nameserver ("<<qname<<") used to process the query"<<endl;
@@ -57,7 +57,7 @@ DNSFilterEngine::Policy DNSFilterEngine::getQueryPolicy(const DNSName& qname, co
 {
   //  cout<<"Got question for "<<qname<<" from "<<ca.toString()<<endl;
 
-  Policy pol{PolicyKind::NoAction, nullptr, "", 0};
+  Policy pol{PolicyKind::NoAction, nullptr, nullptr, 0};
   for(const auto& z : d_zones) {
     if(findNamedPolicy(z.qpolName, qname, pol)) {
       //      cerr<<"Had a hit on the name of the query"<<endl;
@@ -98,7 +98,7 @@ DNSFilterEngine::Policy DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& 
 	return fnd->second;
     }
   }
-  return Policy{PolicyKind::NoAction, nullptr, "", 0};
+  return Policy{PolicyKind::NoAction, nullptr, nullptr, 0};
 }
 
 void DNSFilterEngine::assureZones(int zone)

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -51,7 +51,7 @@ public:
     }
     PolicyKind d_kind;
     std::shared_ptr<DNSRecordContent> d_custom;
-    std::string d_name;
+    std::shared_ptr<const std::string> d_name;
     int d_ttl;
   };
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -757,12 +757,12 @@ void startDoResolve(void *p)
       return; 
     case DNSFilterEngine::PolicyKind::NXDOMAIN:
       res=RCode::NXDomain;
-      appliedPolicy=dfepol.d_name;
+      appliedPolicy=dfepol.d_name ? *dfepol.d_name : "";
       goto haveAnswer;
 
     case DNSFilterEngine::PolicyKind::NODATA:
       res=RCode::NoError;
-      appliedPolicy=dfepol.d_name;
+      appliedPolicy=dfepol.d_name ? *dfepol.d_name : "";
       goto haveAnswer;
 
     case DNSFilterEngine::PolicyKind::Custom:
@@ -774,7 +774,7 @@ void startDoResolve(void *p)
       spoofed.d_content = dfepol.d_custom;
       spoofed.d_place = DNSResourceRecord::ANSWER;
       ret.push_back(spoofed);
-      appliedPolicy=dfepol.d_name;
+      appliedPolicy=dfepol.d_name ? *dfepol.d_name : "";
       goto haveAnswer;
 
 
@@ -782,7 +782,7 @@ void startDoResolve(void *p)
       if(!dc->d_tcp) {
 	res=RCode::NoError;	
 	pw.getHeader()->tc=1;
-        appliedPolicy=dfepol.d_name;
+        appliedPolicy=dfepol.d_name ? *dfepol.d_name : "";
 	goto haveAnswer;
       }
       break;
@@ -811,13 +811,13 @@ void startDoResolve(void *p)
       case DNSFilterEngine::PolicyKind::NXDOMAIN:
 	ret.clear();
 	res=RCode::NXDomain;
-        appliedPolicy=dfepol.d_name;
+        appliedPolicy=dfepol.d_name ? *dfepol.d_name : "";
 	goto haveAnswer;
 	
       case DNSFilterEngine::PolicyKind::NODATA:
 	ret.clear();
 	res=RCode::NoError;
-        appliedPolicy=dfepol.d_name;
+        appliedPolicy=dfepol.d_name ? *dfepol.d_name : "";
 	goto haveAnswer;
 	
       case DNSFilterEngine::PolicyKind::Truncate:
@@ -825,7 +825,7 @@ void startDoResolve(void *p)
 	  ret.clear();
 	  res=RCode::NoError;	
 	  pw.getHeader()->tc=1;
-          appliedPolicy=dfepol.d_name;
+          appliedPolicy=dfepol.d_name ? *dfepol.d_name : "";
 	  goto haveAnswer;
 	}
 	break;
@@ -840,7 +840,7 @@ void startDoResolve(void *p)
 	spoofed.d_content = dfepol.d_custom;
 	spoofed.d_place = DNSResourceRecord::ANSWER;
 	ret.push_back(spoofed);
-        appliedPolicy=dfepol.d_name;
+        appliedPolicy=dfepol.d_name ? *dfepol.d_name : "";
 	goto haveAnswer;
       }
 

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -89,11 +89,11 @@ void loadRecursorLuaConfig(const std::string& fname)
   Lua.writeFunction("rpzFile", [&lci](const string& fname, const boost::optional<std::unordered_map<string,boost::variant<int, string>>>& options) {
       try {
 	boost::optional<DNSFilterEngine::Policy> defpol;
-	std::string polName;
+	std::shared_ptr<std::string> polName;
 	if(options) {
 	  auto& have = *options;
 	  if(have.count("policyName")) {
-	    polName = boost::get<std::string>(constGet(have, "policyName"));
+	    polName = std::make_shared<std::string>(boost::get<std::string>(constGet(have, "policyName")));
 	  }
 	  if(have.count("defpol")) {
 	    defpol=DNSFilterEngine::Policy();
@@ -129,12 +129,12 @@ void loadRecursorLuaConfig(const std::string& fname)
 	boost::optional<DNSFilterEngine::Policy> defpol;
         TSIGTriplet tt;
         int refresh=0;
-	std::string polName;
+	std::shared_ptr<std::string> polName;
 	size_t maxReceivedXFRMBytes = 0;
 	if(options) {
 	  auto& have = *options;
 	  if(have.count("policyName")) {
-	    polName = boost::get<std::string>(constGet(have, "policyName"));
+	    polName = std::make_shared<std::string>(boost::get<std::string>(constGet(have, "policyName")));
 	  }
 	  if(have.count("defpol")) {
 	    //	    cout<<"Set a default policy"<<endl;

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -311,7 +311,7 @@ string reloadAuthAndForwards()
 }
 
 
-void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, const std::string& polName, const TSIGTriplet& tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes)
+void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, std::shared_ptr<const std::string> polName, const TSIGTriplet& tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes)
 {
   int refresh = oursr->d_st.refresh;
   for(;;) {

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -15,7 +15,7 @@ static Netmask makeNetmaskFromRPZ(const DNSName& name)
   return Netmask(parts[4]+"."+parts[3]+"."+parts[2]+"."+parts[1]+"/"+parts[0]);
 }
 
-void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, const std::string& polName, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, int place)
+void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, std::shared_ptr<const std::string> polName, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, int place)
 {
   static const DNSName drop("rpz-drop."), truncate("rpz-tcp-only."), noaction("rpz-passthru.");
   static const DNSName rpzClientIP("rpz-client-ip"), rpzIP("rpz-ip"),
@@ -105,7 +105,7 @@ void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, const std::
   }
 }
 
-shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, const std::string& polName, boost::optional<DNSFilterEngine::Policy> defpol, int place,  const TSIGTriplet& tt, size_t maxReceivedBytes)
+shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, std::shared_ptr<const std::string> polName, boost::optional<DNSFilterEngine::Policy> defpol, int place,  const TSIGTriplet& tt, size_t maxReceivedBytes)
 {
   L<<Logger::Warning<<"Loading RPZ zone '"<<zone<<"' from "<<master.toStringWithPort()<<endl;
   if(!tt.name.empty())
@@ -143,7 +143,7 @@ shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const
 }
 
 // this function is silent - you do the logging
-int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, const std::string& polName, boost::optional<DNSFilterEngine::Policy> defpol, int place)
+int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, std::shared_ptr<const std::string> polName, boost::optional<DNSFilterEngine::Policy> defpol, int place)
 {
   ZoneParserTNG zpt(fname);
   DNSResourceRecord drr;

--- a/pdns/rpzloader.hh
+++ b/pdns/rpzloader.hh
@@ -3,7 +3,7 @@
 #include <string>
 #include "dnsrecords.hh"
 
-int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, const std::string& policyName, boost::optional<DNSFilterEngine::Policy> defpol, int place);
-std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, const std::string& policyName, boost::optional<DNSFilterEngine::Policy> defpol, int place, const TSIGTriplet& tt, size_t maxReceivedBytes);
-void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, const std::string& policyName, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, int place);
-void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, const std::string& policyName, const TSIGTriplet &tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes);
+int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, std::shared_ptr<const std::string> policyName, boost::optional<DNSFilterEngine::Policy> defpol, int place);
+std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, std::shared_ptr<const std::string> policyName, boost::optional<DNSFilterEngine::Policy> defpol, int place, const TSIGTriplet& tt, size_t maxReceivedBytes);
+void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, std::shared_ptr<const std::string> policyName, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, int place);
+void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, std::shared_ptr<const std::string> policyName, const TSIGTriplet &tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes);


### PR DESCRIPTION
The policy name we use to pass an `applied policy` value to our protobuf messages was duplicated for every policy object, and I just realized there could be quite a lot of them.
This commit moves to a shared_ptr instead.