### PR TITLE
It turns out our use of getaddrinfo in communicator.hh would be retur…

### DIFF
--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -275,7 +275,7 @@ private:
     struct addrinfo* res;
     struct addrinfo hints;
     memset(&hints, 0, sizeof(hints));
-
+    hints.ai_socktype = SOCK_DGRAM; // otherwise we get everything in triplicate (!)
     for(int n = 0; n < 2; ++n) {
       hints.ai_family = n ? AF_INET : AF_INET6;
       ComboAddress remote;


### PR DESCRIPTION
…ning all addresses in triplicate (one for each socket type). See https://bugzilla.mozilla.org/show_bug.cgi?id=223811

We may have filtered this out at a later stage, but it was wrong in any case.

### Short description
When looking up IPv4 or IPv6 addresses to notify in the communicator class, getaddrinfo would give us all addresses in triplicate.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
