### PR TITLE
Backport #4861: Do not resolve the NS-records for NOTIFY targets if the "only-notify"…

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -565,9 +565,18 @@ This is the server ID that will be returned on an EDNS NSID query.
 * IP Ranges, separated by commas or whitespace
 * Default: 0.0.0.0/0, ::/0
 
-Only send AXFR NOTIFY to these IP addresses or netmasks. The default is to
-notify the world. The IP addresses or netmasks in [`also-notify`](#also-notify)
-or ALSO-NOTIFY metadata always receive AXFR NOTIFY.
+For type=MASTER zones (or SLAVE zones with slave-renotify enabled) PowerDNS
+automatically sends NOTIFYs to the name servers specified in the NS records.
+By specifying networks/mask as whitelist, the targets can be limited. The default
+is to notify the world. To completely disable these NOTIFYs set only-notify to an
+empty value. Independent of this setting, the IP addresses or netmasks in
+[`also-notify`](#also-notify) or ALSO-NOTIFY metadata always receive AXFR NOTIFY.
+
+Note: Even if NOTIFYs are limited by a netmask, PowerDNS first has to resolve all the
+hostnames to get IP addresses. Thus, PowerDNS relies on DNS. If the respective
+authoritative name servers are slow, PowerDNS becomes slow too. To avoid this, set
+only-notify to an empty value and specify the notification targets with ALSO-NOTIFY
+and also-notify.
 
 ## `out-of-zone-additional-processing`
 * Boolean

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -49,30 +49,32 @@ void CommunicatorClass::queueNotifyDomain(const DNSName &domain, UeberBackend *B
   DNSResourceRecord rr;
   FindNS fns;
 
-  B->lookup(QType(QType::NS),domain);
-  while(B->get(rr))
-    nsset.insert(rr.content);
+  if (d_onlyNotify.size()) {
+    B->lookup(QType(QType::NS),domain);
+    while(B->get(rr))
+      nsset.insert(rr.content);
 
-  for(set<string>::const_iterator j=nsset.begin();j!=nsset.end();++j) {
-    vector<string> nsips=fns.lookup(DNSName(*j), B);
-    if(nsips.empty())
-      L<<Logger::Warning<<"Unable to queue notification of domain '"<<domain<<"': nameservers do not resolve!"<<endl;
-    else
-      for(vector<string>::const_iterator k=nsips.begin();k!=nsips.end();++k) {
-        const ComboAddress caIp(*k, 53);
-        if(!d_preventSelfNotification || !AddressIsUs(caIp)) {
-          if(!d_onlyNotify.match(&caIp))
-            L<<Logger::Info<<"Skipped notification of domain '"<<domain<<"' to "<<*j<<" because it does not match only-notify."<<endl;
-          else
-            ips.insert(caIp.toStringWithPort());
+    for(set<string>::const_iterator j=nsset.begin();j!=nsset.end();++j) {
+      vector<string> nsips=fns.lookup(DNSName(*j), B);
+      if(nsips.empty())
+        L<<Logger::Warning<<"Unable to queue notification of domain '"<<domain<<"': nameservers do not resolve!"<<endl;
+      else
+        for(vector<string>::const_iterator k=nsips.begin();k!=nsips.end();++k) {
+          const ComboAddress caIp(*k, 53);
+          if(!d_preventSelfNotification || !AddressIsUs(caIp)) {
+            if(!d_onlyNotify.match(&caIp))
+              L<<Logger::Info<<"Skipped notification of domain '"<<domain<<"' to "<<*j<<" because it does not match only-notify."<<endl;
+            else
+              ips.insert(caIp.toStringWithPort());
+          }
         }
-      }
-  }
+    }
 
-  for(set<string>::const_iterator j=ips.begin();j!=ips.end();++j) {
-    L<<Logger::Warning<<"Queued notification of domain '"<<domain<<"' to "<<*j<<endl;
-    d_nq.add(domain,*j);
-    hasQueuedItem=true;
+    for(set<string>::const_iterator j=ips.begin();j!=ips.end();++j) {
+      L<<Logger::Warning<<"Queued notification of domain '"<<domain<<"' to "<<*j<<endl;
+      d_nq.add(domain,*j);
+      hasQueuedItem=true;
+    }
   }
 
   set<string> alsoNotify(d_alsoNotify);


### PR DESCRIPTION
… whitelist is empty, as a target will never match an empty whitelist.

(cherry picked from commit 99844905a8abcab33a3b8ed42d3a49f2e419a310)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
