### PR TITLE
Lowercase the TSIG algorithm name in hash computation

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -658,8 +658,7 @@ string makeTSIGMessageFromTSIGPacket(const string& opacket, unsigned int tsigOff
     dw.xfrName(keyname, false);
     dw.xfr16BitInt(QClass::ANY); // class
     dw.xfr32BitInt(0);    // TTL
-    // dw.xfrName(toLower(trc.d_algoName), false); //FIXME400 
-    dw.xfrName(trc.d_algoName, false);
+    dw.xfrName(trc.d_algoName.makeLowerCase(), false);
   }
   
   uint32_t now = trc.d_time; 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`RFC2845` states that the algorithm name should be in `canonical wire format` for the hash computation, which implies it should be lowercased. We actually did lowercase it in 3.x, until it was moved to a `DNSName` in 4.x.

Should fix #4942, thanks @wsanders for the investigative work!

This PR should also add some unit and/or regression tests.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

