### PR TITLE
Auth: Incremental backoff for failed slave checks

### DIFF
--- a/docs/markdown/authoritative/modes-of-operation.md
+++ b/docs/markdown/authoritative/modes-of-operation.md
@@ -65,6 +65,10 @@ is higher, the domain is retrieved and inserted into the database. In any case,
 after the check the domain is declared 'fresh', and will only be checked again
 after '**refresh**' seconds have passed.
 
+When the freshness of a domain cannot be checked, e.g. because the master is offline, PowerDNS will retry the domain after [`slave-cycle-interval`](settings.md#slave-cycle-interval) seconds.
+Every time the domain fails it's freshness check, PowerDNS will hold back on checking the domain for `amount of failures * slave-cycle-interval` seconds, with a maximum of [`soa-retry-default`](settings.md#soa-retry-default) seconds between checks.
+With default settings, this means that PowerDNS will back off for 1, then 2, then 3 etc. minutes, to a maximum of 60 minutes between checks.
+
 **Warning**: Slave support is OFF by default, turn it on by adding [`slave`](settings.md#slave) to the configuration.
 **Note**: When running PowerDNS via the provided systemd service file, [`ProtectSystem`](http://www.freedesktop.org/software/systemd/man/systemd.exec.html#ProtectSystem=) is set to `full`, this means PowerDNS is unable to write to e.g. `/etc` and `/home`, possibly being unable to write AXFR's zones.
 

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -217,6 +217,11 @@ private:
   bool d_masterschanged, d_slaveschanged;
   bool d_preventSelfNotification;
 
+  // Used to keep some state on domains that failed their freshness checks.
+  // uint64_t == counter of the number of failures (increased by 1 every consecutive slave-cycle-interval that the domain fails)
+  // time_t == wait at least until this time before attempting a new check
+  map<DNSName, pair<uint64_t, time_t> > d_failedSlaveRefresh;
+
   struct RemoveSentinel
   {
     explicit RemoveSentinel(const DNSName& dn, CommunicatorClass* cc) : d_dn(dn), d_cc(cc)


### PR DESCRIPTION
### Short description
When we cannot retrieve the SOA record for a slave domain, use an increasing interval between checking the domain again. This prevents hammering down or already busy servers.
Closes #349
Closes #602

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
