### PR TITLE
Make DNSRecordContent::mastermake() return a shared pointer

### DIFF
--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -168,7 +168,7 @@ bool Bind2Backend::getNSEC3PARAM(const DNSName& name, NSEC3PARAMRecordContent* n
 
   static int maxNSEC3Iterations=::arg().asNum("max-nsec3-iterations");
   if(ns3p) {
-    std::shared_ptr<NSEC3PARAMRecordContent> tmp=std::dynamic_pointer_cast<NSEC3PARAMRecordContent>(DNSRecordContent::mastermake(QType::NSEC3PARAM, 1, value));
+    auto tmp=std::dynamic_pointer_cast<NSEC3PARAMRecordContent>(DNSRecordContent::mastermake(QType::NSEC3PARAM, 1, value));
     *ns3p = *tmp;
 
     if (ns3p->d_iterations > maxNSEC3Iterations) {

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -168,9 +168,8 @@ bool Bind2Backend::getNSEC3PARAM(const DNSName& name, NSEC3PARAMRecordContent* n
 
   static int maxNSEC3Iterations=::arg().asNum("max-nsec3-iterations");
   if(ns3p) {
-    NSEC3PARAMRecordContent* tmp=dynamic_cast<NSEC3PARAMRecordContent*>(DNSRecordContent::mastermake(QType::NSEC3PARAM, 1, value));
+    std::shared_ptr<NSEC3PARAMRecordContent> tmp=std::dynamic_pointer_cast<NSEC3PARAMRecordContent>(DNSRecordContent::mastermake(QType::NSEC3PARAM, 1, value));
     *ns3p = *tmp;
-    delete tmp;
 
     if (ns3p->d_iterations > maxNSEC3Iterations) {
       ns3p->d_iterations = maxNSEC3Iterations;

--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -300,7 +300,7 @@ bool TinyDNSBackend::get(DNSResourceRecord &rr)
         dr.d_type = rr.qtype.getCode();
         dr.d_clen = val.size()-pr.d_pos;
 
-        std::shared_ptr<DNSRecordContent> drc = DNSRecordContent::mastermake(dr, pr);
+        auto drc = DNSRecordContent::mastermake(dr, pr);
         rr.content = drc->getZoneRepresentation();
         DLOG(cerr<<"CONTENT: "<<rr.content<<endl);
       }

--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -300,10 +300,9 @@ bool TinyDNSBackend::get(DNSResourceRecord &rr)
         dr.d_type = rr.qtype.getCode();
         dr.d_clen = val.size()-pr.d_pos;
 
-        DNSRecordContent *drc = DNSRecordContent::mastermake(dr, pr);
+        std::shared_ptr<DNSRecordContent> drc = DNSRecordContent::mastermake(dr, pr);
         rr.content = drc->getZoneRepresentation();
         DLOG(cerr<<"CONTENT: "<<rr.content<<endl);
-        delete drc;
       }
       catch (...) {
         if (d_ignorebogus) {

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -166,9 +166,9 @@ struct DNSRecord;
 class DNSRecordContent
 {
 public:
-  static DNSRecordContent* mastermake(const DNSRecord &dr, PacketReader& pr);
-  static DNSRecordContent* mastermake(const DNSRecord &dr, PacketReader& pr, uint16_t opcode);
-  static DNSRecordContent* mastermake(uint16_t qtype, uint16_t qclass, const string& zone);
+  static std::shared_ptr<DNSRecordContent> mastermake(const DNSRecord &dr, PacketReader& pr);
+  static std::shared_ptr<DNSRecordContent> mastermake(const DNSRecord &dr, PacketReader& pr, uint16_t opcode);
+  static std::shared_ptr<DNSRecordContent> mastermake(uint16_t qtype, uint16_t qclass, const string& zone);
   static std::unique_ptr<DNSRecordContent> makeunique(uint16_t qtype, uint16_t qclass, const string& content);
 
   virtual std::string getZoneRepresentation(bool noDot=false) const = 0;

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -142,7 +142,7 @@ AuthLua4::AuthLua4(const std::string& fname) {
     });
 
 
-  d_lw->registerFunction<void(DNSRecord::*)(const std::string&)>("changeContent", [](DNSRecord& dr, const std::string& newContent) { dr.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(dr.d_type, 1, newContent)); });
+  d_lw->registerFunction<void(DNSRecord::*)(const std::string&)>("changeContent", [](DNSRecord& dr, const std::string& newContent) { dr.d_content = DNSRecordContent::mastermake(dr.d_type, 1, newContent); });
 
   d_lw->writeFunction("pdnslog", [](const std::string& msg, boost::optional<int> loglevel) {
       theL() << (Logger::Urgency)loglevel.get_value_or(Logger::Warning) << msg<<endl;

--- a/pdns/lua-pdns.cc
+++ b/pdns/lua-pdns.cc
@@ -255,7 +255,7 @@ void popResourceRecordsTable(lua_State *lua, const DNSName &query, vector<DNSRec
 
     string content;
     getFromTable(lua, "content", content);
-    rr.d_content=shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(rr.d_type, rr.d_class, content));
+    rr.d_content=DNSRecordContent::mastermake(rr.d_type, rr.d_class, content);
 
     if(!getFromTable(lua, "ttl", rr.d_ttl))
       rr.d_ttl=3600;

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -196,7 +196,7 @@ void RecursorLua4::DNSQuestion::addRecord(uint16_t type, const std::string& cont
   dr.d_ttl=ttl.get_value_or(3600);
   dr.d_type = type;
   dr.d_place = place;
-  dr.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(type, 1, content));
+  dr.d_content = DNSRecordContent::mastermake(type, 1, content);
   records.push_back(dr);
 }
 
@@ -372,7 +372,7 @@ RecursorLua4::RecursorLua4(const std::string& fname)
     },
     [](DNSFilterEngine::Policy& pol, const std::string& content) {
       // Only CNAMES for now, when we ever add a d_custom_type, there will be pain
-      pol.d_custom = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::CNAME, 1, content));
+      pol.d_custom = DNSRecordContent::mastermake(QType::CNAME, 1, content);
     }
   );
   d_lw->registerFunction("getDH", &DNSQuestion::getDH);
@@ -401,7 +401,7 @@ RecursorLua4::RecursorLua4(const std::string& fname)
     });
 
 
