### PR TITLE
Add TempFailureCacheTTLAction

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -89,7 +89,7 @@ void DNSDistPacketCache::insertLocked(CacheShard& shard, uint32_t key, const DNS
   value = newValue;
 }
 
-void DNSDistPacketCache::insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp, uint8_t rcode)
+void DNSDistPacketCache::insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp, uint8_t rcode, boost::optional<uint32_t> tempFailureTTL)
 {
   if (responseLen < sizeof(dnsheader))
     return;
@@ -97,7 +97,7 @@ void DNSDistPacketCache::insert(uint32_t key, const DNSName& qname, uint16_t qty
   uint32_t minTTL;
 
   if (rcode == RCode::ServFail || rcode == RCode::Refused) {
-    minTTL = d_tempFailureTTL;
+    minTTL = tempFailureTTL == boost::none ? d_tempFailureTTL : *tempFailureTTL;
     if (minTTL == 0) {
       return;
     }

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -33,7 +33,7 @@ public:
   DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL=86400, uint32_t minTTL=0, uint32_t tempFailureTTL=60, uint32_t staleTTL=60, bool dontAge=false, uint32_t shards=1, bool deferrableInsertLock=true);
   ~DNSDistPacketCache();
 
-  void insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp, uint8_t rcode);
+  void insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp, uint8_t rcode, boost::optional<uint32_t> tempFailureTTL);
   bool get(const DNSQuestion& dq, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, uint32_t* keyOut, uint32_t allowExpired=0, bool skipAging=false);
   void purgeExpired(size_t upTo=0);
   void expunge(size_t upTo=0);

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -419,6 +419,8 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "TagResponseAction", true, "name, value", "set the tag named 'name' to the given value" },
   { "TagRule", true, "name [, value]", "matches if the tag named 'name' is present, with the given 'value' matching if any" },
   { "TCAction", true, "", "create answer to query with TC and RD bits set, to move to TCP" },
+  { "TeeAction", true, "remote [, addECS]", "send copy of query to remote, optionally adding ECS info" },
+  { "TempFailureCacheTTLAction", true, "ttl", "set packetcache TTL for temporary failure replies" },
   { "testCrypto", true, "", "test of the crypto all works" },
   { "TimedIPSetRule", true, "", "Create a rule which matches a set of IP addresses which expire"}, 
   { "topBandwidth", true, "top", "show top-`top` clients that consume the most bandwidth over length of ringbuffer" },

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -527,6 +527,24 @@ public:
   }
 };
 
