### PR TITLE
Fix typo in ldapbackend.cc from issue #5091

### DIFF
--- a/modules/ldapbackend/ldapbackend.cc
+++ b/modules/ldapbackend/ldapbackend.cc
@@ -220,7 +220,7 @@ inline bool LdapBackend::list_simple( const DNSName& target, int domain_id )
 
 inline bool LdapBackend::list_strict( const DNSName& target, int domain_id )
 {
-  if( target.isPartOf(DNSName("in-addr.arpa")) || target.isPartOf(DNSName(".ip6.arpa")) )
+  if( target.isPartOf(DNSName("in-addr.arpa")) || target.isPartOf(DNSName("ip6.arpa")) )
   {
     L << Logger::Warning << m_myname << " Request for reverse zone AXFR, but this is not supported in strict mode" << endl;
     return false;   // AXFR isn't supported in strict mode. Use simple mode and additional PTR records


### PR DESCRIPTION
### Short description
Fixes typo identified in PDNS issue #5091 (erroneous leading "." in ".ip6.arpa")
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code (master - 46d1612)
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)