### PR TITLE
Fix two issues with the build scripts

### DIFF
--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -6,13 +6,67 @@ packages. This README will give a small walkthrough of important files.
 All `build-*` must be run from the root folder of the pdns repository to ensure
 their correct functionality.
 
+## How do I build a package
+
+Before a package can be built, the distribution tarball has to exist in the root
+directory. For auth:
+
+ * `autoreconf -i`
+ * `./configure --without-modules --without-dynmodules --disable-depedency-tracking`
+ * `make dist`
+
+For the recursor:
+
+ * `cd pdns/recursordist`
+ * `autoreconf -i`
+ * `./configure --disable-depedency-tracking`
+ * `make dist`
+ * `mv pdns-recursor*.tar.bz2 ../../`
+ * `cd -`
+
+And dnsdist:
+
+ * `cd pdns/dnsdistdist`
+ * `autoreconf -i`
+ * `./configure --disable-depedency-tracking`
+ * `make dist`
+ * `mv dnsdist*.tar.bz2 ../../`
+ * `cd -`
+
+Now two environment variables need to be set, `$VERSION` and `$RELEASE`.
+
+`$VERSION` must be set to the to the version in the tarball to build a package for.
+If the version of the package has to be different (e.g. '4.1.0~beta1'), set
+`$VERSION` to *that* number and set `$TARBALLVERSION` to the tarball's version.
+
+`$RELEASE` is the 'release' version number for the package (e.g. '1.pdns' or
+'0.beta1').
+
+So, to create a package for 0.0.1 for debian version '0.0.1-1pdns0':
+
+ * VERSION=0.0.1
+ * RELEASE=1pdns0
+
+0.0.1-beta2 for EL7 (0.0.1-0.beta.2.pdns):
+
+ * VERSION=0.0.1
+ * TARBALLVERSION=0.0.1-beta2
+ * RELEASE=0.beta.2.pdns
+
+0.0.1-rc1 for debian (0.0.1~rc1-1pdns0):
+
+ * VERSION=0.0.1~rc1
+ * TARBALLVERSION=0.0.1-rc1
+ * RELEASE=1pdns0
+
+And run the proper script:
+
 ## `build-auth-*`
 These scripts build (based on the suffix) a package of the authoritative
-server. Either RPM's (for several different RHEL-based distro's), .deb's
-(for Debian Jessie only at the moment) or statically compiled RPM's and deb's.
+server. Either RPM's (for several different RHEL-based distro's), .deb's.
 
 ## `build-recursor-*`
-Based on suffix, hese scripts build a deb/RPM package for the Recursor. There is
+Based on suffix, these scripts build a deb/RPM package for the Recursor. There is
 also a semi-static build script.
 
 ## `build-dnsdist-*`

--- a/build-scripts/build-auth-debian
+++ b/build-scripts/build-auth-debian
@@ -1,32 +1,21 @@
 #!/bin/sh
 
-export DEBFULLNAME="PowerDNS.COM BV AutoBuilder"
-export DEBEMAIL="noreply@powerdns.com"
-
 if [ "$0" != "./build-scripts/build-auth-debian" ]; then
   echo "Please run me from the root checkout dir"
   exit 1
 fi
 
-if [ -z "$VERSION" ]; then
-  echo 'Please set $VERSION' >&2
-  exit 1
-fi
+. build-scripts/functions.sh
+TARBALLPREFIX=pdns
 
-if [ -z "$RELEASE" ];then
-  echo 'Please set $RELEASE' >&2
-  exit 1
-fi
-
-DISTDIR=${DISTDIR:=.}
+startup
 
 set -e
 set -x
 
-rm -rf $DISTDIR/debian/
-cp -r build-scripts/debian-authoritative $DISTDIR/debian
+cp_tarball_to_tmp
 
-cd $DISTDIR
+cd ${SRCDIR}
 
 cat > debian/changelog << EOF
 pdns (${VERSION}-${RELEASE}) unstable; urgency=medium
@@ -60,3 +49,5 @@ if $(echo $PDNS_VERSION | grep -q -E '^0\.0\.'); then
 fi
 
 DH_OPTIONS=--parallel fakeroot debian/rules binary
+
+mv_debs_to_pwd

--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -5,40 +5,22 @@ if [ "$0" != "./build-scripts/build-auth-rpm" ]; then
   exit 1
 fi
 
-if [ -z "$VERSION" ]; then
-  echo 'Please set $VERSION' >&2
-  exit 1
-fi
+. build-scripts/functions.sh
+TARBALLPREFIX=pdns
 
-if [ -z "$TARBALLVERSION" ]; then
-  TARBALLVERSION=$VERSION
-fi
-
-if [ -z "$RELEASE" ];then
-  echo 'Please set $RELEASE' >&2
-  exit 1
-fi
+startup
 
 set -e
 set -x
 
