### PR TITLE
dnsdist: Fix destination port reporting on "any" binds

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1072,7 +1072,11 @@ try
 
       uint16_t len = (uint16_t) ret;
       ComboAddress dest;
-      if (!HarvestDestinationAddress(&msgh, &dest)) {
+      if (HarvestDestinationAddress(&msgh, &dest)) {
+        /* we don't get the port, only the address */
+        dest.sin4.sin_port = cs->local.sin4.sin_port;
+      }
+      else {
         dest.sin4.sin_family = 0;
       }
 

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -25,6 +25,7 @@ class DNSDistTest(unittest.TestCase):
     that the queries sent from dnsdist were as expected.
     """
     _dnsDistPort = 5340
+    _dnsDistListeningAddr = "127.0.0.1"
     _testServerPort = 5350
     _toResponderQueue = Queue.Queue()
     _fromResponderQueue = Queue.Queue()
@@ -62,7 +63,7 @@ class DNSDistTest(unittest.TestCase):
             conf.write(cls._config_template % params)
 
         dnsdistcmd = [os.environ['DNSDISTBIN'], '-C', conffile,
-                      '-l', '127.0.0.1:%d' % cls._dnsDistPort]
+                      '-l', '%s:%d' % (cls._dnsDistListeningAddr, cls._dnsDistPort) ]
         for acl in cls._acl:
             dnsdistcmd.extend(['--acl', acl])
         print(' '.join(dnsdistcmd))


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Over UDP we call `HarvestDestinationAddress()` to get the real destination address via `IP_PKTINFO`, but this only sets the destination address, not the destination port. Therefore since
7cea4e39a78ef981ee461b49bbc193fa9903f56d the destination port was always 0 when bound to an "any" address.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
