### PR TITLE
fix reading of ednsflags in recursor testing

### DIFF
--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -655,7 +655,7 @@ distributor-threads=1""".format(confdir=confdir,
         msgFlags = dns.flags.to_text(msg.flags).split()
         missingFlags = [flag for flag in flags if flag not in msgFlags]
 
-        msgEdnsFlags = dns.flags.edns_to_text(msg.flags).split()
+        msgEdnsFlags = dns.flags.edns_to_text(msg.ednsflags).split()
         missingEdnsFlags = [ednsflag for ednsflag in ednsflags if ednsflag not in msgEdnsFlags]
 
         if len(missingFlags) or len(missingEdnsFlags) or len(msgFlags) > len(flags):

--- a/regression-tests.recursor-dnssec/test_Interop.py
+++ b/regression-tests.recursor-dnssec/test_Interop.py
@@ -40,7 +40,7 @@ forward-zones+=undelegated.insecure.example=%s.12
         res = self.sendUDPQuery(query)
 
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], [])
         self.assertRRsetInAnswer(res, expected)
 
     def testUndelegatedForwardedZoneExisting(self):
@@ -56,7 +56,7 @@ forward-zones+=undelegated.insecure.example=%s.12
         res = self.sendUDPQuery(query)
 
         self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
-        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], [])
 
     def testUndelegatedForwardedZoneNXDOMAIN(self):
         """
@@ -71,7 +71,7 @@ forward-zones+=undelegated.insecure.example=%s.12
         res = self.sendUDPQuery(query)
 
         self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
-        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], [])
 
     def testUndelegatedForwardedInsecureZoneExisting(self):
         """
@@ -87,7 +87,7 @@ forward-zones+=undelegated.insecure.example=%s.12
         res = self.sendUDPQuery(query)
 
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], [])
         self.assertRRsetInAnswer(res, expected)
 
     def testUndelegatedForwardedInsecureZoneNXDOMAIN(self):
@@ -103,7 +103,7 @@ forward-zones+=undelegated.insecure.example=%s.12
         res = self.sendUDPQuery(query)
 
         self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
-        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], [])
 
     def testBothSecureCNAMEAtApex(self):
         """
@@ -119,7 +119,7 @@ forward-zones+=undelegated.insecure.example=%s.12
         self.assertRRsetInAnswer(res, expectedA)
         self.assertRRsetInAnswer(res, expectedCNAME)
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertMessageHasFlags(res, ['QR', 'RD', 'RA', 'AD'], ['DO'])
+        self.assertMessageHasFlags(res, ['QR', 'RD', 'RA', 'AD'], [])
 
     @classmethod
     def startResponders(cls):

--- a/regression-tests.recursor-dnssec/test_Sortlist.py
+++ b/regression-tests.recursor-dnssec/test_Sortlist.py
@@ -18,7 +18,7 @@ class testSortlist(RecursorTest):
 
         res = self.sendUDPQuery(msg, fwparams=dict(one_rr_per_rrset=True))
 
-        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], ['DO'])
+        self.assertMessageHasFlags(res, ['QR', 'RA', 'RD'], [])
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
 
         indexCNAME = -1


### PR DESCRIPTION
### Short description
We parsed the DNS header flags section as if it were the EDNS flags section. Due to the placement of the QR and DO bit in these sections respectively, this caused all testcases to always see a DO bit.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
