### PR TITLE
Fix dns_random unit tests with gcc > 4

### DIFF
--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -181,6 +181,7 @@ testrunner_SOURCES = \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dnsparser.hh dnsparser.cc \
+	dns_random.cc dns_random.hh \
 	dnsrecords.cc \
 	dnssecinfra.cc \
 	dnswriter.cc dnswriter.hh \

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -2,7 +2,7 @@
 #define BOOST_TEST_NO_MAIN
 
 // Disable this code for gcc 4.8 and lower
-#if (__GNUC__ == 4 && __GNUC_MINOR__ > 8) || !__GNUC__
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 8) || !__GNUC__
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"


### PR DESCRIPTION
### Short description
The `dns_random` unit test was disabled for gcc 5+, and was recently (35d883a830af0284efafe94d1a6bd1c1ad04bae7) broken in the recursor since `dns_random.cc` wasn't linked to the `testrunner`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
