### PR TITLE
Mark recursor as removed

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1179,8 +1179,7 @@ Seconds to store recursive packets in the :ref:`packet-cache`.
 ------------
 
 -  IP Address
-
-.. deprecated:: 4.1.0
+-  Removed in: 4.1.0
 
 If set, recursive queries will be handed to the recursor specified here.
 


### PR DESCRIPTION
According to #4616 the recursor setting was removed entirely in 4.1.0