### PR TITLE
Enable setting custom pgsql connection parameters

### DIFF
--- a/docs/markdown/authoritative/backend-generic-postgresql.md
+++ b/docs/markdown/authoritative/backend-generic-postgresql.md
@@ -48,6 +48,11 @@ The password to for [`gpgsql-user`](#gpgsql-user).
 ## `gpgsql-dnssec`
 Enable DNSSEC processing for this backend. Default=no.
 
+## `gpsql-extra-connection-parameters`
+Extra connection parameters to forward to postgres. If you want to pin a specific certificate for
+the connection you should set this to `sslmode=verify-full sslrootcert=<path-to-CA-cert>`. Accepted
+parameters are documented [in the PostgreSQL documentation](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS).
+
 # Default schema
 ```
 !!include=../modules/gpgsqlbackend/schema.pgsql.sql

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -44,7 +44,8 @@ gPgSQLBackend::gPgSQLBackend(const string &mode, const string &suffix)  : GSQLBa
         	  getArg("host"),
         	  getArg("port"),
         	  getArg("user"),
-        	  getArg("password")));
+        	  getArg("password"),
+        	  getArg("extra-connection-parameters")));
   }
 
   catch(SSqlException &e) {
@@ -66,6 +67,7 @@ public:
     declare(suffix,"host","Pdns backend host to connect to","");
     declare(suffix,"port","Database backend port to connect to","");
     declare(suffix,"password","Pdns backend password to connect with","");
+    declare(suffix,"extra-connection-parameters", "Extra parameters to add to connection string","");
 
     declare(suffix,"dnssec","Enable DNSSEC processing","no");
 

--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -265,7 +265,7 @@ private:
 bool SPgSQL::s_dolog;
 
 SPgSQL::SPgSQL(const string &database, const string &host, const string& port, const string &user,
-               const string &password)
+               const string &password, const string &extra_connection_parameters)
 {
   d_db=0;
   d_in_trx = false;
@@ -282,6 +282,9 @@ SPgSQL::SPgSQL(const string &database, const string &host, const string& port, c
 
   if(!port.empty())
     d_connectstr+=" port="+port;
+
+  if(!extra_connection_parameters.empty())
+    d_connectstr+=" " + extra_connection_parameters;
 
   d_connectlogstr=d_connectstr;
 

--- a/modules/gpgsqlbackend/spgsql.hh
+++ b/modules/gpgsqlbackend/spgsql.hh
@@ -29,7 +29,8 @@ class SPgSQL : public SSql
 {
 public:
   SPgSQL(const string &database, const string &host="", const string& port="",
-         const string &user="", const string &password="");
+         const string &user="", const string &password="",
+         const string &extra_connection_parameters="");
 
   ~SPgSQL();
   


### PR DESCRIPTION
### Short description
Enable setting custom pgsql connection parameters, like TLS parameters.

Should this be added to documentation or examples anywhere? To validate TLS connections against a local trust root you can set `gpgsql-extra-connection-args=sslmode=verify-ca sslrootcert=<path-to-certs>`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

Closes #2138.