### PR TITLE
Add missing config option in HTTP API docs

### DIFF
--- a/docs/common/api/configsetting.rst
+++ b/docs/common/api/configsetting.rst
@@ -16,5 +16,5 @@ ConfigSetting
     {
       "name": "webserver-port",
       "type": "ConfigSetting",
-      "value": "8082"
+      "value": "8081"
     }

--- a/docs/http-api/index.rst
+++ b/docs/http-api/index.rst
@@ -26,14 +26,17 @@ Enabling the API
 To enable the API, the webserver and the HTTP API need to be enbaled.
 Add these lines to the ``pdns.conf``::
 
-    webserver=yes
-    webserver-port=8082
+    api=yes
     api-key=changeme
+    webserver=yes
+    webserver-port=8081
+
+The API endpoints run off of the same webserver, but the :ref:`setting-api` is required to enable API access. Setting :ref:`setting-api` also implicitly enables the webserver v4.1.x onwards.
 
 And restart, the following examples should start working::
 
-    curl -v -H 'X-API-Key: changeme' http://127.0.0.1:8082/api/v1/servers/localhost | jq .
-    curl -v -H 'X-API-Key: changeme' http://127.0.0.1:8082/api/v1/servers/localhost/zones | jq .
+    curl -v -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost | jq .
+    curl -v -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost/zones | jq .
 
 JSON Objects
 ------------


### PR DESCRIPTION
### Short description

- Add `api=yes` required to enable API
- Change ports in examples from 8082 to 8081 to reflect default port in
  configs for Authoritative DNS

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] included documentation (including possible behaviour changes)
- [x] documented the code


