### PR TITLE
pkcs11signers: Fix yubikey NEO to work

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -96,6 +96,9 @@ shared_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCString(DNSKEYRecor
     }  else if (pdns_iequals(key,"label")) {
       stormap["label"]=value;
       continue;
+    } else if (pdns_iequals(key,"publabel")) {
+      stormap["publabel"]=value;
+      continue;
     }
     else if(pdns_iequals(key, "Private-key-format"))
       continue;
@@ -131,7 +134,7 @@ std::string DNSCryptoKeyEngine::convertToISC() const
   for(const stormap_t::value_type& value :  stormap) {
     if(value.first != "Algorithm" && value.first != "PIN" && 
        value.first != "Slot" && value.first != "Engine" &&
-       value.first != "Label") 
+       value.first != "Label" && value.first != "PubLabel")
       ret<<value.first<<": "<<Base64Encode(value.second)<<"\n";
     else
       ret<<value.first<<": "<<value.second<<"\n";

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2901,7 +2901,10 @@ try
   } else if (cmds[0]=="hsm") {
 #ifdef HAVE_P11KIT1
     UeberBackend B("default");
-    if (cmds[1] == "assign") {
+    if (cmds.size() < 2) {
+      cerr << "Missing sub-command for pdnsutil hsm"<< std::endl;
+      return 0;
+    } else if (cmds[1] == "assign") {
       DNSCryptoKeyEngine::storvector_t storvect;
       DomainInfo di;
       std::vector<DNSBackend::KeyData> keys;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2907,7 +2907,7 @@ try
       std::vector<DNSBackend::KeyData> keys;
 
       if (cmds.size() < 9) {
-        std::cout << "Usage: pdnsutil hsm assign ZONE ALGORITHM {ksk|zsk} MODULE TOKEN PIN LABEL" << std::endl;
+        std::cout << "Usage: pdnsutil hsm assign ZONE ALGORITHM {ksk|zsk} MODULE TOKEN PIN LABEL (PUBLABEL)" << std::endl;
         return 1;
       }
 
@@ -2931,6 +2931,11 @@ try
       string slot = cmds[6];
       string pin = cmds[7];
       string label = cmds[8];
+      string pub_label;
+      if (cmds.size() > 9)
+         pub_label = cmds[9];
+      else
+         pub_label = label;
 
       std::ostringstream iscString;
       iscString << "Private-key-format: v1.2" << std::endl << 
@@ -2938,7 +2943,8 @@ try
         "Engine: " << module << std::endl <<
         "Slot: " << slot << std::endl <<
         "PIN: " << pin << std::endl << 
-        "Label: " << label << std::endl;
+        "Label: " << label << std::endl <<
+        "PubLabel: " << pub_label << std::endl;
 
       DNSKEYRecordContent drc;
       DNSSECPrivateKey dpk;

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -279,6 +279,8 @@ class Pkcs11Token {
     std::string d_ecdsa_params;
 
     std::string d_label;
+    std::string d_pub_label;
+
     bool d_loaded;
     CK_RV d_err;
 
@@ -290,7 +292,7 @@ class Pkcs11Token {
     }
 
   public:
-    Pkcs11Token(const std::shared_ptr<Pkcs11Slot>& slot, const std::string& label); 
+    Pkcs11Token(const std::shared_ptr<Pkcs11Slot>& slot, const std::string& label, const std::string& pub_label); 
     ~Pkcs11Token();
 
     bool Login(const std::string& pin) {
@@ -325,10 +327,10 @@ class Pkcs11Token {
       attr.clear();
       attr.push_back(P11KitAttribute(CKA_CLASS, (unsigned long)CKO_PUBLIC_KEY));
 //      attr.push_back(P11KitAttribute(CKA_VERIFY, (char)CK_TRUE));
-      attr.push_back(P11KitAttribute(CKA_LABEL, d_label));
+      attr.push_back(P11KitAttribute(CKA_LABEL, d_pub_label));
       FindObjects2(attr, key, 1);
       if (key.size() == 0) {
-        L<<Logger::Warning<<"Cannot load PCKS#11 public key "<<d_label<<std::endl;
+        L<<Logger::Warning<<"Cannot load PCKS#11 public key "<<d_pub_label<<std::endl;
         return;
       }
       d_public_key = key[0];
@@ -349,7 +351,7 @@ class Pkcs11Token {
             d_exponent = attr[1].str();
             d_bits = attr[2].ulong();
           } else {
-            throw PDNSException("Cannot load attributes for PCKS#11 public key " + d_label);
+            throw PDNSException("Cannot load attributes for PCKS#11 public key " + d_pub_label);
           }
         } else if (d_key_type == CKK_EC || d_key_type == CKK_ECDSA) {
           attr.clear();
@@ -363,13 +365,13 @@ class Pkcs11Token {
             if (attr[1].str().length() != (d_bits*2/8 + 3)) throw PDNSException("EC Point data invalid");
             d_ec_point = attr[1].str().substr(3);
           } else {
-            throw PDNSException("Cannot load attributes for PCKS#11 public key " + d_label);
+            throw PDNSException("Cannot load attributes for PCKS#11 public key " + d_pub_label);
           }
         } else {
-          throw PDNSException("Cannot determine type for PCKS#11 public key " + d_label);
+          throw PDNSException("Cannot determine type for PCKS#11 public key " + d_pub_label);
         }
       } else {
-        throw PDNSException("Cannot load attributes for PCKS#11 public key " + d_label);
+        throw PDNSException("Cannot load attributes for PCKS#11 public key " + d_pub_label);
       }
 
       d_loaded = true;
@@ -617,7 +619,7 @@ class Pkcs11Token {
       return d_bits;
     }
 
-    static std::shared_ptr<Pkcs11Token> GetToken(const std::string& module, const string& tokenId, const std::string& label);
+    static std::shared_ptr<Pkcs11Token> GetToken(const std::string& module, const string& tokenId, const std::string& label, const std::string& pub_label);
 };
 
 static std::map<std::string, std::shared_ptr<Pkcs11Slot> > pkcs11_slots;
@@ -720,7 +722,7 @@ std::shared_ptr<Pkcs11Slot> Pkcs11Slot::GetSlot(const std::string& module, const
   return pkcs11_slots[sidx];
 }
 
-std::shared_ptr<Pkcs11Token> Pkcs11Token::GetToken(const std::string& module, const string& tokenId, const std::string& label) {
+std::shared_ptr<Pkcs11Token> Pkcs11Token::GetToken(const std::string& module, const string& tokenId, const std::string& label, const std::string& pub_label) {
   // see if we can find module
   std::string tidx = module;
   tidx.append("|");
@@ -731,15 +733,16 @@ std::shared_ptr<Pkcs11Token> Pkcs11Token::GetToken(const std::string& module, co
   if ((tokenIter = pkcs11_tokens.find(tidx)) != pkcs11_tokens.end()) return tokenIter->second;
 
   std::shared_ptr<Pkcs11Slot> slot = Pkcs11Slot::GetSlot(module, tokenId);
-  pkcs11_tokens[tidx] = std::make_shared<Pkcs11Token>(slot, label);
+  pkcs11_tokens[tidx] = std::make_shared<Pkcs11Token>(slot, label, pub_label);
   return pkcs11_tokens[tidx];
 }
 
-Pkcs11Token::Pkcs11Token(const std::shared_ptr<Pkcs11Slot>& slot, const std::string& label) {
+Pkcs11Token::Pkcs11Token(const std::shared_ptr<Pkcs11Slot>& slot, const std::string& label, const std::string& pub_label) {
   // open a session
   this->d_bits = 0;
   this->d_slot = slot;
   this->d_label = label;
+  this->d_pub_label = pub_label;
   this->d_err = 0;
   this->d_loaded = false;
   if (this->d_slot->LoggedIn()) LoadAttributes();
@@ -767,7 +770,7 @@ void PKCS11DNSCryptoKeyEngine::create(unsigned int bits) {
   CK_OBJECT_HANDLE pubKey, privKey;
   CK_RV rv;
   std::shared_ptr<Pkcs11Token> d_slot;
-  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label);
+  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label, d_pub_label);
   if (d_slot->LoggedIn() == false)
     if (d_slot->Login(d_pin) == false)
       throw PDNSException("Not logged in to token");
@@ -782,7 +785,7 @@ void PKCS11DNSCryptoKeyEngine::create(unsigned int bits) {
   pubAttr.push_back(P11KitAttribute(CKA_WRAP, (char)CK_TRUE));
   pubAttr.push_back(P11KitAttribute(CKA_MODULUS_BITS, (unsigned long)bits));
   pubAttr.push_back(P11KitAttribute(CKA_PUBLIC_EXPONENT, pubExp));
-  pubAttr.push_back(P11KitAttribute(CKA_LABEL, d_label));
+  pubAttr.push_back(P11KitAttribute(CKA_LABEL, d_pub_label));
 
   privAttr.push_back(P11KitAttribute(CKA_CLASS, (unsigned long)CKO_PRIVATE_KEY));
   privAttr.push_back(P11KitAttribute(CKA_KEY_TYPE, (unsigned long)CKK_RSA));
@@ -808,7 +811,7 @@ void PKCS11DNSCryptoKeyEngine::create(unsigned int bits) {
 std::string PKCS11DNSCryptoKeyEngine::sign(const std::string& msg) const {
   std::string result;
   std::shared_ptr<Pkcs11Token> d_slot;
-  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label);
+  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label, d_pub_label);
   if (d_slot->LoggedIn() == false)
     if (d_slot->Login(d_pin) == false)
       throw PDNSException("Not logged in to token");
@@ -833,7 +836,7 @@ std::string PKCS11DNSCryptoKeyEngine::hash(const std::string& msg) const {
   mech.pParameter = NULL;
   mech.ulParameterLen = 0;
   std::shared_ptr<Pkcs11Token> d_slot;
-  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label);
+  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label, d_pub_label);
   if (d_slot->LoggedIn() == false)
     if (d_slot->Login(d_pin) == false)
       throw PDNSException("Not logged in to token");
@@ -864,7 +867,7 @@ std::string PKCS11DNSCryptoKeyEngine::hash(const std::string& msg) const {
 
 bool PKCS11DNSCryptoKeyEngine::verify(const std::string& msg, const std::string& signature) const {
   std::shared_ptr<Pkcs11Token> d_slot;
-  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label);
+  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label, d_pub_label);
   if (d_slot->LoggedIn() == false)
     if (d_slot->Login(d_pin) == false)
       throw PDNSException("Not logged in to token");
@@ -883,7 +886,7 @@ bool PKCS11DNSCryptoKeyEngine::verify(const std::string& msg, const std::string&
 std::string PKCS11DNSCryptoKeyEngine::getPubKeyHash() const {
   // find us a public key
   std::shared_ptr<Pkcs11Token> d_slot;
-  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label);
+  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label, d_pub_label);
   if (d_slot->LoggedIn() == false)
     if (d_slot->Login(d_pin) == false)
       throw PDNSException("Not logged in to token");
@@ -896,7 +899,7 @@ std::string PKCS11DNSCryptoKeyEngine::getPubKeyHash() const {
 std::string PKCS11DNSCryptoKeyEngine::getPublicKeyString() const {
   std::string result("");
   std::shared_ptr<Pkcs11Token> d_slot;
-  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label);
+  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label, d_pub_label);
   if (d_slot->LoggedIn() == false)
     if (d_slot->Login(d_pin) == false)
       throw PDNSException("Not logged in to token");
@@ -919,7 +922,7 @@ std::string PKCS11DNSCryptoKeyEngine::getPublicKeyString() const {
 
 int PKCS11DNSCryptoKeyEngine::getBits() const {
   std::shared_ptr<Pkcs11Token> d_slot;
-  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label);
+  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label, d_pub_label);
   if (d_slot->LoggedIn() == false)
     if (d_slot->Login(d_pin) == false)
       throw PDNSException("Not logged in to token");
@@ -937,7 +940,8 @@ DNSCryptoKeyEngine::storvector_t PKCS11DNSCryptoKeyEngine::convertToISCVector() 
    (make_pair("Engine", d_module))
    (make_pair("Slot", d_slot_id))
    (make_pair("PIN", d_pin))
-   (make_pair("Label", d_label));
+   (make_pair("Label", d_label))
+   (make_pair("PubLabel", d_pub_label));
   return storvect;
 };
 
@@ -948,10 +952,14 @@ void PKCS11DNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, stormap_t& s
   boost::trim(d_slot_id);
   d_pin = stormap["pin"];
   d_label = stormap["label"];
+  if (stormap.find("publabel") != stormap.end())
+    d_pub_label = stormap["publabel"];
+  else
+    d_pub_label = d_label;
   // validate parameters
 
   std::shared_ptr<Pkcs11Token> d_slot;
-  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label);
+  d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label, d_pub_label);
   if (d_pin != "" && d_slot->LoggedIn() == false)
     if (d_slot->Login(d_pin) == false)
       throw PDNSException("Could not log in to token (PIN wrong?)");

--- a/pdns/pkcs11signers.hh
+++ b/pdns/pkcs11signers.hh
@@ -29,6 +29,7 @@ class PKCS11DNSCryptoKeyEngine : public DNSCryptoKeyEngine
     std::string d_slot_id;
     std::string d_pin;
     std::string d_label;
+    std::string d_pub_label;
 
   public:
     PKCS11DNSCryptoKeyEngine(unsigned int algorithm);


### PR DESCRIPTION
### Short description

Some devices have slots that do not start from 0, so we ask for the slot IDs from the device and iterate those instead of just guessing the slot ID.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
