### PR TITLE
bindbackend: Fix transaction to return false on failure

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -205,10 +205,10 @@ bool Bind2Backend::startTransaction(const DNSName &qname, int id)
     d_transaction_tmpname=bbd.d_filename+"."+itoa(random());
     d_of=new ofstream(d_transaction_tmpname.c_str());
     if(!*d_of) {
-      throw DBException("Unable to open temporary zonefile '"+d_transaction_tmpname+"': "+stringerror());
       unlink(d_transaction_tmpname.c_str());
       delete d_of;
       d_of=0;
+      throw DBException("Unable to open temporary zonefile '"+d_transaction_tmpname+"': "+stringerror());
     }
     
     *d_of<<"; Written by PowerDNS, don't edit!"<<endl;

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -193,7 +193,7 @@ bool Bind2Backend::startTransaction(const DNSName &qname, int id)
   if(id < 0) {
     d_transaction_tmpname.clear();
     d_transaction_id=id;
-    return true;
+    return false;
   }
   if(id == 0) {
     throw DBException("domain_id 0 is invalid for this backend.");
@@ -209,7 +209,6 @@ bool Bind2Backend::startTransaction(const DNSName &qname, int id)
       unlink(d_transaction_tmpname.c_str());
       delete d_of;
       d_of=0;
-      return false;
     }
     
     *d_of<<"; Written by PowerDNS, don't edit!"<<endl;
@@ -223,7 +222,7 @@ bool Bind2Backend::startTransaction(const DNSName &qname, int id)
 bool Bind2Backend::commitTransaction()
 {
   if(d_transaction_id < 0)
-    return true;
+    return false;
   delete d_of;
   d_of=0;
 

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -209,6 +209,7 @@ bool Bind2Backend::startTransaction(const DNSName &qname, int id)
       unlink(d_transaction_tmpname.c_str());
       delete d_of;
       d_of=0;
+      return false;
     }
     
     *d_of<<"; Written by PowerDNS, don't edit!"<<endl;


### PR DESCRIPTION
### Short description
Make bindbackend `startTransaction` to return false when it has failed.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
