### PR TITLE
Keep trying if the first connection to the remote logger failed

### DIFF
--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -14,6 +14,7 @@ bool RemoteLogger::reconnect()
     close(d_socket);
     d_socket = -1;
   }
+  d_connected = false;
   try {
     d_socket = SSocket(d_remote.sin4.sin_family, SOCK_STREAM, 0);
     setNonBlocking(d_socket);
@@ -27,13 +28,21 @@ bool RemoteLogger::reconnect()
 #endif
     return false;
   }
+  d_connected = true;
   return true;
+}
+
+void RemoteLogger::busyReconnectLoop()
+{
+  while (!reconnect()) {
+    sleep(d_reconnectWaitTime);
+  }
 }
 
 void RemoteLogger::worker()
 {
   if (d_asyncConnect) {
-    reconnect();
+    busyReconnectLoop();
   }
 
   while(true) {
@@ -48,6 +57,10 @@ void RemoteLogger::worker()
       d_writeQueue.pop();
     }
 
+    if (!d_connected) {
+      busyReconnectLoop();
+    }
+
     try {
       uint16_t len = static_cast<uint16_t>(data.length());
       sendSizeAndMsgWithTimeout(d_socket, len, data.c_str(), static_cast<int>(d_timeout), nullptr, nullptr, 0, 0, 0);
@@ -58,9 +71,7 @@ void RemoteLogger::worker()
 #else
       vinfolog("Error sending data to remote logger (%s): %s", d_remote.toStringWithPort(), e.what());
 #endif
-      while (!reconnect()) {
-        sleep(d_reconnectWaitTime);
-      }
+      busyReconnectLoop();
     }
   }
 }
@@ -90,6 +101,7 @@ RemoteLogger::~RemoteLogger()
   if (d_socket >= 0) {
     close(d_socket);
     d_socket = -1;
+    d_connected = false;
   }
   d_queueCond.notify_one();
   d_thread.join();

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -42,6 +42,7 @@ public:
     return d_remote.toStringWithPort();
   }
 private:
+  void busyReconnectLoop();
   bool reconnect();
   void worker();
 
@@ -55,5 +56,6 @@ private:
   uint8_t d_reconnectWaitTime;
   std::atomic<bool> d_exiting{false};
   bool d_asyncConnect{false};
+  bool d_connected{false};
   std::thread d_thread;
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Instead of waiting to have a message to send and failing to send it, causing some messages to be lost in some cases because we would detect the failure too late in the process.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
