### PR TITLE
auth: Don't leak a CDB object in case of bogus data

### DIFF
--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -153,7 +153,7 @@ void TinyDNSBackend::getAllDomains(vector<DomainInfo> *domains, bool include_dis
   d_isAxfr=true;
   d_dnspacket = NULL;
 
-  d_cdbReader=new CDB(getArg("dbfile"));
+  d_cdbReader=std::unique_ptr<CDB>(new CDB(getArg("dbfile")));
   d_cdbReader->searchAll();
   DNSResourceRecord rr;
 
@@ -178,7 +178,7 @@ void TinyDNSBackend::getAllDomains(vector<DomainInfo> *domains, bool include_dis
 bool TinyDNSBackend::list(const DNSName &target, int domain_id, bool include_disabled) {
   d_isAxfr=true;
   string key = target.toDNSString(); // FIXME400 bug: no lowercase here? or promise that from core?
-  d_cdbReader=new CDB(getArg("dbfile"));
+  d_cdbReader=std::unique_ptr<CDB>(new CDB(getArg("dbfile")));
   return d_cdbReader->searchSuffix(key);
 }
 
@@ -199,7 +199,7 @@ void TinyDNSBackend::lookup(const QType &qtype, const DNSName &qdomain, DNSPacke
 
   d_qtype=qtype;
 
-  d_cdbReader=new CDB(getArg("dbfile"));
+  d_cdbReader=std::unique_ptr<CDB>(new CDB(getArg("dbfile")));
   d_cdbReader->searchKey(key);
   d_dnspacket = pkt_p;
 }
@@ -318,7 +318,7 @@ bool TinyDNSBackend::get(DNSResourceRecord &rr)
   } // end of while
   DLOG(L<<Logger::Debug<<backendname<<"No more records to return."<<endl);
 
-  delete d_cdbReader;
+  d_cdbReader = nullptr;
   return false;
 }
 

--- a/modules/tinydnsbackend/tinydnsbackend.hh
+++ b/modules/tinydnsbackend/tinydnsbackend.hh
@@ -96,7 +96,7 @@ private:
   //data member variables
   uint64_t d_taiepoch;
   QType d_qtype;
-  CDB *d_cdbReader;
+  std::unique_ptr<CDB> d_cdbReader;
   DNSPacket *d_dnspacket; // used for location and edns-client support.
   bool d_isWildcardQuery; // Indicate if the query received was a wildcard query.
   bool d_isAxfr; // Indicate if we received a list() and not a lookup().


### PR DESCRIPTION
### Short description
Replace the naked pointer by a `std::unique_ptr` one to prevent leaking the `CDB` object and the associated file descriptor.
Closes #3719.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
