### PR TITLE
Bind backend: update status message on reload, keep the existing zone on failure

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -515,10 +515,12 @@ string Bind2Backend::DLReloadNowHandler(const vector<string>&parts, Utility::pid
 
   for(vector<string>::const_iterator i=parts.begin()+1;i<parts.end();++i) {
     BB2DomainInfo bbd;
-    if(safeGetBBDomainInfo(DNSName(*i), &bbd)) {
+    DNSName zone(*i);
+    if(safeGetBBDomainInfo(zone, &bbd)) {
       Bind2Backend bb2;
       bb2.queueReloadAndStore(bbd.d_id);
-      ret<< *i << ": "<< (bbd.d_loaded ? "": "[rejected]") <<"\t"<<bbd.d_status<<"\n";      
+      safeGetBBDomainInfo(zone, &bbd); // Read the *new* domain status
+      ret<< *i << ": "<< (bbd.d_loaded ? "": "[rejected]") <<"\t"<<bbd.d_status<<"\n";
     }
     else
       ret<< *i << " no such domain\n";
@@ -905,12 +907,14 @@ void Bind2Backend::queueReloadAndStore(unsigned int id)
   catch(PDNSException &ae) {
     ostringstream msg;
     msg<<" error at "+nowTime()+" parsing '"<<bbold.d_name<<"' from file '"<<bbold.d_filename<<"': "<<ae.reason;
+    L<<Logger::Warning<<" error parsing '"<<bbold.d_name<<"' from file '"<<bbold.d_filename<<"': "<<ae.reason<<endl;
     bbold.d_status=msg.str();
     safePutBBDomainInfo(bbold);
   }
   catch(std::exception &ae) {
     ostringstream msg;
     msg<<" error at "+nowTime()+" parsing '"<<bbold.d_name<<"' from file '"<<bbold.d_filename<<"': "<<ae.what();
+    L<<Logger::Warning<<" error parsing '"<<bbold.d_name<<"' from file '"<<bbold.d_filename<<"': "<<ae.what()<<endl;
     bbold.d_status=msg.str();
     safePutBBDomainInfo(bbold);
   }

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -439,7 +439,7 @@ void Bind2Backend::alsoNotifies(const DNSName& domain, set<string> *ips)
 }
 
 // only parses, does NOT add to s_state!
-void Bind2Backend::parseZoneFile(BB2DomainInfo *bbd) 
+void Bind2Backend::parseZoneFile(BB2DomainInfo *bbd)
 {
   NSEC3PARAMRecordContent ns3pr;
   bool nsec3zone;
@@ -899,11 +899,12 @@ void Bind2Backend::queueReloadAndStore(unsigned int id)
   try {
     if(!safeGetBBDomainInfo(id, &bbold))
       return;
-    parseZoneFile(&bbold);
-    bbold.d_checknow=false;
-    bbold.d_wasRejectedLastReload=false;
-    safePutBBDomainInfo(bbold);
-    L<<Logger::Warning<<"Zone '"<<bbold.d_name<<"' ("<<bbold.d_filename<<") reloaded"<<endl;
+    BB2DomainInfo bbnew(bbold);
+    parseZoneFile(&bbnew);
+    bbnew.d_checknow=false;
+    bbnew.d_wasRejectedLastReload=false;
+    safePutBBDomainInfo(bbnew);
+    L<<Logger::Warning<<"Zone '"<<bbnew.d_name<<"' ("<<bbnew.d_filename<<") reloaded"<<endl;
   }
   catch(PDNSException &ae) {
     ostringstream msg;

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -520,7 +520,7 @@ string Bind2Backend::DLReloadNowHandler(const vector<string>&parts, Utility::pid
       Bind2Backend bb2;
       bb2.queueReloadAndStore(bbd.d_id);
       safeGetBBDomainInfo(zone, &bbd); // Read the *new* domain status
-      ret<< *i << ": "<< (bbd.d_loaded ? "": "[rejected]") <<"\t"<<bbd.d_status<<"\n";
+      ret<< *i << ": "<< (bbd.d_wasRejectedLastReload ? "[rejected]": "") <<"\t"<<bbd.d_status<<"\n";
     }
     else
       ret<< *i << " no such domain\n";
@@ -901,6 +901,7 @@ void Bind2Backend::queueReloadAndStore(unsigned int id)
       return;
     parseZoneFile(&bbold);
     bbold.d_checknow=false;
+    bbold.d_wasRejectedLastReload=false;
     safePutBBDomainInfo(bbold);
     L<<Logger::Warning<<"Zone '"<<bbold.d_name<<"' ("<<bbold.d_filename<<") reloaded"<<endl;
   }
@@ -909,6 +910,7 @@ void Bind2Backend::queueReloadAndStore(unsigned int id)
     msg<<" error at "+nowTime()+" parsing '"<<bbold.d_name<<"' from file '"<<bbold.d_filename<<"': "<<ae.reason;
     L<<Logger::Warning<<" error parsing '"<<bbold.d_name<<"' from file '"<<bbold.d_filename<<"': "<<ae.reason<<endl;
     bbold.d_status=msg.str();
+    bbold.d_wasRejectedLastReload=true;
     safePutBBDomainInfo(bbold);
   }
   catch(std::exception &ae) {
@@ -916,6 +918,7 @@ void Bind2Backend::queueReloadAndStore(unsigned int id)
     msg<<" error at "+nowTime()+" parsing '"<<bbold.d_name<<"' from file '"<<bbold.d_filename<<"': "<<ae.what();
     L<<Logger::Warning<<" error parsing '"<<bbold.d_name<<"' from file '"<<bbold.d_filename<<"': "<<ae.what()<<endl;
     bbold.d_status=msg.str();
+    bbold.d_wasRejectedLastReload=true;
     safePutBBDomainInfo(bbold);
   }
 }

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -166,6 +166,7 @@ public:
   unsigned int d_id;  //!< internal id of the domain
   mutable bool d_checknow; //!< if this domain has been flagged for a check
   bool d_loaded;  //!< if a domain is loaded
+  bool d_wasRejectedLastReload{false}; //!< if the domain was rejected during Bind2Backend::queueReloadAndStore
 
 private:
   time_t getCtime();


### PR DESCRIPTION
Supersedes and closes #4256.
