### PR TITLE
rec: Clean up, fix compiler warnings

### DIFF
--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -426,7 +426,7 @@ extern BackendMakerClass &BackendMakers();
 class DBException : public PDNSException
 {
 public:
-  DBException(const string &reason) : PDNSException(reason){}
+  DBException(const string &reason_) : PDNSException(reason_){}
 };
 
 /** helper function for both DNSPacket and addSOARecord() - converts a line into a struct, for easier parsing */

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -231,15 +231,15 @@ inline DNSName operator+(const DNSName& lhs, const DNSName& rhs)
    anything part of that domain will return 'true' in check */
 struct SuffixMatchNode
 {
-  SuffixMatchNode(const std::string& name_="", bool endNode_=false) : name(name_), endNode(endNode_)
+  SuffixMatchNode(const std::string& name_="", bool endNode_=false) : d_name(name_), endNode(endNode_)
   {}
-  std::string name;
+  std::string d_name;
   std::string d_human;
   mutable std::set<SuffixMatchNode> children;
   mutable bool endNode;
   bool operator<(const SuffixMatchNode& rhs) const
   {
-    return strcasecmp(name.c_str(), rhs.name.c_str()) < 0;
+    return strcasecmp(d_name.c_str(), rhs.d_name.c_str()) < 0;
   }
 
   void add(const DNSName& dnsname)

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -340,10 +340,13 @@ class DSRecordContent : public DNSRecordContent
 {
 public:
   DSRecordContent();
-  bool operator==(const DSRecordContent& rhs) const
+  bool operator==(const DNSRecordContent& rhs) const override
   {
+    if(typeid(*this) != typeid(rhs))
+      return false;
+    auto rrhs =dynamic_cast<const decltype(this)>(&rhs);
     return tie(d_tag, d_algorithm, d_digesttype, d_digest) ==
-      tie(rhs.d_tag, rhs.d_algorithm, rhs.d_digesttype, rhs.d_digest);
+      tie(rrhs->d_tag, rrhs->d_algorithm, rrhs->d_digesttype, rrhs->d_digest);
   }
   bool operator<(const DSRecordContent& rhs) const
   {

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -328,8 +328,8 @@ RecursorLua4::RecursorLua4(const std::string& fname)
           cas.insert(ComboAddress(*s));
         }
         else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
-          for(const auto& s : *v)
-            cas.insert(ComboAddress(s.second));
+          for(const auto&entry : *v)
+            cas.insert(ComboAddress(entry.second));
           }
         else {
           cas.insert(boost::get<ComboAddress>(in));
@@ -440,8 +440,8 @@ RecursorLua4::RecursorLua4(const std::string& fname)
 
       if(auto rec = std::dynamic_pointer_cast<ARecordContent>(dr.d_content))
         ret=rec->getCA(53);
-      else if(auto rec = std::dynamic_pointer_cast<AAAARecordContent>(dr.d_content))
-        ret=rec->getCA(53);
+      else if(auto aaaarec = std::dynamic_pointer_cast<AAAARecordContent>(dr.d_content))
+        ret=aaaarec->getCA(53);
       return ret;
     });
 
@@ -487,8 +487,8 @@ RecursorLua4::RecursorLua4(const std::string& fname)
           smn.add(DNSName(*s));
         }
         else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
