### PR TITLE
Backport #5590: skip v6-dependent test when PDNS_TEST_NO_IPV6 is set in environment.

### DIFF
--- a/pdns/test-nameserver_cc.cc
+++ b/pdns/test-nameserver_cc.cc
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(test_AddressIsUs6) {
   
   BOOST_CHECK_EQUAL(AddressIsUs(local1), true);
 //  BOOST_CHECK_EQUAL(AddressIsUs(local2), false);
-  BOOST_CHECK_EQUAL(AddressIsUs(local3), true);
+  if(!getenv("PDNS_TEST_NO_IPV6")) BOOST_CHECK_EQUAL(AddressIsUs(local3), true);
   BOOST_CHECK_EQUAL(AddressIsUs(Remote), false);
   Remote.sin4.sin_port = 1;
   BOOST_CHECK_EQUAL(AddressIsUs(Remote), false);


### PR DESCRIPTION
(cherry picked from commit 2ff8d3d1913f80d72e4584a957aa89cead69dd81)
