### PR TITLE
dnsdist: Fix RecordsTypeCountRule's handling of the # of records in a section

### DIFF
--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -491,7 +491,7 @@ public:
       count = ntohs(dq->dh->arcount);
       break;
     }
-    if (count < d_minCount || count > d_maxCount) {
+    if (count < d_minCount) {
       return false;
     }
     count = getRecordsOfTypeCount(reinterpret_cast<const char*>(dq->dh), dq->len, d_section, d_type);

--- a/regression-tests.dnsdist/test_RecordsCount.py
+++ b/regression-tests.dnsdist/test_RecordsCount.py
@@ -13,7 +13,7 @@ class TestRecordsCountOnlyOneAR(DNSDistTest):
 
     def testRecordsCountRefuseEmptyAR(self):
         """
-        RecordsCount: Refuse arcount == 0
+        RecordsCount: Refuse arcount == 0 (No OPT)
 
         Send a query to "refuseemptyar.recordscount.tests.powerdns.com.",
         check that we are getting a REFUSED response.
@@ -31,7 +31,7 @@ class TestRecordsCountOnlyOneAR(DNSDistTest):
 
     def testRecordsCountAllowOneAR(self):
         """
-        RecordsCount: Allow arcount == 1
+        RecordsCount: Allow arcount == 1 (OPT)
 
         Send a query to "allowonear.recordscount.tests.powerdns.com.",
         check that we are getting a valid response.
@@ -61,7 +61,7 @@ class TestRecordsCountOnlyOneAR(DNSDistTest):
 
     def testRecordsCountRefuseTwoAR(self):
         """
-        RecordsCount: Refuse arcount > 1
+        RecordsCount: Refuse arcount > 1 (OPT + a bogus additional record)
 
         Send a query to "refusetwoar.recordscount.tests.powerdns.com.",
         check that we are getting a REFUSED response.
@@ -264,6 +264,47 @@ class TestRecordsCountNoOPTInAR(DNSDistTest):
         """
         name = 'allowwnooptinar.recordscount.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        response.answer.append(dns.rrset.from_text(name,
+                                                   3600,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.A,
+                                                   '127.0.0.1'))
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+
+    def testRecordsCountAllowTwoARButNoOPT(self):
+        """
+        RecordsTypeCount: Allow arcount > 1 without OPT
+
+        Send a query to "allowtwoarnoopt.recordscount.tests.powerdns.com.",
+        check that we are getting a valid response.
+        """
+        name = 'allowtwoarnoopt.recordscount.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        query.additional.append(dns.rrset.from_text(name,
+                                                    3600,
+                                                    dns.rdataclass.IN,
+                                                    dns.rdatatype.A,
+                                                    '127.0.0.1'))
+        query.additional.append(dns.rrset.from_text(name,
+                                                    3600,
+                                                    dns.rdataclass.IN,
+                                                    dns.rdatatype.A,
+                                                    '127.0.0.1'))
+
         response = dns.message.make_response(query)
         response.answer.append(dns.rrset.from_text(name,
                                                    3600,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We can bail out if the section has less records than the minimum we require, but not if it has more since they obviously might be of different types.

Fixes #5365.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
