### PR TITLE
quote server-id to hosts with - or . in their name get reported again

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -274,7 +274,10 @@ int PacketHandler::doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target)
         r->setRcode(RCode::Refused);
         return 0;
       }
-      rr.dr.d_content=DNSRecordContent::mastermake(QType::TXT, 1, id);
+      string tid=id;
+      if(!tid.empty() && tid[0]!='"') // see #6010 however
+	tid = "\"" + tid + "\"";
+      rr.dr.d_content=DNSRecordContent::mastermake(QType::TXT, 1, tid);
     }
     else {
       r->setRcode(RCode::Refused);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -275,8 +275,9 @@ int PacketHandler::doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target)
         return 0;
       }
       string tid=id;
-      if(!tid.empty() && tid[0]!='"') // see #6010 however
-	tid = "\"" + tid + "\"";
+      if(!tid.empty() && tid[0]!='"') { // see #6010 however
+        tid = "\"" + tid + "\"";
+      }
       rr.dr.d_content=DNSRecordContent::mastermake(QType::TXT, 1, tid);
     }
     else {


### PR DESCRIPTION
### Short description
If our server name contained a dash or a dot, 'dig chaos txt server.id @yourserver' would break in auth.
This applies a minimal fix for the 4.1.early timeframe. I'll leave it up to everyone if this is 4.1.0 material or not. If anyone asks, my vote is 'yes'.

This PR should eventually be succeeded by the result of #6010.
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
