### PR TITLE
Remove preprocessor directives for older GCC versions

### DIFF
--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -21,14 +21,6 @@
  */
 #ifndef DNSPACKET_HH
 
-#if __GNUC__ == 2
-#if __GNUC_MINOR__ < 95
-        #error Your compiler is too old! Try g++ 3.3 or higher
-#else
-        #warning There are known problems with PowerDNS binaries compiled by gcc version 2.95 and 2.96!
-#endif
-#endif
-
 #define DNSPACKET_HH
 
 #include <cstdio>

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -430,9 +430,7 @@ int main(int argc, char **argv)
   signal(SIGILL,tbhandler);
 #endif
 
-#if __GNUC__ >= 3
   std::ios_base::sync_with_stdio(false);
-#endif
 
   L.toConsole(Logger::Warning);
   try {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -935,11 +935,7 @@ public:
   string reason; //! Print this to tell the user what went wrong
 };
 
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 2)
-typedef boost::circular_buffer<SComboAddress> addrringbuf_t;
-#else
 typedef boost::circular_buffer<ComboAddress> addrringbuf_t;
-#endif
 extern thread_local std::unique_ptr<addrringbuf_t> t_servfailremotes, t_largeanswerremotes, t_remotes;
 
 extern thread_local std::unique_ptr<boost::circular_buffer<pair<DNSName,uint16_t> > > t_queryring, t_servfailqueryring;

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -2,7 +2,7 @@
 #define BOOST_TEST_NO_MAIN
 
 // Disable this code for gcc 4.8 and lower
-#if (__GNUC__ == 4 && __GNUC_MINOR__ > 8) || !__GNUC__
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 8) || !__GNUC__
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -2,7 +2,7 @@
 #define BOOST_TEST_NO_MAIN
 
 // Disable this code for gcc 4.8 and lower
-#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 8) || !__GNUC__
+#if (__GNUC__ == 4 && __GNUC_MINOR__ > 8) || !__GNUC__
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/pdns/zone2json.cc
+++ b/pdns/zone2json.cc
@@ -96,9 +96,7 @@ try
   vector<string> lines;
 
     reportAllTypes();
-#if __GNUC__ >= 3
     std::ios_base::sync_with_stdio(false);
-#endif
    
     ::arg().setSwitch("verbose","Verbose comments on operation")="no";
     ::arg().setSwitch("on-error-resume-next","Continue after errors")="no";

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -150,9 +150,7 @@ int main( int argc, char* argv[] )
 
         try
         {
-#if __GNUC__ >= 3
                 std::ios_base::sync_with_stdio( false );
-#endif
                 reportAllTypes();
                 args.setCmd( "help", "Provide a helpful message" );
                 args.setCmd( "version", "Print the version" );

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -267,10 +267,8 @@ int main(int argc, char **argv)
 try
 {
     reportAllTypes();
-#if __GNUC__ >= 3
     std::ios_base::sync_with_stdio(false);
-#endif
-   
+  
     ::arg().setSwitch("gpgsql","Output in format suitable for default gpgsqlbackend")="no";
     ::arg().setSwitch("gmysql","Output in format suitable for default gmysqlbackend")="no";
     ::arg().setSwitch("mydns","Output in format suitable for default mydnsbackend")="no";


### PR DESCRIPTION
…5158

### Short description
Removing preprocessor directives for GCC version lower then 4.7 issue #5158 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)