### PR TITLE
Fix sortlist in the presence of CNAME

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1089,7 +1089,7 @@ static void startDoResolve(void *p)
       if(ret.size()) {
         orderAndShuffle(ret);
 	if(auto sl = luaconfsLocal->sortlist.getOrderCmp(dc->d_remote)) {
-	  sort(ret.begin(), ret.end(), *sl);
+	  stable_sort(ret.begin(), ret.end(), *sl);
 	  variableAnswer=true;
 	}
       }

--- a/pdns/sortlist.cc
+++ b/pdns/sortlist.cc
@@ -65,7 +65,7 @@ bool SortListOrderCmp::operator()(const DNSRecord& ar, const DNSRecord& br) cons
   else if(!aAddr && bAddr)
     return true;
   else if(!aAddr && !bAddr)
-    return true;
+    return false;
   
 
   int aOrder=std::numeric_limits<int>::max();

--- a/pdns/sortlist.cc
+++ b/pdns/sortlist.cc
@@ -52,15 +52,21 @@ bool SortListOrderCmp::operator()(const ComboAddress& a, const ComboAddress& b) 
   return aOrder < bOrder;
 }
 
+// call this with **stable_sort**
 bool SortListOrderCmp::operator()(const DNSRecord& ar, const DNSRecord& br) const
 {
-  if(ar.d_type < br.d_type)
-    return true;
-  if(ar.d_type > br.d_type)
-    return false;
+  bool aAddr = (ar.d_type == QType::A || ar.d_type == QType::AAAA);
+  bool bAddr = (br.d_type == QType::A || br.d_type == QType::AAAA);
 
-  if(ar.d_type != QType::A && ar.d_type != QType::AAAA) 
-    return false;  // all other types are equal among themselves
+  // anything address related is always 'larger', rest is equal
+  
+  if(aAddr && !bAddr)
+    return false;
+  else if(!aAddr && bAddr)
+    return true;
+  else if(!aAddr && !bAddr)
+    return true;
+  
 
   int aOrder=std::numeric_limits<int>::max();
   int bOrder=aOrder;

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -569,7 +569,7 @@ distributor-threads=1""".format(confdir=confdir,
                 raise
 
     @classmethod
-    def sendUDPQuery(cls, query, timeout=2.0):
+    def sendUDPQuery(cls, query, timeout=2.0, fwparams=dict()):
         if timeout:
             cls._sock.settimeout(timeout)
 
@@ -584,7 +584,7 @@ distributor-threads=1""".format(confdir=confdir,
 
         message = None
         if data:
-            message = dns.message.from_wire(data)
+            message = dns.message.from_wire(data, **fwparams)
         return message
 
     @classmethod

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -102,6 +102,12 @@ ns1.ecs-echo.example. 3600 IN A    {prefix}.21
 
 islandofsecurity.example.          3600 IN NS   ns1.islandofsecurity.example.
 ns1.islandofsecurity.example.      3600 IN A    {prefix}.9
+
+sortcname.example.                 3600 IN CNAME sort
+sort.example.                      3600 IN A     17.38.42.80
+sort.example.                      3600 IN A     192.168.0.1
+sort.example.                      3600 IN A     17.238.240.5
+sort.example.                      3600 IN MX    25 mx
         """,
         'secure.example': """
 secure.example.          3600 IN SOA  {soa}

--- a/regression-tests.recursor-dnssec/test_Sortlist.py
+++ b/regression-tests.recursor-dnssec/test_Sortlist.py
@@ -1,0 +1,41 @@
+import dns
+from recursortests import RecursorTest
+
+
+class testSortlist(RecursorTest):
+    _confdir = 'Sortlist'
+
+    _config_template = """dnssec=off"""
+    _lua_config_file = """addSortList("0.0.0.0/0", 
+                {"17.238.240.0/24", "17.138.149.200",
+                    {"17.218.242.254", "17.218.252.254"}, 
+                    "17.38.42.80",
+                    "17.208.240.100" })"""
+
+    def testSortlist(self):
+        msg = dns.message.make_query("sortcname.example.", dns.rdatatype.ANY)
+        msg.flags = dns.flags.from_text('RD')
+
+        res = self.sendUDPQuery(msg, fwparams=dict(one_rr_per_rrset=True))
+
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+
+        indexCNAME = -1
+        indexMX = -1
+        recordsA = []
+
+        for i, ans in enumerate(res.answer):
+            if ans.rdtype == dns.rdatatype.CNAME:
+                self.assertEqual(indexCNAME, -1)
+                indexCNAME = i
+            elif ans.rdtype == dns.rdatatype.MX:
+                self.assertEqual(indexMX, -1)
+                indexMX = i
+            elif ans.rdtype == dns.rdatatype.A:
+                recordsA.append(str(ans).split()[-1])
+
+        self.assertEqual(indexCNAME, 0)
+        self.assertGreater(indexMX, 0)
+
+        self.assertEqual(recordsA, ['17.238.240.5', '17.38.42.80', '192.168.0.1'])


### PR DESCRIPTION
In #5357 @killerwhile discovered we were missorting CNAME records when using sortlist.
With this commit, we should get it right by moving to stable_sort and being more careful about type equivalence.

### Short description
Fix sortlist in the presence of CNAME

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
