### PR TITLE
Auth DNSSEC: Make default options singular and use defaults in Cryptokey API-endpoint

### DIFF
--- a/docs/http-api/endpoint-cryptokeys.rst
+++ b/docs/http-api/endpoint-cryptokeys.rst
@@ -19,7 +19,7 @@ These endpoints allow for the manipulation of DNSSEC crypto material.
 
   if ``content``, ``bits`` and ``algo`` are null, a key will be generated based
   on the :ref:`setting-default-ksk-algorithm` and :ref:`setting-default-ksk-size`
-  sttings for a KSK and the :ref:`setting-default-zsk-algorithm` and :ref:`setting-default-zsk-size`
+  settings for a KSK and the :ref:`setting-default-zsk-algorithm` and :ref:`setting-default-zsk-size`
   options for a ZSK.
 
   :param server_id: The name of the server

--- a/docs/http-api/endpoint-cryptokeys.rst
+++ b/docs/http-api/endpoint-cryptokeys.rst
@@ -17,6 +17,11 @@ These endpoints allow for the manipulation of DNSSEC crypto material.
   This method adds a new key to a zone.
   The key can either be generated or imported by supplying the ``content`` parameter.
 
+  if ``content``, ``bits`` and ``algo`` are null, a key will be generated based
+  on the :ref:`setting-default-ksk-algorithm` and :ref:`setting-default-ksk-size`
+  sttings for a KSK and the :ref:`setting-default-zsk-algorithm` and :ref:`setting-default-zsk-size`
+  options for a ZSK.
+
   :param server_id: The name of the server
   :param zone_id: The id value of the :json:object:`Zone`
   :reqjson string content: The private key to use (The format used is compatible with BIND and NSD/LDNS)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -272,12 +272,16 @@ Debugging switch - don't use.
 Operate as a daemon.
 
 .. _setting-default-ksk-algorithms:
+.. _setting-default-ksk-algorithm:
 
-``default-ksk-algorithms``
+``default-ksk-algorithm``
 --------------------------
 
 -  String
 -  Default: ecdsa256
+
+.. versionchanged:: 4.1.0
+  Renamed from ``default-ksk-algorithms``. Does no longer support multiple algorithm names.
 
 The algorithm that should be used for the KSK when running
 :doc:`pdnsutil secure-zone <manpages/pdnsutil.1>`. Must be one
@@ -301,9 +305,10 @@ of:
 --------------------
 
 -  Integer
--  Default: whichever is default for ``default-ksk-algorithms``
+-  Default: whichever is default for `default-ksk-algorithm`_
 
 The default keysize for the KSK generated with :doc:`pdnsutil secure-zone <dnssec/pdnsutil>`.
+Only relevant for algorithms with non-fixed keysizes (like RSA)
 
 .. _setting-default-soa-name:
 
@@ -358,12 +363,16 @@ Mail address to insert in the SOA record if none set in the backend.
 TTL to use when none is provided.
 
 .. _setting-default-zsk-algorithms:
+.. _setting-default-zsk-algorithm:
 
-``default-zsk-algorithms``
+``default-zsk-algorithm``
 --------------------------
 
 -  String
 -  Default: (empty)
+
+.. versionchanged:: 4.1.0
+  Renamed from ``default-zsk-algorithms``. Does no longer support multiple algorithm names.
 
 The algorithm that should be used for the ZSK when running
 :doc:`pdnsutil secure-zone <manpages/pdnsutil.1>`. Must be one
@@ -387,9 +396,10 @@ of:
 --------------------
 
 -  Integer
--  Default: whichever is default for ``default-zsk-algorithms``
+-  Default: 0 (automatic default for `default-zsk-algorithm`_)
 
 The default keysize for the ZSK generated with :doc:`pdnsutil secure-zone <dnssec/pdnsutil>`.
+Only relevant for algorithms with non-fixed keysizes (like RSA)
 
 .. _setting-direct-dnskey:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -281,23 +281,28 @@ Operate as a daemon.
 -  Default: ecdsa256
 
 .. versionchanged:: 4.1.0
-  Renamed from ``default-ksk-algorithms``. Does no longer support multiple algorithm names.
+  Renamed from ``default-ksk-algorithms``. No longer supports multiple algorithm names.
 
 The algorithm that should be used for the KSK when running
