### PR TITLE
explicitly remove old root when repriming

### DIFF
--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -93,6 +93,7 @@ void primeHints(void)
       }
     }
   }
+  t_RC->doWipeCache(g_rootdnsname, false, QType::NS);
   t_RC->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), false); // and stuff in the cache
 }
 


### PR DESCRIPTION
Whe reprime the root with unauth data. This however opens up a small race condition in which the root is expired (ttl=0), but still auth=1 in the cache. Our attempt to replace it with auth=0 data fails at that point. This is probably due to some fencepost error somewhere. To not be subtle about this, explicitly nuke the root when we reprime.

This may have been the "fencepost" error in syncres.cc:

```
        if(k->d_ttl > (unsigned int)d_now.tv_sec ) {
```
We demand an answer that is 1 second valid. But we also won't replace it in recursor_cache.cc:

```
  if(!auth && ce.d_auth) {  // unauth data came in, we have some auth data, but is it fresh?
    if(ce.d_ttd > now) { // we still have valid data, ignore unauth data
```
But this is not quite it. The solution does work.
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
