### PR TITLE
Turn PDNSException in qthread into an error & exit instead of crash.

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -343,6 +343,7 @@ void sendout(DNSPacket* a)
 
 //! The qthread receives questions over the internet via the Nameserver class, and hands them to the Distributor for further processing
 void *qthread(void *number)
+try
 {
   DNSPacket *P;
   DNSDistributor *distributor = DNSDistributor::Create(::arg().asNum("distributor-threads", 1)); // the big dispatcher!
@@ -455,6 +456,11 @@ void *qthread(void *number)
     }
   }
   return 0;
+}
+catch(PDNSException& pe)
+{
+  L<<Logger::Error<<"Fatal error in question thread: "<<pe.reason<<endl;
+  _exit(1);
 }
 
 static void* dummyThread(void *)


### PR DESCRIPTION

### Short description
Some configuration errors would lead to a crash, instead of a useful error. Closes #3830.

<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
