### PR TITLE
SNMP: Let the compiler elide copy instead of calling the move ctor

### DIFF
--- a/pdns/snmp-agent.hh
+++ b/pdns/snmp-agent.hh
@@ -32,7 +32,7 @@ public:
   void run()
   {
 #ifdef HAVE_NET_SNMP
-  d_thread = std::move(std::thread(&SNMPAgent::worker, this));
+  d_thread = std::thread(&SNMPAgent::worker, this);
 #endif /* HAVE_NET_SNMP */
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
C++11 compiler should do copy elision, which is better than calling the move constructor anyway.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
