### PR TITLE
dnsdist: Include editline/readline.h instead of readline.h/history.h

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -30,7 +30,7 @@ make
 
 To build on OS X, `./configure LIBEDIT_LIBS='-L/usr/lib -ledit' LIBEDIT_CFLAGS=-I/usr/include/editline`
 
-To build on OpenBSD, `./configure CXX=eg++ CPP=ecpp LIBEDIT_LIBS='-ledit -lcurses' LIBEDIT_CFLAGS=-I/usr/include/readline`
+To build on OpenBSD, `./configure CXX=eg++ CPP=ecpp LIBEDIT_LIBS='-ledit -lcurses' LIBEDIT_CFLAGS=' '`
 
 On other recent platforms, installing a Lua and the system C++ compiler should be enough. 
 

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -1,6 +1,13 @@
 #include "dnsdist.hh"
 #include "sodcrypto.hh"
+
+#if defined (__OpenBSD__)
+#include <readline/readline.h>
+#include <readline/history.h>
+#else
 #include <editline/readline.h>
+#endif
+
 #include <fstream>
 #include "dolog.hh"
 #include "ext/json11/json11.hpp"

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -1,7 +1,6 @@
 #include "dnsdist.hh"
 #include "sodcrypto.hh"
-#include <readline.h>
-#include <history.h>
+#include <editline/readline.h>
 #include <fstream>
 #include "dolog.hh"
 #include "ext/json11/json11.hpp"

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -27,7 +27,13 @@
 #include <netinet/tcp.h>
 #include <limits>
 #include "dolog.hh"
-#include <readline.h>
+
+#if defined (__OpenBSD__)
+#include <readline/readline.h>
+#else
+#include <editline/readline.h>
+#endif
+
 #include "dnsname.hh"
 #include "dnswriter.hh"
 #include "base64.hh"


### PR DESCRIPTION
All libedit functions are in `<editline/readline.h`>, at least on Arch, OpenSUSE Leap and Fedora 22, and it looks like including `<readline.h`> and `<history.h`> would get non-libedit headers.