### PR TITLE
Make sure mariadb (mysql on centos/rhel) is started before pdns

### DIFF
--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -3,7 +3,7 @@ Description=PowerDNS Authoritative Server
 Documentation=man:pdns_server(1) man:pdns_control(1)
 Documentation=https://doc.powerdns.com
 Wants=network-online.target
-After=network-online.target mysqld.service postgresql.service slapd.service
+After=network-online.target mysqld.service postgresql.service slapd.service mariadb.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
On recent centos/rhel mariadb is used instead of mysql. 
Make sure it's started before starting pdns.