-  d_lw->registerFunction<void(DNSRecord::*)(const std::string&)>("changeContent", [](DNSRecord& dr, const std::string& newContent) { dr.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(dr.d_type, 1, newContent)); });
+  d_lw->registerFunction<void(DNSRecord::*)(const std::string&)>("changeContent", [](DNSRecord& dr, const std::string& newContent) { dr.d_content = DNSRecordContent::mastermake(dr.d_type, 1, newContent); });
   d_lw->registerFunction("addAnswer", &DNSQuestion::addAnswer);
   d_lw->registerFunction("addRecord", &DNSQuestion::addRecord);
   d_lw->registerFunction("getRecords", &DNSQuestion::getRecords);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -265,7 +265,7 @@ int PacketHandler::doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target)
       }
       else
         content=mode;
-      rr.dr.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::TXT, 1, "\""+content+"\""));
+      rr.dr.d_content = DNSRecordContent::mastermake(QType::TXT, 1, "\""+content+"\"");
     }
     else if (target==idserver) {
       // modes: disabled, hostname or custom
@@ -275,7 +275,7 @@ int PacketHandler::doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target)
         r->setRcode(RCode::Refused);
         return 0;
       }
-      rr.dr.d_content=shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::TXT, 1, id));
+      rr.dr.d_content=DNSRecordContent::mastermake(QType::TXT, 1, id);
     }
     else {
       r->setRcode(RCode::Refused);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1,3 +1,4 @@
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -1465,23 +1466,23 @@ void verifyCrypto(const string& zone)
     if(rr.qtype.getCode() == QType::DNSKEY) {
       cerr<<"got DNSKEY!"<<endl;
       apex=rr.qname;
-      drc = *dynamic_cast<DNSKEYRecordContent*>(DNSRecordContent::mastermake(QType::DNSKEY, 1, rr.content));
+      drc = *std::dynamic_pointer_cast<DNSKEYRecordContent>(DNSRecordContent::mastermake(QType::DNSKEY, 1, rr.content));
     }
     else if(rr.qtype.getCode() == QType::RRSIG) {
       cerr<<"got RRSIG"<<endl;
-      rrc = *dynamic_cast<RRSIGRecordContent*>(DNSRecordContent::mastermake(QType::RRSIG, 1, rr.content));
+      rrc = *std::dynamic_pointer_cast<RRSIGRecordContent>(DNSRecordContent::mastermake(QType::RRSIG, 1, rr.content));
     }
     else if(rr.qtype.getCode() == QType::DS) {
       cerr<<"got DS"<<endl;
-      dsrc = *dynamic_cast<DSRecordContent*>(DNSRecordContent::mastermake(QType::DS, 1, rr.content));
+      dsrc = *std::dynamic_pointer_cast<DSRecordContent>(DNSRecordContent::mastermake(QType::DS, 1, rr.content));
     }
     else {
       qname = rr.qname;
-      toSign.push_back(shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(rr.qtype.getCode(), 1, rr.content)));
+      toSign.push_back(DNSRecordContent::mastermake(rr.qtype.getCode(), 1, rr.content));
     }
   }
   
