### PR TITLE
ixfrdist: Allow setting the inbound AXFR timeout

### DIFF
--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -429,7 +429,7 @@ AXFRRetriever::~AXFRRetriever()
 
 
 
-int AXFRRetriever::getChunk(Resolver::res_t &res, vector<DNSRecord>* records) // Implementation is making sure RFC2845 4.4 is followed.
+int AXFRRetriever::getChunk(Resolver::res_t &res, vector<DNSRecord>* records, uint16_t timeout) // Implementation is making sure RFC2845 4.4 is followed.
 {
   if(d_soacount > 1)
     return false;
@@ -442,7 +442,7 @@ int AXFRRetriever::getChunk(Resolver::res_t &res, vector<DNSRecord>* records) //
   if (d_maxReceivedBytes > 0 && (d_maxReceivedBytes - d_receivedBytes) < (size_t) len)
     throw ResolverException("Reached the maximum number of received bytes during AXFR");
 
-  timeoutReadn(len);
+  timeoutReadn(len, timeout);
 
   d_receivedBytes += (uint16_t) len;
 
@@ -475,13 +475,13 @@ int AXFRRetriever::getChunk(Resolver::res_t &res, vector<DNSRecord>* records) //
   return true;
 }
 
-void AXFRRetriever::timeoutReadn(uint16_t bytes)
+void AXFRRetriever::timeoutReadn(uint16_t bytes, uint16_t timeoutsec)
 {
-  time_t start=time(0);
+  time_t start=time(nullptr);
   int n=0;
   int numread;
   while(n<bytes) {
-    int res=waitForData(d_sock, 10-(time(0)-start));
+    int res=waitForData(d_sock, timeoutsec-(time(nullptr)-start));
     if(res<0)
       throw ResolverException("Reading data from remote nameserver over TCP: "+stringerror());
     if(!res)

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -87,12 +87,12 @@ class AXFRRetriever : public boost::noncopyable
                   const ComboAddress* laddr = NULL,
                   size_t maxReceivedBytes=0);
     ~AXFRRetriever();
-    int getChunk(Resolver::res_t &res, vector<DNSRecord>* records=0);  
+    int getChunk(Resolver::res_t &res, vector<DNSRecord>* records=0, uint16_t timeout=10);
   
   private:
     void connect();
     int getLength();
-    void timeoutReadn(uint16_t bytes);  
+    void timeoutReadn(uint16_t bytes, uint16_t timeoutsec=10);
 
     shared_array<char> d_buf;
     string d_domain;


### PR DESCRIPTION
### Short description
When transferring huge zones, we might not make in the hardcoded 10 seconds. This PR makes `AXFRRetriever::getChunk()` and `timeoutReadn()` get an optional timeout parameter and hooks it up to ixfrdist.

We'll nee dto hook this up to the recursor and the auth in the future as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
