### PR TITLE
Have the REST-API use the `disable-dnssec` function from pdnsutil and…

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -627,8 +627,13 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
       // "dnssec": false in json
       if (isDNSSECZone) {
         disableDNSSECOnZone(dk, zonename);
-        if (!dk.isSecuredZone(zonename)) {
-           throw ApiException("Unable to remove DNSSEC from " + zonename.toString());
+        isDNSSECZone = dk.isSecuredZone(zonename);
+        
+        if (!isDNSSECZone) {
+          // We disabled DNSSEC, so ask to rectify
+          shouldRectify = true;
+        } else {
+          throw ApiException("Unable to remove DNSSEC from " + zonename.toString());
         }
       } else {
         throw ApiException("DNSSEC is not enabled on " + zonename.toString());

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -626,7 +626,16 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
     } else {
       // "dnssec": false in json
       if (isDNSSECZone) {
-        disableDNSSECOnZone(dk, zonename);
+        DNSSECKeeper::keyset_t keyset=dk.getKeys(zone);
+        if(!keyset.empty())  {
+          for(DNSSECKeeper::keyset_t::value_type value :  keyset) {
+            dk.deactivateKey(zonename, value.second.id);
+            dk.removeKey(zonename, value.second.id);
+          }
+        }
+        dk.unsetNSEC3PARAM(zonename);
+        dk.unsetPresigned(zonename);
+        
         isDNSSECZone = dk.isSecuredZone(zonename);
         
         if (!isDNSSECZone) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -626,7 +626,12 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
     } else {
       // "dnssec": false in json
       if (isDNSSECZone) {
-        throw ApiException("Refusing to un-secure zone " + zonename.toString());
+        disableDNSSECOnZone(dk, zonename);
+        if (!dk.isSecuredZone(zonename)) {
+           throw ApiException("Unable to remove DNSSEC from " + zonename.toString());
+        }
+      } else {
+        throw ApiException("DNSSEC is not enabled on " + zonename.toString());
       }
     }
   }


### PR DESCRIPTION
Have the REST-API use the `disable-dnssec` function from pdnsutil and copy behaviour

Fixes #5909

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
