### PR TITLE
dnsscope & dnsreplay improvements: log-histogram

### DIFF
--- a/docs/manpages/dnsreplay.1.rst
+++ b/docs/manpages/dnsreplay.1.rst
@@ -35,6 +35,7 @@ PORT
 --ecs-mask <VAL>         When EDNS forwarding an IP address, mask out first octet with this value
 --ecs-stamp <FLAG>       Add original IP address as EDNS Client Subnet Option when 
                          forwarding to reference server
+--log-histogram          Write out a log-histogram of response times to 'log-histogram'
 --packet-limit <NUM>     Stop after replaying *NUM* packets. Default for *NUM* is 0, which
                          means no limit.
 --quiet <FLAG>           If *FLAG* is set to 1. dnsreplay will not be very noisy with its

--- a/docs/manpages/dnsscope.1.rst
+++ b/docs/manpages/dnsscope.1.rst
@@ -25,6 +25,7 @@ INFILE
                                        flag set. By default, we process all DNS packets in *INFILE*.
 --ipv4=<state>                         Process IPv4 packets. On by default, disable with **--ipv4 false**.
 --ipv6=<state>                         Process IPv6 packets. On by default, disable with **--ipv6 false**.
+--log-histogram                        Write out a log-histogram of response times to 'log-histogram'
 --servfail-tree                        Figure out subtrees that generate servfails.
 -l, --load-stats                       Emit per-second load statistics (questions, answers, outstanding).
 -w <file>, --write-failures <file>     Write weird packets to a PCAP file at *FILENAME*.

--- a/pdns/anadns.hh
+++ b/pdns/anadns.hh
@@ -38,16 +38,17 @@ struct QuestionIdentifier
   bool operator<(const QuestionIdentifier& rhs) const
   {
     return 
-      tie(d_source, d_dest, d_qname, d_qtype, d_id) < 
-      tie(rhs.d_source, rhs.d_dest, rhs.d_qname, rhs.d_qtype, rhs.d_id);
+      tie(d_id,         d_qtype,     d_source,     d_dest,     d_qname) < 
+      tie(rhs.d_id, rhs.d_qtype, rhs.d_source, rhs.d_dest, rhs.d_qname);
   }
 
+
   // the canonical direction is that of the question
-  static QuestionIdentifier create(const ComboAddress& src, const ComboAddress& dst, const MOADNSParser& mdp)
+  static QuestionIdentifier create(const ComboAddress& src, const ComboAddress& dst, const struct dnsheader& header, const DNSName& qname, uint16_t qtype)
   {
     QuestionIdentifier ret;
 
-    if(mdp.d_header.qr) {
+    if(header.qr) {
       ret.d_source = dst;
       ret.d_dest = src;
     }
@@ -55,12 +56,19 @@ struct QuestionIdentifier
       ret.d_source = src;
       ret.d_dest = dst;
     }
-    ret.d_qname=mdp.d_qname;
-    ret.d_qtype=mdp.d_qtype;
-    ret.d_id=mdp.d_header.id;
+    ret.d_qname=qname;
+    ret.d_qtype=qtype;
+    ret.d_id=ntohs(header.id);
     return ret;
   }
 
+  // the canonical direction is that of the question
+  static QuestionIdentifier create(const ComboAddress& src, const ComboAddress& dst, const MOADNSParser& mdp)
+  {
+    return create(src, dst, mdp.d_header, mdp.d_qname, mdp.d_qtype);
+  }
+
+  
   ComboAddress d_source, d_dest;
 
   DNSName d_qname;

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -23,6 +23,8 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "histog.hh"
+
 #include "statbag.hh"
 #include "dnspcap.hh"
 #include "dnsparser.hh"
@@ -35,13 +37,15 @@
 #include <algorithm>
 #include "anadns.hh"
 #include <boost/program_options.hpp>
-
+#include <unordered_set>
 #include <boost/logic/tribool.hpp>
 #include "arguments.hh"
 #include "namespaces.hh"
 #include <deque>
 #include "dnsrecords.hh"
+#include <deque>
 #include "statnode.hh"
+
 
 namespace po = boost::program_options;
 po::variables_map g_vm;
@@ -120,6 +124,13 @@ void visitor(const StatNode* node, const StatNode::Stat& selfstat, const StatNod
   }
 }
 
