### PR TITLE
Auth: Cleanup `DNSName::getRawLabels()` usage

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -334,7 +334,7 @@ vector<DNSZoneRecord> PacketHandler::getBestDNAMESynth(DNSPacket *p, SOAData& sd
     if(!ret.empty())
       return ret;
     if(subdomain.countLabels())
-      prefix+= DNSName(subdomain.getRawLabels()[0]); // XXX DNSName pain this feels wrong
+      prefix.appendRawLabel(subdomain.getRawLabels()[0]); // XXX DNSName pain this feels wrong
     if(subdomain == sd.qname) // stop at SOA
       break;
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -638,7 +638,7 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
 
   for(const auto &i: tlsas) {
     DNSName name = DNSName(i);
-    name.trimToLabels(name.getRawLabels().size()-2);
+    name.trimToLabels(name.countLabels()-2);
     if (cnames.find(name) == cnames.end() && noncnames.find(name) == noncnames.end()) {
       // No specific record for the name in the TLSA record exists, this
       // is already worth emitting a warning. Let's see if a wildcard exist.


### PR DESCRIPTION
### Short description
Cleaning up the use of `DNSName::getRawLabels()`, although there is no real issue I'm aware of with the current code.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
