### PR TITLE
Implementation of the cryptokeys REST-API (PUT, POST, DELETE)

### DIFF
--- a/docs/manpages/pdnsutil.1.md
+++ b/docs/manpages/pdnsutil.1.md
@@ -52,7 +52,7 @@ activate-zone-key *ZONE* *KEY-ID*
 add-zone-key *ZONE* {**KSK**,**ZSK**} [**active**,**inactive**] *KEYBITS* *ALGORITHM*
 :   Create a new key for zone *ZONE*, and make it a KSK or a ZSK, with the
     specified algorithm. The key is inactive by default, set it to **active** to
-    immediately use it to sign *ZONE*.
+    immediately use it to sign *ZONE*. Prints the id of the added key.
 
 create-bind-db *FILE*
 :    Create DNSSEC database (sqlite3) at *FILE* for the BIND backend.
@@ -80,7 +80,7 @@ generate-zone-key {**KSK**,**ZSK**} [*ALGORITHM*] [*KEYBITS*]
 import-zone-key *ZONE* *FILE* {**KSK**,**ZSK**}
 :    Import from *FILE* a full (private) key for zone called *ZONE*. The format
      used is compatible with BIND and NSD/LDNS. **KSK** or **ZSK** specifies the
-     flags this key should have on import.
+     flags this key should have on import. Prints the id of the added key.
 
 remove-zone-key *ZONE* *KEY-ID*
 :    Remove a key with id *KEY-ID* from a zone called *ZONE*.

--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -369,8 +369,8 @@ Coefficient: 6S0vhIQITWzqfQSLj+wwRzs6qCvJckHb1+SD1XpwYjSgMTEUlZhf96m8WiaE1/fIt4Z
 Adds key into local storage. See [`getDomainKeys`](#getdomainkeys) for more information.
 
 * Mandatory: No
-* Parameters: name, key=`<flags,active,content>`
-* Reply: id (>= 0) for success, -1 for failure
+* Parameters: name, key=`<flags,active,content>`, id
+* Reply: true for success, false for failure
 
 #### Example JSON/RPC
 Query:

--- a/docs/markdown/authoritative/backend-remote.md
+++ b/docs/markdown/authoritative/backend-remote.md
@@ -370,7 +370,7 @@ Adds key into local storage. See [`getDomainKeys`](#getdomainkeys) for more info
 
 * Mandatory: No
 * Parameters: name, key=`<flags,active,content>`
-* Reply: true for success, false for failure
+* Reply: id (>= 0) for success, -1 for failure
 
 #### Example JSON/RPC
 Query:

--- a/docs/markdown/httpapi/api_spec.md
+++ b/docs/markdown/httpapi/api_spec.md
@@ -668,14 +668,14 @@ Modifies the metadata entries of a given kind for the zone.
 This returns `200 OK` on success.
 
 
-CryptoKeys
+Cryptokeys
 ==========
 
 cryptokey\_resource
 -------------------
 
     {
-      "type": "CryptoKey",
+      "type": "Cryptokey",
       "id": <int>,
       "active": <bool>,
       "keytype": <keytype>,
@@ -711,42 +711,44 @@ Returns all public data about cryptokeys, but not `privatekey`.
 
 #### POST
 
-This method adds a key to a zone by generate it or content parameter.
+This method adds a new key to a zone. The key can either be generated or imported by supplying the content parameter.
 
 ##### Parameters:
 
-* `content` : "key The format used is compatible with BIND and NSD/LDNS" `<string>`
+* `content` : "\<key\>" `<string>` (The format used is compatible with BIND and NSD/LDNS)
+* `keytype` : "ksk|zsk" `<string>`
+* `active`: "true|false" `<value>` (If not set the key will not be active by default)
 
 If `content` == `null`, the server generates a new key. In this case, the
 following additional fields MAY be supplied:
 
 * `bits`: number of bits `<int>`
-* `algo`: `<algo>`
-* `keytype` : "ksk|zsk" `<string>`
-* `active`: "true|false" `<value>`
+* `algo`: `<algo>` (Default: 13/ECDSA)
 
 Where `<algo>` is one of the supported key algorithms in lowercase OR the
 numeric id, see [`the list`](../authoritative/dnssec.md#supported-algorithms).
 
 ##### Response:
 * `422 Unprocessable Entity`:
-    * keytype isn't ksk|zsk:
-        * `json` {"error" : "Invalid keytype 'keytype'"}
-    * The "algo" isn't supported:
-        * `json` {"error" : "Unknown algorithm: 'algo'"}
-    * Algo <= 10 and no bits were passed:
-        * `json` {"error" : "Creating an algorithm algo key requires the size (in bits) to be passed"}
-    * The wrong keysize was passed:
-        * `json` {"error" : "Wrong bit size!"}
-    * If the server cant guess the keysize:
-        * `json` {"error" : "Can't guess key size for algorithm"}
+    * keytype is not ksk|zsk:
+        * `{"error" : "Invalid keytype 'keytype'"}`
+    * The "algo" is not supported:
+        * `{"error" : "Unknown algorithm: 'algo'"}`
+    * Algo <= 10 and the `bits` parameter is not set:
+        * `{"error" : "Creating an algorithm 'algo' key requires the size (in bits) to be passed."}`
+    * The provided bit size is not supported by the selected algorithm:
+        * `{"error" : "The algorithm does not support the given bit size."}`
+    * The `bits` parameter is not a positive integer value:
+        * `{"error" : "'bits' must be a positive integer value"}`
+    * If the server can not guess the key size:
+        * `{"error" : "Can not guess key size for algorithm"}`
     * The key-creation failed:
-        * `json` {"error" : "Adding key failed, perhaps DNSSEC not enabled in configuration?"}
-    * The key in content has the wrong format:
-        * `json` {"error" : "Wrong key format!"}
-* `201 OK`:
+        * `{"error" : "Adding key failed, perhaps DNSSEC not enabled in configuration?"}`
+    * The key in `content` has the wrong format:
+        * `{"error" : "Key could not be parsed. Make sure your key format is correct."}`
+* `201 Created`:
     * Everything was fine:
-        * `json` all public data about the new cryptokey. Look at cryptokey\_resource.
+        * Returns all public data about the new cryptokey. Look at cryptokey\_resource.
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/cryptokeys/:cryptokey\_id
 ----------------------------------------------------------------------------
@@ -759,37 +761,28 @@ Returns all public data about cryptokeys, including `privatekey`.
 
 #### PUT
 
-This method handles PUT (execute) de/activates a key from `zone_name` specified by `cryptokey_id`.
+This method de/activates a key from `zone_name` specified by `cryptokey_id`.
 
 ##### Parameters:
 
-* `:zone_name`: name of the zone for which the key with `cryptokey_id` should be de/activated
-* `cryptokey_id`: id of the key which wanted to be de/activated
-* `json`: {"active": true|false}
+* `active`: "true|false" `<value>`
 
 ##### Responses:
-* `200 OK`: The key with `cryptokey_id` is de/activated.
-* `400 Bad Request`: The `zone_name` is not found.
+* `204 No Content`: The key with `cryptokey_id` is de/activated.
 * `422 Unprocessable Entity`:
-    &nbsp;&nbsp;The backend returns false on de/activation. An error occoured.
-    &nbsp;&nbsp;json {"error": "Could not de/activate Key: :cryptokey_id in Zone: :zone_name"}
+    &nbsp;&nbsp;The backend returns false on de/activation. An error occurred.
+    &nbsp;&nbsp;`{"error": "Could not de/activate Key: :cryptokey_id in Zone: :zone_name"}`
 
 #### DELETE
 
-This Method deletes a key from a zone.
-
-##### Parameters:
-
-* `:zone_name`: name of the zone which is signed with a key with `cryptokey_id`
-* `cryptokey_id`: id of the key which wanted to be gone
+This method deletes a key from `zone_name` specified by `cryptokey_id`.
 
 ##### Responses:
 
-* `200 No Content`: The Key is gone.
-* `400 Bad Request`: The `zone_name` is not found.
-* `422 Unknown Status`:
+* `200 OK`: The Key is gone.
+* `422 Unprocessable Entity`:
     &nbsp;&nbsp;The backend failed to remove the key.
-    &nbsp;&nbsp;json {"error": Could not DELETE :cryptokey_id"}
+    &nbsp;&nbsp;`{"error": Could not DELETE :cryptokey_id"}`
 
 Data searching
 ==============

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -610,6 +610,7 @@ Bind2Backend::Bind2Backend(const string &suffix, bool loadZones)
   d_getDomainKeysQuery_stmt = NULL;
   d_deleteDomainKeyQuery_stmt = NULL;
   d_insertDomainKeyQuery_stmt = NULL;
+  d_GetLastInsertedKeyIdQuery_stmt = NULL;
   d_activateDomainKeyQuery_stmt = NULL;
   d_deactivateDomainKeyQuery_stmt = NULL;
   d_getTSIGKeyQuery_stmt = NULL;

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -214,7 +214,7 @@ public:
   virtual bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta);
   virtual bool getDomainKeys(const DNSName& name, unsigned int kind, std::vector<KeyData>& keys);
   virtual bool removeDomainKey(const DNSName& name, unsigned int id);
-  virtual int addDomainKey(const DNSName& name, const KeyData& key);
+  virtual bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id);
   virtual bool activateDomainKey(const DNSName& name, unsigned int id);
   virtual bool deactivateDomainKey(const DNSName& name, unsigned int id);
   virtual bool getTSIGKey(const DNSName& name, DNSName* algorithm, string* content);

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -289,6 +289,7 @@ private:
   SSqlStatement* d_getDomainKeysQuery_stmt;
   SSqlStatement* d_deleteDomainKeyQuery_stmt;
   SSqlStatement* d_insertDomainKeyQuery_stmt;
+  SSqlStatement* d_GetLastInsertedKeyIdQuery_stmt;
   SSqlStatement* d_activateDomainKeyQuery_stmt;
   SSqlStatement* d_deactivateDomainKeyQuery_stmt;
   SSqlStatement* d_getTSIGKeyQuery_stmt;

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -89,6 +89,8 @@ void Bind2Backend::freeStatements()
 #include "pdns/logger.hh"
 #include "pdns/ssqlite3.hh"
 
+#define ASSERT_ROW_COLUMNS(query, row, num) { if (row.size() != num) { throw PDNSException(std::string(query) + " returned wrong number of columns, expected "  #num  ", got " + std::to_string(row.size())); } }
+
 void Bind2Backend::setupDNSSEC()
 {
   if(getArg("dnssec-db").empty() || d_hybrid)
@@ -334,6 +336,7 @@ bool Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key, int64_t
     }
     SSqlStatement::row_t row;
     d_GetLastInsertedKeyIdQuery_stmt->nextRow(row);
+    ASSERT_ROW_COLUMNS("get-last-inserted-key-id-query", row, 1);
     int id = std::stoi(row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
     return true;

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -56,7 +56,7 @@ bool Bind2Backend::getDomainKeys(const DNSName& name, unsigned int kind, std::ve
 bool Bind2Backend::removeDomainKey(const DNSName& name, unsigned int id)
 { return false; }
 
-int Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key)
+bool Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key, int64_t& id)
 { return -1; }
 
 bool Bind2Backend::activateDomainKey(const DNSName& name, unsigned int id)
@@ -308,10 +308,10 @@ bool Bind2Backend::removeDomainKey(const DNSName& name, unsigned int id)
   return true;
 }
 
-int Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key)
+bool Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key, int64_t& id)
 {
   if(!d_dnssecdb || d_hybrid)
-    return -1;
+    return false;
 
   try {
     d_insertDomainKeyQuery_stmt->
@@ -328,19 +328,22 @@ int Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key)
 
   try {
     d_GetLastInsertedKeyIdQuery_stmt->execute();
-    if (!d_GetLastInsertedKeyIdQuery_stmt->hasNextRow())
-      throw PDNSException("GSQLBackend unable to get id");
+    if (!d_GetLastInsertedKeyIdQuery_stmt->hasNextRow()) {
+      id = -2;
+      return true;
+    }
     SSqlStatement::row_t row;
     d_GetLastInsertedKeyIdQuery_stmt->nextRow(row);
     int id = std::stoi(row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
-    return id;
+    return true;
   }
   catch (SSqlException &e) {
-    throw PDNSException("DNSSEC database in BIND backend unable to get id: "+e.txtReason());
+    id = -2;
+    return true;
   }
 
-  return -1;
+  return false;
 }
 
 bool Bind2Backend::activateDomainKey(const DNSName& name, unsigned int id)

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -871,7 +871,7 @@ bool GeoIPBackend::removeDomainKey(const DNSName& name, unsigned int id) {
   return false;
 }
 
-int GeoIPBackend::addDomainKey(const DNSName& name, const KeyData& key) {
+bool GeoIPBackend::addDomainKey(const DNSName& name, const KeyData& key, int64_t& id) {
   if (!d_dnssec) return false;
   WriteLock rl(&s_state_lock);
   unsigned int nextid=1;
@@ -899,7 +899,8 @@ int GeoIPBackend::addDomainKey(const DNSName& name, const KeyData& key) {
       ofstream ofs(pathname.str().c_str());
       ofs.write(key.content.c_str(), key.content.size());
       ofs.close();
-      return nextid;
+      id = nextid;
+      return true;
     }
   }
   return false;

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -64,7 +64,7 @@ public:
   virtual bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta);
   virtual bool getDomainKeys(const DNSName& name, unsigned int kind, std::vector<DNSBackend::KeyData>& keys);
   virtual bool removeDomainKey(const DNSName& name, unsigned int id);
-  virtual int addDomainKey(const DNSName& name, const KeyData& key);
+  virtual bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id);
   virtual bool activateDomainKey(const DNSName& name, unsigned int id);
   virtual bool deactivateDomainKey(const DNSName& name, unsigned int id);
 

