### PR TITLE
Always wrap DNSCryptoKeyEngine objects in a shared pointer

### DIFF
--- a/pdns/botan110signers.cc
+++ b/pdns/botan110signers.cc
@@ -45,23 +45,23 @@ public:
   explicit GOSTDNSCryptoKeyEngine(unsigned int algorithm) : DNSCryptoKeyEngine(algorithm) {}
   // XXX FIXME NEEDS COPY CONSTRUCTOR SO WE DON'T SHARE KEYS
   ~GOSTDNSCryptoKeyEngine(){}
-  void create(unsigned int bits);
-  string getName() const { return "Botan 1.10 GOST"; }
-  storvector_t convertToISCVector() const;
-  std::string getPubKeyHash() const;
-  std::string sign(const std::string& hash) const; 
-  std::string hash(const std::string& hash) const; 
-  bool verify(const std::string& hash, const std::string& signature) const;
-  std::string getPublicKeyString() const;
-  int getBits() const;
-  void fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& content);
-  void fromPublicKeyString(const std::string& content);
-  void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw)
+  void create(unsigned int bits) override;
+  string getName() const override { return "Botan 1.10 GOST"; }
+  storvector_t convertToISCVector() const override;
+  std::string getPubKeyHash() const override;
+  std::string sign(const std::string& hash) const override;
+  std::string hash(const std::string& hash) const override;
+  bool verify(const std::string& hash, const std::string& signature) const override;
+  std::string getPublicKeyString() const override;
+  int getBits() const override;
+  void fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& content) override;
+  void fromPublicKeyString(const std::string& content) override;
+  void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) override
   {}
 
-  static DNSCryptoKeyEngine* maker(unsigned int algorithm)
+  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return new GOSTDNSCryptoKeyEngine(algorithm);
+    return std::make_shared<GOSTDNSCryptoKeyEngine>(algorithm);
   }
 
 private:

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -49,7 +49,7 @@
 
 using namespace boost::assign;
 
-DNSCryptoKeyEngine* DNSCryptoKeyEngine::makeFromISCFile(DNSKEYRecordContent& drc, const char* fname)
+shared_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCFile(DNSKEYRecordContent& drc, const char* fname)
 {
   string sline, isc;
   FILE *fp=fopen(fname, "r");
@@ -61,15 +61,14 @@ DNSCryptoKeyEngine* DNSCryptoKeyEngine::makeFromISCFile(DNSKEYRecordContent& drc
     isc += sline;
   }
   fclose(fp);
-  DNSCryptoKeyEngine* dke = makeFromISCString(drc, isc);
+  shared_ptr<DNSCryptoKeyEngine> dke = makeFromISCString(drc, isc);
   if(!dke->checkKey()) {
-    delete dke;
     throw runtime_error("Invalid DNS Private Key in file '"+string(fname));
   }
   return dke;
 }
 
