### PR TITLE
RPZ: some logging fixes

### DIFF
--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -349,7 +349,6 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::opti
       for(const auto& rr : remove) { // should always contain the SOA
         if(rr.d_type == QType::NS)
           continue;
-	totremove++;
 	if(rr.d_type == QType::SOA) {
 	  auto oldsr = getRR<SOARecordContent>(rr);
 	  if(oldsr && oldsr->d_st.serial == oursr->d_st.serial) {
@@ -359,6 +358,7 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::opti
 	    L<<Logger::Error<<"GOT WRONG SOA SERIAL REMOVAL, SHOULD TRIGGER WHOLE RELOAD"<<endl;
 	}
 	else {
+          totremove++;
 	  L<<Logger::Info<<"Had removal of "<<rr.d_name<<endl;
 	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, false, defpol, polZone);
 	}
@@ -367,7 +367,6 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::opti
       for(const auto& rr : add) { // should always contain the new SOA
         if(rr.d_type == QType::NS)
           continue;
-	totadd++;
 	if(rr.d_type == QType::SOA) {
 	  auto newsr = getRR<SOARecordContent>(rr);
 	  //	  L<<Logger::Info<<"New SOA serial for "<<zone<<": "<<newsr->d_st.serial<<endl;
@@ -376,6 +375,7 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::opti
 	  }
 	}
 	else {
+          totadd++;
 	  L<<Logger::Info<<"Had addition of "<<rr.d_name<<endl;
 	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, true, defpol, polZone);
 	}

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -359,7 +359,7 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::opti
 	}
 	else {
           totremove++;
-	  L<<Logger::Info<<"Had removal of "<<rr.d_name<<endl;
+	  L<<Logger::Debug<<"Had removal of "<<rr.d_name<<endl;
 	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, false, defpol, polZone);
 	}
       }
@@ -376,7 +376,7 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::opti
 	}
 	else {
           totadd++;
-	  L<<Logger::Info<<"Had addition of "<<rr.d_name<<endl;
+	  L<<Logger::Debug<<"Had addition of "<<rr.d_name<<endl;
 	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, true, defpol, polZone);
 	}
       }


### PR DESCRIPTION
### Short description
This PR fixes 2 thing wrt to logging in the RPZ-side of the recursor:

1. It stops counting the SOA changes, leading to more a accurate change summary
2. It lowers the loglevel of individual additions and removals to 'debug', to prevent being to spammy

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code