### PR TITLE
Remove DNSPacket from getAuth() signature

### DIFF
--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -33,7 +33,7 @@
 #include "dnspacket.hh"
 #include "dns.hh"
 
-bool DNSBackend::getAuth(DNSPacket *p, SOAData *sd, const DNSName &target)
+bool DNSBackend::getAuth(const DNSName &target, SOAData *sd)
 {
   return this->getSOA(target, *sd);
 }

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -169,7 +169,7 @@ public:
   virtual void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) { }
 
   /** Determines if we are authoritative for a zone, and at what level */
-  virtual bool getAuth(DNSPacket *p, SOAData *sd, const DNSName &target);
+  virtual bool getAuth(const DNSName &target, SOAData *sd);
 
   struct KeyData {
     std::string content;

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1241,7 +1241,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
       return r;
     }
     
-    if(!B.getAuth(p, &sd, target)) {
+    if(!B.getAuth(target, p->qtype, &sd)) {
       DLOG(L<<Logger::Error<<"We have no authority over zone '"<<target<<"'"<<endl);
       if(!retargetcount) {
         r->setA(false); // drop AA if we never had a SOA in the first place

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -255,7 +255,7 @@ void UeberBackend::getUpdatedMasters(vector<DomainInfo>* domains)
   }
 }
 
-bool UeberBackend::getAuth(DNSPacket *p, SOAData *sd, const DNSName &target)
+bool UeberBackend::getAuth(const DNSName &target, const QType& qtype, SOAData* sd, bool cachedOk)
 {
   bool found = false;
   int cstat;
@@ -264,7 +264,7 @@ bool UeberBackend::getAuth(DNSPacket *p, SOAData *sd, const DNSName &target)
   do {
 
     // Check cache
-    if(sd->db != (DNSBackend *)-1 && (d_cache_ttl || d_negcache_ttl)) {
+    if(cachedOk && (d_cache_ttl || d_negcache_ttl)) {
       d_question.qtype = QType::SOA;
       d_question.qname = choppedOff;
       d_question.zoneId = -1;
@@ -307,7 +307,7 @@ bool UeberBackend::getAuth(DNSPacket *p, SOAData *sd, const DNSName &target)
           break;
         } else {
           DLOG(L<<Logger::Error<<"lookup: "<<choppedOff<<endl);
-          if((*i)->getAuth(p, sd, choppedOff)) {
+          if((*i)->getAuth(choppedOff, sd)) {
             DLOG(L<<Logger::Error<<"got: "<<sd->qname<<endl);
             j->first = sd->qname.wirelength();
             j->second = *sd;
@@ -347,7 +347,7 @@ bool UeberBackend::getAuth(DNSPacket *p, SOAData *sd, const DNSName &target)
     }
 
 found:
-    if(found == (p->qtype == QType::DS)){
+    if(found == (qtype == QType::DS)){
       DLOG(L<<Logger::Error<<"found: "<<sd->qname<<endl);
       return true;
     } else {

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -98,7 +98,8 @@ public:
 
   void lookup(const QType &, const DNSName &qdomain, DNSPacket *pkt_p=0,  int zoneId=-1);
 
-  bool getAuth(DNSPacket *p, SOAData *sd, const DNSName &target);
+  /** Determines if we are authoritative for a zone, and at what level */
+  bool getAuth(const DNSName &target, const QType &qtype, SOAData* sd, bool cachedOk=true);
   bool getSOA(const DNSName &domain, SOAData &sd);
   bool getSOAUncached(const DNSName &domain, SOAData &sd);  // same, but ignores cache
   bool get(DNSZoneRecord &r);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -471,10 +471,8 @@ static void gatherRecords(const Json container, const DNSName& qname, const QTyp
       makePtr(rr, &ptr);
 
       // verify that there's a zone for the PTR
-      DNSPacket fakePacket(false);
       SOAData sd;
-      fakePacket.qtype = QType::PTR;
-      if (!B.getAuth(&fakePacket, &sd, ptr.qname))
+      if (!B.getAuth(ptr.qname, QType(QType::PTR), &sd, false))
         throw ApiException("Could not find domain for PTR '"+ptr.qname.toString()+"' requested for '"+ptr.content+"'");
 
       ptr.domain_id = sd.domain_id;
@@ -1313,12 +1311,8 @@ static void makePtr(const DNSResourceRecord& rr, DNSResourceRecord* ptr) {
 
 static void storeChangedPTRs(UeberBackend& B, vector<DNSResourceRecord>& new_ptrs) {
   for(const DNSResourceRecord& rr :  new_ptrs) {
-    DNSPacket fakePacket(false);
     SOAData sd;
-    sd.db = (DNSBackend *)-1;  // getAuth() cache bypass
-    fakePacket.qtype = QType::PTR;
-
-    if (!B.getAuth(&fakePacket, &sd, rr.qname))
+    if (!B.getAuth(rr.qname, QType(QType::PTR), &sd, false))
       throw ApiException("Could not find domain for PTR '"+rr.qname.toString()+"' requested for '"+rr.content+"' (while saving)");
 
     string soa_edit_api_kind;


### PR DESCRIPTION
### Short description
The original motivation for #4545: avoid creating fake DNSPacket objects just for calling getAuth() from API code.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
