### PR TITLE
Two more DNSSEC fixes

### DIFF
--- a/docs/markdown/changelog.raw.md
+++ b/docs/markdown/changelog.raw.md
@@ -8,6 +8,10 @@ This release improves interoperability with DNSSEC clients that expect an AD-bit
 ## Bug fixes
 
  - [#4162](https://github.com/PowerDNS/pdns/pull/4162) Don't validate zones from the local auth store, go one level down while validating when there is a CNAME
+ - [#4187](https://github.com/PowerDNS/pdns/pull/4187):
+   * Don't go bogus on islands of security
+   * Check all possible chains for Insecures
+   * Don't go Bogus on a CNAME at the apex
 
 ## Improvements
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -443,7 +443,7 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
       }
     }
 
-    if(doCNAMECacheCheck(qname,qtype,ret,depth,res)) // will reroute us if needed
+    if(qtype != QType::DS && doCNAMECacheCheck(qname,qtype,ret,depth,res)) // will reroute us if needed
       return res;
 
     if(doCacheCheck(qname,qtype,ret,depth,res)) // we done

--- a/pdns/validate-recursor.cc
+++ b/pdns/validate-recursor.cc
@@ -32,6 +32,25 @@ inline vState increaseDNSSECStateCounter(const vState& state)
   return state;
 }
 
+/*
+ * This inline possibly sets currentState based on the new state. It will only
+ * set it to Secure iff the newState is Secure and mayUpgradeToSecure == true.
+ * This should be set by the calling function when checking more than one record
+ * and this is not the first record, this way, we can never go *back* to Secure
+ * from an Insecure vState
+ */
+inline void processNewState(vState& currentState, const vState& newState, bool& hadNTA, const bool& mayUpgradeToSecure)
+{
+  if (mayUpgradeToSecure && newState == Secure)
+    currentState = Secure;
+
+  if (newState == Insecure || newState == NTA) // We can never go back to Secure
+    currentState = Insecure;
+
+  if (newState == NTA)
+    hadNTA = true;
+}
+
 vState validateRecords(const vector<DNSRecord>& recs)
 {
   if(recs.empty())
@@ -63,15 +82,9 @@ vState validateRecords(const vector<DNSRecord>& recs)
         if (newState == Bogus) // No hope
           return increaseDNSSECStateCounter(Bogus);
 
-        if (first && newState == Secure)
-          state = Secure;
+        processNewState(state, newState, hadNTA, first);
+
         first = false;
-
-        if (newState == Insecure || newState == NTA) // We can never go back to Secure
-          state = Insecure;
-
-        if (newState == NTA)
-          hadNTA = true;
 
         LOG("! state = "<<vStates[state]<<", now have "<<keys.size()<<" keys"<<endl);
         for(const auto& k : keys) {
@@ -83,13 +96,22 @@ vState validateRecords(const vector<DNSRecord>& recs)
   }
   else {
     LOG("! no sigs, hoping for Insecure status of "<<recs.begin()->d_name<<endl);
-    state = getKeysFor(sro, recs.begin()->d_name, keys); // um WHAT DOES THIS MEAN - try first qname??
-   
-    LOG("! state = "<<vStates[state]<<", now have "<<keys.size()<<" keys "<<endl);
-    
+
+    bool first = true;
+    for(const auto& rec : recs) {
+      vState newState = getKeysFor(sro, rec.d_name, keys);
+
+      if (newState == Bogus) // We're done
+        return increaseDNSSECStateCounter(Bogus);
+
+      processNewState(state, newState, hadNTA, first);
+      first = false;
+
+      LOG("! state = "<<vStates[state]<<", now have "<<keys.size()<<" keys "<<endl);
+    }
     return increaseDNSSECStateCounter(state);
   }
-  
+
   LOG("Took "<<sro.d_queries<<" queries"<<endl);
   if(validrrsets.size() == cspmap.size())// shortcut - everything was ok
     return increaseDNSSECStateCounter(Secure);

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -203,16 +203,13 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
   }
 
   vector<string> labels = zone.getRawLabels();
-  vState state;
-
-  state = Indeterminate;
 
   typedef std::multimap<uint16_t, DSRecordContent> dsmap_t;
   dsmap_t dsmap;
   keyset_t validkeys;
 
   DNSName qname = lowestTA;
