### PR TITLE
DNS Header and EDNS Flag access for Lua

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -116,6 +116,8 @@ It also supports the following methods:
 * `getRecords()`: get a table of DNS Records in this DNS Question (or answer by now)
 * `setPolicyTags(tags)`: update the policy tags, taking a table of strings.
 * `setRecords(records)`: after your edits, update the answers of this question
+* `getEDNSFlag(name)`: returns true if the EDNS flag with `name` is set in the query
+* `getEDNSFlags()`: returns a list of strings with all the EDNS flag mnemonics in the query
 * `getEDNSOption(num)`: get the EDNS Option with number `num`
 * `getEDNSOptions()`: get a map of all EDNS Options
 * `getEDNSSubnet()`: returns the netmask specified in the EDNSSubnet option, or empty if there was none

--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -107,6 +107,11 @@ It also supports the following methods:
   the answer too, which defaults to the name of the question
 * `addPolicyTag(tag)`: add a policy tag.
 * `discardPolicy(policyname)`: skip the filtering policy (for example RPZ) named `policyname` for this query. This is mostly useful in the `prerpz` hook.
+* `getDH()` - Returns the DNS Header of the query or nil. A DNS header offers the following methods:
+     * `getRD()`, `getAA()`, `getAD()`, `getCD()`, `getTC()`: query these bits from the DNS Header
+     * `getRCODE()`: get the RCODE of the query
+     * `getOPCODE()`: get the OPCODE of the query
+     * `getID()`: get the ID of the query
 * `getPolicyTags()`: get the current policy tags as a table of strings.
 * `getRecords()`: get a table of DNS Records in this DNS Question (or answer by now)
 * `setPolicyTags(tags)`: update the policy tags, taking a table of strings.
@@ -128,12 +133,7 @@ With this hook, undesired traffic can be dropped rapidly before using precious C
 for parsing.
 
 `remoteip` is the IP(v6) address of the requestor, `localip` is the address on which the query arrived.
-`dh` is the DNS Header of the query, and it offers the following methods:
-
-* `getRD()`, `getAA()`, `getAD()`, `getCD()`, `getRD()`, `getRD()`, `getTC()`: query these bits from the DNS Header
-* `getRCODE()`: get the RCODE of the query
-* `getOPCODE()`: get the OPCODE of the query
-* `getID()`: get the ID of the query
+`dh` is the DNS Header of the query, and it offers the same functions as the `dq.getDH()` object described above.
 
 As an example, to filter all queries coming from 1.2.3.0/24, or with the AD bit set:
 

--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -89,15 +89,15 @@ The DNSQuestion object contains at least the following fields:
 * localaddr - address this query was received on
 * variable - a boolean which, if set, indicates the recursor should not packet cache this answer. Honored even when returning 'false'! Important when providing answers that vary over time or based on sender details.
 * followupFunction - a string that signals the nameserver to take one of the following additional actions:
