### PR TITLE
pdnsutil: Only print zonecount if invoked verbose

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1388,10 +1388,13 @@ int listAllZones(const string &type="") {
     }
   }
 
-  if (kindFilter != -1)
-    cout<<type<<" zonecount: "<<count<<endl;
-  else
-    cout<<"All zonecount: "<<count<<endl;
+  if (g_verbose) {
+    if (kindFilter != -1)
+      cout<<type<<" zonecount: "<<count<<endl;
+    else
+      cout<<"All zonecount: "<<count<<endl;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
### Short description
This pull makes pdnsutil only print zone counts if being invoked with verbose (-v).
Closes #3750 and is a proper resubmission of #4182.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