-# Prepare the build environment
-rpmdev-setuptree
-
-# This is somethat ugly...
-if [ -f pdns-${TARBALLVERSION}.tar.bz2 ]; then
-  mv pdns-${TARBALLVERSION}.tar.bz2 $HOME/rpmbuild/SOURCES
-else
-  echo "pdns-${TARBALLVERSION}.tar.bz2 not found" >&2
-  exit 1
-fi
+cp_tarball_to_rpm_sources
 
 # Some setups need rpmbuild in a 'special' env
 RPMBUILD_COMMAND='rpmbuild -bb pdns.spec'
 
 if [ -r /etc/os-release ]; then
   OLDVERSION=$VERSION
-  source /etc/os-release
+  . /etc/os-release
   OS="${NAME} ${VERSION}"
   VERSION=$OLDVERSION
 fi
@@ -48,8 +30,6 @@ if [ -f /etc/redhat-release ]; then
 fi
 
 case "$OS" in
-#    Fedora\ *\ 21*)
-#      ;;
   CentOS\ *\ 6*)
     RPMBUILD_COMMAND="scl enable devtoolset-3 -- ${RPMBUILD_COMMAND}"
     cat > $HOME/rpmbuild/SOURCES/pdns.init <<EOF

--- a/build-scripts/build-dnsdist-debian
+++ b/build-scripts/build-dnsdist-debian
@@ -5,27 +5,17 @@ if [ "$0" != "./build-scripts/build-dnsdist-debian" ]; then
   exit 1
 fi
 
-if [ -z "$VERSION" ]; then
-  echo 'Please set $VERSION' >&2
-  exit 1
-fi
+. build-scripts/functions.sh
+TARBALLPREFIX=dnsdist
 
-if [ -z "$DISTDIR" ]; then
-  DISTDIR='pdns/dnsdistdist'
-fi
-
-if [ -z "$RELEASE" ];then
-  echo 'Please set $RELEASE' >&2
-  exit 1
-fi
+startup
 
 set -e
 set -x
 
-rm -rf $DISTDIR/debian/
-cp -r build-scripts/debian-dnsdist $DISTDIR/debian
+cp_tarball_to_tmp
 
-cd $DISTDIR
+cd ${SRCDIR}
 
 cat > debian/changelog << EOF
 dnsdist (${VERSION}-${RELEASE}) unstable; urgency=medium
@@ -46,3 +36,5 @@ fi
 
 fakeroot debian/rules debian/control
 fakeroot debian/rules binary
+
+mv_debs_to_pwd

--- a/build-scripts/build-dnsdist-rpm
+++ b/build-scripts/build-dnsdist-rpm
@@ -5,34 +5,15 @@ if [ "$0" != "./build-scripts/build-dnsdist-rpm" ]; then
   exit 1
 fi
 
-if [ -z "$VERSION" ]; then
-  echo 'Please set $VERSION' >&2
-  exit 1
-fi
+. build-scripts/functions.sh
+TARBALLPREFIX=dnsdist
 
-if [ -z "$TARBALLVERSION" ]; then
-  TARBALLVERSION=${VERSION}
-fi
-
-if [ -z "$RELEASE" ];then
-  echo 'Please set $RELEASE' >&2
-  exit 1
-fi
+startup
 
 set -e
 set -x
 
-# Prepare the build environment
-rpmdev-setuptree
-
-# This is somethat ugly...
-if [ -f dnsdist-${TARBALLVERSION}.tar.bz2 ]; then
-  mv dnsdist-${TARBALLVERSION}.tar.bz2 $HOME/rpmbuild/SOURCES
-else
-  echo "dnsdist-${TARBALLVERSION}.tar.bz2 not found" >&2
-  exit 1
-fi
-
+cp_tarball_to_rpm_sources
 
 # Some RPM platforms use systemd, others sysv, we default to systemd here
 INIT_BUILDREQUIRES='BuildRequires: systemd-devel'

--- a/build-scripts/build-recursor-debian
+++ b/build-scripts/build-recursor-debian
@@ -5,28 +5,17 @@ if [ "$0" != "./build-scripts/build-recursor-debian" ]; then
   exit 1
 fi
 
-if [ -z "$VERSION" ]; then
-  echo 'Please set $VERSION' >&2
-  exit 1
-fi
+. build-scripts/functions.sh
+TARBALLPREFIX=pdns-recursor
 
-if [ -z "$RELEASE" ];then
-  echo 'Please set $RELEASE' >&2
-  exit 1
-fi
-
-if [ -z "$DISTDIR" ]; then
-  echo 'Please set $DISTDIR to the directory where pdns-recursor.tar.gz was unpacked' >&2
-  exit 1
-fi
+startup
 
 set -e
 set -x
 
-rm -rf $DISTDIR/debian
-cp -r build-scripts/debian-recursor $DISTDIR/debian
+cp_tarball_to_tmp
 
-cd $DISTDIR
+cd ${SRCDIR}
 
 cat > debian/changelog << EOF
 pdns-recursor (${VERSION}-${RELEASE}) unstable; urgency=medium
@@ -48,5 +37,6 @@ if [ ${ID} = "ubuntu" -a ${VERSION_ID} = "14.04" ]; then
 fi
 
 fakeroot debian/rules debian/control
-
 fakeroot debian/rules binary
+
+mv_debs_to_pwd

