### PR TITLE
API: do not return dnssec info in domain list

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -101,6 +101,12 @@ paths:
             When set to the name of a zone, only this zone is returned.
             If no zone with that name exists, the response is an empty array.
             This can e.g. be used to check if a zone exists in the database without having to guess/encode the zone's id or to check if a zone exists.
+        - name: dnssec
+          in: query
+          required: false
+          type: boolean
+          default: true
+          description: '“true” (default) or “false”, whether to include the “dnssec” and ”edited_serial” fields in the Zone objects. Setting this to ”false” will make the query a lot faster.'
       responses:
         '200':
           description: An array of Zones

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -322,7 +322,7 @@ static inline string makeBackendRecordContent(const QType& qtype, const string& 
   return makeRecordContent(qtype, content, true);
 }
 
-static Json::object getZoneInfo(const DomainInfo& di, DNSSECKeeper *dk) {
+static Json::object getZoneInfo(const DomainInfo& di) {
   string zoneId = apiZoneNameToId(di.zone);
   vector<string> masters;
   for(const auto& m : di.masters)
@@ -334,7 +334,6 @@ static Json::object getZoneInfo(const DomainInfo& di, DNSSECKeeper *dk) {
     { "url", "/api/v1/servers/localhost/zones/" + zoneId },
     { "name", di.zone.toString() },
     { "kind", di.getKindString() },
-    { "dnssec", dk->isSecuredZone(di.zone) },
     { "account", di.account },
     { "masters", masters },
     { "serial", (double)di.serial },
@@ -359,7 +358,7 @@ static void fillZone(UeberBackend& B, const DNSName& zonename, HttpResponse* res
   }
 
   DNSSECKeeper dk(&B);
-  Json::object doc = getZoneInfo(di, &dk);
+  Json::object doc = getZoneInfo(di);
   // extra stuff getZoneInfo doesn't do for us (more expensive)
   string soa_edit_api;
   di.backend->getDomainMetadataOne(zonename, "SOA-EDIT-API", soa_edit_api);
@@ -376,6 +375,7 @@ static void fillZone(UeberBackend& B, const DNSName& zonename, HttpResponse* res
   if (nsec3narrow == "1")
     nsec3narrowbool = true;
   doc["nsec3narrow"] = nsec3narrowbool;
+  doc["dnssec"] = dk.isSecuredZone(zonename);
 
   string api_rectify;
   di.backend->getDomainMetadataOne(zonename, "API-RECTIFY", api_rectify);
@@ -1698,7 +1698,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
 
   Json::array doc;
   for(const DomainInfo& di : domains) {
-    doc.push_back(getZoneInfo(di, &dk));
+    doc.push_back(getZoneInfo(di));
   }
   resp->setBody(doc);
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -322,13 +322,13 @@ static inline string makeBackendRecordContent(const QType& qtype, const string& 
   return makeRecordContent(qtype, content, true);
 }
 
-static Json::object getZoneInfo(const DomainInfo& di) {
+static Json::object getZoneInfo(const DomainInfo& di, DNSSECKeeper* dk) {
   string zoneId = apiZoneNameToId(di.zone);
   vector<string> masters;
   for(const auto& m : di.masters)
     masters.push_back(m.toStringWithPortExcept(53));
 
-  return Json::object {
+  auto obj = Json::object {
     // id is the canonical lookup key, which doesn't actually match the name (in some cases)
     { "id", zoneId },
     { "url", "/api/v1/servers/localhost/zones/" + zoneId },
@@ -337,10 +337,14 @@ static Json::object getZoneInfo(const DomainInfo& di) {
     { "account", di.account },
     { "masters", masters },
     { "serial", (double)di.serial },
-    { "edited_serial", (double)calculateEditSOA(di.serial, *dk, di.zone) },
     { "notified_serial", (double)di.notified_serial },
     { "last_check", (double)di.last_check }
   };
+  if (dk) {
+    obj["dnssec"] = dk->isSecuredZone(di.zone);
+    obj["edited_serial"] = (double)calculateEditSOA(di.serial, *dk, di.zone);
+  }
+  return obj;
 }
 
 static bool shouldDoRRSets(HttpRequest* req) {
@@ -358,7 +362,7 @@ static void fillZone(UeberBackend& B, const DNSName& zonename, HttpResponse* res
   }
 
   DNSSECKeeper dk(&B);
-  Json::object doc = getZoneInfo(di);
+  Json::object doc = getZoneInfo(di, &dk);
   // extra stuff getZoneInfo doesn't do for us (more expensive)
   string soa_edit_api;
   di.backend->getDomainMetadataOne(zonename, "SOA-EDIT-API", soa_edit_api);
@@ -1696,9 +1700,18 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
     }
   }
 
+  bool with_dnssec = true;
+  if (req->getvars.count("dnssec")) {
+    // can send ?dnssec=false to improve performance.
+    string dnssec_flag = req->getvars["dnssec"];
+    if (dnssec_flag == "false") {
+      with_dnssec = false;
+    }
+  }
+
   Json::array doc;
   for(const DomainInfo& di : domains) {
-    doc.push_back(getZoneInfo(di));
+    doc.push_back(getZoneInfo(di, with_dnssec ? &dk : nullptr));
   }
   resp->setBody(doc);
 }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -49,8 +49,11 @@ def eq_zone_rrsets(rrsets, expected):
 
 class Zones(ApiTestCase):
 
-    def test_list_zones(self):
-        r = self.session.get(self.url("/api/v1/servers/localhost/zones"))
+    def _test_list_zones(self, dnssec=True):
+        path = "/api/v1/servers/localhost/zones"
+        if not dnssec:
+            path = path + "?dnssec=false"
+        r = self.session.get(self.url(path))
         self.assert_success_json(r)
         domains = r.json()
         example_com = [domain for domain in domains if domain['name'] in ('example.com', 'example.com.')]
@@ -59,13 +62,22 @@ class Zones(ApiTestCase):
         print(example_com)
         required_fields = ['id', 'url', 'name', 'kind']
         if is_auth():
-            required_fields = required_fields + ['masters', 'last_check', 'notified_serial', 'edited_serial', 'serial', 'account']
+            required_fields = required_fields + ['masters', 'last_check', 'notified_serial', 'serial', 'account']
+            if dnssec:
+                required_fields = required_fields = ['dnssec', 'edited_serial']
             self.assertNotEquals(example_com['serial'], 0)
         elif is_recursor():
             required_fields = required_fields + ['recursion_desired', 'servers']
         for field in required_fields:
             self.assertIn(field, example_com)
+        if not dnssec:
+            self.assertNotIn('dnssec', example_com)
 
+    def test_list_zones_with_dnssec(self):
+        self._test_list_zones(True)
+
+    def test_list_zones_without_dnssec(self):
+        self._test_list_zones(False)
 
 class AuthZonesHelperMixin(object):
     def create_zone(self, name=None, **kwargs):

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -66,15 +66,16 @@ class Zones(ApiTestCase):
             if dnssec:
                 required_fields = required_fields = ['dnssec', 'edited_serial']
             self.assertNotEquals(example_com['serial'], 0)
+            if not dnssec:
+                self.assertNotIn('dnssec', example_com)
         elif is_recursor():
             required_fields = required_fields + ['recursion_desired', 'servers']
         for field in required_fields:
             self.assertIn(field, example_com)
-        if not dnssec:
-            self.assertNotIn('dnssec', example_com)
 
     def test_list_zones_with_dnssec(self):
-        self._test_list_zones(True)
+        if is_auth():
+            self._test_list_zones(True)
 
     def test_list_zones_without_dnssec(self):
         self._test_list_zones(False)


### PR DESCRIPTION
### Short description

Stop backend creation in a tight loop when listing all domains over the API. Should improve performance considerably. Also notes in the docs that "list" is incomplete.
### Checklist

I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
