### PR TITLE
dnsdist: Don't create a Remote Logger in client mode

### DIFF
--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -875,6 +875,9 @@ void moreLua(bool client)
       });
 
     g_lua.writeFunction("newRemoteLogger", [client](const std::string& remote, boost::optional<uint16_t> timeout, boost::optional<uint64_t> maxQueuedEntries, boost::optional<uint8_t> reconnectWaitTime) {
+        if (client) {
+          return std::shared_ptr<RemoteLogger>();
+        }
         return std::make_shared<RemoteLogger>(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? *maxQueuedEntries : 100, reconnectWaitTime ? *reconnectWaitTime : 1);
       });
 

--- a/pdns/dnsrulactions.hh
+++ b/pdns/dnsrulactions.hh
@@ -1272,7 +1272,7 @@ public:
   }
   string toString() const override
   {
-    return "remote log to " + d_logger->toString();
+    return "remote log to " + (d_logger ? d_logger->toString() : "");
   }
 private:
   std::shared_ptr<RemoteLogger> d_logger;
@@ -1329,7 +1329,7 @@ public:
   }
   string toString() const override
   {
-    return "remote log response to " + d_logger->toString();
+    return "remote log response to " + (d_logger ? d_logger->toString() : "");
   }
 private:
   std::shared_ptr<RemoteLogger> d_logger;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
No need to create a TCP connection to the protobuf server every time we are started in client mode.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
