### PR TITLE
Feature request: PowerDNS Forward-Notify Patch

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -364,10 +364,10 @@ Forward DNS updates sent to a slave to the master.
 ## `forward-notify`
 * IP addresses, separated by commas
 
-IP addresses to send received notifications to regardless of master or slave settings.
+IP addresses to forward received notifications to regardless of master or slave settings.
 
 Note: The intended use is in anycast environments where it might be necessary for a
-proxy server to preform the AXFR.  The usual checks are preformed before any received
+proxy server to perform the AXFR.  The usual checks are performed before any received
 notification is forwarded.
 
 ## `guardian`

--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -361,6 +361,15 @@ If this is disabled (the default), ALIAS records will not expanded and the serve
 
 Forward DNS updates sent to a slave to the master.
 
+## `forward-notify`
+* IP addresses, separated by commas
+
+IP addresses to send received notifications to regardless of master or slave settings.
+
+Note: The intended use is in anycast environments where it might be necessary for a
+proxy server to preform the AXFR.  The usual checks are preformed before any received
+notification is forwarded.
+
 ## `guardian`
 * Boolean
 * Default: no

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -159,6 +159,7 @@ void declareArguments()
 
   ::arg().set("trusted-notification-proxy", "IP address of incoming notification proxy")="";
   ::arg().set("slave-renotify", "If we should send out notifications for slaved updates")="no";
+  ::arg().set("forward-notify", "IP addresses to send received notifications to regardless of master or slave settings")="";
 
   ::arg().set("default-ttl","Seconds a result is valid if not set otherwise")="3600";
   ::arg().set("max-tcp-connections","Maximum number of TCP connections")="20";
@@ -545,7 +546,7 @@ void mainthread()
   if(::arg().mustDo("webserver") || ::arg().mustDo("api"))
     webserver.go();
 
-  if(::arg().mustDo("slave") || ::arg().mustDo("master"))
+  if(::arg().mustDo("slave") || ::arg().mustDo("master") || !::arg()["forward-notify"].empty())
     Communicator.go(); 
 
   if(!::arg()["experimental-lua-policy-script"].empty()){

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -159,7 +159,7 @@ void declareArguments()
 
   ::arg().set("trusted-notification-proxy", "IP address of incoming notification proxy")="";
   ::arg().set("slave-renotify", "If we should send out notifications for slaved updates")="no";
-  ::arg().set("forward-notify", "IP addresses to send received notifications to regardless of master or slave settings")="";
+  ::arg().set("forward-notify", "IP addresses to forward received notifications to regardless of master or slave settings")="";
 
   ::arg().set("default-ttl","Seconds a result is valid if not set otherwise")="3600";
   ::arg().set("max-tcp-connections","Maximum number of TCP connections")="20";

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -92,6 +92,19 @@ void CommunicatorClass::go()
       exit(1);
     }
   }
+
+  vector<string> forwards;
+  stringtok(forwards, ::arg()["forward-notify"], ", \t");
+  for (vector<string>::const_iterator iter = forwards.begin(); iter != forwards.end(); ++iter) {
+    try {
+      ComboAddress caIp(*iter, 53);
+      PacketHandler::s_forwardNotify.insert(caIp.toStringWithPort());
+    }
+    catch(PDNSException &e) {
+      L<<Logger::Error<<"Unparseable IP in forward-notify. Error: "<<e.reason<<endl;
+      exit(1);
+    }
+  }
 }
 
 void CommunicatorClass::mainloop(void)

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -37,7 +37,7 @@
 #include "arguments.hh"
 #include "packetcache.hh"
 
-#define CommunicatorLoadArgsIntoSet(listname,listset) do {                                 \
+#define CommunicatorLoadArgsIntoSet(listname, listset) do {                                \
   vector<string> parts;                                                                    \
   stringtok(parts, ::arg()[(listname)], ", \t");                                           \
   for (vector<string>::const_iterator iter = parts.begin(); iter != parts.end(); ++iter) { \
@@ -95,9 +95,9 @@ void CommunicatorClass::go()
     exit(1);
   }
 
-  CommunicatorLoadArgsIntoSet("also-notify",d_alsoNotify);
+  CommunicatorLoadArgsIntoSet("also-notify", d_alsoNotify);
 
-  CommunicatorLoadArgsIntoSet("forward-notify",PacketHandler::s_forwardNotify);
+  CommunicatorLoadArgsIntoSet("forward-notify", PacketHandler::s_forwardNotify);
 }
 
 void CommunicatorClass::mainloop(void)

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -37,21 +37,6 @@
 #include "arguments.hh"
 #include "packetcache.hh"
 
