### PR TITLE
dnsdist: Clarify docs: `maintenance()`, cache memory usage and `exceed*`

### DIFF
--- a/pdns/dnsdistdist/website/markdown/index.md
+++ b/pdns/dnsdistdist/website/markdown/index.md
@@ -17,9 +17,9 @@ Finally, the DNS-OARC presentation is [here](https://indico.dns-oarc.net/event/2
 ([VIDEO!](https://www.youtube.com/watch?feature=player_embedded&v=PX3YYmBER7E#t=6403)).
 
 # Getting dnsdist
-Grab the master, 1.0 or pre-release packages from [our
-repositories](https://repo.powerdns.com).  The announcement of 1.0.0 is
-[here](https://blog.powerdns.com/2016/04/21/dnsdist-1-0-0-released/).
+Grab the latest 1.1 release or development packages from [our
+repositories](https://repo.powerdns.com).  The announcement of 1.1.0 is
+[here](https://blog.powerdns.com/2016/12/29/dnsdist-1-1-0-released/).
 
 ## Compiling dnsdist
 Prefer to compile yourself? Checkout the instructions on [the download page](download.md).


### PR DESCRIPTION
### Short description
* Update the website for the 1.1.0 release
* Document how `maintenance()` is called
* Document the packet cache memory usage
* Document the return value of `exceed*` functions

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
