### PR TITLE
rec: Clear the RPZ NS IP table when clearing the policy

### DIFF
--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -156,6 +156,7 @@ void DNSFilterEngine::clear(size_t zone)
   z.qpolAddr.clear();
   z.postpolAddr.clear();
   z.propolName.clear();
+  z.propolNSAddr.clear();
   z.qpolName.clear();
 }
 
@@ -165,6 +166,7 @@ void DNSFilterEngine::clear()
     z.qpolAddr.clear();
     z.postpolAddr.clear();
     z.propolName.clear();
+    z.propolNSAddr.clear();
     z.qpolName.clear();
   }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Be it the entire policy object or a single zone. Turns out we cleared the other tables but not that one.
This PR could use unit tests. Some of the tests I'm writing for `SyncRes` do test it as a side effect, but we should write independent unit tests for the filter policy stuff.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
