### PR TITLE
Remove #5938 from auth-4.1.0-rc3 ChangeLog.

### DIFF
--- a/docs/changelog/4.1.rst
+++ b/docs/changelog/4.1.rst
@@ -65,12 +65,6 @@ Changelogs for 4.1.x
     Warn if records in a zone are occluded.
 
   .. change::
-    :tags: Bug Fixes
-    :pullreq: 5938
-
-    Don't crash when asked to run with zero threads.
-
-  .. change::
     :tags: API, Improvements
     :pullreq: 5935
 


### PR DESCRIPTION
It was accidentally labeled as `auth` but was only for `rec`.