### PR TITLE
RFC: Allow AXFR of nsec3 narrow zones

### DIFF
--- a/docs/manpages/pdnsutil.1.md
+++ b/docs/manpages/pdnsutil.1.md
@@ -85,7 +85,7 @@ import-zone-key *ZONE* *FILE* {**KSK**,**ZSK**}
 remove-zone-key *ZONE* *KEY-ID*
 :    Remove a key with id *KEY-ID* from a zone called *ZONE*.
 
-set-nsec3 *ZONE* '*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*' [**narrow**]
+set-nsec3 *ZONE* '*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*' [**narrow** [**axfr**]]
 :    Sets NSEC3 parameters for this zone. The quoted parameters are 4 values
      that are used for the the NSEC3PARAM record and decide how NSEC3 records
      are created. The NSEC3 parameters must be quoted on the command line.<br><br>
@@ -99,6 +99,9 @@ set-nsec3 *ZONE* '*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*' [**narrow**]
      secure record. Instead of looking it up in the database, it will send out
      the hash + 1 as the next secure record. <br><br>
      A sample commandline is: "pdnsutil set-nsec3 powerdnssec.org '1 1 1 ab' narrow".<br><br>
+     Setting **axfr** will make PowerDNS reply to AXFR on the zone with full-width
+     nsec3 records while replying with narrow records itself.
+     A sample commandline is: "pdnsutil set-nsec3 powerdnssec.org '1 1 1 ab' narrow axfr".<br><br>
      **WARNING**: If running in RSASHA1 mode (algorithm 5 or 7), switching from
      NSEC to NSEC3 will require a DS update in the parent zone.
 

--- a/docs/markdown/authoritative/dnssec.md
+++ b/docs/markdown/authoritative/dnssec.md
@@ -434,7 +434,7 @@ As stated earlier, PowerDNS uses NSEC by default. If you want to use NSEC3 inste
 issue:
 
 ```
-pdnsutil set-nsec3 ZONE [PARAMETERS]
+pdnsutil set-nsec3 ZONE [PARAMETERS] [narrow [axfr]]
 ```
 
 e.g.
