### PR TITLE
Backport #4407: Fix warning: types may not be defined in a for-range-declaration

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2789,7 +2789,7 @@ loadMainConfig(g_vm["config-dir"].as<string>());
      std::vector<struct TSIGKey> keys;
      UeberBackend B("default");
      if (B.getTSIGKeys(keys)) {
-        for(const struct TSIGKey &key :  keys) {
+        for(const TSIGKey &key :  keys) {
            cout << key.name.toString() << " " << key.algorithm.toString() << " " << key.key << endl;
         }
      }

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1280,7 +1280,7 @@ void TCPNameserver::thread()
         continue;
 
       int sock=-1;
-      for(const struct pollfd& pfd :  d_prfds) {
+      for(const pollfd& pfd :  d_prfds) {
         if(pfd.revents == POLLIN) {
           sock = pfd.fd;
           addrlen=sizeof(remote);


### PR DESCRIPTION
As emitted by gcc 6.2.0 20160830 (Debian 6.2.0-2)

(cherry picked from commit 8ce9e4e67dbe8ce2cf546f5f549c3fb638946c56)