### PR TITLE
Docs: clarify that recursor does not do DNSSEC for zones from auth-zones setting

### DIFF
--- a/docs/markdown/recursor/dnssec.md
+++ b/docs/markdown/recursor/dnssec.md
@@ -17,8 +17,8 @@ AD bits in queries. In this mode, the behaviour is equal to the PowerDNS Recurso
 The default mode. In this mode the Recursor acts as a "security aware, non-validating"
 nameserver, meaning it will set the DO-bit on outgoing queries and will provide
 DNSSEC related RRsets (NSEC, RRSIG) to clients that ask for them (by means of a
-DO-bit in the query). It will not do any validation in this mode, not even when
-requested by the client.
+DO-bit in the query), except for zones provided through the `auth-zones` setting. 
+It will not do any validation in this mode, not even when requested by the client.
 
 ## `process`
 When `dnssec` is set to `process` the behaviour is similar to [`process-no-validate`](#process-no-validate).

--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -88,7 +88,7 @@ have to tick an 'RFC 2181 compliant' box.
 * Comma separated list of 'zonename=filename' pairs
 * Available since: 3.1
 
-Zones read from these files (in BIND format) are served authoritatively. Example:
+Zones read from these files (in BIND format) are served authoritatively. DNSSEC is not supported. Example:
 `auth-zones=example.org=/var/zones/example.org, powerdns.com=/var/zones/powerdns.com`.
 
 ## `carbon-interval`


### PR DESCRIPTION
see https://mailman.powerdns.com/pipermail/pdns-users/2016-September/024445.html