### PR TITLE
gmysqlbackend: Define IDs as unsigned in default schema

### DIFF
--- a/modules/gmysqlbackend/schema.mysql.sql
+++ b/modules/gmysqlbackend/schema.mysql.sql
@@ -1,5 +1,5 @@
 CREATE TABLE domains (
-  id                    INT AUTO_INCREMENT,
+  id                    INT UNSIGNED AUTO_INCREMENT,
   name                  VARCHAR(255) NOT NULL,
   master                VARCHAR(128) DEFAULT NULL,
   last_check            INT DEFAULT NULL,
@@ -13,8 +13,8 @@ CREATE UNIQUE INDEX name_index ON domains(name);
 
 
 CREATE TABLE records (
-  id                    INT AUTO_INCREMENT,
-  domain_id             INT DEFAULT NULL,
+  id                    INT UNSIGNED AUTO_INCREMENT,
+  domain_id             INT UNSIGNED DEFAULT NULL,
   name                  VARCHAR(255) DEFAULT NULL,
   type                  VARCHAR(10) DEFAULT NULL,
   content               VARCHAR(64000) DEFAULT NULL,
@@ -41,8 +41,8 @@ CREATE TABLE supermasters (
 
 
 CREATE TABLE comments (
-  id                    INT AUTO_INCREMENT,
-  domain_id             INT NOT NULL,
+  id                    INT UNSIGNED AUTO_INCREMENT,
+  domain_id             INT UNSIGNED NOT NULL,
   name                  VARCHAR(255) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
@@ -57,8 +57,8 @@ CREATE INDEX comments_order_idx ON comments (domain_id, modified_at);
 
 
 CREATE TABLE domainmetadata (
-  id                    INT AUTO_INCREMENT,
-  domain_id             INT NOT NULL,
+  id                    INT UNSIGNED AUTO_INCREMENT,
+  domain_id             INT UNSIGNED NOT NULL,
   kind                  VARCHAR(32),
   content               TEXT,
   PRIMARY KEY (id)
@@ -68,8 +68,8 @@ CREATE INDEX domainmetadata_idx ON domainmetadata (domain_id, kind);
 
 
 CREATE TABLE cryptokeys (
-  id                    INT AUTO_INCREMENT,
-  domain_id             INT NOT NULL,
+  id                    INT UNSIGNED AUTO_INCREMENT,
+  domain_id             INT UNSIGNED NOT NULL,
   flags                 INT NOT NULL,
   active                BOOL,
   content               TEXT,
@@ -80,7 +80,7 @@ CREATE INDEX domainidindex ON cryptokeys(domain_id);
 
 
 CREATE TABLE tsigkeys (
-  id                    INT AUTO_INCREMENT,
+  id                    INT UNSIGNED AUTO_INCREMENT,
   name                  VARCHAR(255),
   algorithm             VARCHAR(50),
   secret                VARCHAR(255),


### PR DESCRIPTION
### Short description
The gmysqlbackend default schema uses signed integers for both domain and record ids. Since these are auto_increment values and used as uint32_t in the code I suppose it doesn't make much sense to have them defined as signed integers, except for artificially reducing the maximum amount of possible records.
(And yes, in some broken setups admins were already hit by that)
If applied this should be mentioned in changelogs to allow for proper migration.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
