### PR TITLE
Specify that dnsmessage.proto uses protobuf version 2

### DIFF
--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -19,6 +19,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+syntax = "proto2";
+
 message PBDNSMessage {
   enum Type {
     DNSQueryType = 1;


### PR DESCRIPTION
### Short description
Specify that dnsmessage.proto uses protobuf version 2, as recent proto-c versions are complaining loudly otherwise.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
