### PR TITLE
NSEC3 optout and Bogus insecure forward fixes

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -85,7 +85,7 @@ static dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const
         }
 
         /* check if the whole NAME does not exist */
-        if( ((beginHash < h && h < nsec3->d_nexthash) ||                  // no wrap          BEGINNING --- HASH -- END
+        if( ((beginHash < h && h < nsec3->d_nexthash) ||                   // no wrap          BEGINNING --- HASH -- END
               (nsec3->d_nexthash > h  && beginHash > nsec3->d_nexthash) || // wrap             HASH --- END --- BEGINNING
               (nsec3->d_nexthash < beginHash  && beginHash < h) ||         // wrap other case  END --- BEGINNING --- HASH
               beginHash == nsec3->d_nexthash))                             // "we have only 1 NSEC3 record, LOL!"

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -12,7 +12,7 @@ void dotNode(string type, DNSName name, string tag, string content);
 string dotName(string type, DNSName name, string tag);
 string dotEscape(string name);
 
-const char *dStates[]={"nodata", "nxdomain", "nxqtype", "empty non-terminal", "insecure"};
+const char *dStates[]={"nodata", "nxdomain", "nxqtype", "empty non-terminal", "insecure", "opt-out"};
 const char *vStates[]={"Indeterminate", "Bogus", "Insecure", "Secure", "NTA"};
 
 typedef set<DNSKEYRecordContent> keyset_t;
@@ -83,7 +83,12 @@ static dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const
               (nsec3->d_nexthash < beginHash  && beginHash < h) ||         // wrap other case  END --- BEGINNING --- HASH
               beginHash == nsec3->d_nexthash))                             // "we have only 1 NSEC3 record, LOL!"
         {
-          LOG("Denies existence of name "<<qname<<"/"<<QType(qtype).getName()<<"(could be opt-out)!"<<endl);
+          LOG("Denies existence of name "<<qname<<"/"<<QType(qtype).getName());
+          if (qtype == QType::DS && nsec3->d_flags & 1) {
+            LOG(" but is opt-out!"<<endl);
+            return OPTOUT;
+          }
+          LOG(endl);
           return NXDOMAIN;
         }
 
@@ -430,9 +435,9 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
     if(r.first == r.second) {
       LOG("No DS for "<<*(zoneCutIter+1)<<", now look for a secure denial"<<endl);
       dState res = getDenial(validrrsets, *(zoneCutIter+1), QType::DS);
-      if (res == INSECURE)
+      if (res == INSECURE || res == NXDOMAIN)
         return Bogus;
-      if (res == NXDOMAIN || res == NXQTYPE)
+      if (res == NXQTYPE || res == OPTOUT)
         return Insecure;
     }
 

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -69,6 +69,13 @@ static dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const
         // If the name exists, check if the qtype is denied
         if(beginHash == h && !nsec3->d_set.count(qtype)) {
           LOG("Denies existence of type "<<QType(qtype).getName()<<" for name "<<qname<<"  (not opt-out).");
+          /*
+           * RFC 5155 section 8.9:
+           * If there is an NSEC3 RR present in the response that matches the
+           * delegation name, then the validator MUST ensure that the NS bit is
+           * set and that the DS bit is not set in the Type Bit Maps field of the
+           * NSEC3 RR.
+           */
           if (qtype == QType::DS && !nsec3->d_set.count(QType::NS)) {
             LOG("However, no NS record exists at this level!"<<endl);
             return INSECURE;

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -34,7 +34,7 @@ enum vState { Indeterminate, Bogus, Insecure, Secure, NTA };
 extern const char *vStates[];
 
 // NSEC(3) results
-enum dState { NODATA, NXDOMAIN, NXQTYPE, ENT, INSECURE };
+enum dState { NODATA, NXDOMAIN, NXQTYPE, ENT, INSECURE, OPTOUT};
 extern const char *dStates[];
 
 class DNSRecordOracle


### PR DESCRIPTION
After the change to zonecuts to find key material, the NSEC3 checking
returned an (incorrect) 'covering nxdomain' for a forwarded subzone with
no DS record in its parent. After fixing this, the NSEC3 optout test
failed as Bogus (instead of insecure). This was fixed by actually
checking the optout flag on a delegation NSEC3 record.

This PR also adds some comments to the code