### PR TITLE
dnsdist: Replace the Lua mutex with a rw lock to limit contention

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -308,8 +308,8 @@ public:
 
 DNSAction::Action LuaAction::operator()(DNSQuestion* dq, string* ruleresult) const
 {
-  std::lock_guard<std::mutex> lock(g_luamutex);
   try {
+    WriteLock wl(&g_lualock);
     auto ret = d_func(dq);
     if(ruleresult)
       *ruleresult=std::get<1>(ret);
@@ -324,8 +324,8 @@ DNSAction::Action LuaAction::operator()(DNSQuestion* dq, string* ruleresult) con
 
 DNSResponseAction::Action LuaResponseAction::operator()(DNSResponse* dr, string* ruleresult) const
 {
-  std::lock_guard<std::mutex> lock(g_luamutex);
   try {
+    WriteLock wl(&g_lualock);
     auto ret = d_func(dr);
     if(ruleresult)
       *ruleresult=std::get<1>(ret);
@@ -645,7 +645,7 @@ public:
     DnstapMessage message(d_identity, dq->remote, dq->local, dq->tcp, reinterpret_cast<const char*>(dq->dh), dq->len, dq->queryTime, nullptr);
     {
       if (d_alterFunc) {
-        std::lock_guard<std::mutex> lock(g_luamutex);
+        WriteLock wl(&g_lualock);
         (*d_alterFunc)(*dq, &message);
       }
     }
@@ -681,7 +681,7 @@ public:
     DNSDistProtoBufMessage message(*dq);
     {
       if (d_alterFunc) {
-        std::lock_guard<std::mutex> lock(g_luamutex);
+        WriteLock wl(&g_lualock);
         (*d_alterFunc)(*dq, &message);
       }
     }
@@ -761,7 +761,7 @@ public:
     DnstapMessage message(d_identity, dr->remote, dr->local, dr->tcp, reinterpret_cast<const char*>(dr->dh), dr->len, dr->queryTime, &now);
     {
       if (d_alterFunc) {
-        std::lock_guard<std::mutex> lock(g_luamutex);
+        WriteLock wl(&g_lualock);
         (*d_alterFunc)(*dr, &message);
       }
     }
@@ -797,7 +797,7 @@ public:
     DNSDistProtoBufMessage message(*dr, d_includeCNAME);
     {
       if (d_alterFunc) {
-        std::lock_guard<std::mutex> lock(g_luamutex);
+        WriteLock wl(&g_lualock);
         (*d_alterFunc)(*dr, &message);
       }
     }

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -45,15 +45,16 @@ void setupLuaBindings(bool client)
     });
 
   /* ServerPolicy */
-  g_lua.writeFunction("newServerPolicy", [](string name, policyfunc_t policy) { return ServerPolicy{name, policy};});
+  g_lua.writeFunction("newServerPolicy", [](string name, policyfunc_t policy, boost::optional<bool> isReadOnly) { return ServerPolicy{name, policy, isReadOnly ? *isReadOnly : false};});
+  g_lua.registerMember("isReadOnly", &ServerPolicy::isReadOnly);
   g_lua.registerMember("name", &ServerPolicy::name);
   g_lua.registerMember("policy", &ServerPolicy::policy);
 
-  g_lua.writeVariable("firstAvailable", ServerPolicy{"firstAvailable", firstAvailable});
-  g_lua.writeVariable("roundrobin", ServerPolicy{"roundrobin", roundrobin});
-  g_lua.writeVariable("wrandom", ServerPolicy{"wrandom", wrandom});
-  g_lua.writeVariable("whashed", ServerPolicy{"whashed", whashed});
-  g_lua.writeVariable("leastOutstanding", ServerPolicy{"leastOutstanding", leastOutstanding});
+  g_lua.writeVariable("firstAvailable", ServerPolicy{"firstAvailable", firstAvailable, true});
+  g_lua.writeVariable("roundrobin", ServerPolicy{"roundrobin", roundrobin, true});
+  g_lua.writeVariable("wrandom", ServerPolicy{"wrandom", wrandom, true});
+  g_lua.writeVariable("whashed", ServerPolicy{"whashed", whashed, true});
+  g_lua.writeVariable("leastOutstanding", ServerPolicy{"leastOutstanding", leastOutstanding, true});
 
   /* ServerPool */
   g_lua.registerFunction<void(std::shared_ptr<ServerPool>::*)(std::shared_ptr<DNSDistPacketCache>)>("setCache", [](std::shared_ptr<ServerPool> pool, std::shared_ptr<DNSDistPacketCache> cache) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -400,9 +400,9 @@ void setupLuaConfig(bool client)
       setLuaSideEffect();
       g_policy.setState(policy);
     });
-  g_lua.writeFunction("setServerPolicyLua", [](string name, policyfunc_t policy)  {
+  g_lua.writeFunction("setServerPolicyLua", [](string name, policyfunc_t policy, boost::optional<bool> isReadOnly)  {
       setLuaSideEffect();
-      g_policy.setState(ServerPolicy{name, policy});
+      g_policy.setState(ServerPolicy{name, policy, isReadOnly ? *isReadOnly : false});
     });
 
   g_lua.writeFunction("showServerPolicy", []() {
@@ -1339,10 +1339,10 @@ void setupLuaConfig(bool client)
       g_pools.setState(localPools);
     });
 
-  g_lua.writeFunction("setPoolServerPolicyLua", [](string name, policyfunc_t policy, string pool) {
+  g_lua.writeFunction("setPoolServerPolicyLua", [](string name, policyfunc_t policy, string pool, boost::optional<bool> isReadOnly) {
       setLuaSideEffect();
       auto localPools = g_pools.getCopy();
-      setPoolPolicy(localPools, pool, std::make_shared<ServerPolicy>(ServerPolicy{name, policy}));
+      setPoolPolicy(localPools, pool, std::make_shared<ServerPolicy>(ServerPolicy{name, policy, isReadOnly ? *isReadOnly : false}));
       g_pools.setState(localPools);
     });
 

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -383,16 +383,12 @@ void* tcpClientThread(int pipefd)
 	}
 
         std::shared_ptr<ServerPool> serverPool = getPool(*holders.pools, poolname);
-        std::shared_ptr<DNSDistPacketCache> packetCache = nullptr;
-        auto policy = holders.policy->policy;
+        std::shared_ptr<DNSDistPacketCache> packetCache = serverPool->packetCache;
+        auto policy = *(holders.policy);
         if (serverPool->policy != nullptr) {
-          policy = serverPool->policy->policy;
+          policy = *(serverPool->policy);
         }
-        {
-          std::lock_guard<std::mutex> lock(g_luamutex);
-          ds = policy(serverPool->servers, &dq);
-          packetCache = serverPool->packetCache;
-        }
+        ds = getBackendFromPolicy(policy, serverPool->servers, dq);
 
         if (dq.useECS && ds && ds->useECS) {
           uint16_t newLen = dq.len;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -573,7 +573,7 @@ DownstreamState::DownstreamState(const ComboAddress& remote_, const ComboAddress
   }
 }
 
-std::mutex g_luamutex;
+pthread_rwlock_t g_lualock;
 LuaContext g_lua;
 
 GlobalStateHolder<ServerPolicy> g_policy;
@@ -791,6 +791,22 @@ std::shared_ptr<ServerPool> getPool(const pools_t& pools, const std::string& poo
   return it->second;
 }
 
+std::shared_ptr<DownstreamState> getBackendFromPolicy(const ServerPolicy& policy, const NumberedServerVector& servers, const DNSQuestion& dq)
+{
+  std::shared_ptr<DownstreamState> backend = nullptr;
+
+  if (policy.isReadOnly) {
+    ReadLock rl(&g_lualock);
+    backend = policy.policy(servers, &dq);
+  }
+  else {
+    WriteLock wl(&g_lualock);
+    backend = policy.policy(servers, &dq);
+  }
+
+  return backend;
+}
+
 const NumberedServerVector& getDownstreamCandidates(const pools_t& pools, const std::string& poolName)
 {
   std::shared_ptr<ServerPool> pool = getPool(pools, poolName);
@@ -872,7 +888,7 @@ bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int*
     string qname = (*dq.qname).toString(".");
     bool countQuery{true};
     if(g_qcount.filter) {
-      std::lock_guard<std::mutex> lock(g_luamutex);
+      WriteLock wl(&g_lualock);
       std::tie (countQuery, qname) = g_qcount.filter(dq);
     }
 
@@ -1062,7 +1078,7 @@ bool processResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& local
   return true;
 }
 
-static ssize_t udpClientSendRequestToBackend(DownstreamState* ss, const int sd, const char* request, const size_t requestLen)
+static ssize_t udpClientSendRequestToBackend(shared_ptr<DownstreamState>& ss, const int sd, const char* request, const size_t requestLen)
 {
   ssize_t result;
 
@@ -1296,18 +1312,14 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
       return;
     }
 
-    DownstreamState* ss = nullptr;
     std::shared_ptr<ServerPool> serverPool = getPool(*holders.pools, poolname);
-    std::shared_ptr<DNSDistPacketCache> packetCache = nullptr;
-    auto policy = holders.policy->policy;
+    std::shared_ptr<DNSDistPacketCache> packetCache = serverPool->packetCache;
+    auto policy = *(holders.policy);
     if (serverPool->policy != nullptr) {
-      policy = serverPool->policy->policy;
+      policy = *(serverPool->policy);
     }
-    {
-      std::lock_guard<std::mutex> lock(g_luamutex);
-      ss = policy(serverPool->servers, &dq).get();
-      packetCache = serverPool->packetCache;
-    }
+
+    std::shared_ptr<DownstreamState> ss = getBackendFromPolicy(policy, serverPool->servers, dq);
 
     bool ednsAdded = false;
     bool ecsAdded = false;
@@ -1614,29 +1626,29 @@ catch(...)
   return nullptr;
 }
 
-static bool upCheck(DownstreamState& ds)
+static bool upCheck(std::shared_ptr<DownstreamState>& ds)
 try
 {
   vector<uint8_t> packet;
-  DNSPacketWriter dpw(packet, ds.checkName, ds.checkType.getCode(), ds.checkClass);
+  DNSPacketWriter dpw(packet, ds->checkName, ds->checkType.getCode(), ds->checkClass);
   dnsheader * requestHeader = dpw.getHeader();
   requestHeader->rd=true;
-  if (ds.setCD) {
+  if (ds->setCD) {
     requestHeader->cd = true;
   }
 
-  Socket sock(ds.remote.sin4.sin_family, SOCK_DGRAM);
+  Socket sock(ds->remote.sin4.sin_family, SOCK_DGRAM);
   sock.setNonBlocking();
-  if (!IsAnyAddress(ds.sourceAddr)) {
+  if (!IsAnyAddress(ds->sourceAddr)) {
     sock.setReuseAddr();
-    sock.bind(ds.sourceAddr);
+    sock.bind(ds->sourceAddr);
   }
-  sock.connect(ds.remote);
-  ssize_t sent = udpClientSendRequestToBackend(&ds, sock.getHandle(), (char*)&packet[0], packet.size());
+  sock.connect(ds->remote);
+  ssize_t sent = udpClientSendRequestToBackend(ds, sock.getHandle(), (char*)&packet[0], packet.size());
   if (sent < 0) {
     int ret = errno;
     if (g_verboseHealthChecks)
-      infolog("Error while sending a health check query to backend %s: %d", ds.getNameWithAddr(), ret);
+      infolog("Error while sending a health check query to backend %s: %d", ds->getNameWithAddr(), ret);
     return false;
   }
 
@@ -1645,47 +1657,47 @@ try
     if (ret < 0) {
       ret = errno;
       if (g_verboseHealthChecks)
-        infolog("Error while waiting for the health check response from backend %s: %d", ds.getNameWithAddr(), ret);
+        infolog("Error while waiting for the health check response from backend %s: %d", ds->getNameWithAddr(), ret);
     }
     else {
       if (g_verboseHealthChecks)
-        infolog("Timeout while waiting for the health check response from backend %s", ds.getNameWithAddr());
+        infolog("Timeout while waiting for the health check response from backend %s", ds->getNameWithAddr());
     }
     return false;
   }
 
   string reply;
-  sock.recvFrom(reply, ds.remote);
+  sock.recvFrom(reply, ds->remote);
 
   const dnsheader * responseHeader = (const dnsheader *) reply.c_str();
 
   if (reply.size() < sizeof(*responseHeader)) {
     if (g_verboseHealthChecks)
-      infolog("Invalid health check response of size %d from backend %s, expecting at least %d", reply.size(), ds.getNameWithAddr(), sizeof(*responseHeader));
+      infolog("Invalid health check response of size %d from backend %s, expecting at least %d", reply.size(), ds->getNameWithAddr(), sizeof(*responseHeader));
     return false;
   }
 
   if (responseHeader->id != requestHeader->id) {
     if (g_verboseHealthChecks)
-      infolog("Invalid health check response id %d from backend %s, expecting %d", responseHeader->id, ds.getNameWithAddr(), requestHeader->id);
+      infolog("Invalid health check response id %d from backend %s, expecting %d", responseHeader->id, ds->getNameWithAddr(), requestHeader->id);
     return false;
   }
 
   if (!responseHeader->qr) {
     if (g_verboseHealthChecks)
-      infolog("Invalid health check response from backend %s, expecting QR to be set", ds.getNameWithAddr());
+      infolog("Invalid health check response from backend %s, expecting QR to be set", ds->getNameWithAddr());
     return false;
   }
 
   if (responseHeader->rcode == RCode::ServFail) {
     if (g_verboseHealthChecks)
-      infolog("Backend %s responded to health check with ServFail", ds.getNameWithAddr());
+      infolog("Backend %s responded to health check with ServFail", ds->getNameWithAddr());
     return false;
   }
 
-  if (ds.mustResolve && (responseHeader->rcode == RCode::NXDomain || responseHeader->rcode == RCode::Refused)) {
+  if (ds->mustResolve && (responseHeader->rcode == RCode::NXDomain || responseHeader->rcode == RCode::Refused)) {
     if (g_verboseHealthChecks)
-      infolog("Backend %s responded to health check with %s while mustResolve is set", ds.getNameWithAddr(), responseHeader->rcode == RCode::NXDomain ? "NXDomain" : "Refused");
+      infolog("Backend %s responded to health check with %s while mustResolve is set", ds->getNameWithAddr(), responseHeader->rcode == RCode::NXDomain ? "NXDomain" : "Refused");
     return false;
   }
 
@@ -1695,13 +1707,13 @@ try
 catch(const std::exception& e)
 {
   if (g_verboseHealthChecks)
-    infolog("Error checking the health of backend %s: %s", ds.getNameWithAddr(), e.what());
+    infolog("Error checking the health of backend %s: %s", ds->getNameWithAddr(), e.what());
   return false;
 }
 catch(...)
 {
   if (g_verboseHealthChecks)
-    infolog("Unknown exception while checking the health of backend %s", ds.getNameWithAddr());
+    infolog("Unknown exception while checking the health of backend %s", ds->getNameWithAddr());
   return false;
 }
 
@@ -1719,7 +1731,7 @@ void* maintThread()
     sleep(interval);
 
     {
-      std::lock_guard<std::mutex> lock(g_luamutex);
+      WriteLock wl(&g_lualock);
       auto f = g_lua.readVariable<boost::optional<std::function<void()> > >("maintenance");
       if(f) {
         try {
@@ -1741,10 +1753,7 @@ void* maintThread()
       const auto localPools = g_pools.getCopy();
       std::shared_ptr<DNSDistPacketCache> packetCache = nullptr;
       for (const auto& entry : localPools) {
-        {
-          std::lock_guard<std::mutex> lock(g_luamutex);
-          packetCache = entry.second->packetCache;
-        }
+        packetCache = entry.second->packetCache;
         if (packetCache) {
           size_t upTo = (packetCache->getMaxEntries()* (100 - g_cacheCleaningPercentage)) / 100;
           packetCache->purgeExpired(upTo);
@@ -1770,7 +1779,7 @@ void* healthChecksThread()
 
     for(auto& dss : g_dstates.getCopy()) { // this points to the actual shared_ptrs!
       if(dss->availability==DownstreamState::Availability::Auto) {
-        bool newState=upCheck(*dss);
+        bool newState=upCheck(dss);
         if (newState) {
           if (dss->currentCheckFailures != 0) {
             dss->currentCheckFailures = 0;
@@ -1989,6 +1998,8 @@ try
   rl_attempted_completion_function = my_completion;
   rl_completion_append_character = 0;
 
+  pthread_rwlock_init(&g_lualock, nullptr);
+
   signal(SIGPIPE, SIG_IGN);
   signal(SIGCHLD, SIG_IGN);
   openlog("dnsdist", LOG_PID, LOG_DAEMON);
@@ -2187,7 +2198,7 @@ try
     }
   }
 
-  ServerPolicy leastOutstandingPol{"leastOutstanding", leastOutstanding};
+  ServerPolicy leastOutstandingPol{"leastOutstanding", leastOutstanding, true};
 
   g_policy.setState(leastOutstandingPol);
   if(g_cmdLine.beClient || !g_cmdLine.command.empty()) {
@@ -2571,7 +2582,7 @@ try
 
   for(auto& dss : g_dstates.getCopy()) { // it is a copy, but the internal shared_ptrs are the real deal
     if(dss->availability==DownstreamState::Availability::Auto) {
-      bool newState=upCheck(*dss);
+      bool newState=upCheck(dss);
       warnlog("Marking downstream %s as '%s'", dss->getNameWithAddr(), newState ? "up" : "down");
       dss->upStatus = newState;
     }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -614,9 +614,9 @@ using servers_t =vector<std::shared_ptr<DownstreamState>>;
 template <class T> using NumberedVector = std::vector<std::pair<unsigned int, T> >;
 
 void* responderThread(std::shared_ptr<DownstreamState> state);
-extern std::mutex g_luamutex;
+extern pthread_rwlock_t g_lualock;
 extern LuaContext g_lua;
-extern std::string g_outputBuffer; // locking for this is ok, as locked by g_luamutex
+extern std::string g_outputBuffer; // locking for this is ok, as locked by g_lualock
 
 class DNSRule
 {
@@ -636,6 +636,7 @@ struct ServerPolicy
 {
   string name;
   policyfunc_t policy;
+  bool isReadOnly;
 };
 
 struct ServerPool
@@ -768,6 +769,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 std::shared_ptr<ServerPool> getPool(const pools_t& pools, const std::string& poolName);
 std::shared_ptr<ServerPool> createPoolIfNotExists(pools_t& pools, const string& poolName);
 const NumberedServerVector& getDownstreamCandidates(const pools_t& pools, const std::string& poolName);
+std::shared_ptr<DownstreamState> getBackendFromPolicy(const ServerPolicy& policy, const NumberedServerVector& servers, const DNSQuestion& dq);
 
 std::shared_ptr<DownstreamState> firstAvailable(const NumberedServerVector& servers, const DNSQuestion* dq);
 

--- a/pdns/dnsdistdist/docs/guides/serverselection.rst
+++ b/pdns/dnsdistdist/docs/guides/serverselection.rst
@@ -99,13 +99,17 @@ ServerPolicy Objects
 Functions
 ---------
 
-.. function:: newServerPolicy(name, function) -> ServerPolicy
+.. function:: newServerPolicy(name, function [, isReadOnly]) -> ServerPolicy
+
+.. versionchanged:: 1.3.0
+    ``read-only`` optional parameter added.
 
   Create a policy object from a Lua function.
   ``function`` must match the prototype for :func:`ServerPolicy.policy`.
 
   :param string name: Name of the policy
   :param string function: The function to call for this policy
+  :param bool isReadOnly: whether the policy needs a write-lock (false, the default) or a read-only one, to reduce contention
 
 .. function:: setServerPolicy(policy)
 
@@ -113,12 +117,16 @@ Functions
 
   :param ServerPolicy policy: The policy to use
 
-.. function:: setServerPolicyLua(name, function)
+.. function:: setServerPolicyLua(name, function [, isReadOnly])
+
+.. versionchanged:: 1.3.0
+    ``isReadOnly`` optional parameter added.
 
   Set server selection policy to one named `name`` and provided by ``function``.
 
   :param string name: name for this policy
   :param string function: name of the function
+  :param bool isReadOnly: whether the policy needs a write-lock (false, the default) or a read-only one, to reduce contention
 
 .. function:: setServFailWhenNoServer(value)
 
@@ -133,13 +141,17 @@ Functions
   :param ServerPolicy policy: The policy to apply
   :param string pool: Name of the pool
 
-.. function:: setPoolServerPolicyLua(name, function, pool)
+.. function:: setPoolServerPolicyLua(name, function, pool [, isReadOnly])
+
+.. versionchanged:: 1.3.0
+    ``isReadOnly`` optional parameter added.
 
   Set the server selection policy for ``pool`` to one named ``name`` and provided by ``function``.
 
   :param string name: name for this policy
   :param string function: name of the function
   :param string pool: Name of the pool
+  :param bool isReadOnly: whether the policy needs a write-lock (false, the default) or a read-only one, to reduce contention
 
 .. function:: showPoolServerPolicy(pool)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Most policies can run concurrently, and only need to hold a lock because they access the pools. The Lua ones however need a write lock. If you really know what you are doing, you can request a read lock for custom Lua policies too.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
