### PR TITLE
also set d_requestor without Lua: the ECS logic needs it

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -764,9 +764,8 @@ static void startDoResolve(void *p)
     bool DNSSECOK=false;
     if(t_pdl) {
       sr.setLuaEngine(t_pdl);
-      sr.d_requestor=dc->d_remote;
     }
-
+    sr.d_requestor=dc->d_remote; // ECS needs this too
     if(g_dnssecmode != DNSSECMode::Off) {
       sr.setDoDNSSEC(true);
 


### PR DESCRIPTION
### Short description
EDNS Client Subnet would only work if a Lua script was loaded in git master

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
