### PR TITLE
auth: Create additional `reuseport` sockets before dropping privileges

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -43,10 +43,11 @@ PacketCache PC; //!< This is the main PacketCache, shared across all threads
 DNSProxy *DP;
 DynListener *dl;
 CommunicatorClass Communicator;
-UDPNameserver *N;
+shared_ptr<UDPNameserver> N;
 int avg_latency;
 TCPNameserver *TN;
-vector<DNSDistributor*> g_distributors;
+static vector<DNSDistributor*> g_distributors;
+vector<std::shared_ptr<UDPNameserver> > g_udpReceivers;
 AuthLua *LPE;
 
 ArgvMap &arg()
@@ -361,18 +362,17 @@ void *qthread(void *number)
 
   int diff;
   bool logDNSQueries = ::arg().mustDo("log-dns-queries");
-  UDPNameserver *NS = N;
+  shared_ptr<UDPNameserver> NS;
 
   // If we have SO_REUSEPORT then create a new port for all receiver threads
   // other than the first one.
-  if( number != NULL && NS->canReusePort() ) {
-    L<<Logger::Notice<<"Starting new listen thread on the same IPs/ports using SO_REUSEPORT"<<endl;
-    try {
-      NS = new UDPNameserver( true );
-    } catch(PDNSException &e) {
-      L<<Logger::Error<<"Unable to reuse port, falling back to original bind"<<endl;
+  if( number != NULL && N->canReusePort() ) {
+    NS = g_udpReceivers[num];
+    if (NS == nullptr) {
       NS = N;
     }
+  } else {
+    NS = N;
   }
 
   for(;;) {

--- a/pdns/common_startup.hh
+++ b/pdns/common_startup.hh
@@ -40,7 +40,8 @@ extern PacketCache PC; //!< This is the main PacketCache, shared across all thre
 extern DNSProxy *DP;
 extern DynListener *dl;
 extern CommunicatorClass Communicator;
-extern UDPNameserver *N;
+extern std::shared_ptr<UDPNameserver> N;
+extern vector<std::shared_ptr<UDPNameserver> > g_udpReceivers;
 extern int avg_latency;
 extern TCPNameserver *TN;
 extern AuthLua *LPE;


### PR DESCRIPTION
### Short description
When `reuseport` support is enabled and available, we used to create additional sockets after dropping privileges, making impossible to use that feature in a `setuid` setup. This PR moves the additional sockets creation before dropping privileges.
Fixes #1715.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

