### PR TITLE
Backport #4777: only delegate if NS's are below apex in auth-zones

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -211,7 +211,7 @@ bool SyncRes::doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSR
     somedata=true;
     if(qtype.getCode()==QType::ANY || ziter->d_type==qtype.getCode() || ziter->d_type==QType::CNAME)  // let rest of nameserver do the legwork on this one
       ret.push_back(*ziter);
-    else if(ziter->d_type == QType::NS) { // we hit a delegation point!
+    else if(ziter->d_type == QType::NS && ziter->d_name.countLabels() > authdomain.countLabels()) { // we hit a delegation point!
       DNSRecord dr=*ziter;
       dr.d_place=DNSResourceRecord::AUTHORITY;
       ret.push_back(dr);

--- a/regression-tests.recursor/auth-zones/command
+++ b/regression-tests.recursor/auth-zones/command
@@ -3,3 +3,5 @@ cleandig host1.auth-zone.example.net. AAAA | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0
 cleandig host2.auth-zone.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
 cleandig host3.auth-zone.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
 cleandig you-are.wild.auth-zone.example.net. TXT | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+# Non-existing QTYPE at the apex
+cleandig auth-zone.example.net. TXT | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'

--- a/regression-tests.recursor/auth-zones/expected_result
+++ b/regression-tests.recursor/auth-zones/expected_result
@@ -15,3 +15,6 @@ Reply to question for qname='host3.auth-zone.example.net.', qtype=A
 0	you-are.wild.auth-zone.example.net.	IN	TXT	3600	"Hi there!"
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='you-are.wild.auth-zone.example.net.', qtype=TXT
+1	auth-zone.example.net.	IN	SOA	3600	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+Reply to question for qname='auth-zone.example.net.', qtype=TXT


### PR DESCRIPTION
As:
 1. we **are** authoritative for the zone named at the apex
 2. We would servfail because we could get an upward referral

Closes #4771

(cherry picked from commit 221a3f72e117a0e0fdf9e4fedf237a8e6526d145)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
