### PR TITLE
dnsdist: Send a latency of 0 over carbon, null over API for down servers

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -89,7 +89,7 @@ try
           const string base = "dnsdist." + hostname + ".main.servers." + serverName + ".";
           str<<base<<"queries" << ' ' << s->queries.load() << " " << now << "\r\n";
           str<<base<<"drops" << ' ' << s->reuseds.load() << " " << now << "\r\n";
-          str<<base<<"latency" << ' ' << s->latencyUsec/1000.0 << " " << now << "\r\n";
+          str<<base<<"latency" << ' ' << (s->availability != DownstreamState::Availability::Down ? s->latencyUsec/1000.0 : 0) << " " << now << "\r\n";
           str<<base<<"senderrors" << ' ' << s->sendErrors.load() << " " << now << "\r\n";
           str<<base<<"outstanding" << ' ' << s->outstanding.load() << " " << now << "\r\n";
         }

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -354,6 +354,11 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           {"latency", (int)(a->latencyUsec/1000.0)},
           {"queries", (int)a->queries}};
 
+        /* sending a latency for a DOWN server doesn't make sense */
+        if (a->availability == DownstreamState::Availability::Down) {
+          server["latency"] = nullptr;
+        }
+
 	servers.push_back(server);
       }
 


### PR DESCRIPTION
### Short description
It makes no sense to send the previous latency for a server that we know to be down. This PR sends `0` over carbon since I don't know of a better way to signal that the value is not set. Not sending the value at all when a server is down results in very weird graphs.
Closes #4689.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] added regression tests

