### PR TITLE
dnsdist: Flush output in single command client mode

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -75,6 +75,7 @@ void doClient(ComboAddress server, const std::string& command)
         msg.assign(resp.get(), len);
         msg=sodDecryptSym(msg, g_key, theirs);
         cout<<msg;
+        cout.flush();
       }
     }
     else {


### PR DESCRIPTION
Otherwise redirection to a pipe or a file doesn't work, as
reported on IRC  by tmus (thanks!).