### PR TITLE
rec: Make more specific Netmasks < to less specific ones

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -444,7 +444,23 @@ public:
 
   bool operator<(const Netmask& rhs) const 
   {
-    return tie(d_network, d_bits) < tie(rhs.d_network, rhs.d_bits);
+    if (empty() && !rhs.empty())
+      return false;
+
+    if (!empty() && rhs.empty())
+      return true;
+
+    if (d_bits > rhs.d_bits)
+      return true;
+    if (d_bits < rhs.d_bits)
+      return false;
+
+    return d_network < rhs.d_network;
+  }
+
+  bool operator>(const Netmask& rhs) const
+  {
+    return rhs.operator<(*this);
   }
 
   bool operator==(const Netmask& rhs) const 

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -256,6 +256,47 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple) {
     BOOST_REQUIRE_EQUAL(retrieved.size(), 1);
     BOOST_CHECK_EQUAL(getRR<ARecordContent>(retrieved.at(0))->getCA().toString(), dr2Content.toString());
 
+    // Most specific netmask test
+    // wipe everything
+    MRC.doWipeCache(DNSName("."), true);
+    BOOST_CHECK_EQUAL(MRC.size(), 0);
+    records.clear();
+
+    // insert an entry for 192.0.0.1/8
+    records.clear();
+    records.push_back(dr2);
+    MRC.replace(now, power, QType(QType::A), records, signatures, true, boost::optional<Netmask>("192.0.0.1/8"));
+    BOOST_CHECK_EQUAL(MRC.size(), 1);
+
+    /* same as dr2 except for the actual IP */
+    DNSRecord dr4;
+    ComboAddress dr4Content("192.0.2.126");
+    dr4.d_name = power;
+    dr4.d_type = QType::A;
+    dr4.d_class = QClass::IN;
+    dr4.d_content = std::make_shared<ARecordContent>(dr4Content);
+    dr4.d_ttl = static_cast<uint32_t>(ttd);
+    dr4.d_place = DNSResourceRecord::AUTHORITY;
+
+    // insert an other entry but for 192.168.0.1/31
+    records.clear();
+    records.push_back(dr4);
+    MRC.replace(now, power, QType(QType::A), records, signatures, true, boost::optional<Netmask>("192.168.0.1/31"));
+    // we should not have replaced any existing entry
+    BOOST_CHECK_EQUAL(MRC.size(), 2);
+
+    // insert the same than the first one but for 192.168.0.2/32
+    records.clear();
+    records.push_back(dr2);
+    MRC.replace(now, power, QType(QType::A), records, signatures, true, boost::optional<Netmask>("192.168.0.2/32"));
+    // we should not have replaced any existing entry
+    BOOST_CHECK_EQUAL(MRC.size(), 3);
+
+    // we should get the most specific entry for 192.168.0.1, so the second one
+    BOOST_CHECK_EQUAL(MRC.get(now, power, QType(QType::A), &retrieved, ComboAddress("192.168.0.1"), nullptr), (ttd-now));
+    BOOST_REQUIRE_EQUAL(retrieved.size(), 1);
+    BOOST_CHECK_EQUAL(getRR<ARecordContent>(retrieved.at(0))->getCA().toString(), dr4Content.toString());
+    retrieved.clear();
   }
   catch(const PDNSException& e) {
     cerr<<"Had error: "<<e.reason<<endl;

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -191,6 +191,7 @@ BOOST_AUTO_TEST_CASE(test_Netmask) {
   Netmask all6("::/0");
   BOOST_CHECK(all6.match("::1") && all6.match("fe80::92fb:a6ff:fe4a:51da"));
 
+
   Netmask fromCombo1(ComboAddress("192.0.2.1:53"), 32);
   Netmask fromCombo2(ComboAddress("192.0.2.1:54"), 32);
   BOOST_CHECK(fromCombo1 == fromCombo2);
@@ -203,6 +204,30 @@ BOOST_AUTO_TEST_CASE(test_Netmask) {
   BOOST_CHECK(nm25.getBits() == 25);
   BOOST_CHECK(nm25.getNetwork() == ComboAddress("192.0.2.255"));
   BOOST_CHECK(nm25.getMaskedNetwork() == ComboAddress("192.0.2.128"));
+
+  /* Make sure that more specific Netmasks are lesser than less specific ones,
+     as this is very useful when matching. */
+  Netmask specific32("192.0.0.0/32");
+  Netmask specific24("192.0.0.0/24");
+  Netmask specific16("192.0.0.0/16");
+  BOOST_CHECK(specific32 < specific24);
+  BOOST_CHECK(specific24 > specific32);
+  BOOST_CHECK(specific24 < specific16);
+  BOOST_CHECK(specific16 > specific24);
+
+  Netmask sameMask1("192.0.0.0/16");
+  Netmask sameMask2("192.0.0.1/16");
+  BOOST_CHECK(sameMask1 < sameMask2);
+  BOOST_CHECK(sameMask2 > sameMask1);
+
+  /* An empty Netmask should be larger than
+     every others. */
+  Netmask empty = Netmask();
+  Netmask full("255.255.255.255/32");
+  BOOST_CHECK(empty > all);
+  BOOST_CHECK(all < empty);
+  BOOST_CHECK(empty > full);
+  BOOST_CHECK(full < empty);
 }
 
 BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Having the most specific ones first, then the less specific ones then the empty one makes it easier to match the most specific first, in that case in the cache.

Please don't merge before we ponder the impact of this change a bit more!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
