### PR TITLE
Fix negative port detection for IPv6 addresses on 32-bit

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -710,7 +710,8 @@ int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret)
   if(addr.empty())
     return -1;
   string ourAddr(addr);
-  int port = -1;
+  bool portSet = false;
+  unsigned int port;
   if(addr[0]=='[') { // [::]:53 style address
     string::size_type pos = addr.find(']');
     if(pos == string::npos || pos + 2 > addr.size() || addr[pos+1]!=':')
@@ -718,6 +719,7 @@ int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret)
     ourAddr.assign(addr.c_str() + 1, pos-1);
     try {
       port = pdns_stou(addr.substr(pos+2));
+      portSet = true;
     }
     catch(std::out_of_range) {
       return -1;
@@ -744,12 +746,12 @@ int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret)
     freeaddrinfo(res);
   }
 
-  if(port > 65535)
-    // negative ports are found with the pdns_stou above
-    return -1;
+  if(portSet) {
+    if(port > 65535)
+      return -1;
 
-  if(port >= 0)
     ret->sin6_port = htons(port);
+  }
 
   return 0;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
On a 32-bit Arch, our `test_ComboAddress` unit test fails because `ComboAddress("[::1]:-6")` is considered valid. This is caused by `stoul()` not throwing for a negative value and returning an `unsigned
long` value using unsigned integer wraparound rules. Since we used to store the result value in a `signed int` and treat negative values as if the port was not set, the test failed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
