### PR TITLE
Make EDNS Client Subnet masks tunable, improve logging, improve subnet oddity

### DIFF
--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -225,6 +225,20 @@ your network, and may even be a security risk. Therefore, since version 3.1.5,
 the PowerDNS recursor by default does not query private space IP addresses.
 This setting can be used to expand or reduce the limitations.
 
+## `ecs-ipv4-bits`
+* Integer
+* Default: 24
+* Available since 4.1
+
+Number of bits of client IPv4 address to pass when sending EDNS Client Subnet address information.
+
+## `ecs-ipv6-bits`
+* Integer
+* Default: 56
+* Available since 4.1
+
+Number of bits of client IPv6 address to pass when sending EDNS Client Subnet address information.
+
 ## `edns-outgoing-bufsize`
 * Integer
 * Default: 1680

--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -105,6 +105,7 @@ libtestremotebackend_la_SOURCES = \
 	../../pdns/dnsrecords.cc \
 	../../pdns/dnssecinfra.cc \
 	../../pdns/ednssubnet.cc \
+	../../pdns/iputils.cc \
 	../../pdns/logger.cc \
 	../../pdns/misc.cc \
 	../../pdns/nsecrecords.cc \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -445,7 +445,7 @@ sdig_SOURCES = \
 	dnsparser.cc dnsparser.hh \
 	dnsrecords.cc \
 	dnswriter.cc dnswriter.hh \
-	ednssubnet.cc \
+	ednssubnet.cc iputils.cc \
 	logger.cc \
 	misc.cc misc.hh \
 	nsecrecords.cc \
@@ -675,6 +675,7 @@ toysdig_SOURCES = \
 	ednssubnet.cc ednssubnet.hh \
 	filterpo.hh \
 	gss_context.cc gss_context.hh \
+	iputils.cc \
 	logger.cc \
 	misc.cc misc.hh \
 	nsecrecords.cc \
@@ -885,6 +886,7 @@ dnsreplay_SOURCES = \
 	dnswriter.cc dnswriter.hh \
 	ednssubnet.cc ednssubnet.hh \
 	ednsoptions.cc ednsoptions.hh \
+	iputils.cc \
 	logger.cc \
 	misc.cc \
 	nsecrecords.cc \

--- a/pdns/ednssubnet.cc
+++ b/pdns/ednssubnet.cc
@@ -73,7 +73,12 @@ bool getEDNSSubnetOptsFromString(const char* options, unsigned int len, EDNSSubn
     return false;
  // cerr<<"Source address: "<<address.toString()<<", mask: "<<(int)esow.sourceMask<<endl;
   eso->source = Netmask(address, esow.sourceMask);
+  /* 'address' has more bits set (potentially) than scopeMask. This leads to odd looking netmasks that promise
+     more precision than they have. For this reason we truncate the address to scopeMask bits */
+  
+  address.truncate(esow.scopeMask); // truncate will not throw for odd scopeMasks
   eso->scope = Netmask(address, esow.scopeMask);
+
   return true;
 }
 

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -227,7 +227,8 @@ void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, char* cbuf, size_t cbufs
   msgh->msg_flags = 0;
 }
 
-void ComboAddress::truncate(unsigned int bits)
+// warning: various parts of PowerDNS assume 'truncate' will never throw
+void ComboAddress::truncate(unsigned int bits) noexcept
 {
   uint8_t* start;
   int len=4;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -276,7 +276,7 @@ union ComboAddress {
       return "["+toString() + "]:" + std::to_string(ntohs(sin4.sin_port));
   }
 
-  void truncate(unsigned int bits);
+  void truncate(unsigned int bits) noexcept;
 };
 
 /** This exception is thrown by the Netmask class and by extension by the NetmaskGroup class */

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -79,6 +79,7 @@ pdns_recursor_SOURCES = \
 	dnssecinfra.hh dnssecinfra.cc \
 	dnsseckeeper.hh \
 	dnswriter.cc dnswriter.hh \
+	ecs.cc \
 	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
 	filterpo.cc filterpo.hh \

--- a/pdns/recursordist/ecs.cc
+++ b/pdns/recursordist/ecs.cc
@@ -1,0 +1,38 @@
+#include "syncres.hh"
+#include "arguments.hh"
+
+NetmaskGroup g_ednssubnets;
+SuffixMatchNode g_ednsdomains;
+
+boost::optional<Netmask> getEDNSSubnetMask(const ComboAddress& local, const DNSName&dn, const ComboAddress& rem)
+{
+  static int l_ipv4limit, l_ipv6limit;
+  if(!l_ipv4limit) {
+    l_ipv4limit = ::arg().asNum("ecs-ipv4-bits");
+    l_ipv6limit = ::arg().asNum("ecs-ipv6-bits");
+  }
+  if(local.sin4.sin_family != AF_INET || local.sin4.sin_addr.s_addr) { // detect unset 'requestor'
+    if(g_ednsdomains.check(dn) || g_ednssubnets.match(rem)) {
+      int bits = local.sin4.sin_family == AF_INET ? l_ipv4limit : l_ipv6limit;
+      ComboAddress trunc(local);
+      trunc.truncate(bits);
+      return boost::optional<Netmask>(Netmask(trunc, bits));
+    }
+  }
+  return boost::optional<Netmask>();
+}
+
+void  parseEDNSSubnetWhitelist(const std::string& wlist)
+{
+  vector<string> parts;
+  stringtok(parts, wlist, ",; ");
+  for(const auto& a : parts) {
+    try {
+      Netmask nm(a);
+      g_ednssubnets.addMask(nm);
+    }
+    catch(...) {
+      g_ednsdomains.add(DNSName(a));
+    }
+  }
+}

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1118,8 +1118,16 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
 	    }
 	    else {
 	      ednsmask=getEDNSSubnetMask(d_requestor, qname, *remoteIP);
+              if(ednsmask) {
+                LOG(prefix<<qname<<": Adding EDNS Client Subnet Mask "<<ednsmask->toString()<<" to query"<<endl);
+              }
 	      resolveret=asyncresolveWrapper(*remoteIP, d_doDNSSEC, qname,  qtype.getCode(),
 					     doTCP, sendRDQuery, &d_now, ednsmask, &lwr);    // <- we go out on the wire!
+              if(ednsmask) {
+                LOG(prefix<<qname<<": Received EDNS Client Subnet Mask "<<ednsmask->toString()<<" on response"<<endl);
+              }
+
+
 	    }
             if(resolveret==-3)
 	      throw ImmediateServFailException("Query killed by policy");

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -741,6 +741,10 @@ void  parseEDNSSubnetWhitelist(const std::string& wlist);
 
 extern __thread struct timeval g_now;
 
+extern NetmaskGroup g_ednssubnets;
+extern SuffixMatchNode g_ednsdomains;
+
+
 #ifdef HAVE_PROTOBUF
 extern __thread boost::uuids::random_generator* t_uuidGenerator;
 #endif


### PR DESCRIPTION
### Short description
EDNS Client Subnet can reveal x bits of the client subnet to the authoritative server. This makes x tunable. Plus it pretties the logging, and fixes an oddity where we'd return netmasks like '1.2.3.4/8'.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
