### PR TITLE
rec: Purge nsSpeeds entries even if we get less than 2 new entries

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -692,9 +692,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   map<ComboAddress, double> speeds;
   auto& collection = t_sstorage.nsSpeeds[qname].d_collection;
   for(const auto& val: ret) {
-    double speed;
-    speed=collection[val].get(&d_now);
-    speeds[val]=speed;
+    speeds[val] = collection[val].get(&d_now);
   }
 
   t_sstorage.nsSpeeds[qname].purge(speeds);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -685,17 +685,21 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   d_requireAuthData = oldRequireAuthData;
   d_DNSSECValidationRequested = oldValidationRequested;
 
+  /* we need to remove from the nsSpeeds collection the existing IPs
+     for this nameserver that are no longer in the set, even if there
+     is only one or none at all in the current set.
+  */
+  map<ComboAddress, double> speeds;
+  auto& collection = t_sstorage.nsSpeeds[qname].d_collection;
+  for(const auto& val: ret) {
+    double speed;
+    speed=collection[val].get(&d_now);
+    speeds[val]=speed;
+  }
+
+  t_sstorage.nsSpeeds[qname].purge(speeds);
+
   if(ret.size() > 1) {
-    map<ComboAddress, double> speeds;
-    auto& collection = t_sstorage.nsSpeeds[qname].d_collection;
-    for(const auto& val: ret) {
-      double speed;
-      speed=collection[val].get(&d_now);
-      speeds[val]=speed;
-    }
-
-    t_sstorage.nsSpeeds[qname].purge(speeds);
-
     random_shuffle(ret.begin(), ret.end(), dns_random);
     speedOrderCA so(speeds);
     stable_sort(ret.begin(), ret.end(), so);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We only purged existing entries if we had more than one new entry, because the purging code was too tied to the code sorting the new entries.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