+class TempFailureCacheTTLAction : public DNSAction
+{
+public:
+  TempFailureCacheTTLAction(uint32_t ttl) : d_ttl(ttl)
+  {}
+  TempFailureCacheTTLAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  {
+    dq->tempFailureTTL = d_ttl;
+    return Action::None;
+  }
+  string toString() const override
+  {
+    return "set tempfailure cache ttl to "+std::to_string(d_ttl);
+  }
+private:
+  uint32_t d_ttl;
+};
+
 class ECSPrefixLengthAction : public DNSAction
 {
 public:
@@ -947,6 +965,10 @@ void setupLuaActions()
 
   g_lua.writeFunction("SkipCacheAction", []() {
       return std::shared_ptr<DNSAction>(new SkipCacheAction);
+    });
+
+  g_lua.writeFunction("TempFailureCacheTTLAction", [](int maxTTL) {
+      return std::shared_ptr<DNSAction>(new TempFailureCacheTTLAction(maxTTL));
     });
 
   g_lua.writeFunction("DropResponseAction", []() {

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -43,6 +43,14 @@ void setupLuaBindingsDNSQuestion()
   g_lua.registerMember<bool (DNSQuestion::*)>("useECS", [](const DNSQuestion& dq) -> bool { return dq.useECS; }, [](DNSQuestion& dq, bool useECS) { dq.useECS = useECS; });
   g_lua.registerMember<bool (DNSQuestion::*)>("ecsOverride", [](const DNSQuestion& dq) -> bool { return dq.ecsOverride; }, [](DNSQuestion& dq, bool ecsOverride) { dq.ecsOverride = ecsOverride; });
   g_lua.registerMember<uint16_t (DNSQuestion::*)>("ecsPrefixLength", [](const DNSQuestion& dq) -> uint16_t { return dq.ecsPrefixLength; }, [](DNSQuestion& dq, uint16_t newPrefixLength) { dq.ecsPrefixLength = newPrefixLength; });
+  g_lua.registerMember<boost::optional<uint32_t> (DNSQuestion::*)>("tempFailureTTL",
+      [](const DNSQuestion& dq) -> boost::optional<uint32_t> {
+        return dq.tempFailureTTL;
+      },
+      [](DNSQuestion& dq, boost::optional<uint32_t> newValue) {
+        dq.tempFailureTTL = newValue;
+      }
+    );
   g_lua.registerFunction<bool(DNSQuestion::*)()>("getDO", [](const DNSQuestion& dq) {
       return getEDNSZ((const char*)dq.dh, dq.len) & EDNS_HEADER_FLAG_DO;
     });

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -553,7 +553,7 @@ void* tcpClientThread(int pipefd)
         }
 
 	if (packetCache && !dq.skipCache) {
-	  packetCache->insert(cacheKey, qname, qtype, qclass, response, responseLen, true, dh->rcode);
+	  packetCache->insert(cacheKey, qname, qtype, qclass, response, responseLen, true, dh->rcode, dq.tempFailureTTL);
 	}
 
 #ifdef HAVE_DNSCRYPT

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -467,7 +467,7 @@ try {
       }
 
       if (ids->packetCache && !ids->skipCache) {
-        ids->packetCache->insert(ids->cacheKey, ids->qname, ids->qtype, ids->qclass, response, responseLen, false, dh->rcode);
+        ids->packetCache->insert(ids->cacheKey, ids->qname, ids->qtype, ids->qclass, response, responseLen, false, dh->rcode, ids->tempFailureTTL);
       }
 
       if (ids->cs && !ids->cs->muted) {
@@ -1371,6 +1371,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     ids->qtype = dq.qtype;
     ids->qclass = dq.qclass;
     ids->delayMsec = delayMsec;
+    ids->tempFailureTTL = dq.tempFailureTTL;
     ids->origFlags = origFlags;
     ids->cacheKey = cacheKey;
     ids->skipCache = dq.skipCache;

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -791,4 +791,8 @@ The following actions exist.
   :param string remote: An IP:PORT conbination to send the copied queries to
   :param bool addECS: Whether or not to add ECS information. Default false
 
+.. function:: TempFailureCacheTTLAction(ttl)
 
+  Set the cache TTL to use for ServFail and Refused replies. TTL is not applied for successful replies.
+
+  :param int ttl: Cache TTL for temporary failure replies

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheServFailTTL) {
     found = PC.get(dq, a.wirelength(), pwR.getHeader()->id, responseBuf, &responseBufSize, &key, 0, true);
     BOOST_CHECK_EQUAL(found, false);
 
-    // Insert with failure-TTL non-zero (-> should not enter cache).
+    // Insert with failure-TTL non-zero (-> should enter cache).
     PC.insert(key, a, QType::A, QClass::IN, (const char*) response.data(), responseLen, false, RCode::ServFail, boost::optional<uint32_t>(300));
     found = PC.get(dq, a.wirelength(), pwR.getHeader()->id, responseBuf, &responseBufSize, &key, 0, true);
     BOOST_CHECK_EQUAL(found, true);

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -354,6 +354,52 @@ class TestCaching(DNSDistTest):
         self.assertEquals(receivedResponse, differentCaseResponse)
 
 
+class TestTempFailureCacheTTLAction(DNSDistTest):
+
+    _config_template = """
+    pc = newPacketCache(100, 86400, 1)
+    getPool(""):setCache(pc)
+    addAction("servfail.cache.tests.powerdns.com.", TempFailureCacheTTLAction(1))
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testTempFailureCacheTTLAction(self):
+        """
+        Cache: When a TempFailure TTL is set, it should be honored
+
+        dnsdist is configured to cache packets, plus a specific qname is
+        set up with a lower TempFailure Cache TTL. we are sending one request
+        (cache miss) and verify that the cache is hit for the following query,
+        but the TTL then expires before the larger "good" packetcache TTL.
+        """
+        name = 'servfail.cache.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AAAA', 'IN')
+        response = dns.message.make_response(query)
+        response.set_rcode(dns.rcode.SERVFAIL)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(receivedResponse, response)
+
+        # next query should hit the cache
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertFalse(receivedQuery)
+        self.assertTrue(receivedResponse)
+        self.assertEquals(receivedResponse, response)
+
+        # now we wait a bit for the Failure-Cache TTL to expire
+        time.sleep(2)
+
+        # next query should NOT hit the cache
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        self.assertEquals(receivedResponse, response)
+
+
 class TestCachingWithExistingEDNS(DNSDistTest):
 
     _config_template = """

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -385,7 +385,7 @@ class TestTempFailureCacheTTLAction(DNSDistTest):
         self.assertEquals(receivedResponse, response)
 
         # next query should hit the cache
-        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
         self.assertFalse(receivedQuery)
         self.assertTrue(receivedResponse)
         self.assertEquals(receivedResponse, response)


### PR DESCRIPTION
### Short description
Adds a request Action to set the packetcache TTL used for temporary failures, (= ServFail + Refused).

RFC. Will add docs, test etc when not everyone is shouting at me for this.

Usage example:
```
addAction("deduktiva.com.", TempFailureCacheTTLAction(1))
addAction("244.77.in-addr.arpa.", TempFailureCacheTTLAction(86400))
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master