### PR TITLE
unnest Lua exceptions when they get all the way back to main()

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2180,6 +2180,19 @@ try
   _exit(EXIT_SUCCESS);
 
 }
+catch(const LuaContext::ExecutionErrorException& e) {
+  try {
+    errlog("Fatal Lua error: %s", e.what());
+    std::rethrow_if_nested(e);
+  } catch(const std::exception& e) {
+    errlog("Details: %s", e.what());
+  }
+  catch(PDNSException &ae)
+  {
+    errlog("Fatal pdns error: %s", ae.reason);
+  }
+  _exit(EXIT_FAILURE);
+}
 catch(std::exception &e)
 {
   errlog("Fatal error: %s", e.what());


### PR DESCRIPTION
### Short description
Sometimes (like during startup), exceptions from C++ may bubble up via Lua all the way to `main()`. This PR improves error reporting for that situation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
