### PR TITLE
rec: Use the RPZ zone's TTL and add a new `maxTTL` setting

### DIFF
--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -504,9 +504,10 @@ In this example, 'policy.rpz' denotes the name of the zone to query for.
 
 Settings for `rpzFile` and `rpzMaster` can contain:
 
-* defpol = Policy.Custom, Policy.Drop, Policy.NXDOMAIN, Policy.NODATA, Policy.Truncate, Policy.NoAction
+* defpol = Default policy: Policy.Custom, Policy.Drop, Policy.NXDOMAIN, Policy.NODATA, Policy.Truncate, Policy.NoAction
 * defcontent = CNAME field to return in case of defpol=Policy.Custom
-* defttl = the TTL of the CNAME field to be synthesized. The default is to use the zone's TTL
+* defttl = the TTL of the CNAME field to be synthesized for the default policy. The default is to use the zone's TTL
+* maxTTL = the maximum TTL value of the synthesized records, overriding a higher value from `defttl` or the zone. Default is unlimited
 * policyName = the name logged as 'appliedPolicy' in protobuf messages when this policy is applied
 * zoneSizeHint = an indication of the number of expected entries in the zone, speeding up the loading of huge zones by reserving space in advance
 

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -328,6 +328,17 @@ vector<string> DNSName::getRawLabels() const
   return ret;
 }
 
+std::string DNSName::getRawLabel(unsigned int pos) const
+{
+  unsigned int currentPos = 0;
+  for(const unsigned char* p = (const unsigned char*) d_storage.c_str(); p < ((const unsigned char*) d_storage.c_str()) + d_storage.size() && *p; p+=*p+1, currentPos++) {
+    if (currentPos == pos) {
+      return std::string((const char*)p+1, (size_t)*p);
+    }
+  }
+
+  throw std::out_of_range("trying to get label at position "+std::to_string(pos)+" of a DNSName that only has "+std::to_string(currentPos)+" labels");
+}
 
 bool DNSName::chopOff()
 {

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -82,6 +82,7 @@ public:
   void appendRawLabel(const char* start, unsigned int length); //!< Append this unescaped label
   void prependRawLabel(const std::string& str); //!< Prepend this unescaped label
   std::vector<std::string> getRawLabels() const; //!< Individual raw unescaped labels
+  std::string getRawLabel(unsigned int pos) const; //!< Get the specified raw unescaped label
   bool chopOff();                               //!< Turn www.powerdns.com. into powerdns.com., returns false for .
   DNSName makeRelative(const DNSName& zone) const;
   DNSName makeLowerCase() const

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -77,7 +77,7 @@ public:
     PolicyKind d_kind;
     std::shared_ptr<DNSRecordContent> d_custom;
     std::shared_ptr<std::string> d_name;
-    int d_ttl;
+    int32_t d_ttl;
   };
 
   DNSFilterEngine();

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -122,47 +122,46 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 
   Lua.writeFunction("rpzFile", [&lci](const string& filename, const boost::optional<std::unordered_map<string,boost::variant<uint32_t, string>>>& options) {
       try {
-	boost::optional<DNSFilterEngine::Policy> defpol;
-	std::string polName("rpzFile");
-	const size_t zoneIdx = lci.dfe.size();
-	uint32_t maxTTL = std::numeric_limits<uint32_t>::max();
-	if(options) {
-	  auto& have = *options;
+        boost::optional<DNSFilterEngine::Policy> defpol;
+        std::string polName("rpzFile");
+        const size_t zoneIdx = lci.dfe.size();
+        uint32_t maxTTL = std::numeric_limits<uint32_t>::max();
+        if(options) {
+          auto& have = *options;
           size_t zoneSizeHint = 0;
           parseRPZParameters(have, polName, defpol, maxTTL, zoneSizeHint);
           if (zoneSizeHint > 0) {
             lci.dfe.reserve(zoneIdx, zoneSizeHint);
           }
-	}
+        }
         theL()<<Logger::Warning<<"Loading RPZ from file '"<<filename<<"'"<<endl;
         lci.dfe.setPolicyName(zoneIdx, polName);
         loadRPZFromFile(filename, lci.dfe, defpol, maxTTL, zoneIdx);
         theL()<<Logger::Warning<<"Done loading RPZ from file '"<<filename<<"'"<<endl;
       }
       catch(std::exception& e) {
-	theL()<<Logger::Error<<"Unable to load RPZ zone from '"<<filename<<"': "<<e.what()<<endl;
+        theL()<<Logger::Error<<"Unable to load RPZ zone from '"<<filename<<"': "<<e.what()<<endl;
       }
     });
 
