### PR TITLE
added setWeight() and setOrder() functions to DownstreamState

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1392,6 +1392,8 @@ instantiate a server with additional parameters
     * `getOutstanding()`: this *returns* the number of outstanding queries (doesn't print it!)
     * `rmPool(pool)`: remove server from that pool
     * `setQPS(n)`: set the QPS setting to n
+    * `setWeight(n)`: set the weight setting to n
+    * `setOrder(n)`: set the order setting to n
     * `setAuto()`: set this server to automatic availability testing
     * `setDown()`: force this server to be down
     * `setUp()`: force this server to be UP

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1102,6 +1102,8 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
     });
 
   g_lua.registerFunction<void(DownstreamState::*)(int)>("setQPS", [](DownstreamState& s, int lim) { s.qps = lim ? QPSLimiter(lim, lim) : QPSLimiter(); });
+  g_lua.registerFunction<void(DownstreamState::*)(int)>("setWeight", [](DownstreamState& s, int w) { s.weight = w; });
+  g_lua.registerFunction<void(DownstreamState::*)(int)>("setOrder", [](DownstreamState& s, int o) { s.order = o; });
   g_lua.registerFunction<void(std::shared_ptr<DownstreamState>::*)(string)>("addPool", [](std::shared_ptr<DownstreamState> s, string pool) {
       auto localPools = g_pools.getCopy();
       addServerToPool(localPools, pool, s);


### PR DESCRIPTION
### Short description
Added setWeight and setOrder functions to dynamically change both weight and order of a pool's servers.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

Since the change is very small and is basically a copy of `setQPS` which has no specific unit-
 or regression-testing, I figured I perhaps could skip this as well.