### PR TITLE
rec: Fix cache handling of ECS queries with a source length of 0

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -435,7 +435,7 @@ public:
     }
     return result;
   }
-  int getBits() const
+  uint8_t getBits() const
   {
     return d_bits;
   }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2880,6 +2880,33 @@ static int serviceMain(int argc, char*argv[])
   SyncRes::s_ecsipv4limit = ::arg().asNum("ecs-ipv4-bits");
   SyncRes::s_ecsipv6limit = ::arg().asNum("ecs-ipv6-bits");
 
+  if (!::arg().isEmpty("ecs-scope-zero-address")) {
+    ComboAddress scopeZero(::arg()["ecs-scope-zero-address"]);
+    SyncRes::setECSScopeZeroAddress(Netmask(scopeZero, scopeZero.isIPv4() ? 32 : 128));
+  }
+  else {
+    bool found = false;
+    for (const auto& addr : g_localQueryAddresses4) {
+      if (!IsAnyAddress(addr)) {
+        SyncRes::setECSScopeZeroAddress(Netmask(addr, 32));
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      for (const auto& addr : g_localQueryAddresses6) {
+        if (!IsAnyAddress(addr)) {
+          SyncRes::setECSScopeZeroAddress(Netmask(addr, 128));
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        SyncRes::setECSScopeZeroAddress(Netmask("127.0.0.1/32"));
+      }
+    }
+  }
+
   g_networkTimeoutMsec = ::arg().asNum("network-timeout");
 
   g_initialDomainMap = parseAuthAndForwards();
@@ -3277,6 +3304,7 @@ int main(int argc, char **argv)
     ::arg().set("ecs-ipv4-bits", "Number of bits of IPv4 address to pass for EDNS Client Subnet")="24";
     ::arg().set("ecs-ipv6-bits", "Number of bits of IPv6 address to pass for EDNS Client Subnet")="56";
     ::arg().set("edns-subnet-whitelist", "List of netmasks and domains that we should enable EDNS subnet for")="";
+    ::arg().set("ecs-scope-zero-address", "Address to send to whitelisted authoritative servers for incoming queries with ECS prefix-length source of 0")="";
     ::arg().setSwitch( "use-incoming-edns-subnet", "Pass along received EDNS Client Subnet information")="no";
     ::arg().setSwitch( "pdns-distributes-queries", "If PowerDNS itself should distribute queries over threads")="yes";
     ::arg().setSwitch( "root-nx-trust", "If set, believe that an NXDOMAIN from the root means the TLD does not exist")="yes";

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -344,6 +344,22 @@ Number of bits of client IPv4 address to pass when sending EDNS Client Subnet ad
 
 Number of bits of client IPv6 address to pass when sending EDNS Client Subnet address information.
 
+.. _setting-ecs-scope-zero-address:
+
+``ecs-scope-zero-address``
+--------------------------
+.. versionadded:: 4.1.0
+
+- IPv4 or IPv6 Address
+- Default: empty
+
+The IP address sent via EDNS Client Subnet to authoritative servers listed in
+`edns-subnet-whitelist`_ when `use-incoming-ecs`_ is set and the query has
+an ECS source prefix-length set to 0.
+The default is to look for the first usable (not an `any` one) address in
+`query-local-address`_ then `query-local-address6`_. If no suitable address is
+found, the recursor fallbacks to sending 127.0.0.1.
+
 .. _setting-edns-outgoing-bufsize:
 
 ``edns-outgoing-bufsize``

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -536,6 +536,11 @@ public:
     return t_sstorage.domainmap;
   }
 
+  static void setECSScopeZeroAddress(const Netmask& scopeZeroMask)
+  {
+    s_ecsScopeZero.source = scopeZeroMask;
+  }
+
   explicit SyncRes(const struct timeval& now);
 
   int beginResolve(const DNSName &qname, const QType &qtype, uint16_t qclass, vector<DNSRecord>&ret);
@@ -625,16 +630,7 @@ public:
     d_skipCNAMECheck = skip;
   }
 
-  void setIncomingECS(boost::optional<const EDNSSubnetOpts&> incomingECS)
-  {
-    d_incomingECS = incomingECS;
-    if (incomingECS) {
-      d_incomingECSNetwork = incomingECS->source.getMaskedNetwork();
-    }
-    else {
-      d_incomingECSNetwork = ComboAddress();
-    }
-  }
+  void setIncomingECS(boost::optional<const EDNSSubnetOpts&> incomingECS);
 
 #ifdef HAVE_PROTOBUF
   void setInitialRequestId(boost::optional<const boost::uuids::uuid&> initialRequestId)
@@ -702,6 +698,7 @@ private:
   static std::unordered_set<DNSName> s_delegationOnly;
   static NetmaskGroup s_ednssubnets;
   static SuffixMatchNode s_ednsdomains;
+  static EDNSSubnetOpts s_ecsScopeZero;
   static LogMode s_lm;
   static std::unique_ptr<NetmaskGroup> s_dontQuery;
 
@@ -773,7 +770,7 @@ private:
   zonesStates_t d_cutStates;
   ostringstream d_trace;
   shared_ptr<RecursorLua4> d_pdl;
-  boost::optional<const EDNSSubnetOpts&> d_incomingECS;
+  boost::optional<EDNSSubnetOpts> d_incomingECS;
   ComboAddress d_incomingECSNetwork;
 #ifdef HAVE_PROTOBUF
   boost::optional<const boost::uuids::uuid&> d_initialRequestId;

--- a/regression-tests.recursor-dnssec/test_Interop.py
+++ b/regression-tests.recursor-dnssec/test_Interop.py
@@ -130,9 +130,10 @@ forward-zones+=undelegated.insecure.example=%s.12
 
         reactor.listenUDP(port, UDPResponder(), interface=address)
 
-        cls._UDPResponder = threading.Thread(name='UDP Responder', target=reactor.run, args=(False,))
-        cls._UDPResponder.setDaemon(True)
-        cls._UDPResponder.start()
+        if not reactor.running:
+            cls._UDPResponder = threading.Thread(name='UDP Responder', target=reactor.run, args=(False,))
+            cls._UDPResponder.setDaemon(True)
+            cls._UDPResponder.start()
 
     @classmethod
     def tearDownResponders(cls):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The current behavior is to send a query without ECS information and to cache it as a non ECS-specific entry. Unfortunately doing so meant that we wouldn't send any further ECS-specific queries for
this `(qname,qtype)` since we could fallback to the non ECS-specific cached answer.

This commit adds a new parameter, `ecs-scope-zero-addr`, allowing to specify the address sent to ECS-whitelisted authoritative servers in that case. If unset, the default is to take the first usable (non-any) address in `query-local-address` then in `query-local-address6`, and finally to use `127.0.0.1` as a last resort.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
