### PR TITLE
Attempt to clarify use of TSIG key and ALLOW-DNSUPDATE-FROM

### DIFF
--- a/docs/dnsupdate.rst
+++ b/docs/dnsupdate.rst
@@ -135,9 +135,9 @@ An example of how to use a TSIG key with the :program:`nsupdate` command:
     !
 
 If a TSIG key is set for the domain, it is required to be used for the
-update. The TSIG is extra security on top of the
-``ALLOW-DNSUPDATE-FROM`` setting. If a TSIG key is set, the IP(-range)
-still needs to be allowed via ``ALLOW-DNSUPDATE-FROM``.
+update. The TSIG is an alternative means of securing updates, instead of using the
+``ALLOW-DNSUPDATE-FROM`` setting. If a TSIG key is set, and if ``ALLOW-DNSUPDATE-FROM`` is set,
+the IP(-range) of the updater still needs to be allowed via ``ALLOW-DNSUPDATE-FROM``. 
 
 FORWARD-DNSUPDATE
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION


### Short description
Clarify association between use of TSIG key and ALLOW-DNSUPDATE-FROM. Previous description sounded like AND

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] included documentation (including possible behaviour changes)
