### PR TITLE
Don't parse spurious RRs in queries when we don't need them

### DIFF
--- a/pdns/comfun.cc
+++ b/pdns/comfun.cc
@@ -120,7 +120,7 @@ struct SendReceive
       }
       // parse packet, set 'id', fill out 'ip' 
       
-      MOADNSParser mdp(string(buf, len));
+      MOADNSParser mdp(false, string(buf, len));
       if(!g_quiet) {
         cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
         cout<<"Rcode: "<<mdp.d_header.rcode<<", RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr;
@@ -251,7 +251,7 @@ struct SendReceiveRes
       }
       // parse packet, set 'id', fill out 'ip' 
       
-      MOADNSParser mdp(string(buf, len));
+      MOADNSParser mdp(false, string(buf, len));
       if(!g_quiet) {
         cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
         cout<<"Rcode: "<<mdp.d_header.rcode<<", RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr<<", answers: "<<mdp.d_answers.size();

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -350,8 +350,8 @@ void *qthread(void *number)
   DNSDistributor *distributor = DNSDistributor::Create(::arg().asNum("distributor-threads", 1)); // the big dispatcher!
   int num = (int)(unsigned long)number;
   g_distributors[num] = distributor;
-  DNSPacket question;
-  DNSPacket cached;
+  DNSPacket question(true);
+  DNSPacket cached(false);
 
   AtomicCounter &numreceived=*S.getPointer("udp-queries");
   AtomicCounter &numreceiveddo=*S.getPointer("udp-do-queries");

--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -142,7 +142,7 @@ struct SendReceive
       }
       // parse packet, set 'id', fill out 'ip' 
       
