### PR TITLE
Check for valid hostnames in SRV, NS and MX records

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -345,6 +345,16 @@ bool DNSName::isWildcard() const
   return (*p == 0x01 && *++p == '*');
 }
 
+/*
+ * Returns true if the DNSName is a valid RFC 1123 hostname, this function uses
+ * a regex on the string, so it is probably best not used when speed is essential.
+ */
+bool DNSName::isHostname() const
+{
+  static Regex hostNameRegex = Regex("^(([A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)\\.)+$");
+  return hostNameRegex.match(this->toString());
+}
+
 unsigned int DNSName::countLabels() const
 {
   unsigned int count=0;

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -96,6 +96,7 @@ public:
   void makeUsRelative(const DNSName& zone);
   DNSName labelReverse() const;
   bool isWildcard() const;
+  bool isHostname() const;
   unsigned int countLabels() const;
   size_t wirelength() const; //!< Number of total bytes in the name
   bool empty() const { return d_storage.empty(); }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -579,13 +579,27 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
       }
     }
 
-    if(rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA)
-    {
-      Regex hostnameRegex=Regex("^(([A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)\\.)+$");
-      if (!hostnameRegex.match(rr.qname.toString()))
-      {
-        cout<<"[Info] A or AAAA record found at '"<<rr.qname.toString()<<"'. This name is not a valid hostname."<<endl;
-        continue;
+    if((rr.qtype.getCode() == QType::A || rr.qtype.getCode() == QType::AAAA) && !rr.qname.isWildcard() && !rr.qname.isHostname())
+      cout<<"[Info] "<<rr.qname.toString()<<" record for '"<<rr.qtype.getName()<<"' is not a valid hostname."<<endl;
+
+    // Check if the DNSNames that should be hostnames, are hostnames
+    if (rr.qtype.getCode() == QType::NS || rr.qtype.getCode() == QType::MX || rr.qtype.getCode() == QType::SRV) {
+      DNSName toCheck;
+      if (rr.qtype.getCode() == QType::SRV) {
+        vector<string> parts;
+        stringtok(parts, rr.getZoneRepresentation());
+        toCheck = DNSName(parts[3]);
+      } else if (rr.qtype.getCode() == QType::MX) {
+        vector<string> parts;
+        stringtok(parts, rr.getZoneRepresentation());
+        toCheck = DNSName(parts[1]);
+      } else {
+        toCheck = DNSName(rr.content);
+      }
+
+      if (!toCheck.isHostname()) {
+        cout<<"[Warning] "<<rr.qtype.getName()<<" record in zone '"<<zone<<"' has non-hostname content '"<<toCheck<<"'."<<endl;
+        numwarnings++;
       }
     }
 


### PR DESCRIPTION
### Short description
Validate if records that contain a hostname in the RDATA actually have a valid hostname in the RDATA. 

This does not include CNAMEs, as they could be an alias for non-hostname names (i.e. `_443._tcp.www.example.com CNAME _cert.example.com` to only have one TLSA in the zone)

Fixes #512
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)