### PR TITLE
dnsdist: Fix DNSCrypt support when building with libsodium < 1.0.3

### DIFF
--- a/m4/pdns_check_libsodium.m4
+++ b/m4/pdns_check_libsodium.m4
@@ -12,6 +12,13 @@ AC_DEFUN([PDNS_CHECK_LIBSODIUM], [
   AM_COND_IF([LIBSODIUM], [
     PKG_CHECK_MODULES([LIBSODIUM], [libsodium], [
       AC_DEFINE([HAVE_LIBSODIUM], [1], [Define to 1 if you have libsodium])
+      save_CFLAGS=$CFLAGS
+      save_LIBS=$LIBS
+      CFLAGS="$LIBSODIUM_CFLAGS $CFLAGS"
+      LIBS="$LIBSODIUM_LIBS $LIBS"
+      AC_CHECK_FUNCS([crypto_box_easy_afternm])
+      CFLAGS=$save_CFLAGS
+      LIBS=$save_LIBS
     ],[
       AC_MSG_ERROR([libsodium requested but not available])
     ])

--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -112,12 +112,16 @@ public:
   {
   }
   ~DnsCryptQuery();
+#ifdef HAVE_CRYPTO_BOX_EASY_AFTERNM
   int computeSharedKey(const DnsCryptPrivateKey& privateKey);
+#endif /* HAVE_CRYPTO_BOX_EASY_AFTERNM */
 
   static const size_t minUDPLength = 256;
 
   DnsCryptQueryHeader header;
+#ifdef HAVE_CRYPTO_BOX_EASY_AFTERNM
   unsigned char sharedKey[crypto_box_BEFORENMBYTES];
+#endif /* HAVE_CRYPTO_BOX_EASY_AFTERNM */
   DNSName qname;
   DnsCryptContext* ctx;
   uint16_t id{0};
@@ -126,7 +130,9 @@ public:
   bool useOldCert{false};
   bool encrypted{false};
   bool valid{false};
+#ifdef HAVE_CRYPTO_BOX_EASY_AFTERNM
   bool sharedKeyComputed{false};
+#endif /* HAVE_CRYPTO_BOX_EASY_AFTERNM */
 };
 
 class DnsCryptContext


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The pre-computed interface was added in 1.0.3, fall back to computing the key twice with earlier versions.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

