### PR TITLE
Quiet unused variable warning on macOS

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1803,7 +1803,7 @@ catch(std::exception& e)
 
 static void bindAny(int af, int sock)
 {
-  int one = 1;
+  __attribute__((unused)) int one = 1;
 
 #ifdef IP_FREEBIND
   if (setsockopt(sock, IPPROTO_IP, IP_FREEBIND, &one, sizeof(one)) < 0)


### PR DESCRIPTION
### Short description
On macOS, none of the freebind/bindany/... options are available, so the var "one" as used for setsockopt is unused. This quiets clang.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
