### PR TITLE
StateHolder: Allocate (and copy if needed) before taking the lock

### DIFF
--- a/pdns/sholder.hh
+++ b/pdns/sholder.hh
@@ -93,9 +93,12 @@ public:
 
   void setState(T state) //!< Safely & slowly change the global state
   {
-    std::lock_guard<std::mutex> l(d_lock);
-    d_state = std::make_shared<T>(T(state));
-    d_generation++;
+    std::shared_ptr<T> newState = std::make_shared<T>(state);
+    {
+      std::lock_guard<std::mutex> l(d_lock);
+      d_state = newState;
+      d_generation++;
+    }
   }
 
   T getCopy() const  //!< Safely & slowly get a copy of the global state
@@ -110,7 +113,7 @@ public:
     std::lock_guard<std::mutex> l(d_lock); 
     auto state=*d_state; // and yes, these three steps are necessary, can't ever modify state in place, even when locked!
     act(state);
-    d_state = std::make_shared<T>(T(state));
+    d_state = std::make_shared<T>(state);
     ++d_generation;
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
No need to block the other processes while we allocate memory and duplicate the content if needed. That might take a -relatively- long time for large objects like the filter policies contained in the `LuaConfigItems` object. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