-  state = Secure; // the lowest Trust Anchor is secure
+  vState state = Secure; // the lowest Trust Anchor is secure
 
   while(zone.isPartOf(qname))
   {

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -390,8 +390,10 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
               LOG("\t"<<r->getZoneRepresentation()<<endl);
               auto nsec = std::dynamic_pointer_cast<NSECRecordContent>(r);
               if(nsec) {
-                if(v.first.first == qname && !nsec->d_set.count(QType::DS))
+                if(v.first.first == qname && !nsec->d_set.count(QType::DS)) {
+                  LOG("Denies existence of DS!"<<endl);
                   return Insecure;
+                }
                 else if(v.first.first.canonCompare(qname) && qname.canonCompare(nsec->d_next) ) {
                   LOG("Did not find DS for this level, trying one lower"<<endl);
                   goto skipLevel;

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -92,6 +92,9 @@ ns1.optout.example.      3600 IN A    {prefix}.14
 
 insecure-formerr.example. 3600 IN NS   ns1.insecure-formerr.example.
 ns1.insecure-formerr.example. 3600 IN A    {prefix}.2
+
+islandofsecurity.example.          3600 IN NS   ns1.islandofsecurity.example.
+ns1.islandofsecurity.example.      3600 IN A    {prefix}.9
         """,
         'secure.example': """
 secure.example.          3600 IN SOA  {soa}
@@ -102,6 +105,7 @@ host1.secure.example.    3600 IN A    192.0.2.2
 cname.secure.example.    3600 IN CNAME host1.secure.example.
 cname-to-insecure.secure.example. 3600 IN CNAME node1.insecure.example.
 cname-to-bogus.secure.example.    3600 IN CNAME ted.bogus.example.
+cname-to-islandofsecurity.secure.example. 3600 IN CNAME node1.islandofsecurity.example.
 
 host1.sub.secure.example. 3600 IN A    192.0.2.11
 
@@ -164,6 +168,13 @@ secure.optout.example.          3600 IN NS   ns1.secure.optout.example.
 ns1.secure.optout.example.      3600 IN A    {prefix}.15
 
 node1.secure.optout.example.    3600 IN A    192.0.2.8
+        """,
+        'islandofsecurity.example': """
+islandofsecurity.example.          3600 IN SOA  {soa}
+islandofsecurity.example.          3600 IN NS   ns1.islandofsecurity.example.
+ns1.islandofsecurity.example.      3600 IN A    {prefix}.9
+
+node1.islandofsecurity.example.    3600 IN A    192.0.2.20
         """
     }
 
@@ -204,6 +215,12 @@ PrivateKey: efmq9G+J4Y2iPnIBRwJiy6Z/nIHSzpsCy/7XHhlS19A=
 Private-key-format: v1.2
 Algorithm: 13 (ECDSAP256SHA256)
 PrivateKey: xcNUxt1Knj14A00lKQFDboluiJyM2f7FxpgsQaQ3AQ4=
+        """,
+
+        'islandofsecurity.example': """
+Private-key-format: v1.2
+Algorithm: 13 (ECDSAP256SHA256)
+PrivateKey: o9F5iix8V68tnMcuOaM2Lt8XXhIIY//SgHIHEePk6cM=
         """
     }
 
@@ -212,7 +229,7 @@ PrivateKey: xcNUxt1Knj14A00lKQFDboluiJyM2f7FxpgsQaQ3AQ4=
     # go into the _zones's zonecontent
     _auth_zones = {
         '8': ['ROOT'],
-        '9': ['secure.example'],
+        '9': ['secure.example', 'islandofsecurity.example'],
         '10': ['example'],
         '11': ['example'],
         '12': ['bogus.example'],

--- a/regression-tests.recursor-dnssec/test_Simple.py
+++ b/regression-tests.recursor-dnssec/test_Simple.py
@@ -84,3 +84,15 @@ auth-zones=authzone.example=configs/%s/authzone.zone""" % _confdir
 
         self.assertRcodeEqual(resPTR, dns.rcode.NOERROR)
         self.assertRRsetInAnswer(resPTR, expectedPTR)
+
+    def testIslandOfSecurity(self):
+        query = dns.message.make_query('cname-to-islandofsecurity.secure.example.', 'A', want_dnssec=True)
+
+        expectedCNAME = dns.rrset.from_text('cname-to-islandofsecurity.secure.example.', 0, 'IN', 'CNAME', 'node1.islandofsecurity.example.')
+        expectedA = dns.rrset.from_text('node1.islandofsecurity.example.', 0, 'IN', 'A', '192.0.2.20')
+
+        res = self.sendUDPQuery(query)
+
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertRRsetInAnswer(res, expectedA)
+


### PR DESCRIPTION
This PR fixes several DNSSEC issues:

* No longer 'jojo' between Secure and Insecure states. Once we have an Insecure, we can only go Bogus but not Secure.
* Fix the CNAME at apex issue
* Check all DNSSEC chains on a possible Insecure (i.e. no signatures whatsoever)

Needs a very big review.