### PR TITLE
Send a notification to all slave servers after every dnsupdate.

### DIFF
--- a/docs/markdown/authoritative/dnsupdate.md
+++ b/docs/markdown/authoritative/dnsupdate.md
@@ -88,6 +88,15 @@ sql> insert into domainmetadata(domain_id, kind, content) values(5, ‘FORWARD-D
 
 There is no content, the existence of the entry enables the forwarding. This domain-specific setting is only useful when the configuration option **forward-dnsupdate** is set to 'no', as that will disable it globally. Using the domainmetadata setting than allows you to enable it per domain.
 
+## NOTIFY-DNSUPDATE
+Send a notification to all slave servers after every update. This will speed up the propagation of changes and is very usefull for acme verification.
+
+```
+sql> select id from domains where name='example.org';
+5
+sql> insert into domainmetadata(domain_id, kind, content) values(5, ‘NOTIFY-DNSUPDATE’,’1’);
+```
+
 ## SOA-EDIT-DNSUPDATE
 This configures how the soa serial should be updated. See [below](#soa-serial-updates).
 

--- a/docs/markdown/authoritative/domainmetadata.md
+++ b/docs/markdown/authoritative/domainmetadata.md
@@ -33,7 +33,7 @@ To dissallow all IP's, except those explicitly allowed by domainmetadata records
 ## AXFR-SOURCE
 The IP address to use as a source address for sending AXFR and IXFR requests.
 
-## ALLOW-DNSUPDATE-FROM, TSIG-ALLOW-DNSUPDATE, FORWARD-DNSUPDATE, SOA-EDIT-DNSUPDATE
+## ALLOW-DNSUPDATE-FROM, TSIG-ALLOW-DNSUPDATE, FORWARD-DNSUPDATE, SOA-EDIT-DNSUPDATE, NOTIFY-DNSUPDATE
 See the documentation on [Dynamic DNS update](dnsupdate.md)
 
 ## ALSO-NOTIFY

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -14,9 +14,11 @@
 #include "resolver.hh"
 #include "dns_random.hh"
 #include "backends/gsql/ssql.hh"
+#include "communicator.hh"
 
 extern PacketCache PC;
 extern StatBag S;
+extern CommunicatorClass Communicator;
 
 pthread_mutex_t PacketHandler::s_rfc2136lock=PTHREAD_MUTEX_INITIALIZER;
 
@@ -968,6 +970,15 @@ int PacketHandler::processUpdate(DNSPacket *p) {
       string zone(di.zone.toString());
       zone.append("$");
       PC.purge(zone);
+
+      // Notify slaves
+      if (di.kind == DomainInfo::Master) {
+        vector<string> notify;
+        B.getDomainMetadata(p->qdomain, "NOTIFY-DNSUPDATE", notify);
+        if (!notify.empty() && notify.front() == "1") {
+          Communicator.notifyDomain(di.zone);
+        }
+      }
 
       L<<Logger::Info<<msgPrefix<<"Update completed, "<<changedRecords<<" changed records committed."<<endl;
     } else {


### PR DESCRIPTION
This will speed up the propagation of changes and is very usefull for acme verification.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
