### PR TITLE
rec: Add support for the new ASAN fiber switch API

### DIFF
--- a/pdns/mtasker_context.hh
+++ b/pdns/mtasker_context.hh
@@ -76,7 +76,13 @@ static inline void notifyStackSwitchToKernel()
 static inline void notifyStackSwitchDone()
 {
 #ifdef HAVE_FIBER_SANITIZER
+#ifdef HAVE_SANITIZER_FINISH_SWITCH_FIBER_SINGLE_PTR
   __sanitizer_finish_switch_fiber(nullptr);
+#else /* HAVE_SANITIZER_FINISH_SWITCH_FIBER_SINGLE_PTR */
+#ifdef HAVE_SANITIZER_FINISH_SWITCH_FIBER_THREE_PTRS
+  __sanitizer_finish_switch_fiber(nullptr, nullptr, nullptr);
+#endif /* HAVE_SANITIZER_FINISH_SWITCH_FIBER_THREE_PTRS */
+#endif /* HAVE_SANITIZER_FINISH_SWITCH_FIBER_SINGLE_PTR */
 #endif /* HAVE_FIBER_SANITIZER */
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`clang` >= 4.0.0 and `gcc` > 7.1, at least, use the new ASAN fiber switch interface taking three pointers instead of just one.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
