### PR TITLE
rec: Fix all work threads listening on all 'per thread' sockets

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1952,7 +1952,7 @@ static void makeUDPServerSockets(unsigned int threadId)
     sin.sin4.sin_port = htons(st.port);
 
   
-#ifdef SO_REUSEPORT  
+#ifdef SO_REUSEPORT
     if(g_reusePort) {
       if(setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) < 0)
         throw PDNSException("SO_REUSEPORT: "+stringerror());
@@ -3013,10 +3013,8 @@ try
   t_fdm->addReadFD(g_pipes[t_id].readToThread, handlePipeRequest);
 
   if(g_useOneSocketPerThread) {
-    for (unsigned int threadId = 0; threadId < g_numWorkerThreads; threadId++) {
-      for(deferredAdd_t::const_iterator i = deferredAdds[threadId].cbegin(); i != deferredAdds[threadId].cend(); ++i) {
-        t_fdm->addReadFD(i->first, i->second);
-      }
+    for(deferredAdd_t::const_iterator i = deferredAdds[t_id].cbegin(); i != deferredAdds[t_id].cend(); ++i) {
+      t_fdm->addReadFD(i->first, i->second);
     }
   }
   else {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
#5103 made the recursor open a separate listening socket for each worker thread when `reuseport` is enabled and `pdns-distributes-queries`, but also made each worker thread listen on _every_ one of those sockets by mistake..

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
