### PR TITLE
auth: Wait for the connection to the carbon server to be established

### DIFF
--- a/pdns/auth-carbon.cc
+++ b/pdns/auth-carbon.cc
@@ -46,11 +46,12 @@ try
 
     for (const auto& carbonServer : carbonServers) {
       ComboAddress remote(carbonServer, 2003);
-      Socket s(remote.sin4.sin_family, SOCK_STREAM);
-      s.setNonBlocking();
-      s.connect(remote);  // we do the connect so the attempt happens while we gather stats
 
       try {
+        Socket s(remote.sin4.sin_family, SOCK_STREAM);
+        s.setNonBlocking();
+        s.connect(remote, 2);
+
         writen2WithTimeout(s.getHandle(), msg.c_str(), msg.length(), 2);
       } catch (runtime_error &e){
         L<<Logger::Warning<<"Unable to write data to carbon server at "<<remote.toStringWithPort()<<": "<<e.what()<<endl;


### PR DESCRIPTION
Doing a non-blocking `connect()` immediately followed by a `write()`
cause the `write()` to fail with `ENOTCONN` on FreeBSD.
This commit instead wait for the `connect()` operation to finish
using `poll()` with a short timeout if it returned `EINPROGRESS`,
so that either we have a connected socket to write to, or we fail.

Fixes #4120.