### PR TITLE
nsec ent-asterisk test is no longer bogus with unbound 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
  - touch tests/verify-dnssec-zone/allow-missing
  - touch tests/verify-dnssec-zone/skip.nsec3 # some (travis) tools in this test are unable to handle nsec3 zones
  - touch tests/verify-dnssec-zone/skip.optout
+ - touch tests/ent-asterisk/skip.nsec # travis unbound is too old for this test (unbound 1.6.0 required)
  - export geoipregion=oc geoipregionip=1.2.3.4
  - ./timestamp ./start-test-stop 5300 bind-both
  - ./timestamp ./start-test-stop 5300 bind-dnssec-both

--- a/regression-tests/backends/bind-master
+++ b/regression-tests/backends/bind-master
@@ -82,7 +82,7 @@ __EOF__
 			skipreasons="narrow nodyndns"
 		else
 			extracontexts="bind dnssec"
-			skipreasons="nodyndns"
+			skipreasons="nodyndns nsec"
 		fi
 
 		../pdns/pdnssec --config-dir=. --config-name=bind import-tsig-key test $ALGORITHM $KEY

--- a/regression-tests/backends/gsql-common
+++ b/regression-tests/backends/gsql-common
@@ -52,6 +52,6 @@ gsql-master()
 		skipreasons="$skipreasons nodnssec"
 	else
 		extracontexts="dnssec"
-		skipreasons="$skipreasons"
+		skipreasons="$skipreasons nsec"
 	fi
 }

--- a/regression-tests/tests/ent-asterisk/expected_result.dnssec
+++ b/regression-tests/tests/ent-asterisk/expected_result.dnssec
@@ -7,4 +7,3 @@
 2	.	IN	OPT	32768	
 Rcode: 0, RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='sub.host.sub.example.com.', qtype=A
-./tests/ent-asterisk/unbound-host.out:sub.host.sub.example.com has no address (BOGUS (security failure))


### PR DESCRIPTION
### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code

