### PR TITLE
Remove deprecated SOA-EDIT values

### DIFF
--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -150,6 +150,9 @@ January 2016.
 INCEPTION (not recommended)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. deprecated:: 4.1.0
+  Removed in this release
+
 Sets the SOA serial to the last inception time in YYYYMMDD01 format.
 Uses localtime to find the day for inception time.
 
@@ -158,18 +161,17 @@ Uses localtime to find the day for inception time.
   changes to the zone will get visible on slaves only on the following
   inception day.
 
-.. deprecated:: 4.1.0
-
 INCEPTION-WEEK (not recommended)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 4.1.0
+  Removed in this release
 
 Sets the SOA serial to the number of weeks since the epoch, which is the
 last inception time in weeks.
 
 .. warning::
   Same problem as INCEPTION.
-
-.. deprecated:: 4.1.0
 
 EPOCH
 ^^^^^

--- a/pdns/serialtweaker.cc
+++ b/pdns/serialtweaker.cc
@@ -63,12 +63,7 @@ bool editSOARecord(DNSZoneRecord& rr, const string& kind) {
 uint32_t calculateEditSOA(const DNSZoneRecord& rr, const string& kind)
 {
   auto src = getRR<SOARecordContent>(rr.dr);
-  if(pdns_iequals(kind,"INCEPTION")) {
-    L<<Logger::Warning<<"Deprecation warning: The 'INCEPTION' soa-edit value will be removed in PowerDNS 4.1"<<endl;
-    time_t inception = getStartOfWeek();
-    return localtime_format_YYYYMMDDSS(inception, 1);
-  }
-  else if(pdns_iequals(kind,"INCEPTION-INCREMENT")) {
+  if(pdns_iequals(kind,"INCEPTION-INCREMENT")) {
     time_t inception = getStartOfWeek();
     uint32_t inception_serial = localtime_format_YYYYMMDDSS(inception, 1);
     uint32_t dont_increment_after = localtime_format_YYYYMMDDSS(inception + 2*86400, 99);
@@ -79,17 +74,11 @@ uint32_t calculateEditSOA(const DNSZoneRecord& rr, const string& kind)
       return (src->d_st.serial + 2); /* "<inceptionday>00" and "<inceptionday>01" are reserved for inception increasing, so increment sd.serial by two */
     }
   }
-  else if(pdns_iequals(kind,"INCEPTION-WEEK")) {
-    L<<Logger::Warning<<"Deprecation warning: The 'INCEPTION-WEEK' soa-edit value will be removed in PowerDNS 4.1"<<endl;
-    time_t inception = getStartOfWeek();
-    return ( inception / (7*86400) );
-  }
   else if(pdns_iequals(kind,"INCREMENT-WEEKS")) {
     time_t inception = getStartOfWeek();
     return (src->d_st.serial + (inception / (7*86400)));
   }
   else if(pdns_iequals(kind,"EPOCH")) {
-    L<<Logger::Warning<<"Deprecation warning: The 'EPOCH' soa-edit value will be removed in PowerDNS 4.1"<<endl;
     return time(0);
   }
   else if(pdns_iequals(kind,"INCEPTION-EPOCH")) {


### PR DESCRIPTION
### Short description
As alluded to in the docs and warnings in the logs, remove INCEPTION and INCEPTION-WEEK as possible values for SOA-EDIT for 4.1.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)