### PR TITLE
Improve dnsbulktest experience in travis for more robustness

### DIFF
--- a/build-scripts/test-recursor-bulk
+++ b/build-scripts/test-recursor-bulk
@@ -12,7 +12,7 @@ set -x
 
 cd regression-tests
 
-wget -c -N https://s3.amazonaws.com/alexa-static/top-1m.csv.zip
+wget -c -N http://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip
 
 unzip top-1m.csv.zip
 

--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -331,11 +331,11 @@ install_recursor() {
     moreutils \
     snmpd"
   run "cd .."
-  run "wget https://s3.amazonaws.com/alexa-static/top-1m.csv.zip"
+  run "wget http://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip"
   run "unzip top-1m.csv.zip -d ${TRAVIS_BUILD_DIR}/regression-tests"
-  run 'echo -e "deb [arch=amd64] http://repo.powerdns.com/ubuntu trusty-auth-40 main" | sudo tee /etc/apt/sources.list.d/pdns.list'
-  run 'echo -e "Package: pdns-*\nPin: origin PowerDNS\nPin-Priority: 600" | sudo tee /etc/apt/preferences.d/pdns.list'
-  run 'curl https://repo.powerdns.com/FD380FBB-pub.asc | sudo apt-key add - '
+  run 'echo -e "deb [arch=amd64] http://repo.powerdns.com/ubuntu trusty-auth-master main" | sudo tee /etc/apt/sources.list.d/pdns.list'
+  run 'echo -e "Package: pdns-*\nPin: origin repo.powerdns.com\nPin-Priority: 9001" | sudo tee /etc/apt/preferences.d/pdns'
+  run 'curl https://repo.powerdns.com/CBC8B383-pub.asc | sudo apt-key add - '
   run 'sudo apt-get update'
   run 'sudo apt-get -y install pdns-server pdns-tools'
   run "sudo service pdns stop"
@@ -544,7 +544,7 @@ test_recursor() {
   run "./build-scripts/test-recursor"
   export RECURSOR="${PDNSRECURSOR}"
   run "cd regression-tests"
-  run "THRESHOLD=90 TRACE=no ./timestamp ./recursor-test 5300 25000"
+  run "THRESHOLD=90 TRACE=no ./timestamp ./recursor-test 5300 50000"
   run "cd .."
 
   run "cd regression-tests.api"

--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -544,7 +544,7 @@ test_recursor() {
   run "./build-scripts/test-recursor"
   export RECURSOR="${PDNSRECURSOR}"
   run "cd regression-tests"
-  run "THRESHOLD=90 TRACE=no ./timestamp ./recursor-test 5300 50000"
+  run "THRESHOLD=95 TRACE=no ./timestamp ./recursor-test 5300 50000"
   run "cd .."
 
   run "cd regression-tests.api"

--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 port=$1
 [ -z "$port" ] && port=5300
 limit=$2
@@ -6,7 +6,7 @@ limit=$2
 
 : ${RECURSOR:="../pdns/recursordist/pdns_recursor"}
 : ${CSV:="top-1m.csv"}
-: ${IPv6:="1"}
+: ${IPv6:="0"}
 : ${TRACE:="fail"}
 : ${DNSBULKTEST:="../pdns/dnsbulktest"}
 
@@ -24,9 +24,9 @@ rm -f recursor.pid pdns_recursor.pid
 <measurement><name>system CPU seconds</name><value>%S</value></measurement>
 <measurement><name>wallclock seconds</name><value>%e</value></measurement>
 <measurement><name>%% CPU used</name><value>%P</value></measurement>
-'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --query-local-address6="${QLA6}" > recursor.log 2>&1 &
+'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=100 --query-local-address6="${QLA6}" > recursor.log 2>&1 &
 sleep 3
-${DNSBULKTEST} -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
+${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
 kill $(cat pdns_recursor.pid)
 sleep 5
 
@@ -36,7 +36,10 @@ mkdir -p recursor-bulktest
 rm -f failed_tests passed_tests
 touch failed_tests passed_tests
 : ${THRESHOLD:="95"}
-if [ "$DBT_OKPERCENTAGEINT" -ge $THRESHOLD ]
+
+ANANSWER=$[(100*(${DBT_QUEUED}-${DBT_ERRORS}-${DBT_TIMEOUTS}) )/${DBT_QUEUED}]
+
+if [ "$ANANSWER" -ge $THRESHOLD ]
 then
 	echo recursor-bulktest >> passed_tests
 	RETVAL=0


### PR DESCRIPTION
This commit changes our dnsbulktest source from Alexa to Cisco Umbrella, but this turned out not to be as important as we thought.
In addition, it turns out we had been installing pdns-tools incorrectly because of wrong apt-settings. We now install pdns-tools from the master repo at repo.powerdns.com
This commit also tunes pdns_recursor to use less simultaneous outbound connections during testing, which appears to make Travis NAT happier, leading to less errors.
Finally, we use new features of dnsbulktest to extract more statistics for how well we are doing. Success is now dependent on errors and timeouts, and less on NXDOMAIN.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
