### PR TITLE
rec: Call `gettag()` for TCP queries

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -104,8 +104,11 @@ It also supports the following methods:
 
 * `addAnswer(type, content, [ttl, name])`: add an answer to the record of `type` with `content`. Optionally supply TTL and the name of
   the answer too, which defaults to the name of the question
+* `addPolicyTag(tag)`: add a policy tag.
 * `discardPolicy(policyname)`: skip the filtering policy (for example RPZ) named `policyname` for this query. This is mostly useful in the `prerpz` hook.
+* `getPolicyTags()`: get the current policy tags as a table of strings.
 * `getRecords()`: get a table of DNS Records in this DNS Question (or answer by now)
+* `setPolicyTags(tags)`: update the policy tags, taking a table of strings.
 * `setRecords(records)`: after your edits, update the answers of this question
 * `getEDNSOption(num)`: get the EDNS Option with number `num`
 * `getEDNSOptions()`: get a map of all EDNS Options
@@ -143,10 +146,13 @@ This hook does not get the full DNSQuestion object, since filling out the fields
 would require packet parsing, which is what we are trying to prevent with `ipfilter`.
 
 ### `function gettag(remote, ednssubnet, local, qname, qtype)`
-The `gettag` function is invoked when `dq.tag` is called on a dq object or when
-the Recursor attempts to discover in which packetcache an answer is available.
+The `gettag` function is invoked when the Recursor attempts to discover in which
+packetcache an answer is available.
 This function must return an integer, which is the tag number of the packetcache.
 In addition to this integer, this function can return a table of policy tags.
+
+The resulting tag number can be accessed via `dq.tag` in the `preresolve` hook,
+and the policy tags via `dq:getPolicyTags()` in every hook.
 
 The tagged packetcache can e.g. be used to answer queries from cache that have
 e.g. been filtered for certain IPs (this logic should be implemented in the

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1286,23 +1286,48 @@ void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       socklen_t len = dest.getSocklen();
       getsockname(conn->getFD(), (sockaddr*)&dest, &len); // if this fails, we're ok with it
       dc->setLocal(dest);
+      Netmask ednssubnet;
+      DNSName qname;
+      uint16_t qtype=0;
+      uint16_t qclass=0;
+      bool needECS = false;
 #ifdef HAVE_PROTOBUF
       auto luaconfsLocal = g_luaconfs.getLocal();
+      if (luaconfsLocal->protobufServer) {
+        needECS = true;
+      }
+#endif
 
+      if(needECS || (t_pdl->get() && (*t_pdl)->d_gettag)) {
+
+        try {
+          getQNameAndSubnet(std::string(conn->data, conn->qlen), &qname, &qtype, &qclass, &ednssubnet);
+
+          if(t_pdl->get() && (*t_pdl)->d_gettag) {
+            try {
+              dc->d_tag = (*t_pdl)->gettag(conn->d_remote, ednssubnet, dest, qname, qtype, &dc->d_policyTags);
+            }
+            catch(std::exception& e)  {
+              if(g_logCommonErrors)
+                L<<Logger::Warning<<"Error parsing a query packet qname='"<<qname<<"' for tag determination, setting tag=0: "<<e.what()<<endl;
+            }
+          }
+        }
+        catch(std::exception& e)
+        {
+          if(g_logCommonErrors)
+            L<<Logger::Warning<<"Error parsing a query packet for tag determination, setting tag=0: "<<e.what()<<endl;
+        }
+      }
+#ifdef HAVE_PROTOBUF
       if(luaconfsLocal->protobufServer) {
         dc->d_uuid = (*t_uuidGenerator)();
 
         try {
-          DNSName qname;
-          uint16_t qtype;
-          uint16_t qclass;
-          Netmask ednssubnet;
           const struct dnsheader* dh = (const struct dnsheader*) conn->data;
-
-          getQNameAndSubnet(std::string(conn->data, conn->qlen), &qname, &qtype, &qclass, &ednssubnet);
           dc->d_ednssubnet = ednssubnet;
 
-          protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, dc->d_uuid, dest, conn->d_remote, ednssubnet, true, dh->id, conn->qlen, qname, qtype, qclass, std::vector<std::string>());
+          protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, dc->d_uuid, dest, conn->d_remote, ednssubnet, true, dh->id, conn->qlen, qname, qtype, qclass, dc->d_policyTags);
         }
         catch(std::exception& e) {
           if(g_logCommonErrors)


### PR DESCRIPTION
The `gettag()` hook used to be called to set a tag for the packet cache
and hence it did not make sense to call it for TCP queries, but it
can now also be used to policy tags.