### PR TITLE
Fix reference to the wrong product

### DIFF
--- a/pdns/recursordist/docs/manpages/pdns_recursor.rst
+++ b/pdns/recursordist/docs/manpages/pdns_recursor.rst
@@ -1,4 +1,4 @@
-pdns_server manual page
+pdns_recursor manual page
 =======================
 
 Synopsis


### PR DESCRIPTION
### Short description
Point to pdns_recursor and not pdns_server.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
