### PR TITLE
SyncRes clarifications, unit-tests, and doSpecialNamesResolve() method

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -286,7 +286,7 @@ void MOADNSParser::init(bool query, const char *packet, unsigned int len)
 
       if (query && (dr.d_place == DNSResourceRecord::ANSWER || dr.d_place == DNSResourceRecord::AUTHORITY || (dr.d_type != QType::OPT && dr.d_type != QType::TSIG && dr.d_type != QType::SIG && dr.d_type != QType::TKEY) || ((dr.d_type == QType::TSIG || dr.d_type == QType::SIG || dr.d_type == QType::TKEY) && dr.d_class != QClass::ANY))) {
 //        cerr<<"discarding RR, query is "<<query<<", place is "<<dr.d_place<<", type is "<<dr.d_type<<", class is "<<dr.d_class<<endl;
-        dr.d_content=std::shared_ptr<DNSRecordContent>(new UnknownRecordContent(dr, pr));
+        dr.d_content=std::make_shared<UnknownRecordContent>(dr, pr);
       }
       else {
 //        cerr<<"parsing RR, query is "<<query<<", place is "<<dr.d_place<<", type is "<<dr.d_type<<", class is "<<dr.d_class<<endl;

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -361,7 +361,7 @@ public:
 
   typedef vector<pair<DNSRecord, uint16_t > > answers_t;
   
-  //! All answers contained in this packet
+  //! All answers contained in this packet (everything *but* the question section)
   answers_t d_answers;
 
   shared_ptr<PacketReader> getPacketReader(uint16_t offset)

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -500,6 +500,9 @@ uint16_t DNSKEYRecordContent::getTag()
 }
 
 
+/*
+ * Fills `eo` by parsing the EDNS(0) OPT RR (RFC 6891)
+ */
 bool getEDNSOpts(const MOADNSParser& mdp, EDNSOpts* eo)
 {
   eo->d_Z=0;

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -159,6 +159,16 @@ void DNSFilterEngine::clear(size_t zone)
   z.qpolName.clear();
 }
 
+void DNSFilterEngine::clear()
+{
+  for(auto& z : d_zones) {
+    z.qpolAddr.clear();
+    z.postpolAddr.clear();
+    z.propolName.clear();
+    z.qpolName.clear();
+  }
+}
+
 void DNSFilterEngine::addClientTrigger(const Netmask& nm, Policy pol, size_t zone)
 {
   assureZones(zone);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -232,6 +232,11 @@ unsigned int getRecursorThreadId()
   return t_id;
 }
 
+int getMTaskerTID()
+{
+  return MT->getTid();
+}
+
 static void handleTCPClientWritable(int fd, FDMultiplexer::funcparam_t& var);
 
 // -1 is error, 0 is timeout, 1 is success
@@ -675,8 +680,8 @@ static void protobufLogResponse(const std::shared_ptr<RemoteLogger>& logger, con
 static void handleRPZCustom(const DNSRecord& spoofed, const QType& qtype, SyncRes& sr, int& res, vector<DNSRecord>& ret)
 {
   if (spoofed.d_type == QType::CNAME) {
-    bool oldWantsRPZ = sr.d_wantsRPZ;
-    sr.d_wantsRPZ = false;
+    bool oldWantsRPZ = sr.getWantsRPZ();
+    sr.setWantsRPZ(false);
     vector<DNSRecord> ans;
     res = sr.beginResolve(DNSName(spoofed.d_content->getZoneRepresentation()), qtype, 1, ans);
     for (const auto& rec : ans) {
@@ -685,7 +690,7 @@ static void handleRPZCustom(const DNSRecord& spoofed, const QType& qtype, SyncRe
       }
     }
     // Reset the RPZ state of the SyncRes
-    sr.d_wantsRPZ = oldWantsRPZ;
+    sr.setWantsRPZ(oldWantsRPZ);
   }
 }
 
@@ -757,7 +762,7 @@ static void startDoResolve(void *p)
     }
 
     if(g_dnssecmode != DNSSECMode::Off) {
-      sr.d_doDNSSEC=true;
+      sr.setDoDNSSEC(true);
 
       // Does the requestor want DNSSEC records?
       if(edo.d_Z & EDNSOpts::DNSSECOK) {
@@ -769,12 +774,12 @@ static void startDoResolve(void *p)
       pw.getHeader()->cd=0;
     }
 #ifdef HAVE_PROTOBUF
-    sr.d_initialRequestId = dc->d_uuid;
+    sr.setInitialRequestId(dc->d_uuid);
 #endif
     if (g_useIncomingECS) {
-      sr.d_incomingECSFound = dc->d_ecsFound;
+      sr.setIncomingECSFound(dc->d_ecsFound);
       if (dc->d_ecsFound) {
-        sr.d_incomingECS = dc->d_ednssubnet;
+        sr.setIncomingECS(dc->d_ednssubnet);
       }
     }
 
@@ -835,7 +840,7 @@ static void startDoResolve(void *p)
     // if there is a RecursorLua active, and it 'took' the query in preResolve, we don't launch beginResolve
     if(!t_pdl->get() || !(*t_pdl)->preresolve(dq, res)) {
 
-      sr.d_wantsRPZ = wantsRPZ;
+      sr.setWantsRPZ(wantsRPZ);
       if(wantsRPZ) {
         switch(appliedPolicy.d_kind) {
           case DNSFilterEngine::PolicyKind::NoAction:
@@ -1221,7 +1226,7 @@ static void startDoResolve(void *p)
     }
 
     sr.d_outqueries ? t_RC->cacheMisses++ : t_RC->cacheHits++;
-    float spent=makeFloat(sr.d_now-dc->d_now);
+    float spent=makeFloat(sr.getNow()-dc->d_now);
     if(spent < 0.001)
       g_stats.answers0_1++;
     else if(spent < 0.010)
@@ -2073,7 +2078,7 @@ static void houseKeeping(void *)
     }
 
     if(now.tv_sec - last_rootupdate > 7200) {
-      int res = getRootNS();
+      int res = SyncRes::getRootNS(g_now, nullptr);
       if (!res)
         last_rootupdate=now.tv_sec;
     }
@@ -3299,44 +3304,4 @@ int main(int argc, char **argv)
   }
 
   return ret;
-}
-
-int getRootNS(void) {
-  SyncRes sr(g_now);
-  sr.setDoEDNS0(true);
-  sr.setNoCache();
-  sr.d_doDNSSEC = (g_dnssecmode != DNSSECMode::Off);
-
-  vector<DNSRecord> ret;
-  int res=-1;
-  try {
-    res=sr.beginResolve(g_rootdnsname, QType(QType::NS), 1, ret);
-    if (g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate) {
-      ResolveContext ctx;
-      auto state = validateRecords(ctx, ret);
-      if (state == Bogus)
-        throw PDNSException("Got Bogus validation result for .|NS");
-    }
-    return res;
-  }
-  catch(PDNSException& e)
-  {
-    L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.reason<<endl;
-  }
-
-  catch(std::exception& e)
-  {
-    L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.what()<<endl;
-  }
-
-  catch(...)
-  {
-    L<<Logger::Error<<"Failed to update . records, got an exception"<<endl;
-  }
-  if(!res) {
-    L<<Logger::Notice<<"Refreshed . records"<<endl;
-  }
-  else
-    L<<Logger::Error<<"Failed to update . records, RCODE="<<res<<endl;
-  return res;
 }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2810,6 +2810,9 @@ static int serviceMain(int argc, char*argv[])
     SyncRes::s_serverID=tmp;
   }
 
+  SyncRes::s_ecsipv4limit = ::arg().asNum("ecs-ipv4-bits");
+  SyncRes::s_ecsipv6limit = ::arg().asNum("ecs-ipv6-bits");
+
   g_networkTimeoutMsec = ::arg().asNum("network-timeout");
 
   g_initialDomainMap = parseAuthAndForwards();

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -179,16 +179,18 @@ testrunner_SOURCES = \
 	base32.cc \
 	base64.cc base64.hh \
 	dns.cc dns.hh \
+	dns_random.cc dns_random.hh \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dnsparser.hh dnsparser.cc \
-	dns_random.cc dns_random.hh \
 	dnsrecords.cc \
 	dnssecinfra.cc \
 	dnswriter.cc dnswriter.hh \
 	ednscookies.cc ednscookies.hh \
+	ecs.cc \
 	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
+	filterpo.cc filterpo.hh \
 	gettime.cc gettime.hh \
 	gss_context.cc gss_context.hh \
 	iputils.cc iputils.hh \
@@ -199,13 +201,17 @@ testrunner_SOURCES = \
 	pdnsexception.hh \
 	protobuf.cc protobuf.hh \
 	qtype.cc qtype.hh \
+	randomhelper.cc \
 	rcpgenerator.cc \
-	recpacketcache.cc recpacketcache.hh \
 	rec-protobuf.cc rec-protobuf.hh \
+	recpacketcache.cc recpacketcache.hh \
+	recursor_cache.cc recursor_cache.hh \
 	responsestats.cc \
+	root-dnssec.hh \
 	sillyrecords.cc \
 	sholder.hh \
 	sstuff.hh \
+	syncres.cc syncres.hh \
 	test-arguments_cc.cc \
 	test-base32_cc.cc \
 	test-base64_cc.cc \
@@ -220,9 +226,12 @@ testrunner_SOURCES = \
 	test-nmtree.cc \
 	test-rcpgenerator_cc.cc \
 	test-recpacketcache_cc.cc \
+	test-syncres_cc.cc \
 	test-tsig.cc \
 	testrunner.cc \
 	unix_utility.cc \
+	validate.cc validate.hh \
+	validate-recursor.cc validate-recursor.hh \
 	zoneparser-tng.cc zoneparser-tng.hh
 
 testrunner_LDFLAGS = \

