### PR TITLE
rec: Initialize the result var before calling the preoutquery hook

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2330,7 +2330,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
 
 bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType& qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool* truncated)
 {
-  int resolveret;
+  int resolveret = RCode::NoError;
   s_outqueries++;
   d_outqueries++;
 


### PR DESCRIPTION
(cherry picked from commit 17cecc8)

Backport from stable (see #6167).
Fixes #6193.