### PR TITLE
dnsdist: Report Lua(Response)Action failures

### DIFF
--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -33,13 +33,15 @@ void setupLuaVars()
       {"Pool", (int)DNSAction::Action::Pool},
       {"None",(int)DNSAction::Action::None},
       {"Delay", (int)DNSAction::Action::Delay},
-      {"Truncate", (int)DNSAction::Action::Truncate}
+      {"Truncate", (int)DNSAction::Action::Truncate},
+      {"ServFail", (int)DNSAction::Action::ServFail}
     });
 
   g_lua.writeVariable("DNSResponseAction", std::unordered_map<string,int>{
       {"Allow",        (int)DNSResponseAction::Action::Allow        },
       {"Delay",        (int)DNSResponseAction::Action::Delay        },
       {"HeaderModify", (int)DNSResponseAction::Action::HeaderModify },
+      {"ServFail",     (int)DNSResponseAction::Action::ServFail     },
       {"None",         (int)DNSResponseAction::Action::None         }
     });
 

--- a/pdns/dnsdist-snmp.cc
+++ b/pdns/dnsdist-snmp.cc
@@ -46,6 +46,7 @@ static const oid cpuSysMSecOID[] = { DNSDIST_STATS_OID, 33 };
 static const oid fdUsageOID[] = { DNSDIST_STATS_OID, 34 };
 static const oid dynBlockedOID[] = { DNSDIST_STATS_OID, 35 };
 static const oid dynBlockedNMGSizeOID[] = { DNSDIST_STATS_OID, 36 };
+static const oid ruleServFailOID[] = { DNSDIST_STATS_OID, 37 };
 
 static std::unordered_map<oid, DNSDistStats::entry_t> s_statsMap;
 