--- a/pdns/recursordist/contrib/syncres.dot
+++ b/pdns/recursordist/contrib/syncres.dot
@@ -50,12 +50,12 @@ digraph {
     "return res from doOOBResolve()" [color=green];
     doResolve_asyncresolveWrapper -> "return result from asyncresolveWrapper()";
     "return result from asyncresolveWrapper()" [color=green];
-    doResolve_doCNAMECacheCheck -> "Did doCNAMECacheCheck() return a true-ish value?";
-    "Did doCNAMECacheCheck() return a true-ish value?" -> doResolve_return_res [label=yes];
-    "Did doCNAMECacheCheck() return a true-ish value?" -> doResolve_doCacheCheck [label=no];
-    doResolve_doCacheCheck -> "did doCacheCheck() return a true-ish value?";
-    "did doCacheCheck() return a true-ish value?" -> doResolve_return_res [label=yes];
-    "did doCacheCheck() return a true-ish value?" -> doResolve_getBestNSNamesFromCache [label=no];
+
+    doResolve_doCNAMECacheCheck -> doResolve_doCacheCheck [label="returned false"];
+    doResolve_doCNAMECacheCheck -> doResolve_return_res [label="returned true"];
+
+    doResolve_doCacheCheck -> doResolve_getBestNSNamesFromCache [label="returned false"];
+    doResolve_doCacheCheck -> doResolve_return_res [label="returned true"];
 
     doResolve_getBestNSNamesFromCache -> doResolve_doResolveAt;
     doResolve_doResolveAt -> doResolve_return_res [label="res == -2"];

--- a/pdns/recursordist/contrib/syncres.dot
+++ b/pdns/recursordist/contrib/syncres.dot
@@ -28,7 +28,7 @@ digraph {
 
     doResolve_doOOBResolve [label="SyncRes::doOOBResolve()", color=red];
     doResolve_doCNAMECacheCheck [label="SyncRes::doCNAMECacheCheck()", color=red];
-    doResolve_asyncResolveWrapper [label="SyncRes::asyncResolveWrapper()", color=red];
+    doResolve_asyncresolveWrapper [label="SyncRes::asyncresolveWrapper()", color=red];
     doResolve_doCacheCheck [label="SyncRes::doCacheCheck()", color=red];
     doResolve_getBestNSNamesFromCache [label="SyncRes::getBestNSNamesFromCache()", color=red];
     doResolve_doResolveAt [label="SyncRes::doResolveAt()", color=red];
@@ -43,12 +43,12 @@ digraph {
     "Check if RD-bit was not set (d_cacheonly)" -> "Check if there is a forward or auth-zone" [label=yes];
     "Check if there is a forward or auth-zone" -> doResolve_doCNAMECacheCheck [label=no];
     "Check if there is a forward or auth-zone" -> "Check if we are auth" [label=yes];
-    "Check if we are auth" -> doResolve_asyncResolveWrapper [label="no, so forward"];
+    "Check if we are auth" -> doResolve_asyncresolveWrapper [label="no, so forward"];
     "Check if we are auth" -> doResolve_doOOBResolve [label=yes];
     doResolve_doOOBResolve -> "return res from doOOBResolve()";
     "return res from doOOBResolve()" [color=green];
-    doResolve_asyncResolveWrapper -> "return result from asyncResolveWrapper()";
-    "return result from asyncResolveWrapper()" [color=green];
+    doResolve_asyncresolveWrapper -> "return result from asyncresolveWrapper()";
+    "return result from asyncresolveWrapper()" [color=green];
     doResolve_doCNAMECacheCheck -> "Did doCNAMECacheCheck() return a true-ish value?";
     "Did doCNAMECacheCheck() return a true-ish value?" -> doResolve_return_res [label=yes];
     "Did doCNAMECacheCheck() return a true-ish value?" -> doResolve_doCacheCheck [label=no];
@@ -60,6 +60,40 @@ digraph {
     doResolve_doResolveAt -> doResolve_return_res [label="res == -2"];
     doResolve_doResolveAt -> doResolve_return_servfail [label="res < 0 &&\nres != -2"];
     doResolve_doResolveAt -> doResolve_return_res [label="res >= 0"];
+  }
+
+  subgraph cluster_getBestNSFromCache {
+    label="SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vector<DNSRecord>& bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere)\nFills the bestns vector with the 'closest' nameservers for qname\nflawedNSSet will be true if the NSSet has no glue.\nbeenthere contains the list of nameservers already visited during this recursion.";
+
+    getBestNSFromCache_return [label="return", color=green];
+
+    getBestNSFromCache_chopoff_continue -> "Get NS-records for domain from cache" -> "Get one record from the records" -> "Has the TTL expired?";
+    "Get one record from the records" -> "Are there records in bestns?" [label="Checked all records"];
+
+    "Has the TTL expired?" -> "Get one record from the records" [label=yes];
+    "Has the TTL expired?" -> "Is the NS RDATA part of the domain &&\nDo we have A and/or AAAA records for it?" [label=no];
+    "Is the NS RDATA part of the domain &&\nDo we have A and/or AAAA records for it?" -> "Set flawednsset=true" [label=no];
+
+    "Is the NS RDATA part of the domain &&\nDo we have A and/or AAAA records for it?" -> "Add the NS-record to bestns" [label=yes];
+    "Add the NS-record to bestns" -> "Get one record from the records";
+
+    "Set flawednsset=true" -> "Get one record from the records";
+
+    "Are there records in bestns?" -> getBestNSFromCache_chopoff_continue [label=no];
+    "Are there records in bestns?" -> "Is any of the NS records in bestns in beenthere?" [label=yes];
+
+
+    "Is any of the NS records in bestns in beenthere?" -> "Add these records to beenthere" [label=no];
+    "Add these records to beenthere" -> getBestNSFromCache_return;
+
+    "Is any of the NS records in bestns in beenthere?" -> "Clear bestns" [label=yes];
+    "Clear bestns" -> "Was this the root domain?";
+    "Was this the root domain?" -> getBestNSFromCache_chopoff_continue [label=no];
+    "Was this the root domain?" -> "Re-prime the root" [label=yes];
+    "Re-prime the root" -> getBestNSFromCache_return;
+    getBestNSFromCache_chopoff_continue [label="chopoff left-most label"];
+
+    {rank=sink; getBestNSFromCache_chopoff_continue; getBestNSFromCache_return}
   }
 
   subgraph cluster_doOOBResolve {
@@ -89,8 +123,52 @@ digraph {
     "Try to add SOA" -> "Set res to NXDOMAIN" -> doOOBResolve_return_true;
   }
 
-  subgraph cluster_asyncResolveWrapper {
-    label="SyncRes::asyncResolveWrapper()";
+  subgraph cluster_asyncresolveWrapper {
+    label="SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res\nWraps asyncresolve() from lwres.cc to do EDNS probing.";
+
+    {rank=min; "Get current EDNSStatus for ip"}
+
+    asyncresolveWrapper_asyncresolve [label="asyncresolve()", color=red];
+    asyncresolveWrapper_return_minus_1 [label="return -1 (transport error)", color=green];
+    asyncresolveWrapper_return_minus_2 [label="return -2 (OS limits error)", color=green];
+    asyncresolveWrapper_return_0 [label="return 0 (timeout)", color=green];
+    asyncresolveWrapper_return_1 [label="return 1 (success)", color=green];
+    asyncresolveWrapper_setEDNSLevel_0 [label="Set EDNSLevel=0"]
+    asyncresolveWrapper_setEDNSLevel_0 -> "Is EDNSStatus NOEDNS?";
+
+    "Get current EDNSStatus for ip" -> "Is the current EDNSStatus older than an hour?";
+    "Is the current EDNSStatus older than an hour?" -> "Set EDNSStatus to Unknown" [label=yes];
+    "Set EDNSStatus to Unknown" -> asyncresolveWrapper_setEDNSLevel_0;
+    "Is the current EDNSStatus older than an hour?" -> asyncresolveWrapper_setEDNSLevel_0 [label=no];
+
+    "Is EDNSStatus NOEDNS?" -> "Set EDNSLevel=0" [label=yes]
+    "Set EDNSLevel=0" -> asyncresolveWrapper_asyncresolve;
+
+    "Is EDNSStatus NOEDNS?" -> "Is EDNSStatus UNKNOWN, EDNSOK, EDSIGNORANT or is EDNS mandatory?" [label=no]
+    "Is EDNSStatus UNKNOWN, EDNSOK, EDSIGNORANT or is EDNS mandatory?" -> "Set EDNSLevel=1" [label=yes]
+    "Set EDNSLevel=1" -> asyncresolveWrapper_asyncresolve;
+    "Is EDNSStatus UNKNOWN, EDNSOK, EDSIGNORANT or is EDNS mandatory?" ->  asyncresolveWrapper_asyncresolve [label=no];
+
+    asyncresolveWrapper_asyncresolve -> asyncresolveWrapper_return_minus_1 [label="transport error"];
+    asyncresolveWrapper_asyncresolve -> asyncresolveWrapper_return_minus_2 [label="OS limits error"];
+    asyncresolveWrapper_asyncresolve -> asyncresolveWrapper_return_0 [label="timeout error"];
+    asyncresolveWrapper_asyncresolve -> "Is the EDNSStatus UNKNOWN||EDNSOK||EDNSIGNORANT?" [label="resolve OK!"];
+
+    "Is the EDNSStatus UNKNOWN||EDNSOK||EDNSIGNORANT?" -> "Was the RCODE FORMERR||NOTIMP?" [label=yes];
+    "Was the RCODE FORMERR||NOTIMP?" -> "set EDNSStatus to NOEDNS" [label=yes];
+    "set EDNSStatus to NOEDNS" -> "Is EDNSStatus NOEDNS?";
+
+    "Was the RCODE FORMERR||NOTIMP?" -> "Did the remote server respond with EDNS?" [label=no];
+    "Did the remote server respond with EDNS?" -> "Set EDNSStatus to EDNSOK" [label=yes];
+    "Set EDNSStatus to EDNSOK" -> "Is the original EDNSStatus different from the new?";
+
+    "Did the remote server respond with EDNS?" -> "Set EDNSStatus to EDNSIGNORANT" [label=no];
+    "Set EDNSStatus to EDNSIGNORANT" -> "Is the original EDNSStatus different from the new?";
+
+    "Is the EDNSStatus UNKNOWN||EDNSOK||EDNSIGNORANT?" -> "Is the original EDNSStatus different from the new?" [label=no];
+    "Is the original EDNSStatus different from the new?" -> "Save new EDNSStatus" [label=yes];
+    "Is the original EDNSStatus different from the new?" -> asyncresolveWrapper_return_1 [label=no];
+    "Save new EDNSStatus" -> asyncresolveWrapper_return_1;
   }
 
   subgraph cluster_doResolveAt {

--- a/pdns/recursordist/contrib/syncres.dot
+++ b/pdns/recursordist/contrib/syncres.dot
@@ -7,14 +7,15 @@ digraph {
     label="SyncRes::beginResolve(const DNSName &qname, const QType &qtype, uint16_t qclass, vector<DNSRecord>&ret)\nreturns the RCODE\nret is filled with all relevant records";
 
     beginResolve_doResolve [label="SyncRes::doResolve()", color=red];
+    beginResolve_doSpecialNamesResolve [label="SyncRes::doSpecialNamesResolve()", color=red]
 
     "Is this an AXFR request?";
     "Is this an AXFR request?" -> beginResolve_return_minus_1 [label=yes];
-    "Is this an AXFR request?" -> "Is qname+qclass+qtype 'special'?" [label=no];
-    "Is qname+qclass+qtype 'special'?" -> "Handle special names (version.bind, localhost)" [label=yes];
-    "Handle special names (version.bind, localhost)" -> beginResolve_return_0;
+    "Is this an AXFR request?" -> beginResolve_doSpecialNamesResolve [label=no];
 
-    "Is qname+qclass+qtype 'special'?" -> "Is the qlass IN?" [label=no];
+    beginResolve_doSpecialNamesResolve -> "Is the qlass IN?" [label="Was not a special name"];
+    beginResolve_doSpecialNamesResolve -> beginResolve_return_0 [label="Was handled!"];
+
     "Is the qlass IN?" -> beginResolve_return_minus_1 [label=no];
     "Is the qlass IN?" -> beginResolve_doResolve [label=yes];
     beginResolve_doResolve -> beginResolve_return_doResolve;

--- a/pdns/recursordist/contrib/syncres.dot
+++ b/pdns/recursordist/contrib/syncres.dot
@@ -1,0 +1,263 @@
+digraph {
+  graph [fontname = "monospace"];
+  node [fontname = "monospace"];
+  edge [fontname = "monospace"];
+
+  subgraph cluster_beginResolve {
+    label="SyncRes::beginResolve(const DNSName &qname, const QType &qtype, uint16_t qclass, vector<DNSRecord>&ret)\nreturns the RCODE\nret is filled with all relevant records";
+
+    beginResolve_doResolve [label="SyncRes::doResolve()", color=red];
+
+    "Is this an AXFR request?";
+    "Is this an AXFR request?" -> beginResolve_return_minus_1 [label=yes];
+    "Is this an AXFR request?" -> "Is qname+qclass+qtype 'special'?" [label=no];
+    "Is qname+qclass+qtype 'special'?" -> "Handle special names (version.bind, localhost)" [label=yes];
+    "Handle special names (version.bind, localhost)" -> beginResolve_return_0;
+
+    "Is qname+qclass+qtype 'special'?" -> "Is the qlass IN?" [label=no];
+    "Is the qlass IN?" -> beginResolve_return_minus_1 [label=no];
+    "Is the qlass IN?" -> beginResolve_doResolve [label=yes];
+    beginResolve_doResolve -> beginResolve_return_doResolve;
+    beginResolve_return_doResolve [label="return result from doResolve", color=green];
+    beginResolve_return_0 [label="return 0", color=green];
+    beginResolve_return_minus_1 [label="return -1", color=green];
+  }
+
+  subgraph cluster_doResolve {
+    label="SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere)";
+
+    doResolve_doOOBResolve [label="SyncRes::doOOBResolve()", color=red];
+    doResolve_doCNAMECacheCheck [label="SyncRes::doCNAMECacheCheck()", color=red];
+    doResolve_asyncResolveWrapper [label="SyncRes::asyncResolveWrapper()", color=red];
+    doResolve_doCacheCheck [label="SyncRes::doCacheCheck()", color=red];
+    doResolve_getBestNSNamesFromCache [label="SyncRes::getBestNSNamesFromCache()", color=red];
+    doResolve_doResolveAt [label="SyncRes::doResolveAt()", color=red];
+
+    doResolve_return_res [label="return res", color=green];
+    doResolve_return_servfail [label="return SERVFAIL", color=green];
+
+    "SERVFAIL if too deep" -> "Check if called from getRootNS()";
+    "Check if called from getRootNS()" -> "Check if RD-bit was not set (d_cacheonly)" [label=yes];
+    "Check if called from getRootNS()" -> doResolve_getBestNSNamesFromCache [label=no];
+    "Check if RD-bit was not set (d_cacheonly)" -> doResolve_doCNAMECacheCheck [label=no];
+    "Check if RD-bit was not set (d_cacheonly)" -> "Check if there is a forward or auth-zone" [label=yes];
+    "Check if there is a forward or auth-zone" -> doResolve_doCNAMECacheCheck [label=no];
+    "Check if there is a forward or auth-zone" -> "Check if we are auth" [label=yes];
+    "Check if we are auth" -> doResolve_asyncResolveWrapper [label="no, so forward"];
+    "Check if we are auth" -> doResolve_doOOBResolve [label=yes];
+    doResolve_doOOBResolve -> "return res from doOOBResolve()";
+    "return res from doOOBResolve()" [color=green];
+    doResolve_asyncResolveWrapper -> "return result from asyncResolveWrapper()";
+    "return result from asyncResolveWrapper()" [color=green];
+    doResolve_doCNAMECacheCheck -> "Did doCNAMECacheCheck() return a true-ish value?";
+    "Did doCNAMECacheCheck() return a true-ish value?" -> doResolve_return_res [label=yes];
+    "Did doCNAMECacheCheck() return a true-ish value?" -> doResolve_doCacheCheck [label=no];
+    doResolve_doCacheCheck -> "did doCacheCheck() return a true-ish value?";
+    "did doCacheCheck() return a true-ish value?" -> doResolve_return_res [label=yes];
+    "did doCacheCheck() return a true-ish value?" -> doResolve_getBestNSNamesFromCache [label=no];
+
+    doResolve_getBestNSNamesFromCache -> doResolve_doResolveAt;
+    doResolve_doResolveAt -> doResolve_return_res [label="res == -2"];
+    doResolve_doResolveAt -> doResolve_return_servfail [label="res < 0 &&\nres != -2"];
+    doResolve_doResolveAt -> doResolve_return_res [label="res >= 0"];
+  }
+
+  subgraph cluster_doOOBResolve {
+    label="SyncRes::doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int& res)\nReturns true if data came from local auth-store.\nvector<DNSRecord> ret is filled with answers";
+
+    doOOBResolve_getBestAuthZone [label="SyncRes::getBestAuthZone()", color=red];
+    doOOBResolve_return_false [label="return false", color=green];
+    doOOBResolve_return_true [label="return true", color=green];
+
+    doOOBResolve_getBestAuthZone -> doOOBResolve_return_false [label="returned iterator to end of authstorage"];
+    doOOBResolve_getBestAuthZone -> "Add auth-records matching qname+qtype || CNAME || NS to ret" [label="returned iterator in the authstorage"];
+    "Add auth-records matching qname+qtype || CNAME || NS to ret" -> doOOBResolve_return_true [label="records were added to ret"]
+    "Add auth-records matching qname+qtype || CNAME || NS to ret" -> "Did we have any data for the qname?" [label="no records were added to ret"];
+
+    "Did we have any data for the qname?" -> "Add SOA to AUTHORITY in ret" [label="yes (empty NOERROR)"];
+    "Add SOA to AUTHORITY in ret" -> "Set res to NOERROR" -> doOOBResolve_return_true;
+
+    "Did we have any data for the qname?" -> "Is there a wildcard match?" [label=no];
+    "Is there a wildcard match?" -> "Add auth-records from wildcard to ret" [label=yes];
+    "Add auth-records from wildcard to ret" -> "Set res to NOERROR";
+
+    "Is there a wildcard match?" -> "Add NS-records from auth-zone" [label=no];
+
+    "Add NS-records from auth-zone" -> "Set res to NOERROR" [label="NS record were added"];
+    "Add NS-records from auth-zone" -> "Try to add SOA" [label="No NS record were added"];
+
+    "Try to add SOA" -> "Set res to NXDOMAIN" -> doOOBResolve_return_true;
+  }
+
+  subgraph cluster_asyncResolveWrapper {
+    label="SyncRes::asyncResolveWrapper()";
+  }
+
+  subgraph cluster_doResolveAt {
+    label="SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>&beenthere)\nreturns -1 in case of no results, -2 when a FilterEngine Policy was hit, rcode otherwise";
+
+    doResolveAt_nameServersBlockedByRPZ [label="SyncRes::nameserversBlockedByRPZ()", color=red];
+    doResolveAt_doOOBResolve_for_NS [label="SyncRes::doOOBResolve()", color=red];
+    doResolveAt_retrieveAddressesForNS [label="SyncRes::retrieveAddressesForNS()", color=red];
+    doResolveAt_nameserverIPBlockedByRPZ [label="SyncRes::nameserverIPBlockedByRPZ()", color=red];
+    doResolveAt_Lua_preoutquery [label="Lua preoutquery", color=red];
+    doResolveAt_asyncresolveWrapper [label="SyncRes::asyncresolveWrapper()", color=red];
+    doResolveAt_processRecords [label="SyncRes::processRecords()", color=red];
+    doResolveAt_doResolve [label="SyncRes::doResolve()", color=red];
+
+    doResolveAt_return_minus_2 [label="return -2", color=green];
+    doResolveAt_return_minus_1 [label="return -1", color=green];
+    doResolveAt_return_0 [label="return 0", color=green];
+    doResolveAt_return_rcode [label="return rcode", color=green];
+    doResolveAt_return_servfail [label="return SERVFAIL", color=green];
+    doResolveAt_return_nxdomain [label="return NXDOMAIN", color=green];
+
+    doResolveAt_mainloop_continue [label="continue"];
+    doResolveAt_mainloop_continue -> "Get nameserver from nameservers";
+
+    doResolveAt_nsiploop_continue [label="continue"];
+    doResolveAt_nsiploop_continue -> "Get IP from IPs";
+
+    doResolveAt_nameServersBlockedByRPZ -> doResolveAt_return_minus_2 [label="RPZ NSDNAME hit"];
+    doResolveAt_nameServersBlockedByRPZ ->  "Get nameserver from nameservers" [lhead=cluster_doResolveAt_mainloop, label="RPZ NSDNAME not hit"];
+
+    doResolveAt_ImmediateServFailException [label="throw ImmediateServFailException", color=green];
+
+    "Get nameserver from nameservers" -> doResolveAt_mainloop_continue [label="qname == nsname"];
+    "Get nameserver from nameservers" -> doResolveAt_return_minus_1 [label="All nameservers tried"];
+    "Get nameserver from nameservers" -> "Is the nameserver out of band?";
+    "Is the nameserver out of band?" -> doResolveAt_doOOBResolve_for_NS [label=yes];
+    doResolveAt_doOOBResolve_for_NS -> "updateCacheFromRecords()";
+    "Is the nameserver out of band?" -> doResolveAt_retrieveAddressesForNS [label=no];
+    doResolveAt_retrieveAddressesForNS -> doResolveAt_mainloop_continue [label="No IPs returned"];
+    doResolveAt_retrieveAddressesForNS -> doResolveAt_nameserverIPBlockedByRPZ [label="IPs returned"];
+    doResolveAt_nameserverIPBlockedByRPZ -> doResolveAt_return_minus_2 [label="RPZ NSIP hit"];
+    doResolveAt_nameserverIPBlockedByRPZ -> "Get IP from IPs" [label="RPZ NSIP not hit"];
+
+    "Get IP from IPs" -> doResolveAt_nsiploop_continue [label="IP is throttled"];
+    "Get IP from IPs" -> doResolveAt_ImmediateServFailException [label="Too many queries sent while resolving"];
+    "Get IP from IPs" -> doResolveAt_ImmediateServFailException [label="Resolving took too long"];
+    "Get IP from IPs" -> doResolveAt_mainloop_continue [label="No IP address worked"];
+    "Get IP from IPs" -> doResolveAt_Lua_preoutquery;
+
+    doResolveAt_Lua_preoutquery -> "Check resolveret" [label="true"];
+    doResolveAt_Lua_preoutquery -> doResolveAt_getEDNSSubnetMask [label="false"];
+    doResolveAt_getEDNSSubnetMask -> doResolveAt_asyncresolveWrapper;
+    doResolveAt_asyncresolveWrapper ->  "Check resolveret";
+    "Check resolveret" -> doResolveAt_ImmediateServFailException [label="resolveret == -3\n(kill query)"];
+    "Check resolveret" -> "resolveret == 1";
+    "resolveret == 1" -> doResolveAt_nsiploop_continue [label="nameserver returned\nSERVFAIL || REFUSED"];
+    "resolveret == 1" -> "updateCacheFromRecords()";
+    "updateCacheFromRecords()" -> doResolveAt_return_rcode [label="rcode != NOERROR"]; // line 1473
+    "updateCacheFromRecords()" -> doResolveAt_processRecords; // line 1484
+    doResolveAt_processRecords -> doResolveAt_return_0 [label="done == true"];
+    doResolveAt_processRecords -> "Have newtarget?";
+
+    "Have newtarget?" -> "qname == newtarget || depth > 10?" [label=yes];
+    "qname == newtarget || depth > 10?" -> doResolveAt_return_servfail [label=yes];
+    "qname == newtarget || depth > 10?" -> doResolveAt_doResolve [label=no];
+    doResolveAt_doResolve -> doResolveAt_return_rcode;
+
+    "Have newtarget?" -> "Have NXDOMAIN from upstream?" [label=no];
+    "Have NXDOMAIN from upstream?" -> "Add NSECs if needed" [label=yes];
+    "Add NSECs if needed" -> doResolveAt_return_nxdomain;
+
+    "Have NXDOMAIN from upstream?" -> "Have empty NOERROR?" [label=no];
+    "Have empty NOERROR?" -> "Add NSEC records if needed" [label=yes];
+    "Add NSEC records if needed" -> doResolveAt_return_0;
+
+    "Have empty NOERROR?" -> "Have realreferral?" [label=no];
+    "Have realreferral?" -> "Was a server in nsset blocker by RPZNSDNAME?" [label=yes];
+    "Was a server in nsset blocker by RPZNSDNAME?" -> doResolveAt_return_minus_2 [label=yes];
+    "Was a server in nsset blocker by RPZNSDNAME?" -> "Get nameserver from nameservers" [label=no];
+
+    "Have realreferral?" -> "Was this an OOB nameserver?" [label=no];
+    "Was this an OOB nameserver?" -> "Get nameserver from nameservers" [label="no, nameserver was lame"];
+    "Was this an OOB nameserver?" -> "Get nameserver from nameservers" [label=yes];
+  }
+
+  subgraph cluster_processRecords {
+    label="SyncRes::processRecords(const std::string& prefix, const DNSName& qname, const QType& qtype, const DNSName& auth, LWResult& lwr, const bool sendRDQuery, vector<DNSRecord>& ret, set<DNSName>& nsset, DNSName& newtarget, DNSName& newauth, bool& realreferral, bool& negindic, bool& sawDS)\nreturns true is this level of recursion is done";
+
+//    { rank=same; "Get record from lwr.d_records" processRecords_return_done}
+
+//    { rank=same; "Is this a proper CNAME referral?" "Is this a DNSSEC record in the ANSWER section?" "Is this the actual answer?" "Is this an NS record in the AUTHORITY?" "Is this a DS in the AUTHORITY?" "Is this a proper NXDOMAIN?" "Are we not done && is this a NOERROR && is this a SOA in the AUTHORITY?"}
+
+    "Get record from lwr.d_records";
+    "Get record from lwr.d_records" -> "Is this a proper NXDOMAIN?"; // line 1177
+    "Get record from lwr.d_records" -> processRecords_return_done [label="All records checked"];
+    "Get record from lwr.d_records" -> "Get record from lwr.d_records" [label="type != OPT &&\nclass != IN"];
+
+    "Is this a proper NXDOMAIN?" -> "is newtarget empty?" [label=yes]; // note, we have a CNAME chasing bug here issue #679
+    "is newtarget empty?" -> processRecords_wasVariable [label=no];
+    "is newtarget empty?" -> "Add this SOA to ret" [label=yes];
+    processRecords_wasVariable [label="SyncRes::wasVariable", color=red]
+    "Add this SOA to ret" -> processRecords_wasVariable;
+    processRecords_wasVariable -> "Set negindic to true" [label="was indeed variable"];
+    processRecords_wasVariable -> "Add to negative cache" [label="was not variable"];
+    "Add to negative cache" -> "If s_rootNXTrust && auth.isRoot()";
+    "If s_rootNXTrust && auth.isRoot()" -> "Set negindic to true" [label=no];
+    "If s_rootNXTrust && auth.isRoot()" -> "Add tld label to negative cache" [label=yes];
+    "Add tld label to negative cache" -> "Set negindic to true";
+    "Set negindic to true" -> "Get record from lwr.d_records";
+
+    "Is this a proper NXDOMAIN?" -> "Is this a proper CNAME referral?" [label=no];
+    "Is this a proper CNAME referral?" -> "Add CNAME record to ret" [label=yes];
+    "Add CNAME record to ret" -> "Set newtarget to this CNAME" -> "Get record from lwr.d_records";
+
+    "Is this a proper CNAME referral?" -> "Is this a DNSSEC record in the ANSWER section?" [label=no];
+    "Is this a DNSSEC record in the ANSWER section?" -> "Is the record.qtype not RRSIG and is the record's qname the qname we want?"[label=yes];
+    "Is the record.qtype not RRSIG and is the record's qname the qname we want?" -> "Add this record to ret" [label=yes];
+    "Add this record to ret" -> "Get record from lwr.d_records";
+    "Is the record.qtype not RRSIG and is the record's qname the qname we want?" -> "Get record from lwr.d_records" [label=no];
+
+    "Is this a DNSSEC record in the ANSWER section?" -> "Is this the actual answer?" [label=no];
+    "Is this the actual answer?" -> "Set done=true" [label=yes];
+    "Set done=true" -> "Add answer record to ret" -> "Get record from lwr.d_records";
+
+    "Is this the actual answer?" -> "Is this an NS record in the AUTHORITY?" [label=no];
+    "Is this an NS record in the AUTHORITY?" -> "Is record.d_name more specific than the our current auth?" [label=yes];
+    "Is record.d_name more specific than the our current auth?" -> "set newauth to record.d_name" [label=yes];
+    "set newauth to record.d_name" -> "set realreferral=true" -> "add NS record to ret";
+    "Is record.d_name more specific than the our current auth?" -> "add NS record to ret" [label=no];
+    "add NS record to ret" -> "Get record from lwr.d_records";
+
+    "Is this an NS record in the AUTHORITY?" -> "Is this a DS in the AUTHORITY?" [label=no];
+    "Is this a DS in the AUTHORITY?" -> "set sawDS=true" [label=yes];
+    "set sawDS=true" -> "Get record from lwr.d_records";
+
+    "Is this a DS in the AUTHORITY?" -> "Are we not done && is this a NOERROR && is this a SOA in the AUTHORITY?" [label=no];
+    "Are we not done && is this a NOERROR && is this a SOA in the AUTHORITY?" -> "is newtarget empty?" [label=yes];
+    "is newtarget empty?" -> "Harvest DNSSEC data and add to negative cache" [label=yes];
+    "is newtarget empty?" -> "Get record from lwr.d_records";
+    "Harvest DNSSEC data and add to negative cache" -> "Set negindic to true" -> "Get record from lwr.d_records";
+
+    "Are we not done && is this a NOERROR && is this a SOA in the AUTHORITY?" -> "Get record from lwr.d_records" [label=no];
+
+    processRecords_return_done [label="return done", color=green];
+  }
+
+  subgraph cluster_doCNAMECacheCheck {
+    label="SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>& ret, unsigned int depth, int &res)\nreturns true if this function handled the query";
+
+    doCNAMECacheCheck_return_true [label="return true", color=green];
+    doCNAMECacheCheck_return_false [label="return false", color=green];
+
+    doCNAMECacheCheck_servfail [label="Set res to SERVFAIL"];
+    doCNAMECacheCheck_servfail -> doCNAMECacheCheck_return_true;
+
+    doCNAMECacheCheck_doResolve [label="SyncRes::doResolve", color=red];
+
+    "Too deep recursion or CNAMEs?" -> doCNAMECacheCheck_servfail [label=yes];
+    "Too deep recursion or CNAMEs?" -> "Get cache entries for qname|CNAME" [label=no];
+    "Get cache entries for qname|CNAME" -> "get a record from the cache entries" -> "Is the TTL not expired?";
+    "Is the TTL not expired?" -> "get a record from the cache entries" [label=yes];
+    "Is the TTL not expired?" -> "Add record and RRSIGS to ret" [label=no];
+    "Add record and RRSIGS to ret" -> "is qtype CNAME?";
+    "is qtype CNAME?" -> doCNAMECacheCheck_doResolve [label=no];
+    doCNAMECacheCheck_doResolve -> "Set res to the result of doResolve" -> doCNAMECacheCheck_return_true;
+    "is qtype CNAME?" -> "Set res=0" [label=yes];
+    "Set res=0" -> doCNAMECacheCheck_return_true;
+    "Get cache entries for qname|CNAME" -> doCNAMECacheCheck_return_false [label="No cache entries"];
+  }
+}

--- a/pdns/recursordist/contrib/syncres.dot
+++ b/pdns/recursordist/contrib/syncres.dot
@@ -62,6 +62,32 @@ digraph {
     doResolve_doResolveAt -> doResolve_return_res [label="res >= 0"];
   }
 
+  subgraph cluster_doCacheCheck {
+    label="SyncRes::doCacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res)";
+
+    doCacheCheck_return_false [label="return false", color=green];
+    "Did we have a positive or negative answer?" -> doCacheCheck_return_true [label=yes];
+    "Did we have a positive or negative answer?" -> doCacheCheck_return_false [label=no];
+    doCacheCheck_return_true [label="return true", color=green];
+
+    "Allocate return qname, qtype and qttl vars (RVARS) as qname, qtype" -> "Is the last label of qname negatively cached by root and is root-nx-trust enabled?";
+
+    "Is the last label of qname negatively cached by root and is root-nx-trust enabled?" -> "Set res to NXDOMAIN, set RVARS to to this label|SOA" [label=yes];
+    "Is the last label of qname negatively cached by root and is root-nx-trust enabled?" -> "Do we have a negative entry from an auth?" [label=no];
+    "Do we have a negative entry from an auth?" -> "Set RCODE (NOERROR or NXDOMAIN), set RVARS to (smaller) qname|SOA" [label=yes];
+    "Set RCODE (NOERROR or NXDOMAIN), set RVARS to (smaller) qname|SOA" -> "Add DNSSEC proof from cache";
+    "Set res to NXDOMAIN, set RVARS to to this label|SOA" -> "Do we have a positive for RVARS from an auth?";
+
+    "Do we have a negative entry from an auth?" -> "Do we have a positive for RVARS from an auth?" [label=no];
+
+    "Do we have a positive for RVARS from an auth?" -> "Did we have a positive or negative answer?" [label=no];
+    "Add DNSSEC proof from cache" -> "Do we have a positive for RVARS from an auth?";
+
+    "Do we have a positive for RVARS from an auth?" -> "Add positive answers to ret if not expired" [label=yes];
+    "Add positive answers to ret if not expired" -> "Add DNSSEC data to ret";
+    "Add DNSSEC data to ret" -> "Did we have a positive or negative answer?";
+  }
+
   subgraph cluster_getBestNSFromCache {
     label="SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vector<DNSRecord>& bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere)\nFills the bestns vector with the 'closest' nameservers for qname\nflawedNSSet will be true if the NSSet has no glue.\nbeenthere contains the list of nameservers already visited during this recursion.";
 

--- a/pdns/recursordist/ecs.cc
+++ b/pdns/recursordist/ecs.cc
@@ -5,41 +5,6 @@ NetmaskGroup g_ednssubnets;
 SuffixMatchNode g_ednsdomains;
 bool g_useIncomingECS;
 
-boost::optional<Netmask> getEDNSSubnetMask(const ComboAddress& local, const DNSName&dn, const ComboAddress& rem, boost::optional<const EDNSSubnetOpts&> incomingECS)
-{
-  static uint8_t l_ipv4limit, l_ipv6limit;
-  if(!l_ipv4limit) {
-    l_ipv4limit = ::arg().asNum("ecs-ipv4-bits");
-    l_ipv6limit = ::arg().asNum("ecs-ipv6-bits");
-  }
-  boost::optional<Netmask> result;
-  ComboAddress trunc;
-  uint8_t bits;
-  if(incomingECS) {
-    if (incomingECS->source.getBits() == 0) {
-      /* RFC7871 says we MUST NOT send any ECS if the source scope is 0 */
-      return result;
-    }
-    trunc = incomingECS->source.getMaskedNetwork();
-    bits = incomingECS->source.getBits();
-  }
-  else if(!local.isIPv4() || local.sin4.sin_addr.s_addr) { // detect unset 'requestor'
-    trunc = local;
-    bits = local.isIPv4() ? 32 : 128;
-  }
-  else {
-    /* nothing usable */
-    return result;
-  }
-
-  if(g_ednsdomains.check(dn) || g_ednssubnets.match(rem)) {
-    bits = std::min(bits, (trunc.isIPv4() ? l_ipv4limit : l_ipv6limit));
-    trunc.truncate(bits);
-    return boost::optional<Netmask>(Netmask(trunc, bits));
-  }
-  return result;
-}
-
 void  parseEDNSSubnetWhitelist(const std::string& wlist)
 {
   vector<string> parts;

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -1,0 +1,608 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include "arguments.hh"
+#include "lua-recursor4.hh"
+#include "namespaces.hh"
+#include "rec-lua-conf.hh"
+#include "root-dnssec.hh"
+#include "syncres.hh"
+#include "validate-recursor.hh"
+
+std::unordered_set<DNSName> g_delegationOnly;
+RecursorStats g_stats;
+GlobalStateHolder<LuaConfigItems> g_luaconfs;
+NetmaskGroup* g_dontQuery{nullptr};
+__thread MemRecursorCache* t_RC{nullptr};
+SyncRes::domainmap_t* g_initialDomainMap{nullptr};
+unsigned int g_numThreads = 1;
+
+/* Fake some required functions we didn't want the trouble to
+   link with */
+ArgvMap &arg()
+{
+  static ArgvMap theArg;
+  return theArg;
+}
+
+int getMTaskerTID()
+{
+  return 0;
+}
+
+bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret)
+{
+  return false;
+}
+
+int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res)
+{
+  return 0;
+}
+
+/* primeHints() is only here for now because it
+   was way too much trouble to link with the real one.
+   We should fix this, empty functions are one thing, but this is
+   bad.
+*/
+
+#include "root-addresses.hh"
+
+void primeHints(void)
+{
+  vector<DNSRecord> nsset;
+  if(!t_RC)
+    t_RC = new MemRecursorCache();
+
+  DNSRecord arr, aaaarr, nsrr;
+  nsrr.d_name=g_rootdnsname;
+  arr.d_type=QType::A;
+  aaaarr.d_type=QType::AAAA;
+  nsrr.d_type=QType::NS;
+  arr.d_ttl=aaaarr.d_ttl=nsrr.d_ttl=time(nullptr)+3600000;
+
+  for(char c='a';c<='m';++c) {
+    static char templ[40];
+    strncpy(templ,"a.root-servers.net.", sizeof(templ) - 1);
+    templ[sizeof(templ)-1] = '\0';
+    *templ=c;
+    aaaarr.d_name=arr.d_name=DNSName(templ);
+    nsrr.d_content=std::make_shared<NSRecordContent>(DNSName(templ));
+    arr.d_content=std::make_shared<ARecordContent>(ComboAddress(rootIps4[c-'a']));
+    vector<DNSRecord> aset;
+    aset.push_back(arr);
+    t_RC->replace(time(0), DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), true); // auth, nuke it all
+    if (rootIps6[c-'a'] != NULL) {
+      aaaarr.d_content=std::make_shared<AAAARecordContent>(ComboAddress(rootIps6[c-'a']));
+
+      vector<DNSRecord> aaaaset;
+      aaaaset.push_back(aaaarr);
+      t_RC->replace(time(0), DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), true);
+    }
+
+    nsset.push_back(nsrr);
+  }
+  t_RC->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), false); // and stuff in the cache
+}
+
+LuaConfigItems::LuaConfigItems()
+{
+  for (const auto &dsRecord : rootDSs) {
+    auto ds=unique_ptr<DSRecordContent>(dynamic_cast<DSRecordContent*>(DSRecordContent::make(dsRecord)));
+    dsAnchors[g_rootdnsname].insert(*ds);
+  }
+}
+
+/* Some helpers functions */
+
+static void init(bool debug=false)
+{
+  if (debug) {
+    L.setName("test");
+    L.setLoglevel((Logger::Urgency)(6)); // info and up
+    L.disableSyslog(true);
+    L.toConsole(Logger::Info);
+  }
+
+  seedRandom("/dev/urandom");
+
+  if (g_dontQuery)
+    delete g_dontQuery;
+  g_dontQuery = new NetmaskGroup();
+
+  if (t_RC)
+    delete t_RC;
+  t_RC = new MemRecursorCache();
+
+  if (g_initialDomainMap)
+    delete g_initialDomainMap;
+  g_initialDomainMap = new SyncRes::domainmap_t(); // new threads needs this to be setup
+
+  SyncRes::s_maxqperq = 50;
+  SyncRes::s_maxtotusec = 1000*7000;
+  SyncRes::s_maxdepth = 40;
+  SyncRes::s_maxnegttl = 3600;
+  SyncRes::s_maxcachettl = 86400;
+  SyncRes::s_packetcachettl = 3600;
+  SyncRes::s_packetcacheservfailttl = 60;
+  SyncRes::s_serverdownmaxfails = 64;
+  SyncRes::s_serverdownthrottletime = 60;
+  SyncRes::s_doIPv6 = true;
+
+  ::arg().set("ecs-ipv4-bits", "24");
+  ::arg().set("ecs-ipv6-bits", "56");
+}
+
+static void initSR(std::unique_ptr<SyncRes>& sr, bool edns0, bool dnssec)
+{
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+  sr = std::unique_ptr<SyncRes>(new SyncRes(now));
+  sr->setDoEDNS0(edns0);
+  sr->setDoDNSSEC(dnssec);
+  t_sstorage->domainmap = g_initialDomainMap;
+  t_sstorage->negcache.clear();
+  t_sstorage->nsSpeeds.clear();
+  t_sstorage->ednsstatus.clear();
+  t_sstorage->throttle.clear();
+  t_sstorage->fails.clear();
+  t_sstorage->dnssecmap.clear();
+}
+
+static void setLWResult(LWResult* res, int rcode, bool aa=false, bool tc=false, bool edns=false)
+{
+  res->d_rcode = rcode;
+  res->d_aabit = aa;
+  res->d_tcbit = tc;
+  res->d_haveEDNS = edns;
+}
+
+static void addRecordToLW(LWResult* res, const DNSName& name, uint16_t type, const std::string& content, DNSResourceRecord::Place place=DNSResourceRecord::ANSWER, uint32_t ttl=60)
+{
+  DNSRecord rec;
+  rec.d_place = place;
+  rec.d_name = name;
+  rec.d_type = type;
+  rec.d_ttl = ttl;
+
+  if (type == QType::NS) {
+    rec.d_content = std::make_shared<NSRecordContent>(DNSName(content));
+  }
+  else if (type == QType::A) {
+    rec.d_content = std::make_shared<ARecordContent>(ComboAddress(content));
+  }
+  else if (QType::AAAA)
+  {
+    rec.d_content = std::make_shared<AAAARecordContent>(ComboAddress(content));
+  }
+  else {
+    rec.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(type, QClass::IN, content));
+  }
+
+  res->d_records.push_back(rec);
+}
+
+static void addRecordToLW(LWResult* res, const std::string& name, uint16_t type, const std::string& content, DNSResourceRecord::Place place=DNSResourceRecord::ANSWER, uint32_t ttl=60)
+{
+  addRecordToLW(res, DNSName(name), type, content, place, ttl);
+}
+
+static bool isRootServer(const ComboAddress& ip)
+{
+  for (size_t idx = 0; idx < rootIps4Count; idx++) {
+    if (ip.toString() == rootIps4[idx]) {
+      return true;
+    }
+  }
+
+  for (size_t idx = 0; idx < rootIps6Count; idx++) {
+    if (ip.toString() == rootIps6[idx]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/* Real tests */
+
+BOOST_AUTO_TEST_SUITE(syncres_cc)
+
+BOOST_AUTO_TEST_CASE(test_root_primed) {
+  std::unique_ptr<SyncRes> sr;
+  init();
+  initSR(sr, true, false);
+
+  primeHints();
+
+  /* we are primed, we should be able to resolve NS . without any query */
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(DNSName("."), QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(ret.size(), 13);
+}
+
+BOOST_AUTO_TEST_CASE(test_root_not_primed) {
+  std::unique_ptr<SyncRes> sr;
+  init(false);
+  initSR(sr, true, false);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      queriesCount++;
+
+      if (domain == g_rootdnsname && type == QType::NS) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, g_rootdnsname, QType::NS, "a.root-servers.net.", DNSResourceRecord::ANSWER, 3600);
+        addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
+        addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
+
+        return 1;
+      }
+
+      return 0;
+    });
+
+  /* we are not primed yet, so SyncRes will have to call primeHints()
+     then call getRootNS(), for which at least one of the root servers needs to answer */
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(DNSName("."), QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(ret.size(), 1);
+  BOOST_CHECK_EQUAL(queriesCount, 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_root_not_primed_and_no_response) {
+  std::unique_ptr<SyncRes> sr;
+  init();
+  initSR(sr, true, false);
+  std::set<ComboAddress> downServers;
+
+  /* we are not primed yet, so SyncRes will have to call primeHints()
+     then call getRootNS(), for which at least one of the root servers needs to answer.
+     None will, so it should ServFail.
+  */
+  sr->setAsyncCallback([&downServers](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+
+      downServers.insert(ip);
+      return 0;
+    });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(DNSName("."), QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, 2);
+  BOOST_CHECK_EQUAL(ret.size(), 0);
+  BOOST_CHECK(downServers.size() > 0);
+  /* we explicitly refuse to mark the root servers down */
+  for (const auto& server : downServers) {
+    BOOST_CHECK_EQUAL(t_sstorage->fails.value(server), 0);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_edns_formerr_fallback) {
+  std::unique_ptr<SyncRes> sr;
+  init();
+  initSR(sr, true, false);
+
+  ComboAddress noEDNSServer;
+  size_t queriesWithEDNS = 0;
+  size_t queriesWithoutEDNS = 0;
+
+  sr->setAsyncCallback([&queriesWithEDNS, &queriesWithoutEDNS, &noEDNSServer](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      if (EDNS0Level != 0) {
+        queriesWithEDNS++;
+        noEDNSServer = ip;
+
+        setLWResult(res, RCode::FormErr);
+        return 1;
+      }
+
+      queriesWithoutEDNS++;
+
+      if (domain == DNSName("powerdns.com") && type == QType::A && !doTCP) {
+        setLWResult(res, 0, true, false, false);
+        addRecordToLW(res, domain, QType::A, "192.0.2.1");
+        return 1;
+      }
+
+      return 0;
+    });
+
+  primeHints();
+
+  /* fake that the root NS doesn't handle EDNS, check that we fallback */
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(DNSName("powerdns.com."), QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(ret.size(), 1);
+  BOOST_CHECK_EQUAL(queriesWithEDNS, 1);
+  BOOST_CHECK_EQUAL(queriesWithoutEDNS, 1);
+  BOOST_CHECK_EQUAL(t_sstorage->ednsstatus.size(), 1);
+  BOOST_CHECK_EQUAL(t_sstorage->ednsstatus[noEDNSServer].mode, SyncRes::EDNSStatus::NOEDNS);
+}
+
+BOOST_AUTO_TEST_CASE(test_edns_notimp_fallback) {
+  std::unique_ptr<SyncRes> sr;
+  init();
+  initSR(sr, true, false);
+
+  size_t queriesWithEDNS = 0;
+  size_t queriesWithoutEDNS = 0;
+
+  sr->setAsyncCallback([&queriesWithEDNS, &queriesWithoutEDNS](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      if (EDNS0Level != 0) {
+        queriesWithEDNS++;
+        setLWResult(res, RCode::NotImp);
+        return 1;
+      }
+
+      queriesWithoutEDNS++;
+
+      if (domain == DNSName("powerdns.com") && type == QType::A && !doTCP) {
+        setLWResult(res, 0, true, false, false);
+        addRecordToLW(res, domain, QType::A, "192.0.2.1");
+        return 1;
+      }
+
+      return 0;
+    });
+
+  primeHints();
+
+  /* fake that the NS doesn't handle EDNS, check that we fallback */
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(DNSName("powerdns.com."), QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_CHECK_EQUAL(ret.size(), 1);
+  BOOST_CHECK_EQUAL(queriesWithEDNS, 1);
+  BOOST_CHECK_EQUAL(queriesWithoutEDNS, 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_tc_fallback_to_tcp) {
+  std::unique_ptr<SyncRes> sr;
+  init();
+  initSR(sr, true, false);
+
+  sr->setAsyncCallback([](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      if (!doTCP) {
+        setLWResult(res, 0, false, true, false);
+        return 1;
+      }
+      if (domain == DNSName("powerdns.com") && type == QType::A && doTCP) {
+        setLWResult(res, 0, true, false, false);
+        addRecordToLW(res, domain, QType::A, "192.0.2.1");
+        return 1;
+      }
+
+      return 0;
+    });
+
+  primeHints();
+
+  /* fake that the NS truncates every request over UDP, we should fallback to TCP */
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(DNSName("powerdns.com."), QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_all_nss_down) {
+  std::unique_ptr<SyncRes> sr;
+  init();
+  initSR(sr, true, false);
+  std::set<ComboAddress> downServers;
+
+  primeHints();
+
+  sr->setAsyncCallback([&downServers](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
+        addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
+        return 1;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "pdns-public-ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "pdns-public-ns2.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
+        addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 172800);
+        addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::AAAA, "2001:DB8::2", DNSResourceRecord::ADDITIONAL, 172800);
+        addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 172800);
+        addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 172800);
+        return 1;
+      }
+      else {
+        downServers.insert(ip);
+        return 0;
+      }
+    });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(DNSName("powerdns.com."), QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, 2);
+  BOOST_CHECK_EQUAL(ret.size(), 0);
+  BOOST_CHECK_EQUAL(downServers.size(), 4);
+
+  for (const auto& server : downServers) {
+    BOOST_CHECK_EQUAL(t_sstorage->fails.value(server), 1);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_glued_referral) {
+  std::unique_ptr<SyncRes> sr;
+  init();
+  initSR(sr, true, false);
+
+  primeHints();
+
+  const DNSName target("powerdns.com.");
+
+  sr->setAsyncCallback([target](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      /* this will cause issue with qname minimization if we ever implement it */
+      if (domain != target) {
+        return 0;
+      }
+
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
+        addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
+        return 1;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "pdns-public-ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "pdns-public-ns2.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
+        addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 172800);
+        addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::AAAA, "2001:DB8::2", DNSResourceRecord::ADDITIONAL, 172800);
+        addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 172800);
+        addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 172800);
+        return 1;
+      }
+      else if (ip == ComboAddress("192.0.2.2:53") || ip == ComboAddress("192.0.2.3:53") || ip == ComboAddress("[2001:DB8::2]:53") || ip == ComboAddress("[2001:DB8::3]:53")) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, target, QType::A, "192.0.2.4");
+        return 1;
+      }
+      else {
+        return 0;
+      }
+    });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_REQUIRE_EQUAL(ret.size(), 1);
+  BOOST_CHECK_EQUAL(ret[0].d_type, QType::A);
+  BOOST_CHECK_EQUAL(ret[0].d_name, target);
+}
+
+BOOST_AUTO_TEST_CASE(test_glueless_referral) {
+  std::unique_ptr<SyncRes> sr;
+  init();
+  initSR(sr, true, false);
+
+  primeHints();
+
+  const DNSName target("powerdns.com.");
+
+  sr->setAsyncCallback([target](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, true, false, true);
+
+        if (domain.isPartOf(DNSName("com."))) {
+          addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
+        } else if (domain.isPartOf(DNSName("org."))) {
+          addRecordToLW(res, "org.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
+        }
+        else {
+          setLWResult(res, RCode::NXDomain, false, false, true);
+          return 1;
+        }
+
+        addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
+        return 1;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
+        if (domain == target) {
+          setLWResult(res, 0, true, false, true);
+          addRecordToLW(res, "powerdns.com.", QType::NS, "pdns-public-ns1.powerdns.org.", DNSResourceRecord::AUTHORITY, 172800);
+          addRecordToLW(res, "powerdns.com.", QType::NS, "pdns-public-ns2.powerdns.org.", DNSResourceRecord::AUTHORITY, 172800);
+          return 1;
+        }
+        else if (domain == DNSName("pdns-public-ns1.powerdns.org.")) {
+          setLWResult(res, 0, true, false, true);
+          addRecordToLW(res, "pdns-public-ns1.powerdns.org.", QType::A, "192.0.2.2");
+          addRecordToLW(res, "pdns-public-ns1.powerdns.org.", QType::AAAA, "2001:DB8::2");
+          return 1;
+        }
+        else if (domain == DNSName("pdns-public-ns2.powerdns.org.")) {
+          setLWResult(res, 0, true, false, true);
+          addRecordToLW(res, "pdns-public-ns2.powerdns.org.", QType::A, "192.0.2.3");
+          addRecordToLW(res, "pdns-public-ns2.powerdns.org.", QType::AAAA, "2001:DB8::3");
+          return 1;
+        }
+
+        setLWResult(res, RCode::NXDomain, false, false, true);
+        return 1;
+      }
+      else if (ip == ComboAddress("192.0.2.2:53") || ip == ComboAddress("192.0.2.3:53") || ip == ComboAddress("[2001:DB8::2]:53") || ip == ComboAddress("[2001:DB8::3]:53")) {
+        setLWResult(res, 0, true, false, true);
+        addRecordToLW(res, target, QType::A, "192.0.2.4");
+        return 1;
+      }
+      else {
+        return 0;
+      }
+    });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, 0);
+  BOOST_REQUIRE_EQUAL(ret.size(), 1);
+  BOOST_CHECK_EQUAL(ret[0].d_type, QType::A);
+  BOOST_CHECK_EQUAL(ret[0].d_name, target);
+}
+
+/*
+  TODO:
+
+//      cerr<<"asyncresolve called to ask "<<ip.toStringWithPort()<<" about "<<domain.toString()<<" / "<<QType(type).getName()<<" over "<<(doTCP ? "TCP" : "UDP")<<" (rd: "<<sendRDQuery<<", EDNS0 level: "<<EDNS0Level<<")"<<endl;
+
+check RPZ (nameservers name blocked, name server IP blocked)
+check that wantsRPZ false skip the RPZ checks
+
+check that we are asking the more specific nameservers
+
+check that we correctly ignore unauth data?
+
+check out of band support
+
+check throttled
+
+check blocked
+
+check we query the fastest auth available first?
+
+check we correctly store slow servers
+
+check EDNS subnetmask
+
+if possible, check preoutquery
+
+check depth limit
+
+check time limit
+
+check we correctly populate the cache from the results
+
+check we correctly populate the negcache
+
+check we honor s_minimumTTL and s_maxcachettl
+
+check we follow a CNAME
+
+check we follow a CNAME, but not a loop!
+
+check we follow referral
+
+check delegation only
+
+check root NX trust
+
+check direct answer (done I think?)
+
+check incomplete CNAME answer
+
+complete CNAME answer
+
+nxdomain answer
+nodata answer
+*/
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/root-addresses.hh
+++ b/pdns/root-addresses.hh
@@ -21,32 +21,34 @@
  */
 #pragma once
 
