### PR TITLE
auth: Lowercase the qname in getDomainInfo() and isMaster()

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -396,11 +396,12 @@ void Bind2Backend::getUnfreshSlaveInfos(vector<DomainInfo> *unfreshDomains)
 bool Bind2Backend::getDomainInfo(const string &domain, DomainInfo &di)
 {
   BB2DomainInfo bbd;
-  if(!safeGetBBDomainInfo(domain, &bbd))
+  string domainLC(toLower(domain));
+  if(!safeGetBBDomainInfo(domainLC, &bbd))
     return false;
 
   di.id=bbd.d_id;
-  di.zone=domain;
+  di.zone=domainLC;
   di.masters=bbd.d_masters;
   di.last_check=bbd.d_lastcheck;
   di.backend=this;
@@ -1225,7 +1226,7 @@ bool Bind2Backend::handle::get_list(DNSResourceRecord &r)
 bool Bind2Backend::isMaster(const string &name, const string &ip)
 {
   BB2DomainInfo bbd;
-  if(!safeGetBBDomainInfo(name, &bbd))
+  if(!safeGetBBDomainInfo(toLower(name), &bbd))
     return false;
 
   for(vector<string>::const_iterator iter = bbd.d_masters.begin(); iter != bbd.d_masters.end(); ++iter)

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -74,7 +74,7 @@ void GSQLBackend::setFresh(uint32_t domain_id)
 
 bool GSQLBackend::isMaster(const string &domain, const string &ip)
 {
-  string query = (GSQLformat(d_MasterOfDomainsZoneQuery) % sqlEscape(domain)).str();
+  string query = (GSQLformat(d_MasterOfDomainsZoneQuery) % sqlEscape(toLower(domain))).str();
 
   try {
     d_db->doQuery(query, d_result);
@@ -146,7 +146,7 @@ bool GSQLBackend::getDomainInfo(const string &domain, DomainInfo &di)
      id,name,master IP(s),last_check,notified_serial,type,account */
   char output[1024];
   snprintf(output,sizeof(output)-1,d_InfoOfDomainsZoneQuery.c_str(),
-	   sqlEscape(domain).c_str());
+	   sqlEscape(toLower(domain)).c_str());
   try {
     d_db->doQuery(output,d_result);
   }


### PR DESCRIPTION
The generic SQL and bind backends were not properly lowercasing the
qname in `getDomainInfo()` and `isMaster()`. This is already fixed in 4.0.0.
Closes #4575.