### PR TITLE
with this change, DNSName can make a lowercase copy of itself, and we use this for speedup

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -63,6 +63,15 @@ public:
   std::vector<std::string> getRawLabels() const; //!< Individual raw unescaped labels
   bool chopOff();                               //!< Turn www.powerdns.com. into powerdns.com., returns false for .
   DNSName makeRelative(const DNSName& zone) const;
+  DNSName makeLowerCase() const
+  {
+    DNSName ret;
+    ret.d_storage = d_storage;
+    for(auto & c : ret.d_storage) {
+      c=dns2_tolower(c);
+    }
+    return ret;
+  }
   void makeUsRelative(const DNSName& zone);
   DNSName labelReverse() const;
   bool isWildcard() const;

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -192,7 +192,8 @@ void addRRSigs(DNSSECKeeper& dk, UeberBackend& db, const set<DNSName>& authSet, 
   vector<shared_ptr<DNSRecordContent> > toSign;
 
   vector<DNSResourceRecord> signedRecords;
-  
+  signedRecords.reserve(rrs.size()*1.5);
+  //  cout<<rrs.size()<<", "<<sizeof(DNSResourceRecord)<<endl;
   DNSName signer;
   for(vector<DNSResourceRecord>::const_iterator pos = rrs.begin(); pos != rrs.end(); ++pos) {
     if(pos != rrs.begin() && (signQType != pos->qtype.getCode()  || signQName != pos->qname)) {
@@ -200,9 +201,9 @@ void addRRSigs(DNSSECKeeper& dk, UeberBackend& db, const set<DNSName>& authSet, 
         addSignature(dk, db, signer, signQName, wildcardQName, signQType, signTTL, signPlace, toSign, signedRecords, origTTL);
     }
     signedRecords.push_back(*pos);
-    signQName= DNSName(toLower(pos->qname.toString()));
+    signQName= pos->qname.makeLowerCase();
     if(!pos->wildcardname.empty())
-      wildcardQName = DNSName(toLower(pos->wildcardname.toString()));
+      wildcardQName = pos->wildcardname.makeLowerCase();
     else
       wildcardQName.clear();
     signQType = pos ->qtype.getCode();

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -448,6 +448,18 @@ BOOST_AUTO_TEST_CASE(test_compare_empty) {
   BOOST_CHECK(!a.canonCompare(b));
 }
 
+BOOST_AUTO_TEST_CASE(test_casing) {
+  DNSName a("WwW.PoWeRdNS.Com"), b("www.powerdns.com.");
+  BOOST_CHECK_EQUAL(a,b);
+  BOOST_CHECK_EQUAL(a.toString(), "WwW.PoWeRdNS.Com.");
+  DNSName c=a.makeLowerCase();
+  BOOST_CHECK_EQUAL(a,c);
+  BOOST_CHECK_EQUAL(b,c);
+  BOOST_CHECK_EQUAL(c.toString(), b.toString());
+  BOOST_CHECK_EQUAL(c.toString(), "www.powerdns.com.");
+}
+
+
 
 BOOST_AUTO_TEST_CASE(test_compare_canonical) {
   DNSName lower("bert.com."), higher("alpha.nl.");


### PR DESCRIPTION
We make dnssecsigner.cc use that instead of round-tripping through human-escape presentation for lowercasing.

Includes a test, and some malloc trimming in dnssecsigner.cc for free