### PR TITLE
4.1 polish: Add log-timestamp option

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -673,6 +673,22 @@ big problems if you have multiple IP addresses. Unix does not provide a
 way of figuring out what IP address a packet was sent to when binding to
 any.
 
+.. _setting-log-timestamp:
+
+``log-timestamp``
+-----------------
+
+.. versionadded:: 4.1.0
+
+- Bool
+- Default: yes
+
+When printing log lines to stdout, prefix them with timestamps.
+Disable this if the process supervisor timestamps these lines already.
+
+.. note::
+  The systemd unit file supplied with the source code already disables timestamp printing
+
 .. _setting-non-local-bind:
 
 ``non-local-bind``

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -95,6 +95,7 @@ void declareArguments()
   ::arg().set("control-console","Debugging switch - don't use")="no"; // but I know you will!
   ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";
   ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
+  ::arg().set("log-timestamp","Print timestamps in log lines")="yes";
   ::arg().set("default-soa-name","name to insert in the SOA record if none set in the backend")="a.misconfigured.powerdns.server";
   ::arg().set("default-soa-mail","mail address to insert in the SOA record if none set in the backend")="";
   ::arg().set("distributor-threads","Default number of Distributor (backend) threads to start")="3";

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -47,14 +47,16 @@ void Logger::log(const string &msg, Urgency u)
 #ifndef RECURSOR
   bool mustAccount(false);
 #endif
-  struct tm tm;
-  time_t t;
-  time(&t);
-  tm=*localtime(&t);
-
   if(u<=consoleUrgency) {
-    char buffer[50];
-    strftime(buffer,sizeof(buffer),"%b %d %H:%M:%S ", &tm);
+    char buffer[50] = "";
+    if (d_timestamps) {
+      struct tm tm;
+      time_t t;
+      time(&t);
+      tm=*localtime(&t);
+      strftime(buffer,sizeof(buffer),"%b %d %H:%M:%S ", &tm);
+    }
+
     static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
     Lock l(&m); // the C++-2011 spec says we need this, and OSX actually does
     clog << string(buffer) + msg <<endl;

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -60,6 +60,10 @@ public:
     d_disableSyslog = d;
   }
 
+  void setTimestamps(bool t) {
+    d_timestamps = t;
+  }
+
   //! Log to a file.
   void toFile( const string & filename );
   
@@ -107,6 +111,7 @@ private:
   Urgency consoleUrgency;
   bool opened;
   bool d_disableSyslog;
+  bool d_timestamps{true};
   static pthread_once_t s_once;
   static pthread_key_t s_loggerKey;
 };

--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -7,7 +7,7 @@ After=network-online.target mysqld.service postgresql.service slapd.service mari
 
 [Service]
 Type=notify
-ExecStart=@sbindir@/pdns_server --guardian=no --daemon=no --disable-syslog --write-pid=no
+ExecStart=@sbindir@/pdns_server --guardian=no --daemon=no --disable-syslog --log-timestamp=no --write-pid=no
 Restart=on-failure
 RestartSec=1
 StartLimitInterval=0

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2761,6 +2761,7 @@ static int serviceMain(int argc, char*argv[])
 {
   L.setName(s_programname);
   L.disableSyslog(::arg().mustDo("disable-syslog"));
+  L.setTimestamps(::arg().mustDo("log-timestamp"));
 
   if(!::arg()["logging-facility"].empty()) {
     int val=logFacilityToLOG(::arg().asNum("logging-facility") );
@@ -3250,6 +3251,7 @@ int main(int argc, char **argv)
     ::arg().setSwitch("write-pid","Write a PID file")="yes";
     ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="6";
     ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
+    ::arg().set("log-timestamp","Print timestamps in log lines, useful to disable when running with a tool that timestamps stdout already")="yes";
     ::arg().set("log-common-errors","If we should log rather common errors")="no";
     ::arg().set("chroot","switch to chroot jail")="";
     ::arg().set("setgid","If set, change group id to this gid for more security")="";

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -467,6 +467,7 @@ int main(int argc, char **argv)
 
     L.setLoglevel((Logger::Urgency)(::arg().asNum("loglevel")));
     L.disableSyslog(::arg().mustDo("disable-syslog"));
+    L.setTimestamps(::arg().mustDo("log-timestamp"));
     L.toConsole((Logger::Urgency)(::arg().asNum("loglevel")));  
 
     if(::arg().mustDo("help") || ::arg().mustDo("config")) {

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -538,6 +538,22 @@ It is highly recommended to bind to explicit addresses.
 Local port to bind to.
 If an address in `local-address`_ does not have an explicit port, this port is used.
 
+.. _setting-log-timestamp:
+
+``log-timestamp``
+-----------------
+
+.. versionadded:: 4.1.0
+
+- Bool
+- Default: yes
+
+When printing log lines to stdout, prefix them with timestamps.
+Disable this if the process supervisor timestamps these lines already.
+
+.. note::
+  The systemd unit file supplied with the source code already disables timestamp printing
+
 .. _setting-non-local-bind:
 
 ``non-local-bind``

--- a/pdns/recursordist/pdns-recursor.service.in
+++ b/pdns/recursordist/pdns-recursor.service.in
@@ -8,7 +8,7 @@ After=network-online.target
 
 [Service]
 Type=notify
-ExecStart=@sbindir@/pdns_recursor --daemon=no --write-pid=no --disable-syslog
+ExecStart=@sbindir@/pdns_recursor --daemon=no --write-pid=no --disable-syslog --log-timestamp=no
 Restart=on-failure
 StartLimitInterval=0
 PrivateTmp=true


### PR DESCRIPTION
### Short description
This option can be used to disable printing timestamps to stdout, this is useful when using systemd-journald or another supervisor that timestamps stdout by itself. As the logs will not have 2 timestamps.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)