### PR TITLE
Add an --initial-port option to dnsreplay

### DIFF
--- a/docs/manpages/dnsreplay.1.rst
+++ b/docs/manpages/dnsreplay.1.rst
@@ -33,6 +33,7 @@ PORT
 --ecs-mask <VAL>         When EDNS forwarding an IP address, mask out first octet with this value
 --ecs-stamp <FLAG>       Add original IP address as EDNS Client Subnet Option when 
                          forwarding to reference server
+--pcap-dns-port <VAL>    Look at packets from or to this port in the PCAP. Default is 53.
 --packet-limit <NUM>     Stop after replaying *NUM* packets. Default for *NUM* is 0, which
                          means no limit.
 --quiet <FLAG>           If *FLAG* is set to 1. dnsreplay will not be very noisy with its


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Allowing to replay queries received/sent from/to another port than 53.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
