### PR TITLE
[WIP] Make Lua threaded for sync-like programming against kvquery

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2486,10 +2486,11 @@ struct LuaContext::Reader<std::string>
     static auto read(lua_State* state, int index)
         -> boost::optional<std::string>
     {
-        const auto val = lua_tostring(state, index);
+        size_t len;
+        const auto val = lua_tolstring(state, index, &len);
         if (val == 0)
             return boost::none;
-        return std::string(val);
+        return std::string(val, len);
     }
 };
 

--- a/pdns/kv-example-script.lua
+++ b/pdns/kv-example-script.lua
@@ -12,47 +12,37 @@ To benefit from this hook,
 To test, use the 'kvresp' example program provided.
 --]]
 
+function gettag()
+    print "gettag"
+    local kvresp = newCA("127.0.0.1:5555")
+    print "calling kvquery"
+    local res = kvquery(kvresp, "DOMAIN www.example.com")
+    print ("kvquery "..res)
+end
+
 function preresolve (dq)
-	print ("prereesolve handler called for: "..dq.remoteaddr:toString().. ", local: ".. dq.localaddr:toString()..", ".. dq.qname:toString()..", ".. dq.qtype)
-	dq.followupFunction="udpQueryResponse"
-	dq.udpCallback="gotdomaindetails"
-	dq.udpQueryDest=newCA("127.0.0.1:5555")
-	dq.udpQuery = "DOMAIN "..dq.qname:toString()
-	return true;
-end
-
-function gotdomaindetails(dq)
-	print("gotdomaindetails called, got: "..dq.udpAnswer)
-        if(dq.udpAnswer == "0") 
+    print ("prereesolve handler called for: "..dq.remoteaddr:toString().. ", local: ".. dq.localaddr:toString()..", ".. dq.qname:toString()..", ".. dq.qtype)
+    local kvresp = newCA("127.0.0.1:5555")
+    local domaindetails = kvquery(kvresp, "DOMAIN "..dq.qname:toString())
+    if(domaindetails == "0") 
         then
-                print("This domain needs no filtering, not looking up this domain")
-                dq.followupFunction=""   
-                return false
-        end
-        print("Domain might need filtering for some users")
-        dq.variable = true -- disable packet cache
-	local data={}
-	data["domaindetails"]= dq.udpAnswer
-	dq.data=data 
-	dq.udpQuery="IP "..dq.remoteaddr:toString()
-	dq.udpCallback="gotipdetails"
-	print("returning true in gotipdetails")
-	return true
-end
+        print("This domain needs no filtering, not looking up this domain")
+        return false
+    end
+    print("Domain might need filtering for some users")
+    dq.variable = true -- disable packet cache
 
-function gotipdetails(dq)
-        dq.followupFunction=""
-	print("So status of IP is "..dq.udpAnswer.." and status of domain is "..dq.data.domaindetails)
-	if(dq.data.domaindetails=="1" and dq.udpAnswer=="1")
-	then
-		print("IP wants filtering and domain is of the filtered kind")
-		dq:addAnswer(pdns.CNAME, "blocked.powerdns.com")
-		return true
-	else
-                print("Returning false (normal resolution should proceed, for this user)")
-		return false
-	end
+    local ipdetails = kvquery(kvresp, "IP "..dq.remoteaddr:toString())
+    print("So status of IP is "..ipdetails.." and status of domain is "..domaindetails)
+    if(domaindetails=="1" and ipdetails=="1")
+        then
+        print("IP wants filtering and domain is of the filtered kind")
+        dq:addAnswer(pdns.CNAME, "blocked.powerdns.com")
+        return true
+    else
+        print("Returning false (normal resolution should proceed, for this user)")
+        return false
+    end
 end
-
 
 

--- a/pdns/kvresp.cc
+++ b/pdns/kvresp.cc
@@ -56,7 +56,7 @@ try
     if(len < 0)
       unixDie("recvfrom");
     string query(buffer, len);
-    cout<<"Had packet: "<<query<<endl;
+    cout<<"Had packet: "<<query<<" with length "<<len<<endl;
     vector<string> parts;
     stringtok(parts, query);
     string response;

--- a/pdns/kvresp.cc
+++ b/pdns/kvresp.cc
@@ -59,15 +59,15 @@ try
     cout<<"Had packet: "<<query<<endl;
     vector<string> parts;
     stringtok(parts, query);
