### PR TITLE
Bugfix/5054 dnsdist query counters integer overflows

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -349,7 +349,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           {"order", (int)a->order},
           {"pools", pools},
           {"latency", (int)(a->latencyUsec/1000.0)},
-          {"queries", (int)a->queries}};
+          {"queries", (double)a->queries}};
 
         /* sending a latency for a DOWN server doesn't make sense */
         if (a->availability == DownstreamState::Availability::Down) {

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -380,7 +380,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
       for(const auto& a : localRules) {
 	Json::object rule{
 	  {"id", num++},
-	  {"matches", (int)a.first->d_matches},
+	  {"matches", (double)a.first->d_matches},
 	  {"rule", a.first->toString()},
           {"action", a.second->toString()}, 
           {"action-stats", a.second->getStats()} 
@@ -394,7 +394,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
       for(const auto& a : localResponseRules) {
         Json::object rule{
           {"id", num++},
-          {"matches", (int)a.first->d_matches},
+          {"matches", (double)a.first->d_matches},
           {"rule", a.first->toString()},
           {"action", a.second->toString()},
         };


### PR DESCRIPTION
### Short description

This addresses (hopefully all remaining) overflows in the API and web interface for dnsdist as mentioned in issue #5054.

The way it is currently fixed means that matches can still overflow in the web interface because JavaScript has a 2^53 number limit.

However, this fix is in line with how earlier cases have been fixed.

### Checklist

I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)