-  string msg = getMessageForRRSET(qname, rrc, toSign);        
+  string msg = getMessageForRRSET(qname, rrc, toSign);
   cerr<<"Verify: "<<DNSCryptoKeyEngine::makeFromPublicKeyString(drc.d_algorithm, drc.d_key)->verify(msg, rrc.d_signature)<<endl;
   if(dsrc.d_digesttype) {
     cerr<<"Calculated DS: "<<apex.toString()<<" IN DS "<<makeDSFromDNSKey(apex, drc, dsrc.d_digesttype).getZoneRepresentation()<<endl;

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -62,11 +62,9 @@ static void parseRPZParameters(const std::unordered_map<string,boost::variant<ui
     defpol->d_name = std::make_shared<std::string>(polName);
     if(defpol->d_kind == DNSFilterEngine::PolicyKind::Custom) {
       defpol->d_custom=
-        shared_ptr<DNSRecordContent>(
           DNSRecordContent::mastermake(QType::CNAME, 1,
                                        boost::get<string>(constGet(have,"defcontent"))
-            )
-          );
+            );
 
       if(have.count("defttl"))
         defpol->d_ttl = static_cast<int32_t>(boost::get<uint32_t>(constGet(have, "defttl")));

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -14,7 +14,7 @@ static recordsAndSignatures genRecsAndSigs(const DNSName& name, const uint16_t q
   rec.d_type = qtype;
   rec.d_ttl = 600;
   rec.d_place = DNSResourceRecord::AUTHORITY;
-  rec.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(qtype, QClass::IN, content));
+  rec.d_content = DNSRecordContent::mastermake(qtype, QClass::IN, content);
 
   ret.records.push_back(rec);
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -195,7 +195,7 @@ static void addRecordToList(std::vector<DNSRecord>& records, const DNSName& name
     rec.d_content = std::make_shared<OPTRecordContent>();
   }
   else {
-    rec.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(type, QClass::IN, content));
+    rec.d_content = DNSRecordContent::mastermake(type, QClass::IN, content);
   }
 
   records.push_back(rec);

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -108,7 +108,7 @@ static void makeNameToIPZone(std::shared_ptr<SyncRes::domainmap_t> newMap, const
   dr.d_ttl=86400;
   dr.d_type=QType::SOA;
   dr.d_class = 1;
-  dr.d_content = std::shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800"));
+  dr.d_content = DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800");
   
   ad.d_records.insert(dr);
 
@@ -118,7 +118,7 @@ static void makeNameToIPZone(std::shared_ptr<SyncRes::domainmap_t> newMap, const
   ad.d_records.insert(dr);
   
   dr.d_type=QType::A;
-  dr.d_content= std::shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::A, 1, ip));
+  dr.d_content = DNSRecordContent::mastermake(QType::A, 1, ip);
   ad.d_records.insert(dr);
   
   if(newMap->count(dr.d_name)) {  
@@ -151,7 +151,7 @@ static void makeIPToNamesZone(std::shared_ptr<SyncRes::domainmap_t> newMap, cons
   dr.d_place=DNSResourceRecord::ANSWER;
   dr.d_ttl=86400;
   dr.d_type=QType::SOA;
-  dr.d_content=std::shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800"));
+  dr.d_content=DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800");
   
   ad.d_records.insert(dr);
 
@@ -163,7 +163,7 @@ static void makeIPToNamesZone(std::shared_ptr<SyncRes::domainmap_t> newMap, cons
 
   if(ipparts.size()==4)  // otherwise this is a partial zone
     for(unsigned int n=1; n < parts.size(); ++n) {
-      dr.d_content=std::shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(QType::PTR, 1, DNSName(parts[n]).toString())); // XXX FIXME DNSNAME PAIN CAN THIS BE RIGHT?
+      dr.d_content=DNSRecordContent::mastermake(QType::PTR, 1, DNSName(parts[n]).toString()); // XXX FIXME DNSNAME PAIN CAN THIS BE RIGHT?
       ad.d_records.insert(dr);
     }
 

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -229,14 +229,14 @@ vector<uint8_t> makeBigReferral()
   for(char c='a'; c<= 'm';++c) {
     pw.startRecord(DNSName("com"), QType::NS, 3600, 1, DNSResourceRecord::AUTHORITY);
     gtld[0]=c;
-    std::unique_ptr<DNSRecordContent> drc = DNSRecordContent::makeunique(QType::NS, 1, gtld);
+    auto drc = DNSRecordContent::makeunique(QType::NS, 1, gtld);
     drc->toPacket(pw);
   }
 
   for(char c='a'; c<= 'k';++c) {
     gtld[0]=c;
     pw.startRecord(DNSName(gtld), QType::A, 3600, 1, DNSResourceRecord::ADDITIONAL);
-    std::unique_ptr<DNSRecordContent> drc = DNSRecordContent::makeunique(QType::A, 1, "1.2.3.4");
+    auto drc = DNSRecordContent::makeunique(QType::A, 1, "1.2.3.4");
     drc->toPacket(pw);
   }
 

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -229,29 +229,25 @@ vector<uint8_t> makeBigReferral()
   for(char c='a'; c<= 'm';++c) {
     pw.startRecord(DNSName("com"), QType::NS, 3600, 1, DNSResourceRecord::AUTHORITY);
     gtld[0]=c;
-    DNSRecordContent* drc = DNSRecordContent::mastermake(QType::NS, 1, gtld);
+    std::unique_ptr<DNSRecordContent> drc = DNSRecordContent::makeunique(QType::NS, 1, gtld);
     drc->toPacket(pw);
-    delete drc;
   }
 
   for(char c='a'; c<= 'k';++c) {
     gtld[0]=c;
     pw.startRecord(DNSName(gtld), QType::A, 3600, 1, DNSResourceRecord::ADDITIONAL);
-    DNSRecordContent* drc = DNSRecordContent::mastermake(QType::A, 1, "1.2.3.4");
+    std::unique_ptr<DNSRecordContent> drc = DNSRecordContent::makeunique(QType::A, 1, "1.2.3.4");
     drc->toPacket(pw);
-    delete drc;
   }
 
 
   pw.startRecord(DNSName("a.gtld-servers.net"), QType::AAAA, 3600, 1, DNSResourceRecord::ADDITIONAL);
-  auto aaaarc = DNSRecordContent::mastermake(QType::AAAA, 1, "2001:503:a83e::2:30");
+  auto aaaarc = DNSRecordContent::makeunique(QType::AAAA, 1, "2001:503:a83e::2:30");
   aaaarc->toPacket(pw);
-  delete aaaarc;
 
   pw.startRecord(DNSName("b.gtld-servers.net"), QType::AAAA, 3600, 1, DNSResourceRecord::ADDITIONAL);
-  aaaarc = DNSRecordContent::mastermake(QType::AAAA, 1, "2001:503:231d::2:30");
+  aaaarc = DNSRecordContent::makeunique(QType::AAAA, 1, "2001:503:231d::2:30");
   aaaarc->toPacket(pw);
-  delete aaaarc;
 
 
   pw.commit();
@@ -297,9 +293,8 @@ vector<uint8_t> makeBigDNSPacketReferral()
   //  shuffle(records);
   for(const auto& rec : records) {
     pw.startRecord(rec.qname, rec.qtype.getCode(), rec.ttl, 1, DNSResourceRecord::ADDITIONAL);
-    auto drc = DNSRecordContent::mastermake(rec.qtype.getCode(), 1, rec.content);
+    auto drc = DNSRecordContent::makeunique(rec.qtype.getCode(), 1, rec.content);
     drc->toPacket(pw);
-    delete drc;
   }
 
   pw.commit();
@@ -317,9 +312,8 @@ struct MakeARecordTestMM
 
   void operator()() const
   {
-      DNSRecordContent*drc = DNSRecordContent::mastermake(QType::A, 1, 
-                                                          "1.2.3.4");
-      delete drc;
+      auto drc = DNSRecordContent::makeunique(QType::A, 1,
+                                              "1.2.3.4");
   }
 };
 
@@ -391,10 +385,9 @@ struct GenericRecordTest
     DNSPacketWriter pw(packet, DNSName("outpost.ds9a.nl"), d_type);
     for(int records = 0; records < d_records; records++) {
       pw.startRecord(DNSName("outpost.ds9a.nl"), d_type);
-      DNSRecordContent*drc = DNSRecordContent::mastermake(d_type, 1, 
-                                                          d_content);
+      auto drc = DNSRecordContent::makeunique(d_type, 1,
+                                              d_content);
       drc->toPacket(pw);
-      delete drc;
     }
     pw.commit();
   }
@@ -419,9 +412,8 @@ struct AAAARecordTest
     DNSPacketWriter pw(packet, DNSName("outpost.ds9a.nl"), QType::AAAA);
     for(int records = 0; records < d_records; records++) {
       pw.startRecord(DNSName("outpost.ds9a.nl"), QType::AAAA);
-      DNSRecordContent*drc = DNSRecordContent::mastermake(QType::AAAA, 1, "fe80::21d:92ff:fe6d:8441");
+      auto drc = DNSRecordContent::makeunique(QType::AAAA, 1, "fe80::21d:92ff:fe6d:8441");
       drc->toPacket(pw);
-      delete drc;
     }
     pw.commit();
   }
