### PR TITLE
Rec: make the record cache forward-aware

### DIFF
--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -305,6 +305,11 @@ or on the command line:
 Forwarded queries have the 'recursion desired' bit set to 0, meaning that this
 setting is intended to forward queries to authoritative servers.
 
+**IMPORTANT**: When using DNSSEC validation (which is default), forwards to non-delegated (e.g. internal) zones that have a DNSSEC signed parent zone will validate as Bogus.
+To prevent this, add a Negative Trust Anchor (NTA) for this zone in the [`lua-config-file`](#lua-config-file) with `addNTA("your.zone", "A comment")`.
+If this forwarded zone is signed, instead of adding NTA, add the DS record to the [`lua-config-file`](#lua-config-file).
+See the [recursor DNSSEC](dnssec.md) documentation for more information.
+
 ## `forward-zones-file`
 * Path
 * Available since: 3.1.5
@@ -318,6 +323,8 @@ Default behaviour without '+' is as with [`forward-zones`](#forward-zones).
 
 Comments are allowed since version 4.0.0. Everything behind '#' is ignored.
 
+The DNSSEC notes from [`forward-zones`](#forward-zones) apply here as well.
+
 ## `forward-zones-recurse`
 * 'zonename=IP' pairs, comma separated
 * Available since: 3.2
@@ -325,6 +332,8 @@ Comments are allowed since version 4.0.0. Everything behind '#' is ignored.
 Like regular [`forward-zones`](#forward-zones), but forwarded queries have the
 'recursion desired' bit set to 1, meaning that this setting is intended to
 forward queries to other recursive servers.
+
+The DNSSEC notes from [`forward-zones`](#forward-zones) apply here as well.
 
 ## `hint-file`
 * Path

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -175,7 +175,19 @@ islandofsecurity.example.          3600 IN NS   ns1.islandofsecurity.example.
 ns1.islandofsecurity.example.      3600 IN A    {prefix}.9
 
 node1.islandofsecurity.example.    3600 IN A    192.0.2.20
-        """
+        """,
+        'undelegated.secure.example': """
+undelegated.secure.example.        3600 IN SOA  {soa}
+undelegated.secure.example.        3600 IN NS   ns1.undelegated.secure.example.
+
+node1.undelegated.secure.example.  3600 IN A    192.0.2.21
+        """,
+        'undelegated.insecure.example': """
+undelegated.insecure.example.        3600 IN SOA  {soa}
+undelegated.insecure.example.        3600 IN NS   ns1.undelegated.insecure.example.
+
+node1.undelegated.insecure.example.  3600 IN A    192.0.2.22
+        """,
     }
 
     # The private keys for the zones (note that DS records should go into
@@ -232,7 +244,7 @@ PrivateKey: o9F5iix8V68tnMcuOaM2Lt8XXhIIY//SgHIHEePk6cM=
         '9': ['secure.example', 'islandofsecurity.example'],
         '10': ['example'],
         '11': ['example'],
-        '12': ['bogus.example'],
+        '12': ['bogus.example', 'undelegated.secure.example', 'undelegated.insecure.example'],
         '13': ['insecure.example', 'insecure.sub2.secure.example'],
         '14': ['optout.example'],
         '15': ['insecure.optout.example', 'secure.optout.example']

--- a/regression-tests.recursor-dnssec/runtests
+++ b/regression-tests.recursor-dnssec/runtests
@@ -19,7 +19,7 @@ export PDNSRECURSOR=${PDNSRECURSOR:-${PWD}/../pdns/recursordist/pdns_recursor}
 export RECCONTROL=${RECCONTROL:-${PWD}/../pdns/recursordist/rec_control}
 export LIBFAKETIME=${LIBFAKETIME:-/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1} # ubuntu default
 
-export PREFIX=10.0.3
+export PREFIX=127.0.0
 
 
 set -e

--- a/regression-tests.recursor-dnssec/test_Interop.py
+++ b/regression-tests.recursor-dnssec/test_Interop.py
@@ -1,6 +1,7 @@
 import dns
 import socket
 import copy
+import os
 from recursortests import RecursorTest
 from twisted.internet.protocol import DatagramProtocol
 from twisted.internet import reactor
@@ -9,7 +10,11 @@ import threading
 class testInterop(RecursorTest):
     _confdir = 'Interop'
 
-    _config_template = """dnssec=validate"""
+    _config_template = """dnssec=validate
+packetcache-ttl=0 # explicitly disable packetcache
+forward-zones=undelegated.secure.example=%s.12
+forward-zones+=undelegated.insecure.example=%s.12
+    """ % (os.environ['PREFIX'], os.environ['PREFIX'])
 
     def testFORMERR(self):
         """
@@ -37,6 +42,69 @@ class testInterop(RecursorTest):
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
         self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
         self.assertRRsetInAnswer(res, expected)
+
+    def testUndelegatedForwardedZoneExisting(self):
+        """
+        #4369. Ensure we SERVFAIL when forwarding to undelegated zones for a name that exists
+        """
+
+        query = dns.message.make_query('node1.undelegated.secure.example.', 'A')
+        query.flags |= dns.flags.AD
+
+        # twice, so we hit the record cache
+        self.sendUDPQuery(query)
+        res = self.sendUDPQuery(query)
+
+        self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+
+    def testUndelegatedForwardedZoneNXDOMAIN(self):
+        """
+        #4369. Ensure we SERVFAIL when forwarding to undelegated zones for a name that does not exist
+        """
+
+        query = dns.message.make_query('node2.undelegated.secure.example.', 'A')
+        query.flags |= dns.flags.AD
+
+        # twice, so we hit the negative record cache
+        self.sendUDPQuery(query)
+        res = self.sendUDPQuery(query)
+
+        self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+
+    def testUndelegatedForwardedInsecureZoneExisting(self):
+        """
+        #4369. Ensure we answer when forwarding to an undelegated zone in an insecure zone for a name that exists
+        """
+
+        expected = dns.rrset.from_text('node1.undelegated.insecure.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.22')
+        query = dns.message.make_query('node1.undelegated.insecure.example.', 'A')
+        query.flags |= dns.flags.AD
+
+        # twice, so we hit the record cache
+        self.sendUDPQuery(query)
+        res = self.sendUDPQuery(query)
+
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+        self.assertRRsetInAnswer(res, expected)
+
+    def testUndelegatedForwardedInsecureZoneNXDOMAIN(self):
+        """
+        #4369. Ensure we answer when forwarding to an undelegated zone in an insecure zone for a name that does not exist
+        """
+
+        query = dns.message.make_query('node2.undelegated.insecure.example.', 'A')
+        query.flags |= dns.flags.AD
+
+        # twice, so we hit the negative record cache
+        self.sendUDPQuery(query)
+        res = self.sendUDPQuery(query)
+
+        self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+
 
     @classmethod
     def startResponders(cls):


### PR DESCRIPTION
This fixes #4369.

We now consistently SERVFAIL on undelegated, forwarded zones inside secure zone (because validation rightfully fails)

For undelegated, forwarded zones inside insecure zones, we answer the query (as validation notices the parent zone is already insecure).

(unrelated) This PR also moves the DNSSEC regression tests to the local loopback address range.