### PR TITLE
allow newDN to take a DNSName in; document missing methods

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -250,8 +250,12 @@ DNSNames are passed to various functions, and they sport the following methods:
 
 * `:equal`: use this to compare two DNSNames in DNS native fashion. So 'PoWeRdNs.COM' matches 'powerdns.com'
 * `:isPartOf`: returns true if a is a part of b. So: `newDN("www.powerdns.com"):isPartOf(newDN("CoM."))` returns true
+* `:toString` and `:toStringNoDot`: return a string representation of the name, with or without trailing dot.
+* `:chopOff`: removes the leftmost label from the name, returns true if this succeeded.
 
-To make your own DNSName, use `newDN("domain.name")`.
+You can compare DNSNames using `:equal` or the `==` operator.
+
+To make your own DNSName, use `newDN("domain.name")`. To copy an existing DNSName (please remember to do this before using `chopOff`), use `newDN(mydn)`.
 
 ### DNS Suffix Match groups
 The `newDS` function creates a "Suffix Match group" that allows fast checking if

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -229,7 +229,12 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerFunction<int(dnsheader::*)()>("getNSCOUNT", [](dnsheader& dh) { return ntohs(dh.nscount); });
   d_lw->registerFunction<int(dnsheader::*)()>("getARCOUNT", [](dnsheader& dh) { return ntohs(dh.arcount); });
 
-  d_lw->writeFunction("newDN", [](const std::string& dom){ return DNSName(dom); });  
+  d_lw->writeFunction("newDN", [](boost::variant<const std::string, const DNSName> dom){
+    if(dom.which() == 0)
+      return DNSName(boost::get<const std::string>(dom));
+    else
+      return DNSName(boost::get<const DNSName>(dom));
+  });
   d_lw->registerFunction("isPartOf", &DNSName::isPartOf);
   d_lw->registerFunction<bool(DNSName::*)(const std::string&)>("equal",
 							      [](const DNSName& lhs, const std::string& rhs) { return lhs==DNSName(rhs); });


### PR DESCRIPTION
I expect this could also be done with `boost::variant`; in fact I'm not 100% sure I'm not overwriting the first definition here.