### PR TITLE
auth: Use a unique pointer for bind backend's `d_of`

### DIFF
--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -304,7 +304,7 @@ private:
   string d_transaction_tmpname;
   string d_logprefix;
   set<string> alsoNotify; //!< this is used to store the also-notify list of interested peers.
-  ofstream *d_of;
+  std::unique_ptr<ofstream> d_of;
   handle d_handle;
   static string s_binddirectory;                              //!< this is used to store the 'directory' setting of the bind configuration
   static int s_first;                                  //!< this is raised on construction to prevent multiple instances of us being generated


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
While this should not happen, using a smart pointer prevents double-free, user-after-free or invalid pointer dereference if we mess up our transaction logic.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
