### PR TITLE
Fix hang when PATCHing zone during rectify

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -626,6 +626,10 @@ bool DNSSECKeeper::rectifyZone(const DNSName& zone, string& error, string& info,
   std::unique_ptr<UeberBackend> b;
 
   if (d_ourDB) {
+    if (!doTransaction) {
+      error = "Can not rectify a zone with a new Ueberbackend inside a transaction.";
+      return false;
+    }
     // We don't have a *full* Ueberbackend, just a key-only one.
     // Let's create one and use it
     b = std::unique_ptr<UeberBackend>(new UeberBackend());

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1709,7 +1709,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
     throw;
   }
 
-  DNSSECKeeper dk;
+  DNSSECKeeper dk(&B);
   string api_rectify;
   di.backend->getDomainMetadataOne(zonename, "API-RECTIFY", api_rectify);
   if (dk.isSecuredZone(zonename) && !dk.isPresigned(zonename) && api_rectify == "1") {


### PR DESCRIPTION
Before, we would spawn a new UeberBackend in the DNSSECKeeper, but there
was already a transaction going on, so the rectify would never finish,
as rectifyZone would not return.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)