--- a/build-scripts/build-recursor-rpm
+++ b/build-scripts/build-recursor-rpm
@@ -5,33 +5,15 @@ if [ "$0" != "./build-scripts/build-recursor-rpm" ]; then
   exit 1
 fi
 
-if [ -z "$VERSION" ]; then
-  echo 'Please set $VERSION' >&2
-  exit 1
-fi
+. build-scripts/functions.sh
+TARBALLPREFIX=pdns-recursor
 
-if [ -z "$TARBALLVERSION" ]; then
-  TARBALLVERSION=${VERSION}
-fi
-
-if [ -z "$RELEASE" ];then
-  echo 'Please set $RELEASE' >&2
-  exit 1
-fi
+startup
 
 set -e
 set -x
 
-# Prepare the build environment
-rpmdev-setuptree
-
-# This is somethat ugly...
-if [ -f pdns-recursor-${TARBALLVERSION}.tar.bz2 ]; then
-  mv pdns-recursor-${TARBALLVERSION}.tar.bz2 $HOME/rpmbuild/SOURCES
-else
-  echo "pdns-recursor-${TARBALLVERSION}.tar.bz2 not found" >&2
-  exit 1
-fi
+cp_tarball_to_rpm_sources
 
 # Some setups need rpmbuild in a 'special' env
 RPMBUILD_COMMAND='rpmbuild -bb pdns-recursor.spec'
@@ -59,7 +41,7 @@ if [ -f /etc/redhat-release ]; then
 # pidfile: /var/run/pdns_recursor.pid
 #
 
-# source function library
+# . function library
 . /etc/rc.d/init.d/functions
 
 RETVAL=0

--- a/build-scripts/debian-authoritative/control.in
+++ b/build-scripts/debian-authoritative/control.in
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.8
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, po-debconf, libtool, flex, bison, libmysqlclient-dev, libpq-dev, libssl-dev, libgdbm-dev, libldap2-dev, libsqlite3-dev, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libboost-program-options-dev, libboost-test-dev, autotools-dev, automake, autoconf, libluajit5.1-dev, pkg-config, ragel, libgmp-dev, libbotan1.10-dev, libcurl4-openssl-dev, libzmq-dev, libyaml-cpp-dev (>= 0.5), libgeoip-dev, libopendbx1-dev, libcdb-dev, unixodbc-dev (>= 2.3.1), libprotobuf-dev, protobuf-compiler @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
+Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, po-debconf, curl, libtool, flex, bison, libmysqlclient-dev, libpq-dev, libssl-dev, libgdbm-dev, libldap2-dev, libsqlite3-dev, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libboost-program-options-dev, libboost-test-dev, autotools-dev, automake, autoconf, libluajit5.1-dev, pkg-config, ragel, libgmp-dev, libbotan1.10-dev, libcurl4-openssl-dev, libzmq-dev, libyaml-cpp-dev (>= 0.5), libgeoip-dev, libopendbx1-dev, libcdb-dev, unixodbc-dev (>= 2.3.1), libprotobuf-dev, protobuf-compiler @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
 Homepage: http://www.powerdns.com/
 
 Package: pdns-server

--- a/build-scripts/functions.sh
+++ b/build-scripts/functions.sh
@@ -1,0 +1,47 @@
+startup() {
+  export DEBFULLNAME="PowerDNS.COM BV AutoBuilder"
+  export DEBEMAIL="noreply@powerdns.com"
+
+  if [ -z "$VERSION" ]; then
+    echo 'Please set $VERSION' >&2
+    exit 1
+  fi
+
+  if [ -z "$RELEASE" ];then
+    echo 'Please set $RELEASE' >&2
+    exit 1
+  fi
+
+  TARBALLVERSION=${TARBALLVERSION:-$VERSION}
+
+  TARBALLFILE=${TARBALLPREFIX}-${TARBALLVERSION}.tar.bz2
+
+  if [ ! -f ${TARBALLFILE} ]; then
+    echo "${TARBALLFILE} not found" >&2
+    exit 1
+  fi
+}
+
+cp_tarball_to_tmp() {
+  DIR=$(mktemp -d)
+
+  tar -xf ${TARBALLFILE} -C ${DIR}
+
+  SRCDIR=${DIR}/${TARBALLPREFIX}-${TARBALLVERSION}
+  if [ "${TARBALLPREFIX}" = "pdns" ]; then
+    cp -r build-scripts/debian-authoritative ${SRCDIR}/debian
+  elif [ "${TARBALLPREFIX}" = "pdns-recursor" ]; then
+    cp -r build-scripts/debian-recursor ${SRCDIR}/debian
+  else
+    cp -r build-scripts/debian-${TARBALLPREFIX} ${SRCDIR}/debian
+  fi
+}
+
+cp_tarball_to_rpm_sources() {
+  rpmdev-setuptree
+  cp ${TARBALLFILE} ${HOME}/rpmbuild/SOURCES
+}
+
+mv_debs_to_pwd() {
+  mv ${DIR}/*.deb .
+}


### PR DESCRIPTION
### Short description
Closes #5585 and ensures that the build scripts now _only_ use a tarball to build the packages.

Needs backport to 4.0.x

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)