### PR TITLE
rec: Let ASAN know that we are switching stacks, which one is in use

### DIFF
--- a/m4/pdns_enable_sanitizers.m4
+++ b/m4/pdns_enable_sanitizers.m4
@@ -39,7 +39,17 @@ AC_DEFUN([PDNS_ENABLE_ASAN], [
 
   AS_IF([test "x$enable_asan" != "xno"], [
     gl_COMPILER_OPTION_IF([-fsanitize=address],
-      [SANITIZER_FLAGS="-fsanitize=address $SANITIZER_FLAGS"],
+      [
+        [SANITIZER_FLAGS="-fsanitize=address $SANITIZER_FLAGS"]
+        AC_CHECK_HEADERS([sanitizer/common_interface_defs.h], asan_headers=yes, asan_headers=no)
+        AS_IF([test x"$asan_headers" = "xyes" ],
+          [AC_CHECK_DECL(__sanitizer_start_switch_fiber,
+            [ AC_DEFINE([HAVE_FIBER_SANITIZER], [1], [Define if ASAN fiber annotation interface is available.]) ],
+            [ ],
+            [#include <sanitizer/common_interface_defs.h>]
+          )]
+        )
+      ],
       [AC_MSG_ERROR([Cannot enable AddressSanitizer])]
     )
   ])

--- a/pdns/mtasker.hh
+++ b/pdns/mtasker.hh
@@ -94,6 +94,17 @@ public:
 
   waiters_t d_waiters;
 
+  void initMainStackBounds()
+  {
+#ifdef HAVE_FIBER_SANITIZER
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_getattr_np(pthread_self(), &attr);
+    pthread_attr_getstack(&attr, &t_mainStack, &t_mainStackSize);
+    pthread_attr_destroy(&attr);
+#endif /* HAVE_FIBER_SANITIZER */
+  }
+
   //! Constructor
   /** Constructor with a small default stacksize. If any of your threads exceeds this stack, your application will crash. 
       This limit applies solely to the stack, the heap is not limited in any way. If threads need to allocate a lot of data,
@@ -101,6 +112,7 @@ public:
    */
   MTasker(size_t stacksize=8192) : d_tid(0), d_maxtid(0), d_stacksize(stacksize), d_waitstatus(Error)
   {
+    initMainStackBounds();
   }
 
   typedef void tfunc_t(void *); //!< type of the pointer that starts a thread 

--- a/pdns/mtasker_context.hh
+++ b/pdns/mtasker_context.hh
@@ -50,4 +50,35 @@ void
 pdns_makecontext
 (pdns_ucontext_t& ctx, boost::function<void(void)>& start);
 
+#ifdef HAVE_FIBER_SANITIZER
+#include <sanitizer/common_interface_defs.h>
+#endif /* HAVE_FIBER_SANITIZER */
+
+#ifdef HAVE_FIBER_SANITIZER
+extern __thread void* t_mainStack;
+extern __thread size_t t_mainStackSize;
+#endif /* HAVE_FIBER_SANITIZER */
+
+static inline void notifyStackSwitch(void* startOfStack, size_t stackSize)
+{
+#ifdef HAVE_FIBER_SANITIZER
+  __sanitizer_start_switch_fiber(nullptr, startOfStack, stackSize);
+#endif /* HAVE_FIBER_SANITIZER */
+}
+
+static inline void notifyStackSwitchToKernel()
+{
+#ifdef HAVE_FIBER_SANITIZER
+  notifyStackSwitch(t_mainStack, t_mainStackSize);
+#endif /* HAVE_FIBER_SANITIZER */
+}
+
+static inline void notifyStackSwitchDone()
+{
+#ifdef HAVE_FIBER_SANITIZER
+  __sanitizer_finish_switch_fiber(nullptr);
+#endif /* HAVE_FIBER_SANITIZER */
+}
+
+
 #endif // MTASKER_CONTEXT_HH

--- a/pdns/mtasker_fcontext.cc
+++ b/pdns/mtasker_fcontext.cc
@@ -36,6 +36,11 @@ using boost::context::detail::make_fcontext;
 #include <valgrind/valgrind.h>
 #endif /* PDNS_USE_VALGRIND */
 
+#ifdef HAVE_FIBER_SANITIZER
+__thread void* t_mainStack{nullptr};
+__thread size_t t_mainStackSize{0};
+#endif /* HAVE_FIBER_SANITIZER */
+
 #if BOOST_VERSION < 105600
 /* Note: This typedef means functions taking fcontext_t*, like jump_fcontext(),
  * now require a reinterpret_cast rather than a static_cast, since we're
@@ -107,6 +112,7 @@ threadWrapper (transfer_t const t) {
      * the behaviour of the System V implementation, which can inherently only
      * be passed ints and pointers.
      */
+    notifyStackSwitchDone();
 #if BOOST_VERSION < 106100
     auto args = reinterpret_cast<args_t*>(xargs);
 #else
@@ -115,6 +121,7 @@ threadWrapper (transfer_t const t) {
     auto ctx = args->self;
     auto work = args->work;
     /* we switch back to pdns_makecontext() */
+    notifyStackSwitchToKernel();
 #if BOOST_VERSION < 106100
     jump_fcontext (reinterpret_cast<fcontext_t*>(&ctx->uc_mcontext),
                    static_cast<fcontext_t>(args->prev_ctx), 0);
@@ -129,6 +136,7 @@ threadWrapper (transfer_t const t) {
       *ptr = res.fctx;
     }
 #endif
+    notifyStackSwitchDone();
     args = nullptr;
 
     try {
@@ -138,6 +146,7 @@ threadWrapper (transfer_t const t) {
         ctx->exception = std::current_exception();
     }
 
+    notifyStackSwitchToKernel();
     /* Emulate the System V uc_link feature. */
     auto const next_ctx = ctx->uc_link->uc_mcontext;
 #if BOOST_VERSION < 106100
@@ -211,6 +220,7 @@ pdns_makecontext
     args.self = &ctx;
     args.work = &start;
     /* jumping to threadwrapper */
+    notifyStackSwitch(&ctx.uc_stack[ctx.uc_stack.size()], ctx.uc_stack.size());
 #if BOOST_VERSION < 106100
     jump_fcontext (reinterpret_cast<fcontext_t*>(&args.prev_ctx),
                    static_cast<fcontext_t>(ctx.uc_mcontext),
@@ -221,4 +231,6 @@ pdns_makecontext
     /* back from threadwrapper, updating the context */
     ctx.uc_mcontext = res.fctx;
 #endif
+    notifyStackSwitchDone();
+
 }


### PR DESCRIPTION
### Short description
Enabled via the --enable-asan configure switch if the `__sanitizer_start_switch_fiber` function is present in `sanitizer/common_interface_defs.h` (currently only supported by `LLVM/clang` AFAIK).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

