### PR TITLE
Fix . additions on RPZ IXFR

### DIFF
--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -97,7 +97,7 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
 
     //    cout<<"Got a response, rcode: "<<mdp.d_header.rcode<<", got "<<mdp.d_answers.size()<<" answers"<<endl;
     for(auto& r: mdp.d_answers) {
-      if(r.first.d_type == QType::TSIG) 
+      if(r.first.d_type == QType::NS || r.first.d_type == QType::TSIG) 
         continue;
       //      cout<<r.first.d_name<< " " <<r.first.d_content->getZoneRepresentation()<<endl;
       r.first.d_name = r.first.d_name.makeRelative(zone);


### PR DESCRIPTION
RPZ IXFR's were overwriting "."
```
pdns_recursor[22434]: Sep 02 00:59:03 Getting IXFR deltas for my-rpz.info from x.x.x.x:53, our serial: 2016090203
pdns_recursor[22434]: Sep 02 00:59:03 Processing 1 delta for RPZ my-rpz.info
pdns_recursor[22434]: Sep 02 00:59:04 IXFR update is a whole new zone
pdns_recursor[22434]: Sep 02 00:59:04 Had addition of futurmedical.com
pdns_recursor[22434]: Sep 02 00:59:04 Had addition of kookeek.com
pdns_recursor[22434]: Sep 02 00:59:04 Had addition of .
pdns_recursor[22434]: Sep 02 00:59:04 Had addition of nxdomain.org
pdns_recursor[22434]: Sep 02 00:59:04 Had addition of webportalhelpdeskkupgrade.myfreesites.net
pdns_recursor[22434]: Sep 02 00:59:04 Had addition of www.computerservicesoftn.com
pdns_recursor[22434]: Sep 02 00:59:04 Had addition of www.ecostav.cz
pdns_recursor[22434]: Sep 02 00:59:04 Had addition of www.japco.no
pdns_recursor[22434]: Sep 02 00:59:04 Had 0 RPZ removals, 10 additions for my-rpz.info New serial: 2016090204
```

The issue was because of a NS record that ```makeRelative``` made a "."

This patch fixes it by ignoring NS records, same way as in rpzloader.cc https://github.com/PowerDNS/pdns/blob/master/pdns/rpzloader.cc#L178

Not sure if the correct way, but works for me now :)