### PR TITLE
Fix getSOA() in luabackend

### DIFF
--- a/modules/luabackend/minimal.cc
+++ b/modules/luabackend/minimal.cc
@@ -202,6 +202,7 @@ bool LUABackend::getSOA(const string &name, SOAData &soadata, DNSPacket *p) {
 
     soadata.db = this;
     soadata.serial = 0;
+    soadata.qname = name;
     getValueFromTable(lua, "serial", soadata.serial);
     if (soadata.serial == 0) {
 	lua_pop(lua, 1 );


### PR DESCRIPTION
Hello,
Current implementation of the getSOA() function in the Lua Backend does not set the qname member of the SOAData structure. This brakes DNS query processing and causes PowerDNS to return a 'REFUSED' response. Proposed patch sets qname to the name that is passed to getSOA().