### PR TITLE
Revamp label compression code which (+ some cleanups) speeds up large packet creation by ~40%

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -28,6 +28,8 @@
 
 #include <boost/functional/hash.hpp>
 
+const DNSName g_rootdnsname("."), g_wildcarddnsname("*");
+
 /* raw storage
    in DNS label format, with trailing 0. W/o trailing 0, we are 'empty'
    www.powerdns.com = 3www8powerdns3com0
@@ -355,19 +357,6 @@ void DNSName::trimToLabels(unsigned int to)
     ;
 }
 
-bool DNSName::operator==(const DNSName& rhs) const
-{
-  if(rhs.empty() != empty() || rhs.d_storage.size() != d_storage.size())
-    return false;
-
-  auto us = d_storage.crbegin();
-  auto p = rhs.d_storage.crbegin();
-  for(; us != d_storage.crend() && p != rhs.d_storage.crend(); ++us, ++p) {   // why does this go backward? 
-    if(dns2_tolower(*p) != dns2_tolower(*us))
-      return false;
-  }
-  return true;
-}
 
 size_t hash_value(DNSName const& d)
 {

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -177,8 +177,7 @@ public:
   virtual string serialize(const DNSName& qname, bool canonic=false, bool lowerCase=false) // it would rock if this were const, but it is too hard
   {
     vector<uint8_t> packet;
-    DNSName empty;
-    DNSPacketWriter pw(packet, empty, 1);
+    DNSPacketWriter pw(packet, g_rootdnsname, 1);
     if(canonic)
       pw.setCanonic(true);
 

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -186,10 +186,9 @@ public:
 
     pw.startRecord(qname, this->getType());
     this->toPacket(pw);
-    pw.commit();
     
     string record;
-    pw.getRecords(record);
+    pw.getRecordPayload(record); // needs to be called before commit()
     return record;
   }
 

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -557,7 +557,7 @@ DNSRecord makeOpt(int udpsize, int extRCode, int Z)
   static_assert(sizeof(EDNS0Record) == sizeof(dr.d_ttl), "sizeof(EDNS0Record) must match sizeof(DNSRecord.d_ttl)");
   memcpy(&dr.d_ttl, &stuff, sizeof(stuff));
   dr.d_ttl=ntohl(dr.d_ttl);
-  dr.d_name=DNSName(".");
+  dr.d_name=g_rootdnsname;
   dr.d_type = QType::OPT;
   dr.d_class=udpsize;
   dr.d_place=DNSResourceRecord::ADDITIONAL;

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -189,7 +189,7 @@ class PTRRecordContent : public DNSRecordContent
 {
 public:
   includeboilerplate(PTR)
-
+  explicit PTRRecordContent(const DNSName& content) : d_content(content){}
 private:
   DNSName d_content;
 };

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -632,6 +632,7 @@ string makeTSIGMessageFromTSIGPacket(const string& opacket, unsigned int tsigOff
 
   vector<uint8_t> signVect;
   DNSPacketWriter dw(signVect, DNSName(), 0);
+  auto pos=signVect.size();
   if(!timersonly) {
     dw.xfrName(keyname, false);
     dw.xfr16BitInt(QClass::ANY); // class
@@ -648,8 +649,7 @@ string makeTSIGMessageFromTSIGPacket(const string& opacket, unsigned int tsigOff
     dw.xfr16BitInt(trc.d_otherData.length()); // length of 'other' data
     //    dw.xfrBlob(trc->d_otherData);
   }
-  const vector<uint8_t>& signRecord=dw.getRecordBeingWritten();
-  message.append(signRecord.begin(), signRecord.end());
+  message.append(signVect.begin()+pos, signVect.end());
   return message;
 }
 
@@ -672,6 +672,7 @@ void addTSIG(DNSPacketWriter& pw, TSIGRecordContent* trc, const DNSName& tsigkey
   // now add something that looks a lot like a TSIG record, but isn't
   vector<uint8_t> signVect;
   DNSPacketWriter dw(signVect, DNSName(), 0);
+  auto pos=dw.size();
   if(!timersonly) {
     dw.xfrName(tsigkeyname, false);
     dw.xfr16BitInt(QClass::ANY); // class
@@ -688,8 +689,7 @@ void addTSIG(DNSPacketWriter& pw, TSIGRecordContent* trc, const DNSName& tsigkey
     //    dw.xfrBlob(trc->d_otherData);
   }
   
-  const vector<uint8_t>& signRecord=dw.getRecordBeingWritten();
-  toSign.append(signRecord.begin(), signRecord.end());
+  toSign.append(signVect.begin() + pos, signVect.end());
 
   if (algo == TSIG_GSS) {
     if (!gss_add_signature(tsigkeyname, toSign, trc->d_mac)) {

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -338,7 +338,7 @@ DNSCryptoKeyEngine* DNSCryptoKeyEngine::makeFromPEMString(DNSKEYRecordContent& d
 
 bool sharedDNSSECCompare(const shared_ptr<DNSRecordContent>& a, const shared_ptr<DNSRecordContent>& b)
 {
-  return a->serialize(DNSName("."), true, true) < b->serialize(DNSName("."), true, true);
+  return a->serialize(g_rootdnsname, true, true) < b->serialize(g_rootdnsname, true, true);
 }
 
 /**
@@ -359,7 +359,7 @@ string getMessageForRRSET(const DNSName& qname, const RRSIGRecordContent& rrc, v
   sort(signRecords.begin(), signRecords.end(), sharedDNSSECCompare);
 
   string toHash;
-  toHash.append(const_cast<RRSIGRecordContent&>(rrc).serialize(DNSName("."), true, true));
+  toHash.append(const_cast<RRSIGRecordContent&>(rrc).serialize(g_rootdnsname, true, true));
   toHash.resize(toHash.size() - rrc.d_signature.length()); // chop off the end, don't sign the signature!
 
   string nameToHash(qname.toDNSStringLC());
@@ -389,7 +389,7 @@ string getMessageForRRSET(const DNSName& qname, const RRSIGRecordContent& rrc, v
     uint32_t ttl=htonl(rrc.d_originalttl);
     toHash.append((char*)&ttl, 4);
     // for NSEC signatures, we should not lowercase the rdata section
-    string rdata=add->serialize(DNSName("."), true, (add->getType() == QType::NSEC) ? false : true);  // RFC 6840, 5.1
+    string rdata=add->serialize(g_rootdnsname, true, (add->getType() == QType::NSEC) ? false : true);  // RFC 6840, 5.1
     tmp=htons(rdata.length());
     toHash.append((char*)&tmp, 2);
     toHash.append(rdata);

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -25,7 +25,8 @@
 #include "dnswriter.hh"
 #include "misc.hh"
 #include "dnsparser.hh"
-
+#include <boost/container/static_vector.hpp>
+#include <boost/scoped_ptr.hpp>
 #include <limits.h>
 
 DNSPacketWriter::DNSPacketWriter(vector<uint8_t>& content, const DNSName& qname, uint16_t  qtype, uint16_t qclass, uint8_t opcode)
@@ -46,7 +47,7 @@ DNSPacketWriter::DNSPacketWriter(vector<uint8_t>& content, const DNSName& qname,
 
   memcpy(dptr, ptr, sizeof(dnsheader));
   d_stuff=0;
-
+  d_positions.reserve(16);
   xfrName(qname, false);
 
   len=d_content.size();
@@ -69,7 +70,6 @@ DNSPacketWriter::DNSPacketWriter(vector<uint8_t>& content, const DNSName& qname,
   memcpy(&*i, &qclass, 2);
 
   d_stuff=0xffff;
-  d_labelmap.reserve(16);
   d_truncatemarker=d_content.size();
   d_sor = 0;
   d_rollbackmarker = 0;
@@ -205,117 +205,172 @@ void DNSPacketWriter::xfrUnquotedText(const string& text, bool lenField)
   d_record.insert(d_record.end(), text.c_str(), text.c_str() + text.length());
 }
 
-/* FIXME400: check that this beats a map */
-DNSPacketWriter::lmap_t::iterator find(DNSPacketWriter::lmap_t& nmap, const DNSName& name)
+
+static constexpr bool l_verbose=false;
+uint16_t DNSPacketWriter::lookupName(const DNSName& name, uint16_t* matchLen)
 {
-  DNSPacketWriter::lmap_t::iterator ret;
-  for(ret=nmap.begin(); ret != nmap.end(); ++ret)
-    if(ret->first == name)
+  // iterate over the written labels, see if we find a match
+  const auto& raw = name.getStorage();
+
+  /* name might be a.root-servers.net, we need to be able to benefit from finding:
+     b.root-servers.net, or even:
+     b\xc0\x0c 
+  */
+  unsigned int bestpos=0;
+  *matchLen=0;
+  boost::container::static_vector<uint16_t, 34> nvect, pvect;
+
+  for(auto riter= raw.cbegin(); riter < raw.cend(); ) {
+    if(!*riter)
       break;
-  return ret;
+    nvect.push_back(riter - raw.cbegin());
+    riter+=*riter+1;
+  }
+  
+  if(l_verbose) {
+    cout<<"Input vector for lookup "<<name<<": ";
+    for(const auto n : nvect) 
+      cout << n<<" ";
+    cout<<endl;
+    cout<<makeHexDump(string(raw.c_str(), raw.c_str()+raw.size()))<<endl;
+  }
+
+  if(l_verbose)
+    cout<<"Have "<<d_positions.size()<<" to ponder"<<endl;
+  int counter=1;
+  for(auto p : d_positions) {
+    vector<uint8_t>* source=0;
+    if(p < d_content.size())
+      source = &d_content;
+    else {
+      source = &d_record;
+      p-= (d_content.size() + d_stuff);
+
+    }
+    if(l_verbose) {
+      if(source == &d_content) {
+        DNSName pname((const char*)&(*source)[0], (*source).size(), p, true); // only for debugging
+        cout<<"Looking at '"<<pname<<"' in packet at position "<<p<<"/"<<(*source).size()<<", option "<<counter<<"/"<<d_positions.size()<<endl;
+      }
+      else
+      {
+        cout<<"Looking at *record* at position "<<p<<"/"<<(*source).size()<<", option "<<counter<<"/"<<d_positions.size()<<endl;
+      }
+      ++counter;
+    }
+    // memcmp here makes things _slower_
+    pvect.clear();
+    for(auto iter = (*source).cbegin() + p; iter < (*source).cend();) {
+
+      uint8_t c=*iter;
+      if(l_verbose)
+        cout<<"Found label length: "<<(int)c<<endl;
+      if(c & 0xc0) {
+
+        uint16_t npos = 0x100*(c & (~0xc0)) + *++iter;
+        iter = (*source).begin() + npos;
+        if(l_verbose)
+          cout<<"Is compressed label to newpos "<<npos<<", going there"<<endl;
+        // check against going forward here
+        continue;
+      }
+      if(!c)
+        break;
+      pvect.push_back(iter - (*source).cbegin());
+      iter+=*iter+1;
+    }
+    if(l_verbose) {
+      cout<<"Packet vector: "<<endl;
+      for(const auto n : pvect) 
+        cout << n<<" ";
+      cout<<endl;
+    }
+    auto niter=nvect.crbegin(), piter=pvect.crbegin();
+    unsigned int cmatchlen=1;
+    for(; niter != nvect.crend() && piter != pvect.crend(); ++niter, ++piter) {
+      // niter is an offset in raw, pvect an offset in packet
+      uint8_t nlen = raw[*niter], plen=(*source)[*piter];
+      if(l_verbose)
+        cout<<"nlnen="<<(int)nlen<<", plen="<<(int)plen<<endl;
+      if(nlen != plen)
+        break;
+      if(strncasecmp(raw.c_str()+*niter+1, (const char*)&(*source)[*piter]+1, nlen)) {
+        if(l_verbose)
+          cout<<"Mismatch: "<<string(raw.c_str()+*niter+1, raw.c_str()+*niter+nlen+1)<< " != "<<string((const char*)&(*source)[*piter]+1, (const char*)&(*source)[*piter]+nlen+1)<<endl;
+        break;
+      }
+      cmatchlen+=nlen+1;
+      if(cmatchlen == raw.length()) { // have matched all of it, can't improve
+        if(l_verbose)
+          cout<<"Stopping search, matched whole name"<<endl;
+        *matchLen = cmatchlen;
+        return *piter;
+      }
+    }
+    if(piter != pvect.crbegin() && *matchLen < cmatchlen) {
+      *matchLen = cmatchlen;
+      bestpos=*--piter;
+    }
+  }
+  return bestpos;
 }
