### PR TITLE
Backport #4638: auth: In `Bind2Backend::lookup()`, use the `zoneId` when we have it

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1036,9 +1036,17 @@ void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *p
   bool found=false;
   BB2DomainInfo bbd;
 
-  do {
-    found = safeGetBBDomainInfo(domain, &bbd);
-  } while ((!found || (zoneId != (int)bbd.d_id && zoneId != -1)) && domain.chopOff());
+  if (zoneId != -1) {
+    found = safeGetBBDomainInfo(zoneId, &bbd);
+    if (found) {
+      domain = bbd.d_name;
+    }
+  }
+  else {
+    do {
+      found = safeGetBBDomainInfo(domain, &bbd);
+    } while (!found && domain.chopOff());
+  }
 
   if(!found) {
     if(mustlog)


### PR DESCRIPTION
### Short description
After the initial lookup corresponding to a `DNSBackend::getAuth()`,
the subsequent ones already have the `zoneId`, so use it instead of
looping on `chopOff()` again. This should be much more efficient.

(cherry picked from commit 937a66255ff05f2e754ef113833e54cc4cf2004b)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

