### PR TITLE
rec: Set the result to NoError before calling `preresolve`

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -740,7 +740,8 @@ void startDoResolve(void *p)
     bool variableAnswer = false;
     bool shouldNotValidate = false;
 
-    int res;
+    /* preresolve expects res (dq.rcode) to be set to RCode::NoError by default */
+    int res = RCode::NoError;
     DNSFilterEngine::Policy appliedPolicy;
     DNSRecord spoofed;
     std::shared_ptr<RecursorLua4::DNSQuestion> dq = nullptr;


### PR DESCRIPTION
### Short description
Otherwise `rq.rcode` needs to be set explicitly when handling the query from `preresolve`, which is not documented and wasn't the case before.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code


