### PR TITLE
[WIP] Split the DNSSEC mode, logging and SERVFAIL config

### DIFF
--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -112,7 +112,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
    * an "upstream query". To stay true to "dnssec=off means 3.X behaviour", we
    * only set +CD on forwarded query in any mode other than dnssec=off.
    */
-  pw.getHeader()->cd=(sendRDQuery && g_dnssecmode != DNSSECMode::Off);
+  pw.getHeader()->cd=(sendRDQuery && g_dnssecValidationMode != DNSSECValidationMode::Off);
 
   string ping;
   bool weWantEDNSSubnet=false;
@@ -126,7 +126,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
       weWantEDNSSubnet=true;
     }
 
-    pw.addOpt(g_outgoingEDNSBufsize, 0, g_dnssecmode == DNSSECMode::Off ? 0 : EDNSOpts::DNSSECOK, opts); 
+    pw.addOpt(g_outgoingEDNSBufsize, 0, g_dnssecValidationMode == DNSSECValidationMode::Off ? 0 : EDNSOpts::DNSSECOK, opts);
     pw.commit();
   }
   srcmask = boost::none; // this is also our return value, even if EDNS0Level == 0

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -770,7 +770,7 @@ static void startDoResolve(void *p)
       sr.setLuaEngine(t_pdl);
     }
     sr.d_requestor=dc->d_remote; // ECS needs this too
-    if(g_dnssecmode != DNSSECMode::Off) {
+    if(g_dnssecValidationMode != DNSSECValidationMode::Off) {
       sr.setDoDNSSEC(true);
 
       // Does the requestor want DNSSEC records?
@@ -782,7 +782,8 @@ static void startDoResolve(void *p)
       // Ignore the client-set CD flag
       pw.getHeader()->cd=0;
     }
-    sr.setDNSSECValidationRequested(g_dnssecmode == DNSSECMode::ValidateAll || g_dnssecmode==DNSSECMode::ValidateForLog || ((dc->d_mdp.d_header.ad || DNSSECOK) && g_dnssecmode==DNSSECMode::Process));
+    sr.setDNSSECValidationRequested(g_dnssecValidationMode == DNSSECValidationMode::Validate ||
+        ((dc->d_mdp.d_header.ad || DNSSECOK) && g_dnssecValidationMode == DNSSECValidationMode::ClientOnly));
 
 #ifdef HAVE_PROTOBUF
     sr.setInitialRequestId(dc->d_uuid);
@@ -1012,7 +1013,7 @@ static void startDoResolve(void *p)
       dc=0;
       return;
     }
