### PR TITLE
docs: Ensure Lua objects and their attributes are layed-out

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -715,7 +715,7 @@ this reason it is disabled by default.
 
 .. versionadded:: 4.1.0
 
-Script to be used to edit incoming AXFRs, see :ref:_modes-of-operation-axfrfilter`
+Script to be used to edit incoming AXFRs, see :ref:`modes-of-operation-axfrfilter`
 
 .. _setting-local-address-nonexist-fail:
 

--- a/pdns/dnsdistdist/docs/advanced/timedipsetrule.rst
+++ b/pdns/dnsdistdist/docs/advanced/timedipsetrule.rst
@@ -19,24 +19,24 @@ added in :class:`ComboAddress` form.
 
   Can be used to handle IP addresses differentlt based on the date and time
 
-.. classmethod:: TimedIPSetRule:add(address, seconds)
+  .. method:: TimedIPSetRule:add(address, seconds)
 
-  Add an IP address to the set for the next ``second`` seconds.
+    Add an IP address to the set for the next ``second`` seconds.
 
-  :param ComboAddress address: The address to add
-  :param int seconds: Time to keep the address in the Rule
+    :param ComboAddress address: The address to add
+    :param int seconds: Time to keep the address in the Rule
 
-.. classmethod:: TimedIPSetRule:cleanup()
+  .. method:: TimedIPSetRule:cleanup()
 
-  Purge the set from expired IP addresses
+    Purge the set from expired IP addresses
 
-.. classmethod:: TimedIPSetRule:clear()
+  .. method:: TimedIPSetRule:clear()
 
-  Clear the entire set
+    Clear the entire set
 
-.. classmethod:: TimedIPSetRule:slice()
+  .. method:: TimedIPSetRule:slice()
 
-  Convert the TimedIPSetRule into a DNSRule that can be passed to :func:`addAction`
+    Convert the TimedIPSetRule into a DNSRule that can be passed to :func:`addAction`
 
 A working example:
 

--- a/pdns/dnsdistdist/docs/reference/comboaddress.rst
+++ b/pdns/dnsdistdist/docs/reference/comboaddress.rst
@@ -3,12 +3,8 @@
 ComboAddress
 ============
 
-.. class:: ComboAddress
-
-  A ``ComboAddress`` represents an IP address with possibly a port number.
-  The object can be an IPv4 or an IPv6 address.
-
-Functions and methods related to ``ComboAddress``
+IP addresses are moved around in a native format, called a ComboAddress.
+ComboAddresses can be IPv4 or IPv6, and unless you want to know, you don't need to.
 
 .. function:: newCA(address) -> :class:`ComboAddress`
 
@@ -16,40 +12,46 @@ Functions and methods related to ``ComboAddress``
 
   :param string address: The IP address, with optional port, to represent.
 
-.. classmethod:: ComboAddress:getPort() -> int
+.. class:: ComboAddress
 
-  Returns the port number.
+  A ``ComboAddress`` represents an IP address with possibly a port number.
+  The object can be an IPv4 or an IPv6 address.
+  It has these methods:
 
-.. classmethod:: ComboAddress:isIPv4() -> bool
+  .. method:: ComboAddress:getPort() -> int
 
-  Returns true if the address is an IPv4, false otherwise
+    Returns the port number.
 
-.. classmethod:: ComboAddress:isIPv6() -> bool
+  .. method:: ComboAddress:isIPv4() -> bool
 
-  Returns true if the address is an IPv6, false otherwise
+    Returns true if the address is an IPv4, false otherwise
 
-.. classmethod:: ComboAddress:isMappedIPv4() -> bool
+  .. method:: ComboAddress:isIPv6() -> bool
 
-  Returns true if the address is an IPv4 mapped into an IPv6, false otherwise
+    Returns true if the address is an IPv6, false otherwise
 
-.. classmethod:: ComboAddress:mapToIPv4() -> ComboAddress
+  .. method:: ComboAddress:isMappedIPv4() -> bool
 
-  Convert an IPv4 address mapped in a v6 one into an IPv4.
-  Returns a new ComboAddress
+    Returns true if the address is an IPv4 mapped into an IPv6, false otherwise
 
-.. classmethod:: ComboAddress:tostring() -> string
-                 ComboAddress:toString() -> string
+  .. method:: ComboAddress:mapToIPv4() -> ComboAddress
 
-  Returns in human-friendly format
+    Convert an IPv4 address mapped in a v6 one into an IPv4.
+    Returns a new ComboAddress
 
-.. classmethod:: ComboAddress:tostringWithPort() -> string
-                 ComboAddress:toStringWithPort() -> string
+  .. method:: ComboAddress:tostring() -> string
+                   ComboAddress:toString() -> string
 
-  Returns in human-friendly format, with port number
+    Returns in human-friendly format
 
-.. classmethod:: ComboAddress:truncate(bits)
+  .. method:: ComboAddress:tostringWithPort() -> string
+                   ComboAddress:toStringWithPort() -> string
 
-  Truncate the ComboAddress to the specified number of bits.
-  This essentially zeroes all bits after ``bits``.
+    Returns in human-friendly format, with port number
 
-  :param int bits: Amount of bits to truncate to
+  .. method:: ComboAddress:truncate(bits)
+
+    Truncate the ComboAddress to the specified number of bits.
+    This essentially zeroes all bits after ``bits``.
+
+    :param int bits: Amount of bits to truncate to

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -302,86 +302,85 @@ A server object returned by :func:`getServer` can be manipulated with these func
 
   This object represents a backend server. It has several methods.
 
-.. classmethod:: Server:addPool(pool)
+  .. method:: Server:addPool(pool)
 
-  Add this server to a pool.
+    Add this server to a pool.
 
-  :param str pool: The pool to add the server to
+    :param str pool: The pool to add the server to
 
-.. classmethod:: Server:getName() -> string
+  .. method:: Server:getName() -> string
 
-  Get the name of this server.
+    Get the name of this server.
 
-  :returns: The name of the server, or an empty string if it does not have one
+    :returns: The name of the server, or an empty string if it does not have one
 
-.. classmethod:: Server:getNameWithAddr() -> string
+  .. method:: Server:getNameWithAddr() -> string
 
-  Get the name plus IP address and port of the server
+    Get the name plus IP address and port of the server
 
-  :returns: A string containing the server name if any plus the server address and port
+    :returns: A string containing the server name if any plus the server address and port
 
-.. classmethod:: Server:getOutstanding() -> int
+  .. method:: Server:getOutstanding() -> int
 
-  Get the number of outstanding queries for this server.
+    Get the number of outstanding queries for this server.
 
-  :returns: The number of outstanding queries
+    :returns: The number of outstanding queries
 
-.. classmethod:: Server:isUp() -> bool
+  .. method:: Server:isUp() -> bool
 
-  Returns the up status of the server
+    Returns the up status of the server
 
-  :returns: true when the server is up, false otherwise
+    :returns: true when the server is up, false otherwise
 
-.. classmethod:: Server:rmPool(pool)
+  .. method:: Server:rmPool(pool)
 
-  Removes the server from the named pool
+    Removes the server from the named pool
 
-  :param str pool: The pool to remove the server from
+    :param str pool: The pool to remove the server from
 
-.. classmethod:: Server:setAuto([status])
+  .. method:: Server:setAuto([status])
 
-.. versionchanged:: 1.3.0
-    ``status`` optional parameter added.
+    .. versionchanged:: 1.3.0
+        ``status`` optional parameter added.
 
-  Set the server in the default auto state.
-  This will enable health check queries that will set the server ``up`` and ``down`` appropriately.
+    Set the server in the default auto state.
+    This will enable health check queries that will set the server ``up`` and ``down`` appropriately.
 
-  :param bool status: Set the initial status of the server to ``up`` (true) or ``down`` (false) instead of using the last known status
+    :param bool status: Set the initial status of the server to ``up`` (true) or ``down`` (false) instead of using the last known status
 
-.. classmethod:: Server:setQPS(limit)
+  .. method:: Server:setQPS(limit)
 
-  Limit the queries per second for this server.
+    Limit the queries per second for this server.
 
-  :param int limit: The maximum number of queries per second
+    :param int limit: The maximum number of queries per second
 
-.. classmethod:: Server:setDown()
+  .. method:: Server:setDown()
 
-  Set the server in an ``DOWN`` state.
-  The server will not receive queries and the health checks are disabled
+    Set the server in an ``DOWN`` state.
+    The server will not receive queries and the health checks are disabled
 
-.. classmethod:: Server:setUp()
+  .. method:: Server:setUp()
 
-  Set the server in an ``UP`` state.
-  This server will still receive queries and health checks are disabled
+    Set the server in an ``UP`` state.
+    This server will still receive queries and health checks are disabled
 
-Attributes
-~~~~~~~~~~
+  Apart from the functions, a :class:`Server` object has these attributes:
 
-.. attribute:: Server.name
+  .. attribute:: Server.name
 
-  The name of the server
+    The name of the server
 
-.. attribute:: Server.upStatus
+  .. attribute:: Server.upStatus
 
-  Whether or not this server is up or down
+    Whether or not this server is up or down
 
-.. attribute:: Server.order
+  .. attribute:: Server.order
 
-  The order of the server
+    The order of the server
 
-.. attribute:: Server.weight
+  .. attribute:: Server.weight
 
-  The weight of the server
+    The weight of the server
 
 Pools
 -----
@@ -417,19 +416,19 @@ Pools are automatically created when a server is added to a pool (with :func:`ne
 
   This represents the pool where zero or more servers are part of.
 
-.. classmethod:: ServerPool:getCache() -> PacketCache
+  .. method:: ServerPool:getCache() -> PacketCache
 
-  Returns the :class:`PacketCache` for this pool or nil.
+    Returns the :class:`PacketCache` for this pool or nil.
 
-.. classmethod:: ServerPool:setCache(cache)
+  .. method:: ServerPool:setCache(cache)
 
-  Adds ``cache`` as the pool's cache.
+    Adds ``cache`` as the pool's cache.
 
-  :param PacketCache cache: The new cache to add to the pool
+    :param PacketCache cache: The new cache to add to the pool
 
-.. classmethod:: ServerPool:unsetCache()
+  .. method:: ServerPool:unsetCache()
 
-  Removes the cache from this pool.
+    Removes the cache from this pool.
 
 PacketCache
 ~~~~~~~~~~~
@@ -457,40 +456,40 @@ See :doc:`../guides/cache` for a how to.
 
   Represents a cache that can be part of :class:`ServerPool`.
 
-.. classmethod:: PacketCache:expunge(n)
+  .. method:: PacketCache:expunge(n)
 
-  Remove entries from the cache, leaving at most ``n`` entries
+    Remove entries from the cache, leaving at most ``n`` entries
 
-  :param int n: Number of entries to keep
+    :param int n: Number of entries to keep
 
-.. classmethod:: PacketCache:expungeByName(name [, qtype=dnsdist.ANY[, suffixMatch=false]])
+  .. method:: PacketCache:expungeByName(name [, qtype=dnsdist.ANY[, suffixMatch=false]])
 
