### PR TITLE
dnsdist: Fix the oustanding counter when an exception is raised

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -404,6 +404,7 @@ try {
   uint16_t queryId = 0;
   for(;;) {
     dnsheader* dh = reinterpret_cast<struct dnsheader*>(packet);
+    bool outstandingDecreased = false;
     try {
       ssize_t got = recv(state->fd, packet, sizeof(packet), 0);
       char * response = packet;
@@ -436,6 +437,7 @@ try {
       }
 
       --state->outstanding;  // you'd think an attacker could game this, but we're using connected socket
+      outstandingDecreased = true;
 
       if(dh->tc && g_truncateTC) {
         truncateTC(response, &responseLen);
@@ -509,12 +511,21 @@ try {
         ids->dnsCryptQuery = nullptr;
 #endif
         ids->origFD = -1;
+        outstandingDecreased = false;
       }
 
       rewrittenResponse.clear();
     }
-    catch(std::exception& e){
+    catch(const std::exception& e){
       vinfolog("Got an error in UDP responder thread while parsing a response from %s, id %d: %s", state->remote.toStringWithPort(), queryId, e.what());
+      if (outstandingDecreased) {
+        /* so an exception was raised after we decreased the outstanding queries counter,
+           but before we could set ids->origFD to -1 (because we also set outstandingDecreased
+           to false then), meaning the IDS still considered active and we will decrease the
+           counter again on a duplicate, or simply while reaping downstream timeouts, so let's
+           increase it back. */
+        state->outstanding++;
+      }
     }
   }
   return 0;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -521,7 +521,7 @@ try {
       if (outstandingDecreased) {
         /* so an exception was raised after we decreased the outstanding queries counter,
            but before we could set ids->origFD to -1 (because we also set outstandingDecreased
-           to false then), meaning the IDS still considered active and we will decrease the
+           to false then), meaning the IDS is still considered active and we will decrease the
            counter again on a duplicate, or simply while reaping downstream timeouts, so let's
            increase it back. */
         state->outstanding++;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If an exception is raised in the responder thread after the outstanding queries counter has been decremented, but before we could mark the state as processed, the same state would be processed again and the counter decremented a second time, either because of a duplicate answer or more likely by the timeout handler.
This commit simply increase back the outstanding counter when such an exception occurs. It might fixes #5652.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
