### PR TITLE
Extended pdns_control man page: pdns_control notify *

### DIFF
--- a/docs/manpages/pdns_control.1.md
+++ b/docs/manpages/pdns_control.1.md
@@ -75,7 +75,9 @@ list-zones [master,slave,native]
 notify *DOMAIN*
 :    Adds *DOMAIN* to the notification list, causing PowerDNS to send out
      notifications to the nameservers of a domain. Can be used if a slave missed
-     previous notifications or is generally hard of hearing.
+     previous notifications or is generally hard of hearing. Use \* to notify
+     for all domains. (Note that you may need to escape the \* sign in your
+     shell.)
 
 notify-host *DOMAIN* *ADDRESS*
 :    Same as above but with operator specified IP *ADDRESS* as destination, to be


### PR DESCRIPTION
### Short description
Include documentation on method to notify all domains (with one command) in man page.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [n/a] documented the code
- [n/a] added regression tests
- [n/a] added unit tests
- [n/a] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

