### PR TITLE
don't age the root - this was a mistranslation from 3.x to 4.x

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1351,7 +1351,7 @@ int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, con
     for(auto tns=rnameservers.cbegin();;++tns) {
       if(tns==rnameservers.cend()) {
         LOG(prefix<<qname<<": Failed to resolve via any of the "<<(unsigned int)rnameservers.size()<<" offered NS at level '"<<auth<<"'"<<endl);
-        if(!auth.empty() && flawedNSSet) {
+        if(!auth.isRoot() && flawedNSSet) {
           LOG(prefix<<qname<<": Ageing nameservers for level '"<<auth<<"', next query might succeed"<<endl);
 
           if(t_RC->doAgeCache(d_now.tv_sec, auth, QType::NS, 10))


### PR DESCRIPTION
### Short description
When a nameserver set did not work, we eventually 'age' the parent nameservers because it might make sense to see if the (cc)TLD has new nameservers that do work. This logic does not apply to the root. However, we did age the root in 4.x because of a mistranslation from 3.x to 4.x. This restores 3.x behaviour.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