-
   Lua.writeFunction("rpzMaster", [&lci, checkOnly](const string& master_, const string& zone_, const boost::optional<std::unordered_map<string,boost::variant<uint32_t, string>>>& options) {
       try {
-	boost::optional<DNSFilterEngine::Policy> defpol;
+        boost::optional<DNSFilterEngine::Policy> defpol;
         TSIGTriplet tt;
         uint32_t refresh=0;
-	std::string polName(zone_);
-	size_t maxReceivedXFRMBytes = 0;
-	uint32_t maxTTL = std::numeric_limits<uint32_t>::max();
-	ComboAddress localAddress;
-	const size_t zoneIdx = lci.dfe.size();
-	if(options) {
-	  auto& have = *options;
+        std::string polName(zone_);
+        size_t maxReceivedXFRMBytes = 0;
+        uint32_t maxTTL = std::numeric_limits<uint32_t>::max();
+        ComboAddress localAddress;
+        const size_t zoneIdx = lci.dfe.size();
+        if(options) {
+          auto& have = *options;
           size_t zoneSizeHint = 0;
           parseRPZParameters(have, polName, defpol, maxTTL, zoneSizeHint);
           if (zoneSizeHint > 0) {
             lci.dfe.reserve(zoneIdx, zoneSizeHint);
           }
-	  if(have.count("tsigname")) {
+          if(have.count("tsigname")) {
             tt.name=DNSName(toLower(boost::get<string>(constGet(have, "tsigname"))));
             tt.algo=DNSName(toLower(boost::get<string>(constGet(have, "tsigalgo"))));
             if(B64Decode(boost::get<string>(constGet(have, "tsigsecret")), tt.secret))
@@ -177,12 +176,12 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
           if(have.count("localAddress")) {
             localAddress = ComboAddress(boost::get<string>(constGet(have,"localAddress")));
           }
-	}
-	ComboAddress master(master_, 53);
+        }
+        ComboAddress master(master_, 53);
         if (localAddress != ComboAddress() && localAddress.sin4.sin_family != master.sin4.sin_family)
           // We were passed a localAddress, check if its AF matches the master's
           throw PDNSException("Master address("+master.toString()+") is not of the same Address Family as the local address ("+localAddress.toString()+").");
-	DNSName zone(zone_);
+        DNSName zone(zone_);
         lci.dfe.setPolicyName(zoneIdx, polName);
 
         if (!checkOnly) {
@@ -194,10 +193,10 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
         }
       }
       catch(std::exception& e) {
-	theL()<<Logger::Error<<"Unable to load RPZ zone '"<<zone_<<"' from '"<<master_<<"': "<<e.what()<<endl;
+        theL()<<Logger::Error<<"Unable to load RPZ zone '"<<zone_<<"' from '"<<master_<<"': "<<e.what()<<endl;
       }
       catch(PDNSException& e) {
-	theL()<<Logger::Error<<"Unable to load RPZ zone '"<<zone_<<"' from '"<<master_<<"': "<<e.reason<<endl;
+        theL()<<Logger::Error<<"Unable to load RPZ zone '"<<zone_<<"' from '"<<master_<<"': "<<e.reason<<endl;
       }
 
     });

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -60,6 +60,37 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 }
 #else
 
+static void parseRPZParameters(const std::unordered_map<string,boost::variant<uint32_t, string> >& have, std::string& polName, boost::optional<DNSFilterEngine::Policy>& defpol, uint32_t& maxTTL, size_t& zoneSizeHint)
+{
+  if(have.count("policyName")) {
+    polName = boost::get<std::string>(constGet(have, "policyName"));
+  }
+  if(have.count("defpol")) {
+    defpol=DNSFilterEngine::Policy();
+    defpol->d_kind = (DNSFilterEngine::PolicyKind)boost::get<uint32_t>(constGet(have, "defpol"));
+    defpol->d_name = std::make_shared<std::string>(polName);
+    if(defpol->d_kind == DNSFilterEngine::PolicyKind::Custom) {
+      defpol->d_custom=
+        shared_ptr<DNSRecordContent>(
+          DNSRecordContent::mastermake(QType::CNAME, 1,
+                                       boost::get<string>(constGet(have,"defcontent"))
+            )
+          );
+
+      if(have.count("defttl"))
+        defpol->d_ttl = static_cast<int32_t>(boost::get<uint32_t>(constGet(have, "defttl")));
+      else
+        defpol->d_ttl = -1; // get it from the zone
+    }
+  }
+  if(have.count("maxTTL")) {
+    maxTTL = boost::get<uint32_t>(constGet(have, "maxTTL"));
+  }
+  if(have.count("zoneSizeHint")) {
+    zoneSizeHint = static_cast<size_t>(boost::get<uint32_t>(constGet(have, "zoneSizeHint")));
+  }
+}
+
 void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 {
   LuaConfigItems lci;
@@ -89,41 +120,23 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
   };
   Lua.writeVariable("Policy", pmap);
 
-  Lua.writeFunction("rpzFile", [&lci](const string& filename, const boost::optional<std::unordered_map<string,boost::variant<int, string>>>& options) {
+  Lua.writeFunction("rpzFile", [&lci](const string& filename, const boost::optional<std::unordered_map<string,boost::variant<uint32_t, string>>>& options) {
       try {
 	boost::optional<DNSFilterEngine::Policy> defpol;
 	std::string polName("rpzFile");
 	const size_t zoneIdx = lci.dfe.size();
+	uint32_t maxTTL = std::numeric_limits<uint32_t>::max();
 	if(options) {
 	  auto& have = *options;
-	  if(have.count("policyName")) {
-	    polName = boost::get<std::string>(constGet(have, "policyName"));
-	  }
-	  if(have.count("defpol")) {
-	    defpol=DNSFilterEngine::Policy();
-	    defpol->d_kind = (DNSFilterEngine::PolicyKind)boost::get<int>(constGet(have, "defpol"));
-	    defpol->d_name = std::make_shared<std::string>(polName);
-	    if(defpol->d_kind == DNSFilterEngine::PolicyKind::Custom) {
-	      defpol->d_custom=
-		shared_ptr<DNSRecordContent>(
-					     DNSRecordContent::mastermake(QType::CNAME, 1, 
-									  boost::get<string>(constGet(have,"defcontent"))
-									  )
-					     );
-	 
-	      if(have.count("defttl"))
-		defpol->d_ttl = boost::get<int>(constGet(have, "defttl"));
-	      else
-		defpol->d_ttl = -1; // get it from the zone
-	    }
-	  }
-          if(have.count("zoneSizeHint")) {
-            lci.dfe.reserve(zoneIdx, static_cast<size_t>(boost::get<int>(constGet(have, "zoneSizeHint"))));
+          size_t zoneSizeHint = 0;
+          parseRPZParameters(have, polName, defpol, maxTTL, zoneSizeHint);
+          if (zoneSizeHint > 0) {
+            lci.dfe.reserve(zoneIdx, zoneSizeHint);
           }
 	}
         theL()<<Logger::Warning<<"Loading RPZ from file '"<<filename<<"'"<<endl;
         lci.dfe.setPolicyName(zoneIdx, polName);
-        loadRPZFromFile(filename, lci.dfe, defpol, zoneIdx);
+        loadRPZFromFile(filename, lci.dfe, defpol, maxTTL, zoneIdx);
         theL()<<Logger::Warning<<"Done loading RPZ from file '"<<filename<<"'"<<endl;
       }
       catch(std::exception& e) {
@@ -132,41 +145,22 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
     });
 
 
-  Lua.writeFunction("rpzMaster", [&lci, checkOnly](const string& master_, const string& zone_, const boost::optional<std::unordered_map<string,boost::variant<int, string>>>& options) {
+  Lua.writeFunction("rpzMaster", [&lci, checkOnly](const string& master_, const string& zone_, const boost::optional<std::unordered_map<string,boost::variant<uint32_t, string>>>& options) {
       try {
 	boost::optional<DNSFilterEngine::Policy> defpol;
         TSIGTriplet tt;
-        int refresh=0;
-	std::string polName;
+        uint32_t refresh=0;
+	std::string polName(zone_);
 	size_t maxReceivedXFRMBytes = 0;
+	uint32_t maxTTL = std::numeric_limits<uint32_t>::max();
 	ComboAddress localAddress;
 	const size_t zoneIdx = lci.dfe.size();
 	if(options) {
 	  auto& have = *options;
-          polName = zone_;
-	  if(have.count("policyName"))
-	    polName = boost::get<std::string>(constGet(have, "policyName"));
-	  if(have.count("defpol")) {
-	    //	    cout<<"Set a default policy"<<endl;
-	    defpol=DNSFilterEngine::Policy();
-	    defpol->d_kind = (DNSFilterEngine::PolicyKind)boost::get<int>(constGet(have, "defpol"));
-	    defpol->d_name = std::make_shared<std::string>(polName);
-	    if(defpol->d_kind == DNSFilterEngine::PolicyKind::Custom) {
-	      //	      cout<<"Setting a custom field even!"<<endl;
-	      defpol->d_custom=
-		shared_ptr<DNSRecordContent>(
-					     DNSRecordContent::mastermake(QType::CNAME, 1, 
-									  boost::get<string>(constGet(have,"defcontent"))
-									  )
-					     );
-	      if(have.count("defttl"))
-		defpol->d_ttl = boost::get<int>(constGet(have, "defttl"));
-	      else
-		defpol->d_ttl = -1; // get it from the zone
-	    }
-	  }
-          if(have.count("zoneSizeHint")) {
-            lci.dfe.reserve(zoneIdx, static_cast<size_t>(boost::get<int>(constGet(have, "zoneSizeHint"))));
+          size_t zoneSizeHint = 0;
+          parseRPZParameters(have, polName, defpol, maxTTL, zoneSizeHint);
+          if (zoneSizeHint > 0) {
+            lci.dfe.reserve(zoneIdx, zoneSizeHint);
           }
 	  if(have.count("tsigname")) {
             tt.name=DNSName(toLower(boost::get<string>(constGet(have, "tsigname"))));
@@ -175,10 +169,10 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
               throw std::runtime_error("TSIG secret is not valid Base-64 encoded");
           }
           if(have.count("refresh")) {
-            refresh = boost::get<int>(constGet(have,"refresh"));
+            refresh = boost::get<uint32_t>(constGet(have,"refresh"));
           }
           if(have.count("maxReceivedMBytes")) {
-            maxReceivedXFRMBytes = static_cast<size_t>(boost::get<int>(constGet(have,"maxReceivedMBytes")));
+            maxReceivedXFRMBytes = static_cast<size_t>(boost::get<uint32_t>(constGet(have,"maxReceivedMBytes")));
           }
           if(have.count("localAddress")) {
             localAddress = ComboAddress(boost::get<string>(constGet(have,"localAddress")));
@@ -192,10 +186,10 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
         lci.dfe.setPolicyName(zoneIdx, polName);
 
         if (!checkOnly) {
-          auto sr=loadRPZFromServer(master, zone, lci.dfe, defpol, zoneIdx, tt, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
+          auto sr=loadRPZFromServer(master, zone, lci.dfe, defpol, maxTTL, zoneIdx, tt, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
           if(refresh)
             sr->d_st.refresh=refresh;
-          std::thread t(RPZIXFRTracker, master, zone, defpol, zoneIdx, tt, sr, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
+          std::thread t(RPZIXFRTracker, master, zone, defpol, maxTTL, zoneIdx, tt, sr, maxReceivedXFRMBytes * 1024 * 1024, localAddress);
           t.detach();
         }
       }

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -310,9 +310,9 @@ string reloadAuthAndForwards()
 }
 
 
-void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::optional<DNSFilterEngine::Policy> defpol, size_t polZone, const TSIGTriplet& tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress)
+void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t polZone, const TSIGTriplet& tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress)
 {
-  int refresh = oursr->d_st.refresh;
+  uint32_t refresh = oursr->d_st.refresh;
   for(;;) {
     DNSRecord dr;
     dr.d_content=oursr;
@@ -359,7 +359,7 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::opti
 	else {
           totremove++;
 	  L<<Logger::Debug<<"Had removal of "<<rr.d_name<<endl;
-	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, false, defpol, polZone);
+	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, false, defpol, maxTTL, polZone);
 	}
       }
 
@@ -376,7 +376,7 @@ void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::opti
 	else {
           totadd++;
 	  L<<Logger::Debug<<"Had addition of "<<rr.d_name<<endl;
-	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, true, defpol, polZone);
+	  RPZRecordToPolicy(rr, luaconfsCopy.dfe, true, defpol, maxTTL, polZone);
 	}
       }
     }

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -58,7 +58,7 @@ static Netmask makeNetmaskFromRPZ(const DNSName& name)
   return Netmask(v6);
 }
 
-void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, size_t place)
+void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t place)
 {
   static const DNSName drop("rpz-drop."), truncate("rpz-tcp-only."), noaction("rpz-passthru.");
   static const DNSName rpzClientIP("rpz-client-ip"), rpzIP("rpz-ip"),
@@ -115,8 +115,11 @@ void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrR
     }
   }
 
-  if(pol.d_ttl < 0)
-    pol.d_ttl = dr.d_ttl;
+  if (!defpol || defpol->d_ttl < 0) {
+    pol.d_ttl = static_cast<int32_t>(std::min(maxTTL, dr.d_ttl));
+  } else {
+    pol.d_ttl = static_cast<int32_t>(std::min(maxTTL, static_cast<uint32_t>(pol.d_ttl)));
+  }
 
   // now to DO something with that
   
@@ -157,7 +160,7 @@ void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrR
   }
 }
 
-shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, size_t place, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress)
+shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t place, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress)
 {
   L<<Logger::Warning<<"Loading RPZ zone '"<<zone<<"' from "<<master.toStringWithPort()<<endl;
   if(!tt.name.empty())
@@ -185,7 +188,7 @@ shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const
 	continue;
       }
 
