### PR TITLE
Backport #4691: rec: Wait until after daemonizing to start the RPZ and protobuf threads

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2606,7 +2606,7 @@ int serviceMain(int argc, char*argv[])
     exit(99);
   }
 
-  loadRecursorLuaConfig(::arg()["lua-config-file"]);
+  loadRecursorLuaConfig(::arg()["lua-config-file"], ::arg().mustDo("daemon"));
 
   parseACLs();
   sortPublicSuffixList();
@@ -2715,6 +2715,7 @@ int serviceMain(int argc, char*argv[])
     L<<Logger::Warning<<"Calling daemonize, going to background"<<endl;
     L.toConsole(Logger::Critical);
     daemonize();
+    loadRecursorLuaConfig(::arg()["lua-config-file"], false);
   }
   signal(SIGUSR1,usr1Handler);
   signal(SIGUSR2,usr2Handler);

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -52,15 +52,14 @@ typename C::value_type::second_type constGet(const C& c, const std::string& name
 }
 
 #ifndef HAVE_LUA
-void loadRecursorLuaConfig(const std::string& fname)
+void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 {
   if(!fname.empty())
     throw PDNSException("Asked to load a Lua configuration file '"+fname+"' in binary without Lua support");
 }
 #else
 
-
-void loadRecursorLuaConfig(const std::string& fname)
+void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 {
   LuaConfigItems lci;
 
@@ -129,7 +128,7 @@ void loadRecursorLuaConfig(const std::string& fname)
     });
 
 
-  Lua.writeFunction("rpzMaster", [&lci](const string& master_, const string& zone_, const boost::optional<std::unordered_map<string,boost::variant<int, string>>>& options) {
+  Lua.writeFunction("rpzMaster", [&lci, checkOnly](const string& master_, const string& zone_, const boost::optional<std::unordered_map<string,boost::variant<int, string>>>& options) {
       try {
 	boost::optional<DNSFilterEngine::Policy> defpol;
         TSIGTriplet tt;
@@ -185,11 +184,13 @@ void loadRecursorLuaConfig(const std::string& fname)
         const size_t zoneIdx = lci.dfe.size();
         lci.dfe.setPolicyName(zoneIdx, polName);
 
-	auto sr=loadRPZFromServer(master, zone, lci.dfe, defpol, zoneIdx, tt, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
-        if(refresh)
-          sr->d_st.refresh=refresh;
-	std::thread t(RPZIXFRTracker, master, zone, defpol, zoneIdx, tt, sr, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
-	t.detach();
+        if (!checkOnly) {
+          auto sr=loadRPZFromServer(master, zone, lci.dfe, defpol, zoneIdx, tt, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
+          if(refresh)
+            sr->d_st.refresh=refresh;
+          std::thread t(RPZIXFRTracker, master, zone, defpol, zoneIdx, tt, sr, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
+          t.detach();
+        }
       }
       catch(std::exception& e) {
 	theL()<<Logger::Error<<"Unable to load RPZ zone '"<<zone_<<"' from '"<<master_<<"': "<<e.what()<<endl;
@@ -260,11 +261,14 @@ void loadRecursorLuaConfig(const std::string& fname)
     });
 
 #if HAVE_PROTOBUF
-  Lua.writeFunction("protobufServer", [&lci](const string& server_, const boost::optional<uint16_t> timeout, const boost::optional<uint64_t> maxQueuedEntries, const boost::optional<uint8_t> reconnectWaitTime, const boost::optional<uint8_t> maskV4, boost::optional<uint8_t> maskV6, boost::optional<bool> asyncConnect) {
+  Lua.writeFunction("protobufServer", [&lci, checkOnly](const string& server_, const boost::optional<uint16_t> timeout, const boost::optional<uint64_t> maxQueuedEntries, const boost::optional<uint8_t> reconnectWaitTime, const boost::optional<uint8_t> maskV4, boost::optional<uint8_t> maskV6, boost::optional<bool> asyncConnect) {
       try {
 	ComboAddress server(server_);
         if (!lci.protobufServer) {
-          lci.protobufServer = std::make_shared<RemoteLogger>(server, timeout ? *timeout : 2, maxQueuedEntries ? *maxQueuedEntries : 100, reconnectWaitTime ? *reconnectWaitTime : 1, asyncConnect ? *asyncConnect : false);
+          if (!checkOnly) {
+            lci.protobufServer = std::make_shared<RemoteLogger>(server, timeout ? *timeout : 2, maxQueuedEntries ? *maxQueuedEntries : 100, reconnectWaitTime ? *reconnectWaitTime : 1, asyncConnect ? *asyncConnect : false);
+          }
+
           if (maskV4) {
             lci.protobufMaskV4 = *maskV4;
           }

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -40,5 +40,5 @@ public:
 };
 
 extern GlobalStateHolder<LuaConfigItems> g_luaconfs;
-void loadRecursorLuaConfig(const std::string& fname);
+void loadRecursorLuaConfig(const std::string& fname, bool checkOnly);
 

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1211,7 +1211,7 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
       ::arg().set("lua-config-file") = *begin;
 
     try {
-      loadRecursorLuaConfig(::arg()["lua-config-file"]);
+      loadRecursorLuaConfig(::arg()["lua-config-file"], false);
       L<<Logger::Warning<<"Reloaded Lua configuration file '"<<::arg()["lua-config-file"]<<"', requested via control channel"<<endl;
       return "Reloaded Lua configuration file '"+::arg()["lua-config-file"]+"'\n";
     }


### PR DESCRIPTION
Otherwise they are killed when we call `fork()`.
We still want to actually parse the configuration to check for syntax errors before daemonizing to be able to report any error, so when `daemon` is set to `yes`, we parse the Lua configuration early without starting any threads, and then again, starting the threads that time, after daemonizing.

(cherry picked from commit a4241908a1c80c4293cfcd5056bb67138958f0e6)