### PR TITLE
escaping unusual DNS label octets in DNSName is off by one

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -423,7 +423,7 @@ string DNSName::escapeLabel(const std::string& label)
       ret+="\\.";
     else if(p=='\\')
       ret+="\\\\";
-    else if(p > 0x21 && p < 0x7e)
+    else if(p > 0x20 && p < 0x7f)
       ret.append(1, (char)p);
     else {
       ret+="\\" + (boost::format("%03d") % (unsigned int)p).str();

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -128,15 +128,17 @@ BOOST_AUTO_TEST_CASE(test_basic) {
 
   BOOST_CHECK_EQUAL(unset.toString(), "www.powerdns\\.com.com.");
 
+  DNSName rfc4343_2_1("~!.example.");
   DNSName rfc4343_2_2(R"(Donald\032E\.\032Eastlake\0323rd.example.)");
   DNSName example("example.");
+  BOOST_CHECK(rfc4343_2_1.isPartOf(example));
   BOOST_CHECK(rfc4343_2_2.isPartOf(example));
+  BOOST_CHECK_EQUAL(rfc4343_2_1.toString(), "~!.example.");
 
   auto labels=rfc4343_2_2.getRawLabels();
   BOOST_CHECK_EQUAL(*labels.begin(), "Donald E. Eastlake 3rd");
   BOOST_CHECK_EQUAL(*labels.rbegin(), "example");
   BOOST_CHECK_EQUAL(labels.size(), 2);
-
 
   DNSName build;
   build.appendRawLabel("Donald E. Eastlake 3rd");


### PR DESCRIPTION
Closes #6018 (commit is now part of this pull request)

https://tools.ietf.org/html/rfc4343#section-2.1

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

  