### PR TITLE
rec: Wait until after daemonizing to start the RPZ and protobuf threads

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2638,7 +2638,7 @@ int serviceMain(int argc, char*argv[])
 
   g_dnssecLogBogus = ::arg().mustDo("dnssec-log-bogus");
 
-  loadRecursorLuaConfig(::arg()["lua-config-file"]);
+  loadRecursorLuaConfig(::arg()["lua-config-file"], ::arg().mustDo("daemon"));
 
   parseACLs();
   sortPublicSuffixList();
@@ -2730,6 +2730,7 @@ int serviceMain(int argc, char*argv[])
     L<<Logger::Warning<<"Calling daemonize, going to background"<<endl;
     L.toConsole(Logger::Critical);
     daemonize();
+    loadRecursorLuaConfig(::arg()["lua-config-file"], false);
   }
   signal(SIGUSR1,usr1Handler);
   signal(SIGUSR2,usr2Handler);

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -41,5 +41,5 @@ public:
 };
 
 extern GlobalStateHolder<LuaConfigItems> g_luaconfs;
-void loadRecursorLuaConfig(const std::string& fname);
+void loadRecursorLuaConfig(const std::string& fname, bool checkOnly);
 

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1234,7 +1234,7 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
       ::arg().set("lua-config-file") = *begin;
 
     try {
-      loadRecursorLuaConfig(::arg()["lua-config-file"]);
+      loadRecursorLuaConfig(::arg()["lua-config-file"], false);
       L<<Logger::Warning<<"Reloaded Lua configuration file '"<<::arg()["lua-config-file"]<<"', requested via control channel"<<endl;
       return "Reloaded Lua configuration file '"+::arg()["lua-config-file"]+"'\n";
     }


### PR DESCRIPTION
### Short description
Otherwise they are killed when we call `fork()`.
We still want to actually parse the configuration to check for syntax errors before daemonizing to be able to report any error, so when `daemon` is set to `yes`, we parse the Lua configuration early without starting any threads, and then again, starting the threads that time, after daemonizing.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code


