### PR TITLE
Auth: drop broken support for packet-specific SOA replies from backends

### DIFF
--- a/docs/markdown/appendix/backend-writers-guide.md
+++ b/docs/markdown/appendix/backend-writers-guide.md
@@ -34,7 +34,7 @@ Implementing a backend consists of inheriting from the DNSBackend class. For rea
     virtual void lookup(const QType &qtype, const string &qdomain, DNSPacket *pkt_p=0, int zoneId=-1)=0;
     virtual bool list(const string &target, int domain_id)=0;
     virtual bool get(DNSResourceRecord &r)=0;
-    virtual bool getSOA(const string &name, SOAData &soadata, DNSPacket *p=0);
+    virtual bool getSOA(const DNSName &name, SOAData &soadata);
     };
 ```
 

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -236,14 +236,14 @@ public:
 
   void parseZoneFile(BB2DomainInfo *bbd);
   void insertRecord(BB2DomainInfo& bbd, const DNSName &qname, const QType &qtype, const string &content, int ttl, const std::string& hashed=string(), bool *auth=0);
-  void rediscover(string *status=0);
+  void rediscover(string *status=0) override;
 
-  bool isMaster(const DNSName &name, const string &ip);
+  bool isMaster(const DNSName &name, const string &ip) override;
 
   // for supermaster support
-  bool superMasterBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db);
+  bool superMasterBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db) override;
   static pthread_mutex_t s_supermaster_config_lock;
-  bool createSlaveDomain(const string &ip, const DNSName &domain, const string &nameserver, const string &account);
+  bool createSlaveDomain(const string &ip, const DNSName &domain, const string &nameserver, const string &account) override;
 
 private:
   void setupDNSSEC();
@@ -316,7 +316,7 @@ private:
 
   void queueReloadAndStore(unsigned int id);
   bool findBeforeAndAfterUnhashed(BB2DomainInfo& bbd, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after);
-  void reload();
+  void reload() override;
   static string DLDomStatusHandler(const vector<string>&parts, Utility::pid_t ppid);
   static string DLListRejectsHandler(const vector<string>&parts, Utility::pid_t ppid);
   static string DLReloadNowHandler(const vector<string>&parts, Utility::pid_t ppid);

--- a/modules/luabackend/luabackend.hh
+++ b/modules/luabackend/luabackend.hh
@@ -58,7 +58,7 @@ public:
     void lookup(const QType &qtype, const DNSName &qname, DNSPacket *p, int domain_id) override;
     bool get(DNSResourceRecord &rr) override;
     //! fills the soadata struct with the SOA details. Returns false if there is no SOA.
-    bool getSOA(const DNSName &name, SOAData &soadata, DNSPacket *p=0) override;
+    bool getSOA(const DNSName &name, SOAData &soadata);
 
 
 //  MASTER BACKEND

--- a/modules/luabackend/luabackend.hh
+++ b/modules/luabackend/luabackend.hh
@@ -58,13 +58,13 @@ public:
     void lookup(const QType &qtype, const DNSName &qname, DNSPacket *p, int domain_id) override;
     bool get(DNSResourceRecord &rr) override;
     //! fills the soadata struct with the SOA details. Returns false if there is no SOA.
-    bool getSOA(const DNSName &name, SOAData &soadata);
+    bool getSOA(const DNSName &name, SOAData &soadata) override;
 
 
 //  MASTER BACKEND
 
-    void getUpdatedMasters(vector<DomainInfo>* domains);
-    void setNotified(int id, uint32_t serial);
+    void getUpdatedMasters(vector<DomainInfo>* domains) override;
+    void setNotified(uint32_t id, uint32_t serial) override;
 
 
 //  SLAVE BACKEND

--- a/modules/luabackend/master.cc
+++ b/modules/luabackend/master.cc
@@ -28,11 +28,6 @@
 #include "pdns/logger.hh"
 #include "pdns/arguments.hh"
 
-/* 
-    virtual void getUpdatedMasters(vector<DomainInfo>* domains);
-    virtual void setNotified(int id, uint32_t serial);
-*/
-
 void LUABackend::getUpdatedMasters(vector<DomainInfo>* domains) {
 	
     if (f_lua_getupdatedmasters == 0)
@@ -63,7 +58,7 @@ void LUABackend::getUpdatedMasters(vector<DomainInfo>* domains) {
 	L << Logger::Info << backend_name << "(getUpdatedMasters) END" << endl;
 }
 
-void LUABackend::setNotified(int id, uint32_t serial) {
+void LUABackend::setNotified(uint32_t id, uint32_t serial) {
 	
     if (f_lua_setnotified == 0)
 	return;

--- a/modules/luabackend/minimal.cc
+++ b/modules/luabackend/minimal.cc
@@ -176,11 +176,9 @@ bool LUABackend::get(DNSResourceRecord &rr) {
     return !rr.content.empty();
 }
 
-bool LUABackend::getSOA(const DNSName &name, SOAData &soadata, DNSPacket *p) {
+bool LUABackend::getSOA(const DNSName &name, SOAData &soadata) {
     if (logging)
 	L << Logger::Info << backend_name << "(getsoa) BEGIN" << endl;
-
-    dnspacket = p;
 
     lua_rawgeti(lua, LUA_REGISTRYINDEX, f_lua_getsoa);
 
@@ -190,13 +188,9 @@ bool LUABackend::getSOA(const DNSName &name, SOAData &soadata, DNSPacket *p) {
 	string e = backend_name + lua_tostring(lua, -1);
 	lua_pop(lua, 1);
 
-	dnspacket = NULL;
-
 	throw runtime_error(e);
 	return false;
     }
-
-    dnspacket = NULL;
 
     size_t returnedwhat = lua_type(lua, -1);
     if (returnedwhat != LUA_TTABLE) {

--- a/modules/mydnsbackend/mydnsbackend.cc
+++ b/modules/mydnsbackend/mydnsbackend.cc
@@ -210,7 +210,7 @@ bool MyDNSBackend::list(const DNSName &target, int zoneId, bool include_disabled
   return true;
 }
 
-bool MyDNSBackend::getSOA(const DNSName& name, SOAData& soadata, DNSPacket*) {
+bool MyDNSBackend::getSOA(const DNSName& name, SOAData& soadata) {
   string query;
   SSqlStatement::row_t rrow;
 

--- a/modules/mydnsbackend/mydnsbackend.hh
+++ b/modules/mydnsbackend/mydnsbackend.hh
@@ -39,7 +39,7 @@ public:
   void lookup(const QType &, const DNSName &qdomain, DNSPacket *p=0, int zoneId=-1) override;
   bool list(const DNSName &target, int domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
-  bool getSOA(const DNSName& name, SOAData& soadata, DNSPacket*) override;
+  bool getSOA(const DNSName& name, SOAData& soadata) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;
 private:
   SMySQL *d_db; 

--- a/modules/opendbxbackend/odbxbackend.cc
+++ b/modules/opendbxbackend/odbxbackend.cc
@@ -179,7 +179,7 @@ bool OdbxBackend::getDomainInfo( const DNSName& domain, DomainInfo& di )
 
 
 
-bool OdbxBackend::getSOA( const DNSName& domain, SOAData& sd, DNSPacket* p )
+bool OdbxBackend::getSOA( const DNSName& domain, SOAData& sd)
 {
         const char* tmp;
 

--- a/modules/opendbxbackend/odbxbackend.hh
+++ b/modules/opendbxbackend/odbxbackend.hh
@@ -77,7 +77,7 @@ public:
         ~OdbxBackend();
 
         void lookup( const QType& qtype, const DNSName& qdomain, DNSPacket* p = 0, int zoneid = -1 ) override;
-        bool getSOA( const DNSName& domain, SOAData& sd, DNSPacket* p ) override;
+        bool getSOA( const DNSName& domain, SOAData& sd ) override;
         bool list( const DNSName& target, int domain_id, bool include_disabled=false ) override;
         bool get( DNSResourceRecord& rr ) override;
 

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -35,7 +35,7 @@
 
 bool DNSBackend::getAuth(DNSPacket *p, SOAData *sd, const DNSName &target)
 {
-  return this->getSOA(target, *sd, p);
+  return this->getSOA(target, *sd);
 }
 
 void DNSBackend::setArgPrefix(const string &prefix)
@@ -214,9 +214,9 @@ vector<DNSBackend *>BackendMakerClass::all(bool metadataOnly)
     \param domain Domain we want to get the SOA details of
     \param sd SOAData which is filled with the SOA details
 */
-bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd, DNSPacket *p)
+bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd)
 {
-  this->lookup(QType(QType::SOA),domain,p);
+  this->lookup(QType(QType::SOA),domain);
 
   DNSResourceRecord rr;
   rr.auth = true;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -125,7 +125,7 @@ public:
   virtual ~DNSBackend(){};
 
   //! fills the soadata struct with the SOA details. Returns false if there is no SOA.
-  virtual bool getSOA(const DNSName &name, SOAData &soadata, DNSPacket *p=0);
+  virtual bool getSOA(const DNSName &name, SOAData &soadata);
 
   //! Calculates a SOA serial for the zone and stores it in the third argument.
   virtual bool calculateSOASerial(const DNSName& domain, const SOAData& sd, time_t& serial);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -396,7 +396,7 @@ int PacketHandler::doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, c
          !(i->dr.d_type==QType::MX || i->dr.d_type==QType::NS || i->dr.d_type==QType::SRV))
         continue;
 
-      if(r->d.aa && i->dr.d_name.countLabels() && i->dr.d_type==QType::NS && !B.getSOA(i->dr.d_name,sd,p) && !retargeted) { // drop AA in case of non-SOA-level NS answer, except for root referral
+      if(r->d.aa && i->dr.d_name.countLabels() && i->dr.d_type==QType::NS && !B.getSOA(i->dr.d_name,sd) && !retargeted) { // drop AA in case of non-SOA-level NS answer, except for root referral
         r->setA(false);
         //        i->d_place=DNSResourceRecord::AUTHORITY; // XXX FIXME
       }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -359,7 +359,7 @@ found:
   return found;
 }
 
-bool UeberBackend::getSOA(const DNSName &domain, SOAData &sd, DNSPacket *p)
+bool UeberBackend::getSOA(const DNSName &domain, SOAData &sd)
 {
   d_question.qtype=QType::SOA;
   d_question.qname=domain;
@@ -378,17 +378,17 @@ bool UeberBackend::getSOA(const DNSName &domain, SOAData &sd, DNSPacket *p)
   }
 
   // not found in neg. or pos. cache, look it up
-  return getSOAUncached(domain, sd, p);
+  return getSOAUncached(domain, sd);
 }
 
-bool UeberBackend::getSOAUncached(const DNSName &domain, SOAData &sd, DNSPacket *p)
+bool UeberBackend::getSOAUncached(const DNSName &domain, SOAData &sd)
 {
   d_question.qtype=QType::SOA;
   d_question.qname=domain;
   d_question.zoneId=-1;
 
   for(vector<DNSBackend *>::const_iterator i=backends.begin();i!=backends.end();++i)
-    if((*i)->getSOA(domain, sd, p)) {
+    if((*i)->getSOA(domain, sd)) {
       if( d_cache_ttl ) {
         DNSZoneRecord rr;
         rr.dr.d_name = sd.qname;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -99,8 +99,8 @@ public:
   void lookup(const QType &, const DNSName &qdomain, DNSPacket *pkt_p=0,  int zoneId=-1);
 
   bool getAuth(DNSPacket *p, SOAData *sd, const DNSName &target);
-  bool getSOA(const DNSName &domain, SOAData &sd, DNSPacket *p=0);
-  bool getSOAUncached(const DNSName &domain, SOAData &sd, DNSPacket *p=0);  // same, but ignores cache
+  bool getSOA(const DNSName &domain, SOAData &sd);
+  bool getSOAUncached(const DNSName &domain, SOAData &sd);  // same, but ignores cache
   bool get(DNSZoneRecord &r);
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false);
 


### PR DESCRIPTION
### Short description
Remove DNSPacket pointer from getSOA. This was never okay to use (at least with caching enabled).

Split from #4545 per @Habbie's wish.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
