### PR TITLE
rec: Detect zone cuts by asking for DS instead of NS

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -498,6 +498,36 @@ string hashQNameWithSalt(const std::string& salt, unsigned int iterations, const
   return toHash;
 }
 
+void incrementHash(std::string& raw) // I wonder if this is correct, cmouse? ;-)
+{
+  if(raw.empty())
+    return;
+
+  for(string::size_type pos=raw.size(); pos; ) {
+    --pos;
+    unsigned char c = (unsigned char)raw[pos];
+    ++c;
+    raw[pos] = (char) c;
+    if(c)
+      break;
+  }
+}
+
+void decrementHash(std::string& raw) // I wonder if this is correct, cmouse? ;-)
+{
+  if(raw.empty())
+    return;
+
+  for(string::size_type pos=raw.size(); pos; ) {
+    --pos;
+    unsigned char c = (unsigned char)raw[pos];
+    --c;
+    raw[pos] = (char) c;
+    if(c != 0xff)
+      break;
+  }
+}
+
 DNSKEYRecordContent DNSSECPrivateKey::getDNSKEY() const
 {
   return makeDNSKEYFromDNSCryptoKeyEngine(getKey(), d_algorithm, d_flags);

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -155,6 +155,9 @@ uint32_t getStartOfWeek();
 string hashQNameWithSalt(const NSEC3PARAMRecordContent& ns3prc, const DNSName& qname);
 string hashQNameWithSalt(const std::string& salt, unsigned int iterations, const DNSName& qname);
 
+void incrementHash(std::string& raw);
+void decrementHash(std::string& raw);
+
 void addRRSigs(DNSSECKeeper& dk, UeberBackend& db, const std::set<DNSName>& authMap, vector<DNSZoneRecord>& rrs);
 
 void addTSIG(DNSPacketWriter& pw, TSIGRecordContent& trc, const DNSName& tsigkeyname, const string& tsigsecret, const string& tsigprevious, bool timersonly);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -544,37 +544,6 @@ void PacketHandler::addNSECX(DNSPacket *p, DNSPacket *r, const DNSName& target, 
   }
 }
 
-static void incrementHash(std::string& raw) // I wonder if this is correct, cmouse? ;-)
-{
-  if(raw.empty())
-    return;
-    
-  for(string::size_type pos=raw.size(); pos; ) {
-    --pos;
-    unsigned char c = (unsigned char)raw[pos];
-    ++c;
-    raw[pos] = (char) c;
-    if(c)
-      break;
-  }
-}
-
-static void decrementHash(std::string& raw) // I wonder if this is correct, cmouse? ;-)
-{
-  if(raw.empty())
-    return;
-    
-  for(string::size_type pos=raw.size(); pos; ) {
-    --pos;
-    unsigned char c = (unsigned char)raw[pos];
-    --c;
-    raw[pos] = (char) c;
-    if(c != 0xff)
-      break;
-  }
-}
-
-
 bool getNSEC3Hashes(bool narrow, DNSBackend* db, int id, const std::string& hashed, bool decrement, DNSName& unhashed, std::string& before, std::string& after, int mode)
 {
   bool ret;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -755,7 +755,7 @@ private:
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth);
   vState getDSRecords(const DNSName& zone, dsmap_t& ds, bool onlyTA, unsigned int depth, bool bogusOnNXD=true, bool* foundCut=nullptr);
   vState getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int depth);
-  void getDenialValidationState(NegCache::NegCacheEntry& ne, vState& state, const dState expectedState, bool allowOptOut);
+  void getDenialValidationState(NegCache::NegCacheEntry& ne, vState& state, const dState expectedState, bool allowOptOut, bool referralToUnsigned);
   vState getTA(const DNSName& zone, dsmap_t& ds);
   bool haveExactValidationStatus(const DNSName& domain);
   vState getValidationStatus(const DNSName& subdomain, bool allowIndeterminate=true);

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -760,6 +760,7 @@ private:
   bool haveExactValidationStatus(const DNSName& domain);
   vState getValidationStatus(const DNSName& subdomain);
 
+  bool lookForCut(const DNSName& qname, unsigned int depth, const vState existingState, vState& newState);
   void computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned int depth);
 
   void setUpdatingRootNS()

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -753,12 +753,12 @@ private:
   void updateValidationState(vState& state, const vState stateUpdate);
   vState validateRecordsWithSigs(unsigned int depth, const DNSName& qname, const QType& qtype, const DNSName& name, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth);
-  vState getDSRecords(const DNSName& zone, dsmap_t& ds, bool onlyTA, unsigned int depth, bool bogusOnNXD=true);
+  vState getDSRecords(const DNSName& zone, dsmap_t& ds, bool onlyTA, unsigned int depth, bool bogusOnNXD=true, bool* foundCut=nullptr);
   vState getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int depth);
   void getDenialValidationState(NegCache::NegCacheEntry& ne, vState& state, const dState expectedState, bool allowOptOut);
   vState getTA(const DNSName& zone, dsmap_t& ds);
   bool haveExactValidationStatus(const DNSName& domain);
-  vState getValidationStatus(const DNSName& subdomain);
+  vState getValidationStatus(const DNSName& subdomain, bool allowIndeterminate=true);
 
   bool lookForCut(const DNSName& qname, unsigned int depth, const vState existingState, vState& newState);
   void computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned int depth);

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -74,3 +74,4 @@ void validateDNSKeysAgainstDS(time_t now, const DNSName& zone, const dsmap_t& ds
 dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16_t qtype);
 bool isSupportedDS(const DSRecordContent& ds);
 DNSName getSigner(const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
+bool denialProvesNoDelegation(const DNSName& zone, const std::vector<DNSRecord>& dsrecords);

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -71,7 +71,7 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, skeyset_t& keyset);
 bool getTrustAnchor(const map<DNSName,dsmap_t>& anchors, const DNSName& zone, dsmap_t &res);
 bool haveNegativeTrustAnchor(const map<DNSName,std::string>& negAnchors, const DNSName& zone, std::string& reason);
 void validateDNSKeysAgainstDS(time_t now, const DNSName& zone, const dsmap_t& dsmap, const skeyset_t& tkeys, vector<shared_ptr<DNSRecordContent> >& toSign, const vector<shared_ptr<RRSIGRecordContent> >& sigs, skeyset_t& validkeys);
-dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16_t qtype);
+dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16_t qtype, bool referralToUnsigned);
 bool isSupportedDS(const DSRecordContent& ds);
 DNSName getSigner(const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
 bool denialProvesNoDelegation(const DNSName& zone, const std::vector<DNSRecord>& dsrecords);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since there is so many broken DNS servers handing NS queries incorrectly, move to DS queries for figuring out zone cuts since we only care as long as the zone is Secure (including with a TA).
Please review this carefully before merging.
Fixes #5681.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
