### PR TITLE
Edit configname definition to include the 'config-name' argument

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2669,6 +2669,9 @@ void parseACLs()
 
   if(l_initialized) { // only reload configuration file on second call
     string configname=::arg()["config-dir"]+"/recursor.conf";
+    if(::arg()["config-name"]!="") {
+      configname=::arg()["config-dir"]+"/recursor-"+::arg()["config-name"]+".conf";
+    }
     cleanSlashes(configname);
 
     if(!::arg().preParseFile(configname.c_str(), "allow-from-file"))

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -257,6 +257,9 @@ string reloadAuthAndForwards()
     }
 
     string configname=::arg()["config-dir"]+"/recursor.conf";
+    if(::arg()["config-name"]!="") {
+      configname=::arg()["config-dir"]+"/recursor-"+::arg()["config-name"]+".conf";
+    }
     cleanSlashes(configname);
     
     if(!::arg().preParseFile(configname.c_str(), "forward-zones"))


### PR DESCRIPTION
### Short description
Add the config-name argument to the definition of configname.

There was a bug where the config-name parameter was not used to change the path of the config file. This meant that some commands via rec_control (e.g. reload-acls) would fail when run against a recursor which had config-name defined. The correct behaviour was present in some, but not all, definitions of configname. 

This PR adds the existing correct behaviour to 2 more places. 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
