### PR TITLE
Revert "auth: In `Bind2Backend::lookup()`, use the `zoneId` when we have it"

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1015,17 +1015,9 @@ void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *p
   bool found=false;
   BB2DomainInfo bbd;
 
-  if (zoneId != -1) {
-    found = safeGetBBDomainInfo(zoneId, &bbd);
-    if (found) {
-      domain = bbd.d_name;
-    }
-  }
-  else {
-    do {
-      found = safeGetBBDomainInfo(domain, &bbd);
-    } while (!found && domain.chopOff());
-  }
+  do {
+    found = safeGetBBDomainInfo(domain, &bbd);
+  } while ((!found || (zoneId != (int)bbd.d_id && zoneId != -1)) && domain.chopOff());
 
   if(!found) {
     if(mustlog)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This reverts commit 937a66255ff05f2e754ef113833e54cc4cf2004b.
It doesn't work with multiple backends since the `zoneId` is passed to
every available backend on `lookup()`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

