### PR TITLE
dnsdist: Add support for returning several IPs to spoof from Lua

### DIFF
--- a/pdns/README-dnsdist.md
+++ b/pdns/README-dnsdist.md
@@ -591,7 +591,7 @@ Valid return values for `LuaAction` functions are:
  * DNSAction.Nxdomain: return a response with a NXDomain rcode
  * DNSAction.Pool: use the specified pool to forward this query
  * DNSAction.Refused: return a response with a Refused rcode
- * DNSAction.Spoof: spoof the response using the supplied IPv4 (A), IPv6 (AAAA) or string (CNAME) value
+ * DNSAction.Spoof: spoof the response using the supplied string (CNAME) value or a comma-separated list of IPv4 (A) or IPv6 (AAAA)
  * DNSAction.Truncate: return a response with TC=1
 
 The same feature exists to hand off some responses for Lua inspection, using `addLuaResponseAction(x, func)`.

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -715,7 +715,6 @@ std::shared_ptr<DownstreamState> wrandom(const NumberedServerVector& servers, co
 std::shared_ptr<DownstreamState> whashed(const NumberedServerVector& servers, const DNSQuestion* dq);
 std::shared_ptr<DownstreamState> roundrobin(const NumberedServerVector& servers, const DNSQuestion* dq);
 int getEDNSZ(const char* packet, unsigned int len);
-void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent);
 uint16_t getEDNSOptionCode(const char * packet, size_t len);
 void dnsdistWebserverThread(int sock, const ComboAddress& local, const string& password, const string& apiKey, const boost::optional<std::map<std::string, std::string> >&);
 bool getMsgLen32(int fd, uint32_t* len);

--- a/regression-tests.dnsdist/test_Spoofing.py
+++ b/regression-tests.dnsdist/test_Spoofing.py
@@ -270,7 +270,7 @@ class TestSpoofingLuaSpoof(DNSDistTest):
     function spoof1rule(dq)
         if(dq.qtype==1) -- A
         then
-                return DNSAction.Spoof, "192.0.2.1"
+                return DNSAction.Spoof, "192.0.2.1,192.0.2.2"
         elseif(dq.qtype == 28) -- AAAA
         then
                 return DNSAction.Spoof, "2001:DB8::1"
@@ -302,7 +302,7 @@ class TestSpoofingLuaSpoof(DNSDistTest):
                                     60,
                                     dns.rdataclass.IN,
                                     dns.rdatatype.A,
-                                    '192.0.2.1')
+                                    '192.0.2.1', '192.0.2.2')
         expectedResponse.answer.append(rrset)
 
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We could already return several addresses via the `SpoofAction()` rule, but it was not possible from `Lua`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
