### PR TITLE
auth: Reset d_tsigprevious between UDP queries

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -68,7 +68,6 @@ DNSPacket::DNSPacket()
   d_havetsig = false;
   d_socket = -1;
   d_maxreplylen = 0;
-  d_qlen = 0;
   d_tsigtimersonly = false;
   d_haveednssection = false;
 }
@@ -96,7 +95,6 @@ DNSPacket::DNSPacket(const DNSPacket &orig)
   DLOG(L<<"DNSPacket copy constructor called!"<<endl);
   d_socket=orig.d_socket;
   d_remote=orig.d_remote;
-  d_qlen=orig.d_qlen;
   d_dt=orig.d_dt;
   d_compress=orig.d_compress;
   d_tcp=orig.d_tcp;

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -470,6 +470,11 @@ void DNSPacket::setTSIGDetails(const TSIGRecordContent& tr, const DNSName& keyna
   d_tsigtimersonly=timersonly;
 }
 
+void DNSPacket::resetTSIGPrevious()
+{
+  d_tsigprevious.clear();
+}
+
 bool DNSPacket::getTSIGDetails(TSIGRecordContent* trc, DNSName* keyname, string* message) const
 {
   MOADNSParser mdp(d_rawpacket);

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -162,6 +162,7 @@ public:
 
   bool getTSIGDetails(TSIGRecordContent* tr, DNSName* keyname, string* message) const;
   void setTSIGDetails(const TSIGRecordContent& tr, const DNSName& keyname, const string& secret, const string& previous, bool timersonly=false);
+  void resetTSIGPrevious();
   bool getTKEYRecord(TKEYRecordContent* tr, DNSName* keyname) const;
 
   vector<DNSResourceRecord>& getRRS() { return d_rrs; }

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -186,7 +186,6 @@ private:
   uint8_t d_ednsversion;
   // WARNING! This is really 12 bits
   uint16_t d_ednsrcode;
-  uint16_t d_qlen; // length of the question (including class & type) in this packet 2
 
   bool d_compress; // 1
   bool d_tsigtimersonly;

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -357,10 +357,13 @@ DNSPacket *UDPNameserver::receive(DNSPacket *prefilled)
     return 0;
   
   DNSPacket *packet;
-  if(prefilled)  // they gave us a preallocated packet
+  if(prefilled) { // they gave us a preallocated packet
     packet=prefilled;
-  else
+    packet->resetTSIGPrevious();
+  }
+  else {
     packet=new DNSPacket; // don't forget to free it!
+  }
 
   packet->setSocket(sock);
   packet->setRemote(&remote);


### PR DESCRIPTION
Otherwise we try to compute the TSIG signature using an unrelated MAC, as well described in #4259. I looked briefly at the other members of `DNSPacket` and didn't see any other obvious reuse issue. The TCP path is not affected as it doesn't reuse `DNSPacket`.
Also remove the unused `DNSPacket::d_qlen` member.
Fixes #4259.