### PR TITLE
Add configuration option to disable IP_BIND_ADDRESS_NO_PORT.

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -477,6 +477,10 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			  ret->useECS=boost::get<bool>(vars["useClientSubnet"]);
 			}
 
+			if(vars.count("ipBindAddrNoPort")) {
+			  ret->ipBindAddrNoPort=boost::get<bool>(vars["ipBindAddrNoPort"]);
+			}
+
 			if(vars.count("maxCheckFailures")) {
 			  ret->maxCheckFailures=std::stoi(boost::get<string>(vars["maxCheckFailures"]));
 			}

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -56,7 +56,9 @@ static int setupTCPDownstream(shared_ptr<DownstreamState> ds, uint16_t& downstre
       if (!IsAnyAddress(ds->sourceAddr)) {
         SSetsockopt(sock, SOL_SOCKET, SO_REUSEADDR, 1);
 #ifdef IP_BIND_ADDRESS_NO_PORT
-        SSetsockopt(sock, SOL_IP, IP_BIND_ADDRESS_NO_PORT, 1);
+        if (ds->ipBindAddrNoPort) {
+          SSetsockopt(sock, SOL_IP, IP_BIND_ADDRESS_NO_PORT, 1);
+        }
 #endif
         SBind(sock, ds->sourceAddr);
       }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -631,6 +631,7 @@ struct DownstreamState
   bool setCD{false};
   std::atomic<bool> connected{false};
   bool tcpFastOpen{false};
+  bool ipBindAddrNoPort{true};
   bool isUp() const
   {
     if(availability == Availability::Down)

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -224,7 +224,7 @@ Servers
       tcpSendTimeout=NUM,    -- The timeout (in seconds) of a TCP write attempt
       tcpRecvTimeout=NUM,    -- The timeout (in seconds) of a TCP read attempt
       tcpFastOpen=BOOL,      -- Whether to enable TCP Fast Open
-      ipBindAddrNoPort=BOOL, -- Whether to enable IP Bind Address No Port
+      ipBindAddrNoPort=BOOL, -- Whether to enable IP_BIND_ADDRESS_NO_PORT if available, default: true
       name=STRING,           -- The name associated to this backend, for display purpose
       checkName=STRING,      -- Use STRING as QNAME in the health-check query, default: "a.root-servers.net."
       checkType=STRING,      -- Use STRING as QTYPE in the health-check query, default: "A"

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -224,6 +224,7 @@ Servers
       tcpSendTimeout=NUM,    -- The timeout (in seconds) of a TCP write attempt
       tcpRecvTimeout=NUM,    -- The timeout (in seconds) of a TCP read attempt
       tcpFastOpen=BOOL,      -- Whether to enable TCP Fast Open
+      ipBindAddrNoPort=BOOL, -- Whether to enable IP Bind Address No Port
       name=STRING,           -- The name associated to this backend, for display purpose
       checkName=STRING,      -- Use STRING as QNAME in the health-check query, default: "a.root-servers.net."
       checkType=STRING,      -- Use STRING as QTYPE in the health-check query, default: "A"


### PR DESCRIPTION
### Short description
This adds the configuration option `ipBindAddrNoPort` for downstream servers to optionally disable `IP_BIND_ADDRESS_NO_PORT` if `dnsdist` was built with support for it. It defaults to `true` to maintain current behavior by default.

This addresses the problem when `dnsdist` was built on a kernel newer than 4.2, but is running (in my case, in a container) on a system with an older kernel version which does not support `IP_BIND_ADDRESS_NO_PORT`, causing TCP connections to immediately fail.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
