### PR TITLE
Build the bind backend for CentOS 6 differently

### DIFF
--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -287,7 +287,6 @@ BuildRequires: boost-devel
 BuildRequires: lua-devel
 BuildRequires: bison
 Provides: powerdns = %{version}-%{release}
-%global backends %{backends} bind
 
 %description
 The PowerDNS Nameserver is a modern, advanced and high performance
@@ -393,7 +392,7 @@ export CPPFLAGS="-DLDAP_DEPRECATED"
 	--disable-silent-rules \
 	--with-modules='' \
 	--with-lua \
-	--with-dynmodules='%{backends} random' \
+	--with-dynmodules='bind %{backends} random' \
 	--enable-tools \
 	--without-protobuf \
 	--enable-remotebackend-http \


### PR DESCRIPTION
### Short description
For some reason, CentOS 6's rpmbuild didn't like a %global.....

Closes #4669
Closes #4902

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
