### PR TITLE
resolver.cc: fix warnings found by clang-703.0.31 on OS X

### DIFF
--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -91,18 +91,19 @@ int makeQuerySocket(const ComboAddress& local, bool udpOrTCP)
 }
 
 Resolver::Resolver()
-try
 {
-  locals["default4"] = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true);
-  if(!::arg()["query-local-address6"].empty())
-    locals["default6"] = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true);
-  else 
-    locals["default6"] = -1;
-}
-catch(...) {
-  if(locals["default4"]>=0)
-    close(locals["default4"]);
-  throw;
+  locals["default4"] = -1;
+  locals["default6"] = -1;
+  try {
+    locals["default4"] = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true);
+    if(!::arg()["query-local-address6"].empty())
+      locals["default6"] = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true);
+  }
+  catch(...) {
+    if(locals["default4"]>=0)
+      close(locals["default4"]);
+    throw;
+  }
 }
 
 Resolver::~Resolver()


### PR DESCRIPTION
Move try/catch inside the function, as otherwise clang complains:

    cannot refer to a non-static member from the handler of a
    constructor function try block

This also cleans up the initialization of locals[]. Without this,
the code might have ended up closing stdout or another unrelated
socket.