### PR TITLE
rec: Refactor the negative cache into a class

### DIFF
--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -19,8 +19,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#ifndef PDNS_CACHECLEANER_HH
-#define PDNS_CACHECLEANER_HH
+#pragma once
 
 #include "lock.hh"
 
@@ -193,5 +192,3 @@ template <typename T> uint64_t purgeExactLockedCollection(T& mc, const DNSName& 
 
   return delcount;
 }
-
-#endif

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -340,6 +340,13 @@ std::string DNSName::getRawLabel(unsigned int pos) const
   throw std::out_of_range("trying to get label at position "+std::to_string(pos)+" of a DNSName that only has "+std::to_string(currentPos)+" labels");
 }
 
+DNSName DNSName::getLastLabel() const
+{
+  DNSName ret(*this);
+  ret.trimToLabels(1);
+  return ret;
+}
+
 bool DNSName::chopOff()
 {
   if(d_storage.empty() || d_storage[0]==0)

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -83,6 +83,7 @@ public:
   void prependRawLabel(const std::string& str); //!< Prepend this unescaped label
   std::vector<std::string> getRawLabels() const; //!< Individual raw unescaped labels
   std::string getRawLabel(unsigned int pos) const; //!< Get the specified raw unescaped label
+  DNSName getLastLabel() const; //!< Get the DNSName of the last label
   bool chopOff();                               //!< Turn www.powerdns.com. into powerdns.com., returns false for .
   DNSName makeRelative(const DNSName& zone) const;
   DNSName makeLowerCase() const

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2064,7 +2064,7 @@ static void houseKeeping(void *)
       t_RC->doPrune(); // this function is local to a thread, so fine anyhow
       t_packetCache->doPruneTo(::arg().asNum("max-packetcache-entries") / g_numWorkerThreads);
 
-      pruneCollection(t_sstorage->negcache, ::arg().asNum("max-cache-entries") / (g_numWorkerThreads * 10), 200);
+      t_sstorage->negcache.prune(::arg().asNum("max-cache-entries") / (g_numWorkerThreads * 10));
 
       if(!((cleanCounter++)%40)) {  // this is a full scan!
 	time_t limit=now.tv_sec-300;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -11,6 +11,7 @@
 #include "misc.hh"
 #include "recursor_cache.hh"
 #include "syncres.hh"
+#include "negcache.hh"
 #include <boost/function.hpp>
 #include <boost/optional.hpp>
 #include <boost/tuple/tuple.hpp>
@@ -175,26 +176,17 @@ string doGetParameter(T begin, T end)
 }
 
 
-static uint64_t dumpNegCache(SyncRes::negcache_t& negcache, int fd)
+static uint64_t dumpNegCache(NegCache& negcache, int fd)
 {
   FILE* fp=fdopen(dup(fd), "w");
   if(!fp) { // dup probably failed
     return 0;
   }
+  uint64_t ret;
   fprintf(fp, "; negcache dump from thread follows\n;\n");
-  time_t now = time(0);
-  
-  typedef SyncRes::negcache_t::nth_index<1>::type sequence_t;
-  sequence_t& sidx=negcache.get<1>();
-
-  uint64_t count=0;
-  for(const NegCacheEntry& neg :  sidx)
-  {
-    ++count;
-    fprintf(fp, "%s IN %s %d VIA %s\n", neg.d_name.toString().c_str(), neg.d_qtype.getName().c_str(), (unsigned int) (neg.d_ttd - now), neg.d_qname.toString().c_str());
-  }
+  ret = negcache.dumpToFile(fp);
   fclose(fp);
-  return count;
+  return ret;
 }
 
 static uint64_t* pleaseDump(int fd)
@@ -282,23 +274,10 @@ uint64_t* pleaseWipePacketCache(const DNSName& canon, bool subtree)
 
 uint64_t* pleaseWipeAndCountNegCache(const DNSName& canon, bool subtree)
 {
-  if(!subtree) {
-    uint64_t res = t_sstorage->negcache.count(tie(canon));
-    auto range=t_sstorage->negcache.equal_range(tie(canon));
-    t_sstorage->negcache.erase(range.first, range.second);
-    return new uint64_t(res);
-  }
-  else {
-    unsigned int erased=0;
-    for(auto iter = t_sstorage->negcache.lower_bound(tie(canon)); iter != t_sstorage->negcache.end(); ) {
-      if(!iter->d_qname.isPartOf(canon))
-	break;
-      t_sstorage->negcache.erase(iter++);
-      erased++;
-    }
-    return new uint64_t(erased);
-  }
+  uint64_t ret = t_sstorage->negcache.wipe(canon, subtree);
+  return new uint64_t(ret);
 }
+
 
 template<typename T>
 string doWipeCache(T begin, T end)

--- a/pdns/recursordist/.gitignore
+++ b/pdns/recursordist/.gitignore
@@ -41,3 +41,6 @@
 /pdns-recursor.service
 /pdns-recursor@.service
 /lua.hpp
+/test-suite.log
+/testrunner.log
+/testrunner.trs

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -110,6 +110,7 @@ pdns_recursor_SOURCES = \
 	mtasker.hh \
 	mtasker_context.cc mtasker_context.hh \
 	namespaces.hh \
+	negcache.hh negcache.cc \
 	nsecrecords.cc \
 	opensslsigners.cc opensslsigners.hh \
 	packetcache.hh \
@@ -196,6 +197,7 @@ testrunner_SOURCES = \
 	iputils.cc iputils.hh \
 	logger.cc logger.hh \
 	misc.cc misc.hh \
+	negcache.hh negcache.cc \
 	namespaces.hh \
 	nsecrecords.cc \
 	pdnsexception.hh \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -226,6 +226,7 @@ testrunner_SOURCES = \
 	test-iputils_hh.cc \
 	test-misc_hh.cc \
 	test-nmtree.cc \
+	test-negcache_cc.cc \
 	test-rcpgenerator_cc.cc \
 	test-recpacketcache_cc.cc \
 	test-syncres_cc.cc \

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -1,0 +1,155 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "negcache.hh"
+#include "misc.hh"
+#include "cachecleaner.hh"
+
+/*!
+ * Set ne to the NegCacheEntry for the last label in qname and return true
+ *
+ * \param qname    The name to look up (only the last label is used)
+ * \param now      A timeval with the current time, to check if an entry is expired
+ * \param ne       A NegCacheEntry that is filled when there is a cache entry
+ * \return         true if ne was filled out, false otherwise
+ */
+bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne) {
+  // An 'ENT' QType entry, used as "whole name" in the neg-cache context.
+  static const QType qtnull(0);
+  pair<negcache_t::const_iterator, negcache_t::const_iterator> range;
+  DNSName lastLabel = qname.getLastLabel();
+  range.first = d_negcache.find(tie(lastLabel, qtnull));
+
+  if (range.first != d_negcache.end() &&
+      range.first->d_auth.isRoot()) {
+    if ((uint32_t)now.tv_sec < range.first->d_ttd) {
+      ne = *range.first;
+      moveCacheItemToBack(d_negcache, range.first);
+      return true;
+    }
+    moveCacheItemToFront(d_negcache, range.first);
+  }
+  return false;
+}
+
+/*!
+ * Set ne to the NegCacheEntry for the qname|qtype tuple and return true
+ *
+ * \param qname    The name to look up
+ * \param qtype    The qtype to look up
+ * \param now      A timeval with the current time, to check if an entry is expired
+ * \param ne       A NegCacheEntry that is filled when there is a cache entry
+ * \return         true if ne was filled out, false otherwise
+ */
+bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne) {
+  auto range = d_negcache.equal_range(tie(qname));
+  negcache_t::iterator ni = range.first;
+
+  while (ni != range.second) {
+    // We have an entry
+    if (ni->d_qtype.getCode() == 0 || ni->d_qtype == qtype) {
+      // We match the QType or the whole name is denied
+      if((uint32_t) now.tv_sec < ni->d_ttd) {
+        // Not expired
+        ne = *ni;
+        moveCacheItemToBack(d_negcache, ni);
+        return true;
+      }
+      // expired
+      moveCacheItemToFront(d_negcache, ni);
+    }
+    ni++;
+  }
+  return false;
+}
+
+/*!
+ * Places ne into the negative cache, possibly overriding an existing entry.
+ *
+ * \param ne The NegCacheEntry to add to the cache
+ */
+void NegCache::add(const NegCacheEntry& ne) {
+  replacing_insert(d_negcache, ne);
+}
+
+/*!
+ * Returns the amount of entries in the cache
+ */
+uint64_t NegCache::count(const DNSName& qname) const {
+  return d_negcache.count(tie(qname));
+}
+
+/*!
+ * Remove all entries for name from the cache. If subtree is true, wipe all names
+ * underneath it.
+ *
+ * \param name    The DNSName of the entries to wipe
+ * \param subtree Should all entries under name be removed?
+ */
+uint64_t NegCache::wipe(const DNSName& name, bool subtree) {
+  uint64_t ret(0);
+  if (subtree) {
+    for (auto i = d_negcache.lower_bound(tie(name)); i != d_negcache.end();) {
+      if(!i->d_name.isPartOf(name))
+        break;
+      i = d_negcache.erase(i);
+      ret++;
+    }
+    return ret;
+  }
+
+  ret = count(name);
+  auto range = d_negcache.equal_range(tie(name));
+  d_negcache.erase(range.first, range.second);
+  return ret;
+}
+
+/*!
+ * Clear the negative cache
+ */
+void NegCache::clear() {
+  d_negcache.clear();
+}
+
+/*!
+ * Perform some cleanup in the cache, removing stale entries
+ *
+ * \param maxEntries The maximum number of entries that may exist in the cache.
+ */
+void NegCache::prune(unsigned int maxEntries) {
+  pruneCollection(d_negcache, maxEntries, 200);
+}
+
+/*!
+ * Writes the whole negative cache to fp
+ *
+ * \param fp A pointer to an open FILE object
+ */
+uint64_t NegCache::dumpToFile(FILE* fp) {
+  uint64_t ret(0);
+  time_t now = time(0);
+  negcache_sequence_t& sidx = d_negcache.get<1>();
+  for(const NegCacheEntry& ne : sidx) {
+    ret++;
+    fprintf(fp, "%s %d IN %s VIA %s\n", ne.d_name.toString().c_str(), (unsigned int) (ne.d_ttd - now), ne.d_qtype.getName().c_str(), ne.d_auth.toString().c_str());
+  }
+  return ret;
+}

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -100,9 +100,21 @@ void NegCache::add(const NegCacheEntry& ne) {
 
 /*!
  * Returns the amount of entries in the cache
+ *
+ * \param qname The name of the entries to be counted
  */
 uint64_t NegCache::count(const DNSName& qname) const {
   return d_negcache.count(tie(qname));
+}
+
+/*!
+ * Returns the amount of entries in the cache for qname+qtype
+ *
+ * \param qname The name of the entries to be counted
+ * \param qtype The type of the entries to be counted
+ */
+uint64_t NegCache::count(const DNSName& qname, const QType qtype) const {
+  return d_negcache.count(tie(qname, qtype));
 }
 
 /*!

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -1,0 +1,94 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <boost/multi_index_container.hpp>
+#include "dnsparser.hh"
+#include "dnsname.hh"
+#include "dns.hh"
+
+using namespace ::boost::multi_index;
+
+/* FIXME should become part of the normal cache (I think) and shoudl become more like
+ * struct {
+ *   vector<DNSRecord> records;
+ *   vector<DNSRecord> signatures;
+ * } recsig_t;
+ *
+ * typedef vector<recsig_t> recordsAndSignatures;
+ */
+typedef struct {
+  vector<DNSRecord> records;
+  vector<DNSRecord> signatures;
+} recordsAndSignatures;
+
+class NegCache : public boost::noncopyable {
+  public:
+    struct NegCacheEntry {
+      DNSName d_name;                     // The denied name
+      QType d_qtype;                      // The denied type
+      DNSName d_auth;                     // The denying name (aka auth)
+      uint32_t d_ttd;                     // Timestamp when this entry should die
+      recordsAndSignatures authoritySOA;  // The upstream SOA record and RRSIGs
+      recordsAndSignatures DNSSECRecords; // The upstream NSEC(3) and RRSIGs
+      uint32_t getTTD() const {
+        return d_ttd;
+      };
+    };
+
+    void add(const NegCacheEntry& ne);
+    bool get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne);
+    bool getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne);
+    uint64_t count(const DNSName& qname) const;
+    void prune(unsigned int maxEntries);
+    void clear();
+    uint64_t dumpToFile(FILE* fd);
+    uint64_t wipe(const DNSName& name, bool subtree = false);
+
+    uint64_t size() {
+      return d_negcache.size();
+    };
+
+  private:
+    typedef boost::multi_index_container <
+      NegCacheEntry,
+      indexed_by <
+        ordered_unique <
+          composite_key <
+            NegCacheEntry,
+            member<NegCacheEntry, DNSName, &NegCacheEntry::d_name>,
+            member<NegCacheEntry, QType, &NegCacheEntry::d_qtype>
+          >,
+          composite_key_compare <
+            CanonDNSNameCompare, std::less<QType>
+          >
+        >,
+        sequenced<>
+      >
+    > negcache_t;
+
+    // Required for the cachecleaner
+    typedef negcache_t::nth_index<1>::type negcache_sequence_t;
+
+    // Stores the negative cache entries
+    negcache_t d_negcache;
+};

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -59,6 +59,7 @@ class NegCache : public boost::noncopyable {
     bool get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne);
     bool getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne);
     uint64_t count(const DNSName& qname) const;