@@ -444,9 +436,8 @@ struct SOARecordTest
 
     for(int records = 0; records < d_records; records++) {
       pw.startRecord(DNSName("outpost.ds9a.nl"), QType::SOA);
-      DNSRecordContent*drc = DNSRecordContent::mastermake(QType::SOA, 1, "a0.org.afilias-nst.info. noc.afilias-nst.info. 2008758137 1800 900 604800 86400");
+      auto drc = DNSRecordContent::makeunique(QType::SOA, 1, "a0.org.afilias-nst.info. noc.afilias-nst.info. 2008758137 1800 900 604800 86400");
       drc->toPacket(pw);
-      delete drc;
     }
     pw.commit();
   }
@@ -466,25 +457,21 @@ vector<uint8_t> makeTypicalReferral()
   DNSPacketWriter pw(packet, DNSName("outpost.ds9a.nl"), QType::A);
 
   pw.startRecord(DNSName("ds9a.nl"), QType::NS, 3600, 1, DNSResourceRecord::AUTHORITY);
-  DNSRecordContent* drc = DNSRecordContent::mastermake(QType::NS, 1, "ns1.ds9a.nl");
+  auto drc = DNSRecordContent::makeunique(QType::NS, 1, "ns1.ds9a.nl");
   drc->toPacket(pw);
