### PR TITLE
Prevent possible downgrade attacks in the recursor

### DIFF
--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -8287,7 +8287,7 @@ BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_two_highest) {
   }
 }
 
-#ifdef HAVE_BOTAN110
+#ifdef HAVE_BOTAN
 BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_prefer_sha384_over_gost) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -8138,6 +8138,292 @@ BOOST_AUTO_TEST_CASE(test_lowercase_outgoing) {
   g_lowercaseOutgoing = false;
 }
 
+BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo) {
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target("com.");
+  testkeysset_t keys, keys2;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys);
+  g_luaconfs.setState(luaconfsCopy);
+
+  // As testkeysset_t only contains one DSRecordContent, create another one with a different hash algo
+  generateKeyMaterial(DNSName("com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA1, keys2);
+  // But add the existing root key otherwise no RRSIG can be created
+  auto rootkey = keys.find(g_rootdnsname);
+  keys2.insert(*rootkey);
+
+  sr->setAsyncCallback([target, keys, keys2](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      DNSName auth = domain;
+      auth.chopOff();
+      if (type == QType::DS || type == QType::DNSKEY) {
+        if (domain == target) {
+          if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != 1) {
+            return 0;
+          }
+        }
+        return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
+      }
+      return 0;
+    });
+
+  dsmap_t ds;
+  auto state = sr->getDSRecords(target, ds, false, 0, false);
+  BOOST_CHECK_EQUAL(state, Secure);
+  BOOST_REQUIRE_EQUAL(ds.size(), 1);
+  for (const auto& i : ds) {
+    BOOST_CHECK_EQUAL(i.d_digesttype, DNSSECKeeper::SHA256);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_all_sha) {
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target("com.");
+  testkeysset_t keys, keys2, keys3;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys);
+  g_luaconfs.setState(luaconfsCopy);
+
+  // As testkeysset_t only contains one DSRecordContent, create another one with a different hash algo
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA1, keys2);
+  // But add the existing root key otherwise no RRSIG can be created
+  auto rootkey = keys.find(g_rootdnsname);
+  keys2.insert(*rootkey);
+
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA384, keys3);
+  // But add the existing root key otherwise no RRSIG can be created
+  keys3.insert(*rootkey);
+
+  sr->setAsyncCallback([target, keys, keys2, keys3](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      DNSName auth = domain;
+      auth.chopOff();
+      if (type == QType::DS || type == QType::DNSKEY) {
+        if (domain == target) {
+          if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != 1) {
+            return 0;
+          }
+          if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys3) != 1) {
+            return 0;
+          }
+        }
+        return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
+      }
+      return 0;
+    });
+
+  dsmap_t ds;
+  auto state = sr->getDSRecords(target, ds, false, 0, false);
+  BOOST_CHECK_EQUAL(state, Secure);
+  BOOST_REQUIRE_EQUAL(ds.size(), 1);
+  for (const auto& i : ds) {
+    BOOST_CHECK_EQUAL(i.d_digesttype, DNSSECKeeper::SHA384);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_two_highest) {
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target("com.");
+  testkeysset_t keys, keys2, keys3;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys);
+  g_luaconfs.setState(luaconfsCopy);
+
+  // As testkeysset_t only contains one DSRecordContent, create another one with a different hash algo
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys2);
+  // But add the existing root key otherwise no RRSIG can be created
+  auto rootkey = keys.find(g_rootdnsname);
+  keys2.insert(*rootkey);
+
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA1, keys3);
+  // But add the existing root key otherwise no RRSIG can be created
+  keys3.insert(*rootkey);
+
+  sr->setAsyncCallback([target, keys, keys2, keys3](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      DNSName auth = domain;
+      auth.chopOff();
+      if (type == QType::DS || type == QType::DNSKEY) {
+        if (domain == target) {
+          if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != 1) {
+            return 0;
+          }
+          if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys3) != 1) {
+            return 0;
+          }
+        }
+        return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
+      }
+      return 0;
+    });
+
+  dsmap_t ds;
+  auto state = sr->getDSRecords(target, ds, false, 0, false);
+  BOOST_CHECK_EQUAL(state, Secure);
+  BOOST_REQUIRE_EQUAL(ds.size(), 2);
+  for (const auto& i : ds) {
+    BOOST_CHECK_EQUAL(i.d_digesttype, DNSSECKeeper::SHA256);
+  }
+}
+
+#ifdef HAVE_BOTAN110
+BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_prefer_sha384_over_gost) {
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target("com.");
+  testkeysset_t keys, keys2;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA384, keys);
+  g_luaconfs.setState(luaconfsCopy);
+
+  // As testkeysset_t only contains one DSRecordContent, create another one with a different hash algo
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::GOST, keys2);
+  // But add the existing root key otherwise no RRSIG can be created
+  auto rootkey = keys.find(g_rootdnsname);
+  keys2.insert(*rootkey);
+
+  sr->setAsyncCallback([target, keys, keys2](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      DNSName auth = domain;
+      auth.chopOff();
+      if (type == QType::DS || type == QType::DNSKEY) {
+        if (domain == target) {
+          if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != 1) {
+            return 0;
+          }
+        }
+        return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
+      }
+      return 0;
+    });
+
+  dsmap_t ds;
+  auto state = sr->getDSRecords(target, ds, false, 0, false);
+  BOOST_CHECK_EQUAL(state, Secure);
+  BOOST_REQUIRE_EQUAL(ds.size(), 1);
+  for (const auto& i : ds) {
+    BOOST_CHECK_EQUAL(i.d_digesttype, DNSSECKeeper::SHA384);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_prefer_sha256_over_gost) {
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target("com.");
+  testkeysset_t keys, keys2;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys);
+  g_luaconfs.setState(luaconfsCopy);
+
+  // As testkeysset_t only contains one DSRecordContent, create another one with a different hash algo
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::GOST, keys2);
+  // But add the existing root key otherwise no RRSIG can be created
+  auto rootkey = keys.find(g_rootdnsname);
+  keys2.insert(*rootkey);
+
+  sr->setAsyncCallback([target, keys, keys2](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      DNSName auth = domain;
+      auth.chopOff();
+      if (type == QType::DS || type == QType::DNSKEY) {
+        if (domain == target) {
+          if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != 1) {
+            return 0;
+          }
+        }
+        return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
+      }
+      return 0;
+    });
+
+  dsmap_t ds;
+  auto state = sr->getDSRecords(target, ds, false, 0, false);
+  BOOST_CHECK_EQUAL(state, Secure);
+  BOOST_REQUIRE_EQUAL(ds.size(), 1);
+  for (const auto& i : ds) {
+    BOOST_CHECK_EQUAL(i.d_digesttype, DNSSECKeeper::SHA256);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_prefer_gost_over_sha1) {
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target("com.");
+  testkeysset_t keys, keys2;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::SHA1, keys);
+  g_luaconfs.setState(luaconfsCopy);
+
+  // As testkeysset_t only contains one DSRecordContent, create another one with a different hash algo
+  generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::GOST, keys2);
+  // But add the existing root key otherwise no RRSIG can be created
+  auto rootkey = keys.find(g_rootdnsname);
+  keys2.insert(*rootkey);
+
+  sr->setAsyncCallback([target, keys, keys2](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult* res) {
+      DNSName auth = domain;
+      auth.chopOff();
+      if (type == QType::DS || type == QType::DNSKEY) {
+        if (domain == target) {
+          if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != 1) {
+            return 0;
+          }
+        }
+        return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
+      }
+      return 0;
+    });
+
+  dsmap_t ds;
+  auto state = sr->getDSRecords(target, ds, false, 0, false);
+  BOOST_CHECK_EQUAL(state, Secure);
+  BOOST_REQUIRE_EQUAL(ds.size(), 1);
+  for (const auto& i : ds) {
+    BOOST_CHECK_EQUAL(i.d_digesttype, DNSSECKeeper::GOST);
+  }
+}
+#endif // HAVE_BOTAN110
+
 /*
 // cerr<<"asyncresolve called to ask "<<ip.toStringWithPort()<<" about "<<domain.toString()<<" / "<<QType(type).getName()<<" over "<<(doTCP ? "TCP" : "UDP")<<" (rd: "<<sendRDQuery<<", EDNS0 level: "<<EDNS0Level<<")"<<endl;
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -329,6 +329,8 @@ public:
   typedef map<DNSName, DecayingEwmaCollection> nsspeeds_t;
   typedef map<ComboAddress, EDNSStatus> ednsstatus_t;
 
+  vState getDSRecords(const DNSName& zone, dsmap_t& ds, bool onlyTA, unsigned int depth, bool bogusOnNXD=true, bool* foundCut=nullptr);
+
   class AuthDomain
   {
   public:
@@ -754,7 +756,6 @@ private:
   void updateValidationState(vState& state, const vState stateUpdate);
   vState validateRecordsWithSigs(unsigned int depth, const DNSName& qname, const QType& qtype, const DNSName& name, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth);
-  vState getDSRecords(const DNSName& zone, dsmap_t& ds, bool onlyTA, unsigned int depth, bool bogusOnNXD=true, bool* foundCut=nullptr);
   vState getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int depth);
   dState getDenialValidationState(NegCache::NegCacheEntry& ne, const vState state, const dState expectedState, bool referralToUnsigned);
   void updateDenialValidationState(NegCache::NegCacheEntry& ne, vState& state, const dState denialState, const dState expectedState, bool allowOptOut);


### PR DESCRIPTION
### Short description
RFC 4509 section 3: "Validator implementations SHOULD ignore DS RR
containing SHA-1 digests if DS RRs with SHA-256 digests are present in the
DS RRset."

As SHA348 is specified as well, the spirit of the this line is "use the
best algorithm".

This also means that if a delegation has DS records for multiple keys
(and algos) and only a subset have stronger digests, we will discard the
DS records for the weaker digests.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)