### PR TITLE
fix version check for boost 1.61 fcontext include

### DIFF
--- a/pdns/mtasker_fcontext.cc
+++ b/pdns/mtasker_fcontext.cc
@@ -23,12 +23,12 @@
 #include <exception>
 #include <cassert>
 #include <type_traits>
-#if BOOST_VERSION > 106100
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106100
 #include <boost/context/detail/fcontext.hpp>
 #else
 #include <boost/context/fcontext.hpp>
 #endif
-#include <boost/version.hpp>
 
 using boost::context::make_fcontext;
 


### PR DESCRIPTION
This fixes an issue where the wrong (pre boost 1.61 header) was
included as the check only evaluates to true after 1.61 instead if
reflecting what the autoconf changes are checking: greater-equals.

Additionally make sure to include the boost version header before the
version check as it may not be defined yet.

This issue was introduced via a30361f