### PR TITLE
Change truncateTC to defaulting to off

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1406,7 +1406,7 @@ instantiate a server with additional parameters
     * `addDelay(netmask, n)`: delay answers within that netmask by n milliseconds
     * `addDelay({netmask, netmask}, n)`: delay answers within those netmasks (together) by n milliseconds
  * Answer changing functions:
-    * `truncateTC(bool)`: if set (default) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22.
+    * `truncateTC(bool)`: if set (default to no) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22. Note: turning this on breaks compatibility with RFC 6891.
     * `fixupCase(bool)`: if set (default to no), rewrite the first qname of the question part of the answer to match the one from the query. It is only useful when you have a downstream server that messes up the case of the question qname in the answer
  * Dynamic Block related:
     * `maintenance()`: called every second by dnsdist if defined, call functions below from it

--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1406,7 +1406,7 @@ instantiate a server with additional parameters
     * `addDelay(netmask, n)`: delay answers within that netmask by n milliseconds
     * `addDelay({netmask, netmask}, n)`: delay answers within those netmasks (together) by n milliseconds
  * Answer changing functions:
-    * `truncateTC(bool)`: if set (default to no) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22. Note: turning this on breaks compatibility with RFC 6891.
+    * `truncateTC(bool)`: if set (defaults to no starting with dnsdist 1.2.0) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22. Note: turning this on breaks compatibility with RFC 6891.
     * `fixupCase(bool)`: if set (default to no), rewrite the first qname of the question part of the answer to match the one from the query. It is only useful when you have a downstream server that messes up the case of the question qname in the answer
  * Dynamic Block related:
     * `maintenance()`: called every second by dnsdist if defined, call functions below from it

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -366,7 +366,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "topResponseRule", true, "", "move the last response rule to the first position" },
   { "topRule", true, "", "move the last rule to the first position" },
   { "topSlow", true, "[top][, limit][, labels]", "show `top` queries slower than `limit` milliseconds, grouped by last `labels` labels" },
-  { "truncateTC", true, "bool", "if set (default) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22" },
+  { "truncateTC", true, "bool", "if set (default to no) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22. Note: turning this one breaks compatibility with RFC 6891." },
   { "unregisterDynBPFFilter", true, "DynBPFFilter", "unregister this dynamic BPF filter" },
   { "webserver", true, "address:port, password [, apiKey [, customHeaders ]])", "launch a webserver with stats on that address with that password" },
   { "whashed", false, "", "Weighted hashed ('sticky') distribution over available servers, based on the server 'weight' parameter" },

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -366,7 +366,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "topResponseRule", true, "", "move the last response rule to the first position" },
   { "topRule", true, "", "move the last rule to the first position" },
   { "topSlow", true, "[top][, limit][, labels]", "show `top` queries slower than `limit` milliseconds, grouped by last `labels` labels" },
-  { "truncateTC", true, "bool", "if set (default to no) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22. Note: turning this one breaks compatibility with RFC 6891." },
+  { "truncateTC", true, "bool", "if set (defaults to no starting with dnsdist 1.2.0) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22. Note: turning this one breaks compatibility with RFC 6891." },
   { "unregisterDynBPFFilter", true, "DynBPFFilter", "unregister this dynamic BPF filter" },
   { "webserver", true, "address:port, password [, apiKey [, customHeaders ]])", "launch a webserver with stats on that address with that password" },
   { "whashed", false, "", "Weighted hashed ('sticky') distribution over available servers, based on the server 'weight' parameter" },

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -366,7 +366,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "topResponseRule", true, "", "move the last response rule to the first position" },
   { "topRule", true, "", "move the last rule to the first position" },
   { "topSlow", true, "[top][, limit][, labels]", "show `top` queries slower than `limit` milliseconds, grouped by last `labels` labels" },
-  { "truncateTC", true, "bool", "if set (defaults to no starting with dnsdist 1.2.0) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22. Note: turning this one breaks compatibility with RFC 6891." },
+  { "truncateTC", true, "bool", "if set (defaults to no starting with dnsdist 1.2.0) truncate TC=1 answers so they are actually empty. Fixes an issue for PowerDNS Authoritative Server 2.9.22. Note: turning this on breaks compatibility with RFC 6891." },
   { "unregisterDynBPFFilter", true, "DynBPFFilter", "unregister this dynamic BPF filter" },
   { "webserver", true, "address:port, password [, apiKey [, customHeaders ]])", "launch a webserver with stats on that address with that password" },
   { "whashed", false, "", "Weighted hashed ('sticky') distribution over available servers, based on the server 'weight' parameter" },

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -136,7 +136,7 @@ int g_tcpSendTimeout{2};
 int g_udpTimeout{2};
 
 bool g_servFailOnNoPolicy{false};
-bool g_truncateTC{1};
+bool g_truncateTC{0};
 bool g_fixupCase{0};
 static void truncateTC(const char* packet, uint16_t* len)
 try

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -136,7 +136,7 @@ int g_tcpSendTimeout{2};
 int g_udpTimeout{2};
 
 bool g_servFailOnNoPolicy{false};
-bool g_truncateTC{0};
+bool g_truncateTC{false};
 bool g_fixupCase{0};
 static void truncateTC(const char* packet, uint16_t* len)
 try


### PR DESCRIPTION
### Short description
Having truncateTC enabled by default causes dnsdist to break compatibility with RFC 6891 by default. Closes #4857

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
