### PR TITLE
report remote IP when SOA query comes back with empty question section

### DIFF
--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -258,6 +258,9 @@ bool Resolver::tryGetSOASerial(DNSName *domain, uint32_t *theirSerial, uint32_t 
   *id=mdp.d_header.id;
   *domain = mdp.d_qname;
   
+  if(domain->empty())
+    throw ResolverException("SOA query to '" + fromaddr.toStringWithPort() + "' produced response without domain name (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
+
   if(mdp.d_answers.empty())
     throw ResolverException("Query to '" + fromaddr.toStringWithPort() + "' for SOA of '" + domain->toString() + "' produced no results (RCode: " + RCode::to_s(mdp.d_header.rcode) + ")");
   


### PR DESCRIPTION
this improves the #5974 situation a bit

### Short description
instead of `Attempt to print an unset dnsname` we now print `SOA query to 'x.x.x.x:53' produced response without domain name (RCode: Form Error)`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
