### PR TITLE
Backport #4396: add boost context ldflags so freebsd builds can find the libs

### DIFF
--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -152,7 +152,7 @@ pdns_recursor_LDADD = \
 	$(RT_LIBS)
 
 pdns_recursor_LDFLAGS = $(AM_LDFLAGS) \
-	$(LIBCRYPTO_LDFLAGS)
+	$(LIBCRYPTO_LDFLAGS) $(BOOST_CONTEXT_LDFLAGS)
 
 if BOTAN110
 pdns_recursor_SOURCES += \


### PR DESCRIPTION
(cherry picked from commit 01f097e45a286355c93da0acf78756e59ad9c126)