### PR TITLE
auth: first and last SOA in an AXFR must be identical

### DIFF
--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -284,7 +284,7 @@ uint32_t localtime_format_YYYYMMDDSS(time_t t, uint32_t seq);
 uint32_t calculateEditSOA(const DNSZoneRecord& rr, const string& kind);
 uint32_t calculateEditSOA(const SOAData& sd, const string& kind);
 bool editSOA(DNSSECKeeper& dk, const DNSName& qname, DNSPacket* dp);
-bool editSOARecord(DNSZoneRecord& rr, const string& kind, const DNSName& qname);
+bool editSOARecord(DNSZoneRecord& rr, const string& kind);
 // for SOA-EDIT-DNSUPDATE/API
 uint32_t calculateIncreaseSOA(SOAData sd, const string& increaseKind, const string& editKind);
 bool increaseSOARecord(DNSResourceRecord& rr, const string& increaseKind, const string& editKind);

--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -45,13 +45,13 @@ bool editSOA(DNSSECKeeper& dk, const DNSName& qname, DNSPacket* dp)
     if(rr.dr.d_type == QType::SOA && rr.dr.d_name == qname) {
       string kind;
       dk.getSoaEdit(qname, kind);
-      return editSOARecord(rr, kind, qname);
+      return editSOARecord(rr, kind);
     }
   }
   return false;
 }
 
-bool editSOARecord(DNSZoneRecord& rr, const string& kind, const DNSName& qname) {
+bool editSOARecord(DNSZoneRecord& rr, const string& kind) {
   if(kind.empty())
     return false;
   auto src = getRR<SOARecordContent>(rr.dr);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -653,8 +653,12 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   DNSZoneRecord dzrsoa;
   dzrsoa.auth=true;
   dzrsoa.dr=DNSRecord(soa);
+
+  string kind;
+  dk.getSoaEdit(sd.qname, kind);
+  editSOARecord(dzrsoa, kind);
+
   outpacket->addRecord(dzrsoa);
-  editSOA(dk, sd.qname, outpacket.get());
   if(securedZone) {
     set<DNSName> authSet;
     authSet.insert(target);
@@ -1046,7 +1050,6 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   /* and terminate with yet again the SOA record */
   outpacket=getFreshAXFRPacket(q);
   outpacket->addRecord(dzrsoa);
-  editSOA(dk, sd.qname, outpacket.get());
   if(haveTSIGDetails && !tsigkeyname.empty())
     outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); 
   


### PR DESCRIPTION
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
