### PR TITLE
Stubresolver: Use only `resolver` setting if given

### DIFF
--- a/docs/markdown/authoritative/howtos.md
+++ b/docs/markdown/authoritative/howtos.md
@@ -185,6 +185,8 @@ resolver=[::1]:5300
 expand-alias=yes
 ```
 
+**note**: If `resolver` is unset, ALIAS expension is disabled!
+
 and add the ALIAS record to your zone apex. e.g.:
 
 ```

--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -718,10 +718,11 @@ If set, recursive queries will be handed to the recursor specified here. See
 ["Recursion"](recursion.md).
 
 ## `resolver`
-* IP Address
+* IP Addresses with optional port, separated by commas
 * Added in: 4.1.0
 
-Use this resolver for ALIAS and the internal stub resolver.
+Use these resolver addresses for ALIAS and the internal stub resolver.
+If this is not set, `/etc/resolv.conf` is parsed for upstream resolvers.
 
 ## `retrieval-threads`
 * Integer

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -42,7 +42,10 @@ DNSProxy::DNSProxy(const string &remote)
   d_resanswers=S.getPointer("recursing-answers");
   d_resquestions=S.getPointer("recursing-questions");
   d_udpanswers=S.getPointer("udp-answers");
-  ComboAddress remaddr(remote, 53);
+
+  vector<string> addresses;
+  stringtok(addresses, remote, " ,\t");
+  ComboAddress remaddr(addresses[0], 53);
   
   if((d_sock=socket(remaddr.sin4.sin_family, SOCK_DGRAM,0))<0)
     throw PDNSException(string("socket: ")+strerror(errno));

--- a/pdns/stubresolver.hh
+++ b/pdns/stubresolver.hh
@@ -24,4 +24,5 @@
 #include "dnsparser.hh"
 
 void stubParseResolveConf();
+bool resolversDefined();
 int stubDoResolve(const DNSName& qname, uint16_t qtype, vector<DNSZoneRecord>& ret);


### PR DESCRIPTION
Use resolv.conf otherwise. Also, do not use 127.0.0.1:53 as fallback,
as this could be ourselves.

Closes #4655

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)