### PR TITLE
Add quotation chars to make erroneous end of line whitespace easier t…

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -331,7 +331,7 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
     }
     catch(std::exception& e)
     {
-      cout<<"[Error] Following record had a problem: "<<rr.qname<<" IN " <<rr.qtype.getName()<< " " << rr.content<<endl;
+      cout<<"[Error] Following record had a problem: \""<<rr.qname<<" IN "<<rr.qtype.getName()<<" "<<rr.content<<"\""<<endl;
       cout<<"[Error] Error was: "<<e.what()<<endl;
       numerrors++;
       continue;


### PR DESCRIPTION
Instead of:
```
around [Error] Following record had a problem: ampel.nl IN SOA ns1.6core.net job.instituut.net. 2012062900 7200 3600 1209600 900
```

do
```
around [Error] Following record had a problem: "ampel.nl IN SOA ns1.6core.net job.instituut.net. 2012062900 7200 3600 1209600 900 "
```

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)