### PR TITLE
dnsdist: Get rid of std::move() calls preventing copy elision

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -309,11 +309,11 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			  if (ret->connected) {
 			    if(g_launchWork) {
 			      g_launchWork->push_back([ret]() {
-			        ret->tid = move(thread(responderThread, ret));
+			        ret->tid = thread(responderThread, ret);
 			      });
 			    }
 			    else {
-			      ret->tid = move(thread(responderThread, ret));
+			      ret->tid = thread(responderThread, ret);
 			    }
 			  }
 
@@ -470,11 +470,11 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			if (ret->connected) {
 			  if(g_launchWork) {
 			    g_launchWork->push_back([ret]() {
-			      ret->tid = move(thread(responderThread, ret));
+			      ret->tid = thread(responderThread, ret);
 			    });
 			  }
 			  else {
-			    ret->tid = move(thread(responderThread, ret));
+			    ret->tid = thread(responderThread, ret);
 			  }
 			}
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1505,7 +1505,7 @@ void* healthChecksThread()
             try {
               SConnect(dss->fd, dss->remote);
               dss->connected = true;
-              dss->tid = move(thread(responderThread, dss));
+              dss->tid = thread(responderThread, dss);
             }
             catch(const std::runtime_error& error) {
               infolog("Error connecting to new server with address %s: %s", dss->remote.toStringWithPort(), error.what());
@@ -2184,7 +2184,7 @@ try
       auto ret=std::make_shared<DownstreamState>(ComboAddress(address, 53));
       addServerToPool(localPools, "", ret);
       if (ret->connected) {
-        ret->tid = move(thread(responderThread, ret));
+        ret->tid = thread(responderThread, ret);
       }
       g_dstates.modify([ret](servers_t& servers) { servers.push_back(ret); });
     }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We were basically betting on the compiler not doing copy elision, and thus moving the temporary value which effectively prevented him from doing so. Let's just assume that the compiler will do its job.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
