### PR TITLE
auth: retry once is not an error condition.

### DIFF
--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -220,7 +220,7 @@ retry:
 
           delete QD->Q;
         } else {
-          L<<Logger::Error<<"Backend error (retry once): "<<e.reason<<endl;
+          L<<Logger::Notice<<"Backend error (retry once): "<<e.reason<<endl;
           goto retry;
         }
       }
@@ -237,7 +237,7 @@ retry:
 
           delete QD->Q;
         } else {
-          L<<Logger::Error<<"Caught unknown exception in Distributor thread "<<(long)pthread_self()<<" (retry once)"<<endl;
+          L<<Logger::Warning<<"Caught unknown exception in Distributor thread "<<(long)pthread_self()<<" (retry once)"<<endl;
           goto retry;
         }
       }
@@ -282,7 +282,7 @@ retry:
       S.inc("servfail-packets");
       S.ringAccount("servfail-queries",q->qdomain.toLogString());
     } else {
-      L<<Logger::Error<<"Backend error (retry once): "<<e.reason<<endl;
+      L<<Logger::Notice<<"Backend error (retry once): "<<e.reason<<endl;
       goto retry;
     }
   }
@@ -297,7 +297,7 @@ retry:
       S.inc("servfail-packets");
       S.ringAccount("servfail-queries",q->qdomain.toLogString());
     } else {
-      L<<Logger::Error<<"Caught unknown exception in Distributor thread "<<(unsigned long)pthread_self()<<" (retry once)"<<endl;
+      L<<Logger::Warning<<"Caught unknown exception in Distributor thread "<<(unsigned long)pthread_self()<<" (retry once)"<<endl;
       goto retry;
     }
   }


### PR DESCRIPTION
### Short description
'retry once' is no permanent error condition. This is just PowerDNS telling you 'hey something is wrong with my connection to the db server, let me fix this for you'.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
