### PR TITLE
rec: Don't crash on an empty query ring

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -586,7 +586,7 @@ void updateResponseStats(int res, const ComboAddress& remote, unsigned int packe
   case RCode::ServFail:
     if(t_servfailremotes) {
       t_servfailremotes->push_back(remote);
-      if(query) // packet cache
+      if(query && t_servfailqueryring) // packet cache
 	t_servfailqueryring->push_back(make_pair(*query, qtype));
     }
     g_stats.servFails++;
@@ -667,7 +667,8 @@ void startDoResolve(void *p)
 {
   DNSComboWriter* dc=(DNSComboWriter *)p;
   try {
-    t_queryring->push_back(make_pair(dc->d_mdp.d_qname, dc->d_mdp.d_qtype));
+    if (t_queryring)
+      t_queryring->push_back(make_pair(dc->d_mdp.d_qname, dc->d_mdp.d_qtype));
 
     uint32_t maxanswersize= dc->d_tcp ? 65535 : min((uint16_t) 512, g_udpTruncationThreshold);
     EDNSOpts edo;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -963,7 +963,7 @@ vector<pair<DNSName,uint16_t> >* pleaseGetServfailQueryRing()
   vector<query_t>* ret = new vector<query_t>();
   if(!t_servfailqueryring)
     return ret;
-  ret->reserve(t_queryring->size());
+  ret->reserve(t_servfailqueryring->size());
   for(const query_t& q :  *t_servfailqueryring) {
     ret->push_back(q);
   }


### PR DESCRIPTION
### Short description

Check if `t_queryring` and `t_servfailqueryring` are `NULL` before dereferencing them. It obviously happens if stats-ringbuffer-entries is set to 0.
Should fix #4633.
### Checklist

<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