-          for(const auto& s : *v)
-            smn.add(DNSName(s.second));
+          for(const auto& entry : *v)
+            smn.add(DNSName(entry.second));
         }
         else {
           smn.add(boost::get<DNSName>(in));
@@ -683,12 +683,12 @@ loop:;
       }
       else if(dq.followupFunction=="udpQueryResponse") {
         dq.udpAnswer = GenUDPQueryResponse(dq.udpQueryDest, dq.udpQuery);
-        auto func = d_lw->readVariable<boost::optional<luacall_t>>(dq.udpCallback).get_value_or(0);
-        if(!func) {
+        auto cbFunc = d_lw->readVariable<boost::optional<luacall_t>>(dq.udpCallback).get_value_or(0);
+        if(!cbFunc) {
           theL()<<Logger::Error<<"Attempted callback for Lua UDP Query/Response which could not be found"<<endl;
           return false;
         }
-        bool result=func(&dq);
+        bool result=cbFunc(&dq);
         if(!result) {
           return false;
         }

--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -51,7 +51,7 @@ int arecvfrom(char *data, size_t len, int flags, const ComboAddress& ip, size_t 
 class LWResException : public PDNSException
 {
 public:
-  LWResException(const string &reason) : PDNSException(reason){}
+  LWResException(const string &reason_) : PDNSException(reason_){}
 };
 
 //! LWRes class 

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -97,17 +97,17 @@ NSECRecordContent::DNSRecordContent* NSECRecordContent::make(const DNSRecord &dr
   
   for(unsigned int n = 0; n+1 < bitmap.size();) {
     unsigned int window=static_cast<unsigned char>(bitmap[n++]);
-    unsigned int len=static_cast<unsigned char>(bitmap[n++]);
+    unsigned int blen=static_cast<unsigned char>(bitmap[n++]);
 
     // end if zero padding and ensure packet length
-    if(window == 0&&len == 0) break;
-    if(n+len>bitmap.size()) 
+    if(window == 0 && blen == 0) break;
+    if(n + blen > bitmap.size())
       throw MOADNSException("NSEC record with bitmap length > packet length");
 
-    for(unsigned int k=0; k < len; k++) {
+    for(unsigned int k=0; k < blen; k++) {
       uint8_t val=bitmap[n++];
-      for(int bit = 0; bit < 8 ; ++bit , val>>=1) 
-        if(val & 1) { 
+      for(int bit = 0; bit < 8 ; ++bit , val>>=1)
+        if(val & 1) {
           ret->d_set.insert((7-bit) + 8*(k) + 256*window);
         }
       }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1161,15 +1161,15 @@ void startDoResolve(void *p)
       iov[0].iov_base=(void*)buf;              iov[0].iov_len=2;
       iov[1].iov_base=(void*)&*packet.begin(); iov[1].iov_len = packet.size();
 
-      int ret=Utility::writev(dc->d_socket, iov, 2);
+      int wret=Utility::writev(dc->d_socket, iov, 2);
       bool hadError=true;
 
-      if(ret == 0)
+      if(wret == 0)
         L<<Logger::Error<<"EOF writing TCP answer to "<<dc->getRemote()<<endl;
-      else if(ret < 0 )
+      else if(wret < 0 )
         L<<Logger::Error<<"Error writing TCP answer to "<<dc->getRemote()<<": "<< strerror(errno) <<endl;
-      else if((unsigned int)ret != 2 + packet.size())
-        L<<Logger::Error<<"Oops, partial answer sent to "<<dc->getRemote()<<" for "<<dc->d_mdp.d_qname<<" (size="<< (2 + packet.size()) <<", sent "<<ret<<")"<<endl;
+      else if((unsigned int)wret != 2 + packet.size())
+        L<<Logger::Error<<"Oops, partial answer sent to "<<dc->getRemote()<<" for "<<dc->d_mdp.d_qname<<" (size="<< (2 + packet.size()) <<", sent "<<wret<<")"<<endl;
       else
         hadError=false;
 
@@ -1610,9 +1610,9 @@ string* doProcessUDPQuestion(const std::string& question, const ComboAddress& fr
         L<<Logger::Warning<<"Sending UDP reply to client "<<fromaddr.toStringWithPort()<<" failed with: "<<strerror(errno)<<endl;
 
       if(response.length() >= sizeof(struct dnsheader)) {
-        struct dnsheader dh;
-        memcpy(&dh, response.c_str(), sizeof(dh));
-        updateResponseStats(dh.rcode, fromaddr, response.length(), 0, 0);
+        struct dnsheader tmpdh;
+        memcpy(&tmpdh, response.c_str(), sizeof(tmpdh));
+        updateResponseStats(tmpdh.rcode, fromaddr, response.length(), 0, 0);
       }
       g_stats.avgLatencyUsec=(1-1.0/g_latencyStatSize)*g_stats.avgLatencyUsec + 0.0; // we assume 0 usec
       return 0;
@@ -1887,7 +1887,6 @@ void makeUDPServerSockets()
   
 #ifdef SO_REUSEPORT  
     if(::arg().mustDo("reuseport")) {
-      int one=1;
       if(setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) < 0)
         throw PDNSException("SO_REUSEPORT: "+stringerror());
     }

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -89,7 +89,7 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
   };
   Lua.writeVariable("Policy", pmap);
 
-  Lua.writeFunction("rpzFile", [&lci](const string& fname, const boost::optional<std::unordered_map<string,boost::variant<int, string>>>& options) {
+  Lua.writeFunction("rpzFile", [&lci](const string& filename, const boost::optional<std::unordered_map<string,boost::variant<int, string>>>& options) {
       try {
 	boost::optional<DNSFilterEngine::Policy> defpol;
 	std::string polName("rpzFile");
@@ -118,13 +118,13 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 	  }
 	}
         const size_t zoneIdx = lci.dfe.size();
-        theL()<<Logger::Warning<<"Loading RPZ from file '"<<fname<<"'"<<endl;
+        theL()<<Logger::Warning<<"Loading RPZ from file '"<<filename<<"'"<<endl;
         lci.dfe.setPolicyName(zoneIdx, polName);
-        loadRPZFromFile(fname, lci.dfe, defpol, zoneIdx);
-        theL()<<Logger::Warning<<"Done loading RPZ from file '"<<fname<<"'"<<endl;
+        loadRPZFromFile(filename, lci.dfe, defpol, zoneIdx);
+        theL()<<Logger::Warning<<"Done loading RPZ from file '"<<filename<<"'"<<endl;
       }
       catch(std::exception& e) {
-	theL()<<Logger::Error<<"Unable to load RPZ zone from '"<<fname<<"': "<<e.what()<<endl;
+	theL()<<Logger::Error<<"Unable to load RPZ zone from '"<<filename<<"': "<<e.what()<<endl;
       }
     });
 
@@ -222,8 +222,8 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 			    }
 			    else {
 			      const auto& v =boost::get<vector<pair<int, string> > >(e.second);
-			      for(const auto& e : v)
-				lci.sortlist.addEntry(formask, Netmask(e.second), order);
+			      for(const auto& entry : v)
+				lci.sortlist.addEntry(formask, Netmask(entry.second), order);
 			    }
 			    ++order;
 			  }
@@ -325,13 +325,13 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
     theL()<<Logger::Error<<"Unable to load Lua script from '"+fname+"': ";
     try {
       std::rethrow_if_nested(e);
-    } catch(const std::exception& e) {
-      // e is the exception that was thrown from inside the lambda
-      theL() << e.what() << std::endl;      
+    } catch(const std::exception& exp) {
+      // exp is the exception that was thrown from inside the lambda
+      theL() << exp.what() << std::endl;
     }
-    catch(const PDNSException& e) {
-      // e is the exception that was thrown from inside the lambda
-      theL() << e.reason << std::endl;      
+    catch(const PDNSException& exp) {
+      // exp is the exception that was thrown from inside the lambda
+      theL() << exp.reason << std::endl;
     }
     throw;
 

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -448,17 +448,17 @@ string doClearNTA(T begin, T end)
 
   string removed("");
   bool first(true);
-  for (auto const &who : toRemove) {
-    L<<Logger::Warning<<"Clearing Negative Trust Anchor for "<<who<<", requested via control channel"<<endl;
-    g_luaconfs.modify([who](LuaConfigItems& lci) {
-        lci.negAnchors.erase(who);
+  for (auto const &entry : toRemove) {
+    L<<Logger::Warning<<"Clearing Negative Trust Anchor for "<<entry<<", requested via control channel"<<endl;
+    g_luaconfs.modify([entry](LuaConfigItems& lci) {
+        lci.negAnchors.erase(entry);
       });
-    broadcastAccFunction<uint64_t>(boost::bind(pleaseWipePacketCache, who, true));
+    broadcastAccFunction<uint64_t>(boost::bind(pleaseWipePacketCache, entry, true));
     if (!first) {
       first = false;
       removed += ",";
     }
-    removed += " " + who.toStringRootDot();
+    removed += " " + entry.toStringRootDot();
   }
   return "Removed Negative Trust Anchors for " + removed + "\n";
 }
@@ -547,17 +547,17 @@ string doClearTA(T begin, T end)
 
   string removed("");
   bool first(true);
-  for (auto const &who : toRemove) {
-    L<<Logger::Warning<<"Removing Trust Anchor for "<<who<<", requested via control channel"<<endl;
-    g_luaconfs.modify([who](LuaConfigItems& lci) {
-        lci.dsAnchors.erase(who);
+  for (auto const &entry : toRemove) {
+    L<<Logger::Warning<<"Removing Trust Anchor for "<<entry<<", requested via control channel"<<endl;
+    g_luaconfs.modify([entry](LuaConfigItems& lci) {
+        lci.dsAnchors.erase(entry);
       });
-    broadcastAccFunction<uint64_t>(boost::bind(pleaseWipePacketCache, who, true));
+    broadcastAccFunction<uint64_t>(boost::bind(pleaseWipePacketCache, entry, true));
     if (!first) {
       first = false;
       removed += ",";
     }
-    removed += " " + who.toStringRootDot();
+    removed += " " + entry.toStringRootDot();
   }
   return "Removed Trust Anchor(s) for" + removed + "\n";
 }

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -30,33 +30,6 @@ bool RemoteLogger::reconnect()
   return true;
 }
 
-bool RemoteLogger::sendData(const char* buffer, size_t bufferSize)
-{
-  size_t pos = 0;
-  while(pos < bufferSize) {
-    ssize_t written = write(d_socket, buffer + pos, bufferSize - pos);
-    if (written == -1) {
-      int res = errno;
-      if (res == EWOULDBLOCK || res == EAGAIN) {
-        return false;
-      }
-      else if (res != EINTR) {
-        reconnect();
-        return false;
-      }
-    }
-    else if (written == 0) {
-      reconnect();
-      return false;
-    }
-    else {
-      pos += (size_t) written;
-    }
-  }
-
-  return true;
-}
-
 void RemoteLogger::worker()
 {
   if (d_asyncConnect) {

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -41,7 +41,6 @@ public:
   }
 private:
   bool reconnect();
-  bool sendData(const char* buffer, size_t bufferSize);
   void worker();
 
   std::queue<std::string> d_writeQueue;

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -46,7 +46,7 @@
 class ResolverException : public PDNSException
 {
 public:
-  ResolverException(const string &reason) : PDNSException(reason){}
+  ResolverException(const string &reason_) : PDNSException(reason_){}
 };
 
 // make an IPv4 or IPv6 query socket 

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -75,33 +75,33 @@ void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrR
     if (!crc) {
       return;
     }
-    auto target=crc->getTarget();
+    auto crcTarget=crc->getTarget();
     if(defpol) {
       pol=*defpol;
     }
-    else if(target.isRoot()) {
+    else if(crcTarget.isRoot()) {
       // cerr<<"Wants NXDOMAIN for "<<dr.d_name<<": ";
       pol.d_kind = DNSFilterEngine::PolicyKind::NXDOMAIN;
-    } else if(target==g_wildcarddnsname) {
+    } else if(crcTarget==g_wildcarddnsname) {
       // cerr<<"Wants NODATA for "<<dr.d_name<<": ";
       pol.d_kind = DNSFilterEngine::PolicyKind::NODATA;
     }
-    else if(target==drop) {
+    else if(crcTarget==drop) {
       // cerr<<"Wants DROP for "<<dr.d_name<<": ";
       pol.d_kind = DNSFilterEngine::PolicyKind::Drop;
     }
-    else if(target==truncate) {
+    else if(crcTarget==truncate) {
       // cerr<<"Wants TRUNCATE for "<<dr.d_name<<": ";
       pol.d_kind = DNSFilterEngine::PolicyKind::Truncate;
     }
-    else if(target==noaction) {
+    else if(crcTarget==noaction) {
       // cerr<<"Wants NOACTION for "<<dr.d_name<<": ";
       pol.d_kind = DNSFilterEngine::PolicyKind::NoAction;
     }
     else {
       pol.d_kind = DNSFilterEngine::PolicyKind::Custom;
       pol.d_custom = dr.d_content;
-      // cerr<<"Wants custom "<<target<<" for "<<dr.d_name<<": ";
+      // cerr<<"Wants custom "<<crcTarget<<" for "<<dr.d_name<<": ";
     }
   }
   else {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -528,8 +528,8 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
         if(i->d_type == QType::A || i->d_type == QType::AAAA) {
 	  if(auto rec = std::dynamic_pointer_cast<ARecordContent>(i->d_content))
 	    ret.push_back(rec->getCA(53));
-	  else if(auto rec = std::dynamic_pointer_cast<AAAARecordContent>(i->d_content))
-	    ret.push_back(rec->getCA(53));
+	  else if(auto aaaarec = std::dynamic_pointer_cast<AAAARecordContent>(i->d_content))
+	    ret.push_back(aaaarec->getCA(53));
           done=true;
         }
       }
@@ -719,14 +719,14 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
         ret.push_back(dr);
 
 	for(const auto& signature : signatures) {
-	  DNSRecord dr;
-	  dr.d_type=QType::RRSIG;
-	  dr.d_name=qname;
-	  dr.d_ttl=j->d_ttl - d_now.tv_sec;
-	  dr.d_content=signature;
-	  dr.d_place=DNSResourceRecord::ANSWER;
-	  dr.d_class=1;
-	  ret.push_back(dr);
+	  DNSRecord sigdr;
+	  sigdr.d_type=QType::RRSIG;
+	  sigdr.d_name=qname;
+	  sigdr.d_ttl=j->d_ttl - d_now.tv_sec;
+	  sigdr.d_content=signature;
+	  sigdr.d_place=DNSResourceRecord::ANSWER;
+	  sigdr.d_class=1;
+	  ret.push_back(sigdr);
 	}
 
         if(!(qtype==QType(QType::CNAME))) { // perhaps they really wanted a CNAME!

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -204,8 +204,6 @@ void validateWithKeySet(const cspmap_t& rrsets, cspmap_t& validated, const keyse
 //      www.powerdnssec.org -> secure/powerdnssec.org/[keys]
 //      www.dnssec-failed.org -> bogus/dnssec-failed.org/[]
 
-const char *g_rootDS;
-
 cspmap_t harvestCSPFromRecs(const vector<DNSRecord>& recs)
 {
   cspmap_t cspmap;

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -124,9 +124,12 @@ vector<DNSName> getZoneCuts(const DNSName& begin, const DNSName& end, DNSRecordO
   // The shortest name is assumed to a zone cut
   ret.push_back(qname);
   while(qname != begin) {
+    bool foundCut = false;
+    if (labelsToAdd.empty())
+      break;
+
     qname.prependRawLabel(labelsToAdd.back());
     labelsToAdd.pop_back();
-    bool foundCut = false;
     auto records = dro.get(qname, (uint16_t)QType::NS);
     for (const auto record : records) {
       if(record.d_name != qname || record.d_type != QType::NS)

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -151,7 +151,7 @@ void validateWithKeySet(const cspmap_t& rrsets, cspmap_t& validated, const keyse
     cerr<<"\tTag: "<<key.getTag()<<" -> "<<key.getZoneRepresentation()<<endl;
   }
   */
-  for(auto i=rrsets.begin(); i!=rrsets.end(); i++) {
+  for(auto i=rrsets.cbegin(); i!=rrsets.cend(); i++) {
     LOG("validating "<<(i->first.first)<<"/"<<DNSRecordContent::NumberToType(i->first.second)<<" with "<<i->second.signatures.size()<<" sigs"<<endl);
     for(const auto& signature : i->second.signatures) {
       vector<shared_ptr<DNSRecordContent> > toSign = i->second.records;
@@ -281,7 +281,7 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
     LOG(" => "<<zonecut);
   LOG(endl);
 
-  for(auto zoneCutIter = zoneCuts.begin(); zoneCutIter != zoneCuts.end(); ++zoneCutIter)
+  for(auto zoneCutIter = zoneCuts.cbegin(); zoneCutIter != zoneCuts.cend(); ++zoneCutIter)
   {
     vector<RRSIGRecordContent> sigs;
     vector<shared_ptr<DNSRecordContent> > toSign;
@@ -367,7 +367,7 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
       // but not a fully validated DNSKEY set, yet
       // one of these valid DNSKEYs should be able to validate the
       // whole set
-      for(auto i=sigs.begin(); i!=sigs.end(); i++)
+      for(auto i=sigs.cbegin(); i!=sigs.cend(); i++)
       {
         //        cerr<<"got sig for keytag "<<i->d_tag<<" matching "<<getByTag(tkeys, i->d_tag).size()<<" keys of which "<<getByTag(validkeys, i->d_tag).size()<<" valid"<<endl;
         string msg=getMessageForRRSET(*zoneCutIter, *i, toSign);
@@ -416,9 +416,9 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, keyset_t &keyset)
     }
     LOG("situation: we have one or more valid DNSKEYs for ["<<*zoneCutIter<<"] (want ["<<zone<<"])"<<endl);
 
-    if(zoneCutIter == zoneCuts.end()-1) {
+    if(zoneCutIter == zoneCuts.cend()-1) {
       LOG("requested keyset found! returning Secure for the keyset"<<endl);
-      keyset.insert(validkeys.begin(), validkeys.end());
+      keyset.insert(validkeys.cbegin(), validkeys.cend());
       return Secure;
     }
 

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -90,16 +90,16 @@ void HttpResponse::setBody(const json11::Json& document)
   document.dump(this->body);
 }
 
-void HttpResponse::setErrorResult(const std::string& message, const int status)
+void HttpResponse::setErrorResult(const std::string& message, const int status_)
 {
   setBody(json11::Json::object { { "error", message } });
-  this->status = status;
+  this->status = status_;
 }
 
-void HttpResponse::setSuccessResult(const std::string& message, const int status)
+void HttpResponse::setSuccessResult(const std::string& message, const int status_)
 {
   setBody(json11::Json::object { { "result", message } });
-  this->status = status;
+  this->status = status_;
 }
 
 static void bareHandlerWrapper(WebServer::HandlerFunction handler, YaHTTP::Request* req, YaHTTP::Response* resp)

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -177,8 +177,8 @@ static Json logGrep(const string& q, const string& fname, const string& prefix)
   }
 
   Json::array items;
-  for(const string& line : lines) {
-    items.push_back(line);
+  for(const string& iline : lines) {
+    items.push_back(iline);
   }
   return items;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This doesn't fix any real issue, just a minor clean up to try preventing future ones:
* remove some leftovers
* fix shadowed variables (reported by `-Wshadow`)
* fix `DSRecordContent::operator==` hiding virtual `DNSRecordContent::operator==` (reported by `-Woverloaded-virtual`)
* make sure `labelsToAdd` is not empty in `getZoneCuts()`
* explicitely use const iterators in `validateWithKeySet` and `getKeysFor`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

