### PR TITLE
Backport #4793: Don't call `hostname -f` on openbsd (auth)

### DIFF
--- a/m4/pdns_enable_reproducible.m4
+++ b/m4/pdns_enable_reproducible.m4
@@ -15,7 +15,7 @@ AC_DEFUN([PDNS_ENABLE_REPRODUCIBLE], [
     build_user=$(id -u -n)
 
     case "$host_os" in
-    solaris2.1* | SunOS)
+    solaris2.1* | SunOS | openbsd*)
       build_host_host=$(hostname)
       build_host_domain=$(domainname)
       build_host="$build_host_host.$build_host_domain"


### PR DESCRIPTION
Closes #2579

(cherry picked from commit df925537cfe0a4706b85353376da6f12996871bb)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
