### PR TITLE
Backport: Specify that dnsmessage.proto uses protobuf version 2

### DIFF
--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -19,6 +19,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+syntax = "proto2";
+
 message PBDNSMessage {
   enum Type {
     DNSQueryType = 1;


### PR DESCRIPTION
Recent proto-c versions are complaining loudly otherwise.
