### PR TITLE
Fix shadowed variables

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1309,9 +1309,9 @@ bool Bind2Backend::searchRecords(const string &pattern, int maxResults, vector<D
     for(state_t::const_iterator i = s_state.begin(); i != s_state.end() ; ++i) {
       BB2DomainInfo h;
       safeGetBBDomainInfo(i->d_id, &h);
-      shared_ptr<const recordstorage_t> handle = h.d_records.get();
+      shared_ptr<const recordstorage_t> rhandle = h.d_records.get();
 
-      for(recordstorage_t::const_iterator ri = handle->begin(); result.size() < static_cast<vector<DNSResourceRecord>::size_type>(maxResults) && ri != handle->end(); ri++) {
+      for(recordstorage_t::const_iterator ri = rhandle->begin(); result.size() < static_cast<vector<DNSResourceRecord>::size_type>(maxResults) && ri != rhandle->end(); ri++) {
         DNSName name = ri->qname.empty() ? i->d_name : (ri->qname+i->d_name);
         if (sm.match(name) || sm.match(ri->content)) {
           DNSResourceRecord r;

--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -82,7 +82,6 @@ public:
     }
     d_res_set = PQexecPrepared(d_db(), d_stmt.c_str(), d_nparams, paramValues, paramLengths, NULL, 0);
     ExecStatusType status = PQresultStatus(d_res_set);
-    string errmsg(PQresultErrorMessage(d_res_set));
     if (status != PGRES_COMMAND_OK && status != PGRES_TUPLES_OK && status != PGRES_NONFATAL_ERROR) {
       string errmsg(PQresultErrorMessage(d_res_set));
       releaseStatement();

--- a/modules/pipebackend/coprocess.cc
+++ b/modules/pipebackend/coprocess.cc
@@ -125,8 +125,8 @@ void CoProcess::checkStatus()
     throw PDNSException("Unable to ascertain status of coprocess "+itoa(d_pid)+" from "+itoa(getpid())+": "+string(strerror(errno)));
   else if(ret) {
     if(WIFEXITED(status)) {
-      int ret=WEXITSTATUS(status);
-      throw PDNSException("Coprocess exited with code "+itoa(ret));
+      int exitStatus=WEXITSTATUS(status);
+      throw PDNSException("Coprocess exited with code "+itoa(exitStatus));
     }
     if(WIFSIGNALED(status)) {
       int sig=WTERMSIG(status);

--- a/modules/remotebackend/pipeconnector.cc
+++ b/modules/remotebackend/pipeconnector.cc
@@ -24,17 +24,17 @@
 #endif
 #include "remotebackend.hh"
 
-PipeConnector::PipeConnector(std::map<std::string,std::string> options) {
-  if (options.count("command") == 0) {
+PipeConnector::PipeConnector(std::map<std::string,std::string> optionsMap) {
+  if (optionsMap.count("command") == 0) {
     L<<Logger::Error<<"Cannot find 'command' option in connection string"<<endl;
     throw PDNSException();
   }
-  this->command = options.find("command")->second;
-  this->options = options;
+  this->command = optionsMap.find("command")->second;
+  this->options = optionsMap;
   d_timeout=2000;
 
-  if (options.find("timeout") != options.end()) {
-     d_timeout = std::stoi(options.find("timeout")->second);
+  if (optionsMap.find("timeout") != optionsMap.end()) {
+     d_timeout = std::stoi(optionsMap.find("timeout")->second);
   }
 
   d_pid = -1;
@@ -190,8 +190,8 @@ bool PipeConnector::checkStatus()
     throw PDNSException("Unable to ascertain status of coprocess "+itoa(d_pid)+" from "+itoa(getpid())+": "+string(strerror(errno)));
   else if(ret) {
     if(WIFEXITED(status)) {
-      int ret=WEXITSTATUS(status);
-      throw PDNSException("Coprocess exited with code "+itoa(ret));
+      int exitStatus=WEXITSTATUS(status);
+      throw PDNSException("Coprocess exited with code "+itoa(exitStatus));
     }
     if(WIFSIGNALED(status)) {
       int sig=WTERMSIG(status);

--- a/modules/remotebackend/unixconnector.cc
+++ b/modules/remotebackend/unixconnector.cc
@@ -30,17 +30,17 @@
 #define UNIX_PATH_MAX 108
 #endif
 
-UnixsocketConnector::UnixsocketConnector(std::map<std::string,std::string> options) {
-  if (options.count("path") == 0) {
+UnixsocketConnector::UnixsocketConnector(std::map<std::string,std::string> optionsMap) {
+  if (optionsMap.count("path") == 0) {
     L<<Logger::Error<<"Cannot find 'path' option in connection string"<<endl;
     throw PDNSException();
   } 
   this->timeout = 2000;
-  if (options.find("timeout") != options.end()) { 
-    this->timeout = std::stoi(options.find("timeout")->second);
+  if (optionsMap.find("timeout") != optionsMap.end()) {
+    this->timeout = std::stoi(optionsMap.find("timeout")->second);
   }
-  this->path = options.find("path")->second;
-  this->options = options;
+  this->path = optionsMap.find("path")->second;
+  this->options = optionsMap;
   this->connected = false;
   this->fd = -1;
 }

--- a/pdns/auth-querycache.hh
+++ b/pdns/auth-querycache.hh
@@ -107,7 +107,7 @@ private:
 
   uint64_t d_maxEntries{0};
   time_t d_lastclean; // doesn't need to be atomic
-  unsigned long d_nextclean{4906};
+  unsigned long d_nextclean{4096};
   unsigned int d_cleaninterval{4096};
   bool d_cleanskipped{false};
 

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -253,8 +253,8 @@ try
   while(getline(ifs, line)) {
     vector<uint8_t> packet;
     boost::trim(line);
-    auto p = splitField(line, ' ');
-    DNSPacketWriter pw(packet, DNSName(p.first), DNSRecordContent::TypeToNumber(p.second));
+    const auto fields = splitField(line, ' ');
+    DNSPacketWriter pw(packet, DNSName(fields.first), DNSRecordContent::TypeToNumber(fields.second));
     pw.getHeader()->rd=wantRecursion;
     pw.getHeader()->id=random();
     if(pw.getHeader()->id % 2) {

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -645,9 +645,9 @@ bool DNSSECKeeper::rectifyZone(const DNSName& zone, string& error, bool doTransa
 
   set<DNSName> nsec3set;
   if (haveNSEC3 && !narrow) {
-    for (auto &rr: rrs) {
+    for (auto &loopRR: rrs) {
       bool skip=false;
-      DNSName shorter = rr.qname;
+      DNSName shorter = loopRR.qname;
       if (shorter != zone && shorter.chopOff() && shorter != zone) {
         do {
           if(nsset.count(shorter)) {
@@ -656,8 +656,8 @@ bool DNSSECKeeper::rectifyZone(const DNSName& zone, string& error, bool doTransa
           }
         } while(shorter.chopOff() && shorter != zone);
       }
-      shorter = rr.qname;
-      if(!skip && (rr.qtype.getCode() != QType::NS || !isOptOut)) {
+      shorter = loopRR.qname;
+      if(!skip && (loopRR.qtype.getCode() != QType::NS || !isOptOut)) {
 
         do {
           if(!nsec3set.count(shorter)) {

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2477,8 +2477,8 @@ catch(const LuaContext::ExecutionErrorException& e) {
   try {
     errlog("Fatal Lua error: %s", e.what());
     std::rethrow_if_nested(e);
-  } catch(const std::exception& e) {
-    errlog("Details: %s", e.what());
+  } catch(const std::exception& ne) {
+    errlog("Details: %s", ne.what());
   }
   catch(PDNSException &ae)
   {

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -649,17 +649,17 @@ bool sendPacketFromPR(PcapPacketReader& pr, const ComboAddress& remote, int stam
       s_origanswers++;
       qids_t::const_iterator iter=qids.find(qi);      
       if(iter != qids.end()) {
-        QuestionData qd=*iter;
-        qd.d_origAnswers=mdp.d_answers;
-        qd.d_origRcode=mdp.d_header.rcode;
+        QuestionData eqd=*iter;
+        eqd.d_origAnswers=mdp.d_answers;
+        eqd.d_origRcode=mdp.d_header.rcode;
         
         if(!dh->ra) {
           s_norecursionavailable++;
-          qd.d_norecursionavailable=true;
+          eqd.d_norecursionavailable=true;
         }
-        qids.replace(iter, qd);
+        qids.replace(iter, eqd);
 
-        if(qd.d_newRcode!=-1) {
+        if(eqd.d_newRcode!=-1) {
           measureResultAndClean(iter);
         }
         

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -425,7 +425,7 @@ bool isTCPSocketUsable(int sock)
       return false;
     }
     else {
-      int err = errno;
+      err = errno;
 
       if (err == EAGAIN || err == EWOULDBLOCK) {
         /* socket is usable, no data waiting */

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -84,8 +84,8 @@ AuthLua4::AuthLua4(const std::string& fname) {
                                                                                        cas.insert(ComboAddress(*s));
                                                                                      }
                                                                                      else if(auto v = boost::get<vector<pair<unsigned int, string> > >(&in)) {
-                                                                                       for(const auto& s : *v)
-                                                                                         cas.insert(ComboAddress(s.second));
+                                                                                       for(const auto& str : *v)
+                                                                                         cas.insert(ComboAddress(str.second));
                                                                                      }
                                                                                      else
                                                                                        cas.insert(boost::get<ComboAddress>(in));
@@ -136,8 +136,8 @@ AuthLua4::AuthLua4(const std::string& fname) {
 
       if(auto rec = std::dynamic_pointer_cast<ARecordContent>(dr.d_content))
         ret=rec->getCA(53);
-      else if(auto rec = std::dynamic_pointer_cast<AAAARecordContent>(dr.d_content))
-        ret=rec->getCA(53);
+      else if(auto aaaarec = std::dynamic_pointer_cast<AAAARecordContent>(dr.d_content))
+        ret=aaaarec->getCA(53);
       return ret;
     });
 

--- a/pdns/nproxy.cc
+++ b/pdns/nproxy.cc
@@ -91,8 +91,7 @@ try
   if(res < 0) 
     throw runtime_error("reading packet from remote: "+stringerror());
     
-  string packet(buffer, res);
-  MOADNSParser mdp(true, packet);
+  MOADNSParser mdp(true, string(buffer,res));
   nif.domain = mdp.d_qname;
   nif.origID = mdp.d_header.id;
 

--- a/pdns/nsec3dig.cc
+++ b/pdns/nsec3dig.cc
@@ -212,17 +212,17 @@ try
   set<DNSName> proven;
   set<DNSName> denied;
   namesseen.insert(qname);
-  for(const auto &n: namesseen)
+  for(const auto &name: namesseen)
   {
-    DNSName shorter(n);
+    DNSName shorter(name);
     do {
       namestocheck.insert(shorter);
     } while(shorter.chopOff());
   }
-  for(const auto &n: namestocheck)
+  for(const auto &name: namestocheck)
   {
-    proveOrDeny(nsec3s, n, nsec3salt, nsec3iters, proven, denied);
-    proveOrDeny(nsec3s, g_wildcarddnsname+n, nsec3salt, nsec3iters, proven, denied);
+    proveOrDeny(nsec3s, name, nsec3salt, nsec3iters, proven, denied);
+    proveOrDeny(nsec3s, g_wildcarddnsname+name, nsec3salt, nsec3iters, proven, denied);
   }
 
   if(names.count(qname))

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -582,7 +582,6 @@ void PacketHandler::addNSEC3(DNSPacket *p, DNSPacket *r, const DNSName& target, 
   bool doNextcloser = false;
   string before, after, hashed;
   DNSName unhashed, closest;
-  DNSZoneRecord rr;
 
   if (mode == 2 || mode == 3 || mode == 4) {
     closest=wildcard;
@@ -622,8 +621,7 @@ void PacketHandler::addNSEC3(DNSPacket *p, DNSPacket *r, const DNSName& target, 
     if (!after.empty()) {
       DLOG(L<<"Done calling for matching, hashed: '"<<toBase32Hex(hashed)<<"' before='"<<toBase32Hex(before)<<"', after='"<<toBase32Hex(after)<<"'"<<endl);
       emitNSEC3(r, sd, ns3rc, unhashed, before, after, mode);
-    } else if(!before.empty())
-      r->addRecord(rr);
+    }
   }
 
   // add covering NSEC3 RR
@@ -1382,10 +1380,10 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     }
                                        
     if(weRedirected) {
-      for(auto& rr: rrset) {
-        if(rr.dr.d_type == QType::CNAME) {
-          r->addRecord(rr);
-          target = getRR<CNAMERecordContent>(rr.dr)->getTarget();
+      for(auto& loopRR: rrset) {
+        if(loopRR.dr.d_type == QType::CNAME) {
+          r->addRecord(loopRR);
+          target = getRR<CNAMERecordContent>(loopRR.dr)->getTarget();
           retargetcount++;
           goto retargeted;
         }
@@ -1393,9 +1391,9 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     }
     else if(weDone) {
       bool haveRecords = false;
-      for(const auto& rr: rrset) {
-        if((p->qtype.getCode() == QType::ANY || rr.dr.d_type == p->qtype.getCode()) && rr.dr.d_type && rr.dr.d_type != QType::ALIAS && rr.auth) {
-          r->addRecord(rr);
+      for(const auto& loopRR: rrset) {
+        if((p->qtype.getCode() == QType::ANY || loopRR.dr.d_type == p->qtype.getCode()) && loopRR.dr.d_type && loopRR.dr.d_type != QType::ALIAS && loopRR.auth) {
+          r->addRecord(loopRR);
           haveRecords = true;
         }
       }
@@ -1433,8 +1431,8 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
 
     editSOA(d_dk, sd.qname, r);
     
-    for(const auto& rr: r->getRRS()) {
-      if(rr.scopeMask) {
+    for(const auto& loopRR: r->getRRS()) {
+      if(loopRR.scopeMask) {
         noCache=true;
         break;
       }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1267,8 +1267,8 @@ static void startDoResolve(void *p)
     // Luawrapper nests the exception from Lua, so we unnest it here
     try {
         std::rethrow_if_nested(e);
-    } catch(const std::exception& e) {
-        L<<". Extra info: "<<e.what();
+    } catch(const std::exception& ne) {
+        L<<". Extra info: "<<ne.what();
     } catch(...) {}
 
     L<<endl;

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -74,27 +74,27 @@ protected:
     buflen = 0;
   };
 public:
-  P11KitAttribute(CK_ATTRIBUTE_TYPE type, const std::string& value) {
+  P11KitAttribute(CK_ATTRIBUTE_TYPE type_, const std::string& value) {
     Init();
-    this->type = type;
+    this->type = type_;
     setString(value);
   }
 
-  P11KitAttribute(CK_ATTRIBUTE_TYPE type, char value) {
+  P11KitAttribute(CK_ATTRIBUTE_TYPE type_, char value) {
     Init();
-    this->type = type;
+    this->type = type_;
     setByte(value);
   }
 
-  P11KitAttribute(CK_ATTRIBUTE_TYPE type, unsigned char value) {
+  P11KitAttribute(CK_ATTRIBUTE_TYPE type_, unsigned char value) {
     Init();
-    this->type = type;
+    this->type = type_;
     setByte(value);
   }
 
-  P11KitAttribute(CK_ATTRIBUTE_TYPE type, unsigned long value) {
+  P11KitAttribute(CK_ATTRIBUTE_TYPE type_, unsigned long value) {
     Init();
-    this->type = type;
+    this->type = type_;
     setLong(value);
   }
 
@@ -571,9 +571,9 @@ class Pkcs11Token {
       }
 
       // then allocate memory
-      for(size_t k=0; k < attributes.size(); k++) {
-        if (attributes[k].valueType() == Attribute_String) {
-          attr[k].pValue = attributes[k].allocate(attr[k].ulValueLen);
+      for(size_t idx=0; idx < attributes.size(); idx++) {
+        if (attributes[idx].valueType() == Attribute_String) {
+          attr[idx].pValue = attributes[idx].allocate(attr[idx].ulValueLen);
         }
       }
 
@@ -582,9 +582,9 @@ class Pkcs11Token {
       logError("C_GetAttributeValue");
 
       // copy values to map and release allocated memory
-      for(size_t k=0; k < attributes.size(); k++) {
-        if (attributes[k].valueType() == Attribute_String) {
-          attributes[k].commit(attr[k].ulValueLen);
+      for(size_t idx=0; idx < attributes.size(); idx++) {
+        if (attributes[idx].valueType() == Attribute_String) {
+          attributes[idx].commit(attr[idx].ulValueLen);
         }
       }
 

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -574,12 +574,12 @@ BOOST_AUTO_TEST_CASE(test_RecursorCache_ExpungingValidEntries) {
   size_t found = 0;
   for (size_t i = 0; i <= 255; i++) {
     retrieved.clear();
-    ComboAddress who("192.0.2." + std::to_string(i));
+    ComboAddress whoLoop("192.0.2." + std::to_string(i));
 
-    auto ret = MRC.get(now, power1, QType(QType::A), false, &retrieved, who);
+    auto ret = MRC.get(now, power1, QType(QType::A), false, &retrieved, whoLoop);
     if (ret > 0) {
       BOOST_REQUIRE_EQUAL(retrieved.size(), 1);
-      BOOST_CHECK_EQUAL(getRR<ARecordContent>(retrieved.at(0))->getCA().toString(), who.toString());
+      BOOST_CHECK_EQUAL(getRR<ARecordContent>(retrieved.at(0))->getCA().toString(), whoLoop.toString());
       found++;
     }
     else {

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -1911,7 +1911,6 @@ BOOST_AUTO_TEST_CASE(test_no_rd) {
 
 BOOST_AUTO_TEST_CASE(test_cache_min_max_ttl) {
   std::unique_ptr<SyncRes> sr;
-  const time_t now = time(nullptr);
   initSR(sr);
 
   primeHints();
@@ -1938,6 +1937,7 @@ BOOST_AUTO_TEST_CASE(test_cache_min_max_ttl) {
       return 0;
     });
 
+  const time_t now = time(nullptr);
   SyncRes::s_minimumTTL = 60;
   SyncRes::s_maxcachettl = 3600;
 
@@ -7343,7 +7343,6 @@ BOOST_AUTO_TEST_CASE(test_nsec3_insecure_delegation_denial) {
 
 BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity) {
   std::unique_ptr<SyncRes> sr;
-  const time_t now = time(nullptr);
   initSR(sr, true);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
@@ -7381,6 +7380,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity) {
       return 0;
     });
 
+  const time_t now = time(nullptr);
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
@@ -7409,7 +7409,6 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity) {
 
 BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_cache_validity) {
   std::unique_ptr<SyncRes> sr;
-  const time_t now = time(nullptr);
   initSR(sr, true);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
@@ -7446,6 +7445,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_cache_validity) {
       return 0;
     });
 
+  const time_t now = time(nullptr);
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);

--- a/pdns/saxfr.cc
+++ b/pdns/saxfr.cc
@@ -204,9 +204,7 @@ try
       n+=numread;
     }
 
-    string packet = string(creply, len);
-
-    MOADNSParser mdp(false, packet);
+    MOADNSParser mdp(false, string(creply, len));
     if (mdp.d_header.rcode != 0) {
       throw PDNSException(string("Remote server refused: ") + std::to_string(mdp.d_header.rcode));
     }

--- a/pdns/statnode.cc
+++ b/pdns/statnode.cc
@@ -88,8 +88,9 @@ void StatNode::submit(deque<string>& labels, const std::string& domain, int rcod
     name=labels.back();
     //    cerr<<"Set short name to '"<<name<<"'"<<endl;
   }
-  else 
-    ; //    cerr<<"Short name was already set to '"<<name<<"'"<<endl;
+  else {
+    //    cerr<<"Short name was already set to '"<<name<<"'"<<endl;
+  }
 
   if(labels.size()==1) {
     if (fullname.empty()) {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -871,9 +871,9 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
         }
 
         for(const auto& rec : authorityRecs) {
-          DNSRecord dr(*rec);
-          dr.d_ttl=j->d_ttl - d_now.tv_sec;
-          ret.push_back(dr);
+          DNSRecord authDR(*rec);
+          authDR.d_ttl=j->d_ttl - d_now.tv_sec;
+          ret.push_back(authDR);
         }
 
         if(qtype != QType::CNAME) { // perhaps they really wanted a CNAME!
@@ -1559,8 +1559,8 @@ void SyncRes::computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned
        just look for (N)TA
     */
     if (cutState == Insecure || cutState == Bogus) {
-      dsmap_t ds;
-      vState newState = getDSRecords(qname, ds, true, depth);
+      dsmap_t cutDS;
+      vState newState = getDSRecords(qname, cutDS, true, depth);
       if (newState == Indeterminate) {
         continue;
       }

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(test_QuestionHash) {
  
   for(unsigned int n=0; n < 100000; ++n) {
     packet.clear();
-    DNSPacketWriter dpw1(packet, DNSName(std::to_string(n)+"."+std::to_string(n*2)+"."), QType::AAAA);
+    DNSPacketWriter dpw3(packet, DNSName(std::to_string(n)+"."+std::to_string(n*2)+"."), QType::AAAA);
     counts[hashQuestion((char*)&packet[0], packet.size(), 0) % counts.size()]++;
   }
   
@@ -597,17 +597,17 @@ BOOST_AUTO_TEST_CASE(test_compare_canonical) {
   BOOST_CHECK(!a(DNSName("www.powerdns.net"), g_rootdnsname));
 
   vector<DNSName> vec;
-  for(const std::string& a : {"bert.com.", "alpha.nl.", "articles.xxx.",
+  for(const std::string& b : {"bert.com.", "alpha.nl.", "articles.xxx.",
 	"Aleph1.powerdns.com.", "ZOMG.powerdns.com.", "aaa.XXX.", "yyy.XXX.", 
 	"test.powerdns.com.", "\\128.com"}) {
-    vec.push_back(DNSName(a));
+    vec.push_back(DNSName(b));
   }
   sort(vec.begin(), vec.end(), CanonDNSNameCompare());
   //  for(const auto& v : vec)
   //    cerr<<'"'<<v.toString()<<'"'<<endl;
 
   vector<DNSName> right;
-  for(const auto& a: {"bert.com.",  "Aleph1.powerdns.com.",
+  for(const auto& b: {"bert.com.",  "Aleph1.powerdns.com.",
 	"test.powerdns.com.",
 	"ZOMG.powerdns.com.",
 	"\\128.com.",
@@ -615,7 +615,7 @@ BOOST_AUTO_TEST_CASE(test_compare_canonical) {
 	"aaa.XXX.",
 	"articles.xxx.",
 	"yyy.XXX."})
-    right.push_back(DNSName(a));
+    right.push_back(DNSName(b));
 
   
   BOOST_CHECK(vec==right);

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -195,11 +195,11 @@ bool ZoneParserTNG::getTemplateLine()
         char radix='d';
         sscanf(spec.c_str(), "%d,%d,%c", &offset, &width, &radix);  // parse format specifier
 
-        char format[12];
-        snprintf(format, sizeof(format) - 1, "%%0%d%c", width, radix); // make into printf-style format
+        char sformat[12];
+        snprintf(sformat, sizeof(sformat) - 1, "%%0%d%c", width, radix); // make into printf-style format
 
         char tmp[80];
-        snprintf(tmp, sizeof(tmp)-1, format, d_templatecounter + offset); // and do the actual printing
+        snprintf(tmp, sizeof(tmp)-1, sformat, d_templatecounter + offset); // and do the actual printing
         outpart+=tmp;
       }
       else


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Let's try not to shadow variable by declaring a new variable with the same name in the scope of the previous one. Fix a bug in the way `isTCPSocketUsable()` handles `EINTR` errors.
Reported by GCC's `-Wshadow`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
