### PR TITLE
dnsdist: Clean up QTag code

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -693,16 +693,16 @@ private:
 class TagAction : public DNSAction
 {
 public:
-  TagAction(const std::string tag, std::string value): d_tag(tag), d_value(value)
+  TagAction(const std::string tag, const std::string value): d_tag(tag), d_value(value)
   {
   }
   DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
   {
-    if (dq->qTag == nullptr) {
+    if (!dq->qTag) {
       dq->qTag = std::make_shared<QTag>();
     }
 
-    dq->qTag->add(d_tag, d_value);
+    dq->qTag->insert({d_tag, d_value});
 
     return Action::None;
   }
@@ -854,16 +854,16 @@ private:
 class TagResponseAction : public DNSResponseAction
 {
 public:
-  TagResponseAction(const std::string tag, std::string value): d_tag(tag), d_value(value)
+  TagResponseAction(const std::string tag, const std::string value): d_tag(tag), d_value(value)
   {
   }
   DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
   {
-    if (dr->qTag == nullptr) {
+    if (!dr->qTag) {
       dr->qTag = std::make_shared<QTag>();
     }
 
-    dr->qTag->add(d_tag, d_value);
+    dr->qTag->insert({d_tag, d_value});
 
     return Action::None;
   }

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -831,12 +831,12 @@ public:
   }
   bool matches(const DNSQuestion* dq) const override
   {
-    if (dq->qTag == nullptr) {
+    if (!dq->qTag) {
       return false;
     }
 
-    const auto got = dq->qTag->tagData.find(d_tag);
-    if (got == dq->qTag->tagData.cend()) {
+    const auto it = dq->qTag->find(d_tag);
+    if (it == dq->qTag->cend()) {
       return false;
     }
 
@@ -844,7 +844,7 @@ public:
       return true;
     }
 
-    return got->second == *d_value;
+    return it->second == *d_value;
   }
 
   string toString() const override

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -53,76 +53,9 @@ extern uint16_t g_ECSSourcePrefixV4;
 extern uint16_t g_ECSSourcePrefixV6;
 extern bool g_ECSOverride;
 
-class QTag
-{
-public:
-  QTag()
-  {
-  }
-
-  ~QTag()
-  {
-  }
-
-  void add(const std::string& strLabel, const std::string& strValue)
-  {
-    tagData.insert({strLabel, strValue});
-    return;
-  }
-
-  std::string getMatch(const std::string& strLabel)  const
-  {
-    const auto got = tagData.find(strLabel);
-    if (got == tagData.cend()) {
-      return "";
-    }
-
-    return got->second;
-  }
-
-  std::string getEntry(size_t iEntry) const
-  {
-    std::string strEntry;
-    size_t iCounter = 0;
-
-    for (const auto& itr : tagData) {
-      iCounter++;
-      if(iCounter == iEntry) {
-        strEntry = itr.first;
-        strEntry += strSep;
-        strEntry += itr.second;
-        break;
-      }
-    }
-
-    return strEntry;
-  }
-
-  size_t count() const
-  {
-    return tagData.size();
-  }
-
-  std::string dumpString() const
-  {
-    std::string strRet;
-
-    for (const auto& itr : tagData) {
-      strRet += itr.first;
-      strRet += strSep;
-      strRet += itr.second;
-      strRet += "\n";
-    }
-    return strRet;
-  }
-
-  std::unordered_map<std::string, std::string> tagData;
-
-private:
-  static constexpr char const *strSep = "\t";
-};
-
 extern thread_local boost::uuids::random_generator t_uuidGenerator;
+
+typedef std::unordered_map<string, string> QTag;
 
 struct DNSQuestion
 {
@@ -137,7 +70,7 @@ struct DNSQuestion
   const uint16_t qclass;
   const ComboAddress* local;
   const ComboAddress* remote;
-  std::shared_ptr<QTag> qTag;
+  std::shared_ptr<QTag> qTag{nullptr};
   struct dnsheader* dh;
   size_t size;
   uint16_t len;


### PR DESCRIPTION
### Short description
Removes the class QTag wrapper around std::unordered_map, which did not provide any value as far as I could see.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
