### PR TITLE
Avoid shadowing variables

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -665,7 +665,6 @@ void Bind2Backend::reload()
 void Bind2Backend::fixupOrderAndAuth(BB2DomainInfo& bbd, bool nsec3zone, NSEC3PARAMRecordContent ns3pr)
 {
   shared_ptr<recordstorage_t> records = bbd.d_records.getWRITABLE();
-  recordstorage_t::const_iterator iter;
 
   bool skip;
   DNSName shorter;

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -223,9 +223,7 @@ bool PipeBackend::list(const DNSName& target, int inZoneId, bool include_disable
 
 string PipeBackend::directBackendCmd(const string &query) {
   if (d_abiVersion < 5)
-    return "not supported on ABI version " + std::to_string(d_abiVersion) + "(use ABI version 5 or later)\n";
-
-  ostringstream oss;
+    return "not supported on ABI version " + std::to_string(d_abiVersion) + " (use ABI version 5 or later)\n";
 
   try {
     launch();
@@ -237,8 +235,8 @@ string PipeBackend::directBackendCmd(const string &query) {
     L<<Logger::Error<<kBackendId<<" Error from coprocess: "<<ae.reason<<endl;
     cleanup();
   }
-  oss.str("");
 
+  ostringstream oss;
   while(true) {
     string line;
     d_coproc->receive(line);

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -242,12 +242,12 @@ struct SuffixMatchNode
     return strcasecmp(name.c_str(), rhs.name.c_str()) < 0;
   }
 
-  void add(const DNSName& name) 
+  void add(const DNSName& dnsname)
   {
     if(!d_human.empty())
       d_human.append(", ");
-    d_human += name.toString();
-    add(name.getRawLabels());
+    d_human += dnsname.toString();
+    add(dnsname.getRawLabels());
   }
 
   void add(std::vector<std::string> labels) const
@@ -265,11 +265,11 @@ struct SuffixMatchNode
     }
   }
 
-  bool check(const DNSName& name)  const
+  bool check(const DNSName& dnsname)  const
   {
     if(children.empty()) // speed up empty set
       return endNode;
-    return check(name.getRawLabels());
+    return check(dnsname.getRawLabels());
   }
 
   bool check(std::vector<std::string> labels) const

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -214,7 +214,6 @@ NSEC3RecordContent::DNSRecordContent* NSEC3RecordContent::make(const DNSRecord &
   pr.xfrBlob(ret->d_salt, len);
 
   pr.xfr8BitInt(len);
-  
   pr.xfrBlob(ret->d_nexthash, len);
   
   string bitmap;
@@ -230,14 +229,14 @@ NSEC3RecordContent::DNSRecordContent* NSEC3RecordContent::make(const DNSRecord &
 
   for(unsigned int n = 0; n+1 < bitmap.size();) {
     unsigned int window=static_cast<unsigned char>(bitmap[n++]);
-    unsigned int len=static_cast<unsigned char>(bitmap[n++]);
+    unsigned int innerlen=static_cast<unsigned char>(bitmap[n++]);
     
     // end if zero padding and ensure packet length
-    if(window == 0&&len == 0) break;
-    if(n+len>bitmap.size())
+    if(window == 0&&innerlen == 0) break;
+    if(n+innerlen>bitmap.size())
       throw MOADNSException("NSEC record with bitmap length > packet length");
 
-    for(unsigned int k=0; k < len; k++) {
+    for(unsigned int k=0; k < innerlen; k++) {
       uint8_t val=bitmap[n++];
       for(int bit = 0; bit < 8 ; ++bit , val>>=1)
         if(val & 1) {

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -949,7 +949,7 @@ DNSPacket *PacketHandler::question(DNSPacket *p)
     DP->sendPacket(p);
   }
   if(LPE) {
-    int policyres=LPE->police(p, ret);
+    policyres = LPE->police(p, ret);
     if(policyres == PolicyDecision::DROP) {
       delete ret;
       return NULL;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -101,9 +101,9 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
     memset(&st, 0, sizeof(st));
     st.serial=di.serial;
 
-    DNSRecord dr;
-    dr.d_content = std::make_shared<SOARecordContent>(g_rootdnsname, g_rootdnsname, st);
-    auto deltas = getIXFRDeltas(remote, domain, dr, tt, laddr.sin4.sin_family ? &laddr : 0, ((size_t) ::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024);
+    DNSRecord drsoa;
+    drsoa.d_content = std::make_shared<SOARecordContent>(g_rootdnsname, g_rootdnsname, st);
+    auto deltas = getIXFRDeltas(remote, domain, drsoa, tt, laddr.sin4.sin_family ? &laddr : 0, ((size_t) ::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024);
     zs.numDeltas=deltas.size();
     //    cout<<"Got "<<deltas.size()<<" deltas from serial "<<di.serial<<", applying.."<<endl;
     

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -556,7 +556,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
 
     if (!canDoAXFR(q)) {
       L<<Logger::Error<<"AXFR of domain '"<<target<<"' failed: "<<q->getRemote()<<" cannot request AXFR"<<endl;
-      outpacket->setRcode(9); // 'NOTAUTH'
+      outpacket->setRcode(RCode::NotAuth);
       sendPacket(outpacket,outsock);
       return 0;
     }
@@ -564,7 +564,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
     if(!s_P->getBackend()->getSOAUncached(target, sd)) {
       L<<Logger::Error<<"AXFR of domain '"<<target<<"' failed: not authoritative"<<endl;
-      outpacket->setRcode(9); // 'NOTAUTH'
+      outpacket->setRcode(RCode::NotAuth);
       sendPacket(outpacket,outsock);
       return 0;
     }
@@ -726,7 +726,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   // now start list zone
   if(!(sd.db->list(target, sd.domain_id))) {  
     L<<Logger::Error<<"Backend signals error condition"<<endl;
-    outpacket->setRcode(2); // 'SERVFAIL'
+    outpacket->setRcode(RCode::ServFail);
     sendPacket(outpacket,outsock);
     return 0;
   }
@@ -751,7 +751,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
         int ret2 = stubDoResolve(getRR<ALIASRecordContent>(zrr.dr)->d_content, QType::AAAA, ips);
         if(ret1 != RCode::NoError || ret2 != RCode::NoError) {
           L<<Logger::Error<<"Error resolving for ALIAS "<<zrr.dr.d_content->getZoneRepresentation()<<", aborting AXFR"<<endl;
-          outpacket->setRcode(2); // 'SERVFAIL'
+          outpacket->setRcode(RCode::ServFail);
           sendPacket(outpacket,outsock);
           return 0;
         }
@@ -1084,7 +1084,7 @@ int TCPNameserver::doIXFR(shared_ptr<DNSPacket> q, int outsock)
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
     if(!canDoAXFR(q) || !s_P->getBackend()->getSOAUncached(q->qdomain, sd)) {
       L<<Logger::Error<<"IXFR of domain '"<<q->qdomain<<"' failed: not authoritative"<<endl;
-      outpacket->setRcode(9); // 'NOTAUTH'
+      outpacket->setRcode(RCode::NotAuth);
       sendPacket(outpacket,outsock);
       return 0;
     }

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -320,12 +320,12 @@ void *TCPNameserver::doConnection(void *data)
       shared_ptr<DNSPacket> reply; 
       shared_ptr<DNSPacket> cached= shared_ptr<DNSPacket>(new DNSPacket);
       if(logDNSQueries)  {
-        string remote;
-        if(packet->hasEDNSSubnet()) 
-          remote = packet->getRemote().toString() + "<-" + packet->getRealRemote().toString();
+        string remote_text;
+        if(packet->hasEDNSSubnet())
+          remote_text = packet->getRemote().toString() + "<-" + packet->getRealRemote().toString();
         else
-          remote = packet->getRemote().toString();
-        L << Logger::Notice<<"TCP Remote "<< remote <<" wants '" << packet->qdomain<<"|"<<packet->qtype.getName() << 
+          remote_text = packet->getRemote().toString();
+        L << Logger::Notice<<"TCP Remote "<< remote_text <<" wants '" << packet->qdomain<<"|"<<packet->qtype.getName() <<
         "', do = " <<packet->d_dnssecOk <<", bufsize = "<< packet->getMaxReplyLen()<<": ";
       }
 
@@ -737,11 +737,11 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   vector<DNSZoneRecord> zrrs;
 
   // Add the CDNSKEY and CDS records we created earlier
-  for (auto const &zrr : cds)
-    zrrs.push_back(zrr);
+  for (auto const &synth_zrr : cds)
+    zrrs.push_back(synth_zrr);
 
-  for (auto const &zrr : cdnskey)
-    zrrs.push_back(zrr);
+  for (auto const &synth_zrr : cdnskey)
+    zrrs.push_back(synth_zrr);
 
   while(sd.db->get(zrr)) {
     if(zrr.dr.d_name.isPartOf(target)) {

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -51,8 +51,6 @@ extern StatBag S;
 vector<UeberBackend *>UeberBackend::instances;
 pthread_mutex_t UeberBackend::instances_lock=PTHREAD_MUTEX_INITIALIZER;
 
-sem_t UeberBackend::d_dynserialize;
-
 // initially we are blocked
 bool UeberBackend::d_go=false;
 pthread_mutex_t  UeberBackend::d_mut = PTHREAD_MUTEX_INITIALIZER;
@@ -624,13 +622,6 @@ bool UeberBackend::get(DNSZoneRecord &rr)
   d_ancount++;
   d_answers.push_back(rr);
   return true;
-}
-
-bool UeberBackend::list(const DNSName &target, int domain_id, bool include_disabled)
-{
-  L<<Logger::Error<<"UeberBackend::list called, should NEVER EVER HAPPEN"<<endl;
-  exit(1);
-  return false;
 }
 
 bool UeberBackend::searchRecords(const string& pattern, int maxResults, vector<DNSResourceRecord>& result)

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -55,7 +55,6 @@ class UeberBackend : public boost::noncopyable
 public:
   UeberBackend(const string &pname="default");
   ~UeberBackend();
-  typedef DNSBackend *BackendMaker(); //!< typedef for functions returning pointers to new backends
 
   bool superMasterBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db);
 
@@ -106,12 +105,10 @@ public:
   bool getAuth(DNSPacket *p, SOAData *sd, const DNSName &target);
   bool getSOA(const DNSName &domain, SOAData &sd, DNSPacket *p=0);
   bool getSOAUncached(const DNSName &domain, SOAData &sd, DNSPacket *p=0);  // same, but ignores cache
-  bool list(const DNSName &target, int domain_id, bool include_disabled=false);
   bool get(DNSResourceRecord &r);
   bool get(DNSZoneRecord &r);
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false);
 
-  static DNSBackend *maker(const map<string,string> &);
   void getUnfreshSlaveInfos(vector<DomainInfo>* domains);
   void getUpdatedMasters(vector<DomainInfo>* domains);
   bool getDomainInfo(const DNSName &domain, DomainInfo &di);
@@ -145,7 +142,6 @@ private:
 
   static pthread_mutex_t d_mut;
   static pthread_cond_t d_cond;
-  static sem_t d_dynserialize;
 
   struct Question
   {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1489,7 +1489,7 @@ static void apiServerSearchData(HttpRequest* req, HttpResponse* resp) {
 
   if (q.empty())
     throw ApiException("Query q can't be blank");
-  if (sMax.empty() == false)
+  if (!sMax.empty())
     maxEnts = std::stoi(sMax);
   if (maxEnts < 1)
     throw ApiException("Maximum entries must be larger than 0");


### PR DESCRIPTION
At least where we can. Makes the code easier to follow.

Plus drop UeberBackend::list and an unused static int.