### PR TITLE
dnsdist: Gracefully handle invalid addresses in `newServer()`

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -219,15 +219,20 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			ComboAddress sourceAddr;
 			unsigned int sourceItf = 0;
 			if(auto addressStr = boost::get<string>(&pvars)) {
-			  ComboAddress address(*addressStr, 53);
 			  std::shared_ptr<DownstreamState> ret;
-			  if(IsAnyAddress(address)) {
-			    g_outputBuffer="Error creating new server: invalid address for a downstream server.";
-			    errlog("Error creating new server: %s is not a valid address for a downstream server", *addressStr);
-			    return ret;
-			  }
 			  try {
+			    ComboAddress address(*addressStr, 53);
+			    if(IsAnyAddress(address)) {
+			      g_outputBuffer="Error creating new server: invalid address for a downstream server.";
+			      errlog("Error creating new server: %s is not a valid address for a downstream server", *addressStr);
+			      return ret;
+			    }
 			    ret=std::make_shared<DownstreamState>(address);
+			  }
+			  catch(const PDNSException& e) {
+			    g_outputBuffer="Error creating new server: "+string(e.reason);
+			    errlog("Error creating new server with address %s: %s", addressStr, e.reason);
+			    return ret;
 			  }
 			  catch(std::exception& e) {
 			    g_outputBuffer="Error creating new server: "+string(e.what());
@@ -310,14 +315,19 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			}
 
 			std::shared_ptr<DownstreamState> ret;
-			ComboAddress address(boost::get<string>(vars["address"]), 53);
-			if(IsAnyAddress(address)) {
-			  g_outputBuffer="Error creating new server: invalid address for a downstream server.";
-			  errlog("Error creating new server: %s is not a valid address for a downstream server", boost::get<string>(vars["address"]));
-			  return ret;
-			}
 			try {
+			  ComboAddress address(boost::get<string>(vars["address"]), 53);
+			  if(IsAnyAddress(address)) {
+			    g_outputBuffer="Error creating new server: invalid address for a downstream server.";
+			    errlog("Error creating new server: %s is not a valid address for a downstream server", boost::get<string>(vars["address"]));
+			    return ret;
+			  }
 			  ret=std::make_shared<DownstreamState>(address, sourceAddr, sourceItf);
+			}
+			catch(const PDNSException& e) {
+			  g_outputBuffer="Error creating new server: "+string(e.reason);
+			  errlog("Error creating new server with address %s: %s", boost::get<string>(vars["address"]), e.reason);
+			  return ret;
 			}
 			catch(std::exception& e) {
 			  g_outputBuffer="Error creating new server: "+string(e.what());


### PR DESCRIPTION
This makes it easier to understand configuration issues like the one reported in #4471.