-static const char*rootIps4[]={"198.41.0.4",             // a.root-servers.net.
-                              "192.228.79.201",         // b.root-servers.net.
-                              "192.33.4.12",            // c.root-servers.net.
-                              "199.7.91.13",            // d.root-servers.net.
-                              "192.203.230.10",         // e.root-servers.net.
-                              "192.5.5.241",            // f.root-servers.net.
-                              "192.112.36.4",           // g.root-servers.net.
-                              "198.97.190.53",          // h.root-servers.net.
-                              "192.36.148.17",          // i.root-servers.net.
-                              "192.58.128.30",          // j.root-servers.net.
-                              "193.0.14.129",           // k.root-servers.net.
-                              "199.7.83.42",            // l.root-servers.net.
-                              "202.12.27.33"            // m.root-servers.net.
-                              };
+static const char* const rootIps4[]={"198.41.0.4",             // a.root-servers.net.
+                                     "192.228.79.201",         // b.root-servers.net.
+                                     "192.33.4.12",            // c.root-servers.net.
+                                     "199.7.91.13",            // d.root-servers.net.
+                                     "192.203.230.10",         // e.root-servers.net.
+                                     "192.5.5.241",            // f.root-servers.net.
+                                     "192.112.36.4",           // g.root-servers.net.
+                                     "198.97.190.53",          // h.root-servers.net.
+                                     "192.36.148.17",          // i.root-servers.net.
+                                     "192.58.128.30",          // j.root-servers.net.
+                                     "193.0.14.129",           // k.root-servers.net.
+                                     "199.7.83.42",            // l.root-servers.net.
+                                     "202.12.27.33"            // m.root-servers.net.
+                                    };
+static size_t const rootIps4Count = sizeof(rootIps4) / sizeof(*rootIps4);
 
