### PR TITLE
rec: Don't cache merged answers from different sections in a single packet

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -983,7 +983,7 @@ struct CacheKey
   uint16_t type;
   DNSResourceRecord::Place place;
   bool operator<(const CacheKey& rhs) const {
-    return tie(name, type) < tie(rhs.name, rhs.type);
+    return tie(name, type, place) < tie(rhs.name, rhs.type, rhs.place);
   }
 };
 typedef map<CacheKey, CacheEntry> tcache_t;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We incorrectly merged answers for the same qname and qtype coming from a single packet but from different sections when storing them in the cache. It resulted in duplicates for the IP addresses of some NS, for example.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
