### PR TITLE
DNSDist: some service improvements

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1656,7 +1656,7 @@ try
       cout<<endl;
       cout<<"Syntax: dnsdist [-C,--config file] [-c,--client [IP[:PORT]]] [-d,--daemon]\n";
       cout<<"[-p,--pidfile file] [-e,--execute cmd] [-h,--help] [-l,--local addr]\n";
-      cout<<"[-v,--verbose]\n";
+      cout<<"[-v,--verbose] [--check-config]\n";
       cout<<"\n";
       cout<<"-a,--acl netmask      Add this netmask to the ACL\n";
       cout<<"-C,--config file      Load configuration from 'file'\n";
@@ -1668,6 +1668,9 @@ try
       cout<<"                      is similar to setting setKey in the configuration file.\n";
       cout<<"                      NOTE: this will leak this key in your shell's history!\n";
 #endif
+      cout<<"--check-config        Validate the configuration file and exit. The exit-code\n";
+      cout<<"                      reflects the validation, 0 is OK, 1 means an error.\n";
+      cout<<"                      Any errors are printed as well.\n";
       cout<<"-d,--daemon           Operate as a daemon\n";
       cout<<"-e,--execute cmd      Connect to dnsdist and execute 'cmd'\n";
       cout<<"-g,--gid gid          Change the process group ID after binding sockets\n";

--- a/pdns/dnsdistdist/.gitignore
+++ b/pdns/dnsdistdist/.gitignore
@@ -33,3 +33,4 @@
 /dnsmessage.pb.h
 /dnsdist.service
 /lua.hpp
+/test-driver

--- a/pdns/dnsdistdist/contrib/dnsdist.init.centos6
+++ b/pdns/dnsdistdist/contrib/dnsdist.init.centos6
@@ -31,8 +31,20 @@ fi
 
 RETVAL=0
 
+do_check() {
+  msg=$(${DNSDIST} ${DNSDIST_OPTIONS} --check-config 2>&1)
+  if [ $? -ne 0 ]; then
+    echo "Error in configuration file:" >&2
+    echo "${msg}" >&2
+    return 1
+  fi
+}
+
 do_start() {
   echo -n "Starting ${PROG}..."
+  if [ do_check -ne 0 ]; then
+    return 1
+  fi
   daemon --pidfile=${PIDFILE} $DNSDIST -u ${DNSDIST_USER} -g ${DNSDIST_GROUP} -d -p ${PIDFILE} ${DNSDIST_OPTIONS}
   ret=$?
   echo
@@ -63,12 +75,15 @@ case "$1" in
     do_status >/dev/null 2>&1
     ret=$?
 
-    if [ $? -eq 0 ]; then
+    if [ ${ret} -eq 0 ]; then
+      if [ do_check -ne 0 ]; then
+        exit 1 # Don't stop when there's an error
+      fi
       do_stop
-      ret=$?
     fi
 
     do_start
+    RETVAL=$?
     ;;
   status)
     do_status

--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -6,6 +6,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+ExecStartPre=@bindir@/dnsdist --check-config
 # Note: when editing the ExecStart command, keep --supervised and --disable-syslog
 ExecStart=@bindir@/dnsdist --supervised --disable-syslog
 


### PR DESCRIPTION
### Short description
This makes the dnsdist start-up script/service file check the config before attempting to start. The initscript will refuse to stop the servic eon a restart if the config is broken.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] documented the code