### PR TITLE
Set `RemoteLogger::d_socket` to -1 after closing it

### DIFF
--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -12,6 +12,7 @@ bool RemoteLogger::reconnect()
 {
   if (d_socket >= 0) {
     close(d_socket);
+    d_socket = -1;
   }
   try {
     d_socket = SSocket(d_remote.sin4.sin_family, SOCK_STREAM, 0);
@@ -115,8 +116,10 @@ RemoteLogger::RemoteLogger(const ComboAddress& remote, uint16_t timeout, uint64_
 RemoteLogger::~RemoteLogger()
 {
   d_exiting = true;
-  if (d_socket >= 0)
+  if (d_socket >= 0) {
     close(d_socket);
+    d_socket = -1;
+  }
   d_queueCond.notify_one();
   d_thread.join();
 }


### PR DESCRIPTION
### Short description
Otherwise, in the unlikely case `SSocket()` throws an exception
we might end up with a stale file descriptor in `RemoteLogger::reconnect()`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code


