### PR TITLE
Enable PKCS#11 in authoritative packages

### DIFF
--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -534,6 +534,7 @@ BuildRequires: bison
 BuildRequires: openssl-devel
 BuildRequires: protobuf-devel
 BuildRequires: protobuf-compiler
+BuildRequires: p11-kit-devel
 Provides: powerdns = %{version}-%{release}
 %global backends %{backends} bind
 
@@ -676,6 +677,7 @@ export CPPFLAGS="-DLDAP_DEPRECATED"
 	--enable-tools \
 	--enable-libsodium \
 	--enable-unit-tests \
+	--enable-experimental-pkcs11 \
 	--enable-systemd
 
 make %{?_smp_mflags}

--- a/build-scripts/debian-authoritative/control.in
+++ b/build-scripts/debian-authoritative/control.in
@@ -4,7 +4,7 @@ Priority: extra
 Standards-Version: 3.9.8
 Maintainer: PowerDNS Autobuilder <powerdns.support@powerdns.com>
 Origin: PowerDNS
-Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, po-debconf, curl, libtool, flex, bison, libmysqlclient-dev, libpq-dev, libssl-dev, libgdbm-dev, libldap2-dev, libsqlite3-dev, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libboost-program-options-dev, libboost-test-dev, autotools-dev, automake, autoconf, libluajit5.1-dev, pkg-config, ragel, libgmp-dev, libbotan1.10-dev, libcurl4-openssl-dev, libzmq-dev, libyaml-cpp-dev (>= 0.5), libgeoip-dev, libopendbx1-dev, libcdb-dev, unixodbc-dev (>= 2.3.1), libprotobuf-dev, protobuf-compiler @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
+Build-Depends: debhelper (>= 9~), dh-autoreconf, dh-systemd, po-debconf, curl, libtool, flex, bison, libmysqlclient-dev, libpq-dev, libssl-dev, libgdbm-dev, libldap2-dev, libsqlite3-dev, dpkg-dev (>= 1.17.0~), libboost-dev, libboost-serialization-dev, libboost-program-options-dev, libboost-test-dev, autotools-dev, automake, autoconf, libluajit5.1-dev, pkg-config, ragel, libgmp-dev, libbotan1.10-dev, libcurl4-openssl-dev, libzmq-dev, libyaml-cpp-dev (>= 0.5), libgeoip-dev, libopendbx1-dev, libcdb-dev, unixodbc-dev (>= 2.3.1), libprotobuf-dev, protobuf-compiler, libp11-kit-dev @LIBSYSTEMDDEV@ @LIBSODIUMDEV@
 Homepage: http://www.powerdns.com/
 
 Package: pdns-server

--- a/build-scripts/debian-authoritative/rules
+++ b/build-scripts/debian-authoritative/rules
@@ -54,6 +54,7 @@ override_dh_auto_configure:
 		--enable-tools \
 		--enable-unit-tests \
 		--with-luajit \
+		--enable-experimental-pkcs11 \
 		$(ENABLE_SYSTEMD) \
 		$(ENABLE_LIBSODIUM)
 

--- a/configure.ac
+++ b/configure.ac
@@ -367,6 +367,9 @@ AS_IF([test "x$LUAPC" != "x"],
     [AC_MSG_NOTICE([LuaJit: $LUAJITPC])],
     [AC_MSG_NOTICE([Lua/LuaJit: no])])
 ])
+AS_IF([test "x$enable_experimental_pkcs11" = "xyes"],
+  [AC_MSG_NOTICE([PKCS-11: yes])]
+)
 AS_IF([test "x$enable_experimental_gss_tsig" = "xyes"],
   [AC_MSG_NOTICE([GSS-TSIG: yes])]
 )

--- a/docs/changelog/4.1.rst
+++ b/docs/changelog/4.1.rst
@@ -2,7 +2,17 @@ Changelogs for 4.1.x
 ====================
 
 .. changelog::
-  :version: 4.1.0
+  :version: 4.1.0-rc2
+
+  .. change::
+    :tags: Packages, New Features
+    :pullreq: 5665
+
+    Add :doc:`PKCS#11 <../../dnssec/pkcs11>` support to packages on Operating Systems that support it.
+
+.. changelog::
+  :version: 4.1.0-rc1
+  :released: 31st of August 2017
 
   This is the first release candidate of the PowerDNS Authoritative Server in the 4.1 release train.
 

--- a/docs/dnssec/pkcs11.rst
+++ b/docs/dnssec/pkcs11.rst
@@ -18,6 +18,11 @@ empty. PIN is required for assigning keys to zone.
 Using with SoftHSM
 ------------------
 
+.. warning::
+  Due to an interaction between `SoftHSM and Botan <https://github.com/PowerDNS/pdns/issues/2496>`__,
+  the PowerDNS Authoritative Server **will most likely** crash on exit when built with ``--enable-botan1.10 --enable-experimental-pkcs11``.
+  This is the case with the packages provided from the PowerDNS repositories.
+
 To test this feature, a software HSM can be used. It is **not
 recommended** to use this in production.
 

--- a/pdns/version.cc
+++ b/pdns/version.cc
@@ -102,6 +102,9 @@ void showBuildConfiguration()
 #ifdef REMOTEBACKEND_ZEROMQ
     "remotebackend-zeromq" <<
 #endif
+#ifdef HAVE_P11KIT1
+    "PKCS#11" <<
+#endif
 #ifdef VERBOSELOG
     "verboselog" <<
 #endif


### PR DESCRIPTION
### Short description
All distros we build for (except CentOS 6) have a new enough p11kit. Packages built with this support are [here](https://downloads.powerdns.com/autobuilt_browser/#/auth/0.0.authenablepkcs11.1832ge15ac7d).

Closes #3110

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)