@@ -547,6 +548,7 @@ DNSDistSNMPAgent::DNSDistSNMPAgent(const std::string& name, const std::string& m
   registerCounter64Stat("ruleDrop", ruleDropOID, OID_LENGTH(ruleDropOID), &g_stats.ruleDrop);
   registerCounter64Stat("ruleNXDomain", ruleNXDomainOID, OID_LENGTH(ruleNXDomainOID), &g_stats.ruleNXDomain);
   registerCounter64Stat("ruleRefused", ruleRefusedOID, OID_LENGTH(ruleRefusedOID), &g_stats.ruleRefused);
+  registerCounter64Stat("ruleServFail", ruleServFailOID, OID_LENGTH(ruleServFailOID), &g_stats.ruleServFail);
   registerCounter64Stat("selfAnswered", selfAnsweredOID, OID_LENGTH(selfAnsweredOID), &g_stats.selfAnswered);
   registerCounter64Stat("downstreamTimeouts", downstreamTimeoutsOID, OID_LENGTH(downstreamTimeoutsOID), &g_stats.downstreamTimeouts);
   registerCounter64Stat("downstreamSendErrors", downstreamSendErrorsOID, OID_LENGTH(downstreamSendErrorsOID), &g_stats.downstreamSendErrors);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -992,6 +992,12 @@ bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int*
         g_stats.ruleRefused++;
         return true;
         break;
+      case DNSAction::Action::ServFail:
+        dq.dh->rcode = RCode::ServFail;
+        dq.dh->qr=true;
+        g_stats.ruleServFail++;
+        return true;
+        break;
       case DNSAction::Action::Spoof:
         spoofResponseFromString(dq, ruleresult);
         return true;
@@ -1037,6 +1043,10 @@ bool processResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& local
         return false;
         break;
       case DNSResponseAction::Action::HeaderModify:
+        return true;
+        break;
+      case DNSResponseAction::Action::ServFail:
+        dr.dh->rcode = RCode::ServFail;
         return true;
         break;
         /* non-terminal actions follow */

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -169,7 +169,7 @@ struct DNSResponse : DNSQuestion
 class DNSAction
 {
 public:
-  enum class Action { Drop, Nxdomain, Refused, Spoof, Allow, HeaderModify, Pool, Delay, Truncate, None};
+  enum class Action { Drop, Nxdomain, Refused, Spoof, Allow, HeaderModify, Pool, Delay, Truncate, ServFail, None};
   virtual Action operator()(DNSQuestion*, string* ruleresult) const =0;
   virtual ~DNSAction()
   {
@@ -184,7 +184,7 @@ public:
 class DNSResponseAction
 {
 public:
-  enum class Action { Allow, Delay, Drop, HeaderModify, None };
+  enum class Action { Allow, Delay, Drop, HeaderModify, ServFail, None };
   virtual Action operator()(DNSResponse*, string* ruleresult) const =0;
   virtual ~DNSResponseAction()
   {
@@ -230,6 +230,7 @@ struct DNSDistStats
   stat_t ruleDrop{0};
   stat_t ruleNXDomain{0};
   stat_t ruleRefused{0};
+  stat_t ruleServFail{0};
   stat_t selfAnswered{0};
   stat_t downstreamTimeouts{0};
   stat_t downstreamSendErrors{0};
@@ -250,6 +251,7 @@ struct DNSDistStats
     {"rule-drop", &ruleDrop},
     {"rule-nxdomain", &ruleNXDomain},
     {"rule-refused", &ruleRefused},
+    {"rule-servfail", &ruleServFail},
     {"self-answered", &selfAnswered},
     {"downstream-timeouts", &downstreamTimeouts},
     {"downstream-send-errors", &downstreamSendErrors}, 

--- a/pdns/dnsdistdist/DNSDIST-MIB.txt
+++ b/pdns/dnsdistdist/DNSDIST-MIB.txt
@@ -318,6 +318,14 @@ dynBlockNMGSize OBJECT-TYPE
 	"Dynamic blocks (NMG) size"
     ::= { stats 36 }
 
+ruleServFail OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+	"Number of ServFail responses returned because of a rule"
+    ::= { stats 37 }
+
 backendStatTable OBJECT-TYPE
     SYNTAX SEQUENCE OF BackendStatEntry
     MAX-ACCESS not-accessible

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -150,7 +150,7 @@ Rule Generators
 
   Invoke a Lua function that accepts a :class:`DNSQuestion`.
   This function works similar to using :func:`LuaAction`.
-  The ``function`` should return a :ref:`DNSAction`.
+  The ``function`` should return a :ref:`DNSAction`. If the Lua code fails, ServFail is returned.
 
   :param DNSRule: match queries based on this rule
   :param string function: the name of a Lua function
@@ -165,10 +165,9 @@ Rule Generators
   .. versionchanged:: 1.3.0
     Added the optional parameter ``options``.
 
-  Invoke a Lua function that accepts a :class:`DNSQuestion` on the response.
-  This function works similar to using :func:`LuaAction`.
-
-  The ``function`` should return a :ref:`DNSAction`.
+  Invoke a Lua function that accepts a :class:`DNSResponse`.
+  This function works similar to using :func:`LuaResponseAction`.
+  The ``function`` should return a :ref:`DNSResponseAction`. If the Lua code fails, ServFail is returned.
 
   :param DNSRule: match queries based on this rule
   :param string function: the name of a Lua function
@@ -785,7 +784,7 @@ The following actions exist.
 
   Invoke a Lua function that accepts a :class:`DNSQuestion`.
 
-  The ``function`` should return a :ref:`DNSAction`.
+  The ``function`` should return a :ref:`DNSAction`. If the Lua code fails, ServFail is returned.
 
   :param string function: the name of a Lua function
 
@@ -793,7 +792,7 @@ The following actions exist.
 
   Invoke a Lua function that accepts a :class:`DNSResponse`.
 
-  The ``function`` should return a :ref:`DNSResponseAction`.
+  The ``function`` should return a :ref:`DNSResponseAction`. If the Lua code fails, ServFail is returned.
 
   :param string function: the name of a Lua function
 

--- a/pdns/dnsdistdist/docs/statistics.rst
+++ b/pdns/dnsdistdist/docs/statistics.rst
@@ -134,6 +134,10 @@ rule-refused
 ------------
 Number of Refused answers returned because of a rule.
 
+rule-servfail
+-------------
+Number of ServFail answers returned because of a rule.
+
 self-answered
 -------------
 Number of self-answered responses.

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -222,7 +222,7 @@ class TestAPIBasics(DNSDistTest):
                     'latency-avg1000000', 'uptime', 'real-memory-usage', 'noncompliant-queries',
                     'noncompliant-responses', 'rdqueries', 'empty-queries', 'cache-hits',
                     'cache-misses', 'cpu-user-msec', 'cpu-sys-msec', 'fd-usage', 'dyn-blocked',
-                    'dyn-block-nmg-size']
+                    'dyn-block-nmg-size', 'rule-servfail']
 
         for key in expected:
             self.assertIn(key, values)


### PR DESCRIPTION
### Short description
Previously, an error from inside Lua code in an LuaAction or LuaResponseAction would cause the query to not be answered at all, with no diagnostics.

- Creates a new statistic item: rule-servfail
- Logs Lua errors with warnlog
- Failed Lua code causes an immediate ServFail now

Example log:

```
> LuaAction failed inside lua, returning ServFail: [string "chunk"]:21: attempt to call a nil value (global 'rl')
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
