### PR TITLE
Update notrack rules

### DIFF
--- a/docs/markdown/recursor/performance.md
+++ b/docs/markdown/recursor/performance.md
@@ -21,23 +21,53 @@ To get the best out of the PowerDNS recursor, which is important if you are doin
     Sample Linux command lines would be:
 
 ```
-# iptables -t raw -I OUTPUT -p udp --dport 53 -j NOTRACK
-# iptables -t raw -I OUTPUT -p udp --sport 53 -j NOTRACK
-# iptables -t raw -I PREROUTING -p udp --dport 53 -j NOTRACK
-# iptables -t raw -I PREROUTING -p udp --sport 53 -j NOTRACK
+## IPv4
+# iptables -t raw -I OUTPUT -p udp --dport 53 -j CT --notrack
+# iptables -t raw -I OUTPUT -p udp --sport 53 -j CT --notrack
+# iptables -t raw -I PREROUTING -p udp --dport 53 -j CT --notrack
+# iptables -t raw -I PREROUTING -p udp --sport 53 -j CT --notrack
 # iptables -I INPUT -p udp --dport 53 -j ACCEPT
 # iptables -I INPUT -p udp --sport 53 -j ACCEPT
 # iptables -I OUTPUT -p udp --dport 53 -j ACCEPT
+# iptables -I OUTPUT -p udp --sport 53 -j ACCEPT
 
-    # # optionally
-# ip6tables -t raw -I OUTPUT -p udp --dport 53 -j NOTRACK
-# ip6tables -t raw -I OUTPUT -p udp --sport 53 -j NOTRACK
-# ip6tables -t raw -I PREROUTING -p udp --sport 53 -j NOTRACK
-# ip6tables -t raw -I PREROUTING -p udp --dport 53 -j NOTRACK
+
+## IPv6
+# ip6tables -t raw -I OUTPUT -p udp --dport 53 -j CT --notrack
+# ip6tables -t raw -I OUTPUT -p udp --sport 53 -j CT --notrack
+# ip6tables -t raw -I PREROUTING -p udp --sport 53 -j CT --notrack
+# ip6tables -t raw -I PREROUTING -p udp --dport 53 -j CT --notrack
 # ip6tables -I INPUT -p udp --dport 53 -j ACCEPT
 # ip6tables -I INPUT -p udp --sport 53 -j ACCEPT
 # ip6tables -I OUTPUT -p udp --dport 53 -j ACCEPT
+# ip6tables -I OUTPUT -p udp --sport 53 -j ACCEPT
 ```
+
+
+When using FirewallD (Centos 7+ / RedHat 7+ / Fedora 21+) connection tracking can be disabled via direct rules.
+The settings can be made permanent by using the --permanent flag.
+```
+## IPv4
+# firewall-cmd --direct --add-rule ipv4 raw OUTPUT 0 -p udp --dport 53 -j CT --notrack
+# firewall-cmd --direct --add-rule ipv4 raw OUTPUT 0 -p udp --sport 53 -j CT --notrack
+# firewall-cmd --direct --add-rule ipv4 raw PREROUTING 0 -p udp --dport 53 -j CT --notrack
+# firewall-cmd --direct --add-rule ipv4 raw PREROUTING 0 -p udp --sport 53 -j CT --notrack
+# firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -p udp --dport 53 -j ACCEPT
+# firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -p udp --sport 53 -j ACCEPT
+# firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p udp --dport 53 -j ACCEPT
+# firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p udp --sport 53 -j ACCEPT
+
+## IPv6
+# firewall-cmd --direct --add-rule ipv6 raw OUTPUT 0 -p udp --dport 53 -j CT --notrack
+# firewall-cmd --direct --add-rule ipv6 raw OUTPUT 0 -p udp --sport 53 -j CT --notrack
+# firewall-cmd --direct --add-rule ipv6 raw PREROUTING 0 -p udp --dport 53 -j CT --notrack
+# firewall-cmd --direct --add-rule ipv6 raw PREROUTING 0 -p udp --sport 53 -j CT --notrack
+# firewall-cmd --direct --add-rule ipv6 filter INPUT 0 -p udp --dport 53 -j ACCEPT
+# firewall-cmd --direct --add-rule ipv6 filter INPUT 0 -p udp --sport 53 -j ACCEPT
+# firewall-cmd --direct --add-rule ipv6 filter OUTPUT 0 -p udp --dport 53 -j ACCEPT
+# firewall-cmd --direct --add-rule ipv6 filter OUTPUT 0 -p udp --sport 53 -j ACCEPT
+```
+
 
 Following the instructions above, you should be able to attain very high query rates.
 

