### PR TITLE
Support for identifying devices by id such as mac address

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -144,16 +144,20 @@ class PDNSPBConnHandler(object):
         if requestor:
             requestorstr = ' (' + requestor + ')'
 
-        print('[%s] %s of size %d: %s%s -> %s (%s), id: %d, uuid: %s%s' % (datestr,
-                                                                           typestr,
-                                                                           msg.inBytes,
-                                                                           ipfromstr,
-                                                                           requestorstr,
-                                                                           iptostr,
-                                                                           protostr,
-                                                                           msg.id,
-                                                                           messageidstr,
-                                                                           initialrequestidstr))
+        deviceId = binascii.hexlify(bytearray(msg.deviceId))
+        requestorId = msg.requestorId
+
+        print('[%s] %s of size %d: %s%s -> %s (%s), id: %d, uuid: %s%s '
+                  'requestorid: %s deviceid: %s' % (datestr,
+                                                    typestr,
+                                                    msg.inBytes,
+                                                    ipfromstr,
+                                                    requestorstr,
+                                                    iptostr,
+                                                    protostr,
+                                                    msg.id,
+                                                    messageidstr,
+                                                    initialrequestidstr))
 
     def getRequestorSubnet(self, msg):
         requestorstr = None

--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -157,7 +157,9 @@ class PDNSPBConnHandler(object):
                                                     protostr,
                                                     msg.id,
                                                     messageidstr,
-                                                    initialrequestidstr))
+                                                    initialrequestidstr,
+                                                    requestorId,
+                                                    deviceId))
 
     def getRequestorSubnet(self, msg):
         requestorstr = None

--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -75,4 +75,5 @@ message PBDNSMessage {
   optional bytes originalRequestorSubnet = 14;  // EDNS Client Subnet value
   optional string requestorId = 15;             // Username of the requestor
   optional bytes initialRequestId = 16;         // UUID of the incoming query that initiated this outgoing query or incoming response
+  optional bytes deviceId = 17;     		// Device ID of the requestor (could be mac address IP address or e.g. IMEI)
 }

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -597,7 +597,7 @@ bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& loca
   return false; // don't block
 }
 
-unsigned int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const std::map<uint16_t, EDNSOptionView>& ednsOptions, bool tcp, std::string& requestorId)
+unsigned int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const std::map<uint16_t, EDNSOptionView>& ednsOptions, bool tcp, std::string& requestorId, std::string& deviceId)
 {
   if(d_gettag) {
     auto ret = d_gettag(remote, ednssubnet, local, qname, qtype, ednsOptions, tcp);
@@ -617,6 +617,10 @@ unsigned int RecursorLua4::gettag(const ComboAddress& remote, const Netmask& edn
     const auto reqIdret = std::get<3>(ret);
     if (reqIdret) {
       requestorId = *reqIdret;
+    }
+    const auto deviceIdret = std::get<4>(ret);
+    if (deviceIdret) {
+      deviceId = *deviceIdret;
     }
     return std::get<0>(ret);
   }

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -71,6 +71,7 @@ public:
     std::vector<std::string>* policyTags{nullptr};
     std::unordered_map<std::string,bool>* discardedPolicies{nullptr};
     std::string requestorId;
+    std::string deviceId;
     bool& variable;
     bool& wantsRPZ;
     unsigned int tag{0};
@@ -102,7 +103,7 @@ public:
     DNSName followupName;
   };
 
-  unsigned int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const std::map<uint16_t, EDNSOptionView>&, bool tcp, std::string& requestorId);
+  unsigned int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const std::map<uint16_t, EDNSOptionView>&, bool tcp, std::string& requestorId, std::string& deviceId);
 
   bool prerpz(DNSQuestion& dq, int& ret);
   bool preresolve(DNSQuestion& dq, int& ret);
@@ -122,7 +123,7 @@ public:
             d_postresolve);
   }
 
-  typedef std::function<std::tuple<unsigned int,boost::optional<std::unordered_map<int,string> >,boost::optional<LuaContext::LuaObject>,boost::optional<std::string> >(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const std::map<uint16_t, EDNSOptionView>&, bool)> gettag_t;
+  typedef std::function<std::tuple<unsigned int,boost::optional<std::unordered_map<int,string> >,boost::optional<LuaContext::LuaObject>,boost::optional<std::string>,boost::optional<std::string> >(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const std::map<uint16_t, EDNSOptionView>&, bool)> gettag_t;
   gettag_t d_gettag; // public so you can query if we have this hooked
 
 private:

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -206,6 +206,7 @@ struct DNSComboWriter {
 #ifdef HAVE_PROTOBUF
   boost::uuids::uuid d_uuid;
   string d_requestorId;
+  string d_deviceId;
 #endif
   EDNSSubnetOpts d_ednssubnet;
   bool d_ecsFound{false};
@@ -647,13 +648,14 @@ catch(...)
 }
 
 #ifdef HAVE_PROTOBUF
