### PR TITLE
rec_control documentation fix: `show-ntas` -> `get-ntas`

### DIFF
--- a/docs/markdown/recursor/dnssec.md
+++ b/docs/markdown/recursor/dnssec.md
@@ -138,10 +138,10 @@ $ rec_control add-nta domain.example botched keyroll
 Added Negative Trust Anchor for domain.example. with reason 'botched keyroll'
 ```
 
-To view the currently configured negative trust anchors, run `show-ntas`:
+To view the currently configured negative trust anchors, run `get-ntas`:
 
 ```
-$ rec_control show-ntas
+$ rec_control get-ntas
 Configured Negative Trust Anchors:
 subdomain.example.      Operator failed key-roll
 otherdomain.example.    DS in parent, no DNSKEY in zone


### PR DESCRIPTION
The documented rec_control command show-ntas does not appear to be correct.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
