### PR TITLE
 do not hash the message in the ed25519 signer

### DIFF
--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -46,7 +46,11 @@ class DNSCryptoKeyEngine
     virtual storvector_t convertToISCVector() const =0;
     std::string convertToISC() const ;
     virtual std::string sign(const std::string& msg) const =0;
-    virtual std::string hash(const std::string& msg) const =0;
+    virtual std::string hash(const std::string& msg) const
+    {
+       throw std::runtime_error("hash() function not implemented");
+       return msg;
+    }
     virtual bool verify(const std::string& msg, const std::string& signature) const =0;
     
     virtual std::string getPubKeyHash()const =0;


### PR DESCRIPTION
### Short description
Do not hash the message in the ed25519 signer.

Implementation verified against the example in https://www.rfc-editor.org/errata_search.php?rfc=8080
```
This is a Native zone
Metadata items: None
Zone has NSEC semantics
keys:
ID = 1 (CSK), flags = 257, tag = 3613, algo = 15, bits = 256      Active ( ED25519 )
CSK DNSKEY = example.com. IN DNSKEY 257 3 15 l02Woi0iS8Aa25FQkUd9RMzZHJpBoRQwAQEX1SxZJA4= ; ( ED25519 )
DS = example.com. IN DS 3613 15 1 b2c63605467c4a40942b47a953e9c0d38f81083a ; ( SHA1 digest )
DS = example.com. IN DS 3613 15 2 3aa5ab37efce57f737fc1627013fee07bdf241bd10f3b1964ab55c78e79a304b ; ( SHA256 digest )
DS = example.com. IN DS 3613 15 4 89389da437fca8372e67359dfc0dd4428fa2615df6e31bc5501677dd068514fea5c4efaf82188530a8a1645d9d3ef884 ; ( SHA-384 digest )
```
### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
