### PR TITLE
rec: Add support for RPZ wildcarded target names

### DIFF
--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -244,3 +244,31 @@ bool DNSFilterEngine::rmNSIPTrigger(const Netmask& nm, Policy pol, size_t zone)
   pols.erase(nm);
   return true;
 }
+
+DNSRecord DNSFilterEngine::Policy::getCustomRecord(const DNSName& qname) const
+{
+  if (d_kind != PolicyKind::Custom) {
+    throw std::runtime_error("Asking for a custom record from a filtering policy of a non-custom type");
+  }
+
+  DNSRecord result;
+  result.d_name = qname;
+  result.d_type = d_custom->getType();
+  result.d_ttl = d_ttl;
+  result.d_class = QClass::IN;
+  result.d_place = DNSResourceRecord::ANSWER;
+  result.d_content = d_custom;
+
+  if (result.d_type == QType::CNAME) {
+    const auto content = std::dynamic_pointer_cast<CNAMERecordContent>(d_custom);
+    if (content) {
+      DNSName target = content->getTarget();
+      if (target.isWildcard()) {
+        target.chopOff();
+        result.d_content = std::make_shared<CNAMERecordContent>(qname + target);
+      }
+    }
+  }
+
+  return result;
+}

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -74,6 +74,7 @@ public:
     {
       return d_kind == rhs.d_kind; // XXX check d_custom too!
     }
+    DNSRecord getCustomRecord(const DNSName& qname) const;
     PolicyKind d_kind;
     std::shared_ptr<DNSRecordContent> d_custom;
     std::shared_ptr<std::string> d_name;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -862,12 +862,7 @@ static void startDoResolve(void *p)
           case DNSFilterEngine::PolicyKind::Custom:
             g_stats.policyResults[appliedPolicy.d_kind]++;
             res=RCode::NoError;
-            spoofed.d_name=dc->d_mdp.d_qname;
-            spoofed.d_type=appliedPolicy.d_custom->getType();
-            spoofed.d_ttl = appliedPolicy.d_ttl;
-            spoofed.d_class = 1;
-            spoofed.d_content = appliedPolicy.d_custom;
-            spoofed.d_place = DNSResourceRecord::ANSWER;
+            spoofed=appliedPolicy.getCustomRecord(dc->d_mdp.d_qname);
             ret.push_back(spoofed);
             handleRPZCustom(spoofed, QType(dc->d_mdp.d_qtype), sr, res, ret);
             goto haveAnswer;
@@ -927,12 +922,7 @@ static void startDoResolve(void *p)
           case DNSFilterEngine::PolicyKind::Custom:
             ret.clear();
             res=RCode::NoError;
-            spoofed.d_name=dc->d_mdp.d_qname;
-            spoofed.d_type=appliedPolicy.d_custom->getType();
-            spoofed.d_ttl = appliedPolicy.d_ttl;
-            spoofed.d_class = 1;
-            spoofed.d_content = appliedPolicy.d_custom;
-            spoofed.d_place = DNSResourceRecord::ANSWER;
+            spoofed=appliedPolicy.getCustomRecord(dc->d_mdp.d_qname);
             ret.push_back(spoofed);
             handleRPZCustom(spoofed, QType(dc->d_mdp.d_qtype), sr, res, ret);
             goto haveAnswer;
@@ -992,12 +982,7 @@ static void startDoResolve(void *p)
           case DNSFilterEngine::PolicyKind::Custom:
             ret.clear();
             res=RCode::NoError;
-            spoofed.d_name=dc->d_mdp.d_qname;
-            spoofed.d_type=appliedPolicy.d_custom->getType();
-            spoofed.d_ttl = appliedPolicy.d_ttl;
-            spoofed.d_class = 1;
-            spoofed.d_content = appliedPolicy.d_custom;
-            spoofed.d_place = DNSResourceRecord::ANSWER;
+            spoofed=appliedPolicy.getCustomRecord(dc->d_mdp.d_qname);
             ret.push_back(spoofed);
             handleRPZCustom(spoofed, QType(dc->d_mdp.d_qtype), sr, res, ret);
             goto haveAnswer;

--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -32,3 +32,5 @@ echo "==> unsupported2.example.net has an unsupported target, should be ignored 
 $SDIG $nameserver 5301 unsupported2.example.net a recurse 2>&1
 echo "==> not-rpz.example.net is _not_ an RPZ target and should be processed"
 $SDIG $nameserver 5301 not-rpz.example.net a recurse 2>&1
+echo "==> echo-me.wildcard-target.example.net is an RPZ wildcard target"
+$SDIG $nameserver 5301 echo-me.wildcard-target.example.net a recurse 2>&1

--- a/regression-tests.recursor/RPZ/expected_result
+++ b/regression-tests.recursor/RPZ/expected_result
@@ -64,3 +64,7 @@ Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 Reply to question for qname='not-rpz.example.net.', qtype=A
 Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
 0	not-rpz.example.net.	IN	CNAME	5	rpz-not.com.
+==> echo-me.wildcard-target.example.net is an RPZ wildcard target
+Reply to question for qname='echo-me.wildcard-target.example.net.', qtype=A
+Rcode: 3 (Non-Existent domain), RD: 1, QR: 1, TC: 0, AA: 0, opcode: 0
+0	echo-me.wildcard-target.example.net.	IN	CNAME	7200	echo-me.wildcard-target.example.net.walled-garden.example.net.

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -578,6 +578,7 @@ www.example.net        CNAME www2.example.net.   ; Local-Data Action
 www3.example.net       CNAME www4.example.net.   ; Local-Data Action (to be changed in preresolve)
 www5.example.net       A     192.0.2.15          ; Override www5.example.net.
 trillian.example.net   CNAME .                   ; NXDOMAIN on apex, allows all sub-names (#4086)
+*.wildcard-target.example.net          CNAME         *.walled-garden.example.net.         ; Special form of Local Data: a CNAME RR with a wildcarded target name
 
 32.4.2.0.192.rpz-ip    CNAME rpz-drop.           ; www4.example.net resolves to 192.0.2.4, drop A responses with that IP
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Add support for wildcarded target names, as described in section 3.6 "The "Local Data" Action (arbitrary RR types)" of `draft-ietf-dnsop-dns-rpz-00`:

> A special form of Local Data involves a CNAME RR with a wildcarded
> target name. Wildcards are not valid as CNAME targets in ordinary
> DNS zones. However, a wildcard in an RPZ Local Data CNAME target
> causes the matching QNAME to be prepended to the target in the
> rewritten response, which communicates this QNAME value to the walled
> garden DNS server for that DNS server's logs.
> For example a policy Local Data action of "CNAME *.EXAMPLE.COM"
> applied to a QNAME of "EVIL.EXAMPLE.ORG." will result in a synthetic
> response that starts with the RR
> "EVIL.EXAMPLE.ORG CNAME EVIL.EXAMPLE.ORG.EXAMPLE.COM". Resolving the
> CNAME target "EVIL.EXAMPLE.ORG.EXAMPLE.COM" into an RRset of the
> originally requested type generally requires sending a request for
> that type and a QNAME of "EVIL.EXAMPLE.ORG.EXAMPLE.COM" to a DNS
> server for the walled garden, "EXAMPLE.COM". As usual when a CNAME
> is encountered while computing a response, the response from the
> walled garden DNS server concerning "EVIL.EXAMPLE.ORG.EXAMPLE.COM"
> determines the rest of the final rewritten response.

Closes #5237.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)