### PR TITLE
Backport #4319: pipe: SERVFAIL when needed:

### DIFF
--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -340,10 +340,14 @@ bool PipeBackend::get(DNSResourceRecord &r)
         throw PDNSException("Coprocess backend sent incorrect response '"+line+"'");
     }
   }
+  catch (DBException &dbe) {
+    L<<Logger::Error<<kBackendId<<" "<<dbe.reason<<endl;
+    throw;
+  }
   catch (PDNSException &pe) {
     L<<Logger::Error<<kBackendId<<" "<<pe.reason<<endl;
     cleanup();
-    return false;
+    throw;
   }
   return true;
 }


### PR DESCRIPTION
 * SERVFAIL, but don't restart the coprocess if we get a FAIL.
 * SERVFAIL if the coprocess sends something we don't understand.
   * In this case, restart the coprocess.

Closes #4308

(cherry picked from commit 6e0daabf5d93bd240c4c3a5ba5afcb843686f3b8)