-static const char*rootIps6[]={"2001:503:ba3e::2:30",    // a.root-servers.net.
-                              "2001:500:84::b",         // b.root-servers.net.
-                              "2001:500:2::c",          // c.root-servers.net.
-                              "2001:500:2d::d",         // d.root-servers.net.
-                              "2001:500:a8::e",         // e.root-servers.net.
-                              "2001:500:2f::f",         // f.root-servers.net.
-                              "2001:500:12::d0d",       // g.root-servers.net.
-                              "2001:500:1::53",         // h.root-servers.net.
-                              "2001:7fe::53",           // i.root-servers.net.
-                              "2001:503:c27::2:30",     // j.root-servers.net.
-                              "2001:7fd::1",            // k.root-servers.net.
-                              "2001:500:9f::42",        // l.root-servers.net.
-                              "2001:dc3::35"            // m.root-servers.net.
-                              };
+static const char* const rootIps6[]={"2001:503:ba3e::2:30",    // a.root-servers.net.
+                                     "2001:500:84::b",         // b.root-servers.net.
+                                     "2001:500:2::c",          // c.root-servers.net.
+                                     "2001:500:2d::d",         // d.root-servers.net.
+                                     "2001:500:a8::e",         // e.root-servers.net.
+                                     "2001:500:2f::f",         // f.root-servers.net.
+                                     "2001:500:12::d0d",       // g.root-servers.net.
+                                     "2001:500:1::53",         // h.root-servers.net.
+                                     "2001:7fe::53",           // i.root-servers.net.
+                                     "2001:503:c27::2:30",     // j.root-servers.net.
+                                     "2001:7fd::1",            // k.root-servers.net.
+                                     "2001:500:9f::42",        // l.root-servers.net.
+                                     "2001:dc3::35"            // m.root-servers.net.
+                                    };
+static size_t const rootIps6Count = sizeof(rootIps6) / sizeof(*rootIps6);

