### PR TITLE
Overload fix: make overload-queue-length work as intended again, add test for it

### DIFF
--- a/docs/markdown/authoritative/performance.md
+++ b/docs/markdown/authoritative/performance.md
@@ -57,6 +57,7 @@ daemon.
 * `key-cache-size`: Number of entries in the key cache
 * `latency`: Average number of microseconds a packet spends within PowerDNS
 * `meta-cache-size`: Number of entries in the metadata cache
+* `overload-drops`: Number of questions dropped because backends overloaded 
 * `packetcache-hit`: Number of packets which were answered out of the cache
 * `packetcache-miss`: Number of times a packet could not be answered out of the cache
 * `packetcache-size`: Amount of packets in the packetcache

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1024,7 +1024,7 @@ void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *p
 
   static bool mustlog=::arg().mustDo("query-logging");
   if(mustlog) 
-    L<<Logger::Warning<<"Lookup for '"<<qtype.getName()<<"' of '"<<domain<<"'"<<endl;
+    L<<Logger::Warning<<"Lookup for '"<<qtype.getName()<<"' of '"<<domain<<"' within zoneID "<<zoneId<<endl;
   bool found=false;
   BB2DomainInfo bbd;
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -250,6 +250,7 @@ void declareStats(void)
   S.declare("udp4-queries","Number of IPv4 UDP queries received");
   S.declare("udp6-answers","Number of IPv6 answers sent out over UDP");
   S.declare("udp6-queries","Number of IPv6 UDP queries received");
+  S.declare("overload-drops","Queries dropped because backends overloaded");
 
   S.declare("rd-queries", "Number of recursion desired questions");
   S.declare("recursion-unanswered", "Number of packets unanswered by configured recursor");
@@ -351,6 +352,7 @@ void *qthread(void *number)
   AtomicCounter &numreceived4=*S.getPointer("udp4-queries");
 
   AtomicCounter &numreceived6=*S.getPointer("udp6-queries");
+  AtomicCounter &overloadDrops=*S.getPointer("overload-drops");
 
   int diff;
   bool logDNSQueries = ::arg().mustDo("log-dns-queries");
@@ -437,7 +439,8 @@ void *qthread(void *number)
     
     if(distributor->isOverloaded()) {
       if(logDNSQueries) 
-        L<<"Dropped query, db is overloaded"<<endl;
+        L<<"Dropped query, backends are overloaded"<<endl;
+      overloadDrops++;
       continue;
     }
         

--- a/regression-tests.nobackend/counters/expected_result
+++ b/regression-tests.nobackend/counters/expected_result
@@ -10,6 +10,7 @@ incoming-notifications=0
 key-cache-size=0
 latency=0
 meta-cache-size=1
+overload-drops=0
 packetcache-size=0
 qsize-q=0
 rd-queries=0

--- a/regression-tests.nobackend/distributor/command
+++ b/regression-tests.nobackend/distributor/command
@@ -14,7 +14,7 @@ $PDNS --daemon=no --local-ipv6=::1 --local-address=127.0.0.1 \
   --module-dir=../regression-tests/modules --pipe-command=$(pwd)/distributor/slow.pl \
   --pipe-abi-version=5 \
   --overload-queue-length=10 --log-dns-queries --loglevel=9 \
-  --pipe-timeout=1000 &
+  --pipe-timeout=1500 &
 
 sleep 2
 

--- a/regression-tests.nobackend/distributor/command
+++ b/regression-tests.nobackend/distributor/command
@@ -22,7 +22,7 @@ for a in {1..15}
 	do $SDIG 127.0.0.1 $port $a.example.com A >&2 >/dev/null &
 done 
 
-sleep 2
+sleep 10
 
 if [ $($PDNSCONTROL --config-name= --no-config --socket-dir=./ show overload-drops) -gt 0 ]
 then

--- a/regression-tests.nobackend/distributor/command
+++ b/regression-tests.nobackend/distributor/command
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "${PDNS_DEBUG}" = "YES" ]; then
+  set -x
+fi
+
+port=5600
+
+rm -f pdns*.pid
+
+$PDNS --daemon=no --local-ipv6=::1 --local-address=127.0.0.1 \
+  --local-port=$port --socket-dir=./ --no-shuffle --launch=pipe --no-config \
+  --module-dir=../regression-tests/modules --pipe-command=$(pwd)/distributor/slow.pl \
+  --pipe-abi-version=5 \
+  --overload-queue-length=10 --log-dns-queries --loglevel=9 \
+  --pipe-timeout=1000 &
+
+sleep 2
+
+for a in {1..20} 
+	do $SDIG 127.0.0.1 $port $a.example.com A >&2 >/dev/null &
+done 
+
+sleep 1
+
+if [ $($PDNSCONTROL --config-name= --no-config --socket-dir=./ show overload-drops) -gt 0 ]
+then
+	echo had non-zero drops
+fi
+
+sleep 5
+
+$SDIG 127.0.0.1 $port example.com A
+
+kill $(cat pdns*.pid)
+rm pdns*.pid

