### PR TITLE
Feature except send servfail

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -67,6 +67,7 @@ void declareArguments()
   ::arg().setSwitch("forward-dnsupdate","A global setting to allow DNS update packages that are for a Slave domain, to be forwarded to the master.")="yes";
   ::arg().setSwitch("log-dns-details","If PDNS should log DNS non-erroneous details")="no";
   ::arg().setSwitch("log-dns-queries","If PDNS should log all incoming DNS queries")="no";
+  ::arg().setSwitch("except-send-servfail","If PDNS should send ServFail on backends exception")="yes";
   ::arg().set("local-address","Local IP addresses to which we bind")="0.0.0.0";
   ::arg().setSwitch("local-address-nonexist-fail","Fail to start if one or more of the local-address's do not exist on this server")="yes";
   ::arg().setSwitch("non-local-bind", "Enable binding to non-local addresses by using FREEBIND / BINDANY socket options")="no";

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -61,6 +61,7 @@ PacketHandler::PacketHandler():B(s_programname), d_dk(&B)
   d_doDNAME=::arg().mustDo("dname-processing");
   d_doExpandALIAS = ::arg().mustDo("expand-alias");
   d_logDNSDetails= ::arg().mustDo("log-dns-details");
+  d_exceptSendServFail= ::arg().mustDo("except-send-servfail");
   d_doIPv6AdditionalProcessing = ::arg().mustDo("do-ipv6-additional-processing");
   string fname= ::arg()["lua-prequery-script"];
   if(fname.empty())
@@ -1513,12 +1514,18 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     throw; // we WANT to die at this point
   }
   catch(std::exception &e) {
-    L<<Logger::Error<<"Exception building answer packet for "<<p->qdomain<<"/"<<p->qtype.getName()<<" ("<<e.what()<<") sending out servfail"<<endl;
-    delete r;
-    r=p->replyPacket(); // generate an empty reply packet
-    r->setRcode(RCode::ServFail);
-    S.inc("servfail-packets");
-    S.ringAccount("servfail-queries",p->qdomain.toLogString());
+    if (d_exceptSendServFail) {
+      L<<Logger::Error<<"Exception building answer packet for "<<p->qdomain<<"/"<<p->qtype.getName()<<" ("<<e.what()<<") sending out servfail"<<endl;
+      delete r;
+      r=p->replyPacket(); // generate an empty reply packet
+      r->setRcode(RCode::ServFail);
+      S.inc("servfail-packets");
+      S.ringAccount("servfail-queries",p->qdomain.toLogString());
+    }else {
+      L<<Logger::Error<<"Exception building answer packet ("<<e.what()<<") ignore for send out servfail"<<endl;
+      delete r;
+      return 0;
+    }
   }
   return r; 
 

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -106,6 +106,7 @@ private:
   static AtomicCounter s_count;
   static pthread_mutex_t s_rfc2136lock;
   bool d_logDNSDetails;
+  bool d_exceptSendServFail;
   bool d_doIPv6AdditionalProcessing;
   bool d_doDNAME;
   bool d_doExpandALIAS;


### PR DESCRIPTION
### Short description
Improve the resolve service availability on cluster. When one of the server has exception, if it sent ServFail, the resolver dns server will be directly return to the client. When I don't replay anything, the resolver dns server will be sent the request against to another server in the cluster.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

