### PR TITLE
Packages: Build with net-snmp support and against LuaJIT

### DIFF
--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -544,7 +544,7 @@ Requires(postun): systemd-units
 BuildRequires: systemd-units
 BuildRequires: systemd-devel
 BuildRequires: boost-devel
-BuildRequires: lua-devel
+BuildRequires: luajit-devel
 BuildRequires: libsodium-devel
 BuildRequires: bison
 BuildRequires: openssl-devel
@@ -687,7 +687,7 @@ export CPPFLAGS="-DLDAP_DEPRECATED"
 	--disable-dependency-tracking \
 	--disable-silent-rules \
 	--with-modules='' \
-	--with-lua \
+	--with-luajit \
 	--with-dynmodules='%{backends} random' \
 	--enable-tools \
 	--enable-libsodium \

--- a/build-scripts/build-dnsdist-rpm
+++ b/build-scripts/build-dnsdist-rpm
@@ -54,6 +54,10 @@ DNSCRYPT_CONFIGURE='--enable-dnscrypt \'
 RE2_BUILDREQUIRES='BuildRequires: re2-devel'
 RE2_CONFIGURE='--enable-re2 \'
 
+# CentOS 6 has no luajit
+LUA_BUILDREQUIRES='BuildRequires: luajit-devel'
+LUA_CONFIGURE='--with-luajit \'
+
 # These two are the same for sysv and systemd (we don't install defaults files at the moment)
 DEFAULTS_INSTALL=''
 DEFAULTS_FILES=''
@@ -95,6 +99,8 @@ if [ -f /etc/redhat-release ]; then
       SODIUM_BUILDREQUIRES=''
       SODIUM_CONFIGURE='--disable-libsodium \'
       DNSCRYPT_CONFIGURE='--disable-dnscrypt \'
+      LUA_BUILDREQUIRES='BuildRequires: lua-devel'
+      LUA_CONFIGURE=' \'
       SETUP="%setup -n %{name}-${TARBALLVERSION}"
       RPMBUILD_COMMAND="scl enable devtoolset-3 -- ${RPMBUILD_COMMAND}"
       ;;
@@ -119,9 +125,9 @@ Group: System/DNS
 Source: dnsdist-${TARBALLVERSION}.tar.bz2
 Requires(pre): ${SHADOW_REQUIRES}
 BuildRequires: boost-devel
-BuildRequires: lua-devel
 BuildRequires: readline-devel
 BuildRequires: net-snmp-devel
+${LUA_BUILDREQUIRES}
 ${PROTOBUF_BUILDREQUIRES}
 ${RE2_BUILDREQUIRES}
 ${SODIUM_BUILDREQUIRES}
@@ -137,6 +143,7 @@ ${SETUP}
 %configure \
   --sysconfdir=/etc/dnsdist \
   --with-net-snmp \
+  ${LUA_CONFIGURE}
   ${RE2_CONFIGURE}
   ${SODIUM_CONFIGURE}
   ${DNSCRYPT_CONFIGURE}

--- a/build-scripts/build-dnsdist-rpm
+++ b/build-scripts/build-dnsdist-rpm
@@ -121,6 +121,7 @@ Requires(pre): ${SHADOW_REQUIRES}
 BuildRequires: boost-devel
 BuildRequires: lua-devel
 BuildRequires: readline-devel
+BuildRequires: net-snmp-devel
 ${PROTOBUF_BUILDREQUIRES}
 ${RE2_BUILDREQUIRES}
 ${SODIUM_BUILDREQUIRES}
@@ -135,7 +136,7 @@ ${SETUP}
 %build
 %configure \
   --sysconfdir=/etc/dnsdist \
-  --without-net-snmp \
+  --with-net-snmp \
   ${RE2_CONFIGURE}
   ${SODIUM_CONFIGURE}
   ${DNSCRYPT_CONFIGURE}

