### PR TITLE
rec: Fix `dq` members alterations from Lua not being taken into account

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -665,7 +665,7 @@ bool RecursorLua4::genhook(luacall_t& func, DNSQuestion& dq, int& ret)
   dq.udpCallback.clear();
 
   dq.rcode = ret;
-  bool handled=func(dq);
+  bool handled=func(&dq);
 
   if(handled) {
 loop:;
@@ -688,7 +688,7 @@ loop:;
           theL()<<Logger::Error<<"Attempted callback for Lua UDP Query/Response which could not be found"<<endl;
           return false;
         }
-        bool result=func(dq);
+        bool result=func(&dq);
         if(!result) {
           return false;
         }

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -120,7 +120,7 @@ public:
   gettag_t d_gettag; // public so you can query if we have this hooked
 
 private:
-  typedef std::function<bool(DNSQuestion&)> luacall_t;
+  typedef std::function<bool(DNSQuestion*)> luacall_t;
   luacall_t d_prerpz, d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
   bool genhook(luacall_t& func, DNSQuestion& dq, int& ret);
   typedef std::function<bool(ComboAddress,ComboAddress, struct dnsheader)> ipfilter_t;

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -118,6 +118,7 @@ not-auth-zone.example.net. 3600 IN NS ns.not-auth-zone.example.net.
 ns.not-auth-zone.example.net. 3600 IN A $PREFIX.23
 lowercase-outgoing.example.net. 3600 IN NS ns.lowercase-outgoing.example.net.
 ns.lowercase-outgoing.example.net. 3600 IN A $PREFIX.24
+nxdomainme.example.net.            3600 IN A $PREFIX.25
 EOF
 
 mkdir $PREFIX.11
@@ -598,6 +599,10 @@ function prerpz(dq)
 end
 
 function preresolve(dq)
+  if dq.qname:equal("nxdomainme.example.net") then
+    dq.rcode = pdns.NXDOMAIN
+    return true
+  end
   if dq.qname:equal("android.marvin.example.net") then
     dq.wantsRPZ = false -- disable RPZ
   end

--- a/regression-tests.recursor/preresolve-nxdomain/command
+++ b/regression-tests.recursor/preresolve-nxdomain/command
@@ -1,0 +1,1 @@
+$SDIG $nameserver 5301 nxdomainme.example.net a recurse hidettl 2>&1

--- a/regression-tests.recursor/preresolve-nxdomain/description
+++ b/regression-tests.recursor/preresolve-nxdomain/description
@@ -1,0 +1,2 @@
+Test if we can correctly fake a NXDOMAIN answer from Lua preresolve
+

--- a/regression-tests.recursor/preresolve-nxdomain/expected_result
+++ b/regression-tests.recursor/preresolve-nxdomain/expected_result
@@ -1,0 +1,2 @@
+Reply to question for qname='nxdomainme.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0


### PR DESCRIPTION
### Short description
Passing the `dq` object by reference to the hook resulted in the object being passed by value to the `Lua` function, so non-pointer and non-reference members like `rcode`, `tag` were not correctly altered.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
