### PR TITLE
Add ERCodeRule

### DIFF
--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -54,12 +54,17 @@ std::vector<std::string> RCode::rcodes_s = boost::assign::list_of
   ("Duplicate key name")
   ("Algorithm not supported")
   ("Bad Truncation")
+  ("Bad/missing Server Cookie")
 ;
 
 std::string RCode::to_s(unsigned short rcode) {
   if (rcode > RCode::rcodes_s.size()-1 ) 
     return std::string("Err#")+std::to_string(rcode);
   return RCode::rcodes_s[rcode];
+}
+
+std::string ERCode::to_s(unsigned short rcode) {
+  return RCode::to_s(rcode);
 }
 
 class BoundsCheckingPointer

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -57,13 +57,13 @@ std::vector<std::string> RCode::rcodes_s = boost::assign::list_of
   ("Bad/missing Server Cookie")
 ;
 
-std::string RCode::to_s(unsigned short rcode) {
+std::string RCode::to_s(uint8_t rcode) {
   if (rcode > RCode::rcodes_s.size()-1 ) 
     return std::string("Err#")+std::to_string(rcode);
   return RCode::rcodes_s[rcode];
 }
 
-std::string ERCode::to_s(unsigned short rcode) {
+std::string ERCode::to_s(uint8_t rcode) {
   return RCode::to_s(rcode);
 }
 

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -46,7 +46,7 @@ std::vector<std::string> RCode::rcodes_s = boost::assign::list_of
   ("Err#12")
   ("Err#13")
   ("Err#14")
-  ("Err#15")
+  ("Err#15")  // Last non-extended RCode
   ("Bad OPT Version / TSIG Signature Failure")
   ("Key not recognized")
   ("Signature out of time window")
@@ -58,13 +58,15 @@ std::vector<std::string> RCode::rcodes_s = boost::assign::list_of
 ;
 
 std::string RCode::to_s(uint8_t rcode) {
-  if (rcode > RCode::rcodes_s.size()-1 ) 
-    return std::string("Err#")+std::to_string(rcode);
-  return RCode::rcodes_s[rcode];
+  if (rcode > 0xF)
+    return std::string("ErrOutOfRange");
+  return ERCode::to_s(rcode);
 }
 
 std::string ERCode::to_s(uint8_t rcode) {
-  return RCode::to_s(rcode);
+  if (rcode > RCode::rcodes_s.size()-1)
+    return std::string("Err#")+std::to_string(rcode);
+  return RCode::rcodes_s[rcode];
 }
 
 class BoundsCheckingPointer

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -57,7 +57,7 @@ class RCode
 {
 public:
   enum rcodes_ { NoError=0, FormErr=1, ServFail=2, NXDomain=3, NotImp=4, Refused=5, YXDomain=6, YXRRSet=7, NXRRSet=8, NotAuth=9, NotZone=10};
-  static std::string to_s(unsigned short rcode);
+  static std::string to_s(uint8_t rcode);
   static std::vector<std::string> rcodes_s;
 };
 
@@ -65,7 +65,7 @@ class ERCode
 {
 public:
   enum rcodes_ { BADVERS=16, BADSIG=16, BADKEY=17, BADTIME=18, BADMODE=19, BADNAME=20, BADALG=21, BADTRUNC=22, BADCOOKIE=23 };
-  static std::string to_s(unsigned short rcode);
+  static std::string to_s(uint8_t rcode);
 };
 
 class Opcode

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -29,6 +29,9 @@
 #include "dnsname.hh"
 #include <time.h>
 #include <sys/types.h>
+
+#undef BADSIG  // signal.h SIG_ERR
+
 class DNSBackend;
 struct DNSRecord;
 
@@ -56,6 +59,13 @@ public:
   enum rcodes_ { NoError=0, FormErr=1, ServFail=2, NXDomain=3, NotImp=4, Refused=5, YXDomain=6, YXRRSet=7, NXRRSet=8, NotAuth=9, NotZone=10};
   static std::string to_s(unsigned short rcode);
   static std::vector<std::string> rcodes_s;
+};
+
+class ERCode
+{
+public:
+  enum rcodes_ { BADVERS=16, BADSIG=16, BADKEY=17, BADTIME=18, BADMODE=19, BADNAME=20, BADALG=21, BADTRUNC=22, BADCOOKIE=23 };
+  static std::string to_s(unsigned short rcode);
 };
 
 class Opcode

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -361,6 +361,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "QNameWireLengthRule", true, "min, max", "matches if the qname's length on the wire is less than `min` or more than `max` bytes" },
   { "QTypeRule", true, "qtype", "matches queries with the specified qtype" },
   { "RCodeRule", true, "rcode", "matches responses with the specified rcode" },