--- a/build-scripts/build-dnsdist-rpm
+++ b/build-scripts/build-dnsdist-rpm
@@ -54,6 +54,10 @@ DNSCRYPT_CONFIGURE='--enable-dnscrypt \'
 RE2_BUILDREQUIRES='BuildRequires: re2-devel'
 RE2_CONFIGURE='--enable-re2 \'
 
+# nor snmp-devel
+SNMP_BUILDREQUIRES='BuildRequires: net-snmp-devel'
+SNMP_CONFIGURE='--with-net-snmp \'
+
 # CentOS 6 has no luajit
 LUA_BUILDREQUIRES='BuildRequires: luajit-devel'
 LUA_CONFIGURE='--with-luajit \'
@@ -82,6 +86,10 @@ if [ -f /etc/os-release ]; then
       PROTOBUF_BUILDREQUIRES=''
       PROTOBUF_CONFIGURE='--without-protobuf \'
       SHADOW_REQUIRES='shadow'
+      LUA_BUILDREQUIRES='BuildRequires: lua-devel'
+      LUA_CONFIGURE=' \'
+      SNMP_BUILDREQUIRES=''
+      SNMP_CONFIGURE='--without-net-snmp \'
       ;;
   esac
 fi
@@ -126,7 +134,7 @@ Source: dnsdist-${TARBALLVERSION}.tar.bz2
 Requires(pre): ${SHADOW_REQUIRES}
 BuildRequires: boost-devel
 BuildRequires: readline-devel
-BuildRequires: net-snmp-devel
+${SNMP_BUILDREQUIRES}
 ${LUA_BUILDREQUIRES}
 ${PROTOBUF_BUILDREQUIRES}
 ${RE2_BUILDREQUIRES}
@@ -142,7 +150,7 @@ ${SETUP}
 %build
 %configure \
   --sysconfdir=/etc/dnsdist \
-  --with-net-snmp \
+  ${SNMP_CONFIGURE}
   ${LUA_CONFIGURE}
   ${RE2_CONFIGURE}
   ${SODIUM_CONFIGURE}

--- a/build-scripts/build-recursor-rpm
+++ b/build-scripts/build-recursor-rpm
@@ -125,6 +125,7 @@ BuildRequires: lua-devel
 BuildRequires: libsodium-devel
 #BuildRequires: protobuf-devel
 #BuildRequires: protobuf-compiler
+BuildRequires: net-snmp-devel
 
 Requires(pre): shadow-utils
 Requires(post): /sbin/chkconfig
@@ -148,6 +149,7 @@ package if you need a dns cache for your network.
 	--with-protobuf \
 	--enable-unit-tests \
 	--enable-libsodium \
+	--with-net-snmp \
 	--with-boost=/usr/include/boost148 LIBRARY_PATH=/usr/lib64/boost148
 
 make %{?_smp_mflags} LIBRARY_PATH=/usr/lib64/boost148
@@ -217,6 +219,7 @@ BuildRequires: lua-devel
 BuildRequires: systemd-units
 BuildRequires: systemd-devel
 BuildRequires: libsodium-devel
+BuildRequires: net-snmp-devel
 BuildRequires: hostname
 BuildRequires: protobuf-devel
 BuildRequires: protobuf-compiler
@@ -244,6 +247,7 @@ package if you need a dns cache for your network.
 	--enable-unit-tests \
 	--with-protobuf \
 	--enable-libsodium \
+	--with-net-snmp \
 	--enable-systemd
 
 make %{?_smp_mflags}

--- a/build-scripts/build-recursor-rpm
+++ b/build-scripts/build-recursor-rpm
@@ -215,7 +215,7 @@ Source0: ../%{name}-${TARBALLVERSION}.tar.bz2
 
 Provides: powerdns-recursor = %{version}-%{release}
 BuildRequires: boost-devel
-BuildRequires: lua-devel
+BuildRequires: luajit-devel
 BuildRequires: systemd-units
 BuildRequires: systemd-devel
 BuildRequires: libsodium-devel
@@ -248,6 +248,7 @@ package if you need a dns cache for your network.
 	--with-protobuf \
 	--enable-libsodium \
 	--with-net-snmp \
