### PR TITLE
Update dnsupdate.md

### DIFF
--- a/docs/markdown/authoritative/dnsupdate.md
+++ b/docs/markdown/authoritative/dnsupdate.md
@@ -206,12 +206,15 @@ This tells PowerDNS to:
 1.  Enable DNS update support([`dnsupdate`](settings.md#dnsupdate))
 2.  Allow updates from NO ip-address ([`allow-dnsupdate-from=`](settings.md#allow-dnsupdate-from))
 
-We just told powerdns (via the configuration file) that we accept updates from nobody via the [`allow-dnsupdate-from`](settings.md#allow-dnsupdate-from) parameter. That's not very useful, so we're going to give permissions per zone, via the domainmetadata table.
+We just told powerdns (via the configuration file) that we accept updates from nobody via the [`allow-dnsupdate-from`](settings.md#allow-dnsupdate-from) parameter. That's not very useful, so we're going to give permissions per zone (including the appropriate reverse zone), via the domainmetadata table.
 
 ```
 sql> select id from domains where name='example.org';
 5
-sql> insert into domainmetadata(domain_id, kind, content) values(5, ‘ALLOW-DNSUPDATE-FROM’,’127.0.0.1’);
+sql> insert into domainmetadata(domain_id, kind, content) values(5, 'ALLOW-DNSUPDATE-FROM','127.0.0.1');
+sql> select id from domains where name='1.168.192.in-addr.arpa';
+6
+sql> insert into domainmetadata(domain_id, kind, content) values(6, 'ALLOW-DNSUPDATE-FROM','127.0.0.1');
 ```
 
 This gives the ip '127.0.0.1' access to send update messages. Make sure you use the ip address of the machine that runs **dhcpd**.


### PR DESCRIPTION
### Short description
Added missing SQL statement line to dnsupdate.md. See below.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

Added the SQL statements for adding the ALLOW-DNSUPDATE-FROM for the reverse zone. This was needed to make dnsupdate work completely on my personal PowerDNS server when updated remotely from my Sophos UTM. Without it, no records were added to the reverse lookup zone when dhcpd pushed updates.