### PR TITLE
rec: put 15 seconds lower bound on max-cache-ttl

### DIFF
--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -584,6 +584,8 @@ for most installations.
 
 Maximum number of seconds to cache an item in the DNS cache, no matter what the
 original TTL specified.
+Since PowerDNS Recursor 4.1.0, the minimum value of this setting is 15.
+i.e. setting this to lower than 15 will make this value 15.
 
 ## `max-mthreads`
 * Integer

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2750,7 +2750,7 @@ int serviceMain(int argc, char*argv[])
   SyncRes::s_nopacketcache = ::arg().mustDo("disable-packetcache");
 
   SyncRes::s_maxnegttl=::arg().asNum("max-negative-ttl");
-  SyncRes::s_maxcachettl=::arg().asNum("max-cache-ttl");
+  SyncRes::s_maxcachettl=max(::arg().asNum("max-cache-ttl"), 15);
   SyncRes::s_packetcachettl=::arg().asNum("packetcache-ttl");
   // Cap the packetcache-servfail-ttl to the packetcache-ttl
   uint32_t packetCacheServFailTTL = ::arg().asNum("packetcache-servfail-ttl");


### PR DESCRIPTION
### Short description
Having no cache makes no sense and anything below a few seconds will
lead to SERVFAILs on recursors that have a low query load.

Closes #4634

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
