### PR TITLE
FreeBSD build notes and compile fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ FREEBSD NOTES
 -------------
 You need to compile using gmake - regular make only appears to work, but doesn't in fact. Use gmake, not make.
 
+The clang compiler installed through FreeBSD's package manager does not expose all of the C++11 features needed under `std=gnuc++11`. Force the compiler to use `std=c++11` mode instead.
+
+    export CXXFLAGS=-std=c++11
+
 MAC OS X NOTES
 --------------
 PowerDNS Authoritative Server is available through Homebrew:

--- a/ext/json11/json11.cpp
+++ b/ext/json11/json11.cpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <limits>
+#include <string>
 
 namespace json11 {
 


### PR DESCRIPTION
### Short description
This adds a note for building on FreeBSD and fixes a compile error in json11.cpp.

It might make sense to look into setting c++11 for clang instead of gnuc++11 under clang, but the regression scope of that is a bit unclear due to the amount of versions of XCode and FreeBSD releases (each running different versions of clang!) out in the wild.

For the time being, I felt the safer route was to document a flag override only for FreeBSD, as that makes the regression surface minimal to non-existent.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

The one liner include change should have no side effects, so I have omitted extra tests to cover this.