### PR TITLE
Use un-annotated tags for determining version

### DIFF
--- a/build-aux/gen-version
+++ b/build-aux/gen-version
@@ -24,7 +24,7 @@ fi
 if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
   if $(git rev-parse --abbrev-ref HEAD | grep -q 'rel/'); then
     REL_TYPE="$(git rev-parse --abbrev-ref HEAD | cut -d/ -f 2 | cut -d- -f 1)"
-    VERSION="$(git describe --match=${REL_TYPE}-* --dirty=.dirty | cut -d- -f 2-)"
+    VERSION="$(git describe --match=${REL_TYPE}-* --tags --dirty=.dirty | cut -d- -f 2-)"
   else
     GIT_VERSION=$(git show --no-patch --format=format:%h HEAD)
     BRANCH=".$(git rev-parse --abbrev-ref HEAD | perl -p -e 's/[^[:alnum:]]//g;')"


### PR DESCRIPTION
### Short description
Un-annotated tags would not be used, leading to 'older' version numbers than expected.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)