### PR TITLE
dnsdist: unify global stats accounting

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -379,7 +379,6 @@ void* tcpClientThread(int pipefd)
 #endif
           handler.writeSizeAndMsg(query, dq.len, g_tcpSendTimeout);
           g_stats.selfAnswered++;
-          doLatencyStats(0);  // we're not going to measure this
           continue;
         }
 
@@ -426,7 +425,6 @@ void* tcpClientThread(int pipefd)
             }
 #endif
             handler.writeSizeAndMsg(cachedResponse, cachedResponseSize, g_tcpSendTimeout);
-            doLatencyStats(0);  // we're not going to measure this
             g_stats.cacheHits++;
             continue;
           }
@@ -459,7 +457,6 @@ void* tcpClientThread(int pipefd)
             handler.writeSizeAndMsg(query, dq.len, g_tcpSendTimeout);
 
             // no response-only statistics counter to update.
-            doLatencyStats(0);  // we're not going to measure this
             continue;
           }
 
@@ -632,7 +629,6 @@ void* tcpClientThread(int pipefd)
           std::lock_guard<std::mutex> lock(g_rings.respMutex);
           g_rings.respRing.push_back({answertime, ci.remote, qname, dq.qtype, (unsigned int)udiff, (unsigned int)responseLen, *dh, ds->remote});
         }
-        doLatencyStats(udiff);
 
         rewrittenResponse.clear();
       }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -179,7 +179,7 @@ struct DelayedPacket
 
 DelayPipe<DelayedPacket> * g_delay = 0;
 
-static void doLatencyStats(double udiff)
+void doLatencyStats(double udiff)
 {
   if(udiff < 1000) g_stats.latency0_1++;
   else if(udiff < 10000) g_stats.latency1_10++;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1259,7 +1259,6 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     }
 
     if(dq.dh->qr) { // something turned it into a response
-      g_stats.selfAnswered++;
       restoreFlags(dh, origFlags);
 
       if (!cs.muted) {
@@ -1291,6 +1290,8 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
         {
           sendUDPResponse(cs.udpFD, response, responseLen, delayMsec, dest, remote);
         }
+
+        g_stats.selfAnswered++;
       }
 
       return;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -218,6 +218,7 @@ struct DNSDistStats
 
 
 extern struct DNSDistStats g_stats;
+void doLatencyStats(double udiff);
 
 
 struct StopWatch

--- a/pdns/dnsdistdist/docs/statistics.rst
+++ b/pdns/dnsdistdist/docs/statistics.rst
@@ -12,15 +12,15 @@ dnsdist keeps statistics on the queries is receives and send out. They can be ac
 
 acl-drops
 ---------
-The number of packets dropped bacause of the :doc:`ACL <advanced/acl>`.
+The number of packets dropped because of the :doc:`ACL <advanced/acl>`.
 
 cache-hits
 ----------
-Number of times an answer was retrieved from :doc:`cache <guides/cache>`.
+Number of times a response was sent using data found in the :doc:`packet cache <guides/cache>`.
 
 cache-misses
 ------------
-Number of times an answer was not found in the :doc:`cache <guides/cache>`.
+Number of times an answer was not found in the :doc:`packet cache <guides/cache>`. Only counted if a packet cache was setup for the selected pool.
 
 cpu-sys-msec
 ------------


### PR DESCRIPTION
### Short description
Clean up some statistics accounting which was handled inconsistently before:

- Before, UDP selfAnswered was increased even if no response was sent, while this isn't done for TCP or UDP/TCP cacheHits. Now it is only increased if a response goes out.
- ~~Global latency stats were not updated for TCP at all~~ - to avoid changing current behaviour, this is dropped
- Treat selfAnswered, cacheHits, and noPolicy the same (=latency 0) for global latency stats, both UDP and TCP

Additional stats issues that this PR does not fix:
- UDP and TCP update aclDrops, nonCompliantQueries, queries at different times
- nonCompliantQueries is increased either before or after queries is increased

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
