### PR TITLE
add actual EDNS buffer size logging, not just our interpretation

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -405,7 +405,10 @@ try
       else
         remote = P->getRemote().toString();
       L << Logger::Notice<<"Remote "<< remote <<" wants '" << P->qdomain<<"|"<<P->qtype.getName() << 
-            "', do = " <<P->d_dnssecOk <<", bufsize = "<< P->getMaxReplyLen()<<": ";
+        "', do = " <<P->d_dnssecOk <<", bufsize = "<< P->getMaxReplyLen();
+      if(P->d_ednsRawPacketSizeLimit > 0 && P->getMaxReplyLen() != (unsigned int)P->d_ednsRawPacketSizeLimit)
+        L<<" ("<<P->d_ednsRawPacketSizeLimit<<")";
+      L<<": ";
     }
 
     if((P->d.opcode != Opcode::Notify && P->d.opcode != Opcode::Update) && P->couldBeCached()) {

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -121,7 +121,7 @@ DNSPacket::DNSPacket(const DNSPacket &orig)
   d_tsigtimersonly = orig.d_tsigtimersonly;
   d_trc = orig.d_trc;
   d_tsigsecret = orig.d_tsigsecret;
-  
+  d_ednsRawPacketSizeLimit = orig.d_ednsRawPacketSizeLimit;
   d_havetsig = orig.d_havetsig;
   d_wrapped=orig.d_wrapped;
 
@@ -547,13 +547,13 @@ try
   d_havetsig = mdp.getTSIGPos();
   d_haveednssubnet = false;
   d_haveednssection = false;
-  
 
   if(getEDNSOpts(mdp, &edo)) {
     d_haveednssection=true;
     /* rfc6891 6.2.3:
        "Values lower than 512 MUST be treated as equal to 512."
     */
+    d_ednsRawPacketSizeLimit=edo.d_packetsize;
     d_maxreplylen=std::min(std::max(static_cast<uint16_t>(512), edo.d_packetsize), s_udpTruncationThreshold);
 //    cerr<<edo.d_Z<<endl;
     if(edo.d_Z & EDNSOpts::DNSSECOK)
@@ -580,9 +580,10 @@ try
     }
     d_ednsversion = edo.d_version;
     d_ednsrcode = edo.d_extRCode;
-  }
+ }
   else  {
     d_maxreplylen=512;
+    d_ednsRawPacketSizeLimit=-1;
   }
 
   memcpy((void *)&d,(const void *)d_rawpacket.c_str(),12);

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -162,7 +162,8 @@ public:
   bool checkForCorrectTSIG(UeberBackend* B, DNSName* keyname, string* secret, TSIGRecordContent* trc) const;
 
   static bool s_doEDNSSubnetProcessing;
-  static uint16_t s_udpTruncationThreshold; //2
+  static uint16_t s_udpTruncationThreshold; 
+  int d_ednsRawPacketSizeLimit; // only used for Lua record
 private:
   void pasteQ(const char *question, int length); //!< set the question of this packet, useful for crafting replies
 
@@ -179,6 +180,7 @@ private:
   EDNSSubnetOpts d_eso;
 
   int d_maxreplylen;
+
   uint8_t d_ednsversion;
   // WARNING! This is really 12 bits
   uint16_t d_ednsrcode;


### PR DESCRIPTION
### Short description
DNSPacket exposes the aptly named getMaxReplyLen() function which we mistakenly thought meant this was the supplied EDNS buffer size. In some places we want to know the actual raw EDNS buffer size. This PR adds that, and hooks it up to our logging.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
