### PR TITLE
API: Make the /cryptokeys endpoint consistently use CryptoKey objects

### DIFF
--- a/docs/http-api/cryptokeyitem.rst
+++ b/docs/http-api/cryptokeyitem.rst
@@ -15,3 +15,5 @@ CryptoKey
   :param string dnskey: The DNSKEY record for this key
   :param [string] ds: An array of DS records for this key
   :param string privatekey: The private key in ISC format
+  :param string algorithm: The key's algorithm
+  :param int bit: The bitsize of this key

--- a/docs/http-api/endpoint-cryptokeys.rst
+++ b/docs/http-api/endpoint-cryptokeys.rst
@@ -14,21 +14,18 @@ These endpoints allow for the manipulation of DNSSEC crypto material.
 
 .. http:post:: /api/v1/servers/:server_id/zones/:zone_id/cryptokeys
 
-  This method adds a new key to a zone.
-  The key can either be generated or imported by supplying the ``content`` parameter.
+  This method adds a new key to a zone, POST data should be a :json:object:`CryptoKey`.
+  But not all fields needs to be present:
 
-  if ``content``, ``bits`` and ``algo`` are null, a key will be generated based
+  The key can either be generated or imported by supplying the ``privatekey`` parameter.
+
+  if ``privatekey``, ``bits`` and ``algorithm`` are null, a key will be generated based
   on the :ref:`setting-default-ksk-algorithm` and :ref:`setting-default-ksk-size`
   settings for a KSK and the :ref:`setting-default-zsk-algorithm` and :ref:`setting-default-zsk-size`
   options for a ZSK.
 
   :param server_id: The name of the server
   :param zone_id: The id value of the :json:object:`Zone`
-  :reqjson string content: The private key to use (The format used is compatible with BIND and NSD/LDNS)
-  :reqjson string keytype: Either "ksk" or "zsk"
-  :reqjson bool active: If not set the key will not be active by default
-  :reqjson int bits: Number of bits in the key (if ``content`` is not set)
-  :reqjson int,string algo: The DNSSEC algorithm (if ``content`` is not set), see :ref:`dnssec-supported-algos`
   :statuscode 201: Everything was fine, returns all public data as a :json:object:`CryptoKey`.
   :statuscode 422: Returned when something is wrong with the content of the request.
                    Contains an error message
@@ -44,7 +41,8 @@ These endpoints allow for the manipulation of DNSSEC crypto material.
 
 .. http:put:: /api/v1/servers/:server_id/zones/:zone_name/cryptokeys/:cryptokey_id
 
-  This method (de)activates a key from ``zone_name`` specified by ``cryptokey_id``.
+  This method changes a key from ``zone_name`` specified by ``cryptokey_id``.
+  At this time, only changing the ``active`` parameter is supported.
 
   :param string server_id: The name of the server
   :param string zone_id: The id value of the :json:object:`Zone`

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -93,25 +93,25 @@ public:
    */
   static int shorthand2algorithm(const string &algorithm)
   {
-    if (!algorithm.compare("rsamd5")) return RSAMD5;
-    if (!algorithm.compare("dh")) return DH;
-    if (!algorithm.compare("dsa")) return DSA;
-    if (!algorithm.compare("rsasha1")) return RSASHA1;
-    if (!algorithm.compare("dsa-nsec3-sha1")) return DSANSEC3SHA1;
-    if (!algorithm.compare("rsasha1-nsec3-sha1")) return RSASHA1NSEC3SHA1;
-    if (!algorithm.compare("rsasha256")) return RSASHA256;
-    if (!algorithm.compare("rsasha512")) return RSASHA512;
-    if (!algorithm.compare("ecc-gost")) return ECCGOST;
-    if (!algorithm.compare("gost")) return ECCGOST;
-    if (!algorithm.compare("ecdsa256")) return ECDSA256;
-    if (!algorithm.compare("ecdsap256sha256")) return ECDSA256;
-    if (!algorithm.compare("ecdsa384")) return ECDSA384;
-    if (!algorithm.compare("ecdsap384sha384")) return ECDSA384;
-    if (!algorithm.compare("ed25519")) return ED25519;
-    if (!algorithm.compare("ed448")) return ED448;
-    if (!algorithm.compare("indirect")) return 252;
-    if (!algorithm.compare("privatedns")) return 253;
-    if (!algorithm.compare("privateoid")) return 254;
+    if (pdns_iequals(algorithm, "rsamd5")) return RSAMD5;
+    if (pdns_iequals(algorithm, "dh")) return DH;
+    if (pdns_iequals(algorithm, "dsa")) return DSA;
+    if (pdns_iequals(algorithm, "rsasha1")) return RSASHA1;
+    if (pdns_iequals(algorithm, "dsa-nsec3-sha1")) return DSANSEC3SHA1;
+    if (pdns_iequals(algorithm, "rsasha1-nsec3-sha1")) return RSASHA1NSEC3SHA1;
+    if (pdns_iequals(algorithm, "rsasha256")) return RSASHA256;
+    if (pdns_iequals(algorithm, "rsasha512")) return RSASHA512;
+    if (pdns_iequals(algorithm, "ecc-gost")) return ECCGOST;
+    if (pdns_iequals(algorithm, "gost")) return ECCGOST;
+    if (pdns_iequals(algorithm, "ecdsa256")) return ECDSA256;
+    if (pdns_iequals(algorithm, "ecdsap256sha256")) return ECDSA256;
+    if (pdns_iequals(algorithm, "ecdsa384")) return ECDSA384;
+    if (pdns_iequals(algorithm, "ecdsap384sha384")) return ECDSA384;
+    if (pdns_iequals(algorithm, "ed25519")) return ED25519;
+    if (pdns_iequals(algorithm, "ed448")) return ED448;
+    if (pdns_iequals(algorithm, "indirect")) return 252;
+    if (pdns_iequals(algorithm, "privatedns")) return 253;
+    if (pdns_iequals(algorithm, "privateoid")) return 254;
     return -1;
   }
 

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -87,23 +87,37 @@ public:
     }
   }
 
