### PR TITLE
fix off-by-one in dnsreplay --packet-limit

### DIFF
--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -808,7 +808,7 @@ try
       if(sendPacketFromPR(pr, remote, stamp))
         count++;
     } 
-    if(packetLimit && count > packetLimit) 
+    if(packetLimit && count >= packetLimit) 
       break;
 
     mental_time=packet_ts;


### PR DESCRIPTION
### Short description
dnsreplay's `--packet-limit` would actually send one packet too many. This PR fixes that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