--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -126,6 +126,7 @@ public:
     declare(suffix,"delete-names-query","","delete from records where domain_id=? and name=?");
 
     declare(suffix,"add-domain-key-query","", "insert into cryptokeys (domain_id, flags, active, content) select id, ?, ?, ? from domains where name=?");
+    declare(suffix,"get-last-inserted-key-id-query", "", "select LAST_INSERT_ID()");
     declare(suffix,"list-domain-keys-query","", "select cryptokeys.id, flags, active, content from domains, cryptokeys where cryptokeys.domain_id=domains.id and name=?");
     declare(suffix,"get-all-domain-metadata-query","", "select kind,content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name=?");
     declare(suffix,"get-domain-metadata-query","", "select content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name=? and domainmetadata.kind=?");

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -118,6 +118,7 @@ public:
     declare(suffix,"delete-names-query","","delete from records where domain_id=? and name=?");
 
     declare(suffix,"add-domain-key-query","", "insert into cryptokeys (domain_id, flags, active, content) select id, ?, ?, ? from domains where name=?");
+    declare(suffix,"get-last-inserted-key-id-query", "", "select ident_current('cryptokeys')");
     declare(suffix,"list-domain-keys-query","", "select cryptokeys.id, flags, active, content from domains, cryptokeys where cryptokeys.domain_id=domains.id and name=?");
     declare(suffix,"get-all-domain-metadata-query","", "select kind,content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name=?");
     declare(suffix,"get-domain-metadata-query","", "select content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name=? and domainmetadata.kind=?");

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -118,6 +118,7 @@ public:
     declare(suffix,"delete-names-query","","delete from records where domain_id=$1 and name=$2");
 
     declare(suffix,"add-domain-key-query","", "insert into cryptokeys (domain_id, flags, active, content) select id, $1, $2, $3 from domains where name=$4");
