### PR TITLE
auth: Unset _JAVA_OPTIONS before using jdnssec

### DIFF
--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -15,6 +15,8 @@ export ZONE2LDAP=${ZONE2LDAP:-${PWD}/../pdns/zone2ldap}
 export PDNSUTIL=${PDNSUTIL:-${PWD}/../pdns/pdnsutil}
 export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
 
+unset _JAVA_OPTIONS
+
 spectest=$1
 [ -z $spectest ] && spectest=""
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Travis now [1] defaults to _JAVA_OPTIONS="-Xmx2048m -Xms512m". We wouldn't care much, except that every Java command now outputs the following line to stderr, breaking our jdnssec diffs:

> Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m

[1]: https://docs.travis-ci.com/user/build-environment-updates/2017-09-06/

(cherry picked from commit a20029adeecbf314594ca3a921ca1f2e22669e6c)
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
