### PR TITLE
rec: Allow retrieving stats from Lua via the `getStat("name")` call

### DIFF
--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -377,7 +377,7 @@ output and weird results.
 
 ### Statistics
 
-You can retrieve statistics from Lua using the `getStat("name")` call. For example,
+Since 4.1.0, statistics can be retrieved from Lua using the `getStat("name")` call. For example,
 to retrieve the number of cache misses:
 
 ```

--- a/docs/markdown/recursor/scripting.md
+++ b/docs/markdown/recursor/scripting.md
@@ -375,6 +375,18 @@ Note that metrics live in the same namespace as 'system' metrics. So if you
 generate one that overlaps with a PowerDNS stock metric, you will get double
 output and weird results.
 
+### Statistics
+
+You can retrieve statistics from Lua using the `getStat("name")` call. For example,
+to retrieve the number of cache misses:
+
+```
+cacheMisses = getStat("cache-misses")
+```
+
+Please be aware that retrieving statistics is a relatively costly operation, and as such
+should for example not be done for every query.
+
 ### Logging
 To log messages with the main PowerDNS Recursor process, use `pdnslog(message)`.
 pdnslog can also write out to a syslog loglevel if specified.

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -518,6 +518,15 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerFunction("set", &DynMetric::set);
   d_lw->registerFunction("get", &DynMetric::get);
 
+  d_lw->writeFunction("getStat", [](const std::string& str) {
+      uint64_t result = 0;
+      optional<uint64_t> value = getStatByName(str);
+      if (value) {
+        result = *value;
+      }
+      return result;
+    });
+
   d_lw->writeFunction("getRecursorThreadId", []() {
       return getRecursorThreadId();
     });

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3034,6 +3034,7 @@ try
     }
   }
 
+  registerAllStats();
   if(!t_id) {
     t_fdm->addReadFD(s_rcc.d_fd, handleRCC); // control channel
   }

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -36,9 +36,9 @@ try
     boost::replace_all(hostname, ".", "_");    
   }
 
+  registerAllStats();
   string msg;
   for(const auto& carbonServer: carbonServers) {
-    RecursorControlParser rcp; // inits if needed
     ComboAddress remote(carbonServer, 2003);
     Socket s(remote.sin4.sin_family, SOCK_STREAM);
 

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -195,7 +195,7 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
 #ifdef HAVE_NET_SNMP
   /* This is done so that the statistics maps are
      initialized. */
-  RecursorControlParser rcp;
+  registerAllStats();
 
   registerCounter64Stat("questions", questionsOID, OID_LENGTH(questionsOID));
   registerCounter64Stat("ipv6-questions", ipv6QuestionsOID, OID_LENGTH(ipv6QuestionsOID));

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -55,12 +55,12 @@ private:
 class RecursorControlParser
 {
 public:
-  RecursorControlParser();
+  RecursorControlParser()
+  {
+  }
   static void nop(void){}
   typedef void func_t(void);
   std::string getAnswer(const std::string& question, func_t** func);
-private:
-  static bool s_init;
 };
 
 std::map<std::string, std::string> getAllStatsMap();
@@ -74,4 +74,5 @@ std::vector<ComboAddress>* pleaseGetLargeAnswerRemotes();
 DNSName getRegisteredName(const DNSName& dom);
 std::atomic<unsigned long>* getDynMetric(const std::string& str);
 optional<uint64_t> getStatByName(const std::string& name);
+void registerAllStats();
 #endif 

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -78,7 +78,7 @@ std::atomic<unsigned long>* getDynMetric(const std::string& str)
   return ret;
 }
 
-optional<uint64_t> get(const string& name) 
+static optional<uint64_t> get(const string& name)
 {
   optional<uint64_t> ret;
 
@@ -770,9 +770,9 @@ uint64_t doGetMallocated()
 
 extern ResponseStats g_rs;
 
-bool RecursorControlParser::s_init;
-RecursorControlParser::RecursorControlParser()
+void registerAllStats()
 {
+  static bool s_init = false;
   if(s_init)
     return;
   s_init=true;

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -410,7 +410,7 @@ void serveStuff(HttpRequest* req, HttpResponse* resp)
 
 RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
 {
-  RecursorControlParser rcp; // inits
+  registerAllStats();
 
   d_ws = new AsyncWebServer(fdm, arg()["webserver-address"], arg().asNum("webserver-port"));
   d_ws->bind();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Until now, only custom metrics could be set and retrieved from Lua hooks. This PR adds the possibility to retrieve the internal statistics via a new `getStat("name") call.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
