### PR TITLE
auth: fix out of bounds exception in CAA processing, fixes #6089

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -491,7 +491,7 @@ string PacketReader::getText(bool multi, bool lenField)
 
 string PacketReader::getUnquotedText(bool lenField)
 {
-  int16_t stop_at;
+  uint16_t stop_at;
   if(lenField)
     stop_at = (uint8_t)d_content.at(d_pos) + d_pos + 1;
   else


### PR DESCRIPTION
### Short description
Using a signed 16 bit int as a pointer into a block that can be up to 64kbyte long is a recipe for failure.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
