### PR TITLE
backport: add option to set a global lua-axfr-script value

### DIFF
--- a/docs/markdown/authoritative/domainmetadata.md
+++ b/docs/markdown/authoritative/domainmetadata.md
@@ -62,6 +62,8 @@ If set to 1, attempt IXFR when retrieving zone updates. Otherwise IXFR is not at
 
 ## LUA-AXFR-SCRIPT
 Script to be used to edit incoming AXFRs, see [Modifying a slave zone using a script](modes-of-operation.md#modifying-a-slave-zone-using-a-script).
+This value will override the [`lua-axfr-script`](settings.md#lua-axfr-scriptmaster) setting.
+Use 'NONE' to remove a global script.
 
 ## NSEC3NARROW
 Set to "1" to tell PowerDNS this zone operates in NSEC3 'narrow' mode. See

--- a/docs/markdown/authoritative/settings.md
+++ b/docs/markdown/authoritative/settings.md
@@ -405,6 +405,14 @@ options to allow binding to non-local addresses.
 This feature is intended to facilitate ip-failover setups, but it may also
 mask configuration issues and for this reason it is disabled by default.
 
+## `lua-axfr-script`
+
+* String
+* Default: empty
+* Available since: 4.0.4
+
+Script to be used to edit incoming AXFRs, see [Modifying a slave zone using a script](modes-of-operation.md#modifying-a-slave-zone-using-a-script).
+
 ## `local-address-nonexist-fail`
 * Boolean
 * Default: no

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -189,6 +189,7 @@ void declareArguments()
   ::arg().setSwitch("8bit-dns", "Allow 8bit dns queries")="no";
   ::arg().setSwitch("axfr-lower-serial", "Also AXFR a zone from a master with a lower serial")="no";
 
+  ::arg().set("lua-axfr-script", "Script to be used to edit incoming AXFRs")="";
   ::arg().set("xfr-max-received-mbytes", "Maximum number of megabytes received from an incoming XFR")="100";
 }
 

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -325,13 +325,21 @@ void CommunicatorClass::suck(const DNSName &domain, const string &remote)
 
     scoped_ptr<AuthLua> pdl;
     vector<string> scripts;
+    string script=::arg()["lua-axfr-script"];
     if(B.getDomainMetadata(domain, "LUA-AXFR-SCRIPT", scripts) && !scripts.empty()) {
+      if (pdns_iequals(scripts[0], "NONE")) {
+        script.clear();
+      } else {
+        script=scripts[0];
+      }
+    }
+    if(!script.empty()){
       try {
-        pdl.reset(new AuthLua(scripts[0]));
-        L<<Logger::Info<<"Loaded Lua script '"<<scripts[0]<<"' to edit the incoming AXFR of '"<<domain<<"'"<<endl;
+        pdl.reset(new AuthLua(script));
+        L<<Logger::Info<<"Loaded Lua script '"<<script<<"' to edit the incoming AXFR of '"<<domain<<"'"<<endl;
       }
       catch(std::exception& e) {
-        L<<Logger::Error<<"Failed to load Lua editing script '"<<scripts[0]<<"' for incoming AXFR of '"<<domain<<"': "<<e.what()<<endl;
+        L<<Logger::Error<<"Failed to load Lua editing script '"<<script<<"' for incoming AXFR of '"<<domain<<"': "<<e.what()<<endl;
         return;
       }
     }


### PR DESCRIPTION
### Short description
backport of #5316 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
