### PR TITLE
add --www feature to dnsbulktest to make it (not) add www. to everything too

### DIFF
--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -224,6 +224,7 @@ try
     ("type,t",  po::value<string>()->default_value("A"), "What type to query for")
     ("envoutput,e", "write report in shell environment format")
     ("version", "show the version number")
+    ("www", po::value<bool>()->default_value("true"), "duplicate all queries with an additional 'www.' in front")
   ;
 
   po::options_description alloptions;
@@ -258,6 +259,7 @@ try
     return EXIT_FAILURE;
   }
 
+  bool doWww = g_vm["www"].as<bool>();
   g_quiet = g_vm.count("quiet") > 0;
   g_envoutput = g_vm.count("envoutput") > 0;
   uint16_t qtype;
@@ -303,7 +305,8 @@ try
       continue; // this was an IP address
     }
     domains.push_back(TypedQuery(split.second, qtype));
-    domains.push_back(TypedQuery("www."+split.second, qtype));
+    if(doWww)
+      domains.push_back(TypedQuery("www."+split.second, qtype));
   }
   cerr<<"Read "<<domains.size()<<" domains!"<<endl;
   random_shuffle(domains.begin(), domains.end());


### PR DESCRIPTION
This is a priority merge since it holds up our testing. Once merged, it will eventually end up on our repos, which means our testing will only then benefit, since they apt-get the testing tools from our repo!

### Short description
The Umbrella 1M list does not need www doubling in dnsbulktest and in fact is useless if you do.
Make doubling optional.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
