### PR TITLE
rec: Fix delegation-only

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2468,13 +2468,13 @@ void  parseEDNSSubnetWhitelist(const std::string& wlist)
   }
 }
 
-SuffixMatchNode g_delegationOnly;
+std::unordered_set<DNSName> g_delegationOnly;
 static void setupDelegationOnly()
 {
   vector<string> parts;
   stringtok(parts, ::arg()["delegation-only"], ", \t");
   for(const auto& p : parts) {
-    g_delegationOnly.add(DNSName(p));
+    g_delegationOnly.insert(DNSName(p));
   }
 }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1197,14 +1197,14 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
         }
 
         if(rec.d_name.isPartOf(auth)) {
-          if(lwr.d_aabit && lwr.d_rcode==RCode::NoError && rec.d_place==DNSResourceRecord::ANSWER && g_delegationOnly.check(auth)) {
+          if(rec.d_type == QType::RRSIG) {
+            LOG("RRSIG - separate"<<endl);
+          }
+          else if(lwr.d_aabit && lwr.d_rcode==RCode::NoError && rec.d_place==DNSResourceRecord::ANSWER && (rec.d_type != QType::DNSKEY || rec.d_name != auth) && g_delegationOnly.count(auth)) {
             LOG("NO! Is from delegation-only zone"<<endl);
             s_nodelegated++;
             return RCode::NXDomain;
           }
-	  else if(rec.d_type == QType::RRSIG) {
-	    LOG("RRSIG - separate"<<endl);
-	  }
           else {
             bool haveLogged = false;
             if (!t_sstorage->domainmap->empty()) {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -7,6 +7,7 @@
 #include "qtype.hh"
 #include <vector>
 #include <set>
+#include <unordered_set>
 #include <map>
 #include <cmath>
 #include <iostream>
@@ -662,7 +663,7 @@ string doTraceRegex(vector<string>::const_iterator begin, vector<string>::const_
 void parseACLs();
 extern RecursorStats g_stats;
 extern unsigned int g_numThreads;
-extern SuffixMatchNode g_delegationOnly;
+extern std::unordered_set<DNSName> g_delegationOnly;
 extern uint16_t g_outgoingEDNSBufsize;
 
 


### PR DESCRIPTION
* use a `unordered_set` instead of a `SuffixMatchNode`
* allow RRSIG and DNSKEY from delegation-only servers

Fixes #4263.