-  .. versionchanged:: 1.2.0
-    ``suffixMatch`` parameter added.
+    .. versionchanged:: 1.2.0
+      ``suffixMatch`` parameter added.
 
-  Remove entries matching ``name`` and type from the cache.
+    Remove entries matching ``name`` and type from the cache.
 
-  :param DNSName name: The name to expunge
-  :param int qtype: The type to expunge
-  :param bool suffixMatch: When set to true, remove al entries under ``name``
+    :param DNSName name: The name to expunge
+    :param int qtype: The type to expunge
+    :param bool suffixMatch: When set to true, remove al entries under ``name``
 
-.. classmethod:: PacketCache:isFull() -> bool
+  .. method:: PacketCache:isFull() -> bool
 
-  Return true if the cache has reached the maximum number of entries.
+    Return true if the cache has reached the maximum number of entries.
 
-.. classmethod:: PacketCache:printStats()
+  .. method:: PacketCache:printStats()
 
-  Print the cache stats (hits, misses, deferred lookups and deferred inserts).
+    Print the cache stats (hits, misses, deferred lookups and deferred inserts).
 
-.. classmethod:: PacketCache:purgeExpired(n)
+  .. method:: PacketCache:purgeExpired(n)
 
-  Remove expired entries from the cache until there is at most ``n`` entries remaining in the cache.
+    Remove expired entries from the cache until there is at most ``n`` entries remaining in the cache.
 
-  :param int n: Number of entries to keep
+    :param int n: Number of entries to keep
 
-.. classmethod:: PacketCache:toString() -> string
+  .. method:: PacketCache:toString() -> string
 
-  Return the number of entries in the Packet Cache, and the maximum number of entries
+    Return the number of entries in the Packet Cache, and the maximum number of entries
 
 Client State
 ------------
