### PR TITLE
dnsdist: Change dnsdist stats functions to always return lowercase names

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -158,7 +158,7 @@ std::unordered_map<int, vector<boost::variant<string,double>>> getGenResponses(u
   vector<pair<int, DNSName>> rcounts;
   rcounts.reserve(counts.size());
   for(const auto& c : counts) 
-    rcounts.push_back(make_pair(c.second, c.first));
+    rcounts.push_back(make_pair(c.second, c.first.makeLowerCase()));
   
   sort(rcounts.begin(), rcounts.end(), [](const decltype(rcounts)::value_type& a, 
                                           const decltype(rcounts)::value_type& b) {
@@ -1351,7 +1351,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       vector<pair<int, DNSName>> rcounts;
       rcounts.reserve(counts.size());
       for(const auto& c : counts) 
-	rcounts.push_back(make_pair(c.second, c.first));
+	rcounts.push_back(make_pair(c.second, c.first.makeLowerCase()));
 
       sort(rcounts.begin(), rcounts.end(), [](const decltype(rcounts)::value_type& a, 
 					      const decltype(rcounts)::value_type& b) {


### PR DESCRIPTION
### Short description
Changes getTopQueries and getGenResponses to return lowercase versions for all names. Closes #5287 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
