### PR TITLE
rec: Remove pdns.PASS and pdns.TRUNCATE

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -464,8 +464,7 @@ RecursorLua4::RecursorLua4(const std::string& fname)
     });
   typedef vector<pair<string, int> > in_t;
   vector<pair<string, boost::variant<int, in_t, struct timeval* > > >  pd{
-    {"PASS", (int)PolicyDecision::PASS}, {"DROP",  (int)PolicyDecision::DROP},
-    {"TRUNCATE", (int)PolicyDecision::TRUNCATE}
+    {"DROP",  (int)PolicyDecision::DROP}
   };
 
   vector<pair<string, int> > rcodes = {{"NOERROR",  RCode::NoError  },

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1015,7 +1015,7 @@ static void startDoResolve(void *p)
       dc=0;
       return;
     }
-    if(tracedQuery || res == PolicyDecision::PASS || res == RCode::ServFail || pw.getHeader()->rcode == RCode::ServFail)
+    if(tracedQuery || res == -1 || res == RCode::ServFail || pw.getHeader()->rcode == RCode::ServFail)
     { 
       string trace(sr.getTrace());
       if(!trace.empty()) {
@@ -1028,7 +1028,7 @@ static void startDoResolve(void *p)
       }
     }
 
-    if(res == PolicyDecision::PASS) {  // XXX what does this MEAN? Why servfail on PASS?
+    if(res == -1) {
       pw.getHeader()->rcode=RCode::ServFail;
       // no commit here, because no record
       g_stats.servFails++;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Those values are not documented in a recursor context, and does not work as one could expect since `pdns.PASS` results in an immediate `ServFail` and `pdns.TRUNCATE` in a strange status code being sent (showing up as `RESERVED13` in `dig`).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
