### PR TITLE
ixfrdist: Prevent a nullptr exception and guard reads/writes

### DIFF
--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -260,16 +260,16 @@ void updateThread() {
         if (g_verbose) {
           cerr<<"[INFO] Wrote zonedata for "<<domain<<" with serial "<<soa->d_st.serial<<" to "<<dir<<endl;
         }
+        {
+          std::lock_guard<std::mutex> guard(g_soas_mutex);
+          g_soas[domain] = soa;
+        }
+
       } catch (ResolverException &e) {
         cerr<<"[WARNING] Could not retrieve AXFR for '"<<domain<<"': "<<e.reason<<endl;
       } catch (runtime_error &e) {
         cerr<<"[WARNING] Could not save zone '"<<domain<<"' to disk: "<<e.what()<<endl;
       }
-      {
-        std::lock_guard<std::mutex> guard(g_soas_mutex);
-        g_soas[domain] = soa;
-      }
-
       // Now clean up the directory
       cleanUpDomain(domain);
     } /* for (const auto &domain : domains) */


### PR DESCRIPTION
### Short description
It was found that ixfrdist would crash with a segfault under certain circumstances. It seems that we would accidentally write a nullptr into `g_soas` on an update exception. This PR ensures we only write a SOA to g_soas when an update is fully done.

Also, protect every read access to `g_soas` with the mutex.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
