### PR TITLE
API: Allow disabling DNSSEC

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -589,6 +589,26 @@ bool DNSSECKeeper::getTSIGForAccess(const DNSName& zone, const string& master, D
   return false;
 }
 
+bool DNSSECKeeper::unSecureZone(const DNSName& zone, string& error, string& info) {
+  // Not calling isSecuredZone(), as it will return false for zones with zero
+  // active keys.
+  DNSSECKeeper::keyset_t keyset=getKeys(zone);
+
+  if(keyset.empty())  {
+    error = "No keys for zone '" + zone.toLogString() + "'.";
+    return false;
+  }
+
+  for(auto& key : keyset) {
+    deactivateKey(zone, key.second.id);
+    removeKey(zone, key.second.id);
+  }
+
+  unsetNSEC3PARAM(zone);
+  unsetPresigned(zone);
+  return true;
+}
+
 /* Rectifies the zone
  *
  * \param zone The zone to rectify

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -210,6 +210,7 @@ public:
   
   void getFromMeta(const DNSName& zname, const std::string& key, std::string& value);
   void getSoaEdit(const DNSName& zname, std::string& value);
+  bool unSecureZone(const DNSName& zone, std::string& error, std::string& info);
   bool rectifyZone(const DNSName& zone, std::string& error, std::string& info, bool doTransaction);
 private:
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1358,24 +1358,12 @@ bool disableDNSSECOnZone(DNSSECKeeper& dk, const DNSName& zone)
     return false;
   }
 
-  if(!dk.isSecuredZone(zone)) {
-    cerr<<"Zone is not secured"<<endl;
-    return false;
+  string error, info;
+  bool ret = dk.unSecureZone(zone, error, info);
+  if (!ret) {
+    cerr << error << endl;
   }
-  DNSSECKeeper::keyset_t keyset=dk.getKeys(zone);
-
-  if(keyset.empty())  {
-    cerr << "No keys for zone '"<<zone<<"'."<<endl;
-  }
-  else {  
-    for(DNSSECKeeper::keyset_t::value_type value :  keyset) {
-      dk.deactivateKey(zone, value.second.id);
-      dk.removeKey(zone, value.second.id);
-    }
-  }
-  dk.unsetNSEC3PARAM(zone);
-  dk.unsetPresigned(zone);
-  return true;
+  return ret;
 }
 
 int setZoneAccount(const DNSName& zone, const string &account)

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -626,7 +626,15 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
     } else {
       // "dnssec": false in json
       if (isDNSSECZone) {
-        throw ApiException("Refusing to un-secure zone " + zonename.toString());
+        string info, error;
+        if (!dk.unSecureZone(zonename, error, info)) {
+          throw ApiException("Error while un-securing zone '"+ zonename.toString()+"': " + error);
+        }
+        isDNSSECZone = dk.isSecuredZone(zonename);
+        if (isDNSSECZone) {
+          throw ApiException("Unable to un-secure zone '"+ zonename.toString()+"'");
+        }
+        shouldRectify = true;
       }
     }
   }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -363,6 +363,30 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         self.assertEquals(keys[0]['active'], True)
         self.assertEquals(keys[0]['keytype'], 'csk')
 
+    def test_create_zone_with_dnssec_disable_dnssec(self):
+        """
+        Create a zone with "dnssec", then set "dnssec" to false and see if the
+        keys are gone
+        """
+        name = unique_zone_name()
+        name, payload, data = self.create_zone(dnssec=True)
+
+        self.session.put(self.url("/api/v1/servers/localhost/zones/" + name),
+                         data=json.dumps({'dnssec': False}))
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name))
+
+        zoneinfo = r.json()
+
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(zoneinfo['dnssec'], False)
+
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name + '/cryptokeys'))
+
+        keys = r.json()
+
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(len(keys), 0)
+
     def test_create_zone_with_nsec3param(self):
         """
         Create a zone with "nsec3param" set and see if the metadata was added.


### PR DESCRIPTION
### Short description

This PR makes sure we can disable DNSSEC via the API, this is equivalent to doing `pdnsutil disable-dnssec`.

Closes #5909
Closes #5910 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)