### PR TITLE
Corrected addAnyTCRule() documentation

### DIFF
--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -80,7 +80,7 @@ Rule Generators
   Forcing a retry over TCP.
   This is equivalent to doing::
 
-    addAction(AndRule({QTypeRule(255), TCPRule(false)}), TCAction())
+    addAction(AndRule({QTypeRule(dnsdist.ANY), TCPRule(false)}), TCAction())
 
 .. function:: addDelay(DNSrule, delay)
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -76,11 +76,11 @@ Rule Generators
 
 .. function:: addAnyTCRule()
 
-  Set the TC-bit (truncate) on all queries received over UDP.
+  Set the TC-bit (truncate) on ANY queries received over UDP.
   Forcing a retry over TCP.
   This is equivalent to doing::
 
-    addAction(AndRule(AllRule(), TCPRule(false)), TCAction())
+    addAction(AndRule({QTypeRule(255), TCPRule(false)}), TCAction())
 
 .. function:: addDelay(DNSrule, delay)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
fixes #5573
The addAnyTCRule() sets the truncated flag only for type ANY queries not *all queries* as previously noted in the documentation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
