### PR TITLE
dnsdist: Add `setWHashedPertubation()` for consistent `whashed` results

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1407,6 +1407,7 @@ instantiate a server with additional parameters
       function with the parameter `dr`, which returns an action to be taken on this response packet.
       Good for rare packets but where you want to do a lot of processing.
  * Server selection policy related:
+    * `setWHashedPertubation(value)`: set the hash perturbation value to be used in the `whashed` policy instead of a random one, allowing to have consistent `whashed` results on different instances
     * `setServerPolicy(policy)`: set server selection policy to that policy
     * `setServerPolicyLua(name, function)`: set server selection policy to one named 'name' and provided by 'function'
     * `showServerPolicy()`: show name of currently operational server selection policy

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -1160,4 +1160,9 @@ void moreLua(bool client)
       return std::shared_ptr<DNSRule>(new RDRule());
     });
 
+    g_lua.writeFunction("setWHashedPertubation", [](uint32_t pertub) {
+        setLuaSideEffect();
+        g_hashperturb = pertub;
+      });
+
 }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -610,7 +610,7 @@ shared_ptr<DownstreamState> wrandom(const NumberedServerVector& servers, const D
   return valrandom(random(), servers, dq);
 }
 
-static uint32_t g_hashperturb;
+uint32_t g_hashperturb;
 shared_ptr<DownstreamState> whashed(const NumberedServerVector& servers, const DNSQuestion* dq)
 {
   return valrandom(dq->qname->hash(g_hashperturb), servers, dq);

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -637,6 +637,7 @@ extern uint32_t g_staleCacheEntriesTTL;
 extern bool g_apiReadWrite;
 extern std::string g_apiConfigDirectory;
 extern bool g_servFailOnNoPolicy;
+extern uint32_t g_hashperturb;
 
 struct ConsoleKeyword {
   std::string name;


### PR DESCRIPTION
### Short description
This is useful when several `dnsdist` instances are deployed together and need to consistently route queries to the same backend using the `whashed` policy. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

