### PR TITLE
rec: Set `dq.rcode` before calling postresolve

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -521,6 +521,7 @@ bool RecursorLua4::genhook(luacall_t& func, const ComboAddress& remote,const Com
   dq->tag = tag;
   dq->ednsOptions = ednsOpts;
   dq->isTcp = isTcp;
+  dq->rcode = ret;
   dq->policyTags = policyTags;
   bool handled=func(dq);
   if(variable) *variable |= dq->variable; // could still be set to indicate this *name* is variable, even if not 'handled'


### PR DESCRIPTION
It should fix the first part of #4186.