### PR TITLE
auth: Add a `query-non-local-bind` option

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -632,6 +632,16 @@ system uses by default for outgoing packets.
 
 Source IP address for sending IPv6 queries.
 
+## `query-non-local-bind`
+* Boolean
+* Default: no
+
+Enable using non-local addresses set with [`query-local-address`'s](#query-local-address)
+or [`query-local-address6`'s](#query-local-address6) for sending
+queries.
+This feature is intended to facilitate ip-failover setups, but it may also
+mask configuration issues and for this reason it is disabled by default.
+
 ## `query-logging`
 * Boolean
 * Default: no

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -73,6 +73,7 @@ void declareArguments()
   ::arg().setSwitch("local-ipv6-nonexist-fail","Fail to start if one or more of the local-ipv6 addresses do not exist on this server")="yes";
   ::arg().set("query-local-address","Source IP address for sending queries")="0.0.0.0";
   ::arg().set("query-local-address6","Source IPv6 address for sending queries")="::";
+  ::arg().setSwitch("query-non-local-bind", "Enable using non-local addresses for sending queries by using FREEBIND / BINDANY socket options")="no";
   ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";
 

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -276,9 +276,9 @@ bool CommunicatorClass::justNotified(const DNSName &domain, const string &ip)
 
 void CommunicatorClass::makeNotifySockets()
 {
-  d_nsock4 = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true);
+  d_nsock4 = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true, ::arg().mustDo("query-non-local-bind"));
   if(!::arg()["query-local-address6"].empty())
-    d_nsock6 = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true);
+    d_nsock6 = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true, ::arg().mustDo("query-non-local-bind"));
   else
     d_nsock6 = -1;
 }

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -49,7 +49,7 @@ public:
 };
 
 // make an IPv4 or IPv6 query socket 
-int makeQuerySocket(const ComboAddress& local, bool udpOrTCP);
+int makeQuerySocket(const ComboAddress& local, bool udpOrTCP, bool nonLocalBind=false);
 //! Resolver class. Can be used synchronously and asynchronously, over IPv4 and over IPv6 (simultaneously)
 class Resolver  : public boost::noncopyable
 {


### PR DESCRIPTION
This allows using a non-local address for `query-local-address`
or `query-local-address6`. This only makes sense if no query
is going to be sent before the address comes up, otherwise it will
fail.
Fixes #4299.