### PR TITLE
ldapbackend: fix listing zones incl. AXFR

### DIFF
--- a/modules/ldapbackend/ldapbackend.cc
+++ b/modules/ldapbackend/ldapbackend.cc
@@ -150,6 +150,7 @@ bool LdapBackend::list( const DNSName& target, int domain_id, bool include_disab
   try
   {
     m_qname = target;
+    m_qtype = QType::ANY;
     m_axfrqlen = target.toStringRootDot().length();
     m_adomain = m_adomains.end();   // skip loops in get() first time
 


### PR DESCRIPTION
### Short description
list() did not initialise m_qtype, but get() looks at it. This got introduced in #4922.

Lokely fixes #6097 and #6060.

I cannot actually test this.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
