### PR TITLE
Tuning unit file for medium sized setups

### DIFF
--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -22,7 +22,8 @@ NoNewPrivileges=true
 ProtectSystem=full
 ProtectHome=true
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-LimitNOFILE=4096
+LimitNOFILE=16384
+TasksMax=1024
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -23,7 +23,7 @@ ProtectSystem=full
 ProtectHome=true
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 LimitNOFILE=16384
-TasksMax=1024
+TasksMax=8192
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Short description
We would propose to introduce the `TasksMax` setting in the unit file. The default value of 512 seems too low, at least for our setup. In addition, if present in the unit file, people will be aware of it.

`LimitNOFILE=4096` seems also a little bit low.

Our setup consists of 8 DNS backend servers. Each Server with 5 IPv4 and 5 IPv6 addresses. That means dnsdist has to deal with 80 backends. For this setup `TasksMax=512` (default) was too low and dnsdist stopped working correctly. We saw many of these messages:

```
Error creating a TCP thread: Resource temporarily unavailable
Had an error accepting new webserver connection: Resource temporarily unavailable
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master
