### PR TITLE
use _exit() when we really really want to exit, for example after a fatal error

### DIFF
--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -66,7 +66,7 @@ void CommunicatorClass::loadArgsIntoSet(const char *listname, set<string> &lists
     }
     catch(PDNSException &e) {
       L<<Logger::Error<<"Unparseable IP in "<<listname<<". Error: "<<e.reason<<endl;
-      exit(1);
+      _exit(1);
     }
   }
 }
@@ -78,7 +78,7 @@ void CommunicatorClass::go()
   }
   catch(PDNSException &e) {
     L<<Logger::Error<<"Unparseable IP in allow-notify-from. Error: "<<e.reason<<endl;
-    exit(1);
+    _exit(1);
   }
 
   pthread_t tid;
@@ -93,7 +93,7 @@ void CommunicatorClass::go()
   }
   catch(PDNSException &e) {
     L<<Logger::Error<<"Unparseable IP in only-notify. Error: "<<e.reason<<endl;
-    exit(1);
+    _exit(1);
   }
 
   loadArgsIntoSet("also-notify", d_alsoNotify);
@@ -138,16 +138,16 @@ void CommunicatorClass::mainloop(void)
   catch(PDNSException &ae) {
     L<<Logger::Error<<"Exiting because communicator thread died with error: "<<ae.reason<<endl;
     Utility::sleep(1);
-    exit(1);
+    _exit(1);
   }
   catch(std::exception &e) {
     L<<Logger::Error<<"Exiting because communicator thread died with STL error: "<<e.what()<<endl;
-    exit(1);
+    _exit(1);
   }
   catch( ... )
   {
     L << Logger::Error << "Exiting because communicator caught unknown exception." << endl;
-    exit(1);
+    _exit(1);
   }
 }
 

--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -130,11 +130,11 @@ template<class Answer, class Question, class Backend>SingleThreadDistributor<Ans
   }
   catch(const PDNSException &AE) {
     L<<Logger::Error<<"Distributor caught fatal exception: "<<AE.reason<<endl;
-    exit(1);
+    _exit(1);
   }
   catch(...) {
     L<<Logger::Error<<"Caught an unknown exception when creating backend, probably"<<endl;
-    exit(1);
+    _exit(1);
   }
 }
 
@@ -158,7 +158,7 @@ template<class Answer, class Question, class Backend>MultiThreadDistributor<Answ
   
   if (n<1) {
     L<<Logger::Error<<"Asked for fewer than 1 threads, nothing to do"<<endl;
-    exit(1);
+    _exit(1);
   }
 
   L<<Logger::Warning<<"About to create "<<n<<" backend threads for UDP"<<endl;
@@ -250,11 +250,11 @@ retry:
   }
   catch(const PDNSException &AE) {
     L<<Logger::Error<<"Distributor caught fatal exception: "<<AE.reason<<endl;
-    exit(1);
+    _exit(1);
   }
   catch(...) {
     L<<Logger::Error<<"Caught an unknown exception when creating backend, probably"<<endl;
-    exit(1);
+    _exit(1);
   }
   return 0;
 }

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -286,7 +286,7 @@ void DNSProxy::mainloop(void)
     L << Logger::Error << "Caught unknown exception." << endl;
   }
   L<<Logger::Error<<"Exiting because DNS proxy failed"<<endl;
-  exit(1);
+  _exit(1);
 }
 
 DNSProxy::~DNSProxy() {

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1233,7 +1233,7 @@ TCPNameserver::TCPNameserver()
     int tmp=1;
     if(setsockopt(s,SOL_SOCKET,SO_REUSEADDR,(char*)&tmp,sizeof tmp)<0) {
       L<<Logger::Error<<"Setsockopt failed"<<endl;
-      exit(1);  
+      _exit(1);  
     }
 
     if (::arg().asNum("tcp-fast-open") > 0) {
@@ -1285,7 +1285,7 @@ TCPNameserver::TCPNameserver()
     int tmp=1;
     if(setsockopt(s,SOL_SOCKET,SO_REUSEADDR,(char*)&tmp,sizeof tmp)<0) {
       L<<Logger::Error<<"Setsockopt failed"<<endl;
-      exit(1);  
+      _exit(1);  
     }
 
     if (::arg().asNum("tcp-fast-open") > 0) {
@@ -1354,7 +1354,7 @@ void TCPNameserver::thread()
             
             if(errno==EMFILE) {
               L<<Logger::Error<<"TCP handler out of filedescriptors, exiting, won't recover from this"<<endl;
-              exit(1);
+              _exit(1);
             }
           }
           else {
@@ -1393,7 +1393,7 @@ void TCPNameserver::thread()
   catch(...) {
     L<<Logger::Error<<"TCPNameserver dying because of an unexpected fatal error"<<endl;
   }
-  exit(1); // take rest of server with us
+  _exit(1); // take rest of server with us
 }
 
 

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -382,5 +382,5 @@ void WebServer::go()
   catch(...) {
     L<<Logger::Error<<"Unknown exception in main webserver thread"<<endl;
   }
-  exit(1);
+  _exit(1);
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -86,7 +86,7 @@ void AuthWebServer::statThread()
   }
   catch(...) {
     L<<Logger::Error<<"Webserver statThread caught an exception, dying"<<endl;
-    exit(1);
+    _exit(1);
   }
 }
 
@@ -1874,6 +1874,6 @@ void AuthWebServer::webThread()
   }
   catch(...) {
     L<<Logger::Error<<"AuthWebServer thread caught an exception, dying"<<endl;
-    exit(1);
+    _exit(1);
   }
 }


### PR DESCRIPTION

### Short description
This stops us dying while we die. A call to exit() will trigger destructors, which may paradoxically stop the process from exiting, taking down only one thread, but harming the rest of the process.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
