### PR TITLE
Make dnsdist dynamic truncate do right thing on TCP/IP

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -878,23 +878,33 @@ bool processQuery(LocalStateHolder<NetmaskTree<DynBlock> >& localDynNMGBlock,
 
   if(auto got=localDynNMGBlock->lookup(*dq.remote)) {
     if(now < got->second.until) {
-      g_stats.dynBlocked++;
-      got->second.blocks++;
       DNSAction::Action action = got->second.action;
       if (action == DNSAction::Action::None) {
         action = g_dynBlockAction;
       }
       if (action == DNSAction::Action::Refused) {
         vinfolog("Query from %s refused because of dynamic block", dq.remote->toStringWithPort());
+        g_stats.dynBlocked++;
+        got->second.blocks++;
+      
         dq.dh->rcode = RCode::Refused;
         dq.dh->qr=true;
         return true;
       }
-      else if (action == DNSAction::Action::Truncate && !dq.tcp) {
-        vinfolog("Query from %s truncated because of dynamic block", dq.remote->toStringWithPort());
-        dq.dh->tc = true;
-        dq.dh->qr = true;
-        return true;
+      else if (action == DNSAction::Action::Truncate) {
+        if(!dq.tcp) {
+          g_stats.dynBlocked++;
+          got->second.blocks++;
+
+          vinfolog("Query from %s truncated because of dynamic block", dq.remote->toStringWithPort());
+          dq.dh->tc = true;
+          dq.dh->qr = true;
+          return true;
+        }
+        else {
+          vinfolog("Query from %s for %s over TCP *not* truncated because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
+        }
+
       }
       else {
         vinfolog("Query from %s dropped because of dynamic block", dq.remote->toStringWithPort());
@@ -905,23 +915,32 @@ bool processQuery(LocalStateHolder<NetmaskTree<DynBlock> >& localDynNMGBlock,
 
   if(auto got=localDynSMTBlock->lookup(*dq.qname)) {
     if(now < got->until) {
-      g_stats.dynBlocked++;
-      got->blocks++;
       DNSAction::Action action = got->action;
       if (action == DNSAction::Action::None) {
         action = g_dynBlockAction;
       }
       if (action == DNSAction::Action::Refused) {
         vinfolog("Query from %s for %s refused because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
+        g_stats.dynBlocked++;
+        got->blocks++;
+
         dq.dh->rcode = RCode::Refused;
         dq.dh->qr=true;
         return true;
       }
-      else if (action == DNSAction::Action::Truncate && !dq.tcp) {
-        vinfolog("Query from %s for %s truncated because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
-        dq.dh->tc = true;
-        dq.dh->qr = true;
-        return true;
+      else if (action == DNSAction::Action::Truncate) {
+        if(!dq.tcp) {
+          g_stats.dynBlocked++;
+          got->blocks++;
+      
+          vinfolog("Query from %s for %s truncated because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
+          dq.dh->tc = true;
+          dq.dh->qr = true;
+          return true;
+        }
+        else {
+          vinfolog("Query from %s for %s over TCP *not* truncated because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
+        }
       }
       else {
         vinfolog("Query from %s for %s dropped because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());

--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -360,7 +360,7 @@ class TestDynBlockQPSActionTruncated(DNSDistTest):
                 # let's clear the response queue
                 self.clearToResponderQueue()
 
-        # we might be already blocked, but we should have been able to send
+        # we might be already truncated, but we should have been able to send
         # at least self._dynBlockQPS queries
         self.assertGreaterEqual(allowed, self._dynBlockQPS)
 
@@ -371,6 +371,12 @@ class TestDynBlockQPSActionTruncated(DNSDistTest):
         # we should now be 'truncated' for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
         self.assertEquals(receivedResponse, truncatedResponse)
+
+        # check over TCP, which should not be truncated
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(receivedResponse, response)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)


### PR DESCRIPTION
Winfried noted that our new dynamic truncation rule worked fine on UDP, but on TCP/IP a truncate would be converted into a drop, which was not the intended effect.
This commit makes dynamic truncate a NOOP on TCP.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
