### PR TITLE
Use dnsname for nsec generation

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -927,55 +927,33 @@ void Bind2Backend::queueReloadAndStore(unsigned int id)
 bool Bind2Backend::findBeforeAndAfterUnhashed(BB2DomainInfo& bbd, const DNSName& qname, DNSName& unhashed, string& before, string& after)
 {
   shared_ptr<const recordstorage_t> records = bbd.d_records.get();
-  recordstorage_t::const_iterator iter = records->upper_bound(qname);
 
-  if (before.empty()){
-    //cout<<"starting before for: '"<<domain<<"'"<<endl;
-    iter = records->upper_bound(qname);
+  // for(const auto& record: *records)
+  //   cerr<<record.qname<<"\t"<<makeHexDump(record.qname.toDNSString())<<endl;
 
-    while(iter == records->end() || (qname.canonCompare(iter->qname)) || (!(iter->auth) && (!(iter->qtype == QType::NS))) || (!(iter->qtype)))
-      iter--;
+  recordstorage_t::const_iterator iterBefore, iterAfter;
 
-    if(iter->qname.empty())
-      before.clear();
-    else { 
+  iterBefore = iterAfter = records->upper_bound(qname.makeLowerCase());
 
-      before=iter->qname.labelReverse().toString(" ",false);
-    }
-  }
-  else {
-    if(qname.empty())
-      before.clear();
-    else {
-      before=qname.labelReverse().toString(" ",false);
-    }
-  }
+  if(iterBefore != records->begin())
+    --iterBefore;
+  while((!iterBefore->auth && iterBefore->qtype != QType::NS) || !iterBefore->qtype)
+    --iterBefore;
+  before=iterBefore->qname.labelReverse().toString(" ",false);
 
-  //cerr<<"Now after"<<endl;
-  iter = records->upper_bound(qname);
-
-  if(iter == records->end()) {
-    //cerr<<"\tFound the end, begin storage: '"<<bbd.d_records->begin()->qname<<"', '"<<bbd.d_name<<"'"<<endl;
-    after.clear(); // this does the right thing (i.e. point to apex, which is sure to have auth records)
+  if(iterAfter == records->end()) {
+    iterAfter = records->begin();
   } else {
-    //cerr<<"\tFound: '"<<(iter->qname)<<"' (nsec3hash='"<<(iter->nsec3hash)<<"')"<<endl;
-    // this iteration is theoretically unnecessary - glue always sorts right behind a delegation
-    // so we will never get here. But let's do it anyway.
-    while((!(iter->auth) && (!(iter->qtype == QType::NS))) || (!(iter->qtype)))
-    {
-      iter++;
-      if(iter == records->end())
-      {
-        after.clear();
+    while((!iterAfter->auth && iterAfter->qtype != QType::NS) || !iterAfter->qtype) {
+      ++iterAfter;
+      if(iterAfter == records->end()) {
+        iterAfter = records->begin();
         break;
       }
     }
-    if(iter != records->end()) {
-      after = (iter)->qname.labelReverse().toString(" ",false);
-    }
   }
+  after = iterAfter->qname.labelReverse().toString(" ",false);
 
-  // cerr<<"Before: '"<<before<<"', after: '"<<after<<"'\n";
   return true;
 }
 
@@ -985,24 +963,25 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::string
   safeGetBBDomainInfo(id, &bbd);
 
   NSEC3PARAMRecordContent ns3pr;
-  DNSName auth=bbd.d_name;
-    
+
   bool nsec3zone;
   if (d_hybrid) {
     DNSSECKeeper dk;
-    nsec3zone=dk.getNSEC3PARAM(auth, &ns3pr);
+    nsec3zone=dk.getNSEC3PARAM(bbd.d_name, &ns3pr);
   } else
-    nsec3zone=getNSEC3PARAM(auth, &ns3pr);
+    nsec3zone=getNSEC3PARAM(bbd.d_name, &ns3pr);
 
   if(!nsec3zone) {
     DNSName dqname(DNSName(boost::replace_all_copy(qname," ",".")).labelReverse()); // the horror
     return findBeforeAndAfterUnhashed(bbd, dqname, unhashed, before, after);
-  }
-  else {
+  } else {
     auto& hashindex=boost::multi_index::get<NSEC3Tag>(*bbd.d_records.getWRITABLE());
 
+    // for(auto iter = first; iter != hashindex.end(); iter++)
+    //  cerr<<iter->nsec3hash<<endl;
+
     auto first = hashindex.upper_bound("");
-    auto iter = hashindex.upper_bound(toLower(qname));
+    auto iter = hashindex.upper_bound(qname.toStringNoDot());
 
     if (iter == hashindex.end()) {
       --iter;

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -193,7 +193,7 @@ public:
   bool getDomainInfo(const DNSName &domain, DomainInfo &di);
   time_t getCtime(const string &fname);
    // DNSSEC
-  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const string& qname, DNSName& unhashed, string& before, string& after);
+  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after);
   void lookup(const QType &, const DNSName &qdomain, DNSPacket *p=0, int zoneId=-1);
   bool list(const DNSName &target, int id, bool include_disabled=false);
   bool get(DNSResourceRecord &);
@@ -316,7 +316,7 @@ private:
   BB2DomainInfo createDomainEntry(const DNSName& domain, const string &filename); //!< does not insert in s_state
 
   void queueReloadAndStore(unsigned int id);
-  bool findBeforeAndAfterUnhashed(BB2DomainInfo& bbd, const DNSName& qname, DNSName& unhashed, string& before, string& after);
+  bool findBeforeAndAfterUnhashed(BB2DomainInfo& bbd, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after);
   void reload();
   static string DLDomStatusHandler(const vector<string>&parts, Utility::pid_t ppid);
   static string DLListRejectsHandler(const vector<string>&parts, Utility::pid_t ppid);

--- a/modules/luabackend/dnssec.cc
+++ b/modules/luabackend/dnssec.cc
@@ -72,7 +72,7 @@ bool LUABackend::updateDNSSECOrderAndAuth(uint32_t domain_id, const DNSName& zon
     return ok;
 }
 
-bool LUABackend::updateDNSSECOrderNameAndAuth(unsigned int, DNSName const&, DNSName const&, DNSName const&, bool, unsigned short)
+bool LUABackend::updateDNSSECOrderNameAndAuth(unsigned int, DNSName const&, DNSName const&, bool, unsigned short)
 {
   return false;
 }

--- a/modules/luabackend/dnssec.cc
+++ b/modules/luabackend/dnssec.cc
@@ -114,7 +114,7 @@ bool LUABackend::updateDNSSECOrderAndAuthAbsolute(uint32_t domain_id, const DNSN
     return ok;
 }
 
-bool LUABackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::string& qname, DNSName& unhashed, std::string& before, std::string& after) {
+bool LUABackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) {
 
     if(f_lua_getbeforeandafternamesabsolute == 0)
 	return false;
@@ -129,7 +129,7 @@ bool LUABackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::string& 
     lua_rawgeti(lua, LUA_REGISTRYINDEX, f_lua_updatednssecorderandauthabsolute);
 
     lua_pushinteger(lua, id);
-    lua_pushstring(lua, qname.c_str());
+    lua_pushstring(lua, qname.toString().c_str());
 
     if(lua_pcall(lua, 2, 3, f_lua_exec_error) != 0) {
         string e = backend_name + lua_tostring(lua, -1);
@@ -156,13 +156,13 @@ bool LUABackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::string& 
     returnedwhat = lua_type(lua, -1);
     ok = (returnedwhat == LUA_TSTRING) && ok;
     
-    before = lua_tostring(lua, -1);
+    before = DNSName(lua_tostring(lua, -1));
     lua_pop(lua, 1);
 
     returnedwhat = lua_type(lua, -1);
     ok = (returnedwhat == LUA_TSTRING) && ok;
     
-    after = lua_tostring(lua, -1);
+    after = DNSName(lua_tostring(lua, -1));
     lua_pop(lua, 1);
 
     if(logging)

--- a/modules/luabackend/luabackend.hh
+++ b/modules/luabackend/luabackend.hh
@@ -101,7 +101,7 @@ public:
     bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id) override ;
     bool updateDNSSECOrderAndAuthAbsolute(uint32_t domain_id, const DNSName& qname, const std::string& ordername, bool auth);
     bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
-    bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& zonename, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype=QType::ANY) override;
+    bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype=QType::ANY) override;
     bool updateDNSSECOrderAndAuth(uint32_t domain_id, const DNSName& zonename, const DNSName& qname, bool auth);
 //  OTHER
     void reload() override ;

--- a/modules/luabackend/luabackend.hh
+++ b/modules/luabackend/luabackend.hh
@@ -100,7 +100,7 @@ public:
     bool getTSIGKey(const DNSName& name, DNSName* algorithm, string* content) override ;
     bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id) override ;
     bool updateDNSSECOrderAndAuthAbsolute(uint32_t domain_id, const DNSName& qname, const std::string& ordername, bool auth);
