### PR TITLE
make our Lock classes uncopyable, make ReadLock and WriteLock moveable.

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1156,6 +1156,7 @@ testrunner_SOURCES = \
 	test-dnsparser_hh.cc \
 	test-dnsrecords_cc.cc \
 	test-iputils_hh.cc \
+	test-lock_hh.cc \
 	test-md5_hh.cc \
 	test-misc_hh.cc \
 	test-nameserver_cc.cc \

--- a/pdns/test-lock_hh.cc
+++ b/pdns/test-lock_hh.cc
@@ -1,0 +1,54 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <boost/test/unit_test.hpp>
+#include "lock.hh"
+#include <thread>
+
+using namespace boost;
+
+BOOST_AUTO_TEST_SUITE(test_lock_hh)
+
+static std::vector<std::unique_ptr<pthread_rwlock_t> > g_locks;
+
+static void lthread()
+{
+  std::vector<ReadLock> rlocks;
+  for(auto& pp : g_locks)
+    rlocks.emplace_back(&*pp);
+  
+}
+
+BOOST_AUTO_TEST_CASE(test_pdns_lock)
+{
+  for(unsigned int n=0; n < 1000; ++n) {
+    auto p = new pthread_rwlock_t;
+    pthread_rwlock_init(p, 0);
+    g_locks.emplace_back(p);
+  }
+
+  std::vector<ReadLock> rlocks;
+  for(auto& pp : g_locks)
+    rlocks.emplace_back(&*pp);
+
+  std::thread thr(lthread);
+  thr.join();
+  rlocks.clear();
+
+  std::vector<WriteLock> wlocks;
+  for(auto& pp : g_locks)
+    wlocks.emplace_back(&*pp);
+
+  TryReadLock trl(&*g_locks[0]);
+  BOOST_CHECK(!trl.gotIt());
+
+  wlocks.clear();
+  TryReadLock trl2(&*g_locks[0]);
+  BOOST_CHECK(trl2.gotIt());
+  
+  
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -7,7 +7,6 @@
 #include <boost/assign/list_of.hpp>
 
 #include <boost/tuple/tuple.hpp>
-#include <boost/iostreams/stream.hpp>
 #include <boost/iostreams/device/file.hpp>
 #include "dns.hh"
 #include "zoneparser-tng.hh"


### PR DESCRIPTION
### Short description
Right now it is possible to copy our Lock classes, after which bad things will happen. Both destructors will attempt to unlock the mutex. 

With this PR 1) copying becomes impossible 2) the ReadLock and WriteLock classes gain move support, which enables storing them in containers with expected semantics. This is good for having "thousands of locks" that exhibit RAII behaviour.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