+  { "ERCodeRule", true, "rcode", "matches responses with the specified extended rcode (EDNS0)" },
   { "sendCustomTrap", true, "str", "send a custom `SNMP` trap from Lua, containing the `str` string"},
   { "setACL", true, "{netmask, netmask}", "replace the ACL set with these netmasks. Use `setACL({})` to reset the list, meaning no one can use us" },
   { "setAPIWritable", true, "bool, dir", "allow modifications via the API. if `dir` is set, it must be a valid directory where the configuration files will be written by the API" },

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -275,7 +275,7 @@ private:
 class RCodeAction : public DNSAction
 {
 public:
-  RCodeAction(int rcode) : d_rcode(rcode) {}
+  RCodeAction(uint8_t rcode) : d_rcode(rcode) {}
   DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
   {
     dq->dh->rcode = d_rcode;
@@ -288,7 +288,7 @@ public:
   }
 
 private:
-  int d_rcode;
+  uint8_t d_rcode;
 };
 
 class TCAction : public DNSAction
@@ -941,7 +941,7 @@ void setupLuaActions()
       return std::shared_ptr<DNSAction>(new LogAction(fname, binary ? *binary : true, append ? *append : false, buffered ? *buffered : false));
     });
 
-  g_lua.writeFunction("RCodeAction", [](int rcode) {
+  g_lua.writeFunction("RCodeAction", [](uint8_t rcode) {
       return std::shared_ptr<DNSAction>(new RCodeAction(rcode));
     });
 

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -724,7 +724,7 @@ private:
 class RCodeRule : public DNSRule
 {
 public:
-  RCodeRule(int rcode) : d_rcode(rcode)
+  RCodeRule(uint8_t rcode) : d_rcode(rcode)
   {
   }
   bool matches(const DNSQuestion* dq) const override
@@ -736,13 +736,13 @@ public:
     return "rcode=="+RCode::to_s(d_rcode);
   }
 private:
-  int d_rcode;
+  uint8_t d_rcode;
 };
 
 class ERCodeRule : public DNSRule
 {
 public:
-  ERCodeRule(int rcode) : d_rcode(rcode & 0xF), d_extrcode(rcode >> 4)
+  ERCodeRule(uint8_t rcode) : d_rcode(rcode & 0xF), d_extrcode(rcode >> 4)
   {
   }
   bool matches(const DNSQuestion* dq) const override
@@ -781,8 +781,8 @@ public:
     return "ercode=="+ERCode::to_s(d_rcode | (d_extrcode << 4));
   }
 private:
-  int d_rcode;     // plain DNS Rcode
-  int d_extrcode;  // upper bits in EDNS0 record
+  uint8_t d_rcode;     // plain DNS Rcode
+  uint8_t d_extrcode;  // upper bits in EDNS0 record
 };
 
 class RDRule : public DNSRule
@@ -1207,11 +1207,11 @@ void setupLuaRules()
       return std::shared_ptr<DNSRule>(new QNameWireLengthRule(min, max));
     });
 
