### PR TITLE
Root performance fixes after tests by Anand

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -36,6 +36,7 @@
 using namespace ::boost::multi_index;
 
 #include "dns.hh"
+#include <atomic>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -368,57 +369,10 @@ inline bool pdns_iequals_ch(const char a, const char b)
   return true;
 }
 
-// lifted from boost, with thanks
-class AtomicCounter
-{
-public:
-    typedef unsigned long native_t;
-    explicit AtomicCounter( native_t v = 0) : value_( v ) {}
 
-    native_t operator++()
-    {
-      return atomic_exchange_and_add( &value_, +1 ) + 1;
-    }
+typedef std::atomic<unsigned long> AtomicCounter ;
 
-    native_t operator++(int)
-    {
-      return atomic_exchange_and_add( &value_, +1 );
-    }
-
-    native_t operator+=(native_t val)
-    {
-      return atomic_exchange_and_add( &value_, val );
-    }
-
-    native_t operator-=(native_t val)
-    {
-      return atomic_exchange_and_add( &value_, -val );
-    }
-
-    native_t operator--()
-    {
-      return atomic_exchange_and_add( &value_, -1 ) - 1;
-    }
-
-    operator native_t() const
-    {
-      return atomic_exchange_and_add( &value_, 0);
-    }
-
-    AtomicCounter(AtomicCounter const &rhs) : value_(rhs)
-    {
-    }
-
-private:
-    mutable native_t value_;
-
-    static native_t atomic_exchange_and_add( native_t * pw, native_t dv )
-    {
-      return __sync_fetch_and_add(pw, dv);
-    }
-};
-
-// FIXME400 this should probably go?
+// FIXME400 this should probably go? 
 struct CIStringCompare: public std::binary_function<string, string, bool>
 {
   bool operator()(const string& a, const string& b) const

--- a/pdns/packetcache.cc
+++ b/pdns/packetcache.cc
@@ -34,6 +34,7 @@ extern StatBag S;
 
 PacketCache::PacketCache()
 {
+  d_ops=0;
   d_maps.resize(1024);
   for(auto& mc : d_maps) {
     pthread_rwlock_init(&mc.d_mut, 0);

--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -70,8 +70,12 @@ public:
   int size(); //!< number of entries in the cache
   void cleanupIfNeeded()
   {
-    if(!(++d_ops % 300000))
-      cleanup();
+    if(!(++d_ops % 300000)) {
+      if(d_lastclean + 30 < time(0)) {
+        d_lastclean=time(0); 
+        cleanup();
+      }
+    }
   }
   void cleanup(); //!< force the cache to preen itself from expired packets
   int purge();
@@ -143,6 +147,7 @@ private:
   }
 
   AtomicCounter d_ops;
+  time_t d_lastclean{0}; // doesn't need to be atomic
   AtomicCounter *d_statnumhit;
   AtomicCounter *d_statnummiss;
   AtomicCounter *d_statnumentries;

--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -1,6 +1,6 @@
 /*
     PowerDNS Versatile Database Driven Nameserver
-    Copyright (C) 2002 - 2011  PowerDNS.COM BV
+    Copyright (C) 2002 - 2016  PowerDNS.COM BV
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2
@@ -68,6 +68,11 @@ public:
   
 
   int size(); //!< number of entries in the cache
+  void cleanupIfNeeded()
+  {
+    if(!(++d_ops % 300000))
+      cleanup();
+  }
   void cleanup(); //!< force the cache to preen itself from expired packets
   int purge();
   int purge(const std::string& match); // could be $ terminated. Is not a dnsname!

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -405,31 +405,28 @@ int PacketHandler::doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, c
         trim_left(content);
       }
 
-      QType qtypes[2];
-      qtypes[0]="A"; qtypes[1]="AAAA";
-      for(int n=0 ; n < d_doIPv6AdditionalProcessing + 1; ++n) {
-        if (i->qtype.getCode()==QType::SRV) {
-          vector<string>parts;
-          stringtok(parts, content);
-          if (parts.size() >= 3) {
-            B.lookup(qtypes[n], DNSName(parts[2]), p);
-          }
-          else
-            continue;
+      if (i->qtype.getCode()==QType::SRV) {
+        vector<string>parts;
+        stringtok(parts, content);
+        if (parts.size() >= 3) {
+          B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), DNSName(parts[2]), p);
         }
-        else {
-          B.lookup(qtypes[n], DNSName(content), p);
+      }
+      else {
+        B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), DNSName(content), p);
+      }
+      while(B.get(rr)) {
+        if(rr.qtype.getCode() != QType::A && rr.qtype.getCode()!=QType::AAAA)
+          continue;
+        if(rr.domain_id!=i->domain_id && ::arg()["out-of-zone-additional-processing"]=="no") {
+          DLOG(L<<Logger::Warning<<"Not including out-of-zone additional processing of "<<i->qname<<" ("<<rr.qname<<")"<<endl);
+          continue; // not adding out-of-zone additional data
         }
-        while(B.get(rr)) {
-          if(rr.domain_id!=i->domain_id && ::arg()["out-of-zone-additional-processing"]=="no") {
-            DLOG(L<<Logger::Warning<<"Not including out-of-zone additional processing of "<<i->qname<<" ("<<rr.qname<<")"<<endl);
-            continue; // not adding out-of-zone additional data
-          }
-          if(rr.auth && !rr.qname.isPartOf(soadata.qname)) // don't sign out of zone data using the main key 
-            rr.auth=false;
-          rr.d_place=DNSResourceRecord::ADDITIONAL;
-          r->addRecord(rr);
-        }
+        
+        if(rr.auth && !rr.qname.isPartOf(soadata.qname)) // don't sign out of zone data using the main key 
+          rr.auth=false;
+        rr.d_place=DNSResourceRecord::ADDITIONAL;
+        r->addRecord(rr);
       }
     }
   }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -411,6 +411,8 @@ int PacketHandler::doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, c
         if (parts.size() >= 3) {
           B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), DNSName(parts[2]), p);
         }
+        else
+          continue;
       }
       else {
         B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), DNSName(content), p);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2783,7 +2783,7 @@ try
 
   time_t last_carbon=0;
   time_t carbonInterval=::arg().asNum("carbon-interval");
-  counter=AtomicCounter(0); // used to periodically execute certain tasks
+  counter.store(0); // used to periodically execute certain tasks
   for(;;) {
     while(MT->schedule(&g_now)); // MTasker letting the mthreads do their thing
 

--- a/pdns/responsestats.cc
+++ b/pdns/responsestats.cc
@@ -8,9 +8,8 @@
 
 #include "dnsparser.hh"
 
-ResponseStats::ResponseStats()
+ResponseStats::ResponseStats() : d_qtypecounters(65536)
 {
-  d_qtypecounters.resize(std::numeric_limits<uint16_t>::max()+1);
   d_sizecounters.push_back(make_pair(20,0));
   d_sizecounters.push_back(make_pair(40,0));
   d_sizecounters.push_back(make_pair(60,0));

--- a/pdns/responsestats.cc
+++ b/pdns/responsestats.cc
@@ -8,7 +8,7 @@
 
 #include "dnsparser.hh"
 
-ResponseStats::ResponseStats() : d_qtypecounters(65536)
+ResponseStats::ResponseStats() :   d_qtypecounters(new std::atomic<unsigned long>[65536])
 {
   d_sizecounters.push_back(make_pair(20,0));
   d_sizecounters.push_back(make_pair(40,0));
@@ -21,7 +21,7 @@ ResponseStats::ResponseStats() : d_qtypecounters(65536)
   d_sizecounters.push_back(make_pair(std::numeric_limits<uint16_t>::max(),0));
 }
 
-ResponseStats g_rs = ResponseStats();
+ResponseStats g_rs;
 
 static bool pcomp(const pair<uint16_t, uint64_t>&a , const pair<uint16_t, uint64_t>&b)
 {
@@ -42,7 +42,7 @@ map<uint16_t, uint64_t> ResponseStats::getQTypeResponseCounts()
 {
   map<uint16_t, uint64_t> ret;
   uint64_t count;
-  for(unsigned int i = 0 ; i < d_qtypecounters.size() ; ++i) {
+  for(unsigned int i = 0 ; i < 65535 ; ++i) {
     count= d_qtypecounters[i];
     if(count)
       ret[i]=count;

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -14,7 +14,7 @@ public:
   string getQTypeReport();
 
 private:
-  vector<AtomicCounter> d_qtypecounters;
+  boost::scoped_array<std::atomic<unsigned long>> d_qtypecounters;
   typedef vector<pair<uint16_t, uint64_t> > sizecounters_t;
   sizecounters_t d_sizecounters;
 };

--- a/pdns/signingpipe.cc
+++ b/pdns/signingpipe.cc
@@ -71,7 +71,7 @@ catch(...) {
 }
 
 ChunkedSigningPipe::ChunkedSigningPipe(const DNSName& signerName, bool mustSign, const string& servers, unsigned int workers)
-  : d_queued(0), d_outstanding(0), d_numworkers(workers), d_submitted(0), d_signer(signerName),
+  : d_signed(0), d_queued(0), d_outstanding(0), d_numworkers(workers), d_submitted(0), d_signer(signerName),
     d_maxchunkrecords(100), d_tids(d_numworkers), d_mustSign(mustSign), d_final(false)
 {
   d_rrsetToSign = new rrset_t;

--- a/pdns/signingpipe.hh
+++ b/pdns/signingpipe.hh
@@ -24,7 +24,7 @@ public:
   bool submit(const DNSResourceRecord& rr);
   chunk_t getChunk(bool final=false);
 
-  AtomicCounter d_signed;
+  std::atomic<unsigned long> d_signed;
   int d_queued;
   int d_outstanding;
   unsigned int getReady();

--- a/pdns/statbag.cc
+++ b/pdns/statbag.cc
@@ -109,13 +109,13 @@ void StatBag::declare(const string &key, const string &descrip, StatBag::func_t 
 }
 
           
-void StatBag::set(const string &key, AtomicCounter::native_t value)
+void StatBag::set(const string &key, unsigned long value)
 {
   exists(key);
-  *d_stats[key]=AtomicCounter(value);
+  d_stats[key]->store(value);
 }
 
-AtomicCounter::native_t StatBag::read(const string &key)
+unsigned long StatBag::read(const string &key)
 {
   exists(key);
   funcstats_t::const_iterator iter = d_funcstats.find(key);
@@ -124,10 +124,10 @@ AtomicCounter::native_t StatBag::read(const string &key)
   return *d_stats[key];
 }
 
-AtomicCounter::native_t StatBag::readZero(const string &key)
+unsigned long StatBag::readZero(const string &key)
 {
   exists(key);
-  AtomicCounter::native_t tmp=*d_stats[key];
+  unsigned long tmp=*d_stats[key];
   d_stats[key]=0;
   return tmp;
 }

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -116,9 +116,9 @@ public:
   void exists(const string &key); //!< call this function to throw an exception in case a key does not exist
   inline void deposit(const string &key, int value); //!< increment the statistics behind this key by value amount
   inline void inc(const string &key); //!< increase this key's value by one
-  void set(const string &key, AtomicCounter::native_t value); //!< set this key's value
-  AtomicCounter::native_t read(const string &key); //!< read the value behind this key
-  AtomicCounter::native_t readZero(const string &key); //!< read the value behind this key, and zero it afterwards
+  void set(const string &key, unsigned long value); //!< set this key's value
+  unsigned long read(const string &key); //!< read the value behind this key
+  unsigned long readZero(const string &key); //!< read the value behind this key, and zero it afterwards
   AtomicCounter *getPointer(const string &key); //!< get a direct pointer to the value behind a key. Use this for high performance increments
   string getValueStr(const string &key); //!< read a value behind a key, and return it as a string
   string getValueStrZero(const string &key); //!< read a value behind a key, and return it as a string, and zero afterwards

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(test_makeRelative) {
 }
 
 BOOST_AUTO_TEST_CASE(test_AtomicCounter) {
-    AtomicCounter ac;
+    AtomicCounter ac(0);
     ++ac;
     ++ac;
     BOOST_CHECK_EQUAL(ac, 2);

--- a/pdns/test-statbag_cc.cc
+++ b/pdns/test-statbag_cc.cc
@@ -17,7 +17,7 @@ using std::string;
 
 static void *threadMangler(void* a)
 {
-  AtomicCounter* ac = (AtomicCounter*)a;
+  AtomicCounter* ac=(AtomicCounter*)a;
   for(unsigned int n=0; n < 1000000; ++n)
     (*ac)++;
   return 0;
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(test_StatBagBasic) {
 
 #ifdef UINTPTR_MAX  
 #if UINTPTR_MAX > 0xffffffffULL
-    BOOST_CHECK_EQUAL(sizeof(AtomicCounter::native_t), 8);
+    BOOST_CHECK_EQUAL(sizeof(unsigned long), 8);
     s.set("c", 1ULL<<33);
     BOOST_CHECK_EQUAL(s.read("c"), (1ULL<<33) );
     s.inc("c");

--- a/regression-tests.nobackend/distributor/command
+++ b/regression-tests.nobackend/distributor/command
@@ -14,7 +14,7 @@ $PDNS --daemon=no --local-ipv6=::1 --local-address=127.0.0.1 \
   --module-dir=../regression-tests/modules --pipe-command=$(pwd)/distributor/slow.pl \
   --pipe-abi-version=5 \
   --overload-queue-length=10 --log-dns-queries --loglevel=9 \
-  --pipe-timeout=1000 &
+  --pipe-timeout=1500 &
 
 sleep 2
 

--- a/regression-tests.nobackend/distributor/command
+++ b/regression-tests.nobackend/distributor/command
@@ -22,7 +22,7 @@ for a in {1..15}
 	do $SDIG 127.0.0.1 $port $a.example.com A >&2 >/dev/null &
 done 
 
-sleep 2
+sleep 10
 
 if [ $($PDNSCONTROL --config-name= --no-config --socket-dir=./ show overload-drops) -gt 0 ]
 then

--- a/regression-tests.nobackend/distributor/command
+++ b/regression-tests.nobackend/distributor/command
@@ -14,15 +14,15 @@ $PDNS --daemon=no --local-ipv6=::1 --local-address=127.0.0.1 \
   --module-dir=../regression-tests/modules --pipe-command=$(pwd)/distributor/slow.pl \
   --pipe-abi-version=5 \
   --overload-queue-length=10 --log-dns-queries --loglevel=9 \
-  --pipe-timeout=1500 &
+  --pipe-timeout=1000 &
 
 sleep 2
 
-for a in {1..15} 
+for a in {1..20} 
 	do $SDIG 127.0.0.1 $port $a.example.com A >&2 >/dev/null &
 done 
 
-sleep 10
+sleep 1
 
 if [ $($PDNSCONTROL --config-name= --no-config --socket-dir=./ show overload-drops) -gt 0 ]
 then

--- a/regression-tests.nobackend/distributor/command
+++ b/regression-tests.nobackend/distributor/command
@@ -18,11 +18,11 @@ $PDNS --daemon=no --local-ipv6=::1 --local-address=127.0.0.1 \
 
 sleep 2
 
-for a in {1..20} 
+for a in {1..15} 
 	do $SDIG 127.0.0.1 $port $a.example.com A >&2 >/dev/null &
 done 
 
-sleep 1
+sleep 2
 
 if [ $($PDNSCONTROL --config-name= --no-config --socket-dir=./ show overload-drops) -gt 0 ]
 then


### PR DESCRIPTION
This PR does a number of things. 
1) Testing exposed that at high query rates, we were basically cleaning the cache non-stop. With this PR, we only clean once every 30 seconds at most. 
2) some 64 bit unsigned counters would in fact go negative. While investigating, I found a scruffy AtomicCounter implementation, which has now been replaced by std::atomic. 
3) When doing additional processing, we'd do an A and a AAAA query for every eligible record. This has now been replaced by 1 ANY query + filtering
