### PR TITLE
rec: Allow access to EDNS options from the `gettag()` hook

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -151,7 +151,7 @@ end
 This hook does not get the full DNSQuestion object, since filling out the fields
 would require packet parsing, which is what we are trying to prevent with `ipfilter`.
 
-### `function gettag(remote, ednssubnet, local, qname, qtype)`
+### `function gettag(remote, ednssubnet, local, qname, qtype, ednsoptions)`
 The `gettag` function is invoked when the Recursor attempts to discover in which
 packetcache an answer is available.
 
@@ -167,6 +167,11 @@ e.g. been filtered for certain IPs (this logic should be implemented in the
 `gettag` function). This ensure that queries are answered quickly compared to
 setting dq.variable to `true`. In the latter case, repeated queries will pass
 through the entire Lua script.
+
+`ednsoptions` is a table whose keys are EDNS option codes and values are
+`EDNSOptionView` objects, with the EDNS option content size in the `size` member
+and the content accessible as a NULL-safe string object via `getContent()`.
+This table is empty unless the `gettag-needs-edns-options` parameter is set.
 
 ### `function prerpz(dq)`
 

--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -360,6 +360,14 @@ forward queries to other recursive servers.
 
 The DNSSEC notes from [`forward-zones`](#forward-zones) apply here as well.
 
+## `gettag-needs-edns-options`
+* Boolean
+* Default: no
+* Available since: 4.1.0
+
+If set, EDNS options in incoming queries are extracted and passed to the `gettag()`
+hook in the `ednsoptions` table.
+
 ## `hint-file`
 * Path
 

--- a/pdns/ednsoptions.hh
+++ b/pdns/ednsoptions.hh
@@ -31,6 +31,16 @@ struct EDNSOptionCode
 
 /* extract a specific EDNS0 option from a pointer on the beginning rdLen of the OPT RR */
 int getEDNSOption(char* optRR, size_t len, uint16_t wantedOption, char ** optionValue, size_t * optionValueSize);
+
+struct EDNSOptionView
+{
+  const char* content{nullptr};
+  uint16_t size{0};
+};
+
+/* extract all EDNS0 options from a pointer on the beginning rdLen of the OPT RR */
+int getEDNSOptions(const char* optRR, size_t len, std::map<uint16_t, EDNSOptionView>& options);
+
 void generateEDNSOption(uint16_t optionCode, const std::string& payload, std::string& res);
 
 #endif

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -25,7 +25,10 @@
 #include "namespaces.hh"
 #include "dnsrecords.hh"
 #include "filterpo.hh"
+#include "ednsoptions.hh"
+
 #include <unordered_map>
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -98,7 +101,7 @@ public:
     DNSName followupName;
   };
 
-  unsigned int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data);
+  unsigned int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const std::map<uint16_t, EDNSOptionView>&);
 
   bool prerpz(DNSQuestion& dq, int& ret);
   bool preresolve(DNSQuestion& dq, int& ret);
@@ -118,8 +121,7 @@ public:
             d_postresolve);
   }
 
-  typedef std::function<std::tuple<unsigned int,boost::optional<std::unordered_map<int,string> >,boost::optional<LuaContext::LuaObject> >(ComboAddress, Netmask, ComboAddress, DNSName, 
-uint16_t)> gettag_t;
+  typedef std::function<std::tuple<unsigned int,boost::optional<std::unordered_map<int,string> >,boost::optional<LuaContext::LuaObject> >(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const std::map<uint16_t, EDNSOptionView>&)> gettag_t;
   gettag_t d_gettag; // public so you can query if we have this hooked
 
 private:

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -185,6 +185,7 @@ testrunner_SOURCES = \
 	dnsrecords.cc \
 	dnssecinfra.cc \
 	dnswriter.cc dnswriter.hh \
+	ednscookies.cc ednscookies.hh \
 	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
 	gettime.cc gettime.hh \
@@ -212,6 +213,7 @@ testrunner_SOURCES = \
 	test-dnsname_cc.cc \
 	test-dnsparser_hh.cc \
 	test-dnsrecords_cc.cc \
+	test-ednsoptions_cc.cc \
 	test-iputils_hh.cc \
 	test-misc_hh.cc \
 	test-nmtree.cc \

--- a/pdns/recursordist/ednscookies.cc
+++ b/pdns/recursordist/ednscookies.cc
@@ -1,0 +1,1 @@
+../ednscookies.cc

--- a/pdns/recursordist/ednscookies.hh
+++ b/pdns/recursordist/ednscookies.hh
@@ -1,0 +1,1 @@
+../ednscookies.hh

