### PR TITLE
add some better dnsdist -v logging on queries that get dropped, timed out or received

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1226,7 +1226,9 @@ try
 #endif
           sendUDPResponse(cs->udpFD, response, responseLen, 0, dest, remote);
         }
+        vinfolog("Dropped query for %s|%s from %s, no policy applied", dq.qname->toString(), QType(dq.qtype).getName(), remote.toStringWithPort());
         continue;
+
       }
 
       ss->queries++;
@@ -1294,7 +1296,7 @@ try
 	g_stats.downstreamSendErrors++;
       }
 
-      vinfolog("Got query from %s, relayed to %s", remote.toStringWithPort(), ss->getName());
+      vinfolog("Got query for %s|%s from %s, relayed to %s", ids->qname.toString(), QType(ids->qtype).getName(), remote.toStringWithPort(), ss->getName());
     }
     catch(std::exception& e){
       vinfolog("Got an error in UDP question thread while parsing a query from %s, id %d: %s", remote.toStringWithPort(), queryId, e.what());
@@ -1533,6 +1535,9 @@ void* healthChecksThread()
           dss->reuseds++;
           --dss->outstanding;
           g_stats.downstreamTimeouts++; // this is an 'actively' discovered timeout
+          vinfolog("Had a downstream timeout from %s (%s) for query for %s|%s from %s",
+                   dss->remote.toStringWithPort(), dss->name,
+                   ids.qname.toString(), QType(ids.qtype).getName(), ids.origRemote.toStringWithPort());
 
           struct timespec ts;
           gettime(&ts);


### PR DESCRIPTION
### Short description
We support -v for verbose output. This logged some things that happened with packets, but not all of them.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
