### PR TITLE
work around a g++ bug in Ubuntu Xenial, closing #5347.

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -103,6 +103,12 @@ static thread_local std::shared_ptr<Regex> t_traceRegex;
 static thread_local std::unique_ptr<tcpClientCounts_t> t_tcpClientCounts;
 
 thread_local std::unique_ptr<MT_t> MT; // the big MTasker
+MT_t* getMT()
+{
+  return MT ? MT.get() : 0;
+}
+
+
 thread_local std::unique_ptr<MemRecursorCache> t_RC;
 thread_local std::unique_ptr<RecursorPacketCache> t_packetCache;
 thread_local FDMultiplexer* t_fdm{nullptr};

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -596,13 +596,13 @@ static string* pleaseGetCurrentQueries()
 {
   ostringstream ostr;
 
-  ostr << MT->d_waiters.size() <<" currently outstanding questions\n";
+  ostr << getMT()->d_waiters.size() <<" currently outstanding questions\n";
 
   boost::format fmt("%1% %|40t|%2% %|47t|%3% %|63t|%4% %|68t|%5%\n");
 
   ostr << (fmt % "qname" % "qtype" % "remote" % "tcp" % "chained");
   int n=0;
-  for(MT_t::waiters_t::iterator mthread=MT->d_waiters.begin(); mthread!=MT->d_waiters.end() && n < 100; ++mthread, ++n) {
+  for(MT_t::waiters_t::iterator mthread=getMT()->d_waiters.begin(); mthread!=getMT()->d_waiters.end() && n < 100; ++mthread, ++n) {
     const PacketID& pident = mthread->key;
     ostr << (fmt 
              % pident.domain.toLogString() /* ?? */ % DNSRecordContent::NumberToType(pident.type) 
@@ -662,7 +662,7 @@ uint64_t getNsSpeedsSize()
 
 uint64_t* pleaseGetConcurrentQueries()
 {
-  return new uint64_t(MT ? MT->numProcesses() : 0);
+  return new uint64_t(getMT() ? getMT()->numProcesses() : 0);
 }
 
 static uint64_t getConcurrentQueries()

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -819,7 +819,7 @@ struct PacketIDBirthdayCompare: public std::binary_function<PacketID, PacketID, 
 extern thread_local std::unique_ptr<MemRecursorCache> t_RC;
 extern thread_local std::unique_ptr<RecursorPacketCache> t_packetCache;
 typedef MTasker<PacketID,string> MT_t;
-extern thread_local std::unique_ptr<MT_t> MT;
+MT_t* getMT();
 
 struct RecursorStats
 {

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -557,7 +557,7 @@ void AsyncServer::asyncWaitForConnections(FDMultiplexer* fdm, const newconnectio
 
 void AsyncServer::newConnection()
 {
-  MT->makeThread(&AsyncServerNewConnectionMT, this);
+  getMT()->makeThread(&AsyncServerNewConnectionMT, this);
 }
 
 


### PR DESCRIPTION
### Short description
Ubuntu Xenial g++ appears to have a bug related to thread_local. This works around it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
