### PR TITLE
Auth: Publish inactive KSK/CSK as CDNSKEY/CDS

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -398,7 +398,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getEntryPoints(const DNSName& zname)
   DNSSECKeeper::keyset_t keys = getKeys(zname);
 
   for(auto const &keymeta : keys)
-    if(keymeta.second.active && (keymeta.second.keyType == KSK || keymeta.second.keyType == CSK))
+    if(keymeta.second.keyType == KSK || keymeta.second.keyType == CSK)
       ret.push_back(keymeta);
   return ret;
 }


### PR DESCRIPTION
### Short description
This PR makes the auth also publish CDS/CDNSKEY records for inactive keys, as this is needed to roll without double sigs.

Closes #5721

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)