--- a/pdns/root-dnssec.hh
+++ b/pdns/root-dnssec.hh
@@ -22,5 +22,5 @@
 
 #pragma once
 
-static const char*rootDSs[]={"19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5",
-                             "20326 8 2 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d"};
+static const char* const rootDSs[]={"19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5",
+                                    "20326 8 2 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d"};

--- a/pdns/secpoll-recursor.cc
+++ b/pdns/secpoll-recursor.cc
@@ -26,7 +26,7 @@ void doSecPoll(time_t* last_secpoll)
   gettimeofday(&now, 0);
   SyncRes sr(now);
   if (g_dnssecmode != DNSSECMode::Off)
-    sr.d_doDNSSEC=true;
+    sr.setDoDNSSEC(true);
   vector<DNSRecord> ret;
 
   string version = "recursor-" +pkgv;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -796,6 +796,7 @@ bool SyncRes::doCacheCheck(const DNSName &qname, const QType &qtype, vector<DNSR
     prefix.append(depth, ' ');
   }
 
+  // sqname and sqtype are used contain 'higher' names if we have them (e.g. powerdns.com|SOA when we find a negative entry for doesnotexists.powerdns.com|A)
   DNSName sqname(qname);
   QType sqt(qtype);
   uint32_t sttl=0;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -490,12 +490,16 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
 	  boost::optional<Netmask> nm;
           res=asyncresolveWrapper(remoteIP, d_doDNSSEC, qname, qtype.getCode(), false, false, &d_now, nm, &lwr);
           // filter out the good stuff from lwr.result()
