### PR TITLE
Clarify pdnsutil activate-tsig-key description

### DIFF
--- a/docs/manpages/pdnsutil.1.md
+++ b/docs/manpages/pdnsutil.1.md
@@ -133,10 +133,12 @@ require an *ALGORITHM*, the following are available:
  * hmac-sha512
 
 activate-tsig-key *ZONE* *NAME* {**master**,**slave**}
-:    Enable TSIG key *NAME* for zone *ZONE*.
+:    Enable TSIG authenticated AXFR using the key *NAME* for zone *ZONE*.
+     This sets the `TSIG-ALLOW-AXFR` (master) or `AXFR-MASTER-TSIG` (slave)
+     zone metadata.
 
 deactivate-tsig-key *ZONE* *NAME* {**master**,**slave**}
-:    Disable TSIG key *NAME* for zone *ZONE*.
+:    Disable TSIG authenticated AXFR using the key *NAME* for zone *ZONE*.
 
 delete-tsig-key *NAME*
 :    Delete the TSIG key *NAME*. Warning, this does not deactivate said key.

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1935,7 +1935,7 @@ try
     cout<<"Usage: \npdnsutil [options] <command> [params ..]\n"<<endl;
     cout<<"Commands:"<<endl;
     cout<<"activate-tsig-key ZONE NAME {master|slave}"<<endl;
-    cout<<"                                   Enable TSIG key for a zone"<<endl;
+    cout<<"                                   Enable TSIG authenticated AXFR using the key NAME for ZONE"<<endl;
     cout<<"activate-zone-key ZONE KEY-ID      Activate the key with key id KEY-ID in ZONE"<<endl;
     cout<<"add-record ZONE NAME TYPE [ttl] content"<<endl;
     cout<<"             [content..]           Add one or more records to ZONE"<<endl;
@@ -1960,7 +1960,7 @@ try
     cout<<"                                   Change slave zone ZONE master IP address to master-ip"<<endl;
     cout<<"create-zone ZONE [nsname]          Create empty zone ZONE"<<endl;
     cout<<"deactivate-tsig-key ZONE NAME {master|slave}"<<endl;
-    cout<<"                                   Disable TSIG key for a zone"<<endl;
+    cout<<"                                   Disable TSIG authenticated AXFR using the key NAME for ZONE"<<endl;
     cout<<"deactivate-zone-key ZONE KEY-ID    Deactivate the key with key id KEY-ID in ZONE"<<endl;
     cout<<"delete-rrset ZONE NAME TYPE        Delete named RRSET from zone"<<endl;
     cout<<"delete-tsig-key NAME               Delete TSIG key (warning! will not unmap key!)"<<endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This clarifies the description of pdnsutil {de,}activate-tsig-key.
The command enables TSIG authenticated AXFR for a given zone + key, which was not clear from the previous description. 
(Considering other uses of TSIG, "enable TSIG key" didn't really explain much.)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

