### PR TITLE
dnsdist: Send a 404 on unknown API path

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -100,10 +100,7 @@ static bool compareAuthorization(YaHTTP::Request& req, const string &expected_pa
     /* if this is a request for the API,
        check if the API key is correct */
     if (req.url.path=="/jsonstat" ||
-        req.url.path=="/api/v1/servers/localhost" ||
-        req.url.path=="/api/v1/servers/localhost/config" ||
-        req.url.path=="/api/v1/servers/localhost/config/allow-from" ||
-        req.url.path=="/api/v1/servers/localhost/statistics") {
+        req.url.path.find("/api/") == 0) {
       header = req.headers.find("x-api-key");
       if (header != req.headers.end()) {
         auth_ok = (0==strcmp(header->second.c_str(), expectedApiKey.c_str()));

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -100,6 +100,15 @@ class TestAPIBasics(DNSDistTest):
             for key in ['id', 'queries']:
                 self.assertTrue(frontend[key] >= 0)
 
+    def testServersIDontExist(self):
+        """
+        API: /api/v1/servers/idontexist (should be 404)
+        """
+        headers = {'x-api-key': self._webServerAPIKey}
+        url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/idontexist'
+        r = requests.get(url, headers=headers, timeout=self._webTimeout)
+        self.assertEquals(r.status_code, 404)
+
     def testServersLocalhostConfig(self):
         """
         API: /api/v1/servers/localhost/config


### PR DESCRIPTION
### Short description
Before, a 401 would be sent for unknown API paths due to the strict checking.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
