### PR TITLE
auth: Fix missing else braces in TinyDNSBackend::get()

### DIFF
--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -309,9 +309,10 @@ bool TinyDNSBackend::get(DNSResourceRecord &rr)
         if (d_ignorebogus) {
           L<<". Ignoring!"<<endl;
           continue;
-        } else
+        } else {
           L<<". Erroring out!"<<endl;
           throw;
+        }
       }
 //      DLOG(L<<Logger::Debug<<backendname<<"Returning ["<<rr.content<<"] for ["<<rr.qname<<"] of RecordType ["<<rr.qtype.getName()<<"]"<<endl;);
       return true;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It doesn't look like an issue since there is a `continue` at the end of the alternative, but this is a lot cleaner that way.
Reported by Coverity.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
