### PR TITLE
Keep track of forward-zones NS speeds

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1282,26 +1282,27 @@ inline vector<DNSName> SyncRes::shuffleInSpeedOrder(NsSet &tnameservers, const s
   return rnameservers;
 }
 
-inline vector<ComboAddress> SyncRes::shuffleForwardSpeed(vector<ComboAddress> &rnameservers, const string &prefix, const bool wasRd)
+inline vector<ComboAddress> SyncRes::shuffleForwardSpeed(const vector<ComboAddress> &rnameservers, const string &prefix, const bool wasRd)
 {
+  vector<ComboAddress> nameservers = rnameservers;
   map<ComboAddress, double> speeds;
 
-  for(const auto& val: rnameservers) {
+  for(const auto& val: nameservers) {
     double speed;
     DNSName nsName = DNSName(val.toStringWithPort());
     speed=t_sstorage.nsSpeeds[nsName].get(&d_now);
     speeds[val]=speed;
   }
-  random_shuffle(rnameservers.begin(),rnameservers.end(), dns_random);
+  random_shuffle(nameservers.begin(),nameservers.end(), dns_random);
   speedOrderCA so(speeds);
-  stable_sort(rnameservers.begin(),rnameservers.end(), so);
+  stable_sort(nameservers.begin(),nameservers.end(), so);
 
   if(doLog()) {
     LOG(prefix<<"Nameservers: ");
-    for(vector<ComboAddress>::const_iterator i=rnameservers.cbegin();i!=rnameservers.cend();++i) {
-      if(i!=rnameservers.cbegin()) {
+    for(vector<ComboAddress>::const_iterator i=nameservers.cbegin();i!=nameservers.cend();++i) {
+      if(i!=nameservers.cbegin()) {
         LOG(", ");
-        if(!((i-rnameservers.cbegin())%3)) {
+        if(!((i-nameservers.cbegin())%3)) {
           LOG(endl<<prefix<<"             ");
         }
       }
@@ -1309,7 +1310,7 @@ inline vector<ComboAddress> SyncRes::shuffleForwardSpeed(vector<ComboAddress> &r
     }
     LOG(endl);
   }
-  return rnameservers;
+  return nameservers;
 }
 
 static uint32_t getRRSIGTTL(const time_t now, const std::shared_ptr<RRSIGRecordContent>& rrsig)

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -739,7 +739,7 @@ private:
   DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere);
 
   inline vector<DNSName> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);
-  inline vector<ComboAddress> shuffleForwardSpeed(vector<ComboAddress> &nameservers, const string &prefix, const bool wasRd);
+  inline vector<ComboAddress> shuffleForwardSpeed(vector<ComboAddress> &rnameservers, const string &prefix, const bool wasRd);
   bool moreSpecificThan(const DNSName& a, const DNSName &b) const;
   vector<ComboAddress> getAddrs(const DNSName &qname, unsigned int depth, set<GetBestNSAnswer>& beenthere, bool cacheOnly);
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -739,7 +739,7 @@ private:
   DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere);
 
   inline vector<DNSName> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);
-  inline vector<ComboAddress> shuffleForwardSpeed(vector<ComboAddress> &rnameservers, const string &prefix, const bool wasRd);
+  inline vector<ComboAddress> shuffleForwardSpeed(const vector<ComboAddress> &rnameservers, const string &prefix, const bool wasRd);
   bool moreSpecificThan(const DNSName& a, const DNSName &b) const;
   vector<ComboAddress> getAddrs(const DNSName &qname, unsigned int depth, set<GetBestNSAnswer>& beenthere, bool cacheOnly);
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -739,6 +739,7 @@ private:
   DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere);
 
   inline vector<DNSName> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);
+  inline vector<ComboAddress> shuffleForwardSpeed(vector<ComboAddress> &nameservers, const string &prefix, const bool wasRd);
   bool moreSpecificThan(const DNSName& a, const DNSName &b) const;
   vector<ComboAddress> getAddrs(const DNSName &qname, unsigned int depth, set<GetBestNSAnswer>& beenthere, bool cacheOnly);
 


### PR DESCRIPTION
### Short description
Fix for #5187 by slightly abusing our current tracking mechanism by stuffing our ComboAddress in as a DNSName and reusing much of shuffleInSpeedOrder.

This also prints a + in the trace log if the query is RD and - otherwise. Very much like previous versions did.

Pull request originally #5207

This produces log entries and usage such as:

```
./pdns_recursor --trace='.*' --forward-zones-recurse=".=7.7.7.7;7.6.6.6:55;[::1]:6000;8.8.8.8" --forward-zones="google.com=7.7.7.7;8.8.8.8" --local-port=5353 --socket-dir=/tmp --dnssec=off

Jan 10 16:37:06 [2] test3: Cache consultations done, have 1 NS to contact
Jan 10 16:37:06 [2] test3: Domain has hardcoded nameservers
Jan 10 16:37:06 [2] test3.: Nameservers: +8.8.8.8:53(12.85ms), +7.6.6.6:55(913.56ms), +[::1]:6000(913.57ms),
Jan 10 16:37:06 [2] test3.:              +7.7.7.7:53(936.72ms)
Jan 10 16:37:06 [2] test3: Resolved '.' NS (empty) to: 8.8.8.8, 7.6.6.6, ::1, 7.7.7.7
Jan 10 16:37:06 [2] test3: Trying IP 8.8.8.8:53, asking 'test3|A'

Jan 10 16:39:01 [2] test5.google.com: Cache consultations done, have 1 NS to contact
Jan 10 16:39:01 [2] test5.google.com: Domain has hardcoded nameservers
Jan 10 16:39:01 [2] test5.google.com.: Nameservers: -8.8.8.8:53(4.38ms), -7.7.7.7:53(707.65ms)
Jan 10 16:39:01 [2] test5.google.com: Resolved 'google.com' NS (empty) to: 8.8.8.8, 7.7.7.7
Jan 10 16:39:01 [2] test5.google.com: Trying IP 8.8.8.8:53, asking 'test5.google.com|A'
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)