### PR TITLE
Fix some of the issues found by @jpmens

### DIFF
--- a/docs/dnssec/modes-of-operation.rst
+++ b/docs/dnssec/modes-of-operation.rst
@@ -137,6 +137,8 @@ not required to be rectified on the master.
 
 Signatures and Hashing is similar as described in :ref:`dnssec-online-signing`.
 
+.. _dnssec-modes-bind-mode:
+
 BIND-mode operation
 -------------------
 
@@ -147,6 +149,9 @@ To use this mode, add
 ``bind-dnssec-db=/var/db/bind-dnssec-db.sqlite3`` to pdns.conf, and run
 ``pdnsutil create-bind-db /var/db/bind-dnssec-db.sqlite3``. Then,
 restart PowerDNS.
+
+.. note::
+  This sqlite database is different from the database used for the regular :doc:`SQLite 3 backend <../backends/generic-sqlite3>`.
 
 After this, you can use ``pdnsutil secure-zone`` and all other pdnsutil
 commands on your BIND zones without trouble.
@@ -167,8 +172,8 @@ In hybrid mode, keying material and zone records are stored in different
 backends. This allows for 'bindbackend' operation in full DNSSEC mode.
 
 To benefit from this mode, include at least one database-based backend
-in the 'launch' statement. The :doc:`SQLite 3 backend <../backends/generic-sqlite3>` probably complements BIND mode
-best, since it does not require a database server process.
+in the :ref:`setting-launch` statement. See the :doc:`backend specific documentation <../backends/index>`
+on how to initialize the database and backend.
 
 .. warning::
   For now, it is necessary to execute a manual SQL 'insert'
@@ -177,3 +182,9 @@ best, since it does not require a database server process.
   statement::
 
       insert into domains (name, type) values ('powerdnssec.org', 'NATIVE');
+
+The :doc:`SQLite 3 backend <../backends/generic-sqlite3>` probably complements BIND mode best, since it does not require a database server process.
+
+.. note::
+  The sqlite3 database must be created using the normal schema for this backend.
+  The database created with ``pdnsutil create-bind-db`` will not work in this backend.

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -143,6 +143,12 @@ ZONE MANIPULATION COMMANDS
 
 create-zone *ZONE*
     Create an empty zone named *ZONE*.
+create-slave-zone *ZONE* *MASTER* [*MASTER*]..
+    Create a new slave zone *ZONE* with masters *MASTER*. All *MASTER*\ s
+    need to to be IP addresses with an optional port.
+change-slave-zone-master *ZONE* *MASTER* [*MASTER*]..
+    Change the masters for slave zone *ZONE* to new masters *MASTER*. All
+    *MASTER*\ s need to to be IP addresses with an optional port.
 check-all-zones
     Check all zones for correctness.
 check-zone *ZONE*

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -812,6 +812,12 @@ void Bind2Backend::loadConfig(string* status)
         i!=domains.end();
         ++i) 
       {
+        if (!(i->hadFileDirective)) {
+          L<<Logger::Warning<<d_logprefix<<" Zone '"<<i->name<<"' has no 'file' directive set in "<<getArg("config")<<endl;
+          rejected++;
+          continue;
+        }
+
         if(i->type == "")
           L<<Logger::Notice<<d_logprefix<<" Zone '"<<i->name<<"' has no type specified, assuming 'native'"<<endl;
         if(i->type!="master" && i->type!="slave" && i->type != "native" && i->type != "") {

--- a/pdns/bindparser.yy
+++ b/pdns/bindparser.yy
@@ -89,6 +89,8 @@ void BindParser::setVerbose(bool verbose)
 
 void BindParser::commit(BindDomainInfo DI)
 {
+  DI.hadFileDirective = (DI.filename != "");
+
   if(DI.filename[0]!='/')
     DI.filename=d_dir+"/"+DI.filename;
 

--- a/pdns/bindparserclasses.hh
+++ b/pdns/bindparserclasses.hh
@@ -51,6 +51,7 @@ public:
   vector<string> masters;
   set<string> alsoNotify;
   string type;
+  bool hadFileDirective;
     
   dev_t d_dev;
   ino_t d_ino;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3059,6 +3059,12 @@ try
     string kind = cmds[2];
     vector<string> meta(cmds.begin() + 3, cmds.end());
 
+    DomainInfo di;
+    if (!B.getDomainInfo(zone, di)){
+      cerr << "No such zone in the database" << endl;
+      return false;
+    }
+
     if (!B.setDomainMetadata(zone, kind, meta)) {
       cerr << "Unable to set meta for '" << zone << "'" << endl;
       return 1;


### PR DESCRIPTION
### Short description
This PR fixes a bunch of minor issues discovered by @jpmens (thanks!). The following issues are fixed:

* #5787 `pdnsutil set-meta` will now exit with an error code if the domain does not exists
* #5784 Two missing commands for pdnsutil (`create-slave-zone` and `change-slave-zone-master`) have been documented
* #5786 The BIND backend will properly tell the user that they missed setting the 'file' stanza in the 'zone' block of the bind-config file
* #5785 Clarified that the databse used for the hybrid bind mode is not the same one as the `bind-dnssec-db`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)