### PR TITLE
recursor: abort when unused arguments remain

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3435,6 +3435,11 @@ int main(int argc, char **argv)
     }
     cleanSlashes(configname);
 
+    if(!::arg().getCommands().empty()) {
+      cerr<<"Fatal: non-option on the command line, perhaps a '--setting=123' statement missed the '='?"<<endl;
+      exit(99);
+    }
+
     if(::arg().mustDo("config")) {
       cout<<::arg().configstring()<<endl;
       exit(0);


### PR DESCRIPTION
Copied this over from receiver.cc, as @ahupowerdns pointed out that Auth handles this.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