-DNSCryptoKeyEngine* DNSCryptoKeyEngine::makeFromISCString(DNSKEYRecordContent& drc, const std::string& content)
+shared_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCString(DNSKEYRecordContent& drc, const std::string& content)
 {
   bool pkcs11=false;
   int algorithm = 0;
@@ -104,7 +103,7 @@ DNSCryptoKeyEngine* DNSCryptoKeyEngine::makeFromISCString(DNSKEYRecordContent& d
     B64Decode(value, raw);
     stormap[toLower(key)]=raw;
   }
-  DNSCryptoKeyEngine* dpk;
+  shared_ptr<DNSCryptoKeyEngine> dpk;
 
   if (pkcs11) {
 #ifdef HAVE_P11KIT1
@@ -140,7 +139,7 @@ std::string DNSCryptoKeyEngine::convertToISC() const
   return ret.str();
 }
 
-DNSCryptoKeyEngine* DNSCryptoKeyEngine::make(unsigned int algo)
+shared_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::make(unsigned int algo)
 {
   makers_t& makers = getMakers();
   makers_t::const_iterator iter = makers.find(algo);
@@ -308,20 +307,20 @@ pair<unsigned int, unsigned int> DNSCryptoKeyEngine::testMakers(unsigned int alg
   return make_pair(udiffSign, udiffVerify);
 }
 
-DNSCryptoKeyEngine* DNSCryptoKeyEngine::makeFromPublicKeyString(unsigned int algorithm, const std::string& content)
+shared_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromPublicKeyString(unsigned int algorithm, const std::string& content)
 {
-  DNSCryptoKeyEngine* dpk=make(algorithm);
+  shared_ptr<DNSCryptoKeyEngine> dpk=make(algorithm);
   dpk->fromPublicKeyString(content);
   return dpk;
 }
 
 
-DNSCryptoKeyEngine* DNSCryptoKeyEngine::makeFromPEMString(DNSKEYRecordContent& drc, const std::string& raw)
+shared_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromPEMString(DNSKEYRecordContent& drc, const std::string& raw)
 {
   
   for(makers_t::value_type& val :  getMakers())
   {
-    DNSCryptoKeyEngine* ret=0;
+    shared_ptr<DNSCryptoKeyEngine> ret=nullptr;
     try {
       ret = val.second(val.first);
       ret->fromPEMString(drc, raw);
@@ -329,7 +328,6 @@ DNSCryptoKeyEngine* DNSCryptoKeyEngine::makeFromPEMString(DNSKEYRecordContent& d
     }
     catch(...)
     {
-      delete ret; // fine if 0
     }
   }
   return 0;
@@ -432,7 +430,7 @@ DSRecordContent makeDSFromDNSKey(const DNSName& qname, const DNSKEYRecordContent
 }
 
 
-DNSKEYRecordContent makeDNSKEYFromDNSCryptoKeyEngine(const DNSCryptoKeyEngine* pk, uint8_t algorithm, uint16_t flags)
+DNSKEYRecordContent makeDNSKEYFromDNSCryptoKeyEngine(const std::shared_ptr<DNSCryptoKeyEngine> pk, uint8_t algorithm, uint16_t flags)
 {
   DNSKEYRecordContent drc;
 

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -63,13 +63,13 @@ class DNSCryptoKeyEngine
     {
       return true;
     }
-    static DNSCryptoKeyEngine* makeFromISCFile(DNSKEYRecordContent& drc, const char* fname);
-    static DNSCryptoKeyEngine* makeFromISCString(DNSKEYRecordContent& drc, const std::string& content);
-    static DNSCryptoKeyEngine* makeFromPEMString(DNSKEYRecordContent& drc, const std::string& raw);
-    static DNSCryptoKeyEngine* makeFromPublicKeyString(unsigned int algorithm, const std::string& raw);
-    static DNSCryptoKeyEngine* make(unsigned int algorithm);
+    static shared_ptr<DNSCryptoKeyEngine> makeFromISCFile(DNSKEYRecordContent& drc, const char* fname);
+    static shared_ptr<DNSCryptoKeyEngine> makeFromISCString(DNSKEYRecordContent& drc, const std::string& content);
+    static shared_ptr<DNSCryptoKeyEngine> makeFromPEMString(DNSKEYRecordContent& drc, const std::string& raw);
+    static shared_ptr<DNSCryptoKeyEngine> makeFromPublicKeyString(unsigned int algorithm, const std::string& raw);
+    static shared_ptr<DNSCryptoKeyEngine> make(unsigned int algorithm);
     
-    typedef DNSCryptoKeyEngine* maker_t(unsigned int algorithm);
+    typedef shared_ptr<DNSCryptoKeyEngine> maker_t(unsigned int algorithm);
     
     static void report(unsigned int algorithm, maker_t* maker, bool fallback=false);
     static std::pair<unsigned int, unsigned int> testMakers(unsigned int algorithm, maker_t* creator, maker_t* signer, maker_t* verifier);
@@ -98,9 +98,9 @@ struct DNSSECPrivateKey
 {
   uint16_t getTag();
   
-  const DNSCryptoKeyEngine* getKey() const
+  const shared_ptr<DNSCryptoKeyEngine> getKey() const
   {
-    return d_key.get();
+    return d_key;
   }
   
   void setKey(const shared_ptr<DNSCryptoKeyEngine> key)

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -123,7 +123,7 @@ void fillOutRRSIG(DNSSECPrivateKey& dpk, const DNSName& signQName, RRSIGRecordCo
     g_signatureCount = S.getPointer("signatures");
     
   DNSKEYRecordContent drc = dpk.getDNSKEY(); 
-  const DNSCryptoKeyEngine* rc = dpk.getKey();
+  const std::shared_ptr<DNSCryptoKeyEngine> rc = dpk.getKey();
   rrc.d_tag = drc.getTag();
   rrc.d_algorithm = drc.d_algorithm;
   

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -197,9 +197,9 @@ public:
   void fromPublicKeyString(const std::string& content) override;
   bool checkKey() const override;
 
-  static DNSCryptoKeyEngine* maker(unsigned int algorithm)
+  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return new OpenSSLRSADNSCryptoKeyEngine(algorithm);
+    return std::make_shared<OpenSSLRSADNSCryptoKeyEngine>(algorithm);
   }
 
 private:
@@ -630,9 +630,9 @@ public:
   void fromPublicKeyString(const std::string& content) override;
   bool checkKey() const override;
 
-  static DNSCryptoKeyEngine* maker(unsigned int algorithm)
+  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return new OpenSSLECDSADNSCryptoKeyEngine(algorithm);
+    return std::make_shared<OpenSSLECDSADNSCryptoKeyEngine>(algorithm);
   }
 
 private:

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1488,7 +1488,7 @@ void verifyCrypto(const string& zone)
     cerr<<"Original DS:   "<<apex.toString()<<" IN DS "<<dsrc.getZoneRepresentation()<<endl;
   }
 #if 0
-  DNSCryptoKeyEngine*key=DNSCryptoKeyEngine::makeFromISCString(drc, "Private-key-format: v1.2\n"
+  std::shared_ptr<DNSCryptoKeyEngine> key=DNSCryptoKeyEngine::makeFromISCString(drc, "Private-key-format: v1.2\n"
       "Algorithm: 12 (ECC-GOST)\n"
       "GostAsn1: MEUCAQAwHAYGKoUDAgITMBIGByqFAwICIwEGByqFAwICHgEEIgQg/9MiXtXKg9FDXDN/R9CmVhJDyuzRAIgh4tPwCu4NHIs=\n");
   string resign=key->sign(hash);
@@ -1688,7 +1688,7 @@ bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = false)
 
       int bits = -1;
       try {
-        std::unique_ptr<DNSCryptoKeyEngine> engine(DNSCryptoKeyEngine::makeFromPublicKeyString(key.d_algorithm, key.d_key)); // throws on unknown algo or bad key
+        std::shared_ptr<DNSCryptoKeyEngine> engine(DNSCryptoKeyEngine::makeFromPublicKeyString(key.d_algorithm, key.d_key)); // throws on unknown algo or bad key
         bits=engine->getBits();
       }
       catch(std::exception& e) {
@@ -3168,7 +3168,7 @@ try
         return 1;
       } 
 
-      DNSCryptoKeyEngine *dke = NULL;
+      std::shared_ptr<DNSCryptoKeyEngine> dke = nullptr;
       // lookup correct key      
       for(DNSBackend::KeyData &kd :  keys) {
         if (kd.id == id) {

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -944,9 +944,9 @@ void PKCS11DNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, stormap_t& s
       throw PDNSException("Could not log in to token (PIN wrong?)");
 };
 
-DNSCryptoKeyEngine* PKCS11DNSCryptoKeyEngine::maker(unsigned int algorithm)
+std::shared_ptr<DNSCryptoKeyEngine> PKCS11DNSCryptoKeyEngine::maker(unsigned int algorithm)
 {
-  return new PKCS11DNSCryptoKeyEngine(algorithm);
+  return std::make_shared<PKCS11DNSCryptoKeyEngine>(algorithm);
 }
 
 // this is called during program startup

--- a/pdns/pkcs11signers.hh
+++ b/pdns/pkcs11signers.hh
@@ -40,29 +40,29 @@ class PKCS11DNSCryptoKeyEngine : public DNSCryptoKeyEngine
     }
     PKCS11DNSCryptoKeyEngine(const PKCS11DNSCryptoKeyEngine& orig);
 
-    string getName() const { return "P11 Kit PKCS#11"; };
+    string getName() const override { return "P11 Kit PKCS#11"; };
 
-    void create(unsigned int bits);
+    void create(unsigned int bits) override;
 
-    storvector_t convertToISCVector() const;
+    storvector_t convertToISCVector() const override;
 
-    std::string sign(const std::string& msg) const;
+    std::string sign(const std::string& msg) const override;
 
-    std::string hash(const std::string& msg) const;
+    std::string hash(const std::string& msg) const override;
 
-    bool verify(const std::string& msg, const std::string& signature) const;
+    bool verify(const std::string& msg, const std::string& signature) const override;
 
-    std::string getPubKeyHash() const;
+    std::string getPubKeyHash() const override;
 
-    std::string getPublicKeyString() const;
-    int getBits() const;
+    std::string getPublicKeyString() const override;
+    int getBits() const override;
 
-    void fromISCMap(DNSKEYRecordContent& drc, stormap_t& stormap);
+    void fromISCMap(DNSKEYRecordContent& drc, stormap_t& stormap) override;
 
-    void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) { throw "Unimplemented"; };
-    void fromPublicKeyString(const std::string& content) { throw "Unimplemented"; };
+    void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) override { throw "Unimplemented"; };
+    void fromPublicKeyString(const std::string& content) override { throw "Unimplemented"; };
 
-    static DNSCryptoKeyEngine* maker(unsigned int algorithm);
+    static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm);
 };
 
 bool PKCS11ModuleSlotLogin(const std::string& module, const string& tokenId, const std::string& pin);

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -11,23 +11,23 @@ class SodiumED25519DNSCryptoKeyEngine : public DNSCryptoKeyEngine
 public:
   explicit SodiumED25519DNSCryptoKeyEngine(unsigned int algo) : DNSCryptoKeyEngine(algo)
   {}
