### PR TITLE
SNMP: Handle SNMP alarms so we can reconnect to the master

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -338,9 +338,11 @@ install_recursor() {
   run "sudo apt-get -qq --no-install-recommends install \
     authbind \
     daemontools \
+    jq \
     libfaketime \
+    libsnmp-dev \
     moreutils \
-    jq"
+    snmpd"
   run "cd .."
   run "wget https://s3.amazonaws.com/alexa-static/top-1m.csv.zip"
   run "unzip top-1m.csv.zip -d ${TRAVIS_BUILD_DIR}/regression-tests"

--- a/m4/pdns_with_net_snmp.m4
+++ b/m4/pdns_with_net_snmp.m4
@@ -11,6 +11,15 @@ AC_DEFUN([PDNS_WITH_NET_SNMP], [
     AS_IF([test "x$with_net_snmp" = "xyes" -o "x$with_net_snmp" = "xauto"], [
       AC_CHECK_PROG([NET_SNMP_CFLAGS], [net-snmp-config], [`net-snmp-config --cflags`])
       AC_CHECK_PROG([NET_SNMP_LIBS], [net-snmp-config], [`net-snmp-config --agent-libs`])
+      AC_CHECK_DECLS([snmp_select_info2], [ : ], [ : ],
+        [AC_INCLUDES_DEFAULT
+          #include <net-snmp/net-snmp-config.h>
+          #include <net-snmp/definitions.h>
+          #include <net-snmp/types.h>
+          #include <net-snmp/utilities.h>
+          #include <net-snmp/config_api.h>
+          #include <net-snmp/session_api.h>
+      ])
     ])
   ])
   AS_IF([test "x$with_net_snmp" = "xyes"], [

--- a/pdns/devpollmplexer.cc
+++ b/pdns/devpollmplexer.cc
@@ -36,7 +36,6 @@
 #include "syncres.hh"
 
 #include "namespaces.hh"
-#include "namespaces.hh"
 
 class DevPollFDMultiplexer : public FDMultiplexer
 {
@@ -47,7 +46,7 @@ public:
     close(d_devpollfd);
   }
 
-  virtual int run(struct timeval* tv);
+  virtual int run(struct timeval* tv, int timeout=500);
 
   virtual void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const funcparam_t& parameter);
   virtual void removeFD(callbackmap_t& cbmap, int fd);
@@ -113,7 +112,7 @@ void DevPollFDMultiplexer::removeFD(callbackmap_t& cbmap, int fd)
   }
 }
 
-int DevPollFDMultiplexer::run(struct timeval* now)
+int DevPollFDMultiplexer::run(struct timeval* now, int timeout)
 {
   if(d_inrun) {
     throw FDMultiplexerException("FDMultiplexer::run() is not reentrant!\n");
@@ -121,7 +120,7 @@ int DevPollFDMultiplexer::run(struct timeval* now)
   struct dvpoll dvp;
   dvp.dp_nfds = d_readCallbacks.size() + d_writeCallbacks.size();
   dvp.dp_fds = new pollfd[dvp.dp_nfds];
-  dvp.dp_timeout = 500;
+  dvp.dp_timeout = timeout;
   int ret=ioctl(d_devpollfd, DP_POLL, &dvp); 
   gettimeofday(now,0); // MANDATORY!
   
@@ -151,7 +150,7 @@ int DevPollFDMultiplexer::run(struct timeval* now)
   }
   delete[] dvp.dp_fds;
   d_inrun=false;
-  return 0;
+  return ret;
 }
 
 #if 0

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -47,7 +47,11 @@ EXTRA_DIST=dnslabeltext.rl \
 	   bpf-filter.main.ebpf \
 	   bpf-filter.qname.ebpf \
 	   bpf-filter.ebpf.src \
-	   DNSDIST-MIB.txt
+	   DNSDIST-MIB.txt \
+	   devpollmplexer.cc \
+	   epollmplexer.cc \
+	   kqueuemplexer.cc \
+	   portsmplexer.cc
 
 bin_PROGRAMS = dnsdist
 
@@ -93,15 +97,17 @@ dnsdist_SOURCES = \
 	ednscookies.cc ednscookies.hh \
 	ednssubnet.cc ednssubnet.hh \
 	gettime.cc gettime.hh \
+	htmlfiles.h \
 	iputils.cc iputils.hh \
 	lock.hh \
 	misc.cc misc.hh \
-	htmlfiles.h \
+	mplexer.hh \
 	namespaces.hh \
 	pdnsexception.hh \
 	protobuf.cc protobuf.hh \
 	qtype.cc qtype.hh \
 	remote_logger.cc remote_logger.hh \
+	selectmplexer.cc \
 	sholder.hh \
 	snmp-agent.cc snmp-agent.hh \
 	sodcrypto.cc sodcrypto.hh \
@@ -150,6 +156,20 @@ dnsdist_LDADD += $(PROTOBUF_LIBS)
 
 dnsdist.$(OBJEXT): dnsmessage.pb.cc
 endif
+endif
+
+if HAVE_FREEBSD
+dnsdist_SOURCES += kqueuemplexer.cc
+endif
+
+if HAVE_LINUX
+dnsdist_SOURCES += epollmplexer.cc
+endif
+
+if HAVE_SOLARIS
+dnsdist_SOURCES += \
+        devpollmplexer.cc \
+        portsmplexer.cc
 endif
 
 testrunner_SOURCES = \

