### PR TITLE
dnsupdate: Reject updates if they would lead to CNAME+Other data

### DIFF
--- a/regression-tests/tests/1dyndns-cname-and-other-data/command
+++ b/regression-tests/tests/1dyndns-cname-and-other-data/command
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+RECORDNAME=cname-and-other.test.dyndns
+
+echo '* Check if there is nothing there'
+cleandig $RECORDNAME ANY hidesoadetails
+
+echo '* Try to add 2 records that are not allowed together (should lead to FORMERR)'
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update add $RECORDNAME. 3600 CNAME powerdns-cname.example.
+update add $RECORDNAME. 3600 A 192.0.2.1
+send
+answer
+!
+
+echo '* check that indeed nothing was added'
+cleandig $RECORDNAME A hidesoadetails
+cleandig $RECORDNAME CNAME hidesoadetails
+
+echo '* Add a CNAME'
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update add $RECORDNAME. 3600 CNAME powerdns-cname.example.
+send
+answer
+!
+
+echo '* Attempt to add an A record (should be REFUSED)'
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update add $RECORDNAME. 3600 A 192.0.2.1
+send
+answer
+!
+
+echo '* Check that we only still have the CNAME'
+cleandig $RECORDNAME A hidesoadetails
+
+echo '* Delete the CNAME and add the A record in one go'
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update delete $RECORDNAME. 3600 CNAME powerdns-cname.example.
+update add $RECORDNAME. 3600 A 192.0.2.1
+send
+answer
+!
+
+echo '* Check that we have only the A-record'
+cleandig $RECORDNAME A hidesoadetails
+cleandig $RECORDNAME CNAME hidesoadetails
+
+echo '* Attempt to add a CNAME (should be REFUSED)'
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update add $RECORDNAME. 3600 CNAME powerdns-cname.example.
+send
+answer
+!
+
+echo '* check that we have only the A-record'
+cleandig $RECORDNAME ANY hidesoadetails
+
+echo '* Clean up'
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update delete $RECORDNAME. 3600 A 192.0.2.1
+send
+answer
+!

--- a/regression-tests/tests/1dyndns-cname-and-other-data/description
+++ b/regression-tests/tests/1dyndns-cname-and-other-data/description
@@ -1,0 +1,3 @@
+A test to check whether the server detects that the update is trying to add
+records for names where CNAMEs exists or where adding a CNAME is attempted when
+other data exists.

--- a/regression-tests/tests/1dyndns-cname-and-other-data/expected_result
+++ b/regression-tests/tests/1dyndns-cname-and-other-data/expected_result
@@ -1,0 +1,68 @@
+* Check if there is nothing there
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
+Rcode: 3 (Non-Existent domain), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='cname-and-other.test.dyndns.', qtype=ANY
+* Try to add 2 records that are not allowed together (should lead to FORMERR)
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: FORMERR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+* check that indeed nothing was added
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
+Rcode: 3 (Non-Existent domain), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='cname-and-other.test.dyndns.', qtype=A
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
+Rcode: 3 (Non-Existent domain), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='cname-and-other.test.dyndns.', qtype=CNAME
+* Add a CNAME
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+* Attempt to add an A record (should be REFUSED)
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: REFUSED, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+* Check that we only still have the CNAME
+0	cname-and-other.test.dyndns.	IN	CNAME	3600	powerdns-cname.example.
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='cname-and-other.test.dyndns.', qtype=A
+* Delete the CNAME and add the A record in one go
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+* Check that we have only the A-record
+0	cname-and-other.test.dyndns.	IN	A	3600	192.0.2.1
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='cname-and-other.test.dyndns.', qtype=A
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='cname-and-other.test.dyndns.', qtype=CNAME
+* Attempt to add a CNAME (should be REFUSED)
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: REFUSED, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+* check that we have only the A-record
+0	cname-and-other.test.dyndns.	IN	A	3600	192.0.2.1
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='cname-and-other.test.dyndns.', qtype=ANY
+* Clean up
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+

--- a/regression-tests/tests/1dyndns-cname-and-other-data/skip.nodyndns
+++ b/regression-tests/tests/1dyndns-cname-and-other-data/skip.nodyndns
@@ -1,0 +1,1 @@
+Skip this test if the backend does not support dyndns/rfc2136


### PR DESCRIPTION
### Short description
When sending a DNS UPDATE with a CNAME and other data addition for the same name, we will send a FORMERR back to the client.

When an addition of a CNAME is attempted and there is other data at that name (that is not removed in the same update), send a REFUSED to the client.

When data is added and there is a CNAME at that name (that is not removed in the same update), send a REFUSED to the client.

Closes #6270 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)