### PR TITLE
map CDS and CDNSKEY to TYPExxx for jdnssec-verifyzone

### DIFF
--- a/regression-tests/tests/verify-dnssec-zone/command
+++ b/regression-tests/tests/verify-dnssec-zone/command
@@ -2,7 +2,7 @@
 for zone in $(grep 'zone ' named.conf  | cut -f2 -d\" | grep -v '^\(example.com\|nztest.com\)$')
 do
 	TFILE=$(mktemp tmp.XXXXXXXXXX)
-	drill -p $port axfr $zone @$nameserver | ldns-read-zone -z > $TFILE
+	drill -p $port axfr $zone @$nameserver | ldns-read-zone -z -u CDS -u CDNSKEY > $TFILE
 	for validator in "ldns-verify-zone -V2" jdnssec-verifyzone named-checkzone
 	do
 		echo --- $validator $zone


### PR DESCRIPTION
### Short description
On systems with a newer drill than our Travis instances, the AXFRs during the verify-dnssec-zone test yield actual CDS/CDNSKEY records instead of their TYPExxx equivalents. jdnssec-verifyzone does not understand CDS/CDNSKEY. This patch makes sure the verifiers get TYPExxx instead of CDS/CDNSKEY.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
