### PR TITLE
Allow Lua access to the result of the Policy Engine decision, skip RPZ

### DIFF
--- a/docs/manpages/rec_control.1.md
+++ b/docs/manpages/rec_control.1.md
@@ -125,6 +125,10 @@ reload-zones
 :    Reload authoritative and forward zones. Retains current configuration
      in case of errors.
 
+set-carbon-server *CARBON SERVER* [*CARBON OURNAME*]
+:    Set the carbon-server setting to *CARBON SERVER*. If *CARBON OURNAME* is not
+     empty, also set the carbon-ourname setting to *CARBON OURNAME*.
+
 set-dnssec-log-bogus *SETTING*
 :    Set dnssec-log-bogus setting to *SETTING*. Set to 'on' or 'yes' to log DNSSEC
      validation failures and to 'no' or 'off' to disable logging these failures.
@@ -132,9 +136,25 @@ set-dnssec-log-bogus *SETTING*
 set-minimum-ttl *NUM*
 :    Set minimum-ttl-override to *NUM*.
 
+top-queries
+:    Shows the top-20 queries. Statistics are over the last
+     'stats-ringbuffer-entries' queries.
+
+top-largeanswer-remotes
+:    Shows the top-20 remote hosts causing large answers. Statistics are over the
+     last 'stats-ringbuffer-entries' queries.
+
 top-remotes
 :    Shows the top-20 most active remote hosts. Statistics are over the
      last 'stats-ringbuffer-entries' queries.
+
+top-servfail-queries
+:    Shows the top-20 queries causing servfail responses. Statistics are
+     over the last 'stats-ringbuffer-entries' queries.
+
+top-servfail-remotes
+:    Shows the top-20 most active remote hosts causing servfail responses.
+     Statistics are over the last 'stats-ringbuffer-entries' queries.
 
 trace-regex *REGEX*
 :    Emit resolution trace for matching queries. Empty regex to disable trace.

--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -97,6 +97,7 @@ The DNSQuestion object contains at least the following fields:
   * policyAction: The action taken by the engine
   * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
   * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
+* wantsRPZ - A boolean that indicates the use of the Policy Engine, can be set to `false` in `preresolve` to disable RPZ for this query
 
 It also supports the following methods:
 

