### PR TITLE
don't use the libdecaf ed25519 signer when libsoduim is enabled

### DIFF
--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -286,7 +286,7 @@ struct LoaderDecafStruct
 {
   LoaderDecafStruct()
   {
-    DNSCryptoKeyEngine::report(15, &DecafED25519DNSCryptoKeyEngine::maker);
+    DNSCryptoKeyEngine::report(15, &DecafED25519DNSCryptoKeyEngine::maker, true);
     DNSCryptoKeyEngine::report(16, &DecafED448DNSCryptoKeyEngine::maker);
   }
 } loaderdecaf;


### PR DESCRIPTION
### Short description
don't use the libdecaf ed25519 signer when libsoduim is enabled

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
