### PR TITLE
pdns: Fix dependency tracking for backends

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -224,6 +224,7 @@ pdns_server_LDFLAGS = \
 	$(DYNLINKFLAGS) \
 	$(LIBCRYPTO_LDFLAGS)
 
+EXTRA_pdns_server_DEPENDENCIES = @moduleobjects@
 pdns_server_LDADD = \
 	@moduleobjects@ \
 	@modulelibs@ \
@@ -323,6 +324,7 @@ pdnsutil_LDFLAGS = \
 	$(BOOST_PROGRAM_OPTIONS_LDFLAGS) \
 	$(LIBCRYPTO_LDFLAGS)
 
+EXTRA_pdnsutil_DEPENDENCIES = @moduleobjects@
 pdnsutil_LDADD = \
 	@moduleobjects@ \
 	@modulelibs@ \


### PR DESCRIPTION
### Short description
Injects moduleobjects to dependency tracking. This fixes issue where pdns_server did not recompile after backend object(s) were changed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
