### PR TITLE
bindbackend: handle std::exception during startup zone-parsing

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -882,6 +882,18 @@ void Bind2Backend::loadConfig(string* status)
             L<<Logger::Warning<<d_logprefix<<msg.str()<<endl;
             rejected++;
           }
+          catch(std::exception &ae) {
+            ostringstream msg;
+            msg<<" error at "+nowTime()+" parsing '"<<i->name<<"' from file '"<<i->filename<<"': "<<ae.what();
+
+            if(status)
+              *status+=msg.str();
+            bbd.d_status=msg.str();
+
+            L<<Logger::Warning<<d_logprefix<<msg.str()<<endl;
+            cerr << msg.str() << endl;
+            rejected++;
+          }
 	  safePutBBDomainInfo(bbd);
 	  
         }

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -891,7 +891,6 @@ void Bind2Backend::loadConfig(string* status)
             bbd.d_status=msg.str();
 
             L<<Logger::Warning<<d_logprefix<<msg.str()<<endl;
-            cerr << msg.str() << endl;
             rejected++;
           }
 	  safePutBBDomainInfo(bbd);


### PR DESCRIPTION
### Short description

`queueReloadAndStore` already caught `PDNSException` and `std::exception`, but `loadConfig` (called at init time) only caught `PDNSException` and `std::system_error`, neglecting `std::runtime_error`.

This just duplicates the `PDNSException` handling to `std::exception`.

Before:
```
% ../pdns/pdnsutil --config-dir=. check-zone powerdnssec.org
Jan 05 22:20:16 Caught an exception instantiating a backend, cleaning up
Jan 05 22:20:16 UeberBackend destructor called, removing ourselves from instances, and deleting our backends
Error: name too long to append
```

After:
```
% ../pdns/pdnsutil --config-dir=. check-zone powerdnssec.org
 error at 2018-01-05 22:17:15 +0100 parsing 'powerdnssec.org' from file '../regression-tests/zones//powerdnssec.org': name too long to append
Jan 05 22:17:15 [bindbackend] Done parsing domains, 1 rejected, 3 new, 0 removed
Jan 05 22:17:15 UeberBackend destructor called, removing ourselves from instances, and deleting our backends
Jan 05 22:17:15 UeberBackend destructor called, removing ourselves from instances, and deleting our backends
Error: Zone for 'powerdnssec.org' in '../regression-tests/zones//powerdnssec.org' temporarily not available (file missing, or master dead)
```

Related to #6151 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
