### PR TITLE
Rec: create socket-dir from init-script

### DIFF
--- a/build-scripts/build-recursor-rpm
+++ b/build-scripts/build-recursor-rpm
@@ -64,6 +64,10 @@ if [ -f /etc/redhat-release ]; then
 
 RETVAL=0
 
+PIDDIR=\$(awk -F= '/^socket-dir=/ {print \$2}' /etc/powerdns/recursor.conf)
+if [ -z "\$PIDDIR" ]; then PIDDIR=/var/run; fi
+mkdir -p "\$PIDDIR"
+
 start() {
 	echo -n \$"Starting pdns-recursor: "
 	daemon /usr/sbin/pdns_recursor --daemon 2>/dev/null
@@ -76,7 +80,7 @@ stop() {
 	echo -n \$"Stopping pdns-recursor: "
 	killproc pdns_recursor
 	echo
-	[ \$RETVAL -eq 0 ] && rm -f /var/lock/subsys/pdns-recursor && rm -f /var/run/pdns_recursor.controlsocket
+	[ \$RETVAL -eq 0 ] && rm -f /var/lock/subsys/pdns-recursor && rm -f \$PIDDIR/pdns_recursor.controlsocket
 }
 
 restart() {

--- a/build-scripts/debian-recursor/pdns-recursor.init
+++ b/build-scripts/debian-recursor/pdns-recursor.init
@@ -28,6 +28,7 @@ DAEMON=/usr/sbin/$NAME
 # or fall back to the default /var/run if not specified there.
 PIDDIR=$(awk -F= '/^socket-dir=/ {print $2}' /etc/powerdns/recursor.conf)
 if [ -z "$PIDDIR" ]; then PIDDIR=/var/run; fi
+mkdir -p "$PIDDIR"
 PIDFILE=$PIDDIR/$NAME.pid
 
 # Gracefully exit if the package has been removed.


### PR DESCRIPTION
### Short description
This fixes this issue for sys v init. For systemd, it is advices that the admin creates these directories (or doesn't touch the setting).

Closes #5439

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)