### PR TITLE
If we enable the API, always enable the webserver

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -77,7 +77,7 @@ void declareArguments()
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";
 
   ::arg().set("retrieval-threads", "Number of AXFR-retrieval threads for slave operation")="2";
-  ::arg().setSwitch("api", "Enable/disable the REST API. If enabled, also enables 'webserver'")="no";
+  ::arg().setSwitch("api", "Enable/disable the REST API.")="no";
   ::arg().set("api-key", "Static pre-shared authentication key for access to the REST API")="";
   ::arg().set("api-logfile", "Location of the server logfile (used by the REST API)")="/var/log/pdns.log";
   ::arg().setSwitch("api-readonly", "Disallow data modification through the REST API when set")="no";
@@ -125,7 +125,7 @@ void declareArguments()
   ::arg().setSwitch("disable-axfr-rectify","Disable the rectify step during an outgoing AXFR. Only required for regression testing.")="no";
   ::arg().setSwitch("guardian","Run within a guardian process")="no";
   ::arg().setSwitch("prevent-self-notification","Don't send notifications to what we think is ourself")="yes";
-  ::arg().setSwitch("webserver","Start a webserver for monitoring and API")="no";
+  ::arg().setSwitch("webserver","Start a webserver for monitoring")="no";
   ::arg().setSwitch("webserver-print-arguments","If the webserver should print arguments")="no"; 
   ::arg().setSwitch("edns-subnet-processing","If we should act on EDNS Subnet options")="no"; 
   ::arg().setSwitch("any-to-tcp","Answer ANY queries with tc=1, shunting to TCP")="no"; 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -77,7 +77,7 @@ void declareArguments()
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";
 
   ::arg().set("retrieval-threads", "Number of AXFR-retrieval threads for slave operation")="2";
-  ::arg().setSwitch("api", "Enable/disable the REST API")="no";
+  ::arg().setSwitch("api", "Enable/disable the REST API. If enabled, also enables 'webserver'")="no";
   ::arg().set("api-key", "Static pre-shared authentication key for access to the REST API")="";
   ::arg().set("api-logfile", "Location of the server logfile (used by the REST API)")="/var/log/pdns.log";
   ::arg().setSwitch("api-readonly", "Disallow data modification through the REST API when set")="no";
@@ -125,7 +125,7 @@ void declareArguments()
   ::arg().setSwitch("disable-axfr-rectify","Disable the rectify step during an outgoing AXFR. Only required for regression testing.")="no";
   ::arg().setSwitch("guardian","Run within a guardian process")="no";
   ::arg().setSwitch("prevent-self-notification","Don't send notifications to what we think is ourself")="yes";
-  ::arg().setSwitch("webserver","Start a webserver for monitoring")="no"; 
+  ::arg().setSwitch("webserver","Start a webserver for monitoring and API")="no";
   ::arg().setSwitch("webserver-print-arguments","If the webserver should print arguments")="no"; 
   ::arg().setSwitch("edns-subnet-processing","If we should act on EDNS Subnet options")="no"; 
   ::arg().setSwitch("any-to-tcp","Answer ANY queries with tc=1, shunting to TCP")="no"; 
@@ -522,7 +522,7 @@ void mainthread()
 
   pthread_t qtid;
 
-  if(::arg().mustDo("webserver"))
+  if(::arg().mustDo("webserver") || ::arg().mustDo("api"))
     webserver.go();
 
   if(::arg().mustDo("slave") || ::arg().mustDo("master"))

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -60,7 +60,8 @@ AuthWebServer::AuthWebServer()
   d_min10=d_min5=d_min1=0;
   d_ws = 0;
   d_tid = 0;
-  if(arg().mustDo("webserver")) {
+  if(arg().mustDo("webserver") || arg().mustDo("api"))
+  {
     d_ws = new WebServer(arg()["webserver-address"], arg().asNum("webserver-port"));
     d_ws->bind();
   }
@@ -72,6 +73,9 @@ void AuthWebServer::go()
   {
     S.doRings();
     pthread_create(&d_tid, 0, webThreadHelper, this);
+  }
+  if(arg().mustDo("webserver") || arg().mustDo("api"))
+  {
     pthread_create(&d_tid, 0, statThreadHelper, this);
   }
 }
@@ -1256,8 +1260,10 @@ void AuthWebServer::webThread()
       d_ws->registerApiHandler("/api/v1/servers", &apiServer);
       d_ws->registerApiHandler("/api", &apiDiscovery);
     }
-    d_ws->registerWebHandler("/style.css", boost::bind(&AuthWebServer::cssfunction, this, _1, _2));
-    d_ws->registerWebHandler("/", boost::bind(&AuthWebServer::indexfunction, this, _1, _2));
+    if (::arg().mustDo("webserver")) {
+      d_ws->registerWebHandler("/style.css", boost::bind(&AuthWebServer::cssfunction, this, _1, _2));
+      d_ws->registerWebHandler("/", boost::bind(&AuthWebServer::indexfunction, this, _1, _2));
+    }
     d_ws->go();
   }
   catch(...) {


### PR DESCRIPTION
If we enable the API, always enable the webserver with default options. The first does not work without the latter. Also mention the API in the webserver-comment.