### PR TITLE
Backport #5511: Dump RRSIGs on `dump-cache`

### DIFF
--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -295,6 +295,15 @@ uint64_t MemRecursorCache::doDump(int fd)
         fprintf(fp, "; error printing '%s'\n", i->d_qname.empty() ? "EMPTY" : i->d_qname.toString().c_str());
       }
     }
+    for(const auto &sig : i->d_signatures) {
+      count++;
+      try {
+        fprintf(fp, "%s %" PRId64 " IN RRSIG %s ; %s\n", i->d_qname.toString().c_str(), static_cast<int64_t>(i->d_ttd - now), sig->getZoneRepresentation().c_str(), i->d_netmask.empty() ? "" : i->d_netmask.toString().c_str());
+      }
+      catch(...) {
+        fprintf(fp, "; error printing '%s'\n", i->d_qname.empty() ? "EMPTY" : i->d_qname.toString().c_str());
+      }
+    }
   }
   fclose(fp);
   return count;

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -289,7 +289,7 @@ uint64_t MemRecursorCache::doDump(int fd)
     for(auto j=i->d_records.cbegin(); j != i->d_records.cend(); ++j) {
       count++;
       try {
-        fprintf(fp, "%s %d IN %s %s ; %s\n", i->d_qname.toString().c_str(), (int32_t)(i->d_ttd - now), DNSRecordContent::NumberToType(i->d_qtype).c_str(), (*j)->getZoneRepresentation().c_str(), i->d_netmask.empty() ? "" : i->d_netmask.toString().c_str());
+        fprintf(fp, "%s %d IN %s %s ; auth=%i %s\n", i->d_qname.toString().c_str(), (int32_t)(i->d_ttd - now), DNSRecordContent::NumberToType(i->d_qtype).c_str(), (*j)->getZoneRepresentation().c_str(), i->d_auth, i->d_netmask.empty() ? "" : i->d_netmask.toString().c_str());
       }
       catch(...) {
         fprintf(fp, "; error printing '%s'\n", i->d_qname.empty() ? "EMPTY" : i->d_qname.toString().c_str());


### PR DESCRIPTION
### Short description
This closes #5510 for the 4.0.x train.

On a `rec_control dump-cache`, we now dump RRSIGs and show the 'auth' status of the records.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] checked that this code was merged to master
