### PR TITLE
Auth 4.0.x nsec sorting

### DIFF
--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -265,23 +265,13 @@ bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd, DNSPacket *p)
 
 bool DNSBackend::getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, const DNSName& qname, DNSName& before, DNSName& after)
 {
-  // FIXME400 FIXME400 FIXME400
-  // string lcqname=toLower(qname); FIXME400 tolower?
-  // string lczonename=toLower(zonename); FIXME400 tolower?
-  // lcqname=makeRelative(lcqname, lczonename);
-  DNSName lczonename = DNSName(toLower(zonename.toString()));
-  // lcqname=labelReverse(lcqname);
-  DNSName dnc;
-  string relqname, sbefore, safter;
-  relqname=labelReverse(makeRelative(toLower(qname.toStringNoDot()), zonename.toStringNoDot()));
-  //sbefore = before.toString();
-  //safter = after.toString();
-  bool ret = this->getBeforeAndAfterNamesAbsolute(id, relqname, dnc, sbefore, safter);
-  before = DNSName(labelReverse(sbefore)) + lczonename;
-  after = DNSName(labelReverse(safter)) + lczonename;
+  DNSName unhashed;
+  string sbefore, safter;
+  string srelqname=qname.makeRelative(zonename).makeLowerCase().labelReverse().toString(" ", false);
 
-  // before=dotConcat(labelReverse(before), lczonename); FIXME400
-  // after=dotConcat(labelReverse(after), lczonename); FIXME400
+  bool ret = this->getBeforeAndAfterNamesAbsolute(id, srelqname, unhashed, sbefore, safter);
+  before = (DNSName(labelReverse(sbefore)) + zonename).makeLowerCase();
+  after = (DNSName(labelReverse(safter)) + zonename).makeLowerCase();
   return ret;
 }
 

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -273,7 +273,7 @@ bool DNSBackend::getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, co
   // lcqname=labelReverse(lcqname);
   DNSName dnc;
   string relqname, sbefore, safter;
-  relqname=labelReverse(makeRelative(qname.toStringNoDot(), zonename.toStringNoDot())); // FIXME400
+  relqname=labelReverse(makeRelative(toLower(qname.toStringNoDot()), zonename.toStringNoDot()));
   //sbefore = before.toString();
   //safter = after.toString();
   bool ret = this->getBeforeAndAfterNamesAbsolute(id, relqname, dnc, sbefore, safter);

--- a/regression-tests/tests/nsecx-upcase/command
+++ b/regression-tests/tests/nsecx-upcase/command
@@ -1,0 +1,2 @@
+#!/bin/sh
+cleandig Z1234567890.wtest.com A dnssec

--- a/regression-tests/tests/nsecx-upcase/description
+++ b/regression-tests/tests/nsecx-upcase/description
@@ -1,0 +1,1 @@
+Make sure NSEC(3) generation is case insensitive.

--- a/regression-tests/tests/nsecx-upcase/expected_result
+++ b/regression-tests/tests/nsecx-upcase/expected_result
@@ -1,0 +1,9 @@
+0	Z1234567890.wtest.com.	IN	CNAME	3600	server1.wtest.com.
+0	Z1234567890.wtest.com.	IN	RRSIG	3600	CNAME 13 2 3600 [expiry] [inception] [keytag] wtest.com. ...
+0	server1.wtest.com.	IN	A	3600	1.2.3.4
+0	server1.wtest.com.	IN	RRSIG	3600	A 13 3 3600 [expiry] [inception] [keytag] wtest.com. ...
+1	a.something.wtest.com.	IN	NSEC	86400	wtest.com. A RRSIG NSEC
+1	a.something.wtest.com.	IN	RRSIG	86400	NSEC 13 4 86400 [expiry] [inception] [keytag] wtest.com. ...
+2	.	IN	OPT	32768	
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='Z1234567890.wtest.com.', qtype=A

--- a/regression-tests/tests/nsecx-upcase/expected_result.narrow
+++ b/regression-tests/tests/nsecx-upcase/expected_result.narrow
@@ -1,0 +1,9 @@
+0	Z1234567890.wtest.com.	IN	CNAME	3600	server1.wtest.com.
+0	Z1234567890.wtest.com.	IN	RRSIG	3600	CNAME 13 2 3600 [expiry] [inception] [keytag] wtest.com. ...
+0	server1.wtest.com.	IN	A	3600	1.2.3.4
+0	server1.wtest.com.	IN	RRSIG	3600	A 13 3 3600 [expiry] [inception] [keytag] wtest.com. ...
+1	pv38thf7bl9rb2o5cf77jkuehfupln6u.wtest.com.	IN	NSEC3	86400	1 [flags] 1 abcd PV38THF7BL9RB2O5CF77JKUEHFUPLN70
+1	pv38thf7bl9rb2o5cf77jkuehfupln6u.wtest.com.	IN	RRSIG	86400	NSEC3 13 3 86400 [expiry] [inception] [keytag] wtest.com. ...
+2	.	IN	OPT	32768	
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='Z1234567890.wtest.com.', qtype=A

--- a/regression-tests/tests/nsecx-upcase/expected_result.nsec3
+++ b/regression-tests/tests/nsecx-upcase/expected_result.nsec3
@@ -1,0 +1,9 @@
+0	Z1234567890.wtest.com.	IN	CNAME	3600	server1.wtest.com.
+0	Z1234567890.wtest.com.	IN	RRSIG	3600	CNAME 13 2 3600 [expiry] [inception] [keytag] wtest.com. ...
+0	server1.wtest.com.	IN	A	3600	1.2.3.4
+0	server1.wtest.com.	IN	RRSIG	3600	A 13 3 3600 [expiry] [inception] [keytag] wtest.com. ...
+1	pd15qdsjjbfosu5fg2oqrnlb8r8oifl6.wtest.com.	IN	NSEC3	86400	1 [flags] 1 abcd SHEGK154N8362AG22AR9VDDRF3127M6I A RRSIG
+1	pd15qdsjjbfosu5fg2oqrnlb8r8oifl6.wtest.com.	IN	RRSIG	86400	NSEC3 13 3 86400 [expiry] [inception] [keytag] wtest.com. ...
+2	.	IN	OPT	32768	
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='Z1234567890.wtest.com.', qtype=A


### PR DESCRIPTION
### Short description
NSEC sorting is wrong for upcase qnames
### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
