### PR TITLE
Catch DNSName exception in the Zoneparser

### DIFF
--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -422,8 +422,13 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
   case QType::MX:
     stringtok(recparts, rr.content);
     if(recparts.size()==2) {
-      if (recparts[1]!=".")
-        recparts[1] = toCanonic(d_zonename, recparts[1]).toStringRootDot();
+      if (recparts[1]!=".") {
+        try {
+          recparts[1] = toCanonic(d_zonename, recparts[1]).toStringRootDot();
+        } catch (std::exception &e) {
+          throw PDNSException("Error in record '" + rr.qname.toString() + " " + rr.qtype.getName() + "': " + e.what());
+        }
+      }
       rr.content=recparts[0]+" "+recparts[1];
     }
     break;
@@ -440,8 +445,13 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
   case QType::SRV:
     stringtok(recparts, rr.content);
     if(recparts.size()==4) {
-      if(recparts[3]!=".")
-        recparts[3] = toCanonic(d_zonename, recparts[3]).toStringRootDot();
+      if(recparts[3]!=".") {
+        try {
+          recparts[3] = toCanonic(d_zonename, recparts[3]).toStringRootDot();
+        } catch (std::exception &e) {
+          throw PDNSException("Error in record '" + rr.qname.toString() + " " + rr.qtype.getName() + "': " + e.what());
+        }
+      }
       rr.content=recparts[0]+" "+recparts[1]+" "+recparts[2]+" "+recparts[3];
     }
     break;
@@ -452,7 +462,11 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
   case QType::DNAME:
   case QType::PTR:
   case QType::AFSDB:
-    rr.content=toCanonic(d_zonename, rr.content).toStringRootDot();
+    try {
+      rr.content = toCanonic(d_zonename, rr.content).toStringRootDot();
+    } catch (std::exception &e) {
+      throw PDNSException("Error in record '" + rr.qname.toString() + " " + rr.qtype.getName() + "': " + e.what());
+    }
     break;
 
   case QType::SOA:
@@ -463,8 +477,8 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
       try {
         recparts[0]=toCanonic(d_zonename, recparts[0]).toStringRootDot();
         recparts[1]=toCanonic(d_zonename, recparts[1]).toStringRootDot();
-      } catch (runtime_error &re) {
-        throw PDNSException(re.what());
+      } catch (std::exception &e) {
+        throw PDNSException("Error in record '" + rr.qname.toString() + " " + rr.qtype.getName() + "': " + e.what());
       }
     }
     rr.content.clear();


### PR DESCRIPTION
### Short description
This wraps all calls to `toCanonic` in try/catch and rethrows it as a
PDNSException with more information.

Closes #5520.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)