### PR TITLE
dnsdist: Add missing QPSAction

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -788,6 +788,10 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       return std::shared_ptr<DNSAction>(new PoolAction(a));
     });
 
+  g_lua.writeFunction("QPSAction", [](int limit) {
+      return std::shared_ptr<DNSAction>(new QPSAction(limit));
+    });
+
   g_lua.writeFunction("QPSPoolAction", [](int limit, const string& a) {
       return std::shared_ptr<DNSAction>(new QPSPoolAction(limit, a));
     });

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -198,7 +198,7 @@ Rule Generators
   All queries over the limit are dropped.
   This function is deprecated as of 1.2.0 and will be removed in 1.3.0, please use:
 
-    addAction(DNSRule, QPSLimitAction(limit))
+    addAction(DNSRule, QPSAction(limit))
 
   :param DNSRule: match queries based on this rule
   :param int limit: QPS limit for this rule
@@ -222,9 +222,9 @@ Managing Rules
 
 Active Rules can be shown with :func:`showRules` and removed with :func:`rmRule`::
 
-  > addAction("h4xorbooter.xyz.", QPSLimitAction(10))
-  > addAction({"130.161.0.0/16", "145.14.0.0/16"} , QPSLimitAction(20))
-  > addAction({"nl.", "be."}, QPSLimitAction(1))
+  > addAction("h4xorbooter.xyz.", QPSAction(10))
+  > addAction({"130.161.0.0/16", "145.14.0.0/16"} , QPSAction(20))
+  > addAction({"nl.", "be."}, QPSAction(1))
   > showRules()
   #     Matches Rule                                               Action
   0           0 h4xorbooter.xyz.                                   qps limit to 10
@@ -658,6 +658,13 @@ The following actions exist.
   Send the packet into the specified pool.
 
   :param string poolname: The name of the pool
+
+.. function:: QPSAction(maxqps)
+
+  Drop a packet if it does exceed the ``maxqps`` queries per second limits.
+  Letting the subsequent rules apply otherwise.
+
+  :param int maxqps: The QPS limit
 
 .. function:: QPSPoolAction(maxqps, poolname)
 

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -921,7 +921,7 @@ class TestAdvancedRestoreFlagsOnSelfResponse(DNSDistTest):
 class TestAdvancedQPS(DNSDistTest):
 
     _config_template = """
-    addQPSLimit("qps.advanced.tests.powerdns.com", 10)
+    addAction("qps.advanced.tests.powerdns.com", QPSAction(10))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -969,7 +969,7 @@ class TestAdvancedQPS(DNSDistTest):
 class TestAdvancedQPSNone(DNSDistTest):
 
     _config_template = """
-    addQPSLimit("qpsnone.advanced.tests.powerdns.com", 100)
+    addAction("qpsnone.advanced.tests.powerdns.com", QPSAction(100))
     addAction(AllRule(), RCodeAction(dnsdist.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In 1.2.0 we deprecated the `addQPSLimit()` function, suggesting the use of `QPSAction()` as a replacement, but the Lua binding for `QPSAction()` was missing. In addition the documentation was referring to `QPSLimitAction()` instead of `QPSAction()`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
