### PR TITLE
remotebackend: Fix libjson11.la location to top_builddir

### DIFF
--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS += \
 
 AM_LDFLAGS = $(THREADFLAGS)
 
-JSON11_LIBS = $(top_srcdir)/ext/json11/libjson11.la
+JSON11_LIBS = $(top_builddir)/ext/json11/libjson11.la
 
 EXTRA_DIST = \
 	OBJECTFILES \


### PR DESCRIPTION
### Short description
Fix remotebackend out of tree issue in #5743

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
