### PR TITLE
Fix query in howtos.md doc

### DIFF
--- a/docs/markdown/authoritative/howtos.md
+++ b/docs/markdown/authoritative/howtos.md
@@ -73,7 +73,7 @@ Now we need to add some records to our database (in a separate shell):
 # mysql pdnstest
 mysql> INSERT INTO domains (name, type) values ('example.com', 'NATIVE');
 INSERT INTO records (domain_id, name, content, type,ttl,prio)
-VALUES (1,'example.com','localhost admin.example.com 1','SOA',86400,NULL);
+VALUES (1,'example.com','localhost admin.example.com 1 10380 3600 604800 3600','SOA',86400,NULL);
 INSERT INTO records (domain_id, name, content, type,ttl,prio)
 VALUES (1,'example.com','dns-us1.powerdns.net','NS',86400,NULL);
 INSERT INTO records (domain_id, name, content, type,ttl,prio)


### PR DESCRIPTION
I'm not sure if this is a bug in the docs, a bug in pdns, or an old bug
that was fixed. I will open an issue to reference this.

### Short description
Query for SOA record as-is in documentation results in 500 errors when trying to view or edit the zone, like this:

```
Jun  6 13:52:05 debian pdns_server[1108]: Jun 06 13:52:05 HTTP ISE for "/api/v1/servers/localhost/zones/example.com": STL Exception: Parsing record content (try 'pdnsutil check-zone'): missing field at the end of record content 'localhost admin@example.com 1'
```

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