--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -92,6 +92,11 @@ The DNSQuestion object contains at least the following fields:
   * getFakeAAAARecords: Get a fake AAAA record, see [DNS64](#dns64)
   * getFakePTRRecords: Get a fake PTR record, see [DNS64](#dns64)
   * udpQueryResponse: Do a UDP query and call a handler, see [`udpQueryResponse`](#udpqueryresponse)
+* appliedPolicy - The decision that was made by the policy engine, see [Modifying policy decisions](#modifying-policy-decisions). It has the following fields:
+  * policyName: The name of the policy (used in e.g. protobuf logging)
+  * policyAction: The action taken by the engine
+  * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
+  * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
 
 It also supports the following methods:
 
@@ -388,3 +393,63 @@ function preoutquery(dq)
 	return false
 end
 ```
+
+## Modifying Policy Decisions
+The PowerDNS Recursor has a [policy engine based on Response Policy Zones (RPZ)](settings.md#response-policy-zone-rpz).
+Starting with version 4.0.1 of the recursor, it is possible to alter this decision inside the Lua hooks.
+If the decision is modified in a Lua hook, `false` should be returned, as the query is not actually handled by Lua so the decision is picked up by the Recursor.
+The result of the policy decision is checked after `preresolve` and `postresolve`.
+
+For example, if a decision is set to `pdns.policykinds.NODATA` by the policy engine and is unchanged in `preresolve`, the query is replied to with a NODATA response immediately after `preresolve`.
+
+### Example script
+```
+-- Dont ever block my own domain and IPs
+myDomain = newDN("example.com")
+
+myNetblock = newNMG()
+myNetblock:addMasks("192.0.2.0/24")
+
+function preresolve(dq)
+  if dq.qname:isPartOf(myDomain) and dq.appliedPolicy.policyKind != pdns.policykinds.NoAction then
+    pdnslog("Not blocking our own domain!")
+    dq.appliedPolicy.policyKind = pdns.policykinds.NoAction
+  end
+end
+
+function postresolve(dq)
+  if dq.appliedPolicy.policyKind != pdns.policykinds.NoAction then
+    local records = dq:getRecords()
+    for k,v in pairs(records) do
+      if v.type == pdns.A then
+        local blockedIP = newCA(v:getContent())
+        if myNetblock:match(blockedIP) then
+          pdnslog("Not blocking our IP space")
+          dq.appliedPolicy.policyKind = pdns.policykinds.NoAction
+        end
+      end
+    end
+  end
+end
+```
+
+The decision is contained in the `dq` object under `dq.appliedPolicy` and features 4 fields:
+
+### `dq.appliedPolicy.policyName`
+A string with the name of the policy (set by `polName=` in the `rpzFile` and `rpzMaster` configuration items).
+It is advised to overwrite this when modifying the `policyKind`
+
+### `dq.appliedPolicy.policyKind`
+The kind of policy response, there are several policy kinds:
+
+ * `pdns.policykinds.Custom` will return a NoError, CNAME answer with the value specified in `dq.appliedPolicy.policyCustom`
+ * `pdns.policykinds.Drop` will simply cause the query to be dropped
+ * `pdns.policykinds.NoAction` will continue normal processing of the query
+ * `pdns.policykinds.NODATA` will return a NoError response with no value in the answer section
+ * `pdns.policykinds.NXDOMAIN` will return a response with a NXDomain rcode
+ * `pdns.policykinds.Truncate` will return a NoError, no answer, truncated response over UDP. Normal processing will continue over TCP
+
+### `dq.appliedPolicy.policyCustom` and `dq.appliedPolicy.policyTTL`
+These fields are only used when `dq.appliedPolicy.policyKind` is set to `pdns.policykinds.Custom`.
+`dq.appliedPolicy.policyCustom` contains the name for the CNAME target as a string.
+And `dq.appliedPolicy.policyTTL` is the TTL field (in seconds) for the CNAME response.

--- a/docs/markdown/recursor/stats.md
+++ b/docs/markdown/recursor/stats.md
@@ -59,6 +59,12 @@ The `rec_control get` command can be used to query the following statistics, eit
 * `packetcache-hits`: packet cache hits (since 3.2)
 * `packetcache-misses`: packet cache misses (since 3.2)
 * `policy-drops`: packets dropped because of (Lua) policy decision
+* `policy-result-noaction`: packets that were not actioned upon by the RPZ/filter engine
+* `policy-result-drop`: packets that were dropped by the RPZ/filter engine
+* `policy-result-nxdomain`: packets that were replied to with NXDOMAIN by the RPZ/filter engine
+* `policy-result-nodata`: packets that were replied to with no data by the RPZ/filter engine
+* `policy-result-truncate`: packets that were forced to TCP by the RPZ/filter engine
+* `policy-result-custom`: packets that were sent a custom answer by the RPZ/filter engine
 * `qa-latency`: shows the current latency average, in microseconds, exponentially weighted over past 'latency-statistic-size' packets
 * `questions`: counts all end-user initiated queries with the RD bit set
 * `resource-limits`: counts number of queries that could not be performed because of resource limits

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -39,24 +39,21 @@ bool findNamedPolicy(const map<DNSName, DNSFilterEngine::Policy>& polmap, const 
                     *.
    */
 
-  bool first=true;
   map<DNSName, DNSFilterEngine::Policy>::const_iterator iter;
-  do {
-    if(first) {
-      iter = polmap.find(s);
-      if(iter != polmap.end()) {
-        pol=iter->second;
-        return true;
-      }
-    }
-    first=false;
+  iter = polmap.find(s);
 
+  if(iter != polmap.end()) {
+    pol=iter->second;
+    return true;
+  }
+
+  while(s.chopOff()){
     iter = polmap.find(DNSName("*")+s);
     if(iter != polmap.end()) {
       pol=iter->second;
       return true;
     }
-  } while(s.chopOff());
+  }
   return false;
 }
 

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -32,30 +32,30 @@ bool findNamedPolicy(const map<DNSName, DNSFilterEngine::Policy>& polmap, const 
 {
   DNSName s(qname);
 
-    /* for www.powerdns.com, we need to check:
-         www.powerdns.com.
-           *.powerdns.com.
-             powerdns.com.
-	            *.com.
-                      com.
-	 	        *.
-  			 .       */
+  /* for www.powerdns.com, we need to check:
+     www.powerdns.com.
+       *.powerdns.com.
+                *.com.
+                    *.
+   */
  
   bool first=true;
+  map<DNSName, DNSFilterEngine::Policy>::const_iterator iter;
   do {
-    auto iter = polmap.find(s);
+    if(first) {
+      iter = polmap.find(s);
+      if(iter != polmap.end()) {
+        pol=iter->second;
+        return true;
+      }
+    }
+    first=false;
+
+    iter = polmap.find(DNSName("*")+s);
     if(iter != polmap.end()) {
       pol=iter->second;
       return true;
     }
-    if(!first) {
-      iter = polmap.find(DNSName("*")+s);
-      if(iter != polmap.end()) {
-	pol=iter->second;
-	return true;
-      }
-    }
-    first=false;
   } while(s.chopOff());
   return false;
 }

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -71,8 +71,19 @@ DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const DNSName& qnam
     }
   }
   return pol;
-}  
+}
 
+DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const ComboAddress& address) const
+{
+  //  cout<<"Got question for nameserver IP "<<address.toString()<<endl;
+  for(const auto& z : d_zones) {
+    if(auto fnd=z.propolNSAddr.lookup(address)) {
+      //      cerr<<"Had a hit on the nameserver ("<<address.toString()<<") used to process the query"<<endl;
+      return fnd->second;;
+    }
+  }
+  return Policy{PolicyKind::NoAction, nullptr, "", 0};
+}
 
 DNSFilterEngine::Policy DNSFilterEngine::getQueryPolicy(const DNSName& qname, const ComboAddress& ca) const
 {
@@ -162,6 +173,12 @@ void DNSFilterEngine::addNSTrigger(const DNSName& n, Policy pol, int zone)
   d_zones[zone].propolName[n]=pol;
 }
 
+void DNSFilterEngine::addNSIPTrigger(const Netmask& nm, Policy pol, int zone)
+{
+  assureZones(zone);
+  d_zones[zone].propolNSAddr.insert(nm).second = pol;
+}
+
 bool DNSFilterEngine::rmClientTrigger(const Netmask& nm, Policy pol, int zone)
 {
   assureZones(zone);
@@ -190,5 +207,13 @@ bool DNSFilterEngine::rmNSTrigger(const DNSName& n, Policy pol, int zone)
 {
   assureZones(zone);
   d_zones[zone].propolName.erase(n); // XXX verify policy matched? =pol;
+  return true;
+}
+
+bool DNSFilterEngine::rmNSIPTrigger(const Netmask& nm, Policy pol, int zone)
+{
+  assureZones(zone);
+  auto& pols = d_zones[zone].propolNSAddr;
+  pols.erase(nm);
   return true;
 }

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -38,7 +38,7 @@ bool findNamedPolicy(const map<DNSName, DNSFilterEngine::Policy>& polmap, const 
                 *.com.
                     *.
    */
- 
+
   bool first=true;
   map<DNSName, DNSFilterEngine::Policy>::const_iterator iter;
   do {
@@ -60,11 +60,15 @@ bool findNamedPolicy(const map<DNSName, DNSFilterEngine::Policy>& polmap, const 
   return false;
 }
 
-DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const DNSName& qname) const
+DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const DNSName& qname, const std::unordered_map<std::string,bool>& discardedPolicies) const
 {
   //  cout<<"Got question for nameserver name "<<qname<<endl;
-  Policy pol{PolicyKind::NoAction, nullptr, "", 0};
+  Policy pol{PolicyKind::NoAction, nullptr, nullptr, 0};
   for(const auto& z : d_zones) {
+    if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
+      continue;
+    }
+
     if(findNamedPolicy(z.propolName, qname, pol)) {
       //      cerr<<"Had a hit on the nameserver ("<<qname<<") used to process the query"<<endl;
       return pol;
@@ -73,24 +77,31 @@ DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const DNSName& qnam
   return pol;
 }
 
-DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const ComboAddress& address) const
+DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const ComboAddress& address, const std::unordered_map<std::string,bool>& discardedPolicies) const
 {
   //  cout<<"Got question for nameserver IP "<<address.toString()<<endl;
   for(const auto& z : d_zones) {
+    if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
+      continue;
+    }
+
     if(auto fnd=z.propolNSAddr.lookup(address)) {
       //      cerr<<"Had a hit on the nameserver ("<<address.toString()<<") used to process the query"<<endl;
       return fnd->second;;
     }
   }
-  return Policy{PolicyKind::NoAction, nullptr, "", 0};
+  return Policy{PolicyKind::NoAction, nullptr, nullptr, 0};
 }
 
-DNSFilterEngine::Policy DNSFilterEngine::getQueryPolicy(const DNSName& qname, const ComboAddress& ca) const
+DNSFilterEngine::Policy DNSFilterEngine::getQueryPolicy(const DNSName& qname, const ComboAddress& ca, const std::unordered_map<std::string,bool>& discardedPolicies) const
 {
   //  cout<<"Got question for "<<qname<<" from "<<ca.toString()<<endl;
-
-  Policy pol{PolicyKind::NoAction, nullptr, "", 0};
+  Policy pol{PolicyKind::NoAction, nullptr, nullptr, 0};
   for(const auto& z : d_zones) {
+    if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
+      continue;
+    }
+
     if(findNamedPolicy(z.qpolName, qname, pol)) {
       //      cerr<<"Had a hit on the name of the query"<<endl;
       return pol;
@@ -105,10 +116,9 @@ DNSFilterEngine::Policy DNSFilterEngine::getQueryPolicy(const DNSName& qname, co
   return pol;
 }
 
-DNSFilterEngine::Policy DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& records) const
+DNSFilterEngine::Policy DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& records, const std::unordered_map<std::string,bool>& discardedPolicies) const
 {
   ComboAddress ca;
-
   for(const auto& r : records) {
     if(r.d_place != DNSResourceRecord::ANSWER) 
       continue;
@@ -126,20 +136,24 @@ DNSFilterEngine::Policy DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& 
       continue;
 
     for(const auto& z : d_zones) {
+      if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
+        continue;
+      }
+
       if(auto fnd=z.postpolAddr.lookup(ca))
 	return fnd->second;
     }
   }
-  return Policy{PolicyKind::NoAction, nullptr, "", 0};
+  return Policy{PolicyKind::NoAction, nullptr, nullptr, 0};
 }
 
-void DNSFilterEngine::assureZones(int zone)
+void DNSFilterEngine::assureZones(size_t zone)
 {
-  if((int)d_zones.size() <= zone)
+  if(d_zones.size() <= zone)
     d_zones.resize(zone+1);
 }
 
-void DNSFilterEngine::clear(int zone)
+void DNSFilterEngine::clear(size_t zone)
 {
   assureZones(zone);
   auto& z = d_zones[zone];
@@ -149,37 +163,42 @@ void DNSFilterEngine::clear(int zone)
   z.qpolName.clear();
 }
 
-void DNSFilterEngine::addClientTrigger(const Netmask& nm, Policy pol, int zone)
+void DNSFilterEngine::addClientTrigger(const Netmask& nm, Policy pol, size_t zone)
 {
   assureZones(zone);
+  pol.d_name = d_zones[zone].name;
   d_zones[zone].qpolAddr.insert(nm).second=pol;
 }
 
-void DNSFilterEngine::addResponseTrigger(const Netmask& nm, Policy pol, int zone)
+void DNSFilterEngine::addResponseTrigger(const Netmask& nm, Policy pol, size_t zone)
 {
   assureZones(zone);
+  pol.d_name = d_zones[zone].name;
   d_zones[zone].postpolAddr.insert(nm).second=pol;
 }
 
-void DNSFilterEngine::addQNameTrigger(const DNSName& n, Policy pol, int zone)
+void DNSFilterEngine::addQNameTrigger(const DNSName& n, Policy pol, size_t zone)
 {
   assureZones(zone);
+  pol.d_name = d_zones[zone].name;
   d_zones[zone].qpolName[n]=pol;
 }
 
-void DNSFilterEngine::addNSTrigger(const DNSName& n, Policy pol, int zone)
+void DNSFilterEngine::addNSTrigger(const DNSName& n, Policy pol, size_t zone)
 {
   assureZones(zone);
+  pol.d_name = d_zones[zone].name;
   d_zones[zone].propolName[n]=pol;
 }
 
-void DNSFilterEngine::addNSIPTrigger(const Netmask& nm, Policy pol, int zone)
+void DNSFilterEngine::addNSIPTrigger(const Netmask& nm, Policy pol, size_t zone)
 {
   assureZones(zone);
+  pol.d_name = d_zones[zone].name;
   d_zones[zone].propolNSAddr.insert(nm).second = pol;
 }
 
-bool DNSFilterEngine::rmClientTrigger(const Netmask& nm, Policy pol, int zone)
+bool DNSFilterEngine::rmClientTrigger(const Netmask& nm, Policy pol, size_t zone)
 {
   assureZones(zone);
 
@@ -188,7 +207,7 @@ bool DNSFilterEngine::rmClientTrigger(const Netmask& nm, Policy pol, int zone)
   return true;
 }
 
-bool DNSFilterEngine::rmResponseTrigger(const Netmask& nm, Policy pol, int zone)
+bool DNSFilterEngine::rmResponseTrigger(const Netmask& nm, Policy pol, size_t zone)
 {
   assureZones(zone);
   auto& postpols = d_zones[zone].postpolAddr;
@@ -196,21 +215,21 @@ bool DNSFilterEngine::rmResponseTrigger(const Netmask& nm, Policy pol, int zone)
   return true;
 }
 
-bool DNSFilterEngine::rmQNameTrigger(const DNSName& n, Policy pol, int zone)
+bool DNSFilterEngine::rmQNameTrigger(const DNSName& n, Policy pol, size_t zone)
 {
   assureZones(zone);
   d_zones[zone].qpolName.erase(n); // XXX verify we had identical policy?
   return true;
 }
 
-bool DNSFilterEngine::rmNSTrigger(const DNSName& n, Policy pol, int zone)
+bool DNSFilterEngine::rmNSTrigger(const DNSName& n, Policy pol, size_t zone)
 {
   assureZones(zone);
   d_zones[zone].propolName.erase(n); // XXX verify policy matched? =pol;
   return true;
 }
 
-bool DNSFilterEngine::rmNSIPTrigger(const Netmask& nm, Policy pol, int zone)
+bool DNSFilterEngine::rmNSIPTrigger(const Netmask& nm, Policy pol, size_t zone)
 {
   assureZones(zone);
   auto& pols = d_zones[zone].propolNSAddr;

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -24,6 +24,7 @@
 #include "dns.hh"
 #include "dnsparser.hh"
 #include <map>
+#include <unordered_map>
 
 /* This class implements a filtering policy that is able to fully implement RPZ, but is not bound to it.
    In other words, it is generic enough to support RPZ, but could get its data from other places.
@@ -72,42 +73,48 @@ public:
     }
     PolicyKind d_kind;
     std::shared_ptr<DNSRecordContent> d_custom;
-    std::string d_name;
+    std::shared_ptr<std::string> d_name;
     int d_ttl;
   };
 
   DNSFilterEngine();
   void clear();
-  void clear(int zone);
-  void addClientTrigger(const Netmask& nm, Policy pol, int zone=0);
-  void addQNameTrigger(const DNSName& nm, Policy pol, int zone=0);
-  void addNSTrigger(const DNSName& dn, Policy pol, int zone=0);
-  void addNSIPTrigger(const Netmask& nm, Policy pol, int zone=0);
-  void addResponseTrigger(const Netmask& nm, Policy pol, int zone=0);
+  void clear(size_t zone);
+  void addClientTrigger(const Netmask& nm, Policy pol, size_t zone);
+  void addQNameTrigger(const DNSName& nm, Policy pol, size_t zone);
+  void addNSTrigger(const DNSName& dn, Policy pol, size_t zone);
+  void addNSIPTrigger(const Netmask& nm, Policy pol, size_t zone);
+  void addResponseTrigger(const Netmask& nm, Policy pol, size_t zone);
 
-  bool rmClientTrigger(const Netmask& nm, Policy pol, int zone=0);
-  bool rmQNameTrigger(const DNSName& nm, Policy pol, int zone=0);
-  bool rmNSTrigger(const DNSName& dn, Policy pol, int zone=0);
-  bool rmNSIPTrigger(const Netmask& nm, Policy pol, int zone=0);
-  bool rmResponseTrigger(const Netmask& nm, Policy pol, int zone=0);
+  bool rmClientTrigger(const Netmask& nm, Policy pol, size_t zone);
+  bool rmQNameTrigger(const DNSName& nm, Policy pol, size_t zone);
+  bool rmNSTrigger(const DNSName& dn, Policy pol, size_t zone);
+  bool rmNSIPTrigger(const Netmask& nm, Policy pol, size_t zone);
+  bool rmResponseTrigger(const Netmask& nm, Policy pol, size_t zone);
 
 
-  Policy getQueryPolicy(const DNSName& qname, const ComboAddress& nm) const;
-  Policy getProcessingPolicy(const DNSName& qname) const;
-  Policy getProcessingPolicy(const ComboAddress& address) const;
-  Policy getPostPolicy(const vector<DNSRecord>& records) const;
+  Policy getQueryPolicy(const DNSName& qname, const ComboAddress& nm, const std::unordered_map<std::string,bool>& discardedPolicies) const;
+  Policy getProcessingPolicy(const DNSName& qname, const std::unordered_map<std::string,bool>& discardedPolicies) const;
+  Policy getProcessingPolicy(const ComboAddress& address, const std::unordered_map<std::string,bool>& discardedPolicies) const;
+  Policy getPostPolicy(const vector<DNSRecord>& records, const std::unordered_map<std::string,bool>& discardedPolicies) const;
 
   size_t size() {
     return d_zones.size();
   }
+  void setPolicyName(size_t zoneIdx, std::string name)
+  {
+    assureZones(zoneIdx);
+    d_zones[zoneIdx].name = std::make_shared<std::string>(name);
+  }
 private:
-  void assureZones(int zone);
+  void assureZones(size_t zone);
   struct Zone {
     std::map<DNSName, Policy> qpolName;   // QNAME trigger (RPZ)
     NetmaskTree<Policy> qpolAddr;         // Source address
     std::map<DNSName, Policy> propolName; // NSDNAME (RPZ)
     NetmaskTree<Policy> propolNSAddr;     // NSIP (RPZ)
     NetmaskTree<Policy> postpolAddr;      // IP trigger (RPZ)
+    std::shared_ptr<std::string> name;
   };
   vector<Zone> d_zones;
 

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -82,16 +82,19 @@ public:
   void addClientTrigger(const Netmask& nm, Policy pol, int zone=0);
   void addQNameTrigger(const DNSName& nm, Policy pol, int zone=0);
   void addNSTrigger(const DNSName& dn, Policy pol, int zone=0);
+  void addNSIPTrigger(const Netmask& nm, Policy pol, int zone=0);
   void addResponseTrigger(const Netmask& nm, Policy pol, int zone=0);
 
   bool rmClientTrigger(const Netmask& nm, Policy pol, int zone=0);
   bool rmQNameTrigger(const DNSName& nm, Policy pol, int zone=0);
   bool rmNSTrigger(const DNSName& dn, Policy pol, int zone=0);
+  bool rmNSIPTrigger(const Netmask& nm, Policy pol, int zone=0);
   bool rmResponseTrigger(const Netmask& nm, Policy pol, int zone=0);
 
 
   Policy getQueryPolicy(const DNSName& qname, const ComboAddress& nm) const;
   Policy getProcessingPolicy(const DNSName& qname) const;
+  Policy getProcessingPolicy(const ComboAddress& address) const;
   Policy getPostPolicy(const vector<DNSRecord>& records) const;
 
   size_t size() {
@@ -100,10 +103,11 @@ public:
 private:
   void assureZones(int zone);
   struct Zone {
-    std::map<DNSName, Policy> qpolName;
-    NetmaskTree<Policy> qpolAddr;
-    std::map<DNSName, Policy> propolName;
-    NetmaskTree<Policy> postpolAddr;
+    std::map<DNSName, Policy> qpolName;   // QNAME trigger (RPZ)
+    NetmaskTree<Policy> qpolAddr;         // Source address
+    std::map<DNSName, Policy> propolName; // NSDNAME (RPZ)
+    NetmaskTree<Policy> propolNSAddr;     // NSIP (RPZ)
+    NetmaskTree<Policy> postpolAddr;      // IP trigger (RPZ)
   };
   vector<Zone> d_zones;
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -257,8 +257,12 @@ RecursorLua4::RecursorLua4(const std::string& fname)
       return DNSName(boost::get<const DNSName>(dom));
   });
   d_lw->registerFunction("isPartOf", &DNSName::isPartOf);
-  d_lw->registerFunction<bool(DNSName::*)(const std::string&)>("equal",
-							      [](const DNSName& lhs, const std::string& rhs) { return lhs==DNSName(rhs); });
+  d_lw->registerFunction<bool(DNSName::*)(const std::string&)>(
+    "equal",
+     [](const DNSName& lhs, const std::string& rhs) {
+       return lhs==DNSName(rhs);
+    }
+  );
   d_lw->registerFunction("__eq", &DNSName::operator==);
 
   d_lw->registerFunction<string(ComboAddress::*)()>("toString", [](const ComboAddress& ca) { return ca.toString(); });
@@ -277,32 +281,35 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->writeFunction("newCAS", []{ return cas_t(); });
 
 
-  d_lw->registerFunction<void(cas_t::*)(boost::variant<string,ComboAddress, vector<pair<unsigned int,string> > >)>("add",
-                                                                                   [](cas_t& cas, const boost::variant<string,ComboAddress,vector<pair<unsigned int,string> > >& in)
-										   {
-										     try {
-										     if(auto s = boost::get<string>(&in)) {
-										       cas.insert(ComboAddress(*s));
-										     }
-										     else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
-										       for(const auto& s : *v)
-											 cas.insert(ComboAddress(s.second));
-										     }
-										     else
-										       cas.insert(boost::get<ComboAddress>(in));
-										     }
-										     catch(std::exception& e) { theL() <<Logger::Error<<e.what()<<endl; }
-										   });
+  d_lw->registerFunction<void(cas_t::*)(boost::variant<string,ComboAddress, vector<pair<unsigned int,string> > >)>(
+    "add",
+    [](cas_t& cas, const boost::variant<string,ComboAddress,vector<pair<unsigned int,string> > >& in)
+    {
+      try {
+        if(auto s = boost::get<string>(&in)) {
+          cas.insert(ComboAddress(*s));
+        }
+        else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
+          for(const auto& s : *v)
+            cas.insert(ComboAddress(s.second));
+          }
+        else {
+          cas.insert(boost::get<ComboAddress>(in));
+        }
+      }
+      catch(std::exception& e) { theL() <<Logger::Error<<e.what()<<endl; }
+    });
 
   d_lw->registerFunction<bool(cas_t::*)(const ComboAddress&)>("check",[](const cas_t& cas, const ComboAddress&ca) {
       return (bool)cas.count(ca);
     });
 
-
-
-  d_lw->registerFunction<bool(ComboAddress::*)(const ComboAddress&)>("equal", [](const ComboAddress& lhs, const ComboAddress& rhs) {
+  d_lw->registerFunction<bool(ComboAddress::*)(const ComboAddress&)>(
+    "equal",
+    [](const ComboAddress& lhs, const ComboAddress& rhs) {
       return ComboAddress::addressOnlyEqual()(lhs, rhs);
-    });
+    }
+  );
   
 
   d_lw->registerFunction<ComboAddress(Netmask::*)()>("getNetwork", [](const Netmask& nm) { return nm.getNetwork(); } ); // const reference makes this necessary
@@ -316,16 +323,19 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerFunction("__eq", &Netmask::operator==);
 
   d_lw->writeFunction("newNMG", []() { return NetmaskGroup(); });
-  d_lw->registerFunction<void(NetmaskGroup::*)(const std::string&mask)>("addMask", [](NetmaskGroup&nmg, const std::string& mask)
-			 {
-			   nmg.addMask(mask);
-			 });
+  d_lw->registerFunction<void(NetmaskGroup::*)(const std::string&mask)>(
+    "addMask", [](NetmaskGroup&nmg, const std::string& mask){
+      nmg.addMask(mask);
+    }
+  );
 
-  d_lw->registerFunction<void(NetmaskGroup::*)(const vector<pair<unsigned int, std::string>>&)>("addMasks", [](NetmaskGroup&nmg, const vector<pair<unsigned int, std::string>>& masks)
-			 {
-                           for(const auto& mask: masks) 
-                             nmg.addMask(mask.second);
-			 });
+  d_lw->registerFunction<void(NetmaskGroup::*)(const vector<pair<unsigned int, std::string>>&)>(
+    "addMasks",
+    [](NetmaskGroup&nmg, const vector<pair<unsigned int, std::string>>& masks){
+      for(const auto& mask: masks)
+        nmg.addMask(mask.second);
+    }
+  );
 
 
   d_lw->registerFunction("match", (bool (NetmaskGroup::*)(const ComboAddress&) const)&NetmaskGroup::match);
@@ -396,22 +406,27 @@ RecursorLua4::RecursorLua4(const std::string& fname)
     });
 
   d_lw->writeFunction("newDS", []() { return SuffixMatchNode(); });
-  d_lw->registerFunction<void(SuffixMatchNode::*)(boost::variant<string,DNSName, vector<pair<unsigned int,string> > >)>("add",
-										   [](SuffixMatchNode&smn, const boost::variant<string,DNSName,vector<pair<unsigned int,string> > >& in)
-										   {
-										     try {
-										     if(auto s = boost::get<string>(&in)) {
-										       smn.add(DNSName(*s));
-										     }
-										     else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
-										       for(const auto& s : *v)
-											 smn.add(DNSName(s.second));
-										     }
-										     else
-										       smn.add(boost::get<DNSName>(in));
-										     }
-										     catch(std::exception& e) { theL() <<Logger::Error<<e.what()<<endl; }
-										   });
+  d_lw->registerFunction<void(SuffixMatchNode::*)(boost::variant<string,DNSName, vector<pair<unsigned int,string> > >)>(
+    "add",
+    [](SuffixMatchNode&smn, const boost::variant<string,DNSName,vector<pair<unsigned int,string> > >& in){
+      try {
+        if(auto s = boost::get<string>(&in)) {
+          smn.add(DNSName(*s));
+        }
+        else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
+          for(const auto& s : *v)
+            smn.add(DNSName(s.second));
+        }
+        else {
+          smn.add(boost::get<DNSName>(in));
+        }
+      }
+      catch(std::exception& e) {
+        theL() <<Logger::Error<<e.what()<<endl;
+      }
+    }
+  );
+
   d_lw->registerFunction("check",(bool (SuffixMatchNode::*)(const DNSName&) const) &SuffixMatchNode::check);
   d_lw->registerFunction("toString",(string (SuffixMatchNode::*)() const) &SuffixMatchNode::toString);
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -27,6 +27,7 @@
 #include "namespaces.hh"
 #include "rec_channel.hh" 
 #include "ednssubnet.hh"
+#include "filterpo.hh"
 #include <unordered_set>
 
 #if !defined(HAVE_LUA)
@@ -45,12 +46,12 @@ bool RecursorLua4::nodata(const ComboAddress& remote,const ComboAddress& local, 
   return false;
 }
 
-bool RecursorLua4::postresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& ret, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& res, bool* variable)
+bool RecursorLua4::postresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& ret, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& res, bool* variable)
 {
   return false;
 }
 
-bool RecursorLua4::preresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& ret, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& res, bool* variable)
+bool RecursorLua4::preresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& ret, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& res, bool* variable)
 {
   return false;
 }
@@ -359,6 +360,18 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerMember("udpQueryDest", &DNSQuestion::udpQueryDest);
   d_lw->registerMember("udpCallback", &DNSQuestion::udpCallback);
   d_lw->registerMember("appliedPolicy", &DNSQuestion::appliedPolicy);
+  d_lw->registerMember("policyName", &DNSFilterEngine::Policy::d_name);
+  d_lw->registerMember("policyKind", &DNSFilterEngine::Policy::d_kind);
+  d_lw->registerMember("policyTTL", &DNSFilterEngine::Policy::d_ttl);
+  d_lw->registerMember<DNSFilterEngine::Policy, string>("policyCustom",
+    [](const DNSFilterEngine::Policy& pol) -> string {
+      return pol.d_custom->getZoneRepresentation();
+    },
+    [](DNSFilterEngine::Policy& pol, string content) {
+      // Only CNAMES for now, when we ever add a d_custom_type, there will be pain
+      pol.d_custom = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::CNAME, 1, content));
+    }
+  );
   d_lw->registerFunction("getEDNSOptions", &DNSQuestion::getEDNSOptions);
   d_lw->registerFunction("getEDNSOption", &DNSQuestion::getEDNSOption);
   d_lw->registerFunction("getEDNSSubnet", &DNSQuestion::getEDNSSubnet);
@@ -465,6 +478,15 @@ RecursorLua4::RecursorLua4(const std::string& fname)
 	{"Error", LOG_ERR}
 	  }});
 
+  pd.push_back({"policykinds", in_t {
+    {"NoAction", (int)DNSFilterEngine::PolicyKind::NoAction},
+    {"Drop",     (int)DNSFilterEngine::PolicyKind::Drop    },
+    {"NXDOMAIN", (int)DNSFilterEngine::PolicyKind::NXDOMAIN},
+    {"NODATA",   (int)DNSFilterEngine::PolicyKind::NODATA  },
+    {"Truncate", (int)DNSFilterEngine::PolicyKind::Truncate},
+    {"Custom",   (int)DNSFilterEngine::PolicyKind::Custom  }
+    }});
+
   for(const auto& n : QType::names)
     pd.push_back({n.first, n.second});
   pd.push_back({"now", &g_now});
@@ -499,7 +521,7 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_gettag = d_lw->readVariable<boost::optional<gettag_t>>("gettag").get_value_or(0);
 }
 
-bool RecursorLua4::preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable)
+bool RecursorLua4::preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable)
 {
   return genhook(d_preresolve, remote, local, query, qtype, isTcp, res, ednsOpts, tag, appliedPolicy, policyTags, ret, variable);
 }
@@ -514,7 +536,7 @@ bool RecursorLua4::nodata(const ComboAddress& remote,const ComboAddress& local, 
   return genhook(d_nodata, remote, local, query, qtype, isTcp, res, 0, 0, nullptr, nullptr, ret, variable);
 }
 
-bool RecursorLua4::postresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable)
+bool RecursorLua4::postresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable)
 {
   return genhook(d_postresolve, remote, local, query, qtype, isTcp, res, 0, 0, appliedPolicy, policyTags, ret, variable);
 }
@@ -549,7 +571,7 @@ int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, 
   return 0;
 }
 
-bool RecursorLua4::genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable)
+bool RecursorLua4::genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable)
 {
   if(!func)
     return false;
@@ -565,6 +587,7 @@ bool RecursorLua4::genhook(luacall_t& func, const ComboAddress& remote,const Com
   dq->isTcp = isTcp;
   dq->rcode = ret;
   dq->policyTags = policyTags;
+  dq->appliedPolicy = appliedPolicy;
   bool handled=func(dq);
   if(variable) *variable |= dq->variable; // could still be set to indicate this *name* is variable, even if not 'handled'
 
@@ -598,9 +621,6 @@ loop:;
       }
     }
     res=dq->records;
-    if (appliedPolicy) {
-      *appliedPolicy=dq->appliedPolicy;
-    }
   }
 
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -53,6 +53,7 @@ bool RecursorLua4::postresolve(const ComboAddress& remote,const ComboAddress& lo
 
 bool RecursorLua4::prerpz(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, int& ret, bool* wantsRPZ, std::unordered_map<std::string,bool>* discardedPolicies)
 {
+  return false;
 }
 
 bool RecursorLua4::preresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& ret, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& res, bool* variable, bool* wantsRPZ)

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -44,7 +44,7 @@ private:
 public:
   explicit RecursorLua4(const std::string& fname);
   ~RecursorLua4(); // this is so unique_ptr works with an incomplete type
-  bool preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable, bool* wantsRPZ);
   bool nxdomain(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
   bool nodata(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
   bool postresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
@@ -91,11 +91,12 @@ private:
     DNSFilterEngine::Policy* appliedPolicy;
     std::vector<std::string>* policyTags;
     bool isTcp;
+    bool wantsRPZ;
   };
 
   typedef std::function<bool(std::shared_ptr<DNSQuestion>)> luacall_t;
   luacall_t d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
-  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable, bool* wantsRPZ);
   typedef std::function<bool(ComboAddress,ComboAddress, struct dnsheader)> ipfilter_t;
   ipfilter_t d_ipfilter;
 };

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -24,6 +24,7 @@
 #include "dnsname.hh"
 #include "namespaces.hh"
 #include "dnsrecords.hh"
+#include "filterpo.hh"
 #include <unordered_map>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -43,10 +44,10 @@ private:
 public:
   explicit RecursorLua4(const std::string& fname);
   ~RecursorLua4(); // this is so unique_ptr works with an incomplete type
-  bool preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
   bool nxdomain(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
   bool nodata(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
-  bool postresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool postresolve(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
 
   bool preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret);
   bool ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader&);
@@ -87,14 +88,14 @@ private:
     const std::vector<pair<uint16_t, string>>* ednsOptions;
     DNSName followupName;
 
-    string appliedPolicy;
+    DNSFilterEngine::Policy* appliedPolicy;
     std::vector<std::string>* policyTags;
     bool isTcp;
   };
 
   typedef std::function<bool(std::shared_ptr<DNSQuestion>)> luacall_t;
   luacall_t d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
-  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, std::string* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
+  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable);
   typedef std::function<bool(ComboAddress,ComboAddress, struct dnsheader)> ipfilter_t;
   ipfilter_t d_ipfilter;
 };

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -44,6 +44,7 @@ private:
 public:
   explicit RecursorLua4(const std::string& fname);
   ~RecursorLua4(); // this is so unique_ptr works with an incomplete type
+  bool prerpz(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, int& ret, bool* wantsRPZ, std::unordered_map<std::string,bool>* discardedPolicies);
   bool preresolve(const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable, bool* wantsRPZ);
   bool nxdomain(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
   bool nodata(const ComboAddress& remote, const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, bool* variable);
@@ -90,13 +91,14 @@ private:
 
     DNSFilterEngine::Policy* appliedPolicy;
     std::vector<std::string>* policyTags;
+    std::unordered_map<std::string,bool>* discardedPolicies;
     bool isTcp;
-    bool wantsRPZ;
+    bool wantsRPZ{true};
   };
 
   typedef std::function<bool(std::shared_ptr<DNSQuestion>)> luacall_t;
-  luacall_t d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
-  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable, bool* wantsRPZ);
+  luacall_t d_prerpz, d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
+  bool genhook(luacall_t& func, const ComboAddress& remote,const ComboAddress& local, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res,  const vector<pair<uint16_t,string> >* ednsOpts, unsigned int tag, DNSFilterEngine::Policy* appliedPolicy, std::vector<std::string>* policyTags, int& ret, bool* variable, bool* wantsRPZ, std::unordered_map<std::string,bool>* discardedPolicies);
   typedef std::function<bool(ComboAddress,ComboAddress, struct dnsheader)> ipfilter_t;
   ipfilter_t d_ipfilter;
 };

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -751,16 +751,20 @@ void startDoResolve(void *p)
           break;
         case DNSFilterEngine::PolicyKind::Drop:
           g_stats.policyDrops++;
+          g_stats.policyResults[appliedPolicy.d_kind]++;
           delete dc;
           dc=0;
           return; 
         case DNSFilterEngine::PolicyKind::NXDOMAIN:
+          g_stats.policyResults[appliedPolicy.d_kind]++;
           res=RCode::NXDomain;
           goto haveAnswer;
         case DNSFilterEngine::PolicyKind::NODATA:
+          g_stats.policyResults[appliedPolicy.d_kind]++;
           res=RCode::NoError;
           goto haveAnswer;
         case DNSFilterEngine::PolicyKind::Custom:
+          g_stats.policyResults[appliedPolicy.d_kind]++;
           res=RCode::NoError;
           spoofed.d_name=dc->d_mdp.d_qname;
           spoofed.d_type=appliedPolicy.d_custom->getType();
@@ -772,6 +776,7 @@ void startDoResolve(void *p)
           goto haveAnswer;
         case DNSFilterEngine::PolicyKind::Truncate:
           if(!dc->d_tcp) {
+            g_stats.policyResults[appliedPolicy.d_kind]++;
             res=RCode::NoError;	
             pw.getHeader()->tc=1;
             goto haveAnswer;
@@ -809,6 +814,7 @@ void startDoResolve(void *p)
 	(*t_pdl)->postresolve(dc->d_remote, dc->d_local, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, ret, &appliedPolicy, &dc->d_policyTags, res, &variableAnswer);
       }
 
+      g_stats.policyResults[appliedPolicy.d_kind]++;
       switch(appliedPolicy.d_kind) {
       case DNSFilterEngine::PolicyKind::NoAction:
 	break;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -739,9 +739,6 @@ void startDoResolve(void *p)
     if(!dc->d_mdp.d_header.rd)
       sr.setCacheOnly();
 
-
-    // if there is a RecursorLua active, and it 'took' the query in preResolve, we don't launch beginResolve
-
     dfepol = luaconfsLocal->dfe.getQueryPolicy(dc->d_mdp.d_qname, dc->d_remote);
 
     switch(dfepol.d_kind) {
@@ -785,6 +782,7 @@ void startDoResolve(void *p)
       break;
     }
 
+    // if there is a RecursorLua active, and it 'took' the query in preResolve, we don't launch beginResolve
     if(!t_pdl->get() || !(*t_pdl)->preresolve(dc->d_remote, dc->d_local, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, ret, dc->d_ednsOpts.empty() ? 0 : &dc->d_ednsOpts, dc->d_tag, &appliedPolicy, &dc->d_policyTags, res, &variableAnswer)) {
       try {
         res = sr.beginResolve(dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_mdp.d_qclass, ret);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -730,11 +730,8 @@ void startDoResolve(void *p)
     if(!g_quiet || tracedQuery) {
       L<<Logger::Warning<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] " << (dc->d_tcp ? "TCP " : "") << "question for '"<<dc->d_mdp.d_qname<<"|"
        <<DNSRecordContent::NumberToType(dc->d_mdp.d_qtype)<<"' from "<<dc->getRemote();
-#ifdef HAVE_PROTOBUF
-      if(!dc->d_ednssubnet.empty()) {
+      if(!dc->d_ednssubnet.empty())
         L<<" (ecs "<<dc->d_ednssubnet.toString()<<")";
-      }
-#endif
       L<<endl;
     }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -729,8 +729,11 @@ void startDoResolve(void *p)
     if(!g_quiet || tracedQuery) {
       L<<Logger::Warning<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] " << (dc->d_tcp ? "TCP " : "") << "question for '"<<dc->d_mdp.d_qname<<"|"
        <<DNSRecordContent::NumberToType(dc->d_mdp.d_qtype)<<"' from "<<dc->getRemote();
-      if(!dc->d_ednssubnet.empty())
+#ifdef HAVE_PROTOBUF
+      if(!dc->d_ednssubnet.empty()) {
         L<<" (ecs "<<dc->d_ednssubnet.toString()<<")";
+      }
+#endif
       L<<endl;
     }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -611,15 +611,15 @@ catch(...)
 }
 
 #ifdef HAVE_PROTOBUF
-static void protobufLogQuery(const std::shared_ptr<RemoteLogger>& logger, uint8_t maskV4, uint8_t maskV6, const boost::uuids::uuid& uniqueId, const ComboAddress& remote, const ComboAddress& local, const Netmask& ednssubnet, bool tcp, uint16_t id, size_t len, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::string appliedPolicy, const std::vector<std::string>& policyTags)
+static void protobufLogQuery(const std::shared_ptr<RemoteLogger>& logger, uint8_t maskV4, uint8_t maskV6, const boost::uuids::uuid& uniqueId, const ComboAddress& remote, const ComboAddress& local, const Netmask& ednssubnet, bool tcp, uint16_t id, size_t len, const DNSName& qname, uint16_t qtype, uint16_t qclass, const DNSFilterEngine::Policy appliedPolicy, const std::vector<std::string>& policyTags)
 {
   Netmask requestorNM(remote, remote.sin4.sin_family == AF_INET ? maskV4 : maskV6);
   const ComboAddress& requestor = requestorNM.getMaskedNetwork();
   RecProtoBufMessage message(DNSProtoBufMessage::Query, uniqueId, &requestor, &local, qname, qtype, qclass, id, tcp, len);
   message.setEDNSSubnet(ednssubnet, ednssubnet.isIpv4() ? maskV4 : maskV6);
 
-  if (!appliedPolicy.empty()) {
-    message.setAppliedPolicy(appliedPolicy);
+  if (!appliedPolicy.d_name.empty()) {
+    message.setAppliedPolicy(appliedPolicy.d_name);
   }
   if (!policyTags.empty()) {
     message.setPolicyTags(policyTags);
@@ -659,7 +659,7 @@ void startDoResolve(void *p)
     vector<uint8_t> packet;
 
     auto luaconfsLocal = g_luaconfs.getLocal();
-    std::string appliedPolicy;
+    DNSFilterEngine::Policy appliedPolicy;
     RecProtoBufMessage pbMessage(RecProtoBufMessage::Response);
 #ifdef HAVE_PROTOBUF
     if (luaconfsLocal->protobufServer) {
@@ -739,51 +739,47 @@ void startDoResolve(void *p)
     if(!dc->d_mdp.d_header.rd)
       sr.setCacheOnly();
 
+    // Check if the query has a policy attached to it
     dfepol = luaconfsLocal->dfe.getQueryPolicy(dc->d_mdp.d_qname, dc->d_remote);
-
-    switch(dfepol.d_kind) {
-    case DNSFilterEngine::PolicyKind::NoAction:
-      break;
-    case DNSFilterEngine::PolicyKind::Drop:
-      g_stats.policyDrops++;
-      delete dc;
-      dc=0;
-      return; 
-    case DNSFilterEngine::PolicyKind::NXDOMAIN:
-      res=RCode::NXDomain;
-      appliedPolicy=dfepol.d_name;
-      goto haveAnswer;
-
-    case DNSFilterEngine::PolicyKind::NODATA:
-      res=RCode::NoError;
-      appliedPolicy=dfepol.d_name;
-      goto haveAnswer;
-
-    case DNSFilterEngine::PolicyKind::Custom:
-      res=RCode::NoError;
-      spoofed.d_name=dc->d_mdp.d_qname;
-      spoofed.d_type=dfepol.d_custom->getType();
-      spoofed.d_ttl = dfepol.d_ttl;
-      spoofed.d_class = 1;
-      spoofed.d_content = dfepol.d_custom;
-      spoofed.d_place = DNSResourceRecord::ANSWER;
-      ret.push_back(spoofed);
-      appliedPolicy=dfepol.d_name;
-      goto haveAnswer;
-
-
-    case DNSFilterEngine::PolicyKind::Truncate:
-      if(!dc->d_tcp) {
-	res=RCode::NoError;	
-	pw.getHeader()->tc=1;
-        appliedPolicy=dfepol.d_name;
-	goto haveAnswer;
-      }
-      break;
-    }
+    appliedPolicy = dfepol;
 
     // if there is a RecursorLua active, and it 'took' the query in preResolve, we don't launch beginResolve
     if(!t_pdl->get() || !(*t_pdl)->preresolve(dc->d_remote, dc->d_local, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, ret, dc->d_ednsOpts.empty() ? 0 : &dc->d_ednsOpts, dc->d_tag, &appliedPolicy, &dc->d_policyTags, res, &variableAnswer)) {
+
+      switch(appliedPolicy.d_kind) {
+        case DNSFilterEngine::PolicyKind::NoAction:
+          break;
+        case DNSFilterEngine::PolicyKind::Drop:
+          g_stats.policyDrops++;
+          delete dc;
+          dc=0;
+          return; 
+        case DNSFilterEngine::PolicyKind::NXDOMAIN:
+          res=RCode::NXDomain;
+          goto haveAnswer;
+        case DNSFilterEngine::PolicyKind::NODATA:
+          res=RCode::NoError;
+          goto haveAnswer;
+        case DNSFilterEngine::PolicyKind::Custom:
+          res=RCode::NoError;
+          spoofed.d_name=dc->d_mdp.d_qname;
+          spoofed.d_type=appliedPolicy.d_custom->getType();
+          spoofed.d_ttl = appliedPolicy.d_ttl;
+          spoofed.d_class = 1;
+          spoofed.d_content = appliedPolicy.d_custom;
+          spoofed.d_place = DNSResourceRecord::ANSWER;
+          ret.push_back(spoofed);
+          goto haveAnswer;
+        case DNSFilterEngine::PolicyKind::Truncate:
+          if(!dc->d_tcp) {
+            res=RCode::NoError;	
+            pw.getHeader()->tc=1;
+            goto haveAnswer;
+          }
+          break;
+      }
+
+      // Query got not handled for Policy reasons, now actually go out to find an answer
       try {
         res = sr.beginResolve(dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_mdp.d_qclass, ret);
         shouldNotValidate = sr.wasOutOfBand();
@@ -794,50 +790,8 @@ void startDoResolve(void *p)
         res = RCode::ServFail;
       }
 
-      dfepol = luaconfsLocal->dfe.getPostPolicy(ret); 
-      switch(dfepol.d_kind) {
-      case DNSFilterEngine::PolicyKind::NoAction:
-	break;
-      case DNSFilterEngine::PolicyKind::Drop:
-	g_stats.policyDrops++;
-	delete dc;
-	dc=0;
-	return; 
-      case DNSFilterEngine::PolicyKind::NXDOMAIN:
-	ret.clear();
-	res=RCode::NXDomain;
-        appliedPolicy=dfepol.d_name;
-	goto haveAnswer;
-	
-      case DNSFilterEngine::PolicyKind::NODATA:
-	ret.clear();
-	res=RCode::NoError;
-        appliedPolicy=dfepol.d_name;
-	goto haveAnswer;
-	
-      case DNSFilterEngine::PolicyKind::Truncate:
-	if(!dc->d_tcp) {
-	  ret.clear();
-	  res=RCode::NoError;	
-	  pw.getHeader()->tc=1;
-          appliedPolicy=dfepol.d_name;
-	  goto haveAnswer;
-	}
-	break;
-
-      case DNSFilterEngine::PolicyKind::Custom:
-	ret.clear();
-	res=RCode::NoError;
-	spoofed.d_name=dc->d_mdp.d_qname;
-	spoofed.d_type=dfepol.d_custom->getType();
-	spoofed.d_ttl = dfepol.d_ttl;
-	spoofed.d_class = 1;
-	spoofed.d_content = dfepol.d_custom;
-	spoofed.d_place = DNSResourceRecord::ANSWER;
-	ret.push_back(spoofed);
-        appliedPolicy=dfepol.d_name;
-	goto haveAnswer;
-      }
+      dfepol = luaconfsLocal->dfe.getPostPolicy(ret);
+      appliedPolicy = dfepol;
 
       if(t_pdl->get()) {
         if(res == RCode::NoError) {
@@ -853,6 +807,46 @@ void startDoResolve(void *p)
 	
 
 	(*t_pdl)->postresolve(dc->d_remote, dc->d_local, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, ret, &appliedPolicy, &dc->d_policyTags, res, &variableAnswer);
+      }
+
+      switch(appliedPolicy.d_kind) {
+      case DNSFilterEngine::PolicyKind::NoAction:
+	break;
+      case DNSFilterEngine::PolicyKind::Drop:
+	g_stats.policyDrops++;
+	delete dc;
+	dc=0;
+	return; 
+      case DNSFilterEngine::PolicyKind::NXDOMAIN:
+	ret.clear();
+	res=RCode::NXDomain;
+	goto haveAnswer;
+	
+      case DNSFilterEngine::PolicyKind::NODATA:
+	ret.clear();
+	res=RCode::NoError;
+	goto haveAnswer;
+	
+      case DNSFilterEngine::PolicyKind::Truncate:
+	if(!dc->d_tcp) {
+	  ret.clear();
+	  res=RCode::NoError;	
+	  pw.getHeader()->tc=1;
+	  goto haveAnswer;
+	}
+	break;
+
+      case DNSFilterEngine::PolicyKind::Custom:
+	ret.clear();
+	res=RCode::NoError;
+	spoofed.d_name=dc->d_mdp.d_qname;
+	spoofed.d_type=appliedPolicy.d_custom->getType();
+	spoofed.d_ttl = appliedPolicy.d_ttl;
+	spoofed.d_class = 1;
+	spoofed.d_content = appliedPolicy.d_custom;
+	spoofed.d_place = DNSResourceRecord::ANSWER;
+	ret.push_back(spoofed);
+	goto haveAnswer;
       }
     }
   haveAnswer:;
@@ -993,7 +987,7 @@ void startDoResolve(void *p)
     if (luaconfsLocal->protobufServer) {
       pbMessage.setBytes(packet.size());
       pbMessage.setResponseCode(pw.getHeader()->rcode);
-      pbMessage.setAppliedPolicy(appliedPolicy);
+      pbMessage.setAppliedPolicy(appliedPolicy.d_name);
       pbMessage.setPolicyTags(dc->d_policyTags);
       pbMessage.setQueryTime(dc->d_now.tv_sec, dc->d_now.tv_usec);
       protobufLogResponse(luaconfsLocal->protobufServer, pbMessage);
@@ -1240,7 +1234,7 @@ void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
           getQNameAndSubnet(std::string(conn->data, conn->qlen), &qname, &qtype, &qclass, &ednssubnet);
           dc->d_ednssubnet = ednssubnet;
 
-          protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, dc->d_uuid, dest, conn->d_remote, ednssubnet, true, dh->id, conn->qlen, qname, qtype, qclass, std::string(), std::vector<std::string>());
+          protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, dc->d_uuid, dest, conn->d_remote, ednssubnet, true, dh->id, conn->qlen, qname, qtype, qclass, DNSFilterEngine::Policy(), std::vector<std::string>());
         }
         catch(std::exception& e) {
           if(g_logCommonErrors)
@@ -1382,7 +1376,7 @@ string* doProcessUDPQuestion(const std::string& question, const ComboAddress& fr
     RecProtoBufMessage pbMessage(DNSProtoBufMessage::DNSProtoBufMessageType::Response);
 #ifdef HAVE_PROTOBUF
     if(luaconfsLocal->protobufServer) {
-      protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, uniqueId, fromaddr, destaddr, ednssubnet, false, dh->id, question.size(), qname, qtype, qclass, std::string(), policyTags);
+      protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, uniqueId, fromaddr, destaddr, ednssubnet, false, dh->id, question.size(), qname, qtype, qclass, DNSFilterEngine::Policy(), policyTags);
     }
 #endif /* HAVE_PROTOBUF */
 

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -101,7 +101,7 @@ void loadRecursorLuaConfig(const std::string& fname)
 	  if(have.count("defpol")) {
 	    defpol=DNSFilterEngine::Policy();
 	    defpol->d_kind = (DNSFilterEngine::PolicyKind)boost::get<int>(constGet(have, "defpol"));
-	    defpol->d_name = polName;
+	    defpol->d_name = std::make_shared<std::string>(polName);
 	    if(defpol->d_kind == DNSFilterEngine::PolicyKind::Custom) {
 	      defpol->d_custom=
 		shared_ptr<DNSRecordContent>(
@@ -117,8 +117,10 @@ void loadRecursorLuaConfig(const std::string& fname)
 	    }
 	  }
 	}
+        const size_t zoneIdx = lci.dfe.size();
         theL()<<Logger::Warning<<"Loading RPZ from file '"<<fname<<"'"<<endl;
-	loadRPZFromFile(fname, lci.dfe, polName, defpol, 0);
+        lci.dfe.setPolicyName(zoneIdx, polName);
+	loadRPZFromFile(fname, lci.dfe, defpol, zoneIdx);
         theL()<<Logger::Warning<<"Done loading RPZ from file '"<<fname<<"'"<<endl;
       }
       catch(std::exception& e) {
@@ -144,7 +146,7 @@ void loadRecursorLuaConfig(const std::string& fname)
 	    //	    cout<<"Set a default policy"<<endl;
 	    defpol=DNSFilterEngine::Policy();
 	    defpol->d_kind = (DNSFilterEngine::PolicyKind)boost::get<int>(constGet(have, "defpol"));
-	    defpol->d_name = polName;
+	    defpol->d_name = std::make_shared<std::string>(polName);
 	    if(defpol->d_kind == DNSFilterEngine::PolicyKind::Custom) {
 	      //	      cout<<"Setting a custom field even!"<<endl;
 	      defpol->d_custom=
@@ -180,11 +182,13 @@ void loadRecursorLuaConfig(const std::string& fname)
           // We were passed a localAddress, check if its AF matches the master's
           throw PDNSException("Master address("+master.toString()+") is not of the same Address Family as the local address ("+localAddress.toString()+").");
 	DNSName zone(zone_);
+        const size_t zoneIdx = lci.dfe.size();
+        lci.dfe.setPolicyName(zoneIdx, polName);
 
-	auto sr=loadRPZFromServer(master, zone, lci.dfe, polName, defpol, 0, tt, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
+	auto sr=loadRPZFromServer(master, zone, lci.dfe, defpol, zoneIdx, tt, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
         if(refresh)
           sr->d_st.refresh=refresh;
-	std::thread t(RPZIXFRTracker, master, zone, polName, tt, sr, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
+	std::thread t(RPZIXFRTracker, master, zone, zoneIdx, tt, sr, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
 	t.detach();
       }
       catch(std::exception& e) {

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -92,7 +92,7 @@ void loadRecursorLuaConfig(const std::string& fname)
   Lua.writeFunction("rpzFile", [&lci](const string& fname, const boost::optional<std::unordered_map<string,boost::variant<int, string>>>& options) {
       try {
 	boost::optional<DNSFilterEngine::Policy> defpol;
-	std::string polName;
+	std::string polName("rpzFile");
 	if(options) {
 	  auto& have = *options;
 	  if(have.count("policyName")) {
@@ -137,9 +137,9 @@ void loadRecursorLuaConfig(const std::string& fname)
         ComboAddress localAddress;
 	if(options) {
 	  auto& have = *options;
-	  if(have.count("policyName")) {
+          polName = zone_;
+	  if(have.count("policyName"))
 	    polName = boost::get<std::string>(constGet(have, "policyName"));
-	  }
 	  if(have.count("defpol")) {
 	    //	    cout<<"Set a default policy"<<endl;
 	    defpol=DNSFilterEngine::Policy();

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -120,7 +120,7 @@ void loadRecursorLuaConfig(const std::string& fname)
         const size_t zoneIdx = lci.dfe.size();
         theL()<<Logger::Warning<<"Loading RPZ from file '"<<fname<<"'"<<endl;
         lci.dfe.setPolicyName(zoneIdx, polName);
-	loadRPZFromFile(fname, lci.dfe, defpol, zoneIdx);
+        loadRPZFromFile(fname, lci.dfe, defpol, zoneIdx);
         theL()<<Logger::Warning<<"Done loading RPZ from file '"<<fname<<"'"<<endl;
       }
       catch(std::exception& e) {

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -31,6 +31,7 @@
 #include "rec-lua-conf.hh"
 
 #include "validate-recursor.hh"
+#include "filterpo.hh"
 
 #include "secpoll-recursor.hh"
 #include "pubsuffix.hh"
@@ -888,6 +889,13 @@ RecursorControlParser::RecursorControlParser()
   addGetStat("dnssec-result-bogus", &g_stats.dnssecResults[Bogus]);
   addGetStat("dnssec-result-indeterminate", &g_stats.dnssecResults[Indeterminate]);
   addGetStat("dnssec-result-nta", &g_stats.dnssecResults[NTA]);
+
+  addGetStat("policy-result-noaction", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NoAction]);
+  addGetStat("policy-result-drop", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Drop]);
+  addGetStat("policy-result-nxdomain", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NXDOMAIN]);
+  addGetStat("policy-result-nodata", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NODATA]);
+  addGetStat("policy-result-truncate", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Truncate]);
+  addGetStat("policy-result-custom", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Custom]);
 }
 
 static void doExitGeneric(bool nicely)

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1138,7 +1138,7 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
 "clear-nta [DOMAIN]...            Clear the Negative Trust Anchor for DOMAINs, if no DOMAIN is specified, remove all\n"
 "clear-ta [DOMAIN]...             Clear the Trust Anchor for DOMAINs\n"
 "dump-cache <filename>            dump cache contents to the named file\n"
-"dump-edns[status] <filename>     dump EDNS status to the named file\n"
+"dump-edns [status] <filename>    dump EDNS status to the named file\n"
 "dump-nsspeeds <filename>         dump nsspeeds statistics to the named file\n"
 "get [key1] [key2] ..             get specific statistics\n"
 "get-all                          get all statistics\n"

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -311,7 +311,7 @@ string reloadAuthAndForwards()
 }
 
 
-void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, const std::string& polName, const TSIGTriplet& tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress)
+void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, size_t polZone, const TSIGTriplet& tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress)
 {
   int refresh = oursr->d_st.refresh;
   for(;;) {
@@ -358,7 +358,7 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, const std::
 	}
 	else {
 	  L<<Logger::Info<<"Had removal of "<<rr.d_name<<endl;
-	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, polName, false, boost::optional<DNSFilterEngine::Policy>(), 0);
+	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, false, boost::optional<DNSFilterEngine::Policy>(), polZone);
 	}
       }
 
@@ -373,7 +373,7 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, const std::
 	}
 	else {
 	  L<<Logger::Info<<"Had addition of "<<rr.d_name<<endl;
-	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, polName, true, boost::optional<DNSFilterEngine::Policy>(), 0);
+	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, true, boost::optional<DNSFilterEngine::Policy>(), polZone);
 	}
       }
     }

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -58,13 +58,13 @@ static Netmask makeNetmaskFromRPZ(const DNSName& name)
   return Netmask(v6);
 }
 
-void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, const std::string& polName, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, int place)
+void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, size_t place)
 {
   static const DNSName drop("rpz-drop."), truncate("rpz-tcp-only."), noaction("rpz-passthru.");
   static const DNSName rpzClientIP("rpz-client-ip"), rpzIP("rpz-ip"),
     rpzNSDname("rpz-nsdname"), rpzNSIP("rpz-nsip.");
 
-  DNSFilterEngine::Policy pol{DNSFilterEngine::PolicyKind::NoAction, nullptr, polName, 0};
+  DNSFilterEngine::Policy pol{DNSFilterEngine::PolicyKind::NoAction, nullptr, nullptr, 0};
 
   if(dr.d_class != QClass::IN) {
     return;
@@ -123,41 +123,41 @@ void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, const std::
   if(dr.d_name.isPartOf(rpzNSDname)) {
     DNSName filt=dr.d_name.makeRelative(rpzNSDname);
     if(addOrRemove)
-      target.addNSTrigger(filt, pol);
+      target.addNSTrigger(filt, pol, place);
     else
-      target.rmNSTrigger(filt, pol);
+      target.rmNSTrigger(filt, pol, place);
   } else 	if(dr.d_name.isPartOf(rpzClientIP)) {
     DNSName filt=dr.d_name.makeRelative(rpzClientIP);
     auto nm=makeNetmaskFromRPZ(filt);
     if(addOrRemove)
-      target.addClientTrigger(nm, pol);
+      target.addClientTrigger(nm, pol, place);
     else
-      target.rmClientTrigger(nm, pol);
+      target.rmClientTrigger(nm, pol, place);
     
   } else 	if(dr.d_name.isPartOf(rpzIP)) {
     // cerr<<"Should apply answer content IP policy: "<<dr.d_name<<endl;
     DNSName filt=dr.d_name.makeRelative(rpzIP);
     auto nm=makeNetmaskFromRPZ(filt);
     if(addOrRemove)
-      target.addResponseTrigger(nm, pol);
+      target.addResponseTrigger(nm, pol, place);
     else
-      target.rmResponseTrigger(nm, pol);
+      target.rmResponseTrigger(nm, pol, place);
   } else if(dr.d_name.isPartOf(rpzNSIP)) {
     DNSName filt=dr.d_name.makeRelative(rpzNSIP);
     auto nm=makeNetmaskFromRPZ(filt);
     if(addOrRemove)
-      target.addNSIPTrigger(nm, pol);
+      target.addNSIPTrigger(nm, pol, place);
     else
-      target.rmNSIPTrigger(nm, pol);
+      target.rmNSIPTrigger(nm, pol, place);
   } else {
     if(addOrRemove)
-      target.addQNameTrigger(dr.d_name, pol);
+      target.addQNameTrigger(dr.d_name, pol, place);
     else
-      target.rmQNameTrigger(dr.d_name, pol);
+      target.rmQNameTrigger(dr.d_name, pol, place);
   }
 }
 
-shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, const std::string& polName, boost::optional<DNSFilterEngine::Policy> defpol, int place,  const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress)
+shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, size_t place, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress)
 {
   L<<Logger::Warning<<"Loading RPZ zone '"<<zone<<"' from "<<master.toStringWithPort()<<endl;
   if(!tt.name.empty())
@@ -185,7 +185,7 @@ shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const
 	continue;
       }
 
-      RPZRecordToPolicy(dr, target, polName, true, defpol, place);
+      RPZRecordToPolicy(dr, target, true, defpol, place);
       nrecords++;
     } 
     if(last != time(0)) {
@@ -198,7 +198,7 @@ shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const
 }
 
 // this function is silent - you do the logging
-int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, const std::string& polName, boost::optional<DNSFilterEngine::Policy> defpol, int place)
+int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, size_t place)
 {
   ZoneParserTNG zpt(fname);
   DNSResourceRecord drr;
@@ -216,7 +216,7 @@ int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, const std
       }
       else {
 	dr.d_name=dr.d_name.makeRelative(domain);
-	RPZRecordToPolicy(dr, target, polName, true, defpol, place);
+	RPZRecordToPolicy(dr, target, true, defpol, place);
       }
     }
     catch(PDNSException& pe) {

--- a/pdns/rpzloader.hh
+++ b/pdns/rpzloader.hh
@@ -24,7 +24,7 @@
 #include <string>
 #include "dnsrecords.hh"
 
-int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, const std::string& policyName, boost::optional<DNSFilterEngine::Policy> defpol, int place);
-std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, const std::string& policyName, boost::optional<DNSFilterEngine::Policy> defpol, int place, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress);
-void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, const std::string& policyName, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, int place);
-void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, const std::string& policyName, const TSIGTriplet &tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress);
+int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, size_t place);
+std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, size_t place, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress);
+void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, size_t place);
+void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, size_t polZone, const TSIGTriplet &tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -964,17 +964,17 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
 
   if(d_wantsRPZ) {
     for (auto const &ns : nameservers) {
-      d_appliedPolicy = g_luaconfs.getLocal()->dfe.getProcessingPolicy(ns.first);
+      d_appliedPolicy = g_luaconfs.getLocal()->dfe.getProcessingPolicy(ns.first, d_discardedPolicies);
       if (d_appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::NoAction) { // client query needs an RPZ response
-        LOG(", however nameserver "<<ns.first<<" was blocked by RPZ policy '"<<d_appliedPolicy.d_name<<"'"<<endl);
+        LOG(", however nameserver "<<ns.first<<" was blocked by RPZ policy '"<<(d_appliedPolicy.d_name ? *d_appliedPolicy.d_name : "")<<"'"<<endl);
         return -2;
       }
 
       // Traverse all IP addresses for this NS to see if they have an RPN NSIP policy
       for (auto const &address : ns.second.first) {
-        d_appliedPolicy = g_luaconfs.getLocal()->dfe.getProcessingPolicy(address);
+        d_appliedPolicy = g_luaconfs.getLocal()->dfe.getProcessingPolicy(address, d_discardedPolicies);
         if (d_appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::NoAction) { // client query needs an RPZ response
-          LOG(", however nameserver "<<ns.first<<" IP address "<<address.toString()<<" was blocked by RPZ policy '"<<d_appliedPolicy.d_name<<"'"<<endl);
+          LOG(", however nameserver "<<ns.first<<" IP address "<<address.toString()<<" was blocked by RPZ policy '"<<(d_appliedPolicy.d_name ? *d_appliedPolicy.d_name : "")<<"'"<<endl);
           return -2;
         }
       }
@@ -1054,10 +1054,10 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
             }
             LOG(remoteIP->toString());
             if (d_wantsRPZ) {
-              d_appliedPolicy = g_luaconfs.getLocal()->dfe.getProcessingPolicy(*remoteIP);
+              d_appliedPolicy = g_luaconfs.getLocal()->dfe.getProcessingPolicy(*remoteIP, d_discardedPolicies);
               if (d_appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::NoAction) {
                 hitPolicy = true;
-                LOG(" (blocked by RPZ policy '"+d_appliedPolicy.d_name+"')");
+                LOG(" (blocked by RPZ policy '"+(d_appliedPolicy.d_name ? *d_appliedPolicy.d_name : "")+"')");
               }
             }
           }
@@ -1444,9 +1444,9 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
         nameservers.clear();
         for (auto const &nameserver : nsset) {
           if (d_wantsRPZ) {
-            d_appliedPolicy = g_luaconfs.getLocal()->dfe.getProcessingPolicy(nameserver);
+            d_appliedPolicy = g_luaconfs.getLocal()->dfe.getProcessingPolicy(nameserver, d_discardedPolicies);
             if (d_appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::NoAction) { // client query needs an RPZ response
-              LOG("however "<<nameserver<<" was blocked by RPZ policy '"<<d_appliedPolicy.d_name<<"'"<<endl);
+              LOG("however "<<nameserver<<" was blocked by RPZ policy '"<<(d_appliedPolicy.d_name ? *d_appliedPolicy.d_name : "")<<"'"<<endl);
               return -2;
             }
           }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -995,8 +995,10 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
         }
         //
 	// XXX NEED TO HANDLE OTHER POLICY KINDS HERE!
-	if(g_luaconfs.getLocal()->dfe.getProcessingPolicy(*tns).d_kind != DNSFilterEngine::PolicyKind::NoAction)
+	if(g_luaconfs.getLocal()->dfe.getProcessingPolicy(*tns).d_kind != DNSFilterEngine::PolicyKind::NoAction) {
+          g_stats.policyResults[g_luaconfs.getLocal()->dfe.getProcessingPolicy(*tns).d_kind]++;
 	  throw ImmediateServFailException("Dropped because of policy");
+        }
 
         if(tns->empty()) {
           LOG(prefix<<qname<<": Domain has hardcoded nameserver");

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -368,6 +368,8 @@ public:
   
   bool d_wasVariable{false};
   bool d_wasOutOfBand{false};
+  bool d_wantsRPZ{true};
+  DNSFilterEngine::Policy d_appliedPolicy{DNSFilterEngine::PolicyKind::NoAction, nullptr, "", 0};
   
   typedef multi_index_container <
     NegCacheEntry,

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -637,6 +637,7 @@ struct RecursorStats
   unsigned int maxMThreadStackUsage;
   std::atomic<uint64_t> dnssecValidations; // should be the sum of all dnssecResult* stats
   std::map<vState, std::atomic<uint64_t> > dnssecResults;
+  std::map<DNSFilterEngine::PolicyKind, std::atomic<uint64_t> > policyResults;
 };
 
 //! represents a running TCP/IP client session

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -357,6 +357,8 @@ public:
   static bool s_doIPv6;
   static unsigned int s_maxqperq;
   static unsigned int s_maxtotusec;
+  std::unordered_map<std::string,bool> d_discardedPolicies;
+  DNSFilterEngine::Policy d_appliedPolicy{DNSFilterEngine::PolicyKind::NoAction, nullptr, nullptr, 0};
   unsigned int d_outqueries;
   unsigned int d_tcpoutqueries;
   unsigned int d_throttledqueries;
@@ -369,7 +371,6 @@ public:
   bool d_wasVariable{false};
   bool d_wasOutOfBand{false};
   bool d_wantsRPZ{true};
-  DNSFilterEngine::Policy d_appliedPolicy{DNSFilterEngine::PolicyKind::NoAction, nullptr, "", 0};
   
   typedef multi_index_container <
     NegCacheEntry,

--- a/regression-tests.recursor/RPZ-Lua/command
+++ b/regression-tests.recursor/RPZ-Lua/command
@@ -1,2 +1,3 @@
 $SDIG $nameserver 5301 www3.example.net a recurse 2>&1
 $SDIG $nameserver 5301 android.marvin.example.net a recurse 2>&1
+$SDIG $nameserver 5301 www5.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ-Lua/command
+++ b/regression-tests.recursor/RPZ-Lua/command
@@ -1,0 +1,1 @@
+$SDIG $nameserver 5301 www3.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ-Lua/command
+++ b/regression-tests.recursor/RPZ-Lua/command
@@ -1,1 +1,2 @@
 $SDIG $nameserver 5301 www3.example.net a recurse 2>&1
+$SDIG $nameserver 5301 android.marvin.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ-Lua/description
+++ b/regression-tests.recursor/RPZ-Lua/description
@@ -1,0 +1,1 @@
+Test if we can indeed change the action for a policy in Lua

--- a/regression-tests.recursor/RPZ-Lua/expected_result
+++ b/regression-tests.recursor/RPZ-Lua/expected_result
@@ -1,3 +1,6 @@
 Reply to question for qname='www3.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	www3.example.net.	IN	CNAME	0	www2.example.net.
+Reply to question for qname='android.marvin.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	android.marvin.example.net.	IN	A	15	192.0.2.5

--- a/regression-tests.recursor/RPZ-Lua/expected_result
+++ b/regression-tests.recursor/RPZ-Lua/expected_result
@@ -4,3 +4,6 @@ Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='android.marvin.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	android.marvin.example.net.	IN	A	15	192.0.2.5
+Reply to question for qname='www5.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	www5.example.net.	IN	A	0	192.0.2.25

--- a/regression-tests.recursor/RPZ-Lua/expected_result
+++ b/regression-tests.recursor/RPZ-Lua/expected_result
@@ -1,0 +1,3 @@
+Reply to question for qname='www3.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	www3.example.net.	IN	CNAME	0	www2.example.net.

--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -12,3 +12,7 @@ echo "==> trillian.example.net NXDOMAIN"
 $SDIG $nameserver 5301 trillian.example.net a recurse 2>&1
 echo "==> www.trillian.example.net has no RPZ policy attached, so lookup should succeed"
 $SDIG $nameserver 5301 www.trillian.example.net a recurse 2>&1
+echo "==> www.hijackme.example.net is served on ns.hijackme.example.net, which should be NXDOMAIN"
+$SDIG $nameserver 5301 www.hijackme.example.net a recurse 2>&1
+echo "==> host.lowercase-outgoing.example.net is served on ns.lowercase-outgoing.example.net, blocked by NS IP rule"
+$SDIG $nameserver 5301 host.lowercase-outgoing.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -1,0 +1,10 @@
+echo "arthur.example.net RPZ NXDOMAIN"
+$SDIG $nameserver 5301 arthur.example.net a recurse 2>&1
+echo "www.arthur.example.net RPZ NODATA"
+$SDIG $nameserver 5301 www.arthur.example.net a recurse 2>&1
+echo "srv.arthur.example.net RPZ passthru"
+$SDIG $nameserver 5301 srv.arthur.example.net srv recurse 2>&1
+echo "www.example.net RPZ local data to www2.example.net"
+$SDIG $nameserver 5301 www.example.net a recurse 2>&1
+echo "www4.example.net RPZ IP trigger action, dropped"
+$SDIG $nameserver 5301 www4.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -1,10 +1,14 @@
-echo "arthur.example.net RPZ NXDOMAIN"
+echo "==> arthur.example.net RPZ NXDOMAIN"
 $SDIG $nameserver 5301 arthur.example.net a recurse 2>&1
-echo "www.arthur.example.net RPZ NODATA"
+echo "==> www.arthur.example.net RPZ NODATA"
 $SDIG $nameserver 5301 www.arthur.example.net a recurse 2>&1
-echo "srv.arthur.example.net RPZ passthru"
+echo "==> srv.arthur.example.net RPZ passthru"
 $SDIG $nameserver 5301 srv.arthur.example.net srv recurse 2>&1
-echo "www.example.net RPZ local data to www2.example.net"
+echo "==> www.example.net RPZ local data to www2.example.net"
 $SDIG $nameserver 5301 www.example.net a recurse 2>&1
-echo "www4.example.net RPZ IP trigger action, dropped"
+echo "==> www4.example.net RPZ IP trigger action, dropped"
 $SDIG $nameserver 5301 www4.example.net a recurse 2>&1
+echo "==> trillian.example.net NXDOMAIN"
+$SDIG $nameserver 5301 trillian.example.net a recurse 2>&1
+echo "==> www.trillian.example.net has no RPZ policy attached, so lookup should succeed"
+$SDIG $nameserver 5301 www.trillian.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ/description
+++ b/regression-tests.recursor/RPZ/description
@@ -1,0 +1,1 @@
+Test if we can load an RPZ from disk and if the responses are correct

--- a/regression-tests.recursor/RPZ/expected_result
+++ b/regression-tests.recursor/RPZ/expected_result
@@ -21,3 +21,9 @@ Reply to question for qname='www.trillian.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	www.trillian.example.net.	IN	CNAME	15	www2.arthur.example.net.
 0	www2.arthur.example.net.	IN	A	15	192.0.2.6
+==> www.hijackme.example.net is served on ns.hijackme.example.net, which should be NXDOMAIN
+Reply to question for qname='www.hijackme.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+==> host.lowercase-outgoing.example.net is served on ns.lowercase-outgoing.example.net, blocked by NS IP rule
+Reply to question for qname='host.lowercase-outgoing.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0

--- a/regression-tests.recursor/RPZ/expected_result
+++ b/regression-tests.recursor/RPZ/expected_result
@@ -1,0 +1,15 @@
+arthur.example.net RPZ NXDOMAIN
+Reply to question for qname='arthur.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+www.arthur.example.net RPZ NODATA
+Reply to question for qname='www.arthur.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+srv.arthur.example.net RPZ passthru
+Reply to question for qname='srv.arthur.example.net.', qtype=SRV
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	srv.arthur.example.net.	IN	SRV	15	0 100 389 server2.example.net.
+www.example.net RPZ local data to www2.example.net
+Reply to question for qname='www.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	www.example.net.	IN	CNAME	0	www2.example.net.
+www4.example.net RPZ IP trigger action, dropped

--- a/regression-tests.recursor/RPZ/expected_result
+++ b/regression-tests.recursor/RPZ/expected_result
@@ -1,15 +1,23 @@
-arthur.example.net RPZ NXDOMAIN
+==> arthur.example.net RPZ NXDOMAIN
 Reply to question for qname='arthur.example.net.', qtype=A
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-www.arthur.example.net RPZ NODATA
+==> www.arthur.example.net RPZ NODATA
 Reply to question for qname='www.arthur.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-srv.arthur.example.net RPZ passthru
+==> srv.arthur.example.net RPZ passthru
 Reply to question for qname='srv.arthur.example.net.', qtype=SRV
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	srv.arthur.example.net.	IN	SRV	15	0 100 389 server2.example.net.
-www.example.net RPZ local data to www2.example.net
+==> www.example.net RPZ local data to www2.example.net
 Reply to question for qname='www.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	www.example.net.	IN	CNAME	0	www2.example.net.
-www4.example.net RPZ IP trigger action, dropped
+==> www4.example.net RPZ IP trigger action, dropped
+==> trillian.example.net NXDOMAIN
+Reply to question for qname='trillian.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+==> www.trillian.example.net has no RPZ policy attached, so lookup should succeed
+Reply to question for qname='www.trillian.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	www.trillian.example.net.	IN	CNAME	15	www2.arthur.example.net.
+0	www2.arthur.example.net.	IN	A	15	192.0.2.6

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -436,7 +436,7 @@ host2.auth-zone.example.net. 20 IN CNAME host1.another-auth-zone.example.net.
 host3.auth-zone.example.net. 20 IN CNAME host1.not-auth-zone.example.net.
 *.wild.auth-zone.example.net.	3600 IN	TXT "Hi there!"
 france.auth-zone.example.net.	20	IN NS 	ns1.auth-zone.example.net.
-ns1.auth-zone.example.net. 	20	IN	A	10.0.3.23
+ns1.auth-zone.example.net. 	20	IN	A	$PREFIX.23
 EOF
 
 mkdir $PREFIX.24

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -544,6 +544,7 @@ cat > recursor-service3/recursor.conf << EOF
 local-port=5301
 socket-dir=$(pwd)/recursor-service3S
 lua-config-file=$(pwd)/recursor-service3/config.lua
+lua-dns-script=$(pwd)/recursor-service3/script.lua
 
 EOF
 
@@ -561,6 +562,18 @@ arthur.example.net     CNAME .                   ; NXDOMAIN on apex
 *.arthur.example.net   CNAME *.                  ; NODATA for everything below the apex
 srv.arthur.example.net CNAME rpz-passthru.       ; Allow this name though
 www.example.net        CNAME www2.example.net.   ; Local-Data Action
+www3.example.net       CNAME www4.example.net.   ; Local-Data Action (to be changed in preresolve)
 
 32.4.2.0.192.rpz-ip    CNAME rpz-drop.           ; www4.example.net resolves to 192.0.2.4, drop A responses with that IP
+EOF
+
+cat > recursor-service3/script.lua <<EOF
+function preresolve(dq)
+  if dq.appliedPolicy.policyKind == pdns.policykinds.Custom then
+    if dq.qname:equal("www3.example.net") then
+      dq.appliedPolicy.policyCustom = "www2.example.net"
+    end
+  end
+  return false
+end
 EOF

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 if [ "${PDNS_DEBUG}" = "YES" ]; then
   set -x

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -46,6 +46,7 @@ fi
 cd configs
 
 for dir in recursor-service recursor-service2 recursor-service3; do
+  mkdir /tmp/$dir
   mkdir $dir
   cd $dir
 
@@ -528,7 +529,7 @@ api-key=secret
 api-readonly=yes
 forward-zones-file=$(pwd)/recursor-service/forward-zones-file
 
-socket-dir=$(pwd)/recursor-service
+socket-dir=/tmp/recursor-service
 auth-zones=global.box.answer-cname-in-local.example.net=$(pwd)/recursor-service/global.box.answer-cname-in-local.example.net.zone,auth-zone.example.net=$(pwd)/recursor-service/auth-zone.example.net.zone,another-auth-zone.example.net=$(pwd)/recursor-service/another-auth-zone.example.net.zone
 loglevel=9
 
@@ -536,14 +537,14 @@ EOF
 
 cat > recursor-service2/recursor.conf <<EOF
 local-port=5300
-socket-dir=$(pwd)/recursor-service2S
+socket-dir=/tmp/recursor-service2
 lowercase-outgoing=yes
 
 EOF
 
 cat > recursor-service3/recursor.conf << EOF
 local-port=5301
-socket-dir=$(pwd)/recursor-service3S
+socket-dir=/tmp/recursor-service3
 lua-config-file=$(pwd)/recursor-service3/config.lua
 lua-dns-script=$(pwd)/recursor-service3/script.lua
 

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -563,6 +563,7 @@ arthur.example.net     CNAME .                   ; NXDOMAIN on apex
 srv.arthur.example.net CNAME rpz-passthru.       ; Allow this name though
 www.example.net        CNAME www2.example.net.   ; Local-Data Action
 www3.example.net       CNAME www4.example.net.   ; Local-Data Action (to be changed in preresolve)
+trillian.example.net   CNAME .                   ; NXDOMAIN on apex, allows all sub-names (#4086)
 
 32.4.2.0.192.rpz-ip    CNAME rpz-drop.           ; www4.example.net resolves to 192.0.2.4, drop A responses with that IP
 EOF

--- a/regression-tests.recursor/lowercase-outgoing/command
+++ b/regression-tests.recursor/lowercase-outgoing/command
@@ -1,5 +1,6 @@
 #!/bin/sh
-truncate -s 0 configs/10.0.3.24/questions.txt
+. vars
+truncate -s 0 "configs/$PREFIX.24/questions.txt"
 cleandig hOsT.lOwErcAsE-outgoing.example.net a >/dev/null 2>&1
 $SDIG $nameserver 5300 hOsT.lOwErcAsE-outgoing.example.net a recurse >/dev/null 2>&1
-cat configs/10.0.3.24/questions.txt
+cat "configs/$PREFIX.24/questions.txt"

--- a/regression-tests.recursor/rec_control-manpage/command
+++ b/regression-tests.recursor/rec_control-manpage/command
@@ -1,5 +1,5 @@
 #!/bin/sh
-elements="$($RECCONTROL --config-dir=/tmp/recursor-service help | grep -v -e '^ ' | awk '{print $1}')"
+elements="$($RECCONTROL --config-dir=./configs/recursor-service help | grep -v -e '^ ' | awk '{print $1}')"
 
 num_elems="$( echo $elements | wc -l)"
 

--- a/regression-tests.recursor/rec_control-manpage/command
+++ b/regression-tests.recursor/rec_control-manpage/command
@@ -1,16 +1,16 @@
 #!/bin/sh
 elements="$($RECCONTROL --config-dir=./configs/recursor-service help | grep -v -e '^ ' | awk '{print $1}')"
 
-num_elems="$( echo $elements | wc -l)"
+num_elems="$( echo "$elements" | wc -l)"
 
 if [ $num_elems -lt 5 ]; then
-  echo "Not enough elements"
+  echo "Not enough elements ($num_elems)"
   exit 1
 fi
 
 missing_elements=""
 for element in $elements; do
-  grep -e -q "^$element" ../docs/manpages/rec_control.1.md || missing_elements="$element\n$missing_elements"
+  grep -q -e "^$element" ../docs/manpages/rec_control.1.md || missing_elements="$element\n$missing_elements"
 done
 
 if [ "x$missing_elements" != "x" ]; then

--- a/regression-tests.recursor/rec_control-manpage/command
+++ b/regression-tests.recursor/rec_control-manpage/command
@@ -1,5 +1,5 @@
 #!/bin/sh
-elements="$($RECCONTROL --config-dir=./configs/recursor-service help | grep -v -e '^ ' | awk '{print $1}')"
+elements="$($RECCONTROL --config-dir=/tmp/recursor-service help | grep -v -e '^ ' | awk '{print $1}')"
 
 num_elems="$( echo $elements | wc -l)"
 

--- a/regression-tests.recursor/runtests
+++ b/regression-tests.recursor/runtests
@@ -17,4 +17,4 @@ export testsdir
 
 nameserver=$PREFIX.9 port=53 ../regression-tests/runtests
 context=recursor ../regression-tests/toxml
-grep . */diff
+! grep . */diff

--- a/regression-tests.recursor/runtests
+++ b/regression-tests.recursor/runtests
@@ -17,4 +17,4 @@ export testsdir
 
 nameserver=$PREFIX.9 port=53 ../regression-tests/runtests
 context=recursor ../regression-tests/toxml
-grep . */diff || true
+grep . */diff

--- a/regression-tests.recursor/vars.sample
+++ b/regression-tests.recursor/vars.sample
@@ -2,4 +2,4 @@ PREFIX=10.0.3
 # PDNSRECURSOR=    # set to override default location
 # PDNS=            # set to override default location   
 AUTHRUN="exec authbind ${PDNS} --config-dir=. > logfile 2>&1"
-RECRUN="exec authbind ${PDNSRECURSOR} --config-dir=. --socket-dir=. --daemon=no --trace=yes --dont-query= --local-address=$PREFIX.9 --hint-file=hintfile --packetcache-ttl=0 --max-cache-ttl=15 --threads=1 > logfile 2>&1"
+RECRUN="exec authbind ${PDNSRECURSOR} --config-dir=. --daemon=no --trace=yes --dont-query= --local-address=$PREFIX.9 --hint-file=hintfile --packetcache-ttl=0 --max-cache-ttl=15 --threads=1 > logfile 2>&1"


### PR DESCRIPTION
This PR includes and supersedes #4236 with:
* a new `prerpz` hook allowing to completely disable the processing filtering policies by setting `wantsRPZ` to false, or to disable only selected policies by using `dq:discardPolicy(policyname)`
* fix the recursor regression tests
* actually fails if the recursor regression tests fail
