### PR TITLE
[PATCH]: Recursor 4.1.0 alpha 1 fails to build on FreeBSD

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1325,7 +1325,7 @@ bool isSettingThreadCPUAffinitySupported()
 int mapThreadToCPUList(pthread_t tid, const std::set<int>& cpus)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
-#  ifndef cpu_set_t
+#  ifdef __FreeBSD__
 #    define cpu_set_t cpuset_t
 #  endif
   cpu_set_t cpuset;

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -57,7 +57,9 @@
 #include <sys/types.h>
 #include <pwd.h>
 #include <grp.h>
-
+#ifdef __FreeBSD__
+#  include <pthread_np.h>
+#endif
 
 bool g_singleThreaded;
 
@@ -1323,6 +1325,9 @@ bool isSettingThreadCPUAffinitySupported()
 int mapThreadToCPUList(pthread_t tid, const std::set<int>& cpus)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
+#  ifndef cpu_set_t
+#    define cpu_set_t cpuset_t
+#  endif
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   for (const auto cpuID : cpus) {


### PR DESCRIPTION
This fixes compilation on FreeBSD, which requires an extra include file and defines a slightly different type.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Here's the log wich shows the compilation errors: https://pkg.cainites.net/data/freebsd_11-1x64-system/2017-08-30_10h50m42s/logs/errors/powerdns-recursor-4.1.0a1.log

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
