### PR TITLE
Propose to remove redundant indexes from gmysqlbackend default schema

### DIFF
--- a/modules/gmysqlbackend/schema.mysql.sql
+++ b/modules/gmysqlbackend/schema.mysql.sql
@@ -28,7 +28,6 @@ CREATE TABLE records (
 ) Engine=InnoDB;
 
 CREATE INDEX nametype_index ON records(name,type);
-CREATE INDEX domain_id ON records(domain_id);
 CREATE INDEX recordorder ON records (domain_id, ordername);
 
 
@@ -51,7 +50,6 @@ CREATE TABLE comments (
   PRIMARY KEY (id)
 ) Engine=InnoDB;
 
-CREATE INDEX comments_domain_id_idx ON comments (domain_id);
 CREATE INDEX comments_name_type_idx ON comments (name, type);
 CREATE INDEX comments_order_idx ON comments (domain_id, modified_at);
 


### PR DESCRIPTION
### Short description
The gmysqlbackend default schema seems to contain redundant indexes which I'm proposing to remove unless they provide any benefit.

### Slighty longer description
As MySQL will happily use the left-most prefix of a multiple-column index "domain_id" on "records" is covered by "recordorder". Same applies to "comments_domain_id_idx" on "comments" (by "comments_order_idx")
It could be that these indices are left-overs or they might provide some benefit in certain cases, for example increased performance since they are smaller than their multi-column friends. But - is that really the case or does the additional overhead in maintaining both in fact degrade performance?
During my tests the MySQL query optimizer preferred the multi-column index also in cases where a lookup in the single-column one would have been sufficient. Based on that I think we could get rid of those indexes.

In any case this PR could be used to review these indices, and remove them if they are not needed (and otherwise document why they exist).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