-:doc:`pdnsutil secure-zone <manpages/pdnsutil.1>`. Must be one
-of: 
+:doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/endpoint-zones>`
+to enable DNSSEC. Must be one of:
 
-* rsamd5 
-* dh 
-* dsa 
-* ecc 
-* rsasha1 
-* rsasha256 
+* rsamd5
+* dh
+* dsa
+* ecc
+* rsasha1
+* rsasha256
 * rsasha512
-* ecc-gost 
-* ecdsa256 (ECDSA P-256 with SHA256) 
-* ecdsa384 (ECDSA P-384 with SHA384) 
+* ecc-gost
+* ecdsa256 (ECDSA P-256 with SHA256)
+* ecdsa384 (ECDSA P-384 with SHA384)
 * ed25519
+
+.. note::
+  Actual supported algorithms depend on the crypto-libraries
+  PowerDNS was compiled against. To check the supported DNSSEC algoritms
+  in your build of PowerDNS, run ``pdnsutil list-algorithms``.
 
 .. _setting-default-ksk-size:
 
@@ -308,7 +313,7 @@ of:
 -  Default: whichever is default for `default-ksk-algorithm`_
 
 The default keysize for the KSK generated with :doc:`pdnsutil secure-zone <dnssec/pdnsutil>`.
-Only relevant for algorithms with non-fixed keysizes (like RSA)
+Only relevant for algorithms with non-fixed keysizes (like RSA).
 
 .. _setting-default-soa-name:
 
@@ -375,20 +380,25 @@ TTL to use when none is provided.
   Renamed from ``default-zsk-algorithms``. Does no longer support multiple algorithm names.
 
 The algorithm that should be used for the ZSK when running
-:doc:`pdnsutil secure-zone <manpages/pdnsutil.1>`. Must be one
-of: 
+:doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/endpoint-zones>`
+to enable DNSSEC. Must be one of:
 
-* rsamd5 
-* dh 
-* dsa 
-* ecc 
-* rsasha1 
-* rsasha256 
+* rsamd5
+* dh
+* dsa
+* ecc
+* rsasha1
+* rsasha256
 * rsasha512
-* ecc-gost 
-* ecdsa256 (ECDSA P-256 with SHA256) 
-* ecdsa384 (ECDSA P-384 with SHA384) 
+* ecc-gost
+* ecdsa256 (ECDSA P-256 with SHA256)
+* ecdsa384 (ECDSA P-384 with SHA384)
 * ed25519
+
+.. note::
+  Actual supported algorithms depend on the crypto-libraries
+  PowerDNS was compiled against. To check the supported DNSSEC algoritms
+  in your build of PowerDNS, run ``pdnsutil list-algorithms``.
 
 .. _setting-default-zsk-size:
 
@@ -399,7 +409,7 @@ of:
 -  Default: 0 (automatic default for `default-zsk-algorithm`_)
 
 The default keysize for the ZSK generated with :doc:`pdnsutil secure-zone <dnssec/pdnsutil>`.
-Only relevant for algorithms with non-fixed keysizes (like RSA)
+Only relevant for algorithms with non-fixed keysizes (like RSA).
 
 .. _setting-direct-dnskey:
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -36,6 +36,12 @@ Changed options
   ``allow-recursion``, ``recursive-cache-ttl`` and ``recursor`` options have
   been removed as well.
 
+- ``default-ksk-algorithms`` has been renamed to :ref:`setting-default-ksk-algorithm`
+  and only supports a single algorithm name now.
+
+- ``default-zsk-algorithms`` has been renamed to :ref:`setting-default-zsk-algorithm`
+  and only supports a single algorithm name now.
+
 Changed defaults
 ~~~~~~~~~~~~~~~~
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -183,9 +183,9 @@ void declareArguments()
 
   ::arg().setSwitch("traceback-handler","Enable the traceback handler (Linux only)")="yes";
   ::arg().setSwitch("direct-dnskey","Fetch DNSKEY RRs from backend during DNSKEY synthesis")="no";
-  ::arg().set("default-ksk-algorithms","Default KSK algorithms")="ecdsa256";
+  ::arg().set("default-ksk-algorithm","Default KSK algorithms")="ecdsa256";
   ::arg().set("default-ksk-size","Default KSK size (0 means default)")="0";
-  ::arg().set("default-zsk-algorithms","Default ZSK algorithms")="";
+  ::arg().set("default-zsk-algorithm","Default ZSK algorithms")="";
   ::arg().set("default-zsk-size","Default ZSK size (0 means default)")="0";
   ::arg().set("max-nsec3-iterations","Limit the number of NSEC3 hash iterations")="500"; // RFC5155 10.3
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -184,9 +184,9 @@ void declareArguments()
 
   ::arg().setSwitch("traceback-handler","Enable the traceback handler (Linux only)")="yes";
   ::arg().setSwitch("direct-dnskey","Fetch DNSKEY RRs from backend during DNSKEY synthesis")="no";
