### PR TITLE
Fix remotebackend params

### DIFF
--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -80,10 +80,11 @@ std::string HTTPConnector::buildMemberListArgs(std::string prefix, const Json& a
     for(const auto& pair: args.object_items()) {
         if (pair.second.is_bool()) {
           stream << (pair.second.bool_value()?"1":"0");
+        } else if (pair.second.is_null()) {
+          stream << prefix << "[" << pair.first << "]=";
         } else {
           stream << prefix << "[" << pair.first << "]=" << this->asString(pair.second);
         }
-
         stream << "&";
     }
 

--- a/modules/remotebackend/regression-tests/dnsbackend.rb
+++ b/modules/remotebackend/regression-tests/dnsbackend.rb
@@ -47,6 +47,7 @@ class DNSBackendHandler < WEBrick::HTTPServlet::AbstractServlet
          }
      when "list"
         {
+          "id" => url.shift,
           "zonename" => url.shift
         }
      when "getbeforeandafternamesabsolute", "getbeforeandafternames"

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -214,8 +214,8 @@ bool RemoteBackend::list(const DNSName& target, int domain_id, bool include_disa
      { "method", "list" },
      { "parameters", Json::object{
        { "zonename", target.toString() },
-       { "domain-id", domain_id },
-       { "include-disabled", include_disabled }
+       { "domain_id", domain_id },
+       { "include_disabled", include_disabled }
      }}
    };
 

--- a/modules/remotebackend/unittest_http.rb
+++ b/modules/remotebackend/unittest_http.rb
@@ -50,6 +50,7 @@ class DNSBackendHandler < WEBrick::HTTPServlet::AbstractServlet
          }
      when "list"
         {
+	  "id" => url.shift,
           "zonename" => url.shift
         }
      when "getbeforeandafternamesabsolute", "getbeforeandafternames"


### PR DESCRIPTION
### Short description
Fix two problems with remotebackend
 - list method used domain-id json parameter, when it was supposed to use domain_id
 - NULL ordername was not passed as empty string in POST parameters builder, instead it threw exception

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added regression tests
- [x] added unit tests