### PR TITLE
add boost context ldflags so freebsd builds can find the libs

### DIFF
--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -152,7 +152,7 @@ pdns_recursor_LDADD = \
 	$(RT_LIBS)
 
 pdns_recursor_LDFLAGS = $(AM_LDFLAGS) \
-	$(LIBCRYPTO_LDFLAGS)
+	$(LIBCRYPTO_LDFLAGS) $(BOOST_CONTEXT_LDFLAGS)
 
 if BOTAN110
 pdns_recursor_SOURCES += \


### PR DESCRIPTION
Please hold this PR until master vs. 4.0.x merging policy has been decided. This fix should go on both in any case.