### PR TITLE
Add more NetmaskGroup unit tests

### DIFF
--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -187,35 +187,88 @@ BOOST_AUTO_TEST_CASE(test_Netmask) {
 }
 
 BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
-  NetmaskGroup ng;
-  ng.addMask("10.0.1.0");
-  BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
-  ng.toMasks("127.0.0.0/8, 10.0.0.0/24");
-  BOOST_CHECK(ng.match(ComboAddress("127.0.0.1")));
-  BOOST_CHECK(ng.match(ComboAddress("10.0.0.3")));
-  BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
-  BOOST_CHECK(!ng.match(ComboAddress("128.1.2.3")));
-  BOOST_CHECK(!ng.match(ComboAddress("10.0.1.1")));
-  BOOST_CHECK(!ng.match(ComboAddress("::1")));
-  ng.addMask("::1");
-  BOOST_CHECK(ng.match(ComboAddress("::1")));
-  BOOST_CHECK(!ng.match(ComboAddress("::2")));
-  ng.addMask("fe80::/16");
-  BOOST_CHECK(ng.match(ComboAddress("fe80::1")));
-  BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
-  BOOST_CHECK_EQUAL(ng.toString(), "10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16");
 
-  ng.addMask("172.16.0.0/16");
-  BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
-  BOOST_CHECK(ng.match(ComboAddress("172.16.4.50")));
-  ng.addMask("172.16.4.0/24", false);
-  BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
-  BOOST_CHECK(!ng.match(ComboAddress("172.16.4.50")));
+  {
+    NetmaskGroup ng;
+    ng.addMask("10.0.1.0");
+    BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
+    ng.toMasks("127.0.0.0/8, 10.0.0.0/24");
+    BOOST_CHECK(ng.match(ComboAddress("127.0.0.1")));
+    BOOST_CHECK(ng.match(ComboAddress("10.0.0.3")));
+    BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
+    BOOST_CHECK(!ng.match(ComboAddress("128.1.2.3")));
+    BOOST_CHECK(!ng.match(ComboAddress("10.0.1.1")));
+    BOOST_CHECK(!ng.match(ComboAddress("::1")));
+    ng.addMask("::1");
+    BOOST_CHECK(ng.match(ComboAddress("::1")));
+    BOOST_CHECK(!ng.match(ComboAddress("::2")));
+    ng.addMask("fe80::/16");
+    BOOST_CHECK(ng.match(ComboAddress("fe80::1")));
+    BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
+    BOOST_CHECK_EQUAL(ng.toString(), "10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16");
 
-  BOOST_CHECK(ng.match(ComboAddress("172.16.10.80")));
-  ng.addMask("!172.16.10.0/24");
-  BOOST_CHECK(!ng.match(ComboAddress("172.16.10.80")));
-  BOOST_CHECK_EQUAL(ng.toString(), "10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16, 172.16.0.0/16, !172.16.4.0/24, !172.16.10.0/24");
+    /* negative entries using the explicit flag */
+    ng.addMask("172.16.0.0/16", true);
+    BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
+    BOOST_CHECK(ng.match(ComboAddress("172.16.4.50")));
+    ng.addMask("172.16.4.0/24", false);
+    BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
+    BOOST_CHECK(!ng.match(ComboAddress("172.16.4.50")));
+    ng.addMask("fe80::/24", false);
+    BOOST_CHECK(!ng.match(ComboAddress("fe80::1")));
+    BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
+    /* not in fe80::/24 but in fe80::/16, should match */
+    BOOST_CHECK(ng.match(ComboAddress("fe80:0100::1")));
+
+    /* negative entries using '!' */
+    BOOST_CHECK(ng.match(ComboAddress("172.16.10.80")));
+    ng.addMask("!172.16.10.0/24");
+    BOOST_CHECK(!ng.match(ComboAddress("172.16.10.80")));
+    ng.addMask("2001:db8::/32");
+    ng.addMask("!2001:db8::/64");
+    BOOST_CHECK(!ng.match(ComboAddress("2001:db8::1")));
+    /* not in 2001:db8::/64 but in 2001:db8::/32, should match */
+    BOOST_CHECK(ng.match(ComboAddress("2001:db8:1::1")));
+
+    BOOST_CHECK_EQUAL(ng.toString(), "10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16, 172.16.0.0/16, !172.16.4.0/24, !fe80::/24, !172.16.10.0/24, 2001:db8::/32, !2001:db8::/64");
+  }
+
+  {
+    /* this time using Netmask objects instead of strings */
+    NetmaskGroup ng;
+    ng.addMask(Netmask("10.0.1.0"));
+    BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
+    ng.addMask(Netmask("127.0.0.0/8"));
+    ng.addMask(Netmask("10.0.0.0/24"));
+    BOOST_CHECK(ng.match(ComboAddress("127.0.0.1")));
+    BOOST_CHECK(ng.match(ComboAddress("10.0.0.3")));
+    BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
+    BOOST_CHECK(!ng.match(ComboAddress("128.1.2.3")));
+    BOOST_CHECK(!ng.match(ComboAddress("10.0.1.1")));
+    BOOST_CHECK(!ng.match(ComboAddress("::1")));
+    ng.addMask(Netmask("::1"));
+    BOOST_CHECK(ng.match(ComboAddress("::1")));
+    BOOST_CHECK(!ng.match(ComboAddress("::2")));
+    ng.addMask(Netmask("fe80::/16"));
+    BOOST_CHECK(ng.match(ComboAddress("fe80::1")));
+    BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
+    BOOST_CHECK_EQUAL(ng.toString(), "10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16");
+
+    /* negative entries using the explicit flag */
+    ng.addMask(Netmask("172.16.0.0/16"), true);
+    BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
+    BOOST_CHECK(ng.match(ComboAddress("172.16.4.50")));
+    ng.addMask(Netmask("172.16.4.0/24"), false);
+    BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
+    BOOST_CHECK(!ng.match(ComboAddress("172.16.4.50")));
+    ng.addMask("fe80::/24", false);
+    BOOST_CHECK(!ng.match(ComboAddress("fe80::1")));
+    BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
+    /* not in fe80::/24 but in fe80::/16, should match */
+    BOOST_CHECK(ng.match(ComboAddress("fe80:0100::1")));
+
+    BOOST_CHECK_EQUAL(ng.toString(), "10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16, 172.16.0.0/16, !172.16.4.0/24, !fe80::/24");
+  }
 }
 
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Add more NetmaskGroup unit tests:
* negative entries using the explicit flag instead of '!'
* IPv6 negative entries
* regular and negative entries from Netmask objects instead of strings

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [x] added unit tests

