### PR TITLE
Enable EDDSA (ED25519) in auth and recursor builds

### DIFF
--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -285,6 +285,7 @@ Requires(postun): /sbin/service
 
 BuildRequires: boost-devel
 BuildRequires: lua-devel
+BuildRequires: libsodium-devel
 BuildRequires: bison
 Provides: powerdns = %{version}-%{release}
 
@@ -394,6 +395,7 @@ export CPPFLAGS="-DLDAP_DEPRECATED"
 	--with-lua \
 	--with-dynmodules='bind %{backends} random' \
 	--enable-tools \
+	--enable-libsodium \
 	--without-protobuf \
 	--enable-remotebackend-http \
 	--enable-unit-tests
@@ -543,6 +545,7 @@ BuildRequires: systemd-units
 BuildRequires: systemd-devel
 BuildRequires: boost-devel
 BuildRequires: lua-devel
+BuildRequires: libsodium-devel
 BuildRequires: bison
 BuildRequires: openssl-devel
 BuildRequires: protobuf-devel
@@ -687,6 +690,7 @@ export CPPFLAGS="-DLDAP_DEPRECATED"
 	--with-lua \
 	--with-dynmodules='%{backends} random' \
 	--enable-tools \
+	--enable-libsodium \
 	--enable-unit-tests \
 	--enable-systemd
 

--- a/build-scripts/build-recursor-rpm
+++ b/build-scripts/build-recursor-rpm
@@ -122,6 +122,7 @@ Source1: pdns-recursor.init
 Provides: powerdns-recursor = %{version}-%{release}
 BuildRequires: boost148-devel
 BuildRequires: lua-devel
+BuildRequires: libsodium-devel
 #BuildRequires: protobuf-devel
 #BuildRequires: protobuf-compiler
 
@@ -146,6 +147,7 @@ package if you need a dns cache for your network.
 	--disable-silent-rules \
 	--with-protobuf \
 	--enable-unit-tests \
+	--enable-libsodium \
 	--with-boost=/usr/include/boost148 LIBRARY_PATH=/usr/lib64/boost148
 
 make %{?_smp_mflags} LIBRARY_PATH=/usr/lib64/boost148
@@ -214,6 +216,7 @@ BuildRequires: boost-devel
 BuildRequires: lua-devel
 BuildRequires: systemd-units
 BuildRequires: systemd-devel
+BuildRequires: libsodium-devel
 BuildRequires: hostname
 BuildRequires: protobuf-devel
 BuildRequires: protobuf-compiler
@@ -240,6 +243,7 @@ package if you need a dns cache for your network.
 	--disable-silent-rules \
 	--enable-unit-tests \
 	--with-protobuf \
+	--enable-libsodium \
 	--enable-systemd
 
 make %{?_smp_mflags}

--- a/build-scripts/debian-authoritative/control.in
+++ b/build-scripts/debian-authoritative/control.in
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.8
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, po-debconf, libtool, flex, bison, libmysqlclient-dev, libpq-dev, libssl-dev, libgdbm-dev, libldap2-dev, libsqlite3-dev, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libboost-program-options-dev, libboost-test-dev, autotools-dev, automake, autoconf, liblua5.2-dev, pkg-config, ragel, libgmp-dev, libbotan1.10-dev, libcurl4-openssl-dev, libzmq-dev, libyaml-cpp-dev (>= 0.5), libgeoip-dev, libopendbx1-dev, libcdb-dev, unixodbc-dev (>= 2.3.1), libprotobuf-dev, protobuf-compiler @LIBSYSTEMDDEV@
+Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, po-debconf, libtool, flex, bison, libmysqlclient-dev, libpq-dev, libssl-dev, libgdbm-dev, libldap2-dev, libsqlite3-dev, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libboost-program-options-dev, libboost-test-dev, autotools-dev, automake, autoconf, liblua5.2-dev, pkg-config, ragel, libgmp-dev, libbotan1.10-dev, libcurl4-openssl-dev, libzmq-dev, libyaml-cpp-dev (>= 0.5), libgeoip-dev, libopendbx1-dev, libcdb-dev, unixodbc-dev (>= 2.3.1), libprotobuf-dev, protobuf-compiler @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
 Homepage: http://www.powerdns.com/
 
 Package: pdns-server

--- a/build-scripts/debian-authoritative/rules
+++ b/build-scripts/debian-authoritative/rules
@@ -9,6 +9,9 @@ ENABLE_SYSTEMD := --enable-systemd --with-systemd=/lib/systemd/system
 LIBSYSTEMD_DEV := , libsystemd-dev
 DEBHELPER_WITH_SYSTEMD := --with systemd
 
+ENABLE_LIBSODIUM := --enable-libsodium
+LIBSODIUM_DEV := , libsodium-dev
+
 # $(ID) and $(VERSION_ID) come from the environment, source this from /etc/os-release
 ifeq ($(ID), ubuntu)
   ifeq ($(VERSION_ID), 14.04)
@@ -16,11 +19,16 @@ ifeq ($(ID), ubuntu)
     ENABLE_SYSTEMD=
     LIBSYSTEMD_DEV=
     DEBHELPER_WITH_SYSTEMD=
