### PR TITLE
Remove hardcoded tld names co.za, co.il

### DIFF
--- a/pdns/mkpubsuffixcc
+++ b/pdns/mkpubsuffixcc
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 (echo "const char* g_pubsuffix[]={"; 
-	for a in $(grep -v "//" effective_tld_names.dat  | grep \\. | egrep "^[.0-9a-z-]*$" ; echo "co.za" ; echo "co.il" )
+	for a in $(grep -v "//" effective_tld_names.dat  | grep \\. | egrep "^[.0-9a-z-]*$")
 	do 
 		echo \"$a\",
 	done 


### PR DESCRIPTION
These are already in the current public suffix list.
