### PR TITLE
Implement experimental metric tracking time spent within PowerDNS per query

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1237,7 +1237,7 @@ static void startDoResolve(void *p)
     }
 
     sr.d_outqueries ? t_RC->cacheMisses++ : t_RC->cacheHits++;
-            
+
     if(spent < 0.001)
       g_stats.answers0_1++;
     else if(spent < 0.010)

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1271,10 +1271,10 @@ static void startDoResolve(void *p)
       //      cerr<<"SLOW: "<<ourtime<<"ms -> "<<dc->d_mdp.d_qname<<"|"<<DNSRecordContent::NumberToType(dc->d_mdp.d_qtype)<<endl;
       g_stats.ourtimeSlow++;
     }
-
-    newLat=ourtime*1000; // usec
-    g_stats.avgLatencyOursUsec=(1-1.0/g_latencyStatSize)*g_stats.avgLatencyOursUsec + (float)newLat/g_latencyStatSize;
-    
+    if(ourtime >= 0.0) {
+      newLat=ourtime*1000; // usec
+      g_stats.avgLatencyOursUsec=(1-1.0/g_latencyStatSize)*g_stats.avgLatencyOursUsec + (float)newLat/g_latencyStatSize;
+    }
     //    cout<<dc->d_mdp.d_qname<<"\t"<<MT->getUsec()<<"\t"<<sr.d_outqueries<<endl;
     delete dc;
     dc=0;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -880,8 +880,7 @@ void registerAllStats()
   addGetStat("x-ourtime8-16", &g_stats.ourtime8_16);
   addGetStat("x-ourtime16-32", &g_stats.ourtime16_32);
   addGetStat("x-ourtime-slow", &g_stats.ourtimeSlow);
-  
-  
+
   addGetStat("auth4-answers0-1", &g_stats.auth4Answers0_1);
   addGetStat("auth4-answers1-10", &g_stats.auth4Answers1_10);
   addGetStat("auth4-answers10-100", &g_stats.auth4Answers10_100);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -873,6 +873,15 @@ void registerAllStats()
   addGetStat("answers100-1000", &g_stats.answers100_1000);
   addGetStat("answers-slow", &g_stats.answersSlow);
 
+  addGetStat("x-ourtime0-1", &g_stats.ourtime0_1);
+  addGetStat("x-ourtime1-2", &g_stats.ourtime1_2);
+  addGetStat("x-ourtime2-4", &g_stats.ourtime2_4);
+  addGetStat("x-ourtime4-8", &g_stats.ourtime4_8);
+  addGetStat("x-ourtime8-16", &g_stats.ourtime8_16);
+  addGetStat("x-ourtime16-32", &g_stats.ourtime16_32);
+  addGetStat("x-ourtime-slow", &g_stats.ourtimeSlow);
+  
+  
   addGetStat("auth4-answers0-1", &g_stats.auth4Answers0_1);
   addGetStat("auth4-answers1-10", &g_stats.auth4Answers1_10);
   addGetStat("auth4-answers10-100", &g_stats.auth4Answers10_100);
@@ -887,6 +896,7 @@ void registerAllStats()
 
 
   addGetStat("qa-latency", doGetAvgLatencyUsec);
+  addGetStat("x-our-latency", []() { return g_stats.avgLatencyOursUsec; });
   addGetStat("unexpected-packets", &g_stats.unexpectedCount);
   addGetStat("case-mismatches", &g_stats.caseMismatchCount);
   addGetStat("spoof-prevents", &g_stats.spoofCount);

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -439,3 +439,45 @@ number of seconds process has been running (since 3.1.5)
 user-msec
 ^^^^^^^^^
 number of CPU milliseconds spent in 'user' mode
+
+x-our-latency
+^^^^^^^^^^^^^
+New metric, which is not yet proven to be reliable. PowerDNS measures per query how much time has been spent waiting on
+authoritative servers. In addition, the Recursor measures the total amount of time needed to answer a question. The
+difference between these two durations is a measure of how much time was spent within PowerDNS. This metric is the average
+of that difference, in microseconds. Since 4.1.
+
+x-ourtime0-1
+^^^^^^^^^^^^
+New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
+where between 0 and 1 milliseconds was spent within the Recursor. Since 4.1.
+
+x-ourtime1-2
+^^^^^^^^^^^^
+New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
+where between 1 and 2 milliseconds was spent within the Recursor. Since 4.1.
+
+x-ourtime2-4
+^^^^^^^^^^^^
+New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
+where between 2 and 4 milliseconds was spent within the Recursor. Since 4.1.
+
+x-ourtime4-8
+^^^^^^^^^^^^
+New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
+where between 4 and 8 milliseconds was spent within the Recursor. Since 4.1.
+
+x-ourtime8-16
+^^^^^^^^^^^^^
+New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
+where between 8 and 16 milliseconds was spent within the Recursor. Since 4.1.
+
+x-ourtime16-32
+^^^^^^^^^^^^^^
+New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
+where between 16 and 32 milliseconds was spent within the Recursor. Since 4.1.
+
+x-ourtime-slow
+^^^^^^^^^^^^^^
+New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
+where more than 32 milliseconds was spent within the Recursor. Since 4.1.

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -253,7 +253,7 @@ max-cache-entries
 currently configured maximum number of cache entries
 
 max-packetcache-entries
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 currently configured maximum number of packet cache entries
 
 max-mthread-stack
