### PR TITLE
NOTIMP is only appropriate for an unsupported opcode

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1200,7 +1200,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     // L<<Logger::Warning<<"Query for '"<<p->qdomain<<"' "<<p->qtype.getName()<<" from "<<p->getRemote()<< " (tcp="<<p->d_tcp<<")"<<endl;
     
     if(p->qtype.getCode()==QType::IXFR) {
-      r->setRcode(RCode::NotImp);
+      r->setRcode(RCode::Refused);
       return r;
     }
 
@@ -1214,9 +1214,9 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
         return r;
     }
 
-    // we only know about qclass IN (and ANY), send NotImp for everything else.
+    // we only know about qclass IN (and ANY), send Refused for everything else.
     if(p->qclass != QClass::IN && p->qclass!=QClass::ANY) {
-      r->setRcode(RCode::NotImp);
+      r->setRcode(RCode::Refused);
       return r;
     }
 
@@ -1299,7 +1299,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     // this TRUMPS a cname!
     if(p->qtype.getCode() == QType::RRSIG) {
       L<<Logger::Info<<"Direct RRSIG query for "<<target<<" from "<<p->getRemote()<<endl;
-      r->setRcode(RCode::NotImp);
+      r->setRcode(RCode::Refused);
       goto sendit;
     }
 

--- a/regression-tests/tests/direct-rrsig/expected_result
+++ b/regression-tests/tests/direct-rrsig/expected_result
@@ -1,3 +1,3 @@
 2	.	IN	OPT	32768	
-Rcode: 4 (Not Implemented), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Rcode: 5 (Query Refused), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='example.com.', qtype=RRSIG


### PR DESCRIPTION
### Short description

In rfc1035 is not very clear about this
4.1.1
```
OPCODE          A four bit field that specifies kind of query in this
                message. ...
```
and 
```
                4               Not Implemented - The name server does
                                not support the requested kind of query.
```
But there is room for discussion.

rfc2136 on the other hand, is very clear about the use of NOTIMP
2.2
```
              NOTIMP      4       The name server does not support
                                  the specified Opcode.
```
This pull is replacing NOTIMP with REFUSED for non opcode related use.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
