### PR TITLE
dnsdist: Fix pysnmp test error.

### DIFF
--- a/regression-tests.dnsdist/requirements.txt
+++ b/regression-tests.dnsdist/requirements.txt
@@ -4,3 +4,4 @@ libnacl>=1.4.3
 requests>=2.1.0
 protobuf>=2.5,<3.0
 pysnmp>=4.3.2
+pyasn1==0.2.2


### PR DESCRIPTION
The tests fails because of pyasn1 0.2.3.

Should be reverted once https://github.com/etingof/pysnmp/issues/40 is
fixed and released (and pysnmp bumped to the newest version).



### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
