### PR TITLE
Add releaseStatement() to the end of hasNextRow()

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -268,6 +268,7 @@ public:
         }
         mysql_stmt_free_result(d_stmt);
       }
+      releaseStatement();
     }
 #endif
     return this; 


### PR DESCRIPTION
Fixes stale data returned by MySQL when calling stored procedures.

### Short description
Closes issue #6115 by adding releaseStatement() to the end of the "#if MYSQL_VERSION_ID >= 50500" block. Without this, mysql_stmt_close() is never called for stored procedures, which appears to cause MySQL to return stale results from past calls to msql_stmt_fetch().

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
