### PR TITLE
rec: Fix validation at the exact RRSIG inception or expiration time

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -244,13 +244,17 @@ static bool checkSignatureWithKey(time_t now, const shared_ptr<RRSIGRecordConten
 {
   bool result = false;
   try {
-    if(sig->d_siginception < now && sig->d_sigexpire > now) {
+    /* rfc4035:
+       - The validator's notion of the current time MUST be less than or equal to the time listed in the RRSIG RR's Expiration field.
+       - The validator's notion of the current time MUST be greater than or equal to the time listed in the RRSIG RR's Inception field.
+    */
+    if(sig->d_siginception <= now && sig->d_sigexpire >= now) {
       std::shared_ptr<DNSCryptoKeyEngine> dke = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromPublicKeyString(key->d_algorithm, key->d_key));
       result = dke->verify(msg, sig->d_signature);
       LOG("signature by key with tag "<<sig->d_tag<<" and algorithm "<<DNSSECKeeper::algorithm2name(sig->d_algorithm)<<" was " << (result ? "" : "NOT ")<<"valid"<<endl);
     }
     else {
-      LOG("Signature is "<<((sig->d_siginception >= now) ? "not yet valid" : "expired")<<" (inception: "<<sig->d_siginception<<", expiration: "<<sig->d_sigexpire<<", now: "<<now<<")"<<endl);
+      LOG("Signature is "<<((sig->d_siginception > now) ? "not yet valid" : "expired")<<" (inception: "<<sig->d_siginception<<", expiration: "<<sig->d_sigexpire<<", now: "<<now<<")"<<endl);
     }
   }
   catch(const std::exception& e) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`rfc4035` states that:
* >The validator's notion of the current time MUST be less than or equal to the time listed in the RRSIG RR's Expiration field.
* >The validator's notion of the current time MUST be greater than or equal to the time listed in the RRSIG RR's Inception field.

Reported by Petr Špaček of cz.nic (thanks!).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
