### PR TITLE
dnsreplay: Add `--source-ip` and `--source-port` options

### DIFF
--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -709,7 +709,9 @@ try
     ("speedup", po::value<float>()->default_value(1), "replay at this speedup")
     ("timeout-msec", po::value<uint32_t>()->default_value(500), "wait at least this many milliseconds for a reply")
     ("ecs-stamp", "Add original IP address to ECS in replay")
-    ("ecs-mask", po::value<uint16_t>(), "Replace first octet of src IP address with this value in ECS");
+    ("ecs-mask", po::value<uint16_t>(), "Replace first octet of src IP address with this value in ECS")
+    ("source-ip", po::value<string>()->default_value(""), "IP to send the replayed packet from")
+    ("source-port", po::value<uint16_t>()->default_value(0), "Port to send the replayed packet from");
 
   po::options_description alloptions;
   po::options_description hidden("hidden options");
@@ -759,6 +761,10 @@ try
   s_socket= new Socket(AF_INET, SOCK_DGRAM);
 
   s_socket->setNonBlocking();
+
+  if(g_vm.count("source-ip") && !g_vm["source-ip"].as<string>().empty())
+    s_socket->bind(ComboAddress(g_vm["source-ip"].as<string>(), g_vm["source-port"].as<uint16_t>()));
+
   setSocketReceiveBuffer(s_socket->getHandle(), 2000000);
   setSocketSendBuffer(s_socket->getHandle(), 2000000);
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Add two optional parameters, `--source-ip` and `--source-port`  to specify the source address and port used by `dnsreplay` while replaying PCAPs.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
