### PR TITLE
PoC: stop doing individual RRSIG queries during outbound AXFR

### DIFF
--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -128,7 +128,7 @@ static void addSignature(DNSSECKeeper& dk, UeberBackend& db, const DNSName& sign
   vector<RRSIGRecordContent> rrcs;
   if(dk.isPresigned(signer)) {
     //cerr<<"Doing presignatures"<<endl;
-    dk.getPreRRSIGs(db, signer, signQName, wildcardname, QType(signQType), signPlace, outsigned, origTTL); // does it all
+    // dk.getPreRRSIGs(db, signer, signQName, wildcardname, QType(signQType), signPlace, outsigned, origTTL); // does it all
   }
   else {
     if(getRRSIGsForRRSET(dk, signer, wildcardname.countLabels() ? wildcardname : signQName, signQType, signTTL, toSign, rrcs) < 0)  {

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -894,6 +894,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
         DNSName relative=zrr.dr.d_name.makeRelative(target);
         ns3rrs.insert(fromBase32Hex(relative.toStringNoDot()));
       }
+      if(presignedZone) csp.submit(zrr);
       continue;
     }
 


### PR DESCRIPTION
### Short description
When we serve out a PRESIGNED zone over AXFR, we get a full zone listing from the database, including the RRSIGs. We then throw those RRSIGs away only to ask for all of them *individually*, via the query cache. Before #5766 this caused inconsistency issues. After #5766 the inconsistency issues are gone but all of this is very inefficient.

This PR stops the throwing away of RRSIGs that we got from `list()` (in tcpreceiver.cc); in dnssecsigner.cc we stop hitting the database.

Further thoughts: every outbound AXFR passes through the Chunked Signing Pipe, and this does not appear to make sense for unsigned or presigned zones.

This PR is not for merging yet - it breaks direct queries.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