-#define CommunicatorLoadArgsIntoSet(listname, listset) do {                                \
-  vector<string> parts;                                                                    \
-  stringtok(parts, ::arg()[(listname)], ", \t");                                           \
-  for (vector<string>::const_iterator iter = parts.begin(); iter != parts.end(); ++iter) { \
-    try {                                                                                  \
-      ComboAddress caIp(*iter, 53);                                                        \
-      (listset).insert(caIp.toStringWithPort());                                           \
-    }                                                                                      \
-    catch(PDNSException &e) {                                                              \
-      L<<Logger::Error<<"Unparseable IP in "<<(listname)<<". Error: "<<e.reason<<endl;     \
-      exit(1);                                                                             \
-    }                                                                                      \
-  }                                                                                        \
-} while(0)
-
 // there can be MANY OF THESE
 void CommunicatorClass::retrievalLoopThread(void)
 {
@@ -67,6 +52,22 @@ void CommunicatorClass::retrievalLoopThread(void)
       d_suckdomains.pop_front();
     }
     suck(sr.domain, sr.master);
+  }
+}
+
+void CommunicatorClass::LoadArgsIntoSet(const char *listname, set<string> &listset)
+{
+  vector<string> parts;
+  stringtok(parts, ::arg()[listname], ", \t");
+  for (vector<string>::const_iterator iter = parts.begin(); iter != parts.end(); ++iter) {
+    try {
+      ComboAddress caIp(*iter, 53);
+      listset.insert(caIp.toStringWithPort());
+    }
+    catch(PDNSException &e) {
+      L<<Logger::Error<<"Unparseable IP in "<<listname<<". Error: "<<e.reason<<endl;
+      exit(1);
+    }
   }
 }
 
@@ -95,9 +96,9 @@ void CommunicatorClass::go()
     exit(1);
   }
 
-  CommunicatorLoadArgsIntoSet("also-notify", d_alsoNotify);
+  LoadArgsIntoSet("also-notify", d_alsoNotify);
 
-  CommunicatorLoadArgsIntoSet("forward-notify", PacketHandler::s_forwardNotify);
+  LoadArgsIntoSet("forward-notify", PacketHandler::s_forwardNotify);
 }
 
 void CommunicatorClass::mainloop(void)

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -55,7 +55,7 @@ void CommunicatorClass::retrievalLoopThread(void)
   }
 }
 
-void CommunicatorClass::LoadArgsIntoSet(const char *listname, set<string> &listset)
+void CommunicatorClass::loadArgsIntoSet(const char *listname, set<string> &listset)
 {
   vector<string> parts;
   stringtok(parts, ::arg()[listname], ", \t");
@@ -96,9 +96,9 @@ void CommunicatorClass::go()
     exit(1);
   }
 
-  LoadArgsIntoSet("also-notify", d_alsoNotify);
+  loadArgsIntoSet("also-notify", d_alsoNotify);
 
-  LoadArgsIntoSet("forward-notify", PacketHandler::s_forwardNotify);
+  loadArgsIntoSet("forward-notify", PacketHandler::s_forwardNotify);
 }
 
 void CommunicatorClass::mainloop(void)

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -187,7 +187,7 @@ public:
   }
   bool notifyDomain(const DNSName &domain);
 private:
-  void LoadArgsIntoSet(const char *listname, set<string> &listset);
+  void loadArgsIntoSet(const char *listname, set<string> &listset);
   void makeNotifySockets();
   void queueNotifyDomain(const DomainInfo& di, UeberBackend* B);
   int d_nsock4, d_nsock6;

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -187,6 +187,7 @@ public:
   }
   bool notifyDomain(const DNSName &domain);
 private:
+  void LoadArgsIntoSet(const char *listname, set<string> &listset);
   void makeNotifySockets();
   void queueNotifyDomain(const DomainInfo& di, UeberBackend* B);
   int d_nsock4, d_nsock6;

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -66,6 +66,7 @@ public:
 
   int trySuperMasterSynchronous(DNSPacket *p, const DNSName& tsigkeyname);
   static NetmaskGroup s_allowNotifyFrom;
+  static set<string> s_forwardNotify;
 
 private:
   int trySuperMaster(DNSPacket *p, const DNSName& tsigkeyname);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This patch will allow you to redirect inbound notifications to a proxy server.  It's intended use is in anycast environments where it might be necessary for a proxy server to preform the AXFR.

The configuration option "forward-notify" has been added to the pdns.conf parser. The option accepts multiple IPv4 and IPv6 address values.

Obsoletes #4964 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- when not filing this Pull Request against the master branch --> checked that this code was merged to master