-
-	  for(const auto& rec : lwr.d_records) {
-            if(rec.d_place == DNSResourceRecord::ANSWER)
-              ret.push_back(rec);
+          if (res == 1) {
+            for(const auto& rec : lwr.d_records) {
+              if(rec.d_place == DNSResourceRecord::ANSWER)
+                ret.push_back(rec);
+            }
+            return 0;
           }
-          return res;
+          else {
+            return RCode::ServFail;
+          }
         }
       }
     }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -132,7 +132,7 @@ int SyncRes::beginResolve(const DNSName &qname, const QType &qtype, uint16_t qcl
   if (doSpecialNamesResolve(qname, qtype, qclass, ret))
     return 0;
 
-  if( (qtype.getCode() == QType::AXFR))
+  if( (qtype.getCode() == QType::AXFR) || (qtype.getCode() == QType::IXFR))
     return -1;
 
   if(qclass==QClass::ANY)

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -740,7 +740,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
 	  ret.push_back(sigdr);
 	}
 
-        if(!(qtype==QType(QType::CNAME))) { // perhaps they really wanted a CNAME!
+        if(qtype != QType::CNAME) { // perhaps they really wanted a CNAME!
           set<GetBestNSAnswer>beenthere;
           res=doResolve(std::dynamic_pointer_cast<CNAMERecordContent>(j->d_content)->getTarget(), qtype, ret, depth+1, beenthere);
         }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -111,8 +111,8 @@ static void accountAuthLatency(int usec, int family)
 
 
 SyncRes::SyncRes(const struct timeval& now) :  d_outqueries(0), d_tcpoutqueries(0), d_throttledqueries(0), d_timeouts(0), d_unreachables(0),
-					       d_totUsec(0), d_doDNSSEC(false), d_now(now),
-					       d_cacheonly(false), d_nocache(false), d_doEDNS0(false), d_lm(s_lm)
+					       d_totUsec(0), d_now(now),
+					       d_cacheonly(false), d_nocache(false), d_doDNSSEC(false), d_doEDNS0(false), d_lm(s_lm)
                                                  
 { 
   if(!t_sstorage) {
@@ -377,7 +377,7 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
   */
 
   SyncRes::EDNSStatus* ednsstatus;
-  ednsstatus = &t_sstorage->ednsstatus[ip]; // does this include port? 
+  ednsstatus = &t_sstorage->ednsstatus[ip]; // does this include port? YES
 
   if(ednsstatus->modeSetAt && ednsstatus->modeSetAt + 3600 < d_now.tv_sec) {
     *ednsstatus=SyncRes::EDNSStatus();
@@ -403,8 +403,13 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
     }
     else if(ednsMANDATORY || mode==EDNSStatus::UNKNOWN || mode==EDNSStatus::EDNSOK || mode==EDNSStatus::EDNSIGNORANT)
       EDNSLevel = 1;
-    
-    ret=asyncresolve(ip, domain, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, luaconfsLocal->outgoingProtobufServer, res);
+
+    if (d_asyncResolve) {
+      ret = d_asyncResolve(ip, domain, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, luaconfsLocal->outgoingProtobufServer, res);
+    }
+    else {
+      ret=asyncresolve(ip, domain, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, luaconfsLocal->outgoingProtobufServer, res);
+    }
     if(ret < 0) {
       return ret; // transport error, nothing to learn here
     }
@@ -685,7 +690,7 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vecto
       // We lost the root NS records
       primeHints();
       LOG(prefix<<qname<<": reprimed the root"<<endl);
-      getRootNS();
+      getRootNS(d_now, d_asyncResolve);
     }
   }while(subdomain.chopOff());
 }