+    declare(suffix,"get-last-inserted-key-id-query","", "select lastval()");
     declare(suffix,"list-domain-keys-query","", "select cryptokeys.id, flags, case when active then 1 else 0 end as active, content from domains, cryptokeys where cryptokeys.domain_id=domains.id and name=$1");
     declare(suffix,"get-all-domain-metadata-query","", "select kind,content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name=$1");
     declare(suffix,"get-domain-metadata-query","", "select content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name=$1 and domainmetadata.kind=$2");

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -130,6 +130,7 @@ public:
     declare(suffix, "delete-names-query", "", "delete from records where domain_id=:domain_id and name=:qname");
 
     declare(suffix, "add-domain-key-query","", "insert into cryptokeys (domain_id, flags, active, content) select id, :flags,:active, :content from domains where name=:domain");
+    declare(suffix, "get-last-inserted-key-id-query", "", "select last_insert_rowid()");
     declare(suffix, "list-domain-keys-query","", "select cryptokeys.id, flags, active, content from domains, cryptokeys where cryptokeys.domain_id=domains.id and name=:domain");
     declare(suffix, "get-all-domain-metadata-query","", "select kind,content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name=:domain");
     declare(suffix, "get-domain-metadata-query","", "select content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name=:domain and domainmetadata.kind=:kind");

--- a/modules/luabackend/dnssec.cc
+++ b/modules/luabackend/dnssec.cc
@@ -312,13 +312,13 @@ bool LUABackend::removeDomainKey(const DNSName& name, unsigned int id) {
     return ok;
 }
 
-int LUABackend::addDomainKey(const DNSName& name, const KeyData& key) {
+bool LUABackend::addDomainKey(const DNSName& name, const KeyData& key, int64_t& id) {
 // there is no logging function in pdnsutil when running this routine?
 
 //key = id, flags, active, content
 
     if(f_lua_adddomainkey == 0) 
-	return -1;
+	return false;
 
     if(logging)
 	//L << Logger::Info << backend_name << "(addDomainKey) BEGIN name: '" << name << "' id: '" << id << endl;
@@ -347,7 +347,6 @@ int LUABackend::addDomainKey(const DNSName& name, const KeyData& key) {
         lua_pop(lua, 1);
 
         throw runtime_error(e);
-        return -1;
     }
 
     size_t returnedwhat = lua_type(lua, -1);
@@ -359,9 +358,9 @@ int LUABackend::addDomainKey(const DNSName& name, const KeyData& key) {
     lua_pop(lua, 1);
 
     if(logging)
-	cerr << backend_name << "(addDomainKey) END" << endl;
-	
-    return ok;
+        cerr << backend_name << "(addDomainKey) END" << endl;
+
+    return ok >= 0;
 }
 
 bool LUABackend::getDomainKeys(const DNSName& name, unsigned int kind, std::vector<KeyData>& keys) {

--- a/modules/luabackend/luabackend.hh
+++ b/modules/luabackend/luabackend.hh
@@ -98,7 +98,7 @@ public:
     bool activateDomainKey(const DNSName& name, unsigned int id) override ;
     bool deactivateDomainKey(const DNSName& name, unsigned int id) override ;
     bool getTSIGKey(const DNSName& name, DNSName* algorithm, string* content) override ;
-    int addDomainKey(const DNSName& name, const KeyData& key) override ;
+    bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id) override ;
     bool updateDNSSECOrderAndAuthAbsolute(uint32_t domain_id, const DNSName& qname, const std::string& ordername, bool auth);
     bool getBeforeAndAfterNamesAbsolute(uint32_t id, const      string& qname, DNSName& unhashed, string& before, string& after) override;
     bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& zonename, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype=QType::ANY) override;

--- a/modules/oraclebackend/oraclebackend.cc
+++ b/modules/oraclebackend/oraclebackend.cc
@@ -1649,11 +1649,11 @@ OracleBackend::removeDomainKey (const DNSName& name, unsigned int id)
   return true;
 }
 
-int
-OracleBackend::addDomainKey (const DNSName& name, const KeyData& key)
+bool
+OracleBackend::addDomainKey (const DNSName& name, const KeyData& key, int64_t& id)
 {
   if(!d_dnssecQueries)
-    return -1;
+    return false;
   DomainInfo di;
   if (getDomainInfo(name, di) == false) return false;
 
@@ -1697,7 +1697,8 @@ OracleBackend::addDomainKey (const DNSName& name, const KeyData& key)
     throw OracleException("Oracle addDomainKey COMMIT", oraerr);
   }
 
-  return key_id;
+  id = key_id;
+  return key_id >= 0;
 }
 
 bool

--- a/modules/oraclebackend/oraclebackend.hh
+++ b/modules/oraclebackend/oraclebackend.hh
@@ -106,7 +106,7 @@ public:
 
   bool getDomainKeys(const DNSName& name, unsigned int kind, vector<KeyData>& keys);
   bool removeDomainKey(const DNSName& name, unsigned int id);
-  int addDomainKey(const DNSName& name, const KeyData& key);
+  bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id);
   bool activateDomainKey(const DNSName& name, unsigned int id);
   bool deactivateDomainKey(const DNSName& name, unsigned int id);
 

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -405,7 +405,7 @@ bool RemoteBackend::removeDomainKey(const DNSName& name, unsigned int id) {
    return true;
 }
 
-int RemoteBackend::addDomainKey(const DNSName& name, const KeyData& key) {
+bool RemoteBackend::addDomainKey(const DNSName& name, const KeyData& key, int64_t& id) {
    // no point doing dnssec if it's not supported
    if (d_dnssec == false) return false;
 
@@ -425,7 +425,8 @@ int RemoteBackend::addDomainKey(const DNSName& name, const KeyData& key) {
    if (this->send(query) == false || this->recv(answer) == false)
      return false;
 
-   return answer["result"].int_value();
+   id = answer["result"].int_value();
+   return id >= 0;
 }
 
 bool RemoteBackend::activateDomainKey(const DNSName& name, unsigned int id) {

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -165,7 +165,7 @@ class RemoteBackend : public DNSBackend
   virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const string& qname, DNSName& unhashed, string& before, string& after);
   virtual bool setDomainMetadata(const DNSName& name, const string& kind, const std::vector<std::basic_string<char> >& meta);
   virtual bool removeDomainKey(const DNSName& name, unsigned int id);
-  virtual int addDomainKey(const DNSName& name, const KeyData& key);
+  virtual bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id);
   virtual bool activateDomainKey(const DNSName& name, unsigned int id);
   virtual bool deactivateDomainKey(const DNSName& name, unsigned int id);
   virtual bool getDomainInfo(const DNSName& domain, DomainInfo& di);

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -115,8 +115,11 @@ BOOST_AUTO_TEST_CASE(test_method_getAllDomainMetadata) {
 
 BOOST_AUTO_TEST_CASE(test_method_addDomainKey) {
    BOOST_TEST_MESSAGE("Testing addDomainKey method");
-   BOOST_CHECK_EQUAL(be->addDomainKey(DNSName("unit.test."),k1), 1);
-   BOOST_CHECK_EQUAL(be->addDomainKey(DNSName("unit.test."),k2), 2);
+   int64_t id;
+   be->addDomainKey(DNSName("unit.test."),k1,id);
+   BOOST_CHECK_EQUAL(id, 1);
+   be->addDomainKey(DNSName("unit.test."),k2,id);
+   BOOST_CHECK_EQUAL(id, 2);
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getDomainKeys) {

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -671,6 +671,7 @@ bool GSQLBackend::addDomainKey(const DNSName& name, const KeyData& key, int64_t&
     }
     SSqlStatement::row_t row;
     d_GetLastInsertedKeyIdQuery_stmt->nextRow(row);
+    ASSERT_ROW_COLUMNS("get-last-inserted-key-id-query", row, 1);
     id = std::stoi(row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
     return true;

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -217,7 +217,7 @@ public:
 
   bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset);
   bool listSubZone(const DNSName &zone, int domain_id);
-  int addDomainKey(const DNSName& name, const KeyData& key);
+  bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id);
   bool getDomainKeys(const DNSName& name, unsigned int kind, std::vector<KeyData>& keys);
   bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string> >& meta);
   bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta);

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -88,6 +88,7 @@ public:
       d_RemoveEmptyNonTerminalsFromZoneQuery_stmt = d_db->prepare(d_RemoveEmptyNonTerminalsFromZoneQuery, 1);
       d_DeleteEmptyNonTerminalQuery_stmt = d_db->prepare(d_DeleteEmptyNonTerminalQuery, 2);
       d_AddDomainKeyQuery_stmt = d_db->prepare(d_AddDomainKeyQuery, 4);