+  /*
+   * Returns the algorithm number based on the mnemonic (or old PowerDNS value of) a string.
+   * See https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml for the mapping
+   */
   static int shorthand2algorithm(const string &algorithm)
   {
     if (!algorithm.compare("rsamd5")) return RSAMD5;
     if (!algorithm.compare("dh")) return DH;
     if (!algorithm.compare("dsa")) return DSA;
     if (!algorithm.compare("rsasha1")) return RSASHA1;
+    if (!algorithm.compare("dsa-nsec3-sha1")) return DSANSEC3SHA1;
+    if (!algorithm.compare("rsasha1-nsec3-sha1")) return RSASHA1NSEC3SHA1;
     if (!algorithm.compare("rsasha256")) return RSASHA256;
     if (!algorithm.compare("rsasha512")) return RSASHA512;
     if (!algorithm.compare("ecc-gost")) return ECCGOST;
     if (!algorithm.compare("gost")) return ECCGOST;
     if (!algorithm.compare("ecdsa256")) return ECDSA256;
+    if (!algorithm.compare("ecdsap256sha256")) return ECDSA256;
     if (!algorithm.compare("ecdsa384")) return ECDSA384;
+    if (!algorithm.compare("ecdsap384sha384")) return ECDSA384;
     if (!algorithm.compare("ed25519")) return ED25519;
     if (!algorithm.compare("ed448")) return ED448;
+    if (!algorithm.compare("indirect")) return 252;
+    if (!algorithm.compare("privatedns")) return 253;
+    if (!algorithm.compare("privateoid")) return 254;
     return -1;
   }
 
+  /*
+   * Returns the mnemonic from https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
+   */
   static string algorithm2name(uint8_t algo) {
     switch(algo) {
       case 0:

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -988,7 +988,7 @@ static void apiZoneCryptokeysPOST(DNSName zonename, HttpRequest *req, HttpRespon
   bool active = boolFromJson(document, "active", false);
   bool keyOrZone;
 
-  if (stringFromJson(document, "keytype") == "ksk") {
+  if (stringFromJson(document, "keytype") == "ksk" || stringFromJson(document, "keytype") == "csk") {
     keyOrZone = true;
   } else if (stringFromJson(document, "keytype") == "zsk") {
     keyOrZone = false;

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1653,6 +1653,8 @@ class AuthZoneKeys(ApiTestCase, AuthZonesHelperMixin):
         del key0['dnskey']
         del key0['ds']
         expected = {
+            u'algorithm': u'ECDSAP256SHA256',
+            u'bits': 256,
             u'active': True,
             u'type': u'Cryptokey',
             u'keytype': u'csk',

--- a/regression-tests.api/test_cryptokeys.py
+++ b/regression-tests.api/test_cryptokeys.py
@@ -72,7 +72,7 @@ class Cryptokeys(ApiTestCase):
             payload = {
                 'keytype': type,
                 'active' : active,
-                'algo' : algo
+                'algorithm' : algo
             }
         if bits > 0:
             payload['bits'] = bits


### PR DESCRIPTION
### Short description
Add algorithm and bits to the Cryptokey objects and let the POST command accept this CryptoKey object.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)