### PR TITLE
Do not thrown an error for get() if zone was not found (auth-4.0.x)

### DIFF
--- a/modules/mydnsbackend/mydnsbackend.cc
+++ b/modules/mydnsbackend/mydnsbackend.cc
@@ -305,7 +305,7 @@ void MyDNSBackend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *p
     }
 
     if(d_result.empty()) {
-      throw PDNSException("lookup() passed zoneId = "+itoa(zoneId)+" but no such zone!");
+      return; // just return if zone was not found instead of throwing an error
     }
 
     rrow = d_result[0];


### PR DESCRIPTION
Do not thrown an error for get() if zone was not found. Related: https://github.com/PowerDNS/pdns/issues/2759

As talked with @Habbie in IRC, just returning instead of throwing an error. 