### PR TITLE
auth: Apply `non-local-bind` to `query-local-address{,6}` when possible

### DIFF
--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -276,9 +276,9 @@ bool CommunicatorClass::justNotified(const DNSName &domain, const string &ip)
 
 void CommunicatorClass::makeNotifySockets()
 {
-  d_nsock4 = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true);
+  d_nsock4 = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true, ::arg().mustDo("non-local-bind"));
   if(!::arg()["query-local-address6"].empty())
-    d_nsock6 = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true);
+    d_nsock6 = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true, ::arg().mustDo("non-local-bind"));
   else
     d_nsock6 = -1;
 }

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -51,7 +51,7 @@
 #include "gss_context.hh"
 #include "namespaces.hh"
 
-int makeQuerySocket(const ComboAddress& local, bool udpOrTCP)
+int makeQuerySocket(const ComboAddress& local, bool udpOrTCP, bool nonLocalBind)
 {
   ComboAddress ourLocal(local);
   
@@ -64,6 +64,10 @@ int makeQuerySocket(const ComboAddress& local, bool udpOrTCP)
   }
 
   setCloseOnExec(sock);
+
+  if(nonLocalBind)
+    Utility::setBindAny(local.sin4.sin_family, sock);
+
   if(udpOrTCP) {
     // udp, try hard to bind an unpredictable port
     int tries=10;
@@ -95,9 +99,9 @@ Resolver::Resolver()
   locals["default4"] = -1;
   locals["default6"] = -1;
   try {
-    locals["default4"] = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true);
+    locals["default4"] = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true, ::arg().mustDo("non-local-bind"));
     if(!::arg()["query-local-address6"].empty())
-      locals["default6"] = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true);
+      locals["default6"] = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true, ::arg().mustDo("non-local-bind"));
   }
   catch(...) {
     if(locals["default4"]>=0)

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -49,7 +49,7 @@ public:
 };
 
 // make an IPv4 or IPv6 query socket 
-int makeQuerySocket(const ComboAddress& local, bool udpOrTCP);
+int makeQuerySocket(const ComboAddress& local, bool udpOrTCP, bool nonLocalBind=false);
 //! Resolver class. Can be used synchronously and asynchronously, over IPv4 and over IPv6 (simultaneously)
 class Resolver  : public boost::noncopyable
 {


### PR DESCRIPTION
This allows using a non-local address for `query-local-address`
or `query-local-address6`. This only makes sense if no outgoing query
is going to be sent before the address comes up, otherwise it will
fail.
This PR replaces #4330, taking into account @zeha's suggestion to not introduce a new option and just apply the existing `non-local-bind` to `query-local-address` and `query-local-address6` too.
Fixes #4299.