### PR TITLE
dnsdist: Don't log an error when parsing an invalid UDP query

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1092,7 +1092,7 @@ try
       vinfolog("Got query from %s, relayed to %s", remote.toStringWithPort(), ss->getName());
     }
     catch(std::exception& e){
-      errlog("Got an error in UDP question thread while parsing a query from %s, id %d: %s", remote.toStringWithPort(), queryId, e.what());
+      vinfolog("Got an error in UDP question thread while parsing a query from %s, id %d: %s", remote.toStringWithPort(), queryId, e.what());
     }
   }
   return 0;


### PR DESCRIPTION
It can still be displayed in verbose mode, but we don't want to
flood our logs for this.