### PR TITLE
rec: Don't directly store NSEC3 records in the positive cache

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1918,7 +1918,14 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr
       }
     }
 
-    t_RC->replace(d_now.tv_sec, i->first.name, QType(i->first.type), i->second.records, i->second.signatures, authorityRecs, isAA, i->first.place == DNSResourceRecord::ANSWER ? ednsmask : boost::none, recordState);
+    /* We don't need to store NSEC3 records in the positive cache because:
+       - we don't allow direct NSEC3 queries
+       - denial of existence proofs in wildcard expanded positive responses are stored in authorityRecs
+       - denial of existence proofs for negative responses are stored in the negative cache
+    */
+    if (i->first.type != QType::NSEC3) {
+      t_RC->replace(d_now.tv_sec, i->first.name, QType(i->first.type), i->second.records, i->second.signatures, authorityRecs, isAA, i->first.place == DNSResourceRecord::ANSWER ? ednsmask : boost::none, recordState);
+    }
 
     if(i->first.place == DNSResourceRecord::ANSWER && ednsmask)
       d_wasVariable=true;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We don't need to store NSEC3 records in the positive cache because:
* we don't allow direct NSEC3 queries
* denial of existence proofs in wildcard expanded positive responses are stored in `authorityRecs` for the initial qname
* denial of existence proofs for negative responses are stored in the negative cache

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
