### PR TITLE
Added metadata handlers for HTTP API

### DIFF
--- a/docs/markdown/httpapi/api_spec.md
+++ b/docs/markdown/httpapi/api_spec.md
@@ -614,12 +614,17 @@ zone\_metadata\_resource
       ]
     }
 
-Valid values for `<metadata_kind>` are specified in
+##### Parameters:
+
+`kind`: valid values for `<metadata_kind>` are specified in
 [the `domainmetadata` documentation](../authoritative/domainmetadata.md).
 
-Clients MUST NOT modify `NSEC3PARAM`, `NSEC3NARROW` or `PRESIGNED`
-through this interface. The server SHOULD reject updates to these
-metadata.
+`metadata`: an array with all values for this metadata kind.
+
+Clients MUST NOT modify `NSEC3PARAM`, `NSEC3NARROW`, `PRESIGNED` and
+`LUA-AXFR-SCRIPT` through this interface. The server rejects updates to
+these metadata. Modifications to custom metadata kinds are rejected
+through this interface.
 
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/metadata
@@ -629,14 +634,39 @@ Collection access.
 
 Allowed methods: `GET`, `POST`
 
-**TODO**: Not yet implemented.
+#### GET
+
+Returns all metadata entries for the zone.
+
+
+#### POST
+
+Creates a set of metadata entries of given kind for the zone.
+
+* existing metadata entries for the zone with the same kind are not overwritten.
+
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/metadata/:metadata\_kind
 ---------------------------------------------------------------------------
 
 Allowed methods: `GET`, `PUT`, `DELETE`
 
-**TODO**: Not yet implemented.
+#### GET
+
+Returns all metadata entries of a given kind for the zone.
+
+
+#### DELETE
+
+Deletes all metadata entries of a given kind for the zone.
+
+
+#### PUT
+
+Modifies the metadata entries of a given kind for the zone.
+
+This returns `200 OK` on success.
+
 
 CryptoKeys
 ==========

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -560,9 +560,9 @@ static bool isValidMetadataKind(const string& kind, bool readonly) {
 
   bool found = false;
 
-  for (string& s : builtinOptions) {
+  for (const string& s : builtinOptions) {
     if (kind == s) {
-      for (string& s2 : protectedOptions) {
+      for (const string& s2 : protectedOptions) {
         if (!readonly && s == s2)
           return false;
       }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -628,14 +628,7 @@ static void apiZoneMetadata(HttpRequest* req, HttpResponse *resp) {
     if (!B.setDomainMetadata(zonename, kind, vecMetadata))
       throw ApiException("Could not update metadata entries for domain '" + zonename.toString() + "'");
 
-    Json::object key {
-      { "type", "Metadata" },
-      { "kind", document["kind"] },
-      { "metadata", metadata }
-    };
-
     resp->status = 201;
-    resp->setBody(key);
   } else
     throw HttpMethodNotAllowedException();
 }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -286,6 +286,47 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             headers={'content-type': 'application/json'})
         self.assertEquals(r.status_code, 422)
 
+    def test_create_zone_metadata(self):
+        payload_metadata = {"type": "Metadata", "kind": "AXFR-SOURCE", "metadata": ["127.0.0.2"]}
+        r = self.session.post(self.url("/api/v1/servers/localhost/zones/example.com/metadata"),
+                              data=json.dumps(payload_metadata))
+        rdata = r.json()
+        self.assertEquals(r.status_code, 201)
+        self.assertEquals(rdata["metadata"], payload_metadata["metadata"])
+
+    def test_create_zone_metadata_kind(self):
+        payload_metadata = {"metadata": ["127.0.0.2"]}
+        r = self.session.put(self.url("/api/v1/servers/localhost/zones/example.com/metadata/AXFR-SOURCE"),
+                             data=json.dumps(payload_metadata))
+        rdata = r.json()
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(rdata["metadata"], payload_metadata["metadata"])
+
+    def test_create_protected_zone_metadata(self):
+        # test whether it prevents modification of certain kinds
+        for k in ("NSEC3NARROW", "NSEC3PARAM", "PRESIGNED", "LUA-AXFR-SCRIPT"):
+            payload = {"metadata": ["FOO", "BAR"]}
+            r = self.session.put(self.url("/api/v1/servers/localhost/zones/example.com/metadata/%s" % k),
+                                 data=json.dumps(payload))
+            self.assertEquals(r.status_code, 422)
+
+    def test_retrieve_zone_metadata(self):
+        payload_metadata = {"type": "Metadata", "kind": "AXFR-SOURCE", "metadata": ["127.0.0.2"]}
+        self.session.post(self.url("/api/v1/servers/localhost/zones/example.com/metadata"),
+                          data=json.dumps(payload_metadata))
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/example.com/metadata"))
+        rdata = r.json()
+        self.assertEquals(r.status_code, 200)
+        self.assertIn(payload_metadata, rdata)
+
+    def test_delete_zone_metadata(self):
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/example.com/metadata/AXFR-SOURCE"))
+        self.assertEquals(r.status_code, 200)
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/example.com/metadata/AXFR-SOURCE"))
+        rdata = r.json()
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(rdata["metadata"], [])
+
     def test_create_slave_zone(self):
         # Test that nameservers can be absent for slave zones.
         name, payload, data = self.create_zone(kind='Slave', nameservers=None, masters=['127.0.0.2'])


### PR DESCRIPTION
This pull request replaces #4080.

I've also added `LUA-AXFR-SCRIPT` to the list of metadata entries which cannot be modified via API due to security concerns. As discussed previously, the implementation will reject creation and modification of custom metadata entries. We may choose from three possible options to relax the behavior:

1. Leave the implementation as-is, rejecting custom metadata entries at all
2. Accept custom metadata if the configuration option `api-allow-custom-metadata` is set to `yes`, reject otherwise
3. Accept custom metadata at all