### PR TITLE
Refuse to start with chroot set in a systemd env

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -142,6 +142,9 @@ When setting `chroot`, all other paths in the config (except for
 [`config-dir`](#config-dir) and [`module-dir`](#module-dir)) set in the configuration
 are relative to the new root.
 
+When running on a system where systemd manages services, `chroot` does not work out of the box, as PowerDNS cannot use the `NOTIFY_SOCKET`.
+Either don't `chroot` on these systems or set the 'Type' of the this service to 'simple' instead of 'notify' (refer to the systemd documentation on how to modify unit-files)
+
 ## `config-dir`
 * Path
 

--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -129,6 +129,9 @@ in the configuration are relative to the new root.
 When using `chroot` and the API ([`webserver`](#webserver)), [`api-readonly`](#api-readonly)
 must be set and [`api-config-dir`](#api-config-dir) unset.
 
+When running on a system where systemd manages services, `chroot` does not work out of the box, as PowerDNS cannot use the `NOTIFY_SOCKET`.
+Either do not `chroot` on these systems or set the 'Type' of this service to 'simple' instead of 'notify' (refer to the systemd documentation on how to modify unit-files)
+
 ## `client-tcp-timeout`
 * Integer
 * Default: 2

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -498,6 +498,14 @@ void mainthread()
    stubParseResolveConf();
 
    if(!::arg()["chroot"].empty()) {
+#ifdef HAVE_SYSTEMD
+     char *ns;
+     ns = getenv("NOTIFY_SOCKET");
+     if (ns != nullptr) {
+       L<<Logger::Error<<"Unable to chroot when running from systemd. Please disable chroot= or set the 'Type' for this service to 'simple'"<<endl;
+       exit(1);
+     }
+#endif
      triggerLoadOfLibraries();
      if(::arg().mustDo("master") || ::arg().mustDo("slave"))
         gethostbyname("a.root-servers.net"); // this forces all lookup libraries to be loaded

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2819,6 +2819,14 @@ int serviceMain(int argc, char*argv[])
   Utility::dropGroupPrivs(newuid, newgid);
 
   if (!::arg()["chroot"].empty()) {
+#ifdef HAVE_SYSTEMD
+     char *ns;
+     ns = getenv("NOTIFY_SOCKET");
+     if (ns != nullptr) {
+       L<<Logger::Error<<"Unable to chroot when running from systemd. Please disable chroot= or set the 'Type' for this service to 'simple'"<<endl;
+       exit(1);
+     }
+#endif
     if (chroot(::arg()["chroot"].c_str())<0 || chdir("/") < 0) {
       L<<Logger::Error<<"Unable to chroot to '"+::arg()["chroot"]+"': "<<strerror (errno)<<", exiting"<<endl;
       exit(1);


### PR DESCRIPTION
### Short description
When `chroot` is used while ruinning in systemd, PowerDNS can't use [`sd_notify()`](https://www.freedesktop.org/software/systemd/man/sd_notify.html)'s `NOTIFY_SOCKET` to send a notification to systemd that it started successfully, resulting in systemd believing the start up timed out.

This PR exits the server before starting up with a proper error message so the operator can take action.

Closes #4848

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
