### PR TITLE
Feature request: convert ws-auth to produce numerical stats.

### DIFF
--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -63,7 +63,7 @@ private:
   static bool s_init;
 };
 
-std::map<std::string, int> getAllStatsMap();
+std::map<std::string, uint64_t> getAllStatsMap();
 extern pthread_mutex_t g_carbon_config_lock;
 void sortPublicSuffixList();
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetQueryRing();

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -63,7 +63,7 @@ private:
   static bool s_init;
 };
 
-std::map<std::string, std::string> getAllStatsMap();
+std::map<std::string, int> getAllStatsMap();
 extern pthread_mutex_t g_carbon_config_lock;
 void sortPublicSuffixList();
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetQueryRing();

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -129,7 +129,7 @@ string getAllStats()
   varmap_t varmap = getAllStatsMap();
   string ret;
   for(varmap_t::value_type& tup :  varmap) {
-    ret += tup.first + "\t" + tup.second +"\n";
+    ret += tup.first + "\t" + std::to_string(tup.second) +"\n";
   }
   return ret;
 }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -98,34 +98,34 @@ optional<uint64_t> get(const string& name)
   return ret;
 }
 
-map<string,string> getAllStatsMap()
+map<string,uint64_t> getAllStatsMap()
 {
-  map<string,string> ret;
+  map<string,uint64_t> ret;
   
   for(const auto& the32bits :  d_get32bitpointers) {
-    ret.insert(make_pair(the32bits.first, std::to_string(*the32bits.second)));
+    ret.insert(make_pair(the32bits.first, *the32bits.second));
   }
   for(const auto& the64bits :  d_get64bitpointers) {
-    ret.insert(make_pair(the64bits.first, std::to_string(*the64bits.second)));
+    ret.insert(make_pair(the64bits.first, *the64bits.second));
   }
   for(const auto& atomic :  d_getatomics) {
-    ret.insert(make_pair(atomic.first, std::to_string(atomic.second->load())));
+    ret.insert(make_pair(atomic.first, atomic.second->load()));
   }
 
   for(const auto& the64bitmembers :  d_get64bitmembers) { 
     if(the64bitmembers.first == "cache-bytes" || the64bitmembers.first=="packetcache-bytes")
       continue; // too slow for 'get-all'
-    ret.insert(make_pair(the64bitmembers.first, std::to_string(the64bitmembers.second())));
+    ret.insert(make_pair(the64bitmembers.first, the64bitmembers.second()));
   }
   Lock l(&d_dynmetricslock);
   for(const auto& a : d_dynmetrics)
-    ret.insert({a.first, std::to_string(*a.second)});
+    ret.insert({a.first, *a.second});
   return ret;
 }
 
 string getAllStats()
 {
-  typedef map<string, string> varmap_t;
+  typedef map<string, uint64_t> varmap_t;
   varmap_t varmap = getAllStatsMap();
   string ret;
   for(varmap_t::value_type& tup :  varmap) {

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -195,16 +195,16 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp) {
   if(req->method != "GET")
     throw HttpMethodNotAllowedException();
 
-  map<string,int> items;
+  map<string,uint64_t> items;
   productServerStatisticsFetch(items);
 
   Json::array doc;
-  typedef map<string, int> items_t;
+  typedef map<string, uint64_t> items_t;
   for(const items_t::value_type& item : items) {
     doc.push_back(Json::object {
       { "type", "StatisticItem" },
       { "name", item.first },
-      { "value", item.second },
+      { "value", static_cast<double>(item.second) },
     });
   }
 

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -195,11 +195,11 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp) {
   if(req->method != "GET")
     throw HttpMethodNotAllowedException();
 
-  map<string,string> items;
+  map<string,int> items;
   productServerStatisticsFetch(items);
 
   Json::array doc;
-  typedef map<string, string> items_t;
+  typedef map<string, int> items_t;
   for(const items_t::value_type& item : items) {
     doc.push_back(Json::object {
       { "type", "StatisticItem" },

--- a/pdns/ws-api.hh
+++ b/pdns/ws-api.hh
@@ -41,6 +41,6 @@ void apiCheckQNameAllowedCharacters(const string& name);
 DNSName apiNameToDNSName(const string& name);
 
 // To be provided by product code.
-void productServerStatisticsFetch(std::map<string,string>& out);
+void productServerStatisticsFetch(std::map<string,int>& out);
 
 #endif /* PDNS_WSAPI_HH */

--- a/pdns/ws-api.hh
+++ b/pdns/ws-api.hh
@@ -41,6 +41,6 @@ void apiCheckQNameAllowedCharacters(const string& name);
 DNSName apiNameToDNSName(const string& name);
 
 // To be provided by product code.
-void productServerStatisticsFetch(std::map<string,int>& out);
+void productServerStatisticsFetch(std::map<string,uint64_t>& out);
 
 #endif /* PDNS_WSAPI_HH */

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -424,15 +424,15 @@ static void fillZone(const DNSName& zonename, HttpResponse* resp) {
   resp->setBody(doc);
 }
 
-void productServerStatisticsFetch(map<string,string>& out)
+void productServerStatisticsFetch(map<string,int>& out)
 {
   vector<string> items = S.getEntries();
   for(const string& item :  items) {
-    out[item] = std::to_string(S.read(item));
+    out[item] = std::stoi(std::to_string(S.read(item)));
   }
 
   // add uptime
-  out["uptime"] = std::to_string(time(0) - s_starttime);
+  out["uptime"] = time(0) - s_starttime;
 }
 
 static void gatherRecords(const Json container, const DNSName& qname, const QType qtype, const int ttl, vector<DNSResourceRecord>& new_records, vector<DNSResourceRecord>& new_ptrs) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -424,11 +424,11 @@ static void fillZone(const DNSName& zonename, HttpResponse* resp) {
   resp->setBody(doc);
 }
 
-void productServerStatisticsFetch(map<string,int>& out)
+void productServerStatisticsFetch(map<string,uint64_t>& out)
 {
   vector<string> items = S.getEntries();
   for(const string& item :  items) {
-    out[item] = std::stoi(std::to_string(S.read(item)));
+    out[item] = S.read(item);
   }
 
   // add uptime

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -44,9 +44,9 @@ extern __thread FDMultiplexer* t_fdm;
 
 using json11::Json;
 
-void productServerStatisticsFetch(map<string,string>& out)
+void productServerStatisticsFetch(map<string,int>& out)
 {
-  map<string,string> stats = getAllStatsMap();
+  //map<string,string> stats = getAllStatsMap();
   out.swap(stats);
 }
 

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -44,9 +44,9 @@ extern __thread FDMultiplexer* t_fdm;
 
 using json11::Json;
 
-void productServerStatisticsFetch(map<string,int>& out)
+void productServerStatisticsFetch(map<string,uint64_t>& out)
 {
-  //map<string,string> stats = getAllStatsMap();
+  map<string,uint64_t> stats = getAllStatsMap();
   out.swap(stats);
 }
 


### PR DESCRIPTION
### Short description
Currently stats are produced as strings, even though they are numbers. This makes them very hard to consume from metrics systems (we're using New Relic Insights at work).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled the code
- [(could not figure out how to do this. regression-test instructions confusing, not direct!!)] ran tests on the code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
