### PR TITLE
Fix compilation on systems with boost < 1.54

### DIFF
--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -22,7 +22,10 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 105400
 #include <boost/container/static_vector.hpp>
+#endif
 #include "dnswriter.hh"
 #include "misc.hh"
 #include "dnsparser.hh"
@@ -197,7 +200,11 @@ uint16_t DNSPacketWriter::lookupName(const DNSName& name, uint16_t* matchLen)
   */
   unsigned int bestpos=0;
   *matchLen=0;
+#if BOOST_VERSION >= 105400
   boost::container::static_vector<uint16_t, 34> nvect, pvect;
+#else
+  vector<uint16_t> nvect, pvect;
+#endif
 
   try {
     for(auto riter= raw.cbegin(); riter < raw.cend(); ) {


### PR DESCRIPTION
`boost::container::static_vector` exists from boost 1.54 onward. CentOS 6 and 7 have an older boost, so use normal vectors there.

@ahupowerdns: can you review?