### PR TITLE
ixfrdist: Check the serial even if verbose is off

### DIFF
--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -206,15 +206,19 @@ void updateThread() {
       try {
         lastCheck[domain] = now;
         auto newSerial = getSerialFromMaster(g_master, domain, sr); // TODO TSIG
-        if(g_soas.find(domain) != g_soas.end() && g_verbose) {
-          cerr<<"[INFO] Got SOA Serial for "<<domain<<" from "<<g_master.toStringWithPort()<<": "<< newSerial<<", had Serial: "<<g_soas[domain]->d_st.serial;
+        if(g_soas.find(domain) != g_soas.end()) {
+          if (g_verbose) {
+            cerr<<"[INFO] Got SOA Serial for "<<domain<<" from "<<g_master.toStringWithPort()<<": "<< newSerial<<", had Serial: "<<g_soas[domain]->d_st.serial;
+          }
           if (newSerial == g_soas[domain]->d_st.serial) {
             if (g_verbose) {
               cerr<<", not updating."<<endl;
             }
             continue;
           }
-          cerr<<", will update."<<endl;
+          if (g_verbose) {
+            cerr<<", will update."<<endl;
+          }
         }
       } catch (runtime_error &e) {
         cerr<<"[WARNING] Unable to get SOA serial update for '"<<domain<<"': "<<e.what()<<endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
I haven't done a real test but looking at the code, it seems that we do not check if our serial is up to date when running in non-verbose mode.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
