### PR TITLE
rec:  Don't leak when the loading a public ECDSA key fails

### DIFF
--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -474,7 +474,7 @@ void OpenSSLRSADNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, std::map
   if (iqmp == NULL) {
     RSA_free(key);
     BN_clear_free(dmq1);
-    BN_clear_free(iqmp);
+    BN_clear_free(dmp1);
     throw runtime_error(getName()+" allocation of BIGNUM iqmp failed");
   }
   RSA_set0_crt_params(key, dmp1, dmq1, iqmp);
@@ -562,6 +562,7 @@ void OpenSSLRSADNSCryptoKeyEngine::fromPublicKeyString(const std::string& input)
   BIGNUM *n = BN_bin2bn((unsigned char*)modulus.c_str(), modulus.length(), NULL);
   if (!n) {
     RSA_free(key);
+    BN_clear_free(e);
     throw runtime_error(getName()+" error loading n value of public key");
   }
 

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -866,6 +866,7 @@ void OpenSSLECDSADNSCryptoKeyEngine::fromPublicKeyString(const std::string& inpu
 
   int ret = EC_POINT_oct2point(d_ecgroup, pub_key, (unsigned char*) ecdsaPoint.c_str(), ecdsaPoint.length(), d_ctx);
   if (ret != 1) {
+    EC_POINT_free(pub_key);
     throw runtime_error(getName()+" reading ECP point from binary failed");
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Also fix some missing `free` calls in when dealing with `RSA` keys, but those are only reachable on out of memory so they don't really matter.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
