### PR TITLE
Backport #4544: auth: Fix a stack-based off-by-one write in the HTTP remote backend

### DIFF
--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -397,7 +397,6 @@ int HTTPConnector::recv_message(Json& output) {
           throw NetworkError("EOF while reading");
         if (rd<0)
           throw NetworkError(std::string(strerror(rd)));
-        buffer[rd] = 0;
         arl.feed(std::string(buffer, rd));
       }
       // timeout occured.


### PR DESCRIPTION
Reported by mongo (thanks!).

(cherry picked from commit 9e5fa399eea5152a451753f1db68dec46537447c)