### PR TITLE
Switch the default webserver's ACL to "127.0.0.1, ::1"

### DIFF
--- a/docs/http-api/index.rst
+++ b/docs/http-api/index.rst
@@ -9,9 +9,9 @@ Webserver
 
 To launch the internal webserver, add a :ref:`setting-webserver` to the configuration file.
 This will instruct PowerDNS to start a webserver on localhost at port 8081, without password protection.
-Only local users (on the same host) will be able to access the webserver by default, but we still strongly advise the use of a password protection.
-The webserver lists a lot of information about the PowerDNS process, including frequent queries, frequently failing queries, lists of remote hosts sending queries, hosts sending corrupt queries etc.
-The webserver does not allow remote management.
+By default the webserver listens on localhost, meaning only local users (on the same host) will be able to access the webserver. Since the default ACL before 4.1.0 allows access from everywhere if :ref:`webserver-address` is set to a different value, we strongly advise the use of a password protection.
+The webserver lists a lot of potentially sensitive information about the PowerDNS process, including frequent queries, frequently failing queries, lists of remote hosts sending queries, hosts sending corrupt queries etc.
+The webserver does not allow remote management of the daemon, but allows control over the size of the queries and response rings that may be used to monitor activities.
 The following webserver related configuration items are available:
 
 * :ref:`setting-webserver`: If set to anything but 'no', a webserver is launched.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1432,7 +1432,11 @@ IP Address for webserver/API to listen on.
 ------------------------
 
 -  IP ranges, separated by commas or whitespace
--  Default: 0.0.0.0/0,::/0
+-  Default: 127.0.0.1,::1
+
+.. versionchanged:: 4.1.0
+
+    Default is now 127.0.0.1,::1, was 0.0.0.0,::/0 before.
 
 Webserver/API access is only allowed from these subnets.
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -133,7 +133,7 @@ void declareArguments()
   ::arg().set("webserver-address","IP Address of webserver/API to listen on")="127.0.0.1";
   ::arg().set("webserver-port","Port of webserver/API to listen on")="8081";
   ::arg().set("webserver-password","Password required for accessing the webserver")="";
-  ::arg().set("webserver-allow-from","Webserver/API access is only allowed from these subnets")="0.0.0.0/0,::/0";
+  ::arg().set("webserver-allow-from","Webserver/API access is only allowed from these subnets")="127.0.0.1,::1";
 
   ::arg().setSwitch("out-of-zone-additional-processing","Do out of zone additional processing")="yes";
   ::arg().setSwitch("do-ipv6-additional-processing", "Do AAAA additional processing")="yes";

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3218,7 +3218,7 @@ int main(int argc, char **argv)
     ::arg().set("webserver-address", "IP Address of webserver to listen on") = "127.0.0.1";
     ::arg().set("webserver-port", "Port of webserver to listen on") = "8082";
     ::arg().set("webserver-password", "Password required for accessing the webserver") = "";
-    ::arg().set("webserver-allow-from","Webserver access is only allowed from these subnets")="0.0.0.0/0,::/0";
+    ::arg().set("webserver-allow-from","Webserver access is only allowed from these subnets")="127.0.0.1,::1";
     ::arg().set("carbon-ourname", "If set, overrides our reported hostname for carbon stats")="";
     ::arg().set("carbon-server", "If set, send metrics in carbon (graphite) format to this server IP address")="";
     ::arg().set("carbon-interval", "Number of seconds between carbon (graphite) updates")="30";

--- a/pdns/recursordist/docs/http-api/index.rst
+++ b/pdns/recursordist/docs/http-api/index.rst
@@ -21,8 +21,8 @@ Webserver
 
 To launch the internal webserver, add a :ref:`setting-webserver` to the configuration file.
 This will instruct PowerDNS to start a webserver on localhost at port 8081, without password protection.
-Only local users (on the same host) will be able to access the webserver by default, but we still strongly advise the use of a password protection.
-The webserver lists a lot of information about the PowerDNS process, including frequent queries, frequently failing queries, lists of remote hosts sending queries, hosts sending corrupt queries etc.
+By default the webserver listens on localhost, meaning only local users (on the same host) will be able to access the webserver. Since the default ACL before 4.1.0 allows access from everywhere if :ref:`webserver-address` is set to a different value, we strongly advise the use of a password protection.
+The webserver lists a lot of potentially sensitive information about the PowerDNS process, including frequent queries, frequently failing queries, lists of remote hosts sending queries, hosts sending corrupt queries etc.
 The webserver does not allow remote management.
 The following webserver related configuration items are available:
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1069,7 +1069,11 @@ IP address for the webserver to listen on.
 ``webserver-allow-from``
 ------------------------
 -  IP addresses, comma separated
--  Default: 0.0.0.0, ::/0
+-  Default: 127.0.0.1,::1
+
+.. versionchanged:: 4.1.0
+
+    Default is now 127.0.0.1,::1, was 0.0.0.0,::/0 before.
 
 These subnets are allowed to access the webserver.
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The default value of `webserver-allow-from` (0.0.0.0, ::/0) means that the webserver is accessible from everywhere as soon as it's enabled. We don't want to change that in a minor release, but let's switch to a more sensible default (127.0.0.1, ::1) for 4.1.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
