### PR TITLE
dnsdist: Add `NetmaskGroup::addMasks()` to fill a NMG from `exceeds*` results

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1594,6 +1594,8 @@ instantiate a server with additional parameters
     * NetmaskGroup related
         * function `newNMG()`: returns a NetmaskGroup
         * member `addMask(mask)`: adds `mask` to the NetmaskGroup. Prefix with `!` to exclude this mask from matching.
+        * member `addMask(table)`: adds the keys of `table` to the NetmaskGroup. `table` should be a table whose keys
+        are `ComboAddress` objects and values are integers, as returned by `exceed*` functions
         * member `match(ComboAddress)`: checks if ComboAddress is matched by this NetmaskGroup
         * member `clear()`: clears the NetmaskGroup
         * member `size()`: returns number of netmasks in this NetmaskGroup

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -206,9 +206,15 @@ void moreLua(bool client)
 
   g_lua.writeFunction("newNMG", []() { return NetmaskGroup(); });
   g_lua.registerFunction<void(NetmaskGroup::*)(const std::string&mask)>("addMask", [](NetmaskGroup&nmg, const std::string& mask)
-			 {
-			   nmg.addMask(mask);
-			 });
+                         {
+                           nmg.addMask(mask);
+                         });
+    g_lua.registerFunction<void(NetmaskGroup::*)(const std::map<ComboAddress,int>& map)>("addMasks", [](NetmaskGroup&nmg, const std::map<ComboAddress,int>& map)
+                         {
+                           for (const auto& entry : map) {
+                             nmg.addMask(Netmask(entry.first));
+                           }
+                         });
 
   g_lua.registerFunction("match", (bool (NetmaskGroup::*)(const ComboAddress&) const)&NetmaskGroup::match);
   g_lua.registerFunction("size", &NetmaskGroup::size);  


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
That's quite more efficient if you want to use the `exceeds*` functions to fill a `NetmaskGroup` to be used in rules, instead of simply passing it to `addDynBlocks()`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
