### PR TITLE
hide ttl in RPZ tests to avoid random failures

### DIFF
--- a/regression-tests.recursor/RPZ-Lua/command
+++ b/regression-tests.recursor/RPZ-Lua/command
@@ -1,3 +1,3 @@
-$SDIG $nameserver 5301 www3.example.net a recurse 2>&1
-$SDIG $nameserver 5301 android.marvin.example.net a recurse 2>&1
-$SDIG $nameserver 5301 www5.example.net a recurse 2>&1
+$SDIG $nameserver 5301 www3.example.net a recurse hidettl 2>&1
+$SDIG $nameserver 5301 android.marvin.example.net a recurse hidettl 2>&1
+$SDIG $nameserver 5301 www5.example.net a recurse hidettl 2>&1

--- a/regression-tests.recursor/RPZ-Lua/expected_result
+++ b/regression-tests.recursor/RPZ-Lua/expected_result
@@ -1,10 +1,10 @@
 Reply to question for qname='www3.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	www3.example.net.	IN	CNAME	0	www2.example.net.
-0	www2.example.net.	IN	A	10	192.0.2.2
+0	www3.example.net.	IN	CNAME	[ttl]	www2.example.net.
+0	www2.example.net.	IN	A	[ttl]	192.0.2.2
 Reply to question for qname='android.marvin.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	android.marvin.example.net.	IN	A	15	192.0.2.5
+0	android.marvin.example.net.	IN	A	[ttl]	192.0.2.5
 Reply to question for qname='www5.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	www5.example.net.	IN	A	0	192.0.2.25
+0	www5.example.net.	IN	A	[ttl]	192.0.2.25


### PR DESCRIPTION
### Short description
If a test runner VM is slow, TTLs may decrease before we manage to get all our queries in. If we don't hide the TTL in our testing, this may cause tests to fail.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

