### PR TITLE
Doc: `dq.wantsRPZ` is mostly useful in `prerpz`, not `preresolve`

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -184,6 +184,7 @@ function prerpz(dq)
   if dq.qname:equal('example.com') then
     dq:discardPolicy('malware')
   end
+  return false
 end
 ```
 

--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -98,7 +98,7 @@ The DNSQuestion object contains at least the following fields:
      * policyAction: The action taken by the engine
      * policyCustom: The CNAME content for the `pdns.policyactions.Custom` response, a string
      * policyTTL: The TTL in seconds for the `pdns.policyactions.Custom` response
-* wantsRPZ - A boolean that indicates the use of the Policy Engine, can be set to `false` in `preresolve` to disable RPZ for this query
+* wantsRPZ - A boolean that indicates the use of the Policy Engine, can be set to `false` in `prerpz` to disable RPZ for this query
 * data - a table that is persistent throughout the lifetime of the `dq` object and can be used to store custom data. All keys and values in the table must be of type `string`.
 
 It also supports the following methods:


### PR DESCRIPTION
### Short description
`dq.wantsRPZ` is mostly useful in the `prerpz` Lua hook, not in the `preresolve` one, because some `RPZ` checks have already been done by then.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
