### PR TITLE
auth: ldapbackend, use the timeout setting in the PowerLDAP class

### DIFF
--- a/modules/ldapbackend/ldapbackend.cc
+++ b/modules/ldapbackend/ldapbackend.cc
@@ -81,7 +81,7 @@ LdapBackend::LdapBackend( const string &suffix )
 
     L << Logger::Info << m_myname << " LDAP servers = " << hoststr << endl;
 
-    m_pldap = new PowerLDAP( hoststr.c_str(), LDAP_PORT, mustDo( "starttls" ) );
+    m_pldap = new PowerLDAP( hoststr.c_str(), LDAP_PORT, mustDo( "starttls" ), getArgAsNum( "timeout" ) );
     m_pldap->setOption( LDAP_OPT_DEREF, LDAP_DEREF_ALWAYS );
 
     string bindmethod = getArg( "bindmethod" );

--- a/modules/ldapbackend/ldaputils.hh
+++ b/modules/ldapbackend/ldaputils.hh
@@ -31,6 +31,6 @@ void ldapGetOption( LDAP *conn, int option, void *value );
 
 std::string ldapGetError( LDAP *conn, int code );
 
-int ldapWaitResult( LDAP *conn, int msgid = LDAP_RES_ANY, int timeout = 0, LDAPMessage** result = NULL );
+int ldapWaitResult( LDAP *conn, int msgid, int timeout, LDAPMessage** result = NULL );
 
 #endif // LDAPUTILS_HH

--- a/modules/ldapbackend/powerldap.hh
+++ b/modules/ldapbackend/powerldap.hh
@@ -47,16 +47,17 @@ class PowerLDAP
     string d_hosts;
     int d_port;
     bool d_tls;
-  
+    int d_timeout;
+
     const string getError( int rc = -1 );
-    int waitResult( int msgid = LDAP_RES_ANY, int timeout = 0, LDAPMessage** result = NULL );
+    int waitResult( int msgid = LDAP_RES_ANY, LDAPMessage** result = NULL );
     void ensureConnect();
     
   public:
     typedef map<string, vector<string> > sentry_t;
     typedef vector<sentry_t> sresult_t;
   
-    PowerLDAP( const string& hosts = "ldap://127.0.0.1/", uint16_t port = LDAP_PORT, bool tls = false );
+    PowerLDAP( const string& hosts, uint16_t port, bool tls, int timeout );
     ~PowerLDAP();
   
     bool connect();
@@ -65,13 +66,13 @@ class PowerLDAP
     void setOption( int option, int value );
   
     void bind( LdapAuthenticator *authenticator );
-    void bind( const string& ldapbinddn = "", const string& ldapsecret = "", int method = LDAP_AUTH_SIMPLE, int timeout = 5 );
+    void bind( const string& ldapbinddn = "", const string& ldapsecret = "", int method = LDAP_AUTH_SIMPLE );
     void simpleBind( const string& ldapbinddn = "", const string& ldapsecret = "" );
     int search( const string& base, int scope, const string& filter, const char** attr = 0 );
     void modify( const string& dn, LDAPMod *mods[], LDAPControl **scontrols = 0, LDAPControl **ccontrols = 0 );
   
-    bool getSearchEntry( int msgid, sentry_t& entry, bool dn = false, int timeout = 5 );
-    void getSearchResults( int msgid, sresult_t& result, bool dn = false, int timeout = 5 );
+    bool getSearchEntry( int msgid, sentry_t& entry, bool dn = false );
+    void getSearchResults( int msgid, sresult_t& result, bool dn = false );
   
     static const string escape( const string& tobe );
 };


### PR DESCRIPTION
### Short description
Make sure the timeout from the settings is used in the PowerLDAP class
With a little luck this fixes #5742 

Could use some testing. @sooslaca?

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
