### PR TITLE
dnsdist: Fix invalid outstanding count for {A,I}XFR over TCP

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -415,8 +415,11 @@ void* tcpClientThread(int pipefd)
         readn2WithTimeout(dsock, answerbuffer, rlen, ds->tcpRecvTimeout);
         char* response = answerbuffer;
         uint16_t responseLen = rlen;
-        --ds->outstanding;
-        outstanding = false;
+        if (outstanding) {
+          /* might be false for {A,I}XFR */
+          --ds->outstanding;
+          outstanding = false;
+        }
 
         if (rlen < sizeof(dnsheader)) {
           break;


### PR DESCRIPTION
Unrelated to #4344, which is reported against 1.0.0 where this code didn't exist yet.