### PR TITLE
dnsdist: Add labels count to StatNode, only set the name once

### DIFF
--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -372,6 +372,7 @@ void moreLua(bool client)
                                                       } );
 
   g_lua.registerMember("fullname", &StatNode::fullname);
+  g_lua.registerMember("labelsCount", &StatNode::labelsCount);
   g_lua.registerMember("servfails", &StatNode::Stat::servfails);
   g_lua.registerMember("nxdomains", &StatNode::Stat::nxdomains);
   g_lua.registerMember("queries", &StatNode::Stat::queries);

--- a/pdns/statnode.hh
+++ b/pdns/statnode.hh
@@ -28,11 +28,7 @@
 class StatNode
 {
 public:
-  void submit(const DNSName& domain, int rcode, const ComboAddress& remote);
-  void submit(std::deque<std::string>& labels, const std::string& domain, int rcode, const ComboAddress& remote);
 
-  std::string name;
-  std::string fullname;
   struct Stat 
   {
     Stat() : queries(0), noerrors(0), nxdomains(0), servfails(0), drops(0){}
@@ -50,14 +46,21 @@ public:
       }
       return *this;
     }
-typedef std::map<ComboAddress,int,ComboAddress::addressOnlyLessThan> remotes_t;
+    typedef std::map<ComboAddress,int,ComboAddress::addressOnlyLessThan> remotes_t;
     remotes_t remotes;
   };
 
   Stat s;
-  Stat print(int depth=0, Stat newstat=Stat(), bool silent=false) const;
+  std::string name;
+  std::string fullname;
+  unsigned int labelsCount{0};
+
+  void submit(const DNSName& domain, int rcode, const ComboAddress& remote);
+  void submit(std::deque<std::string>& labels, const std::string& domain, int rcode, const ComboAddress& remote, unsigned int count);
+
+  Stat print(unsigned int depth=0, Stat newstat=Stat(), bool silent=false) const;
   typedef boost::function<void(const StatNode*, const Stat& selfstat, const Stat& childstat)> visitor_t;
-  void visit(visitor_t visitor, Stat& newstat, int depth=0) const;
+  void visit(visitor_t visitor, Stat& newstat, unsigned int depth=0) const;
   typedef std::map<std::string,StatNode, CIStringCompare> children_t;
   children_t children;
   


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* Add labels count to the `StatNode` object
* We used to set the full name for every `submit()`, just set it once

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
