### PR TITLE
dnsdist: Make includeDirectory work sorted #5053

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1319,7 +1319,7 @@ Here are all functions:
     * `shutdown()`: shut down `dnsdist`
     * quit or ^D: exit the console
     * `webserver(address:port, password [, apiKey [, customHeaders ]])`: launch a webserver with stats on that address with that password
-    * `includeDirectory(dir)`: all files ending in `.conf` in the directory `dir` are loaded into the configuration
+    * `includeDirectory(dir)`: all files ending in `.conf` in the directory `dir` are loaded into the configuration. Starting with 1.2.0 they are loaded in a sorted manner. Sorting order is ascending and case sensitive.
     * `setAPIWritable(bool, [dir])`: allow modifications via the API. If `dir` is set, it must be a valid directory where the configuration files will be written by the API. Otherwise the modifications done via the API will not be written to the configuration and will not persist after a reload
  * ACL related:
     * `addACL(netmask)`: add to the ACL set who can use this server

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -1168,6 +1168,7 @@ void moreLua(bool client)
 
         DIR *dirp;
         struct dirent *ent;
+        std::list<std::string> files;
         if (!(dirp = opendir(dirname.c_str()))) {
           errlog("Error opening the included directory %s!", dirname.c_str());
           g_outputBuffer="Error opening the included directory " + dirname + "!";
@@ -1187,17 +1188,23 @@ void moreLua(bool client)
               continue;
             }
 
-            std::ifstream ifs(namebuf.str());
-            if (!ifs) {
-              warnlog("Unable to read configuration from '%s'", namebuf.str());
-            } else {
-              vinfolog("Read configuration from '%s'", namebuf.str());
-            }
-
-            g_lua.executeCode(ifs);
+            files.push_back(namebuf.str());
           }
         }
+
         closedir(dirp);
+        files.sort();
+
+        for (auto file = files.begin(); file != files.end(); ++file) {
+          std::ifstream ifs(*file);
+          if (!ifs) {
+            warnlog("Unable to read configuration from '%s'", *file);
+          } else {
+            vinfolog("Read configuration from '%s'", *file);
+          }
+
+          g_lua.executeCode(ifs);
+        }
 
         g_included = false;
     });

--- a/regression-tests.dnsdist/test-include-dir/Test.conf
+++ b/regression-tests.dnsdist/test-include-dir/Test.conf
@@ -1,0 +1,1 @@
+addAction(makeRule("includedir.advanced.tests.powerdns.com."), AllowAction())

--- a/regression-tests.dnsdist/test-include-dir/test.conf
+++ b/regression-tests.dnsdist/test-include-dir/test.conf
@@ -1,1 +1,1 @@
-addAction(makeRule("includedir.advanced.tests.powerdns.com."), AllowAction())
+addAction(AllRule(), RCodeAction(dnsdist.REFUSED))

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -1144,7 +1144,6 @@ class TestAdvancedIncludeDir(DNSDistTest):
     _config_template = """
     -- this directory contains a file allowing includedir.advanced.tests.powerdns.com.
     includeDirectory('test-include-dir')
-    addAction(AllRule(), RCodeAction(dnsdist.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 


### PR DESCRIPTION
### Short description
Make includeDirectory load files in a sorted manner. Current sorted manner is ascending case sensitive. Closes #5053 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