--- a/pdns/recursordist/test-ednsoptions_cc.cc
+++ b/pdns/recursordist/test-ednsoptions_cc.cc
@@ -1,0 +1,115 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <boost/test/unit_test.hpp>
+#include <utility>
+
+#include "dnsname.hh"
+#include "dnswriter.hh"
+#include "ednscookies.hh"
+#include "ednsoptions.hh"
+#include "ednssubnet.hh"
+#include "iputils.hh"
+
+/* extract a specific EDNS0 option from a pointer on the beginning rdLen of the OPT RR */
+int getEDNSOption(char* optRR, size_t len, uint16_t wantedOption, char ** optionValue, size_t * optionValueSize);
+
+BOOST_AUTO_TEST_SUITE(ednsoptions_cc)
+
+static void getRawQueryWithECSAndCookie(const DNSName& name, const Netmask& ecs, const std::string& clientCookie, const std::string& serverCookie, std::vector<uint8_t>& query)
+{
+  DNSPacketWriter pw(query, name, QType::A, QClass::IN, 0);
+  pw.commit();
+
+  EDNSCookiesOpt cookiesOpt;
+  cookiesOpt.client = clientCookie;
+  cookiesOpt.server = serverCookie;
+  string cookiesOptionStr = makeEDNSCookiesOptString(cookiesOpt);
+  EDNSSubnetOpts ecsOpts;
+  ecsOpts.source = ecs;
+  string origECSOptionStr = makeEDNSSubnetOptsString(ecsOpts);
+  DNSPacketWriter::optvect_t opts;
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr));
+  opts.push_back(make_pair(EDNSOptionCode::ECS, origECSOptionStr));
+  opts.push_back(make_pair(EDNSOptionCode::COOKIE, cookiesOptionStr));
+  pw.addOpt(512, 0, 0, opts);
+  pw.commit();
+}
+
+BOOST_AUTO_TEST_CASE(test_getEDNSOption) {
+  DNSName name("www.powerdns.com.");
+  Netmask ecs("127.0.0.1/32");
+  vector<uint8_t> query;
+
+  getRawQueryWithECSAndCookie(name, ecs, "deadbeef", "deadbeef", query);
+
+  const struct dnsheader* dh = reinterpret_cast<struct dnsheader*>(query.data());
+  size_t questionLen = query.size();
+  unsigned int consumed = 0;
+  DNSName dnsname = DNSName(reinterpret_cast<const char*>(query.data()), questionLen, sizeof(dnsheader), false, nullptr, nullptr, &consumed);
+
+  size_t pos = sizeof(dnsheader) + consumed + 4;
+  /* at least OPT root label (1), type (2), class (2) and ttl (4) + OPT RR rdlen (2) = 11 */
+  BOOST_REQUIRE_EQUAL(ntohs(dh->arcount), 1);
+  BOOST_REQUIRE(questionLen > pos + 11);
+  /* OPT root label (1) followed by type (2) */
+  BOOST_REQUIRE_EQUAL(query.at(pos), 0);
+  BOOST_REQUIRE(query.at(pos+2) == QType::OPT);
+
+  char* ecsStart = nullptr;
+  size_t ecsLen = 0;
+  int res = getEDNSOption(reinterpret_cast<char*>(query.data())+pos+9, questionLen - pos - 9, EDNSOptionCode::ECS, &ecsStart, &ecsLen);
+  BOOST_CHECK_EQUAL(res, 0);
+
+  EDNSSubnetOpts eso;
+  BOOST_REQUIRE(getEDNSSubnetOptsFromString(ecsStart + 4, ecsLen - 4, &eso));
+
+  BOOST_CHECK(eso.source == ecs);
+}
+
+BOOST_AUTO_TEST_CASE(test_getEDNSOptions) {
+  DNSName name("www.powerdns.com.");
+  Netmask ecs("127.0.0.1/32");
+  vector<uint8_t> query;
+
+  getRawQueryWithECSAndCookie(name, ecs, "deadbeef", "deadbeef", query);
+
+  const struct dnsheader* dh = reinterpret_cast<struct dnsheader*>(query.data());
+  size_t questionLen = query.size();
+  unsigned int consumed = 0;
+  DNSName dnsname = DNSName(reinterpret_cast<const char*>(query.data()), questionLen, sizeof(dnsheader), false, nullptr, nullptr, &consumed);
+
+  size_t pos = sizeof(dnsheader) + consumed + 4;
+  /* at least OPT root label (1), type (2), class (2) and ttl (4) + OPT RR rdlen (2) = 11 */
+  BOOST_REQUIRE_EQUAL(ntohs(dh->arcount), 1);
+  BOOST_REQUIRE(questionLen > pos + 11);
+  /* OPT root label (1) followed by type (2) */
+  BOOST_REQUIRE_EQUAL(query.at(pos), 0);
+  BOOST_REQUIRE(query.at(pos+2) == QType::OPT);
+
+  std::map<uint16_t, EDNSOptionView> options;
+  int res = getEDNSOptions(reinterpret_cast<char*>(query.data())+pos+9, questionLen - pos - 9, options);
+  BOOST_REQUIRE_EQUAL(res, 0);
+
+  /* 3 EDNS options but two of them are EDNS Cookie, so we only keep one */
+  BOOST_CHECK_EQUAL(options.size(), 2);
+
+  auto it = options.find(EDNSOptionCode::ECS);
+  BOOST_REQUIRE(it != options.end());
+  BOOST_REQUIRE(it->second.content != nullptr);
+  BOOST_REQUIRE_GT(it->second.size, 0);
+
+  EDNSSubnetOpts eso;
+  BOOST_REQUIRE(getEDNSSubnetOptsFromString(it->second.content, it->second.size, &eso));
+  BOOST_CHECK(eso.source == ecs);
+
+  it = options.find(EDNSOptionCode::COOKIE);
+  BOOST_REQUIRE(it != options.end());
+  BOOST_REQUIRE(it->second.content != nullptr);
+  BOOST_REQUIRE_GT(it->second.size, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If `gettag-needs-edns-options` is set, the EDNS options are extracted and passed to the `gettag()` hook as a table whose keys are the EDNS option code and the values are `EDNSOptionView` object.
`EDNSOptionView` has two members, `content` and `size`, with `content` holding the raw, undecoded option value.

Closes #5195.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)