-  ::arg().set("default-ksk-algorithm","Default KSK algorithms")="ecdsa256";
+  ::arg().set("default-ksk-algorithm","Default KSK algorithm")="ecdsa256";
   ::arg().set("default-ksk-size","Default KSK size (0 means default)")="0";
-  ::arg().set("default-zsk-algorithm","Default ZSK algorithms")="";
+  ::arg().set("default-zsk-algorithm","Default ZSK algorithm")="";
   ::arg().set("default-zsk-size","Default ZSK size (0 means default)")="0";
   ::arg().set("max-nsec3-iterations","Limit the number of NSEC3 hash iterations")="500"; // RFC5155 10.3
 
@@ -533,7 +533,7 @@ void mainthread()
     if (algo == -1)
       L<<Logger::Warning<<"Warning: default-"<<algotype<<"-algorithm set to unknown algorithm: "<<::arg()["default-"+algotype+"-algorithm"]<<endl;
     else if (algo <= 10 && size == 0)
-      L<<Logger::Warning<<"Warning: default-"<<algotype<<"-algorithm is set to an algorithm("<<::arg()["default-"+algotype+"-algorithm"]<<") that requires a non-zero default-"<<algotype<<"-size!"<<endl;
+      L<<Logger::Warning<<"Warning: default-"<<algotype<<"-algorithm is set to an algorithm ("<<::arg()["default-"+algotype+"-algorithm"]<<") that requires a non-zero default-"<<algotype<<"-size!"<<endl;
   }
 
   // NOW SAFE TO CREATE THREADS!

--- a/pdns/common_startup.hh
+++ b/pdns/common_startup.hh
@@ -34,6 +34,7 @@
 #include "nameserver.hh"
 #include "statbag.hh"
 #include "tcpreceiver.hh"
+#include "dnsseckeeper.hh"
 
 extern ArgvMap theArg;
 extern StatBag S;  //!< Statistics are gathered across PDNS via the StatBag class S

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -80,9 +80,9 @@ void loadMainConfig(const std::string& configdir)
   string configname=::arg()["config-dir"]+"/"+s_programname+".conf";
   cleanSlashes(configname);
 
-  ::arg().set("default-ksk-algorithm","Default KSK algorithms")="ecdsa256";
+  ::arg().set("default-ksk-algorithm","Default KSK algorithm")="ecdsa256";
   ::arg().set("default-ksk-size","Default KSK size (0 means default)")="0";
-  ::arg().set("default-zsk-algorithm","Default ZSK algorithms")="";
+  ::arg().set("default-zsk-algorithm","Default ZSK algorithm")="";
   ::arg().set("default-zsk-size","Default ZSK size (0 means default)")="0";
   ::arg().set("default-soa-edit","Default SOA-EDIT value")="";
   ::arg().set("default-soa-edit-signed","Default SOA-EDIT value for signed zones")="";

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -80,9 +80,9 @@ void loadMainConfig(const std::string& configdir)
   string configname=::arg()["config-dir"]+"/"+s_programname+".conf";
   cleanSlashes(configname);
 
-  ::arg().set("default-ksk-algorithms","Default KSK algorithms")="ecdsa256";
+  ::arg().set("default-ksk-algorithm","Default KSK algorithms")="ecdsa256";
   ::arg().set("default-ksk-size","Default KSK size (0 means default)")="0";
-  ::arg().set("default-zsk-algorithms","Default ZSK algorithms")="";
+  ::arg().set("default-zsk-algorithm","Default ZSK algorithms")="";
   ::arg().set("default-zsk-size","Default ZSK size (0 means default)")="0";
   ::arg().set("default-soa-edit","Default SOA-EDIT value")="";
   ::arg().set("default-soa-edit-signed","Default SOA-EDIT value for signed zones")="";
