### PR TITLE
API: Auth: forbid mixing CNAME and other RRsets

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1436,6 +1436,16 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
         }
 
         if (replace_records) {
+          di.backend->lookup(QType(QType::ANY), qname);
+          DNSResourceRecord rr;
+          while (di.backend->get(rr)) {
+            if (qtype.getCode() == QType::CNAME && rr.qtype.getCode() != QType::CNAME) {
+              throw ApiException("RRset "+qname.toString()+" IN "+qtype.getName()+": Conflicts with pre-existing non-CNAME RRset");
+            } else if (qtype.getCode() != QType::CNAME && rr.qtype.getCode() == QType::CNAME) {
+              throw ApiException("RRset "+qname.toString()+" IN "+qtype.getName()+": Conflicts with pre-existing CNAME RRset");
+            }
+          }
+
           if (!di.backend->replaceRRSet(di.id, qname, qtype, new_records)) {
             throw ApiException("Hosting backend does not support editing records.");
           }


### PR DESCRIPTION
### Short description
This PR changes the authoritative API to forbid sending a CNAME RRset after a non-CNAME RRset is already in place at a given point in a zone and vice-versa.

Fixes #5305.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
