### PR TITLE
Handle AFSDB record separately in ZoneParser.

### DIFF
--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -468,23 +468,22 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
     }
     break;
   case QType::AFSDB:
-    try {
-      stringtok(recparts, rr.content);
-      if(recparts.size() == 2)
-      {
+    stringtok(recparts, rr.content);
+    if(recparts.size() == 2) {
+      try {
         recparts[1]=toCanonic(d_zonename, recparts[1]).toStringRootDot();
-      } else {
-        throw PDNSException("AFSDB record for "+rr.qname.toString()+" invalid");
+      } catch (std::exception &e) {
+        throw PDNSException("Error in record '" + rr.qname.toString() + " " + rr.qtype.getName() + "': " + e.what());
       }
-      rr.content.clear();
-      for(string::size_type n = 0; n < recparts.size(); ++n) {
-        if(n)
-          rr.content.append(1,' ');
+    } else {
+      throw PDNSException("AFSDB record for "+rr.qname.toString()+" invalid");
+    }
+    rr.content.clear();
+    for(string::size_type n = 0; n < recparts.size(); ++n) {
+      if(n)
+        rr.content.append(1,' ');
 
-        rr.content+=recparts[n];
-      }
-    } catch (std::exception &e) {
-      throw PDNSException("Error in record '" + rr.qname.toString() + " " + rr.qtype.getName() + "': " + e.what());
+      rr.content+=recparts[n];
     }
     break;
   case QType::SOA:

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -461,14 +461,32 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
   case QType::CNAME:
   case QType::DNAME:
   case QType::PTR:
-  case QType::AFSDB:
     try {
       rr.content = toCanonic(d_zonename, rr.content).toStringRootDot();
     } catch (std::exception &e) {
       throw PDNSException("Error in record '" + rr.qname.toString() + " " + rr.qtype.getName() + "': " + e.what());
     }
     break;
+  case QType::AFSDB:
+    try {
+      stringtok(recparts, rr.content);
+      if(recparts.size() == 2)
+      {
+        recparts[1]=toCanonic(d_zonename, recparts[1]).toStringRootDot();
+      } else {
+        throw PDNSException("AFSDB record for "+rr.qname.toString()+" invalid");
+      }
+      rr.content.clear();
+      for(string::size_type n = 0; n < recparts.size(); ++n) {
+        if(n)
+          rr.content.append(1,' ');
 
+        rr.content+=recparts[n];
+      }
+    } catch (std::exception &e) {
+      throw PDNSException("Error in record '" + rr.qname.toString() + " " + rr.qtype.getName() + "': " + e.what());
+    }
+    break;
   case QType::SOA:
     stringtok(recparts, rr.content);
     if(recparts.size() > 7)


### PR DESCRIPTION
### Short description
Closes #4703.

AFSDB records has two elements, `<subtype> <hostname>`,
as per RFC1183, and needs special treatment when parsing as compared to how it was done before.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
