### PR TITLE
dnsdist, rec: Replace net-snmp-includes.h with hand picked headers

### DIFF
--- a/pdns/snmp-agent.hh
+++ b/pdns/snmp-agent.hh
@@ -9,7 +9,10 @@
 
 #ifdef HAVE_NET_SNMP
 #include <net-snmp/net-snmp-config.h>
-#include <net-snmp/net-snmp-includes.h>
+#include <net-snmp/definitions.h>
+#include <net-snmp/types.h>
+#include <net-snmp/utilities.h>
+#include <net-snmp/config_api.h>
 #include <net-snmp/agent/net-snmp-agent-includes.h>
 #undef INET6 /* SRSLY? */
 #endif /* HAVE_NET_SNMP */


### PR DESCRIPTION
### Short description
Replace net-snmp-includes.h with hand picked headers so it no longer breaks compile on FreeBSD. Fixes #5110 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