+    uint64_t count(const DNSName& qname, const QType qtype) const;
     void prune(unsigned int maxEntries);
     void clear();
     uint64_t dumpToFile(FILE* fd);

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -159,6 +159,46 @@ BOOST_AUTO_TEST_CASE(test_add_updated_entry) {
   BOOST_CHECK_EQUAL(ne.d_auth, auth2);
 }
 
+BOOST_AUTO_TEST_CASE(test_getRootNXTrust) {
+  DNSName qname("www2.powerdns.com");
+  DNSName auth("powerdns.com");
+  DNSName qname2("com");
+  DNSName auth2(".");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  cache.add(genNegCacheEntry(qname, auth, now));
+  cache.add(genNegCacheEntry(qname2, auth2, now));
+
+  NegCache::NegCacheEntry ne;
+  bool ret = cache.getRootNXTrust(qname, now, ne);
+
+  BOOST_CHECK(ret);
+  BOOST_CHECK_EQUAL(ne.d_name, qname2);
+  BOOST_CHECK_EQUAL(ne.d_auth, auth2);
+}
+
+BOOST_AUTO_TEST_CASE(test_getRootNXTrust_full_domain_only) {
+  DNSName qname("www2.powerdns.com");
+  DNSName auth("powerdns.com");
+  DNSName qname2("com");
+  DNSName auth2(".");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  cache.add(genNegCacheEntry(qname, auth, now));
+  cache.add(genNegCacheEntry(qname2, auth2, now, 1)); // Add the denial for COM|A
+
+  NegCache::NegCacheEntry ne;
+  bool ret = cache.getRootNXTrust(qname, now, ne);
+
+  BOOST_CHECK_EQUAL(ret, false);
+}
+
 BOOST_AUTO_TEST_CASE(test_prune) {
   string qname(".powerdns.com");
   DNSName auth("powerdns.com");

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -136,6 +136,30 @@ BOOST_AUTO_TEST_CASE(test_add_and_get_expired_entry) {
   BOOST_CHECK(ne.authoritySOA.records.empty());
 }
 
+BOOST_AUTO_TEST_CASE(test_getRootNXTrust_expired_entry) {
+  DNSName qname("com");
+  DNSName auth(".");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+  now.tv_sec -= 1000;
+
+  NegCache cache;
+  cache.add(genNegCacheEntry(qname, auth, now));
+
+  BOOST_CHECK_EQUAL(cache.size(), 1);
+
+  NegCache::NegCacheEntry ne;
+
+  now.tv_sec += 1000;
+  bool ret = cache.getRootNXTrust(qname, now, ne);
+
+  BOOST_CHECK_EQUAL(ret, false);
+  BOOST_CHECK_EQUAL(ne.d_name, DNSName());
+  BOOST_CHECK_EQUAL(ne.d_auth, DNSName());
+  BOOST_CHECK(ne.authoritySOA.records.empty());
+}
+
 BOOST_AUTO_TEST_CASE(test_add_updated_entry) {
   DNSName qname("www2.powerdns.com");
   DNSName auth("powerdns.com");

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -152,8 +152,9 @@ BOOST_AUTO_TEST_CASE(test_add_updated_entry) {
   BOOST_CHECK_EQUAL(cache.size(), 1);
 
   NegCache::NegCacheEntry ne;
-  cache.get(qname, QType(1), now, ne);
+  bool ret = cache.get(qname, QType(1), now, ne);
 
+  BOOST_CHECK(ret);
   BOOST_CHECK_EQUAL(ne.d_name, qname);
   BOOST_CHECK_EQUAL(ne.d_auth, auth2);
 }

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -1,0 +1,303 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include "negcache.hh"
+#include "dnsrecords.hh"
+#include "utility.hh"
+
+static recordsAndSignatures genRecsAndSigs(const DNSName& name, const uint16_t qtype, const string& content, bool sigs) {
+  recordsAndSignatures ret;
+
+  DNSRecord rec;
+  rec.d_name = name;
+  rec.d_type = qtype;
+  rec.d_ttl = 600;
+  rec.d_place = DNSResourceRecord::AUTHORITY;
+  rec.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(qtype, QClass::IN, content));
+
+  ret.records.push_back(rec);
+
+  if (sigs) {
+    rec.d_type = QType::RRSIG;
+    rec.d_content = std::make_shared<RRSIGRecordContent>(QType(qtype).getName() + " 5 3 600 2100010100000000 2100010100000000 24567 dummy data");
+    ret.signatures.push_back(rec);
+  }
+
+  return ret;
+}
+
+static NegCache::NegCacheEntry genNegCacheEntry(const DNSName& name, const DNSName& auth, const struct timeval& now, const uint16_t qtype=0) {
+  NegCache::NegCacheEntry ret;
+
+  ret.d_name = name;
+  ret.d_qtype = QType(qtype);
+  ret.d_auth = auth;
+  ret.d_ttd = now.tv_sec + 600;
+  ret.authoritySOA = genRecsAndSigs(auth, QType::SOA, "ns1 hostmaster 1 2 3 4 5", true);
+  ret.DNSSECRecords = genRecsAndSigs(auth, QType::NSEC, "deadbeef", true);
+
+  return ret;
+}
+
+BOOST_AUTO_TEST_SUITE(negcache_cc)
+
+BOOST_AUTO_TEST_CASE(test_get_entry) {
+  /* Add a full name negative entry to the cache and attempt to get an entry for
+   * the A record. Should yield the full name does not exist entry
+   */
+  DNSName qname("www2.powerdns.com");
+  DNSName auth("powerdns.com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  cache.add(genNegCacheEntry(qname, auth, now));
+
+  BOOST_CHECK_EQUAL(cache.size(), 1);
+
+  NegCache::NegCacheEntry ne;
+  bool ret = cache.get(qname, QType(1), now, ne);
+
+  BOOST_CHECK(ret);
+  BOOST_CHECK_EQUAL(ne.d_name, qname);
+  BOOST_CHECK_EQUAL(ne.d_qtype.getName(), QType(0).getName());
+  BOOST_CHECK_EQUAL(ne.d_auth, auth);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_NODATA_entry) {
+  DNSName qname("www2.powerdns.com");
+  DNSName auth("powerdns.com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  cache.add(genNegCacheEntry(qname, auth, now, 1));
+
+  BOOST_CHECK_EQUAL(cache.size(), 1);
+
+  NegCache::NegCacheEntry ne;
+  bool ret = cache.get(qname, QType(1), now, ne);
+
+  BOOST_CHECK(ret);
+  BOOST_CHECK_EQUAL(ne.d_name, qname);
+  BOOST_CHECK_EQUAL(ne.d_qtype.getName(), QType(1).getName());
+  BOOST_CHECK_EQUAL(ne.d_auth, auth);
+
+  NegCache::NegCacheEntry ne2;
+  ret = cache.get(qname, QType(16), now, ne2);
+  BOOST_CHECK_EQUAL(ret, false);
+}
+
+BOOST_AUTO_TEST_CASE(test_getRootNXTrust_entry) {
+  DNSName qname("com");
+  DNSName auth(".");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  cache.add(genNegCacheEntry(qname, auth, now));
+
+  BOOST_CHECK_EQUAL(cache.size(), 1);
+
+  NegCache::NegCacheEntry ne;
+  bool ret = cache.getRootNXTrust(qname, now, ne);
+
+  BOOST_CHECK(ret);
+  BOOST_CHECK_EQUAL(ne.d_name, qname);
+  BOOST_CHECK_EQUAL(ne.d_qtype.getName(), QType(0).getName());
+  BOOST_CHECK_EQUAL(ne.d_auth, auth);
+}
+
+BOOST_AUTO_TEST_CASE(test_add_and_get_expired_entry) {
+  DNSName qname("www2.powerdns.com");
+  DNSName auth("powerdns.com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+  now.tv_sec -= 1000;
+
+  NegCache cache;
+  cache.add(genNegCacheEntry(qname, auth, now));
+
+  BOOST_CHECK_EQUAL(cache.size(), 1);
+
+  NegCache::NegCacheEntry ne;
+
+  now.tv_sec += 1000;
+  bool ret = cache.get(qname, QType(1), now, ne);
+
+  BOOST_CHECK_EQUAL(ret, false);
+  BOOST_CHECK_EQUAL(ne.d_name, DNSName());
+  BOOST_CHECK_EQUAL(ne.d_auth, DNSName());
+  BOOST_CHECK(ne.authoritySOA.records.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_add_updated_entry) {
+  DNSName qname("www2.powerdns.com");
+  DNSName auth("powerdns.com");
+  DNSName auth2("com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  cache.add(genNegCacheEntry(qname, auth, now));
+  // Should override the existing entry for www2.powerdns.com
+  cache.add(genNegCacheEntry(qname, auth2, now));
+
+  BOOST_CHECK_EQUAL(cache.size(), 1);
+
+  NegCache::NegCacheEntry ne;
+  cache.get(qname, QType(1), now, ne);
+
+  BOOST_CHECK_EQUAL(ne.d_name, qname);
+  BOOST_CHECK_EQUAL(ne.d_auth, auth2);
+}
+
+BOOST_AUTO_TEST_CASE(test_prune) {
+  string qname(".powerdns.com");
+  DNSName auth("powerdns.com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  NegCache::NegCacheEntry ne;
+  for(int i = 0; i < 400; i++) {
+    ne = genNegCacheEntry(DNSName(std::to_string(i) + qname), auth, now);
+    cache.add(ne);
+  }
+
+  BOOST_CHECK_EQUAL(cache.size(), 400);
+
+  cache.prune(100);
+
+  BOOST_CHECK_EQUAL(cache.size(), 100);
+}
+
+BOOST_AUTO_TEST_CASE(test_wipe_single) {
+  string qname(".powerdns.com");
+  DNSName auth("powerdns.com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  NegCache::NegCacheEntry ne;
+  ne = genNegCacheEntry(auth, auth, now);
+  cache.add(ne);
+
+  for(int i = 0; i < 400; i++) {
+    ne = genNegCacheEntry(DNSName(std::to_string(i) + qname), auth, now);
+    cache.add(ne);
+  }
+
+  BOOST_CHECK_EQUAL(cache.size(), 401);
+
+  // Should only wipe the powerdns.com entry
+  cache.wipe(auth);
+  BOOST_CHECK_EQUAL(cache.size(), 400);
+
+  NegCache::NegCacheEntry ne2;
+  bool ret = cache.get(auth, QType(1), now, ne2);
+
+  BOOST_CHECK_EQUAL(ret, false);
+  BOOST_CHECK_EQUAL(ne2.d_auth, DNSName());
+  BOOST_CHECK_EQUAL(ne2.d_name, DNSName());
+
+  cache.wipe(DNSName("1.powerdns.com"));
+  BOOST_CHECK_EQUAL(cache.size(), 399);
+
+  NegCache::NegCacheEntry ne3;
+  ret = cache.get(auth, QType(1), now, ne3);
+
+  BOOST_CHECK_EQUAL(ret, false);
+  BOOST_CHECK_EQUAL(ne3.d_auth, DNSName());
+  BOOST_CHECK_EQUAL(ne3.d_name, DNSName());
+}
+
+BOOST_AUTO_TEST_CASE(test_wipe_subtree) {
+  string qname(".powerdns.com");
+  string qname2("powerdns.org");
+  DNSName auth("powerdns.com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  NegCache::NegCacheEntry ne;
+  ne = genNegCacheEntry(auth, auth, now);
+  cache.add(ne);
+
+  for(int i = 0; i < 400; i++) {
+    ne = genNegCacheEntry(DNSName(std::to_string(i) + qname), auth, now);
+    cache.add(ne);
+    ne = genNegCacheEntry(DNSName(std::to_string(i) + qname2), auth, now);
+    cache.add(ne);
+  }
+
+  BOOST_CHECK_EQUAL(cache.size(), 801);
+
+  // Should wipe all the *.powerdns.com and powerdns.com entries
+  cache.wipe(auth, true);
+  BOOST_CHECK_EQUAL(cache.size(), 400);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear) {
+  string qname(".powerdns.com");
+  DNSName auth("powerdns.com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  NegCache::NegCacheEntry ne;
+
+  for(int i = 0; i < 400; i++) {
+    ne = genNegCacheEntry(DNSName(std::to_string(i) + qname), auth, now);
+    cache.add(ne);
+  }
+
+  BOOST_CHECK_EQUAL(cache.size(), 400);
+  cache.clear();
+  BOOST_CHECK_EQUAL(cache.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_dumpToFile) {
+  NegCache cache;
+  vector<string> expected;
+  expected.push_back("www1.powerdns.com. 600 IN TYPE0 VIA powerdns.com.\n");
+  expected.push_back("www2.powerdns.com. 600 IN TYPE0 VIA powerdns.com.\n");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  cache.add(genNegCacheEntry(DNSName("www1.powerdns.com"), DNSName("powerdns.com"), now));
+  cache.add(genNegCacheEntry(DNSName("www2.powerdns.com"), DNSName("powerdns.com"), now));
+
+  FILE* fp;
+  fp = tmpfile();
+  if (!fp)
+    BOOST_FAIL("Temporary file could not be opened");
+
+  cache.dumpToFile(fp);
+
+  rewind(fp);
+  char *line = nullptr;
+  size_t len = 0;
+  ssize_t read;
+
+  for (const auto& str : expected) {
+    read = getline(&line, &len, fp);
+    if (read == -1)
+      BOOST_FAIL("Unable to read a line from the temp file");
+    BOOST_CHECK_EQUAL(line, str);
+  }
+  fclose(fp);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -341,4 +341,31 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile) {
   fclose(fp);
 }
 
+BOOST_AUTO_TEST_CASE(test_count) {
+  string qname(".powerdns.com");
+  string qname2("powerdns.org");
+  DNSName auth("powerdns.com");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  NegCache::NegCacheEntry ne;
+  ne = genNegCacheEntry(auth, auth, now);
+  cache.add(ne);
+
+  for(int i = 0; i < 400; i++) {
+    ne = genNegCacheEntry(DNSName(std::to_string(i) + qname), auth, now);
+    cache.add(ne);
+    ne = genNegCacheEntry(DNSName(std::to_string(i) + qname2), auth, now);
+    cache.add(ne);
+  }
+
+  uint64_t count;
+  count = cache.count(auth);
+  BOOST_CHECK_EQUAL(count, 1);
+  count = cache.count(auth, QType(1));
+  BOOST_CHECK_EQUAL(count, 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -20,7 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
 
 #include <atomic>
 #include <condition_variable>

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -795,7 +795,14 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
   return false;
 }
 
-static inline void addTTLModifiedRecords(const vector<DNSRecord>& records, const uint32_t ttl, vector<DNSRecord>& ret) {
+/*!
+ * Convience function to push the records from records into ret with a new TTL
+ *
+ * \param records DNSRecords that need to go into ret
+ * \param ttl     The new TTL for these records
+ * \param ret     The vector of DNSRecords that should contian the records with the modified TTL
+ */
+static void addTTLModifiedRecords(const vector<DNSRecord>& records, const uint32_t ttl, vector<DNSRecord>& ret) {
   for (const auto& rec : records) {
     DNSRecord r(rec);
     r.d_ttl = ttl;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -795,13 +795,6 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
   return false;
 }
 
-static const DNSName getLastLabel(const DNSName& qname)
-{
-  DNSName ret(qname);
-  ret.trimToLabels(1);
-  return ret;
-}
-
 static inline void addTTLModifiedRecords(const vector<DNSRecord>& records, const uint32_t ttl, vector<DNSRecord>& ret) {
   for (const auto& rec : records) {
     DNSRecord r(rec);
@@ -1237,7 +1230,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
         harvestNXRecords(lwr.d_records, ne);
         t_sstorage->negcache.add(ne);
         if(s_rootNXTrust && auth.isRoot()) { // We should check if it was forwarded here, see issue #5107
-          ne.d_name = getLastLabel(ne.d_name);
+          ne.d_name = ne.d_name.getLastLabel();
           t_sstorage->negcache.add(ne);
         }
       }

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -858,4 +858,14 @@ BOOST_AUTO_TEST_CASE(test_getrawlabel) {
   BOOST_CHECK_THROW(name.getRawLabel(name.countLabels()), std::out_of_range);
 }
 
+BOOST_AUTO_TEST_CASE(test_getlastlabel) {
+  DNSName name("www.powerdns.com");
+  DNSName ans = name.getLastLabel();
+
+  // Check the const-ness
+  BOOST_CHECK_EQUAL(name, DNSName("www.powerdns.com"));
+
+  // Check if the last label is indeed returned
+  BOOST_CHECK_EQUAL(ans, DNSName("com"));
+}
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
This PR refactors the negative cache of the recursor into a class and uses that class in the SyncRes.

Needs a sturdy review.

It also has some cosmetic improvements:

* Adds `pragma once` to cachecleaner.hh
* Guards the `config.h` include in remote_logger.hh
* git-ignores files generated by the testrunner

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)