### PR TITLE
rec: Fix the tests added in #5569 and #5570, DNSSEC modes changed in #5557

### DIFF
--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -4871,7 +4871,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_ds_sign_loop) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  g_dnssecmode = DNSSECMode::ValidateAll;
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
   primeHints();
   const DNSName target("www.powerdns.com.");
@@ -6714,7 +6714,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nodata) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  g_dnssecmode = DNSSECMode::ValidateAll;
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
   primeHints();
   const DNSName target("powerdns.com.");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The unit tests now need to call `setDNSSECValidation()` to request validation, instead of setting `g_dnssecmode` directly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
