### PR TITLE
Backport 4722: Fix incorrect length check in `DNSName` when extracting qtype or qclass

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -141,15 +141,15 @@ void DNSName::packetParser(const char* qpos, int len, int offset, bool uncompres
   if(consumed)
     *consumed = pos - opos - offset;
   if(qtype) {
-    if (pos + labellen + 2 > end) {
-      throw std::range_error("Trying to read qtype past the end of the buffer ("+std::to_string((pos - opos) + labellen + 2)+ " > "+std::to_string(len)+")");
+    if (pos + 2 > end) {
+      throw std::range_error("Trying to read qtype past the end of the buffer ("+std::to_string((pos - opos) + 2)+ " > "+std::to_string(len)+")");
     }
     *qtype=(*(const unsigned char*)pos)*256 + *((const unsigned char*)pos+1);
   }
   pos+=2;
   if(qclass) {
-    if (pos + labellen + 2 > end) {
-      throw std::range_error("Trying to read qclass past the end of the buffer ("+std::to_string((pos - opos) + labellen + 2)+ " > "+std::to_string(len)+")");
+    if (pos + 2 > end) {
+      throw std::range_error("Trying to read qclass past the end of the buffer ("+std::to_string((pos - opos) + 2)+ " > "+std::to_string(len)+")");
     }
     *qclass=(*(const unsigned char*)pos)*256 + *((const unsigned char*)pos+1);
   }


### PR DESCRIPTION
### Short description
In `DNSName::packetParser()`, the length check might have been incorrect
when the caller asked for the `qtype` and/or the `qclass` to be extracted.
The `pos + labellen + 2 > end` check was wrong because `pos` might have already
been incremented by `labellen`. There are 3 ways to exit the main loop:

* `labellen` is 0, the most common case, and in that case the check is valid
* `pos >= end`, meaning that `pos + labellen + 2 > end` will be true regardless
of the value of `labellen` since it cannot be negative
* if `uncompress` is set and a compressed label is found, the main loop is
broken out of, and `labellen` still holds a now irrelevant, possibly non-zero value
corresponding to the first byte of the compressed label length & ~0xc0.

In that last case, if the compressed label points to a position > 255 the check
is wrong and might have rejected a valid packet.
A quick look throught the code didn't show any place where we request decompression
and ask for `qtype` and/or `qclass` in a response, but I might have missed one.

Reported by Houssam El Hajoui (thanks!).

(cherry picked from commit 7b9c052c617d02e1870195d0f216732047d56e22)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] added unit tests
- [x] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

