### PR TITLE
Always add the QNAME|QTYPE to the query ringbuffer

### DIFF
--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -197,23 +197,34 @@ set-minimum-ttl *NUM*
 
 top-queries
     Shows the top-20 queries. Statistics are over the last
-    'stats-ringbuffer-entries' queries.
+    'stats-ringbuffer-entries' queries. This includes queries answered
+    from the PacketCache.
+
+    .. versionchanged:: 4.2.0
+      PacketCache hits are counted.
 
 top-pub-queries
     Shows the top-20 queries grouped by public suffix list. Statistics are over
-    the last 'stats-ringbuffer-entries' queries.
+    the last 'stats-ringbuffer-entries' queries. This does includes queries
+    answered from the PacketCache.
+
+    .. versionchanged:: 4.2.0
+      PacketCache hits are counted.
 
 top-largeanswer-remotes
     Shows the top-20 remote hosts causing large answers. Statistics are over
-    the last 'stats-ringbuffer-entries' queries.
+    the last 'stats-ringbuffer-entries' queries. This includes queries answered
+    from the PacketCache.
 
 top-remotes
     Shows the top-20 most active remote hosts. Statistics are over the last
-    'stats-ringbuffer-entries' queries.
+    'stats-ringbuffer-entries' queries. This includes queries answered
+    from the PacketCache.
 
 top-servfail-queries
     Shows the top-20 queries causing servfail responses. Statistics are over
-    the last 'stats-ringbuffer-entries' queries.
+    the last 'stats-ringbuffer-entries' queries. This includes queries
+    answered from the PacketCache, but not DNSSEC Bogus responses.
 
 top-bogus-queries
     Shows the top-20 queries causing bogus responses. Statistics are over
@@ -222,7 +233,8 @@ top-bogus-queries
 top-pub-servfail-queries
     Shows the top-20 queries causing servfail responses grouped by public
     suffix list. Statistics are over the last 'stats-ringbuffer-entries'
-    queries.
+    queries. This includes queries answered from the PacketCache but not DNSSEC
+    Bogus responses.
 
 top-pub-bogus-queries
     Shows the top-20 queries causing bogus responses grouped by public
@@ -231,7 +243,9 @@ top-pub-bogus-queries
 
 top-servfail-remotes
     Shows the top-20 most active remote hosts causing servfail responses.
-    Statistics are over the last 'stats-ringbuffer-entries' queries.
+    Statistics are over the last 'stats-ringbuffer-entries' queries. This
+    includes queries answered from the PacketCache, but not DNSSEC Bogus
+    responses.
 
 top-bogus-remotes
     Shows the top-20 most active remote hosts causing bogus responses.


### PR DESCRIPTION
### Short description
Before, queries answered from the PacketCache would not be added to the
query ring buffer (but would be in the answer related ring buffers).

Also document the behaviour _and_ the change.

Closes: #2613

Some questions (maybe for 4.2):

 * Would this be the correct behaviour?
 * Do we need a separate ringbuffer for non-packetcached queries?
 * Should DNSSEC Bogus SERVFAILs ens up in the SERVFAIL ringbuffer (right now they do not)
 * Should DNSSEC results be in a separate ringbuffer?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)