### PR TITLE
Backport #4789: rec: Don't choke on escaped content in getZoneCuts()

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -124,7 +124,7 @@ vector<DNSName> getZoneCuts(const DNSName& begin, const DNSName& end, DNSRecordO
   // The shortest name is assumed to a zone cut
   ret.push_back(qname);
   while(qname != begin) {
-    qname = DNSName(labelsToAdd.back()) + qname;
+    qname.prependRawLabel(labelsToAdd.back());
     labelsToAdd.pop_back();
     bool foundCut = false;
     auto records = dro.get(qname, (uint16_t)QType::NS);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`getZoneCuts()` was constructing a `DNSName` by passing a raw label returned
from `DNSName::getRawLabels()` as a string. The constructor then tried to handle
escaped characters from the string, resulting in a different `DNSName` than the
expected one. This caused the `qname != begin` condition to be false even after
every label in `labelsToAdd` had been added, causing an UB by calling
`std::vector::back()` on an empty vector.
Using `DNSName::prependRawLabel()` instead prevents this issue since the string is
not escaped.

(cherry picked from commit 754914f0177cd990db16ff0cc29c8789e94b32bb)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
