### PR TITLE
auth: Fix returned id from `Bind2Backend::addDomainKey()`, use a unique_ptr for AuthLua4 object

### DIFF
--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -337,7 +337,7 @@ bool Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key, int64_t
     SSqlStatement::row_t row;
     d_GetLastInsertedKeyIdQuery_stmt->nextRow(row);
     ASSERT_ROW_COLUMNS("get-last-inserted-key-id-query", row, 1);
-    int id = std::stoi(row[0]);
+    id = std::stoi(row[0]);
     d_GetLastInsertedKeyIdQuery_stmt->reset();
     return true;
   }

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -11,6 +11,7 @@
 
 AuthLua4::AuthLua4(const std::string& fname) { }
 bool AuthLua4::updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, DNSPacket *packet) { return false; }
+AuthLua4::~AuthLua4() { }
 
 #else
 
@@ -237,5 +238,7 @@ bool AuthLua4::updatePolicy(const DNSName &qname, QType qtype, const DNSName &zo
 
   return d_update_policy(upq);
 }
+
+AuthLua4::~AuthLua4() { }
 
 #endif

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -69,7 +69,7 @@ PacketHandler::PacketHandler():B(s_programname), d_dk(&B)
   }
   else
   {
-    d_pdl = new AuthLua(fname);
+    d_pdl = std::unique_ptr<AuthLua>(new AuthLua(fname));
   }
   fname = ::arg()["lua-dnsupdate-policy-script"];
   if (fname.empty())
@@ -78,7 +78,7 @@ PacketHandler::PacketHandler():B(s_programname), d_dk(&B)
   }
   else
   {
-    d_update_policy_lua = new AuthLua4(fname);
+    d_update_policy_lua = std::unique_ptr<AuthLua4>(new AuthLua4(fname));
   }
 }
 

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -109,8 +109,8 @@ private:
   bool d_logDNSDetails;
   bool d_doIPv6AdditionalProcessing;
   bool d_doDNAME;
-  AuthLua* d_pdl;
-  AuthLua4* d_update_policy_lua;
+  std::unique_ptr<AuthLua> d_pdl;
+  std::unique_ptr<AuthLua4> d_update_policy_lua;
 
   UeberBackend B; // every thread an own instance
   DNSSECKeeper d_dk; // B is shared with DNSSECKeeper

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -757,10 +757,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
         }
         for(const auto& ip: ips) {
           zrr.dr.d_type = ip.dr.d_type;
-          if(ip.dr.d_type == QType::A)
-            zrr.dr.d_content = ip.dr.d_content;
-          else
-            zrr.dr.d_content = ip.dr.d_content;
+          zrr.dr.d_content = ip.dr.d_content;
           zrrs.push_back(zrr);
         }
       }


### PR DESCRIPTION
Reported by Coverity.