@@ -1589,5 +1594,48 @@ int directResolve(const DNSName& qname, const QType& qtype, int qclass, vector<D
   SyncRes sr(now);
   int res = sr.beginResolve(qname, QType(qtype), qclass, ret); 
   
+  return res;
+}
+
+#include "validate-recursor.hh"
+
+int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback) {
+  SyncRes sr(now);
+  sr.setDoEDNS0(true);
+  sr.setNoCache();
+  sr.setDoDNSSEC(g_dnssecmode != DNSSECMode::Off);
+  sr.setAsyncCallback(asyncCallback);
+
+  vector<DNSRecord> ret;
+  int res=-1;
+  try {
+    res=sr.beginResolve(g_rootdnsname, QType(QType::NS), 1, ret);
+    if (g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate) {
+      ResolveContext ctx;
+      auto state = validateRecords(ctx, ret);
+      if (state == Bogus)
+        throw PDNSException("Got Bogus validation result for .|NS");
+    }
+    return res;
+  }
+  catch(PDNSException& e)
+  {
+    L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.reason<<endl;
+  }
+
+  catch(std::exception& e)
+  {
+    L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.what()<<endl;
+  }
+
+  catch(...)
+  {
+    L<<Logger::Error<<"Failed to update . records, got an exception"<<endl;
+  }
+  if(!res) {
+    L<<Logger::Notice<<"Refreshed . records"<<endl;
+  }
+  else
+    L<<Logger::Error<<"Failed to update . records, RCODE="<<res<<endl;
   return res;
 }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -116,10 +116,11 @@ public:
     typename cont_t::iterator i=d_cont.find(t);
     if(i==d_cont.end())
       return false;
