### PR TITLE
Fix minor issues reported by coverity

### DIFF
--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -105,7 +105,6 @@ private:
 
   static AtomicCounter s_count;
   static pthread_mutex_t s_rfc2136lock;
-  bool d_doRecursion;
   bool d_logDNSDetails;
   bool d_doIPv6AdditionalProcessing;
   bool d_doDNAME;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1536,7 +1536,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
   string response;
   const struct dnsheader* dh = (struct dnsheader*)question.c_str();
   unsigned int ctag=0;
-  uint32_t qhash;
+  uint32_t qhash = 0;
   bool needECS = false;
   std::vector<std::string> policyTags;
   std::unordered_map<string,string> data;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* `qhash` is not the initialized when the cache is disabled and is used to initialize `d_qhash`, but neither are used in that case
* `PacketHandler::doRecursion` was leftover but is now useless

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
