### PR TITLE
On (re-)priming, fetch the root NS records

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1950,35 +1950,9 @@ static void houseKeeping(void *)
     }
 
     if(now.tv_sec - last_rootupdate > 7200) {
-      SyncRes sr(now);
-      sr.setDoEDNS0(true);
-      vector<DNSRecord> ret;
-
-      sr.setNoCache();
-      int res=-1;
-      try {
-	res=sr.beginResolve(g_rootdnsname, QType(QType::NS), 1, ret);
-      }
-      catch(PDNSException& e)
-	{
-	  L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.reason<<endl;
-	}
-
-      catch(std::exception& e)
-	{
-	  L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.what()<<endl;
-	}
-
-      catch(...)
-	{
-	  L<<Logger::Error<<"Failed to update . records, got an exception"<<endl;
-	}
-      if(!res) {
-	L<<Logger::Notice<<"Refreshed . records"<<endl;
-	last_rootupdate=now.tv_sec;
-      }
-      else
-	L<<Logger::Error<<"Failed to update . records, RCODE="<<res<<endl;
+      int res = getRootNS();
+      if (!res)
+        last_rootupdate=now.tv_sec;
     }
 
     if(!t_id) {
@@ -3158,4 +3132,43 @@ int main(int argc, char **argv)
   }
 
   return ret;
+}
+
+int getRootNS(void) {
+  SyncRes sr(g_now);
+  sr.setDoEDNS0(true);
+  sr.setNoCache();
+  sr.d_doDNSSEC = (g_dnssecmode != DNSSECMode::Off);
+
+  vector<DNSRecord> ret;
+  int res=-1;
+  try {
+    res=sr.beginResolve(g_rootdnsname, QType(QType::NS), 1, ret);
+    if (g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate) {
+      auto state = validateRecords(ret);
+      if (state == Bogus)
+        throw PDNSException("Got Bogus validation result for .|NS");
+    }
+    return res;
+  }
+  catch(PDNSException& e)
+  {
+    L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.reason<<endl;
+  }
+
+  catch(std::exception& e)
+  {
+    L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.what()<<endl;
+  }
+
+  catch(...)
+  {
+    L<<Logger::Error<<"Failed to update . records, got an exception"<<endl;
+  }
+  if(!res) {
+    L<<Logger::Notice<<"Refreshed . records"<<endl;
+  }
+  else
+    L<<Logger::Error<<"Failed to update . records, RCODE="<<res<<endl;
+  return res;
 }

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -94,7 +94,7 @@ void primeHints(void)
       }
     }
   }
-  t_RC->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), true); // and stuff in the cache (auth)
+  t_RC->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), false); // and stuff in the cache
 }
 
 static void makeNameToIPZone(SyncRes::domainmap_t* newMap, const DNSName& hostname, const string& ip)

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -632,8 +632,10 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vecto
     LOG(prefix<<qname<<": no valid/useful NS in cache for '"<<subdomain<<"'"<<endl);
     ;
     if(subdomain.isRoot() && !brokeloop) {
+      // We lost the root NS records
       primeHints();
       LOG(prefix<<qname<<": reprimed the root"<<endl);
+      getRootNS();
     }
   }while(subdomain.chopOff());
 }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -50,6 +50,7 @@
 #include "filterpo.hh"
 
 void primeHints(void);
+int getRootNS(void);
 class RecursorLua4;
 
 struct BothRecordsAndSignatures


### PR DESCRIPTION
### Short description
Before, when repriming the root because it was evicted or expired from the cache, we did not go out to the internet to immediately update the list we inserted into the cache from the built-in hints or hintfile. While not in issue in the DNS world, in the DNSSEC world this means that we suddenly stop serving RRSIGs for `.|NS` at that point, confusing downstream validators.

This patch also ensures that we don't add the hint data as authoritative to the cache *and* adds DNSSEC validation for the results of this query if the settings support it.

Found by @giganteous 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] documented the code
