### PR TITLE
dnsdist: Add Pools, cacheHitResponseRules to the API

### DIFF
--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -102,8 +102,10 @@ URL Endpoints
   Get a quick overview of several parameters.
 
   :>json string acl: A string of comma-separated netmasks currently allowed by the :ref:`ACL <ACL>`.
+  :>json list cache-hit-response-rules: A list of :json:object:`ResponseRule` objects applied on cache hits
   :>json string daemon_type: The type of daemon, always "dnsdist"
   :>json list frontends: A list of :json:object:`Frontend` objects
+  :>json list pools: A list of :json:object:`Pool` objects
   :>json list response-rules: A list of :json:object:`ResponseRule` objects
   :>json list rules: A list of :json:object:`Rule` objects
   :>json list servers: A list of :json:object:`Server` objects
@@ -162,12 +164,29 @@ JSON Objects
   :property boolean udp: true if this is a UDP bind
   :property boolean tcp: true if this is a TCP bind
 
+.. json:object:: Pool
+
+  A description of a pool of backend servers.
+
+  :property integer id: Internal identifier
+  :property integer cacheDeferredInserts: The number of times an entry could not be inserted in the associated cache, if any, because of a lock
+  :property integer cacheDeferredLookups: The number of times an entry could not be looked up from the associated cache, if any, because of a lock
+  :property integer cacheEntries: The current number of entries in the associated cache, if any
+  :property integer cacheHits: The number of cache hits for the associated cache, if any
+  :property integer cacheLookupCollisions: The number of times an entry retrieved from the cache based on the query hash did not match the actual query
+  :property integer cacheInsertCollisions: The number of times an entry could not be inserted into the cache because a different entry with the same hash already existed
+  :property integer cacheMisses: The number of cache misses for the associated cache, if any
+  :property integer cacheSize: The maximum number of entries in the associated cache, if any
+  :property integer cacheTTLTooShorts: The number of times an entry could not be inserted into the cache because its TTL was set below the minimum threshold
+  :property string name: Name of the pool
+  :property integer serversCount: Number of backends in this pool
+
 .. json:object:: Rule
 
   This represents a policy that is applied to queries
 
   :property string action: The action taken when the rule matches (e.g. "to pool abuse")
-  :property dict action-stats: TODO
+  :property dict action-stats: A list of statistics whose content varies depending on the kind of rule
   :property integer id: The identifier (or order) of this rule
   :property integer matches: How many times this rule was hit
   :property string rule: The matchers for the packet (e.g. "qname==bad-domain1.example., bad-domain2.example.")
@@ -176,7 +195,10 @@ JSON Objects
 
   This represents a policy that is applied to responses
 
-  TODO
+  :property string action: The action taken when the rule matches (e.g. "drop")
+  :property integer id: The identifier (or order) of this rule
+  :property integer matches: How many times this rule was hit
+  :property string rule: The matchers for the packet (e.g. "qname==bad-domain1.example., bad-domain2.example.")
 
 .. json:object:: Server
 
@@ -192,7 +214,8 @@ JSON Objects
   :property integer qps: The current number of queries per second to this server
   :property integer qpsLimit: The configured maximum number of queries per second
   :property integer queries: Total number of queries sent to this backend
-  :property integer reuseds: TODO
+  :property integer reuseds: Number of queries for which a response was not received in time
+  :property integer sendErrors: Number of network errors while sending a query to this server
   :property string state: The state of the server (e.g. "DOWN" or "up")
   :property integer weight: The weight assigned to this server
 

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -78,7 +78,7 @@ class TestAPIBasics(DNSDistTest):
 
         self.assertEquals(content['daemon_type'], 'dnsdist')
 
-        for key in ['version', 'acl', 'local', 'rules', 'response-rules', 'servers', 'frontends']:
+        for key in ['version', 'acl', 'local', 'rules', 'response-rules', 'cache-hit-response-rules', 'servers', 'frontends', 'pools']:
             self.assertIn(key, content)
 
         for rule in content['rules']:
@@ -93,9 +93,15 @@ class TestAPIBasics(DNSDistTest):
             for key in ['id', 'matches']:
                 self.assertTrue(rule[key] >= 0)
 
+        for rule in content['cache-hit-response-rules']:
+            for key in ['id', 'matches', 'rule', 'action']:
+                self.assertIn(key, rule)
+            for key in ['id', 'matches']:
+                self.assertTrue(rule[key] >= 0)
+
         for server in content['servers']:
             for key in ['id', 'latency', 'name', 'weight', 'outstanding', 'qpsLimit',
-                        'reuseds', 'state', 'address', 'pools', 'qps', 'queries', 'order']:
+                        'reuseds', 'state', 'address', 'pools', 'qps', 'queries', 'order', 'sendErrors']:
                 self.assertIn(key, server)
 
             for key in ['id', 'latency', 'weight', 'outstanding', 'qpsLimit', 'reuseds',
@@ -110,6 +116,13 @@ class TestAPIBasics(DNSDistTest):
 
             for key in ['id', 'queries']:
                 self.assertTrue(frontend[key] >= 0)
+
+        for pool in content['pools']:
+            for key in ['id', 'name', 'cacheSize', 'cacheEntries', 'cacheHits', 'cacheMisses', 'cacheDeferredInserts', 'cacheDeferredLookups', 'cacheLookupCollisions', 'cacheInsertCollisions', 'cacheTTLTooShorts']:
+                self.assertIn(key, pool)
+
+            for key in ['id', 'cacheSize', 'cacheEntries', 'cacheHits', 'cacheMisses', 'cacheDeferredInserts', 'cacheDeferredLookups', 'cacheLookupCollisions', 'cacheInsertCollisions', 'cacheTTLTooShorts']:
+                self.assertTrue(pool[key] >= 0)
 
     def testServersIDontExist(self):
         """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Pools are not very interesting by themselves, but since caches are associated with them this provides access to the various cache statistics!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
