### PR TITLE
Add `sendSizeAndMsgWithTimeout` to send size and data in a single call

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1308,7 +1308,7 @@ Here are all functions:
     * `setVerboseHealthChecks(bool)`: set whether health check errors will be logged
  * Server related:
     * `newServer("ip:port")`: instantiate a new downstream server with default settings
-    * `newServer({address="ip:port", qps=1000, order=1, weight=10, pool="abuse", retries=5, tcpConnectTimeout=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName="a.root-servers.net.", checkType="A", setCD=false, maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source="address|interface name|address@interface"})`:
+    * `newServer({address="ip:port", qps=1000, order=1, weight=10, pool="abuse", retries=5, tcpConnectTimeout=5, tcpSendTimeout=30, tcpRecvTimeout=30, tcpFastOpen=false, checkName="a.root-servers.net.", checkType="A", setCD=false, maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source="address|interface name|address@interface"})`:
 instantiate a server with additional parameters
     * `showServers()`: output all servers
     * `getServer(n)`: returns server with index n 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -412,6 +412,10 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			  ret->tcpRecvTimeout=std::stoi(boost::get<string>(vars["tcpRecvTimeout"]));
 			}
 
+			if(vars.count("tcpFastOpen")) {
+			  ret->tcpFastOpen=boost::get<bool>(vars["tcpFastOpen"]);
+			}
+
 			if(vars.count("name")) {
 			  ret->name=boost::get<string>(vars["name"]);
 			}

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -484,6 +484,7 @@ struct DownstreamState
   bool useECS{false};
   bool setCD{false};
   std::atomic<bool> connected{false};
+  bool tcpFastOpen{false};
   bool isUp() const
   {
     if(availability == Availability::Down)

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -300,3 +300,104 @@ ssize_t sendMsgWithTimeout(int fd, const char* buffer, size_t len, int timeout, 
 
 template class NetmaskTree<bool>;
 
+bool sendSizeAndMsgWithTimeout(int sock, uint16_t bufferLen, const char* buffer, int idleTimeout, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int totalTimeout, int flags)
+{
+  uint16_t size = htons(bufferLen);
+  char cbuf[256];
+  struct msghdr msgh;
+  struct iovec iov[2];
+  int remainingTime = totalTimeout;
+  time_t start = 0;
+  if (totalTimeout) {
+    start = time(NULL);
+  }
+
+  /* Set up iov and msgh structures. */
+  memset(&msgh, 0, sizeof(struct msghdr));
+  msgh.msg_control = nullptr;
+  msgh.msg_controllen = 0;
+  if (dest) {
+    msgh.msg_name = reinterpret_cast<void*>(const_cast<ComboAddress*>(dest));
+    msgh.msg_namelen = dest->getSocklen();
+  }
+  else {
+    msgh.msg_name = nullptr;
+    msgh.msg_namelen = 0;
+  }
+
+  msgh.msg_flags = 0;
+
+  if (localItf != 0 && local) {
+    addCMsgSrcAddr(&msgh, cbuf, local, localItf);
+  }
+
+  iov[0].iov_base = &size;
+  iov[0].iov_len = sizeof(size);
+  iov[1].iov_base = reinterpret_cast<void*>(const_cast<char*>(buffer));
+  iov[1].iov_len = bufferLen;
+
+  size_t pos = 0;
+  size_t sent = 0;
+  size_t nbElements = sizeof(iov)/sizeof(*iov);
+  while (true) {
+    msgh.msg_iov = &iov[pos];
+    msgh.msg_iovlen = nbElements - pos;
+
+    ssize_t res = sendmsg(sock, &msgh, flags);
+    if (res > 0) {
+      size_t written = static_cast<size_t>(res);
+      sent += written;
+
+      if (sent == (sizeof(size) + bufferLen)) {
+        return true;
+      }
+      /* partial write, we need to keep only the (parts of) elements
+         that have not been written.
+      */
+      do {
+        if (written < iov[pos].iov_len) {
+          iov[pos].iov_len -= written;
+          written = 0;
+        }
+        else {
+          written -= iov[pos].iov_len;
+          iov[pos].iov_len = 0;
+          pos++;
+        }
+      }
+      while (written > 0 && pos < nbElements);
+    }
+    else if (res == -1) {
+      if (errno == EINTR) {
+        continue;
+      }
+      else if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINPROGRESS) {
+        /* EINPROGRESS might happen with non blocking socket,
+           especially with TCP Fast Open */
+        int ret = waitForRWData(sock, false, (totalTimeout == 0 || idleTimeout <= remainingTime) ? idleTimeout : remainingTime, 0);
+        if (ret > 0) {
+          /* there is room available */
+        }
+        else if (ret == 0) {
+          throw runtime_error("Timeout while waiting to send data");
+        } else {
+          throw runtime_error("Error while waiting for room to send data");
+        }
+      }
+      else {
+        unixDie("failed in sendSizeAndMsgWithTimeout");
+      }
+    }
+    if (totalTimeout) {
+      time_t now = time(NULL);
+      int elapsed = now - start;
+      if (elapsed >= remainingTime) {
+        throw runtime_error("Timeout while sending data");
+      }
+      start = now;
+      remainingTime -= elapsed;
+    }
+  }
+
+  return false;
+}

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -901,7 +901,8 @@ bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv);
 void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, char* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr);
 ssize_t sendfromto(int sock, const char* data, size_t len, int flags, const ComboAddress& from, const ComboAddress& to);
 ssize_t sendMsgWithTimeout(int fd, const char* buffer, size_t len, int timeout, ComboAddress& dest, const ComboAddress& local, unsigned int localItf);
-
-#endif
+bool sendSizeAndMsgWithTimeout(int sock, uint16_t bufferLen, const char* buffer, int idleTimeout, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int totalTimeout, int flags);
 
 extern template class NetmaskTree<bool>;
+
+#endif

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -49,10 +49,8 @@ void RemoteLogger::worker()
     }
 
     try {
-      uint16_t len = data.length();
-      len = htons(len);
-      writen2WithTimeout(d_socket, &len, sizeof(len), (int) d_timeout);
-      writen2WithTimeout(d_socket, data.c_str(), data.length(), (int) d_timeout);
+      uint16_t len = static_cast<uint16_t>(data.length());
+      sendSizeAndMsgWithTimeout(d_socket, len, data.c_str(), static_cast<int>(d_timeout), nullptr, nullptr, 0, 0, 0);
     }
     catch(const std::runtime_error& e) {
 #ifdef WE_ARE_RECURSOR

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -200,8 +200,13 @@ class DNSDistTest(unittest.TestCase):
                 response = copy.copy(response)
                 response.id = request.id
                 wire = response.to_wire()
-                conn.send(struct.pack("!H", len(wire)))
-                conn.send(wire)
+                try:
+                    conn.send(struct.pack("!H", len(wire)))
+                    conn.send(wire)
+                except socket.error as e:
+                    # some of the tests are going to close
+                    # the connection on us, just deal with it
+                    break
 
             conn.close()
 


### PR DESCRIPTION
### Short description
`sendSizeAndMsgWithTimeout()` groups the sending of the size as a `uint16_t` in network byte order and the corresponding data in a single `sendmsg()` syscall, handling short writes and timeouts if needed. It also supports optional source address and interface number. This PR makes use of this new function in the Remote Logger (`protobuf`) and `dnsdist` `TCP` workers.
It also adds `TCP Fast Open` support toward backends in `dnsdist`, if the `MSG_FASTOPEN` flag is available.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

