### PR TITLE
dnsdist: Don't use square brackets for IPv6 in Carbon metrics

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -84,7 +84,7 @@ try
         }
         const auto states = g_dstates.getCopy();
         for(const auto& state : states) {
-          string serverName = state->getName();
+          string serverName = state->name.empty() ? (state->remote.toString() + ":" + std::to_string(state->remote.getPort())) : state->getName();
           boost::replace_all(serverName, ".", "_");
           const string base = "dnsdist." + hostname + ".main.servers." + serverName + ".";
           str<<base<<"queries" << ' ' << state->queries.load() << " " << now << "\r\n";
@@ -97,7 +97,7 @@ try
           if (front->udpFD == -1 && front->tcpFD == -1)
             continue;
 
-          string frontName = front->local.toStringWithPort() + (front->udpFD >= 0 ? "_udp" : "_tcp");
+          string frontName = front->local.toString() + ":" + std::to_string(front->local.getPort()) +  (front->udpFD >= 0 ? "_udp" : "_tcp");
           boost::replace_all(frontName, ".", "_");
           const string base = "dnsdist." + hostname + ".main.frontends." + frontName + ".";
           str<<base<<"queries" << ' ' << front->queries.load() << " " << now << "\r\n";

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -276,6 +276,12 @@ union ComboAddress {
   }
 
   void truncate(unsigned int bits) noexcept;
+
+  uint16_t getPort() const
+  {
+    return ntohs(sin4.sin_port);
+  }
+
 };
 
 /** This exception is thrown by the Netmask class and by extension by the NetmaskGroup class */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Use `2001:db8::1:53_tcp` instead of `[2001:db8::1]:53_tcp`, as square brackets have special meaning for some Carbon storage engines and backends. I went with the `:port` instead of `_port` as suggested in the initial report to be consistent with the current IPv4 encoding. Since the port is always present it shouldn't be ambiguous, but I'm of course open to switch to another encoding. 

Fixes #5538.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