@@ -499,7 +498,7 @@ Also called frontend or bind, the Client State object returned by :func:`getBind
 
 .. function:: getBind(index) -> ClientState
 
-  Return a ClientState object.
+  Return a :class:`ClientState` object.
 
   :param int index: The object index
 
@@ -510,34 +509,25 @@ ClientState functions
 
   This object represents an address and port dnsdist is listening on. When ``reuseport`` is in use, several ClientState objects can be present for the same address and port.
 
-.. classmethod:: Server:addPool(pool)
+  .. method:: ClientState:attachFilter(filter)
 
-  Add this server to a pool.
+     Attach a BPF filter to this frontend.
 
-  :param str pool: The pool to add the server to
+     :param BPFFilter filter: The filter to attach to this frontend
 
-.. classmethod:: ClientState:attachFilter(filter)
+  .. method:: ClientState:detachFilter()
 
-   Attach a BPF filter to this frontend.
+     Remove the BPF filter associated to this frontend, if any.
 
-   :param BPFFilter filter: The filter to attach to this frontend
+  .. method:: ClientState:toString() -> string
 
-.. classmethod:: ClientState:detachFilter()
+    Return the address and port this frontend is listening on.
 
-   Remove the BPF filter associated to this frontend, if any.
+    :returns: The address and port this frontend is listening on
 
-.. classmethod:: ClientState:toString() -> string
+  .. attribute:: ClientState.muted
 
-  Return the address and port this frontend is listening on.
-
-  :returns: The address and port this frontend is listening on
-
-Attributes
-~~~~~~~~~~
-
-.. attribute:: ClientState.muted
-
-  If set to true, queries received on this frontend will be normally processed and sent to a backend if needed, but no response will be ever be sent to the client over UDP. TCP queries are processed normally and responses sent to the client.
+    If set to true, queries received on this frontend will be normally processed and sent to a backend if needed, but no response will be ever be sent to the client over UDP. TCP queries are processed normally and responses sent to the client.
 
 Status, Statistics and More
 ---------------------------
@@ -547,6 +537,7 @@ Status, Statistics and More
   Print all statistics dnsdist gathers
 
 .. function:: getTLSContext(idx)
+
   .. versionadded:: 1.3.0
 
   Return the TLSContext object for the context of index ``idx``.
@@ -601,6 +592,7 @@ Status, Statistics and More
   Show some statistics regarding TCP
 
 .. function:: showTLSContexts()
+
   .. versionadded:: 1.3.0
 
   Print the list of all availables DNS over TLS contexts.
@@ -731,16 +723,17 @@ TLSContext
 ~~~~~~~~~~
 
 .. class:: TLSContext
+
   .. versionadded:: 1.3.0
 
   This object represents an address and port dnsdist is listening on for DNS over TLS queries.
 
-.. classmethod:: TLSContext:rotateTicketsKey()
+  .. method:: TLSContext:rotateTicketsKey()
 
-   Replace the current TLS tickets key by a new random one.
+     Replace the current TLS tickets key by a new random one.
 
-.. classmethod:: TLSContext:loadTicketsKeys(ticketsKeysFile)
+  .. method:: TLSContext:loadTicketsKeys(ticketsKeysFile)
 
-   Load new tickets keys from the selected file, replacing the existing ones. These keys should be rotated often and never written to persistent storage to preserve forward secrecy. The default is to generate a random key. The OpenSSL provider supports several tickets keys to be able to decrypt existing sessions after the rotation, while the GnuTLS provider only supports one key.
+     Load new tickets keys from the selected file, replacing the existing ones. These keys should be rotated often and never written to persistent storage to preserve forward secrecy. The default is to generate a random key. The OpenSSL provider supports several tickets keys to be able to decrypt existing sessions after the rotation, while the GnuTLS provider only supports one key.
 
-  :param str ticketsKeysFile: The path to a file from where TLS tickets keys should be loaded.
+    :param str ticketsKeysFile: The path to a file from where TLS tickets keys should be loaded.

--- a/pdns/dnsdistdist/docs/reference/dnscrypt.rst
+++ b/pdns/dnsdistdist/docs/reference/dnscrypt.rst
@@ -58,41 +58,41 @@ Certificates
 
   Represents a DNSCrypt certificate.
 
-.. classmethod:: DNSCryptCert:getClientMagic() -> string
+  .. method:: DNSCryptCert:getClientMagic() -> string
 
-  Return this certificate's client magic value.
+    Return this certificate's client magic value.
 
-.. classmethod:: DNSCryptCert:getEsVersion() -> string
+  .. method:: DNSCryptCert:getEsVersion() -> string
 
-  Return the cryptographic construction to use with this certificate,.
+    Return the cryptographic construction to use with this certificate,.
 
-.. classmethod:: DNSCryptCert:getMagic() -> string
+  .. method:: DNSCryptCert:getMagic() -> string
 
-  Return the certificate magic number.
+    Return the certificate magic number.
 
-.. classmethod:: DNSCryptCert:getProtocolMinorVersion() -> string
+  .. method:: DNSCryptCert:getProtocolMinorVersion() -> string
 
-  Return this certificate's minor version.
+    Return this certificate's minor version.
 
-.. classmethod:: DNSCryptCert:getResolverPublicKey() -> string
+  .. method:: DNSCryptCert:getResolverPublicKey() -> string
 
-  Return the public key corresponding to this certificate.
+    Return the public key corresponding to this certificate.
 
-.. classmethod:: DNSCryptCert:getSerial() -> int
+  .. method:: DNSCryptCert:getSerial() -> int
 
-  Return the certificate serial number.
+    Return the certificate serial number.
 
-.. classmethod:: DNSCryptCert:getSignature() -> string
+  .. method:: DNSCryptCert:getSignature() -> string
 
-  Return this certificate's signature.
+    Return this certificate's signature.
 
-.. classmethod:: DNSCryptCert:getTSEnd() -> int
+  .. method:: DNSCryptCert:getTSEnd() -> int
 
-  Return the date the certificate is valid from, as a Unix timestamp.
+    Return the date the certificate is valid from, as a Unix timestamp.
 
-.. classmethod:: DNSCryptCert:getTSStart() -> int
+  .. method:: DNSCryptCert:getTSStart() -> int
 
-  Return the date the certificate is valid until (inclusive), as a Unix timestamp
+    Return the date the certificate is valid until (inclusive), as a Unix timestamp
 
 Context
 -------
@@ -101,34 +101,34 @@ Context
 
   Represents a DNSCrypt content. Can be used to rotate certs.
 
-.. classmethod:: DNSCryptContext:generateAndLoadInMemoryCertificate(keyfile, serial, begin, end)
+  .. method:: DNSCryptContext:generateAndLoadInMemoryCertificate(keyfile, serial, begin, end)
 
-  Generate a new resolver key and the associated certificate in-memory, sign it with the provided provider key, and use the new certificate
+    Generate a new resolver key and the associated certificate in-memory, sign it with the provided provider key, and use the new certificate
 
-  :param string keyfile: Path to the key file to use
-  :param int serial: The serial number of the certificate
-  :param int begin: Unix timestamp from when the certificate is valid
-  :param int end: Unix timestamp from until the certificate is valid
+    :param string keyfile: Path to the key file to use
+    :param int serial: The serial number of the certificate
+    :param int begin: Unix timestamp from when the certificate is valid
+    :param int end: Unix timestamp from until the certificate is valid
 
-.. classmethod:: DNSCryptContext:getCurrentCertificate() -> DNSCryptCert
+  .. method:: DNSCryptContext:getCurrentCertificate() -> DNSCryptCert
 
-  Return the current certificate.
+    Return the current certificate.
 
-.. classmethod:: DNSCryptContext:getOldCertificate() -> DNSCryptCert
+  .. method:: DNSCryptContext:getOldCertificate() -> DNSCryptCert
 
-  Return the previous certificate.
+    Return the previous certificate.
 
-.. classmethod:: DNSCryptContext:getProviderName() -> string
+  .. method:: DNSCryptContext:getProviderName() -> string
 
-  Return the provider name
+    Return the provider name
 
-.. classmethod:: DNSCryptContext:hasOldCertificate() -> bool
+  .. method:: DNSCryptContext:hasOldCertificate() -> bool
 
-  Whether or not the context has a previous certificate, from a certificate rotation.
+    Whether or not the context has a previous certificate, from a certificate rotation.
 
-.. classmethod:: DNSCryptContext:loadNewCertificate(certificate, keyfile)
+  .. method:: DNSCryptContext:loadNewCertificate(certificate, keyfile)
 
-  Load a new certificate and the corresponding private key, and use it
+    Load a new certificate and the corresponding private key, and use it
 
-  :param string certificate: Path to a certificate file
-  :param string keyfile: Path to a the corresponding key file
+    :param string certificate: Path to a certificate file
+    :param string keyfile: Path to a the corresponding key file

--- a/pdns/dnsdistdist/docs/reference/dnsname.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsname.rst
@@ -3,11 +3,7 @@
 DNSName objects
 ===============
 
-.. class:: DNSName
-
-  A ``DNSName`` object represents a name in the DNS.
-  It is returned by several functions and has several functions to programmatically interact with it.
-
+A :class:`DNSName` object represents a name in the DNS. It has serveral functions that can manipulate it without conversions to strings.
 Creating a ``DNSName`` is done with the :func:`newDNSName`::
 
   myname = newDNSName("www.example.com")
@@ -25,7 +21,6 @@ The ``myname`` variable has several functions to get information from it
     print('it is')
   end
 
-
 Functions and methods of a ``DNSName``
 --------------------------------------
 
@@ -35,28 +30,33 @@ Functions and methods of a ``DNSName``
 
   :param string name: The name to create a DNSName for
 
-.. classmethod:: DNSName::chopoff() -> bool
+.. class:: DNSName
 
-  .. versionadded:: 1.2.0
+  A ``DNSName`` object represents a name in the DNS.
+  It is returned by several functions and has several functions to programmatically interact with it.
 
-  Removes the left-most label and returns ``true``.
-  ``false`` is returned if no label was removed
+  .. method:: DNSName:chopoff() -> bool
 
-.. classmethod:: DNSName:countLabels() -> int
+    .. versionadded:: 1.2.0
 
-  Returns the number of DNSLabels in the name
+    Removes the left-most label and returns ``true``.
+    ``false`` is returned if no label was removed
 
-.. classmethod:: DNSName:isPartOf(name) -> bool
+  .. method:: DNSName:countLabels() -> int
 
-  Returns true if the DNSName is part of the DNS tree of ``name``.
+    Returns the number of DNSLabels in the name
 
-  :param DNSName name: The name to check against
+  .. method:: DNSName:isPartOf(name) -> bool
 
-.. classmethod:: DNSName:toString() -> string
-                 DNSName:tostring() -> string
+    Returns true if the DNSName is part of the DNS tree of ``name``.
 
-  Returns a human-readable form of the DNSName.
+    :param DNSName name: The name to check against
 
-.. classmethod:: DNSName:wirelength -> int
+  .. method:: DNSName:toString() -> string
+              DNSName:tostring() -> string
 
-  Returns the length in bytes of the DNSName as it would be on the wire.
+    Returns a human-readable form of the DNSName.
+
+  .. method:: DNSName:wirelength() -> int
+
+    Returns the length in bytes of the DNSName as it would be on the wire.

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -7,124 +7,124 @@ A DNSQuestion or ``dq`` object is available in several hooks and Lua actions.
 This object contains details about the current state of the question.
 This state can be modified from the various hooks.
 
-The DNSQuestion object has several attributes, many of them read-only:
-
 .. class:: DNSQuestion
 
-.. attribute:: DNSQuestion.dh
+  The DNSQuestion object has several attributes, many of them read-only:
 
-  The :ref:`DNSHeader` of this query.
+  .. attribute:: DNSQuestion.dh
 
-.. attribute:: DNSQuestion.ecsOverride
+    The :ref:`DNSHeader` of this query.
 
-  Whether an existing ECS value should be overridden, settable.
+  .. attribute:: DNSQuestion.ecsOverride
 
-.. attribute:: DNSQuestion.ecsPrefixLength
+    Whether an existing ECS value should be overridden, settable.
 
-   The ECS prefix length to use, settable.
+  .. attribute:: DNSQuestion.ecsPrefixLength
 
-.. attribute:: DNSQuestion.len
+     The ECS prefix length to use, settable.
 
-  The length of the :attr:`qname <DNSQuestion.qname>`.
+  .. attribute:: DNSQuestion.len
 
-.. attribute:: DNSQuestion.localaddr
+    The length of the :attr:`qname <DNSQuestion.qname>`.
 
-  :ref:`ComboAddress` of the local bind this question was received on.
+  .. attribute:: DNSQuestion.localaddr
 
-.. attribute:: DNSQuestion.opcode
+    :ref:`ComboAddress` of the local bind this question was received on.
 
-  Integer describing the OPCODE of the packet. Can be matched against :ref:`DNSOpcode`.
+  .. attribute:: DNSQuestion.opcode
 
-.. attribute:: DNSQuestion.qclass
+    Integer describing the OPCODE of the packet. Can be matched against :ref:`DNSOpcode`.
 
-  QClass (as an unsigned integer) of this question.
-  Can be compared against :ref:`DNSQClass`.
+  .. attribute:: DNSQuestion.qclass
 
-.. attribute:: DNSQuestion.qname
+    QClass (as an unsigned integer) of this question.
+    Can be compared against :ref:`DNSQClass`.
 
-  :class:`DNSName` of this question.
+  .. attribute:: DNSQuestion.qname
 
-.. attribute:: DNSQuestion.qtype
+    :class:`DNSName` of this question.
 
-  QType (as an unsigned integer) of this question.
-  Can be compared against ``dnsdist.A``, ``dnsdist.AAAA`` etc.
+  .. attribute:: DNSQuestion.qtype
 
-.. attribute:: DNSQuestion.remoteaddr
+    QType (as an unsigned integer) of this question.
+    Can be compared against ``dnsdist.A``, ``dnsdist.AAAA`` etc.
 
-  :ref:`ComboAddress` of the remote client.
+  .. attribute:: DNSQuestion.remoteaddr
 
-.. attribute:: DNSQuestion.rcode
+    :ref:`ComboAddress` of the remote client.
 
-  RCode (as an unsigned integer) of this question.
-  Can be compared against :ref:`DNSRCode`
+  .. attribute:: DNSQuestion.rcode
 
-.. attribute:: DNSQuestion.size
+    RCode (as an unsigned integer) of this question.
+    Can be compared against :ref:`DNSRCode`
 
-  The total size of the buffer starting at :attr:`DNSQuestion.dh`.
+  .. attribute:: DNSQuestion.size
 
-.. attribute:: DNSQuestion.skipCache
+    The total size of the buffer starting at :attr:`DNSQuestion.dh`.
 
-  Whether to skip cache lookup / storing the answer for this question, settable.
+  .. attribute:: DNSQuestion.skipCache
 
-.. attribute:: DNSQuestion.tcp
+    Whether to skip cache lookup / storing the answer for this question, settable.
 
-  Whether the query have been received over TCP.
+  .. attribute:: DNSQuestion.tcp
 
-.. attribute:: DNSQuestion.useECS
+    Whether the query have been received over TCP.
 
-  Whether to send ECS to the backend, settable.
+  .. attribute:: DNSQuestion.useECS
 
-It also supports the following methods:
+    Whether to send ECS to the backend, settable.
 
-.. classmethod:: DNSQuestion:getDO() -> bool
+  It also supports the following methods:
 
-  .. versionadded:: 1.2.0
+  .. method:: DNSQuestion:getDO() -> bool
 
-  Get the value of the DNSSEC OK bit.
+    .. versionadded:: 1.2.0
 
-  :returns: true if the DO bit was set, false otherwise
+    Get the value of the DNSSEC OK bit.
 
-.. classmethod:: DNSQuestion:getTag(key) -> string
+    :returns: true if the DO bit was set, false otherwise
 
-  .. versionadded:: 1.2.0
+  .. method:: DNSQuestion:getTag(key) -> string
 
-  Get the value of a tag stored into the DNSQuestion object.
+    .. versionadded:: 1.2.0
 
-  :param string key: The tag's key
-  :returns: A table of tags, using strings as keys and values
+    Get the value of a tag stored into the DNSQuestion object.
 
-.. classmethod:: DNSQuestion:getTagArray() -> table
+    :param string key: The tag's key
+    :returns: A table of tags, using strings as keys and values
 
-  .. versionadded:: 1.2.0
+  .. method:: DNSQuestion:getTagArray() -> table
 
-  Get all the tags stored into the DNSQuestion object.
+    .. versionadded:: 1.2.0
 
-  :returns: The tag's value if it was set, an empty string otherwise
+    Get all the tags stored into the DNSQuestion object.
 
-.. classmethod:: DNSQuestion:sendTrap(reason)
+    :returns: The tag's value if it was set, an empty string otherwise
 
-  .. versionadded:: 1.2.0
+  .. method:: DNSQuestion:sendTrap(reason)
 
-  Send an SNMP trap.
+    .. versionadded:: 1.2.0
 
-  :param string reason: An optional string describing the reason why this trap was sent
+    Send an SNMP trap.
 
-.. classmethod:: DNSQuestion:setTag(key, value)
+    :param string reason: An optional string describing the reason why this trap was sent
 
-  .. versionadded:: 1.2.0
+  .. method:: DNSQuestion:setTag(key, value)
 
-  Set a tag into the DNSQuestion object.
+    .. versionadded:: 1.2.0
 
-  :param string key: The tag's key
-  :param string value: The tag's value
+    Set a tag into the DNSQuestion object.
 
-.. classmethod:: DNSQuestion:setTagArray(tags)
+    :param string key: The tag's key
+    :param string value: The tag's value
 
-  .. versionadded:: 1.2.0
+  .. method:: DNSQuestion:setTagArray(tags)
 
-  Set an array of tags into the DNSQuestion object.
+    .. versionadded:: 1.2.0
 
-  :param table tags: A table of tags, using strings as keys and values
+    Set an array of tags into the DNSQuestion object.
+
+    :param table tags: A table of tags, using strings as keys and values
 
 .. _DNSResponse:
 
@@ -135,23 +135,23 @@ DNSResponse object
 
   This object has all the functions and members of a :ref:`DNSQuestion <DNSQuestion>` and some more
 
-.. classmethod:: DNSResponse:editTTLs(func)
+  .. method:: DNSResponse:editTTLs(func)
 
-  The function ``func`` is invoked for every entry in the answer, authority and additional section.
+    The function ``func`` is invoked for every entry in the answer, authority and additional section.
 
-  ``func`` points to a function with the following prototype: ``myFunc(section, qclass, qtype, ttl)``
+    ``func`` points to a function with the following prototype: ``myFunc(section, qclass, qtype, ttl)``
 
-  All parameters to ``func`` are integers:
+    All parameters to ``func`` are integers:
 
-  - ``section`` is the section in the packet and can be compared to :ref:`DNSSection`
-  - ``qclass`` is the QClass of the record. Can be compared to :ref:`DNSQClass`
-  - ``qtype`` is the QType of the record. Can be e.g. compared to ``dnsdist.A``, ``dnsdist.AAAA`` and the like.
-  - ``ttl`` is the current TTL
+    - ``section`` is the section in the packet and can be compared to :ref:`DNSSection`
+    - ``qclass`` is the QClass of the record. Can be compared to :ref:`DNSQClass`
+    - ``qtype`` is the QType of the record. Can be e.g. compared to ``dnsdist.A``, ``dnsdist.AAAA`` and the like.
+    - ``ttl`` is the current TTL
 
-  This function must return an integer with the new TTL.
-  Setting this TTL to 0 to leaves it unchanged
+    This function must return an integer with the new TTL.
+    Setting this TTL to 0 to leaves it unchanged
 
-  :param string func: The function to call to edit TTLs.
+    :param string func: The function to call to edit TTLs.
 
 .. _DNSHeader:
 
@@ -162,35 +162,35 @@ DNSHeader (``dh``) object
 
   This object holds a representation of a DNS packet's header.
 
-.. classmethod:: DNSHeader:getRD() -> bool
+  .. method:: DNSHeader:getRD() -> bool
 
-  Get recursion desired flag.
+    Get recursion desired flag.
 
-.. classmethod:: DNSHeader:setRD(rd)
+  .. method:: DNSHeader:setRD(rd)
 
-  Set recursion desired flag.
+    Set recursion desired flag.
 
-  :param bool rd: State of the RD flag
+    :param bool rd: State of the RD flag
 
-.. classmethod:: DNSHeader:setTC(tc)
+  .. method:: DNSHeader:setTC(tc)
 
-  Set truncation flag (TC).
+    Set truncation flag (TC).
 
-  :param bool tc: State of the TC flag
+    :param bool tc: State of the TC flag
 
-.. classmethod:: DNSHeader:setQR(qr)
+  .. method:: DNSHeader:setQR(qr)
 
-  Set Query/Response flag.
-  Setting QR to true means "This is an answer packet".
+    Set Query/Response flag.
+    Setting QR to true means "This is an answer packet".
 
-  :param bool qr: State of the QR flag
+    :param bool qr: State of the QR flag
 
-.. classmethod:: DNSHeader:getCD() -> bool
+  .. method:: DNSHeader:getCD() -> bool
 
-  Get checking disabled flag.
+    Get checking disabled flag.
 
-.. classmethod:: DNSHeader:setCD(cd)
+  .. method:: DNSHeader:setCD(cd)
 
-  Set checking disabled flag.
+    Set checking disabled flag.
 
-  :param bool cd: State of the CD flag
+    :param bool cd: State of the CD flag

--- a/pdns/dnsdistdist/docs/reference/ebpf.rst
+++ b/pdns/dnsdistdist/docs/reference/ebpf.rst
@@ -48,47 +48,46 @@ These are all the functions, objects and methods related to the :doc:`../advance
 
   Represents an eBPF filter
 
