### PR TITLE
Minimal fix to make primeHints threadsafe

### DIFF
--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -66,7 +66,7 @@ void primeHints(void)
   arr.d_ttl=aaaarr.d_ttl=nsrr.d_ttl=time(nullptr)+3600000;
 
   for(char c='a';c<='m';++c) {
-    static char templ[40];
+    char templ[40];
     strncpy(templ,"a.root-servers.net.", sizeof(templ) - 1);
     templ[sizeof(templ)-1] = '\0';
     *templ=c;

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -53,7 +53,7 @@ void primeHints(void)
     arr.d_ttl=aaaarr.d_ttl=nsrr.d_ttl=time(0)+3600000;
     
     for(char c='a';c<='m';++c) {
-      static char templ[40];
+      char templ[40];
       strncpy(templ,"a.root-servers.net.", sizeof(templ) - 1);
       templ[sizeof(templ)-1] = '\0';
       *templ=c;


### PR DESCRIPTION
### Short description
wim on IRC discovered that there is a chance on startup that the root-server IPs will be incorrect.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
