### PR TITLE
Fix throwing exceptions from MThreads, plus add unit tests

### DIFF
--- a/pdns/mtasker.cc
+++ b/pdns/mtasker.cc
@@ -344,6 +344,8 @@ template<class Key, class Val>bool MTasker<Key,Val>::schedule(struct timeval*  n
       }
       else if(i->ttd.tv_sec)
         break;
+      else
+	++i;
     }
   }
   return false;

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -206,7 +206,7 @@ testrunner_SOURCES = \
 	ixfr.cc ixfr.hh \
 	logger.cc logger.hh \
 	misc.cc misc.hh \
-	mtasker_fcontext.cc \
+	mtasker_context.cc \
 	negcache.hh negcache.cc \
 	namespaces.hh \
 	nsecrecords.cc \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -206,6 +206,7 @@ testrunner_SOURCES = \
 	ixfr.cc ixfr.hh \
 	logger.cc logger.hh \
 	misc.cc misc.hh \
+	mtasker_fcontext.cc \
 	negcache.hh negcache.cc \
 	namespaces.hh \
 	nsecrecords.cc \
@@ -237,6 +238,7 @@ testrunner_SOURCES = \
 	test-iputils_hh.cc \
 	test-ixfr_cc.cc \
 	test-misc_hh.cc \
+	test-mtasker.cc \
 	test-nmtree.cc \
 	test-negcache_cc.cc \
 	test-rcpgenerator_cc.cc \
@@ -254,10 +256,12 @@ testrunner_SOURCES = \
 
 testrunner_LDFLAGS = \
 	$(AM_LDFLAGS) \
+	$(BOOST_CONTEXT_LDFLAGS) \
 	$(BOOST_UNIT_TEST_FRAMEWORK_LDFLAGS) \
 	$(LIBCRYPTO_LDFLAGS)
 
 testrunner_LDADD = \
+	$(BOOST_CONTEXT_LIBS) \
 	$(BOOST_UNIT_TEST_FRAMEWORK_LIBS) \
 	$(LIBCRYPTO_LIBS) \
 	$(RT_LIBS)

--- a/pdns/recursordist/test-mtasker.cc
+++ b/pdns/recursordist/test-mtasker.cc
@@ -1,0 +1,60 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+#include "mtasker.hh"
+
+BOOST_AUTO_TEST_SUITE(mtasker_cc)
+
+static int g_result;
+
+static void doSomething(void* p)
+{
+  MTasker<>* mt = reinterpret_cast<MTasker<>*>(p);
+  int i=12, o;
+  mt->waitEvent(i, &o);
+  g_result = o;
+  
+}
+
+BOOST_AUTO_TEST_CASE(test_Simple) {
+  MTasker<> mt;
+  mt.makeThread(doSomething, &mt);
+  struct timeval now;
+  gettimeofday(&now, 0);
+  bool first=true;
+  int o=24;
+  for(;;) {
+    while(mt.schedule(&now));
+    if(first) {
+      mt.sendEvent(12, &o);
+      first=false;
+    }
+    if(mt.noProcesses())
+      break;
+  }
+  BOOST_CHECK_EQUAL(g_result, o);
+}
+
+static void willThrow(void* p)
+{
+  throw std::runtime_error("Help!");
+}
+
+
+BOOST_AUTO_TEST_CASE(test_MtaskerException) {
+  BOOST_CHECK_EXCEPTION( {
+      MTasker<> mt;
+      mt.makeThread(willThrow, 0);
+      struct timeval now;
+      
+      for(;;) {
+	mt.schedule(&now);
+      }
+    }, std::exception, [](const std::exception& e) { return true; });
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-mtasker.cc
+++ b/pdns/recursordist/test-mtasker.cc
@@ -47,7 +47,7 @@ static void willThrow(void* p)
 
 
 BOOST_AUTO_TEST_CASE(test_MtaskerException) {
-  BOOST_CHECK_EXCEPTION( {
+  BOOST_CHECK_THROW( {
       MTasker<> mt;
       mt.makeThread(willThrow, 0);
       struct timeval now;
@@ -55,6 +55,6 @@ BOOST_AUTO_TEST_CASE(test_MtaskerException) {
       for(;;) {
 	mt.schedule(&now);
       }
-    }, std::exception, [](const std::exception& e) { return true; });
+    }, std::exception);
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
In MTasker, MThreads can throw exceptions, which then get caught by the 'kernel' thread. This mechanism was faulty in our 'old boost' support, leading to crashes in std::rethrow_exception. 
This PR fixes the 'old boost' support, plus adds a testcase for throwing & catching such exceptions. In addition, this simple testcase found a bug in MTasker with timeoutless waiters. This has also been solved.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
