### PR TITLE
rec: Use the incoming ECS for cache lookup if `use-incoming-edns-subnet` is set

### DIFF
--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -618,6 +618,12 @@ public:
   void setIncomingECS(boost::optional<const EDNSSubnetOpts&> incomingECS)
   {
     d_incomingECS = incomingECS;
+    if (incomingECS) {
+      d_incomingECSNetwork = incomingECS->source.getMaskedNetwork();
+    }
+    else {
+      d_incomingECSNetwork = ComboAddress();
+    }
   }
 
 #ifdef HAVE_PROTOBUF
@@ -755,6 +761,7 @@ private:
   ostringstream d_trace;
   shared_ptr<RecursorLua4> d_pdl;
   boost::optional<const EDNSSubnetOpts&> d_incomingECS;
+  ComboAddress d_incomingECSNetwork;
 #ifdef HAVE_PROTOBUF
   boost::optional<const boost::uuids::uuid&> d_initialRequestId;
 #endif


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise we insert into the cache based on the incoming ECS but later do the lookup based on the query's source IP.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
