### PR TITLE
Ship ldapbackend schema files in tarball

### DIFF
--- a/modules/ldapbackend/Makefile.am
+++ b/modules/ldapbackend/Makefile.am
@@ -1,6 +1,14 @@
 pkglib_LTLIBRARIES = libldapbackend.la
 
-EXTRA_DIST = OBJECTFILES OBJECTLIBS
+EXTRA_DIST = \
+    OBJECTFILES \
+    OBJECTLIBS \
+    dnsdomain2.schema \
+    pdns-domaininfo.schema
+
+dist_doc_DATA = \
+    dnsdomain2.schema \
+    pdns-domaininfo.schema
 
 libldapbackend_la_SOURCES = \
 	ldapbackend.cc ldapbackend.hh \


### PR DESCRIPTION
### Short description
Schema files for ldapbackend are not shipped in the tarball, making distribution for distributions impossible.

Related to #4443 

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
