### PR TITLE
dnsdist: Don't use a const_iterator for erasing

### DIFF
--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -990,7 +990,7 @@ void moreLua(bool client)
 
     g_lua.writeFunction("unregisterDynBPFFilter", [](std::shared_ptr<DynBPFFilter> dbpf) {
         if (dbpf) {
-          for (auto it = g_dynBPFFilters.cbegin(); it != g_dynBPFFilters.cend(); it++) {
+          for (auto it = g_dynBPFFilters.begin(); it != g_dynBPFFilters.end(); it++) {
             if (*it == dbpf) {
               g_dynBPFFilters.erase(it);
               break;


### PR DESCRIPTION
Some versions of gcc don't support that, even though it's required by C++11. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57158