### PR TITLE
PowerDNS Forward-Notify Patch

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -159,6 +159,7 @@ void declareArguments()
 
   ::arg().set("trusted-notification-proxy", "IP address of incoming notification proxy")="";
   ::arg().set("slave-renotify", "If we should send out notifications for slaved updates")="no";
+  ::arg().set("forward-notify", "IP addresses to send received notifications to regardless of master or slave settings")="";
 
   ::arg().set("default-ttl","Seconds a result is valid if not set otherwise")="3600";
   ::arg().set("max-tcp-connections","Maximum number of TCP connections")="20";
@@ -535,7 +536,7 @@ void mainthread()
   if(::arg().mustDo("webserver") || ::arg().mustDo("api"))
     webserver.go();
 
-  if(::arg().mustDo("slave") || ::arg().mustDo("master"))
+  if(::arg().mustDo("slave") || ::arg().mustDo("master") || !::arg()["forward-notify"].empty())
     Communicator.go(); 
 
   if(!::arg()["experimental-lua-policy-script"].empty()){

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -92,6 +92,19 @@ void CommunicatorClass::go()
       exit(1);
     }
   }
+
+  vector<string> forwards;
+  stringtok(forwards, ::arg()["forward-notify"], ", \t");
+  for (vector<string>::const_iterator iter = forwards.begin(); iter != forwards.end(); ++iter) {
+    try {
+      ComboAddress caIp(*iter, 53);
+      PacketHandler::s_forwardNotify.insert(caIp.toStringWithPort());
+    }
+    catch(PDNSException &e) {
+      L<<Logger::Error<<"Unparseable IP in forward-notify. Error: "<<e.reason<<endl;
+      exit(1);
+    }
+  }
 }
 
 void CommunicatorClass::mainloop(void)

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -66,6 +66,7 @@ public:
 
   int trySuperMasterSynchronous(DNSPacket *p, const DNSName& tsigkeyname);
   static NetmaskGroup s_allowNotifyFrom;
+  static set<string> s_forwardNotify;
 
 private:
   int trySuperMaster(DNSPacket *p, const DNSName& tsigkeyname);


### PR DESCRIPTION
This patch will allow you to redirect inbound notifications to a proxy server.  It's intended use is in anycast environments where it might be necessary for a proxy server to preform the AXFR.

The configuration option "forward-notify" has been added to the pdns.conf parser. The option accepts multiple IPv4 and IPv6 address values.

Obsoletes #1701