### PR TITLE
Check return value for all getTSIGKey calls

### DIFF
--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -788,8 +788,14 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
 
       if(dk.getTSIGForAccess(di.zone, sr.master, &dni.tsigkeyname)) {
         string secret64;
-        B->getTSIGKey(dni.tsigkeyname, &dni.tsigalgname, &secret64);
-        B64Decode(secret64, dni.tsigsecret);
+        if(!B->getTSIGKey(dni.tsigkeyname, &dni.tsigalgname, &secret64)) {
+          L<<Logger::Error<<"TSIG key '"<<dni.tsigkeyname<<"' for domain '"<<di.zone<<"' not found, can not AXFR."<<endl;
+          continue;
+        }
+        if (B64Decode(secret64, dni.tsigsecret) == -1) {
+          L<<Logger::Error<<"Unable to Base-64 decode TSIG key '"<<dni.tsigkeyname<<"' for domain '"<<di.zone<<"', can not AXFR."<<endl;
+          continue;
+        }
       }
 
       localaddr.clear();

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -639,8 +639,14 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
       algorithm = DNSName("hmac-md5");
     if (algorithm != DNSName("gss-tsig")) {
       Lock l(&s_plock);
-      s_P->getBackend()->getTSIGKey(tsigkeyname, &algorithm, &tsig64);
-      B64Decode(tsig64, tsigsecret);
+      if(!s_P->getBackend()->getTSIGKey(tsigkeyname, &algorithm, &tsig64)) {
+        L<<Logger::Error<<"TSIG key '"<<tsigkeyname<<"' for domain '"<<target<<"' not found"<<endl;
+        return 0;
+      }
+      if (B64Decode(tsig64, tsigsecret) == -1) {
+        L<<Logger::Error<<"Unable to Base-64 decode TSIG key '"<<tsigkeyname<<"' for domain '"<<target<<"'"<<endl;
+        return 0;
+      }
     }
   }
   
@@ -1157,8 +1163,14 @@ int TCPNameserver::doIXFR(shared_ptr<DNSPacket> q, int outsock)
       if (algorithm == DNSName("hmac-md5.sig-alg.reg.int"))
         algorithm = DNSName("hmac-md5");
       Lock l(&s_plock);
-      s_P->getBackend()->getTSIGKey(tsigkeyname, &algorithm, &tsig64);
-      B64Decode(tsig64, tsigsecret);
+      if(!s_P->getBackend()->getTSIGKey(tsigkeyname, &algorithm, &tsig64)) {
+        L<<Logger::Error<<"TSIG key '"<<tsigkeyname<<"' for domain '"<<target<<"' not found"<<endl;
+        return 0;
+      }
+      if (B64Decode(tsig64, tsigsecret) == -1) {
+        L<<Logger::Error<<"Unable to Base-64 decode TSIG key '"<<tsigkeyname<<"' for domain '"<<target<<"'"<<endl;
+        return 0;
+      }
     }
 
     UeberBackend signatureDB;


### PR DESCRIPTION
### Short description
This would lead to crashes if the TSIG key was referenced in TSIG-ALLOW-FROM but the key was not in the tsigkeys table.

Closes #5931

I do need to add some regression tests, but need to have a good look at how.

Note: some unchecked calls to `B64Decode` remain in the code, these will be fixed in another PR.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)