### PR TITLE
Rollback fix: when we truncate a packet, make sure we reset writer state

### DIFF
--- a/pdns/dnspcap.cc
+++ b/pdns/dnspcap.cc
@@ -92,7 +92,7 @@ try
 
     checkedFreadSize(d_buffer, d_pheader.caplen);
 
-    if(d_pheader.caplen!=d_pheader.len) {
+    if(d_pheader.caplen < d_pheader.len) {
       d_runts++;
       continue;
     }

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -380,6 +380,7 @@ uint32_t DNSPacketWriter::size()
 void DNSPacketWriter::rollback()
 {
   d_content.resize(d_rollbackmarker);
+  d_sor = 0;
 }
 
 void DNSPacketWriter::truncate()


### PR DESCRIPTION
When we write out a dns packet, we know if we are 'in' a record or not. If we are, the next startRecord() call will auto-commit the previous record. Our rollback() code did not reset that state.