### PR TITLE
::2 is not ::2 on every OS, because of RFC4291

### DIFF
--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -158,10 +158,6 @@ BOOST_AUTO_TEST_CASE(test_Mapping)
 {
   ComboAddress lh("::1");
   BOOST_CHECK_EQUAL(lh.toString(), "::1");
-
-  ComboAddress lh2("::2");
-  BOOST_CHECK_EQUAL(lh2.toString(), "::2");  
-  
 }
 
 BOOST_AUTO_TEST_CASE(test_Netmask) {


### PR DESCRIPTION
### Short description
This PR drops a test that fails on OSX. This test is useless as ::2 will never come up in reality, it is Reserved by IANA.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
