### PR TITLE
dnsdist: Handle unreachable servers at startup, reconnect stale sockets

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -226,13 +226,15 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			  addServerToPool(localPools, "", ret);
 			  g_pools.setState(localPools);
 
-			  if(g_launchWork) {
-			    g_launchWork->push_back([ret]() {
-				ret->tid = move(thread(responderThread, ret));
+			  if (ret->connected) {
+			    if(g_launchWork) {
+			      g_launchWork->push_back([ret]() {
+			        ret->tid = move(thread(responderThread, ret));
 			      });
-			  }
-			  else {
-			    ret->tid = move(thread(responderThread, ret));
+			    }
+			    else {
+			      ret->tid = move(thread(responderThread, ret));
+			    }
 			  }
 
 			  return ret;
@@ -372,13 +374,15 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			  ret->maxCheckFailures=std::stoi(boost::get<string>(vars["maxCheckFailures"]));
 			}
 
-			if(g_launchWork) {
-			  g_launchWork->push_back([ret]() {
+			if (ret->connected) {
+			  if(g_launchWork) {
+			    g_launchWork->push_back([ret]() {
 			      ret->tid = move(thread(responderThread, ret));
 			    });
-			}
-			else {
-			  ret->tid = move(thread(responderThread, ret));
+			  }
+			  else {
+			    ret->tid = move(thread(responderThread, ret));
+			  }
 			}
 
 			auto states = g_dstates.getCopy();

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -356,6 +356,7 @@ struct DownstreamState
   bool upStatus{false};
   bool useECS{false};
   bool setCD{false};
+  std::atomic<bool> connected{false};
   bool isUp() const
   {
     if(availability == Availability::Down)

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -380,7 +380,7 @@ struct DownstreamState
     }
     return name + " (" + remote.toStringWithPort()+ ")";
   }
-
+  void reconnect();
 };
 using servers_t =vector<std::shared_ptr<DownstreamState>>;
 


### PR DESCRIPTION
- If we can't `connect()` when the server is added, keep the server around and `connect()` the socket only when the health check succeeds. Fixes #4131.
- We now try to detect stale backend socket and to recover from it. Fixes #4155.
