### PR TITLE
g.root-servers.net added IPv6

### DIFF
--- a/pdns/root-addresses.hh
+++ b/pdns/root-addresses.hh
@@ -42,7 +42,7 @@ static const char*rootIps6[]={"2001:503:ba3e::2:30",    // a.root-servers.net.
                               "2001:500:2d::d",         // d.root-servers.net.
                               "2001:500:a8::e",         // e.root-servers.net.
                               "2001:500:2f::f",         // f.root-servers.net.
-                              NULL,                     // g.root-servers.net.
+                              "2001:500:12::d0d",       // g.root-servers.net.
                               "2001:500:1::53",         // h.root-servers.net.
                               "2001:7fe::53",           // i.root-servers.net.
                               "2001:503:c27::2:30",     // j.root-servers.net.


### PR DESCRIPTION
http://www.internic.net/domain/db.cache
last update:    October 20, 2016