### PR TITLE
Backport #4986: Use `${TRAVIS_BUILD_DIR}` instead of assuming the repo is in `pdns`

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -242,7 +242,7 @@ install_auth() {
   run "cd .."
   run "wget https://www.verisignlabs.com/dnssec-tools/packages/jdnssec-tools-0.13.tar.gz"
   run "sudo tar xfz jdnssec-tools-0.13.tar.gz --strip-components=1 -C /"
-  run "cd pdns"
+  run "cd ${TRAVIS_BUILD_DIR}"
 
   # pkcs11 test requirements / setup
   run "sudo apt-get -qq --no-install-recommends install \
@@ -265,7 +265,7 @@ install_auth() {
   run "tar xzvf dnsperf-2.0.0.0-1-rhel-6-x86_64.tar.gz"
   run "fakeroot alien --to-deb dnsperf-2.0.0.0-1/dnsperf-2.0.0.0-1.el6.x86_64.rpm"
   run "sudo dpkg -i dnsperf_2.0.0.0-2_amd64.deb"
-  run "cd pdns"
+  run "cd ${TRAVIS_BUILD_DIR}"
 
   # geoip-backend test requirements / setup
   run "sudo apt-get -qq --no-install-recommends install \
@@ -345,7 +345,7 @@ install_recursor() {
     jq"
   run "cd .."
   run "wget http://s3.amazonaws.com/alexa-static/top-1m.csv.zip"
-  run "unzip top-1m.csv.zip -d ./pdns/regression-tests"
+  run "unzip top-1m.csv.zip -d ${TRAVIS_BUILD_DIR}/regression-tests"
   PDNS_SERVER_VERSION="0.0.880gcb54743-1pdns"
   run "wget https://downloads.powerdns.com/autobuilt/auth/deb/$PDNS_SERVER_VERSION.trusty-amd64/pdns-server_$PDNS_SERVER_VERSION.trusty_amd64.deb"
   run "wget https://downloads.powerdns.com/autobuilt/auth/deb/$PDNS_SERVER_VERSION.trusty-amd64/pdns-tools_$PDNS_SERVER_VERSION.trusty_amd64.deb"
@@ -353,7 +353,7 @@ install_recursor() {
   run 'for suffix in {1..40}; do sudo /sbin/ip addr add 10.0.3.$suffix/32 dev lo; done'
   run "sudo touch /etc/authbind/byport/53"
   run "sudo chmod 755 /etc/authbind/byport/53"
-  run "cd pdns"
+  run "cd ${TRAVIS_BUILD_DIR}"
 }
 
 install_dnsdist() {
@@ -587,7 +587,7 @@ run "cd .."
 run "wget http://ppa.launchpad.net/kalon33/gamesgiroll/ubuntu/pool/main/libs/libsodium/libsodium-dev_1.0.3-1~ppa14.04+1_amd64.deb"
 run "wget http://ppa.launchpad.net/kalon33/gamesgiroll/ubuntu/pool/main/libs/libsodium/libsodium13_1.0.3-1~ppa14.04+1_amd64.deb"
 run "sudo dpkg -i libsodium-dev_1.0.3-1~ppa14.04+1_amd64.deb libsodium13_1.0.3-1~ppa14.04+1_amd64.deb"
-run "cd pdns"
+run "cd ${TRAVIS_BUILD_DIR}"
 
 install_$PDNS_BUILD_PRODUCT
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Thus avoiding issues when/if the repository is cloned with a different
name.

(cherry picked from commit 1e0253cad96199647f92ef4fa8230f614637e80c)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