+	--with-luajit \
 	--enable-systemd
 
 make %{?_smp_mflags}

--- a/build-scripts/build-recursor-rpm
+++ b/build-scripts/build-recursor-rpm
@@ -123,9 +123,9 @@ Provides: powerdns-recursor = %{version}-%{release}
 BuildRequires: boost148-devel
 BuildRequires: lua-devel
 BuildRequires: libsodium-devel
-#BuildRequires: protobuf-devel
-#BuildRequires: protobuf-compiler
 BuildRequires: net-snmp-devel
+BuildRequires: protobuf-devel
+BuildRequires: protobuf-compiler
 
 Requires(pre): shadow-utils
 Requires(post): /sbin/chkconfig

--- a/build-scripts/debian-authoritative/control.in
+++ b/build-scripts/debian-authoritative/control.in
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.8
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, po-debconf, libtool, flex, bison, libmysqlclient-dev, libpq-dev, libssl-dev, libgdbm-dev, libldap2-dev, libsqlite3-dev, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libboost-program-options-dev, libboost-test-dev, autotools-dev, automake, autoconf, liblua5.2-dev, pkg-config, ragel, libgmp-dev, libbotan1.10-dev, libcurl4-openssl-dev, libzmq-dev, libyaml-cpp-dev (>= 0.5), libgeoip-dev, libopendbx1-dev, libcdb-dev, unixodbc-dev (>= 2.3.1), libprotobuf-dev, protobuf-compiler @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
+Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, po-debconf, libtool, flex, bison, libmysqlclient-dev, libpq-dev, libssl-dev, libgdbm-dev, libldap2-dev, libsqlite3-dev, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libboost-program-options-dev, libboost-test-dev, autotools-dev, automake, autoconf, libluajit5.1-dev, pkg-config, ragel, libgmp-dev, libbotan1.10-dev, libcurl4-openssl-dev, libzmq-dev, libyaml-cpp-dev (>= 0.5), libgeoip-dev, libopendbx1-dev, libcdb-dev, unixodbc-dev (>= 2.3.1), libprotobuf-dev, protobuf-compiler @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
 Homepage: http://www.powerdns.com/
 
 Package: pdns-server

--- a/build-scripts/debian-authoritative/rules
+++ b/build-scripts/debian-authoritative/rules
@@ -53,6 +53,7 @@ override_dh_auto_configure:
 		--enable-botan1.10 \
 		--enable-tools \
 		--enable-unit-tests \
+		--with-luajit \
 		$(ENABLE_SYSTEMD) \
 		$(ENABLE_LIBSODIUM)
 

--- a/build-scripts/debian-dnsdist/control.in
+++ b/build-scripts/debian-dnsdist/control.in
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9), dh-autoreconf, dh-systemd (>= 1.5), libboost-dev, libedit-dev, liblua5.2-dev, protobuf-compiler, libprotobuf-dev, lib-snmp-dev, pkg-config @LIBRE2DEV@ @LIBSODIUMDEV@ @LIBSYSTEMDDEV@
+Build-Depends: debhelper (>= 9), dh-autoreconf, dh-systemd (>= 1.5), libboost-dev, libedit-dev, libluajit5.1-dev, protobuf-compiler, libprotobuf-dev, lib-snmp-dev, pkg-config @LIBRE2DEV@ @LIBSODIUMDEV@ @LIBSYSTEMDDEV@
 Standards-Version: 3.9.7
 Homepage: http://dnsdist.org
 

--- a/build-scripts/debian-dnsdist/control.in
+++ b/build-scripts/debian-dnsdist/control.in
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9), dh-autoreconf, dh-systemd (>= 1.5), libboost-dev, libedit-dev, liblua5.2-dev, protobuf-compiler, libprotobuf-dev, pkg-config @LIBRE2DEV@ @LIBSODIUMDEV@ @LIBSYSTEMDDEV@
+Build-Depends: debhelper (>= 9), dh-autoreconf, dh-systemd (>= 1.5), libboost-dev, libedit-dev, liblua5.2-dev, protobuf-compiler, libprotobuf-dev, lib-snmp-dev, pkg-config @LIBRE2DEV@ @LIBSODIUMDEV@ @LIBSYSTEMDDEV@
 Standards-Version: 3.9.7
 Homepage: http://dnsdist.org
 

