### PR TITLE
Recursor: allow building against Boost 1.61

### DIFF
--- a/pdns/mtasker_fcontext.cc
+++ b/pdns/mtasker_fcontext.cc
@@ -23,7 +23,11 @@
 #include <exception>
 #include <cassert>
 #include <type_traits>
+#if BOOST_VERSION > 106100
+#include <boost/context/detail/fcontext.hpp>
+#else
 #include <boost/context/fcontext.hpp>
+#endif
 #include <boost/version.hpp>
 
 using boost::context::make_fcontext;

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -54,9 +54,15 @@ AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
       LDFLAGS="$LDFLAGS $BOOST_THREAD_LDFLAGS"
     fi
     AC_MSG_NOTICE([checking whether the Boost context library actually links...])
-    BOOST_FIND_HEADER([boost/context/fcontext.hpp], [ : ], [
-      BOOST_FIND_LIB([context], [$1], [boost/context/fcontext.hpp], [[]])
-    ])
+    if test $boost_major_version -ge 161; then
+      BOOST_FIND_HEADER([boost/context/detail/fcontext.hpp], [ : ], [
+        BOOST_FIND_LIB([context], [$1], [boost/context/detail/fcontext.hpp], [[]])
+      ])
+    else
+      BOOST_FIND_HEADER([boost/context/fcontext.hpp], [ : ], [
+        BOOST_FIND_LIB([context], [$1], [boost/context/fcontext.hpp], [[]])
+      ])
+    fi
     case $boost_cv_lib_context in
       (yes)
         AC_MSG_NOTICE([MTasker will use the Boost context library for context switching])

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -42,6 +42,7 @@ PDNS_CHECK_NETWORK_LIBS
 
 # Boost Context was introduced in 1.51 (Aug 2012), but there was an immediate
 # API break in 1.52 (Nov 2012), so we only support that, and later.
+pdns_context_library="System V ucontexts"
 
 AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
   AC_MSG_CHECKING([whether Boost is new enough to use the context library...])
@@ -65,6 +66,7 @@ AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
     fi
     case $boost_cv_lib_context in
       (yes)
+        pdns_context_library="Boost context"
         AC_MSG_NOTICE([MTasker will use the Boost context library for context switching])
         ;;
       *)
@@ -206,4 +208,5 @@ AS_IF([test "x$systemd" != "xn"],
   [AC_MSG_NOTICE([systemd: yes])],
   [AC_MSG_NOTICE([systemd: no])]
 )
+AC_MSG_NOTICE([Context library: $pdns_context_library])
 AC_MSG_NOTICE([])


### PR DESCRIPTION
The path for the `fcontext` include changed between 1.60 and 1.61.

Fixes #4270