### PR TITLE
Backport #4402: Ignore NS records in a RPZ zone received over IXFR

### DIFF
--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -347,6 +347,8 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, size_t polZ
         luaconfsCopy.dfe.clear(0);
       }
       for(const auto& rr : remove) { // should always contain the SOA
+        if(rr.d_type == QType::NS)
+          continue;
 	totremove++;
 	if(rr.d_type == QType::SOA) {
 	  auto oldsr = getRR<SOARecordContent>(rr);
@@ -363,6 +365,8 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, size_t polZ
       }
 
       for(const auto& rr : add) { // should always contain the new SOA
+        if(rr.d_type == QType::NS)
+          continue;
 	totadd++;
 	if(rr.d_type == QType::SOA) {
 	  auto newsr = getRR<SOARecordContent>(rr);


### PR DESCRIPTION
They are already ignored over AXFR, but not over IXFR.
Reported and based on a patch by @42wim (thanks!).

(cherry picked from commit ed8c725224b5192367149897cfaaaf188ab0b910)