-.. classmethod:: BPFFilter:attachToAllBinds()
+  .. method:: BPFFilter:attachToAllBinds()
 
-  Attach this filter to every bind already defined.
-  This is the run-time equivalent of :func:`setDefaultBPFFilter`
+    Attach this filter to every bind already defined.
+    This is the run-time equivalent of :func:`setDefaultBPFFilter`
 
-.. classmethod:: BPFFilter:block(address)
+  .. method:: BPFFilter:block(address)
 
-  Block this address
+    Block this address
 
-  :param ComboAddress address: The address to block
+    :param ComboAddress address: The address to block
 
-.. classmethod:: BPFFilter:blockQName(name [, qtype=255])
+  .. method:: BPFFilter:blockQName(name [, qtype=255])
 
-  Block queries for this exact qname. An optional qtype can be used, defaults to 255.
+    Block queries for this exact qname. An optional qtype can be used, defaults to 255.
 
-  :param DNSName name: The name to block
-  :param int qtype: QType to block
+    :param DNSName name: The name to block
+    :param int qtype: QType to block
 
-.. classmethod:: BPFFilter:getStats()
+  .. method:: BPFFilter:getStats()
 
-  Print the block tables.
+    Print the block tables.
 
-.. classmethod:: BPFFilter:unblock(address)
+  .. method:: BPFFilter:purgeExpired()
 
-  Unblock this address.
+    Remove the expired ephemeral rules associated with this filter.
 
-  :param ComboAddress address: The address to unblock
+  .. method:: BPFFilter:unblock(address)
 
-.. classmethod:: BPFFilter:unblockQName(name [, qtype=255])
+    Unblock this address.
 
-  Remove this qname from the block list.
+    :param ComboAddress address: The address to unblock
 
-  :param DNSName name: the name to unblock
-  :param int qtype: The qtype to unblock
+  .. method:: BPFFilter:unblockQName(name [, qtype=255])
+
+    Remove this qname from the block list.
+
+    :param DNSName name: the name to unblock
+    :param int qtype: The qtype to unblock
 
 .. class:: DynBPFFilter
 
   Represents an dynamic eBPF filter, allowing the use of ephemeral rules to an existing eBPF filter.
-
-.. classmethod:: BPFFilter:purgeExpired()
-
-  Remove the expired ephemeral rules associated with this filter.
-
 

--- a/pdns/dnsdistdist/docs/reference/netmaskgroup.rst
+++ b/pdns/dnsdistdist/docs/reference/netmaskgroup.rst
@@ -1,32 +1,32 @@
 NetmaskGroup
 ============
 
-.. class:: NetmaskGroup
-
-   Represents a group of netmasks that can be used to match :class:`ComboAddress`\ es against.
-
 .. function:: newNMG() -> NetmaskGroup
 
   Returns a NetmaskGroup
 
-.. classmethod:: NetmaskGroup:addMask(mask)
-                 NetmaskGroup:addMask(masks)
+.. class:: NetmaskGroup
 
-  Add one or more masks to the NMG.
+   Represents a group of netmasks that can be used to match :class:`ComboAddress`\ es against.
 
-  :param string mask: Add this mask, prefix with `!` to exclude this mask from matching.
-  :param table masks: Adds the keys of the table to the :class:`NetmaskGroup`. It should be a table whose keys are :class:`ComboAddress` objects and values are integers, as returned by `exceed*` functions.
+  .. method:: NetmaskGroup:addMask(mask)
+              NetmaskGroup:addMask(masks)
 
-.. classmethod:: NetmaskGroup:match(address) -> bool
+    Add one or more masks to the NMG.
 
-  Checks if ``address`` is matched by this NetmaskGroup.
+    :param string mask: Add this mask, prefix with `!` to exclude this mask from matching.
+    :param table masks: Adds the keys of the table to the :class:`NetmaskGroup`. It should be a table whose keys are :class:`ComboAddress` objects and values are integers, as returned by `exceed*` functions.
 
-  :param ComboAddress address: The address to match.
+  .. method:: NetmaskGroup:match(address) -> bool
 
-.. classmethod:: NetmaskGroup:clear()
+    Checks if ``address`` is matched by this NetmaskGroup.
 
-  Clears the NetmaskGroup.
+    :param ComboAddress address: The address to match.
 
-.. classmethod:: NetmaskGroup:size() -> int
+  .. method:: NetmaskGroup:clear()
 
-  Returns number of netmasks in this NetmaskGroup.
+    Clears the NetmaskGroup.
+
+  .. method:: NetmaskGroup:size() -> int
+
+    Returns number of netmasks in this NetmaskGroup.

--- a/pdns/dnsdistdist/docs/reference/protobuf.rst
+++ b/pdns/dnsdistdist/docs/reference/protobuf.rst
@@ -14,107 +14,107 @@ Protobuf Logging Reference
 
   This object represents a single protobuf message as emitted by :program:`dnsdist`.
 
-.. classmethod:: DNSDistProtoBufMessage:addResponseRR(name, type, class, ttl, blob)
+  .. method:: DNSDistProtoBufMessage:addResponseRR(name, type, class, ttl, blob)
 
-  .. versionadded:: 1.2.0
+    .. versionadded:: 1.2.0
 
-  Add a response RR to the protobuf message.
+    Add a response RR to the protobuf message.
 
-  :param string name: The RR name.
-  :param int type: The RR type.
-  :param int class: The RR class.
-  :param int ttl: The RR TTL.
-  :param string blob: The RR binary content.
+    :param string name: The RR name.
+    :param int type: The RR type.
+    :param int class: The RR class.
+    :param int ttl: The RR TTL.
+    :param string blob: The RR binary content.
 
-.. classmethod:: DNSDistProtoBufMessage:setBytes(bytes)
+  .. method:: DNSDistProtoBufMessage:setBytes(bytes)
 
-  Set the size of the query
+    Set the size of the query
 
-  :param int bytes: Number of bytes in the query.
+    :param int bytes: Number of bytes in the query.
 
-.. classmethod:: DNSDistProtoBufMessage:setEDNSSubnet(netmask)
+  .. method:: DNSDistProtoBufMessage:setEDNSSubnet(netmask)
 
-  Set the EDNS Subnet to ``netmask``.
+    Set the EDNS Subnet to ``netmask``.
 
-  :param string netmask: The netmask to set to.
+    :param string netmask: The netmask to set to.
 
-.. classmethod:: DNSDistProtoBufMessage:setQueryTime(sec, usec)
+  .. method:: DNSDistProtoBufMessage:setQueryTime(sec, usec)
 
-  In a response message, set the time at which the query has been received.
+    In a response message, set the time at which the query has been received.
 
-  :param int sec: Unix timestamp when the query was received.
-  :param int usec: The microsecond the query was received.
+    :param int sec: Unix timestamp when the query was received.
+    :param int usec: The microsecond the query was received.
 
-.. classmethod:: DNSDistProtoBufMessage:setQuestion(name, qtype, qclass)
+  .. method:: DNSDistProtoBufMessage:setQuestion(name, qtype, qclass)
 
-  Set the question in the protobuf message.
+    Set the question in the protobuf message.
 
-  :param DNSName name: The qname of the question
-  :param int qtype: The qtype of the question
-  :param int qclass: The qclass of the question
+    :param DNSName name: The qname of the question
+    :param int qtype: The qtype of the question
+    :param int qclass: The qclass of the question
 
-.. classmethod:: DNSDistProtoBufMessage:setProtobufResponseType(sec, usec)
+  .. method:: DNSDistProtoBufMessage:setProtobufResponseType(sec, usec)
 
-  .. versionadded:: 1.2.0
+    .. versionadded:: 1.2.0
 
-  Change the protobuf response type from a query to a response, and optionally set the query time.
+    Change the protobuf response type from a query to a response, and optionally set the query time.
 
-  :param int sec: Optional query time in seconds.
-  :param int usec: Optional query time in additional micro-seconds.
+    :param int sec: Optional query time in seconds.
+    :param int usec: Optional query time in additional micro-seconds.
 
-.. classmethod:: DNSDistProtoBufMessage:setRequestor(address)
+  .. method:: DNSDistProtoBufMessage:setRequestor(address)
 
-  Set the requestor's address.
+    Set the requestor's address.
 
-  :param ComboAddress address: The address to set to
+    :param ComboAddress address: The address to set to
 
-.. classmethod:: DNSDistProtoBufMessage:setRequestorFromString(address)
+  .. method:: DNSDistProtoBufMessage:setRequestorFromString(address)
 
-  Set the requestor's address from a string.
+    Set the requestor's address from a string.
 
-  :param string address: The address to set to
+    :param string address: The address to set to
 
-.. classmethod:: DNSDistProtoBufMessage:setResponder(address)
+  .. method:: DNSDistProtoBufMessage:setResponder(address)
 
-  Set the responder's address.
+    Set the responder's address.
 
-  :param ComboAddress address: The address to set to
+    :param ComboAddress address: The address to set to
 
