### PR TITLE
dnsdist: Fix the `firstAvailable` policy description

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -705,8 +705,10 @@ The default load balancing policy is called `leastOutstanding`, which means
 we pick the server with the least queries 'in the air' (and within those,
 the one with the lowest `order`, and within those, the one with the lowest latency).
 
-Another policy, `firstAvailable`, picks the server with the lowest `order` that has not
-exceeded its QPS limit. For now this is the only policy using the QPS limit.
+Another policy, `firstAvailable`, picks the first server that has not
+exceeded its QPS limit. If all servers are above their QPS limit, a
+server is selected based on the `leastOutstanding` policy. For now this
+is the only policy using the QPS limit.
 
 A further policy, `wrandom` assigns queries randomly, but based on the
 `weight` parameter passed to `newServer`. `whashed` is a similar weighted policy,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It doesn't use the server's `order`, except when falling back to `leastOutstanding`.