-    * followCNAMERecords: When adding a CNAME to the answer, this tells the recursor to follow that CNAME. See [CNAME chain resolution](#cname-chain-resolution)
-    * getFakeAAAARecords: Get a fake AAAA record, see [DNS64](#dns64)
-    * getFakePTRRecords: Get a fake PTR record, see [DNS64](#dns64)
-    * udpQueryResponse: Do a UDP query and call a handler, see [`udpQueryResponse`](#udpqueryresponse)
+     * followCNAMERecords: When adding a CNAME to the answer, this tells the recursor to follow that CNAME. See [CNAME chain resolution](#cname-chain-resolution)
+     * getFakeAAAARecords: Get a fake AAAA record, see [DNS64](#dns64)
+     * getFakePTRRecords: Get a fake PTR record, see [DNS64](#dns64)
+     * udpQueryResponse: Do a UDP query and call a handler, see [`udpQueryResponse`](#udpqueryresponse)
 * appliedPolicy - The decision that was made by the policy engine, see [Modifying policy decisions](#modifying-policy-decisions). It has the following fields:
-    * policyName: The name of the policy (used in e.g. protobuf logging)
-    * policyAction: The action taken by the engine
-    * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
-    * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
+     * policyName: The name of the policy (used in e.g. protobuf logging)
+     * policyAction: The action taken by the engine
+     * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
+     * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
 * wantsRPZ - A boolean that indicates the use of the Policy Engine, can be set to `false` in `preresolve` to disable RPZ for this query
 * data - a table that is persistent throughout the lifetime of the `dq` object and can be used to store custom data. All keys and values in the table must be of type `string`.
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -166,6 +166,25 @@ boost::optional<dnsheader> RecursorLua4::DNSQuestion::getDH() const
   return boost::optional<dnsheader>();
 }
 
+vector<string> RecursorLua4::DNSQuestion::getEDNSFlags() const
+{
+  vector<string> ret;
+  if (ednsFlags) {
+    if (*ednsFlags & EDNSOpts::DNSSECOK)
+      ret.push_back("DO");
+  }
+  return ret;
+}
+
+bool RecursorLua4::DNSQuestion::getEDNSFlag(string flag) const
+{
+  if (ednsFlags) {
+    if (flag == "DO" && (*ednsFlags & EDNSOpts::DNSSECOK))
+      return true;
+  }
+  return false;
+}
+
 vector<pair<uint16_t, string> > RecursorLua4::DNSQuestion::getEDNSOptions() const
 {
   if(ednsOptions)
@@ -408,6 +427,8 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerFunction("getEDNSOptions", &DNSQuestion::getEDNSOptions);
   d_lw->registerFunction("getEDNSOption", &DNSQuestion::getEDNSOption);
   d_lw->registerFunction("getEDNSSubnet", &DNSQuestion::getEDNSSubnet);
+  d_lw->registerFunction("getEDNSFlags", &DNSQuestion::getEDNSFlags);
+  d_lw->registerFunction("getEDNSFlag", &DNSQuestion::getEDNSFlag);
   d_lw->registerMember("name", &DNSRecord::d_name);
   d_lw->registerMember("type", &DNSRecord::d_type);
   d_lw->registerMember("ttl", &DNSRecord::d_ttl);

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -159,6 +159,13 @@ static int getFakePTRRecords(const DNSName& qname, const std::string& prefix, ve
 
 }
 
+boost::optional<dnsheader> RecursorLua4::DNSQuestion::getDH() const
+{
+  if (dh)
+    return *dh;
+  return boost::optional<dnsheader>();
+}
+
 vector<pair<uint16_t, string> > RecursorLua4::DNSQuestion::getEDNSOptions() const
 {
   if(ednsOptions)
@@ -397,6 +404,7 @@ RecursorLua4::RecursorLua4(const std::string& fname)
       pol.d_custom = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::CNAME, 1, content));
     }
   );
+  d_lw->registerFunction("getDH", &DNSQuestion::getDH);
   d_lw->registerFunction("getEDNSOptions", &DNSQuestion::getEDNSOptions);
   d_lw->registerFunction("getEDNSOption", &DNSQuestion::getEDNSOption);
   d_lw->registerFunction("getEDNSSubnet", &DNSQuestion::getEDNSSubnet);

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -55,6 +55,7 @@ public:
     const uint16_t qtype;
     const ComboAddress& local;
     const ComboAddress& remote;
+    const struct dnsheader* dh{nullptr};
     const bool isTcp;
     const std::vector<pair<uint16_t, string>>* ednsOptions{nullptr};
     vector<DNSRecord>* currentRecords{nullptr};
@@ -69,6 +70,7 @@ public:
     void addAnswer(uint16_t type, const std::string& content, boost::optional<int> ttl, boost::optional<string> name);
     void addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, boost::optional<int> ttl, boost::optional<string> name);
     vector<pair<int,DNSRecord> > getRecords() const;
+    boost::optional<dnsheader> getDH() const;
     vector<pair<uint16_t, string> > getEDNSOptions() const;
     boost::optional<string> getEDNSOption(uint16_t code) const;
     boost::optional<Netmask> getEDNSSubnet() const;

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -58,6 +58,7 @@ public:
     const struct dnsheader* dh{nullptr};
     const bool isTcp;
     const std::vector<pair<uint16_t, string>>* ednsOptions{nullptr};
+    const uint16_t* ednsFlags{nullptr};
     vector<DNSRecord>* currentRecords{nullptr};
     DNSFilterEngine::Policy* appliedPolicy{nullptr};
     std::vector<std::string>* policyTags{nullptr};
@@ -74,6 +75,8 @@ public:
     vector<pair<uint16_t, string> > getEDNSOptions() const;
     boost::optional<string> getEDNSOption(uint16_t code) const;
     boost::optional<Netmask> getEDNSSubnet() const;
+    vector<string> getEDNSFlags() const;
+    bool getEDNSFlag(string flag) const;
     void setRecords(const vector<pair<int,DNSRecord> >& records);
 
     int rcode{0};

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -752,6 +752,7 @@ void startDoResolve(void *p)
       dq->policyTags = &dc->d_policyTags;
       dq->appliedPolicy = &appliedPolicy;
       dq->currentRecords = &ret;
+      dq->dh = &dc->d_mdp.d_header;
     }
 
     if(dc->d_mdp.d_qtype==QType::ANY && !dc->d_tcp && g_anyToTcp) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -746,6 +746,7 @@ void startDoResolve(void *p)
     std::shared_ptr<RecursorLua4::DNSQuestion> dq = nullptr;
     if (t_pdl->get() && (*t_pdl)->needDQ()) {
       dq = std::make_shared<RecursorLua4::DNSQuestion>(dc->d_remote, dc->d_local, dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_tcp, variableAnswer, wantsRPZ);
+      dq->ednsFlags = &edo.d_Z;
       dq->ednsOptions = &dc->d_ednsOpts;
       dq->tag = dc->d_tag;
       dq->discardedPolicies = &sr.d_discardedPolicies;


### PR DESCRIPTION
This PR depends on #4564!

This PR adds a `dq.dh` member that has all the same functions as the `dh` in the ipfilter function. It also adds two functions to the `dq` object to get the EDNS Flags (only DO is supported at the moment)
