### PR TITLE
rec: Disable validation for infra queries, validate entries from the negcache

### DIFF
--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -101,6 +101,21 @@ void NegCache::add(const NegCacheEntry& ne) {
 }
 
 /*!
+ * Update the validation state of an existing entry with the provided state.
+ *
+ * \param qname The name of the entry to replace
+ * \param qtype The type of the entry to replace
+ * \param newState The new validation state
+ */
+void NegCache::updateValidationStatus(const DNSName& qname, const QType& qtype, const vState newState) {
+  auto range = d_negcache.equal_range(tie(qname, qtype));
+
+  if (range.first != range.second) {
+    range.first->d_validationState = newState;
+  }
+}
+
+/*!
  * Returns the amount of entries in the cache
  *
  * \param qname The name of the entries to be counted

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -51,13 +51,14 @@ class NegCache : public boost::noncopyable {
       uint32_t d_ttd;                     // Timestamp when this entry should die
       recordsAndSignatures authoritySOA;  // The upstream SOA record and RRSIGs
       recordsAndSignatures DNSSECRecords; // The upstream NSEC(3) and RRSIGs
-      vState d_validationState{Indeterminate};
+      mutable vState d_validationState{Indeterminate};
       uint32_t getTTD() const {
         return d_ttd;
       };
     };
 
     void add(const NegCacheEntry& ne);
+    void updateValidationStatus(const DNSName& qname, const QType& qtype, const vState newState);
     bool get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne, bool typeMustMatch=false);
     bool getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne);
     uint64_t count(const DNSName& qname) const;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -898,6 +898,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
   return false;
 }
 
+namespace {
 struct CacheEntry
 {
   vector<DNSRecord> records;
@@ -914,6 +915,7 @@ struct CacheKey
   }
 };
 typedef map<CacheKey, CacheEntry> tcache_t;
+}
 
 static void reapRecordsFromNegCacheEntryForValidation(tcache_t& tcache, const vector<DNSRecord>& records)
 {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -617,7 +617,9 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
 
   QType type;
   bool oldRequireAuthData = d_requireAuthData;
+  bool oldValidationRequested = d_DNSSECValidationRequested;
   d_requireAuthData = false;
+  d_DNSSECValidationRequested = false;
 
   for(int j=1; j<2+s_doIPv6; j++)
   {
@@ -665,6 +667,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   }
 
   d_requireAuthData = oldRequireAuthData;
+  d_DNSSECValidationRequested = oldValidationRequested;
 
   if(ret.size() > 1) {
     random_shuffle(ret.begin(), ret.end(), dns_random);
@@ -1534,9 +1537,7 @@ void SyncRes::computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned
   std::vector<string> labelsToAdd = begin.makeRelative(end).getRawLabels();
 
   bool oldSkipCNAME = d_skipCNAMECheck;
-  bool oldRequireAuthData = d_requireAuthData;
   d_skipCNAMECheck = true;
-  d_requireAuthData = false;
 
   while(qname != begin) {
     if (labelsToAdd.empty())
@@ -1594,7 +1595,6 @@ void SyncRes::computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned
   }
 
   d_skipCNAMECheck = oldSkipCNAME;
-  d_requireAuthData = oldRequireAuthData;
 
   LOG(d_prefix<<": list of cuts from "<<begin<<" to "<<end<<endl);
   for (const auto& cut : d_cutStates) {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -755,7 +755,9 @@ private:
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth);
   vState getDSRecords(const DNSName& zone, dsmap_t& ds, bool onlyTA, unsigned int depth, bool bogusOnNXD=true, bool* foundCut=nullptr);
   vState getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int depth);
-  void getDenialValidationState(NegCache::NegCacheEntry& ne, vState& state, const dState expectedState, bool allowOptOut, bool referralToUnsigned);
+  dState getDenialValidationState(NegCache::NegCacheEntry& ne, const vState state, const dState expectedState, bool referralToUnsigned);
+  void updateDenialValidationState(NegCache::NegCacheEntry& ne, vState& state, const dState denialState, const dState expectedState, bool allowOptOut);
+  void computeNegCacheValidationStatus(NegCache::NegCacheEntry& ne, const DNSName& qname, const QType& qtype, const int res, vState& state, unsigned int depth);
   vState getTA(const DNSName& zone, dsmap_t& ds);
   bool haveExactValidationStatus(const DNSName& domain);
   vState getValidationStatus(const DNSName& subdomain, bool allowIndeterminate=true);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We don't need to validate the answers to the "infrastructure" queries, for example to retrieve `NS` records and authoritative servers addresses.
We do however need to validate entries retrieved from our negative cache if the initial query did not ask for validation but the current one does.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