-    if(parts.size()<2)
-      continue;
     string response;
-    if(parts[0]=="DOMAIN") 
-      response=  (parts[1].find("xxx") != string::npos) ? "1" : "0";
-    else if(parts[0]=="IP")
-      response=  (parts[1]=="127.0.0.1") ? "1" : "0";
-    else
+    if(parts.size()<2)
       response= "???";
+    else {
+      if(parts[0]=="DOMAIN")
+        response=  (parts[1].find("xxx") != string::npos) ? "1" : "0";
+      else if(parts[0]=="IP")
+        response=  (parts[1]=="127.0.0.1") ? "1" : "0";
+    }
 
     cout<<"Our reply: "<<response<<endl; 
     if(sendto(s.getHandle(), response.c_str(), response.length(), 0,  (struct sockaddr*)&rem, socklen) < 0)

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -566,6 +566,8 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerFunction("set", &DynMetric::set);
   d_lw->registerFunction("get", &DynMetric::get);
 
+  d_lw->writeFunction("kvquery", &GenUDPQueryResponse);
+
   d_lw->writeFunction("getRecursorThreadId", []() {
       return getRecursorThreadId();
     });
@@ -595,27 +597,27 @@ RecursorLua4::RecursorLua4(const std::string& fname)
 
 bool RecursorLua4::prerpz(DNSQuestion& dq, int& ret)
 {
-  return genhook(d_prerpz, dq, ret);
+  return genhook("prerpz", dq, ret);
 }
 
 bool RecursorLua4::preresolve(DNSQuestion& dq, int& ret)
 {
-  return genhook(d_preresolve, dq, ret);
+  return genhook("preresolve", dq, ret);
 }
 
 bool RecursorLua4::nxdomain(DNSQuestion& dq, int& ret)
 {
-  return genhook(d_nxdomain, dq, ret);
+  return genhook("nxdomain", dq, ret);
 }
 
 bool RecursorLua4::nodata(DNSQuestion& dq, int& ret)
 {
-  return genhook(d_nodata, dq, ret);
+  return genhook("nodata", dq, ret);
 }
 
 bool RecursorLua4::postresolve(DNSQuestion& dq, int& ret)
 {
-  return genhook(d_postresolve, dq, ret);
+  return genhook("postresolve", dq, ret);
 }
 
 bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret)
@@ -625,7 +627,7 @@ bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& reque
   RecursorLua4::DNSQuestion dq(ns, requestor, query, qtype.getCode(), isTcp, variableAnswer, wantsRPZ);
   dq.currentRecords = &res;
 
-  return genhook(d_preoutquery, dq, ret);
+  return genhook("preoutquery", dq, ret);
 }
 
 bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader& dh)
@@ -657,8 +659,10 @@ unsigned int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& edn
   return 0;
 }
 