-    if(now > i->second.ttd || i->second.count-- < 0) {
+    if(now > i->second.ttd || i->second.count == 0) {
       d_cont.erase(i);
       return false;
     }
+    i->second.count--;
 
     return true; // still listed, still blocked
   }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -544,6 +544,8 @@ public:
   static unsigned int s_packetcacheservfailttl;
   static unsigned int s_serverdownmaxfails;
   static unsigned int s_serverdownthrottletime;
+  static uint8_t s_ecsipv4limit;
+  static uint8_t s_ecsipv6limit;
   static bool s_nopacketcache;
   static string s_serverID;
 
@@ -584,6 +586,8 @@ private:
   bool doSpecialNamesResolve(const DNSName &qname, const QType &qtype, const uint16_t &qclass, vector<DNSRecord> &ret);
 
   int asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res) const;
+
+  boost::optional<Netmask> getEDNSSubnetMask(const ComboAddress& local, const DNSName&dn, const ComboAddress& rem);
 
   ostringstream d_trace;
   shared_ptr<RecursorLua4> d_pdl;
@@ -808,7 +812,6 @@ uint64_t* pleaseWipeCache(const DNSName& canon, bool subtree=false);
 uint64_t* pleaseWipePacketCache(const DNSName& canon, bool subtree);
 uint64_t* pleaseWipeAndCountNegCache(const DNSName& canon, bool subtree=false);
 void doCarbonDump(void*);
-boost::optional<Netmask> getEDNSSubnetMask(const ComboAddress& local, const DNSName&dn, const ComboAddress& rem, boost::optional<const EDNSSubnetOpts&> incomingECS);
 void  parseEDNSSubnetWhitelist(const std::string& wlist);
 
 extern __thread struct timeval g_now;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -543,7 +543,14 @@ private:
   ostringstream d_trace;
   shared_ptr<RecursorLua4> d_pdl;
   string d_prefix;
+
+  /* When d_cacheonly is set to true, we will only check the cache.
+   * This is set when the RD bit is unset in the incoming query
+   */
   bool d_cacheonly;
+  /* d_nocache is *only* set in getRootNS() (in pdns_recursor.cc).
+   * It forces us to not look in the cache or local auth.
+   */
   bool d_nocache;
   bool d_doEDNS0;
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -19,8 +19,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#ifndef PDNS_SYNCRES_HH
-#define PDNS_SYNCRES_HH
+#pragma once
 #include <string>
 #include <atomic>
 #include "utility.hh"
@@ -762,6 +761,4 @@ extern SuffixMatchNode g_ednsdomains;
 
 #ifdef HAVE_PROTOBUF
 extern __thread boost::uuids::random_generator* t_uuidGenerator;
-#endif
-
 #endif

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -49,7 +49,10 @@
 #include "ednssubnet.hh"
 #include "filterpo.hh"
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
+
 #ifdef HAVE_PROTOBUF
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -539,7 +539,8 @@ private:
   RCode::rcodes_ updateCacheFromRecords(const std::string& prefix, LWResult& lwr, const DNSName& qname, const DNSName& auth, NsSet& nameservers, const DNSName& tns, const boost::optional<Netmask>);
   bool processRecords(const std::string& prefix, const DNSName& qname, const QType& qtype, const DNSName& auth, LWResult& lwr, const bool sendRDQuery, vector<DNSRecord>& ret, set<DNSName>& nsset, DNSName& newtarget, DNSName& newauth, bool& realreferral, bool& negindic, bool& sawDS);
 
-private:
+  bool doSpecialNamesResolve(const DNSName &qname, const QType &qtype, const uint16_t &qclass, vector<DNSRecord> &ret);
+
   ostringstream d_trace;
   shared_ptr<RecursorLua4> d_pdl;
   string d_prefix;

--- a/pdns/validate-recursor.cc
+++ b/pdns/validate-recursor.cc
@@ -6,6 +6,8 @@
 DNSSECMode g_dnssecmode{DNSSECMode::ProcessNoValidate};
 bool g_dnssecLogBogus;
 
+extern int getMTaskerTID();
+
 #define LOG(x) if(g_dnssecLOG) { L <<Logger::Warning << x; }
 
 class SRRecordOracle : public DNSRecordOracle
@@ -19,13 +21,13 @@ public:
     struct timeval tv;
     gettimeofday(&tv, 0);
     SyncRes sr(tv);
-    sr.setId(MT->getTid());
+    sr.setId(getMTaskerTID());
 #ifdef HAVE_PROTOBUF
-    sr.d_initialRequestId = d_ctx.d_initialRequestId;
+    sr.setInitialRequestId(d_ctx.d_initialRequestId);
 #endif
 
     vector<DNSRecord> ret;
-    sr.d_doDNSSEC=true;
+    sr.setDoDNSSEC(true);
     if (qtype == QType::DS || qtype == QType::DNSKEY || qtype == QType::NS)
       sr.setSkipCNAMECheck(true);
     sr.beginResolve(qname, QType(qtype), 1, ret);


### PR DESCRIPTION
### Short description
Part one of many of the SyncRes refactor.

* a graphviz file of the current flow of the syncres 
* code-comments
* `doSpecialNamesResolve()` method that handles `localhost` (forward and reverse), `version.bind TXT CH` etc.
   * Contains IPv6 information for localhost
   * Handles `ANY` queries for special names
* A metric tonne of unit tests and related infra thanks to @rgacogne 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