@@ -1780,23 +1780,21 @@ bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = false)
 bool secureZone(DNSSECKeeper& dk, const DNSName& zone)
 {
   // parse attribute
-  vector<string> k_algos;
-  vector<string> z_algos;
   int k_size;
   int z_size;
   // temp var for addKey
   int64_t id;
 
-  stringtok(k_algos, ::arg()["default-ksk-algorithms"], " ,");
+  string k_algo = ::arg()["default-ksk-algorithm"];
   k_size = ::arg().asNum("default-ksk-size");
-  stringtok(z_algos, ::arg()["default-zsk-algorithms"], " ,");
+  string z_algo = ::arg()["default-zsk-algorithm"];
   z_size = ::arg().asNum("default-zsk-size");
 
   if (k_size < 0) {
      throw runtime_error("KSK key size must be equal to or greater than 0");
   }
 
-  if (k_algos.size() < 1 && z_algos.size() < 1) {
+  if (k_algo == "" && z_algo == "") {
      throw runtime_error("Zero algorithms given for KSK+ZSK in total");
   }
 
@@ -1822,20 +1820,17 @@ bool secureZone(DNSSECKeeper& dk, const DNSName& zone)
     cerr<<"pdnsutil disable-dnssec "<<zone<<" right now!"<<endl;
   }
 
-  if (k_size)
-    cout << "Securing zone with key size " << k_size << endl;
-  else
-    cout << "Securing zone with default key size" << endl;
+  if (k_algo != "") { // Add a KSK
+    if (k_size)
+      cout << "Securing zone with key size " << k_size << endl;
+    else
+      cout << "Securing zone with default key size" << endl;
 
-  if (k_algos.empty()) { /* only a ZSK was requested by the defaults, set the SEP bit */
-  }
+    cout << "Adding "<<(z_algo == "" ? "CSK (257)" : "KSK")<<" with algorithm " << k_algo << endl;
 
-  for(auto &k_algo: k_algos) {
-    cout << "Adding "<<(z_algos.empty()? "CSK (257)" : "KSK")<<" with algorithm " << k_algo << endl;
+    int k_real_algo = DNSSECKeeper::shorthand2algorithm(k_algo);
 
-    int algo = DNSSECKeeper::shorthand2algorithm(k_algo);
-
-    if (!dk.addKey(zone, true, algo, id, k_size, true)) {
+    if (!dk.addKey(zone, true, k_real_algo, id, k_size, true)) {
       cerr<<"No backend was able to secure '"<<zone<<"', most likely because no DNSSEC"<<endl;
       cerr<<"capable backends are loaded, or because the backends have DNSSEC disabled."<<endl;
       cerr<<"For the Generic SQL backends, set the 'gsqlite3-dnssec', 'gmysql-dnssec' or"<<endl;
@@ -1844,13 +1839,12 @@ bool secureZone(DNSSECKeeper& dk, const DNSName& zone)
     }
   }
 
-  for(auto &z_algo :  z_algos)
-  {
-    cout << "Adding "<<(k_algos.empty()? "CSK (256)" : "ZSK")<<" with algorithm " << z_algo << endl;
+  if (z_algo != "") {
+    cout << "Adding "<<(k_algo == "" ? "CSK (256)" : "ZSK")<<" with algorithm " << z_algo << endl;
 
-    int algo = DNSSECKeeper::shorthand2algorithm(z_algo);
+    int z_real_algo = DNSSECKeeper::shorthand2algorithm(z_algo);
 
-    if (!dk.addKey(zone, false, algo, id, z_size, true)) {
+    if (!dk.addKey(zone, false, z_real_algo, id, z_size, true)) {
       cerr<<"No backend was able to secure '"<<zone<<"', most likely because no DNSSEC"<<endl;
       cerr<<"capable backends are loaded, or because the backends have DNSSEC disabled."<<endl;
       cerr<<"For the Generic SQL backends, set the 'gsqlite3-dnssec', 'gmysql-dnssec' or"<<endl;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -836,7 +836,7 @@ static void apiZoneCryptokeysPOST(DNSName zonename, HttpRequest *req, HttpRespon
   int64_t insertedId;
 
   if (content.is_null()) {
-    int bits = 0;
+    int bits = keyOrZone ? ::arg().asNum("default-ksk-size") : ::arg().asNum("default-zsk-size");
     auto docbits = document["bits"];
     if (!docbits.is_null()) {
       if (!docbits.is_number() || (fmod(docbits.number_value(), 1.0) != 0) || docbits.int_value() < 0) {
@@ -845,7 +845,7 @@ static void apiZoneCryptokeysPOST(DNSName zonename, HttpRequest *req, HttpRespon
         bits = docbits.int_value();
       }
     }
-    int algorithm = 13; // ecdsa256
+    int algorithm = DNSSECKeeper::shorthand2algorithm(keyOrZone ? ::arg()["default-ksk-algorithm"] : ::arg()["default-zsk-algorithm"]);
     auto providedAlgo = document["algo"];
     if (providedAlgo.is_string()) {
       algorithm = DNSSECKeeper::shorthand2algorithm(providedAlgo.string_value());


### PR DESCRIPTION
### Short description
Before, the `default-{k,z}sk-algorithms` options would accept multiple options. While the `default-{k,z}sk-size` would only accept a single value.

The first commit makes the algorithms options singular.

Furthermore, size is only needed for non-fixed length algo's (and we don't have defaults). the second displays a warning on start up if the size is 0 when it should be a number.

The last commit makes the cryptokey endpoint in the API use the defaults if `algo` and/or `size` are not passed in the request.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)