--- a/pdns/dnsdistdist/devpollmplexer.cc
+++ b/pdns/dnsdistdist/devpollmplexer.cc
@@ -1,0 +1,1 @@
+../devpollmplexer.cc

--- a/pdns/dnsdistdist/epollmplexer.cc
+++ b/pdns/dnsdistdist/epollmplexer.cc
@@ -1,0 +1,1 @@
+../epollmplexer.cc

--- a/pdns/dnsdistdist/kqueuemplexer.cc
+++ b/pdns/dnsdistdist/kqueuemplexer.cc
@@ -1,0 +1,1 @@
+../kqueuemplexer.cc

--- a/pdns/dnsdistdist/mplexer.hh
+++ b/pdns/dnsdistdist/mplexer.hh
@@ -1,0 +1,1 @@
+../mplexer.hh

--- a/pdns/dnsdistdist/portsmplexer.cc
+++ b/pdns/dnsdistdist/portsmplexer.cc
@@ -1,0 +1,1 @@
+../portsmplexer.cc

--- a/pdns/dnsdistdist/selectmplexer.cc
+++ b/pdns/dnsdistdist/selectmplexer.cc
@@ -1,0 +1,1 @@
+../selectmplexer.cc

--- a/pdns/epollmplexer.cc
+++ b/pdns/epollmplexer.cc
@@ -32,7 +32,6 @@
 #endif
 
 #include "namespaces.hh"
-#include "namespaces.hh"
 
 class EpollFDMultiplexer : public FDMultiplexer
 {
@@ -43,7 +42,7 @@ public:
     close(d_epollfd);
   }
 
-  virtual int run(struct timeval* tv);
+  virtual int run(struct timeval* tv, int timeout=500);
 
   virtual void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const funcparam_t& parameter);
   virtual void removeFD(callbackmap_t& cbmap, int fd);
@@ -124,13 +123,13 @@ void EpollFDMultiplexer::removeFD(callbackmap_t& cbmap, int fd)
     throw FDMultiplexerException("Removing fd from epoll set: "+stringerror());
 }
 
-int EpollFDMultiplexer::run(struct timeval* now)
+int EpollFDMultiplexer::run(struct timeval* now, int timeout)
 {
   if(d_inrun) {
     throw FDMultiplexerException("FDMultiplexer::run() is not reentrant!\n");
   }
   
-  int ret=epoll_wait(d_epollfd, d_eevents.get(), s_maxevents, 500);
+  int ret=epoll_wait(d_epollfd, d_eevents.get(), s_maxevents, timeout);
   gettimeofday(now,0); // MANDATORY
   
   if(ret < 0 && errno!=EINTR)
@@ -154,7 +153,7 @@ int EpollFDMultiplexer::run(struct timeval* now)
     }
   }
   d_inrun=false;
-  return 0;
+  return ret;
 }
 
 #if 0

--- a/pdns/mplexer.hh
+++ b/pdns/mplexer.hh
@@ -30,7 +30,6 @@
 #include <map>
 #include <stdexcept>
 #include <string>
-#include "utility.hh"
 
 class FDMultiplexerException : public std::runtime_error
 {
@@ -50,7 +49,6 @@ public:
 class FDMultiplexer
 {
 public:
-  //  typedef boost::variant<PacketID, TCPConnection> funcparam_t;
   typedef boost::any funcparam_t;
 protected:
 
@@ -68,7 +66,9 @@ public:
   virtual ~FDMultiplexer()
   {}
 
-  virtual int run(struct timeval* tv) = 0;
+  /* tv will be updated to 'now' before run returns */
+  /* timeout is in ms */
+  virtual int run(struct timeval* tv, int timeout=500) = 0;
 
   //! Add an fd to the read watch list - currently an fd can only be on one list at a time!
   virtual void addReadFD(int fd, callbackfunc_t toDo, const funcparam_t& parameter=funcparam_t())
@@ -131,7 +131,6 @@ public:
   
   virtual std::string getName() = 0;
 
-
 protected:
   typedef std::map<int, Callback> callbackmap_t;
   callbackmap_t d_readCallbacks, d_writeCallbacks;
@@ -168,7 +167,7 @@ public:
   virtual ~SelectFDMultiplexer()
   {}
 
-  virtual int run(struct timeval* tv);
+  virtual int run(struct timeval* tv, int timeout=500);
 
   virtual void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const funcparam_t& parameter);
   virtual void removeFD(callbackmap_t& cbmap, int fd);

--- a/pdns/snmp-agent.hh
+++ b/pdns/snmp-agent.hh
@@ -17,6 +17,8 @@
 #undef INET6 /* SRSLY? */
 #endif /* HAVE_NET_SNMP */
 
+#include "mplexer.hh"
+
 class SNMPAgent
 {
 public:
@@ -49,12 +51,14 @@ protected:
   static bool sendTrap(int fd,
                        netsnmp_variable_list* varList);
 
-  void handleTraps();
-
   int d_trapPipe[2] = { -1, -1};
 #endif /* HAVE_NET_SNMP */
 private:
   void worker();
+  static void handleTrapsCB(int fd, FDMultiplexer::funcparam_t& var);
+  static void handleSNMPQueryCB(int fd, FDMultiplexer::funcparam_t& var);
+  void handleTrapsEvent();
+  void handleSNMPQueryEvent(int fd);
 
   std::thread d_thread;
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If the connection to the master is lost, the SNMP subagent API inserts an alarm to try to reconnect after a certain delay.
Should fix #5327.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
