### PR TITLE
Document cache flushing

### DIFF
--- a/docs/markdown/httpapi/api_spec.md
+++ b/docs/markdown/httpapi/api_spec.md
@@ -668,9 +668,24 @@ Returns all public data about cryptokeys, including `content`, with all the priv
 Cache Access
 ============
 
-**TODO**: Peek at the cache, clear the cache, possibly dump it into a file?
+**TODO**: Peek at the cache, possibly dump it into a file?
 
-**TODO**: Not yet implemented.
+URL: /api/v1/servers/:server\_id/cache/flush?domain=:domain
+--------------------------------------------
+
+Allowed methods: `PUT` (Execute)
+
+#### PUT (Execute)
+
+Flush the cache for a given domain name `:domain`. Response body:
+
+    {
+      "count": 10,
+      "result": "Flushed cache."
+    }
+
+Implementation detail: On Authoritative servers, this clears the packet cache.
+On Recursors, this clears the positive, negative and packet cache.
 
 Logging & Statistics
 ====================


### PR DESCRIPTION
This was implemented in f6487526a80d337a75c5f125bd1e0fa4a5cefbf5 so it's
present since 3.4.2.