### PR TITLE
Correct typo in backend-pipe.md

### DIFF
--- a/docs/markdown/authoritative/backend-pipe.md
+++ b/docs/markdown/authoritative/backend-pipe.md
@@ -67,7 +67,7 @@ If this time is ever exceeded, the backend is declared dead and a new process is
 |Type|String (a regex)|
 
 If set, only questions matching this regular expression are even sent to the backend.
-This makes sure that most of PowerDNS does not slow down if you you deploy a slow backend.
+This makes sure that most of PowerDNS does not slow down if you deploy a slow backend.
 A query for 'www.powerdns.com' would be presented to the regex as 'www.powerdns.com', a matching regex would be `^www\.powerdns\.com$`.
 **Note**: to match the root domain, use a dot, e.g. `^\.$`
 


### PR DESCRIPTION
The word 'you' was repeated twice. This was brought to my attention after noticing it in a diff.