### PR TITLE
BIND backend: support "native" zones

### DIFF
--- a/docs/markdown/authoritative/backend-bind.md
+++ b/docs/markdown/authoritative/backend-bind.md
@@ -85,7 +85,7 @@ its own. Furthermore, on most systems, there will be no benefit in using multipl
 CPUs for the packetcache, so a noticeable speedup can be attained by specifying
 [`distributor-threads`](settings.md#distributor-threads)`=1` in `pdns.conf`.
 
-## Master/slave configuration
+## Master/slave/native configuration
 
 ### Master
 Works as expected. At startup, no notification storm is performed as this is
@@ -103,3 +103,11 @@ parsed only then.
 
 In the future, this may be improved so the old zone remains available should
 parsing fail.
+
+### Native
+PowerDNS has the concept of "native" zones that have the `type native;` in the BIND configuration file.
+These zones are neither a master (no notifies are sent) nor a slave zone (it will never be AXFR'd in).
+This means that the replication mechanism for these zone is not AXFR but out of band, e.g. using `rsync`.
+Changes to native zones are picked up in the same way as master and slave zones, see [Operation](#operation).
+
+**note**: Any zone with no `type` set (an error in BIND) is assumed to be native.

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -809,12 +809,9 @@ void Bind2Backend::loadConfig(string* status)
         i!=domains.end();
         ++i) 
       {
-        if(i->type == "") {
-          L<<Logger::Warning<<d_logprefix<<" Warning! Skipping zone '"<<i->name<<"' because it has no type specified"<<endl;
-          rejected++;
-          continue;
-        }
-        if(i->type!="master" && i->type!="slave") {
+        if(i->type == "")
+          L<<Logger::Notice<<d_logprefix<<" Zone '"<<i->name<<"' has no type specified, assuming 'native'"<<endl;
+        if(i->type!="master" && i->type!="slave" && i->type != "native" && i->type != "") {
           L<<Logger::Warning<<d_logprefix<<" Warning! Skipping zone '"<<i->name<<"' because type '"<<i->type<<"' is invalid"<<endl;
           rejected++;
           continue;


### PR DESCRIPTION
### Short description
Allow the use of `type native;` for zones in BIND config files.
We also assume the type is native if no type is specified.

Closes #1284

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)