### PR TITLE
Making swagger code-gen happy.

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -891,8 +891,8 @@ definitions:
   StatisticItem:
     title: StatisticItem
     allOf:
-      $ref: "#/definitions/BaseStatisticItem"
-      properties:
+    - $ref: "#/definitions/BaseStatisticItem"
+    - properties:
         type:
           enum: [StatisticItem]
           description: 'set to "StatisticItem"'
@@ -903,8 +903,8 @@ definitions:
   MapStatisticItem:
     title: MapStatisticItem
     allOf:
-      $ref: "#/definitions/BaseStatisticItem"
-      properties:
+    - $ref: "#/definitions/BaseStatisticItem"
+    - properties:
         type:
           enum: [MapStatisticItem]
           description: 'set to "MapStatisticItem"'
@@ -924,8 +924,8 @@ definitions:
   RingStatisticItem:
     title: RingStatisticItem
     allOf:
-      $ref: "#/definitions/BaseStatisticItem"
-      properties:
+    - $ref: "#/definitions/BaseStatisticItem"
+    - properties:
         type:
           enum: [RingStatisticItem]
           description: 'set to "RingStatisticItem"'

--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -368,9 +368,9 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/StatisticItem'
-              $ref: '#/definitions/MapStatisticItem'
-              $ref: '#/definitions/RingStatisticItem'
+            - $ref: '#/definitions/StatisticItem'
+            - $ref: '#/definitions/MapStatisticItem'
+            - $ref: '#/definitions/RingStatisticItem'
 
   '/servers/{server_id}/search-log':
     get:


### PR DESCRIPTION
swagger-codegen was throwing errors about invalid syntax and unexpected types. allOf requires to specify a mixed type array, which is syntactically expressed by "-"

See:
https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
https://swagger.io/docs/specification/data-models/data-types/#array