+const struct timeval operator-(const struct pdns_timeval& lhs, const struct pdns_timeval& rhs)
+{
+  struct timeval a{lhs.tv_sec, lhs.tv_usec}, b{rhs.tv_sec, rhs.tv_usec};
+  return operator-(a,b);
+}
+
+
 int main(int argc, char** argv)
 try
 {
@@ -131,6 +142,7 @@ try
     ("ipv4", po::value<bool>()->default_value(true), "Process IPv4 packets")
     ("ipv6", po::value<bool>()->default_value(true), "Process IPv6 packets")
     ("servfail-tree", "Figure out subtrees that generate servfails")
+    ("log-histogram", "Write a log-histogram to file 'log-histogram'")
     ("load-stats,l", po::value<string>()->default_value(""), "if set, emit per-second load statistics (questions, answers, outstanding)")
     ("write-failures,w", po::value<string>()->default_value(""), "if set, write weird packets to this PCAP file")
     ("verbose,v", "be verbose");
@@ -156,7 +168,7 @@ try
   }
 
   if(files.empty() || g_vm.count("help")) {
-    cerr<<"Syntax: dnsscope filename.pcap"<<endl;
+    cerr<<"Syntax: dnsscope filename.pcap [filenam2.pcap...]"<<endl;
     cout << desc << endl;
     exit(0);
   }
@@ -177,7 +189,7 @@ try
   bool doIPv4 = g_vm["ipv4"].as<bool>();
   bool doIPv6 = g_vm["ipv6"].as<bool>();
   bool doServFailTree = g_vm.count("servfail-tree");
-  int dnserrors=0, bogus=0;
+  int dnserrors=0, parsefail=0;
   typedef map<uint32_t,uint32_t> cumul_t;
   cumul_t cumul;
   unsigned int untracked=0, errorresult=0, reallylate=0, nonRDQueries=0, queries=0;
@@ -185,16 +197,18 @@ try
   unsigned int answers=0, nonDNSIP=0, rdFilterMismatch=0;
   unsigned int dnssecOK=0, edns=0;
   unsigned int dnssecCD=0, dnssecAD=0;
+  unsigned int reuses=0;
   typedef map<uint16_t,uint32_t> rcodes_t;
   rcodes_t rcodes;
   
   time_t lowestTime=2000000000, highestTime=0;
   time_t lastsec=0;
   LiveCounts lastcounts;
-  set<ComboAddress, ComboAddress::addressOnlyLessThan> requestors, recipients, rdnonra;
+  std::unordered_set<ComboAddress, ComboAddress::addressOnlyHash> requestors, recipients, rdnonra;
   typedef vector<pair<time_t, LiveCounts> > pcounts_t;
   pcounts_t pcounts;
   OPTRecordContent::report();
+
   for(unsigned int fno=0; fno < files.size(); ++fno) {
     PcapPacketReader pr(files[fno]);
     PcapPacketWriter* pw=0;
@@ -217,19 +231,23 @@ try
 	      continue;
 	    }
 	  }
