### PR TITLE
make Lua mandatory for recursor builds

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -32,54 +32,6 @@
 #include "rec-snmp.hh"
 #include <unordered_set>
 
-#if !defined(HAVE_LUA)
-RecursorLua4::RecursorLua4(const std::string &fname)
-{
-  throw std::runtime_error("Attempt to load a Lua script in a PowerDNS binary without Lua support");
-}
-
-bool RecursorLua4::nxdomain(DNSQuestion& dq, int& res)
-{
-  return false;
-}
-
-bool RecursorLua4::nodata(DNSQuestion& dq, int& res)
-{
-  return false;
-}
-
-bool RecursorLua4::postresolve(DNSQuestion& dq, int& res)
-{
-  return false;
-}
-
-bool RecursorLua4::prerpz(DNSQuestion& dq, int& ret)
-{
-  return false;
-}
-
-bool RecursorLua4::preresolve(DNSQuestion& dq, int& res)
-{
-  return false;
-}
-
-bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret)
-{
-  return false;
-}
-
-bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader& dh)
-{
-  return false;
-}
-
-unsigned int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, std::unordered_map<string,string>& data)
-{
-  return 0;
-}
-
-
-#else
 #undef L
 #include "ext/luawrapper/include/LuaContext.hpp"
 
@@ -715,5 +667,4 @@ loop:;
   return handled;
 }
 
-#endif
 RecursorLua4::~RecursorLua4(){}

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -38,9 +38,7 @@ class LuaContext;
 class RecursorLua4 : public boost::noncopyable
 {
 private:
-#ifdef HAVE_LUA
   std::unique_ptr<LuaContext> d_lw; // this is way on top because it must get destroyed _last_
-#endif
 
 public:
   explicit RecursorLua4(const std::string& fname);
@@ -67,7 +65,6 @@ public:
     bool& wantsRPZ;
     unsigned int tag{0};
 
-#ifdef HAVE_LUA
     void addAnswer(uint16_t type, const std::string& content, boost::optional<int> ttl, boost::optional<string> name);
     void addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, boost::optional<int> ttl, boost::optional<string> name);
     vector<pair<int,DNSRecord> > getRecords() const;
@@ -93,7 +90,6 @@ public:
     
     std::unordered_map<string,string> data;
     DNSName followupName;
-#endif
   };
 
   unsigned int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, std::unordered_map<string,string>& data);

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -1,7 +1,5 @@
 #include "config.h"
-#ifdef HAVE_LUA
 #include "ext/luawrapper/include/LuaContext.hpp"
-#endif
 
 #include <fstream>
 #include <thread>
@@ -52,13 +50,6 @@ typename C::value_type::second_type constGet(const C& c, const std::string& name
   return iter->second;
 }
 
-#ifndef HAVE_LUA
-void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
-{
-  if(!fname.empty())
-    throw PDNSException("Asked to load a Lua configuration file '"+fname+"' in binary without Lua support");
-}
-#else
 
 void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 {
@@ -348,4 +339,3 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 
 }
 
-#endif

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -100,6 +100,9 @@ PDNS_WITH_LUAJIT
 AS_IF([test "x$with_luajit" = "xno"], [
   PDNS_WITH_LUA
 ])
+AS_IF([test "x$LUAPC" = "x" -a "x$LUAJITPC" = "x"], [
+  AC_MSG_ERROR([Neither Lua nor LuaJIT found, Lua support is not optional])
+])
 PDNS_CHECK_LUA_HPP
 
 PDNS_ENABLE_VERBOSE_LOGGING


### PR DESCRIPTION
### Short description
Supporting non-Lua builds is a growing burden, and nobody noticed we broke non-Lua builds a month ago. Meanwhile, several of us were surprised building without Lua even worked in 4.0.x. We are biting the bullet and making Lua mandatory starting with Recursor 4.1.0.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
