### PR TITLE
rec40: Backport ECS fixes

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -313,7 +313,7 @@ public:
   Netmask(const ComboAddress& network, uint8_t bits=0xff)
   {
     d_network = network;
-    
+    d_network.sin4.sin_port=0;
     if(bits > 128)
       bits = (network.sin4.sin_family == AF_INET) ? 32 : 128;
     

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -755,9 +755,8 @@ void startDoResolve(void *p)
     bool DNSSECOK=false;
     if(t_pdl) {
       sr.setLuaEngine(*t_pdl);
-      sr.d_requestor=dc->d_remote;
     }
-
+    sr.d_requestor=dc->d_remote; // ECS needs this too
     if(g_dnssecmode != DNSSECMode::Off) {
       sr.d_doDNSSEC=true;
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -776,6 +776,7 @@ void startDoResolve(void *p)
       sr.d_incomingECSFound = dc->d_ecsFound;
       if (dc->d_ecsFound) {
         sr.d_incomingECS = dc->d_ednssubnet;
+        sr.d_incomingECSNetwork = sr.d_incomingECS ? sr.d_incomingECS->source.getMaskedNetwork() : ComboAddress();
       }
     }
 

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -31,7 +31,7 @@ unsigned int MemRecursorCache::bytes()
 }
 
 // returns -1 for no hits
-int MemRecursorCache::get(time_t now, const DNSName &qname, const QType& qt, vector<DNSRecord>* res, const ComboAddress& who, vector<std::shared_ptr<RRSIGRecordContent>>* signatures)
+int MemRecursorCache::get(time_t now, const DNSName &qname, const QType& qt, vector<DNSRecord>* res, const ComboAddress& who, vector<std::shared_ptr<RRSIGRecordContent>>* signatures, bool* variable)
 {
   unsigned int ttd=0;
   //  cerr<<"looking up "<< qname<<"|"+qt.getName()<<"\n";
@@ -54,6 +54,9 @@ int MemRecursorCache::get(time_t now, const DNSName &qname, const QType& qt, vec
 			    (qt.getCode()==QType::ADDR && (i->d_qtype == QType::A || i->d_qtype == QType::AAAA) )) 
 			    && (i->d_netmask.empty() || i->d_netmask.match(who))
          ) {
+          if(variable && !i->d_netmask.empty()) {
+            *variable=true;
+          }
 
           ttd = i->d_ttd;
 

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -53,7 +53,7 @@ public:
   }
   unsigned int size();
   unsigned int bytes();
-  int get(time_t, const DNSName &qname, const QType& qt, vector<DNSRecord>* res, const ComboAddress& who, vector<std::shared_ptr<RRSIGRecordContent>>* signatures=0);
+  int get(time_t, const DNSName &qname, const QType& qt, vector<DNSRecord>* res, const ComboAddress& who, vector<std::shared_ptr<RRSIGRecordContent>>* signatures=0, bool* variable=0);
 
   void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, bool auth, boost::optional<Netmask> ednsmask=boost::optional<Netmask>());
   void doPrune(void);

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -55,7 +55,7 @@ public:
   unsigned int bytes();
   int get(time_t, const DNSName &qname, const QType& qt, vector<DNSRecord>* res, const ComboAddress& who, vector<std::shared_ptr<RRSIGRecordContent>>* signatures=0, bool* variable=0);
 
-  void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, bool auth, boost::optional<Netmask> ednsmask=boost::optional<Netmask>());
+  void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, bool auth, boost::optional<Netmask> ednsmask=boost::none);
   void doPrune(void);
   void doSlash(int perc);
   uint64_t doDump(int fd);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -356,7 +356,7 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
 
   SyncRes::EDNSStatus::EDNSMode& mode=ednsstatus->mode;
   SyncRes::EDNSStatus::EDNSMode oldmode = mode;
