### PR TITLE
dnsdist: Add DNSQuestion:getEDNSOptions() to access incoming EDNS options

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -54,16 +54,16 @@ DNSDistPacketCache::~DNSDistPacketCache()
 
 bool DNSDistPacketCache::getClientSubnet(const char* packet, unsigned int consumed, uint16_t len, boost::optional<Netmask>& subnet)
 {
-  char * optRDLen = NULL;
+  uint16_t optRDPosition;
   size_t remaining = 0;
 
-  int res = getEDNSOptionsStart(const_cast<char*>(packet), consumed, len, &optRDLen, &remaining);
+  int res = getEDNSOptionsStart(const_cast<char*>(packet), consumed, len, &optRDPosition, &remaining);
 
   if (res == 0) {
-    char * ecsOptionStart = NULL;
+    char * ecsOptionStart = nullptr;
     size_t ecsOptionSize = 0;
 
-    res = getEDNSOption(optRDLen, remaining, EDNSOptionCode::ECS, &ecsOptionStart, &ecsOptionSize);
+    res = getEDNSOption(const_cast<char*>(packet) + optRDPosition, remaining, EDNSOptionCode::ECS, &ecsOptionStart, &ecsOptionSize);
 
     if (res == 0 && ecsOptionSize > (EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE)) {
 

--- a/pdns/dnsdist-ecs.hh
+++ b/pdns/dnsdist-ecs.hh
@@ -26,14 +26,19 @@ extern uint16_t g_PayloadSizeSelfGenAnswers;
 
 int rewriteResponseWithoutEDNS(const std::string& initialPacket, vector<uint8_t>& newContent);
 int locateEDNSOptRR(const std::string& packet, uint16_t * optStart, size_t * optLen, bool * last);
-bool handleEDNSClientSubnet(char * packet, size_t packetSize, unsigned int consumed, uint16_t * len, bool* ednsAdded, bool* ecsAdded, const ComboAddress& remote, bool overrideExisting, uint16_t ecsPrefixLength);
 void generateOptRR(const std::string& optRData, string& res, uint16_t udpPayloadSize, bool dnssecOK);
+void generateECSOption(const ComboAddress& source, string& res, uint16_t ECSPrefixLength);
 int removeEDNSOptionFromOPT(char* optStart, size_t* optLen, const uint16_t optionCodeToRemove);
 int rewriteResponseWithoutEDNSOption(const std::string& initialPacket, const uint16_t optionCodeToSkip, vector<uint8_t>& newContent);
-int getEDNSOptionsStart(char* packet, const size_t offset, const size_t len, char ** optRDLen, size_t * remaining);
+int getEDNSOptionsStart(const char* packet, const size_t offset, const size_t len, uint16_t* optRDPosition, size_t * remaining);
 bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const size_t optLen, const uint16_t optionCodeToFind);
 bool addEDNS(dnsheader* dh, uint16_t& len, const size_t size, bool dnssecOK, uint16_t payloadSize);
 bool addEDNSToQueryTurnedResponse(DNSQuestion& dq);
+
+bool handleEDNSClientSubnet(DNSQuestion& dq, bool* ednsAdded, bool* ecsAdded);
+bool handleEDNSClientSubnet(char* const packet, const size_t packetSize, const unsigned int consumed, uint16_t* const len, bool* const ednsAdded, bool* const ecsAdded, bool overrideExisting, const string& newECSOption);
+
+bool parseEDNSOptions(DNSQuestion& dq);
 
 int getEDNSZ(const DNSQuestion& dq);
 bool queryHasEDNS(const DNSQuestion& dq);

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -155,7 +155,6 @@ TeeAction::~TeeAction()
   d_worker.join();
 }
 
-
 DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) const
 {
   if(dq->tcp) {
@@ -173,7 +172,10 @@ DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) con
       query.reserve(dq->size);
       query.assign((char*) dq->dh, len);
 
-      if (!handleEDNSClientSubnet(const_cast<char*>(query.c_str()), query.capacity(), dq->qname->wirelength(), &len, &ednsAdded, &ecsAdded, dq->ecsSet ? dq->ecs.getNetwork() : *dq->remote, dq->ecsOverride, dq->ecsSet ? dq->ecs.getBits() :  dq->ecsPrefixLength)) {
+      string newECSOption;
+      generateECSOption(dq->ecsSet ? dq->ecs.getNetwork() : *dq->remote, newECSOption, dq->ecsSet ? dq->ecs.getBits() :  dq->ecsPrefixLength);
+
+      if (!handleEDNSClientSubnet(const_cast<char*>(query.c_str()), query.capacity(), dq->qname->wirelength(), &len, &ednsAdded, &ecsAdded, dq->ecsOverride, newECSOption)) {
         return DNSAction::Action::None;
       }
 

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -55,6 +55,15 @@ void setupLuaBindingsDNSQuestion()
   g_lua.registerFunction<bool(DNSQuestion::*)()>("getDO", [](const DNSQuestion& dq) {
       return getEDNSZ(dq) & EDNS_HEADER_FLAG_DO;
     });
+
+  g_lua.registerFunction<std::map<uint16_t, EDNSOptionView>(DNSQuestion::*)()>("getEDNSOptions", [](DNSQuestion& dq) {
+      if (dq.ednsOptions == nullptr) {
+        parseEDNSOptions(dq);
+      }
+
+      return *dq.ednsOptions;
+    });
+
   g_lua.registerFunction<void(DNSQuestion::*)(std::string)>("sendTrap", [](const DNSQuestion& dq, boost::optional<std::string> reason) {
 #ifdef HAVE_NET_SNMP
       if (g_snmpAgent && g_snmpTrapsEnabled) {

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -571,4 +571,16 @@ void setupLuaBindings(bool client)
       }
     });
 #endif /* HAVE_EBPF */
+
+  /* EDNSOptionView */
+  g_lua.registerFunction<size_t(EDNSOptionView::*)()>("count", [](const EDNSOptionView& option) {
+      return option.values.size();
+    });
+  g_lua.registerFunction<std::vector<std::pair<int, string>>(EDNSOptionView::*)()>("getValues", [] (const EDNSOptionView& option) {
+    std::vector<std::pair<int, string> > values;
+    for (const auto& value : option.values) {
+      values.push_back(std::make_pair(values.size(), std::string(value.content, value.size)));
+    }
+    return values;
+  });
 }

--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -118,4 +118,17 @@ void setupLuaVars()
         { "VERSION2", DNSCryptExchangeVersion::VERSION2 },
     });
 #endif
