### PR TITLE
Document pdnsutil set-nsec3 with no salt ("1 0 0 -")

### DIFF
--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -52,7 +52,7 @@ The quoted part is the content of the NSEC3PARAM records, as defined in
    set as ``0``
 -  Number of iterations of the hash function, read :rfc:`RFC 5155, Section
    10.3 <5155#section-10.3>` for recommendations
--  Salt (in hexadecimal) to apply during hashing
+-  Salt to apply during hashing, in hexadecimal, or ``-`` to use no salt
 
 To convert a zone from NSEC3 to NSEC operations, run:
 

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -88,13 +88,13 @@ set-nsec3 *ZONE* '*HASH-ALGORITHM* *FLAGS* *ITERATIONS* *SALT*' [**narrow**]
     know you need it. For *ITERATIONS*, please consult RFC 5155, section
     10.3. And be aware that a high number might overload validating
     resolvers. The *SALT* is a hexadecimal string encoding the bits for
-    the salt. Setting **narrow** will make PowerDNS send out "white
-    lies" about the next secure record. Instead of looking it up in the
-    database, it will send out the hash + 1 as the next secure record. A
-    sample commandline is: "pdnsutil set-nsec3 powerdnssec.org '1 1 1
-    ab' narrow". **WARNING**: If running in RSASHA1 mode (algorithm 5 or
-    7), switching from NSEC to NSEC3 will require a DS update in the
-    parent zone.
+    the salt, or - to use no salt. Setting **narrow** will make PowerDNS
+    send out "white lies" about the next secure record. Instead of
+    looking it up in the database, it will send out the hash + 1 as the
+    next secure record. A sample commandline is: "pdnsutil set-nsec3
+    powerdnssec.org '1 1 1 ab' narrow". **WARNING**: If running in
+    RSASHA1 mode (algorithm 5 or 7), switching from NSEC to NSEC3 will
+    require a DS update in the parent zone.
 unset-nsec3 *ZONE*
     Converts *ZONE* to NSEC operations. **WARNING**: If running in
     RSASHA1 mode (algorithm 5 or 7), switching from NSEC to NSEC3 will


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Brief documentation for `pdnsutil set-nsec3` with no salt (e.g. `"1 0 0 -"`).

They're the only two parts of the documentation I found that discuss `set-nsec3` in detail.

The diff to `pdnsutil.1.rst` is a bit messy because line wrapping, even though I just added a few words.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