--- a/docs/markdown/recursor/performance.md
+++ b/docs/markdown/recursor/performance.md
@@ -22,25 +22,24 @@ To get the best out of the PowerDNS recursor, which is important if you are doin
 
 ```
 ## IPv4
-# iptables -t raw -I OUTPUT -p udp --dport 53 -j CT --notrack
-# iptables -t raw -I OUTPUT -p udp --sport 53 -j CT --notrack
-# iptables -t raw -I PREROUTING -p udp --dport 53 -j CT --notrack
-# iptables -t raw -I PREROUTING -p udp --sport 53 -j CT --notrack
-# iptables -I INPUT -p udp --dport 53 -j ACCEPT
-# iptables -I INPUT -p udp --sport 53 -j ACCEPT
-# iptables -I OUTPUT -p udp --dport 53 -j ACCEPT
-# iptables -I OUTPUT -p udp --sport 53 -j ACCEPT
-
+iptables -t raw -I OUTPUT -p udp --dport 53 -j CT --notrack
+iptables -t raw -I OUTPUT -p udp --sport 53 -j CT --notrack
+iptables -t raw -I PREROUTING -p udp --dport 53 -j CT --notrack
+iptables -t raw -I PREROUTING -p udp --sport 53 -j CT --notrack
+iptables -I INPUT -p udp --dport 53 -j ACCEPT
+iptables -I INPUT -p udp --sport 53 -j ACCEPT
+iptables -I OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -I OUTPUT -p udp --sport 53 -j ACCEPT
 
 ## IPv6
-# ip6tables -t raw -I OUTPUT -p udp --dport 53 -j CT --notrack
-# ip6tables -t raw -I OUTPUT -p udp --sport 53 -j CT --notrack
-# ip6tables -t raw -I PREROUTING -p udp --sport 53 -j CT --notrack
-# ip6tables -t raw -I PREROUTING -p udp --dport 53 -j CT --notrack
-# ip6tables -I INPUT -p udp --dport 53 -j ACCEPT
-# ip6tables -I INPUT -p udp --sport 53 -j ACCEPT
-# ip6tables -I OUTPUT -p udp --dport 53 -j ACCEPT
-# ip6tables -I OUTPUT -p udp --sport 53 -j ACCEPT
+ip6tables -t raw -I OUTPUT -p udp --dport 53 -j CT --notrack
+ip6tables -t raw -I OUTPUT -p udp --sport 53 -j CT --notrack
+ip6tables -t raw -I PREROUTING -p udp --sport 53 -j CT --notrack
+ip6tables -t raw -I PREROUTING -p udp --dport 53 -j CT --notrack
+ip6tables -I INPUT -p udp --dport 53 -j ACCEPT
+ip6tables -I INPUT -p udp --sport 53 -j ACCEPT
+ip6tables -I OUTPUT -p udp --dport 53 -j ACCEPT
+ip6tables -I OUTPUT -p udp --sport 53 -j ACCEPT
 ```
 
 