+
+    # Also disable libsodium
+    ENABLE_LIBSODIUM=
+    LIBSODIUM_DEV=
   endif
 endif
 
 debian/control: debian/control.in
-	sed -e "s!@LIBSYSTEMDDEV@!$(LIBSYSTEMD_DEV)!" $< > $@
+	sed -e "s!@LIBSYSTEMDDEV@!$(LIBSYSTEMD_DEV)!" \
+	    -e "s!@LIBSODIUMDEV@!$(LIBSODIUM_DEV)!" $< > $@
 
 # Use new build system
 %:
@@ -46,7 +54,8 @@ override_dh_auto_configure:
 		--enable-botan1.10 \
 		--enable-tools \
 		--enable-unit-tests \
-		$(ENABLE_SYSTEMD)
+		$(ENABLE_SYSTEMD) \
+		$(ENABLE_LIBSODIUM)
 
 # pdns-server has a debug package
 override_dh_strip:

--- a/build-scripts/debian-recursor/control.in
+++ b/build-scripts/debian-recursor/control.in
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.6
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-systemd, quilt, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, liblua5.2-dev, libprotobuf-dev, protobuf-compiler, pkg-config @LIBSYSTEMDDEV@
+Build-Depends: debhelper (>= 9~), dh-systemd, quilt, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, liblua5.2-dev, libprotobuf-dev, protobuf-compiler, pkg-config @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
 Homepage: http://www.powerdns.com/
 
 Package: pdns-recursor

--- a/build-scripts/debian-recursor/rules
+++ b/build-scripts/debian-recursor/rules
@@ -11,6 +11,9 @@ ENABLE_SYSTEMD := --enable-systemd --with-systemd=/lib/systemd/system
 LIBSYSTEMD_DEV := , libsystemd-dev
 DEBHELPER_WITH_SYSTEMD := --with systemd
 
+ENABLE_LIBSODIUM := --enable-libsodium
+LIBSODIUM_DEV := , libsodium-dev
+
 # $(ID) and $(VERSION_ID) come from the environment, source this from /etc/os-release
 ifeq ($(ID), ubuntu)
   ifeq ($(VERSION_ID), 14.04)
@@ -18,11 +21,16 @@ ifeq ($(ID), ubuntu)
     ENABLE_SYSTEMD=
     LIBSYSTEMD_DEV=
     DEBHELPER_WITH_SYSTEMD=
+
+    # Also disable libsodium
+    ENABLE_LIBSODIUM=
+    LIBSODIUM_DEV=
   endif
 endif
 
 debian/control: debian/control.in
-	sed -e "s!@LIBSYSTEMDDEV@!$(LIBSYSTEMD_DEV)!" $< > $@
+	sed -e "s!@LIBSYSTEMDDEV@!$(LIBSYSTEMD_DEV)!" \
+	    -e "s!@LIBSODIUMDEV@!$(LIBSODIUM_DEV)!" $< > $@
 
 # Use new build system
 %:
@@ -43,7 +51,8 @@ override_dh_auto_configure:
 		--libexecdir='$${prefix}/lib' \
 		--with-lua \
 		--with-protobuf=yes \
-		$(ENABLE_SYSTEMD)
+		$(ENABLE_SYSTEMD) \
+		$(ENABLE_LIBSODIUM)
 
 override_dh_auto_install:
 	./pdns_recursor --config | sed \

--- a/configure.ac
+++ b/configure.ac
@@ -348,6 +348,10 @@ AS_IF([test "x$libcrypto_ecdsa" == "xyes"],
   [AC_MSG_NOTICE([OpenSSL ecdsa: yes])],
   [AC_MSG_NOTICE([OpenSSL ecdsa: no])]
 )
+AS_IF([test "x$LIBSODIUM_LIBS" != "x"],
+  [AC_MSG_NOTICE([libsodium ed25519: yes])],
+  [AC_MSG_NOTICE([libsodium ed25519: no])]
+)
 AS_IF([test "x$needsqlite3" != "x"],
   [AC_MSG_NOTICE([SQLite3: yes])],
   [AC_MSG_NOTICE([SQLite3: no])]

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -208,6 +208,10 @@ AS_IF([test "x$LUAPC" != "x"],
     [AC_MSG_NOTICE([Lua/LuaJit: no])])
 ])
 AC_MSG_NOTICE([OpenSSL ECDSA: $libcrypto_ecdsa])
+AS_IF([test "x$LIBSODIUM_LIBS" != "x"],
+  [AC_MSG_NOTICE([libsodium ed25519: yes])],
+  [AC_MSG_NOTICE([libsodium ed25519: no])]
+)
 AS_IF([test "x$PROTOBUF_LIBS" != "x" -a x"$PROTOC" != "x"],
   [AC_MSG_NOTICE([Protobuf: yes])],
   [AC_MSG_NOTICE([Protobuf: no])]


### PR DESCRIPTION
### Short description
When this PR is merged, the auth and recursor packages we build will be linked against libsodium so ED25519 (algo 15) is supported by these packages.

* auth: https://builder.powerdns.com/#/builders/8/builds/1578
* rec: https://builder.powerdns.com/#/builders/9/builds/1468 (centos 6 failure is unrelated)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)