### PR TITLE
mention slave-renotify in notification warnings

### DIFF
--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -54,7 +54,7 @@ enabled.
 
 .. warning::
   Notifications are only sent for domains with type MASTER in
-  your backend.
+  your backend unless :ref:`setting-slave-renotify` is enabled.
 
 Left open by :rfc:`1996` is who is to be notified - which is harder to
 figure out than it sounds. All slaves for this domain must receive a


### PR DESCRIPTION
### Short description
https://doc.powerdns.com/md/authoritative/modes-of-operation/ claims  that ```Notifications are only sent for domains with type MASTER in your backend.``` but this can (fortunately) be controlled by the `slave-renotify` settings which was not mentioned.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

