### PR TITLE
dnsdist: Don't cache ServFail / Refused if the TTL is set to 0

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -53,6 +53,9 @@ void DNSDistPacketCache::insert(uint32_t key, const DNSName& qname, uint16_t qty
 
   if (rcode == RCode::ServFail || rcode == RCode::Refused) {
     minTTL = d_tempFailureTTL;
+    if (minTTL == 0) {
+      return;
+    }
   }
   else {
     minTTL = getMinTTL(response, responseLen);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If the TTL for ServFail / Refused responses is set to 0, we currently cache these responses for less than 1s, while it would be more logical to simply interpret a 0-TTL as "don't cache".

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added regression tests
- [ ] added unit tests

