### PR TITLE
newServer setting maxCheckFailures makes no sense

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1254,7 +1254,12 @@ void* healthChecksThread()
     for(auto& dss : g_dstates.getCopy()) { // this points to the actual shared_ptrs!
       if(dss->availability==DownstreamState::Availability::Auto) {
 	bool newState=upCheck(*dss);
-	if (!newState && dss->upStatus) {
+	if (newState) {
+		if (dss->currentCheckFailures != 0) {
+			dss->currentCheckFailures = 0;
+		}
+	}
+	else if (!newState && dss->upStatus) {
 	  dss->currentCheckFailures++;
 	  if (dss->currentCheckFailures < dss->maxCheckFailures) {
 	    newState = true;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1253,24 +1253,24 @@ void* healthChecksThread()
 
     for(auto& dss : g_dstates.getCopy()) { // this points to the actual shared_ptrs!
       if(dss->availability==DownstreamState::Availability::Auto) {
-	bool newState=upCheck(*dss);
-	if (newState) {
-		if (dss->currentCheckFailures != 0) {
-			dss->currentCheckFailures = 0;
-		}
-	}
-	else if (!newState && dss->upStatus) {
-	  dss->currentCheckFailures++;
-	  if (dss->currentCheckFailures < dss->maxCheckFailures) {
-	    newState = true;
-	  }
-	}
+        bool newState=upCheck(*dss);
+        if (newState) {
+          if (dss->currentCheckFailures != 0) {
+            dss->currentCheckFailures = 0;
+          }
+        }
+        else if (!newState && dss->upStatus) {
+          dss->currentCheckFailures++;
+          if (dss->currentCheckFailures < dss->maxCheckFailures) {
+            newState = true;
+          }
+        }
 
-	if(newState != dss->upStatus) {
-	  warnlog("Marking downstream %s as '%s'", dss->getNameWithAddr(), newState ? "up" : "down");
-	  dss->upStatus = newState;
-	  dss->currentCheckFailures = 0;
-	}
+        if(newState != dss->upStatus) {
+          warnlog("Marking downstream %s as '%s'", dss->getNameWithAddr(), newState ? "up" : "down");
+          dss->upStatus = newState;
+          dss->currentCheckFailures = 0;
+        }
       }
 
       auto delta = dss->sw.udiffAndSet()/1000000.0;


### PR DESCRIPTION
when dnsdist add `newServer` with `maxCheckFailures` parameter, such as `maxCheckFailures=3`, if the downstream server seems to be down, then the `dss->currentCheckFailures` will increase 1.

but, if `dss->currentCheckFailures` not reach the `maxCheckFailures` value, at this time, the downstream server seems to be up, the `dss->currentCheckFailures` was not reset to 0.

so when `dss->currentCheckFailures` reach `maxCheckFailures`, dnsdist will show downstream down, the change to up in the next second.

```
dnsdist[24734]: Marking downstream 10.63.49.12:53 as 'down'
dnsdist[24734]: Marking downstream 10.63.49.12:53 as 'up'
```

In my opinion, discontinuous failure retry makes no sense, so I post this pull request.

Thanks.