### PR TITLE
LuaJIT 2.1: Lua fallback functionality no longer uses Lua namespace

### DIFF
--- a/pdns/lua-iputils.cc
+++ b/pdns/lua-iputils.cc
@@ -43,7 +43,7 @@ extern "C" {
 /*
 ** Adapted from Lua 5.2.0
 */
-static void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
+static void pdns_luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
   luaL_checkstack(L, nup+1, "too many upvalues");
   for (; l->name != NULL; l++) {  /* fill the table with given functions */
     int i;
@@ -54,6 +54,10 @@ static void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
     lua_settable(L, -(nup + 3));
   }
   lua_pop(L, nup);  /* remove upvalues */
+}
+#else
+static void pdns_luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
+  lual_setfuncs(L, l, nup);
 }
 #endif
 
@@ -261,22 +265,22 @@ extern "C" int luaopen_iputils(lua_State* L)
   luaL_newmetatable(L, "iputils.ca");
   lua_pushvalue(L, -1);
   lua_setfield(L, -2, "__index");
-  luaL_setfuncs(L, iputils_ca_methods, 0);
+  pdns_luaL_setfuncs(L, iputils_ca_methods, 0);
 
   luaL_newmetatable(L, "iputils.ipset");
   lua_pushvalue(L, -1);
   lua_setfield(L, -2, "__index");
-  luaL_setfuncs(L, ipset_methods, 0);
+  pdns_luaL_setfuncs(L, ipset_methods, 0);
 
   luaL_newmetatable(L, "iputils.netmask");
   lua_pushvalue(L, -1);
   lua_setfield(L, -2, "__index");
-  luaL_setfuncs(L, iputils_netmask_methods, 0);
+  pdns_luaL_setfuncs(L, iputils_netmask_methods, 0);
 
   luaL_newmetatable(L, "iputils.nmgroup");
   lua_pushvalue(L, -1);
   lua_setfield(L, -2, "__index");
-  luaL_setfuncs(L, iputils_nmgroup_methods, 0);
+  pdns_luaL_setfuncs(L, iputils_nmgroup_methods, 0);
 
 #if LUA_VERSION_NUM < 502
   luaL_register(L, "iputils", iputils);

--- a/pdns/lua-iputils.cc
+++ b/pdns/lua-iputils.cc
@@ -57,7 +57,7 @@ static void pdns_luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
 }
 #else
 static void pdns_luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
-  lual_setfuncs(L, l, nup);
+  luaL_setfuncs(L, l, nup);
 }
 #endif
 


### PR DESCRIPTION
### Short description
LuaJIT 2.1 betas provide functionality we did not expect for "Lua 5.1", so we added our own 5.2-workalike in the luaL_* namespace. This collided with LuaJIT 2.1 beta. We now no longer use that namespace. Note that we use luaL_setfunction in one other place, but we don't create a new function there, so there is no problem.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
