### PR TITLE
Include unistd.h for chroot(2) et al.

### DIFF
--- a/pdns/nproxy.cc
+++ b/pdns/nproxy.cc
@@ -38,6 +38,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <grp.h>
+#include <unistd.h>
 #include "dnsrecords.hh"
 #include "mplexer.hh"
 #include "statbag.hh"


### PR DESCRIPTION
This used to compile in 4.0.5, in 4.1.0 I get this (on OpenBSD -current amd64):

```
nproxy.cc:303:8: error: use of undeclared identifier 'chroot'
    if(chroot(g_vm["chroot"].as<string>().c_str()) < 0 || chdir("/") < 0)
       ^
nproxy.cc:303:59: error: use of undeclared identifier 'chdir'
    if(chroot(g_vm["chroot"].as<string>().c_str()) < 0 || chdir("/") < 0)
                                                          ^
nproxy.cc:309:8: error: use of undeclared identifier 'setgid'
    if(setgid(g_vm["setgid"].as<int>()) < 0)
       ^
nproxy.cc:312:8: error: use of undeclared identifier 'setgroups'
    if(setgroups(0, NULL) < 0)
       ^
nproxy.cc:317:8: error: use of undeclared identifier 'setuid'
    if(setuid(g_vm["setuid"].as<int>()) < 0)
       ^
nproxy.cc:326:3: error: use of undeclared identifier 'close'
  close(null_fd);
  ^
nproxy.cc:354:6: error: use of undeclared identifier 'fork'
  if(fork())
     ^
nproxy.cc:357:3: error: use of undeclared identifier 'setsid'
  setsid();
  ^
nproxy.cc:359:3: error: use of undeclared identifier 'dup2'
  dup2(null_fd,0); /* stdin */
  ^
nproxy.cc:360:3: error: use of undeclared identifier 'dup2'
  dup2(null_fd,1); /* stderr */
  ^
nproxy.cc:361:3: error: use of undeclared identifier 'dup2'
  dup2(null_fd,2); /* stderr */
```

The file itself did not change in years so some refactoring probably resulted in
unistd.h no longer being included.