### PR TITLE
dnsdist: Add an optional `status` parameter to `setAuto()`

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1187,7 +1187,13 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   g_lua.registerFunction("isUp", &DownstreamState::isUp);
   g_lua.registerFunction("setDown", &DownstreamState::setDown);
   g_lua.registerFunction("setUp", &DownstreamState::setUp);
-  g_lua.registerFunction("setAuto", &DownstreamState::setAuto);
+  g_lua.registerFunction<void(DownstreamState::*)(boost::optional<bool> newStatus)>("setAuto", [](DownstreamState& s, boost::optional<bool> newStatus) {
+      if (newStatus) {
+        s.upStatus = *newStatus;
+      }
+      s.setAuto();
+    });
+
   g_lua.registerFunction("getName", &DownstreamState::getName);
   g_lua.registerFunction("getNameWithAddr", &DownstreamState::getNameWithAddr);
   g_lua.registerMember("upStatus", &DownstreamState::upStatus);

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -303,10 +303,15 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
   :param str pool: The pool to remove the server from
 
-.. classmethod:: Server:setAuto()
+.. classmethod:: Server:setAuto([status])
+
+.. versionchanged:: 1.3.0
+    ``status`` optional parameter added.
 
   Set the server in the default auto state.
-  This will enable health check queries that will set the server ``up`` and ``down`` appropriatly.
+  This will enable health check queries that will set the server ``up`` and ``down`` appropriately.
+
+  :param bool status: Set the initial status of the server to ``up`` (true) or ``down`` (false) instead of using the last known status
 
 .. classmethod:: Server:setQPS(limit)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If the parameter is present, its value is used to set the initial state of the `DownstreamServer` until a health check is performed, instead of using the previous known state.
It's useful if one wants to restore the automatic status detection but knows that the server is either currently down but was previously up (queries sent until the health check is performed will be lost); or currently up but was previously down, so it process queries immediately.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
