### PR TITLE
notify slaves after dnsupdate was processed

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -11,6 +11,7 @@
 #include "base32.hh"
 
 #include "misc.hh"
+#include "communicator.hh"
 #include "arguments.hh"
 #include "resolver.hh"
 #include "dns_random.hh"
@@ -707,6 +708,7 @@ int PacketHandler::forwardPacket(const string &msgPrefix, DNSPacket *p, DomainIn
 }
 
 int PacketHandler::processUpdate(DNSPacket *p) {
+  extern CommunicatorClass Communicator;
   if (! ::arg().mustDo("dnsupdate"))
     return RCode::Refused;
 
@@ -969,6 +971,8 @@ int PacketHandler::processUpdate(DNSPacket *p) {
       purgeAuthCaches(zone);
 
       L<<Logger::Info<<msgPrefix<<"Update completed, "<<changedRecords<<" changed records committed."<<endl;
+      if(::arg().mustDo("master") || ::arg().mustDo("slave-renotify"))
+        Communicator.notifyDomain(di.zone);
     } else {
       //No change, no commit, we perform abort() because some backends might like this more.
       L<<Logger::Info<<msgPrefix<<"Update completed, 0 changes, rolling back."<<endl;


### PR DESCRIPTION
### Short description
After successfully processing a UPDATE message we are not notifying our slaves.

In case of records got changed by the UPDATE send out notifies. Do not send notifies if nothing changed.

This works for me[tm] but I'm not sure if it's correct as I'm not too familiar with the code.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
