### PR TITLE
jdnssec-tools 0.13 has been released

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -240,8 +240,8 @@ install_auth() {
     jq"
 
   run "cd .."
-  run "wget https://www.verisignlabs.com/dnssec-tools/packages/jdnssec-tools-0.12.tar.gz"
-  run "sudo tar xfz jdnssec-tools-0.12.tar.gz --strip-components=1 -C /"
+  run "wget https://www.verisignlabs.com/dnssec-tools/packages/jdnssec-tools-0.13.tar.gz"
+  run "sudo tar xfz jdnssec-tools-0.13.tar.gz --strip-components=1 -C /"
   run "cd pdns"
 
   # pkcs11 test requirements / setup


### PR DESCRIPTION
### Short description
Update the link in our travis script since we use `jdnssec` in our authoritative tests and 0.12 has been moved to the `old-releases` directory.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

