### PR TITLE
Use pkg-config first to find libpq

### DIFF
--- a/build-scripts/debian-authoritative/rules
+++ b/build-scripts/debian-authoritative/rules
@@ -42,7 +42,6 @@ override_dh_auto_configure:
 		--libexecdir='$${prefix}/lib' \
 		--with-dynmodules="$(backends)" \
 		--with-modules="" \
-		--with-pgsql-includes=`pg_config --includedir` \
 		--enable-botan1.10 \
 		--enable-tools \
 		--enable-unit-tests \

--- a/docs/markdown/authoritative/upgrading.md
+++ b/docs/markdown/authoritative/upgrading.md
@@ -2,6 +2,18 @@ Before proceeding, it is advised to check the release notes for your PowerDNS ve
 
 Please upgrade to the PowerDNS Authoritative Server 4.0.0 from 3.4.2+. See the [3.X](https://doc.powerdns.com/3/authoritative/upgrading/) upgrade notes if your version is older than 3.4.2.
 
+# 4.0.X to 4.1.0
+
+## Changed options
+
+### Changed defaults
+
+## Other changes
+
+The `--with-pgsql`, `--with-pgsql-libs`, `--with-pgsql-includes` and `--with-pgsql-config` `configure` options have been deprecated.
+`configure` now attempts to find the Postgresql client libraries via `pkg-config`, falling back to detecting `pg_config`.
+Use `--with-pg-config` to specify a path to a non-default `pg_config` if you have Postgresql installed in a non-default location.
+
 # 4.0.X to 4.0.2
 
 ## Changed options

--- a/m4/pdns_with_postgresql.m4
+++ b/m4/pdns_with_postgresql.m4
@@ -1,108 +1,35 @@
-AC_DEFUN([PDNS_WITH_POSTGRESQL],[
-  AC_ARG_WITH([pgsql],
-    AS_HELP_STRING([--with-pgsql=<path>],
-      [root directory path of PgSQL installation]
-   ),
-   [PGSQL_lib_check="$withval/lib/pgsql $withval/lib"
-    PGSQL_inc_check="$withval/include/pgsql $withval/include"
-   ]
-  )
+dnl
+dnl Attempt to detect the flags we need for the Postgresql client libraries
+dnl First, use pkg-config
+dnl If that yields no results, use (optionally find) pg_config and use it to 
+dnl determine the CFLAGS and LIBS
+dnl
+AC_DEFUN([PDNS_WITH_POSTGRESQL], [
+  PG_CONFIG=""
+  AC_ARG_WITH([pg-config], [
+    AS_HELP_STRING([--with-pg-config=<path>], [path to pg_config])
+  ], [
+    PG_CONFIG="$withval"
+    AS_IF([test "x$PG_CONFIG" = "xyes" -o ! -x "$PG_CONFIG"], [
+      AC_MSG_ERROR([--with-pg-config must provide a valid path to the pg_config executable])
+    ])
+  ])
 
-  AC_ARG_WITH([pgsql-lib],
-    AS_HELP_STRING([--with-pgsql-lib=<path>],
-      [directory path of PgSQL library installation]
-    ),
-    [PGSQL_lib_check="$withval/lib/pgsql $withval/pgsql $withval"]
-  )
+  AS_IF([test "x$PG_CONFIG" = "x"], [
+    PKG_CHECK_MODULES([PGSQL], [libpq], [ : ], [ : ])
+  ])
 
-  AC_ARG_WITH([pgsql-includes],
-    AS_HELP_STRING([--with-pgsql-includes=<path>],
-      [directory path of PgSQL header installation]
-    ),
-    [PGSQL_inc_check="$withval/include/pgsql $withval/pgsql $withval"]
-  )
-
-  AC_ARG_WITH([pgsql-config], 
-    AS_HELP_STRING([--with-pgsql-config=<path>],
-      [location of pg_config]
-    ),
-    [PGSQL_pg_config="$withval"
-     if test "x$PGSQL_pg_config" = "xyes" || test ! -x "$PGSQL_pg_config"; then
-       AC_MSG_ERROR([--with-pgsql-config must provide a valid path to pg_config executable])
-     fi
-    ], 
-    [AC_PATH_PROG([PGSQL_pg_config], [pg_config])]
-  )
-
-  if test "x$PGSQL_pg_config" != "x"; then
-    if test "x$PGSQL_lib_check" = "x"; then
-      PGSQL_lib_check=$($PGSQL_pg_config --libdir)
-    fi
-    if test "x$PGSQL_inc_check" = "x"; then
-      PGSQL_inc_check=$($PGSQL_pg_config --includedir)
-    fi
-    PGSQL_CFLAGS=
-  fi
-
-  if test "x$PGSQL_lib_check" = "x"; then
-    PGSQL_lib_check="/usr/local/pgsql/lib/pgsql /usr/local/lib/pgsql /opt/pgsql/lib/pgsql /usr/lib/pgsql /usr/local/pgsql/lib /usr/local/lib /opt/pgsql/lib /usr/lib /usr/lib64 $full_libdir"
-  fi
-
-  if test "x$PGSQL_inc_check" = "x"; then
-    PGSQL_inc_check="/usr/local/pgsql/include/pgsql /usr/include /usr/local/include/postgresql/ /usr/local/include /opt/pgsql/include/pgsql /opt/pgsql/include /usr/include/pgsql/ /usr/include/postgresql"
-  fi
-
-  AC_SUBST([PGSQL_lib])
-  AC_MSG_CHECKING([for PgSQL library directory])
-  PGSQL_libdir=
-  for m in $PGSQL_lib_check; do
-    if test -d "$m" && (test -f "$m/libpq.a" || test -f "$m/libpq.so"); then
-      PGSQL_libdir=$m
-      break
-    fi
-  done
-  if test -z "$PGSQL_libdir"; then
-    AC_MSG_ERROR([Did not find the pgsql library dir in '$PGSQL_lib_check'])
-  fi
-  case "$PGSQL_libdir" in
-    /usr/lib)
-      PGSQL_lib="-lpq"
-      ;;
-    /usr/lib64)
-      PGSQL_lib="-lpq"
-      ;;
-    $full_libdir)
-      PGSQL_lib="-lpq"
-      ;;
-    /*)
-      PGSQL_lib="-L$PGSQL_libdir -Wl,-rpath,$PGSQL_libdir -lpq"
-      ;;
-    *)
-      AC_MSG_ERROR([The PgSQL library directory ($PGSQL_libdir) must be an absolute path.])
-      ;;
-  esac
-  AC_MSG_RESULT([$PGSQL_libdir])
-
-  AC_SUBST([PGSQL_inc]) 
-  AC_MSG_CHECKING([for PgSQL include directory])
-  PGSQL_incdir=
-  for m in $PGSQL_inc_check; do
-    if test -d "$m" && test -f "$m/libpq-fe.h"; then
-      PGSQL_incdir=$m
-      break
-    fi
-  done
-  if test -z "$PGSQL_incdir"; then 
-    AC_MSG_ERROR([Did not find the PgSQL include dir in '$PGSQL_inc_check'])
-  fi
-  case "$PGSQL_incdir" in
-    /*)
-      PGSQL_inc="-I$PGSQL_incdir"
-      ;;
-    * )
-      AC_MSG_ERROR([The PgSQL include directory ($PGSQL_incdir) must be an absolute path.])
-      ;;
-  esac
-  AC_MSG_RESULT([$PGSQL_incdir])
+  AS_IF([test "x$PG_CONFIG" != "x" -o "x$PGSQL_LIBS" = "x"], [
+    dnl Either a path was provided, or pkg-config failed to produce a result
+    AS_IF([test "x$PG_CONFIG" == "x"], [
+      AC_PATH_PROG([PG_CONFIG], [pg_config])
+    ])
+    AS_IF([test "x$PG_CONFIG" == "x"], [
+      AC_MSG_ERROR([Can not find pg_config, use --with-pg-config to specify the path to pg_config])
+    ])
+    PGSQL_LIBS="-L$($PG_CONFIG --libdir) -lpq"
+    PGSQL_CFLAGS="-I$($PG_CONFIG --includedir)"
+  ])
+  AC_SUBST([PGSQL_LIBS])
+  AC_SUBST([PGSQL_CFLAGS])
 ])
-

--- a/modules/gpgsqlbackend/Makefile.am
+++ b/modules/gpgsqlbackend/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS += $(PGSQL_inc)
+AM_CPPFLAGS += $(PGSQL_CFLAGS)
 pkglib_LTLIBRARIES = libgpgsqlbackend.la
 
 EXTRA_DIST = \
@@ -18,4 +18,4 @@ libgpgsqlbackend_la_SOURCES = \
 	spgsql.cc spgsql.hh
 
 libgpgsqlbackend_la_LDFLAGS = -module -avoid-version
-libgpgsqlbackend_la_LIBADD = $(PGSQL_lib)
+libgpgsqlbackend_la_LIBADD = $(PGSQL_LIBS)


### PR DESCRIPTION
### Short description
Unless a path to pg_config was supplied. If pkg-config does not produce
a result attempt to find pg_config and use that.

This commit also removes support for supplying a path to the postgresql
libs and includes. Use --with-pg-config to use non-default installation
paths.

Closes #2358

<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)