### PR TITLE
rec: Move expired cache entries to the front so they are expunged

### DIFF
--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -61,7 +61,7 @@ template <typename T> void pruneCollection(T& collection, unsigned int maxCached
     else
       ++iter;
 
-    if(toTrim && erased > toTrim)
+    if(toTrim && erased >= toTrim)
       break;
   }
 

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -277,10 +277,15 @@ uint64_t MemRecursorCache::doDump(int fd)
   return count;
 }
 
-void MemRecursorCache::doPrune(void)
+void MemRecursorCache::doPrune(unsigned int keep)
 {
   d_cachecachevalid=false;
 
+  pruneCollection(d_cache, keep);
+}
+
+void MemRecursorCache::doPrune(void)
+{
   unsigned int maxCached=::arg().asNum("max-cache-entries") / g_numThreads;
-  pruneCollection(d_cache, maxCached);
+  doPrune(maxCached);
 }

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -51,41 +51,48 @@ int32_t MemRecursorCache::get(time_t now, const DNSName &qname, const QType& qt,
     res->clear();
 
   if(d_cachecache.first!=d_cachecache.second) {
-    for(cache_t::const_iterator i=d_cachecache.first; i != d_cachecache.second; ++i)
-      if(i->d_ttd > now && ((i->d_qtype == qt.getCode() || qt.getCode()==QType::ANY ||
+    for(cache_t::const_iterator i=d_cachecache.first; i != d_cachecache.second; ++i) {
+      if(i->d_ttd > now) {
+        if ((i->d_qtype == qt.getCode() || qt.getCode()==QType::ANY ||
 			    (qt.getCode()==QType::ADDR && (i->d_qtype == QType::A || i->d_qtype == QType::AAAA) )) 
-			    && (i->d_netmask.empty() || i->d_netmask.match(who)))
-         ) {
-        if(variable && !i->d_netmask.empty()) {
-          *variable=true;
-        }
-	ttd = i->d_ttd;	
-        //        cerr<<"Looking at "<<i->d_records.size()<<" records for this name"<<endl;
-	for(auto k=i->d_records.begin(); k != i->d_records.end(); ++k) {
-	  if(res) {
-	    DNSRecord dr;
-	    dr.d_name = qname;
-	    dr.d_type = i->d_qtype;
-	    dr.d_class = 1;
-	    dr.d_content = *k; 
-	    dr.d_ttl = static_cast<uint32_t>(i->d_ttd);
-	    dr.d_place = DNSResourceRecord::ANSWER;
-	    res->push_back(dr);
-	  }
-	}
-      
-	if(signatures)  // if you do an ANY lookup you are hosed XXXX
-	  *signatures=i->d_signatures;
-        if(res) {
-          if(res->empty())
-            moveCacheItemToFront(d_cache, i);
-          else
-            moveCacheItemToBack(d_cache, i);
-        }
-        if(qt.getCode()!=QType::ANY && qt.getCode()!=QType::ADDR) // normally if we have a hit, we are done
-          break;
-      }
+			    && (i->d_netmask.empty() || i->d_netmask.match(who))) {
 
+          if(variable && !i->d_netmask.empty()) {
+            *variable=true;
+          }
+
+          ttd = i->d_ttd;
+
+          //        cerr<<"Looking at "<<i->d_records.size()<<" records for this name"<<endl;
+          for(auto k=i->d_records.begin(); k != i->d_records.end(); ++k) {
+            if(res) {
+              DNSRecord dr;
+              dr.d_name = qname;
+              dr.d_type = i->d_qtype;
+              dr.d_class = 1;
+              dr.d_content = *k;
+              dr.d_ttl = static_cast<uint32_t>(i->d_ttd);
+              dr.d_place = DNSResourceRecord::ANSWER;
+              res->push_back(dr);
+            }
+          }
+
+          if(signatures)  // if you do an ANY lookup you are hosed XXXX
+            *signatures=i->d_signatures;
+
+          if(res && !res->empty()) {
+            // cache hit
+            moveCacheItemToBack(d_cache, i);
+          }
+
+          if(qt.getCode()!=QType::ANY && qt.getCode()!=QType::ADDR) // normally if we have a hit, we are done
+            break;
+        }
+      } else {
+        // expired entry
+        moveCacheItemToFront(d_cache, i);
+      }
+    }
     //    cerr<<"time left : "<<ttd - now<<", "<< (res ? res->size() : 0) <<"\n";
     return static_cast<int32_t>(ttd-now);
   }

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -57,6 +57,7 @@ public:
 
   void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, bool auth, boost::optional<Netmask> ednsmask=boost::none);
   void doPrune(void);
+  void doPrune(unsigned int keep);
   uint64_t doDump(int fd);
 
   int doWipeCache(const DNSName& name, bool sub, uint16_t qtype=0xffff);

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -263,4 +263,214 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_RecursorCache_ExpungingExpiredEntries) {
+  MemRecursorCache MRC;
+
+  std::vector<DNSRecord> records;
+  std::vector<std::shared_ptr<RRSIGRecordContent>> signatures;
+  BOOST_CHECK_EQUAL(MRC.size(), 0);
+  time_t now = time(nullptr);
+  DNSName power1("powerdns.com.");
+  DNSName power2("powerdns-1.com.");
+  time_t ttd = now - 30;
+  std::vector<DNSRecord> retrieved;
+  ComboAddress who("192.0.2.1");
+
+  /* entry for power, which expired 30s ago */
+  DNSRecord dr1;
+  ComboAddress dr1Content("2001:DB8::1");
+  dr1.d_name = power1;
+  dr1.d_type = QType::AAAA;
+  dr1.d_class = QClass::IN;
+  dr1.d_content = std::make_shared<AAAARecordContent>(dr1Content);
+  dr1.d_ttl = static_cast<uint32_t>(ttd);
+  dr1.d_place = DNSResourceRecord::ANSWER;
+
+  /* entry for power1, which expired 30 ago too */
+  DNSRecord dr2;
+  ComboAddress dr2Content("2001:DB8::2");
+  dr2.d_name = power2;
+  dr2.d_type = QType::AAAA;
+  dr2.d_class = QClass::IN;
+  dr2.d_content = std::make_shared<AAAARecordContent>(dr2Content);
+  dr2.d_ttl = static_cast<uint32_t>(ttd);
+  dr2.d_place = DNSResourceRecord::ANSWER;
+
+  /* insert both entries */
+  records.push_back(dr1);
+  MRC.replace(now, power1, QType(dr1.d_type), records, signatures, true, boost::none);
+  records.clear();
+  records.push_back(dr2);
+  MRC.replace(now, power2, QType(dr2.d_type), records, signatures, true, boost::none);
+  records.clear();
+  BOOST_CHECK_EQUAL(MRC.size(), 2);
+
+  /* the one for power2 having been inserted
+     more recently should be removed last */
+  /* we ask that only entry remains in the cache */
+  MRC.doPrune(1);
+  BOOST_CHECK_EQUAL(MRC.size(), 1);
+
+  /* the remaining entry should be power2, but to get it
+     we need to go back in the past a bit */
+  BOOST_CHECK_EQUAL(MRC.get(ttd - 1, power2, QType(dr2.d_type), &retrieved, who, nullptr), 1);
+  BOOST_REQUIRE_EQUAL(retrieved.size(), 1);
+  BOOST_CHECK_EQUAL(getRR<AAAARecordContent>(retrieved.at(0))->getCA().toString(), dr2Content.toString());
+  /* check that power1 is gone */
+  BOOST_CHECK_EQUAL(MRC.get(ttd - 1, power1, QType(dr1.d_type), &retrieved, who, nullptr), -1);
+
+  /* clear everything up */
+  MRC.doWipeCache(DNSName("."), true);
+  BOOST_CHECK_EQUAL(MRC.size(), 0);
+  records.clear();
+
+  /* insert both entries back */
+  records.push_back(dr1);
+  MRC.replace(now, power1, QType(dr1.d_type), records, signatures, true, boost::none);
+  records.clear();
+  records.push_back(dr2);
+  MRC.replace(now, power2, QType(dr2.d_type), records, signatures, true, boost::none);
+  records.clear();
+  BOOST_CHECK_EQUAL(MRC.size(), 2);
+
+  /* trigger a miss (expired) for power2 */
+  BOOST_CHECK_EQUAL(MRC.get(now, power2, QType(dr2.d_type), &retrieved, who, nullptr), -now);
+
+  /* power2 should have been moved to the front of the expunge
+     queue, and should this time be removed first */
+  /* we ask that only entry remains in the cache */
+  MRC.doPrune(1);
+  BOOST_CHECK_EQUAL(MRC.size(), 1);
+
+  /* the remaining entry should be power1, but to get it
+     we need to go back in the past a bit */
+  BOOST_CHECK_EQUAL(MRC.get(ttd - 1, power1, QType(dr1.d_type), &retrieved, who, nullptr), 1);
+  BOOST_REQUIRE_EQUAL(retrieved.size(), 1);
+  BOOST_CHECK_EQUAL(getRR<AAAARecordContent>(retrieved.at(0))->getCA().toString(), dr1Content.toString());
+  /* check that power2 is gone */
+  BOOST_CHECK_EQUAL(MRC.get(ttd - 1, power2, QType(dr2.d_type), &retrieved, who, nullptr), -1);
+}
+
+BOOST_AUTO_TEST_CASE(test_RecursorCache_ExpungingValidEntries) {
+  MemRecursorCache MRC;
+
+  std::vector<DNSRecord> records;
+  std::vector<std::shared_ptr<RRSIGRecordContent>> signatures;
+  BOOST_CHECK_EQUAL(MRC.size(), 0);
+  time_t now = time(nullptr);
+  DNSName power1("powerdns.com.");
+  DNSName power2("powerdns-1.com.");
+  time_t ttd = now + 30;
+  std::vector<DNSRecord> retrieved;
+  ComboAddress who("192.0.2.1");
+
+  /* entry for power, which will expire in 30s */
+  DNSRecord dr1;
+  ComboAddress dr1Content("2001:DB8::1");
+  dr1.d_name = power1;
+  dr1.d_type = QType::AAAA;
+  dr1.d_class = QClass::IN;
+  dr1.d_content = std::make_shared<AAAARecordContent>(dr1Content);
+  dr1.d_ttl = static_cast<uint32_t>(ttd);
+  dr1.d_place = DNSResourceRecord::ANSWER;
+
+  /* entry for power1, which will expire in 30s too */
+  DNSRecord dr2;
+  ComboAddress dr2Content("2001:DB8::2");
+  dr2.d_name = power2;
+  dr2.d_type = QType::AAAA;
+  dr2.d_class = QClass::IN;
+  dr2.d_content = std::make_shared<AAAARecordContent>(dr2Content);
+  dr2.d_ttl = static_cast<uint32_t>(ttd);
+  dr2.d_place = DNSResourceRecord::ANSWER;
+
+  /* insert both entries */
+  records.push_back(dr1);
+  MRC.replace(now, power1, QType(dr1.d_type), records, signatures, true, boost::none);
+  records.clear();
+  records.push_back(dr2);
+  MRC.replace(now, power2, QType(dr2.d_type), records, signatures, true, boost::none);
+  records.clear();
+  BOOST_CHECK_EQUAL(MRC.size(), 2);
+
+  /* the one for power2 having been inserted
+     more recently should be removed last */
+  /* we ask that only entry remains in the cache */
+  MRC.doPrune(1);
+  BOOST_CHECK_EQUAL(MRC.size(), 1);
+
+  /* the remaining entry should be power2 */
+  BOOST_CHECK_EQUAL(MRC.get(now, power2, QType(dr2.d_type), &retrieved, who, nullptr), ttd-now);
+  BOOST_REQUIRE_EQUAL(retrieved.size(), 1);
+  BOOST_CHECK_EQUAL(getRR<AAAARecordContent>(retrieved.at(0))->getCA().toString(), dr2Content.toString());
+  /* check that power1 is gone */
+  BOOST_CHECK_EQUAL(MRC.get(now, power1, QType(dr1.d_type), &retrieved, who, nullptr), -1);
+
+  /* clear everything up */
+  MRC.doWipeCache(DNSName("."), true);
+  BOOST_CHECK_EQUAL(MRC.size(), 0);
+  records.clear();
+
+  /* insert both entries back */
+  records.push_back(dr1);
+  MRC.replace(now, power1, QType(dr1.d_type), records, signatures, true, boost::none);
+  records.clear();
+  records.push_back(dr2);
+  MRC.replace(now, power2, QType(dr2.d_type), records, signatures, true, boost::none);
+  records.clear();
+  BOOST_CHECK_EQUAL(MRC.size(), 2);
+
+  /* replace the entry for power1 */
+  records.push_back(dr1);
+  MRC.replace(now, power1, QType(dr1.d_type), records, signatures, true, boost::none);
+  records.clear();
+  BOOST_CHECK_EQUAL(MRC.size(), 2);
+
+  /* the replaced entry for power1 should have been moved
+     to the back of the expunge queue, so power2 should be at the front
+     and should this time be removed first */
+  /* we ask that only entry remains in the cache */
+  MRC.doPrune(1);
+  BOOST_CHECK_EQUAL(MRC.size(), 1);
+
+  /* the remaining entry should be power1 */
+  BOOST_CHECK_EQUAL(MRC.get(now, power1, QType(dr1.d_type), &retrieved, who, nullptr), ttd-now);
+  BOOST_REQUIRE_EQUAL(retrieved.size(), 1);
+  BOOST_CHECK_EQUAL(getRR<AAAARecordContent>(retrieved.at(0))->getCA().toString(), dr1Content.toString());
+  /* check that power2 is gone */
+  BOOST_CHECK_EQUAL(MRC.get(now, power2, QType(dr2.d_type), &retrieved, who, nullptr), -1);
+
+  /* clear everything up */
+  MRC.doWipeCache(DNSName("."), true);
+  BOOST_CHECK_EQUAL(MRC.size(), 0);
+  records.clear();
+
+  /* insert both entries back */
+  records.push_back(dr1);
+  MRC.replace(now, power1, QType(dr1.d_type), records, signatures, true, boost::none);
+  records.clear();
+  records.push_back(dr2);
+  MRC.replace(now, power2, QType(dr2.d_type), records, signatures, true, boost::none);
+  records.clear();
+  BOOST_CHECK_EQUAL(MRC.size(), 2);
+
+  /* get a hit for power1 */
+  BOOST_CHECK_EQUAL(MRC.get(now, power1, QType(dr1.d_type), &retrieved, who, nullptr), ttd-now);
+  BOOST_REQUIRE_EQUAL(retrieved.size(), 1);
+  BOOST_CHECK_EQUAL(getRR<AAAARecordContent>(retrieved.at(0))->getCA().toString(), dr1Content.toString());
+
+  /* the entry for power1 should have been moved to the back of the expunge queue
+     due to the hit, so power2 should be at the front and should this time be removed first */
+  /* we ask that only entry remains in the cache */
+  MRC.doPrune(1);
+  BOOST_CHECK_EQUAL(MRC.size(), 1);
+
+  /* the remaining entry should be power1 */
+  BOOST_CHECK_EQUAL(MRC.get(now, power1, QType(dr1.d_type), &retrieved, who, nullptr), ttd-now);
+  BOOST_REQUIRE_EQUAL(retrieved.size(), 1);
+  BOOST_CHECK_EQUAL(getRR<AAAARecordContent>(retrieved.at(0))->getCA().toString(), dr1Content.toString());
+  /* check that power2 is gone */
+  BOOST_CHECK_EQUAL(MRC.get(now, power2, QType(dr2.d_type), &retrieved, who, nullptr), -1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It turns out that the current code does not move them. We used to have per-record TTD so checking if the vector containing the results was empty was a good way to check that the entry only contained expired records, but the current code doesn't even enter the condition if the TTD is expired.

<strike>Don't merge this until I have taken the time to add unit tests for this somehow (or at the very least open an issue so I remember to).</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
