### PR TITLE
Backport #4882: Don't parse spurious RRs in queries when we don't need them

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -309,8 +309,8 @@ void *qthread(void *number)
   DNSDistributor *distributor = DNSDistributor::Create(::arg().asNum("distributor-threads", 1)); // the big dispatcher!
   int num = (int)(unsigned long)number;
   g_distributors[num] = distributor;
-  DNSPacket question;
-  DNSPacket cached;
+  DNSPacket question(true);
+  DNSPacket cached(false);
 
   AtomicCounter &numreceived=*S.getPointer("udp-queries");
   AtomicCounter &numreceiveddo=*S.getPointer("udp-do-queries");

--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -116,7 +116,7 @@ struct SendReceive
       }
       // parse packet, set 'id', fill out 'ip' 
       
-      MOADNSParser mdp(string(buf, len));
+      MOADNSParser mdp(false, string(buf, len));
       if(!g_quiet) {
         cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
         cout<<"Rcode: "<<mdp.d_header.rcode<<", RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr;

--- a/pdns/dnsdemog.cc
+++ b/pdns/dnsdemog.cc
@@ -47,7 +47,7 @@ try
           if(dh->rd || dh->qr)
             continue;
 
-          MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+          MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
 
           memcpy(&entry.ip, &pr.d_ip->ip_src, 4);
           entry.port = pr.d_udp->uh_sport;

--- a/pdns/dnsgram.cc
+++ b/pdns/dnsgram.cc
@@ -111,7 +111,7 @@ try
           ntohs(pr.d_udp->uh_dport)==53   || ntohs(pr.d_udp->uh_sport)==53) &&
          pr.d_len > 12) {
         try {
-          MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+          MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
 
           if(lastreport.tv_sec == 0) {
             lastreport = pr.d_pheader.ts;

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -67,7 +67,7 @@ class DNSSECKeeper;
 class DNSPacket
 {
 public:
-  DNSPacket();
+  DNSPacket(bool isQuery);
   DNSPacket(const DNSPacket &orig);
 
   int noparse(const char *mesg, int len); //!< just suck the data inward
@@ -174,6 +174,7 @@ private:
   string d_tsigkeyname;
   string d_tsigprevious;
   bool d_tsigtimersonly;
+  bool d_isQuery;
 
   vector<DNSResourceRecord> d_rrs; // 4
 };

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -306,15 +306,15 @@ class MOADNSParser : public boost::noncopyable
 {
 public:
   //! Parse from a string
-  MOADNSParser(const string& buffer)  : d_tsigPos(0)
+  MOADNSParser(bool query, const string& buffer)  : d_tsigPos(0)
   {
-    init(buffer.c_str(), (unsigned int)buffer.size());
+    init(query, buffer.c_str(), (unsigned int)buffer.size());
   }
 
   //! Parse from a pointer and length
-  MOADNSParser(const char *packet, unsigned int len) : d_tsigPos(0)
+  MOADNSParser(bool query, const char *packet, unsigned int len) : d_tsigPos(0)
   {
-    init(packet, len);
+    init(query, packet, len);
   }
 
   dnsheader d_header;
@@ -340,7 +340,7 @@ public:
   }
 private:
   void getDnsrecordheader(struct dnsrecordheader &ah);
-  void init(const char *packet, unsigned int len);
+  void init(bool query, const char *packet, unsigned int len);
   vector<uint8_t> d_content;
   uint16_t d_tsigPos;
 };

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -225,7 +225,7 @@ void DNSProxy::mainloop(void)
         d.id=i->second.id;
         memcpy(buffer,&d,sizeof(d));  // commit spoofed id
 
-        DNSPacket p,q;
+        DNSPacket p(false),q(false);
         p.parse(buffer,len);
         q.parse(buffer,len);
 
@@ -240,7 +240,7 @@ void DNSProxy::mainloop(void)
 	string reply; // needs to be alive at time of sendmsg!
 	if(i->second.complete) {
 
-	  MOADNSParser mdp(p.getString());
+	  MOADNSParser mdp(false, p.getString());
 	  //	  cerr<<"Got completion, "<<mdp.d_answers.size()<<" answers, rcode: "<<mdp.d_header.rcode<<endl;
 	  for(MOADNSParser::answers_t::const_iterator j=mdp.d_answers.begin(); j!=mdp.d_answers.end(); ++j) {        
 	    //	    cerr<<"comp: "<<(int)j->first.d_place-1<<" "<<j->first.d_label<<" " << DNSRecordContent::NumberToType(j->first.d_type)<<" "<<j->first.d_content->getZoneRepresentation()<<endl;

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -407,7 +407,7 @@ try
   while(s_socket->recvFromAsync(packet, remote)) {
     try {
       s_weanswers++;
-      MOADNSParser mdp(packet.c_str(), packet.length());
+      MOADNSParser mdp(false, packet.c_str(), packet.length());
       if(!mdp.d_header.qr) {
         cout<<"Received a question from our reference nameserver!"<<endl;
         continue;
@@ -557,7 +557,7 @@ bool sendPacketFromPR(PcapPacketReader& pr, const ComboAddress& remote)
       sent=true;
       dh->id=tmp;
     }
-    MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+    MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
     QuestionIdentifier qi=QuestionIdentifier::create(pr.getSource(), pr.getDest(), mdp);
 
     if(!mdp.d_header.qr) {

--- a/pdns/dnsscan.cc
+++ b/pdns/dnsscan.cc
@@ -47,7 +47,7 @@ try
     
     while(pr.getUDPPacket()) {
       try {
-        MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+        MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
         if(mdp.d_qtype < 256)
           counts[mdp.d_qtype]++;
 

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -329,7 +329,7 @@ try
 	    continue;
 	  }
 	}
-        MOADNSParser mdp((const char*)pr.d_payload, pr.d_len);
+        MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
         if(haveRDFilter && mdp.d_header.rd != rdFilter) {
           rdFilterMismatch++;
           continue;

--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -95,7 +95,7 @@ try
     q->udpUsec = makeUsec(now - tv);
     tv=now;
 
-    MOADNSParser mdp(reply);
+    MOADNSParser mdp(false, reply);
     if(!mdp.d_header.tc)
       return;
     g_truncates++;
@@ -145,7 +145,7 @@ try
   q->tcpUsec = makeUsec(now - tv);
   q->answerSecond = now.tv_sec;
 
-  MOADNSParser mdp(reply);
+  MOADNSParser mdp(false, reply);
   //  cout<<"Had correct TCP/IP response, "<<mdp.d_answers.size()<<" answers, aabit="<<mdp.d_header.aa<<endl;
   if(mdp.d_header.aa)
     g_authAnswers++;

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -157,7 +157,7 @@ int asyncresolve(const ComboAddress& ip, const string& domain, int type, bool do
   lwr->d_result.clear();
   try {
     lwr->d_tcbit=0;
-    MOADNSParser mdp((const char*)buf.get(), len);
+    MOADNSParser mdp(false, (const char*)buf.get(), len);
     lwr->d_aabit=mdp.d_header.aa;
     lwr->d_tcbit=mdp.d_header.tc;
     lwr->d_rcode=mdp.d_header.rcode;

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -164,7 +164,7 @@ time_t CommunicatorClass::doNotifications()
     size=recvfrom(sock,buffer,sizeof(buffer),0,(struct sockaddr *)&from,&fromlen);
     if(size < 0)
       break;
-    DNSPacket p;
+    DNSPacket p(true);
 
     p.setRemote(&from);
 

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -368,7 +368,7 @@ DNSPacket *UDPNameserver::receive(DNSPacket *prefilled)
   if(prefilled)  // they gave us a preallocated packet
     packet=prefilled;
   else
-    packet=new DNSPacket; // don't forget to free it!
+    packet=new DNSPacket(true); // don't forget to free it!
 
   packet->setSocket(sock);
   packet->setRemote(&remote);

--- a/pdns/notify.cc
+++ b/pdns/notify.cc
@@ -65,7 +65,7 @@ try
     throw runtime_error("Unable to receive notification response from PowerDNS: "+stringerror());
 
   string packet(buffer, len);
-  MOADNSParser mdp(packet);
+  MOADNSParser mdp(false, packet);
 
   cerr<<"Received notification response with error: "<<RCode::to_s(mdp.d_header.rcode)<<endl;
   cerr<<"For: '"<<mdp.d_qname<<"'"<<endl;

--- a/pdns/nproxy.cc
+++ b/pdns/nproxy.cc
@@ -66,7 +66,7 @@ try
     throw runtime_error("reading packet from remote: "+stringerror());
     
   string packet(buffer, res);
-  MOADNSParser mdp(packet);
+  MOADNSParser mdp(true, packet);
   nif.domain = mdp.d_qname;
   nif.origID = mdp.d_header.id;
 
@@ -136,7 +136,7 @@ try
     throw runtime_error("reading packet from remote: "+stringerror());
     
   string packet(buffer, len);
-  MOADNSParser mdp(packet);
+  MOADNSParser mdp(false, packet);
 
   //  cerr<<"Inside notification response for: "<<mdp.d_qname<<endl;
 

--- a/pdns/nsec3dig.cc
+++ b/pdns/nsec3dig.cc
@@ -111,7 +111,7 @@ try
   string reply(creply, len);
   delete[] creply;
 
-  MOADNSParser mdp(reply);
+  MOADNSParser mdp(false, reply);
   cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
   cout<<"Rcode: "<<mdp.d_header.rcode<<", RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr;
   cout<<", TC: "<<mdp.d_header.tc<<", AA: "<<mdp.d_header.aa<<", opcode: "<<mdp.d_header.opcode<<endl;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -141,7 +141,7 @@ unsigned int g_numThreads, g_numWorkerThreads;
 
 //! used to send information to a newborn mthread
 struct DNSComboWriter {
-  DNSComboWriter(const char* data, uint16_t len, const struct timeval& now) : d_mdp(data, len), d_now(now), 
+  DNSComboWriter(const char* data, uint16_t len, const struct timeval& now) : d_mdp(true, data, len), d_now(now), 
                                                                                                         d_tcp(false), d_socket(-1)
   {}
   MOADNSParser d_mdp;

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -257,7 +257,7 @@ bool Resolver::tryGetSOASerial(string* domain, uint32_t *theirSerial, uint32_t *
     throw ResolverException("recvfrom error waiting for answer: "+stringerror());
   }
 
-  MOADNSParser mdp((char*)buf, err);
+  MOADNSParser mdp(false, (char*)buf, err);
   *id=mdp.d_header.id;
   *domain = stripDot(mdp.d_qname);
   
@@ -325,7 +325,7 @@ int Resolver::resolve(const string &ipport, const char *domain, int type, Resolv
     if((len=recvfrom(sock, buffer, sizeof(buffer), 0,(struct sockaddr*)(&from), &addrlen)) < 0) 
       throw ResolverException("recvfrom error waiting for answer: "+stringerror());
   
-    MOADNSParser mdp(buffer, len);
+    MOADNSParser mdp(false, buffer, len);
     return parseResult(mdp, domain, type, id, res);
   }
   catch(ResolverException &re) {
@@ -448,7 +448,7 @@ int AXFRRetriever::getChunk(Resolver::res_t &res) // Implementation is making su
     throw ResolverException("EOF trying to read axfr chunk from remote TCP client");
   
   timeoutReadn(len); 
-  MOADNSParser mdp(d_buf.get(), len);
+  MOADNSParser mdp(false, d_buf.get(), len);
 
   int err = parseResult(mdp, "", 0, 0, &res);
   if(err) 

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -648,7 +648,7 @@ int PacketHandler::forwardPacket(const string &msgPrefix, DNSPacket *p, DomainIn
     Utility::closesocket(sock);
 
     try {
-      MOADNSParser mdp(buf, recvRes);
+      MOADNSParser mdp(false, buf, recvRes);
       L<<Logger::Info<<msgPrefix<<"Forward update message to "<<remote.toStringWithPort()<<", result was RCode "<<mdp.d_header.rcode<<endl;
       return mdp.d_header.rcode;
     }
@@ -715,7 +715,7 @@ int PacketHandler::processUpdate(DNSPacket *p) {
   // RFC2136 uses the same DNS Header and Message as defined in RFC1035.
   // This means we can use the MOADNSParser to parse the incoming packet. The result is that we have some different
   // variable names during the use of our MOADNSParser.
-  MOADNSParser mdp(p->getString());
+  MOADNSParser mdp(false, p->getString());
   if (mdp.d_header.qdcount != 1) {
     L<<Logger::Warning<<msgPrefix<<"Zone Count is not 1, sending FormErr"<<endl;
     return RCode::FormErr;

--- a/pdns/saxfr.cc
+++ b/pdns/saxfr.cc
@@ -71,7 +71,7 @@ try
       n+=numread;
     }
 
-    MOADNSParser mdp(string(creply, len));
+    MOADNSParser mdp(false, string(creply, len));
     for(MOADNSParser::answers_t::const_iterator i=mdp.d_answers.begin(); i!=mdp.d_answers.end(); ++i) {
       if(i->first.d_type == QType::SOA)
       {

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -119,7 +119,7 @@ try
     
     sock.recvFrom(reply, dest);
   }
-  MOADNSParser mdp(reply);
+  MOADNSParser mdp(false, reply);
   cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
   cout<<"Rcode: "<<mdp.d_header.rcode<<", RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr;
   cout<<", TC: "<<mdp.d_header.tc<<", AA: "<<mdp.d_header.aa<<", opcode: "<<mdp.d_header.opcode<<endl;

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -95,7 +95,7 @@ int doResolve(const string& qname, uint16_t qtype, vector<DNSResourceRecord>& re
     catch(...) {
       continue;
     }
-    MOADNSParser mdp(reply);
+    MOADNSParser mdp(false, reply);
     if(mdp.d_header.rcode == RCode::ServFail)
       continue;    
     

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -516,7 +516,7 @@ struct ParsePacketTest
 
   void operator()() const
   {
-    MOADNSParser mdp((const char*)&*d_packet.begin(), d_packet.size());
+    MOADNSParser mdp(false, (const char*)&*d_packet.begin(), d_packet.size());
     typedef map<pair<string, QType>, set<DNSResourceRecord>, TCacheComp > tcache_t;
     tcache_t tcache;
     
@@ -679,7 +679,7 @@ struct ParsePacketBareTest
 
   void operator()() const
   {
-    MOADNSParser mdp((const char*)&*d_packet.begin(), d_packet.size());
+    MOADNSParser mdp(false, (const char*)&*d_packet.begin(), d_packet.size());
   }
   const vector<uint8_t>& d_packet;
   std::string d_name;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -287,7 +287,7 @@ void *TCPNameserver::doConnection(void *data)
       getQuestion(fd, mesg.get(), pktlen, remote);
       S.inc("tcp-queries");      
 
-      packet=shared_ptr<DNSPacket>(new DNSPacket);
+      packet=shared_ptr<DNSPacket>(new DNSPacket(true));
       packet->setRemote(&remote);
       packet->d_tcp=true;
       packet->setSocket(fd);
@@ -307,7 +307,7 @@ void *TCPNameserver::doConnection(void *data)
       }
 
       shared_ptr<DNSPacket> reply; 
-      shared_ptr<DNSPacket> cached= shared_ptr<DNSPacket>(new DNSPacket);
+      shared_ptr<DNSPacket> cached= shared_ptr<DNSPacket>(new DNSPacket(false));
       if(logDNSQueries)  {
         string remote;
         if(packet->hasEDNSSubnet()) 
@@ -950,7 +950,7 @@ int TCPNameserver::doIXFR(shared_ptr<DNSPacket> q, int outsock)
   }
 
   uint32_t serial = 0;
-  MOADNSParser mdp(q->getString());
+  MOADNSParser mdp(false, q->getString());
   for(MOADNSParser::answers_t::const_iterator i=mdp.d_answers.begin(); i != mdp.d_answers.end(); ++i) {
     const DNSRecord *rr = &i->first;
     if (rr->d_type == QType::SOA && rr->d_place == DNSRecord::Nameserver) {

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -272,14 +272,15 @@ BOOST_AUTO_TEST_CASE(test_opt_record_in) {
   std::string packet("\xf0\x01\x01\x00\x00\x01\x00\x01\x00\x00\x00\x01\x03www\x08powerdns\x03""com\x00\x00\x01\x00\x01\x03www\x08powerdns\x03""com\x00\x00\x01\x00\x01\x00\x00\x00\x10\x00\x04\x7f\x00\x00\x01\x00\x00\x29\x05\x00\x00\x00\x00\x00\x00\x0c\x00\x03\x00\x08powerdns",89);
   OPTRecordContent::report();
 
-  MOADNSParser mdp((char*)&*packet.begin(), (unsigned int)packet.size());
+  MOADNSParser mdp(true, (char*)&*packet.begin(), (unsigned int)packet.size());
 
-  getEDNSOpts(mdp, &eo);
+  BOOST_CHECK_EQUAL(getEDNSOpts(mdp, &eo), true);
 
   // this should contain NSID now
   BOOST_CHECK_EQUAL(eo.d_packetsize, 1280);
    
   // it should contain NSID option with value 'powerdns', and nothing else
+  BOOST_CHECK_EQUAL(eo.d_options.size(), 1);
   BOOST_CHECK_EQUAL(eo.d_options[0].first, 3); // nsid
   BOOST_CHECK_EQUAL(eo.d_options[0].second, "powerdns");
 }

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCachePacket) {
     vector<pair<uint16_t,string > > opts;
 
     DNSPacketWriter pw(pak, "www.powerdns.com", QType::A);
-    DNSPacket q, r, r2;
+    DNSPacket q(true), r(false), r2(false);
     q.parse((char*)&pak[0], pak.size());
 
     pak.clear();

--- a/pdns/tsig-tests.cc
+++ b/pdns/tsig-tests.cc
@@ -62,7 +62,7 @@ try
   string reply;
   sock.recvFrom(reply, dest);
 
-  MOADNSParser mdp(reply);
+  MOADNSParser mdp(false, reply);
   cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;
   cout<<"Rcode: "<<mdp.d_header.rcode<<", RD: "<<mdp.d_header.rd<<", QR: "<<mdp.d_header.qr;
   cout<<", TC: "<<mdp.d_header.tc<<", AA: "<<mdp.d_header.aa<<", opcode: "<<mdp.d_header.opcode<<endl;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -430,7 +430,7 @@ static void gatherRecords(const Value& container, vector<DNSResourceRecord>& new
         makePtr(rr, &ptr);
 
         // verify that there's a zone for the PTR
-        DNSPacket fakePacket;
+        DNSPacket fakePacket(false);
         SOAData sd;
         fakePacket.qtype = QType::PTR;
         if (!B.getAuth(&fakePacket, &sd, ptr.qname, 0))
@@ -1046,7 +1046,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
 
   // now the PTRs
   BOOST_FOREACH(const DNSResourceRecord& rr, new_ptrs) {
-    DNSPacket fakePacket;
+    DNSPacket fakePacket(false);
     SOAData sd;
     sd.db = (DNSBackend *)-1;
     fakePacket.qtype = QType::PTR;


### PR DESCRIPTION
### Short description
The main idea is to pass a boolean to `MOADNSParser` to let it know that we expect a query, and therefore that:

* `qdcount > 0` should be rejected
* records in answer or authority should not be parsed but handled as `UnknownRecordContent`
* only `OPT`, `TSIG`, `SIG` and `TKEY` records in additional should be parsed, the other should be handled as `UnknownRecordContent`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [x] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