--- a/build-scripts/debian-dnsdist/rules
+++ b/build-scripts/debian-dnsdist/rules
@@ -54,6 +54,7 @@ override_dh_auto_configure:
 	  --libexecdir='$${prefix}/lib' \
 	  --with-protobuf=yes \
 	  --with-net-snmp \
+	  --with-luajit \
 	  $(ENABLE_SYSTEMD) \
 	  $(ENABLE_RE2) \
 	  $(ENABLE_LIBSODIUM)

--- a/build-scripts/debian-dnsdist/rules
+++ b/build-scripts/debian-dnsdist/rules
@@ -53,6 +53,7 @@ override_dh_auto_configure:
 	  --libdir='$${prefix}/lib/$(DEB_HOST_MULTIARCH)' \
 	  --libexecdir='$${prefix}/lib' \
 	  --with-protobuf=yes \
+	  --with-net-snmp \
 	  $(ENABLE_SYSTEMD) \
 	  $(ENABLE_RE2) \
 	  $(ENABLE_LIBSODIUM)

--- a/build-scripts/debian-recursor/control.in
+++ b/build-scripts/debian-recursor/control.in
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.6
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-systemd, quilt, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, liblua5.2-dev, libsnmp-dev, libprotobuf-dev, protobuf-compiler, pkg-config @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
+Build-Depends: debhelper (>= 9~), dh-systemd, quilt, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libluajit5.1-dev, libsnmp-dev, libprotobuf-dev, protobuf-compiler, pkg-config @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
 Homepage: http://www.powerdns.com/
 
 Package: pdns-recursor

--- a/build-scripts/debian-recursor/control.in
+++ b/build-scripts/debian-recursor/control.in
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.6
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-systemd, quilt, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, liblua5.2-dev, libprotobuf-dev, protobuf-compiler, pkg-config @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
+Build-Depends: debhelper (>= 9~), dh-systemd, quilt, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, liblua5.2-dev, libsnmp-dev, libprotobuf-dev, protobuf-compiler, pkg-config @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
 Homepage: http://www.powerdns.com/
 
 Package: pdns-recursor

--- a/build-scripts/debian-recursor/rules
+++ b/build-scripts/debian-recursor/rules
@@ -49,7 +49,7 @@ override_dh_auto_configure:
 		--infodir=\$${prefix}/share/info \
 		--libdir='$${prefix}/lib/$(DEB_HOST_MULTIARCH)' \
 		--libexecdir='$${prefix}/lib' \
-		--with-lua \
+		--with-luajit \
 		--with-protobuf=yes \
 		--with-net-snmp \
 		$(ENABLE_SYSTEMD) \

--- a/build-scripts/debian-recursor/rules
+++ b/build-scripts/debian-recursor/rules
@@ -51,6 +51,7 @@ override_dh_auto_configure:
 		--libexecdir='$${prefix}/lib' \
 		--with-lua \
 		--with-protobuf=yes \
+		--with-net-snmp \
 		$(ENABLE_SYSTEMD) \
 		$(ENABLE_LIBSODIUM)
 

--- a/configure.ac
+++ b/configure.ac
@@ -205,7 +205,7 @@ for a in $modules $dynmodules; do
       AS_IF([test "x$with_lua" = "xno"],
         AC_MSG_ERROR([Lua backend needs lua, run ./configure --with-lua])
       )
-      AS_IF([test "x$LUAPC" = "x"],
+      AS_IF([test "x$LUAPC" = "x" -a "x$LUAJITPC" = "x"],
         AC_MSG_ERROR([Lua backend needs lua but we cannot find it])
       )
       ;;


### PR DESCRIPTION
### Short description
Our packages are linked against whatever Lua was available. After this PR, LuaJIT is used if it is available. This PR also adds net-snmp support to the recursor and dnsdist packages.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)