### PR TITLE
Make everything compile and run on NetBSD, including on multi-homed hosts

### DIFF
--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -130,7 +130,7 @@ struct EDNS0Record
 
 static_assert(sizeof(EDNS0Record) == 4, "EDNS0Record size must be 4");
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
 #include <machine/endian.h>
 #elif __linux__ || __GNU__
 # include <endian.h>

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -23,7 +23,7 @@
 #include "sodcrypto.hh"
 #include "pwd.h"
 
-#if defined (__OpenBSD__)
+#if defined (__OpenBSD__) || defined(__NetBSD__)
 #include <readline/readline.h>
 #include <readline/history.h>
 #else

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -27,7 +27,7 @@
 #include <limits>
 #include "dolog.hh"
 
-#if defined (__OpenBSD__)
+#if defined (__OpenBSD__) || defined(__NetBSD__)
 #include <readline/readline.h>
 #else
 #include <editline/readline.h>

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -146,9 +146,13 @@ bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv)
 bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destination)
 {
   memset(destination, 0, sizeof(*destination));
+#ifdef __NetBSD__
+  struct cmsghdr* cmsg;
+#else
   const struct cmsghdr* cmsg;
+#endif
   for (cmsg = CMSG_FIRSTHDR(msgh); cmsg != NULL; cmsg = CMSG_NXTHDR(const_cast<struct msghdr*>(msgh), const_cast<struct cmsghdr*>(cmsg))) {
-#if defined(IP_PKTINFO) && !defined(__NetBSD__)
+#if defined(IP_PKTINFO)
      if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_PKTINFO)) {
         struct in_pktinfo *i = (struct in_pktinfo *) CMSG_DATA(cmsg);
         destination->sin4.sin_addr = i->ipi_addr;
@@ -157,11 +161,7 @@ bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destinat
     }
 #elif defined(IP_RECVDSTADDR)
     if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_RECVDSTADDR)) {
-#  ifdef __NetBSD__
-      struct in_addr *i = (struct in_addr *) CCMSG_DATA(cmsg);
-#  else
       struct in_addr *i = (struct in_addr *) CMSG_DATA(cmsg);
-#  endif
       destination->sin4.sin_addr = *i;
       destination->sin4.sin_family = AF_INET;      
       return true;
@@ -169,11 +169,7 @@ bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destinat
 #endif
 
     if ((cmsg->cmsg_level == IPPROTO_IPV6) && (cmsg->cmsg_type == IPV6_PKTINFO)) {
-#ifdef __NetBSD__
-        struct in6_pktinfo *i = (struct in6_pktinfo *) CCMSG_DATA(cmsg);
-#else
         struct in6_pktinfo *i = (struct in6_pktinfo *) CMSG_DATA(cmsg);
-#endif
         destination->sin6.sin6_addr = i->ipi6_addr;
         destination->sin4.sin_family = AF_INET6;
         return true;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -987,7 +987,7 @@ int SAccept(int sockfd, ComboAddress& remote);
 int SListen(int sockfd, int limit);
 int SSetsockopt(int sockfd, int level, int opname, int value);
 
-#if defined(IP_PKTINFO) && !defined(__NetBSD__)
+#if defined(IP_PKTINFO)
   #define GEN_IP_PKTINFO IP_PKTINFO
 #elif defined(IP_RECVDSTADDR)
   #define GEN_IP_PKTINFO IP_RECVDSTADDR 

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -987,11 +987,12 @@ int SAccept(int sockfd, ComboAddress& remote);
 int SListen(int sockfd, int limit);
 int SSetsockopt(int sockfd, int level, int opname, int value);
 
-#if defined(IP_PKTINFO)
+#if defined(IP_PKTINFO) && !defined(__NetBSD__)
   #define GEN_IP_PKTINFO IP_PKTINFO
 #elif defined(IP_RECVDSTADDR)
   #define GEN_IP_PKTINFO IP_RECVDSTADDR 
 #endif
+
 bool IsAnyAddress(const ComboAddress& addr);
 bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destination);
 bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv);

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -82,6 +82,10 @@
 #include <sys/endian.h>
 #endif
 
