### PR TITLE
in the recursor secpoll code, we ASSumed the TXT record would be the first record

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2162,6 +2162,15 @@ static void houseKeeping(void *)
         {
           L<<Logger::Error<<"Exception while performing security poll: "<<e.what()<<endl;
         }
+        catch(PDNSException& e)
+        {
+          L<<Logger::Error<<"Exception while performing security poll: "<<e.reason<<endl;
+        }
+        catch(...)
+        {
+          L<<Logger::Error<<"Exception while performing security poll"<<endl;
+        }
+
       }
     }
     s_running=false;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2158,7 +2158,10 @@ static void houseKeeping(void *)
 	try {
 	  doSecPoll(&last_secpoll);
 	}
-	catch(...) {}
+	catch(std::exception& e)
+        {
+          L<<Logger::Error<<"Exception while performing security poll: "<<e.what()<<endl;
+        }
       }
     }
     s_running=false;

--- a/pdns/secpoll-recursor.cc
+++ b/pdns/secpoll-recursor.cc
@@ -36,7 +36,7 @@ void doSecPoll(time_t* last_secpoll)
   }
 
   vector<DNSRecord> ret;
-
+  
   string version = "recursor-" +pkgv;
   string qstring(version.substr(0, 63)+ ".security-status."+::arg()["security-poll-suffix"]);
 
@@ -62,16 +62,20 @@ void doSecPoll(time_t* last_secpoll)
   }
 
   if(!res && !ret.empty()) {
-    string content=ret.begin()->d_content->getZoneRepresentation();
+    string content;
+    for(const auto&r : ret) {
+      if(r.d_type == QType::TXT)
+        content = r.d_content->getZoneRepresentation();
+    }
+
     if(!content.empty() && content[0]=='"' && content[content.size()-1]=='"') {
       content=content.substr(1, content.length()-2);
     }
-      
+
     pair<string, string> split = splitField(content, ' ');
     
     g_security_status = std::stoi(split.first);
     g_security_message = split.second;
-
   }
   else {
     if(pkgv.find("0.0.") != 0)


### PR DESCRIPTION
### Short description
in the recursor secpoll code, we ASSumed the TXT record would be the first record first record we received. Sometimes it was the RRSIG, leading to a silent error, and no secpoll check. Fixed the assumption, added an error.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
