### PR TITLE
allow control socket to listen on IPv6

### DIFF
--- a/pdns/dynlistener.cc
+++ b/pdns/dynlistener.cc
@@ -146,7 +146,11 @@ void DynListener::listenOnUnixDomain(const string& fname)
 
 void DynListener::listenOnTCP(const ComboAddress& local)
 {
-  createSocketAndBind(AF_INET, (struct sockaddr*)& local, local.getSocklen());
+  if (local.isIPv4()) {
+    createSocketAndBind(AF_INET, (struct sockaddr*)& local, local.getSocklen());
+  } else if (local.isIPv6()) {
+    createSocketAndBind(AF_INET6, (struct sockaddr*)& local, local.getSocklen());
+  }
   listen(d_s, 10);
 
   d_socketaddress=local;


### PR DESCRIPTION
### Short description
The change fixes listenOnTCP to allow pdns to bind control sockets to IPv6.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)