### PR TITLE
dnsdist: Be more flexible in the DynBlocks regression tests

### DIFF
--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -328,6 +328,21 @@ class DNSDistTest(unittest.TestCase):
         while not self._fromResponderQueue.empty():
             self._fromResponderQueue.get(False)
 
+    @classmethod
+    def clearToResponderQueue(cls):
+        while not cls._toResponderQueue.empty():
+            cls._toResponderQueue.get(False)
+
+    @classmethod
+    def clearFromResponderQueue(cls):
+        while not cls._fromResponderQueue.empty():
+            cls._fromResponderQueue.get(False)
+
+    @classmethod
+    def clearResponderQueues(cls):
+        cls.clearToResponderQueue()
+        cls.clearFromResponderQueue()
+
     @staticmethod
     def generateConsoleKey():
         return libnacl.utils.salsa_key()


### PR DESCRIPTION
### Short description
During the dynamic blocks regression tests, we might get blocked earlier than I initially expected if the
maintenance function runs while we are sending our queries.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added regression tests
