### PR TITLE
Implement axfrfilter with LuaContext

### DIFF
--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -193,7 +193,7 @@ private:
   map<pair<DNSName,string>,time_t>d_holes;
   pthread_mutex_t d_holelock;
   void suck(const DNSName &domain, const string &remote);
-  void ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, boost::scoped_ptr<AuthLua>& pdl,
+  void ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, boost::scoped_ptr<AuthLua4>& pdl,
                 ZoneStatus& zs, vector<DNSRecord>* axfr);
 
   void slaveRefresh(PacketHandler *P);

--- a/pdns/lua-auth.hh
+++ b/pdns/lua-auth.hh
@@ -32,7 +32,6 @@ class AuthLua : public PowerDNSLua
 public:
   explicit AuthLua(const std::string& fname);
   // ~AuthLua();
-  bool axfrfilter(const ComboAddress& remote, const DNSName& zone, const DNSResourceRecord& in, vector<DNSResourceRecord>& out);
   DNSPacket* prequery(DNSPacket *p);
   int police(DNSPacket *req, DNSPacket *resp, bool isTcp=false);
   string policycmd(const vector<string>&parts);

--- a/pdns/lua-auth4.hh
+++ b/pdns/lua-auth4.hh
@@ -5,6 +5,7 @@
 #include "dnsrecords.hh"
 #include "dnspacket.hh"
 #include <unordered_map>
+#include <boost/variant/variant.hpp>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -21,6 +22,7 @@ private:
 public:
   explicit AuthLua4(const std::string& fname);
   bool updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, DNSPacket *packet);
+  bool axfrfilter(const ComboAddress&, const DNSName&, const DNSResourceRecord&, std::vector<DNSResourceRecord>&);
 
   ~AuthLua4(); // this is so unique_ptr works with an incomplete type
 private:
@@ -35,6 +37,8 @@ private:
   };
 
   typedef std::function<bool(const UpdatePolicyQuery&)> luacall_update_policy_t;
+  typedef std::function<std::tuple<int, std::unordered_map<int, std::unordered_map<std::string,boost::variant<unsigned int,std::string> > > >(const ComboAddress&, const DNSName&, const DNSResourceRecord&)> luacall_axfr_filter_t;
 
   luacall_update_policy_t d_update_policy;
+  luacall_axfr_filter_t d_axfr_filter;
 };

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -81,7 +81,7 @@ struct ZoneStatus
 };
 
 
-void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, scoped_ptr<AuthLua>& pdl,
+void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, scoped_ptr<AuthLua4>& pdl,
                                  ZoneStatus& zs, vector<DNSRecord>* axfr)
 {
   UeberBackend B; // fresh UeberBackend
@@ -234,7 +234,7 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
    5) It updates the Empty Non Terminals
 */
 
-static vector<DNSResourceRecord> doAxfr(const ComboAddress& raddr, const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr,  scoped_ptr<AuthLua>& pdl, ZoneStatus& zs)
+static vector<DNSResourceRecord> doAxfr(const ComboAddress& raddr, const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr,  scoped_ptr<AuthLua4>& pdl, ZoneStatus& zs)
 {
   vector<DNSResourceRecord> rrs;
   AXFRRetriever retriever(raddr, domain, tt, (laddr.sin4.sin_family == 0) ? NULL : &laddr, ((size_t) ::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024);
@@ -325,11 +325,11 @@ void CommunicatorClass::suck(const DNSName &domain, const string &remote)
     }
 
 
-    scoped_ptr<AuthLua> pdl;
+    scoped_ptr<AuthLua4> pdl;
     vector<string> scripts;
     if(B.getDomainMetadata(domain, "LUA-AXFR-SCRIPT", scripts) && !scripts.empty()) {
       try {
-        pdl.reset(new AuthLua(scripts[0]));
+        pdl.reset(new AuthLua4(scripts[0]));
         L<<Logger::Info<<"Loaded Lua script '"<<scripts[0]<<"' to edit the incoming AXFR of '"<<domain<<"'"<<endl;
       }
       catch(std::exception& e) {


### PR DESCRIPTION
### Short description
Implements axfrfilter using the new luacontext system. It also changes slightly how the AXFR filter works, by allowing the hook to also prepend records instead of just replacing them.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)