### PR TITLE
altered postgres schema to match mysql schema

### DIFF
--- a/modules/gpgsqlbackend/schema.pgsql.sql
+++ b/modules/gpgsqlbackend/schema.pgsql.sql
@@ -13,7 +13,7 @@ CREATE UNIQUE INDEX name_index ON domains(name);
 
 
 CREATE TABLE records (
-  id                    SERIAL PRIMARY KEY,
+  id                    BIGSERIAL PRIMARY KEY,
   domain_id             INT DEFAULT NULL,
   name                  VARCHAR(255) DEFAULT NULL,
   type                  VARCHAR(10) DEFAULT NULL,


### PR DESCRIPTION
### Short description
mysql uses BIGINT for records id. 
postgres is also going to use BIGINT (BIGSERIAL) too.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
