### PR TITLE
rec: Add `getRecursorThreadId()` to Lua, identifying the current thread

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -383,6 +383,9 @@ entry.  Entries are listed in the following table:
 Public Suffix List. In general it will tell you the 'registered domain' for a given
 name.
 
+`getRecursorThreadId()` returns an unsigned integer identifying the thread
+handling the current request.
+
 ## DNS64
 The `getFakeAAAARecords` and `getFakePTRRecords` followupFunctions can be used
 to implement DNS64. See [DNS64 support in the PowerDNS Recursor](dns64.md) for

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -531,7 +531,11 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerFunction("incBy", &DynMetric::incBy);
   d_lw->registerFunction("set", &DynMetric::set);
   d_lw->registerFunction("get", &DynMetric::get);
-  
+
+  d_lw->writeFunction("getRecursorThreadId", []() {
+      return getRecursorThreadId();
+    });
+
   
   ifstream ifs(fname);
   if(!ifs) {

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -31,6 +31,7 @@
 #endif
 
 string GenUDPQueryResponse(const ComboAddress& dest, const string& query);
+unsigned int getRecursorThreadId();
 
 class LuaContext;
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -91,7 +91,7 @@ extern SortList g_sortlist;
 #endif
 
 __thread FDMultiplexer* t_fdm;
-__thread unsigned int t_id;
+static __thread unsigned int t_id;
 unsigned int g_maxTCPPerClient;
 unsigned int g_networkTimeoutMsec;
 uint64_t g_latencyStatSize;
@@ -214,6 +214,10 @@ ArgvMap &arg()
   return theArg;
 }
 
+unsigned int getRecursorThreadId()
+{
+  return t_id;
+}
 
 void handleTCPClientWritable(int fd, FDMultiplexer::funcparam_t& var);
 


### PR DESCRIPTION
### Short description
This PR adds a new Lua function, `getRecursorThreadId()`, returning the current thread ID. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code