--- a/regression-tests.nobackend/distributor/command
+++ b/regression-tests.nobackend/distributor/command
@@ -18,11 +18,11 @@ $PDNS --daemon=no --local-ipv6=::1 --local-address=127.0.0.1 \
 
 sleep 2
 
-for a in {1..20} 
+for a in {1..15} 
 	do $SDIG 127.0.0.1 $port $a.example.com A >&2 >/dev/null &
 done 
 
-sleep 1
+sleep 2
 
 if [ $($PDNSCONTROL --config-name= --no-config --socket-dir=./ show overload-drops) -gt 0 ]
 then

--- a/regression-tests.nobackend/distributor/description
+++ b/regression-tests.nobackend/distributor/description
@@ -1,0 +1,1 @@
+check if the distributor implements overload limit correctly

--- a/regression-tests.nobackend/distributor/expected_result
+++ b/regression-tests.nobackend/distributor/expected_result
@@ -1,0 +1,4 @@
+had non-zero drops
+Reply to question for qname='example.com.', qtype=A
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+1	example.com.	IN	SOA	3600	ahu.example.com. ns1.example.com. 2008080300 1800 3600 604800 3600

--- a/regression-tests.nobackend/distributor/slow.pl
+++ b/regression-tests.nobackend/distributor/slow.pl
@@ -1,0 +1,75 @@
+#!/usr/bin/perl -w
+# sample PowerDNS Coprocess backend with edns-client-subnet support
+#
+
+use strict;
+
+
+$|=1;					# no buffering
+
+my $line=<>;
+chomp($line);
+
+unless($line eq "HELO\t5" ) {
+	print "FAIL\n";
+	print STDERR "Received unexpected '$line', wrong ABI version?\n";
+	<>;
+	exit;
+}
+print "OK	Sample backend firing up\n";	# print our banner
+
+while(<>)
+{
+	print STDERR "$$ Received: $_";
+        sleep(1);
+	chomp();
+	my @arr=split(/\t/);
+
+        if ($arr[0] eq "CMD") {
+          print $arr[1],"\n";
+          print "END\n";
+          next;
+        }
+
+	if(@arr < 8) {
+		print "LOG	PowerDNS sent unparseable line\n";
+		print "FAIL\n";
+		next;
+	}
+
+	my ($type,$qname,$qclass,$qtype,$id,$ip,$localip,$ednsip)=split(/\t/);
+	my $bits=21;
+	my $auth = 1;
+
+	if(($qtype eq "SOA" || $qtype eq "ANY") && $qname eq "example.com") {
+		print STDERR "$$ Sent SOA records\n";
+		print "DATA	$bits	$auth	$qname	$qclass	SOA	3600	-1	ahu.example.com ns1.example.com 2008080300 1800 3600 604800 3600\n";
+	}
+	if(($qtype eq "NS" || $qtype eq "ANY") && $qname eq "example.com") {
+		print STDERR "$$ Sent NS records\n";
+		print "DATA	$bits	$auth	$qname	$qclass	NS	3600	-1	ns1.example.com\n";
+		print "DATA	$bits	$auth	$qname	$qclass	NS	3600	-1	ns2.example.com\n";
+	}
+	if(($qtype eq "TXT" || $qtype eq "ANY") && $qname eq "example.com") {
+		print STDERR "$$ Sent TXT records\n";
+		print "DATA	$bits	$auth	$qname	$qclass	TXT	3600	-1	\"hallo allemaal!\"\n";
+	}
+	if(($qtype eq "A" || $qtype eq "ANY") && $qname eq "webserver.example.com") {
+		print STDERR "$$ Sent A records\n";
+		print "DATA	$bits	$auth	$qname	$qclass	A	3600	-1	1.2.3.4\n";
+		print "DATA	$bits	$auth	$qname	$qclass	A	3600	-1	1.2.3.5\n";
+		print "DATA	$bits	$auth	$qname	$qclass	A	3600	-1	1.2.3.6\n";
+	}
+	if(($qtype eq "CNAME" || $qtype eq "ANY") && $qname eq "www.example.com") {
+		print STDERR "$$ Sent CNAME records\n";
+		print "DATA	$bits	$auth	$qname	$qclass	CNAME	3600	-1	webserver.example.com\n";
+	}
+	if(($qtype eq "MX" || $qtype eq "ANY") && $qname eq "example.com") {
+		print STDERR "$$ Sent MX records\n";
+		print "DATA	$bits	$auth	$qname	$qclass	MX	3600	-1	25	smtp.powerdns.com\n";
+	}
+
+	print STDERR "$$ End of data\n";
+	print "END\n";
+}
+


### PR DESCRIPTION
This closes #4311 when merged. Previously, once we hit the overload-queue-length, we'd be forever down over UDP from that point. Also adds new counter for overload drops & documents it.