### PR TITLE
auth: use 302 redirects in the webserver for ringbuffer reset or resize

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -200,7 +200,7 @@ void AuthWebServer::indexfunction(HttpRequest* req, HttpResponse* resp)
   if(!req->getvars["resetring"].empty()) {
     if (S.ringExists(req->getvars["resetring"]))
       S.resetRing(req->getvars["resetring"]);
-    resp->status = 301;
+    resp->status = 302;
     resp->headers["Location"] = req->url.path;
     return;
   }
@@ -208,7 +208,7 @@ void AuthWebServer::indexfunction(HttpRequest* req, HttpResponse* resp)
     int size=std::stoi(req->getvars["size"]);
     if (S.ringExists(req->getvars["resizering"]) && size > 0 && size <= 500000)
       S.resizeRing(req->getvars["resizering"], std::stoi(req->getvars["size"]));
-    resp->status = 301;
+    resp->status = 302;
     resp->headers["Location"] = req->url.path;
     return;
   }


### PR DESCRIPTION
### Short description
With the current 301 redirect it is only possible to reset or resize once. Every next duplicate action is replaced by the destination cached in the browser.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
