### PR TITLE
rec: Fix the use of a deleted iterator in SyncRes::getDSRecords()

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1590,9 +1590,12 @@ vState SyncRes::getDSRecords(const DNSName& zone, dsmap_t& ds, bool taOnly, unsi
        * digests if DS RRs with SHA-256 digests are present in the DS RRset."
        * As SHA348 is specified as well, the spirit of the this line is "use the best algorithm".
        */
-      for (const auto& dsrec : ds) {
-        if (dsrec.d_digesttype != bestDigestType) {
-          ds.erase(dsrec);
+      for (auto dsrec = ds.begin(); dsrec != ds.end(); ) {
+        if (dsrec->d_digesttype != bestDigestType) {
+          dsrec = ds.erase(dsrec);
+        }
+        else {
+          ++dsrec;
         }
       }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The iterator is invalidated after being erased, so we have to handle that case explicitly. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
