### PR TITLE
e.root-servers.net has IPv6 now

### DIFF
--- a/pdns/root-addresses.hh
+++ b/pdns/root-addresses.hh
@@ -40,7 +40,7 @@ static const char*rootIps6[]={"2001:503:ba3e::2:30",    // a.root-servers.net.
                               "2001:500:84::b",         // b.root-servers.net.
                               "2001:500:2::c",          // c.root-servers.net.
                               "2001:500:2d::d",         // d.root-servers.net.
-                              NULL,                     // e.root-servers.net.
+                              "2001:500:a8::e",         // e.root-servers.net.
                               "2001:500:2f::f",         // f.root-servers.net.
                               NULL,                     // g.root-servers.net.
                               "2001:500:1::53",         // h.root-servers.net.


### PR DESCRIPTION
As of August 25, 2016 e.root-servers.net has an IPv6 address.