### PR TITLE
BIND backend: Several improvements for b2b-migrate

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -353,6 +353,7 @@ void Bind2Backend::getAllDomains(vector<DomainInfo> *domains, bool include_disab
       di.zone=i->d_name;
       di.last_check=i->d_lastcheck;
       di.kind=i->d_masters.empty() ? DomainInfo::Master : DomainInfo::Slave; //TODO: what about Native?
+      di.masters=i->d_masters;
       di.backend=this;
       domains->push_back(di);
     };

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -302,7 +302,7 @@ void Bind2Backend::getUpdatedMasters(vector<DomainInfo> *changedDomains)
     ReadLock rl(&s_state_lock);
 
     for(state_t::const_iterator i = s_state.begin(); i != s_state.end() ; ++i) {
-      if(i->d_kind != DomainInfo::Master)
+      if(i->d_kind != DomainInfo::Master && this->alsoNotify.empty() && i->d_also_notify.empty())
         continue;
 
       DomainInfo di;

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -159,6 +159,7 @@ public:
   void setCheckInterval(time_t seconds);
 
   DNSName d_name;   //!< actual name of the domain
+  DomainInfo::DomainKind d_kind; //!< the kind of domain
   string d_filename; //!< full absolute filename of the zone on disk
   string d_status; //!< message describing status of a domain, for human consumption
   vector<string> d_masters;     //!< IP address of the master of this domain

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3241,9 +3241,15 @@ try
       if (!tgt->createDomain(di.zone)) throw PDNSException("Failed to create zone");
       tgt->setKind(di.zone, di.kind);
       tgt->setAccount(di.zone,di.account);
+      string masters="";
+      bool first = true;
       for(const string& master: di.masters) {
-        tgt->setMaster(di.zone, master);
+        if (!first)
+          masters += ", ";
+        first = false;
+        masters += master;
       }
+      tgt->setMaster(di.zone, masters);
       // move records
       if (!src->list(di.zone, di.id, true)) throw PDNSException("Failed to list records");
       nr=0;


### PR DESCRIPTION
### Short description
While attempting to do a migration from the BIND backend to gsqlite3, several issues arose:

* No masters were set in the target db (#5807)
* Only the last master in the list of masters would be added to the target database
* The BIND backend was not fully aware of native zones

The last issue stemmed from an incomplete implementation in #5115.

This PR aims to fix all these issues.

Note: the b2b-migrate patch for setting the masters correctly and the patch to add the masters to the DomainInfo might need to be backported to 4.0.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)