### PR TITLE
 auth: Handle a signing pipe worker dying with work still pending

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1424,7 +1424,7 @@ void testSpeed(DNSSECKeeper& dk, const DNSName& zone, const string& remote, int 
     throw runtime_error("No backends available for DNSSEC key storage");
   }
 
-  ChunkedSigningPipe csp(DNSName(zone), 1, remote, cores);
+  ChunkedSigningPipe csp(DNSName(zone), 1, cores);
   
   vector<DNSZoneRecord> signatures;
   uint32_t rnd;

--- a/pdns/signingpipe.cc
+++ b/pdns/signingpipe.cc
@@ -45,34 +45,19 @@ int readn(int fd, void* buffer, unsigned int len)
 }
 }
 
-
-// used to pass information to the new thread
-struct StartHelperStruct
-{
-  StartHelperStruct(ChunkedSigningPipe* csp, int id, int fd) : d_csp(csp), d_id(id), d_fd(fd){}
-  ChunkedSigningPipe* d_csp;
-  int d_id;
-  int d_fd;
-};
-
-// used to launch the new thread
-void* ChunkedSigningPipe::helperWorker(void* p)
-try
-{
-  StartHelperStruct shs=*(StartHelperStruct*)p;
-  delete (StartHelperStruct*)p;
-  
-  shs.d_csp->worker(shs.d_id, shs.d_fd);
-  return 0;
+void* ChunkedSigningPipe::helperWorker(ChunkedSigningPipe* csp, int fd)
+try {
+  csp->worker(fd);
+  return nullptr;
 }
 catch(...) {
   L<<Logger::Error<<"Unknown exception in signing thread occurred"<<endl;
-  return 0;
+  return nullptr;
 }
 
 ChunkedSigningPipe::ChunkedSigningPipe(const DNSName& signerName, bool mustSign, const string& servers, unsigned int workers)
   : d_signed(0), d_queued(0), d_outstanding(0), d_numworkers(workers), d_submitted(0), d_signer(signerName),
-    d_maxchunkrecords(100), d_tids(d_numworkers), d_mustSign(mustSign), d_final(false)
+    d_maxchunkrecords(100), d_threads(d_numworkers), d_mustSign(mustSign), d_final(false)
 {
   d_rrsetToSign = new rrset_t;
   d_chunks.push_back(vector<DNSZoneRecord>()); // load an empty chunk
@@ -87,7 +72,7 @@ ChunkedSigningPipe::ChunkedSigningPipe(const DNSName& signerName, bool mustSign,
       throw runtime_error("Unable to create communication socket in for ChunkedSigningPipe");
     setCloseOnExec(fds[0]);
     setCloseOnExec(fds[1]);
-    pthread_create(&d_tids[n], 0, helperWorker, (void*) new StartHelperStruct(this, n, fds[1]));
+    d_threads[n] = std::thread(helperWorker, this, fds[1]);
     setNonBlocking(fds[0]);
     d_sockets.push_back(fds[0]);
   }
@@ -96,15 +81,16 @@ ChunkedSigningPipe::ChunkedSigningPipe(const DNSName& signerName, bool mustSign,
 ChunkedSigningPipe::~ChunkedSigningPipe()
 {
   delete d_rrsetToSign;
+
   if(!d_mustSign)
     return;
+
   for(int fd :  d_sockets) {
     close(fd); // this will trigger all threads to exit
   }
-    
-  void* res;
-  for(pthread_t& tid :  d_tids) {
-    pthread_join(tid, &res);
+
+  for(auto& thread : d_threads) {
+    thread.join();
   }
   //cout<<"Did: "<<d_signed<<", records (!= chunks) submitted: "<<d_submitted<<endl;
 }
@@ -273,7 +259,8 @@ unsigned int ChunkedSigningPipe::getReady()
    }
    return sum;
 }
-void ChunkedSigningPipe::worker(int id, int fd)
+
+void ChunkedSigningPipe::worker(int fd)
 try
 {
   DNSSECKeeper dk;
@@ -347,62 +334,4 @@ vector<DNSZoneRecord> ChunkedSigningPipe::getChunk(bool final)
   return front;
 }
 
-#if 0
-
-  ServiceTuple st;
-  ComboAddress remote;
-  if(!servers.empty()) {
-    st.port=2000;
-    parseService(servers, st);
-    remote=ComboAddress(st.host, st.port);
-  }
-  
-  ///
-    if(!servers.empty()) {
-      fds[0] = socket(AF_INET, SOCK_STREAM, 0);
-      fds[1] = -1;
-      
-      if(connect(fds[0], (struct sockaddr*)&remote, remote.getSocklen()) < 0)
-        unixDie("Connecting to signing server");
-    }
-    else {
-/////
-      signal(SIGCHLD, SIG_IGN);
-      if(!fork()) { // child
-        dup2(fds[1], 0);
-        execl("./pdnsutil", "./pdnsutil", "--config-dir=./", "signing-slave", NULL);
-        // helperWorker(new StartHelperStruct(this, n));
-        return;
-      }
-      else 
-        close(fds[1]);
-#endif
-
-#if 0
-bool readLStringFromSocket(int fd, string& msg)
-{
-  msg.clear();
-  uint32_t len;
-  if(!readn(fd, &len, sizeof(len)))
-    return false;
-  
-  len = ntohl(len);
-  
-  scoped_array<char> buf(new char[len]);
-  readn(fd, buf.get(), len);
-  
-  msg.assign(buf.get(), len);
-  return true;
-}
-void writeLStringToSocket(int fd, const string& msg)
-{
-  string realmsg;
-  uint32_t len = htonl(msg.length());
-  string tot((char*)&len, 4);
-  tot+=msg;
-  
-  writen2(fd, tot.c_str(), tot.length());
-}
-
-#endif 
 

--- a/pdns/signingpipe.hh
+++ b/pdns/signingpipe.hh
@@ -21,9 +21,10 @@
  */
 #ifndef PDNS_SIGNINGPIPE
 #define PDNS_SIGNINGPIPE
-#include <vector>
-#include <pthread.h>
 #include <stdio.h>
+#include <thread>
+#include <vector>
+
 #include "dnsseckeeper.hh"
 #include "dns.hh"
 
@@ -56,9 +57,8 @@ private:
   void addSignedToChunks(chunk_t* signedChunk);
   pair<vector<int>, vector<int> > waitForRW(bool rd, bool wr, int seconds);
 
-  void worker(int n, int fd);
-  
-  static void* helperWorker(void* p);
+  static void* helperWorker(ChunkedSigningPipe* csp, int fd);
+  void worker(int fd);
 
   unsigned int d_numworkers;
   int d_submitted;
@@ -71,7 +71,7 @@ private:
   
   std::vector<int> d_sockets;
   std::set<int> d_eof;
-  vector<pthread_t> d_tids;
+  vector<std::thread> d_threads;
   bool d_mustSign;
   bool d_final;
 };

--- a/pdns/signingpipe.hh
+++ b/pdns/signingpipe.hh
@@ -41,15 +41,16 @@ public:
   typedef vector<DNSZoneRecord> rrset_t; 
   typedef rrset_t chunk_t; // for now
   
-  ChunkedSigningPipe(const DNSName& signerName, bool mustSign, /* FIXME servers is unused? */ const string& servers=string(), unsigned int numWorkers=3);
+  ChunkedSigningPipe(const DNSName& signerName, bool mustSign, unsigned int numWorkers=3);
   ~ChunkedSigningPipe();
   bool submit(const DNSZoneRecord& rr);
   chunk_t getChunk(bool final=false);
+  unsigned int getReady() const;
 
   std::atomic<unsigned long> d_signed;
-  int d_queued;
-  int d_outstanding;
-  unsigned int getReady();
+  unsigned int d_queued;
+  unsigned int d_outstanding;
+
 private:
   void flushToSign();	
   void dedupRRSet();
@@ -61,7 +62,7 @@ private:
   void worker(int fd);
 
   unsigned int d_numworkers;
-  int d_submitted;
+  unsigned int d_submitted;
 
   rrset_t* d_rrsetToSign;
   std::deque< std::vector<DNSZoneRecord> > d_chunks;
@@ -71,6 +72,8 @@ private:
   
   std::vector<int> d_sockets;
   std::set<int> d_eof;
+  std::map<int,int> d_outstandings;
+
   vector<std::thread> d_threads;
   bool d_mustSign;
   bool d_final;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -673,7 +673,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   trc.d_mac = outpacket->d_trc.d_mac;
   outpacket = getFreshAXFRPacket(q);
   
-  ChunkedSigningPipe csp(target, securedZone, "", ::arg().asNum("signing-threads", 1));
+  ChunkedSigningPipe csp(target, securedZone, ::arg().asNum("signing-threads", 1));
   
   typedef map<string, NSECXEntry> nsecxrepo_t;
   nsecxrepo_t nsecxrepo;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The current code detects that the corresponding pipe has been closed, but has no way to know if we were still expecting something from this worker or if this is a "normal" exit. This leads to `d_outstanding` not being decreased if we expected an answer from the dying worker, meaning we will wait forever for the result.
This patch keeps track of the number of answers we are expecting from each worker, treating a worker exiting while we still expect some answer from its end as an error.
It also move to the use of `std::thread` to get rid of the temporary allocated struct used to pass parameters to the new thread.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
