### PR TITLE
Dnsdist qnamerule

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -343,6 +343,7 @@ Rules have selectors and actions. Current selectors are:
  * QPS Limit total
  * QPS Limit per IP address or subnet
  * QClass (QClassRule)
+ * QName (QNameRule)
  * QType (QTypeRule)
  * RegexRule on query name
  * RE2Rule on query name (optional)
@@ -427,6 +428,7 @@ A DNS rule can be:
  * an OrRule
  * a QClassRule
  * a QNameLabelsCountRule
+ * a QNameRule
  * a QNameWireLengthRule
  * a QTypeRule
  * a RCodeRule
@@ -1411,6 +1413,7 @@ instantiate a server with additional parameters
     * `OpcodeRule()`: matches queries with the specified opcode
     * `QClassRule(qclass)`: matches queries with the specified qclass (numeric)
     * `QNameLabelsCountRule(min, max)`: matches if the qname has less than `min` or more than `max` labels
+    * `QNameRule(qname)`: matches queries with the specified qname
     * `QNameWireLengthRule(min, max)`: matches if the qname's length on the wire is less than `min` or more than `max` bytes
     * `QTypeRule(qtype)`: matches queries with the specified qtype
     * `RCodeRule(rcode)`: matches queries or responses the specified rcode

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -349,6 +349,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "rmServer", true, "n", "remove server with index n" },
   { "roundrobin", false, "", "Simple round robin over available servers" },
   { "QNameLabelsCountRule", true, "min, max", "matches if the qname has less than `min` or more than `max` labels" },
+  { "QNameRule", true, "qname", "matches queries with the specified qname" },
   { "QNameWireLengthRule", true, "min, max", "matches if the qname's length on the wire is less than `min` or more than `max` bytes" },
   { "QTypeRule", true, "qtype", "matches queries with the specified qtype" },
   { "RCodeRule", true, "rcode", "matches responses with the specified rcode" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -922,6 +922,10 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       return std::shared_ptr<DNSRule>(new AllRule());
     });
 
+  g_lua.writeFunction("QNameRule", [](const std::string& qname) {
+      return std::shared_ptr<DNSRule>(new QNameRule(DNSName(qname)));
+    });
+  
   g_lua.writeFunction("QTypeRule", [](boost::variant<int, std::string> str) {
       uint16_t qtype;
       if(auto dir = boost::get<int>(&str)) {

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -300,12 +300,31 @@ public:
     if(d_quiet)
       return "qname==in-set";
     else
-      return "qname=="+d_smn.toString();
+      return "qname in "+d_smn.toString();
   }
 private:
   SuffixMatchNode d_smn;
   bool d_quiet;
 };
+
+class QNameRule : public DNSRule
+{
+public:
+  QNameRule(const DNSName& qname) : d_qname(qname)
+  {
+  }
+  bool matches(const DNSQuestion* dq) const override
+  {
+    return d_qname==*dq->qname;
+  }
+  string toString() const override
+  {
+    return "qname=="+d_qname.toString();
+  }
+private:
+  DNSName d_qname;
+};
+
 
 class QTypeRule : public DNSRule
 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR 1) adds an actual QNameRule that matches a single QName exactly 2) changes the SuffixMatchNode rule to no longer claim "qname ==" but now to say "qname in".
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
