### PR TITLE
add ProbaRule to dnsdist: match with given probability

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -969,6 +969,11 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       return std::shared_ptr<DNSRule>(new AllRule());
     });
 
+  g_lua.writeFunction("ProbaRule", [](double proba) {
+      return std::shared_ptr<DNSRule>(new ProbaRule(proba));
+    });
+
+  
   g_lua.writeFunction("QNameRule", [](const std::string& qname) {
       return std::shared_ptr<DNSRule>(new QNameRule(DNSName(qname)));
     });

--- a/pdns/dnsdistdist/dnsrulactions.cc
+++ b/pdns/dnsdistdist/dnsrulactions.cc
@@ -21,8 +21,23 @@
  */
 #include "dnsrulactions.hh"
 #include <iostream>
+#include <boost/format.hpp>
 
 using namespace std;
+
+bool ProbaRule::matches(const DNSQuestion* dq) const
+{
+  if(d_proba == 1.0)
+    return true;
+  double rnd = 1.0*random() / RAND_MAX;
+  return rnd > (1.0 - d_proba);
+}
+
+string ProbaRule::toString() const 
+{
+  return "match with prob. " + (boost::format("%0.2f") % d_proba).str();
+}
+
 
 TeeAction::TeeAction(const ComboAddress& ca, bool addECS) : d_remote(ca), d_addECS(addECS)
 {
@@ -39,10 +54,12 @@ TeeAction::~TeeAction()
   d_worker.join();
 }
 
+
 DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) const 
 {
-  if(dq->tcp) 
+  if(dq->tcp) {
     d_tcpdrops++;
+  }
   else {
     ssize_t res;
     d_queries++;

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -414,6 +414,14 @@ These ``DNSRule``\ s be one of the following items:
 
   :param int code: The opcode to match
 
+.. function:: ProbaRule(probability)
+
+  .. versionadded:: 1.3.0
+
+  Matches queries with a given probability. 1.0 means "always"
+
+  :param double probability: Probability of a match
+
 .. function:: QClassRule(qclass)
 
   Matches queries with the specified ``qclass``.

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -760,6 +760,18 @@ public:
 };
 
 
+class ProbaRule : public DNSRule
+{
+public:
+  ProbaRule(double proba) : d_proba(proba)
+  {
+  }
+  bool matches(const DNSQuestion* dq) const override;
+  string toString() const override;
+  double d_proba;
+};
+
+
 class DropAction : public DNSAction
 {
 public:
@@ -834,6 +846,7 @@ public:
   DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override;
   string toString() const override;
   std::unordered_map<string, double> getStats() const override;
+
 private:
   ComboAddress d_remote;
   std::thread d_worker;
@@ -855,8 +868,6 @@ private:
   std::atomic<bool> d_pleaseQuit{false};
   bool d_addECS{false};
 };
-
-
 
 class PoolAction : public DNSAction
 {


### PR DESCRIPTION
This adds a ProbaRule, ProbaRule(1.0) means 'match always', 0.1 '10%'. Useful for TeeAction.

### Short description
Sometimes you don't want an action to happen 100% of the time. With ProbaRule you can for example 'Tee' 1% of your traffic to hot spares which then always have a hot cache:

addAction(ProbaRule(0.1), TeeAction("127.0.0.1:5301"))

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
