### PR TITLE
geoipbackend: Service for apex record

### DIFF
--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -167,6 +167,9 @@ then caching will not happen for any records of something.example.com.
 If you need to use TXT for debugging, make sure you use dedicated name
 for it.
 
+Since v4.1.0 you can mix service and static records to produce the sum
+of these records, including apex record.
+
 .. warning::
   If your services match wildcard records in your zone file
   then these will be returned as CNAMEs. This will only be an issue if you

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -368,8 +368,7 @@ void GeoIPBackend::lookup(const QType &qtype, const DNSName& qdomain, DNSPacket 
 
   gl.netmask = 0;
 
-  if (this->lookup_static(dom, search, qtype, qdomain, ip, gl, v6))
-    return;
+  (void)this->lookup_static(dom, search, qtype, qdomain, ip, gl, v6);
 
   auto target = dom.services.find(search);
   if (target == dom.services.end()) return; // no hit
@@ -387,6 +386,15 @@ void GeoIPBackend::lookup(const QType &qtype, const DNSName& qdomain, DNSPacket 
     // see if the record can be found
     if (this->lookup_static(dom, format, qtype, qdomain, ip, gl, v6))
       return;
+  }
+
+  if (!d_result.empty()) {
+    L<<Logger::Error<<
+       "Cannot have static record and CNAME at the same time" <<
+       "Please fix your configuration for \"" << qdomain << "\", so that" <<
+       "it can be resolved by GeoIP backend directly."<< std::endl;
+    d_result.clear();
+    return;
   }
 
   // we need this line since we otherwise claim to have NS records etc

--- a/modules/geoipbackend/regression-tests/apex-record/command
+++ b/modules/geoipbackend/regression-tests/apex-record/command
@@ -1,0 +1,3 @@
+#!/bin/sh
+cleandig geo.example.com A
+

--- a/modules/geoipbackend/regression-tests/apex-record/description
+++ b/modules/geoipbackend/regression-tests/apex-record/description
@@ -1,0 +1,1 @@
+This test checks that you can have a apex record as both service record and static record.

--- a/modules/geoipbackend/regression-tests/apex-record/expected_result
+++ b/modules/geoipbackend/regression-tests/apex-record/expected_result
@@ -1,0 +1,3 @@
+0	geo.example.com.	IN	A	30	127.0.0.1
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='geo.example.com.', qtype=A

--- a/modules/geoipbackend/regression-tests/static-any-resolution/expected_result
+++ b/modules/geoipbackend/regression-tests/static-any-resolution/expected_result
@@ -1,3 +1,4 @@
+0	geo.example.com.	IN	A	30	127.0.0.1
 0	geo.example.com.	IN	MX	30	10 mx.example.com.
 0	geo.example.com.	IN	NS	30	ns1.example.com.
 0	geo.example.com.	IN	NS	30	ns2.example.com.

--- a/regression-tests/backends/geoip-master
+++ b/regression-tests/backends/geoip-master
@@ -45,6 +45,7 @@ domains:
     unknown.service.geo.example.com:
       - a: 127.0.0.1
   services:
+    geo.example.com: '%cn.service.geo.example.com'
     www.geo.example.com: '%cn.service.geo.example.com'
     indirect.geo.example.com: '%cn.elsewhere.example.com'
     city.geo.example.com: '%ci.%re.%cc.city.geo.example.com'


### PR DESCRIPTION
### Short description
Add ability to have service record for apex record and any other static record. Fixes #3747.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)