### PR TITLE
API: prevent sending nameservers list and zone-level NS in rrsets

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1026,6 +1026,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
 
     // if records/comments are given, load and check them
     bool have_soa = false;
+    bool have_zone_ns = false;
     vector<DNSResourceRecord> new_records;
     vector<Comment> new_comments;
     vector<DNSResourceRecord> new_ptrs;
@@ -1061,6 +1062,9 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
         increaseSOARecord(rr, soa_edit_api_kind, soa_edit_kind);
         // fixup dots after serializeSOAData/increaseSOARecord
         rr.content = makeBackendRecordContent(rr.qtype, rr.content);
+      }
+      if (rr.qtype.getCode() == QType::NS && rr.qname==zonename) {
+        have_zone_ns = true;
       }
     }
 
@@ -1102,6 +1106,9 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       }
       autorr.qtype = "NS";
       new_records.push_back(autorr);
+      if (have_zone_ns) {
+        throw ApiException("Nameservers list MUST NOT be mixed with zone-level NS in rrsets");
+      }
     }
 
     // no going back after this

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -261,6 +261,55 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         self.assertEquals(r.status_code, 422)
         self.assertIn('contains unsupported characters', r.json()['error'])
 
+    def test_create_zone_mixed_nameservers_ns_rrset_zonelevel(self):
+        name = unique_zone_name()
+        rrset = {
+            "name": name,
+            "type": "NS",
+            "ttl": 3600,
+            "records": [{
+                "content": "ns2.example.com.",
+                "disabled": False,
+            }],
+        }
+        payload = {
+            'name': name,
+            'kind': 'Native',
+            'nameservers': ['ns1.example.com.'],
+            'rrsets': [rrset],
+        }
+        print payload
+        r = self.session.post(
+            self.url("/api/v1/servers/localhost/zones"),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(r.status_code, 422)
+        self.assertIn('Nameservers list MUST NOT be mixed with zone-level NS in rrsets', r.json()['error'])
+
+    def test_create_zone_mixed_nameservers_ns_rrset_below_zonelevel(self):
+        name = unique_zone_name()
+        rrset = {
+            "name": 'subzone.'+name,
+            "type": "NS",
+            "ttl": 3600,
+            "records": [{
+                "content": "ns2.example.com.",
+                "disabled": False,
+            }],
+        }
+        payload = {
+            'name': name,
+            'kind': 'Native',
+            'nameservers': ['ns1.example.com.'],
+            'rrsets': [rrset],
+        }
+        print payload
+        r = self.session.post(
+            self.url("/api/v1/servers/localhost/zones"),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assert_success_json(r)
+
     def test_create_zone_with_symbols(self):
         name, payload, data = self.create_zone(name='foo/bar.'+unique_zone_name())
         name = payload['name']


### PR DESCRIPTION
Fixes #4132.

Prevent surprises when a user tries to mix nameservers as list and passes in a zone-level NS RRset too. This was previously part of #4195, but because that changes more I've split it out.

- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added regression tests
- [ ] added unit tests
