### PR TITLE
Autoconf improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,9 @@ BOOST_REQUIRE([1.35])
 AM_CONDITIONAL([HAVE_BOOST_GE_148], [test "$boost_major_version" -ge 148])
 
 BOOST_PROGRAM_OPTIONS([mt])
+AS_IF([test "$boost_cv_lib_program_options" = "no"], [
+  AC_MSG_ERROR([Boost Program Options library not found])
+])
 PDNS_ENABLE_UNIT_TESTS
 PDNS_ENABLE_REPRODUCIBLE
 

--- a/m4/pdns_enable_unit_tests.m4
+++ b/m4/pdns_enable_unit_tests.m4
@@ -21,5 +21,8 @@ AC_DEFUN([PDNS_ENABLE_UNIT_TESTS], [
 
   AS_IF([test "x$enable_unit_tests" != "xno" || test "x$enable_backend_unit_tests" != "xno"], [
      BOOST_TEST([mt])
+     AS_IF([test "$boost_cv_lib_unit_test_framework" = "no"], [
+       AC_MSG_ERROR([Boost Unit Test library not found])
+     ])
    ])
 ])

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -30,7 +30,6 @@ AS_IF([test "x$PROTOBUF_LIBS" != "x" -a x"$PROTOC" != "x"],
 )
 
 BOOST_REQUIRE([$boost_required_version])
-BOOST_FOREACH
 
 PDNS_ENABLE_UNIT_TESTS
 PDNS_CHECK_RE2


### PR DESCRIPTION
Fail auth configure when boost libraries are missing and remove a check for an unused function in dnsdist