### PR TITLE
Use ruby-json 1.8.2 instead of 1.8.1 to build on travis

### DIFF
--- a/modules/remotebackend/Gemfile.lock
+++ b/modules/remotebackend/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       ffi-rzmq-core (>= 1.0.1)
     ffi-rzmq-core (1.0.3)
       ffi (~> 1.9)
-    json (1.8.1)
+    json (1.8.2)
     sqlite3 (1.3.9)
     webrick (1.3.1)
     zeromqrb (0.1.3)

--- a/modules/remotebackend/regression-tests/Gemfile.lock
+++ b/modules/remotebackend/regression-tests/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       ffi-rzmq-core (>= 1.0.1)
     ffi-rzmq-core (1.0.3)
       ffi (~> 1.9)
-    json (1.8.1)
+    json (1.8.2)
     sqlite3 (1.3.9)
     webrick (1.3.1)
     zeromqrb (0.1.3)


### PR DESCRIPTION
Since travis upgraded their trusty image, ruby has been updated to
2.3.1 and doesn't play well with ruby-json 1.8.1.
This should be fixed in 1.8.2 according to
https://github.com/flori/json/issues/229