### PR TITLE
dnsdist: Stop sending queries as soon as we are dyn-blocked in tests

### DIFF
--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -394,7 +394,7 @@ class TestDynBlockResponseBytes(DNSDistTest):
                 # let's clear the response queue
                 self.clearToResponderQueue()
                 # and stop right there, otherwise we might
-                # wait for so long than the dynblock is gone
+                # wait for so long that the dynblock is gone
                 # by the time we finished
                 break
 
@@ -455,7 +455,7 @@ class TestDynBlockResponseBytes(DNSDistTest):
                 # let's clear the response queue
                 self.clearToResponderQueue()
                 # and stop right there, otherwise we might
-                # wait for so long than the dynblock is gone
+                # wait for so long that the dynblock is gone
                 # by the time we finished
                 break
 

--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -393,6 +393,10 @@ class TestDynBlockResponseBytes(DNSDistTest):
                 # the query has not reached the responder,
                 # let's clear the response queue
                 self.clearToResponderQueue()
+                # and stop right there, otherwise we might
+                # wait for so long than the dynblock is gone
+                # by the time we finished
+                break
 
         # we might be already blocked, but we should have been able to send
         # at least self._dynBlockBytesPerSecond bytes
@@ -450,6 +454,10 @@ class TestDynBlockResponseBytes(DNSDistTest):
                 # the query has not reached the responder,
                 # let's clear the response queue
                 self.clearToResponderQueue()
+                # and stop right there, otherwise we might
+                # wait for so long than the dynblock is gone
+                # by the time we finished
+                break
 
         # we might be already blocked, but we should have been able to send
         # at least self._dynBlockBytesPerSecond bytes


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise we might take too much time to finish sending our queries (2s timeout per query), ending up with the dynamic block rule gone by the time we finish.
Hopefully this will reduce or even get rid of the random travis failures this test is causing.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