-    bool getBeforeAndAfterNamesAbsolute(uint32_t id, const      string& qname, DNSName& unhashed, string& before, string& after) override;
+    bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
     bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& zonename, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype=QType::ANY) override;
     bool updateDNSSECOrderAndAuth(uint32_t domain_id, const DNSName& zonename, const DNSName& qname, bool auth);
 //  OTHER

--- a/modules/oraclebackend/oraclebackend.cc
+++ b/modules/oraclebackend/oraclebackend.cc
@@ -521,7 +521,7 @@ OracleBackend::getBeforeAndAfterNames (
 
 bool
 OracleBackend::getBeforeAndAfterNamesAbsolute(uint32_t zoneId,
-  const string& name, DNSName& unhashed, string& before, string& after)
+  const DNSName& name, DNSName& unhashed, DNSName& before, DNSName& after)
 {
   if(!d_dnssecQueries)
     return -1; 
@@ -536,7 +536,7 @@ OracleBackend::getBeforeAndAfterNamesAbsolute(uint32_t zoneId,
   bind_str_ind(stmt, ":prev", mResultPrevName, sizeof(mResultPrevName), &mResultPrevNameInd);
   bind_str_ind(stmt, ":next", mResultNextName, sizeof(mResultNextName), &mResultNextNameInd);
   bind_uint32(stmt, ":zoneid", &zoneId);
-  string_to_cbuf(mQueryName, name, sizeof(mQueryName));
+  string_to_cbuf(mQueryName, name.labelReverse().toString(" ", false)), sizeof(mQueryName));
   mResultNameInd = -1;
   mResultPrevNameInd = -1;
   mResultNextNameInd = -1;
@@ -554,8 +554,8 @@ OracleBackend::getBeforeAndAfterNamesAbsolute(uint32_t zoneId,
   check_indicator(mResultNextNameInd, false);
 
   unhashed = DNSName(mResultName);
-  before = mResultPrevName;
-  after = mResultNextName;
+  before = DNSName(boost::replace_all_copy(mResultPrevName," ",".")).labelReverse();
+  after = DNSName(boost::replace_all_copy(mResultNextName," ",".")).labelReverse();
 
   release_query(stmt, prevNextHashQueryKey);
   return true;

--- a/modules/oraclebackend/oraclebackend.hh
+++ b/modules/oraclebackend/oraclebackend.hh
@@ -70,10 +70,10 @@ public:
                               const DNSName& name,
                               DNSName& before, DNSName& after);
   bool getBeforeAndAfterNamesAbsolute(uint32_t zoneId,
-                                      const string& name,
+                                      const DNSName& name,
                                       DNSName& unhashed,
-                                      string& before,
-                                      string& after);
+                                      DNSName& before,
+                                      DNSName& after);
   bool get(DNSResourceRecord &rr);
   vector<string> getDomainMasters(const DNSName& domain, int zoneId);
   bool isMaster(const DNSName& domain, const string &master);

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -252,7 +252,7 @@ bool RemoteBackend::get(DNSResourceRecord &rr) {
    return true;
 }
 
