### PR TITLE
auth 4.1.x: limit travis builds to auth only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,6 @@ compiler:
   - clang
 env:
   - PDNS_BUILD_PRODUCT=auth
-  - PDNS_BUILD_PRODUCT=recursor
-  - PDNS_BUILD_PRODUCT=dnsdist
-
-matrix:
-  exclude:
-    - compiler: clang
-      env: PDNS_BUILD_PRODUCT=recursor
-  include:
-    - compiler: clang
-      env: PDNS_BUILD_PRODUCT=recursor COMPILER=clang++-3.6
-      addons:
-        apt:
-          packages: ['clang-3.6']
 
 before_script:
   - git describe --always --dirty=+


### PR DESCRIPTION
### Short description
Building/testing recursor and dnsdist on this branch is useless.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
