### PR TITLE
auth: Don't look up the packet cache for TSIG-enabled queries

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -246,7 +246,7 @@ void DNSPacket::setCompress(bool compress)
 
 bool DNSPacket::couldBeCached()
 {
-  return d_ednsping.empty() && !d_wantsnsid && qclass==QClass::IN;
+  return d_ednsping.empty() && !d_wantsnsid && qclass==QClass::IN && !d_havetsig;
 }
 
 unsigned int DNSPacket::getMinTTL()


### PR DESCRIPTION
We are rightfully careful about not caching responses for TSIG-enabled
queries, but we would nevertheless happily serve cached entries for those.

This should fix #4355 on master.