-      RPZRecordToPolicy(dr, target, true, defpol, place);
+      RPZRecordToPolicy(dr, target, true, defpol, maxTTL, place);
       nrecords++;
     } 
     if(last != time(0)) {
@@ -198,7 +201,7 @@ shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const
 }
 
 // this function is silent - you do the logging
-int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, size_t place)
+int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t place)
 {
   ZoneParserTNG zpt(fname);
   DNSResourceRecord drr;
@@ -216,7 +219,7 @@ int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, boost::op
       }
       else {
 	dr.d_name=dr.d_name.makeRelative(domain);
-	RPZRecordToPolicy(dr, target, true, defpol, place);
+	RPZRecordToPolicy(dr, target, true, defpol, maxTTL, place);
       }
     }
     catch(PDNSException& pe) {

--- a/pdns/rpzloader.hh
+++ b/pdns/rpzloader.hh
@@ -24,7 +24,7 @@
 #include <string>
 #include "dnsrecords.hh"
 
-int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, size_t place);
-std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, size_t place, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress);
-void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, size_t place);
-void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::optional<DNSFilterEngine::Policy> defpol, size_t polZone, const TSIGTriplet &tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress);
+int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t place);
+std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t place, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress);
+void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t place);
+void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t polZone, const TSIGTriplet &tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress);

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -849,5 +849,13 @@ BOOST_AUTO_TEST_CASE(test_wirelength) { // Testing if we get the correct value f
   BOOST_CHECK_EQUAL(sname.wirelength(), 19);
 }
 
