### PR TITLE
verify parts.size(). Fixes #5688

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -584,16 +584,16 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
       if (rr.qtype.getCode() == QType::SRV) {
         vector<string> parts;
         stringtok(parts, rr.getZoneRepresentation());
-        toCheck = DNSName(parts[3]);
+        if (parts.size() == 4) toCheck = DNSName(parts[3]);
       } else if (rr.qtype.getCode() == QType::MX) {
         vector<string> parts;
         stringtok(parts, rr.getZoneRepresentation());
-        toCheck = DNSName(parts[1]);
+        if (parts.size() == 2) toCheck = DNSName(parts[1]);
       } else {
         toCheck = DNSName(rr.content);
       }
 
-      if (!toCheck.isHostname()) {
+      if (!toCheck.empty() && !toCheck.isHostname()) {
         cout<<"[Warning] "<<rr.qtype.getName()<<" record in zone '"<<zone<<"' has non-hostname content '"<<toCheck<<"'."<<endl;
         numwarnings++;
       }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -593,8 +593,10 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
         toCheck = DNSName(rr.content);
       }
 
-      if (!toCheck.empty() && !toCheck.isHostname()) {
-        cout<<"[Warning] "<<rr.qtype.getName()<<" record in zone '"<<zone<<"' has non-hostname content '"<<toCheck<<"'."<<endl;
+      if (toCheck.empty())
+        cout<<"[Warning] "<<rr.qtype.getName()<<" record in zone '"<<zone<<"': unable to extract hostname from content."<<endl;
+      else if(!toCheck.isHostname()) {
+        cout<<"[Warning] "<<rr.qtype.getName()<<" record in zone '"<<zone<<"' has non-hostname content '"<<toCheck.toString()<<"'."<<endl;
         numwarnings++;
       }
     }


### PR DESCRIPTION
### Short description
We would read out of bounds if SRV or MX content did not have enough parts.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