-bool RecursorLua4::genhook(luacall_t& func, DNSQuestion& dq, int& ret)
+bool RecursorLua4::genhook(const string& funcname, DNSQuestion& dq, int& ret)
 {
+  auto luathread = d_lw->createThread();
+  auto func = d_lw->readVariable<boost::optional<luacall_t>>(luathread, funcname).get_value_or(0);
   if(!func)
     return false;
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -639,8 +639,10 @@ bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& loca
 
 unsigned int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, std::unordered_map<string,string>& data)
 {
-  if(d_gettag) {
-    auto ret = d_gettag(remote, ednssubnet, local, qname, qtype);
+  auto luathread = d_lw->createThread();
+  auto gettag = d_lw->readVariable<boost::optional<gettag_t>>(luathread, "gettag").get_value_or(0);
+  if(gettag) {
+    auto ret = gettag(remote, ednssubnet, local, qname, qtype);
 
     if (policyTags) {
       const auto& tags = std::get<1>(ret);

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -123,7 +123,7 @@ uint16_t)> gettag_t;
 private:
   typedef std::function<bool(DNSQuestion*)> luacall_t;
   luacall_t d_prerpz, d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
-  bool genhook(luacall_t& func, DNSQuestion& dq, int& ret);
+  bool genhook(const string& funcname, DNSQuestion& dq, int& ret);
   typedef std::function<bool(ComboAddress,ComboAddress, struct dnsheader)> ipfilter_t;
   ipfilter_t d_ipfilter;
 };

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1526,7 +1526,7 @@ struct doProcessUDPQuestionArguments {
         int fd;
 };
 
-bool overCapacity(const ComboAddress& fromaddr)
+static bool overCapacity(const ComboAddress& fromaddr)
 {
   if(MT->numProcesses() > g_maxMThreads) {
     if(!g_quiet)
@@ -1710,7 +1710,7 @@ static void realDoProcessUDPQuestion(const std::string& question, const ComboAdd
   return;
 }
 
-void indirectDoProcessUDPQuestion(void *p)
+static void indirectDoProcessUDPQuestion(void *p)
 {
   doProcessUDPQuestionArguments* args=(doProcessUDPQuestionArguments *)p;
 
@@ -1725,7 +1725,7 @@ void indirectDoProcessUDPQuestion(void *p)
   realDoProcessUDPQuestion(question, fromaddr, destaddr, tv, fd, true);
 }
 
-string *doProcessUDPQuestion(const std::string& question, const ComboAddress& fromaddr, const ComboAddress& destaddr, struct timeval tv, int fd)
+static string *doProcessUDPQuestion(const std::string& question, const ComboAddress& fromaddr, const ComboAddress& destaddr, struct timeval tv, int fd)
 {
 
   if (::arg().mustDo("start-mthread-early")) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1671,14 +1671,6 @@ static void realDoProcessUDPQuestion(const std::string& question, const ComboAdd
     }
   }
 
-  if(MT->numProcesses() > g_maxMThreads) {
-    if(!g_quiet)
-      L<<Logger::Notice<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] DROPPED question from "<<fromaddr.toStringWithPort()<<", over capacity"<<endl;
-
-    g_stats.overCapacityDrops++;
-    return;
-  }
-
   DNSComboWriter* dc = new DNSComboWriter(question.c_str(), question.size(), g_now);
   dc->setSocket(fd);
   dc->d_tag=ctag;
@@ -1720,6 +1712,14 @@ void indirectDoProcessUDPQuestion(void *p)
 
 string *doProcessUDPQuestion(const std::string& question, const ComboAddress& fromaddr, const ComboAddress& destaddr, struct timeval tv, int fd)
 {
+  if(MT->numProcesses() > g_maxMThreads) {
+    if(!g_quiet)
+      L<<Logger::Notice<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] DROPPED question from "<<fromaddr.toStringWithPort()<<", over capacity"<<endl;
+
+    g_stats.overCapacityDrops++;
+    return 0;
+  }
+
   if (::arg().mustDo("start-mthread-early")) {
       doProcessUDPQuestionArguments *args = new doProcessUDPQuestionArguments;
       args->question = question;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1518,7 +1518,15 @@ static void handleNewTCPQuestion(int fd, FDMultiplexer::funcparam_t& )
   }
 }
 
-static string* doProcessUDPQuestion(const std::string& question, const ComboAddress& fromaddr, const ComboAddress& destaddr, struct timeval tv, int fd)
+struct doProcessUDPQuestionArguments {
+        std::string question;
+        ComboAddress fromaddr;
+        ComboAddress destaddr;
+        struct timeval tv;
+        int fd;
+};
+
+static void realDoProcessUDPQuestion(const std::string& question, const ComboAddress& fromaddr, const ComboAddress& destaddr, struct timeval tv, int fd, bool inmthread=false)
 {
   gettimeofday(&g_now, 0);
   struct timeval diff = g_now - tv;
@@ -1526,7 +1534,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
 
   if(tv.tv_sec && delta > 1000.0) {
     g_stats.tooOldDrops++;
-    return 0;
+    return;
   }
 
   ++g_stats.qcounter;
@@ -1646,12 +1654,12 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
         updateResponseStats(tmpdh.rcode, fromaddr, response.length(), 0, 0);
       }
       g_stats.avgLatencyUsec=(1-1.0/g_latencyStatSize)*g_stats.avgLatencyUsec + 0.0; // we assume 0 usec
-      return 0;
+      return;
     }
   }
   catch(std::exception& e) {
     L<<Logger::Error<<"Error processing or aging answer packet: "<<e.what()<<endl;
-    return 0;
+    return;
   }
 
   if(t_pdl->get()) {
@@ -1659,7 +1667,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
       if(!g_quiet)
 	L<<Logger::Notice<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] DROPPED question from "<<fromaddr.toStringWithPort()<<" based on policy"<<endl;
       g_stats.policyDrops++;
