### PR TITLE
dnsdist: Fix TCP with Fast Open requested but unsupported

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -437,7 +437,14 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			}
 
 			if(vars.count("tcpFastOpen")) {
-			  ret->tcpFastOpen=boost::get<bool>(vars["tcpFastOpen"]);
+			  bool fastOpen = boost::get<bool>(vars["tcpFastOpen"]);
+			  if (fastOpen) {
+#ifdef MSG_FASTOPEN
+			    ret->tcpFastOpen=true;
+#else
+			    warnlog("TCP Fast Open has been configured on downstream server %s but is not supported", boost::get<string>(vars["address"]));
+#endif
+			  }
 			}
 
 			if(vars.count("name")) {

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -61,9 +61,13 @@ static int setupTCPDownstream(shared_ptr<DownstreamState> ds, uint16_t& downstre
         SBind(sock, ds->sourceAddr);
       }
       setNonBlocking(sock);
+#ifdef MSG_FASTOPEN
       if (!ds->tcpFastOpen) {
         SConnectWithTimeout(sock, ds->remote, ds->tcpConnectTimeout);
       }
+#else
+      SConnectWithTimeout(sock, ds->remote, ds->tcpConnectTimeout);
+#endif /* MSG_FASTOPEN */
       return sock;
     }
     catch(const std::runtime_error& e) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If `tcpFastOpen` is set on a backend, we used to skip the `connect()` call regardless of `MSG_FASTOPEN` availability. We then tried to call `sendmsg()` (without `MSG_FASTOPEN`) on an unconnected TCP socket, which failed.

Fixes #5452.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
