### PR TITLE
fix type

### DIFF
--- a/pdns/mtasker_ucontext.cc
+++ b/pdns/mtasker_ucontext.cc
@@ -72,8 +72,8 @@ pdns_ucontext_t::~pdns_ucontext_t() {
 void
 pdns_swapcontext
 (pdns_ucontext_t& __restrict octx, pdns_ucontext_t const& __restrict ctx) {
-    if (::swapcontext (static_cast<ucontext*>(octx.uc_mcontext),
-                       static_cast<ucontext*>(ctx.uc_mcontext))) {
+    if (::swapcontext (static_cast<ucontext_t*>(octx.uc_mcontext),
+                       static_cast<ucontext_t*>(ctx.uc_mcontext))) {
         throw_errno ("swapcontext() failed");
     }
     if (ctx.exception) {
@@ -87,8 +87,8 @@ pdns_makecontext
     assert (ctx.uc_link);
     assert (ctx.uc_stack.size());
 
-    auto const mcp = static_cast<ucontext*>(ctx.uc_mcontext);
-    auto const next = static_cast<ucontext*>(ctx.uc_link->uc_mcontext);
+    auto const mcp = static_cast<ucontext_t*>(ctx.uc_mcontext);
+    auto const next = static_cast<ucontext_t*>(ctx.uc_link->uc_mcontext);
     if (::getcontext (mcp)) {
         throw_errno ("getcontext() failed");
     }


### PR DESCRIPTION
I don't see how this code ever compiled. On OSX (10.10) and Debian 8 I can find `struct ucontext` and `ucontext_t` but never `ucontext`. Yet, git log tells me this code works on EL6 i386. Needs testing there.

For OSX, this works around #4270.