### PR TITLE
add net/if.h dependencies

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1,3 +1,5 @@
+#include <sys/types.h>
+#include <sys/socket.h>
 #include <net/if.h>
 #include "dnsdist.hh"
 #include "dnsrulactions.hh"


### PR DESCRIPTION
This fixes compilation on OpenBSD after the OpenIndiana fixes. @pieterlexis if this (on top of #4065) works on OI, please merge.