### PR TITLE
dnsdist: Fix building without libssl

### DIFF
--- a/pdns/dnsdistdist/m4/dnsdist_check_gnutls.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_check_gnutls.m4
@@ -1,9 +1,10 @@
 AC_DEFUN([DNSDIST_CHECK_GNUTLS], [
   AC_MSG_CHECKING([whether we will be linking in GnuTLS])
+  HAVE_GNUTLS=0
   AC_ARG_ENABLE([gnutls],
     AS_HELP_STRING([--enable-gnutls],[use GnuTLS @<:@default=auto@:>@]),
     [enable_gnutls=$enableval],
-    [enable_gnutls=no],
+    [enable_gnutls=auto],
   )
   AC_MSG_RESULT([$enable_gnutls])
 
@@ -11,6 +12,7 @@ AC_DEFUN([DNSDIST_CHECK_GNUTLS], [
     AS_IF([test "x$enable_gnutls" = "xyes" -o "x$enable_gnutls" = "xauto"], [
       # we require gnutls_certificate_set_x509_key_file, added in 3.1.11
       PKG_CHECK_MODULES([GNUTLS], [gnutls >= 3.1.11], [
+        [HAVE_GNUTLS=1]
         AC_DEFINE([HAVE_GNUTLS], [1], [Define to 1 if you have GnuTLS])
       ], [ : ])
     ])

--- a/pdns/dnsdistdist/m4/dnsdist_check_libssl.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_check_libssl.m4
@@ -1,7 +1,7 @@
 AC_DEFUN([DNSDIST_CHECK_LIBSSL], [
   AC_MSG_CHECKING([whether we will be linking in OpenSSL libssl])
   HAVE_LIBSSL=0
-    AC_ARG_ENABLE([libssl],
+  AC_ARG_ENABLE([libssl],
     AS_HELP_STRING([--enable-libssl],[use OpenSSL libssl @<:@default=auto@:>@]),
     [enable_libssl=$enableval],
     [enable_libssl=auto],

--- a/pdns/dnsdistdist/m4/dnsdist_check_libssl.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_check_libssl.m4
@@ -1,9 +1,25 @@
 AC_DEFUN([DNSDIST_CHECK_LIBSSL], [
+  AC_MSG_CHECKING([whether we will be linking in OpenSSL libssl])
   HAVE_LIBSSL=0
-  AC_MSG_CHECKING([if OpenSSL libssl is available])
-  PKG_CHECK_MODULES([LIBSSL], [libssl], [
-    [HAVE_LIBSSL=1],
-    AC_DEFINE([HAVE_LIBSSL], [1], [Define to 1 if you have OpenSSL libssl])
+    AC_ARG_ENABLE([libssl],
+    AS_HELP_STRING([--enable-libssl],[use OpenSSL libssl @<:@default=auto@:>@]),
+    [enable_libssl=$enableval],
+    [enable_libssl=auto],
+  )
+  AC_MSG_RESULT([$enable_libssl])
+
+  AS_IF([test "x$enable_libssl" != "xno"], [
+    AS_IF([test "x$enable_libssl" = "xyes" -o "x$enable_libssl" = "xauto"], [
+      PKG_CHECK_MODULES([LIBSSL], [libssl], [
+        [HAVE_LIBSSL=1]
+        AC_DEFINE([HAVE_LIBSSL], [1], [Define to 1 if you have OpenSSL libssl])
+      ], [ : ])
+    ])
   ])
   AM_CONDITIONAL([HAVE_LIBSSL], [test "x$LIBSSL_LIBS" != "x"])
+  AS_IF([test "x$enable_libssl" = "xyes"], [
+    AS_IF([test x"$LIBSSL_LIBS" = "x"], [
+      AC_MSG_ERROR([OpenSSL libssl requested but libraries were not found])
+    ])
+  ])
 ])

--- a/pdns/dnsdistdist/m4/dnsdist_enable_tls.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_enable_tls.m4
@@ -1,7 +1,7 @@
 AC_DEFUN([DNSDIST_ENABLE_DNS_OVER_TLS], [
   AC_MSG_CHECKING([whether to enable DNS over TLS support])
   AC_ARG_ENABLE([dns-over-tls],
-    AS_HELP_STRING([--enable-dns-over-tls], [enable DNS over TLS support (require OpenSSL or s2n) @<:@default=no@:>@]),
+    AS_HELP_STRING([--enable-dns-over-tls], [enable DNS over TLS support (requires GnuTLS or OpenSSL) @<:@default=no@:>@]),
     [enable_dns_over_tls=$enableval],
     [enable_dns_over_tls=no]
   )

--- a/pdns/dnsdistdist/m4/pdns_check_libcrypto.m4
+++ b/pdns/dnsdistdist/m4/pdns_check_libcrypto.m4
@@ -1,0 +1,1 @@
+../../../m4/pdns_check_libcrypto.m4


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* Only fail if DNS over TLS is enabled and we don't have either `GnuTLS` or `OpenSSL` libssl
* Switch `GnuTLS` to `auto`, we will detect it but should only link it if DNS over TLS is enabled

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