-  string getName() const { return "Sodium ED25519"; }
-  void create(unsigned int bits);
-  storvector_t convertToISCVector() const;
-  std::string getPubKeyHash() const;
-  std::string sign(const std::string& hash) const;
-  std::string hash(const std::string& hash) const;
-  bool verify(const std::string& msg, const std::string& signature) const;
-  std::string getPublicKeyString() const;
-  int getBits() const;
-  void fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& stormap);
-  void fromPublicKeyString(const std::string& content);
-  void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw)
+  string getName() const override { return "Sodium ED25519"; }
+  void create(unsigned int bits) override;
+  storvector_t convertToISCVector() const override;
+  std::string getPubKeyHash() const override;
+  std::string sign(const std::string& hash) const override;
+  std::string hash(const std::string& hash) const override;
+  bool verify(const std::string& msg, const std::string& signature) const override;
+  std::string getPublicKeyString() const override;
+  int getBits() const override;
+  void fromISCMap(DNSKEYRecordContent& drc, std::map<std::string, std::string>& stormap) override;
+  void fromPublicKeyString(const std::string& content) override;
+  void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) override
   {}
 
-  static DNSCryptoKeyEngine* maker(unsigned int algorithm)
+  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return new SodiumED25519DNSCryptoKeyEngine(algorithm);
+    return std::make_shared<SodiumED25519DNSCryptoKeyEngine>(algorithm);
   }
 
 private:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It's done almost everywhere, but not quite, and some of the paths where it's not could leak if an exception is raised.
Also mark the overridden virtual methods with `override` to prevent future mistakes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
