### PR TITLE
LuaWrapper: Use the correct index when storing a function

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1642,10 +1642,10 @@ private:
     // structure that will ensure that a certain is stored somewhere in the registry
     struct ValueInRegistry {
         // this constructor will clone and hold the value at the top of the stack in the registry
-        ValueInRegistry(lua_State* lua) : lua{lua}
+        ValueInRegistry(lua_State* lua, int index=-1) : lua{lua}
         {
             lua_pushlightuserdata(lua, this);
-            lua_pushvalue(lua, -2);
+            lua_pushvalue(lua, -1 + index);
             lua_settable(lua, LUA_REGISTRYINDEX);
         }
         
@@ -1821,8 +1821,8 @@ private:
 
 private:
     friend LuaContext;
-    explicit LuaFunctionCaller(lua_State* state) :
-        valueHolder(std::make_shared<ValueInRegistry>(state)),
+    explicit LuaFunctionCaller(lua_State* state, int index) :
+        valueHolder(std::make_shared<ValueInRegistry>(state, index)),
         state(state)
     {}
 };
@@ -2521,7 +2521,7 @@ struct LuaContext::Reader<LuaContext::LuaFunctionCaller<TRetValue (TParameters..
     {
         if (lua_isfunction(state, index) == 0 && lua_isuserdata(state, index) == 0)
             return boost::none;
-        return ReturnType(state);
+        return ReturnType(state, index);
     }
 };
 

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1639,9 +1639,9 @@ private:
     /**************************************************/
     /*                   UTILITIES                    */
     /**************************************************/
-    // structure that will ensure that a certain is stored somewhere in the registry
+    // structure that will ensure that a certain value is stored somewhere in the registry
     struct ValueInRegistry {
-        // this constructor will clone and hold the value at the top of the stack in the registry
+        // this constructor will clone and hold the value at the specified index (or by default at the top of the stack) in the registry
         ValueInRegistry(lua_State* lua, int index=-1) : lua{lua}
         {
             lua_pushlightuserdata(lua, this);


### PR DESCRIPTION
### Short description
The LuaWrapper used to assume that the function was at the top of the stack, making it effectively impossible to have a callback function parameter anywhere else than as the last parameter.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
