### PR TITLE
rec: Use `DNSName::makeLowerCase()` instead of converting to string and back

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -728,7 +728,7 @@ void startDoResolve(void *p)
 
     // DO NOT MOVE THIS CODE UP - DNSPacketWriter needs to get the original-cased version
     if (g_lowercaseOutgoing)
-      dc->d_mdp.d_qname = DNSName(toLower(dc->d_mdp.d_qname.toString()));
+      dc->d_mdp.d_qname = dc->d_mdp.d_qname.makeLowerCase();
 
     uint32_t minTTL=std::numeric_limits<uint32_t>::max();
 

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -199,7 +199,7 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
       throw PDNSException("Zones with a mixture of Opt-Out NSEC3 RRs and non-Opt-Out NSEC3 RRs are not supported.");
     zs.optOutFlag = ns3rc.d_flags & 1;
     if (ns3rc.d_set.count(QType::NS) && !(rr.qname==domain)) {
-      DNSName hashPart = DNSName(toLower(rr.qname.makeRelative(domain).toString()));
+      DNSName hashPart = rr.qname.makeRelative(domain).makeLowerCase();
       zs.secured.insert(hashPart);
     }
     return false;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Use `DNSName::makeLowerCase()` instead of converting to string and back.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