+BOOST_AUTO_TEST_CASE(test_getrawlabel) {
+  DNSName name("a.bb.ccc.dddd.");
+  BOOST_CHECK_EQUAL(name.getRawLabel(0), "a");
+  BOOST_CHECK_EQUAL(name.getRawLabel(1), "bb");
+  BOOST_CHECK_EQUAL(name.getRawLabel(2), "ccc");
+  BOOST_CHECK_EQUAL(name.getRawLabel(3), "dddd");
+  BOOST_CHECK_THROW(name.getRawLabel(name.countLabels()), std::out_of_range);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -16,3 +16,19 @@ echo "==> www.hijackme.example.net is served on ns.hijackme.example.net, which s
 $SDIG $nameserver 5301 www.hijackme.example.net a recurse 2>&1
 echo "==> host.lowercase-outgoing.example.net is served on ns.lowercase-outgoing.example.net, blocked by NS IP rule"
 $SDIG $nameserver 5301 host.lowercase-outgoing.example.net a recurse 2>&1
+echo "==> capped-ttl.example.net TTL exceeds the maximum TTL for the zone"
+$SDIG $nameserver 5301 capped-ttl.example.net a recurse 2>&1
+echo "==> defpol-with-ttl.example.net should use the default policy's TTL and not the zone one"
+$SDIG $nameserver 5301 defpol-with-ttl.example.net a recurse 2>&1
+echo "==> defpol-with-ttl-capped.example.net should use the default policy's TTL, but capped to maxTTL"
+$SDIG $nameserver 5301 defpol-with-ttl-capped.example.net a recurse 2>&1
+echo "==> defpol-without-ttl.example.net should use the zone's TTL"
+$SDIG $nameserver 5301 defpol-without-ttl.example.net a recurse 2>&1
+echo "==> defpol-without-ttl-capped.example.net should use the zone's TTL but capped to maxTTL"
+$SDIG $nameserver 5301 defpol-without-ttl-capped.example.net a recurse 2>&1
+echo "==> unsupported.example.net has an unsupported target, should be ignored from the RPZ zone"
+$SDIG $nameserver 5301 unsupported.example.net a recurse 2>&1
+echo "==> unsupported2.example.net has an unsupported target, should be ignored from the RPZ zone"
+$SDIG $nameserver 5301 unsupported2.example.net a recurse 2>&1
+echo "==> not-rpz.example.net is _not_ an RPZ target and should be processed"
+$SDIG $nameserver 5301 not-rpz.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ/expected_result
+++ b/regression-tests.recursor/RPZ/expected_result
@@ -11,7 +11,7 @@ Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 ==> www.example.net RPZ local data to www2.example.net
 Reply to question for qname='www.example.net.', qtype=A
 Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
-0	www.example.net.	IN	CNAME	0	www2.example.net.
+0	www.example.net.	IN	CNAME	7200	www2.example.net.
 0	www2.example.net.	IN	A	15	192.0.2.2
 ==> www4.example.net RPZ IP trigger action, dropped
 ==> trillian.example.net NXDOMAIN
@@ -28,3 +28,39 @@ Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 ==> host.lowercase-outgoing.example.net is served on ns.lowercase-outgoing.example.net, blocked by NS IP rule
 Reply to question for qname='host.lowercase-outgoing.example.net.', qtype=A
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+==> capped-ttl.example.net TTL exceeds the maximum TTL for the zone
+Reply to question for qname='capped-ttl.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	capped-ttl.example.net.	IN	A	5	192.0.2.35
+==> defpol-with-ttl.example.net should use the default policy's TTL and not the zone one
+Reply to question for qname='defpol-with-ttl.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	defpol-with-ttl.example.net.	IN	CNAME	10	default.example.net.
+0	default.example.net.	IN	A	15	192.0.2.42
+==> defpol-with-ttl-capped.example.net should use the default policy's TTL, but capped to maxTTL
+Reply to question for qname='defpol-with-ttl-capped.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	defpol-with-ttl-capped.example.net.	IN	CNAME	20	default.example.net.
+0	default.example.net.	IN	A	15	192.0.2.42
+==> defpol-without-ttl.example.net should use the zone's TTL
+Reply to question for qname='defpol-without-ttl.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	defpol-without-ttl.example.net.	IN	CNAME	7200	default.example.net.
+0	default.example.net.	IN	A	15	192.0.2.42
+==> defpol-without-ttl-capped.example.net should use the zone's TTL but capped to maxTTL
+Reply to question for qname='defpol-without-ttl-capped.example.net.', qtype=A
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	defpol-without-ttl-capped.example.net.	IN	CNAME	50	default.example.net.
+0	default.example.net.	IN	A	15	192.0.2.42
+==> unsupported.example.net has an unsupported target, should be ignored from the RPZ zone
+Reply to question for qname='unsupported.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+1	example.net.	IN	SOA	15	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+==> unsupported2.example.net has an unsupported target, should be ignored from the RPZ zone
+Reply to question for qname='unsupported2.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+1	example.net.	IN	SOA	15	ns.example.net. hostmaster.example.net. 1 3600 1800 1209600 300
+==> not-rpz.example.net is _not_ an RPZ target and should be processed
+Reply to question for qname='not-rpz.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	not-rpz.example.net.	IN	CNAME	5	rpz-not.com.

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -91,6 +91,7 @@ www2.example.net.        3600 IN A   192.0.2.2
 www3.example.net.        3600 IN A   192.0.2.3
 www4.example.net.        3600 IN A   192.0.2.4
 www5.example.net.        3600 IN A   192.0.2.5
+default.example.net.     3600 IN A   192.0.2.42
 weirdtxt.example.net.    3600 IN IN  TXT "x\014x"
 arthur.example.net.      3600 IN NS  ns.arthur.example.net.
 arthur.example.net.      3600 IN NS  ns2.arthur.example.net.
@@ -554,6 +555,11 @@ EOF
 cat > recursor-service3/config.lua <<EOF
 rpzFile("$(pwd)/recursor-service3/rpz.zone", {policyName="myRPZ"})
 rpzFile("$(pwd)/recursor-service3/rpz2.zone", {policyName="mySecondRPZ"})
+rpzFile("$(pwd)/recursor-service3/rpz3.zone", {policyName="cappedTTLRPZ", maxTTL=5})
+rpzFile("$(pwd)/recursor-service3/rpz4.zone", {policyName="defPolicyTTL", defpol=Policy.Custom, defcontent="default.example.net", defttl=10, maxTTL=20})
+rpzFile("$(pwd)/recursor-service3/rpz5.zone", {policyName="defPolicyCappedTTL", defpol=Policy.Custom, defcontent="default.example.net", defttl=50, maxTTL=20})
+rpzFile("$(pwd)/recursor-service3/rpz6.zone", {policyName="defPolicyWithoutTTL", defpol=Policy.Custom, defcontent="default.example.net"})
+rpzFile("$(pwd)/recursor-service3/rpz7.zone", {policyName="defPolicyWithoutTTLCapped", defpol=Policy.Custom, defcontent="default.example.net", maxTTL=50})
 EOF
 
 IFS=. read REV_PREFIX1 REV_PREFIX2 REV_PREFIX3 <<< $(echo $PREFIX) # This will bite us in the ass if we ever test on IPv6
@@ -587,6 +593,59 @@ cat > recursor-service3/rpz2.zone <<EOF
 @ NS ns.example.net.
 
 www5.example.net       A     192.0.2.25          ; Override www5.example.net.
+
+EOF
+
+cat > recursor-service3/rpz3.zone <<EOF
+\$TTL 2h;
+\$ORIGIN domain.example.
+@ SOA $SOA
+@ NS ns.example.net.
+
+capped-ttl.example.net       50       IN      A     192.0.2.35          ; exceeds the maxTTL setting
+unsupported.example.net      50       IN      CNAME rpz-unsupported.    ; unsupported target
+unsupported2.example.net      50       IN      CNAME 32.3.2.0.192.rpz-unsupported.    ; also unsupported target
+not-rpz.example.net           50       IN      CNAME rpz-not.com.                     ; this one is not a special RPZ target
+
+EOF
+
+cat > recursor-service3/rpz4.zone <<EOF
+\$TTL 2h;
+\$ORIGIN domain.example.
+@ SOA $SOA
+@ NS ns.example.net.
+
+defpol-with-ttl.example.net       50       IN      A     192.0.2.35          ; will be overriden by the default policy and the default TTL
+
+EOF
+
+cat > recursor-service3/rpz5.zone <<EOF
+\$TTL 2h;
+\$ORIGIN domain.example.
+@ SOA $SOA
+@ NS ns.example.net.
+
+defpol-with-ttl-capped.example.net       100       IN      A     192.0.2.35          ; will be overriden by the default policy and the default TTL (but capped by maxTTL)
+
+EOF
+
+cat > recursor-service3/rpz6.zone <<EOF
+\$TTL 2h;
+\$ORIGIN domain.example.
+@ SOA $SOA
+@ NS ns.example.net.
+
+defpol-without-ttl.example.net       A     192.0.2.35          ; will be overriden by the default policy, but with the zone's TTL
+
+EOF
+
+cat > recursor-service3/rpz7.zone <<EOF
+\$TTL 2h;
+\$ORIGIN domain.example.
+@ SOA $SOA
+@ NS ns.example.net.
+
+defpol-without-ttl-capped.example.net       A     192.0.2.35          ; will be overriden by the default policy, but with the zone's TTL capped by maxTTL
 
 EOF
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

* Use the RPZ zone's TTL, except for the default policy if `deftll` is set
* Add a new `maxTTL` setting, capping the zone's TTL as well as `defttl`
* Properly ignore unsupported RPZ special targets

Fixes #4931.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

