### PR TITLE
Warn about TXT content without ""

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -490,8 +490,11 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
       rr.content=o.str();
     }
 
-    if(rr.qtype.getCode() == QType::TXT && !rr.content.empty() && rr.content[0]!='"')
+    if(rr.qtype.getCode() == QType::TXT && !rr.content.empty() && rr.content[0]!='"') {
+      cout<<"[Warning] TXT does not start with '\"': "<< rr.content<<endl;
+      numwarnings++;
       rr.content = "\""+rr.content+"\"";
+    }
 
     try {
       shared_ptr<DNSRecordContent> drc(DNSRecordContent::mastermake(rr.qtype.getCode(), 1, rr.content));


### PR DESCRIPTION
TXT records not enclosed by double quotes break the PowerDNS API and pdnsutil edit-zone. If they are not mandatory, at least emit a warning about that.