-bool RemoteBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::string& qname, DNSName& unhashed, std::string& before, std::string& after) {
+bool RemoteBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) {
    // no point doing dnssec if it's not supported
    if (d_dnssec == false) return false;
 
@@ -260,7 +260,7 @@ bool RemoteBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::strin
      { "method", "getBeforeAndAfterNamesAbsolute" },
      { "parameters", Json::object {
        { "id", Json(static_cast<double>(id)) },
-       { "qname", qname }
+       { "qname", qname.toString() }
      }}
    };
    Json answer;
@@ -269,12 +269,12 @@ bool RemoteBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const std::strin
      return false;
 
    unhashed = DNSName(stringFromJson(answer["result"], "unhashed"));
-   before = "";
-   after = "";
+   before.clear();
+   after.clear();
    if (answer["result"]["before"] != Json())
-     before = stringFromJson(answer["result"], "before");
+     before = DNSName(stringFromJson(answer["result"], "before"));
    if (answer["result"]["after"] != Json())
-     after = stringFromJson(answer["result"], "after");
+     after = DNSName(stringFromJson(answer["result"], "after"));
 
    return true;
 }

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -162,7 +162,7 @@ class RemoteBackend : public DNSBackend
   virtual bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta);
   virtual bool getDomainKeys(const DNSName& name, unsigned int kind, std::vector<DNSBackend::KeyData>& keys);
   virtual bool getTSIGKey(const DNSName& name, DNSName* algorithm, std::string* content);
