### PR TITLE
[WIP] re-enable MYSQL_OPT_RECONNECT; deal with re-preparing statements

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -169,7 +169,7 @@ retry:
 
     if ((err = mysql_stmt_execute(d_stmt))) {
       string error(mysql_stmt_error(d_stmt));
-      if(allowRetry && mysql_stmt_errno(d_stmt) == CR_SERVER_LOST) {
+      if(allowRetry && mysql_stmt_errno(d_stmt) == CR_SERVER_LOST && !d_db->in_trx()) {
         allowRetry = false;
         rePrepareStatement();
         goto retry;

--- a/modules/gmysqlbackend/smysql.hh
+++ b/modules/gmysqlbackend/smysql.hh
@@ -23,6 +23,7 @@
 #define SMYSQL_HH
 
 #include <mysql.h>
+#include <errmsg.h>
 #include "pdns/backends/gsql/ssql.hh"
 #include "pdns/utility.hh"
 

--- a/modules/gmysqlbackend/smysql.hh
+++ b/modules/gmysqlbackend/smysql.hh
@@ -45,11 +45,14 @@ public:
   void startTransaction();
   void commit();
   void rollback();
+  MYSQL* db() { return &d_db; }
+  bool in_trx() { return d_in_trx; }
 
 private:
   MYSQL d_db;
   static bool s_dolog;
   static pthread_mutex_t s_myinitlock;
+  bool d_in_trx;
 };
 
 #endif /* SSMYSQL_HH */


### PR DESCRIPTION
THIS IS BROKEN

### Short description
When `MYSQL_OPT_RECONNECT` is enabled (which is desirable), statements can silently get unprepared. This PR silently re-prepares them in that situation, and enables `MYSQL_OPT_RECONNECT` again.

HOWEVER, while figuring this out, I realise that the automatic reconnect will rollback the active query and re-enable autocommit mode for subsequent queries, while those queries assume a transaction is ongoing. To tackle this, smysql needs to start keeping track of whether a transaction is open (like spgsql does). Then, if a silent reconnect is detected (because a statement has gone invalid) and a transaction is open, we need to abort after all.

Furthermore, given that a silent reconnect also resets LAST_INSERT_ID(), `GSQLBackend::addDomainKey` perhaps needs to wrap its two queries in a transaction to avoid returning a bogus 0. On the other hand, then it becomes impossible to use `addDomainKey` inside another transaction. So maybe not.

Comments?

TODO:
- [x] track transactions in smysql
- [x] turn 'silent re-prepare' into abort while in a transaction
- [ ] turn `addDomainKey` into a transactional operation

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
