### PR TITLE
Use constant-time string comparison for the webserver's passwords

### DIFF
--- a/m4/pdns_check_libcrypto.m4
+++ b/m4/pdns_check_libcrypto.m4
@@ -108,9 +108,11 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO], [
         [
             AC_MSG_RESULT([yes])
             $1
+            AC_DEFINE([HAVE_OPENSSL_LIBCRYPTO], [1], [define to 1 if OpenSSL's libcrypto support is available.])
         ], [
             AC_MSG_RESULT([no])
             $2
+            AC_DEFINE([HAVE_OPENSSL_LIBCRYPTO], [0], [define to 1 if OpenSSL's libcrypto support is available.])
         ])
     CPPFLAGS="$save_CPPFLAGS"
     LDFLAGS="$save_LDFLAGS"

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -514,6 +514,13 @@ dumresp_SOURCES = \
 	unix_utility.cc \
 	qtype.cc 
 
+dumresp_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(LIBCRYPTO_LDFLAGS)
+
+dumresp_LDADD = \
+	$(LIBCRYPTO_LIBS)
+
 kvresp_SOURCES = \
 	dnslabeltext.cc dnsname.cc dnsname.hh \
 	kvresp.cc \
@@ -522,6 +529,13 @@ kvresp_SOURCES = \
 	statbag.cc \
 	unix_utility.cc \
 	qtype.cc 
+
+kvresp_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(LIBCRYPTO_LDFLAGS)
+
+kvresp_LDADD = \
+	$(LIBCRYPTO_LIBS)
 
 stubquery_SOURCES = \
 	arguments.cc arguments.hh \
@@ -809,6 +823,12 @@ dnswasher_SOURCES = \
 	statbag.cc \
 	unix_utility.cc
 
+dnswasher_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(LIBCRYPTO_LDFLAGS)
+
+dnswasher_LDADD = \
+	$(LIBCRYPTO_LIBS)
 
 dnsbulktest_SOURCES = \
 	base32.cc \
@@ -1229,6 +1249,13 @@ pdns_control_SOURCES = \
 	unix_utility.cc \
 	dnsname.cc \
 	dnslabeltext.cc
+
+pdns_control_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(LIBCRYPTO_LDFLAGS)
+
+pdns_control_LDADD = \
+	$(LIBCRYPTO_LIBS)
 
 if UNIT_TESTS
 

--- a/pdns/comfun.cc
+++ b/pdns/comfun.cc
@@ -420,7 +420,7 @@ try
   }
   else if(mode=="scan-ns") {
     ifstream ns(string(argv[2])+".nameservers");
-    g_powerdns = make_unique<ofstream>(string(argv[2])+".powerdns");
+    g_powerdns = std::unique_ptr<ofstream>(new ofstream(string(argv[2])+".powerdns"));
     string line;
     int count=0;
     vector<string> parts;

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -87,7 +87,7 @@ static bool checkAPIKey(const YaHTTP::Request& req, const string& expectedApiKey
 
   const auto header = req.headers.find("x-api-key");
   if (header != req.headers.end()) {
-    return (header->second == expectedApiKey);
+    return constantTimeStringEquals(header->second, expectedApiKey);
   }
 
   return false;
@@ -109,7 +109,7 @@ static bool checkWebPassword(const YaHTTP::Request& req, const string &expected_
     stringtok(cparts, plain, ":");
 
     if (cparts.size() == 2) {
-      return cparts[1] == expected_password;
+      return constantTimeStringEquals(cparts[1], expected_password);
     }
   }
 

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -588,27 +588,6 @@ static string calculateHMAC(const std::string& key, const std::string& text, TSI
   return string((char*) hash, outlen);
 }
 
-static bool constantTimeStringEquals(const std::string& a, const std::string& b)
-{
-  if (a.size() != b.size()) {
-    return false;
-  }
-  const size_t size = a.size();
-#if OPENSSL_VERSION_NUMBER >= 0x0090819fL
-  return CRYPTO_memcmp(a.c_str(), b.c_str(), size) == 0;
-#else
-  const volatile unsigned char *_a = (const volatile unsigned char *) a.c_str();
-  const volatile unsigned char *_b = (const volatile unsigned char *) b.c_str();
-  unsigned char res = 0;
-
-  for (size_t idx = 0; idx < size; idx++) {
-    res |= _a[idx] ^ _b[idx];
-  }
-
-  return res == 0;
-#endif
-}
-
 static string makeTSIGPayload(const string& previous, const char* packetBegin, size_t packetSize, const DNSName& tsigKeyName, const TSIGRecordContent& trc, bool timersonly)
 {
   string message;

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -593,6 +593,7 @@ uid_t strToUID(const string &str);
 gid_t strToGID(const string &str);
 
 unsigned int pdns_stou(const std::string& str, size_t * idx = 0, int base = 10);
+bool constantTimeStringEquals(const std::string& a, const std::string& b);
 
 bool isSettingThreadCPUAffinitySupported();
 int mapThreadToCPUList(pthread_t tid, const std::set<int>& cpus);

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -335,6 +335,14 @@ rec_control_SOURCES = \
 	rec_control.cc \
 	unix_utility.cc
 
+rec_control_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(LIBCRYPTO_LDFLAGS)
+
+rec_control_LDADD = \
+	$(LIBCRYPTO_LIBS) \
+	$(RT_LIBS)
+
 dnslabeltext.cc: dnslabeltext.rl
 	$(AM_V_GEN)$(RAGEL) $< -o dnslabeltext.cc
 

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -64,8 +64,7 @@ bool HttpRequest::compareAuthorization(const string &expected_password)
     vector<string> cparts;
     stringtok(cparts, plain, ":");
 
-    // this gets rid of terminating zeros
-    auth_ok = (cparts.size()==2 && (0==strcmp(cparts[1].c_str(), expected_password.c_str())));
+    auth_ok = (cparts.size()==2 && constantTimeStringEquals(cparts[1], expected_password));
   }
   return auth_ok;
 }
@@ -77,7 +76,7 @@ bool HttpRequest::compareHeader(const string &header_name, const string &expecte
     return false;
 
   // this gets rid of terminating zeros
-  return (0==strcmp(header->second.c_str(), expected_value.c_str()));
+  return constantTimeStringEquals(header->second, expected_value);
 }
 
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It prevents the (very theoretical) possibility for an attacker with very low-jitter access to the webserver and in one of the `webserver-allow-from` ranges from guessing the password with a timing attack.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
