### PR TITLE
rec: Add the DNSSEC validation state to the DNSQuestion Lua object

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -337,6 +337,7 @@ RecursorLua4::RecursorLua4(const std::string& fname)
   d_lw->registerMember<bool (DNSQuestion::*)>("isTcp", [](const DNSQuestion& dq) -> bool { return dq.isTcp; }, [](DNSQuestion& dq, bool newTcp) { (void) newTcp; });
   d_lw->registerMember<const ComboAddress (DNSQuestion::*)>("localaddr", [](const DNSQuestion& dq) -> const ComboAddress& { return dq.local; }, [](DNSQuestion& dq, const ComboAddress& newLocal) { (void) newLocal; });
   d_lw->registerMember<const ComboAddress (DNSQuestion::*)>("remoteaddr", [](const DNSQuestion& dq) -> const ComboAddress& { return dq.remote; }, [](DNSQuestion& dq, const ComboAddress& newRemote) { (void) newRemote; });
+  d_lw->registerMember<vState (DNSQuestion::*)>("validationState", [](const DNSQuestion& dq) -> vState { return dq.validationState; }, [](DNSQuestion& dq, vState newState) { (void) newState; });
 
   d_lw->registerMember<bool (DNSQuestion::*)>("variable", [](const DNSQuestion& dq) -> bool { return dq.variable; }, [](DNSQuestion& dq, bool newVariable) { dq.variable = newVariable; });
   d_lw->registerMember<bool (DNSQuestion::*)>("wantsRPZ", [](const DNSQuestion& dq) -> bool { return dq.wantsRPZ; }, [](DNSQuestion& dq, bool newWantsRPZ) { dq.wantsRPZ = newWantsRPZ; });
@@ -503,6 +504,14 @@ RecursorLua4::RecursorLua4(const std::string& fname)
 
   for(const auto& n : QType::names)
     pd.push_back({n.first, n.second});
+
+  pd.push_back({"validationstates", in_t{
+        {"Indeterminate", Indeterminate },
+        {"Bogus", Bogus },
+        {"Insecure", Insecure },
+        {"Secure", Secure },
+  }});
+
   pd.push_back({"now", &g_now});
   d_lw->registerMember("tv_sec", &timeval::tv_sec);
   d_lw->registerMember("tv_usec", &timeval::tv_usec);

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -20,18 +20,20 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include "iputils.hh"
-#include "dnsname.hh"
-#include "namespaces.hh"
-#include "dnsrecords.hh"
-#include "filterpo.hh"
-#include "ednsoptions.hh"
 
 #include <unordered_map>
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#include "iputils.hh"
+#include "dnsname.hh"
+#include "namespaces.hh"
+#include "dnsrecords.hh"
+#include "filterpo.hh"
+#include "ednsoptions.hh"
+#include "validate.hh"
 
 string GenUDPQueryResponse(const ComboAddress& dest, const string& query);
 unsigned int getRecursorThreadId();
@@ -72,6 +74,7 @@ public:
     std::unordered_map<std::string,bool>* discardedPolicies{nullptr};
     std::string requestorId;
     std::string deviceId;
+    vState validationState{Indeterminate};
     bool& variable;
     bool& wantsRPZ;
     unsigned int tag{0};

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -904,6 +904,8 @@ static void startDoResolve(void *p)
         res = RCode::ServFail;
       }
 
+      dq.validationState = sr.getValidationState();
+
       // During lookup, an NSDNAME or NSIP trigger was hit in RPZ
       if (res == -2) { // XXX This block should be macro'd, it is repeated post-resolve.
         appliedPolicy = sr.d_appliedPolicy;

--- a/pdns/recursordist/contrib/dns64.lua
+++ b/pdns/recursordist/contrib/dns64.lua
@@ -6,6 +6,11 @@ function nodata ( dq )
     return false
   end  --  only AAAA records
 
+  -- don't fake AAAA records if DNSSEC validation failed
+  if dq.validationState == pdns.validationstates.Bogus then
+     return false
+  end
+
   dq.followupFunction = "getFakeAAAARecords"
   dq.followupPrefix = prefix
   dq.followupName = dq.qname

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -124,6 +124,14 @@ The DNSQuestion object contains at least the following fields:
 
     The name of the callback function that is called when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>` when an answer is received.
 
+.. attribute:: DNSQuestion.validationState
+
+    .. versionadded:: 4.1.0
+
+    The result of the DNSSEC validation, accessible from the ``postresolve``, ``nxdomain`` and ``nodata`` hooks.
+    Possible states are ``pdns.validationstates.Indeterminate``, ``pdns.validationstates.Bogus``, ``pdns.validationstates.Insecure`` and ``pdns.validationstates.Secure``.
+    The result will always be ``pdns.validationstates.Indeterminate`` is validation is disabled or was not requested.
+
 It also supports the following methods:
 
 .. classmethod:: DNSQuestion:addAnswer(type, content, [ttl, name])


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR exposes the DNSSEC validation state to Lua hooks that run after the normal resolution process (`nodata`, `nxdomain`, `postresolve`).
This should fix #5888, although the ability to update the validation state from these hooks is postponed to after 4.1.0.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
