### PR TITLE
dnsdist: Sort the servers based on their 'order' after it has been set

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -400,24 +400,6 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 			  ret->qps=QPSLimiter(qpsVal, qpsVal);
 			}
 
-			auto localPools = g_pools.getCopy();
-			if(vars.count("pool")) {
-			  if(auto* pool = boost::get<string>(&vars["pool"]))
-			    ret->pools.insert(*pool);
-			  else {
-			    auto pools = boost::get<vector<pair<int, string> > >(vars["pool"]);
-			    for(auto& p : pools)
-			      ret->pools.insert(p.second);
-			  }
-			  for(const auto& poolName: ret->pools) {
-			    addServerToPool(localPools, poolName, ret);
-			  }
-			}
-			else {
-			  addServerToPool(localPools, "", ret);
-			}
-			g_pools.setState(localPools);
-
 			if(vars.count("order")) {
 			  ret->order=std::stoi(boost::get<string>(vars["order"]));
 			}
@@ -490,6 +472,28 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
                             cpus.insert(std::stoi(cpu.second));
                           }
 			}
+
+                        /* this needs to be done _AFTER_ the order has been set,
+                           since the server are kept ordered inside the pool */
+                        auto localPools = g_pools.getCopy();
+                        if(vars.count("pool")) {
+                          if(auto* pool = boost::get<string>(&vars["pool"])) {
+                            ret->pools.insert(*pool);
+                          }
+                          else {
+                            auto pools = boost::get<vector<pair<int, string> > >(vars["pool"]);
+                            for(auto& p : pools) {
+			      ret->pools.insert(p.second);
+                            }
+                          }
+                          for(const auto& poolName: ret->pools) {
+                            addServerToPool(localPools, poolName, ret);
+                          }
+                        }
+                        else {
+                          addServerToPool(localPools, "", ret);
+                        }
+                        g_pools.setState(localPools);
 
 			if (ret->connected) {
 			  if(g_launchWork) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We keep the servers ordered inside their pools because it's easier for the policies that way, so we sort them whenever a new one is added. However we were doing the sorting _before_ the order of the
new server had been set, resulting in the last added server to be sorted based on an order of 0, regardless of its actual order.
Reported by Frank Even (thanks!).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
