### PR TITLE
improve dnsdist error message on a common typo/config mistake

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -186,7 +186,6 @@ void doConsole()
               >
             >
           >(withReturn ? ("return "+line) : line);
-        
         if(ret) {
           if (const auto strValue = boost::get<shared_ptr<DownstreamState>>(&*ret)) {
             cout<<(*strValue)->getName()<<endl;
@@ -221,9 +220,13 @@ void doConsole()
       // tried to return something we don't understand
     }
     catch(const LuaContext::ExecutionErrorException& e) {
-      std::cerr << e.what(); 
+      if(!strcmp(e.what(),"invalid key to 'next'"))
+        std::cerr<<"Error parsing parameters, did you forget parameter name?";
+      else
+        std::cerr << e.what(); 
       try {
         std::rethrow_if_nested(e);
+
         std::cerr << std::endl;
       } catch(const std::exception& e) {
         // e is the exception that was thrown from inside the lambda
@@ -488,16 +491,19 @@ try
       // tried to return something we don't understand
     }
     catch(const LuaContext::ExecutionErrorException& e) {
-      response = "Error: " + string(e.what()) + ": ";
+      if(!strcmp(e.what(),"invalid key to 'next'"))
+        response = "Error: Parsing function parameters, did you forget parameter name?";
+      else
+        response = "Error: " + string(e.what());
       try {
         std::rethrow_if_nested(e);
       } catch(const std::exception& e) {
         // e is the exception that was thrown from inside the lambda
-        response+= string(e.what());
+        response+= ": " + string(e.what());
       }
       catch(const PDNSException& e) {
         // e is the exception that was thrown from inside the lambda
-        response += string(e.reason);
+        response += ": " + string(e.reason);
       }
     }
     catch(const LuaContext::SyntaxErrorException& e) {


### PR DESCRIPTION
### Short description

running newServer({"1.2.3.4", pool="primary"}) would produce a bloody useless error message.
### Checklist

<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

We improve the error in a pretty ugly way though.

The cause of the error is deep in the bowels of Lua and/or LuaWrapper. Even if we caught/fixed this error in a more karmic place, we'd still want to output this error message. 

Also, dragons live there.
