### PR TITLE
skip v6-dependent test when PDNS_TEST_NO_IPV6 is set in environment

### DIFF
--- a/pdns/test-nameserver_cc.cc
+++ b/pdns/test-nameserver_cc.cc
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(test_AddressIsUs6) {
   
   BOOST_CHECK_EQUAL(AddressIsUs(local1), true);
 //  BOOST_CHECK_EQUAL(AddressIsUs(local2), false);
-  BOOST_CHECK_EQUAL(AddressIsUs(local3), true);
+  if(!getenv("PDNS_TEST_NO_IPV6")) BOOST_CHECK_EQUAL(AddressIsUs(local3), true);
   BOOST_CHECK_EQUAL(AddressIsUs(Remote), false);
   Remote.sin4.sin_port = 1;
   BOOST_CHECK_EQUAL(AddressIsUs(Remote), false);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
