### PR TITLE
auth: make outgoing-query-address{,6} behaviour equivalent

### DIFF
--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -162,9 +162,10 @@ time_t CommunicatorClass::doNotifications()
   char buffer[1500];
   int sock;
   ssize_t size;
+  set<int> fds = {d_nsock4, d_nsock6};
 
   // receive incoming notifications on the nonblocking socket and take them off the list
-  while(waitFor2Data(d_nsock4, d_nsock6, 0, 0, &sock) > 0) {
+  while(waitForMultiData(fds, 0, 0, &sock) > 0) {
     fromlen=sizeof(from);
     size=recvfrom(sock,buffer,sizeof(buffer),0,(struct sockaddr *)&from,&fromlen);
     if(size < 0)

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -200,12 +200,15 @@ time_t CommunicatorClass::doNotifications()
       try {
         ComboAddress remote(ip, 53); // default to 53
         if((d_nsock6 < 0 && remote.sin4.sin_family == AF_INET6) ||
-           (d_nsock4 < 0 && remote.sin4.sin_family == AF_INET))
+           (d_nsock4 < 0 && remote.sin4.sin_family == AF_INET)) {
+             L<<Logger::Warning<<"Unable to notify "<<remote.toStringWithPort()<<" for domain '"<<domain<<"', address family is disabled. Is query-local-address"<<(remote.sin4.sin_family == AF_INET ? "" : "6")<<" unset?"<<endl;
+             d_nq.removeIf(remote.toStringWithPort(), id, domain); // Remove, we'll never be able to notify
              continue; // don't try to notify what we can't!
+        }
         if(d_preventSelfNotification && AddressIsUs(remote))
           continue;
 
-        sendNotification(remote.sin4.sin_family == AF_INET ? d_nsock4 : d_nsock6, domain, remote, id); 
+        sendNotification(remote.sin4.sin_family == AF_INET ? d_nsock4 : d_nsock6, domain, remote, id);
         drillHole(domain, ip);
       }
       catch(ResolverException &re) {
@@ -284,11 +287,16 @@ bool CommunicatorClass::justNotified(const DNSName &domain, const string &ip)
 
 void CommunicatorClass::makeNotifySockets()
 {
-  d_nsock4 = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true, ::arg().mustDo("non-local-bind"));
-  if(!::arg()["query-local-address6"].empty())
+  if(!::arg()["query-local-address"].empty()) {
+    d_nsock4 = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true, ::arg().mustDo("non-local-bind"));
+  } else {
+    d_nsock4 = -1;
+  }
+  if(!::arg()["query-local-address6"].empty()) {
     d_nsock6 = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true, ::arg().mustDo("non-local-bind"));
-  else
+  } else {
     d_nsock6 = -1;
+  }
 }
 
 void CommunicatorClass::notify(const DNSName &domain, const string &ip)

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -354,6 +354,46 @@ int waitForRWData(int fd, bool waitForRead, int seconds, int useconds, bool* err
 }
 
 // returns -1 in case of error, 0 if no data is available, 1 if there is. In the first two cases, errno is set
+int waitForMultiData(const set<int>& fds, const int seconds, const int useconds, int* fd) {
+  set<int> realFDs;
+  for (const auto& fd : fds) {
+    if (fd >= 0 && realFDs.count(fd) == 0) {
+      realFDs.insert(fd);
+    }
+  }
+
+  struct pollfd pfds[realFDs.size()];
+  memset(&pfds[0], 0, realFDs.size()*sizeof(struct pollfd));
+  int ctr = 0;
+  for (const auto& fd : realFDs) {
+    pfds[ctr].fd = fd;
+    pfds[ctr].events = POLLIN;
+    ctr++;
+  }
+
+  int ret;
+  if(seconds >= 0)
+    ret = poll(pfds, realFDs.size(), seconds * 1000 + useconds/1000);
+  else
+    ret = poll(pfds, realFDs.size(), -1);
+  if(ret <= 0)
+    return ret;
+
+  set<int> pollinFDs;
+  ctr = 0;
+  for (const auto& fd : realFDs) {
+    if (pfds[ctr].revents & POLLIN) {
+      pollinFDs.insert(pfds[ctr].fd);
+    }
+    ctr++;
+  }
+  set<int>::const_iterator it(pollinFDs.begin());
+  advance(it, random() % pollinFDs.size());
+  *fd = *it;
+  return 1;
+}
+
+// returns -1 in case of error, 0 if no data is available, 1 if there is. In the first two cases, errno is set
 int waitFor2Data(int fd1, int fd2, int seconds, int useconds, int*fd)
 {
   int ret;

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -63,6 +63,7 @@ string getHostname();
 string urlEncode(const string &text);
 int waitForData(int fd, int seconds, int useconds=0);
 int waitFor2Data(int fd1, int fd2, int seconds, int useconds, int* fd);
+int waitForMultiData(const set<int>& fds, const int seconds, const int useconds, int* fd);
 int waitForRWData(int fd, bool waitForRead, int seconds, int useconds, bool* error=nullptr, bool* disconnected=nullptr);
 uint16_t getShort(const unsigned char *p);
 uint16_t getShort(const char *p);

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -368,11 +368,11 @@ AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
   if (laddr != nullptr) {
     local = ComboAddress(*laddr);
   } else {
-    if(remote.sin4.sin_family == AF_INET && !::arg()["query-local-address"].empty()) {
-      local=ComboAddress(::arg()["query-local-address"]);
-    } else if(remote.sin4.sin_family == AF_INET6 && !::arg()["query-local-address6"].empty()) {
-      local=ComboAddress(::arg()["query-local-address6"]);
+    string qlas = remote.sin4.sin_family == AF_INET ? "query-local-address" : "query-local-address6";
+    if (::arg()[qlas].empty()) {
+      throw ResolverException("Unable to determine source address for AXFR request to " + remote.toStringWithPort() + " for " + domain.toLogString() + ". " + qlas + " is unset");
     }
+    local=ComboAddress(::arg()[qlas]);
   }
   d_sock = -1;
   try {

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -597,12 +597,13 @@ int PacketHandler::forwardPacket(const string &msgPrefix, DNSPacket *p, DomainIn
     }
 
     ComboAddress local;
-    if(remote.sin4.sin_family == AF_INET)
+    if (remote.sin4.sin_family == AF_INET && !::arg()["query-local-address"].empty()) {
       local = ComboAddress(::arg()["query-local-address"]);
-    else if(!::arg()["query-local-address6"].empty())
+    } else if(remote.sin4.sin_family == AF_INET6 && !::arg()["query-local-address6"].empty()) {
       local = ComboAddress(::arg()["query-local-address6"]);
-    else
-      local = ComboAddress("::");
+    } else {
+      continue;
+    }
     int sock = makeQuerySocket(local, false); // create TCP socket. RFC2136 section 6.2 seems to be ok with this.
     if(sock < 0) {
       L<<Logger::Error<<msgPrefix<<"Error creating socket: "<<stringerror()<<endl;


### PR DESCRIPTION
### Short description
If either is unset, don't send out notifications or AXFR requests using
that address family.

This PR probably needs some docs and some tests. But already opened for a code-review

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)