-
-// //! tokenize a label into parts, the parts describe a begin offset and an end offset
-// bool labeltokUnescape(labelparts_t& parts, const string& label)
-// {
-//   string::size_type epos = label.size(), lpos(0), pos;
-//   bool unescapedSomething = false;
-//   const char* ptr=label.c_str();
-
-//   parts.clear();
-
-//   for(pos = 0 ; pos < epos; ++pos) {
-//     if(ptr[pos]=='\\') {
-//       pos++;
-//       unescapedSomething = true;
-//       continue;
-//     }
-//     if(ptr[pos]=='.') {
-//       parts.push_back(make_pair(lpos, pos));
-//       lpos=pos+1;
-//     }
-//   }
-
-//   if(lpos < pos)
-//     parts.push_back(make_pair(lpos, pos));
-//   return unescapedSomething;
-// }
 
 // this is the absolute hottest function in the pdns recursor
 void DNSPacketWriter::xfrName(const DNSName& name, bool compress, bool)
 {
-  //cerr<<"xfrName: name=["<<name.toString()<<"] compress="<<compress<<endl;
-  // string label = d_lowerCase ? toLower(Label) : Label;
-  // FIXME400: we ignore d_lowerCase for now
-  // cerr<<"xfrName writing ["<<name.toString()<<"]"<<endl;
-  std::vector<std::string> parts = name.getRawLabels();
-  // labelparts_t parts;
-  // cerr<<"labelcount: "<<parts.size()<<endl;
-
-  if(d_canonic)
+  if(l_verbose)
+    cout<<"Wants to write "<<name<<", compress="<<compress<<", canonic="<<d_canonic<<", LC="<<d_lowerCase<<endl;
+  if(d_canonic || d_lowerCase)   // d_lowerCase implies canonic
     compress=false;
 
-  if(!parts.size()) { // otherwise we encode '..'
+  if(name.empty() || name.isRoot()) { // for speed
     d_record.push_back(0);
     return;
   }
 
-  // d_stuff is amount of stuff that is yet to be written out - the dnsrecordheader for example
-  unsigned int pos=d_content.size() + d_record.size() + d_stuff;
-  // bool deDot = labellen && (label[labellen-1]=='.'); // make sure we don't store trailing dots in the labelmap
+  uint16_t li=0;
+  uint16_t matchlen=0;
+  if(compress && (li=lookupName(name, &matchlen))) {
+    const auto& dns=name.getStorage(); 
+    if(l_verbose)
+      cout<<"Found a substring of "<<matchlen<<" bytes from the back, offset: "<<li<<", dnslen: "<<dns.size()<<endl;
+    // found a substring, if www.powerdns.com matched powerdns.com, we get back matchlen = 13
 
-  unsigned int startRecordSize=d_record.size();
-  unsigned int startPos;
-
-  DNSName towrite = name;
-  /* FIXME400: if we are not compressing, there is no reason to work per-label */
-  for(auto &label: parts) {
-    if(d_lowerCase) label=toLower(label);
-    //cerr<<"xfrName labelpart ["<<label<<"], left to write ["<<towrite.toString()<<"]"<<endl;
-
-    auto li=d_labelmap.end();
-    // see if we've written out this domain before
-    //cerr<<"compress="<<compress<<", searching? for compression pointer to '"<<towrite.toString()<<"', "<<d_labelmap.size()<<" cmp-records"<<endl;
-    if(compress && (li=find(d_labelmap, towrite))!=d_labelmap.end()) {
-      //cerr<<"doing compression, my label=["<<label<<"] found match ["<<li->first.toString()<<"]"<<endl;
-      //cerr<<"\tFound a compression pointer to '"<<towrite.toString()<<"': "<<li->second<<endl;
-      if (d_record.size() - startRecordSize + label.size() > 253) // chopped does not include a length octet for the first label and the root label
-        throw MOADNSException("DNSPacketWriter::xfrName() found overly large (compressed) name");
-      uint16_t offset=li->second;
-      offset|=0xc000;
-      d_record.push_back((char)(offset >> 8));
-      d_record.push_back((char)(offset & 0xff));
-      goto out;                                 // skip trailing 0 in case of compression
+    unsigned int pos=d_content.size() + d_record.size() + d_stuff;  
+    if(pos < 16384 && matchlen != dns.size()) {
+      if(l_verbose)
+        cout<<"Inserting pos "<<pos<<" for "<<name<<" for compressed case"<<endl;
+      d_positions.push_back(pos);
     }
 
-    if(li==d_labelmap.end() && pos< 16384) {
-      //      cerr<<"\tStoring a compression pointer to '"<<chopped<<"': "<<pos<<endl;
-      d_labelmap.push_back(make_pair(towrite, pos));                       //  if untrue, we need to count - also, don't store offsets > 16384, won't work
-      //cerr<<"stored ["<<towrite.toString()<<"] at pos "<<pos<<endl;
-    }
+    if(l_verbose)
+      cout<<"Going to write unique part: '"<<makeHexDump(string(dns.c_str(), dns.c_str() + dns.size() - matchlen)) <<"'"<<endl;
+    d_record.insert(d_record.end(), (const unsigned char*)dns.c_str(), (const unsigned char*)dns.c_str() + dns.size() - matchlen);
+    uint16_t offset=li;
+    offset|=0xc000;
 
-    startPos=pos;
-
-    char labelsize=label.size();
-    //cerr<<"labelsize = "<<int(labelsize)<<" for label ["<<label<<"]"<<endl;
-    d_record.push_back(labelsize);
-    unsigned int len=d_record.size();
-    d_record.resize(len + labelsize);
-    memcpy(((&*d_record.begin()) + len), label.c_str(), labelsize); // FIXME400 do not want memcpy
-    pos+=labelsize+1;
-
-    if(pos - startPos == 1)
-      throw MOADNSException("DNSPacketWriter::xfrName() found empty label in the middle of name");
-    if(pos - startPos > 64)
-      throw MOADNSException("DNSPacketWriter::xfrName() found overly large label in name");
-    towrite.chopOff();   /* FIXME400: iterating the label vector while keeping this chopoff in sync is a hack */
+    d_record.push_back((char)(offset >> 8));
+    d_record.push_back((char)(offset & 0xff));
   }
-  d_record.push_back(0); // insert root label
+  else {
+    unsigned int pos=d_content.size() + d_record.size() + d_stuff;
+    if(l_verbose)
+      cout<<"Found nothing, we are at pos "<<pos<<", inserting whole name"<<endl;
+    if(pos < 16384) {
+      if(l_verbose)
+        cout<<"Inserting pos "<<pos<<" for "<<name<<" for uncompressed case"<<endl;
+      d_positions.push_back(pos);
+    }
 
-  if (d_record.size() - startRecordSize > 255)
-    throw MOADNSException("DNSPacketWriter::xfrName() found overly large name");
+    std::unique_ptr<DNSName> lc;
+    if(d_lowerCase)
+      lc = make_unique<DNSName>(name.makeLowerCase());
 
- out:;
+    const DNSName::string_t& raw = (lc ? *lc : name).getStorage();
+    if(l_verbose)
+      cout<<"Writing out the whole thing "<<makeHexDump(string(raw.c_str(),  raw.c_str() + raw.length()))<<endl;
+    d_record.insert(d_record.end(), raw.c_str(), raw.c_str() + raw.size());
+  }
 }
 
 void DNSPacketWriter::xfrBlob(const string& blob, int  )

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -127,7 +127,7 @@ void DNSPacketWriter::addOpt(uint16_t udpsize, int extRCode, int Z, const vector
 
   ttl=ntohl(ttl); // will be reversed later on
 
-  startRecord(DNSName("."), QType::OPT, ttl, udpsize, DNSResourceRecord::ADDITIONAL, false);
+  startRecord(g_rootdnsname, QType::OPT, ttl, udpsize, DNSResourceRecord::ADDITIONAL, false);
   for(optvect_t::const_iterator iter = options.begin(); iter != options.end(); ++iter) {
     xfr16BitInt(iter->first);
     xfr16BitInt(iter->second.length());

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -22,11 +22,11 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <boost/container/static_vector.hpp>
 #include "dnswriter.hh"
 #include "misc.hh"
 #include "dnsparser.hh"
-#include <boost/container/static_vector.hpp>
-#include <boost/scoped_ptr.hpp>
+
 #include <limits.h>
 
 DNSPacketWriter::DNSPacketWriter(vector<uint8_t>& content, const DNSName& qname, uint16_t  qtype, uint16_t qclass, uint8_t opcode)

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -30,7 +30,7 @@
 #include <limits.h>
 
 DNSPacketWriter::DNSPacketWriter(vector<uint8_t>& content, const DNSName& qname, uint16_t  qtype, uint16_t qclass, uint8_t opcode)
-  : d_pos(0), d_content(content), d_qname(qname), d_canonic(false), d_lowerCase(false)
+  : d_content(content), d_qname(qname), d_canonic(false), d_lowerCase(false)
 {
   d_content.clear();
   dnsheader dnsheader;
@@ -47,7 +47,7 @@ DNSPacketWriter::DNSPacketWriter(vector<uint8_t>& content, const DNSName& qname,
 
   memcpy(dptr, ptr, sizeof(dnsheader));
   d_stuff=0;
-  d_positions.reserve(16);
+  d_namepositions.reserve(16);
   xfrName(qname, false);
 
   len=d_content.size();
@@ -236,9 +236,9 @@ uint16_t DNSPacketWriter::lookupName(const DNSName& name, uint16_t* matchLen)
   }
 
   if(l_verbose)
-    cout<<"Have "<<d_positions.size()<<" to ponder"<<endl;
+    cout<<"Have "<<d_namepositions.size()<<" to ponder"<<endl;
   int counter=1;
-  for(auto p : d_positions) {
+  for(auto p : d_namepositions) {
     vector<uint8_t>* source=0;
     if(p < d_content.size())
       source = &d_content;
@@ -250,11 +250,11 @@ uint16_t DNSPacketWriter::lookupName(const DNSName& name, uint16_t* matchLen)
     if(l_verbose) {
       if(source == &d_content) {
         DNSName pname((const char*)&(*source)[0], (*source).size(), p, true); // only for debugging
-        cout<<"Looking at '"<<pname<<"' in packet at position "<<p<<"/"<<(*source).size()<<", option "<<counter<<"/"<<d_positions.size()<<endl;
+        cout<<"Looking at '"<<pname<<"' in packet at position "<<p<<"/"<<(*source).size()<<", option "<<counter<<"/"<<d_namepositions.size()<<endl;
       }
       else
       {
-        cout<<"Looking at *record* at position "<<p<<"/"<<(*source).size()<<", option "<<counter<<"/"<<d_positions.size()<<endl;
+        cout<<"Looking at *record* at position "<<p<<"/"<<(*source).size()<<", option "<<counter<<"/"<<d_namepositions.size()<<endl;
       }
       ++counter;
     }
@@ -340,7 +340,7 @@ void DNSPacketWriter::xfrName(const DNSName& name, bool compress, bool)
     if(pos < 16384 && matchlen != dns.size()) {
       if(l_verbose)
         cout<<"Inserting pos "<<pos<<" for "<<name<<" for compressed case"<<endl;
-      d_positions.push_back(pos);
+      d_namepositions.push_back(pos);
     }
 
     if(l_verbose)
@@ -359,7 +359,7 @@ void DNSPacketWriter::xfrName(const DNSName& name, bool compress, bool)
     if(pos < 16384) {
       if(l_verbose)
         cout<<"Inserting pos "<<pos<<" for "<<name<<" for uncompressed case"<<endl;
-      d_positions.push_back(pos);
+      d_namepositions.push_back(pos);
     }
 
     std::unique_ptr<DNSName> lc;

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -114,8 +114,6 @@ public:
   void xfrBlobNoSpaces(const string& blob, int len=-1);
   void xfrHexBlob(const string& blob, bool keepReading=false);
 
-  uint16_t d_pos;
-
   dnsheader* getHeader();
   void getRecords(string& records);
   const vector<uint8_t>& getRecordBeingWritten() { return d_record; }
@@ -137,7 +135,7 @@ public:
 
 private:
   uint16_t lookupName(const DNSName& name, uint16_t* matchlen);
-  vector<uint16_t> d_positions;
+  vector<uint16_t> d_namepositions;
   // We declare 1 uint_16 in the public section, these 3 align on a 8-byte boundry
   uint16_t d_stuff;
   uint16_t d_sor;

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -116,7 +116,6 @@ public:
 
   dnsheader* getHeader();
   void getRecordPayload(string& records); // call __before commit__
-  const vector<uint8_t> getRecordBeingWritten() { return vector<uint8_t>(d_content.begin()+d_sor, d_content.end()); }
 
   void setCanonic(bool val)
   {

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -115,8 +115,8 @@ public:
   void xfrHexBlob(const string& blob, bool keepReading=false);
 
   dnsheader* getHeader();
-  void getRecords(string& records);
-  const vector<uint8_t>& getRecordBeingWritten() { return d_record; }
+  void getRecordPayload(string& records); // call __before commit__
+  const vector<uint8_t> getRecordBeingWritten() { return vector<uint8_t>(d_content.begin()+d_sor, d_content.end()); }
 
   void setCanonic(bool val)
   {
@@ -137,17 +137,11 @@ private:
   uint16_t lookupName(const DNSName& name, uint16_t* matchlen);
   vector<uint16_t> d_namepositions;
   // We declare 1 uint_16 in the public section, these 3 align on a 8-byte boundry
-  uint16_t d_stuff;
   uint16_t d_sor;
   uint16_t d_rollbackmarker; // start of last complete packet, for rollback
 
   vector <uint8_t>& d_content;
-  vector <uint8_t> d_record;
   DNSName d_qname;
-  DNSName d_recordqname;
-
-  uint32_t d_recordttl;
-  uint16_t d_recordqtype, d_recordqclass;
 
   uint16_t d_truncatemarker; // end of header, for truncate
   DNSResourceRecord::Place d_recordplace;

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -29,6 +29,8 @@
 #include "dnsname.hh"
 #include "namespaces.hh"
 #include <arpa/inet.h>
+
+
 /** this class can be used to write DNS packets. It knows about DNS in the sense that it makes
     the packet header and record headers.
 
@@ -59,8 +61,6 @@ class DNSPacketWriter : public boost::noncopyable
 {
 
 public:
-  typedef vector<pair<DNSName, uint16_t> > lmap_t;
-
   //! Start a DNS Packet in the vector passed, with question qname, qtype and qclass
   DNSPacketWriter(vector<uint8_t>& content, const DNSName& qname, uint16_t  qtype, uint16_t qclass=QClass::IN, uint8_t opcode=0);
 
@@ -136,6 +136,8 @@ public:
   bool eof() { return true; } // we don't know how long the record should be
 
 private:
+  uint16_t lookupName(const DNSName& name, uint16_t* matchlen);
+  vector<uint16_t> d_positions;
   // We declare 1 uint_16 in the public section, these 3 align on a 8-byte boundry
   uint16_t d_stuff;
   uint16_t d_sor;
@@ -145,7 +147,6 @@ private:
   vector <uint8_t> d_record;
   DNSName d_qname;
   DNSName d_recordqname;
-  lmap_t d_labelmap;
 
   uint32_t d_recordttl;
   uint16_t d_recordqtype, d_recordqclass;

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -48,7 +48,7 @@ bool findNamedPolicy(const map<DNSName, DNSFilterEngine::Policy>& polmap, const 
   }
 
   while(s.chopOff()){
-    iter = polmap.find(DNSName("*")+s);
+    iter = polmap.find(g_wildcarddnsname+s);
     if(iter != polmap.end()) {
       pol=iter->second;
       return true;

--- a/pdns/nsec3dig.cc
+++ b/pdns/nsec3dig.cc
@@ -222,7 +222,7 @@ try
   for(const auto &n: namestocheck)
   {
     proveOrDeny(nsec3s, n, nsec3salt, nsec3iters, proven, denied);
-    proveOrDeny(nsec3s, DNSName("*")+n, nsec3salt, nsec3iters, proven, denied);
+    proveOrDeny(nsec3s, g_wildcarddnsname+n, nsec3salt, nsec3iters, proven, denied);
   }
 
   if(names.count(qname))
@@ -262,7 +262,7 @@ try
     {
       cout<<"next closer ("<<nextcloser.toString()<<") NOT denied"<<endl;
     }
-    DNSName wcplusencloser=DNSName("*")+encloser;
+    DNSName wcplusencloser=g_wildcarddnsname+encloser;
     if(denied.count(wcplusencloser))
     {
       cout<<"wildcard at encloser ("<<wcplusencloser.toString()<<") is denied correctly"<<endl;

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -345,14 +345,14 @@ bool PacketHandler::getBestWildcard(DNSPacket *p, SOAData& sd, const DNSName &ta
   wildcard=subdomain;
   while( subdomain.chopOff() && !haveSomething )  {
     if (subdomain.empty()) {
-      B.lookup(QType(QType::ANY), DNSName("*"), p, sd.domain_id); 
+      B.lookup(QType(QType::ANY), g_wildcarddnsname, p, sd.domain_id); 
     } else {
-      B.lookup(QType(QType::ANY), DNSName("*")+subdomain, p, sd.domain_id);
+      B.lookup(QType(QType::ANY), g_wildcarddnsname+subdomain, p, sd.domain_id);
     }
     while(B.get(rr)) {
       if(rr.qtype == p->qtype || rr.qtype.getCode() == QType::CNAME || (p->qtype.getCode() == QType::ANY && rr.qtype.getCode() != QType::RRSIG))
         ret->push_back(rr);
-      wildcard=DNSName("*")+subdomain;
+      wildcard=g_wildcarddnsname+subdomain;
       haveSomething=true;
     }
 
@@ -676,7 +676,7 @@ void PacketHandler::addNSEC3(DNSPacket *p, DNSPacket *r, const DNSName& target, 
 
   // wildcard denial
   if (mode == 2 || mode == 4) {
-    unhashed=DNSName("*")+closest;
+    unhashed=g_wildcarddnsname+closest;
 
     hashed=hashQNameWithSalt(ns3rc, unhashed);
     DLOG(L<<"3 hash: "<<toBase32Hex(hashed)<<" "<<unhashed<<endl);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1892,7 +1892,7 @@ static void houseKeeping(void *)
       sr.setNoCache();
       int res=-1;
       try {
-	res=sr.beginResolve(DNSName("."), QType(QType::NS), 1, ret);
+	res=sr.beginResolve(g_rootdnsname, QType(QType::NS), 1, ret);
       }
       catch(PDNSException& e)
 	{

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -996,7 +996,7 @@ int editZone(DNSSECKeeper& dk, const DNSName &zone) {
     unixDie("Editing file with: '"+cmdline+"', perhaps set EDITOR variable");
   }
   cmdline.clear();
-  ZoneParserTNG zpt(tmpnam, DNSName("."));
+  ZoneParserTNG zpt(tmpnam, g_rootdnsname);
   map<pair<DNSName,uint16_t>, vector<DNSRecord> > grouped;
   while(zpt.get(rr)) {
     try {

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -36,7 +36,7 @@ LuaConfigItems::LuaConfigItems()
 {
   for (const auto &dsRecord : rootDSs) {
     auto ds=unique_ptr<DSRecordContent>(dynamic_cast<DSRecordContent*>(DSRecordContent::make(dsRecord)));
-    dsAnchors[DNSName(".")].insert(*ds);
+    dsAnchors[g_rootdnsname].insert(*ds);
   }
 }
 

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -46,7 +46,7 @@ void primeHints(void)
 
   if(::arg()["hint-file"].empty()) {
     DNSRecord arr, aaaarr, nsrr;
-    nsrr.d_name=DNSName(".");
+    nsrr.d_name=g_rootdnsname;
     arr.d_type=QType::A;
     aaaarr.d_type=QType::AAAA;
     nsrr.d_type=QType::NS;
@@ -94,7 +94,7 @@ void primeHints(void)
       }
     }
   }
-  t_RC->replace(time(0), DNSName("."), QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), true); // and stuff in the cache (auth)
+  t_RC->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), true); // and stuff in the cache (auth)
 }
 
 static void makeNameToIPZone(SyncRes::domainmap_t* newMap, const DNSName& hostname, const string& ip)

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -82,7 +82,7 @@ void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrR
     else if(target.isRoot()) {
       // cerr<<"Wants NXDOMAIN for "<<dr.d_name<<": ";
       pol.d_kind = DNSFilterEngine::PolicyKind::NXDOMAIN;
-    } else if(target==DNSName("*")) {
+    } else if(target==g_wildcarddnsname) {
       // cerr<<"Wants NODATA for "<<dr.d_name<<": ";
       pol.d_kind = DNSFilterEngine::PolicyKind::NODATA;
     }

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -102,7 +102,7 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
     st.serial=di.serial;
 
     DNSRecord dr;
-    dr.d_content = std::make_shared<SOARecordContent>(DNSName("."), DNSName("."), st);
+    dr.d_content = std::make_shared<SOARecordContent>(g_rootdnsname, g_rootdnsname, st);
     auto deltas = getIXFRDeltas(remote, domain, dr, tt, laddr.sin4.sin_family ? &laddr : 0, ((size_t) ::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024);
     zs.numDeltas=deltas.size();
     //    cout<<"Got "<<deltas.size()<<" deltas from serial "<<di.serial<<", applying.."<<endl;

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -4,16 +4,16 @@
 #include "misc.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
+#include <fstream>
 #include <boost/format.hpp>
 #ifndef RECURSOR
 #include "statbag.hh"
 #include "base64.hh"
 StatBag S;
 #endif
-
+#include <boost/container/string.hpp>
 volatile bool g_ret; // make sure the optimizer does not get too smart
 uint64_t g_totalRuns;
-
 volatile bool g_stop;
 
 void alarmHandler(int)
@@ -182,6 +182,25 @@ struct StringAppendTest
 };
 
 
+struct BoostStringAppendTest
+{
+  string getName() const
+  {
+    return "booststringappend";
+  }
+  
+  void operator()() const 
+  {
+    boost::container::string str;
+    static char i;
+    for(int n=0; n < 1000; ++n)
+      str.append(1, i);
+    i++; 
+  }
+};
+
+
+
 struct MakeARecordTest
 {
   string getName() const
@@ -197,6 +216,96 @@ struct MakeARecordTest
 
   }
 };
+
+vector<uint8_t> makeBigReferral()
+{
+
+  vector<uint8_t> packet;
+  DNSPacketWriter pw(packet, DNSName("www.google.com"), QType::A);
+
+  string gtld="x.gtld-servers.net";
+  for(char c='a'; c<= 'm';++c) {
+    pw.startRecord(DNSName("com"), QType::NS, 3600, 1, DNSResourceRecord::AUTHORITY);
+    gtld[0]=c;
+    DNSRecordContent* drc = DNSRecordContent::mastermake(QType::NS, 1, gtld);
+    drc->toPacket(pw);
+    delete drc;
+  }
+
+  for(char c='a'; c<= 'k';++c) {
+    gtld[0]=c;
+    pw.startRecord(DNSName(gtld), QType::A, 3600, 1, DNSResourceRecord::ADDITIONAL);
+    DNSRecordContent* drc = DNSRecordContent::mastermake(QType::A, 1, "1.2.3.4");
+    drc->toPacket(pw);
+    delete drc;
+  }
+
+
+  pw.startRecord(DNSName("a.gtld-servers.net"), QType::AAAA, 3600, 1, DNSResourceRecord::ADDITIONAL);
+  auto aaaarc = DNSRecordContent::mastermake(QType::AAAA, 1, "2001:503:a83e::2:30");
+  aaaarc->toPacket(pw);
+  delete aaaarc;
+
+  pw.startRecord(DNSName("b.gtld-servers.net"), QType::AAAA, 3600, 1, DNSResourceRecord::ADDITIONAL);
+  aaaarc = DNSRecordContent::mastermake(QType::AAAA, 1, "2001:503:231d::2:30");
+  aaaarc->toPacket(pw);
+  delete aaaarc;
+
+
+  pw.commit();
+  return  packet;
+}
+
+vector<uint8_t> makeBigDNSPacketReferral()
+{
+  vector<DNSResourceRecord> records;
+  DNSResourceRecord rr;
+  rr.qtype = QType::NS;
+  rr.ttl=3600;
+  rr.qname=DNSName("com");
+  rr.d_place = DNSResourceRecord::ADDITIONAL;
+
+  string gtld="x.gtld-servers.net";
+  for(char c='a'; c<= 'm';++c) {
+    gtld[0]=c;
+    rr.content = gtld;
+    records.push_back(rr);
+  }
+
+  rr.qtype = QType::A;
+  for(char c='a'; c<= 'k';++c) {
+    gtld[0]=c;
+    rr.qname=DNSName(gtld);
+    rr.content="1.2.3.4";
+    records.push_back(rr);
+  }
+
+  rr.qname=DNSName("a.gtld-servers.net");
+  rr.qtype=QType::AAAA;
+  rr.content="2001:503:a83e::2:30";
+  records.push_back(rr);
+
+  rr.qname=DNSName("b.gtld-servers.net");
+  rr.qtype=QType::AAAA;
+  rr.content="2001:503:231d::2:30";
+  records.push_back(rr);
+
+
+  vector<uint8_t> packet;
+  DNSPacketWriter pw(packet, DNSName("www.google.com"), QType::A);
+  shuffle(records);
+  for(const auto& rec : records) {
+    pw.startRecord(rec.qname, rec.qtype.getCode(), rec.ttl, 1, rec.d_place);
+    auto drc = DNSRecordContent::mastermake(rec.qtype.getCode(), 1, rec.content);
+    drc->toPacket(pw);
+    delete drc;
+  }
+
+  pw.commit();
+  return  packet;
+}
+
+
 
 struct MakeARecordTestMM
 {
@@ -423,6 +532,35 @@ struct TypicalRefTest
   }
 
 };
+
+struct BigRefTest
+{
+  string getName() const
+  {
+    return "write big referral";
+  }
+
+  void operator()() const
+  {
+    vector<uint8_t> packet=makeBigReferral();
+  }
+
+};
+
+struct BigDNSPacketRefTest
+{
+  string getName() const
+  {
+    return "write big dnspacket referral";
+  }
+
+  void operator()() const
+  {
+    vector<uint8_t> packet=makeBigDNSPacketReferral();
+  }
+
+};
+
 
 struct TCacheComp
 {
@@ -686,7 +824,8 @@ try
 
   doRun(EmptyQueryTest());
   doRun(TypicalRefTest());
-
+  doRun(BigRefTest());
+  doRun(BigDNSPacketRefTest());
 
   auto packet = makeEmptyQuery();
   doRun(ParsePacketTest(packet, "empty-query"));
@@ -746,6 +885,7 @@ try
   doRun(StringtokTest());
   doRun(VStringtokTest());  
   doRun(StringAppendTest());  
+  doRun(BoostStringAppendTest());  
 
   doRun(DNSNameParseTest());
   doRun(DNSNameRootTest());

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -1,17 +1,19 @@
 #include "config.h"
+#include <boost/format.hpp>
+#include <boost/container/string.hpp>
 #include "dnsparser.hh"
 #include "sstuff.hh"
 #include "misc.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
 #include <fstream>
-#include <boost/format.hpp>
+
 #ifndef RECURSOR
 #include "statbag.hh"
 #include "base64.hh"
 StatBag S;
 #endif
-#include <boost/container/string.hpp>
+
 volatile bool g_ret; // make sure the optimizer does not get too smart
 uint64_t g_totalRuns;
 volatile bool g_stop;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -239,7 +239,7 @@ bool SyncRes::doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSR
   DNSName wcarddomain(qname);
   while(wcarddomain != iter->first && wcarddomain.chopOff()) {
     LOG(prefix<<qname<<": trying '*."<<wcarddomain<<"' in "<<authdomain<<endl);
-    range=iter->second.d_records.equal_range(boost::make_tuple(DNSName("*")+wcarddomain));
+    range=iter->second.d_records.equal_range(boost::make_tuple(g_wildcarddnsname+wcarddomain));
     if(range.first==range.second)
       continue;
 
@@ -1133,7 +1133,7 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
 		t_sstorage->nsSpeeds[*tns].submit(*remoteIP, 1000000, &d_now); // 1 sec
 
 		// code below makes sure we don't filter COM or the root
-                if (s_serverdownmaxfails > 0 && (auth != DNSName(".")) && t_sstorage->fails.incr(*remoteIP) >= s_serverdownmaxfails) {
+                if (s_serverdownmaxfails > 0 && (auth != g_rootdnsname) && t_sstorage->fails.incr(*remoteIP) >= s_serverdownmaxfails) {
                   LOG(prefix<<qname<<": Max fails reached resolving on "<< remoteIP->toString() <<". Going full throttle for "<< s_serverdownthrottletime <<" seconds" <<endl);
                   t_sstorage->throttle.throttle(d_now.tv_sec, boost::make_tuple(*remoteIP, "", 0), s_serverdownthrottletime, 10000); // mark server as down
                 } else if(resolveret==-1)

--- a/pdns/test-base32_cc.cc
+++ b/pdns/test-base32_cc.cc
@@ -11,7 +11,7 @@
 
 BOOST_AUTO_TEST_SUITE(test_base32_cc)
 
-BOOST_AUTO_TEST_CASE(test_record_types) {
+BOOST_AUTO_TEST_CASE(test_base32_basic) {
   typedef boost::tuple<const std::string, const std::string> case_t;
   typedef std::list<case_t> cases_t;
 

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -249,6 +249,39 @@ BOOST_AUTO_TEST_CASE(test_Append) {
   BOOST_CHECK(dn == DNSName("www.powerdns.com."));
 }
 
+BOOST_AUTO_TEST_CASE(test_packetCompress) {
+  reportBasicTypes();
+  vector<unsigned char> packet;
+  DNSPacketWriter dpw(packet, DNSName("www.ds9a.nl."), QType::AAAA);
+  dpw.startRecord(DNSName("ds9a.nl"), QType::SOA);
+  SOARecordContent src("ns1.ds9a.nl admin.ds9a.nl 1 2 3 4 5");
+  src.toPacket(dpw);
+  AAAARecordContent aaaa("::1");
+  dpw.startRecord(DNSName("www.dS9A.nl"), QType::AAAA);
+  aaaa.toPacket(dpw);
+  dpw.startRecord(DNSName("www.ds9A.nl"), QType::AAAA);
+  aaaa.toPacket(dpw);
+  dpw.startRecord(DNSName("www.dS9a.nl"), QType::AAAA);
+  aaaa.toPacket(dpw);
+  dpw.startRecord(DNSName("www2.DS9a.nl"), QType::AAAA);
+  aaaa.toPacket(dpw);
+  dpw.startRecord(DNSName("www2.dS9a.nl"), QType::AAAA);
+  aaaa.toPacket(dpw);
+  dpw.commit();
+  string str((const char*)&packet[0], (const char*)&packet[0] + packet.size());
+
+  size_t pos = 0; 
+  int count=0;
+  while((pos = str.find("ds9a", pos)) != string::npos) {
+    ++pos;
+    ++count;
+  }
+  BOOST_CHECK_EQUAL(count, 1);
+}
+
+
+
+
 BOOST_AUTO_TEST_CASE(test_PacketParse) {
   vector<unsigned char> packet;
   reportBasicTypes();

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(test_packetCompress) {
   vector<unsigned char> packet;
   DNSPacketWriter dpw(packet, DNSName("www.ds9a.nl."), QType::AAAA);
   dpw.startRecord(DNSName("ds9a.nl"), QType::SOA);
-  SOARecordContent src("ns1.ds9a.nl admin.ds9a.nl 1 2 3 4 5");
+  SOARecordContent src("ns1.powerdns.nl admin.powerdns.nl 1 2 3 4 5");
   src.toPacket(dpw);
   AAAARecordContent aaaa("::1");
   dpw.startRecord(DNSName("www.dS9A.nl"), QType::AAAA);
@@ -269,7 +269,6 @@ BOOST_AUTO_TEST_CASE(test_packetCompress) {
   aaaa.toPacket(dpw);
   dpw.commit();
   string str((const char*)&packet[0], (const char*)&packet[0] + packet.size());
-
   size_t pos = 0; 
   int count=0;
   while((pos = str.find("ds9a", pos)) != string::npos) {
@@ -277,6 +276,14 @@ BOOST_AUTO_TEST_CASE(test_packetCompress) {
     ++count;
   }
   BOOST_CHECK_EQUAL(count, 1);
+  pos = 0; 
+  count=0;
+  while((pos = str.find("powerdns", pos)) != string::npos) {
+    ++pos;
+    ++count;
+  }
+  BOOST_CHECK_EQUAL(count, 1);
+
 }
 
 

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(test_PacketParse) {
   vector<unsigned char> packet;
   reportBasicTypes();
   DNSName root(".");
-  DNSPacketWriter dpw1(packet, DNSName("."), QType::AAAA);
+  DNSPacketWriter dpw1(packet, g_rootdnsname, QType::AAAA);
   DNSName p((char*)&packet[0], packet.size(), 12, false);
   BOOST_CHECK_EQUAL(p, root);
   unsigned char* buffer=&packet[0];
@@ -458,7 +458,7 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch) {
 
   BOOST_CHECK(!smn.check(DNSName("www.news.gov.uk.")));
 
-  smn.add(DNSName(".")); // block the root
+  smn.add(g_rootdnsname); // block the root
   BOOST_CHECK(smn.check(DNSName("a.root-servers.net.")));
 }
 
@@ -503,9 +503,9 @@ BOOST_AUTO_TEST_CASE(test_compare_canonical) {
   BOOST_CHECK(!DNSName("www.BeRt.com").canonCompare(DNSName("WWW.berT.com")));
 
   CanonDNSNameCompare a;
-  BOOST_CHECK(a(DNSName("."), DNSName("www.powerdns.com")));
-  BOOST_CHECK(a(DNSName("."), DNSName("www.powerdns.net")));
-  BOOST_CHECK(!a(DNSName("www.powerdns.net"), DNSName(".")));
+  BOOST_CHECK(a(g_rootdnsname, DNSName("www.powerdns.com")));
+  BOOST_CHECK(a(g_rootdnsname, DNSName("www.powerdns.net")));
+  BOOST_CHECK(!a(DNSName("www.powerdns.net"), g_rootdnsname));
 
   vector<DNSName> vec;
   for(const std::string& a : {"bert.com.", "alpha.nl.", "articles.xxx.",

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -286,6 +286,30 @@ BOOST_AUTO_TEST_CASE(test_packetCompress) {
 
 }
 
+BOOST_AUTO_TEST_CASE(test_packetCompressLong) {
+  reportBasicTypes();
+  vector<unsigned char> packet;
+  DNSName loopback("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa");
+  DNSPacketWriter dpw(packet, loopback, QType::PTR);
+
+  dpw.startRecord(loopback, QType::PTR);
+  PTRRecordContent prc(DNSName("localhost"));
+  prc.toPacket(dpw);
+  dpw.commit();
+  DNSName roundtrip((char*)&packet[0], packet.size(), 12, false);
+  BOOST_CHECK_EQUAL(loopback,roundtrip);
+  
+  packet.clear();
+  DNSName longer("1.2.3.4.5.6.7.8.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa");
+  DNSPacketWriter dpw2(packet, longer, QType::PTR);
+
+  dpw2.startRecord(DNSName("a.b.c.d.e")+longer, QType::PTR);
+  PTRRecordContent prc2(DNSName("localhost"));
+  prc2.toPacket(dpw2);
+  dpw2.commit();
+
+}
+
 
 
 

--- a/pdns/toysdig.cc
+++ b/pdns/toysdig.cc
@@ -103,7 +103,7 @@ LuaConfigItems::LuaConfigItems()
 {
   for (const auto &dsRecord : rootDSs) {
     auto ds=unique_ptr<DSRecordContent>(dynamic_cast<DSRecordContent*>(DSRecordContent::make(dsRecord)));
-    dsAnchors[DNSName(".")].insert(*ds);
+    dsAnchors[g_rootdnsname].insert(*ds);
   }
 }
 

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -283,7 +283,7 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
 	  LOG("DNSKEY did not match the DS, parent DS: "<<drc.getZoneRepresentation() << " ! = "<<dsrc2.getZoneRepresentation()<<endl);
 	}
         // cout<<"    subgraph "<<dotEscape("cluster "+qname)<<" { "<<dotEscape("DS "+qname)<<" -> "<<dotEscape("DNSKEY "+qname)<<" [ label = \""<<dsrc.d_tag<<"/"<<static_cast<int>(dsrc.d_digesttype)<<"\" ]; label = \"zone: "<<qname<<"\"; }"<<endl;
-	dotEdge(DNSName("."), "DS", qname, "" /*std::to_string(dsrc.d_tag)*/, "DNSKEY", qname, std::to_string(drc.getTag()), isValid ? "green" : "red");
+	dotEdge(g_rootdnsname, "DS", qname, "" /*std::to_string(dsrc.d_tag)*/, "DNSKEY", qname, std::to_string(drc.getTag()), isValid ? "green" : "red");
         // dotNode("DNSKEY", qname, (boost::format("tag=%d, algo=%d") % drc.getTag() % static_cast<int>(drc.d_algorithm)).str());
       }
     }
@@ -486,13 +486,13 @@ void dotEdge(DNSName zone, string type1, DNSName name1, string tag1, string type
 {
 #ifdef GRAPHVIZ
   cout<<"    ";
-  if(zone != DNSName(".")) cout<<"subgraph "<<dotEscape("cluster "+zone.toString())<<" { ";
+  if(zone != g_rootdnsname) cout<<"subgraph "<<dotEscape("cluster "+zone.toString())<<" { ";
   cout<<dotEscape(dotName(type1, name1, tag1))
       <<" -> "
       <<dotEscape(dotName(type2, name2, tag2));
   if(color != "") cout<<" [ color=\""<<color<<"\" ]; ";
   else cout<<"; ";
-  if(zone != DNSName(".")) cout<<"label = "<<dotEscape("zone: "+zone.toString())<<";"<<"}";
+  if(zone != g_rootdnsname) cout<<"label = "<<dotEscape("zone: "+zone.toString())<<";"<<"}";
   cout<<endl;
 #endif
 }

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -210,7 +210,7 @@ int main( int argc, char* argv[] )
                                         }
                                 try
                                 {
-				  if( i->name != DNSName(".") && i->name != DNSName("localhost") && i->name != DNSName("0.0.127.in-addr.arpa") )
+				  if( i->name != g_rootdnsname && i->name != DNSName("localhost") && i->name != DNSName("0.0.127.in-addr.arpa") )
                                         {
                                                 cerr << "Parsing file: " << i->filename << ", domain: " << i->name << endl;
                                                 g_zonename = i->name;


### PR DESCRIPTION
This is a big change that comes with a number of new tests. 

After:
'write big referral' 0.10 seconds: 67707.6 runs/s, 14.77 usec/run
Before:
'write big referral' 0.10 seconds: 42556.4 runs/s, 23.50 usec/run

A 37% improvement. 

Impact on root-server performance:
![rootplot](https://cloud.githubusercontent.com/assets/1223657/18028965/03a4fa3c-6c8b-11e6-9404-f301978d46b6.png)

Is in line with these numbers - we now have good service in 4 cores up to around 80kqps, trouble used to start a bit beyond 40kqps. This graph has 60% packet cacheability. 
