### PR TITLE
howtos: avoid unrestricted recursive resolution in 4.0.x ALIAS example

### DIFF
--- a/docs/markdown/authoritative/howtos.md
+++ b/docs/markdown/authoritative/howtos.md
@@ -187,10 +187,11 @@ expand-alias=yes
 
 **note**: If `resolver` is unset, ALIAS expension is disabled!
 
-**note**: In PowerDNS Authoritative Server 4.0.x, the setting [`recursor`](settings.md#recursor) is used instead, and you should omit the [`expand-alias`](settings.md#expand-alias) setting:
+**note**: In PowerDNS Authoritative Server 4.0.x, the setting [`recursor`](settings.md#recursor) is used instead, and you should omit the [`expand-alias`](settings.md#expand-alias) setting. Note that setting [`recursor`](settings.md#recursor) will allow recursive queries to all clients by default, which you likely do not want for security reasons, so you should restrict this:
 
 ```
 recursor=[::1]:5300
+allow-recursion=::1, 127.0.0.1
 ```
 
 Then add the ALIAS record to your zone apex. e.g.:


### PR DESCRIPTION
### Short description
Previous 4.0.x example for ALIAS opened up an unrestricted recursive server due to `allow-recursion` default. Make the example secure.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master