-  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const string& qname, DNSName& unhashed, string& before, string& after);
+  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after);
   virtual bool setDomainMetadata(const DNSName& name, const string& kind, const std::vector<std::basic_string<char> >& meta);
   virtual bool removeDomainKey(const DNSName& name, unsigned int id);
   virtual bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id);

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -157,14 +157,13 @@ BOOST_AUTO_TEST_CASE(test_method_removeDomainKey) {
 }
 
 BOOST_AUTO_TEST_CASE(test_method_getBeforeAndAfterNamesAbsolute) {
-   DNSName unhashed;
-   std::string before,after;
+   DNSName unhashed, before, after;
    BOOST_TEST_MESSAGE("Testing getBeforeAndAfterNamesAbsolute method");
    
-   be->getBeforeAndAfterNamesAbsolute(-1, "middle.unit.test.", unhashed, before, after);
+   be->getBeforeAndAfterNamesAbsolute(-1, DNSName("middle.unit.test."), unhashed, before, after);
    BOOST_CHECK_EQUAL(unhashed.toString(), "middle.");
-   BOOST_CHECK_EQUAL(before, "begin.");
-   BOOST_CHECK_EQUAL(after, "stop.");
+   BOOST_CHECK_EQUAL(before.toString(), "begin.");
+   BOOST_CHECK_EQUAL(after.toString(), "stop.");
 }
 
 BOOST_AUTO_TEST_CASE(test_method_setTSIGKey) {

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -552,7 +552,6 @@ bool GSQLBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qna
 {
   if(!d_dnssecQueries)
     return false;
-  // cerr<<"gsql before/after called for id="<<id<<", qname='"<<qname<<"'"<<endl;
   after.clear();
 
   SSqlStatement::row_t row;
@@ -564,7 +563,9 @@ bool GSQLBackend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qna
     while(d_afterOrderQuery_stmt->hasNextRow()) {
       d_afterOrderQuery_stmt->nextRow(row);
       ASSERT_ROW_COLUMNS("get-order-after-query", row, 1);
-      after=DNSName(boost::replace_all_copy(row[0]," ",".")).labelReverse();
+      if(! row[0].empty()) { // Hack because NULL values are passed on as empty strings
+        after=DNSName(boost::replace_all_copy(row[0]," ",".")).labelReverse();
+      }
     }
     d_afterOrderQuery_stmt->reset();
   }

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -428,7 +428,7 @@ void GSQLBackend::getUpdatedMasters(vector<DomainInfo> *updatedDomains)
   }
 }
 
-bool GSQLBackend::updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& zonename, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype)
+bool GSQLBackend::updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype)
 {
   if(!d_dnssecQueries)
     return false;
@@ -437,7 +437,7 @@ bool GSQLBackend::updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName
     if (qtype == QType::ANY) {
       try {
         d_updateOrderNameAndAuthQuery_stmt->
-          bind("ordername", ordername.makeRelative(zonename).labelReverse().toString(" ", false))->
+          bind("ordername", ordername.labelReverse().toString(" ", false))->
           bind("auth", auth)->
           bind("domain_id", domain_id)->
           bind("qname", qname)->
@@ -450,7 +450,7 @@ bool GSQLBackend::updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName
     } else {
       try {
         d_updateOrderNameAndAuthTypeQuery_stmt->
-          bind("ordername", ordername.makeRelative(zonename).labelReverse().toString(" ", false))->
+          bind("ordername", ordername.labelReverse().toString(" ", false))->
           bind("auth", auth)->
           bind("domain_id", domain_id)->
           bind("qname", qname)->
@@ -493,7 +493,7 @@ bool GSQLBackend::updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName
   return true;
 }
 
-bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, const DNSName& zonename, set<DNSName>& insert, set<DNSName>& erase, bool remove)
+bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& insert, set<DNSName>& erase, bool remove)
 {
   if(remove) {
     try {

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -207,7 +207,7 @@ public:
   bool setKind(const DNSName &domain, const DomainInfo::DomainKind kind);
   bool setAccount(const DNSName &domain, const string &account);
 
-  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const string& qname, DNSName& unhashed, std::string& before, std::string& after);
+  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after);
   virtual bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& zonename, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t=QType::ANY);
 
   virtual bool updateEmptyNonTerminals(uint32_t domain_id, const DNSName& zonename, set<DNSName>& insert ,set<DNSName>& erase, bool remove);

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -208,9 +208,9 @@ public:
   bool setAccount(const DNSName &domain, const string &account);
 
   virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after);
-  virtual bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& zonename, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t=QType::ANY);
+  virtual bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t=QType::ANY);
 
