### PR TITLE
Add an option to allow AXFR of zones with a different (higher/lower) serial.

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -96,6 +96,13 @@ Static pre-shared authentication key for access to the REST API.
 
 Disallow data modification through the REST API when set.
 
+## `axfr-lower-serial`
+* Boolean
+* Default: no
+* Available since: 4.0.4
+
+Also AXFR a zone from a master with a lower serial.
+
 ## `cache-ttl`
 * Integer
 * Default: 20

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -193,6 +193,7 @@ void declareArguments()
 
   ::arg().setSwitch("outgoing-axfr-expand-alias", "Expand ALIAS records during outgoing AXFR")="no";
   ::arg().setSwitch("8bit-dns", "Allow 8bit dns queries")="no";
+  ::arg().setSwitch("axfr-lower-serial", "Also AXFR a zone from a master with a lower serial")="no";
 
   ::arg().set("xfr-max-received-mbytes", "Maximum number of megabytes received from an incoming XFR")="100";
 }

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -861,7 +861,7 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
 
     uint32_t theirserial = ssr.d_freshness[di.id].theirSerial, ourserial = di.serial;
 
-    if(rfc1982LessThan(theirserial, ourserial) && ourserial != 0) {
+    if(rfc1982LessThan(theirserial, ourserial) && ourserial != 0 && !::arg().mustDo("axfr-lower-serial"))  {
       L<<Logger::Error<<"Domain '"<<di.zone<<"' more recent than master, our serial " << ourserial << " > their serial "<< theirserial << endl;
       di.backend->setFresh(di.id);
     }


### PR DESCRIPTION
### Short description
Atm the AXFR of a zone stops if the serial is moving backwards and signatures start to expire. This is a very common problem in setups where the nameserver is secondary for many customers. Not everyone is a dns expert ;) 
With this option it is possible to tell pdns to axfr the zone if the serial on the slave is different (higher/lower) from the one on the master. 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
