### PR TITLE
extract nested exception from Luawrapper

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1183,7 +1183,16 @@ void startDoResolve(void *p)
     delete dc;
   }
   catch(std::exception& e) {
-    L<<Logger::Error<<"STL error "<< makeLoginfo(dc)<<": "<<e.what()<<endl;
+    L<<Logger::Error<<"STL error "<< makeLoginfo(dc)<<": "<<e.what();
+
+    // Luawrapper nests the exception from Lua, so we unnest it here
+    try {
+        std::rethrow_if_nested(e);
+    } catch(const std::exception& e) {
+        L<<". Extra info: "<<e.what();
+    } catch(...) {}
+
+    L<<endl;
     delete dc;
   }
   catch(...) {


### PR DESCRIPTION
### Short description

This PR makes errors from inside Lua more visible in the log.
### Checklist

<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

Before:
Oct 28 15:30:34 STL error (www.foobar.com/A from 127.0.0.1): Exception thrown by a callback function called by Lua

After:
Oct 28 15:30:34 STL error (www.foobar.com/A from 127.0.0.1): Exception thrown by a callback function called by Lua. Extra info: Found . in wrong position in DNSName www.foobar.com..internal

reported by @elad, thanks!
