### PR TITLE
actually abort when virtualenv is missing. Fixes #5701

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -78,7 +78,7 @@ upload-docs: all-docs
 	rsync -crv --no-p --chmod=g=rwX --exclude '*~' ./PowerDNS-Authoritative.pdf web1.powerdns.com:/srv/www/doc.powerdns.com/authoritative/
 
 else # if HAVE_VIRTUALENV
-$(dist_MANS):
+$(MANPAGES_DIST):
 	echo "You need virtualenv to generate the manpages"
 	exit 1
 


### PR DESCRIPTION
### Short description
Without this, not having virtualenv leads to a confusing error, as seen in #5701 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
