### PR TITLE
dnsdist: Change the default max number of queued TCP conns to 1000

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -915,9 +915,9 @@ The maximum number of threads in the TCP pool is controlled by the
 increased to handle a large number of simultaneous TCP connections.
 If all the TCP threads are busy, new TCP connections are queued while
 they wait to be picked up. The maximum number of queued connections
-can be configured with `setMaxTCPQueuedConnections()`, and any value other
-than 0 (the default) will cause new connections to be dropped if there
-are already too many queued.
+can be configured with `setMaxTCPQueuedConnections()` and defaults to 1000.
+Any value larger than 0 will cause new connections to be dropped if there are
+already too many queued.
 
 When dispatching UDP queries to backend servers, `dnsdist` keeps track of at
 most `n` outstanding queries for each backend. This number `n` can be tuned by
@@ -1476,7 +1476,7 @@ instantiate a server with additional parameters
     * `setTCPRecvTimeout(n)`: set the read timeout on TCP connections from the client, in seconds
     * `setTCPSendTimeout(n)`: set the write timeout on TCP connections from the client, in seconds
     * `setMaxTCPClientThreads(n)`: set the maximum of TCP client threads, handling TCP connections
-    * `setMaxTCPQueuedConnections(n)`: set the maximum number of TCP connections queued (waiting to be picked up by a client thread)
+    * `setMaxTCPQueuedConnections(n)`: set the maximum number of TCP connections queued (waiting to be picked up by a client thread), defaults to 1000. 0 means unlimited
     * `setMaxUDPOutstanding(n)`: set the maximum number of outstanding UDP queries to a given backend server. This can only be set at configuration time and defaults to 10240
     * `setCacheCleaningDelay(n)`: set the interval in seconds between two runs of the cache cleaning algorithm, removing expired entries
     * `setStaleCacheEntriesTTL(n)`: allows using cache entries expired for at most `n` seconds when no backend available to answer for a query

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -67,7 +67,7 @@ struct ConnectionInfo
   ClientState* cs;
 };
 
-uint64_t g_maxTCPQueuedConnections{0};
+uint64_t g_maxTCPQueuedConnections{1000};
 void* tcpClientThread(int pipefd);
 
 // Should not be called simultaneously!

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1425,6 +1425,7 @@ static void checkFileDescriptorsLimits(size_t udpBindsCount, size_t tcpBindsCoun
   /* stdin, stdout, stderr */
   size_t requiredFDsCount = 3;
   size_t backendsCount = g_dstates.getCopy().size();
+  /* listening sockets */
   requiredFDsCount += udpBindsCount;
   requiredFDsCount += tcpBindsCount;
   /* max TCP connections currently served */
@@ -1436,7 +1437,7 @@ static void checkFileDescriptorsLimits(size_t udpBindsCount, size_t tcpBindsCoun
   /* TCP sockets to backends */
   requiredFDsCount += (backendsCount * g_maxTCPClientThreads);
   /* max TCP queued connections */
-  requiredFDsCount += (tcpBindsCount * g_maxTCPQueuedConnections);
+  requiredFDsCount += g_maxTCPQueuedConnections;
   /* DelayPipe pipe */
   requiredFDsCount += 2;
   /* syslog socket */
@@ -1451,7 +1452,7 @@ static void checkFileDescriptorsLimits(size_t udpBindsCount, size_t tcpBindsCoun
   requiredFDsCount++;
   struct rlimit rl;
   getrlimit(RLIMIT_NOFILE, &rl);
-  if (((rl.rlim_cur * 3) / 4) < requiredFDsCount) {
+  if (rl.rlim_cur <= requiredFDsCount) {
     warnlog("Warning, this configuration can use more than %d file descriptors, web server and console connections not included, and the current limit is %d.", std::to_string(requiredFDsCount), std::to_string(rl.rlim_cur));
 #ifdef HAVE_SYSTEMD
     warnlog("You can increase this value by using LimitNOFILE= in the systemd unit file or ulimit.");


### PR DESCRIPTION
With the existing default value of 0, we could consume an unlimited
number of file descriptors if the queued connections kept piling up.