### PR TITLE
rec: Only apply root-nx-trust if the received SOA is "."

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1229,14 +1229,13 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
       if(!wasVariable()) {
         NegCache::NegCacheEntry ne;
 
-        ne.d_name = rec.d_name;
         ne.d_ttd = d_now.tv_sec + rec.d_ttl;
         ne.d_name = qname;
         ne.d_qtype = QType(0); // this encodes 'whole record'
-        ne.d_auth = auth;
+        ne.d_auth = rec.d_name;
         harvestNXRecords(lwr.d_records, ne);
         t_sstorage->negcache.add(ne);
-        if(s_rootNXTrust && auth.isRoot()) { // We should check if it was forwarded here, see issue #5107
+        if(s_rootNXTrust && ne.d_auth.isRoot()) { // We should check if it was forwarded here, see issue #5107
           ne.d_name = ne.d_name.getLastLabel();
           t_sstorage->negcache.add(ne);
         }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1235,7 +1235,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
         ne.d_auth = rec.d_name;
         harvestNXRecords(lwr.d_records, ne);
         t_sstorage->negcache.add(ne);
-        if(s_rootNXTrust && ne.d_auth.isRoot()) { // We should check if it was forwarded here, see issue #5107
+        if(s_rootNXTrust && ne.d_auth.isRoot() && auth.isRoot()) {
           ne.d_name = ne.d_name.getLastLabel();
           t_sstorage->negcache.add(ne);
         }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If `root-nx-trust` is enabled and we got a NX answer from the root, check that the received SOA is for the root before negatively caching the entire TLD. This might happen if "." is forwarded, for example.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
