### PR TITLE
Travis: Use auth 4.0 for recursor tests

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -338,18 +338,17 @@ install_recursor() {
   run "sudo apt-get -qq --no-install-recommends install \
     authbind \
     daemontools \
-    libbotan-1.10-0 \
     libfaketime \
-    liblua5.2-0 \
     moreutils \
     jq"
   run "cd .."
   run "wget https://s3.amazonaws.com/alexa-static/top-1m.csv.zip"
   run "unzip top-1m.csv.zip -d ${TRAVIS_BUILD_DIR}/regression-tests"
-  PDNS_SERVER_VERSION="0.0.880gcb54743-1pdns"
-  run "wget https://downloads.powerdns.com/autobuilt/auth/deb/$PDNS_SERVER_VERSION.trusty-amd64/pdns-server_$PDNS_SERVER_VERSION.trusty_amd64.deb"
-  run "wget https://downloads.powerdns.com/autobuilt/auth/deb/$PDNS_SERVER_VERSION.trusty-amd64/pdns-tools_$PDNS_SERVER_VERSION.trusty_amd64.deb"
-  run "sudo dpkg -i pdns-server_$PDNS_SERVER_VERSION.trusty_amd64.deb pdns-tools_$PDNS_SERVER_VERSION.trusty_amd64.deb"
+  run 'echo -e "deb [arch=amd64] http://repo.powerdns.com/ubuntu trusty-auth-40 main" | sudo tee /etc/apt/sources.list.d/pdns.list'
+  run 'echo -e "Package: pdns-*\nPin: origin PowerDNS\nPin-Priority: 600" | sudo tee /etc/apt/preferences.d/pdns.list'
+  run 'curl https://repo.powerdns.com/FD380FBB-pub.asc | sudo apt-key add - '
+  run 'sudo apt-get update'
+  run 'sudo apt-get -y install pdns-server pdns-tools'
   run "sudo service pdns stop"
   run 'for suffix in {1..40}; do sudo /sbin/ip addr add 10.0.3.$suffix/32 dev lo; done'
   run "sudo touch /etc/authbind/byport/53"


### PR DESCRIPTION
### Short description
Before, we used to download an ancient version. This was needed back then for the 'spring cleaning' (to have a recent version of the authoritative server). Now add the 4.0 repo to the travis builder and use those binaries to test the recursor.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)