### PR TITLE
dnsdist: Only declare/set `freshConn` if `MSG_FASTOPEN` is defined

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -448,14 +448,18 @@ void* tcpClientThread(int pipefd)
 
 	int dsock = -1;
 	uint16_t downstreamFailures=0;
+#ifdef MSG_FASTOPEN
 	bool freshConn = true;
+#endif /* MSG_FASTOPEN */
 	if(sockets.count(ds->remote) == 0) {
 	  dsock=setupTCPDownstream(ds, downstreamFailures);
 	  sockets[ds->remote]=dsock;
 	}
 	else {
 	  dsock=sockets[ds->remote];
+#ifdef MSG_FASTOPEN
 	  freshConn = false;
+#endif /* MSG_FASTOPEN */
         }
 
         ds->queries++;
@@ -493,7 +497,9 @@ void* tcpClientThread(int pipefd)
           downstreamFailures++;
           dsock=setupTCPDownstream(ds, downstreamFailures);
           sockets[ds->remote]=dsock;
+#ifdef MSG_FASTOPEN
           freshConn=true;
+#endif /* MSG_FASTOPEN */
           goto retry;
         }
 
@@ -513,7 +519,9 @@ void* tcpClientThread(int pipefd)
           downstreamFailures++;
           dsock=setupTCPDownstream(ds, downstreamFailures);
           sockets[ds->remote]=dsock;
+#ifdef MSG_FASTOPEN
           freshConn=true;
+#endif /* MSG_FASTOPEN */
           if(xfrStarted) {
             goto drop;
           }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise the compiler rightly warns about the variable being set but not used when `MSG_FASTOPEN` is not available:
> warning: variable 'freshConn' set but not used 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
