### PR TITLE
With this commit, the root-anchor provisioning machinery no longer uses g_rootdnsname

### DIFF
--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -33,9 +33,10 @@ GlobalStateHolder<LuaConfigItems> g_luaconfs;
 
 LuaConfigItems::LuaConfigItems()
 {
+  DNSName root("."); // don't use g_rootdnsname here, it might not exist yet
   for (const auto &dsRecord : rootDSs) {
     auto ds=unique_ptr<DSRecordContent>(dynamic_cast<DSRecordContent*>(DSRecordContent::make(dsRecord)));
-    dsAnchors[g_rootdnsname].insert(*ds);
+    dsAnchors[root].insert(*ds);
   }
 }
 


### PR DESCRIPTION
g_rootdnsname which might not yet have been initialized when our global scope DNSSEC trust anchor initializing code runs. This broke DNSSEC validation with `-flto`.

I also audited the code for other global scope uses of g_rootdnsname and did not find any, but I did not look too hard. 

This minimal fix is super safe for 4.1. A broader fix might be setting a `__attribute__((init_priority(0))` on `g_rootdnsname`. 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
