### PR TITLE
dnsdist: Fix a buffer overflow when displaying an OpcodeRule

### DIFF
--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -323,7 +323,7 @@ public:
   }
   string toString() const override
   {
-    return "opcode=="+d_opcode;
+    return "opcode=="+std::to_string(d_opcode);
   }
 private:
   uint8_t d_opcode;


### PR DESCRIPTION
Thanks clang for the warning!