### PR TITLE
Changes to compile and run on NetBSD

### DIFF
--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -130,7 +130,7 @@ struct EDNS0Record
 
 static_assert(sizeof(EDNS0Record) == 4, "EDNS0Record size must be 4");
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
 #include <machine/endian.h>
 #elif __linux__ || __GNU__
 # include <endian.h>

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -23,7 +23,7 @@
 #include "sodcrypto.hh"
 #include "pwd.h"
 
-#if defined (__OpenBSD__)
+#if defined (__OpenBSD__) || defined(__NetBSD__)
 #include <readline/readline.h>
 #include <readline/history.h>
 #else

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -27,7 +27,7 @@
 #include <limits>
 #include "dolog.hh"
 
-#if defined (__OpenBSD__)
+#if defined (__OpenBSD__) || defined(__NetBSD__)
 #include <readline/readline.h>
 #else
 #include <editline/readline.h>

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -146,7 +146,11 @@ bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv)
 bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destination)
 {
   memset(destination, 0, sizeof(*destination));
+#ifdef __NetBSD__
+  struct cmsghdr* cmsg;
+#else
   const struct cmsghdr* cmsg;
+#endif
   for (cmsg = CMSG_FIRSTHDR(msgh); cmsg != NULL; cmsg = CMSG_NXTHDR(const_cast<struct msghdr*>(msgh), const_cast<struct cmsghdr*>(cmsg))) {
 #if defined(IP_PKTINFO)
      if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_PKTINFO)) {

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -82,6 +82,12 @@
 #include <sys/endian.h>
 #endif
 
+#if defined(__NetBSD__) && defined(IP_PKTINFO) && !defined(IP_SENDSRCADDR)
+// The IP_PKTINFO option in NetBSD was incompatible with Linux until a
+// change that also introduced IP_SENDSRCADDR for FreeBSD compatibility.
+#undef IP_PKTINFO
+#endif
+
 union ComboAddress {
   struct sockaddr_in sin4;
   struct sockaddr_in6 sin6;
@@ -992,6 +998,7 @@ int SSetsockopt(int sockfd, int level, int opname, int value);
 #elif defined(IP_RECVDSTADDR)
   #define GEN_IP_PKTINFO IP_RECVDSTADDR 
 #endif
+
 bool IsAnyAddress(const ComboAddress& addr);
 bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destination);
 bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv);

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -28,7 +28,7 @@
 #include <unistd.h>
 #include "misc.hh"
 #include <sys/types.h>
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
 #include <sys/event.h>
 #endif
 #include <sys/time.h>

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -60,6 +60,10 @@
 #ifdef __FreeBSD__
 #  include <pthread_np.h>
 #endif
+#ifdef __NetBSD__
+#  include <pthread.h>
+#  include <sched.h>
+#endif
 
 bool g_singleThreaded;
 
@@ -866,7 +870,7 @@ void addCMsgSrcAddr(struct msghdr* msgh, void* cmsgbuf, const ComboAddress* sour
     pkt->ipi6_ifindex = itfIndex;
   }
   else {
-#ifdef IP_PKTINFO
+#if defined(IP_PKTINFO)
     struct in_pktinfo *pkt;
 
     msgh->msg_control = cmsgbuf;
@@ -881,8 +885,7 @@ void addCMsgSrcAddr(struct msghdr* msgh, void* cmsgbuf, const ComboAddress* sour
     memset(pkt, 0, sizeof(*pkt));
     pkt->ipi_spec_dst = source->sin4.sin_addr;
     pkt->ipi_ifindex = itfIndex;
-#endif
-#ifdef IP_SENDSRCADDR
+#elif defined(IP_SENDSRCADDR)
     struct in_addr *in;
 
     msgh->msg_control = cmsgbuf;
@@ -1329,9 +1332,20 @@ bool isSettingThreadCPUAffinitySupported()
 int mapThreadToCPUList(pthread_t tid, const std::set<int>& cpus)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
-#  ifdef __FreeBSD__
-#    define cpu_set_t cpuset_t
-#  endif
+#  ifdef __NetBSD__
+  cpuset_t *cpuset;
+  cpuset = cpuset_create();
+  for (const auto cpuID : cpus) {
+    cpuset_set(cpuID, cpuset);
+  }
+
+  return pthread_setaffinity_np(tid,
+                                cpuset_size(cpuset),
+                                cpuset);
+#  else
+#    ifdef __FreeBSD__
+#      define cpu_set_t cpuset_t
+#    endif
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   for (const auto cpuID : cpus) {
@@ -1341,6 +1355,7 @@ int mapThreadToCPUList(pthread_t tid, const std::set<int>& cpus)
   return pthread_setaffinity_np(tid,
                                 sizeof(cpuset),
                                 &cpuset);
+#  endif
 #endif /* HAVE_PTHREAD_SETAFFINITY_NP */
   return ENOSYS;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
These are the minimal changes to make the authoritative server, the
recursor, and dnsdist compile and run properly on NetBSD.

The changes fall into three groups:

1) A number of existing "#if defined" lines already in place for other
   BSD variants needed to be expanded with "|| defined(__NetBSD__)" to
   get the same effect here.

2) The pthread CPU affinity code in pdns/misc.cc needed changes,
   because the underlying cpuset_t is opaque in NetBSD, and one must
   use function calls operating on a pointer to a CPU set returned by
   cpuset_create(), instead of declaring a local struct and operating
   on that.

3) The socket control message interface uses the CMSG_DATA() macro to
   fetch optional information for packets, but expects that to assume
   a "const struct cmsghdr" declaration.  NetBSD has a CCMSG_DATA()
   that does this.

4) The implementation of socket options IP_PKTINFO et al in NetBSD was
   not compatible with anything, and this has required source code
   workarounds in software that uses them.  As part of this project,
   I submitted a set of fixes to NetBSD that makes it source code
   compatible with Linux, Solaris, and FreeBSD -- the two former by
   making the IP_PKTINFO support detect which of their behaviours the
   programmer expects, the latter by implementing IP_SENDSRCADDR.  My
   modifications are expected to be in NetBSD 8.0 when it is released.

   My change here is simply to "#undef IP_PKTINFO" unless the version
   of NetBSD we're compiling on is new enough to have my changes.  For
   older versions, server sockets bound to INADDR_ANY won't work right.
   This has been the way NetBSD "pkgsrc" has handled this so far, too,
   so it's not likely to surprise anyone.

The result works as it should, and I've verified that the servers now
respond correctly to queries addressed to them on IPv4 addresses other
than the one that's the primary address of the interface the query
arrives on.

One quirk I haven't done anything about is the difficulty configure
experiences finding libedit on NetBSD, where it is in the base
installation.  The workaround is to configure dnsdist by saying
./configure LIBEDIT_CFLAGS="-I/usr/include" "LIBEDIT_LIBS=-L/usr/lib -ledit"
but I'm sure something could be done to configure to help it.  I don't
know the tool well enough to try, though.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
