### PR TITLE
rec: Split NODATA/NXDOMAIN NSEC wildcard denial proof of existence

### DIFF
--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -7856,7 +7856,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_ent_denial) {
   pair.signatures = signatureContents;
   denialMap[std::make_pair(DNSName(").powerdns.com."), QType::NSEC)] = pair;
 
-  denialState = getDenial(denialMap, DNSName("b.powerdns.com."), QType::A, true, true);
+  denialState = getDenial(denialMap, DNSName("b.powerdns.com."), QType::A, true, false);
   BOOST_CHECK_EQUAL(denialState, NXDOMAIN);
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise there is a very real risk that a `NSEC` will cover a more specific wildcard and we end up with what looks like a `NXDOMAIN` proof but is a `NODATA` one.

Fixes #5882.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
