### PR TITLE
Deresource & uphash: gigabit DNSSEC root-server performance

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -431,9 +431,9 @@ test_auth() {
 
   run "cd regression-tests"
 
-  run "./timestamp ./start-test-stop 5300 ldap-tree"
-  run "./timestamp ./start-test-stop 5300 ldap-simple"
-  run "./timestamp ./start-test-stop 5300 ldap-strict"
+#  run "./timestamp ./start-test-stop 5300 ldap-tree"
+#  run "./timestamp ./start-test-stop 5300 ldap-simple"
+#  run "./timestamp ./start-test-stop 5300 ldap-strict"
 
   run "./timestamp ./start-test-stop 5300 bind-both"
   run "./timestamp ./start-test-stop 5300 bind-dnssec-both"

--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -431,9 +431,9 @@ test_auth() {
 
   run "cd regression-tests"
 
-#  run "./timestamp ./start-test-stop 5300 ldap-tree"
-#  run "./timestamp ./start-test-stop 5300 ldap-simple"
-#  run "./timestamp ./start-test-stop 5300 ldap-strict"
+  run "./timestamp ./start-test-stop 5300 ldap-tree"
+  run "./timestamp ./start-test-stop 5300 ldap-simple"
+  run "./timestamp ./start-test-stop 5300 ldap-strict"
 
   run "./timestamp ./start-test-stop 5300 bind-both"
   run "./timestamp ./start-test-stop 5300 bind-dnssec-both"

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -993,7 +993,7 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::string
     nsec3zone=getNSEC3PARAM(auth, &ns3pr);
 
   if(!nsec3zone) {
-    DNSName dqname = DNSName(labelReverse(qname));
+    DNSName dqname = DNSName(qname).labelReverse();
     //cerr<<"in bind2backend::getBeforeAndAfterAbsolute: no nsec3 for "<<auth<<endl;
     return findBeforeAndAfterUnhashed(bbd, dqname, unhashed, before, after);
   }

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -939,15 +939,17 @@ bool Bind2Backend::findBeforeAndAfterUnhashed(BB2DomainInfo& bbd, const DNSName&
 
     if(iter->qname.empty())
       before.clear();
-    else {
+    else { 
+
       before=iter->qname.labelReverse().toString(" ",false);
     }
   }
   else {
     if(qname.empty())
       before.clear();
-    else
+    else {
       before=qname.labelReverse().toString(" ",false);
+    }
   }
 
   //cerr<<"Now after"<<endl;
@@ -969,8 +971,9 @@ bool Bind2Backend::findBeforeAndAfterUnhashed(BB2DomainInfo& bbd, const DNSName&
         break;
       }
     }
-    if(iter != records->end())
+    if(iter != records->end()) {
       after = (iter)->qname.labelReverse().toString(" ",false);
+    }
   }
 
   // cerr<<"Before: '"<<before<<"', after: '"<<after<<"'\n";
@@ -993,8 +996,7 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::string
     nsec3zone=getNSEC3PARAM(auth, &ns3pr);
 
   if(!nsec3zone) {
-    DNSName dqname(DNSName(qname).labelReverse().toString(" ", false)); // the horror
-    //cerr<<"in bind2backend::getBeforeAndAfterAbsolute: no nsec3 for "<<auth<<endl;
+    DNSName dqname(DNSName(boost::replace_all_copy(qname," ",".")).labelReverse()); // the horror
     return findBeforeAndAfterUnhashed(bbd, dqname, unhashed, before, after);
   }
   else {

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -998,16 +998,11 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::string
     return findBeforeAndAfterUnhashed(bbd, dqname, unhashed, before, after);
   }
   else {
-    typedef recordstorage_t::index<HashedTag>::type records_by_hashindex_t;
-    records_by_hashindex_t& hashindex=boost::multi_index::get<HashedTag>(*bbd.d_records.getWRITABLE());
+    auto& hashindex=boost::multi_index::get<NSEC3Tag>(*bbd.d_records.getWRITABLE());
 
-    records_by_hashindex_t::const_iterator iter, first;
-    first = hashindex.upper_bound(""); // skip records without a hash
+    auto first = hashindex.upper_bound("");
+    auto iter = hashindex.upper_bound(toLower(qname));
 
-    // for(auto iter = first; iter != hashindex.end(); iter++)
-    //   cerr<<iter->nsec3hash<<endl;
-
-    iter = hashindex.upper_bound(toLower(qname));
     if (iter == hashindex.end()) {
       --iter;
       before = iter->nsec3hash;
@@ -1081,20 +1076,17 @@ void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *p
   if(d_handle.d_records->empty())
     DLOG(L<<"Query with no results"<<endl);
 
-  pair<recordstorage_t::const_iterator, recordstorage_t::const_iterator> range;
-
-  range = d_handle.d_records->equal_range(d_handle.qname);
-  //cout<<"End equal range"<<endl;
   d_handle.mustlog = mustlog;
+
+  auto& hashedidx = boost::multi_index::get<UnorderedNameTag>(*d_handle.d_records);
+  auto range = hashedidx.equal_range(d_handle.qname);
   
   if(range.first==range.second) {
-    // cerr<<"Found nothing!"<<endl;
     d_handle.d_list=false;
     d_handle.d_iter = d_handle.d_end_iter  = range.first;
     return;
   }
   else {
-    // cerr<<"Found something!"<<endl;
     d_handle.d_iter=range.first;
     d_handle.d_end_iter=range.second;
   }

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -993,7 +993,7 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::string
     nsec3zone=getNSEC3PARAM(auth, &ns3pr);
 
   if(!nsec3zone) {
-    DNSName dqname = DNSName(qname).labelReverse();
+    DNSName dqname(DNSName(qname).labelReverse().toString(" ", false)); // the horror
     //cerr<<"in bind2backend::getBeforeAndAfterAbsolute: no nsec3 for "<<auth<<endl;
     return findBeforeAndAfterUnhashed(bbd, dqname, unhashed, before, after);
   }

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -194,6 +194,7 @@ public:
   void lookup(const QType &, const DNSName &qdomain, DNSPacket *p=0, int zoneId=-1);
   bool list(const DNSName &target, int id, bool include_disabled=false);
   bool get(DNSResourceRecord &);
+  bool get(DNSZoneRecord &) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false);
 
   static DNSBackend *maker();

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -34,6 +34,7 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/member.hpp>
@@ -86,13 +87,15 @@ struct Bind2DNSCompare : std::less<Bind2DNSRecord>
     {return a.qname.canonCompare(b.qname);}
 };
 
-struct HashedTag{};
+struct NSEC3Tag{};
+struct UnorderedNameTag{};
 
 typedef multi_index_container<
   Bind2DNSRecord,
   indexed_by  <
                 ordered_non_unique<identity<Bind2DNSRecord>, Bind2DNSCompare >,
-                ordered_non_unique<tag<HashedTag>, member<Bind2DNSRecord, std::string, &Bind2DNSRecord::nsec3hash> >
+                hashed_non_unique<tag<UnorderedNameTag>, member<Bind2DNSRecord, DNSName, &Bind2DNSRecord::qname> >,
+                ordered_non_unique<tag<NSEC3Tag>, member<Bind2DNSRecord, std::string, &Bind2DNSRecord::nsec3hash> >
               >
 > recordstorage_t;
 
@@ -194,7 +197,7 @@ public:
   void lookup(const QType &, const DNSName &qdomain, DNSPacket *p=0, int zoneId=-1);
   bool list(const DNSName &target, int id, bool include_disabled=false);
   bool get(DNSResourceRecord &);
-  bool get(DNSZoneRecord &) override;
+  //  bool get(DNSZoneRecord &) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false);
 
   static DNSBackend *maker();
@@ -264,9 +267,10 @@ private:
     handle();
 
     shared_ptr<const recordstorage_t > d_records;
-    recordstorage_t::const_iterator d_iter, d_end_iter;
-    recordstorage_t::const_iterator d_qname_iter;
-    recordstorage_t::const_iterator d_qname_end;
+    recordstorage_t::index<UnorderedNameTag>::type::const_iterator d_iter, d_end_iter;
+
+    recordstorage_t::const_iterator d_qname_iter, d_qname_end;
+
     DNSName qname;
     DNSName domain;
 

--- a/modules/ldapbackend/ldapbackend.cc
+++ b/modules/ldapbackend/ldapbackend.cc
@@ -26,7 +26,8 @@
 #include "ldapbackend.hh"
 
 unsigned int ldap_host_index = 0;
-
+#undef DLOG
+#define DLOG(x) x
 LdapBackend::LdapBackend( const string &suffix )
 {
         string hoststr;
@@ -167,7 +168,7 @@ inline bool LdapBackend::list_simple( const DNSName& target, int domain_id )
 
         prepare();
         filter = strbind( ":target:", "associatedDomain=*." + qesc, getArg( "filter-axfr" ) );
-        DLOG( L << Logger::Debug << m_myname << " Search = basedn: " << dn << ", filter: " << filter << endl );
+        DLOG( L << Logger::Warning << m_myname << " Search = basedn: " << dn << ", filter: " << filter << endl );
         m_msgid = m_pldap->search( dn, LDAP_SCOPE_SUBTREE, filter, (const char**) ldap_attrany );
 
         return true;
@@ -238,7 +239,7 @@ void LdapBackend::lookup_simple( const QType &qtype, const DNSName &qname, DNSPa
 
         filter = strbind( ":target:", filter, getArg( "filter-lookup" ) );
 
-        DLOG( L << Logger::Debug << m_myname << " Search = basedn: " << getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
+        DLOG( L << Logger::Warning << m_myname << " Search = basedn: " << getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
         m_msgid = m_pldap->search( getArg( "basedn" ), LDAP_SCOPE_SUBTREE, filter, attributes );
 }
 
@@ -283,7 +284,7 @@ void LdapBackend::lookup_strict( const QType &qtype, const DNSName &qname, DNSPa
 
         filter = strbind( ":target:", filter, getArg( "filter-lookup" ) );
 
-        DLOG( L << Logger::Debug << m_myname << " Search = basedn: " << getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
+        DLOG( L << Logger::Warning << m_myname << " Search = basedn: " << getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
         m_msgid = m_pldap->search( getArg( "basedn" ), LDAP_SCOPE_SUBTREE, filter, attributes );
 }
 
@@ -316,7 +317,7 @@ void LdapBackend::lookup_tree( const QType &qtype, const DNSName &qname, DNSPack
         	dn = "dc=" + *i + "," + dn;
         }
 
-        DLOG( L << Logger::Debug << m_myname << " Search = basedn: " << dn + getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
+        DLOG( L << Logger::Warning << m_myname << " Search = basedn: " << dn + getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
         m_msgid = m_pldap->search( dn + getArg( "basedn" ), LDAP_SCOPE_BASE, filter, attributes );
 }
 
@@ -445,7 +446,7 @@ bool LdapBackend::get( DNSResourceRecord &rr )
         					rr.content = *m_value;
         					m_value++;
 
-        					DLOG( L << Logger::Debug << m_myname << " Record = qname: " << rr.qname << ", qtype: " << (rr.qtype).getName() << ", ttl: " << rr.ttl << ", content: " << rr.content << endl );
+        					DLOG( L << Logger::Warning << m_myname << " Record = qname: " << rr.qname << ", qtype: " << (rr.qtype).getName() << ", ttl: " << rr.ttl << ", content: " << rr.content << endl );
         					return true;
         				}
 

--- a/modules/ldapbackend/ldapbackend.cc
+++ b/modules/ldapbackend/ldapbackend.cc
@@ -26,8 +26,7 @@
 #include "ldapbackend.hh"
 
 unsigned int ldap_host_index = 0;
-#undef DLOG
-#define DLOG(x) x
+
 LdapBackend::LdapBackend( const string &suffix )
 {
         string hoststr;
@@ -168,7 +167,7 @@ inline bool LdapBackend::list_simple( const DNSName& target, int domain_id )
 
         prepare();
         filter = strbind( ":target:", "associatedDomain=*." + qesc, getArg( "filter-axfr" ) );
-        DLOG( L << Logger::Warning << m_myname << " Search = basedn: " << dn << ", filter: " << filter << endl );
+        DLOG( L << Logger::Debug << m_myname << " Search = basedn: " << dn << ", filter: " << filter << endl );
         m_msgid = m_pldap->search( dn, LDAP_SCOPE_SUBTREE, filter, (const char**) ldap_attrany );
 
         return true;
@@ -239,7 +238,7 @@ void LdapBackend::lookup_simple( const QType &qtype, const DNSName &qname, DNSPa
 
         filter = strbind( ":target:", filter, getArg( "filter-lookup" ) );
 
-        DLOG( L << Logger::Warning << m_myname << " Search = basedn: " << getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
+        DLOG( L << Logger::Debug << m_myname << " Search = basedn: " << getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
         m_msgid = m_pldap->search( getArg( "basedn" ), LDAP_SCOPE_SUBTREE, filter, attributes );
 }
 
@@ -284,7 +283,7 @@ void LdapBackend::lookup_strict( const QType &qtype, const DNSName &qname, DNSPa
 
         filter = strbind( ":target:", filter, getArg( "filter-lookup" ) );
 
-        DLOG( L << Logger::Warning << m_myname << " Search = basedn: " << getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
+        DLOG( L << Logger::Debug << m_myname << " Search = basedn: " << getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
         m_msgid = m_pldap->search( getArg( "basedn" ), LDAP_SCOPE_SUBTREE, filter, attributes );
 }
 
@@ -317,7 +316,7 @@ void LdapBackend::lookup_tree( const QType &qtype, const DNSName &qname, DNSPack
         	dn = "dc=" + *i + "," + dn;
         }
 
-        DLOG( L << Logger::Warning << m_myname << " Search = basedn: " << dn + getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
+        DLOG( L << Logger::Debug << m_myname << " Search = basedn: " << dn + getArg( "basedn" ) << ", filter: " << filter << ", qtype: " << qtype.getName() << endl );
         m_msgid = m_pldap->search( dn + getArg( "basedn" ), LDAP_SCOPE_BASE, filter, attributes );
 }
 
@@ -446,7 +445,7 @@ bool LdapBackend::get( DNSResourceRecord &rr )
         					rr.content = *m_value;
         					m_value++;
 
-        					DLOG( L << Logger::Warning << m_myname << " Record = qname: " << rr.qname << ", qtype: " << (rr.qtype).getName() << ", ttl: " << rr.ttl << ", content: " << rr.content << endl );
+        					DLOG( L << Logger::Debug << m_myname << " Record = qname: " << rr.qname << ", qtype: " << (rr.qtype).getName() << ", ttl: " << rr.ttl << ", content: " << rr.content << endl );
         					return true;
         				}
 

--- a/modules/luabackend/dnssec.cc
+++ b/modules/luabackend/dnssec.cc
@@ -36,7 +36,7 @@ bool LUABackend::updateDNSSECOrderAndAuth(uint32_t domain_id, const DNSName& zon
 	if(logging)
 	    L << Logger::Info << backend_name << "(updateDNSSECOrderAndAuth) domain_id: '" << domain_id << "' zonename: '" << zonename << "' qname: '" << qname << "' auth: '" << auth << "'" << endl;
 	    
-	string ins=toLower(labelReverse(qname.makeRelative(zonename).toString()));
+	string ins=qname.makeRelative(zonename).makeLowerCase().labelReverse().toString();
 	return this->updateDNSSECOrderAndAuthAbsolute(domain_id, qname, ins, auth);
     } 
 

--- a/modules/luabackend/dnssec.cc
+++ b/modules/luabackend/dnssec.cc
@@ -36,7 +36,7 @@ bool LUABackend::updateDNSSECOrderAndAuth(uint32_t domain_id, const DNSName& zon
 	if(logging)
 	    L << Logger::Info << backend_name << "(updateDNSSECOrderAndAuth) domain_id: '" << domain_id << "' zonename: '" << zonename << "' qname: '" << qname << "' auth: '" << auth << "'" << endl;
 	    
-	string ins=qname.makeRelative(zonename).makeLowerCase().labelReverse().toString();
+	string ins=qname.makeRelative(zonename).makeLowerCase().labelReverse().toString(" ", false);
 	return this->updateDNSSECOrderAndAuthAbsolute(domain_id, qname, ins, auth);
     } 
 

--- a/modules/mydnsbackend/mydnsbackend.cc
+++ b/modules/mydnsbackend/mydnsbackend.cc
@@ -129,7 +129,7 @@ MyDNSBackend::MyDNSBackend(const string &suffix) {
 
     d_listQuery_stmt = d_db->prepare(listQuery, 1);
   
-    anyQuery += ") UNION (SELECT 'SOA' AS type, origin AS data, '0' AS aux, ttl, id AS zone FROM `"+soatable+"` WHERE id = ? AND origin = ?";
+    anyQuery += ") UNION (SELECT 'SOA' AS type, CONCAT_WS(' ', ns, mbox,serial,refresh,retry,expire,minimum) AS data, '0' AS aux, ttl, id AS zone FROM `"+soatable+"` WHERE id = ? AND origin = ?";
 
     if (!soawhere.empty()) {
       anyQuery += " AND "+soawhere;

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1136,6 +1136,7 @@ testrunner_SOURCES = \
 	test-base64_cc.cc \
 	test-bindparser_cc.cc \
 	test-delaypipe_hh.cc \
+	test-dnsrecordcontent.cc \
 	test-distributor_hh.cc \
 	test-dns_random_hh.cc \
 	test-dnsname_cc.cc \

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -285,10 +285,12 @@ bool DNSBackend::getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, co
   // lcqname=labelReverse(lcqname);
   DNSName dnc;
   string relqname, sbefore, safter;
-  relqname=qname.makeRelative(zonename).toStringNoDot();
+  relqname=qname.makeRelative(zonename).labelReverse().toString(" ", false);
   //sbefore = before.toString();
   //safter = after.toString();
   bool ret = this->getBeforeAndAfterNamesAbsolute(id, relqname, dnc, sbefore, safter);
+  boost::replace_all(sbefore, " ", ".");
+  boost::replace_all(safter, " ", ".");
   before = DNSName(sbefore).labelReverse() + lczonename;
   after = DNSName(safter).labelReverse() + lczonename;
 

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -271,6 +271,7 @@ bool DNSBackend::get(DNSZoneRecord& dzr)
     return false;
   dzr.auth = rr.auth;
   dzr.domain_id = rr.domain_id;
+  dzr.scopeMask = rr.scopeMask;
   if(rr.qtype.getCode() == QType::TXT && !rr.content.empty() && rr.content[0]!='"')
     rr.content = "\""+ rr.content + "\"";
   dzr.dr = DNSRecord(rr);

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -274,7 +274,29 @@ bool DNSBackend::get(DNSZoneRecord& dzr)
   dzr.scopeMask = rr.scopeMask;
   if(rr.qtype.getCode() == QType::TXT && !rr.content.empty() && rr.content[0]!='"')
     rr.content = "\""+ rr.content + "\"";
-  dzr.dr = DNSRecord(rr);
+  if(rr.qtype.getCode() == QType::SOA) {
+    try {
+      dzr.dr = DNSRecord(rr);
+    } catch(...) {
+      vector<string> parts;
+      stringtok(parts, rr.content, " \t");
+      if(parts.size() < 1)
+        rr.content+=arg()["default-soa-name"];
+      if(parts.size() < 2)
+        rr.content+=" "+arg()["default-soa-mail"];      
+      if(parts.size() < 3)
+        rr.content += " 0";
+      if(parts.size() < 4)
+        rr.content += " " + ::arg()["soa-refresh-default"];
+      if(parts.size() < 5)
+        rr.content += " " + ::arg()["soa-expire-default"];
+      if(parts.size() < 6)
+        rr.content += " " + ::arg()["soa-minimum-default"];
+      dzr.dr = DNSRecord(rr);        
+    }
+  }
+  else 
+    dzr.dr = DNSRecord(rr);
   return true;
 }
 

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -271,6 +271,8 @@ bool DNSBackend::get(DNSZoneRecord& dzr)
     return false;
   dzr.auth = rr.auth;
   dzr.domain_id = rr.domain_id;
+  if(rr.qtype.getCode() == QType::TXT && !rr.content.empty() && rr.content[0]!='"')
+    rr.content = "\""+ rr.content + "\"";
   dzr.dr = DNSRecord(rr);
   return true;
 }

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -265,6 +265,7 @@ bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd, DNSPacket *p)
 
 bool DNSBackend::get(DNSZoneRecord& dzr)
 {
+  //  cout<<"DNSBackend::get(DNSZoneRecord&) called - translating into DNSResourceRecord query"<<endl;
   DNSResourceRecord rr;
   if(!this->get(rr))
     return false;

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -263,22 +263,33 @@ bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd, DNSPacket *p)
   return true;
 }
 
+bool DNSBackend::get(DNSZoneRecord& dzr)
+{
+  DNSResourceRecord rr;
+  if(!this->get(rr))
+    return false;
+  dzr.auth = rr.auth;
+  dzr.domain_id = rr.domain_id;
+  dzr.dr = DNSRecord(rr);
+  return true;
+}
+
 bool DNSBackend::getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, const DNSName& qname, DNSName& before, DNSName& after)
 {
   // FIXME400 FIXME400 FIXME400
   // string lcqname=toLower(qname); FIXME400 tolower?
   // string lczonename=toLower(zonename); FIXME400 tolower?
   // lcqname=makeRelative(lcqname, lczonename);
-  DNSName lczonename = DNSName(toLower(zonename.toString()));
+  DNSName lczonename = zonename.makeLowerCase(); 
   // lcqname=labelReverse(lcqname);
   DNSName dnc;
   string relqname, sbefore, safter;
-  relqname=labelReverse(makeRelative(qname.toStringNoDot(), zonename.toStringNoDot())); // FIXME400
+  relqname=qname.makeRelative(zonename).toStringNoDot();
   //sbefore = before.toString();
   //safter = after.toString();
   bool ret = this->getBeforeAndAfterNamesAbsolute(id, relqname, dnc, sbefore, safter);
-  before = DNSName(labelReverse(sbefore)) + lczonename;
-  after = DNSName(labelReverse(safter)) + lczonename;
+  before = DNSName(sbefore).labelReverse() + lczonename;
+  after = DNSName(safter).labelReverse() + lczonename;
 
   // before=dotConcat(labelReverse(before), lczonename); FIXME400
   // after=dotConcat(labelReverse(after), lczonename); FIXME400
@@ -317,6 +328,32 @@ bool DNSBackend::calculateSOASerial(const DNSName& domain, const SOAData& sd, ti
 
     return true;
 }
+void fillSOAData(const DNSZoneRecord& in, SOAData& sd)
+{
+  sd.domain_id = in.domain_id;
+  sd.ttl = in.dr.d_ttl;
+
+  auto src=getRR<SOARecordContent>(in.dr);
+  sd.nameserver = src->d_mname;
+  sd.hostmaster = src->d_rname;
+  sd.serial = src->d_st.serial;
+  sd.refresh = src->d_st.refresh;
+  sd.retry = src->d_st.retry;
+  sd.expire = src->d_st.expire;
+  sd.default_ttl = src->d_st.minimum;
+}
+
+std::shared_ptr<DNSRecordContent> makeSOAContent(const SOAData& sd)
+{
+    struct soatimes st;
+    st.serial = sd.serial;
+    st.refresh = sd.refresh;
+    st.retry = sd.retry;
+    st.expire = sd.expire;
+    st.minimum = sd.default_ttl;
+    return std::make_shared<SOARecordContent>(sd.nameserver, sd.hostmaster, st);
+}
+
 
 void fillSOAData(const string &content, SOAData &data)
 {

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -113,6 +113,7 @@ public:
   //! lookup() initiates a lookup. A lookup without results should not throw!
   virtual void lookup(const QType &qtype, const DNSName &qdomain, DNSPacket *pkt_p=0, int zoneId=-1)=0; 
   virtual bool get(DNSResourceRecord &)=0; //!< retrieves one DNSResource record, returns false if no more were available
+  virtual bool get(DNSZoneRecord &r);
 
   //! Initiates a list of the specified domain
   /** Once initiated, DNSResourceRecord objects can be retrieved using get(). Should return false
@@ -430,6 +431,9 @@ public:
 
 /** helper function for both DNSPacket and addSOARecord() - converts a line into a struct, for easier parsing */
 void fillSOAData(const string &content, SOAData &data);
-
+// same but more karmic
+void fillSOAData(const DNSZoneRecord& in, SOAData& data);
+// the reverse
+std::shared_ptr<DNSRecordContent> makeSOAContent(const SOAData& sd);
 
 #endif

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -256,10 +256,6 @@ bool DNSPacket::isEmpty()
   return (d_rrs.empty());
 }
 
-static void shuffle(vector<DNSZoneRecord>& rrs)
-{
-}
-
 /** Must be called before attempting to access getData(). This function stuffs all resource
  *  records found in rrs into the data buffer. It also frees resource records queued for us.
  */

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -174,42 +174,36 @@ void DNSPacket::clearRecords()
   d_rrs.clear();
 }
 
-void DNSPacket::addRecord(const DNSResourceRecord &rr)
+void DNSPacket::addRecord(const DNSZoneRecord &rr)
 {
   // this removes duplicates from the packet in case we are not compressing
   // for AXFR, no such checking is performed!
   // cerr<<"addrecord, content=["<<rr.content<<"]"<<endl;
-  if(d_compress)
-    for(vector<DNSResourceRecord>::const_iterator i=d_rrs.begin();i!=d_rrs.end();++i) 
-      if(rr.qname==i->qname && rr.qtype==i->qtype && rr.content==i->content) {
+  if(0 && d_compress) {
+    for(auto i=d_rrs.begin();i!=d_rrs.end();++i) {
+      if(rr.dr == i->dr)
           return;
-      }
+    }
+  }
+
   // cerr<<"added to d_rrs"<<endl;
   d_rrs.push_back(rr);
 }
 
 
 
-static int rrcomp(const DNSResourceRecord &A, const DNSResourceRecord &B)
+vector<DNSZoneRecord*> DNSPacket::getAPRecords()
 {
-  if(A.d_place < B.d_place)
-    return 1;
+  vector<DNSZoneRecord*> arrs;
 
-  return 0;
-}
-
-vector<DNSResourceRecord*> DNSPacket::getAPRecords()
-{
-  vector<DNSResourceRecord*> arrs;
-
-  for(vector<DNSResourceRecord>::iterator i=d_rrs.begin();
+  for(vector<DNSZoneRecord>::iterator i=d_rrs.begin();
       i!=d_rrs.end();
       ++i)
     {
-      if(i->d_place!=DNSResourceRecord::ADDITIONAL &&
-         (i->qtype.getCode()==QType::MX ||
-          i->qtype.getCode()==QType::NS ||
-          i->qtype.getCode()==QType::SRV))
+      if(i->dr.d_place!=DNSResourceRecord::ADDITIONAL &&
+         (i->dr.d_type==QType::MX ||
+          i->dr.d_type==QType::NS ||
+          i->dr.d_type==QType::SRV))
         {
           arrs.push_back(&*i);
         }
@@ -219,15 +213,15 @@ vector<DNSResourceRecord*> DNSPacket::getAPRecords()
 
 }
 
-vector<DNSResourceRecord*> DNSPacket::getAnswerRecords()
+vector<DNSZoneRecord*> DNSPacket::getAnswerRecords()
 {
-  vector<DNSResourceRecord*> arrs;
+  vector<DNSZoneRecord*> arrs;
 
-  for(vector<DNSResourceRecord>::iterator i=d_rrs.begin();
+  for(vector<DNSZoneRecord>::iterator i=d_rrs.begin();
       i!=d_rrs.end();
       ++i)
     {
-      if(i->d_place!=DNSResourceRecord::ADDITIONAL)
+      if(i->dr.d_place!=DNSResourceRecord::ADDITIONAL)
         arrs.push_back(&*i);
     }
   return arrs;
@@ -249,9 +243,9 @@ bool DNSPacket::couldBeCached()
 unsigned int DNSPacket::getMinTTL()
 {
   unsigned int minttl = UINT_MAX;
-  for(const DNSResourceRecord& rr :  d_rrs) {
-  if (rr.ttl < minttl)
-      minttl = rr.ttl;
+  for(const DNSZoneRecord& rr :  d_rrs) {
+  if (rr.dr.d_ttl < minttl)
+      minttl = rr.dr.d_ttl;
   }
 
   return minttl;
@@ -260,6 +254,10 @@ unsigned int DNSPacket::getMinTTL()
 bool DNSPacket::isEmpty()
 {
   return (d_rrs.empty());
+}
+
+static void shuffle(vector<DNSZoneRecord>& rrs)
+{
 }
 
 /** Must be called before attempting to access getData(). This function stuffs all resource
@@ -271,13 +269,15 @@ void DNSPacket::wrapup()
     return;
   }
 
-  DNSResourceRecord rr;
-  vector<DNSResourceRecord>::iterator pos;
+  DNSZoneRecord rr;
+  vector<DNSZoneRecord>::iterator pos;
 
   // we now need to order rrs so that the different sections come at the right place
   // we want a stable sort, based on the d_place field
 
-  stable_sort(d_rrs.begin(),d_rrs.end(), rrcomp);
+  stable_sort(d_rrs.begin(),d_rrs.end(), [](const DNSZoneRecord& a, const DNSZoneRecord& b) {
+      return a.dr.d_place < b.dr.d_place;
+    });
   static bool mustNotShuffle = ::arg().mustDo("no-shuffle");
 
   if(!d_tcp && !mustNotShuffle) {
@@ -316,19 +316,12 @@ void DNSPacket::wrapup()
       for(pos=d_rrs.begin(); pos < d_rrs.end(); ++pos) {
         // cerr<<"during wrapup, content=["<<pos->content<<"]"<<endl;
         maxScopeMask = max(maxScopeMask, pos->scopeMask);
-
-        if(!pos->content.empty() && pos->qtype.getCode()==QType::TXT && pos->content[0]!='"') {
-          pos->content="\""+pos->content+"\"";
-        }
-        if(pos->content.empty())  // empty contents confuse the MOADNS setup
-          pos->content=".";
         
-        pw.startRecord(pos->qname, pos->qtype.getCode(), pos->ttl, pos->qclass, pos->d_place);
-        shared_ptr<DNSRecordContent> drc(DNSRecordContent::mastermake(pos->qtype.getCode(), pos->qclass, pos->content));
-              drc->toPacket(pw);
+        pw.startRecord(pos->dr.d_name, pos->dr.d_type, pos->dr.d_ttl, pos->dr.d_class, pos->dr.d_place);
+        pos->dr.d_content->toPacket(pw);
         if(pw.size() + 20U > (d_tcp ? 65535 : getMaxReplyLen())) { // 20 = room for EDNS0
           pw.rollback();
-          if(pos->d_place == DNSResourceRecord::ANSWER || pos->d_place == DNSResourceRecord::AUTHORITY) {
+          if(pos->dr.d_place == DNSResourceRecord::ANSWER || pos->dr.d_place == DNSResourceRecord::AUTHORITY) {
             pw.getHeader()->tc=1;
           }
           goto noCommit;
@@ -365,7 +358,7 @@ void DNSPacket::wrapup()
   if(d_trc.d_algoName.countLabels())
     addTSIG(pw, &d_trc, d_tsigkeyname, d_tsigsecret, d_tsigprevious, d_tsigtimersonly);
   
-  d_rawpacket.assign((char*)&packet[0], packet.size());
+  d_rawpacket.assign((char*)&packet[0], packet.size()); // XXX we could do this natively on a vector..
 
   // copy RR counts so LPE can read them
   d.qdcount = pw.getHeader()->qdcount;

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -179,9 +179,9 @@ void DNSPacket::addRecord(const DNSZoneRecord &rr)
   // this removes duplicates from the packet in case we are not compressing
   // for AXFR, no such checking is performed!
   // cerr<<"addrecord, content=["<<rr.content<<"]"<<endl;
-  if(0 && d_compress) {
+  if(d_compress) {
     for(auto i=d_rrs.begin();i!=d_rrs.end();++i) {
-      if(rr.dr == i->dr)
+      if(rr.dr == i->dr)  // XXX SUPER SLOW
           return;
     }
   }

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -55,10 +55,9 @@
 #include "pdnsexception.hh"
 #include "dnsrecords.hh"
 
-
-
 class UeberBackend;
 class DNSSECKeeper;
+
 
 //! This class represents DNS packets, either received or to be sent.
 class DNSPacket
@@ -105,10 +104,10 @@ public:
 
   void clearRecords(); //!< when building a packet, wipe all previously added records (clears 'rrs')
 
-  /** Add a DNSResourceRecord to this packet. A DNSPacket (as does a DNS Packet) has 4 kinds of resource records. Questions, 
+  /** Add a DNSZoneRecord to this packet. A DNSPacket (as does a DNS Packet) has 4 kinds of resource records. Questions, 
       Answers, Authority and Additional. See RFC 1034 and 1035 for details. You can specify where a record needs to go in the
-      DNSResourceRecord d_place field */
-  void addRecord(const DNSResourceRecord &);  // adds to 'rrs'
+      DNSZoneRecord d_place field */
+  void addRecord(const DNSZoneRecord &);  // adds to 'rrs'
 
   void setQuestion(int op, const DNSName &qdomain, int qtype);  // wipes 'd', sets a random id, creates start of packet (domain, type, class etc)
 
@@ -118,8 +117,8 @@ public:
   unsigned int getMinTTL(); //!< returns lowest TTL of any record in the packet
   bool isEmpty(); //!< returns true if there are no rrs in the packet
 
-  vector<DNSResourceRecord*> getAPRecords(); //!< get a vector with DNSResourceRecords that need additional processing
-  vector<DNSResourceRecord*> getAnswerRecords(); //!< get a vector with DNSResourceRecords that are answers
+  vector<DNSZoneRecord*> getAPRecords(); //!< get a vector with DNSZoneRecords that need additional processing
+  vector<DNSZoneRecord*> getAnswerRecords(); //!< get a vector with DNSZoneRecords that are answers
   void setCompress(bool compress);
 
   DNSPacket *replyPacket() const; //!< convenience function that creates a virgin answer packet to this question
@@ -164,7 +163,7 @@ public:
   void setTSIGDetails(const TSIGRecordContent& tr, const DNSName& keyname, const string& secret, const string& previous, bool timersonly=false);
   bool getTKEYRecord(TKEYRecordContent* tr, DNSName* keyname) const;
 
-  vector<DNSResourceRecord>& getRRS() { return d_rrs; }
+  vector<DNSZoneRecord>& getRRS() { return d_rrs; }
   static bool s_doEDNSSubnetProcessing;
   static uint16_t s_udpTruncationThreshold; //2
 private:
@@ -177,7 +176,7 @@ private:
   DNSName d_tsigkeyname;
   string d_tsigprevious;
 
-  vector<DNSResourceRecord> d_rrs; // 8
+  vector<DNSZoneRecord> d_rrs; // 8
   string d_rawpacket; // this is where everything lives 8
   string d_ednsping;
   EDNSSubnetOpts d_eso;

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -192,6 +192,11 @@ public:
     return record;
   }
 
+  virtual bool operator==(const DNSRecordContent& rhs) const
+  {
+    return typeid(*this)==typeid(rhs) && this->getZoneRepresentation() == rhs.getZoneRepresentation();
+  }
+  
   static shared_ptr<DNSRecordContent> unserialize(const DNSName& qname, uint16_t qtype, const string& serialized);
 
   void doRecordCheck(const struct DNSRecord&){}
@@ -318,13 +323,7 @@ struct DNSRecord
     if(d_type != rhs.d_type || d_class != rhs.d_class || d_name != rhs.d_name)
       return false;
     
-    string lzrp, rzrp;
-    if(d_content)
-      lzrp=toLower(d_content->getZoneRepresentation());
-    if(rhs.d_content)
-      rzrp=toLower(rhs.d_content->getZoneRepresentation());
-
-    return lzrp == rzrp;
+    return *d_content == *rhs.d_content;
   }
 };
 

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -315,20 +315,29 @@ struct DNSRecord
 
   bool operator==(const DNSRecord& rhs) const
   {
+    if(d_type != rhs.d_type || d_class != rhs.d_class || d_name != rhs.d_name)
+      return false;
+    
     string lzrp, rzrp;
     if(d_content)
       lzrp=toLower(d_content->getZoneRepresentation());
     if(rhs.d_content)
       rzrp=toLower(rhs.d_content->getZoneRepresentation());
-    
-    string llabel=toLower(d_name.toString()); 
-    string rlabel=toLower(rhs.d_name.toString()); 
-    
-    return 
-      tie(llabel,     d_type,     d_class, lzrp) ==
-      tie(rlabel, rhs.d_type, rhs.d_class, rzrp);
+
+    return lzrp == rzrp;
   }
 };
+
+struct DNSZoneRecord
+{
+  int domain_id;
+  uint8_t scopeMask;
+  int signttl;
+  DNSName wildcardname;
+  bool auth;
+  DNSRecord dr;
+};
+
 
 //! This class can be used to parse incoming packets, and is copyable
 class MOADNSParser : public boost::noncopyable

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -330,11 +330,11 @@ struct DNSRecord
 
 struct DNSZoneRecord
 {
-  int domain_id;
-  uint8_t scopeMask;
-  int signttl;
+  int domain_id{-1};
+  uint8_t scopeMask{0};
+  int signttl{0};
   DNSName wildcardname;
-  bool auth;
+  bool auth{true};
   DNSRecord dr;
 };
 

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -249,15 +249,14 @@ void DNSProxy::mainloop(void)
 	    //	    cerr<<"comp: "<<(int)j->first.d_place-1<<" "<<j->first.d_label<<" " << DNSRecordContent::NumberToType(j->first.d_type)<<" "<<j->first.d_content->getZoneRepresentation()<<endl;
 	    if(j->first.d_place == DNSResourceRecord::ANSWER || (j->first.d_place == DNSResourceRecord::AUTHORITY && j->first.d_type == QType::SOA)) {
 	    
-	      DNSResourceRecord rr;
-
 	      if(j->first.d_type == i->second.qtype || (i->second.qtype == QType::ANY && (j->first.d_type == QType::A || j->first.d_type == QType::AAAA))) {
-		rr.qname=i->second.aname;
-		rr.qtype = j->first.d_type;
-		rr.ttl=j->first.d_ttl;
-		rr.d_place= j->first.d_place;
-		rr.content=j->first.d_content->getZoneRepresentation();
-		i->second.complete->addRecord(rr);
+                DNSZoneRecord dzr;
+		dzr.dr.d_name=i->second.aname;
+		dzr.dr.d_type = j->first.d_type;
+		dzr.dr.d_ttl=j->first.d_ttl;
+		dzr.dr.d_place= j->first.d_place;
+		dzr.dr.d_content=j->first.d_content;
+		i->second.complete->addRecord(dzr);
 	      }
 	    }
 	  }

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -150,6 +150,7 @@ boilerplate_conv(DNAME, QType::DNAME, conv.xfrName(d_content));
 boilerplate_conv(MR, QType::MR, conv.xfrName(d_alias, true));
 boilerplate_conv(MINFO, QType::MINFO, conv.xfrName(d_rmailbx, true); conv.xfrName(d_emailbx, true));
 boilerplate_conv(TXT, QType::TXT, conv.xfrText(d_text, true));
+boilerplate_conv(ENT, 0, );
 boilerplate_conv(SPF, 99, conv.xfrText(d_text, true));
 boilerplate_conv(HINFO, QType::HINFO,  conv.xfrText(d_cpu);   conv.xfrText(d_host));
 
@@ -592,6 +593,7 @@ void reportOtherTypes()
    SPFRecordContent::report();
    NAPTRRecordContent::report();
    LOCRecordContent::report();
+   ENTRecordContent::report();
    HINFORecordContent::report();
    RPRecordContent::report();
    KEYRecordContent::report();

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -161,7 +161,6 @@ class TXTRecordContent : public DNSRecordContent
 public:
   includeboilerplate(TXT)
 
-private:
   string d_text;
 };
 
@@ -198,6 +197,7 @@ class CNAMERecordContent : public DNSRecordContent
 {
 public:
   includeboilerplate(CNAME)
+  CNAMERecordContent(const DNSName& content) : d_content(content){}
   DNSName getTarget() const { return d_content; }
 private:
   DNSName d_content;
@@ -208,7 +208,6 @@ class ALIASRecordContent : public DNSRecordContent
 public:
   includeboilerplate(ALIAS)
 
-private:
   DNSName d_content;
 };
 
@@ -217,8 +216,6 @@ class DNAMERecordContent : public DNSRecordContent
 {
 public:
   includeboilerplate(DNAME)
-
-private:
   DNSName d_content;
 };
 

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -62,6 +62,12 @@ public:
   includeboilerplate(A);
   void doRecordCheck(const DNSRecord& dr);
   ComboAddress getCA(int port=0) const;
+  bool operator==(const DNSRecordContent& rhs) const override
+  {
+    if(typeid(*this) != typeid(rhs))
+      return false;
+    return d_ip == dynamic_cast<const ARecordContent&>(rhs).d_ip;
+  }
 private:
   uint32_t d_ip;
 };
@@ -73,6 +79,12 @@ public:
   explicit AAAARecordContent(const ComboAddress& ca);
   includeboilerplate(AAAA);
   ComboAddress getCA(int port=0) const;
+  bool operator==(const DNSRecordContent& rhs) const override
+  {
+    if(typeid(*this) != typeid(rhs))
+      return false;
+    return d_ip6 == dynamic_cast<const decltype(this)>(&rhs)->d_ip6;
+  }
 private:
   string d_ip6; // why??
 };
@@ -86,6 +98,15 @@ public:
 
   uint16_t d_preference;
   DNSName d_mxname;
+
+  bool operator==(const DNSRecordContent& rhs) const override
+  {
+    if(typeid(*this) != typeid(rhs))
+      return false;
+    auto rrhs =dynamic_cast<const decltype(this)>(&rhs);
+    return std::tie(d_preference, d_mxname) == std::tie(rrhs->d_preference, rrhs->d_mxname);
+  }
+
 };
 
 class KXRecordContent : public DNSRecordContent
@@ -185,7 +206,15 @@ class NSRecordContent : public DNSRecordContent
 public:
   includeboilerplate(NS)
   explicit NSRecordContent(const DNSName& content) : d_content(content){}
-  const DNSName& getNS() const { return d_content; } 
+  const DNSName& getNS() const { return d_content; }
+  bool operator==(const DNSRecordContent& rhs) const override
+  {
+    if(typeid(*this) != typeid(rhs))
+      return false;
+    auto rrhs =dynamic_cast<const decltype(this)>(&rhs);
+    return d_content == rrhs->d_content;
+  }
+
 private:
   DNSName d_content;
 };

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -164,6 +164,12 @@ public:
   string d_text;
 };
 
+class ENTRecordContent : public DNSRecordContent
+{
+public:
+  includeboilerplate(ENT)
+};
+
 class SPFRecordContent : public DNSRecordContent
 {
 public:

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -179,7 +179,7 @@ class NSRecordContent : public DNSRecordContent
 public:
   includeboilerplate(NS)
   explicit NSRecordContent(const DNSName& content) : d_content(content){}
-  DNSName getNS() const { return d_content; } 
+  const DNSName& getNS() const { return d_content; } 
 private:
   DNSName d_content;
 };

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -154,7 +154,7 @@ string hashQNameWithSalt(const NSEC3PARAMRecordContent& ns3prc, const DNSName& q
 string hashQNameWithSalt(const std::string& salt, unsigned int iterations, const DNSName& qname);
 void decodeDERIntegerSequence(const std::string& input, vector<string>& output);
 class DNSPacket;
-void addRRSigs(DNSSECKeeper& dk, UeberBackend& db, const std::set<DNSName>& authMap, vector<DNSResourceRecord>& rrs);
+void addRRSigs(DNSSECKeeper& dk, UeberBackend& db, const std::set<DNSName>& authMap, vector<DNSZoneRecord>& rrs);
 
 string calculateHMAC(const std::string& key, const std::string& text, TSIGHashEnum hash);
 

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -173,7 +173,7 @@ public:
   bool unsetNSEC3PARAM(const DNSName& zname);
   void clearAllCaches();
   void clearCaches(const DNSName& name);
-  bool getPreRRSIGs(UeberBackend& db, const DNSName& signer, const DNSName& qname, const DNSName& wildcardname, const QType& qtype, DNSResourceRecord::Place, vector<DNSResourceRecord>& rrsigs, uint32_t signTTL);
+  bool getPreRRSIGs(UeberBackend& db, const DNSName& signer, const DNSName& qname, const DNSName& wildcardname, const QType& qtype, DNSResourceRecord::Place, vector<DNSZoneRecord>& rrsigs, uint32_t signTTL);
   bool isPresigned(const DNSName& zname);
   bool setPresigned(const DNSName& zname);
   bool unsetPresigned(const DNSName& zname);
@@ -261,9 +261,11 @@ private:
 class DNSPacket;
 uint32_t localtime_format_YYYYMMDDSS(time_t t, uint32_t seq);
 // for SOA-EDIT
-uint32_t calculateEditSOA(SOAData sd, const string& kind);
+uint32_t calculateEditSOA(const DNSZoneRecord& rr, const string& kind);
+uint32_t calculateEditSOA(const SOAData& sd, const string& kind);
 bool editSOA(DNSSECKeeper& dk, const DNSName& qname, DNSPacket* dp);
-bool editSOARecord(DNSResourceRecord& rr, const string& kind, const DNSName& qname);
+bool editSOARecord(DNSZoneRecord& rr, const string& kind, const DNSName& qname);
 // for SOA-EDIT-DNSUPDATE/API
 uint32_t calculateIncreaseSOA(SOAData sd, const string& increaseKind, const string& editKind);
 bool increaseSOARecord(DNSResourceRecord& rr, const string& increaseKind, const string& editKind);
+bool increaseSOARecord(DNSZoneRecord& rr, const string& increaseKind, const string& editKind);

--- a/pdns/lua-auth.cc
+++ b/pdns/lua-auth.cc
@@ -207,7 +207,10 @@ static int ldp_addRecords(lua_State *L) {
   vector<DNSRecord> rrs;
   popResourceRecordsTable(L, DNSName("BOGUS"), rrs);
   for(const DNSRecord& dr :  rrs) {
-    p->addRecord(DNSResourceRecord(dr));
+    DNSZoneRecord dzr;
+    dzr.dr=dr;
+    dzr.auth=true; // LET'S HOPE THIS IS TRUE XXX
+    p->addRecord(dzr);
   }
   return 0;
 }

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -192,11 +192,14 @@ AuthLua4::AuthLua4(const std::string& fname) {
   d_lw->writeVariable("pdns", pd);
 
   d_lw->writeFunction("resolve", [](const std::string& qname, uint16_t qtype) {
-      std::vector<DNSResourceRecord> ret;
+      std::vector<DNSZoneRecord> ret;
       std::unordered_map<int, DNSResourceRecord> luaResult;
-      stubDoResolve(qname, qtype, ret);
+      stubDoResolve(DNSName(qname), qtype, ret);
       int i = 0;
-      for(const auto &row: ret) luaResult[++i] = row;
+      for(const auto &row: ret) {
+        luaResult[++i] = DNSResourceRecord(row.dr);
+        luaResult[i].auth = row.auth;
+      }
       return luaResult;
   });
 

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -688,45 +688,6 @@ string stripDot(const string& dom)
 }
 
 
-string labelReverse(const std::string& qname)
-{
-  if(qname.empty())
-    return qname;
-
-  bool dotName = qname.find('.') != string::npos;
-
-  vector<string> labels;
-  stringtok(labels, qname, ". ");
-  if(labels.size()==1)
-    return qname;
-
-  string ret;  // vv const_reverse_iter http://gcc.gnu.org/bugzilla/show_bug.cgi?id=11729
-  for(vector<string>::reverse_iterator iter = labels.rbegin(); iter != labels.rend(); ++iter) {
-    if(iter != labels.rbegin())
-      ret.append(1, dotName ? ' ' : '.');
-    ret+=*iter;
-  }
-  return ret;
-}
-
-// do NOT feed trailing dots!
-// www.powerdns.com, powerdns.com -> www
-string makeRelative(const std::string& fqdn, const std::string& zone)
-{
-  if(zone.empty())
-    return fqdn;
-  if(toLower(fqdn) != toLower(zone))
-    return fqdn.substr(0, fqdn.size() - zone.length() - 1); // strip domain name
-  return "";
-}
-
-string dotConcat(const std::string& a, const std::string &b)
-{
-  if(a.empty() || b.empty())
-    return a+b;
-  else
-    return a+"."+b;
-}
 
 int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret)
 {

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -533,25 +533,25 @@ string makeHexDump(const string& str)
 }
 
 // shuffle, maintaining some semblance of order
-void shuffle(vector<DNSResourceRecord>& rrs)
+void shuffle(vector<DNSZoneRecord>& rrs)
 {
-  vector<DNSResourceRecord>::iterator first, second;
+  vector<DNSZoneRecord>::iterator first, second;
   for(first=rrs.begin();first!=rrs.end();++first)
-    if(first->d_place==DNSResourceRecord::ANSWER && first->qtype.getCode() != QType::CNAME) // CNAME must come first
+    if(first->dr.d_place==DNSResourceRecord::ANSWER && first->dr.d_type != QType::CNAME) // CNAME must come first
       break;
   for(second=first;second!=rrs.end();++second)
-    if(second->d_place!=DNSResourceRecord::ANSWER)
+    if(second->dr.d_place!=DNSResourceRecord::ANSWER)
       break;
 
-  if(second-first>1)
+  if(second-first > 1)
     random_shuffle(first,second);
 
   // now shuffle the additional records
   for(first=second;first!=rrs.end();++first)
-    if(first->d_place==DNSResourceRecord::ADDITIONAL && first->qtype.getCode() != QType::CNAME) // CNAME must come first
+    if(first->dr.d_place==DNSResourceRecord::ADDITIONAL && first->dr.d_type != QType::CNAME) // CNAME must come first
       break;
   for(second=first;second!=rrs.end();++second)
-    if(second->d_place!=DNSResourceRecord::ADDITIONAL)
+    if(second->dr.d_place!=DNSResourceRecord::ADDITIONAL)
       break;
 
   if(second-first>1)

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -306,6 +306,7 @@ inline void unixDie(const string &why)
 string makeHexDump(const string& str);
 void shuffle(vector<DNSRecord>& rrs);
 void shuffle(vector<DNSResourceRecord>& rrs);
+
 void orderAndShuffle(vector<DNSRecord>& rrs);
 
 void normalizeTV(struct timeval& tv);
@@ -442,9 +443,6 @@ inline DNSName toCanonic(const DNSName& zone, const string& qname)
 string stripDot(const string& dom);
 
 void seedRandom(const string& source);
-string makeRelative(const std::string& fqdn, const std::string& zone);
-string labelReverse(const std::string& qname);
-std::string dotConcat(const std::string& a, const std::string &b);
 int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret);
 int makeIPv4sockaddr(const std::string& str, struct sockaddr_in* ret);
 int makeUNsockaddr(const std::string& path, struct sockaddr_un* ret);

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -33,6 +33,7 @@
 #include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index/key_extractors.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
+
 using namespace ::boost::multi_index;
 
 #include "dns.hh"
@@ -305,7 +306,8 @@ inline void unixDie(const string &why)
 
 string makeHexDump(const string& str);
 void shuffle(vector<DNSRecord>& rrs);
-void shuffle(vector<DNSResourceRecord>& rrs);
+class DNSZoneRecord;
+void shuffle(vector<DNSZoneRecord>& rrs);
 
 void orderAndShuffle(vector<DNSRecord>& rrs);
 

--- a/pdns/packetcache.cc
+++ b/pdns/packetcache.cc
@@ -196,7 +196,7 @@ void PacketCache::insert(const DNSName &qname, const QType& qtype, CacheEntryTyp
     S.inc("deferred-cache-inserts"); 
 }
 
-void PacketCache::insert(const DNSName &qname, const QType& qtype, CacheEntryType cet, const vector<DNSResourceRecord>& value, unsigned int ttl, int zoneID)
+void PacketCache::insert(const DNSName &qname, const QType& qtype, CacheEntryType cet, const vector<DNSZoneRecord>& value, unsigned int ttl, int zoneID)
 {
   cleanupIfNeeded();
 
@@ -290,7 +290,7 @@ int PacketCache::purge(const string &match)
   }
 }
 // called from ueberbackend
-bool PacketCache::getEntry(const DNSName &qname, const QType& qtype, CacheEntryType cet, vector<DNSResourceRecord>& value, int zoneID)
+bool PacketCache::getEntry(const DNSName &qname, const QType& qtype, CacheEntryType cet, vector<DNSZoneRecord>& value, int zoneID)
 {
   if(d_ttl<0) 
     getTTLS();
@@ -327,7 +327,7 @@ bool PacketCache::getEntryLocked(const DNSName &qname, const QType& qtype, Cache
   return ret;
 }
 			   
-bool PacketCache::getEntryLocked(const DNSName &qname, const QType& qtype, CacheEntryType cet, vector<DNSResourceRecord>& value, int zoneID)
+bool PacketCache::getEntryLocked(const DNSName &qname, const QType& qtype, CacheEntryType cet, vector<DNSZoneRecord>& value, int zoneID)
 {
   uint16_t qt = qtype.getCode();
   //cerr<<"Lookup for maxReplyLen: "<<maxReplyLen<<endl;

--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -59,12 +59,12 @@ public:
   void insert(const DNSName &qname, const QType& qtype, CacheEntryType cet, const string& value, unsigned int ttl, int zoneID=-1, bool meritsRecursion=false,
     unsigned int maxReplyLen=512, bool dnssecOk=false, bool EDNS=false);
 
-  void insert(const DNSName &qname, const QType& qtype, CacheEntryType cet, const vector<DNSResourceRecord>& content, unsigned int ttl, int zoneID=-1);
+  void insert(const DNSName &qname, const QType& qtype, CacheEntryType cet, const vector<DNSZoneRecord>& content, unsigned int ttl, int zoneID=-1);
 
   int get(DNSPacket *p, DNSPacket *q, bool recursive); //!< We return a dynamically allocated copy out of our cache. You need to delete it. You also need to spoof in the right ID with the DNSPacket.spoofID() method.
   bool getEntry(const DNSName &qname, const QType& qtype, CacheEntryType cet, string& entry, int zoneID=-1,
     bool meritsRecursion=false, unsigned int maxReplyLen=512, bool dnssecOk=false, bool hasEDNS=false, unsigned int *age=0);
-  bool getEntry(const DNSName &qname, const QType& qtype, CacheEntryType cet, vector<DNSResourceRecord>& entry, int zoneID=-1);
+  bool getEntry(const DNSName &qname, const QType& qtype, CacheEntryType cet, vector<DNSZoneRecord>& entry, int zoneID=-1);
   
 
   int size(); //!< number of entries in the cache
@@ -86,7 +86,7 @@ public:
 private:
   bool getEntryLocked(const DNSName &content, const QType& qtype, CacheEntryType cet, string& entry, int zoneID=-1,
     bool meritsRecursion=false, unsigned int maxReplyLen=512, bool dnssecOk=false, bool hasEDNS=false, unsigned int *age=0);
-  bool getEntryLocked(const DNSName &content, const QType& qtype, CacheEntryType cet, vector<DNSResourceRecord>& entry, int zoneID=-1);
+  bool getEntryLocked(const DNSName &content, const QType& qtype, CacheEntryType cet, vector<DNSZoneRecord>& entry, int zoneID=-1);
 
 
   struct CacheEntry
@@ -95,7 +95,7 @@ private:
 
     DNSName qname;
     string value;
-    vector<DNSResourceRecord> drs;
+    vector<DNSZoneRecord> drs;
     time_t created;
     time_t ttd;
 

--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -32,6 +32,7 @@
 using namespace ::boost::multi_index;
 
 #include "namespaces.hh"
+#include <boost/multi_index/hashed_index.hpp> 
 #include "dnspacket.hh"
 #include "lock.hh"
 #include "statbag.hh"
@@ -111,6 +112,7 @@ private:
 
   void getTTLS();
 
+  struct UnorderedNameTag{};
   typedef multi_index_container<
     CacheEntry,
     indexed_by <
@@ -128,8 +130,13 @@ private:
                         >,
 		       composite_key_compare<CanonDNSNameCompare, std::less<uint16_t>, std::less<uint16_t>, std::less<int>, std::less<bool>, 
                           std::less<unsigned int>, std::less<bool>, std::less<bool> >
-                            >,
-                           sequenced<>
+                       >,
+      hashed_non_unique<tag<UnorderedNameTag>, composite_key<CacheEntry,
+                                                             member<CacheEntry,DNSName,&CacheEntry::qname>,
+                                                             member<CacheEntry,uint16_t,&CacheEntry::qtype>,
+                                                             member<CacheEntry,uint16_t, &CacheEntry::ctype>,
+                                                             member<CacheEntry,int, &CacheEntry::zoneID> > > ,
+      sequenced<>
                            >
   > cmap_t;
 

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -108,16 +108,16 @@ bool PacketHandler::addCDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd)
   if (publishCDNSKEY != "1")
     return false;
 
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
   bool haveOne=false;
   DNSSECPrivateKey dpk;
 
   DNSSECKeeper::keyset_t entryPoints = d_dk.getEntryPoints(p->qdomain);
   for(const auto& value: entryPoints) {
-    rr.qtype=QType::CDNSKEY;
-    rr.ttl=sd.default_ttl;
-    rr.qname=p->qdomain;
-    rr.content=value.first.getDNSKEY().getZoneRepresentation();
+    rr.dr.d_type=QType::CDNSKEY;
+    rr.dr.d_ttl=sd.default_ttl;
+    rr.dr.d_name=p->qdomain;
+    rr.dr.d_content=std::make_shared<DNSKEYRecordContent>(value.first.getDNSKEY());
     rr.auth=true;
     r->addRecord(rr);
     haveOne=true;
@@ -127,7 +127,7 @@ bool PacketHandler::addCDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd)
     B.lookup(QType(QType::CDNSKEY), p->qdomain, p, sd.domain_id);
 
     while(B.get(rr)) {
-      rr.ttl=sd.default_ttl;
+      rr.dr.d_ttl=sd.default_ttl;
       r->addRecord(rr);
       haveOne=true;
     }
@@ -145,16 +145,16 @@ bool PacketHandler::addCDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 **/
 bool PacketHandler::addDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 {
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
   bool haveOne=false;
   DNSSECPrivateKey dpk;
 
   DNSSECKeeper::keyset_t keyset = d_dk.getKeys(p->qdomain);
   for(const auto& value: keyset) {
-    rr.qtype=QType::DNSKEY;
-    rr.ttl=sd.default_ttl;
-    rr.qname=p->qdomain;
-    rr.content=value.first.getDNSKEY().getZoneRepresentation();
+    rr.dr.d_type=QType::DNSKEY;
+    rr.dr.d_ttl=sd.default_ttl;
+    rr.dr.d_name=p->qdomain;
+    rr.dr.d_content=std::make_shared<DNSKEYRecordContent>(value.first.getDNSKEY());
     rr.auth=true;
     r->addRecord(rr);
     haveOne=true;
@@ -164,7 +164,7 @@ bool PacketHandler::addDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd)
     B.lookup(QType(QType::DNSKEY), p->qdomain, p, sd.domain_id);
 
     while(B.get(rr)) {
-      rr.ttl=sd.default_ttl;
+      rr.dr.d_ttl=sd.default_ttl;
       r->addRecord(rr);
       haveOne=true;
     }
@@ -192,10 +192,10 @@ bool PacketHandler::addCDS(DNSPacket *p, DNSPacket *r, const SOAData& sd)
   vector<string> digestAlgos;
   stringtok(digestAlgos, publishCDS, ", ");
 
-  DNSResourceRecord rr;
-  rr.qtype=QType::CDS;
-  rr.ttl=sd.default_ttl;
-  rr.qname=p->qdomain;
+  DNSZoneRecord rr;
+  rr.dr.d_type=QType::CDS;
+  rr.dr.d_ttl=sd.default_ttl;
+  rr.dr.d_name=p->qdomain;
   rr.auth=true;
 
   bool haveOne=false;
@@ -205,7 +205,7 @@ bool PacketHandler::addCDS(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 
   for(auto const &value : keyset) {
     for(auto const &digestAlgo : digestAlgos){
-      rr.content=makeDSFromDNSKey(p->qdomain, value.first.getDNSKEY(), std::stoi(digestAlgo)).getZoneRepresentation();
+      rr.dr.d_content=std::make_shared<DSRecordContent>(makeDSFromDNSKey(p->qdomain, value.first.getDNSKEY(), std::stoi(digestAlgo)));
       r->addRecord(rr);
       haveOne=true;
     }
@@ -215,7 +215,7 @@ bool PacketHandler::addCDS(DNSPacket *p, DNSPacket *r, const SOAData& sd)
     B.lookup(QType(QType::CDS), p->qdomain, p, sd.domain_id);
 
     while(B.get(rr)) {
-      rr.ttl=sd.default_ttl;
+      rr.dr.d_ttl=sd.default_ttl;
       r->addRecord(rr);
       haveOne=true;
     }
@@ -227,15 +227,15 @@ bool PacketHandler::addCDS(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 /** This adds NSEC3PARAM records. Returns true if one was added */
 bool PacketHandler::addNSEC3PARAM(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 {
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
 
   NSEC3PARAMRecordContent ns3prc;
   if(d_dk.getNSEC3PARAM(p->qdomain, &ns3prc)) {
-    rr.qtype=QType::NSEC3PARAM;
-    rr.ttl=sd.default_ttl;
-    rr.qname=p->qdomain;
+    rr.dr.d_type=QType::NSEC3PARAM;
+    rr.dr.d_ttl=sd.default_ttl;
+    rr.dr.d_name=p->qdomain;
     ns3prc.d_flags = 0; // the NSEC3PARAM 'flag' is defined to always be zero in RFC5155.
-    rr.content=ns3prc.getZoneRepresentation(); 
+    rr.dr.d_content=std::make_shared<NSEC3PARAMRecordContent>(ns3prc);
     rr.auth = true;
     r->addRecord(rr);
     return true;
@@ -247,24 +247,25 @@ bool PacketHandler::addNSEC3PARAM(DNSPacket *p, DNSPacket *r, const SOAData& sd)
 // This is our chaos class requests handler. Return 1 if content was added, 0 if it wasn't
 int PacketHandler::doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target)
 {
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
 
   if(p->qtype.getCode()==QType::TXT) {
     static const DNSName versionbind("version.bind."), versionpdns("version.pdns."), idserver("id.server.");
     if (target==versionbind || target==versionpdns) {
       // modes: full, powerdns only, anonymous or custom
       const static string mode=::arg()["version-string"];
-
+      string content;
       if(mode.empty() || mode=="full")
-        rr.content=fullVersionString();
+        content=fullVersionString();
       else if(mode=="powerdns")
-        rr.content="Served by PowerDNS - https://www.powerdns.com/";
+        content="Served by PowerDNS - https://www.powerdns.com/";
       else if(mode=="anonymous") {
         r->setRcode(RCode::ServFail);
         return 0;
       }
       else
-        rr.content=mode;
+        content=mode;
+      rr.dr.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::TXT, 1, content));
     }
     else if (target==idserver) {
       // modes: disabled, hostname or custom
@@ -274,17 +275,17 @@ int PacketHandler::doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target)
         r->setRcode(RCode::Refused);
         return 0;
       }
-      rr.content=id;
+      rr.dr.d_content=shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::TXT, 1, id));
     }
     else {
       r->setRcode(RCode::Refused);
       return 0;
     }
 
-    rr.ttl=5;
-    rr.qname=target;
-    rr.qtype=QType::TXT;
-    rr.qclass=QClass::CHAOS;
+    rr.dr.d_ttl=5;
+    rr.dr.d_name=target;
+    rr.dr.d_type=QType::TXT;
+    rr.dr.d_class=QClass::CHAOS;
     r->addRecord(rr);
     return 1;
   }
@@ -293,10 +294,10 @@ int PacketHandler::doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target)
   return 0;
 }
 
-vector<DNSResourceRecord> PacketHandler::getBestReferralNS(DNSPacket *p, SOAData& sd, const DNSName &target)
+vector<DNSZoneRecord> PacketHandler::getBestReferralNS(DNSPacket *p, SOAData& sd, const DNSName &target)
 {
-  vector<DNSResourceRecord> ret;
-  DNSResourceRecord rr;
+  vector<DNSZoneRecord> ret;
+  DNSZoneRecord rr;
   DNSName subdomain(target);
   do {
     if(subdomain == sd.qname) // stop at SOA
@@ -311,10 +312,10 @@ vector<DNSResourceRecord> PacketHandler::getBestReferralNS(DNSPacket *p, SOAData
   return ret;
 }
 
-vector<DNSResourceRecord> PacketHandler::getBestDNAMESynth(DNSPacket *p, SOAData& sd, DNSName &target)
+vector<DNSZoneRecord> PacketHandler::getBestDNAMESynth(DNSPacket *p, SOAData& sd, DNSName &target)
 {
-  vector<DNSResourceRecord> ret;
-  DNSResourceRecord rr;
+  vector<DNSZoneRecord> ret;
+  DNSZoneRecord rr;
   DNSName prefix;
   DNSName subdomain(target);
   do {
@@ -323,11 +324,11 @@ vector<DNSResourceRecord> PacketHandler::getBestDNAMESynth(DNSPacket *p, SOAData
     B.lookup(QType(QType::DNAME), subdomain, p, sd.domain_id);
     while(B.get(rr)) {
       ret.push_back(rr);  // put in the original
-      rr.qtype = QType::CNAME;
-      rr.qname = prefix + rr.qname;
-      rr.content = (prefix + DNSName(rr.content)).toStringNoDot();
+      rr.dr.d_type = QType::CNAME;
+      rr.dr.d_name = prefix + rr.dr.d_name;
+      rr.dr.d_content = std::make_shared<CNAMERecordContent>(CNAMERecordContent(prefix + getRR<DNAMERecordContent>(rr.dr)->d_content));
       rr.auth = 0; // don't sign CNAME
-      target= DNSName(rr.content);
+      target= getRR<CNAMERecordContent>(rr.dr)->getTarget();
       ret.push_back(rr); 
     }
     if(!ret.empty())
@@ -343,10 +344,10 @@ vector<DNSResourceRecord> PacketHandler::getBestDNAMESynth(DNSPacket *p, SOAData
 
 
 // Return best matching wildcard or next closer name
-bool PacketHandler::getBestWildcard(DNSPacket *p, SOAData& sd, const DNSName &target, DNSName &wildcard, vector<DNSResourceRecord>* ret)
+bool PacketHandler::getBestWildcard(DNSPacket *p, SOAData& sd, const DNSName &target, DNSName &wildcard, vector<DNSZoneRecord>* ret)
 {
   ret->clear();
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
   DNSName subdomain(target);
   bool haveSomething=false;
 
@@ -358,7 +359,7 @@ bool PacketHandler::getBestWildcard(DNSPacket *p, SOAData& sd, const DNSName &ta
       B.lookup(QType(QType::ANY), g_wildcarddnsname+subdomain, p, sd.domain_id);
     }
     while(B.get(rr)) {
-      if(rr.qtype == p->qtype || rr.qtype.getCode() == QType::CNAME || (p->qtype.getCode() == QType::ANY && rr.qtype.getCode() != QType::RRSIG))
+      if(rr.dr.d_type == p->qtype.getCode() || rr.dr.d_type == QType::CNAME || (p->qtype.getCode() == QType::ANY && rr.dr.d_type != QType::RRSIG))
         ret->push_back(rr);
       wildcard=g_wildcarddnsname+subdomain;
       haveSomething=true;
@@ -382,60 +383,49 @@ bool PacketHandler::getBestWildcard(DNSPacket *p, SOAData& sd, const DNSName &ta
 /** dangling is declared true if we were unable to resolve everything */
 int PacketHandler::doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, const SOAData& soadata, bool retargeted)
 {
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
   SOAData sd;
   sd.db=0;
 
   if(p->qtype.getCode()!=QType::AXFR) { // this packet needs additional processing
-    vector<DNSResourceRecord *> arrs=r->getAPRecords();
+    vector<DNSZoneRecord *> arrs=r->getAPRecords();
     if(arrs.empty()) 
       return 1;
 
     DLOG(L<<Logger::Warning<<"This packet needs additional processing!"<<endl);
 
-    vector<DNSResourceRecord> crrs;
+    vector<DNSZoneRecord> crrs;
 
-    for(vector<DNSResourceRecord *>::const_iterator i=arrs.begin(); i!=arrs.end(); ++i) 
+    for(vector<DNSZoneRecord *>::const_iterator i=arrs.begin(); i!=arrs.end(); ++i) 
       crrs.push_back(**i);
 
     // we now have a copy, push_back on packet might reallocate!
-    for(vector<DNSResourceRecord>::const_iterator i=crrs.begin(); i!=crrs.end(); ++i) {
-      if(r->d.aa && i->qname.countLabels() && i->qtype.getCode()==QType::NS && !B.getSOA(i->qname,sd,p) && !retargeted) { // drop AA in case of non-SOA-level NS answer, except for root referral
+    for(auto i=crrs.cbegin(); i!=crrs.cend(); ++i) {
+      if(r->d.aa && i->dr.d_name.countLabels() && i->dr.d_type==QType::NS && !B.getSOA(i->dr.d_name,sd,p) && !retargeted) { // drop AA in case of non-SOA-level NS answer, except for root referral
         r->setA(false);
         //        i->d_place=DNSResourceRecord::AUTHORITY; // XXX FIXME
       }
 
-      string content = stripDot(i->content);
-      if(i->qtype == QType::MX || i->qtype == QType::SRV) {
-        string::size_type pos = content.find_first_not_of("0123456789");
-        if(pos != string::npos)
-          boost::erase_head(content, pos);
-        trim_left(content);
-      }
+      DNSName lookup;
 
-      if (i->qtype.getCode()==QType::SRV) {
-        vector<string>parts;
-        stringtok(parts, content);
-        if (parts.size() >= 3) {
-          B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), DNSName(parts[2]), p);
-        }
-        else
-          continue;
-      }
-      else {
-        B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), DNSName(content), p);
-      }
+      if(i->dr.d_type == QType::MX)
+        lookup = getRR<MXRecordContent>(i->dr)->d_mxname;
+      else if(i->dr.d_type == QType::SRV)
+        lookup = getRR<SRVRecordContent>(i->dr)->d_target;
+
+      B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), lookup, p);
+
       while(B.get(rr)) {
-        if(rr.qtype.getCode() != QType::A && rr.qtype.getCode()!=QType::AAAA)
+        if(rr.dr.d_type != QType::A && rr.dr.d_type!=QType::AAAA)
           continue;
         if(rr.domain_id!=i->domain_id && ::arg()["out-of-zone-additional-processing"]=="no") {
-          DLOG(L<<Logger::Warning<<"Not including out-of-zone additional processing of "<<i->qname<<" ("<<rr.qname<<")"<<endl);
+          DLOG(L<<Logger::Warning<<"Not including out-of-zone additional processing of "<<i->dr.d_name<<" ("<<rr.dr.d_name<<")"<<endl);
           continue; // not adding out-of-zone additional data
         }
         
-        if(rr.auth && !rr.qname.isPartOf(soadata.qname)) // don't sign out of zone data using the main key 
+        if(rr.auth && !rr.dr.d_name.isPartOf(soadata.qname)) // don't sign out of zone data using the main key 
           rr.auth=false;
-        rr.d_place=DNSResourceRecord::ADDITIONAL;
+        rr.dr.d_place=DNSResourceRecord::ADDITIONAL;
         r->addRecord(rr);
       }
     }
@@ -464,19 +454,19 @@ void PacketHandler::emitNSEC(DNSPacket *r, const SOAData& sd, const DNSName& nam
       nrc.d_set.insert(QType::CDS);
   }
 
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
 
   B.lookup(QType(QType::ANY), name, NULL, sd.domain_id);
   while(B.get(rr)) {
-    if(rr.qtype.getCode() == QType::NS || rr.auth)
-      nrc.d_set.insert(rr.qtype.getCode());
+    if(rr.dr.d_type == QType::NS || rr.auth)
+      nrc.d_set.insert(rr.dr.d_type);
   }
 
-  rr.qname = name;
-  rr.ttl = sd.default_ttl;
-  rr.qtype = QType::NSEC;
-  rr.content = nrc.getZoneRepresentation();
-  rr.d_place = (mode == 5 ) ? DNSResourceRecord::ANSWER: DNSResourceRecord::AUTHORITY;
+  rr.dr.d_name = name;
+  rr.dr.d_ttl = sd.default_ttl;
+  rr.dr.d_type = QType::NSEC;
+  rr.dr.d_content = std::make_shared<NSECRecordContent>(nrc);
+  rr.dr.d_place = (mode == 5 ) ? DNSResourceRecord::ANSWER: DNSResourceRecord::AUTHORITY;
   rr.auth = true;
 
   r->addRecord(rr);
@@ -491,7 +481,7 @@ void PacketHandler::emitNSEC3(DNSPacket *r, const SOAData& sd, const NSEC3PARAMR
   n3rc.d_salt = ns3prc.d_salt;
   n3rc.d_nexthash = nexthash;
 
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
 
   if(!name.empty()) {
     if (sd.qname == name) {
@@ -510,19 +500,19 @@ void PacketHandler::emitNSEC3(DNSPacket *r, const SOAData& sd, const NSEC3PARAMR
 
     B.lookup(QType(QType::ANY), name, NULL, sd.domain_id);
     while(B.get(rr)) {
-      if(rr.qtype.getCode() && (rr.qtype.getCode() == QType::NS || rr.auth)) // skip empty non-terminals
-        n3rc.d_set.insert(rr.qtype.getCode());
+      if(rr.dr.d_type && (rr.dr.d_type == QType::NS || rr.auth)) // skip empty non-terminals
+        n3rc.d_set.insert(rr.dr.d_type);
     }
   }
 
   if (n3rc.d_set.size() && !(n3rc.d_set.size() == 1 && n3rc.d_set.count(QType::NS)))
     n3rc.d_set.insert(QType::RRSIG);
 
-  rr.qname = DNSName(toBase32Hex(namehash))+sd.qname;
-  rr.ttl = sd.default_ttl;
-  rr.qtype=QType::NSEC3;
-  rr.content=n3rc.getZoneRepresentation();
-  rr.d_place = (mode == 5 ) ? DNSResourceRecord::ANSWER: DNSResourceRecord::AUTHORITY;
+  rr.dr.d_name = DNSName(toBase32Hex(namehash))+sd.qname;
+  rr.dr.d_ttl = sd.default_ttl;
+  rr.dr.d_type=QType::NSEC3;
+  rr.dr.d_content=std::make_shared<NSEC3RecordContent>(n3rc);
+  rr.dr.d_place = (mode == 5 ) ? DNSResourceRecord::ANSWER: DNSResourceRecord::AUTHORITY;
   rr.auth = true;
 
   r->addRecord(rr);
@@ -622,7 +612,7 @@ void PacketHandler::addNSEC3(DNSPacket *p, DNSPacket *r, const DNSName& target, 
   bool doNextcloser = false;
   string before, after, hashed;
   DNSName unhashed, closest;
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
 
   if (mode == 2 || mode == 3 || mode == 4) {
     closest=wildcard;
@@ -642,7 +632,7 @@ void PacketHandler::addNSEC3(DNSPacket *p, DNSPacket *r, const DNSName& target, 
       DLOG(L<<"No matching NSEC3, do closest (provable) encloser"<<endl);
 
       bool doBreak = false;
-      DNSResourceRecord rr;
+      DNSZoneRecord rr;
       while( closest.chopOff() && (closest != sd.qname))  { // stop at SOA
         B.lookup(QType(QType::ANY), closest, p, sd.domain_id);
         while(B.get(rr))
@@ -787,7 +777,7 @@ int PacketHandler::trySuperMasterSynchronous(DNSPacket *p, const DNSName& tsigke
   // check if the returned records are NS records
   bool haveNS=false;
   for(const auto& ns: nsset) {
-    if(ns.qtype.getCode()==QType::NS)
+    if(ns.qtype==QType::NS)
       haveNS=true;
   }
 
@@ -807,7 +797,7 @@ int PacketHandler::trySuperMasterSynchronous(DNSPacket *p, const DNSName& tsigke
   if(!B.superMasterBackend(remote, p->qdomain, nsset, &nameserver, &account, &db)) {
     L<<Logger::Error<<"Unable to find backend willing to host "<<p->qdomain<<" for potential supermaster "<<remote<<". Remote nameservers: "<<endl;
     for(const auto& rr: nsset) {
-      if(rr.qtype.getCode()==QType::NS)
+      if(rr.qtype==QType::NS)
         L<<Logger::Error<<rr.content<<endl;
     }
     return RCode::Refused;
@@ -972,16 +962,18 @@ DNSPacket *PacketHandler::question(DNSPacket *p)
   return ret;
 }
 
+
 void PacketHandler::makeNXDomain(DNSPacket* p, DNSPacket* r, const DNSName& target, const DNSName& wildcard, SOAData& sd)
 {
-  DNSResourceRecord rr;
-  rr.qname=sd.qname;
-  rr.qtype=QType::SOA;
-  rr.content=serializeSOAData(sd);
-  rr.ttl=min(sd.ttl, sd.default_ttl);
+  DNSZoneRecord rr;
+  rr.dr.d_name=sd.qname;
+  rr.dr.d_type=QType::SOA;
+  
+  rr.dr.d_content=makeSOAContent(sd);
+  rr.dr.d_ttl=min(sd.ttl, sd.default_ttl);
   rr.signttl=sd.ttl;
   rr.domain_id=sd.domain_id;
-  rr.d_place=DNSResourceRecord::AUTHORITY;
+  rr.dr.d_place=DNSResourceRecord::AUTHORITY;
   rr.auth = 1;
   rr.scopeMask = sd.scopeMask;
   r->addRecord(rr);
@@ -994,15 +986,15 @@ void PacketHandler::makeNXDomain(DNSPacket* p, DNSPacket* r, const DNSName& targ
 
 void PacketHandler::makeNOError(DNSPacket* p, DNSPacket* r, const DNSName& target, const DNSName& wildcard, SOAData& sd, int mode)
 {
-  DNSResourceRecord rr;
-  rr.qname=sd.qname;
-  rr.qtype=QType::SOA;
-  rr.content=serializeSOAData(sd);
-  rr.ttl=sd.ttl;
-  rr.ttl=min(sd.ttl, sd.default_ttl);
+  DNSZoneRecord rr;
+  rr.dr.d_name=sd.qname;
+  rr.dr.d_type=QType::SOA;
+  rr.dr.d_content=makeSOAContent(sd);
+  rr.dr.d_ttl=sd.ttl;
+  rr.dr.d_ttl=min(sd.ttl, sd.default_ttl);
   rr.signttl=sd.ttl;
   rr.domain_id=sd.domain_id;
-  rr.d_place=DNSResourceRecord::AUTHORITY;
+  rr.dr.d_place=DNSResourceRecord::AUTHORITY;
   rr.auth = 1;
   r->addRecord(rr);
 
@@ -1017,11 +1009,11 @@ bool PacketHandler::addDSforNS(DNSPacket* p, DNSPacket* r, SOAData& sd, const DN
 {
   //cerr<<"Trying to find a DS for '"<<dsname<<"', domain_id = "<<sd.domain_id<<endl;
   B.lookup(QType(QType::DS), dsname, p, sd.domain_id);
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
   bool gotOne=false;
   while(B.get(rr)) {
     gotOne=true;
-    rr.d_place = DNSResourceRecord::AUTHORITY;
+    rr.dr.d_place = DNSResourceRecord::AUTHORITY;
     r->addRecord(rr);
   }
   return gotOne;
@@ -1029,21 +1021,21 @@ bool PacketHandler::addDSforNS(DNSPacket* p, DNSPacket* r, SOAData& sd, const DN
 
 bool PacketHandler::tryReferral(DNSPacket *p, DNSPacket*r, SOAData& sd, const DNSName &target, bool retargeted)
 {
-  vector<DNSResourceRecord> rrset = getBestReferralNS(p, sd, target);
+  vector<DNSZoneRecord> rrset = getBestReferralNS(p, sd, target);
   if(rrset.empty())
     return false;
   
   DLOG(L<<"The best NS is: "<<rrset.begin()->qname<<endl);
   for(auto& rr: rrset) {
     DLOG(L<<"\tadding '"<<rr.content<<"'"<<endl);
-    rr.d_place=DNSResourceRecord::AUTHORITY;
+    rr.dr.d_place=DNSResourceRecord::AUTHORITY;
     r->addRecord(rr);
   }
   if(!retargeted)
     r->setA(false);
 
-  if(d_dk.isSecuredZone(sd.qname) && !addDSforNS(p, r, sd, rrset.begin()->qname))
-    addNSECX(p, r, rrset.begin()->qname, DNSName(), sd.qname, 1);
+  if(d_dk.isSecuredZone(sd.qname) && !addDSforNS(p, r, sd, rrset.begin()->dr.d_name))
+    addNSECX(p, r, rrset.begin()->dr.d_name, DNSName(), sd.qname, 1);
   
   return true;
 }
@@ -1070,10 +1062,10 @@ bool PacketHandler::tryDNAME(DNSPacket *p, DNSPacket*r, SOAData& sd, DNSName &ta
   if(!d_doDNAME)
     return false;
   DLOG(L<<Logger::Warning<<"Let's try DNAME.."<<endl);
-  vector<DNSResourceRecord> rrset = getBestDNAMESynth(p, sd, target);
+  vector<DNSZoneRecord> rrset = getBestDNAMESynth(p, sd, target);
   if(!rrset.empty()) {
     for(auto& rr: rrset) {
-      rr.d_place = DNSResourceRecord::ANSWER;
+      rr.dr.d_place = DNSResourceRecord::ANSWER;
       r->addRecord(rr);
     }
     return true;
@@ -1085,7 +1077,7 @@ bool PacketHandler::tryWildcard(DNSPacket *p, DNSPacket*r, SOAData& sd, DNSName 
   retargeted = nodata = false;
   DNSName bestmatch;
 
-  vector<DNSResourceRecord> rrset;
+  vector<DNSZoneRecord> rrset;
   if(!getBestWildcard(p, sd, target, wildcard, &rrset))
     return false;
 
@@ -1096,16 +1088,16 @@ bool PacketHandler::tryWildcard(DNSPacket *p, DNSPacket*r, SOAData& sd, DNSName 
   else {
     DLOG(L<<"The best wildcard match: "<<rrset.begin()->qname<<endl);
     for(auto& rr: rrset) {
-      rr.wildcardname = rr.qname;
-      rr.qname=bestmatch=target;
+      rr.wildcardname = rr.dr.d_name;
+      rr.dr.d_name=bestmatch=target;
 
-      if(rr.qtype.getCode() == QType::CNAME)  {
+      if(rr.dr.d_type == QType::CNAME)  {
         retargeted=true;
-        target=DNSName(rr.content);
+        target=getRR<CNAMERecordContent>(rr.dr)->getTarget();
       }
   
       DLOG(L<<"\tadding '"<<rr.content<<"'"<<endl);
-      rr.d_place=DNSResourceRecord::ANSWER;
+      rr.dr.d_place=DNSResourceRecord::ANSWER;
       r->addRecord(rr);
     }
   }
@@ -1119,7 +1111,7 @@ bool PacketHandler::tryWildcard(DNSPacket *p, DNSPacket*r, SOAData& sd, DNSName 
 DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
 {
   *shouldRecurse=false;
-  DNSResourceRecord rr;
+  DNSZoneRecord rr;
   SOAData sd;
 
   // string subdomain="";
@@ -1127,7 +1119,7 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
   int retargetcount=0;
   set<DNSName> authSet;
 
-  vector<DNSResourceRecord> rrset;
+  vector<DNSZoneRecord> rrset;
   bool weDone=0, weRedirected=0, weHaveUnauth=0;
   DNSName haveAlias;
 
@@ -1324,12 +1316,12 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
     }
 
     if(p->qtype.getCode() == QType::SOA && sd.qname==p->qdomain) {
-      rr.qname=sd.qname;
-      rr.qtype=QType::SOA;
-      rr.content=serializeSOAData(sd);
-      rr.ttl=sd.ttl;
+      rr.dr.d_name=sd.qname;
+      rr.dr.d_type=QType::SOA;
+      rr.dr.d_content=makeSOAContent(sd);
+      rr.dr.d_ttl=sd.ttl;
       rr.domain_id=sd.domain_id;
-      rr.d_place=DNSResourceRecord::ANSWER;
+      rr.dr.d_place=DNSResourceRecord::ANSWER;
       rr.auth = true;
       r->addRecord(rr);
       goto sendit;
@@ -1363,27 +1355,27 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
     
     while(B.get(rr)) {
       //cerr<<"got content: ["<<rr.content<<"]"<<endl;
-      if (p->qtype.getCode() == QType::ANY && !p->d_dnssecOk && (rr.qtype.getCode() == QType:: DNSKEY || rr.qtype.getCode() == QType::NSEC3PARAM))
+      if (p->qtype.getCode() == QType::ANY && !p->d_dnssecOk && (rr.dr.d_type == QType:: DNSKEY || rr.dr.d_type == QType::NSEC3PARAM))
         continue; // Don't send dnssec info to non validating resolvers.
-      if (rr.qtype.getCode() == QType::RRSIG) // RRSIGS are added later any way.
+      if (rr.dr.d_type == QType::RRSIG) // RRSIGS are added later any way.
         continue; // TODO: this actually means addRRSig should check if the RRSig is already there
 
-      // cerr<<"Auth: "<<rr.auth<<", "<<(rr.qtype == p->qtype)<<", "<<rr.qtype.getName()<<endl;
-      if((p->qtype.getCode() == QType::ANY || rr.qtype == p->qtype) && rr.auth) 
+      // cerr<<"Auth: "<<rr.auth<<", "<<(rr.dr.d_type == p->qtype)<<", "<<rr.dr.d_type.getName()<<endl;
+      if((p->qtype.getCode() == QType::ANY || rr.dr.d_type == p->qtype.getCode()) && rr.auth) 
         weDone=1;
       // the line below fakes 'unauth NS' for delegations for non-DNSSEC backends.
-      if((rr.qtype == p->qtype && !rr.auth) || (rr.qtype.getCode() == QType::NS && (!rr.auth || !(sd.qname==rr.qname))))
+      if((rr.dr.d_type == p->qtype.getCode() && !rr.auth) || (rr.dr.d_type == QType::NS && (!rr.auth || !(sd.qname==rr.dr.d_name))))
         weHaveUnauth=1;
 
-      if(rr.qtype.getCode() == QType::CNAME && p->qtype.getCode() != QType::CNAME) 
+      if(rr.dr.d_type == QType::CNAME && p->qtype.getCode() != QType::CNAME) 
         weRedirected=1;
 
-      if(DP && rr.qtype.getCode() == QType::ALIAS && (p->qtype.getCode() == QType::A || p->qtype.getCode() == QType::AAAA || p->qtype.getCode() == QType::ANY)) {
-        haveAlias=DNSName(rr.content);
+      if(DP && rr.dr.d_type == QType::ALIAS && (p->qtype.getCode() == QType::A || p->qtype.getCode() == QType::AAAA || p->qtype.getCode() == QType::ANY)) {
+        haveAlias=getRR<ALIASRecordContent>(rr.dr)->d_content;
       }
 
       // Filter out all SOA's and add them in later
-      if(rr.qtype.getCode() == QType::SOA)
+      if(rr.dr.d_type == QType::SOA)
         continue;
 
       rrset.push_back(rr);
@@ -1391,10 +1383,10 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
 
     /* Add in SOA if required */
     if(target==sd.qname) {
-        rr.qtype = QType::SOA;
-        rr.content = serializeSOAData(sd);
-        rr.qname = sd.qname;
-        rr.ttl = sd.ttl;
+        rr.dr.d_type = QType::SOA;
+        rr.dr.d_content = makeSOAContent(sd);
+        rr.dr.d_name = sd.qname;
+        rr.dr.d_ttl = sd.ttl;
         rr.domain_id = sd.domain_id;
         rr.auth = true;
         rrset.push_back(rr);
@@ -1456,9 +1448,9 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
                                        
     if(weRedirected) {
       for(auto& rr: rrset) {
-        if(rr.qtype.getCode() == QType::CNAME) {
+        if(rr.dr.d_type == QType::CNAME) {
           r->addRecord(rr);
-          target = DNSName(rr.content);
+          target = getRR<CNAMERecordContent>(rr.dr)->getTarget();
           retargetcount++;
           goto retargeted;
         }
@@ -1467,7 +1459,7 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
     else if(weDone) {
       bool haveRecords = false;
       for(const auto& rr: rrset) {
-        if((p->qtype.getCode() == QType::ANY || rr.qtype == p->qtype) && rr.qtype.getCode() && rr.qtype != QType::ALIAS && rr.auth) {
+        if((p->qtype.getCode() == QType::ANY || rr.dr.d_type == p->qtype.getCode()) && rr.dr.d_type && rr.dr.d_type != QType::ALIAS && rr.auth) {
           r->addRecord(rr);
           haveRecords = true;
         }
@@ -1478,7 +1470,7 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
           completeANYRecords(p, r, sd, target);
       }
       else
-        makeNOError(p, r, rr.qname, DNSName(), sd, 0);
+        makeNOError(p, r, rr.dr.d_name, DNSName(), sd, 0);
 
       goto sendit;
     }
@@ -1487,7 +1479,7 @@ DNSPacket *PacketHandler::questionOrRecurse(DNSPacket *p, bool *shouldRecurse)
       if(tryReferral(p, r, sd, target, retargetcount))
         goto sendit;
       // check whether this could be fixed easily
-      // if (*(rr.qname.rbegin()) == '.') {
+      // if (*(rr.dr.d_name.rbegin()) == '.') {
       //      L<<Logger::Error<<"Should not get here ("<<p->qdomain<<"|"<<p->qtype.getCode()<<"): you have a trailing dot, this could be the problem (or run pdnsutil rectify-zone " <<sd.qname<<")"<<endl;
       // } else {
            L<<Logger::Error<<"Should not get here ("<<p->qdomain<<"|"<<p->qtype.getCode()<<"): please run pdnsutil rectify-zone "<<sd.qname<<endl;

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -428,8 +428,10 @@ int PacketHandler::doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, c
         toAdd.push_back(rr);
       }
     }
-    //    records.reserve(records.size()+toAdd.size());
-    records.insert(records.end(), toAdd.cbegin(), toAdd.cend());
+    for(const auto& rec : toAdd)
+      r->addRecord(rec);
+    
+    //records.insert(records.end(), toAdd.cbegin(), toAdd.cend()); // would be faster, but no dedup
   }
   return 1;
 }

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -91,12 +91,12 @@ private:
 
   void makeNXDomain(DNSPacket* p, DNSPacket* r, const DNSName& target, const DNSName& wildcard, SOAData& sd);
   void makeNOError(DNSPacket* p, DNSPacket* r, const DNSName& target, const DNSName& wildcard, SOAData& sd, int mode);
-  vector<DNSResourceRecord> getBestReferralNS(DNSPacket *p, SOAData& sd, const DNSName &target);
-  vector<DNSResourceRecord> getBestDNAMESynth(DNSPacket *p, SOAData& sd, DNSName &target);
+  vector<DNSZoneRecord> getBestReferralNS(DNSPacket *p, SOAData& sd, const DNSName &target);
+  vector<DNSZoneRecord> getBestDNAMESynth(DNSPacket *p, SOAData& sd, DNSName &target);
   bool tryDNAME(DNSPacket *p, DNSPacket*r, SOAData& sd, DNSName &target);
   bool tryReferral(DNSPacket *p, DNSPacket*r, SOAData& sd, const DNSName &target, bool retargeted);
 
-  bool getBestWildcard(DNSPacket *p, SOAData& sd, const DNSName &target, DNSName &wildcard, vector<DNSResourceRecord>* ret);
+  bool getBestWildcard(DNSPacket *p, SOAData& sd, const DNSName &target, DNSName &wildcard, vector<DNSZoneRecord>* ret);
   bool tryWildcard(DNSPacket *p, DNSPacket*r, SOAData& sd, DNSName &target, DNSName &wildcard, bool& retargeted, bool& nodata);
   bool addDSforNS(DNSPacket* p, DNSPacket* r, SOAData& sd, const DNSName& dsname);
   void completeANYRecords(DNSPacket *p, DNSPacket*r, SOAData& sd, const DNSName &target);
@@ -116,4 +116,5 @@ private:
   DNSSECKeeper d_dk; // B is shared with DNSSECKeeper
 };
 bool getNSEC3Hashes(bool narrow, DNSBackend* db, int id, const std::string& hashed, bool decrement, DNSName& unhashed, string& before, string& after, int mode=0);
+std::shared_ptr<DNSRecordContent> makeSOAContent(const SOAData& sd);
 #endif /* PACKETHANDLER */

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -77,6 +77,7 @@ public:
 
   static int chartocode(const char *p); //!< convert a character string to a code
   enum typeenum : uint16_t {
+    ENT=0,
     A=1,
     NS=2,
     CNAME=5,

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -66,7 +66,7 @@ void RecordTextReader::xfr32BitInt(uint32_t &val)
     throw RecordTextException("expected digits at position "+std::to_string(d_pos)+" in '"+d_string+"'");
 
   size_t pos;
-  val=pdns_stou(d_string.substr(d_pos), &pos);
+  val=pdns_stou(d_string.c_str()+d_pos, &pos);
  
   d_pos += pos;
 }

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -15,6 +15,7 @@
 #include "namespaces.hh"
 #include "statbag.hh"
 #include "stubresolver.hh"
+#include "dnsrecords.hh"
 #include <stdint.h>
 #ifndef PACKAGEVERSION
 #define PACKAGEVERSION getPDNSVersion()
@@ -44,17 +45,14 @@ void doSecPoll(bool first)
   boost::replace_all(query, "+", "_");
   boost::replace_all(query, "~", "_");
 
-  vector<DNSResourceRecord> ret;
+  vector<DNSZoneRecord> ret;
 
-  int res=stubDoResolve(query, QType::TXT, ret);
+  int res=stubDoResolve(DNSName(query), QType::TXT, ret);
 
   int security_status=0;
 
   if(!res && !ret.empty()) {
-    string content=ret.begin()->content;
-    if(!content.empty() && content[0]=='"' && content[content.size()-1]=='"') {
-      content=content.substr(1, content.length()-2);
-    }
+    string content=getRR<TXTRecordContent>(ret.begin()->dr)->d_text;
 
     pair<string, string> split = splitField(content, ' ');
 

--- a/pdns/signingpipe.hh
+++ b/pdns/signingpipe.hh
@@ -30,19 +30,19 @@
 void writeLStringToSocket(int fd, const string& msg);
 bool readLStringFromSocket(int fd, string& msg);
 
-/** input: DNSResourceRecords ordered in qname,qtype (we emit a signature chunk on a break)
- *  output: "chunks" of those very same DNSResourceRecords, interleaved with signatures
+/** input: DNSZoneRecords ordered in qname,qtype (we emit a signature chunk on a break)
+ *  output: "chunks" of those very same DNSZoneRecords, interleaved with signatures
  */
 
 class ChunkedSigningPipe
 {
 public:
-  typedef vector<DNSResourceRecord> rrset_t; 
+  typedef vector<DNSZoneRecord> rrset_t; 
   typedef rrset_t chunk_t; // for now
   
   ChunkedSigningPipe(const DNSName& signerName, bool mustSign, /* FIXME servers is unused? */ const string& servers=string(), unsigned int numWorkers=3);
   ~ChunkedSigningPipe();
-  bool submit(const DNSResourceRecord& rr);
+  bool submit(const DNSZoneRecord& rr);
   chunk_t getChunk(bool final=false);
 
   std::atomic<unsigned long> d_signed;
@@ -64,7 +64,7 @@ private:
   int d_submitted;
 
   rrset_t* d_rrsetToSign;
-  std::deque< std::vector<DNSResourceRecord> > d_chunks;
+  std::deque< std::vector<DNSZoneRecord> > d_chunks;
   DNSName d_signer;
   
   chunk_t::size_type d_maxchunkrecords;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -547,7 +547,7 @@ void CommunicatorClass::suck(const DNSName &domain, const string &remote)
         } else {
           // NSEC
           if (rr.auth || rr.qtype.getCode() == QType::NS) {
-            ordername=rr.qname.makeRelative(domain).makeLowerCase().labelReverse().toStringNoDot(); 
+            ordername=rr.qname.makeRelative(domain).makeLowerCase().labelReverse().toString(" ", false); 
             di.backend->feedRecord(rr, &ordername);
           } else
             di.backend->feedRecord(rr);

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -547,7 +547,7 @@ void CommunicatorClass::suck(const DNSName &domain, const string &remote)
         } else {
           // NSEC
           if (rr.auth || rr.qtype.getCode() == QType::NS) {
-            ordername=toLower(labelReverse(makeRelative(rr.qname.toStringNoDot(), domain.toStringNoDot()))); // FIXME400
+            ordername=rr.qname.makeRelative(domain).makeLowerCase().labelReverse().toStringNoDot(); 
             di.backend->feedRecord(rr, &ordername);
           } else
             di.backend->feedRecord(rr);

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -295,7 +295,7 @@ vector<uint8_t> makeBigDNSPacketReferral()
 
   vector<uint8_t> packet;
   DNSPacketWriter pw(packet, DNSName("www.google.com"), QType::A);
-  shuffle(records);
+  //  shuffle(records);
   for(const auto& rec : records) {
     pw.startRecord(rec.qname, rec.qtype.getCode(), rec.ttl, 1, rec.d_place);
     auto drc = DNSRecordContent::mastermake(rec.qtype.getCode(), 1, rec.content);

--- a/pdns/stubquery.cc
+++ b/pdns/stubquery.cc
@@ -49,13 +49,13 @@ try
   dns_random_init("0123456789abcdef");
   stubParseResolveConf();
 
-  vector<DNSResourceRecord> ret;
+  vector<DNSZoneRecord> ret;
 
-  int res=stubDoResolve(argv[1], DNSRecordContent::TypeToNumber(argv[2]), ret);
+  int res=stubDoResolve(DNSName(argv[1]), DNSRecordContent::TypeToNumber(argv[2]), ret);
 
   cout<<"res: "<<res<<endl;
   for(const auto& r : ret) {
-    cout<<r.getZoneRepresentation()<<endl;
+    cout<<r.dr.d_content->getZoneRepresentation()<<endl;
   }
 }
 catch(std::exception &e)

--- a/pdns/stubresolver.hh
+++ b/pdns/stubresolver.hh
@@ -24,4 +24,4 @@
 #include "dnsparser.hh"
 
 void stubParseResolveConf();
-int stubDoResolve(const string& qname, uint16_t qtype, vector<DNSResourceRecord>& ret);
+int stubDoResolve(const DNSName& qname, uint16_t qtype, vector<DNSZoneRecord>& ret);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -863,7 +863,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   int records=0;
   for(DNSZoneRecord &zrr :  zrrs) {
     if (zrr.dr.d_type == QType::RRSIG) {
-      if(presignedZone && zrr.dr.d_type == QType::NSEC3) {
+      if(presignedZone && getRR<RRSIGRecordContent>(zrr.dr)->d_type == QType::NSEC3) {
         DNSName relative=zrr.dr.d_name.makeRelative(target);
         ns3rrs.insert(fromBase32Hex(relative.toStringNoDot()));
       }

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -877,7 +877,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
     records++;
     if(securedZone && (zrr.auth || zrr.dr.d_type == QType::NS)) {
       if (NSEC3Zone || zrr.dr.d_type) {
-        keyname = NSEC3Zone ? hashQNameWithSalt(ns3pr, zrr.dr.d_name) : zrr.dr.d_name.labelReverse().toString();
+        keyname = NSEC3Zone ? hashQNameWithSalt(ns3pr, zrr.dr.d_name) : zrr.dr.d_name.labelReverse().toString(" ", false);
         NSECXEntry& ne = nsecxrepo[keyname];
         ne.d_ttl = sd.default_ttl;
         ne.d_auth = (ne.d_auth || zrr.auth || (NSEC3Zone && (!ns3pr.d_flags || (presignedZone && ns3pr.d_flags))));
@@ -967,12 +967,12 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
       nrc.d_set.insert(QType::RRSIG);
       nrc.d_set.insert(QType::NSEC);
       if(boost::next(iter) != nsecxrepo.end()) {
-        nrc.d_next = DNSName(boost::next(iter)->first).labelReverse();
+        nrc.d_next = DNSName(boost::next(iter)->first).labelReverse();  // XXX likely we need to do the spaces thing here
       }
       else
-        nrc.d_next=DNSName(nsecxrepo.begin()->first).labelReverse();
+        nrc.d_next=DNSName(nsecxrepo.begin()->first).labelReverse();     // XXX likely we need to do the spaces thing here
   
-      zrr.dr.d_name = DNSName(iter->first).labelReverse();
+      zrr.dr.d_name = DNSName(iter->first).labelReverse();  // XXX likely we need to do the spaces thing here
   
       zrr.dr.d_ttl = sd.default_ttl;
       zrr.dr.d_content = std::make_shared<NSECRecordContent>(nrc);

--- a/pdns/test-dnsrecordcontent.cc
+++ b/pdns/test-dnsrecordcontent.cc
@@ -1,0 +1,46 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <boost/test/unit_test.hpp>
+#include "dnsrecords.hh"
+#include "iputils.hh"
+
+BOOST_AUTO_TEST_SUITE(test_dnsrecordcontent)
+
+BOOST_AUTO_TEST_CASE(test_equality) {
+  reportAllTypes();
+  ComboAddress ip("1.2.3.4"), ip2("10.0.0.1"), ip6("::1");
+  ARecordContent a1(ip), a2(ip), a3(ip2);
+  AAAARecordContent aaaa(ip6), aaaa1(ip6);
+  
+  BOOST_CHECK(a1==a2);
+  BOOST_CHECK(!(a1==a3));
+
+  BOOST_CHECK(aaaa == aaaa1);
+
+
+  auto rec1=DNSRecordContent::makeunique(QType::A, 1, "192.168.0.1");
+  auto rec2=DNSRecordContent::makeunique(QType::A, 1, "192.168.222.222");
+  auto rec3=DNSRecordContent::makeunique(QType::AAAA, 1, "::1");
+  auto recMX=DNSRecordContent::makeunique(QType::MX, 1, "25 smtp.powerdns.com");
+  auto recMX2=DNSRecordContent::makeunique(QType::MX, 1, "26 smtp.powerdns.com");
+  auto recMX3=DNSRecordContent::makeunique(QType::MX, 1, "26 SMTP.powerdns.com");
+  BOOST_CHECK(!(*rec1==*rec2));
+  BOOST_CHECK(*rec1==*rec1);
+  BOOST_CHECK(*rec3==*rec3);
+
+  BOOST_CHECK(*recMX==*recMX);
+  BOOST_CHECK(*recMX2==*recMX3);
+  BOOST_CHECK(!(*recMX==*recMX3));
+  
+  
+  BOOST_CHECK(!(*rec1==*rec3));
+
+  NSRecordContent ns1(DNSName("ns1.powerdns.com")), ns2(DNSName("NS1.powerdns.COM")), ns3(DNSName("powerdns.net"));
+  BOOST_CHECK(ns1==ns2);
+  BOOST_CHECK(!(ns1==ns3));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -109,13 +109,9 @@ BOOST_AUTO_TEST_CASE(test_stripDot) {
 }
 
 BOOST_AUTO_TEST_CASE(test_labelReverse) {
-    BOOST_CHECK_EQUAL(labelReverse("www.powerdns.com"), "com powerdns www");
+  BOOST_CHECK_EQUAL(DNSName("www.powerdns.com").labelReverse().toString(" ", false), "com powerdns www");
 }
 
-BOOST_AUTO_TEST_CASE(test_makeRelative) {
-    BOOST_CHECK_EQUAL(makeRelative("www.powerdns.com", "powerdns.com"), "www");
-    BOOST_CHECK_EQUAL(makeRelative("PoWeRdNs.CoM", "powerdns.com"), "");
-}
 
 BOOST_AUTO_TEST_CASE(test_AtomicCounter) {
     AtomicCounter ac(0);

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
     BOOST_CHECK_EQUAL(PC.size(), counter-delcounter);
     
     int matches=0;
-    vector<DNSResourceRecord> entry;
+    vector<DNSZoneRecord> entry;
     int expected=counter-delcounter;
     for(; delcounter < counter; ++delcounter) {
       if(PC.getEntry(DNSName("hello ")+DNSName(std::to_string(delcounter)), QType(QType::A), PacketCache::QUERYCACHE, entry, 1)) {
@@ -97,7 +97,7 @@ static void *threadReader(void* a)
 try
 {
   unsigned int offset=(unsigned int)(unsigned long)a;
-  vector<DNSResourceRecord> entry;
+  vector<DNSZoneRecord> entry;
   for(unsigned int counter=0; counter < 100000; ++counter)
     if(!g_PC->getEntry(DNSName("hello ")+DNSName(std::to_string(counter+offset)), QType(QType::A), PacketCache::QUERYCACHE, entry, 1)) {
 	g_missing++;

--- a/pdns/tkey.cc
+++ b/pdns/tkey.cc
@@ -71,19 +71,15 @@ void PacketHandler::tkeyHandler(DNSPacket *p, DNSPacket *r) {
   tkey_out->d_keysize = tkey_out->d_key.size();
   tkey_out->d_othersize = tkey_out->d_other.size();
 
-  DNSRecord rec;
-  rec.d_name = name;
-  rec.d_ttl = 0;
-  rec.d_type = QType::TKEY;
-  rec.d_class = QClass::ANY;
-  rec.d_content = tkey_out;
-  rec.d_place = DNSResourceRecord::ANSWER;
+  DNSZoneRecord zrr;
 
-  DNSResourceRecord rr(rec);
-  rr.qclass = QClass::ANY;
-  rr.qtype = QType::TKEY;
-  rr.d_place = DNSResourceRecord::ANSWER;
-  r->addRecord(rr);
+  zrr.dr.d_name = name;
+  zrr.dr.d_ttl = 0;
+  zrr.dr.d_type = QType::TKEY;
+  zrr.dr.d_class = QClass::ANY;
+  zrr.dr.d_content = tkey_out;
+  zrr.dr.d_place = DNSResourceRecord::ANSWER;
+  r->addRecord(zrr);
 
   if (sign)
   {

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -79,7 +79,7 @@ public:
   class handle
   {
   public:
-    bool get(DNSResourceRecord &r);
+    bool get(DNSZoneRecord &dr);
     handle();
     ~handle();
 
@@ -108,6 +108,7 @@ public:
   bool getSOAUncached(const DNSName &domain, SOAData &sd, DNSPacket *p=0);  // same, but ignores cache
   bool list(const DNSName &target, int domain_id, bool include_disabled=false);
   bool get(DNSResourceRecord &r);
+  bool get(DNSZoneRecord &r);
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false);
 
   static DNSBackend *maker(const map<string,string> &);
@@ -139,8 +140,8 @@ public:
 private:
   pthread_t tid;
   handle d_handle;
-  vector<DNSResourceRecord> d_answers;
-  vector<DNSResourceRecord>::const_iterator d_cachehandleiter;
+  vector<DNSZoneRecord> d_answers;
+  vector<DNSZoneRecord>::const_iterator d_cachehandleiter;
 
   static pthread_mutex_t d_mut;
   static pthread_cond_t d_cond;
@@ -162,9 +163,9 @@ private:
   static bool d_go;
   bool stale;
 
-  int cacheHas(const Question &q, vector<DNSResourceRecord> &rrs);
+  int cacheHas(const Question &q, vector<DNSZoneRecord> &rrs);
   void addNegCache(const Question &q);
-  void addCache(const Question &q, const vector<DNSResourceRecord> &rrs);
+  void addCache(const Question &q, const vector<DNSZoneRecord> &rrs);
   
 };
 

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -136,8 +136,8 @@ static void callback_tree( unsigned int domain_id, const DNSName &domain, const 
                 cout << "changetype: modify" << endl;
                 cout << "add: " << qtype << "Record" << endl;
         }
-
-        cout << qtype << "Record: " << stripDot( content ) << endl << endl;
+        string stripped=stripDot(content);
+        cout << qtype << "Record: " << stripped << ((stripped.empty() || stripped[stripped.size()-1]==' ') ? "." : "") << endl << endl;
 }
 
 

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -83,8 +83,8 @@ static void callback_simple( unsigned int domain_id, const DNSName &domain, cons
                 cout << "changetype: modify" << endl;
                 cout << "add: " << qtype << "Record" << endl;
         }
-
-        cout << qtype << "Record: " << stripDot( content ) << endl << endl;
+        string stripped=stripDot(content);
+        cout << qtype << "Record: " << stripped << ((stripped.empty() || stripped[stripped.size()-1]==' ') ? "." : "") << endl << endl;
 }
 
 

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -202,7 +202,7 @@ static void emitRecord(const DNSName& zoneName, const DNSName &DNSqname, const s
   else if(g_mode==POSTGRES) {
     cout<<"insert into records (domain_id, name, ordername, auth, type,content,ttl,prio,disabled) select id ,"<<
       sqlstr(toLower(qname))<<", "<<
-      sqlstr(DNSName(qname).makeRelative(DNSName(zname)).toLower().labelReverse().toStringNoDot()<<", '"<< (auth  ? 't' : 'f') <<"', "<<
+      sqlstr(DNSName(qname).makeRelative(DNSName(zname)).makeLowerCase().labelReverse().toStringNoDot())<<", '"<< (auth  ? 't' : 'f') <<"', "<<
       sqlstr(qtype)<<", "<<
       sqlstr(stripDotContent(content))<<", "<<ttl<<", "<<prio<<", '"<<(disabled ? 't': 'f') <<
       "' from domains where name="<<toLower(sqlstr(zname))<<";\n";

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -202,7 +202,7 @@ static void emitRecord(const DNSName& zoneName, const DNSName &DNSqname, const s
   else if(g_mode==POSTGRES) {
     cout<<"insert into records (domain_id, name, ordername, auth, type,content,ttl,prio,disabled) select id ,"<<
       sqlstr(toLower(qname))<<", "<<
-      sqlstr(DNSName(qname).makeRelative(DNSName(zname)).makeLowerCase().labelReverse().toStringNoDot())<<", '"<< (auth  ? 't' : 'f') <<"', "<<
+      sqlstr(DNSName(qname).makeRelative(DNSName(zname)).makeLowerCase().labelReverse().toString(" ", false))<<", '"<< (auth  ? 't' : 'f') <<"', "<<
       sqlstr(qtype)<<", "<<
       sqlstr(stripDotContent(content))<<", "<<ttl<<", "<<prio<<", '"<<(disabled ? 't': 'f') <<
       "' from domains where name="<<toLower(sqlstr(zname))<<";\n";

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -202,7 +202,7 @@ static void emitRecord(const DNSName& zoneName, const DNSName &DNSqname, const s
   else if(g_mode==POSTGRES) {
     cout<<"insert into records (domain_id, name, ordername, auth, type,content,ttl,prio,disabled) select id ,"<<
       sqlstr(toLower(qname))<<", "<<
-      sqlstr(toLower(labelReverse(makeRelative(qname, zname))))<<", '"<< (auth  ? 't' : 'f') <<"', "<<
+      sqlstr(DNSName(qname).makeRelative(DNSName(zname)).toLower().labelReverse().toStringNoDot()<<", '"<< (auth  ? 't' : 'f') <<"', "<<
       sqlstr(qtype)<<", "<<
       sqlstr(stripDotContent(content))<<", "<<ttl<<", "<<prio<<", '"<<(disabled ? 't': 'f') <<
       "' from domains where name="<<toLower(sqlstr(zname))<<";\n";


### PR DESCRIPTION
This commit does a number of unrelated things that are difficult to untangle. We remove the ASCII DNSResourceRecord from the hot path of packet assembly in auth. It is still around for looking up various other things, and these can go later.
In addition, we hash the storage of records in the bindbackend. We also hash the packetcache.
This PR comes with a few additional unit tests, and incidentally fixes some bugs in the LDAP backend and in the MyDNS backend.
Finally as an example, this PR makes the randombackend go 'native' and directly supply records that can be sent to packets. With no ASCII. 
The performance benefit of this PR is measured in "factors" for being a root-server.