### PR TITLE
Fix matches overflow in dnsdist API.

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -380,7 +380,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
       for(const auto& a : localRules) {
 	Json::object rule{
 	  {"id", num++},
-	  {"matches", (int)a.first->d_matches},
+	  {"matches", (double)a.first->d_matches},
 	  {"rule", a.first->toString()},
           {"action", a.second->toString()}, 
           {"action-stats", a.second->getStats()} 
@@ -394,7 +394,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
       for(const auto& a : localResponseRules) {
         Json::object rule{
           {"id", num++},
-          {"matches", (int)a.first->d_matches},
+          {"matches", (double)a.first->d_matches},
           {"rule", a.first->toString()},
           {"action", a.second->toString()},
         };


### PR DESCRIPTION
The way it is currently fixed means that matches can still overflow
in the web interface because JavaScript has a 2^53 number limit.

However, this fix is in line with how earlier cases have been fixed.

This fixes issue #5054.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
