### PR TITLE
Allow Lua access to the result of the Policy Engine decision

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -97,6 +97,7 @@ The DNSQuestion object contains at least the following fields:
   * policyAction: The action taken by the engine
   * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
   * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
+* wantsRPZ - A boolean that indicates the use of the Policy Engine, can be set to `false` in `preresolve` to disable RPZ for this query
 
 It also supports the following methods:
 

--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -92,6 +92,11 @@ The DNSQuestion object contains at least the following fields:
   * getFakeAAAARecords: Get a fake AAAA record, see [DNS64](#dns64)
   * getFakePTRRecords: Get a fake PTR record, see [DNS64](#dns64)
   * udpQueryResponse: Do a UDP query and call a handler, see [`udpQueryResponse`](#udpqueryresponse)
+* appliedPolicy - The decision that was made by the policy engine, see [Modifying policy decisions](#modifying-policy-decisions). It has the following fields:
+  * policyName: The name of the policy (used in e.g. protobuf logging)
+  * policyAction: The action taken by the engine
+  * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
+  * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
 
 It also supports the following methods:
 
@@ -376,3 +381,63 @@ function preoutquery(dq)
 	return false
 end
 ```
+
+## Modifying Policy Decisions
+The PowerDNS Recursor has a [policy engine based on Response Policy Zones (RPZ)](settings.md#response-policy-zone-rpz).
+Starting with version 4.0.1 of the recursor, it is possible to alter this decision inside the Lua hooks.
+If the decision is modified in a Lua hook, `false` should be returned, as the query is not actually handled by Lua so the decision is picked up by the Recursor.
+The result of the policy decision is checked after `preresolve` and `postresolve`.
+
+For example, if a decision is set to `pdns.policykinds.NODATA` by the policy engine and is unchanged in `preresolve`, the query is replied to with a NODATA response immediately after `preresolve`.
+
+### Example script
+```
+-- Dont ever block my own domain and IPs
+myDomain = newDN("example.com")
+
+myNetblock = newNMG()
+myNetblock:addMasks("192.0.2.0/24")
+
+function preresolve(dq)
+  if dq.qname:isPartOf(myDomain) and dq.appliedPolicy.policyKind != pdns.policykinds.NoAction then
+    pdnslog("Not blocking our own domain!")
+    dq.appliedPolicy.policyKind = pdns.policykinds.NoAction
+  end
+end
+
+function postresolve(dq)
+  if dq.appliedPolicy.policyKind != pdns.policykinds.NoAction then
+    local records = dq:getRecords()
+    for k,v in pairs(records) do
+      if v.type == pdns.A then
+        local blockedIP = newCA(v:getContent())
+        if myNetblock:match(blockedIP) then
+          pdnslog("Not blocking our IP space")
+          dq.appliedPolicy.policyKind = pdns.policykinds.NoAction
+        end
+      end
+    end
+  end
+end
+```
+
+The decision is contained in the `dq` object under `dq.appliedPolicy` and features 4 fields:
+
+### `dq.appliedPolicy.policyName`
+A string with the name of the policy (set by `polName=` in the `rpzFile` and `rpzMaster` configuration items).
+It is advised to overwrite this when modifying the `policyKind`
+
+### `dq.appliedPolicy.policyKind`
+The kind of policy response, there are several policy kinds:
+
+ * `pdns.policykinds.Custom` will return a NoError, CNAME answer with the value specified in `dq.appliedPolicy.policyCustom`
+ * `pdns.policykinds.Drop` will simply cause the query to be dropped
+ * `pdns.policykinds.NoAction` will continue normal processing of the query
+ * `pdns.policykinds.NODATA` will return a NoError response with no value in the answer section
+ * `pdns.policykinds.NXDOMAIN` will return a response with a NXDomain rcode
+ * `pdns.policykinds.Truncate` will return a NoError, no answer, truncated response over UDP. Normal processing will continue over TCP
+
+### `dq.appliedPolicy.policyCustom` and `dq.appliedPolicy.policyTTL`
+These fields are only used when `dq.appliedPolicy.policyKind` is set to `pdns.policykinds.Custom`.
+`dq.appliedPolicy.policyCustom` contains the name for the CNAME target as a string.
+And `dq.appliedPolicy.policyTTL` is the TTL field (in seconds) for the CNAME response.

--- a/docs/markdown/recursor/stats.md
+++ b/docs/markdown/recursor/stats.md
@@ -59,6 +59,12 @@ The `rec_control get` command can be used to query the following statistics, eit
 * `packetcache-hits`: packet cache hits (since 3.2)
 * `packetcache-misses`: packet cache misses (since 3.2)
 * `policy-drops`: packets dropped because of (Lua) policy decision
+* `policy-result-noaction`: packets that were not actioned upon by the RPZ/filter engine
+* `policy-result-drop`: packets that were dropped by the RPZ/filter engine
+* `policy-result-nxdomain`: packets that were replied to with NXDOMAIN by the RPZ/filter engine
+* `policy-result-nodata`: packets that were replied to with no data by the RPZ/filter engine
+* `policy-result-truncate`: packets that were forced to TCP by the RPZ/filter engine
+* `policy-result-custom`: packets that were sent a custom answer by the RPZ/filter engine
 * `qa-latency`: shows the current latency average, in microseconds, exponentially weighted over past 'latency-statistic-size' packets
 * `questions`: counts all end-user initiated queries with the RD bit set
 * `resource-limits`: counts number of queries that could not be performed because of resource limits

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -11,30 +11,30 @@ bool findNamedPolicy(const map<DNSName, DNSFilterEngine::Policy>& polmap, const 
 {
   DNSName s(qname);
 
-    /* for www.powerdns.com, we need to check:
-         www.powerdns.com.
-           *.powerdns.com.
-             powerdns.com.
-	            *.com.
-                      com.
-	 	        *.
-  			 .       */
+  /* for www.powerdns.com, we need to check:
+     www.powerdns.com.
+       *.powerdns.com.
+                *.com.
+                    *.
+   */
  
   bool first=true;
+  map<DNSName, DNSFilterEngine::Policy>::const_iterator iter;
   do {
-    auto iter = polmap.find(s);
+    if(first) {
+      iter = polmap.find(s);
+      if(iter != polmap.end()) {
+        pol=iter->second;
+        return true;
+      }
+    }
+    first=false;
+
+    iter = polmap.find(DNSName("*")+s);
     if(iter != polmap.end()) {
       pol=iter->second;
       return true;
     }
-    if(!first) {
-      iter = polmap.find(DNSName("*")+s);
-      if(iter != polmap.end()) {
-	pol=iter->second;
-	return true;
-      }
-    }
-    first=false;
   } while(s.chopOff());
   return false;
 }

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -61,16 +61,19 @@ public:
   void addClientTrigger(const Netmask& nm, Policy pol, int zone=0);
   void addQNameTrigger(const DNSName& nm, Policy pol, int zone=0);
   void addNSTrigger(const DNSName& dn, Policy pol, int zone=0);
+  void addNSIPTrigger(const Netmask& nm, Policy pol, int zone=0);
   void addResponseTrigger(const Netmask& nm, Policy pol, int zone=0);
 
   bool rmClientTrigger(const Netmask& nm, Policy pol, int zone=0);
   bool rmQNameTrigger(const DNSName& nm, Policy pol, int zone=0);
   bool rmNSTrigger(const DNSName& dn, Policy pol, int zone=0);
+  bool rmNSIPTrigger(const Netmask& nm, Policy pol, int zone=0);
   bool rmResponseTrigger(const Netmask& nm, Policy pol, int zone=0);
 
 
   Policy getQueryPolicy(const DNSName& qname, const ComboAddress& nm) const;
   Policy getProcessingPolicy(const DNSName& qname) const;
+  Policy getProcessingPolicy(const ComboAddress& address) const;
   Policy getPostPolicy(const vector<DNSRecord>& records) const;
 
   size_t size() {
@@ -79,10 +82,11 @@ public:
 private:
   void assureZones(int zone);
   struct Zone {
-    std::map<DNSName, Policy> qpolName;
-    NetmaskTree<Policy> qpolAddr;
-    std::map<DNSName, Policy> propolName;
-    NetmaskTree<Policy> postpolAddr;
+    std::map<DNSName, Policy> qpolName;   // QNAME trigger (RPZ)
+    NetmaskTree<Policy> qpolAddr;         // Source address
+    std::map<DNSName, Policy> propolName; // NSDNAME (RPZ)
+    NetmaskTree<Policy> propolNSAddr;     // NSIP (RPZ)
+    NetmaskTree<Policy> postpolAddr;      // IP trigger (RPZ)
   };
   vector<Zone> d_zones;
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -231,8 +231,12 @@ RecursorLua4::RecursorLua4(const std::string& fname)
 
   d_lw->writeFunction("newDN", [](const std::string& dom){ return DNSName(dom); });  
   d_lw->registerFunction("isPartOf", &DNSName::isPartOf);
-  d_lw->registerFunction<bool(DNSName::*)(const std::string&)>("equal",
-							      [](const DNSName& lhs, const std::string& rhs) { return lhs==DNSName(rhs); });
+  d_lw->registerFunction<bool(DNSName::*)(const std::string&)>(
+    "equal",
+     [](const DNSName& lhs, const std::string& rhs) {
+       return lhs==DNSName(rhs);
+    }
+  );
   d_lw->registerFunction("__eq", &DNSName::operator==);
 
   d_lw->registerFunction<string(ComboAddress::*)()>("toString", [](const ComboAddress& ca) { return ca.toString(); });
@@ -251,32 +255,35 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->writeFunction("newCAS", []{ return cas_t(); });
 
 
-  d_lw->registerFunction<void(cas_t::*)(boost::variant<string,ComboAddress, vector<pair<unsigned int,string> > >)>("add",
-                                                                                   [](cas_t& cas, const boost::variant<string,ComboAddress,vector<pair<unsigned int,string> > >& in)
-										   {
-										     try {
-										     if(auto s = boost::get<string>(&in)) {
-										       cas.insert(ComboAddress(*s));
-										     }
-										     else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
-										       for(const auto& s : *v)
-											 cas.insert(ComboAddress(s.second));
-										     }
-										     else
-										       cas.insert(boost::get<ComboAddress>(in));
-										     }
-										     catch(std::exception& e) { theL() <<Logger::Error<<e.what()<<endl; }
-										   });
+  d_lw->registerFunction<void(cas_t::*)(boost::variant<string,ComboAddress, vector<pair<unsigned int,string> > >)>(
+    "add",
+    [](cas_t& cas, const boost::variant<string,ComboAddress,vector<pair<unsigned int,string> > >& in)
+    {
+      try {
+        if(auto s = boost::get<string>(&in)) {
+          cas.insert(ComboAddress(*s));
+        }
+        else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
+          for(const auto& s : *v)
+            cas.insert(ComboAddress(s.second));
+          }
+        else {
+          cas.insert(boost::get<ComboAddress>(in));
+        }
+      }
+      catch(std::exception& e) { theL() <<Logger::Error<<e.what()<<endl; }
+    });
 
   d_lw->registerFunction<bool(cas_t::*)(const ComboAddress&)>("check",[](const cas_t& cas, const ComboAddress&ca) {
       return (bool)cas.count(ca);
     });
 
-
-
-  d_lw->registerFunction<bool(ComboAddress::*)(const ComboAddress&)>("equal", [](const ComboAddress& lhs, const ComboAddress& rhs) {
+  d_lw->registerFunction<bool(ComboAddress::*)(const ComboAddress&)>(
+    "equal",
+    [](const ComboAddress& lhs, const ComboAddress& rhs) {
       return ComboAddress::addressOnlyEqual()(lhs, rhs);
-    });
+    }
+  );
   
 
   d_lw->registerFunction<ComboAddress(Netmask::*)()>("getNetwork", [](const Netmask& nm) { return nm.getNetwork(); } ); // const reference makes this necessary
@@ -284,16 +291,19 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerFunction("empty", &Netmask::empty);
 
   d_lw->writeFunction("newNMG", []() { return NetmaskGroup(); });
-  d_lw->registerFunction<void(NetmaskGroup::*)(const std::string&mask)>("addMask", [](NetmaskGroup&nmg, const std::string& mask)
-			 {
-			   nmg.addMask(mask);
-			 });
+  d_lw->registerFunction<void(NetmaskGroup::*)(const std::string&mask)>(
+    "addMask", [](NetmaskGroup&nmg, const std::string& mask){
+      nmg.addMask(mask);
+    }
+  );
 
-  d_lw->registerFunction<void(NetmaskGroup::*)(const vector<pair<unsigned int, std::string>>&)>("addMasks", [](NetmaskGroup&nmg, const vector<pair<unsigned int, std::string>>& masks)
-			 {
-                           for(const auto& mask: masks) 
-                             nmg.addMask(mask.second);
-			 });
+  d_lw->registerFunction<void(NetmaskGroup::*)(const vector<pair<unsigned int, std::string>>&)>(
+    "addMasks",
+    [](NetmaskGroup&nmg, const vector<pair<unsigned int, std::string>>& masks){
+      for(const auto& mask: masks)
+        nmg.addMask(mask.second);
+    }
+  );
 
 
   d_lw->registerFunction("match", (bool (NetmaskGroup::*)(const ComboAddress&) const)&NetmaskGroup::match);
@@ -364,22 +374,27 @@ RecursorLua4::RecursorLua4(const std::string& fname)
     });
 
   d_lw->writeFunction("newDS", []() { return SuffixMatchNode(); });
-  d_lw->registerFunction<void(SuffixMatchNode::*)(boost::variant<string,DNSName, vector<pair<unsigned int,string> > >)>("add",
-										   [](SuffixMatchNode&smn, const boost::variant<string,DNSName,vector<pair<unsigned int,string> > >& in)
-										   {
-										     try {
-										     if(auto s = boost::get<string>(&in)) {
-										       smn.add(DNSName(*s));
-										     }
-										     else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
-										       for(const auto& s : *v)
-											 smn.add(DNSName(s.second));
-										     }
-										     else
-										       smn.add(boost::get<DNSName>(in));
-										     }
-										     catch(std::exception& e) { theL() <<Logger::Error<<e.what()<<endl; }
-										   });
+  d_lw->registerFunction<void(SuffixMatchNode::*)(boost::variant<string,DNSName, vector<pair<unsigned int,string> > >)>(
+    "add",
+    [](SuffixMatchNode&smn, const boost::variant<string,DNSName,vector<pair<unsigned int,string> > >& in){
+      try {
+        if(auto s = boost::get<string>(&in)) {
+          smn.add(DNSName(*s));
+        }
+        else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
+          for(const auto& s : *v)
+            smn.add(DNSName(s.second));
+        }
+        else {
+          smn.add(boost::get<DNSName>(in));
+        }
+      }
+      catch(std::exception& e) {
+        theL() <<Logger::Error<<e.what()<<endl;
+      }
+    }
+  );
+
   d_lw->registerFunction("check",(bool (SuffixMatchNode::*)(const DNSName&) const) &SuffixMatchNode::check);
 
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -30,7 +30,7 @@ bool RecursorLua4::postresolve(const ComboAddress& remote,const ComboAddress& lo
   return false;
 }
 
-bool RecursorLua4::preresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& ret, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& res, bool* variable)
+bool RecursorLua4::preresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& ret, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& res, bool* variable, bool* wantsRPZ)
 {
   return false;
 }
@@ -327,6 +327,7 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerMember("udpAnswer", &DNSQuestion::udpAnswer);
   d_lw->registerMember("udpQueryDest", &DNSQuestion::udpQueryDest);
   d_lw->registerMember("udpCallback", &DNSQuestion::udpCallback);
+  d_lw->registerMember("wantsRPZ", &DNSQuestion::wantsRPZ);
   d_lw->registerMember("appliedPolicy", &DNSQuestion::appliedPolicy);
   d_lw->registerMember("policyName", &DNSFilterEngine::Policy::d_name);
   d_lw->registerMember("policyKind", &DNSFilterEngine::Policy::d_kind);
@@ -488,29 +489,29 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_gettag = d_lw->readVariable<boost::optional<gettag_t>>("gettag").get_value_or(0);
 }
 
-bool RecursorLua4::preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable)
+bool RecursorLua4::preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable, bool* wantsRPZ)
 {
-  return genhook(d_preresolve, remote, local, query, qtype, isTcp, res, ednsOpts, tag, appliedPolicy, policyTags, ret, variable);
+  return genhook(d_preresolve, remote, local, query, qtype, isTcp, res, ednsOpts, tag, appliedPolicy, policyTags, ret, variable, wantsRPZ);
 }
 
 bool RecursorLua4::nxdomain(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable)
 {
-  return genhook(d_nxdomain, remote, local, query, qtype, isTcp, res, 0, 0, nullptr, nullptr, ret, variable);
+  return genhook(d_nxdomain, remote, local, query, qtype, isTcp, res, 0, 0, nullptr, nullptr, ret, variable, 0);
 }
 
 bool RecursorLua4::nodata(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable)
 {
-  return genhook(d_nodata, remote, local, query, qtype, isTcp, res, 0, 0, nullptr, nullptr, ret, variable);
+  return genhook(d_nodata, remote, local, query, qtype, isTcp, res, 0, 0, nullptr, nullptr, ret, variable, 0);
 }
 
 bool RecursorLua4::postresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable)
 {
-  return genhook(d_postresolve, remote, local, query, qtype, isTcp, res, 0, 0, appliedPolicy, policyTags, ret, variable);
+  return genhook(d_postresolve, remote, local, query, qtype, isTcp, res, 0, 0, appliedPolicy, policyTags, ret, variable, 0);
 }
 
 bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret)
 {
-  return genhook(d_preoutquery, ns, requestor, query, qtype, isTcp, res, 0, 0, nullptr, nullptr, ret, 0);
+  return genhook(d_preoutquery, ns, requestor, query, qtype, isTcp, res, 0, 0, nullptr, nullptr, ret, 0, 0);
 }
 
 bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader& dh)
@@ -538,7 +539,7 @@ int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, 
   return 0;
 }
 
-bool RecursorLua4::genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable)
+bool RecursorLua4::genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable, bool* wantsRPZ)
 {
   if(!func)
     return false;
@@ -554,8 +555,10 @@ bool RecursorLua4::genhook(luacall_t& func, const ComboAddress& remote,const Com
   dq->isTcp = isTcp;
   dq->policyTags = policyTags;
   dq->appliedPolicy = appliedPolicy;
+  dq->wantsRPZ = wantsRPZ;
   bool handled=func(dq);
   if(variable) *variable |= dq->variable; // could still be set to indicate this *name* is variable, even if not 'handled'
+  *wantsRPZ = dq->wantsRPZ; // Even if we did not handle the query, RPZ could be disabled
 
   if(handled) {
 loop:;

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -23,7 +23,7 @@ private:
 public:
   explicit RecursorLua4(const std::string& fname);
   ~RecursorLua4(); // this is so unique_ptr works with an incomplete type
-  bool preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable, bool* wantsRPZ);
   bool nxdomain(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
   bool nodata(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
   bool postresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
@@ -70,11 +70,12 @@ private:
     DNSFilterEngine::Policy* appliedPolicy;
     std::vector<std::string>* policyTags;
     bool isTcp;
+    bool wantsRPZ;
   };
 
   typedef std::function<bool(std::shared_ptr<DNSQuestion>)> luacall_t;
   luacall_t d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
-  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable, bool* wantsRPZ);
   typedef std::function<bool(ComboAddress,ComboAddress, struct dnsheader)> ipfilter_t;
   ipfilter_t d_ipfilter;
 };

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -3,6 +3,7 @@
 #include "dnsname.hh"
 #include "namespaces.hh"
 #include "dnsrecords.hh"
+#include "filterpo.hh"
 #include <unordered_map>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -22,10 +23,10 @@ private:
 public:
   explicit RecursorLua4(const std::string& fname);
   ~RecursorLua4(); // this is so unique_ptr works with an incomplete type
-  bool preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
   bool nxdomain(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
   bool nodata(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
-  bool postresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool postresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
 
   bool preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret);
   bool ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader&);
@@ -66,14 +67,14 @@ private:
     const std::vector<pair<uint16_t, string>>* ednsOptions;
     DNSName followupName;
 
-    string appliedPolicy;
+    DNSFilterEngine::Policy* appliedPolicy;
     std::vector<std::string>* policyTags;
     bool isTcp;
   };
 
   typedef std::function<bool(std::shared_ptr<DNSQuestion>)> luacall_t;
   luacall_t d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
-  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
   typedef std::function<bool(ComboAddress,ComboAddress, struct dnsheader)> ipfilter_t;
   ipfilter_t d_ipfilter;
 };

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -611,15 +611,15 @@ catch(...)
 }
 
 #ifdef HAVE_PROTOBUF
-static void protobufLogQuery(const std::shared_ptr<RemoteLogger>& logger, uint8_t maskV4, uint8_t maskV6, const boost::uuids::uuid& uniqueId, const ComboAddress& remote, const ComboAddress& local, const Netmask& ednssubnet, bool tcp, uint16_t id, size_t len, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::string appliedPolicy, const std::vector<std::string>& policyTags)
+static void protobufLogQuery(const std::shared_ptr<RemoteLogger>& logger, uint8_t maskV4, uint8_t maskV6, const boost::uuids::uuid& uniqueId, const ComboAddress& remote, const ComboAddress& local, const Netmask& ednssubnet, bool tcp, uint16_t id, size_t len, const DNSName& qname, uint16_t qtype, uint16_t qclass, const DNSFilterEngine::Policy appliedPolicy, const std::vector<std::string>& policyTags)
 {
   Netmask requestorNM(remote, remote.sin4.sin_family == AF_INET ? maskV4 : maskV6);
   const ComboAddress& requestor = requestorNM.getMaskedNetwork();
   RecProtoBufMessage message(DNSProtoBufMessage::Query, uniqueId, &requestor, &local, qname, qtype, qclass, id, tcp, len);
   message.setEDNSSubnet(ednssubnet);
 
-  if (!appliedPolicy.empty()) {
-    message.setAppliedPolicy(appliedPolicy);
+  if (!appliedPolicy.d_name.empty()) {
+    message.setAppliedPolicy(appliedPolicy.d_name);
   }
   if (!policyTags.empty()) {
     message.setPolicyTags(policyTags);
@@ -659,7 +659,7 @@ void startDoResolve(void *p)
     vector<uint8_t> packet;
 
     auto luaconfsLocal = g_luaconfs.getLocal();
-    std::string appliedPolicy;
+    DNSFilterEngine::Policy appliedPolicy;
     RecProtoBufMessage pbMessage(RecProtoBufMessage::Response);
 #ifdef HAVE_PROTOBUF
     if (luaconfsLocal->protobufServer) {
@@ -739,51 +739,47 @@ void startDoResolve(void *p)
     if(!dc->d_mdp.d_header.rd)
       sr.setCacheOnly();
 
+    // Check if the query has a policy attached to it
     dfepol = luaconfsLocal->dfe.getQueryPolicy(dc->d_mdp.d_qname, dc->d_remote);
-
-    switch(dfepol.d_kind) {
-    case DNSFilterEngine::PolicyKind::NoAction:
-      break;
-    case DNSFilterEngine::PolicyKind::Drop:
-      g_stats.policyDrops++;
-      delete dc;
-      dc=0;
-      return; 
-    case DNSFilterEngine::PolicyKind::NXDOMAIN:
-      res=RCode::NXDomain;
-      appliedPolicy=dfepol.d_name;
-      goto haveAnswer;
-
-    case DNSFilterEngine::PolicyKind::NODATA:
-      res=RCode::NoError;
-      appliedPolicy=dfepol.d_name;
-      goto haveAnswer;
-
-    case DNSFilterEngine::PolicyKind::Custom:
-      res=RCode::NoError;
-      spoofed.d_name=dc->d_mdp.d_qname;
-      spoofed.d_type=dfepol.d_custom->getType();
-      spoofed.d_ttl = dfepol.d_ttl;
-      spoofed.d_class = 1;
-      spoofed.d_content = dfepol.d_custom;
-      spoofed.d_place = DNSResourceRecord::ANSWER;
-      ret.push_back(spoofed);
-      appliedPolicy=dfepol.d_name;
-      goto haveAnswer;
-
-
-    case DNSFilterEngine::PolicyKind::Truncate:
-      if(!dc->d_tcp) {
-	res=RCode::NoError;	
-	pw.getHeader()->tc=1;
-        appliedPolicy=dfepol.d_name;
-	goto haveAnswer;
-      }
-      break;
-    }
+    appliedPolicy = dfepol;
 
     // if there is a RecursorLua active, and it 'took' the query in preResolve, we don't launch beginResolve
     if(!t_pdl->get() || !(*t_pdl)->preresolve(dc->d_remote, dc->d_local, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, ret, dc->d_ednsOpts.empty() ? 0 : &dc->d_ednsOpts, dc->d_tag, &appliedPolicy, &dc->d_policyTags, res, &variableAnswer)) {
+
+      switch(appliedPolicy.d_kind) {
+        case DNSFilterEngine::PolicyKind::NoAction:
+          break;
+        case DNSFilterEngine::PolicyKind::Drop:
+          g_stats.policyDrops++;
+          delete dc;
+          dc=0;
+          return; 
+        case DNSFilterEngine::PolicyKind::NXDOMAIN:
+          res=RCode::NXDomain;
+          goto haveAnswer;
+        case DNSFilterEngine::PolicyKind::NODATA:
+          res=RCode::NoError;
+          goto haveAnswer;
+        case DNSFilterEngine::PolicyKind::Custom:
+          res=RCode::NoError;
+          spoofed.d_name=dc->d_mdp.d_qname;
+          spoofed.d_type=appliedPolicy.d_custom->getType();
+          spoofed.d_ttl = appliedPolicy.d_ttl;
+          spoofed.d_class = 1;
+          spoofed.d_content = appliedPolicy.d_custom;
+          spoofed.d_place = DNSResourceRecord::ANSWER;
+          ret.push_back(spoofed);
+          goto haveAnswer;
+        case DNSFilterEngine::PolicyKind::Truncate:
+          if(!dc->d_tcp) {
+            res=RCode::NoError;	
+            pw.getHeader()->tc=1;
+            goto haveAnswer;
+          }
+          break;
+      }
+
+      // Query got not handled for Policy reasons, now actually go out to find an answer
       try {
         res = sr.beginResolve(dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_mdp.d_qclass, ret);
         shouldNotValidate = sr.wasOutOfBand();
@@ -794,50 +790,8 @@ void startDoResolve(void *p)
         res = RCode::ServFail;
       }
 
-      dfepol = luaconfsLocal->dfe.getPostPolicy(ret); 
-      switch(dfepol.d_kind) {
-      case DNSFilterEngine::PolicyKind::NoAction:
-	break;
-      case DNSFilterEngine::PolicyKind::Drop:
-	g_stats.policyDrops++;
-	delete dc;
-	dc=0;
-	return; 
-      case DNSFilterEngine::PolicyKind::NXDOMAIN:
-	ret.clear();
-	res=RCode::NXDomain;
-        appliedPolicy=dfepol.d_name;
-	goto haveAnswer;
-	
-      case DNSFilterEngine::PolicyKind::NODATA:
-	ret.clear();
-	res=RCode::NoError;
-        appliedPolicy=dfepol.d_name;
-	goto haveAnswer;
-	
-      case DNSFilterEngine::PolicyKind::Truncate:
-	if(!dc->d_tcp) {
-	  ret.clear();
-	  res=RCode::NoError;	
-	  pw.getHeader()->tc=1;
-          appliedPolicy=dfepol.d_name;
-	  goto haveAnswer;
-	}
-	break;
-
-      case DNSFilterEngine::PolicyKind::Custom:
-	ret.clear();
-	res=RCode::NoError;
-	spoofed.d_name=dc->d_mdp.d_qname;
-	spoofed.d_type=dfepol.d_custom->getType();
-	spoofed.d_ttl = dfepol.d_ttl;
-	spoofed.d_class = 1;
-	spoofed.d_content = dfepol.d_custom;
-	spoofed.d_place = DNSResourceRecord::ANSWER;
-	ret.push_back(spoofed);
-        appliedPolicy=dfepol.d_name;
-	goto haveAnswer;
-      }
+      dfepol = luaconfsLocal->dfe.getPostPolicy(ret);
+      appliedPolicy = dfepol;
 
       if(t_pdl->get()) {
         if(res == RCode::NoError) {
@@ -853,6 +807,46 @@ void startDoResolve(void *p)
 	
 
 	(*t_pdl)->postresolve(dc->d_remote, dc->d_local, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, ret, &appliedPolicy, &dc->d_policyTags, res, &variableAnswer);
+      }
+
+      switch(appliedPolicy.d_kind) {
+      case DNSFilterEngine::PolicyKind::NoAction:
+	break;
+      case DNSFilterEngine::PolicyKind::Drop:
+	g_stats.policyDrops++;
+	delete dc;
+	dc=0;
+	return; 
+      case DNSFilterEngine::PolicyKind::NXDOMAIN:
+	ret.clear();
+	res=RCode::NXDomain;
+	goto haveAnswer;
+	
+      case DNSFilterEngine::PolicyKind::NODATA:
+	ret.clear();
+	res=RCode::NoError;
+	goto haveAnswer;
+	
+      case DNSFilterEngine::PolicyKind::Truncate:
+	if(!dc->d_tcp) {
+	  ret.clear();
+	  res=RCode::NoError;	
+	  pw.getHeader()->tc=1;
+	  goto haveAnswer;
+	}
+	break;
+
+      case DNSFilterEngine::PolicyKind::Custom:
+	ret.clear();
+	res=RCode::NoError;
+	spoofed.d_name=dc->d_mdp.d_qname;
+	spoofed.d_type=appliedPolicy.d_custom->getType();
+	spoofed.d_ttl = appliedPolicy.d_ttl;
+	spoofed.d_class = 1;
+	spoofed.d_content = appliedPolicy.d_custom;
+	spoofed.d_place = DNSResourceRecord::ANSWER;
+	ret.push_back(spoofed);
+	goto haveAnswer;
       }
     }
   haveAnswer:;
@@ -993,7 +987,7 @@ void startDoResolve(void *p)
     if (luaconfsLocal->protobufServer) {
       pbMessage.setBytes(packet.size());
       pbMessage.setResponseCode(pw.getHeader()->rcode);
-      pbMessage.setAppliedPolicy(appliedPolicy);
+      pbMessage.setAppliedPolicy(appliedPolicy.d_name);
       pbMessage.setPolicyTags(dc->d_policyTags);
       pbMessage.setQueryTime(dc->d_now.tv_sec, dc->d_now.tv_usec);
       protobufLogResponse(luaconfsLocal->protobufServer, pbMessage);
@@ -1240,7 +1234,7 @@ void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
           getQNameAndSubnet(std::string(conn->data, conn->qlen), &qname, &qtype, &qclass, &ednssubnet);
           dc->d_ednssubnet = ednssubnet;
 
-          protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, dc->d_uuid, dest, conn->d_remote, ednssubnet, true, dh->id, conn->qlen, qname, qtype, qclass, std::string(), std::vector<std::string>());
+          protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, dc->d_uuid, dest, conn->d_remote, ednssubnet, true, dh->id, conn->qlen, qname, qtype, qclass, DNSFilterEngine::Policy(), std::vector<std::string>());
         }
         catch(std::exception& e) {
           if(g_logCommonErrors)
@@ -1382,7 +1376,7 @@ string* doProcessUDPQuestion(const std::string& question, const ComboAddress& fr
     RecProtoBufMessage pbMessage(DNSProtoBufMessage::DNSProtoBufMessageType::Response);
 #ifdef HAVE_PROTOBUF
     if(luaconfsLocal->protobufServer) {
-      protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, uniqueId, fromaddr, destaddr, ednssubnet, false, dh->id, question.size(), qname, qtype, qclass, std::string(), policyTags);
+      protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, uniqueId, fromaddr, destaddr, ednssubnet, false, dh->id, question.size(), qname, qtype, qclass, DNSFilterEngine::Policy(), policyTags);
     }
 #endif /* HAVE_PROTOBUF */
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -751,16 +751,20 @@ void startDoResolve(void *p)
           break;
         case DNSFilterEngine::PolicyKind::Drop:
           g_stats.policyDrops++;
+          g_stats.policyResults[appliedPolicy.d_kind]++;
           delete dc;
           dc=0;
           return; 
         case DNSFilterEngine::PolicyKind::NXDOMAIN:
+          g_stats.policyResults[appliedPolicy.d_kind]++;
           res=RCode::NXDomain;
           goto haveAnswer;
         case DNSFilterEngine::PolicyKind::NODATA:
+          g_stats.policyResults[appliedPolicy.d_kind]++;
           res=RCode::NoError;
           goto haveAnswer;
         case DNSFilterEngine::PolicyKind::Custom:
+          g_stats.policyResults[appliedPolicy.d_kind]++;
           res=RCode::NoError;
           spoofed.d_name=dc->d_mdp.d_qname;
           spoofed.d_type=appliedPolicy.d_custom->getType();
@@ -772,6 +776,7 @@ void startDoResolve(void *p)
           goto haveAnswer;
         case DNSFilterEngine::PolicyKind::Truncate:
           if(!dc->d_tcp) {
+            g_stats.policyResults[appliedPolicy.d_kind]++;
             res=RCode::NoError;	
             pw.getHeader()->tc=1;
             goto haveAnswer;
@@ -809,6 +814,7 @@ void startDoResolve(void *p)
 	(*t_pdl)->postresolve(dc->d_remote, dc->d_local, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, ret, &appliedPolicy, &dc->d_policyTags, res, &variableAnswer);
       }
 
+      g_stats.policyResults[appliedPolicy.d_kind]++;
       switch(appliedPolicy.d_kind) {
       case DNSFilterEngine::PolicyKind::NoAction:
 	break;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -739,9 +739,6 @@ void startDoResolve(void *p)
     if(!dc->d_mdp.d_header.rd)
       sr.setCacheOnly();
 
-
-    // if there is a RecursorLua active, and it 'took' the query in preResolve, we don't launch beginResolve
-
     dfepol = luaconfsLocal->dfe.getQueryPolicy(dc->d_mdp.d_qname, dc->d_remote);
 
     switch(dfepol.d_kind) {
@@ -785,6 +782,7 @@ void startDoResolve(void *p)
       break;
     }
 
+    // if there is a RecursorLua active, and it 'took' the query in preResolve, we don't launch beginResolve
     if(!t_pdl->get() || !(*t_pdl)->preresolve(dc->d_remote, dc->d_local, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, ret, dc->d_ednsOpts.empty() ? 0 : &dc->d_ednsOpts, dc->d_tag, &appliedPolicy, &dc->d_policyTags, res, &variableAnswer)) {
       try {
         res = sr.beginResolve(dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_mdp.d_qclass, ret);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -730,11 +730,8 @@ void startDoResolve(void *p)
     if(!g_quiet || tracedQuery) {
       L<<Logger::Warning<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] " << (dc->d_tcp ? "TCP " : "") << "question for '"<<dc->d_mdp.d_qname<<"|"
        <<DNSRecordContent::NumberToType(dc->d_mdp.d_qtype)<<"' from "<<dc->getRemote();
-#ifdef HAVE_PROTOBUF
-      if(!dc->d_ednssubnet.empty()) {
+      if(!dc->d_ednssubnet.empty())
         L<<" (ecs "<<dc->d_ednssubnet.toString()<<")";
-      }
-#endif
       L<<endl;
     }
 

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -89,7 +89,7 @@ void loadRecursorLuaConfig(const std::string& fname)
   Lua.writeFunction("rpzFile", [&lci](const string& fname, const boost::optional<std::unordered_map<string,boost::variant<int, string>>>& options) {
       try {
 	boost::optional<DNSFilterEngine::Policy> defpol;
-	std::string polName;
+	std::string polName("rpzFile");
 	if(options) {
 	  auto& have = *options;
 	  if(have.count("policyName")) {
@@ -133,9 +133,9 @@ void loadRecursorLuaConfig(const std::string& fname)
 	size_t maxReceivedXFRMBytes = 0;
 	if(options) {
 	  auto& have = *options;
-	  if(have.count("policyName")) {
+          polName = zone_;
+	  if(have.count("policyName"))
 	    polName = boost::get<std::string>(constGet(have, "policyName"));
-	  }
 	  if(have.count("defpol")) {
 	    //	    cout<<"Set a default policy"<<endl;
 	    defpol=DNSFilterEngine::Policy();

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -31,6 +31,7 @@
 #include "rec-lua-conf.hh"
 
 #include "validate-recursor.hh"
+#include "filterpo.hh"
 
 #include "secpoll-recursor.hh"
 #include "pubsuffix.hh"
@@ -882,6 +883,13 @@ RecursorControlParser::RecursorControlParser()
   addGetStat("dnssec-result-bogus", &g_stats.dnssecResults[Bogus]);
   addGetStat("dnssec-result-indeterminate", &g_stats.dnssecResults[Indeterminate]);
   addGetStat("dnssec-result-nta", &g_stats.dnssecResults[NTA]);
+
+  addGetStat("policy-result-noaction", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NoAction]);
+  addGetStat("policy-result-drop", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Drop]);
+  addGetStat("policy-result-nxdomain", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NXDOMAIN]);
+  addGetStat("policy-result-nodata", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NODATA]);
+  addGetStat("policy-result-truncate", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Truncate]);
+  addGetStat("policy-result-custom", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Custom]);
 }
 
 static void doExitGeneric(bool nicely)

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -995,8 +995,10 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
         }
         //
 	// XXX NEED TO HANDLE OTHER POLICY KINDS HERE!
-	if(g_luaconfs.getLocal()->dfe.getProcessingPolicy(*tns).d_kind != DNSFilterEngine::PolicyKind::NoAction)
+	if(g_luaconfs.getLocal()->dfe.getProcessingPolicy(*tns).d_kind != DNSFilterEngine::PolicyKind::NoAction) {
+          g_stats.policyResults[g_luaconfs.getLocal()->dfe.getProcessingPolicy(*tns).d_kind]++;
 	  throw ImmediateServFailException("Dropped because of policy");
+        }
 
         if(tns->empty()) {
           LOG(prefix<<qname<<": Domain has hardcoded nameserver");

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -346,6 +346,8 @@ public:
   
   bool d_wasVariable{false};
   bool d_wasOutOfBand{false};
+  bool d_wantsRPZ{true};
+  DNSFilterEngine::Policy d_appliedPolicy{DNSFilterEngine::PolicyKind::NoAction, nullptr, "", 0};
   
   typedef multi_index_container <
     NegCacheEntry,

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -615,6 +615,7 @@ struct RecursorStats
   unsigned int maxMThreadStackUsage;
   std::atomic<uint64_t> dnssecValidations; // should be the sum of all dnssecResult* stats
   std::map<vState, std::atomic<uint64_t> > dnssecResults;
+  std::map<DNSFilterEngine::PolicyKind, std::atomic<uint64_t> > policyResults;
 };
 
 //! represents a running TCP/IP client session

--- a/regression-tests.recursor/RPZ-Lua/command
+++ b/regression-tests.recursor/RPZ-Lua/command
@@ -1,0 +1,1 @@
+$SDIG $nameserver 5301 www3.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ-Lua/command
+++ b/regression-tests.recursor/RPZ-Lua/command
@@ -1,1 +1,2 @@
 $SDIG $nameserver 5301 www3.example.net a recurse 2>&1
+$SDIG $nameserver 5301 android.marvin.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ-Lua/description
+++ b/regression-tests.recursor/RPZ-Lua/description
@@ -1,0 +1,1 @@
+Test if we can indeed change the action for a policy in Lua

--- a/regression-tests.recursor/RPZ-Lua/expected_result
+++ b/regression-tests.recursor/RPZ-Lua/expected_result
@@ -1,3 +1,6 @@
 Reply to question for qname='www3.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	www3.example.net.	IN	CNAME	0	www2.example.net.
+Reply to question for qname='android.marvin.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	android.marvin.example.net.	IN	A	15	192.0.2.5

--- a/regression-tests.recursor/RPZ-Lua/expected_result
+++ b/regression-tests.recursor/RPZ-Lua/expected_result
@@ -1,0 +1,3 @@
+Reply to question for qname='www3.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	www3.example.net.	IN	CNAME	0	www2.example.net.

--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -12,3 +12,7 @@ echo "==> trillian.example.net NXDOMAIN"
 $SDIG $nameserver 5301 trillian.example.net a recurse 2>&1
 echo "==> www.trillian.example.net has no RPZ policy attached, so lookup should succeed"
 $SDIG $nameserver 5301 www.trillian.example.net a recurse 2>&1
+echo "==> www.hijackme.example.net is served on ns.hijackme.example.net, which should be NXDOMAIN"
+$SDIG $nameserver 5301 www.hijackme.example.net a recurse 2>&1
+echo "==> host.lowercase-outgoing.example.net is served on ns.lowercase-outgoing.example.net, blocked by NS IP rule"
+$SDIG $nameserver 5301 host.lowercase-outgoing.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -1,0 +1,10 @@
+echo "arthur.example.net RPZ NXDOMAIN"
+$SDIG $nameserver 5301 arthur.example.net a recurse 2>&1
+echo "www.arthur.example.net RPZ NODATA"
+$SDIG $nameserver 5301 www.arthur.example.net a recurse 2>&1
+echo "srv.arthur.example.net RPZ passthru"
+$SDIG $nameserver 5301 srv.arthur.example.net srv recurse 2>&1
+echo "www.example.net RPZ local data to www2.example.net"
+$SDIG $nameserver 5301 www.example.net a recurse 2>&1
+echo "www4.example.net RPZ IP trigger action, dropped"
+$SDIG $nameserver 5301 www4.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -1,10 +1,14 @@
-echo "arthur.example.net RPZ NXDOMAIN"
+echo "==> arthur.example.net RPZ NXDOMAIN"
 $SDIG $nameserver 5301 arthur.example.net a recurse 2>&1
-echo "www.arthur.example.net RPZ NODATA"
+echo "==> www.arthur.example.net RPZ NODATA"
 $SDIG $nameserver 5301 www.arthur.example.net a recurse 2>&1
-echo "srv.arthur.example.net RPZ passthru"
+echo "==> srv.arthur.example.net RPZ passthru"
 $SDIG $nameserver 5301 srv.arthur.example.net srv recurse 2>&1
-echo "www.example.net RPZ local data to www2.example.net"
+echo "==> www.example.net RPZ local data to www2.example.net"
 $SDIG $nameserver 5301 www.example.net a recurse 2>&1
-echo "www4.example.net RPZ IP trigger action, dropped"
+echo "==> www4.example.net RPZ IP trigger action, dropped"
 $SDIG $nameserver 5301 www4.example.net a recurse 2>&1
+echo "==> trillian.example.net NXDOMAIN"
+$SDIG $nameserver 5301 trillian.example.net a recurse 2>&1
+echo "==> www.trillian.example.net has no RPZ policy attached, so lookup should succeed"
+$SDIG $nameserver 5301 www.trillian.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ/description
+++ b/regression-tests.recursor/RPZ/description
@@ -1,0 +1,1 @@
+Test if we can load an RPZ from disk and if the responses are correct

--- a/regression-tests.recursor/RPZ/expected_result
+++ b/regression-tests.recursor/RPZ/expected_result
@@ -21,3 +21,9 @@ Reply to question for qname='www.trillian.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	www.trillian.example.net.	IN	CNAME	15	www2.arthur.example.net.
 0	www2.arthur.example.net.	IN	A	15	192.0.2.6
+==> www.hijackme.example.net is served on ns.hijackme.example.net, which should be NXDOMAIN
+Reply to question for qname='www.hijackme.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+==> host.lowercase-outgoing.example.net is served on ns.lowercase-outgoing.example.net, blocked by NS IP rule
+Reply to question for qname='host.lowercase-outgoing.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0

--- a/regression-tests.recursor/RPZ/expected_result
+++ b/regression-tests.recursor/RPZ/expected_result
@@ -1,0 +1,15 @@
+arthur.example.net RPZ NXDOMAIN
+Reply to question for qname='arthur.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+www.arthur.example.net RPZ NODATA
+Reply to question for qname='www.arthur.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+srv.arthur.example.net RPZ passthru
+Reply to question for qname='srv.arthur.example.net.', qtype=SRV
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	srv.arthur.example.net.	IN	SRV	15	0 100 389 server2.example.net.
+www.example.net RPZ local data to www2.example.net
+Reply to question for qname='www.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	www.example.net.	IN	CNAME	0	www2.example.net.
+www4.example.net RPZ IP trigger action, dropped

--- a/regression-tests.recursor/RPZ/expected_result
+++ b/regression-tests.recursor/RPZ/expected_result
@@ -1,15 +1,23 @@
-arthur.example.net RPZ NXDOMAIN
+==> arthur.example.net RPZ NXDOMAIN
 Reply to question for qname='arthur.example.net.', qtype=A
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-www.arthur.example.net RPZ NODATA
+==> www.arthur.example.net RPZ NODATA
 Reply to question for qname='www.arthur.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-srv.arthur.example.net RPZ passthru
+==> srv.arthur.example.net RPZ passthru
 Reply to question for qname='srv.arthur.example.net.', qtype=SRV
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	srv.arthur.example.net.	IN	SRV	15	0 100 389 server2.example.net.
-www.example.net RPZ local data to www2.example.net
+==> www.example.net RPZ local data to www2.example.net
 Reply to question for qname='www.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	www.example.net.	IN	CNAME	0	www2.example.net.
-www4.example.net RPZ IP trigger action, dropped
+==> www4.example.net RPZ IP trigger action, dropped
+==> trillian.example.net NXDOMAIN
+Reply to question for qname='trillian.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+==> www.trillian.example.net has no RPZ policy attached, so lookup should succeed
+Reply to question for qname='www.trillian.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	www.trillian.example.net.	IN	CNAME	15	www2.arthur.example.net.
+0	www2.arthur.example.net.	IN	A	15	192.0.2.6

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -544,6 +544,7 @@ cat > recursor-service3/recursor.conf << EOF
 local-port=5301
 socket-dir=$(pwd)/recursor-service3S
 lua-config-file=$(pwd)/recursor-service3/config.lua
+lua-dns-script=$(pwd)/recursor-service3/script.lua
 
 EOF
 
@@ -561,6 +562,18 @@ arthur.example.net     CNAME .                   ; NXDOMAIN on apex
 *.arthur.example.net   CNAME *.                  ; NODATA for everything below the apex
 srv.arthur.example.net CNAME rpz-passthru.       ; Allow this name though
 www.example.net        CNAME www2.example.net.   ; Local-Data Action
+www3.example.net       CNAME www4.example.net.   ; Local-Data Action (to be changed in preresolve)
 
 32.4.2.0.192.rpz-ip    CNAME rpz-drop.           ; www4.example.net resolves to 192.0.2.4, drop A responses with that IP
+EOF
+
+cat > recursor-service3/script.lua <<EOF
+function preresolve(dq)
+  if dq.appliedPolicy.policyKind == pdns.policykinds.Custom then
+    if dq.qname:equal("www3.example.net") then
+      dq.appliedPolicy.policyCustom = "www2.example.net"
+    end
+  end
+  return false
+end
 EOF

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -563,6 +563,7 @@ arthur.example.net     CNAME .                   ; NXDOMAIN on apex
 srv.arthur.example.net CNAME rpz-passthru.       ; Allow this name though
 www.example.net        CNAME www2.example.net.   ; Local-Data Action
 www3.example.net       CNAME www4.example.net.   ; Local-Data Action (to be changed in preresolve)
+trillian.example.net   CNAME .                   ; NXDOMAIN on apex, allows all sub-names (#4086)
 
 32.4.2.0.192.rpz-ip    CNAME rpz-drop.           ; www4.example.net resolves to 192.0.2.4, drop A responses with that IP
 EOF


### PR DESCRIPTION
This PR fixes some small things with the RPZ code, adds basic RPZ tests and allows access to the policy decision inside of Lua. It also adds metrics for the taken decision.

Fixes:
 * Whitespace and comment fixes
 * Correct subzone blocking (#4086)

I think this PR addresses the issues raised in #4088 and #4226 by looking up the policy and allow it to be changed inside existing hooks. This should be flexible enough.

Comments and code reviews welcome