### PR TITLE
dnsdist: add inClientStartup() function

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -335,6 +335,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "getResponseRing", true, "", "return the current content of the response ring" },
   { "getServer", true, "n", "returns server with index n" },
   { "getServers", true, "", "returns a table with all defined servers" },
+  { "inClientStartup", true, "", "returns true during console client parsing of configuration" },
   { "grepq", true, "Netmask|DNS Name|100ms|{\"::1\", \"powerdns.com\", \"100ms\"} [, n]", "shows the last n queries and responses matching the specified client address or range (Netmask), or the specified DNS Name, or slower than 100ms" },
   { "leastOutstanding", false, "", "Send traffic to downstream server with least outstanding queries, with the lowest 'order', and within that the lowest recent latency"},
   { "LogAction", true, "[filename], [binary], [append], [buffered]", "Log a line for each query, to the specified file if any, to the console (require verbose) otherwise. When logging to a file, the `binary` optional parameter specifies whether we log in binary form (default) or in textual form, the `append` optional parameter specifies whether we open the file for appending or truncate each time (default), and the `buffered` optional parameter specifies whether writes to the file are buffered (default) or not." },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -267,7 +267,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   g_lua.writeVariable("dnsdist", dd);
   
   g_lua.writeFunction("inClientStartup", [client]() {
-        return client;
+        return client && !g_configurationDone;
   });
 
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -266,6 +266,11 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
     dd.push_back({n.first, n.second});
   g_lua.writeVariable("dnsdist", dd);
   
+  g_lua.writeFunction("inClientStartup", [client]() {
+        return client;
+  });
+
+
   g_lua.writeFunction("newServer", 
 		      [client](boost::variant<string,newserver_t> pvars, boost::optional<int> qps)
 		      { 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -118,6 +118,10 @@ Control Socket, Console and Webserver
 
   :param str address: An IP address with optional port. By default, the port is 5199.
 
+.. function:: inClientStartup()
+
+  Returns true while the console client is parsing the configuration.
+
 .. function:: makeKey()
 
   Generate and print an encryption key.


### PR DESCRIPTION
### Short description
This allows the user to, for example, print certain things during daemon startup but not while connecting a client.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

