### PR TITLE
rec: Only increase `no-packet-error` on the first read

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1729,12 +1729,16 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
   struct msghdr msgh;
   struct iovec iov;
   char cbuf[256];
+  bool firstQuery = true;
 
   fromaddr.sin6.sin6_family=AF_INET6; // this makes sure fromaddr is big enough
   fillMSGHdr(&msgh, &iov, cbuf, sizeof(cbuf), data, sizeof(data), &fromaddr);
 
   for(;;)
   if((len=recvmsg(fd, &msgh, 0)) >= 0) {
+
+    firstQuery = false;
+
     if(t_remotes)
       t_remotes->push_back(fromaddr);
 
@@ -1807,8 +1811,9 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
   }
   else {
     // cerr<<t_id<<" had error: "<<stringerror()<<endl;
-    if(errno == EAGAIN)
+    if(firstQuery && errno == EAGAIN)
       g_stats.noPacketError++;
+
     break;
   }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We try to read as many messages as possible after being woken up, but only the first read can count as a no-packet error.
Fixes #5474.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
