### PR TITLE
b.root renumbering, effective 2017-10-24

### DIFF
--- a/pdns/root-addresses.hh
+++ b/pdns/root-addresses.hh
@@ -22,7 +22,7 @@
 #pragma once
 
 static const char* const rootIps4[]={"198.41.0.4",             // a.root-servers.net.
-                                     "192.228.79.201",         // b.root-servers.net.
+                                     "199.9.14.201",           // b.root-servers.net.
                                      "192.33.4.12",            // c.root-servers.net.
                                      "199.7.91.13",            // d.root-servers.net.
                                      "192.203.230.10",         // e.root-servers.net.
@@ -38,7 +38,7 @@ static const char* const rootIps4[]={"198.41.0.4",             // a.root-servers
 static size_t const rootIps4Count = sizeof(rootIps4) / sizeof(*rootIps4);
 
 static const char* const rootIps6[]={"2001:503:ba3e::2:30",    // a.root-servers.net.
-                                     "2001:500:200::b",         // b.root-servers.net.
+                                     "2001:500:200::b",        // b.root-servers.net.
                                      "2001:500:2::c",          // c.root-servers.net.
                                      "2001:500:2d::d",         // d.root-servers.net.
                                      "2001:500:a8::e",         // e.root-servers.net.


### PR DESCRIPTION
### Short description
new b.root ipv4 address
closes  #5663

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
