### PR TITLE
dnsdist: Add the `setRingBuffersSize()` directive

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1277,6 +1277,7 @@ Here are all functions:
     * `topSlow([top][, limit][, labels])`: show `top` queries slower than `limit` milliseconds, grouped by last `labels` labels
     * `topBandwidth(top)`: show top-`top` clients that consume the most bandwidth over length of ringbuffer
     * `topClients(n)`: show top-`n` clients sending the most queries over length of ringbuffer
+    * `setRingBuffersSize(n)`: set the capacity of the ringbuffers used for live traffic inspection to `n` (default to 10000)
     * `showResponseLatency()`: show a plot of the response time latency distribution
     * `showTCPStats()`: show some statistics regarding TCP
     * `showVersion()`: show the current version of dnsdist

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -336,6 +336,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "setMaxUDPOutstanding", true, "n", "set the maximum number of outstanding UDP queries to a given backend server. This can only be set at configuration time and defaults to 10240" },
   { "setQueryCount", true, "bool", "set whether queries should be counted" },
   { "setQueryCountFilter", true, "func", "filter queries that would be counted, where `func` is a function with parameter `dq` which decides whether a query should and how it should be counted" },
+  { "setRingBuffersSize", true, "n", "set the capacity of the ringbuffers used for live traffic inspection to `n`" },
   { "setRules", true, "list of rules", "replace the current rules with the supplied list of pairs of DNS Rules and DNS Actions (see `newRuleAction()`)" },
   { "setServerPolicy", true, "policy", "set server selection policy to that policy" },
   { "setServerPolicyLua", true, "name, function", "set server selection policy to one named 'name' and provided by 'function'" },

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -1128,4 +1128,14 @@ void moreLua(bool client)
         setLuaSideEffect();
         g_servFailOnNoPolicy = servfail;
       });
+
+    g_lua.writeFunction("setRingBuffersSize", [](size_t capacity) {
+        setLuaSideEffect();
+        if (g_configurationDone) {
+          errlog("setRingBuffersSize() cannot be used at runtime!");
+          g_outputBuffer="setRingBuffersSize() cannot be used at runtime!\n";
+          return;
+        }
+        g_rings.setCapacity(capacity);
+      });    
 }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -273,10 +273,10 @@ struct IDState
 };
 
 struct Rings {
-  Rings()
+  Rings(size_t capacity=10000)
   {
-    queryRing.set_capacity(10000);
-    respRing.set_capacity(10000);
+    queryRing.set_capacity(capacity);
+    respRing.set_capacity(capacity);
     pthread_rwlock_init(&queryLock, 0);
   }
   struct Query
@@ -306,6 +306,17 @@ struct Rings {
 
   std::unordered_map<int, vector<boost::variant<string,double> > > getTopBandwidth(unsigned int numentries);
   size_t numDistinctRequestors();
+  void setCapacity(size_t newCapacity) 
+  {
+    {
+      WriteLock wl(&queryLock);
+      queryRing.set_capacity(newCapacity);
+    }
+    {
+      std::lock_guard<std::mutex> lock(respMutex);
+      respRing.set_capacity(newCapacity);
+    }
+  }
 };
 
 extern Rings g_rings;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The default ringbuffers size might be too small for large deployments, this new directive allows changing it without recompiling.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

