### PR TITLE
Add an option to add the server-id to the pid filename

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -150,6 +150,7 @@ void declareArguments()
   ::arg().set("query-cache-ttl","Seconds to store query results in the QueryCache")="20";
   ::arg().set("soa-minimum-ttl","Default SOA minimum ttl")="3600";
   ::arg().set("server-id", "Returned when queried for 'id.server' TXT or NSID, defaults to hostname - disabled or custom")="";
+  ::arg().set("server-id-in-pidname", "Add the server-id to the pid filename, disabled by default, enabled when set to 1")="";
   ::arg().set("soa-refresh-default","Default SOA refresh")="10800";
   ::arg().set("soa-retry-default","Default SOA retry")="3600";
   ::arg().set("soa-expire-default","Default SOA expire")="604800";

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3091,7 +3091,12 @@ static int serviceMain(int argc, char*argv[])
       L<<Logger::Error<<"Chrooted to '"<<::arg()["chroot"]<<"'"<<endl;
   }
 
-  s_pidfname=::arg()["socket-dir"]+"/"+s_programname+".pid";
+  if(::arg()["server-id-in-pidname"] == "1") {
+    s_pidfname=::arg()["socket-dir"]+"/"+s_programname+"_"+SyncRes::s_serverID+".pid";
+  }
+  else {
+    s_pidfname=::arg()["socket-dir"]+"/"+s_programname+".pid";
+  }
   if(!s_pidfname.empty())
     unlink(s_pidfname.c_str()); // remove possible old pid file
   writePid();
@@ -3368,6 +3373,7 @@ int main(int argc, char **argv)
     ::arg().set("max-packetcache-entries", "maximum number of entries to keep in the packetcache")="500000";
     ::arg().set("packetcache-servfail-ttl", "maximum number of seconds to keep a cached servfail entry in packetcache")="60";
     ::arg().set("server-id", "Returned when queried for 'id.server' TXT or NSID, defaults to hostname")="";
+    ::arg().set("server-id-in-pidname", "server-id-in-pidname", "Add the server-id to the pid filename, disabled by default, enabled when set to 1")="";
     ::arg().set("stats-ringbuffer-entries", "maximum number of packets to store statistics for")="10000";
     ::arg().set("version-string", "string reported on version.pdns or version.bind")=fullVersionString();
     ::arg().set("allow-from", "If set, only allow these comma separated netmasks to recurse")=LOCAL_NETS;


### PR DESCRIPTION
### Short description
When running multiple instances of the recursor on the same machine, the same pid filename is reused (/var/run/pdns_recursor.pid by default). This has the effect that the instance your started last can be found via the pidfile, but not the other ones.
This patch adds a configuration option which adds the server-id to the pid filename, when enabled. It is disabled by default, to not change the current behaviour.
This fixes issue #6109

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

### Documentation
I've updated pdns/recursordist/pdns_recursor.conf-dist with my new configuration option, but this file is in the .gitignore, so it isn't part of this PR. If anyone can explain how to update the distributed config file, that would be great.
This is the part I would like to add to the pdns_recursor.conf:
`#################################
# server-id-in-pidname  Add the server-id to the pid filename. Disabled by default, enabled when set to 1
#
# server-id-in-pidname=no`