### PR TITLE
dnsdist: In tests use protobuf3 on macOS

### DIFF
--- a/regression-tests.dnsdist/requirements.txt
+++ b/regression-tests.dnsdist/requirements.txt
@@ -2,5 +2,6 @@ dnspython>=1.11
 nose>=1.3.7
 libnacl>=1.4.3
 requests>=2.1.0
-protobuf>=2.5,<3.0
+protobuf>=2.5,<3.0; sys_platform != 'darwin'
+protobuf>=3.0; sys_platform == 'darwin'
 pysnmp>=4.3.4


### PR DESCRIPTION
### Short description
Use protobuf 3.x library when running dnsdist regression tests on macOS.
(`protobuf` from brew is 3.5.1.)

Makes this error go away for me:

```
======================================================================
ERROR: Failure: TypeError (__init__() got an unexpected keyword argument 'syntax')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ch/Source/Deduktiva/pdns/regression-tests.dnsdist/.venv/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/ch/Source/Deduktiva/pdns/regression-tests.dnsdist/.venv/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/ch/Source/Deduktiva/pdns/regression-tests.dnsdist/.venv/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/ch/Source/Deduktiva/pdns/regression-tests.dnsdist/test_NamedCache.py", line 11, in <module>
    import dnsmessage_pb2
  File "/Users/ch/Source/Deduktiva/pdns/regression-tests.dnsdist/dnsmessage_pb2.py", line 22, in <module>
    serialized_pb=_b('\n\x10\x64nsmessage.proto\"\xc4\x08\n\x0cPBDNSMessage\x12 \n\x04type\x18\x01 \x02(\x0e\x32\x12.PBDNSMessage.Type\x12\x11\n\tmessageId\x18\x02 \x01(\x0c\x12\x16\n\x0eserverIdentity\x18\x03 \x01(\x0c\x12\x30\n\x0csocketFamily\x18\x04 \x01(\x0e\x32\x1a.PBDNSMessage.SocketFamily\x12\x34\n\x0esocketProtocol\x18\x05 \x01(\x0e\x32\x1c.PBDNSMessage.SocketProtocol\x12\x0c\n\x04\x66rom\x18\x06 \x01(\x0c\x12\n\n\x02to\x18\x07 \x01(\x0c\x12\x0f\n\x07inBytes\x18\x08 \x01(\x04\x12\x0f\n\x07timeSec\x18\t \x01(\r\x12\x10\n\x08timeUsec\x18\n \x01(\r\x12\n\n\x02id\x18\x0b \x01(\r\x12+\n\x08question\x18\x0c \x01(\x0b\x32\x19.PBDNSMessage.DNSQuestion\x12+\n\x08response\x18\r \x01(\x0b\x32\x19.PBDNSMessage.DNSResponse\x12\x1f\n\x17originalRequestorSubnet\x18\x0e \x01(\x0c\x12\x13\n\x0brequestorId\x18\x0f \x01(\t\x12\x18\n\x10initialRequestId\x18\x10 \x01(\x0c\x12\x10\n\x08\x64\x65viceId\x18\x11 \x01(\x0c\x1a;\n\x0b\x44NSQuestion\x12\r\n\x05qName\x18\x01 \x01(\t\x12\r\n\x05qType\x18\x02 \x01(\r\x12\x0e\n\x06qClass\x18\x03 \x01(\r\x1a\xa1\x02\n\x0b\x44NSResponse\x12\r\n\x05rcode\x18\x01 \x01(\r\x12,\n\x03rrs\x18\x02 \x03(\x0b\x32\x1f.PBDNSMessage.DNSResponse.DNSRR\x12\x15\n\rappliedPolicy\x18\x03 \x01(\t\x12\x0c\n\x04tags\x18\x04 \x03(\t\x12\x14\n\x0cqueryTimeSec\x18\x05 \x01(\r\x12\x15\n\rqueryTimeUsec\x18\x06 \x01(\r\x12\x33\n\x11\x61ppliedPolicyType\x18\x07 \x01(\x0e\x32\x18.PBDNSMessage.PolicyType\x1aN\n\x05\x44NSRR\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\r\x12\r\n\x05\x63lass\x18\x03 \x01(\r\x12\x0b\n\x03ttl\x18\x04 \x01(\r\x12\r\n\x05rdata\x18\x05 \x01(\x0c\"d\n\x04Type\x12\x10\n\x0c\x44NSQueryType\x10\x01\x12\x13\n\x0f\x44NSResponseType\x10\x02\x12\x18\n\x14\x44NSOutgoingQueryType\x10\x03\x12\x1b\n\x17\x44NSIncomingResponseType\x10\x04\"#\n\x0cSocketFamily\x12\x08\n\x04INET\x10\x01\x12\t\n\x05INET6\x10\x02\"\"\n\x0eSocketProtocol\x12\x07\n\x03UDP\x10\x01\x12\x07\n\x03TCP\x10\x02\"Y\n\nPolicyType\x12\x0b\n\x07UNKNOWN\x10\x01\x12\t\n\x05QNAME\x10\x02\x12\x0c\n\x08\x43LIENTIP\x10\x03\x12\x0e\n\nRESPONSEIP\x10\x04\x12\x0b\n\x07NSDNAME\x10\x05\x12\x08\n\x04NSIP\x10\x06')
TypeError: __init__() got an unexpected keyword argument 'syntax'
```


### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
