### PR TITLE
Backport #4762: SuffixMatchNode: Fix insertion issue for an existing node (rec)

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -254,7 +254,12 @@ struct SuffixMatchNode
       endNode=true;
     }
     else if(labels.size()==1) {
-      children.insert(SuffixMatchNode(*labels.begin(), true));
+      auto res=children.insert(SuffixMatchNode(*labels.begin(), true));
+      if(!res.second) {
+        if(!res.first->endNode) {
+          res.first->endNode = true;
+        }
+      }
     }
     else {
       auto res=children.insert(SuffixMatchNode(*labels.rbegin(), false));

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -427,6 +427,13 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch) {
 
   smn.add(DNSName(".")); // block the root
   BOOST_CHECK(smn.check(DNSName("a.root-servers.net.")));
+
+  DNSName examplenet("example.net.");
+  DNSName net("net.");
+  smn.add(examplenet);
+  smn.add(net);
+  BOOST_CHECK(smn.check(examplenet));
+  BOOST_CHECK(smn.check(net));
 }
 
 


### PR DESCRIPTION
If the node we are about to insert already existed as an intermediary
one, we need to mark it as an end node.

(cherry picked from commit ed221d0bc700158c21fcb8fc4463085713d07c53)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
