### PR TITLE
Revamp the manpage building

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -24,38 +24,41 @@ MANPAGES_TARGET_TOOLS += dnsbulktest.1 \
 	dnstcpbench.1
 endif
 
-
 if HAVE_PROTOBUF
 if HAVE_PROTOC
 MANPAGES_TARGET_TOOLS += dnspcap2protobuf.1
 endif
 endif
 
-MANPAGES_TARGET_DNSDIST = dnsdist.1
+EXTRA_DIST = manpages markdown/*.md markdown/appendix markdown/authoritative markdown/common markdown/httpapi markdown/recursor markdown/security markdown/tools $(MANPAGES_TARGET_AUTH) $(MANPAGES_TARGET_TOOLS)
 
-MANPAGES_TARGET_RECURSOR = pdns_recursor.1 \
-	rec_control.1
+# Figure out the manpages to build/install
+MANPAGES_TARGET_ALL=$(MANPAGES_TARGET_AUTH)
+man_MANS = $(MANPAGES_TARGET_AUTH)
 
-MANPAGES_TARGET_ALL=$(MANPAGES_TARGET_AUTH) \
-		$(MANPAGES_TARGET_RECURSOR) \
-		$(MANPAGES_TARGET_TOOLS) \
-		$(MANPAGES_TARGET_DNSDIST)
+if TOOLS
+MANPAGES_TARGET_ALL += $(MANPAGES_TARGET_TOOLS)
+man_MANS += $(MANPAGES_TARGET_TOOLS)
+endif
 
-# The manpages to distribute and install are only those for the
-# auth server and tools. For the recursor and dnsdist tarballs,
-# the respective dist- scripts will take care of this
+all-manpages: $(MANPAGES_TARGET_ALL)
+
+# If we can't rebuild the manpages, don't allow creation or deletion
 if HAVE_PANDOC
-dist_man_MANS = $(MANPAGES_TARGET_AUTH) $(MANPAGES_TARGET_TOOLS)
+$(MANPAGES_TARGET_ALL): %: manpages/%.md
+	$(PANDOC) -s -t man $< -o $@
+
+clean:
+	rm -rf html html.tar.bz2 *.8 *.1
+else
+if !HAVE_MANPAGES
+$(MANPAGES_TARGET_ALL):
+	echo "You need pandoc to generate the manpages"
+	exit 1
 endif
-if HAVE_MANPAGES
-dist_man_MANS = $(MANPAGES_TARGET_AUTH) $(MANPAGES_TARGET_TOOLS)
 endif
 
-EXTRA_DIST = manpages markdown/*.md markdown/appendix markdown/authoritative markdown/common markdown/httpapi markdown/recursor markdown/security markdown/tools
-
-
-.PHONY: html all-manpages
-
+# HTML documentation
 html: html/index.html
 
 if FROM_GIT
@@ -82,16 +85,4 @@ html/index.html:
 	@echo "supported from a git checkout"
 endif
 
-all-manpages: $(MANPAGES_TARGET_ALL)
-
-if HAVE_PANDOC
-$(MANPAGES_TARGET_ALL): %: manpages/%.md
-	$(PANDOC) -s -t man $< -o $@
-else
-$(MANPAGES_TARGET_ALL):
-	echo "You need pandoc to generate the manpages"
-	exit 1
-endif
-
-clean:
-	rm -rf html html.tar.bz2 *.8 *.1
+.PHONY: html all-manpages


### PR DESCRIPTION
### Short description
* Always dist the relevant manpages
* Don't build tools manpages is configured with `--disable-tools`
  (Closes #4643)
* Don't remove manpages if they cannot be rebuilt (Closes #3306)
* Removes support for building non-auth manpages from auth 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code