### PR TITLE
Add more metrics to dnsbulktest -e output

### DIFF
--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -354,6 +354,11 @@ try
     cout<<"DBT_QUEUED="<<domains.size()<<endl;
     cout<<"DBT_SENDERRORS="<<sr.d_senderrors<<endl;
     cout<<"DBT_RECEIVED="<<sr.d_receiveds<<endl;
+    cout<<"DBT_NXDOMAINS="<<sr.d_nxdomains<<endl;
+    cout<<"DBT_NODATAS="<<sr.d_nodatas<<endl;
+    cout<<"DBT_UNKNOWNS="<<sr.d_unknowns<<endl;
+    cout<<"DBT_OKS="<<sr.d_oks<<endl;
+    cout<<"DBT_ERRORS="<<sr.d_errors<<endl;
     cout<<"DBT_TIMEOUTS="<<inflighter.getTimeouts()<<endl;
     cout<<"DBT_UNEXPECTEDS="<<inflighter.getUnexpecteds()<<endl;
     cout<<"DBT_OKPERCENTAGE="<<((float)sr.d_oks/domains.size()*100)<<endl;


### PR DESCRIPTION
With this commit, dnsbulktest writes out more statistics when invoked with -e. This enables more granular limits for determining build success in travis.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
