### PR TITLE
Replace luawrapper's std::forward/std::make_tuple combo with std::forward_as_tuple

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1310,7 +1310,7 @@ private:
             RealReturnType;
         
         // we push the parameters on the stack
-        auto inArguments = Pusher<std::tuple<TParameters...>>::push(state, std::make_tuple(std::forward<TParameters>(input)...));
+        auto inArguments = Pusher<std::tuple<TParameters...>>::push(state, std::forward_as_tuple((input)...));
 
         // 
         const int outArgumentsCount = std::tuple_size<RealReturnType>::value;


### PR DESCRIPTION
Fixes #3552, building dnsdist and auth master with clang on FreeBSD and OS X.
