### PR TITLE
Recursor would shuffle CNAME records until after the name they referred to.

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -561,7 +561,7 @@ void shuffle(vector<DNSRecord>& rrs)
     if(first->d_place==DNSResourceRecord::ANSWER && first->d_type != QType::CNAME) // CNAME must come first
       break;
   for(second=first;second!=rrs.end();++second)
-    if(second->d_place!=DNSResourceRecord::ANSWER)
+    if(second->d_place!=DNSResourceRecord::ANSWER || second->d_type == QType::RRSIG) // leave RRSIGs at the end
       break;
 
   if(second-first>1)
@@ -581,10 +581,12 @@ void shuffle(vector<DNSRecord>& rrs)
   // we don't shuffle the rest
 }
 
-static uint16_t mapCnameToFirst(uint16_t type)
+static uint16_t mapTypesToOrder(uint16_t type)
 {
   if(type == QType::CNAME)
     return 0;
+  if(type == QType::RRSIG)
+    return 65535;
   else
     return 1;
 }
@@ -594,7 +596,7 @@ static uint16_t mapCnameToFirst(uint16_t type)
 void orderAndShuffle(vector<DNSRecord>& rrs)
 {
   std::stable_sort(rrs.begin(), rrs.end(), [](const DNSRecord&a, const DNSRecord& b) { 
-      return std::make_tuple(a.d_place, mapCnameToFirst(a.d_type)) < std::make_tuple(b.d_place, mapCnameToFirst(b.d_type));
+      return std::make_tuple(a.d_place, mapTypesToOrder(a.d_type)) < std::make_tuple(b.d_place, mapTypesToOrder(b.d_type));
     });
   shuffle(rrs);
 }

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -581,12 +581,20 @@ void shuffle(vector<DNSRecord>& rrs)
   // we don't shuffle the rest
 }
 
+static uint16_t mapCnameToFirst(uint16_t type)
+{
+  if(type == QType::CNAME)
+    return 0;
+  else
+    return 1;
+}
+
 // make sure rrs is sorted in d_place order to avoid surprises later
 // then shuffle the parts that desire shuffling
 void orderAndShuffle(vector<DNSRecord>& rrs)
 {
   std::stable_sort(rrs.begin(), rrs.end(), [](const DNSRecord&a, const DNSRecord& b) { 
-      return a.d_place < b.d_place;
+      return std::make_tuple(a.d_place, mapCnameToFirst(a.d_type)) < std::make_tuple(b.d_place, mapCnameToFirst(b.d_type));
     });
   shuffle(rrs);
 }


### PR DESCRIPTION
The PowerDNS Recursor shuffles answers randomly, so no single A record gets overloaded. This logic also took care not to shuffle a CNAME record until after the name it points to, because we theorized this would upset some resolvers.

Our logic however assumed all the CNAMEs would initially be at the front of the packet. We'd start our shuffling after skipping all the CNAMEs up front. It now turns out that sometimes we end up with a 'CNAME A CNAME A' packet to shuffle.
This would happily shuffle the last three records. With this PR, we put the CNAMEs up front explicitly before commencing the shuffle. Closes #4339.

Still to be investigated: why didn't this bite us before?