-static void protobufLogQuery(const std::shared_ptr<RemoteLogger>& logger, uint8_t maskV4, uint8_t maskV6, const boost::uuids::uuid& uniqueId, const ComboAddress& remote, const ComboAddress& local, const Netmask& ednssubnet, bool tcp, uint16_t id, size_t len, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::vector<std::string>& policyTags, const std::string& requestorId)
+static void protobufLogQuery(const std::shared_ptr<RemoteLogger>& logger, uint8_t maskV4, uint8_t maskV6, const boost::uuids::uuid& uniqueId, const ComboAddress& remote, const ComboAddress& local, const Netmask& ednssubnet, bool tcp, uint16_t id, size_t len, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::vector<std::string>& policyTags, const std::string& requestorId, const std::string& deviceId)
 {
   Netmask requestorNM(remote, remote.sin4.sin_family == AF_INET ? maskV4 : maskV6);
   const ComboAddress& requestor = requestorNM.getMaskedNetwork();
   RecProtoBufMessage message(DNSProtoBufMessage::Query, uniqueId, &requestor, &local, qname, qtype, qclass, id, tcp, len);
   message.setEDNSSubnet(ednssubnet, ednssubnet.isIpv4() ? maskV4 : maskV6);
   message.setRequestorId(requestorId);
+  message.setDeviceId(deviceId);
 
   if (!policyTags.empty()) {
     message.setPolicyTags(policyTags);
@@ -816,6 +818,7 @@ static void startDoResolve(void *p)
     dq.data = dc->d_data;
 #ifdef HAVE_PROTOBUF
     dq.requestorId = dc->d_requestorId;
+    dq.deviceId = dc->d_deviceId;
 #endif
 
     if(dc->d_mdp.d_qtype==QType::ANY && !dc->d_tcp && g_anyToTcp) {
@@ -1150,6 +1153,7 @@ static void startDoResolve(void *p)
       pbMessage.setPolicyTags(dc->d_policyTags);
       pbMessage.setQueryTime(dc->d_now.tv_sec, dc->d_now.tv_usec);
       pbMessage.setRequestorId(dq.requestorId);
+      pbMessage.setDeviceId(dq.deviceId);
       protobufLogResponse(luaconfsLocal->protobufServer, pbMessage);
     }
 #endif
@@ -1416,6 +1420,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       uint16_t qclass=0;
       bool needECS = false;
       string requestorId;
+      string deviceId;
 #ifdef HAVE_PROTOBUF
       auto luaconfsLocal = g_luaconfs.getLocal();
       if (luaconfsLocal->protobufServer) {
@@ -1432,7 +1437,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
 
           if(t_pdl && t_pdl->d_gettag) {
             try {
-              dc->d_tag = t_pdl->gettag(conn->d_remote, dc->d_ednssubnet.source, dest, qname, qtype, &dc->d_policyTags, dc->d_data, ednsOptions, true, requestorId);
+              dc->d_tag = t_pdl->gettag(conn->d_remote, dc->d_ednssubnet.source, dest, qname, qtype, &dc->d_policyTags, dc->d_data, ednsOptions, true, requestorId, deviceId);
             }
             catch(std::exception& e)  {
               if(g_logCommonErrors)
@@ -1449,6 +1454,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
 #ifdef HAVE_PROTOBUF
       if(luaconfsLocal->protobufServer || luaconfsLocal->outgoingProtobufServer) {
         dc->d_requestorId = requestorId;
+        dc->d_deviceId = deviceId;
         dc->d_uuid = (*t_uuidGenerator)();
       }
 
@@ -1457,7 +1463,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
           const struct dnsheader* dh = (const struct dnsheader*) conn->data;
 
           if (!luaconfsLocal->protobufTaggedOnly) {
-            protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, dc->d_uuid, conn->d_remote, dest, dc->d_ednssubnet.source, true, dh->id, conn->qlen, qname, qtype, qclass, dc->d_policyTags, dc->d_requestorId);
+            protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, dc->d_uuid, conn->d_remote, dest, dc->d_ednssubnet.source, true, dh->id, conn->qlen, qname, qtype, qclass, dc->d_policyTags, dc->d_requestorId, dc->d_deviceId);
           }
         }
         catch(std::exception& e) {
@@ -1567,6 +1573,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
   std::vector<std::string> policyTags;
   LuaContext::LuaObject data;
   string requestorId;
+  string deviceId;
 #ifdef HAVE_PROTOBUF
   boost::uuids::uuid uniqueId;
   auto luaconfsLocal = g_luaconfs.getLocal();
@@ -1607,7 +1614,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
 
         if(t_pdl && t_pdl->d_gettag) {
           try {
-            ctag=t_pdl->gettag(fromaddr, ednssubnet.source, destaddr, qname, qtype, &policyTags, data, ednsOptions, false, requestorId);
+            ctag=t_pdl->gettag(fromaddr, ednssubnet.source, destaddr, qname, qtype, &policyTags, data, ednsOptions, false, requestorId, deviceId);
           }
           catch(std::exception& e)  {
             if(g_logCommonErrors)
@@ -1627,7 +1634,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
 #ifdef HAVE_PROTOBUF
     if(luaconfsLocal->protobufServer) {
       if (!luaconfsLocal->protobufTaggedOnly || !policyTags.empty()) {
-        protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, uniqueId, fromaddr, destaddr, ednssubnet.source, false, dh->id, question.size(), qname, qtype, qclass, policyTags, requestorId);
+        protobufLogQuery(luaconfsLocal->protobufServer, luaconfsLocal->protobufMaskV4, luaconfsLocal->protobufMaskV6, uniqueId, fromaddr, destaddr, ednssubnet.source, false, dh->id, question.size(), qname, qtype, qclass, policyTags, requestorId, deviceId);
       }
     }
 #endif /* HAVE_PROTOBUF */
@@ -1648,6 +1655,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
         pbMessage.setEDNSSubnet(ednssubnet.source, ednssubnet.source.isIpv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
         pbMessage.setQueryTime(g_now.tv_sec, g_now.tv_usec);
         pbMessage.setRequestorId(requestorId);
+        pbMessage.setDeviceId(deviceId);
         protobufLogResponse(luaconfsLocal->protobufServer, pbMessage);
       }
 #endif /* HAVE_PROTOBUF */
@@ -1718,6 +1726,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
     dc->d_uuid = uniqueId;
   }
   dc->d_requestorId = requestorId;
+  dc->d_deviceId = deviceId;
 #endif
 
   MT->makeThread(startDoResolve, (void*) dc); // deletes dc

--- a/pdns/protobuf.cc
+++ b/pdns/protobuf.cc
@@ -236,6 +236,13 @@ void DNSProtoBufMessage::setRequestorId(const std::string& requestorId)
 #endif /* HAVE_PROTOBUF */
 }
 
+void DNSProtoBufMessage::setDeviceId(const std::string& deviceId)
+{
+#ifdef HAVE_PROTOBUF
+  d_message.set_deviceid(deviceId);
+#endif /* HAVE_PROTOBUF */
+}
+
 void DNSProtoBufMessage::setResponder(const std::string& responder)
 {
 #ifdef HAVE_PROTOBUF

--- a/pdns/protobuf.hh
+++ b/pdns/protobuf.hh
@@ -69,6 +69,7 @@ public:
   void setResponder(const std::string& responder);
   void setResponder(const ComboAddress& responder);
   void setRequestorId(const std::string& requestorId);
+  void setDeviceId(const std::string& deviceId);
   std::string toDebugString() const;
   void addTag(const std::string& strValue);
   void addRR(const DNSName& qame, uint16_t utype, uint16_t uClass, uint32_t uTTl, const std::string& strBlob);

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -101,6 +101,12 @@ The DNSQuestion object contains at least the following fields:
 
     A string that will be used to set the ``requestorId`` field in :doc:`protobuf <../lua-config/protobuf>` messages.
 
+.. attribute:: DNSQuestion.deviceId str
+
+    .. versionadded:: 4.1.0
+
+    A string that will be used to set the ``deviceId`` field in :doc:`protobuf <../lua-config/protobuf>` messages.
+
 .. attribute:: DNSQuestion.udpAnswer -> str
 
     Answer to the :attr:`udpQuery <DNSQuestion.udpQuery>` when when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>`.

--- a/pdns/recursordist/docs/lua-scripting/hooks.rst
+++ b/pdns/recursordist/docs/lua-scripting/hooks.rst
@@ -68,7 +68,7 @@ Interception Functions
 
     .. versionadded:: 4.1.0
 
-        It can also return a table whose keys and values are strings to fill the :attr:`DNSQuestion.data` table, as well as a ``requestorId`` value to fill the :attr:`DNSQuestion.requestorId` field.
+        It can also return a table whose keys and values are strings to fill the :attr:`DNSQuestion.data` table, as well as a ``requestorId`` value to fill the :attr:`DNSQuestion.requestorId` field and a ``deviceId`` value to fill the :attr:`DNSQuestion.deviceId` field.
 
     The tagged packetcache can e.g. be used to answer queries from cache that have e.g. been filtered for certain IPs (this logic should be implemented in :func:`gettag`).
     This ensure that queries are answered quickly compared to setting :attr:`dq.variable <DNSQuestion.variable>` to true.


### PR DESCRIPTION
### Short description
This PR provides support for a deviceId field, set by Lua, and included in protobuf messages. I essentially just shadowed what was already done for requestorID.

DeviceId would typically be parsed from an EDNS option such as 65001 or the new edns0-clientid draft, and would usually be a mac address but could also be an IP 4/6 address.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code and tested it
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)