### PR TITLE
dnsdist: fix build without protobuf

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -59,9 +59,7 @@
 #include "sstuff.hh"
 #include "xpf.hh"
 
-#ifdef HAVE_PROTOBUF
 thread_local boost::uuids::random_generator t_uuidGenerator;
-#endif
 
 /* Known sins:
 


### PR DESCRIPTION
### Short description
t_uuidGenerator is now used in makeRuleID, but was only present under HAVE_PROTOBUF.

Found by @Habbie.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
