### PR TITLE
rec: RPZ updates are done zone by zone, zones are now shared pointers

### DIFF
--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -61,11 +61,12 @@ DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const DNSName& qnam
   //  cout<<"Got question for nameserver name "<<qname<<endl;
   Policy pol;
   for(const auto& z : d_zones) {
-    if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
+    const auto zoneName = z->getName();
+    if(zoneName && discardedPolicies.find(*zoneName) != discardedPolicies.end()) {
       continue;
     }
 
-    if(findNamedPolicy(z.propolName, qname, pol)) {
+    if(findNamedPolicy(z->d_propolName, qname, pol)) {
       //      cerr<<"Had a hit on the nameserver ("<<qname<<") used to process the query"<<endl;
       return pol;
     }
@@ -77,11 +78,12 @@ DNSFilterEngine::Policy DNSFilterEngine::getProcessingPolicy(const ComboAddress&
 {
   //  cout<<"Got question for nameserver IP "<<address.toString()<<endl;
   for(const auto& z : d_zones) {
-    if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
+    const auto zoneName = z->getName();
+    if(zoneName && discardedPolicies.find(*zoneName) != discardedPolicies.end()) {
       continue;
     }
 
-    if(auto fnd=z.propolNSAddr.lookup(address)) {
+    if(auto fnd=z->d_propolNSAddr.lookup(address)) {
       //      cerr<<"Had a hit on the nameserver ("<<address.toString()<<") used to process the query"<<endl;
       return fnd->second;;
     }
@@ -94,16 +96,17 @@ DNSFilterEngine::Policy DNSFilterEngine::getQueryPolicy(const DNSName& qname, co
   //  cout<<"Got question for "<<qname<<" from "<<ca.toString()<<endl;
   Policy pol;
   for(const auto& z : d_zones) {
-    if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
+    const auto zoneName = z->getName();
+    if(zoneName && discardedPolicies.find(*zoneName) != discardedPolicies.end()) {
       continue;
     }
 
-    if(findNamedPolicy(z.qpolName, qname, pol)) {
+    if(findNamedPolicy(z->d_qpolName, qname, pol)) {
       //      cerr<<"Had a hit on the name of the query"<<endl;
       return pol;
     }
     
-    if(auto fnd=z.qpolAddr.lookup(ca)) {
+    if(auto fnd=z->d_qpolAddr.lookup(ca)) {
       //	cerr<<"Had a hit on the IP address ("<<ca.toString()<<") of the client"<<endl;
       return fnd->second;
     }
@@ -132,11 +135,12 @@ DNSFilterEngine::Policy DNSFilterEngine::getPostPolicy(const vector<DNSRecord>& 
       continue;
 
     for(const auto& z : d_zones) {
-      if(z.name && discardedPolicies.find(*z.name) != discardedPolicies.end()) {
+      const auto zoneName = z->getName();
+      if(zoneName && discardedPolicies.find(*zoneName) != discardedPolicies.end()) {
         continue;
       }
 
-      if(auto fnd=z.postpolAddr.lookup(ca))
+      if(auto fnd=z->d_postpolAddr.lookup(ca))
 	return fnd->second;
     }
   }
@@ -149,98 +153,62 @@ void DNSFilterEngine::assureZones(size_t zone)
     d_zones.resize(zone+1);
 }
 
-void DNSFilterEngine::clear(size_t zone)
+void DNSFilterEngine::Zone::addClientTrigger(const Netmask& nm, Policy pol)
 {
-  assureZones(zone);
-  auto& z = d_zones[zone];
-  z.qpolAddr.clear();
-  z.postpolAddr.clear();
-  z.propolName.clear();
-  z.propolNSAddr.clear();
-  z.qpolName.clear();
+  pol.d_name = d_name;
+  d_qpolAddr.insert(nm).second=pol;
 }
 
-void DNSFilterEngine::clear()
+void DNSFilterEngine::Zone::addResponseTrigger(const Netmask& nm, Policy pol)
 {
-  for(auto& z : d_zones) {
-    z.qpolAddr.clear();
-    z.postpolAddr.clear();
-    z.propolName.clear();
-    z.propolNSAddr.clear();
-    z.qpolName.clear();
-  }
+  pol.d_name = d_name;
+  d_postpolAddr.insert(nm).second=pol;
 }
 
-void DNSFilterEngine::addClientTrigger(const Netmask& nm, Policy pol, size_t zone)
+void DNSFilterEngine::Zone::addQNameTrigger(const DNSName& n, Policy pol)
 {
-  assureZones(zone);
-  pol.d_name = d_zones[zone].name;
-  d_zones[zone].qpolAddr.insert(nm).second=pol;
+  pol.d_name = d_name;
+  d_qpolName[n]=pol;
 }
 
-void DNSFilterEngine::addResponseTrigger(const Netmask& nm, Policy pol, size_t zone)
+void DNSFilterEngine::Zone::addNSTrigger(const DNSName& n, Policy pol)
 {
-  assureZones(zone);
-  pol.d_name = d_zones[zone].name;
-  d_zones[zone].postpolAddr.insert(nm).second=pol;
+  pol.d_name = d_name;
+  d_propolName[n]=pol;
 }
 
-void DNSFilterEngine::addQNameTrigger(const DNSName& n, Policy pol, size_t zone)
+void DNSFilterEngine::Zone::addNSIPTrigger(const Netmask& nm, Policy pol)
 {
-  assureZones(zone);
-  pol.d_name = d_zones[zone].name;
-  d_zones[zone].qpolName[n]=pol;
+  pol.d_name = d_name;
+  d_propolNSAddr.insert(nm).second = pol;
 }
 
-void DNSFilterEngine::addNSTrigger(const DNSName& n, Policy pol, size_t zone)
+bool DNSFilterEngine::Zone::rmClientTrigger(const Netmask& nm, Policy pol)
 {
-  assureZones(zone);
-  pol.d_name = d_zones[zone].name;
-  d_zones[zone].propolName[n]=pol;
-}
-
-void DNSFilterEngine::addNSIPTrigger(const Netmask& nm, Policy pol, size_t zone)
-{
-  assureZones(zone);
-  pol.d_name = d_zones[zone].name;
-  d_zones[zone].propolNSAddr.insert(nm).second = pol;
-}
-
-bool DNSFilterEngine::rmClientTrigger(const Netmask& nm, Policy pol, size_t zone)
-{
-  assureZones(zone);
-
-  auto& qpols = d_zones[zone].qpolAddr;
-  qpols.erase(nm);
+  d_qpolAddr.erase(nm);
   return true;
 }
 
-bool DNSFilterEngine::rmResponseTrigger(const Netmask& nm, Policy pol, size_t zone)
+bool DNSFilterEngine::Zone::rmResponseTrigger(const Netmask& nm, Policy pol)
 {
-  assureZones(zone);
-  auto& postpols = d_zones[zone].postpolAddr;
-  postpols.erase(nm);  
+  d_postpolAddr.erase(nm);
   return true;
 }
 
-bool DNSFilterEngine::rmQNameTrigger(const DNSName& n, Policy pol, size_t zone)
+bool DNSFilterEngine::Zone::rmQNameTrigger(const DNSName& n, Policy pol)
 {
-  assureZones(zone);
-  d_zones[zone].qpolName.erase(n); // XXX verify we had identical policy?
+  d_qpolName.erase(n); // XXX verify we had identical policy?
   return true;
 }
 
-bool DNSFilterEngine::rmNSTrigger(const DNSName& n, Policy pol, size_t zone)
+bool DNSFilterEngine::Zone::rmNSTrigger(const DNSName& n, Policy pol)
 {
-  assureZones(zone);
-  d_zones[zone].propolName.erase(n); // XXX verify policy matched? =pol;
+  d_propolName.erase(n); // XXX verify policy matched? =pol;
   return true;
 }
 
-bool DNSFilterEngine::rmNSIPTrigger(const Netmask& nm, Policy pol, size_t zone)
+bool DNSFilterEngine::Zone::rmNSIPTrigger(const Netmask& nm, Policy pol)
 {
-  assureZones(zone);
-  auto& pols = d_zones[zone].propolNSAddr;
-  pols.erase(nm);
+  d_propolNSAddr.erase(nm);
   return true;
 }

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -80,48 +80,85 @@ public:
     int32_t d_ttl;
   };
 
+  class Zone {
+  public:
+    void clear()
+    {
+      d_qpolAddr.clear();
+      d_postpolAddr.clear();
+      d_propolName.clear();
+      d_qpolName.clear();
+    }
+    void reserve(size_t entriesCount)
+    {
+      d_qpolName.reserve(entriesCount);
+    }
+    void setName(const std::string& name)
+    {
+      d_name = std::make_shared<std::string>(name);
+    }
+    const std::shared_ptr<std::string> getName() const
+    {
+      return d_name;
+    }
+
+    void addClientTrigger(const Netmask& nm, Policy pol);
+    void addQNameTrigger(const DNSName& nm, Policy pol);
+    void addNSTrigger(const DNSName& dn, Policy pol);
+    void addNSIPTrigger(const Netmask& nm, Policy pol);
+    void addResponseTrigger(const Netmask& nm, Policy pol);
+
+    bool rmClientTrigger(const Netmask& nm, Policy pol);
+    bool rmQNameTrigger(const DNSName& nm, Policy pol);
+    bool rmNSTrigger(const DNSName& dn, Policy pol);
+    bool rmNSIPTrigger(const Netmask& nm, Policy pol);
+    bool rmResponseTrigger(const Netmask& nm, Policy pol);
+
+    std::unordered_map<DNSName, Policy> d_qpolName;   // QNAME trigger (RPZ)
+    NetmaskTree<Policy> d_qpolAddr;         // Source address
+    std::unordered_map<DNSName, Policy> d_propolName; // NSDNAME (RPZ)
+    NetmaskTree<Policy> d_propolNSAddr;     // NSIP (RPZ)
+    NetmaskTree<Policy> d_postpolAddr;      // IP trigger (RPZ)
+    std::shared_ptr<std::string> d_name;
+  };
+
   DNSFilterEngine();
-  void clear();
-  void clear(size_t zone);
-  void reserve(size_t zone, size_t entriesCount) {
-    assureZones(zone);
-    d_zones[zone].qpolName.reserve(entriesCount);
+  void clear()
+  {
+    for(auto& z : d_zones) {
+      z->clear();
+    }
   }
-  void addClientTrigger(const Netmask& nm, Policy pol, size_t zone);
-  void addQNameTrigger(const DNSName& nm, Policy pol, size_t zone);
-  void addNSTrigger(const DNSName& dn, Policy pol, size_t zone);
-  void addNSIPTrigger(const Netmask& nm, Policy pol, size_t zone);
-  void addResponseTrigger(const Netmask& nm, Policy pol, size_t zone);
-
-  bool rmClientTrigger(const Netmask& nm, Policy pol, size_t zone);
-  bool rmQNameTrigger(const DNSName& nm, Policy pol, size_t zone);
-  bool rmNSTrigger(const DNSName& dn, Policy pol, size_t zone);
-  bool rmNSIPTrigger(const Netmask& nm, Policy pol, size_t zone);
-  bool rmResponseTrigger(const Netmask& nm, Policy pol, size_t zone);
-
+  const std::shared_ptr<Zone> getZone(size_t zoneIdx) const
+  {
+    std::shared_ptr<Zone> result{nullptr};
+    if (zoneIdx < d_zones.size()) {
+      result = d_zones[zoneIdx];
+    }
+    return result;
+  }
+  size_t addZone(std::shared_ptr<Zone> newZone)
+  {
+    d_zones.push_back(newZone);
+    return (d_zones.size() - 1);
+  }
+  void setZone(size_t zoneIdx, std::shared_ptr<Zone> newZone)
+  {
+    if (newZone) {
+      assureZones(zoneIdx);
+      d_zones[zoneIdx] = newZone;
+    }
+  }
 
   Policy getQueryPolicy(const DNSName& qname, const ComboAddress& nm, const std::unordered_map<std::string,bool>& discardedPolicies) const;
   Policy getProcessingPolicy(const DNSName& qname, const std::unordered_map<std::string,bool>& discardedPolicies) const;
   Policy getProcessingPolicy(const ComboAddress& address, const std::unordered_map<std::string,bool>& discardedPolicies) const;
   Policy getPostPolicy(const vector<DNSRecord>& records, const std::unordered_map<std::string,bool>& discardedPolicies) const;
 
-  size_t size() {
+  size_t size() const {
     return d_zones.size();
-  }
-  void setPolicyName(size_t zoneIdx, std::string name)
-  {
-    assureZones(zoneIdx);
-    d_zones[zoneIdx].name = std::make_shared<std::string>(name);
   }
 private:
   void assureZones(size_t zone);
-  struct Zone {
-    std::unordered_map<DNSName, Policy> qpolName;   // QNAME trigger (RPZ)
-    NetmaskTree<Policy> qpolAddr;         // Source address
-    std::unordered_map<DNSName, Policy> propolName; // NSDNAME (RPZ)
-    NetmaskTree<Policy> propolNSAddr;     // NSIP (RPZ)
-    NetmaskTree<Policy> postpolAddr;      // IP trigger (RPZ)
-    std::shared_ptr<std::string> name;
-  };
-  vector<Zone> d_zones;
+  vector<std::shared_ptr<Zone>> d_zones;
 };

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -2081,9 +2081,11 @@ BOOST_AUTO_TEST_CASE(test_nameserver_ipv4_rpz) {
 
   DNSFilterEngine::Policy pol;
   pol.d_kind = DNSFilterEngine::PolicyKind::Drop;
+  std::shared_ptr<DNSFilterEngine::Zone> zone = std::make_shared<DNSFilterEngine::Zone>();
+  zone->setName("Unit test policy 0");
+  zone->addNSIPTrigger(Netmask(ns, 32), pol);
   auto luaconfsCopy = g_luaconfs.getCopy();
-  luaconfsCopy.dfe.setPolicyName(0, "Unit test policy 0");
-  luaconfsCopy.dfe.addNSIPTrigger(Netmask(ns, 32), pol, 0);
+  luaconfsCopy.dfe.addZone(zone);
   g_luaconfs.setState(luaconfsCopy);
 
   vector<DNSRecord> ret;
@@ -2121,9 +2123,11 @@ BOOST_AUTO_TEST_CASE(test_nameserver_ipv6_rpz) {
 
   DNSFilterEngine::Policy pol;
   pol.d_kind = DNSFilterEngine::PolicyKind::Drop;
+  std::shared_ptr<DNSFilterEngine::Zone> zone = std::make_shared<DNSFilterEngine::Zone>();
+  zone->setName("Unit test policy 0");
+  zone->addNSIPTrigger(Netmask(ns, 128), pol);
   auto luaconfsCopy = g_luaconfs.getCopy();
-  luaconfsCopy.dfe.setPolicyName(0, "Unit test policy 0");
-  luaconfsCopy.dfe.addNSIPTrigger(Netmask(ns, 128), pol, 0);
+  luaconfsCopy.dfe.addZone(zone);
   g_luaconfs.setState(luaconfsCopy);
 
   vector<DNSRecord> ret;
@@ -2162,9 +2166,11 @@ BOOST_AUTO_TEST_CASE(test_nameserver_name_rpz) {
 
   DNSFilterEngine::Policy pol;
   pol.d_kind = DNSFilterEngine::PolicyKind::Drop;
+  std::shared_ptr<DNSFilterEngine::Zone> zone = std::make_shared<DNSFilterEngine::Zone>();
+  zone->setName("Unit test policy 0");
+  zone->addNSTrigger(nsName, pol);
   auto luaconfsCopy = g_luaconfs.getCopy();
-  luaconfsCopy.dfe.setPolicyName(0, "Unit test policy 0");
-  luaconfsCopy.dfe.addNSTrigger(nsName, pol, 0);
+  luaconfsCopy.dfe.addZone(zone);
   g_luaconfs.setState(luaconfsCopy);
 
   vector<DNSRecord> ret;
@@ -2203,10 +2209,12 @@ BOOST_AUTO_TEST_CASE(test_nameserver_name_rpz_disabled) {
 
   DNSFilterEngine::Policy pol;
   pol.d_kind = DNSFilterEngine::PolicyKind::Drop;
+  std::shared_ptr<DNSFilterEngine::Zone> zone = std::make_shared<DNSFilterEngine::Zone>();
+  zone->setName("Unit test policy 0");
+  zone->addNSIPTrigger(Netmask(ns, 128), pol);
+  zone->addNSTrigger(nsName, pol);
   auto luaconfsCopy = g_luaconfs.getCopy();
-  luaconfsCopy.dfe.setPolicyName(0, "Unit test policy 0");
-  luaconfsCopy.dfe.addNSIPTrigger(Netmask(ns, 128), pol, 0);
-  luaconfsCopy.dfe.addNSTrigger(nsName, pol, 0);
+  luaconfsCopy.dfe.addZone(zone);
   g_luaconfs.setState(luaconfsCopy);
 
   /* RPZ is disabled for this query, we should not be blocked */

--- a/pdns/rpzloader.hh
+++ b/pdns/rpzloader.hh
@@ -24,7 +24,7 @@
 #include <string>
 #include "dnsrecords.hh"
 
-int loadRPZFromFile(const std::string& fname, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t place);
-std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zone, DNSFilterEngine& target, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t place, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress);
-void RPZRecordToPolicy(const DNSRecord& dr, DNSFilterEngine& target, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t place);
-void RPZIXFRTracker(const ComboAddress& master, const DNSName& zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t polZone, const TSIGTriplet &tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress);
+void loadRPZFromFile(const std::string& fname, std::shared_ptr<DNSFilterEngine::Zone> zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL);
+std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zoneName, std::shared_ptr<DNSFilterEngine::Zone> zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress);
+void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngine::Zone> zone, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL);
+void RPZIXFRTracker(const ComboAddress& master, const DNSName& zoneName, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t polZone, const TSIGTriplet &tt, shared_ptr<SOARecordContent> oursr, size_t maxReceivedBytes, const ComboAddress& localAddress);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This prevents having to copy and update all the zones even though the RPZ IXFR tracker only works on one of them at a time. Also prevents race conditions if two RPZ IXFR tracker threads update the state at the same time by using `GlobalStateHolder::modify()` instead of `GlobalStateHolder::setState()`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