+      d_GetLastInsertedKeyIdQuery_stmt = d_db->prepare(d_GetLastInsertedKeyIdQuery, 0);
       d_ListDomainKeysQuery_stmt = d_db->prepare(d_ListDomainKeysQuery, 1);
       d_GetAllDomainMetadataQuery_stmt = d_db->prepare(d_GetAllDomainMetadataQuery, 1);
       d_GetDomainMetadataQuery_stmt = d_db->prepare(d_GetDomainMetadataQuery, 2);
@@ -154,6 +155,7 @@ public:
     release(&d_RemoveEmptyNonTerminalsFromZoneQuery_stmt);
     release(&d_DeleteEmptyNonTerminalQuery_stmt);
     release(&d_AddDomainKeyQuery_stmt);
+    release(&d_GetLastInsertedKeyIdQuery_stmt);
     release(&d_ListDomainKeysQuery_stmt);
     release(&d_GetAllDomainMetadataQuery_stmt);
     release(&d_GetDomainMetadataQuery_stmt);
@@ -296,6 +298,7 @@ private:
   string d_DeleteEmptyNonTerminalQuery;
 
   string d_AddDomainKeyQuery;
+  string d_GetLastInsertedKeyIdQuery;
   string d_ListDomainKeysQuery;
   string d_GetAllDomainMetadataQuery;
   string d_GetDomainMetadataQuery;
@@ -361,6 +364,7 @@ private:
   SSqlStatement* d_RemoveEmptyNonTerminalsFromZoneQuery_stmt;
   SSqlStatement* d_DeleteEmptyNonTerminalQuery_stmt;
   SSqlStatement* d_AddDomainKeyQuery_stmt;
+  SSqlStatement* d_GetLastInsertedKeyIdQuery_stmt;
   SSqlStatement* d_ListDomainKeysQuery_stmt;
   SSqlStatement* d_GetAllDomainMetadataQuery_stmt;
   SSqlStatement* d_GetDomainMetadataQuery_stmt;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -73,7 +73,7 @@ bool DNSSECKeeper::isPresigned(const DNSName& name)
   return meta=="1";
 }
 