-      MOADNSParser mdp(string(buf, len));
+      MOADNSParser mdp(false, string(buf, len));
       if(!g_quiet) {
         cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
         cout<<"Rcode: "<<mdp.d_header.rcode<<", RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr;

--- a/pdns/dnsdemog.cc
+++ b/pdns/dnsdemog.cc
@@ -70,7 +70,7 @@ try
           if(dh->rd || dh->qr)
             continue;
 
-          MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+          MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
 
           entry.ip = pr.getSource();
           entry.port = pr.d_udp->uh_sport;

--- a/pdns/dnsgram.cc
+++ b/pdns/dnsgram.cc
@@ -157,7 +157,7 @@ try
           ntohs(pr.d_udp->uh_dport)==53   || ntohs(pr.d_udp->uh_sport)==53) &&
          pr.d_len > 12) {
         try {
-          MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+          MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
 
           if(lastreport.tv_sec == 0) {
             lastreport = pr.d_pheader.ts;

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -52,7 +52,7 @@
 bool DNSPacket::s_doEDNSSubnetProcessing;
 uint16_t DNSPacket::s_udpTruncationThreshold;
  
-DNSPacket::DNSPacket() 
+DNSPacket::DNSPacket(bool isQuery)
 {
   d_wrapped=false;
   d_compress=true;
@@ -70,6 +70,7 @@ DNSPacket::DNSPacket()
   d_maxreplylen = 0;
   d_tsigtimersonly = false;
   d_haveednssection = false;
+  d_isQuery = isQuery;
 }
 
 const string& DNSPacket::getString()
@@ -380,7 +381,7 @@ void DNSPacket::setQuestion(int op, const DNSName &qd, int newqtype)
 /** convenience function for creating a reply packet from a question packet. Do not forget to delete it after use! */
 DNSPacket *DNSPacket::replyPacket() const
 {
-  DNSPacket *r=new DNSPacket;
+  DNSPacket *r=new DNSPacket(false);
   r->setSocket(d_socket);
   r->d_anyLocal=d_anyLocal;
   r->setRemote(&d_remote);
@@ -461,7 +462,7 @@ void DNSPacket::setTSIGDetails(const TSIGRecordContent& tr, const DNSName& keyna
 
 bool DNSPacket::getTSIGDetails(TSIGRecordContent* trc, DNSName* keyname, string* message) const
 {
-  MOADNSParser mdp(d_rawpacket);
+  MOADNSParser mdp(d_isQuery, d_rawpacket);
 
   if(!mdp.getTSIGPos()) 
     return false;
@@ -490,7 +491,7 @@ bool DNSPacket::getTSIGDetails(TSIGRecordContent* trc, DNSName* keyname, string*
 
 bool DNSPacket::getTKEYRecord(TKEYRecordContent *tr, DNSName *keyname) const
 {
-  MOADNSParser mdp(d_rawpacket);
+  MOADNSParser mdp(d_isQuery, d_rawpacket);
   bool gotit=false;
 
   for(MOADNSParser::answers_t::const_iterator i=mdp.d_answers.begin(); i!=mdp.d_answers.end(); ++i) {
@@ -530,7 +531,7 @@ try
     return -1;
   }
 
-  MOADNSParser mdp(d_rawpacket);
+  MOADNSParser mdp(d_isQuery, d_rawpacket);
   EDNSOpts edo;
 
   // ANY OPTION WHICH *MIGHT* BE SET DOWN BELOW SHOULD BE CLEARED FIRST!

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -63,7 +63,7 @@ class DNSSECKeeper;
 class DNSPacket
 {
 public:
-  DNSPacket();
+  DNSPacket(bool isQuery);
   DNSPacket(const DNSPacket &orig);
 
   int noparse(const char *mesg, size_t len); //!< just suck the data inward
@@ -191,6 +191,7 @@ private:
   bool d_wantsnsid;
   bool d_haveednssubnet;
   bool d_haveednssection;
+  bool d_isQuery;
 };
 
 

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -116,7 +116,7 @@ shared_ptr<DNSRecordContent> DNSRecordContent::unserialize(const DNSName& qname,
   memcpy(&packet[pos], &drh, sizeof(drh)); pos+=sizeof(drh);
   memcpy(&packet[pos], serialized.c_str(), serialized.size()); pos+=(uint16_t)serialized.size();
 
-  MOADNSParser mdp((char*)&*packet.begin(), (unsigned int)packet.size());
+  MOADNSParser mdp(false, (char*)&*packet.begin(), (unsigned int)packet.size());
   shared_ptr<DNSRecordContent> ret= mdp.d_answers.begin()->first.d_content;
   return ret;
 }
@@ -211,7 +211,7 @@ DNSRecord::DNSRecord(const DNSResourceRecord& rr)
   d_content = std::shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(d_type, rr.qclass, rr.content));
 }
 
-void MOADNSParser::init(const char *packet, unsigned int len)
+void MOADNSParser::init(bool query, const char *packet, unsigned int len)
 {
   if(len < sizeof(dnsheader))
     throw MOADNSException("Packet shorter than minimal header");
@@ -225,7 +225,10 @@ void MOADNSParser::init(const char *packet, unsigned int len)
   d_header.ancount=ntohs(d_header.ancount);
   d_header.nscount=ntohs(d_header.nscount);
   d_header.arcount=ntohs(d_header.arcount);
-  
+
+  if (query && (d_header.qdcount > 1))
+    throw MOADNSException("Query with QD > 1 ("+std::to_string(d_header.qdcount)+")");
+
   uint16_t contentlen=len-sizeof(dnsheader);
 
   d_content.resize(contentlen);
@@ -270,7 +273,15 @@ void MOADNSParser::init(const char *packet, unsigned int len)
       dr.d_name=name;
       dr.d_clen=ah.d_clen;
 
-      dr.d_content=std::shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(dr, pr, d_header.opcode));
+      if (query && (dr.d_place == DNSResourceRecord::ANSWER || dr.d_place == DNSResourceRecord::AUTHORITY || (dr.d_type != QType::OPT && dr.d_type != QType::TSIG && dr.d_type != QType::SIG && dr.d_type != QType::TKEY) || ((dr.d_type == QType::TSIG || dr.d_type == QType::SIG || dr.d_type == QType::TKEY) && dr.d_class != QClass::ANY))) {
+//        cerr<<"discarding RR, query is "<<query<<", place is "<<dr.d_place<<", type is "<<dr.d_type<<", class is "<<dr.d_class<<endl;
+        dr.d_content=std::shared_ptr<DNSRecordContent>(new UnknownRecordContent(dr, pr));
+      }
+      else {
+//        cerr<<"parsing RR, query is "<<query<<", place is "<<dr.d_place<<", type is "<<dr.d_type<<", class is "<<dr.d_class<<endl;
+        dr.d_content=std::shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(dr, pr, d_header.opcode));
+      }
+
       d_answers.push_back(make_pair(dr, pr.d_pos));
 
       if(dr.d_type == QType::TSIG && dr.d_class == 0xff) 

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -343,15 +343,15 @@ class MOADNSParser : public boost::noncopyable
 {
 public:
   //! Parse from a string
-  MOADNSParser(const string& buffer)  : d_tsigPos(0)
+  MOADNSParser(bool query, const string& buffer)  : d_tsigPos(0)
   {
-    init(buffer.c_str(), (unsigned int)buffer.size());
+    init(query, buffer.c_str(), (unsigned int)buffer.size());
   }
 
   //! Parse from a pointer and length
-  MOADNSParser(const char *packet, unsigned int len) : d_tsigPos(0)
+  MOADNSParser(bool query, const char *packet, unsigned int len) : d_tsigPos(0)
   {
-    init(packet, len);
+    init(query, packet, len);
   }
 
   DNSName d_qname;
@@ -377,7 +377,7 @@ public:
   }
 private:
   void getDnsrecordheader(struct dnsrecordheader &ah);
-  void init(const char *packet, unsigned int len);
+  void init(bool query, const char *packet, unsigned int len);
   vector<uint8_t> d_content;
   uint16_t d_tsigPos;
 };

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -228,7 +228,7 @@ void DNSProxy::mainloop(void)
         d.id=i->second.id;
         memcpy(buffer,&d,sizeof(d));  // commit spoofed id
 
-        DNSPacket p,q;
+        DNSPacket p(false),q(false);
         p.parse(buffer,(size_t)len);
         q.parse(buffer,(size_t)len);
 
@@ -243,7 +243,7 @@ void DNSProxy::mainloop(void)
 	string reply; // needs to be alive at time of sendmsg!
 	if(i->second.complete) {
 
-	  MOADNSParser mdp(p.getString());
+	  MOADNSParser mdp(false, p.getString());
 	  //	  cerr<<"Got completion, "<<mdp.d_answers.size()<<" answers, rcode: "<<mdp.d_header.rcode<<endl;
 	  for(MOADNSParser::answers_t::const_iterator j=mdp.d_answers.begin(); j!=mdp.d_answers.end(); ++j) {        
 	    //	    cerr<<"comp: "<<(int)j->first.d_place-1<<" "<<j->first.d_label<<" " << DNSRecordContent::NumberToType(j->first.d_type)<<" "<<j->first.d_content->getZoneRepresentation()<<endl;

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -421,7 +421,7 @@ try
   while(s_socket->recvFromAsync(packet, remote)) {
     try {
       s_weanswers++;
-      MOADNSParser mdp(packet.c_str(), packet.length());
+      MOADNSParser mdp(false, packet.c_str(), packet.length());
       if(!mdp.d_header.qr) {
         cout<<"Received a question from our reference nameserver!"<<endl;
         continue;
@@ -628,7 +628,7 @@ bool sendPacketFromPR(PcapPacketReader& pr, const ComboAddress& remote, int stam
       sent=true;
       dh->id=tmp;
     }
-    MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+    MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
     QuestionIdentifier qi=QuestionIdentifier::create(pr.getSource(), pr.getDest(), mdp);
 
     if(!mdp.d_header.qr) {

--- a/pdns/dnsscan.cc
+++ b/pdns/dnsscan.cc
@@ -87,7 +87,7 @@ try
     
     while(pr.getUDPPacket()) {
       try {
-        MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+        MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
         if(mdp.d_qtype < 256)
           counts[mdp.d_qtype]++;
 

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -217,7 +217,7 @@ try
 	      continue;
 	    }
 	  }
-	  MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+	  MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
 	  if(haveRDFilter && mdp.d_header.rd != rdFilter) {
 	    rdFilterMismatch++;
 	    continue;

--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -98,7 +98,7 @@ try
     q->udpUsec = makeUsec(now - tv);
     tv=now;
 
-    MOADNSParser mdp(reply);
+    MOADNSParser mdp(false, reply);
     if(!mdp.d_header.tc)
       return;
     g_truncates++;
@@ -148,7 +148,7 @@ try
   q->tcpUsec = makeUsec(now - tv);
   q->answerSecond = now.tv_sec;
 
-  MOADNSParser mdp(reply);
+  MOADNSParser mdp(false, reply);
   //  cout<<"Had correct TCP/IP response, "<<mdp.d_answers.size()<<" answers, aabit="<<mdp.d_header.aa<<endl;
   if(mdp.d_header.aa)
     g_authAnswers++;

--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -91,7 +91,7 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
     char reply[len]; 
     readn2(s.getHandle(), reply, len);
     receivedBytes += len;
-    MOADNSParser mdp(string(reply, len));
+    MOADNSParser mdp(false, string(reply, len));
     if(mdp.d_header.rcode) 
       throw std::runtime_error("Got an error trying to IXFR zone '"+zone.toString()+"' from master '"+master.toStringWithPort()+"': "+RCode::to_s(mdp.d_header.rcode));
 

--- a/pdns/ixplore.cc
+++ b/pdns/ixplore.cc
@@ -98,7 +98,7 @@ uint32_t getSerialFromMaster(const ComboAddress& master, const DNSName& zone, sh
 
   string reply;
   s.read(reply);
-  MOADNSParser mdp(reply);
+  MOADNSParser mdp(false, reply);
   if(mdp.d_header.rcode) {
     throw std::runtime_error("Unable to retrieve SOA serial from master '"+master.toStringWithPort()+"': "+RCode::to_s(mdp.d_header.rcode));
   }

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -220,7 +220,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
   lwr->d_records.clear();
   try {
     lwr->d_tcbit=0;
-    MOADNSParser mdp((const char*)buf.get(), len);
+    MOADNSParser mdp(false, (const char*)buf.get(), len);
     lwr->d_aabit=mdp.d_header.aa;
     lwr->d_tcbit=mdp.d_header.tc;
     lwr->d_rcode=mdp.d_header.rcode;

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -167,7 +167,7 @@ time_t CommunicatorClass::doNotifications()
     size=recvfrom(sock,buffer,sizeof(buffer),0,(struct sockaddr *)&from,&fromlen);
     if(size < 0)
       break;
-    DNSPacket p;
+    DNSPacket p(true);
 
     p.setRemote(&from);
 

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -360,7 +360,7 @@ DNSPacket *UDPNameserver::receive(DNSPacket *prefilled)
   if(prefilled)  // they gave us a preallocated packet
     packet=prefilled;
   else
-    packet=new DNSPacket; // don't forget to free it!
+    packet=new DNSPacket(true); // don't forget to free it!
 
   packet->setSocket(sock);
   packet->setRemote(&remote);

--- a/pdns/notify.cc
+++ b/pdns/notify.cc
@@ -106,7 +106,7 @@ try
     throw runtime_error("Unable to receive notification response from PowerDNS: "+stringerror());
 
   string packet(buffer, len);
-  MOADNSParser mdp(packet);
+  MOADNSParser mdp(false, packet);
 
   cerr<<"Received notification response with error: "<<RCode::to_s(mdp.d_header.rcode)<<endl;
   cerr<<"For: '"<<mdp.d_qname<<"'"<<endl;

--- a/pdns/nproxy.cc
+++ b/pdns/nproxy.cc
@@ -90,7 +90,7 @@ try
     throw runtime_error("reading packet from remote: "+stringerror());
     
   string packet(buffer, res);
-  MOADNSParser mdp(packet);
+  MOADNSParser mdp(true, packet);
   nif.domain = mdp.d_qname;
   nif.origID = mdp.d_header.id;
 
@@ -160,7 +160,7 @@ try
     throw runtime_error("reading packet from remote: "+stringerror());
     
   string packet(buffer, len);
-  MOADNSParser mdp(packet);
+  MOADNSParser mdp(false, packet);
 
   //  cerr<<"Inside notification response for: "<<mdp.d_qname<<endl;
 

--- a/pdns/nsec3dig.cc
+++ b/pdns/nsec3dig.cc
@@ -155,7 +155,7 @@ try
   string reply(creply, len);
   delete[] creply;
 
-  MOADNSParser mdp(reply);
+  MOADNSParser mdp(false, reply);
   cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
   cout<<"Rcode: "<<mdp.d_header.rcode<<", RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr;
   cout<<", TC: "<<mdp.d_header.tc<<", AA: "<<mdp.d_header.aa<<", opcode: "<<mdp.d_header.opcode<<endl;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -168,7 +168,7 @@ unsigned int g_numThreads, g_numWorkerThreads;
 
 //! used to send information to a newborn mthread
 struct DNSComboWriter {
-  DNSComboWriter(const char* data, uint16_t len, const struct timeval& now) : d_mdp(data, len), d_now(now),
+  DNSComboWriter(const char* data, uint16_t len, const struct timeval& now) : d_mdp(true, data, len), d_now(now),
                                                                                                         d_tcp(false), d_socket(-1)
   {}
   MOADNSParser d_mdp;

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -257,7 +257,7 @@ bool Resolver::tryGetSOASerial(DNSName *domain, uint32_t *theirSerial, uint32_t 
     throw ResolverException("recvfrom error waiting for answer: "+stringerror());
   }
 
-  MOADNSParser mdp((char*)buf, err);
+  MOADNSParser mdp(false, (char*)buf, err);
   *id=mdp.d_header.id;
   *domain = mdp.d_qname;
   
@@ -327,7 +327,7 @@ int Resolver::resolve(const string &ipport, const DNSName &domain, int type, Res
     if((len=recvfrom(sock, buffer, sizeof(buffer), 0,(struct sockaddr*)(&from), &addrlen)) < 0) 
       throw ResolverException("recvfrom error waiting for answer: "+stringerror());
   
-    MOADNSParser mdp(buffer, len);
+    MOADNSParser mdp(false, buffer, len);
     return parseResult(mdp, domain, type, id, res);
   }
   catch(ResolverException &re) {
@@ -463,7 +463,7 @@ int AXFRRetriever::getChunk(Resolver::res_t &res, vector<DNSRecord>* records) //
 
   d_receivedBytes += (uint16_t) len;
 
-  MOADNSParser mdp(d_buf.get(), len);
+  MOADNSParser mdp(false, d_buf.get(), len);
 
   int err;
   if(!records)

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -693,7 +693,7 @@ int PacketHandler::forwardPacket(const string &msgPrefix, DNSPacket *p, DomainIn
     }
 
     try {
-      MOADNSParser mdp(buf, recvRes);
+      MOADNSParser mdp(false, buf, recvRes);
       L<<Logger::Info<<msgPrefix<<"Forward update message to "<<remote.toStringWithPort()<<", result was RCode "<<mdp.d_header.rcode<<endl;
       return mdp.d_header.rcode;
     }
@@ -778,7 +778,7 @@ int PacketHandler::processUpdate(DNSPacket *p) {
   // RFC2136 uses the same DNS Header and Message as defined in RFC1035.
   // This means we can use the MOADNSParser to parse the incoming packet. The result is that we have some different
   // variable names during the use of our MOADNSParser.
-  MOADNSParser mdp(p->getString());
+  MOADNSParser mdp(false, p->getString());
   if (mdp.d_header.qdcount != 1) {
     L<<Logger::Warning<<msgPrefix<<"Zone Count is not 1, sending FormErr"<<endl;
     return RCode::FormErr;

--- a/pdns/saxfr.cc
+++ b/pdns/saxfr.cc
@@ -162,7 +162,7 @@ try
         n+=numread;
       }
 
-       MOADNSParser mdp(string(creply, len));
+      MOADNSParser mdp(false, string(creply, len));
        if (mdp.d_header.rcode != 0) {
          throw PDNSException(string("Remote server refused: ") + std::to_string(mdp.d_header.rcode));
        }
@@ -229,7 +229,7 @@ try
 
     string packet = string(creply, len);
 
-    MOADNSParser mdp(packet);
+    MOADNSParser mdp(false, packet);
     if (mdp.d_header.rcode != 0) {
       throw PDNSException(string("Remote server refused: ") + std::to_string(mdp.d_header.rcode));
     }

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -145,7 +145,7 @@ try
       throw std::runtime_error("Timeout waiting for data");
     sock.recvFrom(reply, dest);
   }
-  MOADNSParser mdp(reply);
+  MOADNSParser mdp(false, reply);
   cout<<"Reply to question for qname='"<<mdp.d_qname.toString()<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
   cout<<"Rcode: "<<mdp.d_header.rcode<<" ("<<RCode::to_s(mdp.d_header.rcode)<<"), RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr;
   cout<<", TC: "<<mdp.d_header.tc<<", AA: "<<mdp.d_header.aa<<", opcode: "<<mdp.d_header.opcode<<endl;

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -603,7 +603,7 @@ struct ParsePacketTest
 
   void operator()() const
   {
-    MOADNSParser mdp((const char*)&*d_packet.begin(), d_packet.size());
+    MOADNSParser mdp(false, (const char*)&*d_packet.begin(), d_packet.size());
     typedef map<pair<DNSName, QType>, set<DNSResourceRecord>, TCacheComp > tcache_t;
     tcache_t tcache;
     
@@ -643,7 +643,7 @@ struct ParsePacketBareTest
 
   void operator()() const
   {
-    MOADNSParser mdp((const char*)&*d_packet.begin(), d_packet.size());
+    MOADNSParser mdp(false, (const char*)&*d_packet.begin(), d_packet.size());
   }
   const vector<uint8_t>& d_packet;
   std::string d_name;

--- a/pdns/stubresolver.cc
+++ b/pdns/stubresolver.cc
@@ -100,7 +100,7 @@ int stubDoResolve(const DNSName& qname, uint16_t qtype, vector<DNSZoneRecord>& r
     catch(...) {
       continue;
     }
-    MOADNSParser mdp(reply);
+    MOADNSParser mdp(false, reply);
     if(mdp.d_header.rcode == RCode::ServFail)
       continue;
 

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -367,7 +367,7 @@ void *TCPNameserver::doConnection(void *data)
       else
         S.inc("tcp4-queries");
 
-      packet=shared_ptr<DNSPacket>(new DNSPacket);
+      packet=shared_ptr<DNSPacket>(new DNSPacket(true));
       packet->setRemote(&remote);
       packet->d_tcp=true;
       packet->setSocket(fd);
@@ -387,7 +387,7 @@ void *TCPNameserver::doConnection(void *data)
       }
 
       shared_ptr<DNSPacket> reply; 
-      shared_ptr<DNSPacket> cached= shared_ptr<DNSPacket>(new DNSPacket);
+      shared_ptr<DNSPacket> cached= shared_ptr<DNSPacket>(new DNSPacket(false));
       if(logDNSQueries)  {
         string remote_text;
         if(packet->hasEDNSSubnet())
@@ -1113,7 +1113,7 @@ int TCPNameserver::doIXFR(shared_ptr<DNSPacket> q, int outsock)
     outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
 
   uint32_t serial = 0;
-  MOADNSParser mdp(q->getString());
+  MOADNSParser mdp(false, q->getString());
   for(MOADNSParser::answers_t::const_iterator i=mdp.d_answers.begin(); i != mdp.d_answers.end(); ++i) {
     const DNSRecord *rr = &i->first;
     if (rr->d_type == QType::SOA && rr->d_place == DNSResourceRecord::AUTHORITY) {

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -19,7 +19,7 @@ struct Question
   DNSName qdomain;
   DNSPacket* replyPacket()
   {
-    return new DNSPacket();
+    return new DNSPacket(false);
   }
 };
 
@@ -27,7 +27,7 @@ struct Backend
 {
   DNSPacket* question(Question*)
   {
-    return new DNSPacket();
+    return new DNSPacket(true);
   }
 };
 
@@ -62,7 +62,7 @@ struct BackendSlow
   DNSPacket* question(Question*)
   {
     sleep(1);
-    return new DNSPacket();
+    return new DNSPacket(true);
   }
 };
 
@@ -96,7 +96,7 @@ struct BackendDies
       // cerr<<"Going.. down!"<<endl;
       throw runtime_error("kill");
     }
-    return new DNSPacket();
+    return new DNSPacket(true);
   }
   static std::atomic<int> s_count;
   int d_count{0};

--- a/pdns/test-dnscrypt_cc.cc
+++ b/pdns/test-dnscrypt_cc.cc
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(DNSCryptPlaintextQuery) {
 
   ctx.getCertificateResponse(query, response);
 
-  MOADNSParser mdp((char*) response.data(), response.size());
+  MOADNSParser mdp(false, (char*) response.data(), response.size());
 
   BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1);
   BOOST_CHECK_EQUAL(mdp.d_header.ancount, 1);
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(DNSCryptEncryptedQueryValid) {
   BOOST_CHECK_EQUAL(query->valid, true);
   BOOST_CHECK_EQUAL(query->encrypted, true);
 
-  MOADNSParser mdp((char*) plainQuery.data(), decryptedLen);
+  MOADNSParser mdp(true, (char*) plainQuery.data(), decryptedLen);
 
   BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1);
   BOOST_CHECK_EQUAL(mdp.d_header.ancount, 0);
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE(DNSCryptEncryptedQueryValidWithOldKey) {
   BOOST_CHECK_EQUAL(query->valid, true);
   BOOST_CHECK_EQUAL(query->encrypted, true);
 
-  MOADNSParser mdp((char*) plainQuery.data(), decryptedLen);
+  MOADNSParser mdp(true, (char*) plainQuery.data(), decryptedLen);
 
   BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1);
   BOOST_CHECK_EQUAL(mdp.d_header.ancount, 0);

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -48,7 +48,7 @@ static const uint16_t ECSSourcePrefixV6 = 56;
 
 static void validateQuery(const char * packet, size_t packetSize)
 {
-  MOADNSParser mdp(packet, packetSize);
+  MOADNSParser mdp(true, packet, packetSize);
 
   BOOST_CHECK_EQUAL(mdp.d_qname.toString(), "www.powerdns.com.");
 
@@ -60,7 +60,7 @@ static void validateQuery(const char * packet, size_t packetSize)
 
 static void validateResponse(const char * packet, size_t packetSize, bool hasEdns, uint8_t additionalCount=0)
 {
-  MOADNSParser mdp(packet, packetSize);
+  MOADNSParser mdp(false, packet, packetSize);
 
   BOOST_CHECK_EQUAL(mdp.d_qname.toString(), "www.powerdns.com.");
 

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -284,14 +284,15 @@ BOOST_AUTO_TEST_CASE(test_opt_record_in) {
   std::string packet("\xf0\x01\x01\x00\x00\x01\x00\x01\x00\x00\x00\x01\x03www\x08powerdns\x03""com\x00\x00\x01\x00\x01\x03www\x08powerdns\x03""com\x00\x00\x01\x00\x01\x00\x00\x00\x10\x00\x04\x7f\x00\x00\x01\x00\x00\x29\x05\x00\x00\x00\x00\x00\x00\x0c\x00\x03\x00\x08powerdns",89);
   OPTRecordContent::report();
 
-  MOADNSParser mdp((char*)&*packet.begin(), (unsigned int)packet.size());
+  MOADNSParser mdp(true, (char*)&*packet.begin(), (unsigned int)packet.size());
 
-  getEDNSOpts(mdp, &eo);
+  BOOST_CHECK_EQUAL(getEDNSOpts(mdp, &eo), true);
 
   // this should contain NSID now
   BOOST_CHECK_EQUAL(eo.d_packetsize, 1280);
    
   // it should contain NSID option with value 'powerdns', and nothing else
+  BOOST_CHECK_EQUAL(eo.d_options.size(), 1);
   BOOST_CHECK_EQUAL(eo.d_options[0].first, 3); // nsid
   BOOST_CHECK_EQUAL(eo.d_options[0].second, "powerdns");
 }

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCachePacket) {
     vector<pair<uint16_t,string > > opts;
 
     DNSPacketWriter pw(pak, DNSName("www.powerdns.com"), QType::A);
-    DNSPacket q, r, r2;
+    DNSPacket q(true), r(false), r2(false);
     q.parse((char*)&pak[0], pak.size());
 
     pak.clear();

--- a/pdns/toysdig.cc
+++ b/pdns/toysdig.cc
@@ -86,7 +86,7 @@ public:
   {
     TCPResolver tr(d_dest);
     string resp=tr.query(qname, qtype);
-    MOADNSParser mdp(resp);
+    MOADNSParser mdp(false, resp);
     vector<DNSRecord> ret;
     ret.reserve(mdp.d_answers.size());
     for(const auto& a : mdp.d_answers) {

--- a/pdns/tsig-tests.cc
+++ b/pdns/tsig-tests.cc
@@ -65,7 +65,7 @@ try
   string reply;
   sock.recvFrom(reply, dest);
 
-  MOADNSParser mdp(reply);
+  MOADNSParser mdp(false, reply);
   cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
   cout<<"Rcode: "<<mdp.d_header.rcode<<", RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr;
   cout<<", TC: "<<mdp.d_header.tc<<", AA: "<<mdp.d_header.aa<<", opcode: "<<mdp.d_header.opcode<<endl;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -472,7 +472,7 @@ static void gatherRecords(const Json container, const DNSName& qname, const QTyp
       makePtr(rr, &ptr);
 
       // verify that there's a zone for the PTR
-      DNSPacket fakePacket;
+      DNSPacket fakePacket(false);
       SOAData sd;
       fakePacket.qtype = QType::PTR;
       if (!B.getAuth(&fakePacket, &sd, ptr.qname))
@@ -1310,7 +1310,7 @@ static void makePtr(const DNSResourceRecord& rr, DNSResourceRecord* ptr) {
 
 static void storeChangedPTRs(UeberBackend& B, vector<DNSResourceRecord>& new_ptrs) {
   for(const DNSResourceRecord& rr :  new_ptrs) {
-    DNSPacket fakePacket;
+    DNSPacket fakePacket(false);
     SOAData sd;
     sd.db = (DNSBackend *)-1;  // getAuth() cache bypass
     fakePacket.qtype = QType::PTR;


### PR DESCRIPTION
### Short description
The main idea is to pass a boolean to `MOADNSParser` to let it know that we expect a query, and therefore that:

* `qdcount > 0` should be rejected
* records in answer or authority should not be parsed but handled as `UnknownRecordContent`
* only `OPT`, `TSIG`, `SIG` and `TKEY` records in additional should be parsed, the other should be handled as `UnknownRecordContent`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
