### PR TITLE
rec: Do not allow direct queries for RRSIG or NSEC3

### DIFF
--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -2151,13 +2151,13 @@ BOOST_AUTO_TEST_CASE(test_qclass_none) {
   BOOST_CHECK_EQUAL(queriesCount, 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_xfr) {
+BOOST_AUTO_TEST_CASE(test_special_types) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr);
 
   primeHints();
 
-  /* {A,I}XFR should be rejected right away */
+  /* {A,I}XFR, RRSIG and NSEC3 should be rejected right away */
   size_t queriesCount = 0;
 
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
@@ -2175,6 +2175,16 @@ BOOST_AUTO_TEST_CASE(test_xfr) {
   BOOST_CHECK_EQUAL(queriesCount, 0);
 
   res = sr->beginResolve(target, QType(QType::IXFR), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, -1);
+  BOOST_CHECK_EQUAL(ret.size(), 0);
+  BOOST_CHECK_EQUAL(queriesCount, 0);
+
+  res = sr->beginResolve(target, QType(QType::RRSIG), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, -1);
+  BOOST_CHECK_EQUAL(ret.size(), 0);
+  BOOST_CHECK_EQUAL(queriesCount, 0);
+
+  res = sr->beginResolve(target, QType(QType::NSEC3), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, -1);
   BOOST_CHECK_EQUAL(ret.size(), 0);
   BOOST_CHECK_EQUAL(queriesCount, 0);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -125,7 +125,7 @@ int SyncRes::beginResolve(const DNSName &qname, const QType &qtype, uint16_t qcl
     return 0;
   }
 
-  if( (qtype.getCode() == QType::AXFR) || (qtype.getCode() == QType::IXFR))
+  if( (qtype.getCode() == QType::AXFR) || (qtype.getCode() == QType::IXFR) || (qtype.getCode() == QType::RRSIG) || (qtype.getCode() == QType::NSEC3))
     return -1;
 
   if(qclass==QClass::ANY)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
As pointed out in https://github.com/PowerDNS/pdns/issues/5735, the recursor has an interesting issue when handling a direct query for the `RRSIG` type. It would send a query to the corresponding authoritative server and assume that a `NOTIMPL` answer, as sent for example by PowerDNS 4.0.x, is an indication that this server does not support `EDNS`.
Since it does not make a lot of sense to directly ask for `RRSIG` or `NSEC3` records anyway, let's just refuse those queries as we already do for `AXFR` and `IXFR`.

One thing to ponder is that the current code sends a `ServFail` answer for `AXFR` and `IXFR`, and that feels wrong. Perhaps `REFUSED` would be more suited?

Fixes #5735.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
