### PR TITLE
Add protobuf fields for the query's time in the response

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -70,6 +70,13 @@ class PDNSPBConnHandler(object):
     def printResponse(self, message):
         if message.HasField('response'):
             response = message.response
+
+            if response.HasField('queryTimeSec'):
+                datestr = datetime.datetime.fromtimestamp(response.queryTimeSec).strftime('%Y-%m-%d %H:%M:%S')
+                if response.HasField('queryTimeUsec'):
+                    datestr = datestr + '.' + str(response.queryTimeUsec)
+                print("- Query time: %s" % (datestr))
+
             policystr = ''
             if response.HasField('appliedPolicy') and response.appliedPolicy:
                 policystr = ', Applied policy: ' + response.appliedPolicy

--- a/pdns/dnsdist-protobuf.cc
+++ b/pdns/dnsdist-protobuf.cc
@@ -21,4 +21,11 @@ DNSDistProtoBufMessage::DNSDistProtoBufMessage(DNSProtoBufMessageType type, cons
   }
 };
 
+DNSDistProtoBufMessage::DNSDistProtoBufMessage(const DNSResponse& dr): DNSProtoBufMessage(Response, dr.uniqueId, dr.remote, dr.local, *dr.qname, dr.qtype, dr.qclass, dr.dh->id, dr.tcp, dr.len)
+{
+  setQueryTime(dr.queryTime->tv_sec, dr.queryTime->tv_nsec / 1000);
+  setResponseCode(dr.dh->rcode);
+  addRRsFromPacket((const char*) dr.dh, dr.len);
+};
+
 #endif /* HAVE_PROTOBUF */

--- a/pdns/dnsdist-protobuf.hh
+++ b/pdns/dnsdist-protobuf.hh
@@ -6,4 +6,5 @@ class DNSDistProtoBufMessage: public DNSProtoBufMessage
 {
 public:
   DNSDistProtoBufMessage(DNSProtoBufMessageType type, const DNSQuestion& dq);
+  DNSDistProtoBufMessage(const DNSResponse& dr);
 };

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -267,7 +267,7 @@ void* tcpClientThread(int pipefd)
 	string poolname;
 	int delayMsec=0;
 	struct timespec now;
-	gettime(&now);
+	gettime(&now, true);
 
 	if (!processQuery(localDynBlockNMG, localDynBlockSMT, localRulactions, blockFilter, dq, poolname, &delayMsec, now)) {
 	  goto drop;
@@ -431,7 +431,7 @@ void* tcpClientThread(int pipefd)
         }
 
         dh = (struct dnsheader*) response;
-        DNSQuestion dr(&qname, qtype, qclass, &ci.cs->local, &ci.remote, dh, responseSize, responseLen, true);
+        DNSResponse dr(&qname, qtype, qclass, &ci.cs->local, &ci.remote, dh, responseSize, responseLen, true, &now);
 #ifdef HAVE_PROTOBUF
         dr.uniqueId = dq.uniqueId;
 #endif

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -400,7 +400,7 @@ void* responderThread(std::shared_ptr<DownstreamState> state)
     dh->id = ids->origID;
 
     uint16_t addRoom = 0;
-    DNSQuestion dr(&ids->qname, ids->qtype, ids->qclass, &ids->origDest, &ids->origRemote, dh, sizeof(packet), responseLen, false);
+    DNSResponse dr(&ids->qname, ids->qtype, ids->qclass, &ids->origDest, &ids->origRemote, dh, sizeof(packet), responseLen, false, &ids->sentTime.d_start);
 #ifdef HAVE_PROTOBUF
     dr.uniqueId = ids->uniqueId;
 #endif
@@ -821,7 +821,7 @@ bool processQuery(LocalStateHolder<NetmaskTree<DynBlock> >& localDynNMGBlock,
   return true;
 }
 
-bool processResponse(LocalStateHolder<vector<pair<std::shared_ptr<DNSRule>, std::shared_ptr<DNSResponseAction> > > >& localRespRulactions, DNSQuestion& dr)
+bool processResponse(LocalStateHolder<vector<pair<std::shared_ptr<DNSRule>, std::shared_ptr<DNSResponseAction> > > >& localRespRulactions, DNSResponse& dr)
 {
   std::string ruleresult;
   for(const auto& lr : *localRespRulactions) {

--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -43,6 +43,8 @@ message PBDNSMessage {
     repeated DNSRR rrs = 2;
     optional string appliedPolicy = 3;
     repeated string tags = 4;
+    optional uint32 queryTimeSec = 5;
+    optional uint32 queryTimeUsec = 6;
   }
 
   optional DNSResponse response = 13;

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -934,10 +934,10 @@ public:
   RemoteLogResponseAction(std::shared_ptr<RemoteLogger> logger): d_logger(logger)
   {
   }
-  DNSResponseAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
   {
 #ifdef HAVE_PROTOBUF
-    DNSDistProtoBufMessage message(DNSDistProtoBufMessage::Response, *dq);
+    DNSDistProtoBufMessage message(*dr);
     std::string data;
     message.serialize(data);
     d_logger->queueData(data);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -985,6 +985,7 @@ void startDoResolve(void *p)
       pbMessage.setResponseCode(pw.getHeader()->rcode);
       pbMessage.setAppliedPolicy(appliedPolicy);
       pbMessage.setPolicyTags(dc->d_policyTags);
+      pbMessage.setQueryTime(dc->d_now.tv_sec, dc->d_now.tv_usec);
       protobufLogResponse(luaconfsLocal->protobufServer, pbMessage);
     }
 #endif
@@ -1383,6 +1384,7 @@ string* doProcessUDPQuestion(const std::string& question, const ComboAddress& fr
         const ComboAddress& requestor = requestorNM.getMaskedNetwork();
         pbMessage.update(uniqueId, &requestor, &destaddr, false, dh->id);
         pbMessage.setEDNSSubnet(ednssubnet);
+        pbMessage.setQueryTime(g_now.tv_sec, g_now.tv_usec);
         protobufLogResponse(luaconfsLocal->protobufServer, pbMessage);
       }
 #endif /* HAVE_PROTOBUF */

--- a/pdns/protobuf.cc
+++ b/pdns/protobuf.cc
@@ -47,6 +47,17 @@ void DNSProtoBufMessage::setTime(time_t sec, uint32_t usec)
 #endif /* HAVE_PROTOBUF */
 }
 
+void DNSProtoBufMessage::setQueryTime(time_t sec, uint32_t usec)
+{
+#ifdef HAVE_PROTOBUF
+  PBDNSMessage_DNSResponse* response = d_message.mutable_response();
+  if (response) {
+    response->set_querytimesec(sec);
+    response->set_querytimeusec(usec);
+  }
+#endif /* HAVE_PROTOBUF */
+}
+
 void DNSProtoBufMessage::setEDNSSubnet(const Netmask& subnet)
 {
 #ifdef HAVE_PROTOBUF

--- a/pdns/protobuf.hh
+++ b/pdns/protobuf.hh
@@ -37,6 +37,7 @@ public:
   void setEDNSSubnet(const Netmask& subnet);
   void setBytes(size_t bytes);
   void setTime(time_t sec, uint32_t usec);
+  void setQueryTime(time_t sec, uint32_t usec);
   void setResponseCode(uint8_t rcode);
   void addRRsFromPacket(const char* packet, const size_t len);
   void serialize(std::string& data) const;


### PR DESCRIPTION
This way it's possible to compute the latency by looking only
at the response message.
Implemented for:
* dnsdist
* dnspcap2protobuf
* ProtobufLogger.py
* rec