### PR TITLE
dnsdist: Add `DNSRule::toString()`, fix dtors for rules and actions

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1216,6 +1216,8 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       dh.qr=v;
     });
 
+  g_lua.registerFunction<string(std::shared_ptr<DNSRule>::*)()>("toString", [](const std::shared_ptr<DNSRule>& rule) { return rule->toString(); });
+
   g_lua.registerFunction<string(ComboAddress::*)()>("tostring", [](const ComboAddress& ca) { return ca.toString(); });
   g_lua.registerFunction<string(ComboAddress::*)()>("tostringWithPort", [](const ComboAddress& ca) { return ca.toStringWithPort(); });
   g_lua.registerFunction<string(ComboAddress::*)()>("toString", [](const ComboAddress& ca) { return ca.toString(); });

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -94,6 +94,9 @@ class DNSAction
 public:
   enum class Action { Drop, Nxdomain, Refused, Spoof, Allow, HeaderModify, Pool, Delay, Truncate, None};
   virtual Action operator()(DNSQuestion*, string* ruleresult) const =0;
+  virtual ~DNSAction()
+  {
+  }
   virtual string toString() const = 0;
   virtual std::unordered_map<string, double> getStats() const 
   {
@@ -106,6 +109,9 @@ class DNSResponseAction
 public:
   enum class Action { Allow, Delay, Drop, HeaderModify, None };
   virtual Action operator()(DNSResponse*, string* ruleresult) const =0;
+  virtual ~DNSResponseAction()
+  {
+  }
   virtual string toString() const = 0;
 };
 
@@ -598,6 +604,9 @@ extern std::string g_outputBuffer; // locking for this is ok, as locked by g_lua
 class DNSRule
 {
 public:
+  virtual ~DNSRule ()
+  {
+  }
   virtual bool matches(const DNSQuestion* dq) const =0;
   virtual string toString() const = 0;
   mutable std::atomic<uint64_t> d_matches{0};

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -830,7 +830,7 @@ class TeeAction : public DNSAction
 {
 public:
   TeeAction(const ComboAddress& ca, bool addECS=false);
-  ~TeeAction();
+  ~TeeAction() override;
   DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override;
   string toString() const override;
   std::unordered_map<string, double> getStats() const override;
@@ -1115,7 +1115,7 @@ public:
     if(!buffered)
       setbuf(d_fp, 0);
   }
-  ~LogAction()
+  ~LogAction() override
   {
     if(d_fp)
       fclose(d_fp);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* Add a `DNSRule::toString()` to make debugging from Lua or the console easier
* Add virtual destructors to `DNSRule`, `DNSAction` and `DNSResponseAction` so the destructors of derived classes are run even when deleted via the base type

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
