### PR TITLE
If accept() returns EAGAIN, Socket::accept() returns a null pointer

### DIFF
--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -96,7 +96,7 @@ public:
     int s=::accept(d_socket,(sockaddr *)&remote, &remlen);
     if(s<0) {
       if(errno==EAGAIN)
-        return 0;
+        return nullptr;
 
       throw NetworkError("Accepting a connection: "+string(strerror(errno)));
     }

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -350,6 +350,9 @@ void WebServer::go()
     while(true) {
       try {
         auto client = d_server->accept();
+        if (!client) {
+          continue;
+        }
         if (client->acl(acl)) {
           std::thread webHandler(WebServerConnectionThreadStart, this, client);
           webHandler.detach();

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -541,7 +541,9 @@ void AsyncServerNewConnectionMT(void *p) {
   AsyncServer *server = (AsyncServer*)p;
   try {
     auto socket = server->accept();
-    server->d_asyncNewConnectionCallback(socket);
+    if (socket) {
+      server->d_asyncNewConnectionCallback(socket);
+    }
   } catch (NetworkError &e) {
     // we're running in a shared process/thread, so can't just terminate/abort.
     return;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Gracefully handle `Socket::accept()` returning a null pointer on `EAGAIN`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
