### PR TITLE
dnsdist: Add `getStatisticsCounters()` to access counters from Lua

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1245,6 +1245,7 @@ Here are all functions:
     * `controlSocket(addr)`: open a control socket on this address / connect to this address in client mode
  * Diagnostics and statistics
     * `dumpStats()`: print all statistics we gather
+    * `getStatisticsCounters()`: return the statistics counters as a Lua table
     * `grepq(Netmask|DNS Name|100ms [, n])`: shows the last n queries and responses matching the specified client address or range (Netmask), or the specified DNS Name, or slower than 100ms
     * `grepq({"::1", "powerdns.com", "100ms"} [, n])`: shows the last n queries and responses matching the specified client address AND range (Netmask) AND the specified DNS Name AND slower than 100ms
     * `topQueries(n[, labels])`: show top 'n' queries, as grouped when optionally cut down to 'labels' labels

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -1012,4 +1012,14 @@ void moreLua(bool client)
       });
 
 #endif /* HAVE_EBPF */
+
+    g_lua.writeFunction<std::unordered_map<string,uint64_t>()>("getStatisticsCounters", []() {
+        setLuaNoSideEffect();
+        std::unordered_map<string,uint64_t> res;
+        for(const auto& entry : g_stats.entries) {
+          if(const auto& val = boost::get<DNSDistStats::stat_t*>(&entry.second))
+            res[entry.first] = (*val)->load();
+        }
+        return res;
+      });
 }


### PR DESCRIPTION
### Short description
Using `getStatisticsCounters()` we can now access the various counters from Lua, for example to detect QPS spikes from `maintenance()`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added regression tests
