### PR TITLE
API: Allow setting extra domain metadata

### DIFF
--- a/docs/markdown/authoritative/domainmetadata.md
+++ b/docs/markdown/authoritative/domainmetadata.md
@@ -107,3 +107,7 @@ Allow these named TSIG keys to AXFR this zone, see [Provisioning outbound AXFR a
 ## TSIG-ALLOW-DNSUPDATE
 This setting allows you to set the TSIG key required to do an [DNS update](dnsupdate.md). If
 [GSS-TSIG](tsig.md#gss-tsig) is enabled, you can put kerberos principals here as well.
+
+## Extra metadata
+Through the API and on the [`pdnsutil set-meta`](dnssec.md#pdnsutil) commandline, metadata unused by PowerDNS can be added.
+It is mandatory to prefix this extra metadata with "X-" and the name of the external application; the API will only allow this metadata if it starts with "X-".

--- a/docs/markdown/httpapi/api_spec.md
+++ b/docs/markdown/httpapi/api_spec.md
@@ -626,8 +626,7 @@ zone\_metadata\_resource
 
 Clients MUST NOT modify `NSEC3PARAM`, `NSEC3NARROW`, `PRESIGNED` and
 `LUA-AXFR-SCRIPT` through this interface. The server rejects updates to
-these metadata. Modifications to custom metadata kinds are rejected
-through this interface.
+these metadata. Modifications to custom metadata kinds starting with `X-` is allowed as well.
 
 
 URL: /api/v1/servers/:server\_id/zones/:zone\_name/metadata

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -555,6 +555,9 @@ static bool isValidMetadataKind(const string& kind, bool readonly) {
     "LUA-AXFR-SCRIPT"
   };
 
+  if (kind.find("X-") == 0)
+    return true;
+
   bool found = false;
 
   for (const string& s : builtinOptions) {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -385,6 +385,14 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         self.assertEquals(r.status_code, 200)
         self.assertEquals(rdata["metadata"], [])
 
+    def test_create_external_zone_metadata(self):
+        payload_metadata = {"metadata": ["My very important message"]}
+        r = self.session.put(self.url("/api/v1/servers/localhost/zones/example.com/metadata/X-MYMETA"),
+                             data=json.dumps(payload_metadata))
+        self.assertEquals(r.status_code, 200)
+        rdata = r.json()
+        self.assertEquals(rdata["metadata"], payload_metadata["metadata"])
+
     def test_create_slave_zone(self):
         # Test that nameservers can be absent for slave zones.
         name, payload, data = self.create_zone(kind='Slave', nameservers=None, masters=['127.0.0.2'])


### PR DESCRIPTION
### Short description
This allows setting domain metadata starting with "X-" via the API.

This will allow external applications to store data related to domains.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added regression tests
- [ ] added unit tests