### PR TITLE
rec: fix the use of an uninitialized filtering policy

### DIFF
--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -60,7 +60,7 @@ bool findNamedPolicy(const map<DNSName, DNSFilterEngine::Policy>& polmap, const 
 DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const DNSName& qname, const std::unordered_map<std::string,bool>& discardedPolicies) const
 {
   //  cout<<"Got question for nameserver name "<<qname<<endl;
-  Policy pol{PolicyKind::NoAction, nullptr, nullptr, 0};
+  Policy pol;
   for(const auto& z : d_zones) {
     if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
       continue;
@@ -87,13 +87,13 @@ DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const ComboAddress&
       return fnd->second;;
     }
   }
-  return Policy{PolicyKind::NoAction, nullptr, nullptr, 0};
+  return Policy();
 }
 
 DNSFilterEngine::Policy DNSFilterEngine::getQueryPolicy(const DNSName& qname, const ComboAddress& ca, const std::unordered_map<std::string,bool>& discardedPolicies) const
 {
   //  cout<<"Got question for "<<qname<<" from "<<ca.toString()<<endl;
-  Policy pol{PolicyKind::NoAction, nullptr, nullptr, 0};
+  Policy pol;
   for(const auto& z : d_zones) {
     if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
       continue;
@@ -141,7 +141,7 @@ DNSFilterEngine::Policy DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& 
 	return fnd->second;
     }
   }
-  return Policy{PolicyKind::NoAction, nullptr, nullptr, 0};
+  return Policy();
 }
 
 void DNSFilterEngine::assureZones(size_t zone)

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -67,6 +67,9 @@ public:
   enum class PolicyKind { NoAction, Drop, NXDOMAIN, NODATA, Truncate, Custom};
   struct Policy
   {
+    Policy(): d_kind(PolicyKind::NoAction), d_custom(nullptr), d_name(nullptr), d_ttl(0)
+    {
+    }
     bool operator==(const Policy& rhs) const
     {
       return d_kind == rhs.d_kind; // XXX check d_custom too!

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -64,7 +64,7 @@ void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrR
   static const DNSName rpzClientIP("rpz-client-ip"), rpzIP("rpz-ip"),
     rpzNSDname("rpz-nsdname"), rpzNSIP("rpz-nsip.");
 
-  DNSFilterEngine::Policy pol{DNSFilterEngine::PolicyKind::NoAction, nullptr, nullptr, 0};
+  DNSFilterEngine::Policy pol;
 
   if(dr.d_class != QClass::IN) {
     return;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -358,7 +358,7 @@ public:
   static unsigned int s_maxqperq;
   static unsigned int s_maxtotusec;
   std::unordered_map<std::string,bool> d_discardedPolicies;
-  DNSFilterEngine::Policy d_appliedPolicy{DNSFilterEngine::PolicyKind::NoAction, nullptr, nullptr, 0};
+  DNSFilterEngine::Policy d_appliedPolicy;
   unsigned int d_outqueries;
   unsigned int d_tcpoutqueries;
   unsigned int d_throttledqueries;


### PR DESCRIPTION
If `wantsRPZ` is set to false by the `prerpz` hook, `dfepol` might
not be correctly initialized. This leads to `appliedPolicy` not being
either before being passed to `preresolve` and `postresolve`.

Reported by Coverity.