### PR TITLE
dnsdist: Move Lua(Response)Action operator() out of header file

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -306,6 +306,38 @@ public:
   }
 };
 
+DNSAction::Action LuaAction::operator()(DNSQuestion* dq, string* ruleresult) const
+{
+  std::lock_guard<std::mutex> lock(g_luamutex);
+  try {
+    auto ret = d_func(dq);
+    if(ruleresult)
+      *ruleresult=std::get<1>(ret);
+    return (Action)std::get<0>(ret);
+  } catch (std::exception &e) {
+    warnlog("LuaAction failed inside lua, returning ServFail: %s", e.what());
+  } catch (...) {
+    warnlog("LuaAction failed inside lua, returning ServFail: [unknown exception]");
+  }
+  return DNSAction::Action::ServFail;
+}
+
+DNSResponseAction::Action LuaResponseAction::operator()(DNSResponse* dr, string* ruleresult) const
+{
+  std::lock_guard<std::mutex> lock(g_luamutex);
+  try {
+    auto ret = d_func(dr);
+    if(ruleresult)
+      *ruleresult=std::get<1>(ret);
+    return (Action)std::get<0>(ret);
+  } catch (std::exception &e) {
+    warnlog("LuaResponseAction failed inside lua, returning ServFail: %s", e.what());
+  } catch (...) {
+    warnlog("LuaResponseAction failed inside lua, returning ServFail: [unknown exception]");
+  }
+  return DNSResponseAction::Action::ServFail;
+}
+
 DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, string* ruleresult) const
 {
   uint16_t qtype = dq->qtype;

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -21,36 +21,17 @@
  */
 #pragma once
 
-#include "dolog.hh"
-
 class LuaAction : public DNSAction
 {
 public:
   typedef std::function<std::tuple<int, string>(DNSQuestion* dq)> func_t;
   LuaAction(LuaAction::func_t func) : d_func(func)
   {}
-
-  Action operator()(DNSQuestion* dq, string* ruleresult) const override
-  {
-    std::lock_guard<std::mutex> lock(g_luamutex);
-    try {
-      auto ret = d_func(dq);
-      if(ruleresult)
-        *ruleresult=std::get<1>(ret);
-      return (Action)std::get<0>(ret);
-    } catch (std::exception &e) {
-      warnlog("LuaAction failed inside lua, returning ServFail: %s", e.what());
-    } catch (...) {
-      warnlog("LuaAction failed inside lua, returning ServFail: [unknown exception]");
-    }
-    return DNSAction::Action::ServFail;
-  }
-
+  Action operator()(DNSQuestion* dq, string* ruleresult) const override;
   string toString() const override
   {
     return "Lua script";
   }
-
 private:
   func_t d_func;
 };
@@ -61,28 +42,11 @@ public:
   typedef std::function<std::tuple<int, string>(DNSResponse* dr)> func_t;
   LuaResponseAction(LuaResponseAction::func_t func) : d_func(func)
   {}
-
-  Action operator()(DNSResponse* dr, string* ruleresult) const override
-  {
-    std::lock_guard<std::mutex> lock(g_luamutex);
-    try {
-      auto ret = d_func(dr);
-      if(ruleresult)
-        *ruleresult=std::get<1>(ret);
-      return (Action)std::get<0>(ret);
-    } catch (std::exception &e) {
-      warnlog("LuaResponseAction failed inside lua, returning ServFail: %s", e.what());
-    } catch (...) {
-      warnlog("LuaResponseAction failed inside lua, returning ServFail: [unknown exception]");
-    }
-    return DNSResponseAction::Action::ServFail;
-  }
-
+  Action operator()(DNSResponse* dr, string* ruleresult) const override;
   string toString() const override
   {
     return "Lua response script";
   }
-
 private:
   func_t d_func;
 };


### PR DESCRIPTION
### Short description
Move implementation code out of header file. Allows the dolog.hh include to go away again, and hopefully less recompiles in the future.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