-  virtual bool updateEmptyNonTerminals(uint32_t domain_id, const DNSName& zonename, set<DNSName>& insert ,set<DNSName>& erase, bool remove);
+  virtual bool updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& insert ,set<DNSName>& erase, bool remove);
   virtual bool doesDNSSEC();
 
   virtual bool calculateSOASerial(const DNSName& domain, const SOAData& sd, time_t& serial);

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -311,25 +311,11 @@ bool DNSBackend::get(DNSZoneRecord& dzr)
 
 bool DNSBackend::getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, const DNSName& qname, DNSName& before, DNSName& after)
 {
-  // FIXME400 FIXME400 FIXME400
-  // string lcqname=toLower(qname); FIXME400 tolower?
-  // string lczonename=toLower(zonename); FIXME400 tolower?
-  // lcqname=makeRelative(lcqname, lczonename);
-  DNSName lczonename = zonename.makeLowerCase(); 
-  // lcqname=labelReverse(lcqname);
-  DNSName dnc;
-  string relqname, sbefore, safter;
-  relqname=qname.makeRelative(zonename).labelReverse().toString(" ", false);
-  //sbefore = before.toString();
-  //safter = after.toString();
-  bool ret = this->getBeforeAndAfterNamesAbsolute(id, relqname, dnc, sbefore, safter);
-  boost::replace_all(sbefore, " ", ".");
-  boost::replace_all(safter, " ", ".");
-  before = DNSName(sbefore).labelReverse() + lczonename;
-  after = DNSName(safter).labelReverse() + lczonename;
-
-  // before=dotConcat(labelReverse(before), lczonename); FIXME400
-  // after=dotConcat(labelReverse(after), lczonename); FIXME400
+  DNSName unhashed;
+  bool ret = this->getBeforeAndAfterNamesAbsolute(id, qname.makeRelative(zonename).makeLowerCase(), unhashed, before, after);
+  DNSName lczonename = zonename.makeLowerCase();
+  before += lczonename;
+  after += lczonename;
   return ret;
 }
 

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -189,7 +189,7 @@ public:
   virtual bool deleteTSIGKey(const DNSName& name) { return false; }
   virtual bool getTSIGKeys(std::vector< struct TSIGKey > &keys) { return false; }
 
-  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const string& qname, DNSName& unhashed, string& before, string& after)
+  virtual bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after)
   {
     std::cerr<<"Default beforeAndAfterAbsolute called!"<<std::endl;
     abort();

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -198,12 +198,12 @@ public:
 
   virtual bool getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, const DNSName& qname, DNSName& before, DNSName& after);
 
-  virtual bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& zonename, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype=QType::ANY)
+  virtual bool updateDNSSECOrderNameAndAuth(uint32_t domain_id, const DNSName& qname, const DNSName& ordername, bool auth, const uint16_t qtype=QType::ANY)
   {
     return false;
   }
 
-  virtual bool updateEmptyNonTerminals(uint32_t domain_id, const DNSName& zonename, set<DNSName>& insert, set<DNSName>& erase, bool remove)
+  virtual bool updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& insert, set<DNSName>& erase, bool remove)
   {
     return false;
   }

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -53,7 +53,7 @@ uint32_t burtleCI(const unsigned char* k, uint32_t lengh, uint32_t init);
    NOTE: For now, everything MUST be . terminated, otherwise it is an error
 */
 
