### PR TITLE
rec: Don't take the initial ECS source for a scope one if EDNS is off

### DIFF
--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -55,7 +55,7 @@ public:
   unsigned int bytes();
   int32_t get(time_t, const DNSName &qname, const QType& qt, vector<DNSRecord>* res, const ComboAddress& who, vector<std::shared_ptr<RRSIGRecordContent>>* signatures=0);
 
-  void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, bool auth, boost::optional<Netmask> ednsmask=boost::optional<Netmask>());
+  void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, bool auth, boost::optional<Netmask> ednsmask=boost::none);
   void doPrune(void);
   uint64_t doDump(int fd);
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -417,7 +417,7 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
 
   SyncRes::EDNSStatus::EDNSMode& mode=ednsstatus->mode;
   SyncRes::EDNSStatus::EDNSMode oldmode = mode;
-  int EDNSLevel=0;
+  int EDNSLevel = 0;
   auto luaconfsLocal = g_luaconfs.getLocal();
   ResolveContext ctx;
 #ifdef HAVE_PROTOBUF
@@ -1245,7 +1245,7 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(const std::string& prefix, LWResu
     if(i->second.records.empty()) // this happens when we did store signatures, but passed on the records themselves
       continue;
 
-    t_RC->replace(d_now.tv_sec, i->first.name, QType(i->first.type), i->second.records, i->second.signatures, lwr.d_aabit, i->first.place == DNSResourceRecord::ANSWER ? ednsmask : boost::optional<Netmask>());
+    t_RC->replace(d_now.tv_sec, i->first.name, QType(i->first.type), i->second.records, i->second.signatures, lwr.d_aabit, i->first.place == DNSResourceRecord::ANSWER ? ednsmask : boost::none);
 
     if(i->first.place == DNSResourceRecord::ANSWER && ednsmask)
       d_wasVariable=true;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1800,24 +1800,24 @@ int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback) {
     }
     return res;
   }
-  catch(PDNSException& e)
-  {
+  catch(const PDNSException& e) {
     L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.reason<<endl;
   }
-
-  catch(std::exception& e)
-  {
+  catch(const ImmediateServFailException& e) {
+    L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.reason<<endl;
+  }
+  catch(const std::exception& e) {
     L<<Logger::Error<<"Failed to update . records, got an exception: "<<e.what()<<endl;
   }
-
-  catch(...)
-  {
+  catch(...) {
     L<<Logger::Error<<"Failed to update . records, got an exception"<<endl;
   }
+
   if(!res) {
     L<<Logger::Notice<<"Refreshed . records"<<endl;
   }
   else
     L<<Logger::Error<<"Failed to update . records, RCODE="<<res<<endl;
+
   return res;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We use the same reference for passing the `ECS` source value to send in the query and to return the `ECS` scope value received from the server. That's fine but in the case were we send a query without `EDNS`, because we have detected the server chokes on it, we forgot to reset the value, causing the caller to believe the server actually returned an `ECS` scope value if it passed any `ECS` source value.

This PR also enhances the logging of `ImmediateServFailException` raised in `SyncRes::getRootNS()`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
