### PR TITLE
servfail-ttl: reduce from 60 to 5, and cap at 60

### DIFF
--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -668,13 +668,14 @@ the original TTL specified.
 
 ## `packetcache-servfail-ttl`
 * Integer
-* Default: 60
+* Default: 5 (since 4.1.0), 60 (before 4.1.0)
 * Available since: 3.2
 
 Maximum number of seconds to cache a 'server failure' answer in the packet cache.
 From 4.0.0 onward, this settings maximum is capped to [`packetcache-ttl`](#packetcache-ttl).
-i.e. setting `packetcache-ttl=15` and keeping `packetcache-servfail-ttl` at the
-default will lower `packetcache-servfail-ttl` to `15`.
+i.e. setting `packetcache-ttl=0` and keeping `packetcache-servfail-ttl` at the
+default will lower `packetcache-servfail-ttl` to `0`.
+From 4.1.0 onward, this setting is additionally capped at 60.
 
 ## `pdns-distributes-queries`
 * Boolean

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2754,6 +2754,8 @@ int serviceMain(int argc, char*argv[])
   SyncRes::s_packetcachettl=::arg().asNum("packetcache-ttl");
   // Cap the packetcache-servfail-ttl to the packetcache-ttl
   uint32_t packetCacheServFailTTL = ::arg().asNum("packetcache-servfail-ttl");
+  if (packetCacheServFailTTL > 60)
+    packetCacheServFailTTL = 60;
   SyncRes::s_packetcacheservfailttl=(packetCacheServFailTTL > SyncRes::s_packetcachettl) ? SyncRes::s_packetcachettl : packetCacheServFailTTL;
   SyncRes::s_serverdownmaxfails=::arg().asNum("server-down-max-fails");
   SyncRes::s_serverdownthrottletime=::arg().asNum("server-down-throttle-time");
@@ -3083,7 +3085,7 @@ int main(int argc, char **argv)
     ::arg().set("max-cache-ttl", "maximum number of seconds to keep a cached entry in memory")="86400";
     ::arg().set("packetcache-ttl", "maximum number of seconds to keep a cached entry in packetcache")="3600";
     ::arg().set("max-packetcache-entries", "maximum number of entries to keep in the packetcache")="500000";
-    ::arg().set("packetcache-servfail-ttl", "maximum number of seconds to keep a cached servfail entry in packetcache")="60";
+    ::arg().set("packetcache-servfail-ttl", "maximum number of seconds to keep a cached servfail entry in packetcache")="5";
     ::arg().set("server-id", "Returned when queried for 'server.id' TXT or NSID, defaults to hostname")="";
     ::arg().set("stats-ringbuffer-entries", "maximum number of packets to store statistics for")="10000";
     ::arg().set("version-string", "string reported on version.pdns or version.bind")=fullVersionString();


### PR DESCRIPTION
According to http://tools.ietf.org/html/rfc2308#section-7.1,
server failure MUST NOT be cached for longer than 5 minutes.

In reality, caching server failure for an extended period of time
is be detrimental for client experience, where a short period of
downtime would then be amplified to a prolonged DNS outage.

This has been pointed out many years ago by DJB:

http://cr.yp.to/djbdns/third-party.html

>  The second tactic is to claim that widespread DNS clients will do something Particularly Evil when they are unable to reach all DNS servers. The problem with this argument is that the claim is false. Any such client is clearly buggy, and will be unable to survive in the marketplace: consider what happens if the *client's* routers briefly go down, or if the client's network is temporarily flooded.

Let's try not to do anything *Particularly Evil*. :-)

Additionally, when BIND first introduced this feature, it was set at 10 with a cap of 300, but was subsequently found to be detrimental, supposedly turned off for a release or two, and then came back with a default of 1 second (in place of the original 10), and a cap of 30 (in place of the original 300).

* https://source.isc.org/cgi-bin/gitweb.cgi?p=bind9.git;a=commit;h=a8783019814daa36dd57afe3f527462822834c3b

* https://kb.isc.org/article/AA-01178/

* https://source.isc.org/cgi-bin/gitweb.cgi?p=bind9.git;a=commit;h=90174e64f49bb7cba6a83fb665ebcb597aad7b57

Personally, I think any double-digit number should definitely not be the default.  On the other hand, `1s` is so small as to make it difficult to ascertain whether or not any cache is active in the first place.  I think `5s` may be the sweet spot of caching a failure, yet only enough for a couple of refresh clicks per user max (or maybe we should even go to `2s` or even `1s`, because software is meant for production, not for testing whether or not the caching works).

As for the cap, I think it's likewise important to ensure that admins cannot shoot their own users into the foot; I think 60s would be the sweet spot between pragmatism (cap is 30s in BIND) and flexibility (after all, 60s was the default in a few prior versions of PowerDNS).  I don't think it would be reasonable for anyone to cache failures for over a minute.