### PR TITLE
Implement CNAME wildcards in recursor authoritative component

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -245,7 +245,8 @@ bool SyncRes::doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSR
 
     for(ziter=range.first; ziter!=range.second; ++ziter) {
       DNSRecord dr=*ziter;
-      if(dr.d_type == qtype.getCode() || qtype.getCode() == QType::ANY) {
+      // if we hit a CNAME, just answer that - rest of recursor will do the needful & follow
+      if(dr.d_type == qtype.getCode() || qtype.getCode() == QType::ANY || dr.d_type == QType::CNAME) {
         dr.d_name = qname;
         dr.d_place=DNSResourceRecord::ANSWER;
         ret.push_back(dr);

--- a/regression-tests.recursor/auth-zone-cname-wildcard/command
+++ b/regression-tests.recursor/auth-zone-cname-wildcard/command
@@ -1,0 +1,2 @@
+cleandig host1.something.auth-zone.example.net. A | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'
+cleandig host1.something.auth-zone.example.net. AAAA | sed 's/\(.*\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\13600/'

--- a/regression-tests.recursor/auth-zone-cname-wildcard/description
+++ b/regression-tests.recursor/auth-zone-cname-wildcard/description
@@ -1,0 +1,1 @@
+Tries a CNAME wildcard in an authoritative zone in the recursor

--- a/regression-tests.recursor/auth-zone-cname-wildcard/expected_result
+++ b/regression-tests.recursor/auth-zone-cname-wildcard/expected_result
@@ -1,0 +1,8 @@
+0	host1.auth-zone.example.net.	IN	A	3600	127.0.0.55
+0	host1.something.auth-zone.example.net.	IN	CNAME	3600	host1.auth-zone.example.net.
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+Reply to question for qname='host1.something.auth-zone.example.net.', qtype=A
+0	host1.auth-zone.example.net.	IN	AAAA	3600	2001:db8::1:45ba
+0	host1.something.auth-zone.example.net.	IN	CNAME	3600	host1.auth-zone.example.net.
+Rcode: 0 (No Error), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+Reply to question for qname='host1.something.auth-zone.example.net.', qtype=AAAA

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -438,6 +438,7 @@ host3.auth-zone.example.net. 20 IN CNAME host1.not-auth-zone.example.net.
 *.wild.auth-zone.example.net.	3600 IN	TXT "Hi there!"
 france.auth-zone.example.net.	20	IN NS 	ns1.auth-zone.example.net.
 ns1.auth-zone.example.net. 	20	IN	A	$PREFIX.23
+*.something.auth-zone.example.net.      20      IN      CNAME   host1.auth-zone.example.net.
 EOF
 
 mkdir $PREFIX.24


### PR DESCRIPTION
With this commit, the recursor authoritative server can deal with CNAME wildcards. This closes #2818.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
