### PR TITLE
Extend zone2ldap to add the domain info attributes

### DIFF
--- a/docs/manpages/zone2ldap.1.md
+++ b/docs/manpages/zone2ldap.1.md
@@ -12,6 +12,8 @@
 # DESCRIPTION
 **zone2ldap** is a program that converts bind zonefiles to ldif format which can
 inserted to an LDAP server.
+Optionally it can add PowerDNS specific LDAP attributes to manage the domains
+with pdnutil.
 
 # OPTIONS
 --help
@@ -19,6 +21,11 @@ inserted to an LDAP server.
 
 --basedn=*DN*
 :    Base DN to store objects below
+
+--domainid=*ID*
+:    The ID of the first zone found, incremented by one for each zone in the
+:    current source. This option only has an effect when used with --pdns-info.
+:    Defaults to 1.
 
 --dnsttl
 :    Add dnsttl attribute to every entry
@@ -28,6 +35,10 @@ inserted to an LDAP server.
 
 --named-conf=*PATH*
 :    Path to a Bind 8 named.conf to parse
+
+--pdns-info
+:    Add the PowerDNS attributes to the SOA LDAP entry. The schema provided
+:    in pdns-domaininfo.schema must be loaded for this to work.
 
 --resume
 :    Continue after errors


### PR DESCRIPTION
This adds two new flags to the command: --pdns-info to add the
attributes from the pdns-domaininfo schema and --domainid to
give the domain id of the first domain found in the file.