### PR TITLE
docs: API: clarify what happens if rrsets is empty

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -141,7 +141,7 @@ paths:
         '200':
           description: OK
     patch:
-      summary: 'Modifies present RRsets and comments. Returns 204 No Content on success.'
+      summary: 'Creates/modifies/deletes RRsets present in the payload and their comments. Returns 204 No Content on success.'
       operationId: patchZone
       tags:
         - zones


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Makes it clear that when a zone is PATCHed, pdns operates on each of the RRsets present in the `rrsets` JSON array. In other words, if that array is empty, nothing happens (in particular, nothing is deleted).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
