### PR TITLE
Backport #5446: rec: Treat requestor's payload size lower than 512 as equal to 512

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -694,12 +694,16 @@ void startDoResolve(void *p)
     if (t_queryring)
       t_queryring->push_back(make_pair(dc->d_mdp.d_qname, dc->d_mdp.d_qtype));
 
-    uint32_t maxanswersize= dc->d_tcp ? 65535 : min((uint16_t) 512, g_udpTruncationThreshold);
+    uint16_t maxanswersize = dc->d_tcp ? 65535 : min(static_cast<uint16_t>(512), g_udpTruncationThreshold);
     EDNSOpts edo;
     bool haveEDNS=false;
     if(getEDNSOpts(dc->d_mdp, &edo)) {
-      if(!dc->d_tcp)
-	maxanswersize = min(edo.d_packetsize, g_udpTruncationThreshold);
+      if(!dc->d_tcp) {
+        /* rfc6891 6.2.3:
+           "Values lower than 512 MUST be treated as equal to 512."
+        */
+        maxanswersize = min(static_cast<uint16_t>(edo.d_packetsize >= 512 ? edo.d_packetsize : 512), g_udpTruncationThreshold);
+      }
       dc->d_ednsOpts = edo.d_options;
       haveEDNS=true;
 
@@ -1086,7 +1090,7 @@ void startDoResolve(void *p)
 	if(i->d_type != QType::OPT) // their TTL ain't real
 	  minTTL = min(minTTL, i->d_ttl);
 	i->d_content->toPacket(pw);
-	if(pw.size() > maxanswersize) {
+	if(pw.size() > static_cast<size_t>(maxanswersize)) {
 	  pw.rollback();
 	  if(i->d_place==DNSResourceRecord::ANSWER)  // only truncate if we actually omitted parts of the answer
             {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`rfc6891` states in section 6.2.3 that:

> [a requestor's payload] lower than 512 MUST be treated as equal to 512

(cherry picked from commit 320157487ec1cd0a9c4bcfd5309d9d651c26eb72)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
