### PR TITLE
Backport of #5335 to auth-4.0.x: configure.ac: corrects syntax error in test statement on existance of libcrypto_ecdsa

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -344,7 +344,7 @@ AC_MSG_NOTICE([----------------])
 AC_MSG_NOTICE([Built-in modules: $modules])
 AC_MSG_NOTICE([Dynamic modules: $dynmodules])
 AC_MSG_NOTICE([])
-AS_IF([test "x$libcrypto_ecdsa" == "xyes"],
+AS_IF([test "x$libcrypto_ecdsa" = "xyes"],
   [AC_MSG_NOTICE([OpenSSL ecdsa: yes])],
   [AC_MSG_NOTICE([OpenSSL ecdsa: no])]
 )


### PR DESCRIPTION
### Short description
This is a backport pull request of #5335
Fixes a small syntax error in configure.ac while comparing a string with "test" for libcrypto_ecdsa

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
