### PR TITLE
remove unreliable `latency` variable from counters test

### DIFF
--- a/regression-tests.nobackend/counters/command
+++ b/regression-tests.nobackend/counters/command
@@ -27,7 +27,7 @@ $SDIG ::1 $port example.com SOA >&2 >/dev/null
 $SDIG ::1 $port example.com SOA tcp >&2 >/dev/null
 
 $PDNSCONTROL --config-name= --no-config --socket-dir=./ 'show *' | \
-  tr ',' '\n'| grep -v -E '(user-msec|sys-msec|uptime|udp-noport-errors|udp-in-errors|real-memory-usage|udp-recvbuf-errors|udp-sndbuf-errors|-hit|-miss|fd-usage)' | LC_ALL=C sort
+  tr ',' '\n'| grep -v -E '(user-msec|sys-msec|uptime|udp-noport-errors|udp-in-errors|real-memory-usage|udp-recvbuf-errors|udp-sndbuf-errors|-hit|-miss|fd-usage|latency)' | LC_ALL=C sort
 
 kill $(cat pdns*.pid)
 rm pdns*.pid

--- a/regression-tests.nobackend/counters/expected_result
+++ b/regression-tests.nobackend/counters/expected_result
@@ -8,7 +8,6 @@ dnsupdate-queries=0
 dnsupdate-refused=0
 incoming-notifications=0
 key-cache-size=0
-latency=0
 meta-cache-size=1
 overload-drops=0
 packetcache-size=8


### PR DESCRIPTION
### Short description
The `latency` counter is not always zero at the end of this test, especially on Travis VMs with varying performance.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

