### PR TITLE
calidns: Use the correct socket family (IPv4 / IPv6)

### DIFF
--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -231,7 +231,7 @@ try
   vector<Socket*> sockets;
   ComboAddress dest(argv[2], 53);  
   for(int i=0; i < 24; ++i) {
-    Socket *sock = new Socket(AF_INET, SOCK_DGRAM);
+    Socket *sock = new Socket(dest.sin4.sin_family, SOCK_DGRAM);
     //    sock->connect(dest);
     setSocketSendBuffer(sock->getHandle(), 2000000);
     setSocketReceiveBuffer(sock->getHandle(), 2000000);


### PR DESCRIPTION
### Short description
`calidns` used to create IPv4 sockets even if the supplied address was an IPv6 one.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
