### PR TITLE
dnsdist: Add the TCP socket to the map only if the connection succeeds

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -340,7 +340,8 @@ void* tcpClientThread(int pipefd)
 
 	int dsock = -1;
 	if(sockets.count(ds->remote) == 0) {
-	  dsock=sockets[ds->remote]=setupTCPDownstream(ds);
+	  dsock=setupTCPDownstream(ds);
+	  sockets[ds->remote]=dsock;
 	}
 	else
 	  dsock=sockets[ds->remote];
@@ -369,7 +370,8 @@ void* tcpClientThread(int pipefd)
           close(dsock);
           dsock=-1;
           sockets.erase(ds->remote);
-          sockets[ds->remote]=dsock=setupTCPDownstream(ds);
+          dsock=setupTCPDownstream(ds);
+          sockets[ds->remote]=dsock;
           downstream_failures++;
           goto retry;
         }
@@ -387,7 +389,8 @@ void* tcpClientThread(int pipefd)
           close(dsock);
           dsock=-1;
           sockets.erase(ds->remote);
-          sockets[ds->remote]=dsock=setupTCPDownstream(ds);
+          dsock=setupTCPDownstream(ds);
+          sockets[ds->remote]=dsock;
           downstream_failures++;
           goto retry;
         }
@@ -405,7 +408,8 @@ void* tcpClientThread(int pipefd)
           close(dsock);
           dsock=-1;
           sockets.erase(ds->remote);
-          sockets[ds->remote]=dsock=setupTCPDownstream(ds);
+          dsock=setupTCPDownstream(ds);
+          sockets[ds->remote]=dsock;
           downstream_failures++;
           if(xfrStarted) {
             goto drop;


### PR DESCRIPTION
### Short description
Otherwise we create a value-initialized (to 0) entry in the map and try to use it later, as reported by @philmayers and tracked down by @ahupowerdns in #4733.
Fixes #4733. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code

