### PR TITLE
dnsdist: Add a `setCD` parameter to set cd=1 on health check queries

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -147,6 +147,7 @@ of `newServer` is set to true, a response will only be considered valid if
 its RCODE differs from NXDomain, ServFail and Refused.
 The number of health check failures before a server is considered down is
 configurable via the`maxCheckFailures` parameter, defaulting to 1.
+The `CD` flag can be set on the query by setting `setCD` to true.
 
 ```
 newServer({address="192.0.2.1", checkType="AAAA", checkName="a.root-servers.net.", mustResolve=true})
@@ -1190,7 +1191,7 @@ Here are all functions:
     * `setVerboseHealthChecks(bool)`: set whether health check errors will be logged
  * Server related:
     * `newServer("ip:port")`: instantiate a new downstream server with default settings
-    * `newServer({address="ip:port", qps=1000, order=1, weight=10, pool="abuse", retries=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName="a.root-servers.net.", checkType="A", maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source="address|interface name|address@interface"})`:
+    * `newServer({address="ip:port", qps=1000, order=1, weight=10, pool="abuse", retries=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName="a.root-servers.net.", checkType="A", setCD=false, maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source="address|interface name|address@interface"})`:
 instantiate a server with additional parameters
     * `showServers()`: output all servers
     * `getServer(n)`: returns server with index n 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -356,6 +356,10 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			  ret->checkType=boost::get<string>(vars["checkType"]);
 			}
 
+			if(vars.count("setCD")) {
+			  ret->setCD=boost::get<bool>(vars["setCD"]);
+			}
+
 			if(vars.count("mustResolve")) {
 			  ret->mustResolve=boost::get<bool>(vars["mustResolve"]);
 			}

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1121,6 +1121,9 @@ try
   DNSPacketWriter dpw(packet, ds.checkName, ds.checkType.getCode());
   dnsheader * requestHeader = dpw.getHeader();
   requestHeader->rd=true;
+  if (ds.setCD) {
+    requestHeader->cd = true;
+  }
 
   Socket sock(ds.remote.sin4.sin_family, SOCK_DGRAM);
   sock.setNonBlocking();

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -355,6 +355,7 @@ struct DownstreamState
   bool mustResolve{false};
   bool upStatus{false};
   bool useECS{false};
+  bool setCD{false};
   bool isUp() const
   {
     if(availability == Availability::Down)


### PR DESCRIPTION
Closes #4233.