### PR TITLE
Add limits to the size of received AXFR, in megabytes

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -170,6 +170,8 @@ void declareArguments()
 
   ::arg().set("include-dir","Include *.conf files from this directory");
   ::arg().set("security-poll-suffix","Domain name from which to query security update notifications")="secpoll.powerdns.com.";
+
+  ::arg().set("xfr-max-received-mbytes", "Maximum number of megabytes received from an incoming AXFR")="100";
 }
 
 static uint64_t uptimeOfProcess(const std::string& str)

--- a/pdns/docs/pdns.xml
+++ b/pdns/docs/pdns.xml
@@ -17863,6 +17863,17 @@ This setting will make PowerDNS renotify the slaves after an AXFR is *received* 
 	    <listitem><para>
 	      Check for wildcard URL records.
 	      </para></listitem></varlistentry>
+	  <varlistentry>
+	    <term>xfr-max-received-mbytes=...</term>
+	  <listitem>
+	    <para>
+	      Specifies the maximum number of received megabytes allowed on an incoming AXFR update, to prevent
+              resource exhaustion. A value of 0 means no restriction.
+	      The default is 100. Available since 3.4.10.
+	    </para>
+	  </listitem>
+	</varlistentry>
+
       </variablelist>
     </para>
   </chapter>

--- a/pdns/pdns.conf-dist
+++ b/pdns/pdns.conf-dist
@@ -534,4 +534,9 @@
 #
 # webserver-print-arguments=no
 
+#################################
+# xfr-max-received-mbytes	Maximum number of megabytes received from an incoming AXFR
+#
+# xfr-max-received-mbytes=100
+
 

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -85,7 +85,8 @@ class AXFRRetriever : public boost::noncopyable
         const string& tsigkeyname=string(),
         const string& tsigalgorithm=string(),
         const string& tsigsecret=string(),
-        const ComboAddress* laddr = NULL);
+        const ComboAddress* laddr = NULL,
+        size_t maxReceivedBytes=0);
 	~AXFRRetriever();
     int getChunk(Resolver::res_t &res);  
   
@@ -104,6 +105,8 @@ class AXFRRetriever : public boost::noncopyable
     string d_tsigsecret;
     string d_prevMac; // RFC2845 4.4
     string d_signData;
+    size_t d_receivedBytes;
+    size_t d_maxReceivedBytes;
     uint32_t d_tsigPos;
     uint d_nonSignedMessages; // RFC2845 4.4
     TSIGRecordContent d_trc;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -151,7 +151,7 @@ void CommunicatorClass::suck(const string &domain,const string &remote)
     vector<DNSResourceRecord> rrs;
 
     ComboAddress raddr(remote, 53);
-    AXFRRetriever retriever(raddr, domain.c_str(), tsigkeyname, tsigalgorithm, tsigsecret, (laddr.sin4.sin_family == 0) ? NULL : &laddr);
+    AXFRRetriever retriever(raddr, domain.c_str(), tsigkeyname, tsigalgorithm, tsigsecret, (laddr.sin4.sin_family == 0) ? NULL : &laddr, ((size_t) ::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024);
     Resolver::res_t recs;
     while(retriever.getChunk(recs)) {
       if(first) {


### PR DESCRIPTION
This prevents resource exhaustion in case the master is sending a
very large amount of data in an update.