### PR TITLE
Add a / at the beginning of the zone info url

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -308,7 +308,7 @@ static Json::object getZoneInfo(const DomainInfo& di) {
   return Json::object {
     // id is the canonical lookup key, which doesn't actually match the name (in some cases)
     { "id", zoneId },
-    { "url", "api/v1/servers/localhost/zones/" + zoneId },
+    { "url", "/api/v1/servers/localhost/zones/" + zoneId },
     { "name", di.zone.toString() },
     { "kind", di.getKindString() },
     { "dnssec", dk.isSecuredZone(di.zone) },


### PR DESCRIPTION
The zone info json is missing a forward slash in the url, this is
inconsistent with other url fields and is not according to the api
docs. This commit adds a slash to the url and fixes #4524 .
