### PR TITLE
rec: Don't retry security polling too often when it fails

### DIFF
--- a/pdns/secpoll-recursor.cc
+++ b/pdns/secpoll-recursor.cc
@@ -24,6 +24,11 @@ void doSecPoll(time_t* last_secpoll)
   string pkgv(PACKAGEVERSION);
   struct timeval now;
   gettimeofday(&now, 0);
+
+  /* update last_secpoll right now, even if it fails
+     we don't want to retry right away and hammer the server */
+  *last_secpoll=now.tv_sec;
+
   SyncRes sr(now);
   if (g_dnssecmode != DNSSECMode::Off) {
     sr.setDoDNSSEC(true);
@@ -67,7 +72,6 @@ void doSecPoll(time_t* last_secpoll)
     g_security_status = std::stoi(split.first);
     g_security_message = split.second;
 
-    *last_secpoll=now.tv_sec;
   }
   else {
     if(pkgv.find("0.0.") != 0)
@@ -77,8 +81,6 @@ void doSecPoll(time_t* last_secpoll)
 
     if(g_security_status == 1) // it was ok, now it is unknown
       g_security_status = 0;
-    if(res == RCode::NXDomain) // if we had NXDOMAIN, keep on trying more more frequently
-      *last_secpoll=now.tv_sec; 
   }
 
   if(g_security_status == 2) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Even if the security polling fails because of a `Servfail` or DNSSEC validation, there is no reason to retry right away during the next `houseKeeping()` iteration. On recursor with an important workload, we could end up doing a security polling every second.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
