### PR TITLE
DNSCrypt: Store the computed shared key and reuse it for the response

### DIFF
--- a/pdns/dnscrypt.cc
+++ b/pdns/dnscrypt.cc
@@ -56,7 +56,6 @@ void DnsCryptPrivateKey::saveToFile(const std::string& keyFile) const
 
 DnsCryptPrivateKey::~DnsCryptPrivateKey()
 {
-  sodium_memzero(key, sizeof(key));
   sodium_munlock(key, sizeof(key));
 }
 
@@ -67,7 +66,6 @@ DnsCryptQuery::DnsCryptQuery()
 
 DnsCryptQuery::~DnsCryptQuery()
 {
-  sodium_memzero(sharedKey, sizeof(sharedKey));
   sodium_munlock(sharedKey, sizeof(sharedKey));
 }
 

--- a/pdns/dnscrypt.cc
+++ b/pdns/dnscrypt.cc
@@ -60,6 +60,17 @@ DnsCryptPrivateKey::~DnsCryptPrivateKey()
   sodium_munlock(key, sizeof(key));
 }
 
+DnsCryptQuery::DnsCryptQuery()
+{
+  sodium_mlock(sharedKey, sizeof(sharedKey));
+}
+
+DnsCryptQuery::~DnsCryptQuery()
+{
+  sodium_memzero(sharedKey, sizeof(sharedKey));
+  sodium_munlock(sharedKey, sizeof(sharedKey));
+}
+
 void DnsCryptContext::generateProviderKeys(unsigned char publicKey[DNSCRYPT_PROVIDER_PUBLIC_KEY_SIZE], unsigned char privateKey[DNSCRYPT_PROVIDER_PRIVATE_KEY_SIZE])
 {
   int res = crypto_sign_ed25519_keypair(publicKey, privateKey);
@@ -292,18 +303,24 @@ void DnsCryptContext::getDecryptedQuery(std::shared_ptr<DnsCryptQuery> query, bo
   memcpy(nonce, &query->header.clientNonce, sizeof(query->header.clientNonce));
   memset(nonce + sizeof(query->header.clientNonce), 0, sizeof(nonce) - sizeof(query->header.clientNonce));
 
-  /* we could compute and store the intermediary shared key, in order to not having to compute it a second
-     time for the response:
-     - crypto_box_beforenm() into an unsigned char[crypto_box_BEFORENMBYTES]
-     - crypto_box_open_easy_afternm()
-     - crypto_box_easy_afternm()
-  */
-  int res = crypto_box_open_easy((unsigned char*) packet,
-                                 (unsigned char*) packet + sizeof(DnsCryptQueryHeader),
-                                 packetSize - sizeof(DnsCryptQueryHeader),
-                                 nonce,
-                                 query->header.clientPK,
-                                 query->useOldCert ? oldPrivateKey.key : privateKey.key);
+  int res = 0;
+  if (!query->sharedKeyComputed) {
+    res = crypto_box_beforenm(query->sharedKey,
+                              query->header.clientPK,
+                              query->useOldCert ? oldPrivateKey.key : privateKey.key);
+
+    if (res != 0) {
+      vinfolog("Dropping encrypted query we can't compute the shared key for");
+      return;
+    }
+    query->sharedKeyComputed = true;
+  }
+
+  res = crypto_box_open_easy_afternm((unsigned char*) packet,
+                                     (unsigned char*) packet + sizeof(DnsCryptQueryHeader),
+                                     packetSize - sizeof(DnsCryptQueryHeader),
+                                     nonce,
+                                     query->sharedKey);
 
   if (res != 0) {
     vinfolog("Dropping encrypted query we can't decrypt");
@@ -452,13 +469,25 @@ int DnsCryptContext::encryptResponse(char* response, uint16_t responseLen, uint1
   pos++;
   memset(response + pos, 0, paddingSize - 1);
   pos += (paddingSize - 1);
+
   /* encrypting */
-  int res = crypto_box_easy((unsigned char*) (response + sizeof(header)),
-                            (unsigned char*) (response + toEncryptPos),
-                            responseLen + paddingSize,
-                            header.nonce,
-                            query->header.clientPK,
-                            query->useOldCert ? oldPrivateKey.key : privateKey.key);
+  int res = 0;
+  if (!query->sharedKeyComputed) {
+    res = crypto_box_beforenm(query->sharedKey,
+                              query->header.clientPK,
+                              query->useOldCert ? oldPrivateKey.key : privateKey.key);
+
+    if (res != 0) {
+      return res;
+    }
+    query->sharedKeyComputed = true;
+  }
+
+  res = crypto_box_easy_afternm((unsigned char*) (response + sizeof(header)),
+                                (unsigned char*) (response + toEncryptPos),
+                                responseLen + paddingSize,
+                                header.nonce,
+                                query->sharedKey);
 
   if (res == 0) {
     assert(pos == requiredSize);

--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -88,26 +88,6 @@ struct DnsCryptQueryHeader
 
 static_assert(sizeof(DnsCryptQueryHeader) == 52, "Dnscrypt query header size should be 52!");
 
-class DnsCryptQuery
-{
-public:
-  DnsCryptQuery();
-  ~DnsCryptQuery();
-  static const size_t minUDPLength = 256;
-
-  DnsCryptQueryHeader header;
-  unsigned char sharedKey[crypto_box_BEFORENMBYTES];
-  DNSName qname;
-  DnsCryptContext* ctx;
-  uint16_t id{0};
-  uint16_t len{0};
-  uint16_t paddedLen;
-  bool useOldCert{false};
-  bool encrypted{false};
-  bool valid{false};
-  bool sharedKeyComputed{false};
-};
-
 struct DnsCryptResponseHeader
 {
   const unsigned char resolverMagic[DNSCRYPT_RESOLVER_MAGIC_SIZE] = DNSCRYPT_RESOLVER_MAGIC;
@@ -123,6 +103,30 @@ public:
   void saveToFile(const std::string& keyFile) const;
 
   unsigned char key[DNSCRYPT_PRIVATE_KEY_SIZE];
+};
+
+class DnsCryptQuery
+{
+public:
+  DnsCryptQuery()
+  {
+  }
+  ~DnsCryptQuery();
+  int computeSharedKey(const DnsCryptPrivateKey& privateKey);
+
+  static const size_t minUDPLength = 256;
+
+  DnsCryptQueryHeader header;
+  unsigned char sharedKey[crypto_box_BEFORENMBYTES];
+  DNSName qname;
+  DnsCryptContext* ctx;
+  uint16_t id{0};
+  uint16_t len{0};
+  uint16_t paddedLen;
+  bool useOldCert{false};
+  bool encrypted{false};
+  bool valid{false};
+  bool sharedKeyComputed{false};
 };
 
 class DnsCryptContext

--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -91,9 +91,12 @@ static_assert(sizeof(DnsCryptQueryHeader) == 52, "Dnscrypt query header size sho
 class DnsCryptQuery
 {
 public:
+  DnsCryptQuery();
+  ~DnsCryptQuery();
   static const size_t minUDPLength = 256;
 
   DnsCryptQueryHeader header;
+  unsigned char sharedKey[crypto_box_BEFORENMBYTES];
   DNSName qname;
   DnsCryptContext* ctx;
   uint16_t id{0};
@@ -102,6 +105,7 @@ public:
   bool useOldCert{false};
   bool encrypted{false};
   bool valid{false};
+  bool sharedKeyComputed{false};
 };
 
 struct DnsCryptResponseHeader


### PR DESCRIPTION
### Short description
Instead of computing the shared-key derived from the public and private keys twice -when decrypting the query and when encrypting the response- we now store and reuse the shared key.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code

