### PR TITLE
Silence a GCC 6.2 compiler warning

### DIFF
--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -211,7 +211,7 @@ uint64_t RecursorPacketCache::size()
 uint64_t RecursorPacketCache::bytes()
 {
   uint64_t sum=0;
-  for(const struct Entry& e :  d_packetCache) {
+  for(const auto& e :  d_packetCache) {
     sum += sizeof(e) + e.d_packet.length() + 4;
   }
   return sum;


### PR DESCRIPTION
This PR fixes several compiler warnings from GCC 6.2. as well as a mistake in the bind backend DNSSEC where the key ID is not returned after creation in `Bind2Backend::addDomainKey`