### PR TITLE
API docs: reduce RRSets/Records confusion 

### DIFF
--- a/docs/common/api/zone.rst
+++ b/docs/common/api/zone.rst
@@ -9,15 +9,15 @@ RRSet
   :property string type: Type of this record (e.g. "A", "PTR", "MX")
   :property integer ttl: DNS TTL of the records, in seconds. MUST NOT be included when ``changetype`` is set to "DELETE".
   :property string changetype: MUST be added when updating the RRSet. Must be ``REPLACE`` or ``DELETE``. With ``DELETE``, all existing RRs matching ``name`` and ``type`` will be deleted,  including all comments. With ``REPLACE``: when ``records`` is present, all existing RRs matching ``name`` and ``type`` will be deleted, and then new records given in ``records`` will be created. If no records are left, any existing comments will be deleted as well. When ``comments`` is present, all existing comments for the RRs matching ``name`` and ``type`` will be deleted, and then new comments given in ``comments`` will be created.
-  :property [Record] records: All records in this RRSet. When updating Records, this is the list of new records (replacing the old ones). Must be empty when ``changetype`` is set to ``DELETE``. An empty list results in deletion of all records (and comments).
+  :property [RREntry] records: All records in this RRSet. When updating records, this is the list of new records (replacing the old ones). Must be empty when ``changetype`` is set to ``DELETE``. An empty list results in deletion of all records (and comments).
   :property [Comment] comments: List of :json:object:`Comment`. Must be empty when ``changetype`` is set to ``DELETE``. An empty list results in deletion of all comments. ``modified_at`` is optional and defaults to the current server time.
 
-Record
-------
+RREntry
+-------
 
-.. json:object:: Record
+.. json:object:: RREntry
 
-  The Record object represents a single record in an :json:object:`RRSet`.
+  The RREntry object represents a single record in an :json:object:`RRSet`.
 
   :property string content: The content of this record
   :property bool disabled: Whether or not this record is disabled

--- a/docs/http-api/zone.rst
+++ b/docs/http-api/zone.rst
@@ -56,6 +56,6 @@ Backends might implement additional features (by coincidence or not).
 These things are not supported through the API.
 
 When creating a slave zone, it is recommended to not set any of
-``nameservers``, ``records`` or ``zone``.
+``nameservers``, ``rrsets`` or ``zone``.
 
 .. include:: ../common/api/zone.rst


### PR DESCRIPTION
Naming stuff is hard. Docs only change.