### PR TITLE
Sync gmysql/gpgsql default settings and docs

### DIFF
--- a/docs/backends/generic-mysql.rst
+++ b/docs/backends/generic-mysql.rst
@@ -64,7 +64,7 @@ Host (ip address) to connect to. Mutually exclusive with :ref:`setting-gmysql-so
 ``gmysql-port``
 ^^^^^^^^^^^^^^^
 
-The port to connect to on :ref:`setting-gmysql-host`. Default: 3306
+The port to connect to on :ref:`setting-gmysql-host`. Default: 3306.
 
 .. _setting-gmysql-socket:
 
@@ -106,14 +106,14 @@ The password to for :ref:`setting-gmysql-user`.
 ``gmysql-dnssec``
 ^^^^^^^^^^^^^^^^^
 
-Enable DNSSEC processing for this backend. Default=no.
+Enable DNSSEC processing for this backend. Default: no.
 
 .. _setting-gmysql-innodb-read-committed:
 
 ``gmysql-innodb-read-committed``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use the InnoDB READ-COMMITTED transaction isolation level. Default=yes.
+Use the InnoDB READ-COMMITTED transaction isolation level. Default: yes.
 
 .. _setting-gmysql-timeout:
 

--- a/docs/backends/generic-postgresql.rst
+++ b/docs/backends/generic-postgresql.rst
@@ -77,7 +77,7 @@ The password to for :ref:`setting-gpgsql-user`. Default: not set.
 ``gpgsql-dnssec``
 ^^^^^^^^^^^^^^^^^
 
-Enable DNSSEC processing for this backend. Default=no.
+Enable DNSSEC processing for this backend. Default: no.
 
 .. _setting-gpsql-extra-connection-parameters:
 

--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -69,13 +69,13 @@ public:
 
   void declareArguments(const string &suffix="")
   {
-    declare(suffix,"dbname","Pdns backend database name to connect to","powerdns");
+    declare(suffix,"dbname","Database name to connect to","powerdns");
     declare(suffix,"user","Database backend user to connect as","powerdns");
     declare(suffix,"host","Database backend host to connect to","");
-    declare(suffix,"port","Database backend port to connect to","0");
-    declare(suffix,"socket","Pdns backend socket to connect to","");
-    declare(suffix,"password","Pdns backend password to connect with","");
-    declare(suffix,"group", "Pdns backend MySQL 'group' to connect as", "client");
+    declare(suffix,"port","Database backend port to connect to","3306");
+    declare(suffix,"socket","Database backend socket to connect to","");
+    declare(suffix,"password","Database backend password to connect with","");
+    declare(suffix,"group", "Database backend MySQL 'group' to connect as", "client");
     declare(suffix,"innodb-read-committed","Use InnoDB READ-COMMITTED transaction isolation level","yes");
     declare(suffix,"timeout", "The timeout in seconds for each attempt to read/write to the server", "10");
 

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -79,11 +79,11 @@ public:
 
   void declareArguments(const string &suffix="")
   {
-    declare(suffix,"dbname","Pdns backend database name to connect to","");
-    declare(suffix,"user","Pdns backend user to connect as","");
-    declare(suffix,"host","Pdns backend host to connect to","");
+    declare(suffix,"dbname","Backend database name to connect to","");
+    declare(suffix,"user","Database backend user to connect as","");
+    declare(suffix,"host","Database backend host to connect to","");
     declare(suffix,"port","Database backend port to connect to","");
-    declare(suffix,"password","Pdns backend password to connect with","");
+    declare(suffix,"password","Database backend password to connect with","");
     declare(suffix,"extra-connection-parameters", "Extra parameters to add to connection string","");
 
     declare(suffix,"dnssec","Enable DNSSEC processing","no");


### PR DESCRIPTION
### Short description

Sync defaults in code and docs for gmysqlbackend and gpgsqlbackend. Fixes #5668 (just the remaining bits).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

