### PR TITLE
Backport #4537: Replace std::forward/std::make_tuple combo with std::forward_as_tuple

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1310,7 +1310,7 @@ private:
             RealReturnType;
         
         // we push the parameters on the stack
-        auto inArguments = Pusher<std::tuple<TParameters...>>::push(state, std::make_tuple(std::forward<TParameters>(input)...));
+        auto inArguments = Pusher<std::tuple<TParameters...>>::push(state, std::forward_as_tuple((input)...));
 
         // 
         const int outArgumentsCount = std::tuple_size<RealReturnType>::value;


### PR DESCRIPTION
Quick and dirty fix for #3552. May not work or break compatibility
with other compilers.

(cherry picked from commit 352bc0409454032acc5e8fb256d5ed8f46445b5a)