-inline char dns2_tolower(char c)
+inline unsigned char dns2_tolower(unsigned char c)
 {
   if(c>='A' && c<='Z')
     return c+('a'-'A');
@@ -125,7 +125,7 @@ public:
   {
     return std::lexicographical_compare(d_storage.rbegin(), d_storage.rend(), 
 				 rhs.d_storage.rbegin(), rhs.d_storage.rend(),
-				 [](const char& a, const char& b) {
+				 [](const unsigned char& a, const unsigned char& b) {
 					  return dns2_tolower(a) < dns2_tolower(b); 
 					}); // note that this is case insensitive, including on the label lengths
   }
@@ -189,7 +189,7 @@ inline bool DNSName::canonCompare(const DNSName& rhs) const
 					  d_storage.c_str() + ourpos[ourcount] + 1 + *(d_storage.c_str() + ourpos[ourcount]),
 					  rhs.d_storage.c_str() + rhspos[rhscount] + 1, 
 					  rhs.d_storage.c_str() + rhspos[rhscount] + 1 + *(rhs.d_storage.c_str() + rhspos[rhscount]),
-					  [](const char& a, const char& b) {
+					  [](const unsigned char& a, const unsigned char& b) {
 					    return dns2_tolower(a) < dns2_tolower(b); 
 					  });
     
@@ -201,7 +201,7 @@ inline bool DNSName::canonCompare(const DNSName& rhs) const
 					  rhs.d_storage.c_str() + rhspos[rhscount] + 1 + *(rhs.d_storage.c_str() + rhspos[rhscount]),
 					  d_storage.c_str() + ourpos[ourcount] + 1, 
 					  d_storage.c_str() + ourpos[ourcount] + 1 + *(d_storage.c_str() + ourpos[ourcount]),
-					  [](const char& a, const char& b) {
+					  [](const unsigned char& a, const unsigned char& b) {
 					    return dns2_tolower(a) < dns2_tolower(b); 
 					  });
     //    cout<<"Reverse: "<<res<<endl;

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -235,14 +235,14 @@ inline bool dns_isspace(char c)
   return c==' ' || c=='\t' || c=='\r' || c=='\n';
 }
 
-inline char dns_tolower(char c)
+inline unsigned char dns_tolower(unsigned char c)
 {
   if(c>='A' && c<='Z')
     c+='a'-'A';
   return c;
 }
 
-inline char dns_toupper(char c)
+inline unsigned char dns_toupper(unsigned char c)
 {
   if(c>='a' && c<='z')
     c+='A'-'a';
@@ -266,7 +266,7 @@ inline const string toLowerCanonic(const string &upper)
   string reply(upper);
   if(!upper.empty()) {
     unsigned int i, limit= ( unsigned int ) reply.length();
-    char c;
+    unsigned char c;
     for(i = 0; i < limit ; i++) {
       c = dns_tolower(upper[i]);
       if(c != upper[i])

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -576,7 +576,7 @@ static void decrementHash(std::string& raw) // I wonder if this is correct, cmou
 }
 
 
-bool getNSEC3Hashes(bool narrow, DNSBackend* db, int id, const std::string& hashed, bool decrement, DNSName& unhashed, string& before, string& after, int mode)
+bool getNSEC3Hashes(bool narrow, DNSBackend* db, int id, const std::string& hashed, bool decrement, DNSName& unhashed, std::string& before, std::string& after, int mode)
 {
   bool ret;
   if(narrow) { // nsec3-narrow
@@ -590,15 +590,14 @@ bool getNSEC3Hashes(bool narrow, DNSBackend* db, int id, const std::string& hash
     incrementHash(after);
   }
   else {
-    if (decrement || mode <= 1)
-      before.clear();
-    else
-      before=' ';
-    ret=db->getBeforeAndAfterNamesAbsolute(id, toBase32Hex(hashed), unhashed, before, after);
-    before=fromBase32Hex(before);
-    after=fromBase32Hex(after);
+    DNSName hashedName = DNSName(toBase32Hex(hashed));
+    DNSName beforeName, afterName;
+    if (!decrement && mode >= 2)
+      beforeName = hashedName;
+    ret=db->getBeforeAndAfterNamesAbsolute(id, hashedName, unhashed, beforeName, afterName);
+    before=fromBase32Hex(beforeName.toString());
+    after=fromBase32Hex(afterName.toString());
   }
-  // cerr<<"rgetNSEC3Hashes: "<<hashed<<", "<<unhashed<<", "<<before<<", "<<after<<endl;
   return ret;
 }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -250,29 +250,29 @@ bool rectifyZone(DNSSECKeeper& dk, const DNSName& zone)
     if(haveNSEC3) // NSEC3
     {
       if(!narrow && nsec3set.count(qname)) {
-        ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname))) + zone;
+        ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname)));
         if(!realrr)
           auth=true;
       } else if(!realrr)
         auth=false;
     }
     else if (realrr) // NSEC
-      ordername=qname;
+      ordername=qname.makeRelative(zone);
 
     if(g_verbose)
       cerr<<"'"<<qname<<"' -> '"<< ordername <<"'"<<endl;
-    sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, auth);
+    sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, auth);
 
     if(realrr)
     {
       if (dsnames.count(qname))
-        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, true, QType::DS);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, true, QType::DS);
       if (!auth || nsset.count(qname)) {
         ordername.clear();
         if(isOptOut && !dsnames.count(qname))
-          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, false, QType::NS);
-        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, false, QType::A);
-        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, qname, ordername, false, QType::AAAA);
+          sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::NS);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::A);
+        sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, qname, ordername, false, QType::AAAA);
       }
 
       if(doent)
@@ -312,7 +312,7 @@ bool rectifyZone(DNSSECKeeper& dk, const DNSName& zone)
     //cerr<<"Total: "<<nonterm.size()<<" Insert: "<<insnonterm.size()<<" Delete: "<<delnonterm.size()<<endl;
     if(!insnonterm.empty() || !delnonterm.empty() || !doent)
     {
-      sd.db->updateEmptyNonTerminals(sd.domain_id, zone, insnonterm, delnonterm, !doent);
+      sd.db->updateEmptyNonTerminals(sd.domain_id, insnonterm, delnonterm, !doent);
     }
     if(doent)
     {
@@ -772,7 +772,7 @@ int increaseSerial(const DNSName& zone, DNSSECKeeper &dk)
       ordername=zone;
     if(g_verbose)
       cerr<<"'"<<rrs[0].qname<<"' -> '"<< ordername <<"'"<<endl;
-    sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, zone, rrs[0].qname, ordername, true);
+    sd.db->updateDNSSECOrderNameAndAuth(sd.domain_id, rrs[0].qname, ordername, true);
   }
 
   sd.db->commitTransaction();

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -147,21 +147,21 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
             ++ddepth;
         } while(shorter.chopOff());
 
