### PR TITLE
 PowerDNS sdig does not truncate trailing bits of EDNS Client Subnet mask

### DIFF
--- a/pdns/ednssubnet.cc
+++ b/pdns/ednssubnet.cc
@@ -95,10 +95,13 @@ string makeEDNSSubnetOptsString(const EDNSSubnetOpts& eso)
   ret.assign((const char*)&esow, sizeof(esow));
   int octetsout = ((esow.sourceMask - 1)>> 3)+1;
 
+  ComboAddress src=eso.source.getNetwork();
+  src.truncate(esow.sourceMask);
+  
   if(family == htons(1)) 
-    ret.append((const char*) &eso.source.getNetwork().sin4.sin_addr.s_addr, octetsout);
+    ret.append((const char*) &src.sin4.sin_addr.s_addr, octetsout);
   else
-    ret.append((const char*) &eso.source.getNetwork().sin6.sin6_addr.s6_addr, octetsout);
+    ret.append((const char*) &src.sin6.sin6_addr.s6_addr, octetsout);
   return ret;
 }
 


### PR DESCRIPTION
So if you'd truncate something as
a /9, we'd have to use 2 bytes anyhow, but we would not zero the last 7 bits.

We do now. Thanks Mukund & ISC!

### Short description
Use ComboAddress::truncate logic.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
