### PR TITLE
dnsdist: avoid port reuse in tests

### DIFF
--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -79,7 +79,7 @@ def checkDnstapResponse(testinstance, dnstap, protocol, response, initiator='127
 
 
 class TestDnstapOverRemoteLogger(DNSDistTest):
-    _remoteLoggerServerPort = 4242
+    _remoteLoggerServerPort = 4243
     _remoteLoggerQueue = Queue.Queue()
     _remoteLoggerCounter = 0
     _config_params = ['_testServerPort', '_remoteLoggerServerPort']


### PR DESCRIPTION
### Short description
Apparently the dnstap listener does not always shut down correctly. Using a different port than the protobuf tests avoids an annoying failure.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
