### PR TITLE
rec: Guard `registerAllStats()` with an atomic flag instead of a bool

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -775,10 +775,9 @@ extern ResponseStats g_rs;
 
 void registerAllStats()
 {
-  static bool s_init = false;
-  if(s_init)
+  static std::atomic_flag s_init = ATOMIC_FLAG_INIT;
+  if(s_init.test_and_set())
     return;
-  s_init=true;
 
   addGetStat("questions", &g_stats.qcounter);
   addGetStat("ipv6-questions", &g_stats.ipv6qcounter);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Unlikely as it seems, I just got hit by a race where three threads were trying to register the stats at the same time, causing my starting recursor to stay stuck while consuming a lot of CPU.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