-	  MOADNSParser mdp(false, (const char*)pr.d_payload, pr.d_len);
-	  if(haveRDFilter && mdp.d_header.rd != rdFilter) {
+	  uint16_t qtype;
+	  DNSName qname((const char*)pr.d_payload, pr.d_len, 12, false, &qtype);
+	  struct dnsheader header;
+	  memcpy(&header, (struct dnsheader*)pr.d_payload, 12);
+
+	  if(haveRDFilter && header.rd != rdFilter) {
 	    rdFilterMismatch++;
 	    continue;
 	  }
 
-	  if(!mdp.d_header.qr && getEDNSOpts(mdp, &edo)) {
-	    edns++;
-	    if(edo.d_Z & EDNSOpts::DNSSECOK)
-	      dnssecOK++;
-	    if(mdp.d_header.cd)
+	  if(!header.qr) {
+	    //	    edns++;
+	    //if(edo.d_Z & EDNSOpts::DNSSECOK)
+	      //dnssecOK++;
+	    if(header.cd)
 	      dnssecCD++;
-	    if(mdp.d_header.ad)
+	    if(header.ad)
 	      dnssecAD++;
 	  }
 	  
@@ -257,12 +275,11 @@ try
 	  lowestTime=min((time_t)lowestTime,  (time_t)pr.d_pheader.ts.tv_sec);
 	  highestTime=max((time_t)highestTime, (time_t)pr.d_pheader.ts.tv_sec);
 
-	  string name=mdp.d_qname.toString()+"|"+DNSRecordContent::NumberToType(mdp.d_qtype);
-        
-	  QuestionIdentifier qi=QuestionIdentifier::create(pr.getSource(), pr.getDest(), mdp);
+	  QuestionIdentifier qi=QuestionIdentifier::create(pr.getSource(), pr.getDest(), header, qname, qtype);
 
-	  if(!mdp.d_header.qr) { // question
-	    if(!mdp.d_header.rd)
+	  if(!header.qr) { // question
+	    //	    cout<<"Query "<<qi<<endl;
+	    if(!header.rd)
 	      nonRDQueries++;
 	    queries++;
 
@@ -270,64 +287,70 @@ try
 	    rem.sin4.sin_port=0;
 	    requestors.insert(rem);	  
 
-	    QuestionData& qd=statmap[qi];
+            QuestionData& qd=statmap[qi];
           
 	    if(!qd.d_firstquestiontime.tv_sec)
 	      qd.d_firstquestiontime=pr.d_pheader.ts;
-	    qd.d_qcount++;
+	    else {
+	      auto delta=makeFloat(pr.d_pheader.ts - qd.d_firstquestiontime);
+	      //	      cout<<"Reuse of "<<qi<<", delta t="<<delta<<", count="<<qd.d_qcount<<endl;
+	      if(delta > 2.0) {
+		//		cout<<"Resetting old entry for "<<qi<<", too old"<<endl;
+		qd.d_qcount=0;
+		qd.d_answercount=0;
+		qd.d_firstquestiontime=pr.d_pheader.ts;
+	      }
+	    }
+	    if(qd.d_qcount++)
+              reuses++;
 	  }
 	  else  {  // answer
-	    rcodes[mdp.d_header.rcode]++;
+	    //	    cout<<"Response "<<qi<<endl;
+	    rcodes[header.rcode]++;
 	    answers++;
-	    if(mdp.d_header.rd && !mdp.d_header.ra) {
+	    if(header.rd && !header.ra) {
 	      rdNonRAAnswers++;
 	      rdnonra.insert(pr.getDest());
 	    }
 	  
-	    if(mdp.d_header.ra) {
+	    if(header.ra) {
 	      ComboAddress rem = pr.getDest();
 	      rem.sin4.sin_port=0;
 	      recipients.insert(rem);	  
 	    }
 
 	    QuestionData& qd=statmap[qi];
-
-	    if(!qd.d_qcount)
+	    if(!qd.d_qcount) {
+	      //	      cout<<"Untracked answer: "<<qi<<endl;
 	      untracked++;
+	    }
 
 	    qd.d_answercount++;
 
 	    if(qd.d_qcount) {
 	      uint32_t usecs= (pr.d_pheader.ts.tv_sec - qd.d_firstquestiontime.tv_sec) * 1000000 +  
 		(pr.d_pheader.ts.tv_usec - qd.d_firstquestiontime.tv_usec) ;
-	      //            cout<<"Took: "<<usecs<<"usec\n";
-	      if(usecs<2049000)
-		cumul[usecs]++;
-	      else
-		reallylate++;
+
+	      //	      cout<<"Usecs for "<<qi<<": "<<usecs<<endl;
+	      cumul[usecs]++;
             
-	      if(mdp.d_header.rcode != 0 && mdp.d_header.rcode!=3) 
+	      if(header.rcode != 0 && header.rcode!=3) 
 		errorresult++;
 	      ComboAddress rem = pr.getDest();
 	      rem.sin4.sin_port=0;
 
 	      if(doServFailTree)
-		root.submit(mdp.d_qname, mdp.d_header.rcode, rem);
+		root.submit(qname, header.rcode, rem);
 	    }
 
-	    if(!qd.d_qcount || qd.d_qcount == qd.d_answercount)
+	    if(!qd.d_qcount || qd.d_qcount == qd.d_answercount) {
+	      //	      cout<<"Clearing state for "<<qi<<endl<<endl;
 	      statmap.erase(qi);
+	    }
+	    else
+	      ;//	      cout<<"State for qi remains open, qcount="<<qd.d_qcount<<", answercount="<<qd.d_answercount<<endl;
+	     
 	  }
-
-        
-	}
-	catch(MOADNSException& mde) {
-	  if(verbose)
-	    cout<<"error parsing packet: "<<mde.what()<<endl;
-	  if(pw)
-	    pw->write();
-	  dnserrors++;
-	  continue;
 	}
 	catch(std::exception& e) {
 	  if(verbose)
@@ -335,7 +358,7 @@ try
 
 	  if(pw)
 	    pw->write();
-	  bogus++;
+	  parsefail++;
 	  continue;
 	}
       }
@@ -346,13 +369,22 @@ try
     cout<<"PCAP contained "<<pr.d_correctpackets<<" correct packets, "<<pr.d_runts<<" runts, "<< pr.d_oversized<<" oversize, "<<pr.d_nonetheripudp<<" non-UDP.\n";
 
   }
+
+  /*
+  cout<<"Open when done: "<<endl;
+  for(const auto& a : statmap) {
+    cout<<a.first<<": qcount="<<a.second.d_qcount<<", answercount="<<a.second.d_answercount<<endl;
+  }
+  */
+  
   cout<<"Timespan: "<<(highestTime-lowestTime)/3600.0<<" hours"<<endl;
 
-  cout<<nonDNSIP<<" non-DNS UDP, "<<dnserrors<<" dns decoding errors, "<<bogus<<" bogus packets"<<endl;
+  cout<<nonDNSIP<<" non-DNS UDP, "<<dnserrors<<" dns decoding errors, "<<parsefail<<" packets failed to parse"<<endl;
   cout<<"Ignored fragment packets: "<<fragmented<<endl;
   cout<<"Dropped DNS packets based on recursion-desired filter: "<<rdFilterMismatch<<endl;
   cout<<"DNS IPv4: "<<ipv4DNSPackets<<" packets, IPv6: "<<ipv6DNSPackets<<" packets"<<endl;
   cout<<"Questions: "<<queries<<", answers: "<<answers<<endl;
+  cout<<"Reuses of same state entry: "<<reuses<<endl;
   unsigned int unanswered=0;
 
 
@@ -388,26 +420,18 @@ try
   
   typedef map<uint32_t, bool> done_t;
   done_t done;
-  done[50];
-  done[100];
-  done[200];
-  done[300];
-  done[400];
-  done[800];
-  done[1000];
-  done[2000];
-  done[4000];
-  done[8000];
-  done[32000];
-  done[64000];
-  done[256000];
-  done[1024000];
-  done[2048000];
+  for(auto a : {50, 100, 200, 300, 400, 800, 1000, 2000, 4000, 8000, 32000, 64000, 256000, 1024000, 2048000})
+    done[a]=false;
 
   cout.setf(std::ios::fixed);
-  cout.precision(2);
+  cout.precision(4);
   sum=0;
-  
+
+  if(g_vm.count("log-histogram")) {
+    ofstream loglog("log-histogram");
+    writeLogHistogramFile(cumul, loglog);
+  }
+  sum=0;
   double lastperc=0, perc=0;
   for(cumul_t::const_iterator i=cumul.begin(); i!=cumul.end(); ++i) {
     sum+=i->second;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -106,9 +106,9 @@ union ComboAddress {
     if(sin4.sin_family == 0) {
       return false;
     } 
-    if(boost::tie(sin4.sin_family, sin4.sin_port) < boost::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
+    if(std::tie(sin4.sin_family, sin4.sin_port) < std::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
       return true;
-    if(boost::tie(sin4.sin_family, sin4.sin_port) > boost::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
+    if(std::tie(sin4.sin_family, sin4.sin_port) > std::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
       return false;
     
     if(sin4.sin_family == AF_INET)


### PR DESCRIPTION
### Short description
With this PR, dnsscope and dnsreplay gain speed, features and correctness.

Specifically, both gain --log-histogram which creates a histogram that when fed to (for example) gnuplot leads to nice graphs that display performance. 

In addition, both tools receive some love to make them deal better with statistics for duplicate simultaneous queries. 

Finally, there are some small cleanups here and there. 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
