### PR TITLE
rec: Split SyncRes::doResolveAt, add const and static whenever possible

### DIFF
--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -533,6 +533,15 @@ private:
   inline vector<DNSName> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);
   bool moreSpecificThan(const DNSName& a, const DNSName &b);
   vector<ComboAddress> getAddrs(const DNSName &qname, unsigned int depth, set<GetBestNSAnswer>& beenthere);
+
+  bool nameserversBlockedByRPZ(const NsSet& nameservers);
+  bool nameserverIPBlockedByRPZ(const ComboAddress&);
+  bool throttledOrBlocked(const std::string& prefix, const ComboAddress& remoteIP, const DNSName& qname, const QType& qtype, bool pierceDontQuery);
+
+  vector<ComboAddress> retrieveAddressesForNS(const std::string& prefix, const DNSName& qname, vector<DNSName >::const_iterator& tns, const unsigned int depth, set<GetBestNSAnswer>& beenthere, const vector<DNSName >& rnameservers, NsSet& nameservers, bool& sendRDQuery, bool& pierceDontQuery, bool& flawedNSSet);
+  RCode::rcodes_ updateCacheFromRecords(const std::string& prefix, LWResult& lwr, const DNSName& qname, const DNSName& auth, NsSet& nameservers, const DNSName& tns, const boost::optional<Netmask>);
+  bool processRecords(const std::string& prefix, const DNSName& qname, const QType& qtype, const DNSName& auth, LWResult& lwr, const bool sendRDQuery, vector<DNSRecord>& ret, set<DNSName>& nsset, DNSName& newtarget, DNSName& newauth, bool& realreferral, bool& negindic, bool& sawDS);
+
 private:
   ostringstream d_trace;
   shared_ptr<RecursorLua4> d_pdl;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -67,9 +67,6 @@ struct BothRecordsAndSignatures
 };
 typedef map<pair<DNSName,uint16_t>, BothRecordsAndSignatures> recsig_t;
 
-recsig_t harvestRecords(const std::vector<DNSRecord>& records, const std::set<uint16_t>& types);
-
-
 struct NegCacheEntry
 {
   DNSName d_name;
@@ -308,7 +305,7 @@ public:
     d_lm = lm;
   }
 
-  bool doLog()
+  bool doLog() const
   {
     return d_lm != LogNone;
   }
@@ -352,7 +349,7 @@ public:
     d_skipCNAMECheck = skip;
   }
 
-  int asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res);
+  int asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res) const;
 
   static void doEDNSDumpAndClose(int fd);
 
@@ -524,18 +521,18 @@ private:
                   unsigned int depth, set<GetBestNSAnswer>&beenthere);
   int doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere);
   bool doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res);
-  domainmap_t::const_iterator getBestAuthZone(DNSName* qname);
+  domainmap_t::const_iterator getBestAuthZone(DNSName* qname) const;
   bool doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res);
   bool doCacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res);
   void getBestNSFromCache(const DNSName &qname, const QType &qtype, vector<DNSRecord>&bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere);
   DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere);
 
   inline vector<DNSName> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);
-  bool moreSpecificThan(const DNSName& a, const DNSName &b);
+  bool moreSpecificThan(const DNSName& a, const DNSName &b) const;
   vector<ComboAddress> getAddrs(const DNSName &qname, unsigned int depth, set<GetBestNSAnswer>& beenthere);
 
-  bool nameserversBlockedByRPZ(const NsSet& nameservers);
-  bool nameserverIPBlockedByRPZ(const ComboAddress&);
+  bool nameserversBlockedByRPZ(const DNSFilterEngine& dfe, const NsSet& nameservers);
+  bool nameserverIPBlockedByRPZ(const DNSFilterEngine& dfe, const ComboAddress&);
   bool throttledOrBlocked(const std::string& prefix, const ComboAddress& remoteIP, const DNSName& qname, const QType& qtype, bool pierceDontQuery);
 
   vector<ComboAddress> retrieveAddressesForNS(const std::string& prefix, const DNSName& qname, vector<DNSName >::const_iterator& tns, const unsigned int depth, set<GetBestNSAnswer>& beenthere, const vector<DNSName >& rnameservers, NsSet& nameservers, bool& sendRDQuery, bool& pierceDontQuery, bool& flawedNSSet);


### PR DESCRIPTION
### Short description
* Split `SyncRes::doResolveAt()` to make it more readable.
* `Const`-ify `SyncRes` methods whenever possible, and mark functions and global variables as `static` in `pdns_recursor.cc` whenever possible. This might allow the compiler to do some optimizations, and make it easier to see where functions and variables are used when reading the code.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
