### PR TITLE
dnsdist: Fix a warning about braces around scalar initializer

### DIFF
--- a/pdns/dnsdistdist/tcpiohandler.hh
+++ b/pdns/dnsdistdist/tcpiohandler.hh
@@ -19,6 +19,10 @@ protected:
 class TLSCtx
 {
 public:
+  TLSCtx()
+  {
+    d_rotatingTicketsKey.clear();
+  }
   virtual ~TLSCtx() {}
   virtual std::unique_ptr<TLSConnection> getConnection(int socket, unsigned int timeout, time_t now) = 0;
   virtual void rotateTicketsKey(time_t now) = 0;
@@ -53,7 +57,7 @@ public:
   virtual size_t getTicketsKeysCount() = 0;
 
 protected:
-  std::atomic_flag d_rotatingTicketsKey{ATOMIC_FLAG_INIT};
+  std::atomic_flag d_rotatingTicketsKey;
   time_t d_ticketsKeyRotationDelay{0};
   time_t d_ticketsKeyNextRotation{0};
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`clang` emits a warning when `std::atomic_flag`'s `ATOMIC_FLAG_INIT` is used as a member initializer. Unfortunately the default constructor leaves in a undefined state, so we need to clear it in the constructor.
Fixes #6184.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
