### PR TITLE
recursor-tests: Check if supervise and authbind are installed

### DIFF
--- a/regression-tests.recursor/start.sh
+++ b/regression-tests.recursor/start.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+SUPERVISE="`which supervise`"
+AUTHBIND="`which authbind`"
+
 set -e
 if [ "${PDNS_DEBUG}" = "YES" ]; then
   set -x
@@ -9,6 +13,16 @@ fi
 if [ -z "$PREFIX" ] 
 then
     echo "config not found or PREFIX not set"
+    exit 1
+fi
+
+if [ -z "$SUPERVISE" ]; then
+    echo "daemontools is not installed"
+    exit 1
+fi
+
+if [ -z "$AUTHBIND" ]; then
+    echo "authbind is not installed"
     exit 1
 fi
 


### PR DESCRIPTION
### Short description
Fail start.sh in recursor tests if supervise or authbind is missing.

### Checklist
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
