### PR TITLE
dnsdist: Fix a typo in the documentation of NetmaskGroup:addMasks()

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -1603,7 +1603,7 @@ instantiate a server with additional parameters
     * NetmaskGroup related
         * function `newNMG()`: returns a NetmaskGroup
         * member `addMask(mask)`: adds `mask` to the NetmaskGroup. Prefix with `!` to exclude this mask from matching.
-        * member `addMask(table)`: adds the keys of `table` to the NetmaskGroup. `table` should be a table whose keys
+        * member `addMasks(table)`: adds the keys of `table` to the NetmaskGroup. `table` should be a table whose keys
         are `ComboAddress` objects and values are integers, as returned by `exceed*` functions
         * member `match(ComboAddress)`: checks if ComboAddress is matched by this NetmaskGroup
         * member `clear()`: clears the NetmaskGroup

--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -209,7 +209,7 @@ void moreLua(bool client)
                          {
                            nmg.addMask(mask);
                          });
-    g_lua.registerFunction<void(NetmaskGroup::*)(const std::map<ComboAddress,int>& map)>("addMasks", [](NetmaskGroup&nmg, const std::map<ComboAddress,int>& map)
+  g_lua.registerFunction<void(NetmaskGroup::*)(const std::map<ComboAddress,int>& map)>("addMasks", [](NetmaskGroup&nmg, const std::map<ComboAddress,int>& map)
                          {
                            for (const auto& entry : map) {
                              nmg.addMask(Netmask(entry.first));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`NetmaskGroup:addMasks(table)` was incorrectly documented as `NetmaskGroup:addMask(table)`.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
