### PR TITLE
add "enable-notification-warning" option to make logging of warnings configureable

### DIFF
--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -641,8 +641,7 @@ and/or `ALSO-NOTIFY` domain metadata to avoid this potential bottleneck.
 
 By default PowerDNS will log a warning if all NOTIFYs were suppressed due to
 `only-notify` and there were no explict ALSO-NOTIFYs. This warning can be suppressed by
-setting this option to `no`. Disabling the warning may be useful with `slave-renotify=yes`
-and empty `only-notify`, but only a few slave zones have ALSO-NOTIFYs configured.
+setting this option to `no`.
 
 ## `out-of-zone-additional-processing`
 * Boolean

--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -635,14 +635,14 @@ method to distribute the zone data to the slaves), then set `only-notify` to an 
 value and specify the notification targets explicitly using [`also-notify`](#also-notify)
 and/or `ALSO-NOTIFY` domain metadata to avoid this potential bottleneck.
 
-## `disable-notification-warning`
+## `enable-notification-warning`
 * Boolean
-* Default: no
+* Default: yes
 
-If all NOTIFYs were suppressed due to `only-notify` and there were no explict
-ALSO-NOTIFYs, PowerDNS will log a warning. This warning can be suppressed with
-this option. This may be useful with `slave-renotify=yes` but only a few slave
-zones have ALSO-NOTIFYs configured.
+By default PowerDNS will log a warning if all NOTIFYs were suppressed due to
+`only-notify` and there were no explict ALSO-NOTIFYs. This warning can be suppressed by
+setting this option to `no`. Disabling the warning may be useful with `slave-renotify=yes`
+and empty `only-notify`, but only a few slave zones have ALSO-NOTIFYs configured.
 
 ## `out-of-zone-additional-processing`
 * Boolean

--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -635,6 +635,15 @@ method to distribute the zone data to the slaves), then set `only-notify` to an 
 value and specify the notification targets explicitly using [`also-notify`](#also-notify)
 and/or `ALSO-NOTIFY` domain metadata to avoid this potential bottleneck.
 
+## `disable-notification-warning`
+* Boolean
+* Default: no
+
+If all NOTIFYs were suppressed due to `only-notify` and there were no explict
+ALSO-NOTIFYs, PowerDNS will log a warning. This warning can be suppressed with
+this option. This may be useful with `slave-renotify=yes` but only a few slave
+zones have ALSO-NOTIFYs configured.
+
 ## `out-of-zone-additional-processing`
 * Boolean
 * Default: yes

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -113,6 +113,7 @@ void declareArguments()
   ::arg().set("allow-axfr-ips","Allow zonetransfers only to these subnets")="127.0.0.0/8,::1";
   ::arg().set("only-notify", "Only send AXFR NOTIFY to these IP addresses or netmasks")="0.0.0.0/0,::/0";
   ::arg().set("also-notify", "When notifying a domain, also notify these nameservers")="";
+  ::arg().set("disable-notification-warning","Disable the logging of warnings if all NOTIFYs were suppressed")="no";
   ::arg().set("allow-notify-from","Allow AXFR NOTIFY from these IP ranges. If empty, drop all incoming notifies.")="0.0.0.0/0,::/0";
   ::arg().set("slave-cycle-interval","Schedule slave freshness checks once every .. seconds")="60";
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -113,7 +113,7 @@ void declareArguments()
   ::arg().set("allow-axfr-ips","Allow zonetransfers only to these subnets")="127.0.0.0/8,::1";
   ::arg().set("only-notify", "Only send AXFR NOTIFY to these IP addresses or netmasks")="0.0.0.0/0,::/0";
   ::arg().set("also-notify", "When notifying a domain, also notify these nameservers")="";
-  ::arg().set("disable-notification-warning","Disable the logging of warnings if all NOTIFYs were suppressed")="no";
+  ::arg().set("enable-notification-warning","Enable the logging of warnings if all NOTIFYs were suppressed")="yes";
   ::arg().set("allow-notify-from","Allow AXFR NOTIFY from these IP ranges. If empty, drop all incoming notifies.")="0.0.0.0/0,::/0";
   ::arg().set("slave-cycle-interval","Schedule slave freshness checks once every .. seconds")="60";
 

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -96,8 +96,9 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
     }
   }
 
-  if (!hasQueuedItem)
+  if (!hasQueuedItem && !::arg().mustDo("disable-notification-warning")) {
     L<<Logger::Warning<<"Request to queue notification for domain '"<<di.zone<<"' was processed, but no valid nameservers or ALSO-NOTIFYs found. Not notifying!"<<endl;
+  }
 }
 
 

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -96,7 +96,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
     }
   }
 
-  if (!hasQueuedItem && !::arg().mustDo("disable-notification-warning")) {
+  if (!hasQueuedItem && ::arg().mustDo("enable-notification-warning")) {
     L<<Logger::Warning<<"Request to queue notification for domain '"<<di.zone<<"' was processed, but no valid nameservers or ALSO-NOTIFYs found. Not notifying!"<<endl;
   }
 }


### PR DESCRIPTION
…t sending NOTIFYs

If all NOTIFYs were suppresed due to `only-notify` and there were no explict
ALSO-NOTIFY, PowerDNS will log a warning. This warning can be suppressed with
this option. This may be useful with `slave-renotify=yes` but only a few slave
zones have ALSO-NOTIFY configured.