### PR TITLE
DNSSEC: Actually follow RFC 7646 §2.1

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -183,7 +183,7 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
     DNSName lowestNTA;
 
     for (auto const &negAnchor : negAnchors)
-      if (zone.isPartOf(negAnchor.first) && lowestNTA.countLabels() < negAnchor.first.countLabels())
+      if (zone.isPartOf(negAnchor.first) && lowestNTA.countLabels() <= negAnchor.first.countLabels())
         lowestNTA = negAnchor.first;
 
     if(!lowestNTA.empty()) {
@@ -194,7 +194,7 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
        * attempt validation for. However, section 3 tells us this positive
        * Trust Anchor MUST be *below* the name and not the name itself
        */
-      if(lowestTA.countLabels() < lowestNTA.countLabels()) {
+      if(lowestTA.countLabels() <= lowestNTA.countLabels()) {
         LOG("marking answer Insecure"<<endl);
         return NTA; // Not Insecure, this way validateRecords() can shortcut
       }

--- a/regression-tests.recursor-dnssec/test_NTA.py
+++ b/regression-tests.recursor-dnssec/test_NTA.py
@@ -5,7 +5,9 @@ class testSimple(RecursorTest):
     _confdir = 'NTA'
 
     _config_template = """dnssec=validate"""
-    _lua_config_file = """addNTA("bogus.example")"""
+    _lua_config_file = """addNTA("bogus.example")
+addNTA('secure.optout.example', 'Should be Insecure, even with DS configured')
+addDS('secure.optout.example', '64215 13 1 b88284d7a8d8605c398e8942262f97b9a5a31787')"""
 
     def testDirectNTA(self):
         """Ensure a direct query to a bogus name with an NTA is Insecure"""
@@ -22,6 +24,17 @@ class testSimple(RecursorTest):
     def testCNAMENTA(self):
         """Ensure a CNAME from a secure zone to a bogus one with an NTA is Insecure"""
         msg = dns.message.make_query("cname-to-bogus.secure.example.", dns.rdatatype.A)
+        msg.flags = dns.flags.from_text('AD RD')
+        msg.use_edns(edns=0, ednsflags=dns.flags.edns_from_text('DO'))
+
+        res = self.sendUDPQuery(msg)
+
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+
+    def testSecureWithNTAandDS(self):
+        """#4391: when there is a TA *and* NTA configured for a name, the result must be insecure"""
+        msg = dns.message.make_query("node1.secure.optout.example.", dns.rdatatype.A)
         msg.flags = dns.flags.from_text('AD RD')
         msg.use_edns(edns=0, ednsflags=dns.flags.edns_from_text('DO'))
 


### PR DESCRIPTION
We were off by one when counting labels, so when an NTA was added for a
name where a TA was configured, we would still attempt validation.

Reported by @jpmens