### PR TITLE
resolver.cc: fix warnings with gcc on musl-libc

### DIFF
--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -47,7 +47,7 @@
 
 
 #include "dns_random.hh"
-#include <sys/poll.h>
+#include <poll.h>
 #include "gss_context.hh"
 #include "namespaces.hh"
 


### PR DESCRIPTION
According to `man 2 poll` the correct syntax for the include is:

`#include <poll.h>`

There is possibly more cases of includes that can be rectified to be
more correct, however this will do for now.