-        DNSName ordername = DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, qname))) + di->zone;
+        DNSName ordername = DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, qname)));
         if (! *narrow && (ddepth == 0 || (ddepth == 1 && nssets.count(qname)))) {
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, ordername, (ddepth == 0 ));
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, ordername, (ddepth == 0 ));
 
           if (nssets.count(qname)) {
             if (ns3pr->d_flags)
-              di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, DNSName(), false, QType::NS );
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, DNSName(), false, QType::A);
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, DNSName(), false, QType::AAAA);
+              di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::NS );
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::A);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::AAAA);
           }
         } else {
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, DNSName(), (ddepth == 0));
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), (ddepth == 0));
         }
         if (ddepth == 1 || dssets.count(qname)) // FIXME400 && ?
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, ordername, false, QType::DS);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, ordername, false, QType::DS);
       }
       return 1;
     }
@@ -241,23 +241,23 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
         if(*haveNSEC3) {
           DNSName ordername;
           if(! *narrow)
-            ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, rr->d_name)))+di->zone;
+            ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, rr->d_name)));
 
           if (*narrow)
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), auth);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), auth);
           else
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, ordername, auth);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, ordername, auth);
           if(!auth || rrType == QType::DS) {
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::NS);
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::A);
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::AAAA);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::NS);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::A);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::AAAA);
           }
 
         } else { // NSEC
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, rr->d_name, auth);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, rr->d_name.makeRelative(di->zone), auth);
           if(!auth || rrType == QType::DS) {
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::A);
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::AAAA);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::A);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::AAAA);
           }
         }
       }
@@ -308,33 +308,34 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
       {
         DNSName ordername;
         if(! *narrow)
-          ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, rr->d_name)))+di->zone;
+          ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, rr->d_name)));
 
         if (*narrow)
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), auth);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), auth);
         else
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, ordername, auth);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, ordername, auth);
 
         if (fixDS)
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, ordername, true, QType::DS);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, ordername, true, QType::DS);
 
         if(!auth)
         {
           if (ns3pr->d_flags)
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::NS);
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::A);
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::AAAA);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::NS);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::A);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::AAAA);
         }
       }
       else // NSEC
       {
-        di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, rr->d_name, auth);
+        DNSName ordername=rr->d_name.makeRelative(di->zone);
+        di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, ordername, auth);
         if (fixDS) {
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, rr->d_name, true, QType::DS);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, ordername, true, QType::DS);
         }
         if(!auth) {
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::A);
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), false, QType::AAAA);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::A);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), false, QType::AAAA);
         }
       }
 
@@ -354,21 +355,23 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
           if(*haveNSEC3)  {
             DNSName ordername;
             if(! *narrow)
-              ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, *qname)))+di->zone;
+              ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, *qname)));
 
             if (*narrow)
-              di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, rr->d_name, DNSName(), auth); // FIXME400 no *qname here?
+              di->backend->updateDNSSECOrderNameAndAuth(di->id, rr->d_name, DNSName(), auth); // FIXME400 no *qname here?
             else
-              di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, *qname, ordername, auth);
+              di->backend->updateDNSSECOrderNameAndAuth(di->id, *qname, ordername, auth);
 
             if (ns3pr->d_flags)
-              di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, *qname, DNSName(), false, QType::NS);
+              di->backend->updateDNSSECOrderNameAndAuth(di->id, *qname, DNSName(), false, QType::NS);
           }
-          else // NSEC
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, *qname, *qname, false, QType::NS);
+          else { // NSEC
+            DNSName ordername=DNSName(*qname).makeRelative(di->zone);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, *qname, ordername, false, QType::NS);
+          }
 
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, *qname, DNSName(), false, QType::A);
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, *qname, DNSName(), false, QType::AAAA);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, *qname, DNSName(), false, QType::A);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, *qname, DNSName(), false, QType::AAAA);
         }
       }
     }
@@ -421,18 +424,19 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
             ++ddepth;
         } while(shorter.chopOff());
 
