### PR TITLE
rec: Add more unit tests for the NetmaskTree and ECS cache index

### DIFF
--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -14,13 +14,18 @@
 #include "cachecleaner.hh"
 #include "namespaces.hh"
 
-unsigned int MemRecursorCache::size()
+unsigned int MemRecursorCache::size() const
 {
   return (unsigned int)d_cache.size();
 }
 
+size_t MemRecursorCache::ecsIndexSize() const
+{
+  return d_ecsIndex.size();
+}
+
 // this function is too slow to poll!
-unsigned int MemRecursorCache::bytes()
+unsigned int MemRecursorCache::bytes() const
 {
   unsigned int ret=0;
 

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -53,8 +53,10 @@ public:
   {
     cacheHits = cacheMisses = 0;
   }
-  unsigned int size();
-  unsigned int bytes();
+  unsigned int size() const;
+  unsigned int bytes() const;
+  size_t ecsIndexSize() const;
+
   int32_t get(time_t, const DNSName &qname, const QType& qt, bool requireAuth, vector<DNSRecord>* res, const ComboAddress& who, vector<std::shared_ptr<RRSIGRecordContent>>* signatures=nullptr, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs=nullptr, bool* variable=nullptr, vState* state=nullptr, bool* wasAuth=nullptr);
 
   void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs, bool auth, boost::optional<Netmask> ednsmask=boost::none, vState state=Indeterminate);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We lacked tests removing things for the NMT, as well as tests for the removal and expiration of entries in the ECS cache index.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
