### PR TITLE
auth: Fix Coverity warnings in apiZoneCryptokeysPOST and BindDomainInfo

### DIFF
--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -57,7 +57,7 @@ bool Bind2Backend::removeDomainKey(const DNSName& name, unsigned int id)
 { return false; }
 
 bool Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key, int64_t& id)
-{ return -1; }
+{ return false; }
 
 bool Bind2Backend::activateDomainKey(const DNSName& name, unsigned int id)
 { return false; }

--- a/pdns/bindparserclasses.hh
+++ b/pdns/bindparserclasses.hh
@@ -33,7 +33,7 @@
 class BindDomainInfo 
 {
 public:
-  BindDomainInfo() : d_dev(0), d_ino(0)
+  BindDomainInfo() : hadFileDirective(false), d_dev(0), d_ino(0)
   {}
 
   void clear() 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -970,7 +970,7 @@ static void apiZoneCryptokeysPOST(DNSName zonename, HttpRequest *req, HttpRespon
     throw ApiException("Invalid keytype " + stringFromJson(document, "keytype"));
   }
 
-  int64_t insertedId;
+  int64_t insertedId = -1;
 
   if (content.is_null()) {
     int bits = keyOrZone ? ::arg().asNum("default-ksk-size") : ::arg().asNum("default-zsk-size");
@@ -995,7 +995,9 @@ static void apiZoneCryptokeysPOST(DNSName zonename, HttpRequest *req, HttpRespon
     }
 
     try {
-      dk->addKey(zonename, keyOrZone, algorithm, insertedId, bits, active);
+      if (!dk->addKey(zonename, keyOrZone, algorithm, insertedId, bits, active)) {
+        throw ApiException("Adding key failed, perhaps DNSSEC not enabled in configuration?");
+      }
     } catch (std::runtime_error& error) {
       throw ApiException(error.what());
     }
@@ -1021,7 +1023,9 @@ static void apiZoneCryptokeysPOST(DNSName zonename, HttpRequest *req, HttpRespon
     catch (std::runtime_error& error) {
       throw ApiException("Key could not be parsed. Make sure your key format is correct.");
     } try {
-      dk->addKey(zonename, dpk,insertedId, active);
+      if (!dk->addKey(zonename, dpk,insertedId, active)) {
+        throw ApiException("Adding key failed, perhaps DNSSEC not enabled in configuration?");
+      }
     } catch (std::runtime_error& error) {
       throw ApiException(error.what());
     }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* Fix `Bind2Backend::addDomainKey()` return value without `SQLite3`
* Handle `addKey()` returning false in `apiZoneCryptokeysPOST`
* Make sure `hadFileDirective` is initialized in `BindDomainInfo`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
