### PR TITLE
Increase MTasker stacksize to avoid crash in exception unwinding

### DIFF
--- a/pdns/mtasker.hh
+++ b/pdns/mtasker.hh
@@ -110,7 +110,7 @@ public:
       This limit applies solely to the stack, the heap is not limited in any way. If threads need to allocate a lot of data,
       the use of new/delete is suggested. 
    */
-  MTasker(size_t stacksize=8192) : d_tid(0), d_maxtid(0), d_stacksize(stacksize), d_waitstatus(Error)
+  MTasker(size_t stacksize=16*8192) : d_tid(0), d_maxtid(0), d_stacksize(stacksize), d_waitstatus(Error)
   {
     initMainStackBounds();
   }


### PR DESCRIPTION
### Short description

Throwing an exception uses libgcc's stack unwinder. On mips64el
the unwinder will overflow the default stack size of 8K. In turn
the return ucontext gets overwritten, resulting in a jump into
garbage.

This is Debian bug #887034. Patch is applied in Debian pdns-recursor 4.1.0-3. Build logs will be at https://buildd.debian.org/status/package.php?p=pdns%2drecursor

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
