### PR TITLE
Add -latomic on powerpc

### DIFF
--- a/m4/pdns_check_os.m4
+++ b/m4/pdns_check_os.m4
@@ -39,6 +39,9 @@ AC_DEFUN([PDNS_CHECK_OS],[
   mips*)
     LDFLAGS="-latomic $LDFLAGS"
     ;;
+  powerpc*)
+    LDFLAGS="-latomic $LDFLAGS"
+    ;;
   esac
 
   AC_SUBST(THREADFLAGS)


### PR DESCRIPTION
### Short description
It looks like we need to explicitly add `-latomic` on powerpc, as we are already doing on mips. However please be aware that I haven't tested this on powerpc. 
Hopefully fixes #4782. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code