+        DNSName ordername=qname.makeRelative(di->zone);
         if (!ents.count(qname) && (ddepth == 0 || (ddepth == 1 && nssets.count(qname)))) {
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, qname, (ddepth == 0));
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, ordername, (ddepth == 0));
 
           if (nssets.count(qname)) {
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, DNSName(), false, QType::A);
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, DNSName(), false, QType::AAAA);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::A);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), false, QType::AAAA);
           }
         } else {
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, DNSName(), (ddepth == 0));
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, DNSName(), (ddepth == 0));
         }
         if (ddepth == 1 || dssets.count(qname))
-          di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, qname, qname, true, QType::DS);
+          di->backend->updateDNSSECOrderNameAndAuth(di->id, qname, ordername, true, QType::DS);
       }
       return 1;
     } // end of NSEC3PARAM delete block
@@ -488,12 +492,14 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
           if(*haveNSEC3)  {
             DNSName ordername;
             if(! *narrow)
-              ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, changeRec)))+di->zone;
+              ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, changeRec)));
 
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, changeRec, ordername, true);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, changeRec, ordername, true);
           }
-          else // NSEC
-            di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, changeRec, changeRec, true);
+          else { // NSEC
+            DNSName ordername=changeRec.makeRelative(di->zone);
+            di->backend->updateDNSSECOrderNameAndAuth(di->id, changeRec, ordername, true);
+          }
         }
       }
 
@@ -552,15 +558,15 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
   //Insert and delete ENT's
   if (insnonterm.size() > 0 || delnonterm.size() > 0) {
     DLOG(L<<msgPrefix<<"Updating ENT records - "<<insnonterm.size()<<"|"<<delnonterm.size()<<endl);
-    di->backend->updateEmptyNonTerminals(di->id, di->zone, insnonterm, delnonterm, false);
+    di->backend->updateEmptyNonTerminals(di->id, insnonterm, delnonterm, false);
     for (const auto &i: insnonterm) {
       string hashed;
       if(*haveNSEC3)
       {
         DNSName ordername;
         if(! *narrow)
-          ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, i)))+di->zone;
-        di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, i, ordername, true);
+          ordername=DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, i)));
+        di->backend->updateDNSSECOrderNameAndAuth(di->id, i, ordername, true);
       }
     }
   }
@@ -1010,14 +1016,16 @@ void PacketHandler::increaseSerial(const string &msgPrefix, const DomainInfo *di
 
   //Correct ordername + auth flag
   if (haveNSEC3 && narrow)
-    di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, newRec.qname, DNSName(), true);
+    di->backend->updateDNSSECOrderNameAndAuth(di->id, newRec.qname, DNSName(), true);
   else if (haveNSEC3) {
     DNSName ordername;
     if (!narrow)
-      ordername = DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, newRec.qname)))+di->zone;
+      ordername = DNSName(toBase32Hex(hashQNameWithSalt(*ns3pr, newRec.qname)));
 
-    di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, newRec.qname, ordername, true);
+    di->backend->updateDNSSECOrderNameAndAuth(di->id, newRec.qname, ordername, true);
   }
-  else // NSEC
-    di->backend->updateDNSSECOrderNameAndAuth(di->id, di->zone, newRec.qname, newRec.qname, true);
+  else { // NSEC
+    DNSName ordername=newRec.qname.makeRelative(di->zone);
+    di->backend->updateDNSSECOrderNameAndAuth(di->id, newRec.qname, ordername, true);
+  }
 }

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE(test_compare_canonical) {
   vector<DNSName> vec;
   for(const std::string& a : {"bert.com.", "alpha.nl.", "articles.xxx.",
 	"Aleph1.powerdns.com.", "ZOMG.powerdns.com.", "aaa.XXX.", "yyy.XXX.", 
-	"test.powerdns.com."}) {
+	"test.powerdns.com.", "\\128.com"}) {
     vec.push_back(DNSName(a));
   }
   sort(vec.begin(), vec.end(), CanonDNSNameCompare());
@@ -552,6 +552,7 @@ BOOST_AUTO_TEST_CASE(test_compare_canonical) {
   for(const auto& a: {"bert.com.",  "Aleph1.powerdns.com.",
 	"test.powerdns.com.",
 	"ZOMG.powerdns.com.",
+	"\\128.com.",
 	"alpha.nl.",
 	"aaa.XXX.",
 	"articles.xxx.",


### PR DESCRIPTION
and a massive cleanup in internal before and aftername handling. Before and afternames are now relative DNSNames and the backends are responsible for converting these values to the right format if needed (labelreverse, replace dots by spaces and things like this) 

PS. replacing dots by spaces in dns name string is a very bad idea for a backend as it will break NSEC sorting rules for characters < 32

Closes #4345 (included in this pull)
