### PR TITLE
get-remote-ring's "other" report should only have two items.

### DIFF
--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -525,7 +525,7 @@ void RecursorWebServer::jsonstat(HttpRequest* req, HttpResponse *resp)
     }
     if(queries.size() != totIncluded) {
       entries.push_back(Json::array {
-        (int)(queries.size() - totIncluded), "", ""
+        (int)(queries.size() - totIncluded), ""
       });
     }
 


### PR DESCRIPTION
### Short description
Requesting a remote ring via the `/jsonstat` endpoint returns tuples of two items: `(count, IP address)`, except the last value which has three items: `(count, "", "")`. I believe this is a copy and paste error from [`get-query-ring` section of this file](https://github.com/PowerDNS/pdns/blob/39cab2dc96abfd03db937a19e687b7a97521f6a7/pdns/ws-recursor.cc#L475-L489). (Compare to the [`get-remote-ring` section](https://github.com/PowerDNS/pdns/blob/39cab2dc96abfd03db937a19e687b7a97521f6a7/pdns/ws-recursor.cc#L516-L530).)

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
