### PR TITLE
Don't build with SNMP on Debian Stretch

### DIFF
--- a/build-scripts/debian-recursor/control.in
+++ b/build-scripts/debian-recursor/control.in
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.6
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-systemd, quilt, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libluajit5.1-dev, libsnmp-dev, libprotobuf-dev, protobuf-compiler, pkg-config @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
+Build-Depends: debhelper (>= 9~), dh-systemd, quilt, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libluajit5.1-dev, libprotobuf-dev, protobuf-compiler, pkg-config @LIBSYSTEMDDEV@ @LIBSODIUMDEV@ @LIBSNMPDEV@
 Homepage: http://www.powerdns.com/
 
 Package: pdns-recursor

--- a/build-scripts/debian-recursor/rules
+++ b/build-scripts/debian-recursor/rules
@@ -14,6 +14,9 @@ DEBHELPER_WITH_SYSTEMD := --with systemd
 ENABLE_LIBSODIUM := --enable-libsodium
 LIBSODIUM_DEV := , libsodium-dev
 
+ENABLE_NETSNMP := --with-net-snmp
+NETSNMP_DEV := , libsnmp-dev
+
 # $(ID) and $(VERSION_ID) come from the environment, source this from /etc/os-release
 ifeq ($(ID), ubuntu)
   ifeq ($(VERSION_ID), 14.04)
@@ -28,9 +31,19 @@ ifeq ($(ID), ubuntu)
   endif
 endif
 
+ifeq ($(ID), debian)
+  ifeq ($(VERSION_ID), 9)
+    # SNMP is linked to OpenSSL 1.0 while we link against OpenSSL 1.1
+    ENABLE_NETSNMP = --without-net-snmp
+    NETSNMP_DEV =
+  endif
+endif
+
 debian/control: debian/control.in
 	sed -e "s!@LIBSYSTEMDDEV@!$(LIBSYSTEMD_DEV)!" \
-	    -e "s!@LIBSODIUMDEV@!$(LIBSODIUM_DEV)!" $< > $@
+	    -e "s!@LIBSODIUMDEV@!$(LIBSODIUM_DEV)!" \
+	    -e "s!@LIBSNMPDEV@!$(LIBSNMP_DEV)!" \
+	    $< > $@
 
 # Use new build system
 %:
@@ -51,7 +64,7 @@ override_dh_auto_configure:
 		--libexecdir='$${prefix}/lib' \
 		--with-luajit \
 		--with-protobuf=yes \
-		--with-net-snmp \
+		$(ENABLE_NETSNMP) \
 		$(ENABLE_SYSTEMD) \
 		$(ENABLE_LIBSODIUM)
 

--- a/pdns/recursordist/.gitignore
+++ b/pdns/recursordist/.gitignore
@@ -44,3 +44,5 @@
 /test-suite.log
 /testrunner.log
 /testrunner.trs
+/test_libcrypto.log
+/test_libcrypto.trs

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -59,15 +59,18 @@ EXTRA_DIST = \
 	rec_control.1.md \
 	rrd/* \
 	html incfiles \
+	test_libcrypto \
 	pdns-recursor.service.in
 
 sbin_PROGRAMS = pdns_recursor
 bin_PROGRAMS = rec_control
 
+TESTS=test_libcrypto
+
 if UNIT_TESTS
 noinst_PROGRAMS = testrunner
 TESTS_ENVIRONMENT = env BOOST_TEST_LOG_LEVEL=message SRCDIR='$(srcdir)'
-TESTS=testrunner
+TESTS += testrunner
 else
 check-local:
 	@echo "Unit tests are not enabled"

--- a/pdns/recursordist/test_libcrypto
+++ b/pdns/recursordist/test_libcrypto
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ $(ldd pdns_recursor | grep -c libcrypto) -gt 1 ]; then
+  echo "Error! pdns_recursor is linked against multiple OpenSSL versions!"
+  echo "This happens when one dependency is linked to OpenSSL 1.0, while"
+  echo "pdns_recursor is linked against OpenSSL 1.1. Please set --with-libcrypto"
+  echo "to the directory of the dependency's OpenSSL or drop the dependency."
+  echo ""
+  echo "On Debian Stretch, this error is most likely caused by attempting to"
+  echo "link in net-snmp."
+  exit 1;
+fi


### PR DESCRIPTION
### Short description
As net snmp is linked to OpenSSL 1.0 and we link against 1.1, users get 'interesting' crashes.

**note**: needs to be tested in our builder.

This disables building our packages with netsnmp.

It also adds tests that catch this during `make check`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)