### PR TITLE
Revert "notify slaves after dnsupdate was processed"

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -11,7 +11,6 @@
 #include "base32.hh"
 
 #include "misc.hh"
-#include "communicator.hh"
 #include "arguments.hh"
 #include "resolver.hh"
 #include "dns_random.hh"
@@ -710,7 +709,6 @@ int PacketHandler::forwardPacket(const string &msgPrefix, DNSPacket *p, DomainIn
 }
 
 int PacketHandler::processUpdate(DNSPacket *p) {
-  extern CommunicatorClass Communicator;
   if (! ::arg().mustDo("dnsupdate"))
     return RCode::Refused;
 
@@ -982,8 +980,6 @@ int PacketHandler::processUpdate(DNSPacket *p) {
       }
 
       L<<Logger::Info<<msgPrefix<<"Update completed, "<<changedRecords<<" changed records committed."<<endl;
-      if(::arg().mustDo("master") || ::arg().mustDo("slave-renotify"))
-        Communicator.notifyDomain(di.zone);
     } else {
       //No change, no commit, we perform abort() because some backends might like this more.
       L<<Logger::Info<<msgPrefix<<"Update completed, 0 changes, rolling back."<<endl;


### PR DESCRIPTION
This reverts commit 89033f988aa6f4ffbac08c9447a2a7f062f3a34f.

### Short description
The description for "slave-renotify" is "If we should send out notifications for slaved updates". Rfc2136 zones are by definition type 'MASTER' or 'NATIVE'. Using an option designed for slave zones to trigger a notify after a dnsupdate is confusing and may lead to unwanted side affects. 

This pull also remove a duplicate include and an unnecessary extern CommunicatorClass Communicator; line.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
