### PR TITLE
Change from time_t to uint32_t for serial in calculateSOASerial

### DIFF
--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -845,7 +845,7 @@ bool RemoteBackend::abortTransaction() {
    return true;
 }
 
-bool RemoteBackend::calculateSOASerial(const DNSName& domain, const SOAData& sd, time_t& serial) {
+bool RemoteBackend::calculateSOASerial(const DNSName& domain, const SOAData& sd, uint32_t& serial) {
    Json query = Json::object{
      { "method", "calculateSOASerial" },
      { "parameters", Json::object{

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -180,7 +180,7 @@ class RemoteBackend : public DNSBackend
   bool startTransaction(const DNSName& domain, int domain_id) override;
   bool commitTransaction() override;
   bool abortTransaction() override;
-  bool calculateSOASerial(const DNSName& domain, const SOAData& sd, time_t& serial) override;
+  bool calculateSOASerial(const DNSName& domain, const SOAData& sd, uint32_t& serial) override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
   bool deleteTSIGKey(const DNSName& name) override;
   bool getTSIGKeys(std::vector< struct TSIGKey > &keys) override;

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -326,7 +326,7 @@ BOOST_AUTO_TEST_CASE(test_method_abortTransaction) {
 
 BOOST_AUTO_TEST_CASE(test_method_calculateSOASerial) {
    SOAData sd;
-   time_t serial;
+   uint32_t serial;
  
    be->getSOA(DNSName("unit.test."),sd);
    BOOST_CHECK(be->calculateSOASerial(DNSName("unit.test."),sd,serial));

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1506,7 +1506,7 @@ bool GSQLBackend::abortTransaction()
   return true;
 }
 
-bool GSQLBackend::calculateSOASerial(const DNSName& domain, const SOAData& sd, time_t& serial)
+bool GSQLBackend::calculateSOASerial(const DNSName& domain, const SOAData& sd, uint32_t& serial)
 {
   if (d_ZoneLastChangeQuery.empty()) {
     // query not set => fall back to default impl

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -207,7 +207,7 @@ public:
   bool updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& insert ,set<DNSName>& erase, bool remove) override;
   bool doesDNSSEC() override;
 
-  bool calculateSOASerial(const DNSName& domain, const SOAData& sd, time_t& serial) override;
+  bool calculateSOASerial(const DNSName& domain, const SOAData& sd, uint32_t& serial) override;
 
   bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
   bool listSubZone(const DNSName &zone, int domain_id) override;

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -250,7 +250,7 @@ bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd)
   if(!sd.serial) { // magic time!
     DLOG(L<<Logger::Warning<<"Doing SOA serial number autocalculation for "<<rr.qname<<endl);
 
-    time_t serial;
+    uint32_t serial = 0;
     if (calculateSOASerial(domain, sd, serial)) {
       sd.serial = serial;
       //DLOG(L<<"autocalculated soa serialnumber for "<<rr.qname<<" is "<<newest<<endl);
@@ -330,12 +330,12 @@ bool DNSBackend::getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, co
  * \param sd Information about the SOA record already available
  * \param serial Output parameter. Only inspected when we return true
  */
-bool DNSBackend::calculateSOASerial(const DNSName& domain, const SOAData& sd, time_t& serial)
+bool DNSBackend::calculateSOASerial(const DNSName& domain, const SOAData& sd, uint32_t& serial)
 {
     // we do this by listing the domain and taking the maximum last modified timestamp
 
     DNSResourceRecord i;
-    time_t newest=0;
+    uint32_t newest=0;
 
     if(!(this->list(domain, sd.domain_id))) {
       DLOG(L<<Logger::Warning<<"Backend error trying to determine magic serial number of zone '"<<domain<<"'"<<endl);

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -128,7 +128,7 @@ public:
   virtual bool getSOA(const DNSName &name, SOAData &soadata);
 
   //! Calculates a SOA serial for the zone and stores it in the third argument.
-  virtual bool calculateSOASerial(const DNSName& domain, const SOAData& sd, time_t& serial);
+  virtual bool calculateSOASerial(const DNSName& domain, const SOAData& sd, uint32_t& serial);
 
   virtual bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset)
   {


### PR DESCRIPTION
### Short description
time_t can be bigger, which could lead to overflow/underflow issues.

Closes #1010

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
