### PR TITLE
API: return 404 for non-existing zones

### DIFF
--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -500,8 +500,9 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         payload_metadata = {"type": "Metadata", "kind": "AXFR-SOURCE", "metadata": ["127.0.0.2"]}
         r = self.session.post(self.url("/api/v1/servers/localhost/zones/idonotexist.123.456.example./metadata"),
                               data=json.dumps(payload_metadata))
-        self.assertEquals(r.status_code, 422)
-        self.assertIn('Could not find domain ', r.json()['error'])
+        self.assertEquals(r.status_code, 404)
+        # Note: errors should probably contain json (see #5988)
+        # self.assertIn('Could not find domain ', r.json()['error'])
 
     def test_create_slave_zone(self):
         # Test that nameservers can be absent for slave zones.

--- a/regression-tests.api/test_cryptokeys.py
+++ b/regression-tests.api/test_cryptokeys.py
@@ -47,11 +47,16 @@ class Cryptokeys(ApiTestCase):
         except subprocess.CalledProcessError as e:
             self.fail("pdnsutil list-keys failed: " + e.output)
 
+    def test_get_wrong_zone(self):
+        self.keyid = self.add_zone_key()
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/"+self.zone+"fail/cryptokeys/"+self.keyid))
+        self.assertEquals(r.status_code, 404)
+
     def test_delete_wrong_zone(self):
         self.keyid = self.add_zone_key()
         #checks for not covered zonename
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+self.zone+"fail/cryptokeys/"+self.keyid))
-        self.assertEquals(r.status_code, 400)
+        self.assertEquals(r.status_code, 404)
 
     def test_delete_key_is_gone(self):
         self.keyid = self.add_zone_key()


### PR DESCRIPTION
### Short description
This commit ensures that any request for a path inside a non-existing
zone returns an HTTP 404 code.

Closes #6074

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
