### PR TITLE
Backport #4526: API: url in zone info should be absolute

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -311,7 +311,7 @@ static Json::object getZoneInfo(const DomainInfo& di) {
   return Json::object {
     // id is the canonical lookup key, which doesn't actually match the name (in some cases)
     { "id", zoneId },
-    { "url", "api/v1/servers/localhost/zones/" + zoneId },
+    { "url", "/api/v1/servers/localhost/zones/" + zoneId },
     { "name", di.zone.toString() },
     { "kind", di.getKindString() },
     { "dnssec", dk.isSecuredZone(di.zone) },

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -286,6 +286,54 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             headers={'content-type': 'application/json'})
         self.assertEquals(r.status_code, 422)
 
+    def test_zone_absolute_url(self):
+        name, payload, data = self.create_zone()
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones"))
+        rdata = r.json()
+        print(rdata[0])
+        self.assertTrue(rdata[0]['url'].startswith('/api/v'))
+
+    def test_create_zone_metadata(self):
+        payload_metadata = {"type": "Metadata", "kind": "AXFR-SOURCE", "metadata": ["127.0.0.2"]}
+        r = self.session.post(self.url("/api/v1/servers/localhost/zones/example.com/metadata"),
+                              data=json.dumps(payload_metadata))
+        rdata = r.json()
+        self.assertEquals(r.status_code, 201)
+        self.assertEquals(rdata["metadata"], payload_metadata["metadata"])
+
+    def test_create_zone_metadata_kind(self):
+        payload_metadata = {"metadata": ["127.0.0.2"]}
+        r = self.session.put(self.url("/api/v1/servers/localhost/zones/example.com/metadata/AXFR-SOURCE"),
+                             data=json.dumps(payload_metadata))
+        rdata = r.json()
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(rdata["metadata"], payload_metadata["metadata"])
+
+    def test_create_protected_zone_metadata(self):
+        # test whether it prevents modification of certain kinds
+        for k in ("NSEC3NARROW", "NSEC3PARAM", "PRESIGNED", "LUA-AXFR-SCRIPT"):
+            payload = {"metadata": ["FOO", "BAR"]}
+            r = self.session.put(self.url("/api/v1/servers/localhost/zones/example.com/metadata/%s" % k),
+                                 data=json.dumps(payload))
+            self.assertEquals(r.status_code, 422)
+
+    def test_retrieve_zone_metadata(self):
+        payload_metadata = {"type": "Metadata", "kind": "AXFR-SOURCE", "metadata": ["127.0.0.2"]}
+        self.session.post(self.url("/api/v1/servers/localhost/zones/example.com/metadata"),
+                          data=json.dumps(payload_metadata))
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/example.com/metadata"))
+        rdata = r.json()
+        self.assertEquals(r.status_code, 200)
+        self.assertIn(payload_metadata, rdata)
+
+    def test_delete_zone_metadata(self):
+        r = self.session.delete(self.url("/api/v1/servers/localhost/zones/example.com/metadata/AXFR-SOURCE"))
+        self.assertEquals(r.status_code, 200)
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/example.com/metadata/AXFR-SOURCE"))
+        rdata = r.json()
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(rdata["metadata"], [])
+
     def test_create_slave_zone(self):
         # Test that nameservers can be absent for slave zones.
         name, payload, data = self.create_zone(kind='Slave', nameservers=None, masters=['127.0.0.2'])


### PR DESCRIPTION
Fixes #4524.

(cherry picked from commit 16e25450a17bee09f83a6cf7817ebd95e3504c6a)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
