### PR TITLE
Improve slave-check: Check every configured master and AXFR from mast…

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -885,6 +885,7 @@ int PacketHandler::processNotify(DNSPacket *p)
     
   // ok, we've done our checks
   di.backend = 0;
+  L<<Logger::Error<<"Received NOTIFY for "<<p->qdomain<<" from "<<p->getRemote()<<": forwardNotify and addSlaveCheckRequest() ..."<<endl;
 
   if(!s_forwardNotify.empty()) {
     set<string> forwardNotify(s_forwardNotify);


### PR DESCRIPTION
…er with highest serial

Currently PDNS as slave has a poor logic when there are multiple masters:

1. On incoming NOTIFY, PDNS queues the zone for refresh. Then, the SOA query uses a
random master to get the master's serial. On timeout, PDNS does not try another master.

2. If the SOA query was successful and the serial increased, PDNS queues the domain for
AXFR, but this AXFR uses only the first master.

Thus, if the first master is offline, even if the second master sends
NOTIFYs and has a newer zone, PDNS will never transfer it.

This patch does 2 things:

a) If a slave check for a domain is requested and the domain has multiple masters, the SOA
check will be performed against every master. Further, the name server which answered with
the highest serial will be used for the AXFR.

Known issue: If there is a serial rollover, then choosing the highest serial is not the best
choice. But as soon as the rollover happend on every master the logic is correct again.