### PR TITLE
Backport #4901: Fix AtomicCounter unit tests on 32-bit

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -370,7 +370,8 @@ inline bool pdns_iequals_ch(const char a, const char b)
 }
 
 
-typedef std::atomic<unsigned long> AtomicCounter ;
+typedef unsigned long AtomicCounterInner;
+typedef std::atomic<AtomicCounterInner> AtomicCounter ;
 
 // FIXME400 this should probably go? 
 struct CIStringCompare: public std::binary_function<string, string, bool>

--- a/pdns/test-statbag_cc.cc
+++ b/pdns/test-statbag_cc.cc
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(test_StatBagBasic) {
 
 #ifdef UINTPTR_MAX  
 #if UINTPTR_MAX > 0xffffffffULL
-    BOOST_CHECK_EQUAL(sizeof(unsigned long), 8);
+    BOOST_CHECK_EQUAL(sizeof(AtomicCounterInner), 8);
     s.set("c", 1ULL<<33);
     BOOST_CHECK_EQUAL(s.read("c"), (1ULL<<33) );
     s.inc("c");
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(test_StatBagBasic) {
     s.inc("c");
     BOOST_CHECK_EQUAL(s.read("c"), 0 );
 #else
-    BOOST_CHECK_EQUAL(sizeof(AtomicCounter::native_t), 4);
+    BOOST_CHECK_EQUAL(sizeof(AtomicCounterInner), 4);
     BOOST_CHECK_EQUAL(~0UL, 0xffffffffUL);
     s.set("c", ~0UL);
     BOOST_CHECK_EQUAL(s.read("c"), 0xffffffffUL );


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
(cherry picked from commit 00c6f2b9f5173c98cc883332f5ecf8b941715abc)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [x] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
