### PR TITLE
support exclusions in NetmaskGroup

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -268,6 +268,8 @@ if nmg:match(dq.remoteaddr) then
 end
 ```
 
+Prefixing a mask with `!` excludes that mask from matching.
+
 ### IP Addresses
 We move IP addresses around in native format, called ComboAddress within PowerDNS.
 ComboAddresses can be IPv4 or IPv6, and unless you want to know, you don't need

--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1507,7 +1507,7 @@ instantiate a server with additional parameters
         * member `setCD(bool)`: set checking disabled flag
     * NetmaskGroup related
         * function `newNMG()`: returns a NetmaskGroup
-        * member `addMask(mask)`: adds `mask` to the NetmaskGroup
+        * member `addMask(mask)`: adds `mask` to the NetmaskGroup. Prefix with `!` to exclude this mask from matching.
         * member `match(ComboAddress)`: checks if ComboAddress is matched by this NetmaskGroup
         * member `clear()`: clears the NetmaskGroup
         * member `size()`: returns number of netmasks in this NetmaskGroup

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -208,6 +208,18 @@ BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
   BOOST_CHECK(ng.match(ComboAddress("fe80::1")));
   BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
   BOOST_CHECK_EQUAL(ng.toString(), "10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16");
+
+  ng.addMask("172.16.0.0/16");
+  BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
+  BOOST_CHECK(ng.match(ComboAddress("172.16.4.50")));
+  ng.addMask("172.16.4.0/24", false);
+  BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
+  BOOST_CHECK(!ng.match(ComboAddress("172.16.4.50")));
+
+  BOOST_CHECK(ng.match(ComboAddress("172.16.10.80")));
+  ng.addMask("!172.16.10.0/24");
+  BOOST_CHECK(!ng.match(ComboAddress("172.16.10.80")));
+  BOOST_CHECK_EQUAL(ng.toString(), "10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16, 172.16.0.0/16, !172.16.4.0/24, !172.16.10.0/24");
 }
 
 

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -207,6 +207,7 @@ BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
   ng.addMask("fe80::/16");
   BOOST_CHECK(ng.match(ComboAddress("fe80::1")));
   BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
+  BOOST_CHECK_EQUAL(ng.toString(), "10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16");
 }
 
 


### PR DESCRIPTION
### Short description
With this change, `NetmaskGroup::addMask` takes an optional boolean that when set false, excludes the given netmask. Additionally, a leading `!` on netmasks passed as strings also leads to exclusion.

While doing this I also added a `toString` test to the pre-exclusion tests.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [x] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
