### PR TITLE
auth: Correctly purge entries from the caches after a transfer

### DIFF
--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -415,6 +415,7 @@ void CommunicatorClass::suck(const DNSName &domain, const string &remote)
         }
         else {
           L<<Logger::Warning<<"Done with IXFR of '"<<domain<<"' from remote '"<<remote<<"', got "<<zs.numDeltas<<" delta"<<addS(zs.numDeltas)<<", serial now "<<zs.soa_serial<<endl;
+          purgeAuthCaches(domain.toString()+"$");
           return;
         }
       }

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -22,7 +22,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "packetcache.hh"
+
 #include "utility.hh"
 #include "dnssecinfra.hh"
 #include "dnsseckeeper.hh"
@@ -38,7 +38,7 @@
 #include "logger.hh"
 #include "dns.hh"
 #include "arguments.hh"
-#include "packetcache.hh"
+#include "auth-caches.hh"
 
 #include "base64.hh"
 #include "inflighter.cc"
@@ -581,7 +581,7 @@ void CommunicatorClass::suck(const DNSName &domain, const string &remote)
     di.backend->commitTransaction();
     transaction = false;
     di.backend->setFresh(zs.domain_id);
-    PC.purge(domain.toString()+"$");
+    purgeAuthCaches(domain.toString()+"$");
 
 
     L<<Logger::Error<<"AXFR done for '"<<domain<<"', zone committed with serial number "<<zs.soa_serial<<endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since the QC/PC split up, we only removed entries for the AXFR'd domain from the packet cache, not the query cache.
We also did not remove entries in case of IXFR. We might want to backport that second part to 4.0.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
