### PR TITLE
See #3602, made requests always return to sender, for usage in multi …

### DIFF
--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -710,6 +710,19 @@ void CommunicatorClass::addSlaveCheckRequest(const DomainInfo& di, const ComboAd
   Lock l(&d_lock);
   DomainInfo ours = di;
   ours.backend = 0;
+  string remote_address = remote.toString();
+
+  // When adding a check, if the remote addr from which notification was
+  // received is a master, clear all other masters so we can be sure the
+  // query goes to that one.
+  for (const auto& master : ours.masters) {
+    if (master == remote_address) {
+      ours.masters.clear();
+      ours.masters.push_back(remote_address);
+      break;
+    }
+  }
+  d_tocheck.erase(di);
   d_tocheck.insert(ours);
   d_any_sem.post(); // kick the loop!
 }
@@ -856,10 +869,17 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
   time_t now = time(0);
   for(val_t& val :  sdomains) {
     DomainInfo& di(val.di);
+    DomainInfo tempdi;
     // might've come from the packethandler
-    if(!di.backend && !B->getDomainInfo(di.zone, di)) {
+    // Please do not overwrite received DI just to make sure it exists in backend.
+    if(!di.backend) {
+      if (!B->getDomainInfo(di.zone, tempdi)) {
         L<<Logger::Warning<<"Ignore domain "<< di.zone<<" since it has been removed from our backend"<<endl;
         continue;
+      }
+      // Backend for di still doesn't exist and this might cause us to
+      // SEGFAULT on the setFresh command later on
+      di.backend = tempdi.backend;
     }
 
     if(!ssr.d_freshness.count(di.id)) { // If we don't have an answer for the domain


### PR DESCRIPTION
…master slave zones. Also - made sure that the master that is questioned for updates will be selected randomly, to prevent repeatidally asking a dead master for updates

### Short description
It's a fix as part of my issue #3602. What this does is the following:

1. Make sure that if an AXFR request was made by a master, this master will be the only possible master to contact (as we know that it lives).
2. Make sure that we pass the randomized master list to the code that asks the master for its zone file, as that way we won't just ask the first master, that might be dead.
3. Make sure that if there is no backend for the DomainInfo (because it was received from packethandler) we make sure it receives it from the Temporary copy (as to not SEGFAULT later on. - This occured on our production, only rarely, but still).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
