### PR TITLE
Backport #4622: API dot-inconsistencies

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -725,7 +725,7 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
         throw ApiException("Nameserver is not canonical: '" + nameserver + "'");
       try {
         // ensure the name parses
-        autorr.content = DNSName(nameserver).toStringNoDot();
+        autorr.content = DNSName(nameserver).toStringRootDot();
       } catch (...) {
         throw ApiException("Unable to parse DNS Name for NS '" + nameserver + "'");
       }
@@ -927,7 +927,7 @@ static void makePtr(const DNSResourceRecord& rr, DNSResourceRecord* ptr) {
   ptr->qtype = "PTR";
   ptr->ttl = rr.ttl;
   ptr->disabled = rr.disabled;
-  ptr->content = rr.qname.toString();
+  ptr->content = rr.qname.toStringRootDot();
 }
 
 static void storeChangedPTRs(UeberBackend& B, vector<DNSResourceRecord>& new_ptrs) {


### PR DESCRIPTION
(cherry picked from commit 8f95565346ba5dcc7d26fbd4165da7d9c7faf362)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
