### PR TITLE
Don't call `hostname -f` on openbsd

### DIFF
--- a/m4/pdns_enable_reproducible.m4
+++ b/m4/pdns_enable_reproducible.m4
@@ -15,7 +15,7 @@ AC_DEFUN([PDNS_ENABLE_REPRODUCIBLE], [
     build_user=$(id -u -n)
 
     case "$host_os" in
-    solaris2.1* | SunOS)
+    solaris2.1* | SunOS | openbsd*)
       build_host_host=$(hostname)
       build_host_domain=$(domainname)
       build_host="$build_host_host.$build_host_domain"


### PR DESCRIPTION
### Short description
OpenBSD would shout at you when `-f` is passed to `hostname`
Closes #2579

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
