### PR TITLE
Backport #4769 rec: Set the result to NoError before calling `preresolve`

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -739,7 +739,8 @@ void startDoResolve(void *p)
     bool variableAnswer = false;
     bool shouldNotValidate = false;
 
-    int res;
+    /* preresolve expects res (dq.rcode) to be set to RCode::NoError by default */
+    int res = RCode::NoError;
     DNSFilterEngine::Policy appliedPolicy;
     DNSRecord spoofed;
     if(dc->d_mdp.d_qtype==QType::ANY && !dc->d_tcp && g_anyToTcp) {


### PR DESCRIPTION
### Short description
Otherwise `rq.rcode` needs to be set explicitly when handling the query from `preresolve`, which is not documented and wasn't the case before.

(cherry picked from commit ef3b6cd7719e968364f6ad7692ff4287829f37f1)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master

