### PR TITLE
Document dq.data (from @Habbie)

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -99,7 +99,7 @@ The DNSQuestion object contains at least the following fields:
     * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
     * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
 * wantsRPZ - A boolean that indicates the use of the Policy Engine, can be set to `false` in `preresolve` to disable RPZ for this query
-* data - a table that is persistent throughout the lifetime of the `dq` object and can be used to store custom context.
+* data - a table that is persistent throughout the lifetime of the `dq` object and can be used to store custom data.
 
 It also supports the following methods:
 

--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -99,7 +99,7 @@ The DNSQuestion object contains at least the following fields:
     * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
     * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
 * wantsRPZ - A boolean that indicates the use of the Policy Engine, can be set to `false` in `preresolve` to disable RPZ for this query
-* data - a table that is persistent throughout the lifetime of the `dq` object and can be used to store custom data.
+* data - a table that is persistent throughout the lifetime of the `dq` object and can be used to store custom data. All keys and values in the table must be of type `string`.
 
 It also supports the following methods:
 

--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -99,6 +99,7 @@ The DNSQuestion object contains at least the following fields:
     * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
     * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
 * wantsRPZ - A boolean that indicates the use of the Policy Engine, can be set to `false` in `preresolve` to disable RPZ for this query
+* data - a table that is persistent throughout the lifetime of the `dq` object and can be used to store custom context.
 
 It also supports the following methods:
 


### PR DESCRIPTION
### Short description
Document `dq.data` - a table that is persistent across the lifetime of the `dq` object and can be used to store custom context.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] checked that this code was merged to master

