### PR TITLE
rec: Normalize the TTLs for default.example.net. in the RPZ tests

### DIFF
--- a/regression-tests.recursor/RPZ/command
+++ b/regression-tests.recursor/RPZ/command
@@ -21,11 +21,11 @@ $SDIG $nameserver 5301 capped-ttl.example.net a recurse 2>&1
 echo "==> defpol-with-ttl.example.net should use the default policy's TTL and not the zone one"
 $SDIG $nameserver 5301 defpol-with-ttl.example.net a recurse 2>&1
 echo "==> defpol-with-ttl-capped.example.net should use the default policy's TTL, but capped to maxTTL"
-$SDIG $nameserver 5301 defpol-with-ttl-capped.example.net a recurse 2>&1
+$SDIG $nameserver 5301 defpol-with-ttl-capped.example.net a recurse 2>&1 | sed 's/\(0\tdefault.example.net.\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\115/'
 echo "==> defpol-without-ttl.example.net should use the zone's TTL"
-$SDIG $nameserver 5301 defpol-without-ttl.example.net a recurse 2>&1
+$SDIG $nameserver 5301 defpol-without-ttl.example.net a recurse 2>&1 | sed 's/\(0\tdefault.example.net.\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\115/'
 echo "==> defpol-without-ttl-capped.example.net should use the zone's TTL but capped to maxTTL"
-$SDIG $nameserver 5301 defpol-without-ttl-capped.example.net a recurse 2>&1
+$SDIG $nameserver 5301 defpol-without-ttl-capped.example.net a recurse 2>&1 | sed 's/\(0\tdefault.example.net.\tIN\t[A-Z0-9]\+\t\)\([0-9]\+\)/\115/'
 echo "==> unsupported.example.net has an unsupported target, should be ignored from the RPZ zone"
 $SDIG $nameserver 5301 unsupported.example.net a recurse 2>&1
 echo "==> unsupported2.example.net has an unsupported target, should be ignored from the RPZ zone"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since we ask for several records that are CNAME to default.example.net. the TTL might have been decreased by the time we get to the last ones. That's fine, the TTL we are interested in are for other records, so we can just ignore the TTL for this exact record.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