-.. classmethod:: DNSDistProtoBufMessage:setResponderFromString(string)
+  .. method:: DNSDistProtoBufMessage:setResponderFromString(string)
 
-  Set the responder's address.
+    Set the responder's address.
 
-  :param string address: The address to set to
+    :param string address: The address to set to
 
-.. classmethod:: DNSDistProtoBufMessage:setResponseCode(rcode)
+  .. method:: DNSDistProtoBufMessage:setResponseCode(rcode)
 
-  Set the response code of the query.
+    Set the response code of the query.
 
-  :param int rcode: The response code of the answer
+    :param int rcode: The response code of the answer
 
-.. classmethod:: DNSDistProtoBufMessage:setTag(value)
+  .. method:: DNSDistProtoBufMessage:setTag(value)
 
-  .. versionadded:: 1.2.0
+    .. versionadded:: 1.2.0
 
-  Add a tag to the list of tags.
+    Add a tag to the list of tags.
 
-  :param string value: The tag value
+    :param string value: The tag value
 
-.. classmethod:: DNSDistProtoBufMessage:setTagArray(valueList)
+  .. method:: DNSDistProtoBufMessage:setTagArray(valueList)
 
-  .. versionadded:: 1.2.0
+    .. versionadded:: 1.2.0
 
-  Add a list of tags.
+    Add a list of tags.
 
-  :param table tags: A list of tags as strings
+    :param table tags: A list of tags as strings
 
-.. classmethod:: DNSDistProtoBufMessage:setTime(sec, usec)
+  .. method:: DNSDistProtoBufMessage:setTime(sec, usec)
 
-  Set the time at which the query or response has been received.
+    Set the time at which the query or response has been received.
 
-  :param int sec: Unix timestamp when the query was received.
-  :param int usec: The microsecond the query was received.
+    :param int sec: Unix timestamp when the query was received.
+    :param int usec: The microsecond the query was received.
 
-.. classmethod:: DNSDistProtoBufMessage:toDebugString() -> string
+  .. method:: DNSDistProtoBufMessage:toDebugString() -> string
 
-  Return an string containing the content of the message
+    Return an string containing the content of the message

--- a/pdns/recursordist/docs/changelog/4.1.rst
+++ b/pdns/recursordist/docs/changelog/4.1.rst
@@ -9,7 +9,7 @@ Changelogs for 4.1.x
 
   This release fixes PowerDNS Security Advisory :doc:`2018-01 <../security-advisories/powerdns-advisory-2018-01>`.
 
-  The full release notes can be read `on the blog <https://blog.powerdns.com/2018/01/22/powerdns-recursor-4-1-1/>`_.
+  The full release notes can be read `on the blog <https://blog.powerdns.com/2018/01/22/powerdns-recursor-4-1-1/>`__.
 
   This is a release on the stable branch, containing a fix for the
   abovementioned security issue and several bug fixes from the
@@ -76,7 +76,7 @@ Changelogs for 4.1.x
 
   This is the first release in the 4.1 train.
 
-  The full release notes can be read `on the blog <https://blog.powerdns.com/2017/12/04/powerdns-recursor-4-1/>`_.
+  The full release notes can be read `on the blog <https://blog.powerdns.com/2017/12/04/powerdns-recursor-4-1/>`__.
 
   This is a major release containing significant speedups (both in throughput and latency), enhanced capabilities and a highly conformant and robust DNSSEC validation implementation that is ready for heavy production use. In addition, our EDNS Client Subnet implementation now scales effortlessly to networks needing very fine grained scopes (as used by some ‘country sized’ service providers).
 

