### PR TITLE
Backport #4781: API: correctly take TTL from first record even if we are at the last comment

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -384,7 +384,7 @@ static void fillZone(const DNSName& zonename, HttpResponse* resp) {
   auto cit = comments.begin();
 
   while (rit != records.end() || cit != comments.end()) {
-    if (cit == comments.end() || (rit != records.end() && (cit->qname.toString() < rit->qname.toString() || cit->qtype < rit->qtype))) {
+    if (cit == comments.end() || (rit != records.end() && (cit->qname.toString() <= rit->qname.toString() || cit->qtype < rit->qtype || cit->qtype == rit->qtype))) {
       current_qname = rit->qname;
       current_qtype = rit->qtype;
       ttl = rit->ttl;

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -886,6 +886,8 @@ fred   IN  A      192.168.0.4
         self.assertNotEquals(serverset['comments'], [])
         # verify that modified_at has been set by pdns
         self.assertNotEquals([c for c in serverset['comments']][0]['modified_at'], 0)
+        # verify that TTL is correct (regression test)
+        self.assertEquals(serverset['ttl'], 3600)
 
     def test_zone_comment_delete(self):
         # Test: Delete ONLY comments.


### PR DESCRIPTION
Cherry picked from master 50d739d0ae978b8b0b737b079992744ff8aa126d

### Short description
Fixes TTL returned as 0 when comments are present 

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [X] checked that this code was merged to master
