### PR TITLE
 rec: Pass the correct buffer size to arecvfrom()

### DIFF
--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -161,7 +161,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
   
     // sleep until we see an answer to this, interface to mtasker
     
-    ret=arecvfrom(reinterpret_cast<char *>(buf.get()), bufsize-1,0, ip, &len, qid,
+    ret=arecvfrom(reinterpret_cast<char *>(buf.get()), bufsize, 0, ip, &len, qid,
                   domain, type, queryfd, now);
   }
   else {

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -575,7 +575,7 @@ distributor-threads=1""".format(confdir=confdir,
                 raise
 
     @classmethod
-    def sendUDPQuery(cls, query, timeout=2.0, fwparams=dict()):
+    def sendUDPQuery(cls, query, timeout=2.0, decode=True, fwparams=dict()):
         if timeout:
             cls._sock.settimeout(timeout)
 
@@ -590,6 +590,8 @@ distributor-threads=1""".format(confdir=confdir,
 
         message = None
         if data:
+            if not decode:
+                return data
             message = dns.message.from_wire(data, **fwparams)
         return message
 

--- a/regression-tests.recursor-dnssec/test_ECS.py
+++ b/regression-tests.recursor-dnssec/test_ECS.py
@@ -70,7 +70,7 @@ disable-syslog=yes
             ecsReactorRunning = True
 
         if not reactor.running:
-            cls._UDPResponder = threading.Thread(name='UDP ECS Responder', target=reactor.run, args=(False,))
+            cls._UDPResponder = threading.Thread(name='UDP Responder', target=reactor.run, args=(False,))
             cls._UDPResponder.setDaemon(True)
             cls._UDPResponder.start()
 

--- a/regression-tests.recursor-dnssec/test_Interop.py
+++ b/regression-tests.recursor-dnssec/test_Interop.py
@@ -135,10 +135,6 @@ forward-zones+=undelegated.insecure.example=%s.12
             cls._UDPResponder.setDaemon(True)
             cls._UDPResponder.start()
 
-    @classmethod
-    def tearDownResponders(cls):
-        reactor.stop()
-
 class UDPResponder(DatagramProtocol):
     def datagramReceived(self, datagram, address):
         request = dns.message.from_wire(datagram)

--- a/regression-tests.recursor-dnssec/test_LargeAnswer.py
+++ b/regression-tests.recursor-dnssec/test_LargeAnswer.py
@@ -1,0 +1,110 @@
+import dns
+import os
+import socket
+import struct
+import threading
+import time
+
+from recursortests import RecursorTest
+from twisted.internet.protocol import DatagramProtocol
+from twisted.internet import reactor
+
+largeReactorRunning = False
+
+class LargeAnswerTest(RecursorTest):
+    """
+    This test makes sure that we correctly process an answer matching our exact
+    udp-truncation-threshold buffer size.
+    """
+    _confdir = 'LargeAnswer'
+    _udpTruncationThreshold = 1680
+
+    _config_template = """
+forward-zones=large-answer.example=%s.22
+udp-truncation-threshold=%d
+    """ % (os.environ['PREFIX'], _udpTruncationThreshold)
+
+    @classmethod
+    def startResponders(cls):
+        global largeReactorRunning
+        print("Launching responders..")
+
+        address = cls._PREFIX + '.22'
+        port = 53
+
+        if not largeReactorRunning:
+            reactor.listenUDP(port, UDPLargeResponder(), interface=address)
+            largeReactorRunning = True
+
+        if not reactor.running:
+            cls._UDPResponder = threading.Thread(name='UDP Large Responder', target=reactor.run, args=(False,))
+            cls._UDPResponder.setDaemon(True)
+            cls._UDPResponder.start()
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setUpSockets()
+
+        cls.startResponders()
+
+        confdir = os.path.join('configs', cls._confdir)
+        cls.createConfigDir(confdir)
+
+        cls.generateRecursorConfig(confdir)
+        cls.startRecursor(confdir, cls._recursorPort)
+
+        print("Launching tests..")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tearDownRecursor()
+
+    def checkResponseContent(self, rawResponse, value):
+       self.assertEquals(len(rawResponse), self._udpTruncationThreshold)
+       response = dns.message.from_wire(rawResponse)
+
+       self.assertRcodeEqual(response, dns.rcode.NOERROR)
+       self.assertFalse(response.flags & dns.flags.TC)
+
+       for record in response.answer:
+           self.assertEquals(record.rdtype, dns.rdatatype.TXT)
+           for part in record:
+               for string in part.strings:
+                   self.assertTrue(len(string) == 255 or len(string) == 16)
+                   for c in string:
+                       self.assertEquals(c, value)
+
+    def testLargeAnswer(self):
+        # why the same query 10 times, do you ask? because if we are reading from
+        # unintialized buffer memory, there is small risk that we find exactly the
+        # value we expected by chance so let's  massage our buffer a bit
+        query = dns.message.make_query('AAAA.large-answer.example.', 'TXT', 'IN', use_edns=True, payload=4096)
+        for _ in range(10):
+            raw = self.sendUDPQuery(query, decode=False)
+            self.checkResponseContent(raw, 'A')
+
+        query = dns.message.make_query('ZZZZ.large-answer.example.', 'TXT', 'IN', use_edns=True, payload=4096)
+        for _ in range(10):
+            raw = self.sendUDPQuery(query, decode=False)
+            self.checkResponseContent(raw, 'Z')
+
+class UDPLargeResponder(DatagramProtocol):
+
+    def datagramReceived(self, datagram, address):
+        request = dns.message.from_wire(datagram)
+
+        response = dns.message.make_response(request)
+        response.use_edns(edns=False)
+        response.flags |= dns.flags.AA
+
+        if request.question[0].name == dns.name.from_text('AAAA.large-answer.example.'):
+            value = 'A'
+        else:
+            value = 'Z'
+
+        answer = dns.rrset.from_text(request.question[0].name, 0, dns.rdataclass.IN, 'TXT', value*255)
+        for _ in range(6):
+            response.answer.append(answer)
+        answer = dns.rrset.from_text(request.question[0].name, 0, dns.rdataclass.IN, 'TXT', value*16)
+        response.answer.append(answer)
+        self.transport.write(response.to_wire(max_size=65535), address)

--- a/regression-tests.recursor-dnssec/test_LargeAnswer.py
+++ b/regression-tests.recursor-dnssec/test_LargeAnswer.py
@@ -37,27 +37,9 @@ udp-truncation-threshold=%d
             largeReactorRunning = True
 
         if not reactor.running:
-            cls._UDPResponder = threading.Thread(name='UDP Large Responder', target=reactor.run, args=(False,))
+            cls._UDPResponder = threading.Thread(name='UDP Responder', target=reactor.run, args=(False,))
             cls._UDPResponder.setDaemon(True)
             cls._UDPResponder.start()
-
-    @classmethod
-    def setUpClass(cls):
-        cls.setUpSockets()
-
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-        print("Launching tests..")
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
 
     def checkResponseContent(self, rawResponse, value):
        self.assertEquals(len(rawResponse), self._udpTruncationThreshold)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The size we used to pass to `arecvfrom()` along with our buffer was off by one byte, resulting in the last byte of our buffer to be uninitialized for answers exactly matching our outgoing buffer size. Since we passed the correct size to `MOADNSParser`, we were reading one bye of uninitialized memory for such answers.
This caused issue with some authoritative servers sending an answer of our exact buffer size, causing a parsing error. We would then retry without `EDNS`, causing `DNSSEC` validation failures for some domains on such authoritative servers.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
