### PR TITLE
dnsdist: Mark backend as down on `setAuto()`

### DIFF
--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -638,7 +638,10 @@ struct DownstreamState
   }
   void setUp() { availability = Availability::Up; }
   void setDown() { availability = Availability::Down; }
-  void setAuto() { availability = Availability::Auto; }
+  void setAuto() {
+    upStatus = false;
+    availability = Availability::Auto;
+  }
   string getName() const {
     if (name.empty()) {
       return remote.toStringWithPort();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
That way the backend will be marked down until the next health check, as opposed to the current behavior of returning the last known state.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
