### PR TITLE
rec: Prevent an infinite loop if we need auth and the best match is not

### DIFF
--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -105,6 +105,8 @@ MemRecursorCache::cache_t::const_iterator MemRecursorCache::getEntryUsingECSInde
         if (!requireAuth || entry->d_auth) {
           return entry;
         }
+        /* we need auth data and the best match is not authoritative */
+        return d_cache.end();
       }
       else {
         /* this netmask-specific entry has expired */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The current code gets the most specific entry, and checks whether it's still valid. If it's not, it removes it from the index and loops to fetch the next best match. However, if the entry is valid but doesn't hold authoritative data and the caller requested it, it tries to loop to get a new match. Since the entry is still present in the index, it will just get the same entry over and over, triggering an infinite loop.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