--- a/pdns/recursordist/docs/lua-scripting/comboaddress.rst
+++ b/pdns/recursordist/docs/lua-scripting/comboaddress.rst
@@ -24,44 +24,50 @@ To compare the address (so not the port) of two ComboAddresses, use :meth:`:equa
 To convert an address to human-friendly representation, use :meth:`:toString <ComboAddress:toString>` or :meth:`:toStringWithPort <ComboAddress:toStringWithPort()>`.
 To get only the port number, use :meth:`:getPort() <ComboAddress:getPort>`.
 
+.. function:: NewCA(address) -> ComboAddress
+
+  Creates a :class:`ComboAddress`.
+
+  :param string address: The address to convert
+
 .. class:: ComboAddress
 
-    An object representing an IP address and port tuple.
+  An object representing an IP address and port tuple.
 
-.. classmethod:: ComboAddress:getPort() -> int
+  .. method:: ComboAddress:getPort() -> int
 
-    The portnumber.
+      The portnumber.
 
-.. classmethod:: ComboAddress:getRaw() -> str
+  .. method:: ComboAddress:getRaw() -> str
 
-    A bytestring representing the address.
+      A bytestring representing the address.
 
-.. classmethod:: ComboAddress:isIPv4() -> bool
+  .. method:: ComboAddress:isIPv4() -> bool
 
-    True if the address is an IPv4 address.
+      True if the address is an IPv4 address.
 
-.. classmethod:: ComboAddress:isIPv6() -> bool
+  .. method:: ComboAddress:isIPv6() -> bool
 
-    True if the address is an IPv6 address.
+      True if the address is an IPv6 address.
 
-.. classmethod:: ComboAddress:isMappedIPv4() -> bool
+  .. method:: ComboAddress:isMappedIPv4() -> bool
 
-    True if the address is an IPv4 address mapped into an IPv6 one.
+      True if the address is an IPv4 address mapped into an IPv6 one.
 
-.. classmethod:: ComboAddress:mapToIPv4() -> ???
+  .. method:: ComboAddress:mapToIPv4() -> ComboAddress
 
-    If the address is an IPv4 mapped into an IPv6 one, return the corresponding IPv4 address.
+      If the address is an IPv4 mapped into an IPv6 one, return the corresponding IPv4 :class:`ComboAddress`.
 
-.. classmethod:: ComboAddress:toString() -> str
+  .. method:: ComboAddress:toString() -> str
 
-    Returns the IP address without the port number as a string.
+      Returns the IP address without the port number as a string.
 
-.. classmethod:: ComboAddress:toStringWithPort() -> str
+  .. method:: ComboAddress:toStringWithPort() -> str
 
-    Returns the IP address with the port number as a string.
+      Returns the IP address with the port number as a string.
 
-.. classmethod:: ComboAddress:truncate(bits)
+  .. method:: ComboAddress:truncate(bits)
 
-    Truncate to the supplied number of bits
+      Truncate to the supplied number of bits
 
-    :param int bits: The number of bits to truncate to
+      :param int bits: The number of bits to truncate to

--- a/pdns/recursordist/docs/lua-scripting/dnsname.rst
+++ b/pdns/recursordist/docs/lua-scripting/dnsname.rst
@@ -6,14 +6,15 @@ This native format is exposed to Lua as well.
 
 The DNSName object
 ------------------
-
-.. class:: DNSName
-
-  A ``DNSName`` object represents a name in the DNS.
-  It is returned by several functions and has several functions to programmatically interact with it.
+The PowerDNS Recursor's Lua engine has the notion of a :class:`DNSName`, an object that represents a name in the DNS.
+It is returned by several functions and has several functions to programmatically interact with it.
+:class:`DNSNames <DNSName>` can be compared agains each other using the :meth:`:equal <DNSName:equal>` function or the ``==`` operator.
+As names in the DNS are case-insensitive, ``www.powerdns.com`` is equal to ``Www.PowerDNS.cOM``.
 
 Creating a :class:`DNSName` is done with :func:`newDN()`.
 The PowerDNS Recursor will complain loudly if the name is invalid (e.g. too long, dot in the wrong place).
+
+A small example of the functionality of a :class:`DNSName` is shown below:
 
 .. code-block:: lua
 
@@ -22,11 +23,10 @@ The PowerDNS Recursor will complain loudly if the name is invalid (e.g. too long
   print(myname:wirelength()) -- prints "17"
   name2 = newDN(myname)
   name2:chopoff() -- returns true, as 'www' was stripped
+  print(name2:countLabels()) -- prints "2"
   if myname:isPartOf(name2) then -- prints "it is"
     print('it is')
   end
-
-:class:`DNSNames <DNSName>` can be compared agains each other using the :meth:`:equal <DNSName:equal>` function or the ``==`` operator.
 
 .. function:: newDN(name) -> DNSName
 
@@ -34,46 +34,56 @@ The PowerDNS Recursor will complain loudly if the name is invalid (e.g. too long
 
   :param string name: The name to create a DNSName for
 
-.. classmethod:: DNSName::chopOff() -> bool
+.. class:: DNSName
 
-  Removes the left-most label and returns ``true``.
-  ``false`` is returned if no label was removed
+  A ``DNSName`` object represents a name in the DNS.
 
-.. classmethod:: DNSName:countLabels() -> int
+  .. method:: DNSName:chopOff() -> bool
 
-  Returns the number of DNSLabels in the name
+    Removes the left-most label and returns ``true``.
+    ``false`` is returned if no label was removed
 
-.. classmethod:: DNSName:isPartOf(name) -> bool
+  .. method:: DNSName:countLabels() -> int
 
-  Returns true if the DNSName is part of the DNS tree of ``name``.
+    Returns the number of DNSLabels in the name
 
-  .. code-block:: Lua
+  .. method:: DNSName:equal(name) -> bool
 
-    newDN("www.powerdns.com"):isPartOf(newDN("CoM.")) -- true
+    Returns true when both names are equal for the DNS, i.e case insensitive.
 
-  :param DNSName name: The name to check against
+    :param DNSName name: The name to compare against.
 
-.. classmethod:: DNSName:toString() -> str
-                 DNSName:toStringNoDot() -> str
+  .. method:: DNSName:isPartOf(name) -> bool
 
-  Returns a human-readable form of the DNSName.
-  With or without trailing dot.
+    Returns true if the DNSName is part of the DNS tree of ``name``.
 
-.. classmethod:: DNSName:wirelength -> int
+    .. code-block:: Lua
 
-  Returns the length in bytes of the DNSName as it would be on the wire.
+      newDN("www.powerdns.com"):isPartOf(newDN("CoM.")) -- true
+
+    :param DNSName name: The name to check against
+
+  .. method:: DNSName:toString() -> str
+              DNSName:toStringNoDot() -> str
+
+    Returns a human-readable form of the DNSName.
+    With or without trailing dot.
+
+  .. method:: DNSName:wirelength() -> int
+
+    Returns the length in bytes of the DNSName as it would be on the wire.
 
 DNS Suffix Match Groups
 -----------------------
 
-The func:`newDS` function creates a "Suffix Match group" that allows fast checking if a :class:`DNSName` is part of a group.
+The :func:`newDS` function creates a "Suffix Match group" that allows fast checking if a :class:`DNSName` is part of a group.
 This could e.g. be used to answer questions for known malware domains.
-To check e.g. the ``dq.qname`` against a list:
+To check e.g. the :attr:`dq.qname` against a list:
 
-.. code-block:: Lua
+.. code-block:: lua
 
   m = newDS()
-  m:add({'example.com', 'example.net})
+  m:add({'example.com', 'example.net'})
   m:check(dq.qname) -- Would be true is dq.qname is a name in example.com or example.net
 
 .. function:: newDS() -> DNSSuffixMatchGroup
@@ -84,21 +94,21 @@ To check e.g. the ``dq.qname`` against a list:
 
   This class represents a group of DNS names that can be used to quickly compare a single :class:`DNSName` against.
 
-.. classmethod:: DNSSuffixMatchGroup::add(domain)
-                 DNSSuffixMatchGroup::add(domains)
+  .. method:: DNSSuffixMatchGroup:add(domain)
+              DNSSuffixMatchGroup:add(domains)
 
-  Add one or more domains to the Suffix Match Group.
+    Add one or more domains to the Suffix Match Group.
 
-  :param str domain: A domain name to add
-  :param {str} domain: A list of Domains to add
+    :param str domain: A domain name to add
+    :param {str} domain: A list of Domains to add
 
-.. classmethod:: DNSSuffixMatchGroup:check(domain) -> bool
+  .. method:: DNSSuffixMatchGroup:check(domain) -> bool
 
-  Check ``domain`` against the Suffix Match Group.
-  Returns true if it is matched, false otherwise.
+    Check ``domain`` against the Suffix Match Group.
+    Returns true if it is matched, false otherwise.
 
-  :param DNSName domain: The domain name to check
+    :param DNSName domain: The domain name to check
 
-.. classmethod:: DNSSuffixMatchGroup:toString() -> str
+  .. method:: DNSSuffixMatchGroup:toString() -> str
 
-  Returns a string of the set of suffixes matched by the Suffix Match Group
+    Returns a string of the set of suffixes matched by the Suffix Match Group

--- a/pdns/recursordist/docs/lua-scripting/dnsrecord.rst
+++ b/pdns/recursordist/docs/lua-scripting/dnsrecord.rst
@@ -6,37 +6,42 @@ DNS record objects are returned by :meth:`DNSQuestion:getRecords`.
 .. class:: DNSRecord
 
   Represents a single DNS record.
+  It has these attributes:
 
-.. attribute:: DNSRecord.name -> DNSName
+  .. attribute:: DNSRecord.name
 
-  The name of the record.
+    The name of the record. A :class:`DNSName`.
 
-.. attribute:: DNSRecord.place -> int
+  .. attribute:: DNSRecord.place
 
-  The place where the record is located,
-  - 1 for the answer section
-  - 2 for the authority section
-  - 3 for the additional section
+    The place where the record is located,
 
-.. attribute:: DNSRecord.ttl -> int
+    - 0 for the question section
+    - 1 for the answer section
+    - 2 for the authority section
+    - 3 for the additional section
 
-  The TTL of the record
+  .. attribute:: DNSRecord.ttl
 
-.. attribute:: DNSRecord.type -> int
+    The TTL of the record
 
-  The type of the record, for example pdns.A
+  .. attribute:: DNSRecord.type
 
-.. classmethod:: DNSRecord:changeContent(newcontent)
+    The type of the record (as an integer). Can for example be compared to ``pdns.A``.
 
-  Replace the record content with ``newcontent``.
-  The type and class cannot be changed.
+  And the following methods:
 
-  :param str newcontent: The replacing content
+  .. method:: DNSRecord:changeContent(newcontent)
 
-.. classmethod:: DNSRecord:getCA() -> ComboAddress
+    Replace the record content with ``newcontent``.
+    The type and class cannot be changed.
 
-  If the record type is A or AAAA, a :class:`ComboAddress` representing the content is returned, nil otherwise.
+    :param str newcontent: The replacing content
 
-.. classmethod:: DNSRecord:getContent() -> str
+  .. method:: DNSRecord:getCA() -> ComboAddress
 
-  Return a string representation of the record content.
+    If the record type is A or AAAA, a :class:`ComboAddress` representing the content is returned, nil otherwise.
+
+  .. method:: DNSRecord:getContent() -> str
+
+    Return a string representation of the record content.

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -8,211 +8,210 @@ The DNSQuestion object contains at least the following fields:
 
 .. class:: DNSQuestion
 
-    An object that contains everything about the current query.
+  An object that contains everything about the current query.
+  This object has the following attributes:
 
-.. attribute:: DNSQuestion.qname
+  .. attribute:: DNSQuestion.qname
 
-    :class:`DNSName` of the name this query is for.
+      :class:`DNSName` of the name this query is for.
 
-.. attribute:: DNSQuestion.qtype
+  .. attribute:: DNSQuestion.qtype
 
-    Type this query is for as an integer, can be compared against ``pdns.A``, ``pdns.AAAA``.
+      Type this query is for as an integer, can be compared against ``pdns.A``, ``pdns.AAAA``.
 
-.. attribute:: DNSQuestion.rcode
+  .. attribute:: DNSQuestion.rcode
 
-    current DNS Result Code, which can be overridden, including to several magical values
-    The rcode can be set to pdns.DROP to drop the query.
-    Other statuses are normal DNS return codes, like ``pdns.NOERROR``, ``pdns.NXDOMAIN`` etc.
+      current DNS Result Code, which can be overridden, including to several magical values
+      The rcode can be set to pdns.DROP to drop the query.
+      Other statuses are normal DNS return codes, like ``pdns.NOERROR``, ``pdns.NXDOMAIN`` etc.
 
-.. attribute:: DNSQuestion.isTcp
+  .. attribute:: DNSQuestion.isTcp
 
-    Boolean whether the query have been received over TCP.
+      Boolean whether the query have been received over TCP.
 
-.. attribute:: DNSQuestion.remoteaddr -> ComboAddress
+  .. attribute:: DNSQuestion.remoteaddr
 
-    :class:`ComboAddress` of the requestor.
+      :class:`ComboAddress` of the requestor.
 
-.. attribute:: DNSQuestion.localaddr -> ComboAddress
+  .. attribute:: DNSQuestion.localaddr
 
-    :class:`ComboAddress` where this query was received on.
+      :class:`ComboAddress` where this query was received on.
 
-.. attribute:: DNSQuestion.variable
+  .. attribute:: DNSQuestion.variable
 
-    Boolean which, if set, indicates the recursor should not packet cache this answer.
-    Honored even when returning false from a hook!
-    Important when providing answers that vary over time or based on sender details.
+      Boolean which, if set, indicates the recursor should not packet cache this answer.
+      Honored even when returning false from a hook!
+      Important when providing answers that vary over time or based on sender details.
 
-.. attribute:: DNSQuestion.followupFunction
+  .. attribute:: DNSQuestion.followupFunction
 
-    String that signals the nameserver to take one an additional action:
+      String that signals the nameserver to take one an additional action:
 
-    - followCNAMERecords: When adding a CNAME to the answer, this tells the recursor to follow that CNAME. See :ref:`CNAME Chain Resolution <cnamechainresolution>`
-    - getFakeAAAARecords: Get a fake AAAA record, see :doc:`DNS64 <../dns64>`
-    - getFakePTRRecords: Get a fake PTR record, see :doc:`DNS64 <../dns64>`
-    - udpQueryResponse: Do a UDP query and call a handler, see :ref:`UDP Query Response <udpqueryresponse>`
+      - followCNAMERecords: When adding a CNAME to the answer, this tells the recursor to follow that CNAME. See :ref:`CNAME Chain Resolution <cnamechainresolution>`
+      - getFakeAAAARecords: Get a fake AAAA record, see :doc:`DNS64 <../dns64>`
+      - getFakePTRRecords: Get a fake PTR record, see :doc:`DNS64 <../dns64>`
+      - udpQueryResponse: Do a UDP query and call a handler, see :ref:`UDP Query Response <udpqueryresponse>`
 
-.. attribute:: DNSQuestion.appliedPolicy
+  .. attribute:: DNSQuestion.appliedPolicy
 
     The decision that was made by the policy engine, see :ref:`modifyingpolicydecisions`.
 
-.. attribute:: DNSQuestion.appliedPolicy.policyName
+    .. attribute:: DNSQuestion.appliedPolicy.policyName
 
-  A string with the name of the policy.
-  Set by :ref:`policyName <rpz-policyName>` in the :func:`rpzFile` and :func:`rpzMaster` configuration items.
-  It is advised to overwrite this when modifying the :attr:`DNSQuestion.appliedPolicy.policyKind`
+      A string with the name of the policy.
+      Set by :ref:`policyName <rpz-policyName>` in the :func:`rpzFile` and :func:`rpzMaster` configuration items.
+      It is advised to overwrite this when modifying the :attr:`DNSQuestion.appliedPolicy.policyKind`
 
-.. attribute:: DNSQuestion.appliedPolicy.policyAction
+    .. attribute:: DNSQuestion.appliedPolicy.policyAction
 
-    The action taken by the engine
+        The action taken by the engine
 
-.. attribute:: DNSQuestion.appliedPolicy.policyCustom
+    .. attribute:: DNSQuestion.appliedPolicy.policyCustom
 
-    The CNAME content for the ``pdns.policyactions.Custom`` response, a string
+        The CNAME content for the ``pdns.policyactions.Custom`` response, a string
 
-.. attribute:: DNSQuestion.appliedPolicy.policyKind
+    .. attribute:: DNSQuestion.appliedPolicy.policyKind
 
-  The kind of policy response, there are several policy kinds:
+      The kind of policy response, there are several policy kinds:
 
-  -  ``pdns.policykinds.Custom`` will return a NoError, CNAME answer with the value specified in :attr:`DNSQuestion.appliedPolicy.policyCustom`
-  -  ``pdns.policykinds.Drop`` will simply cause the query to be dropped
-  -  ``pdns.policykinds.NoAction`` will continue normal processing of the query
-  -  ``pdns.policykinds.NODATA`` will return a NoError response with no value in the answer section
-  -  ``pdns.policykinds.NXDOMAIN`` will return a response with a NXDomain rcode
-  -  ``pdns.policykinds.Truncate`` will return a NoError, no answer, truncated response over UDP. Normal processing will continue over TCP
+      -  ``pdns.policykinds.Custom`` will return a NoError, CNAME answer with the value specified in :attr:`DNSQuestion.appliedPolicy.policyCustom`
+      -  ``pdns.policykinds.Drop`` will simply cause the query to be dropped
+      -  ``pdns.policykinds.NoAction`` will continue normal processing of the query
+      -  ``pdns.policykinds.NODATA`` will return a NoError response with no value in the answer section
+      -  ``pdns.policykinds.NXDOMAIN`` will return a response with a NXDomain rcode
+      -  ``pdns.policykinds.Truncate`` will return a NoError, no answer, truncated response over UDP. Normal processing will continue over TCP
 
-.. attribute:: DNSQuestion.appliedPolicy.policyTTL
+    .. attribute:: DNSQuestion.appliedPolicy.policyTTL
 
-    The TTL in seconds for the ``pdns.policyactions.Custom`` response
+        The TTL in seconds for the ``pdns.policyactions.Custom`` response
 
-.. attribute:: DNSQuestion.wantsRPZ
+  .. attribute:: DNSQuestion.wantsRPZ
 
-    A boolean that indicates the use of the Policy Engine.
-    Can be set to ``false`` in ``prerpz`` to disable RPZ for this query.
+      A boolean that indicates the use of the Policy Engine.
+      Can be set to ``false`` in ``prerpz`` to disable RPZ for this query.
 
-.. attribute:: DNSQuestion.data
+  .. attribute:: DNSQuestion.data
 
-    A Lua object reference that is persistent throughout the lifetime of the :class:`DNSQuestion` object for a single query.
-    It can be used to store custom data.
-    Most scripts initialise this to an empty table early on so they can store multiple items.
+      A Lua object reference that is persistent throughout the lifetime of the :class:`DNSQuestion` object for a single query.
+      It can be used to store custom data.
+      Most scripts initialise this to an empty table early on so they can store multiple items.
 
-.. attribute:: DNSQuestion.requestorId str
+  .. attribute:: DNSQuestion.requestorId
 
-    .. versionadded:: 4.1.0
+      .. versionadded:: 4.1.0
 
-    A string that will be used to set the ``requestorId`` field in :doc:`protobuf <../lua-config/protobuf>` messages.
+      A string that will be used to set the ``requestorId`` field in :doc:`protobuf <../lua-config/protobuf>` messages.
 
-.. attribute:: DNSQuestion.deviceId str
+  .. attribute:: DNSQuestion.deviceId
 
-    .. versionadded:: 4.1.0
+      .. versionadded:: 4.1.0
 
-    A string that will be used to set the ``deviceId`` field in :doc:`protobuf <../lua-config/protobuf>` messages.
+      A string that will be used to set the ``deviceId`` field in :doc:`protobuf <../lua-config/protobuf>` messages.
 
-.. attribute:: DNSQuestion.udpAnswer -> str
+  .. attribute:: DNSQuestion.udpAnswer
 
-    Answer to the :attr:`udpQuery <DNSQuestion.udpQuery>` when when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>`.
-    Only filled when the call-back function is invoked.
+      Answer to the :attr:`udpQuery <DNSQuestion.udpQuery>` when when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>`.
+      Only filled when the call-back function is invoked.
 
-.. attribute:: DNSQuestion.udpQueryDest -> str
+  .. attribute:: DNSQuestion.udpQueryDest
 
-    Destination IP address to send the UDP packet to when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>`
+      Destination IP address to send the UDP packet to when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>`
 
-.. attribute:: DNSQuestion.udpQuery -> str
+  .. attribute:: DNSQuestion.udpQuery
 
-    The content of the UDP payload when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>`
+      The content of the UDP payload when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>`
 
-.. attribute:: DNSQuestion.udpCallback -> str
+  .. attribute:: DNSQuestion.udpCallback
 
-    The name of the callback function that is called when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>` when an answer is received.
+      The name of the callback function that is called when using the ``udpQueryResponse`` :attr:`followupFunction <DNSQuestion.followupFunction>` when an answer is received.
 
