### PR TITLE
Bump SOA record for rec-4.1.0-rc2.

### DIFF
--- a/docs/secpoll.zone
+++ b/docs/secpoll.zone
@@ -1,4 +1,4 @@
-@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2017101001 10800 3600 604800 10800
+@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2017103001 10800 3600 604800 10800
 @       3600    IN  NS  pdns-public-ns1.powerdns.com.
 @       3600    IN  NS  pdns-public-ns2.powerdns.com.
 ; Auth


### PR DESCRIPTION
We (I) forgot to bump the SOA record when adding the info for rec-4.1.0-rc2.

Fixes #5887.
