### PR TITLE
rec: Don't always override `loglevel` to 6

### DIFF
--- a/docs/markdown/recursor/settings.md
+++ b/docs/markdown/recursor/settings.md
@@ -432,7 +432,7 @@ mask configuration issues and for this reason it is disabled by default.
 
 ## `loglevel`
 * Integer between 0 and 9
-* Default: 4
+* Default: 6
 * Available since: 3.6
 
 Amount of logging. Higher is more, more logging may destroy performance.

--- a/docs/markdown/recursor/upgrading.md
+++ b/docs/markdown/recursor/upgrading.md
@@ -1,6 +1,12 @@
 Before upgrading, it is advised to read the [changelog](../changelog.md).
 When upgrading several versions, please read **all** notes applying to the upgrade.
 
+# 4.0.x to 4.1.0
+
+[`setting-max-recursion-depth`](settings.md#setting-max-recursion-depth) defaulted to 4 but
+was always overridden to 6 during the startup. The issue has been fixed and the default value
+set to 6 to keep the behavior consistent.
+
 # 4.0.5 to 4.0.6
 
 One default was changed:

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2678,7 +2678,6 @@ static void setupDelegationOnly()
 static int serviceMain(int argc, char*argv[])
 {
   L.setName(s_programname);
-  L.setLoglevel((Logger::Urgency)(6)); // info and up
   L.disableSyslog(::arg().mustDo("disable-syslog"));
 
   if(!::arg()["logging-facility"].empty()) {
@@ -3132,7 +3131,7 @@ int main(int argc, char **argv)
     ::arg().set("dnssec-log-bogus", "Log DNSSEC bogus validations")="no";
     ::arg().set("daemon","Operate as a daemon")="no";
     ::arg().setSwitch("write-pid","Write a PID file")="yes";
-    ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";
+    ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="6";
     ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
     ::arg().set("log-common-errors","If we should log rather common errors")="no";
     ::arg().set("chroot","switch to chroot jail")="";

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -517,7 +517,7 @@ This feature is intended to facilitate ip-failover setups, but it may also mask 
 ``loglevel``
 ------------
 -  Integer between 0 and 9
--  Default: 4
+-  Default: 6
 
 Amount of logging.
 Higher is more, more logging may destroy performance.

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -4,6 +4,13 @@ Upgrade Guide
 Before upgrading, it is advised to read the :doc:`changelog/index`.
 When upgrading several versions, please read **all** notes applying to the upgrade.
 
+4.0.x to 4.1.0
+--------------
+
+:ref:`setting-max-recursion-depth` defaulted to 4 but was always overridden to 6 during
+the startup. The issue has been fixed and the default value set to 6 to keep the behavior
+consistent.
+
 4.0.3 to 4.0.4
 --------------
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It looks like we always overrode the `loglevel` value to 6, so change and document the default to 6, but don't override it otherwise.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
