### PR TITLE
Document webserver=yes is needed for API until 4.1.0

### DIFF
--- a/docs/markdown/httpapi/README.md
+++ b/docs/markdown/httpapi/README.md
@@ -18,6 +18,8 @@ Then configure as follows:
 
     api=yes
     api-key=changeme
+    # Needed before 4.1.0
+    webserver=yes
 
 
 After restarting `pdns_server`, the following examples should start working:


### PR DESCRIPTION
536ab56f5d6e3f657c787c2e6be1a55c7a422241 removed the need for webserver=yes in pdns.conf when api=yes but that hasn't made it to a stable release. This ensures the documentation provides a working configuration for new users.