### PR TITLE
API: Clean up auth/recursor code mismatches

### DIFF
--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -571,7 +571,6 @@ void AsyncWebServer::serveConnection(Socket *client)
   string data;
   try {
     while(!req.complete) {
-      data.clear();
       int bytes = arecvtcp(data, 16384, client, true);
       if (bytes > 0) {
         req.complete = yarl.feed(data);

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -560,9 +560,9 @@ void AsyncServer::newConnection()
   getMT()->makeThread(&AsyncServerNewConnectionMT, this);
 }
 
-
+// This is an entry point from FDM, so it needs to catch everything.
 void AsyncWebServer::serveConnection(Socket *client)
-{
+try {
   HttpRequest req;
   YaHTTP::AsyncRequestLoader yarl;
   yarl.initialize(&req);
@@ -594,6 +594,16 @@ void AsyncWebServer::serveConnection(Socket *client)
   if (asendtcp(data, client) == -1 || data.empty()) {
     L<<Logger::Error<<"Failed sending reply to HTTP client"<<endl;
   }
+}
+catch(PDNSException &e) {
+  L<<Logger::Error<<"HTTP Exception: "<<e.reason<<endl;
+}
+catch(std::exception &e) {
+  if(strstr(e.what(), "timeout")==0)
+    L<<Logger::Error<<"HTTP STL Exception: "<<e.what()<<endl;
+}
+catch(...) {
+  L<<Logger::Error<<"HTTP: Unknown exception"<<endl;
 }
 
 void AsyncWebServer::go() {


### PR DESCRIPTION
### Short description
serveConnection in auth caught a lot more exceptions than the recursor code, which then would just hang on an uncaught exception.

Also cleans up a duplicated data.clear().

Fixes #5398.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
