### PR TITLE
autoconf: set --enable-libsodium to 'auto'

### DIFF
--- a/m4/pdns_check_libsodium.m4
+++ b/m4/pdns_check_libsodium.m4
@@ -1,26 +1,30 @@
 AC_DEFUN([PDNS_CHECK_LIBSODIUM], [
   AC_MSG_CHECKING([whether we will be linking in libsodium])
   AC_ARG_ENABLE([libsodium],
-    AS_HELP_STRING([--enable-libsodium],[use libsodium @<:@default=no@:>@]),
+    AS_HELP_STRING([--enable-libsodium],[use libsodium @<:@default=auto@:>@]),
     [enable_libsodium=$enableval],
-    [enable_libsodium=no],
+    [enable_libsodium=auto],
   )
   AC_MSG_RESULT([$enable_libsodium])
 
-  AM_CONDITIONAL([LIBSODIUM], [test "x$enable_libsodium" != "xno"])
-
-  AM_COND_IF([LIBSODIUM], [
-    PKG_CHECK_MODULES([LIBSODIUM], [libsodium], [
-      AC_DEFINE([HAVE_LIBSODIUM], [1], [Define to 1 if you have libsodium])
-      save_CFLAGS=$CFLAGS
-      save_LIBS=$LIBS
-      CFLAGS="$LIBSODIUM_CFLAGS $CFLAGS"
-      LIBS="$LIBSODIUM_LIBS $LIBS"
-      AC_CHECK_FUNCS([crypto_box_easy_afternm])
-      CFLAGS=$save_CFLAGS
-      LIBS=$save_LIBS
-    ],[
-      AC_MSG_ERROR([libsodium requested but not available])
+  AS_IF([test "x$enable_libsodium" != "xno"], [
+    AS_IF([test "x$enable_libsodium" = "xyes" -o "x$enable_libsodium" = "xauto"], [
+      PKG_CHECK_MODULES([LIBSODIUM], [libsodium], [
+        AC_DEFINE([HAVE_LIBSODIUM], [1], [Define to 1 if you have libsodium])
+        save_CFLAGS=$CFLAGS
+        save_LIBS=$LIBS
+        CFLAGS="$LIBSODIUM_CFLAGS $CFLAGS"
+        LIBS="$LIBSODIUM_LIBS $LIBS"
+        AC_CHECK_FUNCS([crypto_box_easy_afternm])
+        CFLAGS=$save_CFLAGS
+        LIBS=$save_LIBS
+      ])
+    ])
+  ])
+  AM_CONDITIONAL([LIBSODIUM], [test "x$LIBSODIUM_LIBS" != "x"])
+  AS_IF([test "x$enable_libsodium" = "xyes"], [
+    AS_IF([test x"$LIBSODIUM_LIBS" = "x"], [
+      AC_MSG_ERROR([libsodium requested but libraries were not found])
     ])
   ])
 ])


### PR DESCRIPTION
### Short description
This was 'no' before. As we (want to) use libsodium for dnsdist's
console *and* for ed25519 for the auth and the recursor, we might as wel
use it when we detect it.

This would a good change to have in auth 4.1, rec 4.1 and dndist 1.3,
currently on master.

NOTE: will need an entry in the upgrade guides

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)