### PR TITLE
auth: Don't try to deallocate empty PG statements

### DIFF
--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -184,9 +184,12 @@ private:
   void releaseStatement() {
     d_prepared = false;
     reset();
-    string cmd = string("DEALLOCATE " + d_stmt);
-    PGresult *res = PQexec(d_db(), cmd.c_str());
-    PQclear(res);
+    if (!d_stmt.empty()) {
+      string cmd = string("DEALLOCATE " + d_stmt);
+      PGresult *res = PQexec(d_db(), cmd.c_str());
+      PQclear(res);
+      d_stmt.clear();
+    }
   }
 
   void prepareStatement() {


### PR DESCRIPTION
When a SPgSQLStatement is released without having been prepared,
we execute an invalid 'DEALLOCATE ' SQL command. This might happen
if the statement has not been used before being destroyed, for example.
Fixes #4201.