### PR TITLE
IXFR: correct behavior of dealing with DNS Name with multiple records; speed up IXFR transaction

### DIFF
--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -168,8 +168,12 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
   std::shared_ptr<SOARecordContent> masterSOA = nullptr;
   vector<DNSRecord> records;
   size_t receivedBytes = 0;
+  int8_t ixfrInProgress = -2;
 
   for(;;) {
+    if (!ixfrInProgress)
+      break;
+
     if(s.read((char*)&len, sizeof(len)) != sizeof(len))
       break;
 
@@ -203,8 +207,8 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
           throw std::runtime_error("The first record of the IXFR answer for zone '"+zone.toLogString()+"' from master '"+master.toStringWithPort()+"' is not a SOA ("+QType(r.first.d_type).getName()+")");
         }
 
-	auto sr = getRR<SOARecordContent>(r.first);
-	if (!sr) {
+        auto sr = getRR<SOARecordContent>(r.first);
+        if (!sr) {
           throw std::runtime_error("Error getting the content of the first SOA record of the IXFR answer for zone '"+zone.toLogString()+"' from master '"+master.toStringWithPort()+"'");
         }
 
@@ -213,6 +217,12 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
           return ret;
         }
         masterSOA = sr;
+      } else {
+        // we hit the last SOA record
+        // ixfr is considered to be done if we hit the last SOA record twice
+        if (r.first.d_type == QType::SOA && masterSOA->d_st.serial == getRR<SOARecordContent>(r.first)->d_st.serial) {
+          ixfrInProgress++;
+        }
       }
 
       if(r.first.d_place != DNSResourceRecord::ANSWER) {

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -136,8 +136,9 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
         vector<DNSRecord> rrset;
         {
           DNSZoneRecord zrr;
-          B.lookup(QType(g.first.second), g.first.first, 0, di.id);
+          B.lookup(QType(g.first.second), g.first.first+domain, 0, di.id);
           while(B.get(zrr)) {
+            zrr.dr.d_name.makeUsRelative(domain);
             rrset.push_back(zrr.dr);
           }
         }


### PR DESCRIPTION
### Short description
##### commit 397ed71
Makes IXFR client actively close connection to IXFR server when IXFR is considered to be done. Right now the client would keep reading data from socket even server has sent out all the IXFR responses, until server close the TCP connection. The whole transaction can last for 30s or longer, depends on IXFR server.

##### commit 668624c
Fix bug.

Say a.test.com has two A records.
```
a.test.com.  IN  A  10.0.0.1
a.test.com.  IN  A  10.0.0.2
```
IXFR client receives an add change that a.test.com has another A record 10.0.0.3. The update will remove all A records of a.test.com and only keep the newly added one. The final result will be:
```
a.test.com.  IN  A  10.0.0.3
```

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)