### PR TITLE
when making a netmask from a comboaddress, we neglected to zero the port

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -313,7 +313,7 @@ public:
   Netmask(const ComboAddress& network, uint8_t bits=0xff)
   {
     d_network = network;
-    
+    d_network.sin4.sin_port=0;
     if(bits > 128)
       bits = (network.sin4.sin_family == AF_INET) ? 32 : 128;
     


### PR DESCRIPTION
when making a netmask from a comboaddress, we neglected to zero the port. This could lead to a proliferation of netmasks when compared naively (the port could be random!)

### Short description
Hardcode the port of a netmask to 0. It really should not HAVE a port, but this does speed up "conversion".
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
