### PR TITLE
auth: Add support for "NONE" SOA-EDIT kind

### DIFF
--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -72,6 +72,9 @@ uint32_t calculateEditSOA(uint32_t old_serial, const string& kind, const DNSName
   else if(!kind.empty()) {
     g_log<<Logger::Warning<<"SOA-EDIT type '"<<kind<<"' for zone "<<zonename<<" is unknown."<<endl;
   }
+  // Seen strictly, this is a broken config: we can only come here if
+  // both SOA-EDIT and default-soa-edit are set to "", but the latter
+  // should be set to "NONE" instead.
   return old_serial;
 }
 

--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -65,7 +65,11 @@ uint32_t calculateEditSOA(uint32_t old_serial, const string& kind, const DNSName
     uint32_t inception = getStartOfWeek();
     if (old_serial < inception)
       return inception;
-  } else if(!kind.empty()) {
+  }
+  else if(pdns_iequals(kind,"NONE")) {
+    // do nothing to serial. needed because a metadata of "" will use the default-soa-edit setting instead.
+  }
+  else if(!kind.empty()) {
     g_log<<Logger::Warning<<"SOA-EDIT type '"<<kind<<"' for zone "<<zonename<<" is unknown."<<endl;
   }
   return old_serial;

--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -81,8 +81,6 @@ uint32_t calculateEditSOA(uint32_t old_serial, const string& kind, const DNSName
 uint32_t calculateEditSOA(uint32_t old_serial, DNSSECKeeper& dk, const DNSName& zonename) {
   string kind;
   dk.getSoaEdit(zonename, kind);
-  if(kind.empty())
-    return old_serial;
   return calculateEditSOA(old_serial, kind, zonename);
 }
 


### PR DESCRIPTION
Setting the "SOA-EDIT" value for a zone to "NONE" causes an error:
'SOA-EDIT type 'NONE' for zone ZONENAME is unknown.'

The calculateEditSOA function could return the SOA as-is in such cases.