-.. attribute:: DNSQuestion.validationState
+  .. attribute:: DNSQuestion.validationState
 
-    .. versionadded:: 4.1.0
+      .. versionadded:: 4.1.0
 
-    The result of the DNSSEC validation, accessible from the ``postresolve``, ``nxdomain`` and ``nodata`` hooks.
-    Possible states are ``pdns.validationstates.Indeterminate``, ``pdns.validationstates.Bogus``, ``pdns.validationstates.Insecure`` and ``pdns.validationstates.Secure``.
-    The result will always be ``pdns.validationstates.Indeterminate`` is validation is disabled or was not requested.
+      The result of the DNSSEC validation, accessible from the ``postresolve``, ``nxdomain`` and ``nodata`` hooks.
+      Possible states are ``pdns.validationstates.Indeterminate``, ``pdns.validationstates.Bogus``, ``pdns.validationstates.Insecure`` and ``pdns.validationstates.Secure``.
+      The result will always be ``pdns.validationstates.Indeterminate`` is validation is disabled or was not requested.
 
-It also supports the following methods:
+  It also supports the following methods:
 
-.. classmethod:: DNSQuestion:addAnswer(type, content, [ttl, name])
+  .. method:: DNSQuestion:addAnswer(type, content, [ttl, name])
 
-   Add an answer to the record of ``type`` with ``content``.
+     Add an answer to the record of ``type`` with ``content``.
 
-   :param int type: The type of record to add, can be ``pdns.AAAA`` etc.
-   :param str content: The content of the record, will be parsed into wireformat based on the ``type``
-   :param int ttl: The TTL in seconds for this record
-   :param ??? name: The name of this record, defaults to :attr:`DNSQuestion.qname`
+     :param int type: The type of record to add, can be ``pdns.AAAA`` etc.
+     :param str content: The content of the record, will be parsed into wireformat based on the ``type``
+     :param int ttl: The TTL in seconds for this record
+     :param DNSName name: The name of this record, defaults to :attr:`DNSQuestion.qname`
 
-.. classmethod:: DNSQuestion:addPolicyTag(tag)
+  .. method:: DNSQuestion:addPolicyTag(tag)
 
-   Add a policy tag.
+     Add a policy tag.
 
-   :param str tag: The tag to add
+     :param str tag: The tag to add
 
-.. classmethod:: DNSQuestion:discardPolicy(policyname)
+  .. method:: DNSQuestion:discardPolicy(policyname)
 
-    Skip the filtering policy (for example RPZ) named ``policyname`` for this query.
-    This is mostly useful in the ``prerpz`` hook.
+     Skip the filtering policy (for example RPZ) named ``policyname`` for this query.
+     This is mostly useful in the ``prerpz`` hook.
 
-    :param str policyname: The name of the policy to ignore.
+     :param str policyname: The name of the policy to ignore.
 
-.. classmethod:: DNSQuestion:getDH() -> DNSHeader
+  .. method:: DNSQuestion:getDH() -> DNSHeader
 
-    Returns the :class:`DNSHeader` of the query or nil.
+      Returns the :class:`DNSHeader` of the query or nil.
 
-.. classmethod:: DNSQuestion:getPolicyTags() -> {str}
+  .. method:: DNSQuestion:getPolicyTags() -> {str}
 
-    Get the current policy tags as a table of strings.
+      Get the current policy tags as a table of strings.
 
-.. classmethod:: DNSQuestion:getRecords() -> {DNSRecord}
+  .. method:: DNSQuestion:getRecords() -> {DNSRecord}
 
-    Get a table of DNS Records in this DNS Question (or answer by now).
+      Get a table of DNS Records in this DNS Question (or answer by now).
 
-.. classmethod:: DNSQuestion:setPolicyTags(tags)
+  .. method:: DNSQuestion:setPolicyTags(tags)
 
-    Set the policy tags to ``tags``, overwriting any existing policy tags.
+      Set the policy tags to ``tags``, overwriting any existing policy tags.
 
-    :param {str} tags: The policy tags
+      :param {str} tags: The policy tags
 
-.. classmethod:: DNSQuestion:setRecords(records)
+  .. method:: DNSQuestion:setRecords(records)
 
-    After your edits, update the answers of this question
+      After your edits, update the answers of this question
 
-    :param {DNSRecord} records: The records to put in the packet
+      :param {DNSRecord} records: The records to put in the packet
 
-.. classmethod:: DNSQuestion:getEDNSFlag(name) -> bool
+  .. method:: DNSQuestion:getEDNSFlag(name) -> bool
 
-    Returns true if the EDNS flag with ``name`` is set in the query.
+      Returns true if the EDNS flag with ``name`` is set in the query.
 
-    :param string name: Name of the flag.
+      :param string name: Name of the flag.
 
-.. classmethod:: DNSQuestion:getEDNSFlags() -> {str}
+  .. method:: DNSQuestion:getEDNSFlags() -> {str}
 
-    Returns a list of strings with all the EDNS flag mnemonics in the query.
+      Returns a list of strings with all the EDNS flag mnemonics in the query.
 
-.. classmethod:: DNSQuestion:getEDNSOption(num) -> str
+  .. method:: DNSQuestion:getEDNSOption(num) -> str
 
-    Get the EDNS Option with number ``num`` as a bytestring.
+      Get the EDNS Option with number ``num`` as a bytestring.
 
-.. classmethod:: DNSQuestion:getEDNSOptions() {str: str}
+  .. method:: DNSQuestion:getEDNSOptions() -> {str: str}
 
-    Get a map of all EDNS Options
+      Get a map of all EDNS Options
 
-.. classmethod:: DNSQuestion:getEDNSSubnet() -> Netmask
+  .. method:: DNSQuestion:getEDNSSubnet() -> Netmask
 
-    Returns the netmask specified in the EDNSSubnet option, or empty if there was none.
+      Returns the :class:`Netmask` specified in the EDNSSubnet option, or empty if there was none.
 
-.. classmethod:: DNSQuestion:addPolicyTag(tag)
+  .. method:: DNSQuestion:addPolicyTag(tag)
 
-    Add policyTag ``tag`` to the list of policyTags
+      Add policyTag ``tag`` to the list of policyTags
 
-    :param str tag: The tag to add
+      :param str tag: The tag to add
 
-.. classmethod:: DNSQuestion:getPolicyTags() -> {str}
+  .. method:: DNSQuestion:getPolicyTags() -> {str}
 
-    Get a list the policyTags for this message.
-
-
+      Get a list the policyTags for this message.
 
 DNSHeader Object
 ================
@@ -223,37 +222,37 @@ The DNS header as returned by :meth:`DNSQuestion:getDH()` represents a header of
 
     represents a header of a DNS message.
 
-.. classmethod:: DNSHeader:getRD() -> bool
+  .. method:: DNSHeader:getRD() -> bool
 
-    The value of the Recursion Desired bit.
+      The value of the Recursion Desired bit.
 
-.. classmethod:: DNSHeader:getAA() -> bool
+  .. method:: DNSHeader:getAA() -> bool
 
-    The value of the Authoritative Answer bit.
+      The value of the Authoritative Answer bit.
 
-.. classmethod:: DNSHeader:getAD() -> bool
+  .. method:: DNSHeader:getAD() -> bool
 
-    The value of the Authenticated Data bit.
+      The value of the Authenticated Data bit.
 
-.. classmethod:: DNSHeader:getCD() -> bool
+  .. method:: DNSHeader:getCD() -> bool
 
-    The value of the Checking Disabled bit.
+      The value of the Checking Disabled bit.
 
-.. classmethod:: DNSHeader:getTC() -> bool
+  .. method:: DNSHeader:getTC() -> bool
 
-    The value of the Truncation bit.
+      The value of the Truncation bit.
 
-.. classmethod:: DNSHeader:getRCODE() -> int
+  .. method:: DNSHeader:getRCODE() -> int
 
-    The Response Code of the query
+      The Response Code of the query
 
