### PR TITLE
auth: Fix a crash when getting a public GOST key if the private one is not set

### DIFF
--- a/pdns/botan110signers.cc
+++ b/pdns/botan110signers.cc
@@ -181,8 +181,9 @@ std::string GOSTDNSCryptoKeyEngine::getPubKeyHash() const
 
 std::string GOSTDNSCryptoKeyEngine::getPublicKeyString() const
 {
-  const BigInt&x =d_key->public_point().get_affine_x();
-  const BigInt&y =d_key->public_point().get_affine_y();
+  std::shared_ptr<GOST_3410_PublicKey> pk = d_pubkey ? d_pubkey : d_key;
+  const BigInt&x =pk->public_point().get_affine_x();
+  const BigInt&y =pk->public_point().get_affine_y();
   
   size_t part_size = std::max(x.bytes(), y.bytes());
  


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is included in https://github.com/PowerDNS/pdns/pull/5498, so don't merge this PR unless we decide not to include #5498 in 4.1.

In the same manner we should backport this fix to 4.0 if we don't backport #5498 there, and I don't think we should backport it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
