### PR TITLE
dnsdist: Add an optional `seconds` parameter to `statNodeRespRing()`

### DIFF
--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
+import base64
 from datetime import datetime, timedelta
 import os
+import string
 import time
 import dns
 from dnsdisttests import DNSDistTest
@@ -1243,3 +1245,88 @@ class TestAdvancedLuaDO(DNSDistTest):
         self.assertTrue(receivedResponse)
         doResponse.id = receivedResponse.id
         self.assertEquals(receivedResponse, doResponse)
+
+class TestStatNodeRespRingSince(DNSDistTest):
+
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey)
+    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort']
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%s")
+    s1 = newServer{address="127.0.0.1:%s"}
+    s1:setUp()
+    function visitor(node, self, childstat)
+        table.insert(nodesSeen, node.fullname)
+    end
+    """
+
+    def testStatNodeRespRingSince(self):
+        """
+        Advanced: StatNodeRespRing with optional since parameter
+
+        """
+        name = 'statnodesince.advanced.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    1,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        self.sendConsoleCommand("nodesSeen = {}")
+        self.sendConsoleCommand("statNodeRespRing(visitor)")
+        nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
+        nodes = string.strip(nodes, "\n")
+        self.assertEquals(nodes, """statnodesince.advanced.tests.powerdns.com.
+advanced.tests.powerdns.com.
+tests.powerdns.com.
+powerdns.com.
+com.""")
+
+        self.sendConsoleCommand("nodesSeen = {}")
+        self.sendConsoleCommand("statNodeRespRing(visitor, 0)")
+        nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
+        nodes = string.strip(nodes, "\n")
+        self.assertEquals(nodes, """statnodesince.advanced.tests.powerdns.com.
+advanced.tests.powerdns.com.
+tests.powerdns.com.
+powerdns.com.
+com.""")
+
+        time.sleep(5)
+
+        self.sendConsoleCommand("nodesSeen = {}")
+        self.sendConsoleCommand("statNodeRespRing(visitor)")
+        nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
+        nodes = string.strip(nodes, "\n")
+        self.assertEquals(nodes, """statnodesince.advanced.tests.powerdns.com.
+advanced.tests.powerdns.com.
+tests.powerdns.com.
+powerdns.com.
+com.""")
+
+        self.sendConsoleCommand("nodesSeen = {}")
+        self.sendConsoleCommand("statNodeRespRing(visitor, 5)")
+        nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
+        nodes = string.strip(nodes, "\n")
+        self.assertEquals(nodes, """""")
+
+        self.sendConsoleCommand("nodesSeen = {}")
+        self.sendConsoleCommand("statNodeRespRing(visitor, 10)")
+        nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
+        nodes = string.strip(nodes, "\n")
+        self.assertEquals(nodes, """statnodesince.advanced.tests.powerdns.com.
+advanced.tests.powerdns.com.
+tests.powerdns.com.
+powerdns.com.
+com.""")


### PR DESCRIPTION
### Short description
By default `statNodeRespRing()` applies the visitor function to every entry in the responses ring. When passed a non-zero `seconds` parameter, it will only apply it to entries added in the last `seconds` seconds.
Based on top of #4775, replaces #4660.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] added regression tests

