### PR TITLE
recursor-lua: add some function and hook to support change query ns

### DIFF
--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -67,6 +67,7 @@ public:
     const std::vector<pair<uint16_t, string>>* ednsOptions{nullptr};
     const uint16_t* ednsFlags{nullptr};
     vector<DNSRecord>* currentRecords{nullptr};
+    vector<ComboAddress>* currentNSs{nullptr};
     DNSFilterEngine::Policy* appliedPolicy{nullptr};
     std::vector<std::string>* policyTags{nullptr};
     std::unordered_map<std::string,bool>* discardedPolicies{nullptr};
@@ -84,6 +85,9 @@ public:
     vector<string> getEDNSFlags() const;
     bool getEDNSFlag(string flag) const;
     void setRecords(const vector<pair<int,DNSRecord> >& records);
+    vector<pair<int,ComboAddress> > getNSs() const;
+    void resetNS();
+    void addNS(ComboAddress &addr);
 
     int rcode{0};
     // struct dnsheader, packet length would be great
@@ -109,6 +113,7 @@ public:
   bool nodata(DNSQuestion& dq, int& ret);
   bool postresolve(DNSQuestion& dq, int& ret);
 
+  bool postgetns(vector<ComboAddress>& nsList, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret);
   bool preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret);
   bool ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader&);
 
@@ -126,7 +131,7 @@ public:
 
 private:
   typedef std::function<bool(DNSQuestion*)> luacall_t;
-  luacall_t d_prerpz, d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_preoutquery, d_postoutquery;
+  luacall_t d_prerpz, d_preresolve, d_nxdomain, d_nodata, d_postresolve, d_postgetns, d_preoutquery, d_postoutquery;
   bool genhook(luacall_t& func, DNSQuestion& dq, int& ret);
   typedef std::function<bool(ComboAddress,ComboAddress, struct dnsheader)> ipfilter_t;
   ipfilter_t d_ipfilter;

--- a/pdns/recursordist/contrib/syncres.dot
+++ b/pdns/recursordist/contrib/syncres.dot
@@ -206,6 +206,7 @@ digraph {
     doResolveAt_retrieveAddressesForNS [label="SyncRes::retrieveAddressesForNS()", color=red];
     doResolveAt_nameserverIPBlockedByRPZ [label="SyncRes::nameserverIPBlockedByRPZ()", color=red];
     doResolveAt_Lua_preoutquery [label="Lua preoutquery", color=red];
+    doResolveAt_Lua_postgetns [label="Lua postgetns", color=red];
     doResolveAt_asyncresolveWrapper [label="SyncRes::asyncresolveWrapper()", color=red];
     doResolveAt_processRecords [label="SyncRes::processRecords()", color=red];
     doResolveAt_doResolve [label="SyncRes::doResolve()", color=red];
@@ -243,6 +244,7 @@ digraph {
     "Get IP from IPs" -> doResolveAt_ImmediateServFailException [label="Too many queries sent while resolving"];
     "Get IP from IPs" -> doResolveAt_ImmediateServFailException [label="Resolving took too long"];
     "Get IP from IPs" -> doResolveAt_mainloop_continue [label="No IP address worked"];
+    "Get IP from IPs" -> doResolveAt_Lua_postgetns;
     "Get IP from IPs" -> doResolveAt_Lua_preoutquery;
 
     doResolveAt_Lua_preoutquery -> "Check resolveret" [label="true"];

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1362,6 +1362,7 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
       bool doTCP=false;
       bool pierceDontQuery=false;
       bool sendRDQuery=false;
+      int postgetnsret;
       boost::optional<Netmask> ednsmask;
       LWResult lwr;
       if(tns->empty() && nameservers[*tns].first.empty() ) {
@@ -1373,6 +1374,9 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
       else {
         remoteIPs = retrieveAddressesForNS(prefix, qname, tns, depth, beenthere, rnameservers, nameservers, sendRDQuery, pierceDontQuery, flawedNSSet);
 
+	    if(d_pdl && d_pdl->postgetns(remoteIPs, d_requestor, qname, qtype, doTCP, lwr.d_records, postgetnsret)) {
+		  LOG(prefix<<qname<<": query handled by Lua"<<endl);
+	    }
         if(remoteIPs.empty()) {
           LOG(prefix<<qname<<": Failed to get IP for NS "<<*tns<<", trying next if available"<<endl);
           flawedNSSet=true;


### PR DESCRIPTION
### Short description
Allow to change target query NS servers.

add hook postgetns for after get ns server lists and before send
add function resetNS to clear the outgoing query ns server lists
add function addNS to add new outgoing query ns server


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