-  int EDNSLevel=0;
+  int EDNSLevel = 0;
   auto luaconfsLocal = g_luaconfs.getLocal();
   ResolveContext ctx;
 #ifdef HAVE_PROTOBUF

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -541,7 +541,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
     if(done) {
       if(j==1 && s_doIPv6) { // we got an A record, see if we have some AAAA lying around
 	vector<DNSRecord> cset;
-	if(t_RC->get(d_now.tv_sec, qname, QType(QType::AAAA), &cset, d_requestor) > 0) {
+	if(t_RC->get(d_now.tv_sec, qname, QType(QType::AAAA), &cset, d_incomingECSFound ? d_incomingECSNetwork : d_requestor) > 0) {
 	  for(auto k=cset.cbegin();k!=cset.cend();++k) {
 	    if(k->d_ttl > (unsigned int)d_now.tv_sec ) {
 	      if (auto drc = std::dynamic_pointer_cast<AAAARecordContent>(k->d_content)) {
@@ -592,7 +592,7 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vecto
     LOG(prefix<<qname<<": Checking if we have NS in cache for '"<<subdomain<<"'"<<endl);
     vector<DNSRecord> ns;
     *flawedNSSet = false;
-    if(t_RC->get(d_now.tv_sec, subdomain, QType(QType::NS), &ns, d_requestor) > 0) {
+    if(t_RC->get(d_now.tv_sec, subdomain, QType(QType::NS), &ns, d_incomingECSFound ? d_incomingECSNetwork : d_requestor) > 0) {
       for(auto k=ns.cbegin();k!=ns.cend(); ++k) {
         if(k->d_ttl > (unsigned int)d_now.tv_sec ) {
           vector<DNSRecord> aset;
@@ -600,7 +600,7 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vecto
           const DNSRecord& dr=*k;
 	  auto nrr = getRR<NSRecordContent>(dr);
           if(nrr && (!nrr->getNS().isPartOf(subdomain) || t_RC->get(d_now.tv_sec, nrr->getNS(), s_doIPv6 ? QType(QType::ADDR) : QType(QType::A),
-                                                                    doLog() ? &aset : 0, d_requestor) > 5)) {
+                                                                    doLog() ? &aset : 0, d_incomingECSFound ? d_incomingECSNetwork : d_requestor) > 5)) {
             bestns.push_back(dr);
             LOG(prefix<<qname<<": NS (with ip, or non-glue) in cache for '"<<subdomain<<"' -> '"<<nrr->getNS()<<"'"<<endl);
             LOG(prefix<<qname<<": within bailiwick: "<< nrr->getNS().isPartOf(subdomain));
@@ -713,7 +713,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
   LOG(prefix<<qname<<": Looking for CNAME cache hit of '"<<qname<<"|CNAME"<<"'"<<endl);
   vector<DNSRecord> cset;
   vector<std::shared_ptr<RRSIGRecordContent>> signatures;
-  if(t_RC->get(d_now.tv_sec, qname,QType(QType::CNAME), &cset, d_requestor, &signatures, &d_wasVariable) > 0) {
+  if(t_RC->get(d_now.tv_sec, qname,QType(QType::CNAME), &cset, d_incomingECSFound ? d_incomingECSNetwork : d_requestor, &signatures, &d_wasVariable) > 0) {
 
     for(auto j=cset.cbegin() ; j != cset.cend() ; ++j) {
       if(j->d_ttl>(unsigned int) d_now.tv_sec) {
@@ -842,7 +842,7 @@ bool SyncRes::doCacheCheck(const DNSName &qname, const QType &qtype, vector<DNSR
   bool found=false, expired=false;
   vector<std::shared_ptr<RRSIGRecordContent>> signatures;
   uint32_t ttl=0;
-  if(t_RC->get(d_now.tv_sec, sqname, sqt, &cset, d_requestor, d_doDNSSEC ? &signatures : 0, &d_wasVariable) > 0) {
+  if(t_RC->get(d_now.tv_sec, sqname, sqt, &cset, d_incomingECSFound ? d_incomingECSNetwork : d_requestor, d_doDNSSEC ? &signatures : 0, &d_wasVariable) > 0) {
     LOG(prefix<<sqname<<": Found cache hit for "<<sqt.getName()<<": ");
     for(auto j=cset.cbegin() ; j != cset.cend() ; ++j) {
       LOG(j->d_content->getZoneRepresentation());

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -713,7 +713,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
   LOG(prefix<<qname<<": Looking for CNAME cache hit of '"<<qname<<"|CNAME"<<"'"<<endl);
   vector<DNSRecord> cset;
   vector<std::shared_ptr<RRSIGRecordContent>> signatures;
-  if(t_RC->get(d_now.tv_sec, qname,QType(QType::CNAME), &cset, d_requestor, &signatures) > 0) {
+  if(t_RC->get(d_now.tv_sec, qname,QType(QType::CNAME), &cset, d_requestor, &signatures, &d_wasVariable) > 0) {
 
     for(auto j=cset.cbegin() ; j != cset.cend() ; ++j) {
       if(j->d_ttl>(unsigned int) d_now.tv_sec) {
@@ -842,7 +842,7 @@ bool SyncRes::doCacheCheck(const DNSName &qname, const QType &qtype, vector<DNSR
   bool found=false, expired=false;
   vector<std::shared_ptr<RRSIGRecordContent>> signatures;
   uint32_t ttl=0;
-  if(t_RC->get(d_now.tv_sec, sqname, sqt, &cset, d_requestor, d_doDNSSEC ? &signatures : 0) > 0) {
+  if(t_RC->get(d_now.tv_sec, sqname, sqt, &cset, d_requestor, d_doDNSSEC ? &signatures : 0, &d_wasVariable) > 0) {
     LOG(prefix<<sqname<<": Found cache hit for "<<sqt.getName()<<": ");
     for(auto j=cset.cbegin() ; j != cset.cend() ; ++j) {
       LOG(j->d_content->getZoneRepresentation());

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -353,7 +353,6 @@ public:
   }
 
   int asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res);
-
   static void doEDNSDumpAndClose(int fd);
 
   static std::atomic<uint64_t> s_queries;
@@ -374,6 +373,7 @@ public:
   std::unordered_map<std::string,bool> d_discardedPolicies;
   DNSFilterEngine::Policy d_appliedPolicy;
   boost::optional<const EDNSSubnetOpts&> d_incomingECS;
+  ComboAddress d_incomingECSNetwork;
 #ifdef HAVE_PROTOBUF
   boost::optional<const boost::uuids::uuid&> d_initialRequestId;
 #endif

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -169,12 +169,18 @@ BOOST_AUTO_TEST_CASE(test_Netmask) {
   ComboAddress remote("130.161.252.29", 53);
   
   Netmask nm("127.0.0.1/24");
+  BOOST_CHECK(nm.getBits() == 24);
   BOOST_CHECK(nm.match(local));
   BOOST_CHECK(!nm.match(remote));
+  BOOST_CHECK(nm.isIpv4());
+  BOOST_CHECK(!nm.isIpv6());
 
   Netmask nm6("fe80::92fb:a6ff:fe4a:51da/64");
+  BOOST_CHECK(nm6.getBits() == 64);
   BOOST_CHECK(nm6.match("fe80::92fb:a6ff:fe4a:51db"));
   BOOST_CHECK(!nm6.match("fe81::92fb:a6ff:fe4a:51db"));
+  BOOST_CHECK(!nm6.isIpv4());
+  BOOST_CHECK(nm6.isIpv6());
 
   Netmask nmp("130.161.252.29/32");
   BOOST_CHECK(nmp.match(remote));
@@ -188,6 +194,19 @@ BOOST_AUTO_TEST_CASE(test_Netmask) {
 
   Netmask all6("::/0");
   BOOST_CHECK(all6.match("::1") && all6.match("fe80::92fb:a6ff:fe4a:51da"));
+
+  Netmask fromCombo1(ComboAddress("192.0.2.1:53"), 32);
+  Netmask fromCombo2(ComboAddress("192.0.2.1:54"), 32);
+  BOOST_CHECK(fromCombo1 == fromCombo2);
+  BOOST_CHECK(fromCombo1.match("192.0.2.1"));
+  BOOST_CHECK(fromCombo1.match(ComboAddress("192.0.2.1:80")));
+  BOOST_CHECK(fromCombo1.getNetwork() == ComboAddress("192.0.2.1"));
+  BOOST_CHECK(fromCombo1.getMaskedNetwork() == ComboAddress("192.0.2.1"));
+
+  Netmask nm25("192.0.2.255/25");
+  BOOST_CHECK(nm25.getBits() == 25);
+  BOOST_CHECK(nm25.getNetwork() == ComboAddress("192.0.2.255"));
+  BOOST_CHECK(nm25.getMaskedNetwork() == ComboAddress("192.0.2.128"));
 }
 
 BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backports:
* #5372 
* #5397 
* #5399 
* #5403
* #5408 
* #5414

We should ponder #5406 for rec-4.0.x. It doesn't make much sense on master now that we have an ECS index in our cache, but it might still be relevant for rec-4.0.x to make sure that the cache always picks up the _best_ ECS match. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
