### PR TITLE
Enable Protobuf in CentOS 6 packages

### DIFF
--- a/build-scripts/build-recursor-rpm
+++ b/build-scripts/build-recursor-rpm
@@ -120,7 +120,7 @@ Source0: ../%{name}-${TARBALLVERSION}.tar.bz2
 Source1: pdns-recursor.init
 
 Provides: powerdns-recursor = %{version}-%{release}
-BuildRequires: boost-devel
+BuildRequires: boost148-devel
 BuildRequires: lua-devel
 #BuildRequires: protobuf-devel
 #BuildRequires: protobuf-compiler
@@ -144,10 +144,11 @@ package if you need a dns cache for your network.
 	--disable-static \
 	--disable-dependency-tracking \
 	--disable-silent-rules \
-	--without-protobuf \
-	--enable-unit-tests
+	--with-protobuf \
+	--enable-unit-tests \
+	--with-boost=/usr/include/boost148 LIBRARY_PATH=/usr/lib64/boost148
 
-make %{?_smp_mflags}
+make %{?_smp_mflags} LIBRARY_PATH=/usr/lib64/boost148
 
 %install
 %{__rm} -rf %{buildroot}

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -30,7 +30,7 @@
 #include <boost/version.hpp>
 
 // it crashes on OSX and doesn't compile on OpenBSD
-#if BOOST_VERSION >= 104800 && ! defined( __APPLE__ ) && ! defined(__OpenBSD__)
+#if BOOST_VERSION >= 105300 && ! defined( __APPLE__ ) && ! defined(__OpenBSD__)
 #include <boost/container/string.hpp>
 #endif
 
@@ -133,7 +133,7 @@ public:
   inline bool canonCompare(const DNSName& rhs) const;
   bool slowCanonCompare(const DNSName& rhs) const;  
 
-#if BOOST_VERSION >= 104800 && ! defined( __APPLE__ ) && ! defined(__OpenBSD__)
+#if BOOST_VERSION >= 105300 && ! defined( __APPLE__ ) && ! defined(__OpenBSD__)
   typedef boost::container::string string_t;
 #else
   typedef std::string string_t;


### PR DESCRIPTION
### Short description
This PR adds protobuf support to the CentOS 6 packages. It features a patch to dnsname.hh, as the boost used in EL6 (1.48), does not play nice with the storage used.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code