### PR TITLE
Dnssec axfr

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -51,6 +51,11 @@ pthread_rwlock_t DNSSECKeeper::s_keycachelock = PTHREAD_RWLOCK_INITIALIZER;
 AtomicCounter DNSSECKeeper::s_ops;
 time_t DNSSECKeeper::s_last_prune;
 
+bool DNSSECKeeper::doesDNSSEC()
+{
+  return d_keymetadb->doesDNSSEC();
+}
+
 bool DNSSECKeeper::isSecuredZone(const DNSName& zone) 
 {
   if(isPresigned(zone))

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -156,6 +156,7 @@ public:
     if(d_ourDB)
       delete d_keymetadb;
   }
+  bool doesDNSSEC();
   bool isSecuredZone(const DNSName& zone);
   static uint64_t dbdnssecCacheSizes(const std::string& str);
   keyset_t getEntryPoints(const DNSName& zname);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1293,7 +1293,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
         if(addCDS(p,r, sd))
           goto sendit;
       }
-      else if(p->qtype.getCode() == QType::NSEC3PARAM)
+      else if(p->qtype.getCode() == QType::NSEC3PARAM && d_dk.isSecuredZone(sd.qname))
       {
         if(addNSEC3PARAM(p,r, sd))
           goto sendit;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -614,7 +614,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   NSEC3PARAMRecordContent ns3pr;
   bool narrow;
   bool NSEC3Zone=false;
-  if(dk.getNSEC3PARAM(target, &ns3pr, &narrow)) {
+  if(securedZone && dk.getNSEC3PARAM(target, &ns3pr, &narrow)) {
     NSEC3Zone=true;
     if(narrow) {
       L<<Logger::Error<<"Not doing AXFR of an NSEC3 narrow zone '"<<target<<"' for "<<q->getRemote()<<endl;

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -98,6 +98,15 @@ bool UeberBackend::createDomain(const DNSName &domain)
   return false;
 }
 
+bool UeberBackend::doesDNSSEC()
+{
+  for(auto* db :  backends) {
+    if(db->doesDNSSEC())
+      return true;
+  }
+  return false;
+}
+
 bool UeberBackend::addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& id)
 {
   id = -1;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -109,6 +109,7 @@ public:
   bool getDomainInfo(const DNSName &domain, DomainInfo &di);
   bool createDomain(const DNSName &domain);
   
+  bool doesDNSSEC();
   bool addDomainKey(const DNSName& name, const DNSBackend::KeyData& key, int64_t& id);
   bool getDomainKeys(const DNSName& name, std::vector<DNSBackend::KeyData>& keys);
   bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string> >& meta);


### PR DESCRIPTION
### Short description
- Improve the axfr dnssec freshness check. It is no longer necessary to increase a serial after a zone was signed/unsigned. 
Note: an insecure master zone only get refreshed on a slave after all existing signatures have expired, to keep the existing resilience against losing private keys on the master... 
- Ignore NSEC3PARAM metadata in an unsigned zones

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)