@@ -48,24 +47,24 @@ When using FirewallD (Centos 7+ / RedHat 7+ / Fedora 21+) connection tracking ca
 The settings can be made permanent by using the --permanent flag.
 ```
 ## IPv4
-# firewall-cmd --direct --add-rule ipv4 raw OUTPUT 0 -p udp --dport 53 -j CT --notrack
-# firewall-cmd --direct --add-rule ipv4 raw OUTPUT 0 -p udp --sport 53 -j CT --notrack
-# firewall-cmd --direct --add-rule ipv4 raw PREROUTING 0 -p udp --dport 53 -j CT --notrack
-# firewall-cmd --direct --add-rule ipv4 raw PREROUTING 0 -p udp --sport 53 -j CT --notrack
-# firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -p udp --dport 53 -j ACCEPT
-# firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -p udp --sport 53 -j ACCEPT
-# firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p udp --dport 53 -j ACCEPT
-# firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p udp --sport 53 -j ACCEPT
+firewall-cmd --direct --add-rule ipv4 raw OUTPUT 0 -p udp --dport 53 -j CT --notrack
+firewall-cmd --direct --add-rule ipv4 raw OUTPUT 0 -p udp --sport 53 -j CT --notrack
+firewall-cmd --direct --add-rule ipv4 raw PREROUTING 0 -p udp --dport 53 -j CT --notrack
+firewall-cmd --direct --add-rule ipv4 raw PREROUTING 0 -p udp --sport 53 -j CT --notrack
+firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -p udp --dport 53 -j ACCEPT
+firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -p udp --sport 53 -j ACCEPT
+firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p udp --dport 53 -j ACCEPT
+firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p udp --sport 53 -j ACCEPT
 
 ## IPv6
-# firewall-cmd --direct --add-rule ipv6 raw OUTPUT 0 -p udp --dport 53 -j CT --notrack
-# firewall-cmd --direct --add-rule ipv6 raw OUTPUT 0 -p udp --sport 53 -j CT --notrack
-# firewall-cmd --direct --add-rule ipv6 raw PREROUTING 0 -p udp --dport 53 -j CT --notrack
-# firewall-cmd --direct --add-rule ipv6 raw PREROUTING 0 -p udp --sport 53 -j CT --notrack
-# firewall-cmd --direct --add-rule ipv6 filter INPUT 0 -p udp --dport 53 -j ACCEPT
-# firewall-cmd --direct --add-rule ipv6 filter INPUT 0 -p udp --sport 53 -j ACCEPT
-# firewall-cmd --direct --add-rule ipv6 filter OUTPUT 0 -p udp --dport 53 -j ACCEPT
-# firewall-cmd --direct --add-rule ipv6 filter OUTPUT 0 -p udp --sport 53 -j ACCEPT
+firewall-cmd --direct --add-rule ipv6 raw OUTPUT 0 -p udp --dport 53 -j CT --notrack
+firewall-cmd --direct --add-rule ipv6 raw OUTPUT 0 -p udp --sport 53 -j CT --notrack
+firewall-cmd --direct --add-rule ipv6 raw PREROUTING 0 -p udp --dport 53 -j CT --notrack
+firewall-cmd --direct --add-rule ipv6 raw PREROUTING 0 -p udp --sport 53 -j CT --notrack
+firewall-cmd --direct --add-rule ipv6 filter INPUT 0 -p udp --dport 53 -j ACCEPT
+firewall-cmd --direct --add-rule ipv6 filter INPUT 0 -p udp --sport 53 -j ACCEPT
+firewall-cmd --direct --add-rule ipv6 filter OUTPUT 0 -p udp --dport 53 -j ACCEPT
+firewall-cmd --direct --add-rule ipv6 filter OUTPUT 0 -p udp --sport 53 -j ACCEPT
 ```
 
 


### PR DESCRIPTION
* switch from NOTRACK to CT target (deprecated around 2012)
* add output accept for sport 53
* describe firewalld configuration for newer centos/fedora/redhat versions

```
Date: Thu, 20 Dec 2012 12:26:22 +0100
Subject: [PATCH] netfilter: xt_CT: recover NOTRACK target support

Florian Westphal reported that the removal of the NOTRACK target
(9655050 netfilter: remove xt_NOTRACK) is breaking some existing
setups.

That removal was scheduled for removal since long time ago as
described in Documentation/feature-removal-schedule.txt
```

https://patchwork.ozlabs.org/patch/207653/