### PR TITLE
Backport #4887: auth: Don't exit if the webserver can't accept a connection

### DIFF
--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -358,14 +358,31 @@ void WebServer::go()
       // data and data->client will be freed by thread
       connectionThreadData *data = new connectionThreadData;
       data->webServer = this;
-      data->client = d_server->accept();
-      if (data->client->acl(acl)) {
-        pthread_create(&tid, 0, &WebServerConnectionThreadStart, (void *)data);
-      } else {
-        ComboAddress remote;
-        if (data->client->getRemote(remote))
-          L<<Logger::Error<<"Webserver closing socket: remote ("<< remote.toString() <<") does not match 'webserver-allow-from'"<<endl;
-        delete data->client; // close socket
+      try {
+        data->client = d_server->accept();
+        if (data->client->acl(acl)) {
+          pthread_create(&tid, 0, &WebServerConnectionThreadStart, (void *)data);
+        } else {
+          ComboAddress remote;
+          if (data->client->getRemote(remote))
+            L<<Logger::Error<<"Webserver closing socket: remote ("<< remote.toString() <<") does not match 'webserver-allow-from'"<<endl;
+          delete data->client; // close socket
+          delete data;
+        }
+      }
+      catch(PDNSException &e) {
+        L<<Logger::Error<<"PDNSException while accepting a connection in main webserver thread: "<<e.reason<<endl;
+        delete data->client;
+        delete data;
+      }
+      catch(std::exception &e) {
+        L<<Logger::Error<<"STL Exception while accepting a connection in main webserver thread: "<<e.what()<<endl;
+        delete data->client;
+        delete data;
+      }
+      catch(...) {
+        L<<Logger::Error<<"Unknown exception while accepting a connection in main webserver thread"<<endl;
+        delete data->client;
         delete data;
       }
     }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This could lead to a Denial Of Service, before we even got a chance
to check that the remote client is allowed by the ACL.

Reported by mongo (thanks!).

(cherry picked from commit a84b0d994dfc39d4379050ff9249891ed3e82f56)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
