### PR TITLE
auth: Unify usage of randomness source by using `dns_random()`

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -475,7 +475,7 @@ static void triggerLoadOfLibraries()
 
 void mainthread()
 {
-  Utility::srandom(time(0));
+   Utility::srandom(time(0) ^ getpid());
 
    int newgid=0;      
    if(!::arg()["setgid"].empty()) 

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -42,6 +42,7 @@ using namespace boost::multi_index;
 #include "packethandler.hh"
 
 #include "namespaces.hh"
+#include "dns_random.hh"
 
 struct SuckRequest
 {
@@ -75,7 +76,7 @@ public:
     nr.domain   = domain;
     nr.ip       = caIp.toStringWithPort();
     nr.attempts = 0;
-    nr.id       = Utility::random()%0xffff;
+    nr.id       = dns_random(0xffff);
     nr.next     = time(0);
 
     d_nqueue.push_back(nr);

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -47,6 +47,7 @@
 #include "base64.hh"
 #include "ednssubnet.hh"
 #include "gss_context.hh"
+#include "dns_random.hh"
 
 bool DNSPacket::s_doEDNSSubnetProcessing;
 uint16_t DNSPacket::s_udpTruncationThreshold;
@@ -366,7 +367,7 @@ void DNSPacket::wrapup()
 void DNSPacket::setQuestion(int op, const DNSName &qd, int newqtype)
 {
   memset(&d,0,sizeof(d));
-  d.id=Utility::random();
+  d.id=dns_random(0xffff);
   d.rd=d.tc=d.aa=false;
   d.qr=false;
   d.qdcount=1; // is htons'ed later on

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -31,7 +31,7 @@
 #include "dns.hh"
 #include "logger.hh"
 #include "statbag.hh"
-
+#include "dns_random.hh"
 
 extern StatBag S;
 extern PacketCache PC;
@@ -55,7 +55,7 @@ DNSProxy::DNSProxy(const string &remote)
     
   int n=0;
   for(;n<10;n++) {
-    local.sin4.sin_port = htons(10000+( Utility::random()%50000));
+    local.sin4.sin_port = htons(10000+dns_random(50000));
     
     if(::bind(d_sock, (struct sockaddr *)&local, local.getSocklen()) >= 0) 
       break;
@@ -69,7 +69,7 @@ DNSProxy::DNSProxy(const string &remote)
   if(connect(d_sock, (sockaddr *)&remaddr, remaddr.getSocklen())<0) 
     throw PDNSException("Unable to UDP connect to remote nameserver "+remaddr.toStringWithPort()+": "+stringerror());
 
-  d_xor=Utility::random()&0xffff;
+  d_xor=dns_random(0xffff);
   L<<Logger::Error<<"DNS Proxy launched, local port "<<ntohs(local.sin4.sin_port)<<", remote "<<remaddr.toStringWithPort()<<endl;
 } 
 


### PR DESCRIPTION
### Short description

`Utility::random()` is not impossible to predict, so even if we are not using it for anything sensitive it's better to just use `dns_random()` instead.
Reported by mongo (thanks!).
### Checklist

<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
