### PR TITLE
Backport #5085: calidns: Use the correct socket family (IPv4 / IPv6)

### DIFF
--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -225,7 +225,7 @@ try
   vector<Socket*> sockets;
   ComboAddress dest(argv[2], 53);  
   for(int i=0; i < 24; ++i) {
-    Socket *sock = new Socket(AF_INET, SOCK_DGRAM);
+    Socket *sock = new Socket(dest.sin4.sin_family, SOCK_DGRAM);
     //    sock->connect(dest);
     setSocketSendBuffer(sock->getHandle(), 2000000);
     setSocketReceiveBuffer(sock->getHandle(), 2000000);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
(cherry picked from commit 7f363f60451fa8e54508c2628be122a8eb021b53)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
