### PR TITLE
Add showTCPStats function

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1183,6 +1183,7 @@ Here are all functions:
     * `topBandwidth(top)`: show top-`top` clients that consume the most bandwidth over length of ringbuffer
     * `topClients(n)`: show top-`n` clients sending the most queries over length of ringbuffer
     * `showResponseLatency()`: show a plot of the response time latency distribution
+    * `showTCPStats()`: show some statistics regarding TCP
     * `showVersion()`: show the current version of dnsdist
  * Logging related
     * `infolog(string)`: log at level info

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -316,6 +316,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "showRules", true, "", "show all defined rules" },
   { "showServerPolicy", true, "", "show name of currently operational server selection policy" },
   { "showServers", true, "", "output all servers" },
+  { "showTCPStats", true, "", "show some statistics regarding TCP" },
   { "showVersion", true, "", "show the current version" },
   { "shutdown", true, "", "shut down `dnsdist`" },
   { "SpoofAction", true, "{ip, ...} ", "forge a response with the specified IPv4 (for an A query) or IPv6 (for an AAAA). If you specify multiple addresses, all that match the query type (A, AAAA or ANY) will get spoofed in" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1429,6 +1429,13 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       }
     });
 
+  g_lua.writeFunction("showTCPStats", [] {
+      setLuaNoSideEffect();
+      boost::format fmt("%-10d %-10d %-10d %-10d\n");
+      g_outputBuffer += (fmt % "Clients" % "MaxClients" % "Queued" % "MaxQueued").str();
+      g_outputBuffer += (fmt % g_tcpclientthreads->d_numthreads % g_maxTCPClientThreads % g_tcpclientthreads->d_queued % g_maxTCPQueuedConnections).str();
+    });
+
   g_lua.writeFunction("setCacheCleaningDelay", [](uint32_t delay) { g_cacheCleaningDelay = delay; });
 
   g_lua.writeFunction("setECSSourcePrefixV4", [](uint16_t prefix) { g_ECSSourcePrefixV4=prefix; });


### PR DESCRIPTION
Add a handy function, allowing you to see the currently set values for the TCP connection settings and the amount of currently queued requests and connections. This is handy when determining the ideal settings for your specific use case.