### PR TITLE
nsec ent-asterisk test is no longer bogus with unbound 1.6.0

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -439,6 +439,9 @@ test_auth() {
 
   run "cd regression-tests"
 
+  #travis unbound is too old for this test (unbound 1.6.0 required)
+  run "touch tests/ent-asterisk/fail.nsec"
+
   run "./timestamp ./start-test-stop 5300 ldap-tree"
   run "./timestamp ./start-test-stop 5300 ldap-simple"
   run "./timestamp ./start-test-stop 5300 ldap-strict"
@@ -490,6 +493,9 @@ test_auth() {
   run "./timestamp ./start-test-stop 5300 remotebackend-zeromq-dnssec"
 
   run "./timestamp ./start-test-stop 5300 tinydns"
+
+  run "rm tests/ent-asterisk/fail.nsec"
+
   run "cd .."
 
   run "cd regression-tests.rootzone"

--- a/regression-tests/backends/bind-master
+++ b/regression-tests/backends/bind-master
@@ -85,7 +85,7 @@ __EOF__
 			skipreasons="narrow nodyndns noalias"
 		else
 			extracontexts="bind dnssec"
-			skipreasons="nodyndns noalias"
+			skipreasons="nodyndns noalias nsec"
 		fi
 
 		$RUNWRAPPER $PDNS --daemon=no --local-port=$port --config-dir=. \

--- a/regression-tests/backends/gsql-common
+++ b/regression-tests/backends/gsql-common
@@ -58,6 +58,6 @@ gsql_master()
 		skipreasons="$skipreasons nodnssec"
 	else
 		extracontexts="dnssec"
-		skipreasons="$skipreasons"
+		skipreasons="$skipreasons nsec"
 	fi
 }

--- a/regression-tests/tests/ent-asterisk/expected_result.dnssec
+++ b/regression-tests/tests/ent-asterisk/expected_result.dnssec
@@ -7,4 +7,3 @@
 2	.	IN	OPT	32768	
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='sub.host.sub.example.com.', qtype=A
-./tests/ent-asterisk/unbound-host.out:sub.host.sub.example.com has no address (BOGUS (security failure))


### PR DESCRIPTION
### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
