### PR TITLE
Backport #4716: rec: Remove leftover debug msg in `RecursorLua4::DNSQuestion::setRecords()`

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -209,7 +209,6 @@ void RecursorLua4::DNSQuestion::setRecords(const vector<pair<int, DNSRecord> >& 
   records.clear();
   for(const auto& p : recs) {
     records.push_back(p.second);
-    cout<<"Setting: "<<p.second.d_content->getZoneRepresentation()<<endl;
   }
 }
 


### PR DESCRIPTION
(cherry picked from commit 3c82a3e58f689324b4c700c8bdad9dd9fb351065)