### PR TITLE
setKey() was actually "appendKey()". In addition, '-k' would not override for server configuration

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1462,11 +1462,16 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
     });
   
   g_lua.writeFunction("setKey", [](const std::string& key) {
+      if(!g_configurationDone && ! g_key.empty()) { // this makes sure the commandline -k key prevails over dnsdist.conf
+        return;                                     // but later setKeys() trump the -k value again
+      }
+
       setLuaSideEffect();
+      g_key.clear();
       if(B64Decode(key, g_key) < 0) {
-	  g_outputBuffer=string("Unable to decode ")+key+" as Base64";
-	  errlog("%s", g_outputBuffer);
-	}
+        g_outputBuffer=string("Unable to decode ")+key+" as Base64";
+        errlog("%s", g_outputBuffer);
+      }
     });
 
   

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1467,11 +1467,13 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       }
 
       setLuaSideEffect();
-      g_key.clear();
-      if(B64Decode(key, g_key) < 0) {
+      string newkey;
+      if(B64Decode(key, newkey) < 0) {
         g_outputBuffer=string("Unable to decode ")+key+" as Base64";
         errlog("%s", g_outputBuffer);
       }
+      else
+	g_key=newkey;
     });
 
   

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1670,9 +1670,6 @@ struct
   string pidfile;
   string command;
   string config;
-#ifdef HAVE_LIBSODIUM
-  string setKey;
-#endif
   string uid;
   string gid;
 } g_cmdLine;
@@ -1804,7 +1801,7 @@ try
       break;
 #ifdef HAVE_LIBSODIUM
     case 'k':
-      if (B64Decode(string(optarg), g_cmdLine.setKey) < 0) {
+      if (B64Decode(string(optarg), g_key) < 0) {
         cerr<<"Unable to decode key '"<<optarg<<"'."<<endl;
         exit(EXIT_FAILURE);
       }
@@ -1870,10 +1867,6 @@ try
     setupLua(true, g_cmdLine.config);
     if (clientAddress != ComboAddress())
       g_serverControl = clientAddress;
-#ifdef HAVE_LIBSODIUM
-    if (!g_cmdLine.setKey.empty())
-      g_key = g_cmdLine.setKey;
-#endif
     doClient(g_serverControl, g_cmdLine.command);
     _exit(EXIT_SUCCESS);
   }


### PR DESCRIPTION
Unified -k behaviour for client and server mode now.

### Short description
Using setKey() at runtime actually did not work if a key had been set already. setKey() was in fact appendKey(). Furthermore, -k did not operate in server mode. In client mode, there was an ugly override to make -k work. Unified this now to too server and client modes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
