### PR TITLE
Allow a pipe backend to send a higher SOA

### DIFF
--- a/docs/markdown/authoritative/backend-pipe.md
+++ b/docs/markdown/authoritative/backend-pipe.md
@@ -20,6 +20,11 @@ It allows end-users to write PowerDNS backends in any language, a perl sample is
 The PipeBackend is also very well suited for dynamic resolution of queries.
 Example applications include DNS based load balancing, geo-direction, DNS-based failover with low TTLs.
 
+Since version 4.0.1 the PipeBackend can send a 'higher' SOA record when asked for the SOA.
+e.g. A question for `1.2.3.4.5.6.7.8.9.0.8.b.d.1.0.0.2.ip6.arpa|SOA` could be answered with the SOA for `1.0.0.2.ip6.arpa`.
+PowerDNS will then not ask this PipeBacked anymore for any other SOA for every label when searching for the authoritative backend.
+Sending this 'higher' SOA will this decrease load on the nameserver and be faster, as the script is asked fewer questions.
+
 **Note**: The [Remote Backend](backend-remote.md) offers a superset of the functionality of the PipeBackend.
 
 **Note**: Please do read the [Backend Writer' guide](../appendix/backend-writers-guide.md) carefully.

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -332,6 +332,22 @@ bool PipeBackend::get(DNSResourceRecord &r)
   return true;
 }
 
+bool PipeBackend::getAuth(const DNSName &domain, SOAData &sd, DNSPacket *p)
+{
+  if (DNSBackend::getSOA(domain, sd, p)) {
+    /* check if we secretly have a higher SOA and set that in the returned record*/
+    this->lookup(QType(QType::SOA),domain,p);
+    DNSResourceRecord rr;
+    while(this->get(rr)) {
+      if (rr.qtype != QType::SOA) throw PDNSException("Got non-SOA record when asking for SOA");
+      sd.qname = rr.qname;
+    }
+    return true;
+  }
+  return false;
+}
+
+
 //
 // Magic class that is activated when the dynamic library is loaded
 //

--- a/modules/pipebackend/pipebackend.hh
+++ b/modules/pipebackend/pipebackend.hh
@@ -37,6 +37,7 @@ class PipeBackend : public DNSBackend
 public:
   PipeBackend(const string &suffix="");
   ~PipeBackend();
+  bool getAuth(const DNSName &domain, SOAData &sd, DNSPacket *p);
   void lookup(const QType&, const DNSName& qdomain, DNSPacket *p=0, int zoneId=-1);
   bool list(const DNSName& target, int domain_id, bool include_disabled=false);
   bool get(DNSResourceRecord &r);


### PR DESCRIPTION
This prevents superfluous queries to the pipe-command and will speed up
lookups.
