### PR TITLE
dnsdist: Add `includeDirectory(dir)`

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1223,6 +1223,7 @@ Here are all functions:
     * `shutdown()`: shut down `dnsdist`
     * quit or ^D: exit the console
     * `webserver(address:port, password [, apiKey [, customHeaders ]])`: launch a webserver with stats on that address with that password
+    * `includeDirectory(dir)`: all files ending in `.conf` in the directory `dir` are loaded into the configuration
  * ACL related:
     * `addACL(netmask)`: add to the ACL set who can use this server
     * `setACL({netmask, netmask})`: replace the ACL set with these netmasks. Use `setACL({})` to reset the list, meaning no one can use us

--- a/regression-tests.dnsdist/test-include-dir/test.conf
+++ b/regression-tests.dnsdist/test-include-dir/test.conf
@@ -1,0 +1,1 @@
+addAction(makeRule("includedir.advanced.tests.powerdns.com."), AllowAction())


### PR DESCRIPTION
### Short description
Add the `includeDirectory(dir)` directive to load configuration files ending in `.conf` present in the given directory.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added regression tests
