### PR TITLE
Improve DNSUPDATE prereq check log messages

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -833,7 +833,7 @@ int PacketHandler::processUpdate(DNSPacket *p) {
     if (rr->d_place == DNSResourceRecord::ANSWER) {
       int res = checkUpdatePrerequisites(rr, &di);
       if (res>0) {
-        L<<Logger::Error<<msgPrefix<<"Failed PreRequisites check, returning "<<res<<endl;
+        L<<Logger::Error<<msgPrefix<<"Failed PreRequisites check, returning "<<RCode::to_s(res)<<endl;
         di.backend->abortTransaction();
         return res;
       }
@@ -880,7 +880,7 @@ int PacketHandler::processUpdate(DNSPacket *p) {
         }
       }
       if (matchRR != foundRR || foundRR != vec->size()) {
-        L<<Logger::Error<<msgPrefix<<"Failed PreRequisites check, returning NXRRSet"<<endl;
+        L<<Logger::Error<<msgPrefix<<"Failed PreRequisites check (RRs differ), returning NXRRSet"<<endl;
         di.backend->abortTransaction();
         return RCode::NXRRSet;
       }


### PR DESCRIPTION
### Short description
Improve two DNSUPDATE log messages.

Before:

```
UPDATE (11434) from 10.2.1.6 for dynamic.home.zeha.at: Failed PreRequisites check, returning 6
UPDATE (10230) from 10.2.1.6 for dynamic.home.zeha.at: Failed PreRequisites check, returning NXRRSet
```

Hopefully, after:

```
UPDATE (x) from 10.2.1.6 for dynamic.home.zeha.at: Failed PreRequisites check, returning YXDomain
UPDATE (x) from 10.2.1.6 for dynamic.home.zeha.at: Failed PreRequisites check (RRs differ), returning NXRRSet
```

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

Haven't actually run it!

  