### PR TITLE
rec: Handle Secure to Insecure cut on the same auth servers

### DIFF
--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -5343,9 +5343,6 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_skipped_cut) {
             }
             else if (domain == DNSName("sub.powerdns.com.")) {
               addRecordToLW(res, domain, QType::NS, "ns1.powerdns.com.");
-              addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
-              addNSECRecordToLW(domain, DNSName("tub.powerdns.com."), { QType::NS }, 600, res->d_records);
-              addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
             }
             else if (domain == DNSName("powerdns.com.")) {
               addRecordToLW(res, domain, QType::NS, "ns1.powerdns.com.");

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -750,6 +750,7 @@ private:
   vState getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int depth);
   void getDenialValidationState(NegCache::NegCacheEntry& ne, vState& state, const dState expectedState, bool allowOptOut);
   vState getTA(const DNSName& zone, dsmap_t& ds);
+  bool haveExactValidationStatus(const DNSName& domain);
   vState getValidationStatus(const DNSName& subdomain);
 
   void computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned int depth);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Properly handle a Secure to Insecure cut on the same auth servers. We correctly detected the zone cut by retrieving the `DS` after getting the `NS` answer, but we incorrectly marked the `NS` answer as Bogus because we expected it to be signed.
The existing `SyncRes` unit test was completely wrong, simulating a secure `DS` denial.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
