### PR TITLE
Forbid creating algo 5/8/10 keys with out-of-spec sizes

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -85,11 +85,11 @@ bool DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, in
     if(algorithm <= 10)
       throw runtime_error("Creating an algorithm " +std::to_string(algorithm)+" ("+algorithm2name(algorithm)+") key requires the size (in bits) to be passed.");
     else {
-      if(algorithm == 12 || algorithm == 13 || algorithm == 15) // GOST, ECDSAP256SHA256, ED25519
+      if(algorithm == DNSSECKeeper::ECCGOST || algorithm == DNSSECKeeper::ECDSA256 || algorithm == DNSSECKeeper::ED25519)
         bits = 256;
-      else if(algorithm == 14) // ECDSAP384SHA384
+      else if(algorithm == DNSSECKeeper::ECDSA384)
         bits = 384;
-      else if(algorithm == 16) // ED448
+      else if(algorithm == DNSSECKeeper::ED448)
         bits = 456;
       else {
         throw runtime_error("Can not guess key size for algorithm "+std::to_string(algorithm));
@@ -163,8 +163,8 @@ DNSSECPrivateKey DNSSECKeeper::getKeyById(const DNSName& zname, unsigned int id)
     dpk.d_flags = kd.flags;
     dpk.d_algorithm = dkrc.d_algorithm;
     
-    if(dpk.d_algorithm == 5 && getNSEC3PARAM(zname)) {
-      dpk.d_algorithm += 2;
+    if(dpk.d_algorithm == DNSSECKeeper::RSASHA1 && getNSEC3PARAM(zname)) {
+      dpk.d_algorithm = DNSSECKeeper::RSASHA1NSEC3SHA1;
     }
     
     return dpk;    
@@ -485,9 +485,9 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
 
     dpk.d_flags = kd.flags;
     dpk.d_algorithm = dkrc.d_algorithm;
-    if(dpk.d_algorithm == 5 && getNSEC3PARAM(zone)) {
+    if(dpk.d_algorithm == DNSSECKeeper::RSASHA1 && getNSEC3PARAM(zone)) {
       L<<Logger::Warning<<"Zone '"<<zone<<"' has NSEC3 semantics, but the "<< (kd.active ? "" : "in" ) <<"active key with id "<<kd.id<<" has 'Algorithm: 5'. This should be corrected to 'Algorithm: 7' in the database (or NSEC3 should be disabled)."<<endl;
-      dpk.d_algorithm+=2;
+      dpk.d_algorithm = DNSSECKeeper::RSASHA1NSEC3SHA1;
     }
 
     KeyMetaData kmd;

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -235,11 +235,11 @@ pair<unsigned int, unsigned int> DNSCryptoKeyEngine::testMakers(unsigned int alg
   unsigned int bits;
   if(algo <= 10)
     bits=1024;
-  else if(algo == 12 || algo == 13 || algo == 15) // ECC-GOST or ECDSAP256SHA256 or ED25519
-    bits=256;
-  else if(algo == 14) // ECDSAP384SHA384
+  else if(algo == DNSSECKeeper::ECCGOST || algo == DNSSECKeeper::ECDSA256 || algo == DNSSECKeeper::ED25519)
+    bits = 256;
+  else if(algo == DNSSECKeeper::ECDSA384)
     bits = 384;
-  else if(algo == 16) // ED448
+  else if(algo == DNSSECKeeper::ED448)
     bits = 456;
   else
     throw runtime_error("Can't guess key size for algorithm "+std::to_string(algo));

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -278,14 +278,14 @@ DNSCryptoKeyEngine::storvector_t OpenSSLRSADNSCryptoKeyEngine::convertToISCVecto
 
   string algorithm=std::to_string(d_algorithm);
   switch(d_algorithm) {
-    case 5:
-    case 7:
+    case DNSSECKeeper::RSASHA1:
+    case DNSSECKeeper::RSASHA1NSEC3SHA1:
       algorithm += " (RSASHA1)";
       break;
-    case 8:
+    case DNSSECKeeper::RSASHA256:
       algorithm += " (RSASHA256)";
       break;
-    case 10:
+    case DNSSECKeeper::RSASHA512:
       algorithm += " (RSASHA512)";
       break;
     default:
@@ -305,20 +305,17 @@ DNSCryptoKeyEngine::storvector_t OpenSSLRSADNSCryptoKeyEngine::convertToISCVecto
 
 std::string OpenSSLRSADNSCryptoKeyEngine::hash(const std::string& orig) const
 {
-  if (d_algorithm == 5 || d_algorithm == 7) {
-    /* RSA SHA1 */
+  if (d_algorithm == DNSSECKeeper::RSASHA1 || d_algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1) {
     unsigned char hash[SHA_DIGEST_LENGTH];
     SHA1((unsigned char*) orig.c_str(), orig.length(), hash);
     return string((char*) hash, sizeof(hash));
   }
-  else if (d_algorithm == 8) {
-    /* RSA SHA256 */
+  else if (d_algorithm == DNSSECKeeper::RSASHA256) {
     unsigned char hash[SHA256_DIGEST_LENGTH];
     SHA256((unsigned char*) orig.c_str(), orig.length(), hash);
     return string((char*) hash, sizeof(hash));
   }
-  else if (d_algorithm == 10) {
-    /* RSA SHA512 */
+  else if (d_algorithm == DNSSECKeeper::RSASHA512) {
     unsigned char hash[SHA512_DIGEST_LENGTH];
     SHA512((unsigned char*) orig.c_str(), orig.length(), hash);
     return string((char*) hash, sizeof(hash));

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -247,7 +247,7 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
       DNSKEYRecordContent dkrc;
       shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
 
-      if(dkrc.d_algorithm == 5) {
+      if(dkrc.d_algorithm == DNSSECKeeper::RSASHA1) {
         cout<<"[Warning] zone '"<<zone<<"' has NSEC3 semantics, but the "<< (kd.active ? "" : "in" ) <<"active key with id "<<kd.id<<" has 'Algorithm: 5'. This should be corrected to 'Algorithm: 7' in the database (or NSEC3 should be disabled)."<<endl;
         numwarnings++;
       }
@@ -2186,7 +2186,7 @@ try
     bool keyOrZone=false;
     int tmp_algo=0;
     int bits=0;
-    int algorithm=13; // ecdsa256
+    int algorithm=DNSSECKeeper::ECDSA256;
     bool active=false;
     for(unsigned int n=2; n < cmds.size(); ++n) {
       if(pdns_iequals(cmds[n], "zsk"))
@@ -2586,8 +2586,8 @@ try
     
     dpk.d_algorithm = pdns_stou(cmds[3]);
     
-    if(dpk.d_algorithm == 7)
-      dpk.d_algorithm = 5;
+    if(dpk.d_algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1)
+      dpk.d_algorithm = DNSSECKeeper::RSASHA1;
       
     cerr<<(int)dpk.d_algorithm<<endl;
     
@@ -2631,8 +2631,8 @@ try
     dpk.setKey(key);
     dpk.d_algorithm = drc.d_algorithm;
     
-    if(dpk.d_algorithm == 7)
-      dpk.d_algorithm = 5;
+    if(dpk.d_algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1)
+      dpk.d_algorithm = DNSSECKeeper::RSASHA1;
     
     dpk.d_flags = 257; 
     bool active=true;
@@ -2684,7 +2684,7 @@ try
     bool keyOrZone=false;
     int tmp_algo=0;
     int bits=0;
-    int algorithm=13; // ecdsa256
+    int algorithm=DNSSECKeeper::ECDSA256;
     for(unsigned int n=1; n < cmds.size(); ++n) {
       if(pdns_iequals(cmds[n], "zsk"))
         keyOrZone = false;
@@ -2709,14 +2709,14 @@ try
       if(algorithm <= 10)
         bits = keyOrZone ? 2048 : 1024;
       else {
-        if(algorithm == 12 || algorithm == 13 || algorithm == 15) // ECDSA, GOST, ED25519
+        if(algorithm == DNSSECKeeper::ECCGOST || algorithm == DNSSECKeeper::ECDSA256 || algorithm == DNSSECKeeper::ED25519)
           bits = 256;
-        else if(algorithm == 14)
+        else if(algorithm == DNSSECKeeper::ECDSA384)
           bits = 384;
-        else if(algorithm == 16) // ED448
+        else if(algorithm == DNSSECKeeper::ED448)
           bits = 456;
         else {
-          throw runtime_error("Can't guess key size for algorithm "+std::to_string(algorithm));
+          throw runtime_error("Can not guess key size for algorithm "+std::to_string(algorithm));
         }
       }
     }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1040,8 +1040,8 @@ static void apiZoneCryptokeysPOST(DNSName zonename, HttpRequest *req, HttpRespon
       shared_ptr<DNSCryptoKeyEngine> dke(DNSCryptoKeyEngine::makeFromISCString(dkrc, keyData));
       dpk.d_algorithm = dkrc.d_algorithm;
       // TODO remove in 4.2.0
-      if(dpk.d_algorithm == 7)
-        dpk.d_algorithm = 5;
+      if(dpk.d_algorithm == DNSSECKeeper::RSASHA1NSEC3SHA1)
+        dpk.d_algorithm = DNSSECKeeper::RSASHA1;
 
       if (keyOrZone)
         dpk.d_flags = 257;

--- a/regression-tests.api/test_cryptokeys.py
+++ b/regression-tests.api/test_cryptokeys.py
@@ -112,11 +112,11 @@ class Cryptokeys(ApiTestCase):
 
     # Test POST to add a key with specific algorithm number
     def test_post_specific_number(self):
-        self.post_helper(algo=10, bits=512)
+        self.post_helper(algo=10, bits=1024)
 
     # Test POST to add a key with specific name and bits
     def test_post_specific_name_bits(self):
-        self.post_helper(algo="rsasha256", bits=256)
+        self.post_helper(algo="rsasha256", bits=2048)
 
     # Test POST to add a key with specific name
     def test_post_specific_name(self):


### PR DESCRIPTION
### Short description
Previously, creating keys with tiny sizes would fail because OpenSSL would not allow it. Newer versions apparently accept sizes lower than the RFCs allow.

Might need to go into the upgrade notes?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