@@ -442,6 +442,8 @@ number of CPU milliseconds spent in 'user' mode
 
 x-our-latency
 ^^^^^^^^^^^^^
+.. versionadded:: 4.1
+
 New metric, which is not yet proven to be reliable. PowerDNS measures per query how much time has been spent waiting on
 authoritative servers. In addition, the Recursor measures the total amount of time needed to answer a question. The
 difference between these two durations is a measure of how much time was spent within PowerDNS. This metric is the average
@@ -449,35 +451,49 @@ of that difference, in microseconds. Since 4.1.
 
 x-ourtime0-1
 ^^^^^^^^^^^^
+.. versionadded:: 4.1
+
 New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
 where between 0 and 1 milliseconds was spent within the Recursor. Since 4.1.
 
 x-ourtime1-2
 ^^^^^^^^^^^^
+.. versionadded:: 4.1
+
 New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
 where between 1 and 2 milliseconds was spent within the Recursor. Since 4.1.
 
 x-ourtime2-4
 ^^^^^^^^^^^^
+.. versionadded:: 4.1
+
 New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
 where between 2 and 4 milliseconds was spent within the Recursor. Since 4.1.
 
 x-ourtime4-8
 ^^^^^^^^^^^^
+.. versionadded:: 4.1
+
 New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
 where between 4 and 8 milliseconds was spent within the Recursor. Since 4.1.
 
 x-ourtime8-16
 ^^^^^^^^^^^^^
+.. versionadded:: 4.1
+
 New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
 where between 8 and 16 milliseconds was spent within the Recursor. Since 4.1.
 
 x-ourtime16-32
 ^^^^^^^^^^^^^^
+.. versionadded:: 4.1
+
 New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
 where between 16 and 32 milliseconds was spent within the Recursor. Since 4.1.
 
 x-ourtime-slow
 ^^^^^^^^^^^^^^
+.. versionadded:: 4.1
+
 New metric, which is not yet proven to be reliable. See x-our-latency for further details. Counts responses
 where more than 32 milliseconds was spent within the Recursor. Since 4.1.

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -536,6 +536,10 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
 
           boost::optional<Netmask> nm;
           res=asyncresolveWrapper(remoteIP, d_doDNSSEC, qname, qtype.getCode(), false, false, &d_now, nm, &lwr);
+
+          d_totUsec += lwr.d_usec;
+          accountAuthLatency(lwr.d_usec, remoteIP.sin4.sin_family);
+
           // filter out the good stuff from lwr.result()
           if (res == 1) {
             for(const auto& rec : lwr.d_records) {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -870,7 +870,9 @@ struct RecursorStats
   std::atomic<uint64_t> answers0_1, answers1_10, answers10_100, answers100_1000, answersSlow;
   std::atomic<uint64_t> auth4Answers0_1, auth4Answers1_10, auth4Answers10_100, auth4Answers100_1000, auth4AnswersSlow;
   std::atomic<uint64_t> auth6Answers0_1, auth6Answers1_10, auth6Answers10_100, auth6Answers100_1000, auth6AnswersSlow;
-  double avgLatencyUsec;
+  std::atomic<uint64_t> ourtime0_1, ourtime1_2, ourtime2_4, ourtime4_8, ourtime8_16, ourtime16_32, ourtimeSlow;
+  double avgLatencyUsec{0};
+  double avgLatencyOursUsec{0};
   std::atomic<uint64_t> qcounter;     // not increased for unauth packets
   std::atomic<uint64_t> ipv6qcounter;
   std::atomic<uint64_t> tcpqcounter;


### PR DESCRIPTION
### Short description

With this commit, PowerDNS provides metrics on the difference between the time spent waiting for authoritative servers, and the amount of time elapsed between arrival of query
and sending out the response. This metric should be seen as experimental until operational experience proves its relevance.

<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
