### PR TITLE
rec: Sort NS addresses by speed, remove old ones

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -215,7 +215,16 @@ string doDumpNSSpeeds(T begin, T end)
   try {
     total = broadcastAccFunction<uint64_t>(boost::bind(pleaseDumpNSSpeeds, fd));
   }
-  catch(...){}
+  catch(std::exception& e)
+  {
+    close(fd);
+    return "error dumping NS speeds: "+string(e.what())+"\n";
+  }
+  catch(PDNSException& e)
+  {
+    close(fd);
+    return "error dumping NS speeds: "+e.reason+"\n";
+  }
 
   close(fd);
   return "dumped "+std::to_string(total)+" records\n";

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -368,7 +368,9 @@ uint64_t SyncRes::doDumpNSSpeeds(int fd)
   for(const auto& i : t_sstorage.nsSpeeds)
   {
     count++;
-    fprintf(fp, "%s -> ", i.first.toString().c_str());
+
+    // an <empty> can appear hear in case of authoritative (hosted) zones
+    fprintf(fp, "%s -> ", i.first.toLogString().c_str());
     for(const auto& j : i.second.d_collection)
     {
       // typedef vector<pair<ComboAddress, DecayingEwma> > collection_t;
@@ -685,7 +687,6 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
 
   if(ret.size() > 1) {
     map<ComboAddress, double> speeds;
-
     auto& collection = t_sstorage.nsSpeeds[qname].d_collection;
     for(const auto& val: ret) {
       double speed;
@@ -1202,8 +1203,10 @@ inline vector<DNSName> SyncRes::shuffleInSpeedOrder(NsSet &tnameservers, const s
 {
   vector<DNSName> rnameservers;
   rnameservers.reserve(tnameservers.size());
-  for(const auto& tns:tnameservers) {
+  for(const auto& tns: tnameservers) {
     rnameservers.push_back(tns.first);
+    if(tns.first.empty()) // this was an authoritative OOB zone, don't pollute the nsSpeeds with that
+      return rnameservers;
   }
   map<DNSName, double> speeds;
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -609,6 +609,16 @@ static bool ipv6First(const ComboAddress& a, const ComboAddress& b)
 }
 #endif
 
+struct speedOrderCA
+{
+  speedOrderCA(std::map<ComboAddress,double>& speeds): d_speeds(speeds) {}
+  bool operator()(const ComboAddress& a, const ComboAddress& b) const
+  {
+    return d_speeds[a] < d_speeds[b];
+  }
+  std::map<ComboAddress, double>& d_speeds;
+};
+
 /** This function explicitly goes out for A or AAAA addresses
 */
 vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth, set<GetBestNSAnswer>& beenthere)
@@ -674,21 +684,37 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   d_DNSSECValidationRequested = oldValidationRequested;
 
   if(ret.size() > 1) {
+    map<ComboAddress, double> speeds;
+
+    auto& collection = t_sstorage.nsSpeeds[qname].d_collection;
+    for(const auto& val: ret) {
+      double speed;
+      speed=collection[val].get(&d_now);
+      speeds[val]=speed;
+    }
+
+    t_sstorage.nsSpeeds[qname].purge(speeds);
+
     random_shuffle(ret.begin(), ret.end(), dns_random);
+    speedOrderCA so(speeds);
+    stable_sort(ret.begin(), ret.end(), so);
 
-    // move 'best' address for this nameserver name up front
-    nsspeeds_t::iterator best = t_sstorage.nsSpeeds.find(qname);
-
-    if(best != t_sstorage.nsSpeeds.end())
-      for(ret_t::iterator i=ret.begin(); i != ret.end(); ++i) {
-        if(*i==best->second.d_best) {  // got the fastest one
-          if(i!=ret.begin()) {
-            *i=*ret.begin();
-            *ret.begin()=best->second.d_best;
-          }
-          break;
+    if(doLog()) {
+      string prefix=d_prefix;
+      prefix.append(depth, ' ');
+      LOG(prefix<<"Nameserver "<<qname<<" IPs: ");
+      bool first = true;
+      for(const auto& addr : ret) {
+        if (first) {
+          first = false;
         }
+        else {
+          LOG(", ");
+        }
+        LOG((addr.toString())<<"(" << (boost::format("%0.2f") % (speeds[addr]/1000.0)).str() <<"ms)");
       }
+      LOG(endl);
+    }
   }
 
   return ret;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to not sort the different addresses we had for a given NS by speed, only taking care of placing the first one in front. However we also didn't remove existing entries for a given NS, meaning that if a given IP stopped being advertised it would stay in our NS speeds map and keep being used to determine the fastest NS, even if we would only send queries to the new IPs after the selection. Since we didn't send any query to the old IP anymore, its latency would only keep decaying meaning the computed latency of the corresponding NS would only keep decreasing, completely uncorrelated from its real latency.

This commit removes old entries from the NS speeds map if they are no longer present when we refresh the addresses of a given NS. In addition, it orders all NS IPs by decaying latency, meaning new ones will have a fair chance of being picked up.

It might fix #1066, although it did not test that exact case.

Don't merge without a careful review!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