-.. classmethod:: DNSHeader:getOPCODE() -> int
+  .. method:: DNSHeader:getOPCODE() -> int
 
-    The Operation Code of the query
+      The Operation Code of the query
 
-.. classmethod:: DNSHeader:getID() -> int
+  .. method:: DNSHeader:getID() -> int
 
-    The ID of the query
+      The ID of the query
 
 The EDNSOptionView Class
 ========================
@@ -262,10 +261,10 @@ The EDNSOptionView Class
 
   An object that represents a single EDNS option
 
-.. attribute:: EDNSOptionView.size -> int
+  .. attribute:: EDNSOptionView.size
 
-  The size in bytes of the EDNS option.
+    The size in bytes of the EDNS option.
 
-.. classmethod:: EDNSOptionView:getContent() -> str
+  .. method:: EDNSOptionView:getContent()
 
-  Returns a NULL-safe string object of the EDNS option's content
+    Returns a NULL-safe string object of the EDNS option's content

--- a/pdns/recursordist/docs/lua-scripting/functions.rst
+++ b/pdns/recursordist/docs/lua-scripting/functions.rst
@@ -3,12 +3,14 @@ Other functions
 
 These are some functions that don't really have a place in one of the other categories.
 
-.. function:: getregisteredname(name)
+.. function:: getregisteredname(name) -> str
 
   Returns the shortest domain name based on Mozilla's Public Suffix List.
   In general it will tell you the 'registered domain' for a given name.
 
   For example ``getregisteredname('www.powerdns.com')`` returns "powerdns.com"
+
+  :param str name: The name to check for.
 
 .. function:: getRecursorThreadId() -> int
 

--- a/pdns/recursordist/docs/lua-scripting/netmask.rst
+++ b/pdns/recursordist/docs/lua-scripting/netmask.rst
@@ -7,87 +7,99 @@ There are two classes in the PowerDNS Recursor that can be used to match IP addr
 
 Netmask class
 -------------
+The :class:`Netmask` class represents an IP netmask.
+
+.. code-block:: Lua
+
+    mask = newNetmask("192.0.2.1/24")
+    mask:isIPv4() -- true
+    mask:match("192.0.2.8") -- true
+
+.. function:: newNetmask(mask) -> Netmask
+
+  Creates a new :class:`Netmask`.
+
+  :param str mask: The mask to convert.
 
 .. class:: Netmask
 
-    Represents an IP netmask.
-    Can be created with
+  Represents a netmask.
 
-    .. code-block:: Lua
+  .. method:: Netmask:empty() -> bool
 
-        newNetmask("192.0.2.1/24")
+      True if the netmask doesn't contain a valid address.
 
-.. classmethod:: Netmask:empty() -> bool
+  .. method:: Netmask:getBits() -> int
 
-    True if the netmask doesn't contain a valid address.
+      The number of bits in the address.
 
-.. classmethod:: Netmask:getBits() -> int
+  .. method:: Netmask:getNetwork() -> ComboAddress
 
-    The number of bits in the address.
+      Returns a :class:`ComboAddress` representing the network (no mask applied).
 
-.. classmethod:: Netmask:getNetwork() -> ComboAddress
+  .. method:: Netmask:getMaskedNetwork() -> ComboAddress
 
-    Returns a :class:`ComboAddress` representing the network (no mask applied).
+      Returns a :class:`ComboAddress` representing the network (truncating according to the mask).
 
-.. classmethod:: Netmask:getMaskedNetwork() -> ComboAddress
+  .. method:: Netmask:isIpv4() -> bool
 
-    Returns a :class:`ComboAddress` representing the network (truncating according to the mask).
+      True if the netmask is an IPv4 netmask.
 
-.. classmethod:: Netmask:isIpv4() -> bool
+  .. method:: Netmask:isIpv6() -> bool
 
-    True if the netmask is an IPv4 netmask.
+      True if the netmask is an IPv6 netmask.
 
-.. classmethod:: Netmask:isIpv6 -> bool
+  .. method:: Netmask:match(address) -> bool
 
-    True if the netmask is an IPv6 netmask.
+      True if the address passed in address matches
 
-.. classmethod:: Netmask:match(address) -> bool
+      :param str address: IP Address to match against.
 
-    True if the address passed in address matches
+  .. method:: Netmask:toString() -> str
 
-    :param str address: IP Address to match against.
-
-.. classmethod:: Netmask:toString() -> str
-
-    Returns a human-friendly representation.
+      Returns a human-friendly representation.
 
 NetMaskGroup class
 ------------------
 
 NetMaskGroups are more powerful than plain Netmasks.
+They can be matched against netmasks objects:
+
+.. code-block:: lua
+
+  nmg = newNMG()
+  nmg:addMask("127.0.0.0/8")
+  nmg:addMasks({"213.244.168.0/24", "130.161.0.0/16"})
+  nmg:addMasks(dofile("bad.ips")) -- contains return {"ip1","ip2"..}
+
+  if nmg:match(dq.remoteaddr) then
+    print("Intercepting query from ", dq.remoteaddr)
+  end
+
+Prefixing a mask with ``!`` excludes that mask from matching.
+
+.. function:: newNMG() -> NetMaskGroup
+
+  Returns a new, empty :class:`NetMaskGroup`.
 
 .. class:: NetMaskGroup
 
-   IP addresses are passed to Lua in native format.
-   They can be matched against netmasks objects:
+  IP addresses are passed to Lua in native format.
 
-   .. code-block:: Lua
+  .. method:: NetMaskGroup:addMask(mask)
 
-        nmg = newNMG()
-        nmg:addMask("127.0.0.0/8")
-        nmg:addMasks({"213.244.168.0/24", "130.161.0.0/16"})
-        nmg:addMasks(dofile("bad.ips")) -- contains return {"ip1","ip2"..}
+      Adds ``mask`` to the NetMaskGroup.
 
-        if nmg:match(dq.remoteaddr) then
-            print("Intercepting query from ", dq.remoteaddr)
-        end
+      :param str mask: The mask to add.
 
-   Prefixing a mask with ``!`` excludes that mask from matching.
+  .. method:: NetMaskGroup:addMasks(masks)
 
-.. classmethod:: NetMaskGroup:addMask(mask)
+      Adds ``masks`` to the NetMaskGroup.
 
-    Adds ``mask`` to the NetMaskGroup.
+      :param {str} mask: The masks to add.
 
-    :param str mask: The mask to add.
+  .. method:: NetMaskGroup:match(address) -> bool
 
-.. classmethod:: NetMaskGroup:addMasks(masks)
+      Returns true if ``address`` matches any of the masks in the group.
 
-    Adds ``masks`` to the NetMaskGroup.
-
-    :param {str} mask: The masks to add.
-
-.. classmethod:: NetMaskGroup:match(address) -> bool
-
-    Returns true if ``address`` matches any of the masks in the group.
-
-    :param ComboAddress address: The IP addres to match the netmasks against.
+      :param ComboAddress address: The IP addres to match the netmasks against.

--- a/pdns/recursordist/docs/lua-scripting/statistics.rst
+++ b/pdns/recursordist/docs/lua-scripting/statistics.rst
@@ -8,11 +8,15 @@ Generating Metrics
 Custom metrics can be added which will be shown in the output of 'rec_control get-all' and sent to the metrics server over the Carbon protocol.
 They will also appear in the JSON HTTP API.
 
-Create a custom metric with: ``myMetric=getMetric("myspecialmetric")``.
+Create a custom metric with:
+
+.. code-block:: lua
+
+  myMetric=getMetric("myspecialmetric")
 
 .. function:: getMetric(name) -> Metric
 
-  Returns the :class:`Metric` object with the name ``name``.
+  Returns the :class:`Metric` object with the name ``name``, creating the metric if it does not exist.
 
   :param str name: The metric to retrieve
 
@@ -20,25 +24,25 @@ Create a custom metric with: ``myMetric=getMetric("myspecialmetric")``.
 
   Represents a custom metric
 
-.. classmethod:: Metric::inc()
+  .. method:: Metric::inc()
 
-  Increase metric by 1
+    Increase metric by 1
 
-.. classmethod:: Metric::incBy(amount)
+  .. method:: Metric::incBy(amount)
 
-  Increase metric by amount
+    Increase metric by amount
 
-  :param int amount:
+    :param int amount:
 
-.. classmethod:: Metric::set(to)
+  .. method:: Metric::set(to)
 
-  Set metric to value ``to``
+    Set metric to value ``to``
 
-  :param int to:
+    :param int to:
 
-.. classmethod:: Metric::get() -> int
+  .. method:: Metric::get() -> int
 
-  Get value of metric
+    Get value of metric
 
 Metrics are shared across all of PowerDNS and are fully atomic and high performance.
 A :class:`Metric` object is effectively a pointer to an atomic value.

--- a/pdns/recursordist/docs/running.rst
+++ b/pdns/recursordist/docs/running.rst
@@ -57,7 +57,7 @@ To log only info messages, use ``local0.=info``
 Cache Management
 ----------------
 Sometimes a domain fails to resolve due to an error on the domain owner's end, or records for your own domain have updated and you want your users to immediatly see them without waiting for the TTL to expire.
-The :doc:`rec_control <manpages/rec_control>` tool can be used to selectively wipe the cache.
+The :doc:`rec_control <manpages/rec_control.1>` tool can be used to selectively wipe the cache.
 
 To wipe all records for the exact name 'www.example.com'::
 
@@ -72,7 +72,7 @@ Whole subtrees can we wiped as well, to wipe all cache entries for 'example.com'
   When wiping cache entries, matching entries in *all* caches (packet cache, recursor cache, negative cache) are removed.
 
 When debugging resolving issues, it can be advantagious to have a dump of all the cache entries.
-:doc:`rec_control <manpages/rec_control>` can write the caches of all threads to a file::
+:doc:`rec_control <manpages/rec_control.1>` can write the caches of all threads to a file::
 
   rec_control dump-cache /tmp/cache
 
@@ -89,7 +89,7 @@ To enable tracing for all queries, enable the :ref:`setting-trace` setting.
 
 Tracing can also be enabled at runtime, without restarting the Recursor, for specific domains.
 These specific domains can be specified as a regular expression.
-This can be done using :doc:`rec_control trace-regex <manpages/rec_control>`::
+This can be done using :doc:`rec_control trace-regex <manpages/rec_control.1>`::
 
     rec_control trace-regex '.*\.example.com\.$'
 


### PR DESCRIPTION
### Short description
This PR fixes some issues with the documentation regarding Lua objects. The layout is improved by this.

*before*
![screenshot_2018-01-25_18-13-43](https://user-images.githubusercontent.com/731232/35402088-be63cb30-01fb-11e8-9d2f-b79c6c1d2b9c.png)

*after*
![screenshot_2018-01-25_18-13-59](https://user-images.githubusercontent.com/731232/35402089-be95bd70-01fb-11e8-876a-dde9cde84cba.png)

Several other small rendering issues and missing refs are fixed as well

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)