### PR TITLE
check carefully: plugs memory leak in postgresql backend

### DIFF
--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -77,7 +77,8 @@ public:
       L<<Logger::Warning<<"Query: "<<d_query<<endl;
     }
     if (!d_parent->in_trx()) {
-      PQexec(d_db(),"BEGIN");
+      auto res=PQexec(d_db(),"BEGIN");
+      PQclear(res);
       d_do_commit = true;
     } else d_do_commit = false;
     d_res_set = PQexecPrepared(d_db(), d_stmt.c_str(), d_nparams, paramValues, paramLengths, NULL, 0);


### PR DESCRIPTION
eleksir noted that we leak a ton of memory in postgresql. I'm no postgres expert, but this plugs my leak and still appears to function. In other news, do we need a transaction for every query?