### PR TITLE
dnsdist addAction: Also DNSName(s)

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -412,6 +412,10 @@ Cache Hit Response rules, triggered on a cache hit, can be added via:
 
 A DNS rule can be:
 
+ * A string that is either a domain name or netmask
+ * A list of strings that are either domain names or netmasks
+ * A DNSName
+ * A list of DNSNames
  * an AllRule
  * an AndRule
  * a DNSSECRule

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -21,5 +21,5 @@
  */
 #pragma once
 
-typedef boost::variant<string,vector<pair<int, string>>, std::shared_ptr<DNSRule> > luadnsrule_t;
+typedef boost::variant<string, vector<pair<int, string>>, std::shared_ptr<DNSRule>, DNSName, vector<pair<int, DNSName> > > luadnsrule_t;
 std::shared_ptr<DNSRule> makeRule(const luadnsrule_t& var);


### PR DESCRIPTION
### Short description
This adds the possibility to feed a DNSName, or table of DNSNames to addAction.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)