### PR TITLE
Backport #4824: Check in the detected OpenSSL/libcrypto for ECDSA

### DIFF
--- a/m4/pdns_check_libcrypto.m4
+++ b/m4/pdns_check_libcrypto.m4
@@ -54,6 +54,7 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO], [
                 if test $? = 0; then
                     LIBCRYPTO_LIBS=`$PKG_CONFIG libcrypto --libs-only-l 2>/dev/null`
                     LIBCRYPTO_INCLUDES=`$PKG_CONFIG libcrypto --cflags-only-I 2>/dev/null`
+                    ssldir=`$PKG_CONFIG libcrypto --variable=prefix 2>/dev/null`
                     found=true
                 fi
             fi

--- a/m4/pdns_check_libcrypto_ecdsa.m4
+++ b/m4/pdns_check_libcrypto_ecdsa.m4
@@ -1,11 +1,22 @@
 AC_DEFUN([PDNS_CHECK_LIBCRYPTO_ECDSA], [
   AC_REQUIRE([PDNS_CHECK_LIBCRYPTO])
+
+  # Set the environment correctly for a possibly non-default OpenSSL path that was found by/supplied to PDNS_CHECK_LIBCRYPTO
+  save_CPPFLAGS="$CPPFLAGS"
+  save_LDFLAGS="$LDFLAGS"
+  save_LIBS="$LIBS"
+
+  CPPFLAGS="$LIBCRYPTO_INCLUDES $CPPFLAGS"
+  LDFLAGS="$LIBCRYPTO_LDFLAGS $LDFLAGS"
+  LIBS="$LIBCRYPTO_LIBS $LIBS"
+
+  # Find the headers we need for ECDSA
   libcrypto_ecdsa=yes
-  AC_CHECK_HEADER([openssl/ecdsa.h], [
+  AC_CHECK_HEADER([$ssldir/include/openssl/ecdsa.h], [
     AC_CHECK_DECLS([NID_X9_62_prime256v1, NID_secp384r1], [ : ], [
       libcrypto_ecdsa=no
     ], [AC_INCLUDES_DEFAULT
-#include <openssl/evp.h>
+#include <$ssldir/include/openssl/evp.h>
     ])
   ], [
     libcrypto_ecdsa=no
@@ -14,4 +25,9 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO_ECDSA], [
   AS_IF([test "x$libcrypto_ecdsa" = "xyes"], [
     AC_DEFINE([HAVE_LIBCRYPTO_ECDSA], [1], [define to 1 if OpenSSL ecdsa support is available.])
   ])
+
+  # Restore variables
+  CPPFLAGS="$save_CPPFLAGS"
+  LDFLAGS="$save_LDFLAGS"
+  LIBS="$save_LIBS"
 ])


### PR DESCRIPTION
Check in the detected OpenSSL/libcrypto for ECDSA

We used to 'just' use the default includes for this detection.

Fixes #4680

### Short description
Backport #4842 because development without it is a pain.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
