### PR TITLE
implement dynamic cache sizeing for recursor

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -618,7 +618,7 @@ string setMaxCacheEntries(T begin, T end)
   if(end-begin != 1) 
     return "Need to supply new cache size\n";
   g_maxCacheEntries = pdns_stou(*begin);
-  return "New minimum TTL: " + std::to_string(g_maxCacheEntries) + "\n";
+  return "New max cache entries: " + std::to_string(g_maxCacheEntries) + "\n";
 }
 
 template<typename T>
@@ -627,7 +627,7 @@ string setMaxPacketCacheEntries(T begin, T end)
   if(end-begin != 1) 
     return "Need to supply new packet cache size\n";
   g_maxPacketCacheEntries = pdns_stou(*begin);
-  return "New minimum TTL: " + std::to_string(g_maxPacketCacheEntries) + "\n";
+  return "New max packetcache entries: " + std::to_string(g_maxPacketCacheEntries) + "\n";
 }
 
 
@@ -1223,8 +1223,8 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
 "reload-lua-script [filename]     (re)load Lua script\n"
 "reload-lua-config [filename]     (re)load Lua configuration file\n"
 "reload-zones                     reload all auth and forward zones\n"
-"set-max-cache-entries value      set new maximum cache size"
-"set-max-packetcache-entries val  set new maximum packet cache size"      
+"set-max-cache-entries value      set new maximum cache size\n"
+"set-max-packetcache-entries val  set new maximum packet cache size\n"      
 "set-minimum-ttl value            set minimum-ttl-override\n"
 "set-carbon-server                set a carbon server for telemetry\n"
 "set-dnssec-log-bogus SETTING     enable (SETTING=yes) or disable (SETTING=no) logging of DNSSEC validation failures\n"

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -843,7 +843,9 @@ void registerAllStats()
 
   addGetStat("cache-hits", doGetCacheHits);
   addGetStat("cache-misses", doGetCacheMisses); 
-  addGetStat("cache-entries", doGetCacheSize); 
+  addGetStat("cache-entries", doGetCacheSize);
+  addGetStat("max-cache-entries", []() { return g_maxCacheEntries.load(); });
+  addGetStat("max-packetcache-entries", []() { return g_maxPacketCacheEntries.load();}); 
   addGetStat("cache-bytes", doGetCacheBytes); 
   
   addGetStat("packetcache-hits", doGetPacketCacheHits);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -612,6 +612,24 @@ string setMinimumTTL(T begin, T end)
   return "New minimum TTL: " + std::to_string(SyncRes::s_minimumTTL) + "\n";
 }
 
+template<typename T>
+string setMaxCacheEntries(T begin, T end)
+{
+  if(end-begin != 1) 
+    return "Need to supply new cache size\n";
+  g_maxCacheEntries = pdns_stou(*begin);
+  return "New minimum TTL: " + std::to_string(g_maxCacheEntries) + "\n";
+}
+
+template<typename T>
+string setMaxPacketCacheEntries(T begin, T end)
+{
+  if(end-begin != 1) 
+    return "Need to supply new packet cache size\n";
+  g_maxPacketCacheEntries = pdns_stou(*begin);
+  return "New minimum TTL: " + std::to_string(g_maxPacketCacheEntries) + "\n";
+}
+
 
 static uint64_t getSysTimeMsec()
 {
@@ -1205,6 +1223,8 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
 "reload-lua-script [filename]     (re)load Lua script\n"
 "reload-lua-config [filename]     (re)load Lua configuration file\n"
 "reload-zones                     reload all auth and forward zones\n"
+"set-max-cache-entries value      set new maximum cache size"
+"set-max-packetcache-entries val  set new maximum packet cache size"      
 "set-minimum-ttl value            set minimum-ttl-override\n"
 "set-carbon-server                set a carbon server for telemetry\n"
 "set-dnssec-log-bogus SETTING     enable (SETTING=yes) or disable (SETTING=no) logging of DNSSEC validation failures\n"
@@ -1352,6 +1372,13 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
     return reloadAuthAndForwards();
   }
 
+  if(cmd=="set-max-cache-entries") {
+    return setMaxCacheEntries(begin, end);
+  }
+  if(cmd=="set-max-packetcache-entries") {
+    return setMaxPacketCacheEntries(begin, end);
+  }
+  
   if(cmd=="set-minimum-ttl") {
     return setMinimumTTL(begin, end);
   }

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -484,8 +484,3 @@ void MemRecursorCache::doPrune(unsigned int keep)
   pruneCollection(*this, d_cache, keep);
 }
 
-void MemRecursorCache::doPrune(void)
-{
-  unsigned int maxCached=::arg().asNum("max-cache-entries") / g_numThreads;
-  doPrune(maxCached);
-}

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -61,7 +61,6 @@ public:
 
   void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs, bool auth, boost::optional<Netmask> ednsmask=boost::none, vState state=Indeterminate);
 
-  void doPrune(void);
   void doPrune(unsigned int keep);
   uint64_t doDump(int fd);
 

--- a/pdns/recursordist/docs/manpages/rec_control.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.rst
@@ -150,6 +150,16 @@ set-dnssec-log-bogus *SETTING*
     DNSSEC validation failures and to 'no' or 'off' to disable logging these
     failures.
 
+set-max-cache-entries *NUM*
+    Change the maximum number of entries in the DNS cache.  If reduced, the
+    cache size will start shrinking to this number as part of the normal
+    cache purging process, which might take a while.
+
+set-max-packetcache-entries *NUM*
+    Change the maximum number of entries in the packet cache.  If reduced, the
+    cache size will start shrinking to this number as part of the normal
+    cache purging process, which might take a while.
+
 set-minimum-ttl *NUM*
     Set minimum-ttl-override to *NUM*.
 

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -246,7 +246,15 @@ counts all end-user initiated queries with the RD   bit set, received over IPv6 
 
 malloc-bytes
 ^^^^^^^^^^^^
-returns the number of bytes allocated by the   process (broken, always returns 0)
+returns the number of bytes allocated by the process (broken, always returns 0)
+
+max-cache-entries
+^^^^^^^^^^^^^^^^^
+currently configured maximum number of cache entries
+
+max-packetcache-entries
+^^^^^^^^^^^^^^^^^
+currently configured maximum number of packet cache entries
 
 max-mthread-stack
 ^^^^^^^^^^^^^^^^^

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -949,6 +949,7 @@ void parseACLs();
 extern RecursorStats g_stats;
 extern unsigned int g_numThreads;
 extern uint16_t g_outgoingEDNSBufsize;
+extern std::atomic<uint32_t> g_maxCacheEntries, g_maxPacketCacheEntries;
 
 
 std::string reloadAuthAndForwards();


### PR DESCRIPTION
### Short description
With this commit, the number of (packet)cache entries can be changed at runtime, although the effect may not be immediate in case of shrinking the cache.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