-      return 0;
+      return;
     }
   }
 
@@ -1668,7 +1676,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
       L<<Logger::Notice<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] DROPPED question from "<<fromaddr.toStringWithPort()<<", over capacity"<<endl;
 
     g_stats.overCapacityDrops++;
-    return 0;
+    return;
   }
 
   DNSComboWriter* dc = new DNSComboWriter(question.c_str(), question.size(), g_now);
@@ -1690,10 +1698,43 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
   }
 #endif
 
-  MT->makeThread(startDoResolve, (void*) dc); // deletes dc
-  return 0;
+  if(inmthread) startDoResolve(dc); // deletes dc
+  else MT->makeThread(startDoResolve, (void*) dc); // deletes dc
+  return;
 }
 
+void indirectDoProcessUDPQuestion(void *p)
+{
+  doProcessUDPQuestionArguments* args=(doProcessUDPQuestionArguments *)p;
+
+  std::string question = args->question;
+  ComboAddress fromaddr = args->fromaddr;
+  ComboAddress destaddr = args->destaddr;
+  struct timeval tv = args->tv;
+  int fd = args->fd;
+
+  delete args;
+
+  realDoProcessUDPQuestion(question, fromaddr, destaddr, tv, fd, true);
+}
+
+string *doProcessUDPQuestion(const std::string& question, const ComboAddress& fromaddr, const ComboAddress& destaddr, struct timeval tv, int fd)
+{
+  if (::arg().mustDo("start-mthread-early")) {
+      doProcessUDPQuestionArguments *args = new doProcessUDPQuestionArguments;
+      args->question = question;
+      args->fromaddr = fromaddr;
+      args->destaddr = destaddr;
+      args->tv = tv;
+      args->fd = fd;
+      MT->makeThread(indirectDoProcessUDPQuestion, (void*) args);
+      return 0;
+  }
+  else {
+    realDoProcessUDPQuestion(question, fromaddr, destaddr, tv, fd);
+    return 0;
+  }
+}
 
 static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
 {
@@ -3102,6 +3143,7 @@ int main(int argc, char **argv)
     ::arg().set("query-local-address6","Source IPv6 address for sending queries. IF UNSET, IPv6 WILL NOT BE USED FOR OUTGOING QUERIES")="";
     ::arg().set("client-tcp-timeout","Timeout in seconds when talking to TCP clients")="2";
     ::arg().set("max-mthreads", "Maximum number of simultaneous Mtasker threads")="2048";
+    ::arg().setSwitch("start-mthread-early", "Assign an mthread to a query even before checking the cache")="no";
     ::arg().set("max-tcp-clients","Maximum number of simultaneous TCP clients")="128";
     ::arg().set("server-down-max-fails","Maximum number of consecutive timeouts (and unreachables) to mark a server as down ( 0 => disabled )")="64";
     ::arg().set("server-down-throttle-time","Number of seconds to throttle all queries to a server after being marked as down")="60";


### PR DESCRIPTION
### Short description
Fixes #5099 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master

### Open problems/questions
 - [ ] we leak ThreadIDs, I'm pretty sure
 - [ ] reloads are painful, most likely
 - [ ] should we make a single Lua thread per mthread and reuse that until the mthread dies? Would be slightly more efficient and might allow some cheap state keeping over the runtime of a query
 - [ ] kvquery is UDP right now, which can be flaky. Should we support TCP? This means keepalives, pooling, etc. and/or a tagged protocol.
 - [x] apparently questions are not NUL-safe
 - [x] check g_maxThreads (i.e. refactor that check into a separate function that we call early in case `start-mthread-early` is enabled)
 - [ ] response buffer size is limited to 512 bytes
 - [ ] we destroyed the 'table lookup' optimisation at https://github.com/PowerDNS/pdns/pull/5122/commits/348adb89b330d287b57604de9b80a6900f5669be#diff-7fb8a7d9628127b764d5aad70850602aL613 (if that link goes dead, it's where `genhook` now takes `const string &funcname` instead of `luacall_t &func`). It should be possible to reuse those refs in individual Lua threads but I haven't found out how to do that with LuaWrapper yet.
 - [ ] also do this change for TCP queries