+
+  g_lua.writeVariable("EDNSOptionCode", std::unordered_map<string, uint8_t>{
+      { "NSID", EDNSOptionCode::NSID },
+      { "DAU", EDNSOptionCode::DAU },
+      { "DHU", EDNSOptionCode::DHU },
+      { "N3U", EDNSOptionCode::N3U },
+      { "ECS", EDNSOptionCode::ECS },
+      { "EXPIRE", EDNSOptionCode::EXPIRE },
+      { "COOKIE", EDNSOptionCode::COOKIE },
+      { "TCPKEEPALIVE", EDNSOptionCode::TCPKEEPALIVE },
+      { "PADDING", EDNSOptionCode::PADDING },
+      { "CHAIN", EDNSOptionCode::CHAIN }
+    });
 }

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -404,12 +404,10 @@ void* tcpClientThread(int pipefd)
         }
 
         if (dq.useECS && ((ds && ds->useECS) || (!ds && serverPool->getECS()))) {
-          uint16_t newLen = dq.len;
-          if (!handleEDNSClientSubnet(query, dq.size, consumed, &newLen, &ednsAdded, &ecsAdded, dq.ecsSet ? dq.ecs.getNetwork() : ci.remote, dq.ecsOverride, dq.ecsSet ? dq.ecs.getBits() : dq.ecsPrefixLength)) {
+          if (!handleEDNSClientSubnet(dq, &(ednsAdded), &(ecsAdded))) {
             vinfolog("Dropping query from %s because we couldn't insert the ECS value", ci.remote.toStringWithPort());
             goto drop;
           }
-          dq.len = newLen;
         }
 
         uint32_t cacheKey = 0;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1403,7 +1403,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     bool ednsAdded = false;
     bool ecsAdded = false;
     if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
-      if (!handleEDNSClientSubnet(query, dq.size, consumed, &dq.len, &(ednsAdded), &(ecsAdded), dq.ecsSet ? dq.ecs.getNetwork() : remote, dq.ecsOverride, dq.ecsSet ? dq.ecs.getBits() : dq.ecsPrefixLength)) {
+      if (!handleEDNSClientSubnet(dq, &(ednsAdded), &(ecsAdded))) {
         vinfolog("Dropping query from %s because we couldn't insert the ECS value", remote.toStringWithPort());
         return;
       }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -22,24 +22,29 @@
 #pragma once
 #include "config.h"
 #include "ext/luawrapper/include/LuaContext.hpp"
-#include <time.h>
-#include "misc.hh"
-#include "mplexer.hh"
-#include "iputils.hh"
-#include "dnsname.hh"
+
 #include <atomic>
-#include <boost/variant.hpp>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <time.h>
 #include <unistd.h>
-#include "sholder.hh"
+#include <unordered_map>
+
+#include <boost/circular_buffer.hpp>
+#include <boost/variant.hpp>
+
+#include "bpf-filter.hh"
 #include "dnscrypt.hh"
 #include "dnsdist-cache.hh"
-#include "gettime.hh"
 #include "dnsdist-dynbpf.hh"
-#include "bpf-filter.hh"
-#include <string>
-#include <unordered_map>
+#include "dnsname.hh"
+#include "ednsoptions.hh"
+#include "gettime.hh"
+#include "iputils.hh"
+#include "misc.hh"
+#include "mplexer.hh"
+#include "sholder.hh"
 #include "tcpiohandler.hh"
 
 #include <boost/uuid/uuid.hpp>
@@ -72,6 +77,7 @@ struct DNSQuestion
   const ComboAddress* local;
   const ComboAddress* remote;
   std::shared_ptr<QTag> qTag{nullptr};
+  std::shared_ptr<std::map<uint16_t, EDNSOptionView> > ednsOptions;
   struct dnsheader* dh;
   size_t size;
   unsigned int consumed{0};

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -84,6 +84,14 @@ This state can be modified from the various hooks.
 
     :returns: true if the DO bit was set, false otherwise
 
+  .. method:: DNSQuestion:getEDNSOptions() -> table
+
+    .. versionadded:: 1.3.1
+
+    Return the list of EDNS Options, if any.
+
+    :returns: A table of EDNSOptionView objects, indexed on the ECS Option code
+
   .. method:: DNSQuestion:getTag(key) -> string
 
     .. versionadded:: 1.2.0
@@ -194,3 +202,22 @@ DNSHeader (``dh``) object
     Set checking disabled flag.
 
     :param bool cd: State of the CD flag
+
+.. _EDNSOptionView:
+
+EDNSOptionView object
+=====================
+
+.. class:: EDNSOptionView
+
+  .. versionadded:: 1.3.1
+
+  An object that represents the values of a single EDNS option received in a query.
+
+  .. attribute:: EDNSOptionView.count -> int
+
+    The number of values for this EDNS option.
+
+  .. method:: EDNSOptionView:getValues()
+
+    Return a table of NULL-safe strings values for this EDNS option.

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -491,18 +491,25 @@ class DNSDistTest(unittest.TestCase):
             for option in received.options:
                 self.assertEquals(option.otype, 10)
 
-    def checkMessageEDNSWithECS(self, expected, received):
+    def checkMessageEDNSWithECS(self, expected, received, additionalOptions=0):
         self.assertEquals(expected, received)
         self.assertEquals(received.edns, 0)
-        self.assertEquals(len(received.options), 1)
-        self.assertEquals(received.options[0].otype, clientsubnetoption.ASSIGNED_OPTION_CODE)
+        self.assertEquals(len(received.options), 1 + additionalOptions)
+        hasECS = False
+        for option in received.options:
+            if option.otype == clientsubnetoption.ASSIGNED_OPTION_CODE:
+                hasECS = True
+            else:
+                self.assertNotEquals(additionalOptions, 0)
+
         self.compareOptions(expected.options, received.options)
+        self.assertTrue(hasECS)
 
-    def checkQueryEDNSWithECS(self, expected, received):
-        self.checkMessageEDNSWithECS(expected, received)
+    def checkQueryEDNSWithECS(self, expected, received, additionalOptions=0):
+        self.checkMessageEDNSWithECS(expected, received, additionalOptions)
 
-    def checkResponseEDNSWithECS(self, expected, received):
-        self.checkMessageEDNSWithECS(expected, received)
+    def checkResponseEDNSWithECS(self, expected, received, additionalOptions=0):
+        self.checkMessageEDNSWithECS(expected, received, additionalOptions)
 
     def checkQueryEDNSWithoutECS(self, expected, received):
         self.checkMessageEDNSWithoutECS(expected, received)

--- a/regression-tests.dnsdist/test_EDNSOptions.py
+++ b/regression-tests.dnsdist/test_EDNSOptions.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python
+import dns
+import clientsubnetoption
+import cookiesoption
+from dnsdisttests import DNSDistTest
+
+class EDNSOptionsBase(DNSDistTest):
+    _ednsTestFunction = """
+    function testEDNSOptions(dq)
+      local options = dq:getEDNSOptions()
+      local qname = dq.qname:toString()
+
+      if string.match(qname, 'noedns') then
+        if next(options) ~= nil then
+          return DNSAction.Spoof, "192.0.2.255"
+        end
+      end
+
+      if string.match(qname, 'multiplecookies') then
+        if options[EDNSOptionCode.COOKIE] == nil then
+          return DNSAction.Spoof, "192.0.2.1"
+        end
+        if options[EDNSOptionCode.COOKIE]:count() ~= 2 then
+          return DNSAction.Spoof, "192.0.2.2"
+        end
+        if options[EDNSOptionCode.COOKIE]:getValues()[0]:len() ~= 16 then
+          return DNSAction.Spoof, "192.0.2.3"
+        end
+        if options[EDNSOptionCode.COOKIE]:getValues()[1]:len() ~= 16 then
+          return DNSAction.Spoof, "192.0.2.4"
+        end
+      elseif string.match(qname, 'cookie') then
+        if options[EDNSOptionCode.COOKIE] == nil then
+          return DNSAction.Spoof, "192.0.2.1"
+        end
+        if options[EDNSOptionCode.COOKIE]:count() ~= 1 or options[EDNSOptionCode.COOKIE]:getValues()[0]:len() ~= 16 then
+          return DNSAction.Spoof, "192.0.2.2"
+        end
+      end
+
+      if string.match(qname, 'ecs4') then
+        if options[EDNSOptionCode.ECS] == nil then
+          return DNSAction.Spoof, "192.0.2.51"
+        end
+        if options[EDNSOptionCode.ECS]:count() ~= 1 or options[EDNSOptionCode.ECS]:getValues()[0]:len() ~= 8 then
+          return DNSAction.Spoof, "192.0.2.52"
+        end
+      end
+
+      if string.match(qname, 'ecs6') then
+        if options[EDNSOptionCode.ECS] == nil then
+          return DNSAction.Spoof, "192.0.2.101"
+        end
+        if options[EDNSOptionCode.ECS]:count() ~= 1 or options[EDNSOptionCode.ECS]:getValues()[0]:len() ~= 20 then
+          return DNSAction.Spoof, "192.0.2.102"
+        end
+      end
+
+      return DNSAction.None, ""
+
+    end
+    """
+
+class TestEDNSOptions(EDNSOptionsBase):
+
+    _config_template = """
+    %s
+
+    addLuaAction(AllRule(), testEDNSOptions)
+
+    newServer{address="127.0.0.1:%s"}
+    """
+    _config_params = ['_ednsTestFunction', '_testServerPort']
+
+    def testWithoutEDNS(self):
+        """
+        EDNS Options: No EDNS
+        """
+        name = 'noedns.ednsoptions.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '192.0.2.255')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+    def testCookie(self):
+        """
+        EDNS Options: Cookie
+        """
+        name = 'cookie.ednsoptions.tests.powerdns.com.'
+        eco = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[eco])
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+    def testECS4(self):
+        """
+        EDNS Options: ECS4
+        """
+        name = 'ecs4.ednsoptions.tests.powerdns.com.'
+        ecso = clientsubnetoption.ClientSubnetOption('1.2.3.4', 32)
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[ecso])
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+    def testECS6(self):
+        """
+        EDNS Options: ECS6
+        """
+        name = 'ecs6.ednsoptions.tests.powerdns.com.'
+        ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[ecso])
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+    def testECS6Cookie(self):
+        """
+        EDNS Options: Cookie + ECS6
+        """
+        name = 'cookie-ecs6.ednsoptions.tests.powerdns.com.'
+        eco = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[ecso,eco])
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+    def testMultiCookiesECS6(self):
+        """
+        EDNS Options: Two Cookies + ECS6
+        """
+        name = 'multiplecookies-ecs6.ednsoptions.tests.powerdns.com.'
+        eco1 = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
+        eco2 = cookiesoption.CookiesOption('deadc0de', 'deadc0de')
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[eco1, ecso, eco2])
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+class TestEDNSOptionsAddingECS(EDNSOptionsBase):
+
+    _config_template = """
+    %s
+
+    addLuaAction(AllRule(), testEDNSOptions)
+
+    newServer{address="127.0.0.1:%s", useClientSubnet=true}
+    """
+    _config_params = ['_ednsTestFunction', '_testServerPort']
+
+    def testWithoutEDNS(self):
+        """
+        EDNS Options: No EDNS (adding ECS)
+        """
+        name = 'noedns.ednsoptions-ecs.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        ecso = clientsubnetoption.ClientSubnetOption('127.0.0.1', 24)
+        expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, options=[ecso], payload=512)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = expectedQuery.id
+        self.checkQueryEDNSWithECS(expectedQuery, receivedQuery)
+        self.checkResponseNoEDNS(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = expectedQuery.id
+        self.checkQueryEDNSWithECS(expectedQuery, receivedQuery)
+        self.checkResponseNoEDNS(response, receivedResponse)
+
+    def testCookie(self):
+        """
+        EDNS Options: Cookie (adding ECS)
+        """
+        name = 'cookie.ednsoptions-ecs.tests.powerdns.com.'
+        eco = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[eco])
+        ecso = clientsubnetoption.ClientSubnetOption('127.0.0.1', 24)
+        expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, options=[eco,ecso], payload=512)
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = expectedQuery.id
+        self.checkQueryEDNSWithECS(expectedQuery, receivedQuery, 1)
+        self.checkResponseEDNSWithoutECS(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = expectedQuery.id
+        self.checkQueryEDNSWithECS(expectedQuery, receivedQuery, 1)
+        self.checkResponseEDNSWithoutECS(response, receivedResponse)
+
+    def testECS4(self):
+        """
+        EDNS Options: ECS4 (adding ECS)
+        """
+        name = 'ecs4.ednsoptions-ecs.tests.powerdns.com.'
+        ecso = clientsubnetoption.ClientSubnetOption('1.2.3.4', 32)
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[ecso])
+        ecsoResponse = clientsubnetoption.ClientSubnetOption('1.2.3.4', 24, scope=24)
+        response = dns.message.make_response(query)
+        response.use_edns(edns=True, payload=4096, options=[ecsoResponse])
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.checkQueryEDNSWithECS(query, receivedQuery)
+        self.checkResponseEDNSWithECS(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.checkQueryEDNSWithECS(query, receivedQuery)
+        self.checkResponseEDNSWithECS(response, receivedResponse)
+
+    def testECS6(self):
+        """
+        EDNS Options: ECS6 (adding ECS)
+        """
+        name = 'ecs6.ednsoptions-ecs.tests.powerdns.com.'
+        ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[ecso])
+        ecsoResponse = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128, scope=56)
+        response = dns.message.make_response(query)
+        response.use_edns(edns=True, payload=4096, options=[ecsoResponse])
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.checkQueryEDNSWithECS(query, receivedQuery)
+        self.checkResponseEDNSWithECS(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.checkQueryEDNSWithECS(query, receivedQuery)
+        self.checkResponseEDNSWithECS(response, receivedResponse)
+
+    def testECS6Cookie(self):
+        """
+        EDNS Options: Cookie + ECS6 (adding ECS)
+        """
+        name = 'cookie-ecs6.ednsoptions-ecs.tests.powerdns.com.'
+        eco = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[ecso,eco])
+        ecsoResponse = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128, scope=56)
+        response = dns.message.make_response(query)
+        response.use_edns(edns=True, payload=4096, options=[ecsoResponse])
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.checkQueryEDNSWithECS(query, receivedQuery, 1)
+        self.checkResponseEDNSWithECS(response, receivedResponse)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.checkQueryEDNSWithECS(query, receivedQuery, 1)
+        self.checkResponseEDNSWithECS(response, receivedResponse)
+
+    def testMultiCookiesECS6(self):
+        """
+        EDNS Options: Two Cookies + ECS6
+        """
+        name = 'multiplecookies-ecs6.ednsoptions.tests.powerdns.com.'
+        eco1 = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
+        eco2 = cookiesoption.CookiesOption('deadc0de', 'deadc0de')
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[eco1, ecso, eco2])
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)
+
+        (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(receivedQuery, query)
+        self.assertEquals(receivedResponse, response)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Enabling access to the raw binary content of incoming `EDNS` options from `Lua` rules via `DNSQuestion::getEDNSOptions()`. This call returns a table with option code as keys and `EDNSOptionView`s as values. The size of the raw binary content can be retrieved via `EDNSOptionView::size` and the content with `EDNSOptionView::getContent()`, the later returning the binary content as a string.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
