### PR TITLE
dnsdist: Add an option to return ServFail when no server is available

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1385,6 +1385,7 @@ instantiate a server with additional parameters
     * `setServerPolicyLua(name, function)`: set server selection policy to one named 'name' and provided by 'function'
     * `showServerPolicy()`: show name of currently operational server selection policy
     * `newServerPolicy(name, function)`: create a policy object from a Lua function
+    * `setServFailWhenNoServer(bool)`: if set, return a ServFail when no servers are available, instead of the default behaviour of dropping the query
  * Available policies:
     * `firstAvailable`: Pick first server that has not exceeded its QPS limit, ordered by the server 'order' parameter
     * `whashed`: Weighted hashed ('sticky') distribution over available servers, based on the server 'weight' parameter

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -339,6 +339,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "setRules", true, "list of rules", "replace the current rules with the supplied list of pairs of DNS Rules and DNS Actions (see `newRuleAction()`)" },
   { "setServerPolicy", true, "policy", "set server selection policy to that policy" },
   { "setServerPolicyLua", true, "name, function", "set server selection policy to one named 'name' and provided by 'function'" },
+  { "setServFailWhenNoServer", true, "bool", "if set, return a ServFail when no servers are available, instead of the default behaviour of dropping the query" },
   { "setTCPRecvTimeout", true, "n", "set the read timeout on TCP connections from the client, in seconds" },
   { "setTCPSendTimeout", true, "n", "set the write timeout on TCP connections from the client, in seconds" },
   { "setVerboseHealthChecks", true, "bool", "set whether health check errors will be logged" },

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -1117,4 +1117,9 @@ void moreLua(bool client)
           }
         }
       });
+
+    g_lua.writeFunction("setServFailWhenNoServer", [](bool servfail) {
+        setLuaSideEffect();
+        g_servFailOnNoPolicy = servfail;
+      });
 }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -692,6 +692,7 @@ extern bool g_verboseHealthChecks;
 extern uint32_t g_staleCacheEntriesTTL;
 extern bool g_apiReadWrite;
 extern std::string g_apiConfigDirectory;
+extern bool g_servFailOnNoPolicy;
 
 struct ConsoleKeyword {
   std::string name;


### PR DESCRIPTION
### Short description

By default dnsdist drops the query if there is no server available to forward it to. This PR adds the `setServFailWhenNoServer(bool)` directive to reply with a ServFail instead.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added regression tests

