### PR TITLE
Handle bracketed IPv6 addresses without ports

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -178,6 +178,7 @@ testrunner_SOURCES = \
 	test-dnsdist_cc.cc \
 	test-dnsdistpacketcache_cc.cc \
 	test-dnscrypt_cc.cc \
+	test-iputils_hh.cc \
 	dnsdist.hh \
 	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \

--- a/pdns/dnsdistdist/test-iputils_hh.cc
+++ b/pdns/dnsdistdist/test-iputils_hh.cc
@@ -1,0 +1,1 @@
+../test-iputils_hh.cc

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -719,9 +719,7 @@ int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret)
     if(pos == string::npos)
       return -1;
     ourAddr.assign(addr.c_str() + 1, pos-1);
-    if (pos + 1 == addr.size()) {
-      port = 0;
-    } else {
+    if (pos + 1 != addr.size()) { // complete after ], no port specified
       if (pos + 2 > addr.size() || addr[pos+1]!=':')
         return -1;
       try {

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -716,15 +716,21 @@ int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret)
   unsigned int port;
   if(addr[0]=='[') { // [::]:53 style address
     string::size_type pos = addr.find(']');
-    if(pos == string::npos || pos + 2 > addr.size() || addr[pos+1]!=':')
+    if(pos == string::npos)
       return -1;
     ourAddr.assign(addr.c_str() + 1, pos-1);
-    try {
-      port = pdns_stou(addr.substr(pos+2));
-      portSet = true;
-    }
-    catch(std::out_of_range) {
-      return -1;
+    if (pos + 1 == addr.size()) {
+      port = 0;
+    } else {
+      if (pos + 2 > addr.size() || addr[pos+1]!=':')
+        return -1;
+      try {
+        port = pdns_stou(addr.substr(pos+2));
+        portSet = true;
+      }
+      catch(std::out_of_range) {
+        return -1;
+      }
     }
   }
   ret->sin6_scope_id=0;

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -34,6 +34,15 @@ BOOST_AUTO_TEST_CASE(test_ComboAddress) {
   withport = ComboAddress("[::]:5300", 53);
   BOOST_CHECK_EQUAL(withport.sin4.sin_port, htons(5300));
 
+  ComboAddress defaultport("213.244.168.210");
+  BOOST_CHECK_EQUAL(defaultport.sin4.sin_port, htons(0));
+
+  defaultport = ComboAddress("[::1]");
+  BOOST_CHECK_EQUAL(defaultport.sin4.sin_port, htons(0));
+
+  defaultport = ComboAddress("::1");
+  BOOST_CHECK_EQUAL(defaultport.sin4.sin_port, htons(0));
+
   // Verify that 2 'empty' ComboAddresses are equal, used in syncres.hh to
   // signal auth-zones
   ComboAddress a = ComboAddress();


### PR DESCRIPTION
dnsdist's newServer source parameter is documented to take values
of those forms (plus some more):
  - v4 address ("192.0.2.1")
  - v6 address ("2001:DB8::1")

For consistency, bracketed addresses ("[2001:DB8::1]") should work too, and all of them
should have a test.

Example that would previously "fail":
```
newServer({name="pdns", address="[::1]:5300", source="[::1]"}):setUp()
```

Gives:
```
Dismissing source [::1] because '[::1]' is not a valid interface name
Added downstream server [::1]:5300
```

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
