### PR TITLE
DNSPacket naming was confusing + small cleanups

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -524,8 +524,9 @@ bool DNSPacket::getTKEYRecord(TKEYRecordContent *tr, DNSName *keyname) const
 /** This function takes data from the network, possibly received with recvfrom, and parses
     it into our class. Results of calling this function multiple times on one packet are
     unknown. Returns -1 if the packet cannot be parsed.
+    Does not actually store data records in d_rrs!
 */
-int DNSPacket::parse(const char *mesg, size_t length)
+int DNSPacket::questionparse(const char *mesg, size_t length)
 try
 {
   d_rawpacket.assign(mesg,length); 

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -63,11 +63,11 @@ class DNSSECKeeper;
 class DNSPacket
 {
 public:
-  DNSPacket(bool isQuery);
+  explicit DNSPacket(bool isQuery);
   DNSPacket(const DNSPacket &orig);
 
   int noparse(const char *mesg, size_t len); //!< just suck the data inward
-  int parse(const char *mesg, size_t len); //!< parse a raw UDP or TCP packet and suck the data inward
+  int questionparse(const char *mesg, size_t len); //!< parse a raw UDP or TCP packet and suck the data inward. DOES NOT FILL d_rrs!!
   const string& getString(); //!< for serialization - just passes the whole packet
 
   // address & socket manipulation

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -216,9 +216,8 @@ void DNSProxy::mainloop(void)
         d.id=i->second.id;
         memcpy(buffer,&d,sizeof(d));  // commit spoofed id
 
-        DNSPacket p(false),q(false);
-        p.parse(buffer,(size_t)len);
-        q.parse(buffer,(size_t)len);
+        DNSPacket p(false);
+        p.questionparse(buffer,(size_t)len);
 
         if(p.qtype.getCode() != i->second.qtype || p.qdomain != i->second.qname) {
           L<<Logger::Error<<"Discarding packet from recursor backend with id "<<(d.id^d_xor)<<

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -173,7 +173,7 @@ time_t CommunicatorClass::doNotifications()
 
     p.setRemote(&from);
 
-    if(p.parse(buffer,(size_t)size)<0) {
+    if(p.questionparse(buffer,(size_t)size)<0) {
       L<<Logger::Warning<<"Unable to parse SOA notification answer from "<<p.getRemote()<<endl;
       continue;
     }

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -378,7 +378,7 @@ DNSPacket *UDPNameserver::receive(DNSPacket *prefilled)
   else
     packet->d_dt.set(); // timing    
 
-  if(packet->parse(mesg, (size_t) len)<0) {
+  if(packet->questionparse(mesg, (size_t) len)<0) {
     S.inc("corrupt-packets");
     S.ringAccount("remotes-corrupt", packet->d_remote);
 

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -329,7 +329,7 @@ void *TCPNameserver::doConnection(void *data)
       packet->setRemote(&remote);
       packet->d_tcp=true;
       packet->setSocket(fd);
-      if(packet->parse(mesg.get(), pktlen)<0)
+      if(packet->questionparse(mesg.get(), pktlen)<0)
         break;
       
       if(packet->qtype.getCode()==QType::AXFR) {

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -145,7 +145,7 @@ try
 
     DNSPacketWriter pw(pak, qname, QType::A);
     DNSPacket q(true);
-    q.parse((char*)&pak[0], pak.size());
+    q.questionparse((char*)&pak[0], pak.size());
 
     pak.clear();
     DNSPacketWriter pw2(pak, qname, QType::A);
@@ -154,7 +154,7 @@ try
     pw2.commit();
 
     DNSPacket r(false);
-    r.parse((char*)&pak[0], pak.size());
+    r.questionparse((char*)&pak[0], pak.size());
 
     /* this step is necessary to get a valid hash */
     DNSPacket cached(false);
@@ -181,7 +181,7 @@ try
 
     DNSPacketWriter pw(pak, qname, QType::A);
     DNSPacket q(true);
-    q.parse((char*)&pak[0], pak.size());
+    q.questionparse((char*)&pak[0], pak.size());
     DNSPacket r(false);
 
     if(!g_PC->get(&q, &r)) {
@@ -296,14 +296,14 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
 
     {
       DNSPacketWriter pw(pak, DNSName("www.powerdns.com"), QType::A);
-      q.parse((char*)&pak[0], pak.size());
+      q.questionparse((char*)&pak[0], pak.size());
 
-      differentIDQ.parse((char*)&pak[0], pak.size());
+      differentIDQ.questionparse((char*)&pak[0], pak.size());
       differentIDQ.setID(4242);
 
       pw.addOpt(512, 0, 0);
       pw.commit();
-      ednsQ.parse((char*)&pak[0], pak.size());
+      ednsQ.questionparse((char*)&pak[0], pak.size());
 
       pak.clear();
     }
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
       DNSPacketWriter pw(pak, DNSName("www.powerdns.com"), QType::A);
       pw.addOpt(512, 0, 0, DNSPacketWriter::optvect_t(), 42);
       pw.commit();
-      ednsVersion42.parse((char*)&pak[0], pak.size());
+      ednsVersion42.questionparse((char*)&pak[0], pak.size());
       pak.clear();
     }
 
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
       DNSPacketWriter pw(pak, DNSName("www.powerdns.com"), QType::A);
       pw.addOpt(512, 0, EDNSOpts::DNSSECOK);
       pw.commit();
-      ednsDO.parse((char*)&pak[0], pak.size());
+      ednsDO.questionparse((char*)&pak[0], pak.size());
       pak.clear();
     }
 
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
       DNSPacketWriter pw(pak, DNSName("www.powerdns.com"), QType::A);
       pw.addOpt(512, 0, 0, opts);
       pw.commit();
-      ecs1.parse((char*)&pak[0], pak.size());
+      ecs1.questionparse((char*)&pak[0], pak.size());
       pak.clear();
       opts.clear();
     }
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
       opts.push_back(make_pair(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(ecsOpts)));
       pw.addOpt(512, 0, 0, opts);
       pw.commit();
-      ecs2.parse((char*)&pak[0], pak.size());
+      ecs2.questionparse((char*)&pak[0], pak.size());
       pak.clear();
       opts.clear();
     }
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
       opts.push_back(make_pair(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(ecsOpts)));
       pw.addOpt(512, 0, 0, opts);
       pw.commit();
-      ecs3.parse((char*)&pak[0], pak.size());
+      ecs3.questionparse((char*)&pak[0], pak.size());
       pak.clear();
       opts.clear();
     }
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
       pw.xfrIP(htonl(0x7f000001));
       pw.commit();
 
-      r.parse((char*)&pak[0], pak.size());
+      r.questionparse((char*)&pak[0], pak.size());
     }
 
     /* this call is required so the correct hash is set into q->d_hash */


### PR DESCRIPTION
rename DNSPacket::parse() to questionparse() & add comment it does not parse answers. Remove needless parsing from dnsproxy.cc, make DNSPacket bool constructor explicit. ALIAS still works after these changes.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