-int DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, int bits, bool active)
+bool DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, int64_t& id, int bits, bool active)
 {
   if(!bits) {
     if(algorithm <= 10)
@@ -98,7 +98,7 @@ int DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, int
   dspk.setKey(dpk);
   dspk.d_algorithm = algorithm;
   dspk.d_flags = setSEPBit ? 257 : 256;
-  return addKey(name, dspk, active);
+  return addKey(name, dspk, id, active);
 }
 
 void DNSSECKeeper::clearAllCaches() {
@@ -123,7 +123,7 @@ void DNSSECKeeper::clearCaches(const DNSName& name)
 }
 
 
-int DNSSECKeeper::addKey(const DNSName& name, const DNSSECPrivateKey& dpk, bool active)
+bool DNSSECKeeper::addKey(const DNSName& name, const DNSSECPrivateKey& dpk, int64_t& id, bool active)
 {
   clearCaches(name);
   DNSBackend::KeyData kd;
@@ -131,7 +131,7 @@ int DNSSECKeeper::addKey(const DNSName& name, const DNSSECPrivateKey& dpk, bool 
   kd.active = active;
   kd.content = dpk.getKey()->convertToISC();
  // now store it
-  return d_keymetadb->addDomainKey(name, kd);
+  return d_keymetadb->addDomainKey(name, kd, id);
 }
 
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -90,7 +90,11 @@ int DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, int
   }
   DNSSECPrivateKey dspk;
   shared_ptr<DNSCryptoKeyEngine> dpk(DNSCryptoKeyEngine::make(algorithm));
-  dpk->create(bits);
+  try{
+    dpk->create(bits);
+  } catch (std::runtime_error error){
+    throw runtime_error("Wrong bit size!");
+  }
   dspk.setKey(dpk);
   dspk.d_algorithm = algorithm;
   dspk.d_flags = setSEPBit ? 257 : 256;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -77,14 +77,14 @@ bool DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, in
 {
   if(!bits) {
     if(algorithm <= 10)
-      throw runtime_error("Creating an algorithm " +std::to_string(algorithm)+" ("+algorithm2name(algorithm)+") key requires the size (in bits) to be passed");
+      throw runtime_error("Creating an algorithm " +std::to_string(algorithm)+" ("+algorithm2name(algorithm)+") key requires the size (in bits) to be passed.");
     else {
       if(algorithm == 12 || algorithm == 13 || algorithm == 250) // GOST, ECDSAP256SHA256, ED25519SHA512
         bits = 256;
       else if(algorithm == 14) // ECDSAP384SHA384
         bits = 384;
       else {
-        throw runtime_error("Can't guess key size for algorithm "+std::to_string(algorithm));
+        throw runtime_error("Can not guess key size for algorithm "+std::to_string(algorithm));
       }
     }
   }
@@ -93,7 +93,7 @@ bool DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, in
   try{
     dpk->create(bits);
   } catch (std::runtime_error error){
-    throw runtime_error("Wrong bit size!");
+    throw runtime_error("The algorithm does not support the given bit size.");
   }
   dspk.setKey(dpk);
   dspk.d_algorithm = algorithm;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -73,7 +73,7 @@ bool DNSSECKeeper::isPresigned(const DNSName& name)
   return meta=="1";
 }
 
-bool DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, int bits, bool active)
+int DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, int bits, bool active)
 {
   if(!bits) {
     if(algorithm <= 10)
@@ -119,7 +119,7 @@ void DNSSECKeeper::clearCaches(const DNSName& name)
 }
 
 
-bool DNSSECKeeper::addKey(const DNSName& name, const DNSSECPrivateKey& dpk, bool active)
+int DNSSECKeeper::addKey(const DNSName& name, const DNSSECPrivateKey& dpk, bool active)
 {
   clearCaches(name);
   DNSBackend::KeyData kd;
@@ -127,7 +127,7 @@ bool DNSSECKeeper::addKey(const DNSName& name, const DNSSECPrivateKey& dpk, bool
   kd.active = active;
   kd.content = dpk.getKey()->convertToISC();
  // now store it
-  return d_keymetadb->addDomainKey(name, kd) >= 0; // >= 0 == s
+  return d_keymetadb->addDomainKey(name, kd);
 }
 
 

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -179,7 +179,7 @@ public:
 
   virtual bool getDomainKeys(const DNSName& name, unsigned int kind, std::vector<KeyData>& keys) { return false;}
   virtual bool removeDomainKey(const DNSName& name, unsigned int id) { return false; }
-  virtual int addDomainKey(const DNSName& name, const KeyData& key){ return -1; }
+  virtual bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id){ return false; }
   virtual bool activateDomainKey(const DNSName& name, unsigned int id) { return false; }
   virtual bool deactivateDomainKey(const DNSName& name, unsigned int id) { return false; }
 

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -161,8 +161,8 @@ public:
   keyset_t getEntryPoints(const DNSName& zname);
   keyset_t getKeys(const DNSName& zone, bool useCache = true);
   DNSSECPrivateKey getKeyById(const DNSName& zone, unsigned int id);
-  bool addKey(const DNSName& zname, bool setSEPBit, int algorithm, int bits=0, bool active=true);
-  bool addKey(const DNSName& zname, const DNSSECPrivateKey& dpk, bool active=true);
+  int addKey(const DNSName& zname, bool setSEPBit, int algorithm, int bits=0, bool active=true);
+  int addKey(const DNSName& zname, const DNSSECPrivateKey& dpk, bool active=true);
   bool removeKey(const DNSName& zname, unsigned int id);
   bool activateKey(const DNSName& zname, unsigned int id);
   bool deactivateKey(const DNSName& zname, unsigned int id);

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -161,8 +161,8 @@ public:
   keyset_t getEntryPoints(const DNSName& zname);
   keyset_t getKeys(const DNSName& zone, bool useCache = true);
   DNSSECPrivateKey getKeyById(const DNSName& zone, unsigned int id);
-  int addKey(const DNSName& zname, bool setSEPBit, int algorithm, int bits=0, bool active=true);
-  int addKey(const DNSName& zname, const DNSSECPrivateKey& dpk, bool active=true);
+  bool addKey(const DNSName& zname, bool setSEPBit, int algorithm, int64_t& id, int bits=0, bool active=true);
+  bool addKey(const DNSName& zname, const DNSSECPrivateKey& dpk, int64_t& id, bool active=true);
   bool removeKey(const DNSName& zname, unsigned int id);
   bool activateKey(const DNSName& zname, unsigned int id);
   bool deactivateKey(const DNSName& zname, unsigned int id);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1753,7 +1753,7 @@ bool secureZone(DNSSECKeeper& dk, const DNSName& zone)
 
     int algo = DNSSECKeeper::shorthand2algorithm(k_algo);
 
-    if(!dk.addKey(zone, true, algo, k_size, true)) {
+    if(dk.addKey(zone, true, algo, k_size, true) < 0) {
       cerr<<"No backend was able to secure '"<<zone<<"', most likely because no DNSSEC"<<endl;
       cerr<<"capable backends are loaded, or because the backends have DNSSEC disabled."<<endl;
       cerr<<"For the Generic SQL backends, set the 'gsqlite3-dnssec', 'gmysql-dnssec' or"<<endl;
@@ -1768,7 +1768,7 @@ bool secureZone(DNSSECKeeper& dk, const DNSName& zone)
 
     int algo = DNSSECKeeper::shorthand2algorithm(z_algo);
 
-    if(!dk.addKey(zone, false, algo, z_size, true)) {
+    if(!dk.addKey(zone, false, algo, z_size, true) < 0) {
       cerr<<"No backend was able to secure '"<<zone<<"', most likely because no DNSSEC"<<endl;
       cerr<<"capable backends are loaded, or because the backends have DNSSEC disabled."<<endl;
       cerr<<"For the Generic SQL backends, set the 'gsqlite3-dnssec', 'gmysql-dnssec' or"<<endl;
@@ -2254,7 +2254,8 @@ loadMainConfig(g_vm["config-dir"].as<string>());
         exit(EXIT_FAILURE);;
       }
     }
-    if(!dk.addKey(zone, keyOrZone, algorithm, bits, active)) {
+    int id;
+    if((id = dk.addKey(zone, keyOrZone, algorithm, bits, active)) < 0) {
       cerr<<"Adding key failed, perhaps DNSSEC not enabled in configuration?"<<endl;
       exit(1);
     }
@@ -2262,6 +2263,7 @@ loadMainConfig(g_vm["config-dir"].as<string>());
       cerr<<"Added a " << (keyOrZone ? "KSK" : "ZSK")<<" with algorithm = "<<algorithm<<", active="<<active<<endl;
       if(bits)
         cerr<<"Requested specific key size of "<<bits<<" bits"<<endl;
+      cout<<std::to_string(id)<<endl;
     }
   }
   else if(cmds[0] == "remove-zone-key") {
@@ -2637,11 +2639,13 @@ loadMainConfig(g_vm["config-dir"].as<string>());
     }
     else
       dpk.d_flags = 257; // ksk
-      
-    if(!dk.addKey(DNSName(zone), dpk)) {
+
+    int id;
+    if((id = dk.addKey(DNSName(zone), dpk)) < 0) {
       cerr<<"Adding key failed, perhaps DNSSEC not enabled in configuration?"<<endl;
       exit(1);
     }
+    cout<<std::to_string(id)<<endl;
     
   }
   else if(cmds[0]=="import-zone-key") {
@@ -2677,10 +2681,12 @@ loadMainConfig(g_vm["config-dir"].as<string>());
         exit(1);
       }          
     }
-    if(!dk.addKey(DNSName(zone), dpk, active)) {
+    int id;
+    if((id = dk.addKey(DNSName(zone), dpk, active)) < 0) {
       cerr<<"Adding key failed, perhaps DNSSEC not enabled in configuration?"<<endl;
       exit(1);
     }
+    cout<<std::to_string(id)<<endl;
   }
   else if(cmds[0]=="export-zone-dnskey") {
     if(cmds.size() < 3) {

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -99,14 +99,14 @@ bool UeberBackend::createDomain(const DNSName &domain)
   return false;
 }
 
-int UeberBackend::addDomainKey(const DNSName& name, const DNSBackend::KeyData& key)
+bool UeberBackend::addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& id)
 {
-  int ret;
+  id = -1;
   for(DNSBackend* db :  backends) {
-    if((ret = db->addDomainKey(name, key)) >= 0)
-      return ret;
+    if(db->addDomainKey(name, key, id))
+      return true;
   }
-  return -1;
+  return false;
 }
 bool UeberBackend::getDomainKeys(const DNSName& name, unsigned int kind, std::vector<DNSBackend::KeyData>& keys)
 {

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -116,7 +116,7 @@ public:
   bool getDomainInfo(const DNSName &domain, DomainInfo &di);
   bool createDomain(const DNSName &domain);
   
-  int addDomainKey(const DNSName& name, const DNSBackend::KeyData& key);
+  bool addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& id);
   bool getDomainKeys(const DNSName& name, unsigned int kind, std::vector<DNSBackend::KeyData>& keys);
   bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string> >& meta);
   bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta);

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -19,6 +19,7 @@ NAMED_CONF_TPL = """
 options { directory "../regression-tests/zones/"; };
 zone "example.com" { type master; file "example.com"; };
 zone "powerdnssec.org" { type master; file "powerdnssec.org"; };
+zone "cryptokeys.org" { type master; file "cryptokeys.org"; };
 """
 
 AUTH_CONF_TPL = """

--- a/regression-tests.api/test_cryptokeys.py
+++ b/regression-tests.api/test_cryptokeys.py
@@ -1,0 +1,269 @@
+import subprocess
+import json
+import unittest
+
+from test_helper import ApiTestCase, is_auth
+
+@unittest.skipIf(not is_auth(), "Not applicable")
+class Cryptokeys(ApiTestCase):
+    zone = "cryptokeyzone"
+    def setUp(self):
+        super(Cryptokeys, self).setUp()
+        try:
+            subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "create-zone", Cryptokeys.zone])
+        except subprocess.CalledProcessError as e:
+            self.fail("Couldn't create zone: "+e.output)
+
+
+    def tearDown(self):
+        super(Cryptokeys,self).tearDown()
+        try:
+            subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "delete-zone", Cryptokeys.zone])
+        except subprocess.CalledProcessError as e:
+            self.fail("Couldn't delete zone: "+e.output)
+
+
+    # This methode test the DELETE api call. Sometimes 200 or 422 are valid return codes,
+    # because it "could" happen that the backend crashes during the test or the remove function returns false.
+    # In this case 422 is correct. I don't know how to force false backend behavior. So i assume that the backend
+    # works correct.
+    def test_delete(self):
+        try:
+            keyid = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "add-zone-key", Cryptokeys.zone, "ksk"])
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil add-zone-key failed: "+e.output)
+
+        #checks the status code. I don't know how to test explicit that the backend fail removing a key.
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid))
+        self.assertTrue(r.status_code == 200 or r.status_code == 422)
+
+        # Check that the key is actually deleted
+        try:
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "list-keys", Cryptokeys.zone])
+            self.assertFalse(Cryptokeys.zone in out)
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil list-keys failed: " + e.output)
+
+        #checks for not covered zonename
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"fail/cryptokeys/"+keyid))
+        self.assertEquals(r.status_code, 400)
+
+        #checks for key is gone. Its ok even if no key had to be deleted. Or something went wrong with the backend.
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid))
+        self.assertTrue(r.status_code == 200 or r.status_code == 422)
+
+    # Prepares the json object for Post and sends it to the server
+    def add_key(self, content='', type='ksk', active='true' , algo='', bits=0):
+        if algo == '':
+            payload = {
+                'keytype': type,
+                'active' : active
+            }
+        else:
+            payload = {
+                'keytype': type,
+                'active' : active,
+                'algo' : algo
+            }
+        if bits > 0:
+            payload['bits'] = bits
+        if content != '':
+            payload['content'] = content
+        r = self.session.post(
+            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys"),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        return r
+
+    # Removes a key by id using the pdnsutil command
+    def remove_key(self, key_id):
+        try:
+            subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "remove-zone-key", Cryptokeys.zone, str(key_id)])
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil remove-zone-key failed: "+e.output)
+
+    # Tests POST for a positiv result and deletes the added key
+    def post_helper(self,content='', algo='', bits=0):
+        r = self.add_key(content=content, algo=algo, bits=bits)
+        self.assert_success_json(r)
+        self.assertEquals(r.status_code, 201)
+        response = r.json()
+        # Only a ksk added, so expected type is csk
+        self.assertEquals(response['keytype'], 'csk')
+        key_id = response['id']
+        # Check if the key is actually added
+        try:
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "list-keys", Cryptokeys.zone])
+            self.assertTrue(Cryptokeys.zone in out)
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil list-keys failed: " + e.output)
+
+        # Remove it for further testing
+        self.remove_key(key_id)
+
+    def test_post(self):
+        # Test add a key with default algorithm
+        self.post_helper()
+
+        # Test add a key with specific number
+        self.post_helper(algo=10, bits=512)
+
+        # Test add a key with specific name and bits
+        self.post_helper(algo="rsasha256", bits=256)
+
+        # Test add a key with specific name
+        self.post_helper(algo='ecdsa256')
+
+        # Test add a private key from extern resource
+        self.post_helper(content="Private-key-format: v1.2\n"+
+                                 "Algorithm: 8 (RSASHA256)\n"+
+                                 "Modulus: 4GlYLGgDI7ohnP8SmEW8EBERbNRusDcg0VQda/EPVHU=\n"+
+                                 "PublicExponent: AQAB\n"+
+                                 "PrivateExponent: JBnuXF5zOtkjtSz3odV+Fk5UNUTTeCsiI16dkcM7TVU=\n"+
+                                 "Prime1: /w7TM4118RoSEvP8+dgnCw==\n"+
+                                 "Prime2: 4T2KhkYLa3w7rdK3Cb2ifw==\n"+
+                                 "Exponent1: 3aeKj9Ct4JuhfWsgPBhGxQ==\n"+
+                                 "Exponent2: tfh1OMPQKBdnU6iATjNR2w==\n"+
+                                 "Coefficient: eVrHe/kauqOewSKndIImrg==)\n")
+
+        # Test wrong key format
+        r = self.add_key(content="trollololoooolll")
+        self.assert_error_json(r)
+        self.assertEquals(r.status_code, 422)
+        self.assertIn("Wrong key format!",r.json()['error'])
+
+        # Test wrong keytype
+        r = self.add_key(type='sdfdhhgj')
+        self.assert_error_json(r)
+        self.assertEquals(r.status_code, 422)
+        self.assertIn("Invalid keytype",r.json()['error'])
+
+        #Test unsupported algorithem
+        r = self.add_key(algo='lkjhgf')
+        self.assert_error_json(r)
+        self.assertEquals(r.status_code, 422)
+        self.assertIn("Unknown algorithm:",r.json()['error'])
+
+        #Test add a key and forgot bits
+        r = self.add_key(algo="rsasha256")
+        self.assert_error_json(r)
+        self.assertEquals(r.status_code, 422)
+        self.assertIn("key requires the size (in bits) to be passed", r.json()['error'])
+
+        #Test wrong bit size
+        r = self.add_key(algo=10, bits=30)
+        self.assert_error_json(r)
+        self.assertEquals(r.status_code,422)
+        self.assertIn("Wrong bit size!", r.json()['error'])
+
+        #Test can't guess key size
+        r = self.add_key(algo=15)
+        self.assert_error_json(r)
+        self.assertEquals(r.status_code,422)
+        self.assertIn("Can't guess key size for algorithm", r.json()['error'])
+
+    def test_put_activate_deactivate_key(self):
+
+        #create key
+        try:
+            keyid = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "add-zone-key", Cryptokeys.zone, "ksk"])
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil add-zone-key failed: "+e.output)
+
+        # activate key
+        payload = {
+            'active': True
+        }
+        o = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(o.status_code, 200)
+
+        # check if key is activated
+        try:
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
+            self.assertTrue("Active" in out)
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil show-zone failed: " + e.output)
+
+        # deactivate key
+        payload2 = {
+            'active': False
+        }
+        q = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
+            data=json.dumps(payload2),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(q.status_code, 200)
+        self.assert_success_json(q)
+
+        # check if key is deactivated
+        try:
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
+            self.assertTrue("Inactive" in out)
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil show-zone failed: " + e.output)
+
+        # Remove it for further testing
+        try:
+            subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "remove-zone-key", Cryptokeys.zone, str(keyid)])
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil remove-zone-key failed: "+e.output)
+
+    def test_put_deactivate_deactivated_activate_activated_key(self):
+
+        #create key
+        try:
+            keyid = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "add-zone-key", Cryptokeys.zone, "ksk"])
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil add-zone-key failed: "+e.output)
+
+        # deactivate key
+        payload = {
+            'active': False
+        }
+        q = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(q.status_code, 200)
+        self.assert_success_json(q)
+
+        # check if key is still deactivated
+        try:
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
+            self.assertTrue("Inactive" in out)
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil show-zone failed: " + e.output)
+
+        # activate key
+        payload2 = {
+            'active': True
+        }
+        o = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
+            data=json.dumps(payload2),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(o.status_code, 200)
+
+        # check if key is activated
+        try:
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
+            self.assertTrue("Active" in out)
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil show-zone failed: " + e.output)
+
+        #activate again
+        z = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
+            data=json.dumps(payload2),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(z.status_code, 200)
+
+        # check if key is still activated
+        try:
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
+            self.assertTrue("Active" in out)
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil show-zone failed: " + e.output)

--- a/regression-tests.api/test_cryptokeys.py
+++ b/regression-tests.api/test_cryptokeys.py
@@ -1,56 +1,65 @@
 import subprocess
 import json
 import unittest
+import os
 
 from test_helper import ApiTestCase, is_auth
 
 @unittest.skipIf(not is_auth(), "Not applicable")
 class Cryptokeys(ApiTestCase):
-    zone = "cryptokeyzone"
-    def setUp(self):
-        super(Cryptokeys, self).setUp()
-        try:
-            subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "create-zone", Cryptokeys.zone])
-        except subprocess.CalledProcessError as e:
-            self.fail("Couldn't create zone: "+e.output)
 
+    def __init__(self, *args, **kwds):
+        super(Cryptokeys, self).__init__(*args, **kwds)
+        self.keyid = 0
+        self.zone = "cryptokeys.org"
 
     def tearDown(self):
         super(Cryptokeys,self).tearDown()
-        try:
-            subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "delete-zone", Cryptokeys.zone])
-        except subprocess.CalledProcessError as e:
-            self.fail("Couldn't delete zone: "+e.output)
+        self.remove_zone_key(self.keyid)
 
-
-    # This methode test the DELETE api call. Sometimes 200 or 422 are valid return codes,
-    # because it "could" happen that the backend crashes during the test or the remove function returns false.
-    # In this case 422 is correct. I don't know how to force false backend behavior. So i assume that the backend
-    # works correct.
-    def test_delete(self):
+    # Adding a key to self.zone using the pdnsutil command
+    def add_zone_key(self, status='inactive'):
         try:
-            keyid = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "add-zone-key", Cryptokeys.zone, "ksk"])
+            return subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "add-zone-key", self.zone, "ksk", status], stderr=open(os.devnull, 'wb'))
         except subprocess.CalledProcessError as e:
             self.fail("pdnsutil add-zone-key failed: "+e.output)
 
+    # Removes a key from self.zone by id using the pdnsutil command
+    def remove_zone_key(self, key_id):
+        try:
+            subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "remove-zone-key", self.zone, str(key_id)])
+        except subprocess.CalledProcessError as e:
+            self.fail("pdnsutil remove-zone-key failed: "+e.output)
+
+    # This method tests the DELETE api call.
+    def test_delete(self):
+        self.keyid = self.add_zone_key()
+
         #checks the status code. I don't know how to test explicit that the backend fail removing a key.
-        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid))
-        self.assertTrue(r.status_code == 200 or r.status_code == 422)
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid))
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(r.content, "")
 
         # Check that the key is actually deleted
         try:
-            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "list-keys", Cryptokeys.zone])
-            self.assertFalse(Cryptokeys.zone in out)
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "list-keys", self.zone])
+            self.assertNotIn(self.zone, out)
         except subprocess.CalledProcessError as e:
             self.fail("pdnsutil list-keys failed: " + e.output)
 
+    def test_delete_wrong_zone(self):
+        self.keyid = self.add_zone_key()
         #checks for not covered zonename
-        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"fail/cryptokeys/"+keyid))
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+self.zone+"fail/cryptokeys/"+self.keyid))
         self.assertEquals(r.status_code, 400)
 
+    def test_delete_key_is_gone(self):
+        self.keyid = self.add_zone_key()
+        self.remove_zone_key(self.keyid)
         #checks for key is gone. Its ok even if no key had to be deleted. Or something went wrong with the backend.
-        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid))
-        self.assertTrue(r.status_code == 200 or r.status_code == 422)
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid))
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(r.content, "")
 
     # Prepares the json object for Post and sends it to the server
     def add_key(self, content='', type='ksk', active='true' , algo='', bits=0):
@@ -70,19 +79,13 @@ class Cryptokeys(ApiTestCase):
         if content != '':
             payload['content'] = content
         r = self.session.post(
-            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys"),
+            self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
+
         return r
 
-    # Removes a key by id using the pdnsutil command
-    def remove_key(self, key_id):
-        try:
-            subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "remove-zone-key", Cryptokeys.zone, str(key_id)])
-        except subprocess.CalledProcessError as e:
-            self.fail("pdnsutil remove-zone-key failed: "+e.output)
-
-    # Tests POST for a positiv result and deletes the added key
+    # Test POST for a positive result and delete the added key
     def post_helper(self,content='', algo='', bits=0):
         r = self.add_key(content=content, algo=algo, bits=bits)
         self.assert_success_json(r)
@@ -90,31 +93,32 @@ class Cryptokeys(ApiTestCase):
         response = r.json()
         # Only a ksk added, so expected type is csk
         self.assertEquals(response['keytype'], 'csk')
-        key_id = response['id']
+        self.keyid = response['id']
         # Check if the key is actually added
         try:
-            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "list-keys", Cryptokeys.zone])
-            self.assertTrue(Cryptokeys.zone in out)
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "list-keys", self.zone])
+            self.assertIn(self.zone, out)
         except subprocess.CalledProcessError as e:
             self.fail("pdnsutil list-keys failed: " + e.output)
 
-        # Remove it for further testing
-        self.remove_key(key_id)
-
+    # Test POST to add a key with default algorithm
     def test_post(self):
-        # Test add a key with default algorithm
         self.post_helper()
 
-        # Test add a key with specific number
+    # Test POST to add a key with specific algorithm number
+    def test_post_specific_number(self):
         self.post_helper(algo=10, bits=512)
 
-        # Test add a key with specific name and bits
+    # Test POST to add a key with specific name and bits
+    def test_post_specific_name_bits(self):
         self.post_helper(algo="rsasha256", bits=256)
 
-        # Test add a key with specific name
+    # Test POST to add a key with specific name
+    def test_post_specific_name(self):
         self.post_helper(algo='ecdsa256')
 
-        # Test add a private key from extern resource
+    # Test POST to add a private key from external resource
+    def test_post_content(self):
         self.post_helper(content="Private-key-format: v1.2\n"+
                                  "Algorithm: 8 (RSASHA256)\n"+
                                  "Modulus: 4GlYLGgDI7ohnP8SmEW8EBERbNRusDcg0VQda/EPVHU=\n"+
@@ -126,144 +130,138 @@ class Cryptokeys(ApiTestCase):
                                  "Exponent2: tfh1OMPQKBdnU6iATjNR2w==\n"+
                                  "Coefficient: eVrHe/kauqOewSKndIImrg==)\n")
 
-        # Test wrong key format
+    def test_post_wrong_key_format(self):
         r = self.add_key(content="trollololoooolll")
         self.assert_error_json(r)
         self.assertEquals(r.status_code, 422)
-        self.assertIn("Wrong key format!",r.json()['error'])
+        self.assertIn("Key could not be parsed. Make sure your key format is correct.",r.json()['error'])
 
-        # Test wrong keytype
+    def test_post_wrong_keytype(self):
         r = self.add_key(type='sdfdhhgj')
         self.assert_error_json(r)
         self.assertEquals(r.status_code, 422)
         self.assertIn("Invalid keytype",r.json()['error'])
 
-        #Test unsupported algorithem
+    def test_post_wrong_bits_format(self):
+        r = self.add_key(bits='sdfdhhgj')
+        self.assert_error_json(r)
+        self.assertEquals(r.status_code, 422)
+        self.assertIn("'bits' must be a positive integer value",r.json()['error'])
+
+        r = self.add_key(bits='5.5')
+        self.assert_error_json(r)
+        self.assertEquals(r.status_code, 422)
+        self.assertIn("'bits' must be a positive integer value",r.json()['error'])
+
+        r = self.add_key(bits='-6')
+        self.assert_error_json(r)
+        self.assertEquals(r.status_code, 422)
+        self.assertIn("'bits' must be a positive integer value",r.json()['error'])
+
+    def test_post_unsupported_algorithm(self):
         r = self.add_key(algo='lkjhgf')
         self.assert_error_json(r)
         self.assertEquals(r.status_code, 422)
         self.assertIn("Unknown algorithm:",r.json()['error'])
 
-        #Test add a key and forgot bits
+    def test_post_forgot_bits(self):
         r = self.add_key(algo="rsasha256")
         self.assert_error_json(r)
         self.assertEquals(r.status_code, 422)
         self.assertIn("key requires the size (in bits) to be passed", r.json()['error'])
 
-        #Test wrong bit size
+    def test_post_wrong_bit_size(self):
         r = self.add_key(algo=10, bits=30)
         self.assert_error_json(r)
         self.assertEquals(r.status_code,422)
-        self.assertIn("Wrong bit size!", r.json()['error'])
+        self.assertIn("The algorithm does not support the given bit size.", r.json()['error'])
 
-        #Test can't guess key size
+    def test_post_can_not_guess_key_size(self):
         r = self.add_key(algo=15)
         self.assert_error_json(r)
         self.assertEquals(r.status_code,422)
-        self.assertIn("Can't guess key size for algorithm", r.json()['error'])
+        self.assertIn("Can not guess key size for algorithm", r.json()['error'])
 
-    def test_put_activate_deactivate_key(self):
+    def test_put_activate_key(self):
+        self.keyid = self.add_zone_key()
 
-        #create key
-        try:
-            keyid = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "add-zone-key", Cryptokeys.zone, "ksk"])
-        except subprocess.CalledProcessError as e:
-            self.fail("pdnsutil add-zone-key failed: "+e.output)
-
-        # activate key
         payload = {
             'active': True
         }
-        o = self.session.put(
-            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
+        r = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(o.status_code, 200)
+        self.assertEquals(r.status_code, 204)
+        self.assertEquals(r.content, "")
 
         # check if key is activated
         try:
-            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
-            self.assertTrue("Active" in out)
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", self.zone])
+            self.assertIn("Active", out)
         except subprocess.CalledProcessError as e:
             self.fail("pdnsutil show-zone failed: " + e.output)
 
+    def test_put_deactivate_key(self):
+        self.keyid= self.add_zone_key(status='active')
         # deactivate key
         payload2 = {
             'active': False
         }
-        q = self.session.put(
-            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
+
+        r = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload2),
             headers={'content-type': 'application/json'})
-        self.assertEquals(q.status_code, 200)
-        self.assert_success_json(q)
+        self.assertEquals(r.status_code, 204)
+        self.assertEquals(r.content, "")
 
         # check if key is deactivated
         try:
-            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
-            self.assertTrue("Inactive" in out)
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", self.zone])
+            self.assertIn("Inactive", out)
         except subprocess.CalledProcessError as e:
             self.fail("pdnsutil show-zone failed: " + e.output)
 
-        # Remove it for further testing
-        try:
-            subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "remove-zone-key", Cryptokeys.zone, str(keyid)])
-        except subprocess.CalledProcessError as e:
-            self.fail("pdnsutil remove-zone-key failed: "+e.output)
-
-    def test_put_deactivate_deactivated_activate_activated_key(self):
-
-        #create key
-        try:
-            keyid = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "add-zone-key", Cryptokeys.zone, "ksk"])
-        except subprocess.CalledProcessError as e:
-            self.fail("pdnsutil add-zone-key failed: "+e.output)
+    def test_put_deactivate_inactive_key(self):
+        self.keyid = self.add_zone_key()
 
         # deactivate key
         payload = {
             'active': False
         }
-        q = self.session.put(
-            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
+
+        r = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(q.status_code, 200)
-        self.assert_success_json(q)
+        self.assertEquals(r.status_code, 204)
+        self.assertEquals(r.content, "")
 
         # check if key is still deactivated
         try:
-            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
-            self.assertTrue("Inactive" in out)
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", self.zone])
+            self.assertIn("Inactive", out)
         except subprocess.CalledProcessError as e:
             self.fail("pdnsutil show-zone failed: " + e.output)
+
+    def test_put_activate_active_key(self):
+        self.keyid =self.add_zone_key(status='active')
 
         # activate key
         payload2 = {
             'active': True
         }
-        o = self.session.put(
-            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
+        r = self.session.put(
+            self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload2),
             headers={'content-type': 'application/json'})
-        self.assertEquals(o.status_code, 200)
+        self.assertEquals(r.status_code, 204)
+        self.assertEquals(r.content, "")
 
         # check if key is activated
         try:
-            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
-            self.assertTrue("Active" in out)
-        except subprocess.CalledProcessError as e:
-            self.fail("pdnsutil show-zone failed: " + e.output)
-
-        #activate again
-        z = self.session.put(
-            self.url("/api/v1/servers/localhost/zones/"+Cryptokeys.zone+"/cryptokeys/"+keyid),
-            data=json.dumps(payload2),
-            headers={'content-type': 'application/json'})
-        self.assertEquals(z.status_code, 200)
-
-        # check if key is still activated
-        try:
-            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", Cryptokeys.zone])
-            self.assertTrue("Active" in out)
+            out = subprocess.check_output(["../pdns/pdnsutil", "--config-dir=.", "show-zone", self.zone])
+            self.assertIn("Active", out)
         except subprocess.CalledProcessError as e:
             self.fail("pdnsutil show-zone failed: " + e.output)

--- a/regression-tests.api/test_helper.py
+++ b/regression-tests.api/test_helper.py
@@ -30,6 +30,10 @@ class ApiTestCase(unittest.TestCase):
             raise
         self.assertEquals(result.headers['Content-Type'], 'application/json')
 
+    def assert_error_json(self, result):
+        self.assertTrue(400 <= result.status_code < 600, "Response has not an error code "+str(result.status_code))
+        self.assertEquals(result.headers['Content-Type'], 'application/json', "Response status code "+str(result.status_code))
+
     def assert_success(self, result):
         try:
             result.raise_for_status()

--- a/regression-tests/zones/cryptokeys.org
+++ b/regression-tests/zones/cryptokeys.org
@@ -1,0 +1,24 @@
+cryptokeys.org.		3600	IN SOA	cryptokeys.ds9a.nl. ahu.ds9a.nl. (
+					2009071301 ; serial
+					14400       ; refresh (2 hours 30 minutes)
+					3600        ; retry (7 minutes 30 seconds)
+					604800     ; expire (1 week)
+					3600       ; minimum (7 minutes 30 seconds)
+					)
+			3600	NS	cryptokeys.ds9a.nl.
+			3600	NS	cryptokeys.ds9a.nl.
+			3600	MX	10	cryptokeys.easy-server.com.
+			3600	A	212.123.148.70
+www.cryptokeys.org.	3600	CNAME	cryptokeys.org.
+webserver		3600	A	1.2.3.4
+smtp			3600	A	4.3.2.1
+localhost		3600	A	127.0.0.1
+			3600	AAAA	::1
+ipv6			3600	AAAA	2001:888:1036:0:208:a1ff:fe19:f000
+zbefore.a.cryptokeys.org.		3600	TXT	"before"
+after.cryptokeys.org.		3600	TXT	"after"
+zzz.cryptokeys.org.		3600	TXT	"this is the end.."
+delegated			3600	IN	NS ns1.delegated
+delegated			3600	IN	NS ns2.delegated
+ns1.delegated			3600	IN	A	1.2.3.4
+ns2.delegated			3600	IN	A	4.3.2.1


### PR DESCRIPTION
We are a group of students at the Freie Universität Berlin. Our team consists of @zervnet, @MrM0nkey, @taudor and @benj-zen.

We implemented the Rest-Api methods for the cryptokeys module. While doing that we realized we need to fix #706, so we can return the id of the added key e.g. using POST. As proposed in #706 pdnsutil prints the added key-id to stdout.

As suggested in the discussion in the IRC channel, we only implemented the (return-id-)functionality for the major backend-modules (gmysql, gpgsql, gsqlite3, godbc, bind).

Documentation and tests are included.