### PR TITLE
dnsdist: Fix TCP short writes handling

### DIFF
--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -357,6 +357,7 @@ bool sendSizeAndMsgWithTimeout(int sock, uint16_t bufferLen, const char* buffer,
       do {
         if (written < iov[pos].iov_len) {
           iov[pos].iov_len -= written;
+          iov[pos].iov_base = reinterpret_cast<void*>(reinterpret_cast<char*>(iov[pos].iov_base) + written);
           written = 0;
         }
         else {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fix a bug in the handling of short writes over `TCP`. It could have led to sending data from the beginning of the buffer twice instead of from the proper place in the buffer, sending corrupted responses.
Since it requires filling out the `TCP` window, and thus large answers toward the same `TCP` client to occur, `AXFR` answers are the most likely to be affected.
Introduced in https://github.com/PowerDNS/pdns/pull/4985, so only master is affected.

Fixes #5494.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