+#if defined(__NetBSD_Version__) && __NetBSD_Version__ < 899001100 && defined(IP_PKTINFO)
+#undef IP_PKTINFO
+#endif
+
 union ComboAddress {
   struct sockaddr_in sin4;
   struct sockaddr_in6 sin6;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -82,7 +82,9 @@
 #include <sys/endian.h>
 #endif
 
-#if defined(__NetBSD_Version__) && __NetBSD_Version__ < 899001100 && defined(IP_PKTINFO)
+#if defined(__NetBSD__) && defined(IP_PKTINFO) && !defined(IP_SENDSRCADDR)
+// The IP_PKTINFO option in NetBSD was incompatible with Linux until a
+// change that also introduced IP_SENDSRCADDR for FreeBSD compatibility.
 #undef IP_PKTINFO
 #endif
 

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -28,7 +28,7 @@
 #include <unistd.h>
 #include "misc.hh"
 #include <sys/types.h>
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
 #include <sys/event.h>
 #endif
 #include <sys/time.h>

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -883,11 +883,7 @@ void addCMsgSrcAddr(struct msghdr* msgh, void* cmsgbuf, const ComboAddress* sour
 
     pkt = (struct in_pktinfo *) CMSG_DATA(cmsg);
     memset(pkt, 0, sizeof(*pkt));
-#  ifdef __NetBSD__
-    pkt->ipi_addr = source->sin4.sin_addr;
-#  else
     pkt->ipi_spec_dst = source->sin4.sin_addr;
-#  endif
     pkt->ipi_ifindex = itfIndex;
 #elif defined(IP_SENDSRCADDR)
     struct in_addr *in;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
These are the minimal changes to make everything (auth, recursor, and
dnsdist) compile and run properly on NetBSD.  The changes fall into
three groups:

1) A number of existing "#if defined" lines already in place for other
   BSD variants needed to be expanded with "|| defined(__NetBSD__)" to
   get the same effect here.

2) The pthread CPU affinity code in pdns/misc.cc needed changes,
   because the underlying cpuset_t is opaque in NetBSD, and one must
   use function calls operating on a pointer to a CPU set returned by
   cpuset_create(), instead of declaring a local struct and operating
   on that.

3) The use of socket options IP_PKTINFO et al is slightly different in
   NetBSD.  It can be used to make recvmsg() supply information about
   the source address of an incoming packet, or to make sendmsg() use
   a specific source address for an outgoing packet.  Thus, it is a
   direct parallel to the IPV6_PKTINFO option, and uses similarly
   named struct members.  To get information about the destination
   address of an incoming packet (which multi-homed servers will need
   to be able to respond from the right address), one would use the
   IP_RECVPKTINFO option instead -- while Linux conflates these two
   features into one, by adding a struct member "ipi_spec_dst" for the
   "specific destination" of an incoming packet.  (It then overloads
   that field by using it for the "specific source" of an outgoing
   packet, which looks somewhat inelegant to me.)

   So the IP_PKTINFO option can be used to set the source for an
   outgoing packet for sendmsg(), but we have to use the "ipi_addr"
   struct member instead of "ipi_spec_dst", so I #ifdef that for
   NetBSD.  For getting the destination address of an incoming packet,
   PowerDNS already has code to use the IP_RECVDSTADDR option instead
   of IP_PKTINFO, so I just added an "&& !defined(__NetBSD__) to the
   test for IP_PKTINFO being available.  (Pretending that IP_PKTINFO
   isn't available is fine here, but wouldn't help for setting the
   source address of outgoing packets, as IP_SENDSRCADDR (which there
   was already code in place to use) is not available on NetBSD.)

   Another tiny discrepancy: the existing code uses the CMSG_DATA()
   macro to fetch optional information for packets, of course.  The
   implementation of this on NetBSD clashes with the declaration
   "const struct cmsghdr* cmsg;", and I had to use CCMSG_DATA()
   instead.

The result works as it should, and is -- I've verified that the
servers now respond correctly to queries addressed to them on IPv4
addresses other than the one on the interface the query arrives on.

One quirk I haven't done anything about is the difficulty configure
experiences finding libedit on NetBSD, where it is in the base
installation.  The workaround is to configure dnsdist by saying
"./configure LIBEDIT_CFLAGS=-I/usr/include LIBEDIT_LIBS=-L/usr/lib -ledit"
but I'm sure something could be done to configure to help it.  I don't
know the tool well enough to try, though.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
