### PR TITLE
Throw an error when lua-conf-file can't be loaded

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2704,7 +2704,13 @@ int serviceMain(int argc, char*argv[])
 
   g_dnssecLogBogus = ::arg().mustDo("dnssec-log-bogus");
 
-  loadRecursorLuaConfig(::arg()["lua-config-file"], ::arg().mustDo("daemon"));
+  try {
+    loadRecursorLuaConfig(::arg()["lua-config-file"], ::arg().mustDo("daemon"));
+  }
+  catch (PDNSException &e) {
+    L<<Logger::Error<<"Cannot load Lua configuration: "<<e.reason<<endl;
+    exit(1);
+  }
 
   parseACLs();
   sortPublicSuffixList();

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -68,10 +68,9 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
   if(fname.empty())
     return;
   ifstream ifs(fname);
-  if(!ifs) {
-    theL()<<"Unable to read configuration file from '"<<fname<<"': "<<strerror(errno)<<endl;
-    return;
-  }
+  if(!ifs)
+    throw PDNSException("Cannot open file '"+fname+"': "+strerror(errno));
+
   Lua.writeFunction("clearSortlist", [&lci]() { lci.sortlist.clear(); });
   
   /* we can get: "1.2.3.4"


### PR DESCRIPTION
### Short description
This ensures we cannot start up if the file is unreadable.
Closes #4939
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
