### PR TITLE
auth api: return new serial in header after PATCH

### DIFF
--- a/docs/http-api/endpoint-zones.rst
+++ b/docs/http-api/endpoint-zones.rst
@@ -42,6 +42,8 @@ Zones endpoint
 
   Modifies present RRsets and comments. Returns ``204 No Content`` on success.
 
+  The new zone serial will be returned in an `X-PDNS-Zone-Serial` header (auth 4.1+).
+
   :param server_id: The name of the server
   :param zone_id: The id number of the :json:object:`Zone`
 

--- a/docs/http-api/endpoint-zones.rst
+++ b/docs/http-api/endpoint-zones.rst
@@ -42,7 +42,7 @@ Zones endpoint
 
   Modifies present RRsets and comments. Returns ``204 No Content`` on success.
 
-  The new zone serial will be returned in an `X-PDNS-Zone-Serial` header (auth 4.1+).
+  The new and old zone serials will be returned in `X-PDNS-New-Serial` and `X-PDNS-Old-Serial` headers (auth 4.1+).
 
   :param server_id: The name of the server
   :param zone_id: The id number of the :json:object:`Zone`

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1499,6 +1499,10 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
       if (!di.backend->replaceRRSet(di.id, rr.qname, rr.qtype, vector<DNSResourceRecord>(1, rr))) {
         throw ApiException("Hosting backend does not support editing records.");
       }
+
+      // return new serial in a header
+      fillSOAData(rr.content, sd);
+      resp->headers["X-PDNS-Zone-Serial"] = std::to_string(sd.serial);
     }
 
   } catch(...) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1500,9 +1500,10 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
         throw ApiException("Hosting backend does not support editing records.");
       }
 
-      // return new serial in a header
+      // return old and new serials in headers
+      resp->headers["X-PDNS-Old-Serial"] = std::to_string(sd.serial);
       fillSOAData(rr.content, sd);
-      resp->headers["X-PDNS-Zone-Serial"] = std::to_string(sd.serial);
+      resp->headers["X-PDNS-New-Serial"] = std::to_string(sd.serial);
     }
 
   } catch(...) {


### PR DESCRIPTION
For zone PATCH requests, this adds new `X-PDNS-Old-Serial` and `X-PDNS-New-Serial` response
headers with the zone serials before and after the changes.

Ideally this would be returned in a response JSON object, but this API
currently return 204 No Content and I did not want to break any clients
that might rely on this.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