@@ -450,6 +450,18 @@ The quoted part is the content of the NSEC3PARAM records, as defined in [RFC 515
 * Flags, set to `1` for [NSEC3 Opt-out](https://tools.ietf.org/html/rfc5155#section-6), this best set as `0`
 * Number of iterations of the hash function, read [RFC 5155, Section 10.3](https://tools.ietf.org/html/rfc5155#section-10.3) for recommendations
 * Salt (in hexadecimal) to apply during hashing
+
+
+To enable NSEC3 narrow mode on a zone:
+```
+pdnsutil set-nsec3 example.net '1 0 1 ab' narrow
+```
+
+To allow AXFR on a zone running in NSEC3 narrow mode:
+```
+pdnsutil set-nsec3 example.net '1 0 1 ab' narrow axfr
+```
+**Note**: The AXFR zone will be full-width.
 
 To convert a zone from NSEC3 to NSEC operations, run:
 

--- a/docs/markdown/authoritative/domainmetadata.md
+++ b/docs/markdown/authoritative/domainmetadata.md
@@ -45,6 +45,11 @@ insert into domainmetadata (domain_id, kind, content) values (7,'ALSO-NOTIFY','1
 insert into domainmetadata (domain_id, kind, content) values (7,'ALLOW-AXFR-FROM','2001:db8:53::1');
 ```
 
+## AXFR-NSEC3NARROW
+Set to "1" to tell PowerDNS to allow AXFR if zone is running in NSEC3 'narrow' mode.
+In such case, the AXFR reply will have full-width NSEC3 records. See
+`set-nsec3` for [`pdnsutil`](dnssec.md#pdnsutil).
+
 ## AXFR-MASTER-TSIG
 Use this named TSIG key to retrieve this zone from its master, see
 [Provisioning signed notification and AXFR requests](tsig.md#provisioning-signed-notification-and-axfr-requests).

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -168,8 +168,8 @@ public:
   bool deactivateKey(const DNSName& zname, unsigned int id);
   bool checkKeys(const DNSName& zname);
 
-  bool getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* n3p=0, bool* narrow=0);
-  bool setNSEC3PARAM(const DNSName& zname, const NSEC3PARAMRecordContent& n3p, const bool& narrow=false);
+  bool getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* n3p=0, bool* narrow=0, bool* axfr=0);
+  bool setNSEC3PARAM(const DNSName& zname, const NSEC3PARAMRecordContent& n3p, const bool& narrow=false, const bool& axfr=false);
   bool unsetNSEC3PARAM(const DNSName& zname);
   void clearAllCaches();
   void clearCaches(const DNSName& name);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2073,7 +2073,8 @@ try
     cout<<"secure-zone ZONE [ZONE ..]         Add DNSSEC to zone ZONE"<<endl;
     cout<<"set-kind ZONE KIND                 Change the kind of ZONE to KIND (master, slave native)"<<endl;
     cout<<"set-account ZONE ACCOUNT           Change the account (owner) of ZONE to ACCOUNT"<<endl;
-    cout<<"set-nsec3 ZONE ['PARAMS' [narrow]] Enable NSEC3 with PARAMS. Optionally narrow"<<endl;
+    cout<<"set-nsec3 ZONE ['PARAMS' [narrow [axfr]]]" <<endl;
+    cout<<"                                   Enable NSEC3 with PARAMS. Optionally narrow. Optionally axfr"<<endl;
     cout<<"set-presigned ZONE                 Use presigned RRSIGs from storage"<<endl;
     cout<<"set-publish-cdnskey ZONE           Enable sending CDNSKEY responses for ZONE"<<endl;
     cout<<"set-publish-cds ZONE [DIGESTALGOS] Enable sending CDS responses for ZONE, using DIGESTALGOS as signature algorithms"<<endl;
@@ -2546,11 +2547,12 @@ try
   }
   else if(cmds[0]=="set-nsec3") {
     if(cmds.size() < 2) {
-      cerr<<"Syntax: pdnsutil set-nsec3 ZONE 'params' [narrow]"<<endl;
+      cerr<<"Syntax: pdnsutil set-nsec3 ZONE 'params' [narrow [axfr]]"<<endl;
       return 0;
     }
     string nsec3params =  cmds.size() > 2 ? cmds[2] : "1 0 1 ab";
     bool narrow = cmds.size() > 3 && cmds[3]=="narrow";
+    bool axfr = cmds.size() > 4 && cmds[3]=="narrow" && cmds[4]=="axfr";
     NSEC3PARAMRecordContent ns3pr(nsec3params);
 
     DNSName zone(cmds[1]);
@@ -2562,7 +2564,7 @@ try
       cerr<<"NSEC3PARAM algorithm set to '"<<std::to_string(ns3pr.d_algorithm)<<"', but '1' is the only valid value"<<endl;
       return EXIT_FAILURE;
     }
-    if (! dk.setNSEC3PARAM(zone, ns3pr, narrow)) {
+    if (! dk.setNSEC3PARAM(zone, ns3pr, narrow, axfr)) {
       cerr<<"Cannot set NSEC3 param for " << zone << endl;
       return 1;
     }

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -610,24 +610,11 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   bool securedZone = dk.isSecuredZone(target);
   bool presignedZone = dk.isPresigned(target);
 
-  bool noAXFRBecauseOfNSEC3Narrow=false;
   NSEC3PARAMRecordContent ns3pr;
   bool narrow;
   bool NSEC3Zone=false;
   if(dk.getNSEC3PARAM(target, &ns3pr, &narrow)) {
     NSEC3Zone=true;
-    if(narrow) {
-      L<<Logger::Error<<"Not doing AXFR of an NSEC3 narrow zone '"<<target<<"' for "<<q->getRemote()<<endl;
-      noAXFRBecauseOfNSEC3Narrow=true;
-    }
-  }
-
-  if(noAXFRBecauseOfNSEC3Narrow) {
-    L<<Logger::Error<<"AXFR of domain '"<<target<<"' denied to "<<q->getRemote()<<endl;
-    outpacket->setRcode(RCode::Refused);
-    // FIXME: should actually figure out if we are auth over a zone, and send out 9 if we aren't
-    sendPacket(outpacket,outsock);
-    return 0;
   }
 
   TSIGRecordContent trc;

--- a/regression-tests/backends/bind-master
+++ b/regression-tests/backends/bind-master
@@ -63,7 +63,7 @@ __EOF__
 				$PDNSUTIL --config-dir=. --config-name=bind set-nsec3 $zone "1 $optout 1 abcd" 2>&1
 			elif [ $context = bind-dnssec-nsec3-narrow ]
 			then
-				$PDNSUTIL --config-dir=. --config-name=bind set-nsec3 $zone '1 1 1 abcd' narrow 2>&1
+				$PDNSUTIL --config-dir=. --config-name=bind set-nsec3 $zone '1 1 1 abcd' narrow axfr 2>&1
 			fi
 			if [ "$zone" = "tsig.com" ]; then
 				$PDNSUTIL --config-dir=. --config-name=bind import-tsig-key test $ALGORITHM $KEY

--- a/regression-tests/backends/gsql-common
+++ b/regression-tests/backends/gsql-common
@@ -22,7 +22,7 @@ gsql_master()
 				$PDNSUTIL --config-dir=. --config-name=$backend set-nsec3 $zone "1 $optout 1 abcd" 2>&1
 			elif [ $context = ${backend}-nsec3-narrow ]
 			then
-				$PDNSUTIL --config-dir=. --config-name=$backend set-nsec3 $zone '1 1 1 abcd' narrow 2>&1
+				$PDNSUTIL --config-dir=. --config-name=$backend set-nsec3 $zone '1 1 1 abcd' narrow axfr 2>&1
 			fi
 			securezone $zone ${backend}
 		else
@@ -40,7 +40,7 @@ gsql_master()
 		--dnsupdate=yes --resolver=8.8.8.8 --outgoing-axfr-expand-alias=yes \
 		--expand-alias=yes \
 		--cache-ttl=$cachettl --dname-processing \
-		--disable-axfr-rectify=yes $lua_prequery &
+		$lua_prequery &
 
 	if [ $context = ${backend}-nsec3 ]
 	then

--- a/regression-tests/tests/verify-dnssec-zone/command
+++ b/regression-tests/tests/verify-dnssec-zone/command
@@ -5,30 +5,39 @@ do
 	drill -p $port axfr $zone @$nameserver | ldns-read-zone -z -u CDS -u CDNSKEY > $TFILE
 	for validator in "ldns-verify-zone -V2" jdnssec-verifyzone named-checkzone
 	do
-		echo --- $validator $zone
-		if [ "$validator" = "named-checkzone" ]
+		if [[ $skipreasons = *narrow* ]] &&\
+		   [ "$validator" = "ldns-verify-zone -V2" ]
 		then
-			named-checkzone -i local $zone $TFILE 2>&1 | grep -v 'addnode: NSEC node already exists'
+			# ldns has bugs on travis / need 1.7.0 for nsec3 on ENT (df647670ecc632d842d9ed5746964714b75a6fc3)
+			# Ubuntu only provides 1.6.7
+			echo --- $validator $zone
+			echo --- skipped
 		else
-			if [ ! -e ${testsdir}/${testname}/allow-missing ] || [[ $(type -P "$validator") ]]
+			echo --- $validator $zone
+			if [ "$validator" = "named-checkzone" ]
 			then
-				$validator $TFILE 2>&1
+				named-checkzone -i local $zone $TFILE 2>&1 | grep -v 'addnode: NSEC node already exists'
 			else
-				#fake output for missing validators
-				if [ "$validator" = "jdnssec-verifyzone" ]
+				if [ ! -e ${testsdir}/${testname}/allow-missing ] || [[ $(type -P "$validator") ]]
 				then
-					echo zone verified.
+					$validator $TFILE 2>&1
+				else
+					#fake output for missing validators
+					if [ "$validator" = "jdnssec-verifyzone" ]
+					then
+						echo zone verified.
+					fi
 				fi
 			fi
-		fi
-		RETVAL=$?
-		echo RETVAL: $RETVAL
-		if [ $RETVAL -gt 0 ] && { [[ $validator != ldns-verify-zone* ]] || { [[ $skipreasons != *nsec3* ]] && [[ $skipreasons != *optout* ]]; }; }
-		then
-			echo $validator reported error, full zone content:
-			echo ---
-			cat $TFILE
-			echo --- end of zone content
+			RETVAL=$?
+			echo RETVAL: $RETVAL
+			if [ $RETVAL -gt 0 ] && { [[ $validator != ldns-verify-zone* ]] || { [[ $skipreasons != *nsec3* ]] && [[ $skipreasons != *optout* ]]; }; }
+			then
+				echo $validator reported error, full zone content:
+				echo ---
+				cat $TFILE
+				echo --- end of zone content
+			fi
 		fi
 		echo
 	done

--- a/regression-tests/tests/verify-dnssec-zone/expected_result.narrow
+++ b/regression-tests/tests/verify-dnssec-zone/expected_result.narrow
@@ -1,0 +1,135 @@
+--- ldns-verify-zone -V2 test.com
+--- skipped
+
+--- jdnssec-verifyzone test.com
+zone verified.
+RETVAL: 0
+
+--- named-checkzone test.com
+zone test.com/IN: test.com/MX 'smtp-servers.test.com' has no address records (A or AAAA)
+zone test.com/IN: sub.test.test.com/NS 'ns-test.example.net.test.com' has no address records (A or AAAA)
+zone test.com/IN: loaded serial 2005092501 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 test.dyndns
+--- skipped
+
+--- jdnssec-verifyzone test.dyndns
+zone verified.
+RETVAL: 0
+
+--- named-checkzone test.dyndns
+zone test.dyndns/IN: loaded serial 2012060701 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 wtest.com
+--- skipped
+
+--- jdnssec-verifyzone wtest.com
+zone verified.
+RETVAL: 0
+
+--- named-checkzone wtest.com
+zone wtest.com/IN: wtest.com/MX 'smtp-servers.wtest.com' is a CNAME (illegal)
+zone wtest.com/IN: loaded serial 2005092501 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 dnssec-parent.com
+--- skipped
+
+--- jdnssec-verifyzone dnssec-parent.com
+zone verified.
+RETVAL: 0
+
+--- named-checkzone dnssec-parent.com
+zone dnssec-parent.com/IN: loaded serial 2005092501 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 delegated.dnssec-parent.com
+--- skipped
+
+--- jdnssec-verifyzone delegated.dnssec-parent.com
+zone verified.
+RETVAL: 0
+
+--- named-checkzone delegated.dnssec-parent.com
+zone delegated.dnssec-parent.com/IN: loaded serial 2005092501 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 secure-delegated.dnssec-parent.com
+--- skipped
+
+--- jdnssec-verifyzone secure-delegated.dnssec-parent.com
+zone verified.
+RETVAL: 0
+
+--- named-checkzone secure-delegated.dnssec-parent.com
+zone secure-delegated.dnssec-parent.com/IN: loaded serial 2005092501 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 minimal.com
+--- skipped
+
+--- jdnssec-verifyzone minimal.com
+zone verified.
+RETVAL: 0
+
+--- named-checkzone minimal.com
+zone minimal.com/IN: loaded serial 2000081501 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 tsig.com
+--- skipped
+
+--- jdnssec-verifyzone tsig.com
+zone verified.
+RETVAL: 0
+
+--- named-checkzone tsig.com
+zone tsig.com/IN: loaded serial 2000081501 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 stest.com
+--- skipped
+
+--- jdnssec-verifyzone stest.com
+zone verified.
+RETVAL: 0
+
+--- named-checkzone stest.com
+zone stest.com/IN: loaded serial 2000081501 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 cdnskey-cds-test.com
+--- skipped
+
+--- jdnssec-verifyzone cdnskey-cds-test.com
+zone verified.
+RETVAL: 0
+
+--- named-checkzone cdnskey-cds-test.com
+zone cdnskey-cds-test.com/IN: loaded serial 2005092501 (DNSSEC signed)
+OK
+RETVAL: 0
+
+--- ldns-verify-zone -V2 2.0.192.in-addr.arpa
+--- skipped
+
+--- jdnssec-verifyzone 2.0.192.in-addr.arpa
+zone verified.
+RETVAL: 0
+
+--- named-checkzone 2.0.192.in-addr.arpa
+zone 2.0.192.in-addr.arpa/IN: loaded serial 2000081501 (DNSSEC signed)
+OK
+RETVAL: 0
+


### PR DESCRIPTION
I believe it's okay to allow axfr on narrow zone and that it does not
introduces security problems.

The narrow mode will dynamically create a nsec3 range around the
record.

Something like:
```
$ dig +dnssec aaaab.meeeee.eu.
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 28784
;; AUTHORITY SECTION:
hkvb2h0gtd2nbiuk741aab6cbkl1fsg8.meeeee.eu. 10800 IN NSEC3 1 0 3 EA33014A HKVB2H0GTD2NBIUK741AAB6CBKL1FSGA
```

In this example, the hash of `aaaab.meeeee.eu.` is `hkvb2h0gtd2nbiuk741aab6cbkl1fsg9.meeeee.eu`
which translate to a NSEC3 record like:
```
hkvb2h0gtd2nbiuk741aab6cbkl1fsg8.meeeee.eu. 10800 IN NSEC3 1 0 3 EA33014A HKVB2H0GTD2NBIUK741AAB6CBKL1FSGA
\------------------------------/                           \------------/ \------------------------------/
                     |                                           |                      |
Start of the range --/                                           |                      |
Alg + Salt (NSEC3PARAM) -----------------------------------------/                      |
End of the range   ---------------------------------------------------------------------/
```

While correct, this is not **exact**. The range could be larger than
that. In my case, the largest range could be:
```
ftdcumdfkc5rqsv077mjp9v0bb19c6ev.meeeee.eu. 10800 IN NSEC3 1 0 3 EA33014A I2UF1DNHSOTNACGN056KBFGBFPIICNMG A AAAA RRSIG
```

Because `]hkvb2h0gtd2nbiuk741aab6cbkl1fsg8;hkvb2h0gtd2nbiuk741aab6cbkl1fsga[`
is a subset of `]ftdcumdfkc5rqsv077mjp9v0bb19c6ev;i2uf1dnhsotnacgn056kbfgbfpiicnmg[`
both are correct, the later being the largest range possible.

This would make the primary reply differently than a slave. While this
may looks strange, I believe this is accepted by all the RFC I know.

Not being 100% sure, I'd prefer to ask. Please let me know if I forgot
something.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