-  delete drc;
 
   pw.startRecord(DNSName("ds9a.nl"), QType::NS, 3600, 1, DNSResourceRecord::AUTHORITY);
-  drc = DNSRecordContent::mastermake(QType::NS, 1, "ns2.ds9a.nl");
+  drc = DNSRecordContent::makeunique(QType::NS, 1, "ns2.ds9a.nl");
   drc->toPacket(pw);
-  delete drc;
 
 
   pw.startRecord(DNSName("ns1.ds9a.nl"), QType::A, 3600, 1, DNSResourceRecord::ADDITIONAL);
-  drc = DNSRecordContent::mastermake(QType::A, 1, "1.2.3.4");
+  drc = DNSRecordContent::makeunique(QType::A, 1, "1.2.3.4");
   drc->toPacket(pw);
-  delete drc;
 
   pw.startRecord(DNSName("ns2.ds9a.nl"), QType::A, 3600, 1, DNSResourceRecord::ADDITIONAL);
-  drc = DNSRecordContent::mastermake(QType::A, 1, "4.3.2.1");
+  drc = DNSRecordContent::makeunique(QType::A, 1, "4.3.2.1");
   drc->toPacket(pw);
-  delete drc;
 
   pw.commit();
   return  packet;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -190,7 +190,7 @@ bool SyncRes::doSpecialNamesResolve(const DNSName &qname, const QType &qtype, co
     dr.d_ttl = 86400;
     for (const auto& ans : answers) {
       dr.d_type = ans.first;
-      dr.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(ans.first, qclass, ans.second));
+      dr.d_content = DNSRecordContent::mastermake(ans.first, qclass, ans.second);
       ret.push_back(dr);
     }
   }

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
    try {
       std::string recData;
       if (q.getCode() != QType::TSIG) {
-        boost::scoped_ptr<DNSRecordContent> rec(DNSRecordContent::mastermake(q.getCode(), 1, val.get<1>()));
+        auto rec = DNSRecordContent::mastermake(q.getCode(), 1, val.get<1>());
         BOOST_CHECK_MESSAGE(rec != NULL, "mastermake( " << q.getCode() << ", 1, " << val.get<1>() << ") returned NULL");
         if (rec == NULL) continue;
         // now verify the record (note that this will be same as *zone* value (except for certain QTypes)
@@ -268,10 +268,10 @@ BOOST_AUTO_TEST_CASE(test_record_types_bad_values) {
 
     if (val.get<2>()) {
       bool success=true;
-      BOOST_WARN_EXCEPTION( { boost::scoped_ptr<DNSRecordContent> drc(DNSRecordContent::mastermake(q.getCode(), 1, val.get<1>())); pw.startRecord(DNSName("unit.test"), q.getCode()); drc->toPacket(pw); success=false; }, std::exception, test_dnsrecords_cc_predicate );
+      BOOST_WARN_EXCEPTION( { auto drc = DNSRecordContent::mastermake(q.getCode(), 1, val.get<1>()); pw.startRecord(DNSName("unit.test"), q.getCode()); drc->toPacket(pw); success=false; }, std::exception, test_dnsrecords_cc_predicate );
       if (success==false) REC_FAIL_XSUCCESS2(q.getName() << " test #" << n << " has unexpectedly passed"); // a bad record was detected when it was supposed not to be detected
     } else {
-      BOOST_CHECK_EXCEPTION( { boost::scoped_ptr<DNSRecordContent> drc(DNSRecordContent::mastermake(q.getCode(), 1, val.get<1>())); pw.startRecord(DNSName("unit.test"), q.getCode()); drc->toPacket(pw); }, std::exception, test_dnsrecords_cc_predicate );
+      BOOST_CHECK_EXCEPTION( { auto drc = DNSRecordContent::mastermake(q.getCode(), 1, val.get<1>()); pw.startRecord(DNSName("unit.test"), q.getCode()); drc->toPacket(pw); }, std::exception, test_dnsrecords_cc_predicate );
     }
   };
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -287,7 +287,7 @@ void AuthWebServer::indexfunction(HttpRequest* req, HttpResponse* resp)
 /** Helper to build a record content as needed. */
 static inline string makeRecordContent(const QType& qtype, const string& content, bool noDot) {
   // noDot: for backend storage, pass true. for API users, pass false.
-  std::unique_ptr<DNSRecordContent> drc(DNSRecordContent::mastermake(qtype.getCode(), 1, content));
+  std::unique_ptr<DNSRecordContent> drc(DNSRecordContent::makeunique(qtype.getCode(), QClass::IN, content));
   return drc->getZoneRepresentation(noDot);
 }
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -287,7 +287,7 @@ void AuthWebServer::indexfunction(HttpRequest* req, HttpResponse* resp)
 /** Helper to build a record content as needed. */
 static inline string makeRecordContent(const QType& qtype, const string& content, bool noDot) {
   // noDot: for backend storage, pass true. for API users, pass false.
-  std::unique_ptr<DNSRecordContent> drc(DNSRecordContent::makeunique(qtype.getCode(), QClass::IN, content));
+  auto drc = DNSRecordContent::makeunique(qtype.getCode(), QClass::IN, content);
   return drc->getZoneRepresentation(noDot);
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Make `DNSRecordContent::mastermake()` return a shared pointer instead of a naked one, since we almost always wrapped it into one afterward, and had no good reason not to anyway.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
