### PR TITLE
Backport #4684: Clarify pdnsutil activate-tsig-key description

### DIFF
--- a/docs/manpages/pdnsutil.1.md
+++ b/docs/manpages/pdnsutil.1.md
@@ -133,10 +133,12 @@ require an *ALGORITHM*, the following are available:
  * hmac-sha512
 
 activate-tsig-key *ZONE* *NAME* {**master**,**slave**}
-:    Enable TSIG key *NAME* for zone *ZONE*.
+:    Enable TSIG authenticated AXFR using the key *NAME* for zone *ZONE*.
+     This sets the `TSIG-ALLOW-AXFR` (master) or `AXFR-MASTER-TSIG` (slave)
+     zone metadata.
 
 deactivate-tsig-key *ZONE* *NAME* {**master**,**slave**}
-:    Disable TSIG key *NAME* for zone *ZONE*.
+:    Disable TSIG authenticated AXFR using the key *NAME* for zone *ZONE*.
 
 delete-tsig-key *NAME*
 :    Delete the TSIG key *NAME*. Warning, this does not deactivate said key.

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1903,7 +1903,7 @@ try
     cout<<"Usage: \npdnsutil [options] <command> [params ..]\n"<<endl;
     cout<<"Commands:"<<endl;
     cout<<"activate-tsig-key ZONE NAME {master|slave}"<<endl;
-    cout<<"                                   Enable TSIG key for a zone"<<endl;
+    cout<<"                                   Enable TSIG authenticated AXFR using the key NAME for ZONE"<<endl;
     cout<<"activate-zone-key ZONE KEY-ID      Activate the key with key id KEY-ID in ZONE"<<endl;
     cout<<"add-record ZONE NAME TYPE [ttl] content"<<endl;
     cout<<"             [content..]           Add one or more records to ZONE"<<endl;
@@ -1926,7 +1926,7 @@ try
     cout<<"                                   Create slave zone ZONE with master IP address master-ip"<<endl;
     cout<<"create-zone ZONE [nsname]          Create empty zone ZONE"<<endl;
     cout<<"deactivate-tsig-key ZONE NAME {master|slave}"<<endl;
-    cout<<"                                   Disable TSIG key for a zone"<<endl;
+    cout<<"                                   Disable TSIG authenticated AXFR using the key NAME for ZONE"<<endl;
     cout<<"deactivate-zone-key ZONE KEY-ID    Deactivate the key with key id KEY-ID in ZONE"<<endl;
     cout<<"delete-rrset ZONE NAME TYPE        Delete named RRSET from zone"<<endl;
     cout<<"delete-tsig-key NAME               Delete TSIG key (warning! will not unmap key!)"<<endl;


### PR DESCRIPTION
This clarifies the description of pdnsutil {de,}activate-tsig-key.
The command enables TSIG authenticated AXFR for a given zone + key,
which was not clear from the previous description.

(cherry picked from commit ad7568d52bdd29eb708e16176f8b410f0e07b891)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