-  g_lua.writeFunction("RCodeRule", [](int rcode) {
+  g_lua.writeFunction("RCodeRule", [](uint8_t rcode) {
       return std::shared_ptr<DNSRule>(new RCodeRule(rcode));
     });
 
-  g_lua.writeFunction("ERCodeRule", [](int rcode) {
+  g_lua.writeFunction("ERCodeRule", [](uint8_t rcode) {
       return std::shared_ptr<DNSRule>(new ERCodeRule(rcode));
     });
 

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -755,7 +755,7 @@ public:
     char * optStart = NULL;
     size_t optLen = 0;
     bool last = false;
-    int res = locateEDNSOptRR((char*)dq->dh, dq->len, &optStart, &optLen, &last);
+    int res = locateEDNSOptRR(const_cast<char*>(reinterpret_cast<const char*>(dq->dh)), dq->len, &optStart, &optLen, &last);
     if (res != 0) {
       // no EDNS OPT RR
       return d_extrcode == 0;

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -761,7 +761,7 @@ public:
       return d_extrcode == 0;
     }
 
-    /* root label (1), type (2), class (2), ttl (4) + rdlen (2)*/
+    // root label (1), type (2), class (2), ttl (4) + rdlen (2)
     if (optLen < 11) {
       return false;
     }
@@ -772,6 +772,7 @@ public:
     }
     EDNS0Record edns0;
     static_assert(sizeof(EDNS0Record) == sizeof(uint32_t), "sizeof(EDNS0Record) must match sizeof(uint32_t) AKA RR TTL size");
+    // copy out 4-byte "ttl" (really the EDNS0 record), after root label (1) + type (2) + class (2).
     memcpy(&edns0, optStart + 5, sizeof edns0);
 
     return d_extrcode == edns0.extRCode;

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "dnsdist.hh"
+#include "dnsdist-ecs.hh"
 #include "dnsdist-lua.hh"
 
 #include "dnsparser.hh"
@@ -738,6 +739,52 @@ private:
   int d_rcode;
 };
 
+class ERCodeRule : public DNSRule
+{
+public:
+  ERCodeRule(int rcode) : d_rcode(rcode & 0xF), d_extrcode(rcode >> 4)
+  {
+  }
+  bool matches(const DNSQuestion* dq) const override
+  {
+    // avoid parsing EDNS OPT RR when not needed.
+    if (d_rcode != dq->dh->rcode) {
+      return false;
+    }
+
+    char * optStart = NULL;
+    size_t optLen = 0;
+    bool last = false;
+    int res = locateEDNSOptRR((char*)dq->dh, dq->len, &optStart, &optLen, &last);
+    if (res != 0) {
+      // no EDNS OPT RR
+      return d_extrcode == 0;
+    }
+
+    /* root label (1), type (2), class (2), ttl (4) + rdlen (2)*/
+    if (optLen < 11) {
+      return false;
+    }
+
+    if (*optStart != 0) {
+      // OPT RR Name != '.'
+      return false;
+    }
+    EDNS0Record edns0;
+    static_assert(sizeof(EDNS0Record) == sizeof(uint32_t), "sizeof(EDNS0Record) must match sizeof(uint32_t) AKA RR TTL size");
+    memcpy(&edns0, optStart + 5, sizeof edns0);
+
+    return d_extrcode == edns0.extRCode;
+  }
+  string toString() const override
+  {
+    return "ercode=="+ERCode::to_s(d_rcode | (d_extrcode << 4));
+  }
+private:
+  int d_rcode;     // plain DNS Rcode
+  int d_extrcode;  // upper bits in EDNS0 record
+};
+
 class RDRule : public DNSRule
 {
 public:
@@ -1162,6 +1209,10 @@ void setupLuaRules()
 
   g_lua.writeFunction("RCodeRule", [](int rcode) {
       return std::shared_ptr<DNSRule>(new RCodeRule(rcode));
+    });
+
+  g_lua.writeFunction("ERCodeRule", [](int rcode) {
+      return std::shared_ptr<DNSRule>(new ERCodeRule(rcode));
     });
 
   g_lua.writeFunction("showRules", []() {

--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -75,7 +75,16 @@ void setupLuaVars()
                                        {"YXRRSET",  RCode::YXRRSet  },
                                        {"NXRRSET",  RCode::NXRRSet  },
                                        {"NOTAUTH",  RCode::NotAuth  },
-                                       {"NOTZONE",  RCode::NotZone  }
+                                       {"NOTZONE",  RCode::NotZone  },
+                                       {"BADVERS",  ERCode::BADVERS },
+                                       {"BADSIG",   ERCode::BADSIG  },
+                                       {"BADKEY",   ERCode::BADKEY  },
+                                       {"BADTIME",  ERCode::BADTIME   },
+                                       {"BADMODE",  ERCode::BADMODE   },
+                                       {"BADNAME",  ERCode::BADNAME   },
+                                       {"BADALG",   ERCode::BADALG    },
+                                       {"BADTRUNC", ERCode::BADTRUNC  },
+                                       {"BADCOOKIE",ERCode::BADCOOKIE },
   };
   vector<pair<string, int> > dd;
   for(const auto& n : QType::names)

--- a/pdns/dnsdistdist/docs/reference/constants.rst
+++ b/pdns/dnsdistdist/docs/reference/constants.rst
@@ -14,6 +14,8 @@ OPCode
 - ``DNSOpcode.Notify``
 - ``DNSOpcode.Update``
 
+Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-5
+
 .. _DNSQClass:
 
 QClass
@@ -23,6 +25,8 @@ QClass
 - ``QClass.CHAOS``
 - ``QClass.NONE``
 - ``QClass.ANY``
+
+Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-2
 
 .. _DNSRCode:
 
@@ -40,6 +44,19 @@ RCode
 - ``dnsdist.NXRRSET``
 - ``dnsdist.NOTAUTH``
 - ``dnsdist.NOTZONE``
+- ``dnsdist.BADVERS``
+- ``dnsdist.BADSIG``
+- ``dnsdist.BADKEY``
+- ``dnsdist.BADTIME``
+- ``dnsdist.BADMODE``
+- ``dnsdist.BADNAME``
+- ``dnsdist.BADALG``
+- ``dnsdist.BADTRUNC``
+- ``dnsdist.BADCOOKIE``
+
+RCodes below and including ``BADVERS`` are extended RCodes that can only be matched using :func:`ERCodeRule`.
+
+Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 
 .. _DNSSection:
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -462,8 +462,17 @@ These ``DNSRule``\ s be one of the following items:
 
 .. function:: RCodeRule(rcode)
 
-  Matches queries or responses the specified ``rcode``.
-  ``rcode`` can be specified as an integer or as one of the built-in `RCode <DNSRcode>`.
+  Matches queries or responses with the specified ``rcode``.
+  ``rcode`` can be specified as an integer or as one of the built-in :ref:`DNSRCode`.
+  Only the non-extended RCode is matched (lower 4bits).
+
+  :param int rcode: The RCODE to match on
+
+.. function:: ERCodeRule(rcode)
+
+  Matches queries or responses with the specified ``rcode``.
+  ``rcode`` can be specified as an integer or as one of the built-in :ref:`DNSRCode`.
+  The full 16bit RCode will be matched. If no EDNS OPT RR is present, the upper 12 bits are treated as 0.
 
   :param int rcode: The RCODE to match on
 
@@ -709,7 +718,7 @@ The following actions exist.
 .. function:: RCodeAction(rcode)
 
   Reply immediatly by turning the query into a response with the specified ``rcode``.
-  ``rcode`` can be specified as an integer or as one of the built-in `RCode <#rcode>`_.
+  ``rcode`` can be specified as an integer or as one of the built-in :ref:`DNSRCode`.
 
   :param int rcode: The RCODE to respond with.
 

--- a/regression-tests.dnsdist/test_EdnsClientSubnet.py
+++ b/regression-tests.dnsdist/test_EdnsClientSubnet.py
@@ -3,6 +3,7 @@ import dns
 import clientsubnetoption
 import cookiesoption
 from dnsdisttests import DNSDistTest
+from datetime import datetime, timedelta
 
 class TestEdnsClientSubnetNoOverride(DNSDistTest):
     """

--- a/regression-tests.dnsdist/test_Responses.py
+++ b/regression-tests.dnsdist/test_Responses.py
@@ -53,6 +53,57 @@ class TestResponseRuleNXDelayed(DNSDistTest):
         self.assertEquals(response, receivedResponse)
         self.assertTrue((end - begin) < timedelta(0, 1))
 
+class TestResponseRuleERCode(DNSDistTest):
+
+    _config_template = """
+    newServer{address="127.0.0.1:%s"}
+    addResponseAction(ERCodeRule(dnsdist.BADVERS), DelayResponseAction(1000))
+    """
+
+    def testBADVERSDelayed(self):
+        """
+        Responses: Delayed on BADVERS
+
+        Send an A query to "delayed.responses.tests.powerdns.com.",
+        check that the response delay is longer than 1000 ms
+        for a BADVERS response over UDP, shorter for BADKEY and NoError.
+        """
+        name = 'delayed.responses.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        response.use_edns(edns=True)
+
+        # BADVERS over UDP
+        # BADVERS == 16, so rcode==0, ercode==1
+        response.set_rcode(dns.rcode.BADVERS)
+        begin = datetime.now()
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        end = datetime.now()
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+        self.assertTrue((end - begin) > timedelta(0, 1))
+
+        # BADKEY (17, an ERCode) over UDP
+        response.set_rcode(17)
+        begin = datetime.now()
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        end = datetime.now()
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+        self.assertTrue((end - begin) < timedelta(0, 1))
+
+        # NoError (non-ERcode, basic RCode bits match BADVERS) over UDP
+        response.set_rcode(dns.rcode.NOERROR)
+        begin = datetime.now()
+        (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+        end = datetime.now()
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)
+        self.assertTrue((end - begin) < timedelta(0, 1))
+
 class TestResponseRuleQNameDropped(DNSDistTest):
 
     _config_template = """


### PR DESCRIPTION
### Short description
Add ERCodeRule to match on EDNS Extended RCodes.

Separate rule to avoid performance cost for non-EDNS packets. Unclear if this is a good idea for correctness.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