-    if(tracedQuery || res == -1 || res == RCode::ServFail || pw.getHeader()->rcode == RCode::ServFail)
+    if(tracedQuery || g_dnssecLogMode == DNSSECLogMode::Trace || res == -1 || res == RCode::ServFail || pw.getHeader()->rcode == RCode::ServFail)
     { 
       string trace(sr.getTrace());
       if(!trace.empty()) {
@@ -1042,9 +1043,11 @@ static void startDoResolve(void *p)
 
           auto state = sr.getValidationState();
 
+          bool shouldLog = (g_dnssecLogMode == DNSSECLogMode::On || g_dnssecLogMode == DNSSECLogMode::Trace || sr.doLog());
+
           if(state == Secure) {
-            if(sr.doLog()) {
-              L<<Logger::Warning<<"Answer to "<<dc->d_mdp.d_qname<<"|"<<QType(dc->d_mdp.d_qtype).getName()<<" for "<<dc->d_remote.toStringWithPort()<<" validates correctly"<<endl;
+            if(shouldLog) {
+              L<<Logger::Warning<<"Answer to "<<dc->d_mdp.d_qname<<"|"<<QType(dc->d_mdp.d_qtype).getName()<<" for "<<dc->d_remote.toStringWithPort()<<" validates as Secure"<<endl;
             }
             
             // Is the query source interested in the value of the ad-bit?
@@ -1052,20 +1055,22 @@ static void startDoResolve(void *p)
               pw.getHeader()->ad=1;
           }
           else if(state == Insecure) {
-            if(sr.doLog()) {
+            if(shouldLog) {
               L<<Logger::Warning<<"Answer to "<<dc->d_mdp.d_qname<<"|"<<QType(dc->d_mdp.d_qtype).getName()<<" for "<<dc->d_remote.toStringWithPort()<<" validates as Insecure"<<endl;
             }
             
             pw.getHeader()->ad=0;
           }
           else if(state == Bogus) {
-            if(g_dnssecLogBogus || sr.doLog() || g_dnssecmode == DNSSECMode::ValidateForLog) {
+            if(shouldLog || g_dnssecLogMode == DNSSECLogMode::BogusOnly) {
               L<<Logger::Warning<<"Answer to "<<dc->d_mdp.d_qname<<"|"<<QType(dc->d_mdp.d_qtype).getName()<<" for "<<dc->d_remote.toStringWithPort()<<" validates as Bogus"<<endl;
             }
             
             // Does the query or validation mode sending out a SERVFAIL on validation errors?
-            if(!pw.getHeader()->cd && (g_dnssecmode == DNSSECMode::ValidateAll || dc->d_mdp.d_header.ad || DNSSECOK)) {
-              if(sr.doLog()) {
+            if(!pw.getHeader()->cd &&
+                ((g_dnssecBogusServfailMode == DNSSECBogusServfailMode::ClientOnly && (dc->d_mdp.d_header.ad || DNSSECOK)) ||
+                g_dnssecBogusServfailMode == DNSSECBogusServfailMode::On)) {
+              if(sr.doLog() || shouldLog || g_dnssecLogMode == DNSSECLogMode::BogusOnly) {
                 L<<Logger::Warning<<"Sending out SERVFAIL for "<<dc->d_mdp.d_qname<<"|"<<QType(dc->d_mdp.d_qtype).getName()<<" because recursor or query demands it for Bogus results"<<endl;
               }
               
@@ -2826,22 +2831,43 @@ static int serviceMain(int argc, char*argv[])
   }
 
   // keep this ABOVE loadRecursorLuaConfig!
-  if(::arg()["dnssec"]=="off")
-    g_dnssecmode=DNSSECMode::Off;
-  else if(::arg()["dnssec"]=="process-no-validate")
-    g_dnssecmode=DNSSECMode::ProcessNoValidate;
-  else if(::arg()["dnssec"]=="process")
-    g_dnssecmode=DNSSECMode::Process;
-  else if(::arg()["dnssec"]=="validate")
-    g_dnssecmode=DNSSECMode::ValidateAll;
-  else if(::arg()["dnssec"]=="log-fail")
-    g_dnssecmode=DNSSECMode::ValidateForLog;
-  else {
-    L<<Logger::Error<<"Unknown DNSSEC mode "<<::arg()["dnssec"]<<endl;
+  if(pdns_iequals(::arg()["dnssec-validation"], "yes")) {
+    g_dnssecValidationMode = DNSSECValidationMode::Validate;
+  } else if(pdns_iequals(::arg()["dnssec-validation"], "process")) {
+    g_dnssecValidationMode = DNSSECValidationMode::Process;
+  } else if(pdns_iequals(::arg()["dnssec-validation"],  "no")) {
+    g_dnssecValidationMode = DNSSECValidationMode::Off;
+  } else if(pdns_iequals(::arg()["dnssec-validation"], "client")) {
+    g_dnssecValidationMode = DNSSECValidationMode::ClientOnly;
+  } else {
+    L<<Logger::Error<<"Unknown DNSSEC Validation mode "<<::arg()["dnssec-validation"]<<endl;
     exit(1);
   }
 
-  g_dnssecLogBogus = ::arg().mustDo("dnssec-log-bogus");
+  if(pdns_iequals(::arg()["dnssec-servfail"], "yes")) {
+    g_dnssecBogusServfailMode = DNSSECBogusServfailMode::On;
+  } else if(pdns_iequals(::arg()["dnssec-servfail"], "no")) {
+    g_dnssecBogusServfailMode = DNSSECBogusServfailMode::Off;
+  } else if(pdns_iequals(::arg()["dnssec-servfail"], "client")) {
+    g_dnssecBogusServfailMode = DNSSECBogusServfailMode::ClientOnly;
+  } else {
+    L<<Logger::Error<<"Unknown DNSSEC BogusServfail mode "<<::arg()["dnssec-servfail"]<<endl;
+    exit(1);
+  }
+
+  if (pdns_iequals(::arg()["dnssec-log"], "yes") || pdns_iequals(::arg()["dnssec-log"], "all")) {
+    g_dnssecLogMode = DNSSECLogMode::On;
+  } else if (pdns_iequals(::arg()["dnssec-log"], "no")) {
+    g_dnssecLogMode = DNSSECLogMode::Off;
+  } else if (pdns_iequals(::arg()["dnssec-log"], "bogus")) {
+    g_dnssecLogMode = DNSSECLogMode::BogusOnly;
+  } else if (pdns_iequals(::arg()["dnssec-log"], "trace")) {
+    g_dnssecLogMode = DNSSECLogMode::Trace;
+  } else {
+    L<<Logger::Error<<"Unknown DNSSEC Logging mode "<<::arg()["dnssec-log"]<<endl;
+    exit(1);
+  }
+
   g_maxNSEC3Iterations = ::arg().asNum("nsec3-max-iterations");
 
   g_maxCacheEntries = ::arg().asNum("max-cache-entries");
@@ -2891,7 +2917,7 @@ static int serviceMain(int argc, char*argv[])
     SyncRes::setDefaultLogMode(SyncRes::Log);
     ::arg().set("quiet")="no";
     g_quiet=false;
-    g_dnssecLOG=true;
+    g_dnssecLogMode = DNSSECLogMode::On;
   }
 
   SyncRes::s_minimumTTL = ::arg().asNum("minimum-ttl-override");
@@ -3268,8 +3294,9 @@ int main(int argc, char **argv)
     ::arg().set("local-address","IP addresses to listen on, separated by spaces or commas. Also accepts ports.")="127.0.0.1";
     ::arg().setSwitch("non-local-bind", "Enable binding to non-local addresses by using FREEBIND / BINDANY socket options")="no";
     ::arg().set("trace","if we should output heaps of logging. set to 'fail' to only log failing domains")="off";
-    ::arg().set("dnssec", "DNSSEC mode: off/process-no-validate (default)/process/log-fail/validate")="process-no-validate";
-    ::arg().set("dnssec-log-bogus", "Log DNSSEC bogus validations")="no";
+    ::arg().set("dnssec-validation", "DNSSEC validation mode: yes/no/client")="no";
+    ::arg().set("dnssec-servfail", "DNSSEC send SERVFAIL on bogus: yes/no/client")="no";
+    ::arg().set("dnssec-log", "DNSSEC log validation results: yes/all/no/bogus")="no";
     ::arg().set("daemon","Operate as a daemon")="no";
     ::arg().setSwitch("write-pid","Write a PID file")="yes";
     ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="6";

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -370,30 +370,39 @@ string doSetCarbonServer(T begin, T end)
 }
 
 template<typename T>
-string doSetDnssecLogBogus(T begin, T end)
+string doSetDnssecLog(T begin, T end)
 {
   if(checkDNSSECDisabled())
-    return "DNSSEC is disabled in the configuration, not changing the Bogus logging setting\n";
+    return "DNSSEC is disabled in the configuration, not changing the DNSSEC validation logging setting\n";
 
   if (begin == end)
-    return "No DNSSEC Bogus logging setting specified\n";
+    return "No DNSSEC validation logging setting specified\n";
 
   if (pdns_iequals(*begin, "on") || pdns_iequals(*begin, "yes")) {
-    if (!g_dnssecLogBogus) {
+    if (g_dnssecLogMode != DNSSECLogMode::On) {
       L<<Logger::Warning<<"Enabling DNSSEC Bogus logging, requested via control channel"<<endl;
-      g_dnssecLogBogus = true;
+      g_dnssecLogMode = DNSSECLogMode::On;
       return "DNSSEC Bogus logging enabled\n";
     }
-    return "DNSSEC Bogus logging was already enabled\n";
+    return "DNSSEC validation logging was already enabled\n";
   }
 
   if (pdns_iequals(*begin, "off") || pdns_iequals(*begin, "no")) {
-    if (g_dnssecLogBogus) {
-      L<<Logger::Warning<<"Disabling DNSSEC Bogus logging, requested via control channel"<<endl;
-      g_dnssecLogBogus = false;
-      return "DNSSEC Bogus logging disabled\n";
+    if (g_dnssecLogMode != DNSSECLogMode::Off) {
+      L<<Logger::Warning<<"Disabling DNSSEC validation logging, requested via control channel"<<endl;
+      g_dnssecLogMode = DNSSECLogMode::Off;
+      return "DNSSEC validation logging disabled\n";
     }
-    return "DNSSEC Bogus logging was already disabled\n";
+    return "DNSSEC validation logging was already disabled\n";
+  }
+
+  if (pdns_iequals(*begin, "bogus")) {
+    if (g_dnssecLogMode != DNSSECLogMode::BogusOnly) {
+      L<<Logger::Warning<<"Enabling DNSSEC Bogus validation logging, requested via control channel"<<endl;
+      g_dnssecLogMode = DNSSECLogMode::BogusOnly;
+      return "DNSSEC Bogus validation logging enabled\n";
+    }
+    return "DNSSEC Bogus validation logging was already enabled\n";
   }
 
   return "Unknown DNSSEC Bogus setting: '" + *begin +"'\n";
@@ -1422,8 +1431,8 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
     return getTAs();
   }
 
-  if (cmd=="set-dnssec-log-bogus")
-    return doSetDnssecLogBogus(begin, end);
+  if (cmd=="set-dnssec-log")
+    return doSetDnssecLog(begin, end);
 
   return "Unknown command '"+cmd+"', try 'help'\n";
 }

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -152,8 +152,8 @@ static void init(bool debug=false)
   luaconfsCopy.negAnchors.clear();
   g_luaconfs.setState(luaconfsCopy);
 
-  g_dnssecmode = DNSSECMode::Off;
-  g_dnssecLOG = debug;
+  g_dnssecValidationMode = DNSSECValidationMode::Off;
+  g_dnssecLogMode = debug ? DNSSECLogMode::On : DNSSECLogMode::Off;
 
   ::arg().set("version-string", "string reported on version.pdns or version.bind")="PowerDNS Unit Tests";
 }
@@ -183,10 +183,10 @@ static void initSR(std::unique_ptr<SyncRes>& sr, bool dnssec=false, bool debug=f
   SyncRes::clearNegCache();
 }
 
-static void setDNSSECValidation(std::unique_ptr<SyncRes>& sr, const DNSSECMode& mode)
+static void setDNSSECValidation(std::unique_ptr<SyncRes>& sr, const DNSSECValidationMode& mode)
 {
   sr->setDNSSECValidationRequested(true);
-  g_dnssecmode = mode;
+  g_dnssecValidationMode = mode;
 }
 
 static void setLWResult(LWResult* res, int rcode, bool aa=false, bool tc=false, bool edns=false)
@@ -3362,7 +3362,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_root_validation_csk) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -3427,7 +3427,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_root_validation_ksk_zsk) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -3513,7 +3513,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_no_dnskey) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -3577,7 +3577,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_doesnt_match_ds) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -3662,7 +3662,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_rrsig_signed_with_unknown_dnskey) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -3737,7 +3737,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_no_rrsig) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -3803,7 +3803,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_algorithm) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -3884,7 +3884,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_digest) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -3963,7 +3963,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_bad_sig) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -4029,7 +4029,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_bad_algo) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -4096,7 +4096,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_various_algos) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -4191,7 +4191,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_a_then_ns) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -4295,7 +4295,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_a_then_ns) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -4395,7 +4395,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_with_nta) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -4495,7 +4495,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_with_nta) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -4582,7 +4582,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -4672,7 +4672,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nxdomain_nsec) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("nx.powerdns.com.");
@@ -4787,7 +4787,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.powerdns.com.");
@@ -4895,7 +4895,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_nodata_nowildcard) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.com.");
@@ -4974,7 +4974,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.com.");
@@ -5064,7 +5064,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.powerdns.com.");
@@ -5176,7 +5176,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_missing) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.powerdns.com.");
@@ -5281,7 +5281,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_secure) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.powerdns.com.");
@@ -5391,7 +5391,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_ds_sign_loop) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.powerdns.com.");
@@ -5505,7 +5505,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_insecure) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.powerdns.com.");
@@ -5614,7 +5614,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_bogus_unsigned_nsec) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -5701,7 +5701,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_bogus_no_nsec) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -5788,7 +5788,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -5902,7 +5902,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_direct_ds) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -5968,7 +5968,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_direct_ds) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -6029,7 +6029,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_skipped_cut) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.sub.powerdns.com.");
@@ -6150,7 +6150,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_ta_skipped_cut) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("www.sub.powerdns.com.");
@@ -6276,7 +6276,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nodata) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -6387,7 +6387,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -6514,7 +6514,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_secure_cname) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("power-dns.com.");
@@ -6638,7 +6638,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_secure_cname) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("power-dns.com.");
@@ -6733,7 +6733,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_bogus_cname) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("power-dns.com.");
@@ -6828,7 +6828,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_secure_cname) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("power-dns.com.");
@@ -6923,7 +6923,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_insecure_cname) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -7043,7 +7043,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -7138,7 +7138,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta_norrsig) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -7233,7 +7233,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_nta) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -7299,7 +7299,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ta) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target(".");
@@ -7354,7 +7354,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nodata) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("powerdns.com.");
@@ -7950,7 +7950,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("com.");
@@ -8016,7 +8016,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_cache_validity) {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
 
-  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+  setDNSSECValidation(sr, DNSSECValidationMode::Validate);
 
   primeHints();
   const DNSName target("com.");

--- a/pdns/secpoll-recursor.cc
+++ b/pdns/secpoll-recursor.cc
@@ -25,7 +25,7 @@ void doSecPoll(time_t* last_secpoll)
   struct timeval now;
   gettimeofday(&now, 0);
   SyncRes sr(now);
-  if (g_dnssecmode != DNSSECMode::Off) {
+  if (g_dnssecValidationMode != DNSSECValidationMode::Off) {
     sr.setDoDNSSEC(true);
     sr.setDNSSECValidationRequested(true);
   }
@@ -45,7 +45,7 @@ void doSecPoll(time_t* last_secpoll)
   DNSName query(qstring);
   int res=sr.beginResolve(query, QType(QType::TXT), 1, ret);
 
-  if (g_dnssecmode != DNSSECMode::Off && res) {
+  if (g_dnssecValidationMode != DNSSECValidationMode::Off && res) {
     state = sr.getValidationState();
   }
 

--- a/pdns/validate-recursor.cc
+++ b/pdns/validate-recursor.cc
@@ -3,15 +3,15 @@
 #include "syncres.hh"
 #include "logger.hh"
 
-DNSSECMode g_dnssecmode{DNSSECMode::ProcessNoValidate};
-bool g_dnssecLogBogus;
+DNSSECValidationMode g_dnssecValidationMode{DNSSECValidationMode::Process};
+DNSSECBogusServfailMode g_dnssecBogusServfailMode{DNSSECBogusServfailMode::Off};
 
 bool checkDNSSECDisabled() {
   return warnIfDNSSECDisabled("");
 }
 
 bool warnIfDNSSECDisabled(const string& msg) {
-  if(g_dnssecmode == DNSSECMode::Off) {
+  if(g_dnssecValidationMode == DNSSECValidationMode::Off) {
     if (!msg.empty())
       L<<Logger::Warning<<msg<<endl;
     return true;

--- a/pdns/validate-recursor.hh
+++ b/pdns/validate-recursor.hh
@@ -24,16 +24,22 @@
 #include "validate.hh"
 #include "logger.hh"
 
-/* Off: 3.x behaviour, we do no DNSSEC, no EDNS
-   ProcessNoValidate: we gather DNSSEC records on all queries, but we will never validate
-   Process: we gather DNSSEC records on all queries, if you do ad=1, we'll validate for you (unless you set cd=1)
-   ValidateForLog: Process + validate all answers, but only log failures
-   ValidateAll: DNSSEC issue -> servfail
-*/
+/* Off: 3.x behaviour, no DNSSEC, no EDNS
+ * Process: Set DO on outgoing queries, return RRSIGs and NSEC(3) on +DO from clients
+ * ClientOnly: Like Process, but validate as well if the client sets +DO
+ * Validate: Validate all answers
+ */
+enum class DNSSECValidationMode { Off, Process, ClientOnly, Validate };
+extern DNSSECValidationMode g_dnssecValidationMode;
 
-enum class DNSSECMode { Off, Process, ProcessNoValidate, ValidateForLog, ValidateAll };
-extern DNSSECMode g_dnssecmode;
-extern bool g_dnssecLogBogus;
+/* Off: Never send out SERVFAIL on a Bogus
+ * On: Always send out SERVFAIL on a Bogus
+ * ClientOnly: Send SERVFAIL on a bogus if the client query had +AD or +DO set
+ *
+ * note: a +CD from a client will not yield a DNSSEC SERVFAIL
+ */
+enum class DNSSECBogusServfailMode { Off, On, ClientOnly };
+extern DNSSECBogusServfailMode g_dnssecBogusServfailMode;
 
 bool checkDNSSECDisabled();
 bool warnIfDNSSECDisabled(const string& msg);

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -5,10 +5,11 @@
 #include "rec-lua-conf.hh"
 #include "base32.hh"
 #include "logger.hh"
-bool g_dnssecLOG{false};
+
+DNSSECLogMode g_dnssecLogMode{DNSSECLogMode::Off};
 uint16_t g_maxNSEC3Iterations{0};
 
-#define LOG(x) if(g_dnssecLOG) { L <<Logger::Warning << x; }
+#define LOG(x) if(g_dnssecLogMode == DNSSECLogMode::Trace) { L <<Logger::Warning << x; }
 void dotEdge(DNSName zone, string type1, DNSName name1, string tag1, string type2, DNSName name2, string tag2, string color="");
 void dotNode(string type, DNSName name, string tag, string content);
 string dotName(string type, DNSName name, string tag);

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -26,8 +26,15 @@
 #include <vector>
 #include "namespaces.hh"
 #include "dnsrecords.hh"
- 
-extern bool g_dnssecLOG;
+
+/* Off: Do not log DNSSEC validation results
+ * On: Log all DNSSEC validation results
+ * BogusOnly: Log all DNSSEC Bogus validations
+ * Trace: Log all DNSSEC validation steps
+ */
+enum class DNSSECLogMode { Off, On, BogusOnly, Trace };
+extern DNSSECLogMode g_dnssecLogMode;
+
 extern uint16_t g_maxNSEC3Iterations;
 
 // 4033 5


### PR DESCRIPTION
### Short description
This should implement the suggestions in #4436 and allow operators to
control their log volumes when e.g. only validation results are
required.

Not that running with `--trace` will also print the DNSSEC traces.

I open this PR for feedback now, as we have to decide if it goes in 4.1.0 or 4.2.0. What is really missing here, is the documentation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)