### PR TITLE
make master branch work on the new travis image

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -240,8 +240,8 @@ install_auth() {
     jq"
 
   run "cd .."
-  run "wget https://www.verisignlabs.com/dnssec-tools/packages/jdnssec-tools-0.13.tar.gz"
-  run "sudo tar xfz jdnssec-tools-0.13.tar.gz --strip-components=1 -C /"
+  run "wget https://www.monshouwer.eu/download/3rd_party/jdnssec-tools-0.13.ecdsafix.tar.gz"
+  run "sudo tar xfz jdnssec-tools-0.13.ecdsafix.tar.gz --strip-components=1 -C /"
   run "cd ${TRAVIS_BUILD_DIR}"
 
   # pkcs11 test requirements / setup
@@ -258,7 +258,8 @@ install_auth() {
 
   # bind-backend tests requirements
   run "sudo apt-get -qq --no-install-recommends install \
-    alien"
+    alien\
+    fakeroot"
   run "cd .."
   run "wget ftp://ftp.nominum.com/pub/nominum/dnsperf/2.0.0.0/dnsperf-2.0.0.0-1-rhel-6-x86_64.tar.gz"
   run "tar xzvf dnsperf-2.0.0.0-1-rhel-6-x86_64.tar.gz"

--- a/modules/remotebackend/Gemfile.lock
+++ b/modules/remotebackend/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       ffi-rzmq-core (>= 1.0.1)
     ffi-rzmq-core (1.0.3)
       ffi (~> 1.9)
-    json (1.8.2)
+    json (1.8.5)
     sqlite3 (1.3.9)
     webrick (1.3.1)
     zeromqrb (0.1.3)


### PR DESCRIPTION
### Short description
I think the last commit should make this pass. PRing already since I might not be able to finish it today.

If somebody else needs to pick this up, please:
* remove the `group: edge` line
* regroup the commits such that the jdnssec removal (which is spread over several commits) is easily reverted later
* remove the `set -x`

Furthermore:
* presumably replacing jdnssec with https://www.monshouwer.eu/download/3rd_party/jdnssec-tools-0.13.ecdsafix.tar.gz would allow it to work again

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
