### PR TITLE
dnsdist: Merge the client and server nonces to prevent replay attacks

### DIFF
--- a/pdns/sodcrypto.hh
+++ b/pdns/sodcrypto.hh
@@ -29,9 +29,10 @@
 #ifndef HAVE_LIBSODIUM
 struct SodiumNonce
 {
-	void init(){};
-	void increment(){};
-	unsigned char value[1];
+  void init(){};
+  void merge(const SodiumNonce& lower, const SodiumNonce& higher) {};
+  void increment(){};
+  unsigned char value[1];
 };
 #else
 #include <sodium.h>
@@ -42,7 +43,14 @@ struct SodiumNonce
   {
     randombytes_buf(value, sizeof value);
   }
-  
+
+  void merge(const SodiumNonce& lower, const SodiumNonce& higher)
+  {
+    static const size_t halfSize = (sizeof value) / 2;
+    memcpy(value, lower.value, halfSize);
+    memcpy(value + halfSize, higher.value + halfSize, halfSize);
+  }
+
   void increment()
   {
     uint32_t* p = (uint32_t*)value;

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -371,11 +371,15 @@ class DNSDistTest(unittest.TestCase):
         sock.send(ourNonce)
         theirNonce = sock.recv(len(ourNonce))
 
-        msg = cls._encryptConsole(command, ourNonce)
+        halfNonceSize = len(ourNonce) / 2
+        readingNonce = ourNonce[0:halfNonceSize] + theirNonce[halfNonceSize:]
+        writingNonce = theirNonce[0:halfNonceSize] + ourNonce[halfNonceSize:]
+
+        msg = cls._encryptConsole(command, writingNonce)
         sock.send(struct.pack("!I", len(msg)))
         sock.send(msg)
         data = sock.recv(4)
         (responseLen,) = struct.unpack("!I", data)
         data = sock.recv(responseLen)
-        response = cls._decryptConsole(data, theirNonce)
+        response = cls._decryptConsole(data, readingNonce)
         return response


### PR DESCRIPTION
### Short description

Instead of using the local nonce to send messages (and so the remote one for received ones), split and merge the local and remote nonces to create two new nonces, one for client to server and one for server
to client.
This makes us more resistant against reply attacks, but note that it does break compatibility with previous versions.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code

