### PR TITLE
Postgres bigint

### DIFF
--- a/modules/gpgsqlbackend/3.4.0_to_4.1.0_schema.pgsql.sql
+++ b/modules/gpgsqlbackend/3.4.0_to_4.1.0_schema.pgsql.sql
@@ -1,0 +1,1 @@
+ALTER TABLE records ALTER id TYPE BIGINT;

--- a/modules/gpgsqlbackend/schema.pgsql.sql
+++ b/modules/gpgsqlbackend/schema.pgsql.sql
@@ -13,7 +13,7 @@ CREATE UNIQUE INDEX name_index ON domains(name);
 
 
 CREATE TABLE records (
-  id                    SERIAL PRIMARY KEY,
+  id                    BIGSERIAL PRIMARY KEY,
   domain_id             INT DEFAULT NULL,
   name                  VARCHAR(255) DEFAULT NULL,
   type                  VARCHAR(10) DEFAULT NULL,


### PR DESCRIPTION
### Short description

mysql uses BIGINT for records id.
postgres is also uses BIGINT (BIGSERIAL) too.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
