### PR TITLE
rec: Document behaviour of dont-query with forward-zones.

### DIFF
--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -241,6 +241,11 @@ your network, and may even be a security risk. Therefore, since version 3.1.5,
 the PowerDNS recursor by default does not query private space IP addresses.
 This setting can be used to expand or reduce the limitations.
 
+Queries to addresses for zones as configured in any of the settings
+[`forward-zones`](#forward-zones), [`forward-zones-file`](#forward-zones-file)
+or [`forward-zones-recurse`](#forward-zones-recurse) are performed regardless
+of these limitations.
+
 ## `ecs-ipv4-bits`
 * Integer
 * Default: 24


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

In testing, it appears to me that setting a zone in `forward-zones` to query for an address limited by `dont-query` is not stopped by it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
