### PR TITLE
gmysql-backend: set unsigned attribute on notified_serial column

### DIFF
--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -471,6 +471,7 @@ fi
 %doc %{_defaultdocdir}/%{name}/nodnssec-3.x_to_3.4.0_schema.mysql.sql
 %doc %{_defaultdocdir}/%{name}/dnssec-3.x_to_3.4.0_schema.mysql.sql
 %doc %{_defaultdocdir}/%{name}/3.4.0_to_4.1.0_schema.mysql.sql
+%doc %{_defaultdocdir}/%{name}/4.1.0_to_4.1.1_schema.mysql.sql
 %{_libdir}/%{name}/libgmysqlbackend.so
 
 %files backend-postgresql

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -8,6 +8,16 @@ Please upgrade to the PowerDNS Authoritative Server 4.0.0 from 3.4.2+.
 See the `3.X <https://doc.powerdns.com/3/authoritative/upgrading/>`__
 upgrade notes if your version is older than 3.4.2.
 
+4.1.0 to 4.1.1
+--------------
+
+- The :doc:`Generic MySQL backend <backends/generic-mysql>` schema has
+  changed: the ``notified_serial`` column default in the ``domains``
+  table has been changed from ``INT DEFAULT NULL`` to ``INT UNSIGNED
+  DEFAULT NULL``:
+
+  - ``ALTER TABLE domains MODIFY notified_serial INT UNSIGNED DEFAULT NULL;``
+
 4.0.X to 4.1.0
 --------------
 

--- a/modules/gmysqlbackend/4.1.0_to_4.1.1_schema.mysql.sql
+++ b/modules/gmysqlbackend/4.1.0_to_4.1.1_schema.mysql.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domains MODIFY notified_serial INT UNSIGNED DEFAULT NULL;

--- a/modules/gmysqlbackend/Makefile.am
+++ b/modules/gmysqlbackend/Makefile.am
@@ -13,6 +13,7 @@ dist_doc_DATA = \
 	dnssec-3.x_to_3.4.0_schema.mysql.sql \
 	nodnssec-3.x_to_3.4.0_schema.mysql.sql \
 	3.4.0_to_4.1.0_schema.mysql.sql \
+	4.1.0_to_4.1.1_schema.mysql.sql \
 	schema.mysql.sql
 
 libgmysqlbackend_la_SOURCES = \

--- a/modules/gmysqlbackend/schema.mysql.sql
+++ b/modules/gmysqlbackend/schema.mysql.sql
@@ -4,7 +4,7 @@ CREATE TABLE domains (
   master                VARCHAR(128) DEFAULT NULL,
   last_check            INT DEFAULT NULL,
   type                  VARCHAR(6) NOT NULL,
-  notified_serial       INT DEFAULT NULL,
+  notified_serial       INT UNSIGNED DEFAULT NULL,
   account               VARCHAR(40) CHARACTER SET 'utf8' DEFAULT NULL,
   PRIMARY KEY (id)
 ) Engine=InnoDB CHARACTER SET 'latin1';


### PR DESCRIPTION
### Short description
fixes #5915 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
