### PR TITLE
Update docs to reflect actual default database name.

### DIFF
--- a/docs/backends/generic-mysql.rst
+++ b/docs/backends/generic-mysql.rst
@@ -78,7 +78,7 @@ Connect to the UNIX socket at this path. Mutually exclusive with :ref:`setting-g
 ``gmysql-dbname``
 ^^^^^^^^^^^^^^^^^
 
-Name of the database to connect to. Default: "pdns".
+Name of the database to connect to. Default: "powerdns".
 
 .. _setting-gmysql-user:
 


### PR DESCRIPTION
### Short description
Addresses doc issue #5668 for default database name.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)


Note: the doc currently has the default port as 3306, but the default port is actually set to 0. I might recommend changing the default to reflect the document (3306).
