### PR TITLE
ixfrdist: Read only the amount of bytes we need

### DIFF
--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 #include <boost/program_options.hpp>
+#include <arpa/inet.h>
 #include <sys/types.h>
 #include <grp.h>
 #include <pwd.h>
@@ -619,8 +620,7 @@ void handleTCPRequest(int fd, boost::any&) {
     return;
   }
 
-  char buf[4096];
-  // Discard the first 2 bytes (qlen)
+  char buf[65535];
   int res;
   res = recv(cfd, &buf, 2, 0);
   if (res != 2) {
@@ -636,7 +636,8 @@ void handleTCPRequest(int fd, boost::any&) {
     }
   }
 
-  res = recv(cfd, &buf, sizeof(buf), 0);
+  size_t toRead = std::min(static_cast<size_t>(ntohs((buf[0]<<8) + buf[1])), sizeof(buf));
+  res = recv(cfd, &buf, toRead, 0);
 
   if (res == -1) {
     auto savedErrno = errno;

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -620,33 +620,15 @@ void handleTCPRequest(int fd, boost::any&) {
     return;
   }
 
-  char buf[65535];
-  int res;
-  res = recv(cfd, &buf, 2, 0);
-  if (res != 2) {
-    if (res == 0) { // Connection is closed
-      close(cfd);
-      return;
-    }
-    if (res == -1) {
-      auto savedErrno = errno;
-      cerr<<"[WARNING] Could not read message from "<<saddr.toStringWithPort()<<": "<<strerror(savedErrno)<<endl;
-      close(cfd);
-      return;
-    }
-  }
-
-  size_t toRead = std::min(static_cast<size_t>(ntohs((buf[0]<<8) + buf[1])), sizeof(buf));
-  res = recv(cfd, &buf, toRead, 0);
-
-  if (res == -1) {
-    auto savedErrno = errno;
-    cerr<<"[WARNING] Could not read message from "<<saddr.toStringWithPort()<<": "<<strerror(savedErrno)<<endl;
-    close(cfd);
-    return;
-  }
-
-  if (res == 0) { // Connection is closed
+  char buf[4096];
+  ssize_t res;
+  try {
+    uint16_t toRead;
+    readn2(cfd, &toRead, sizeof(toRead));
+    toRead = std::min(ntohs(toRead), static_cast<uint16_t>(sizeof(buf)));
+    res = readn2WithTimeout(cfd, &buf, toRead, 2);
+  } catch (runtime_error &e) {
+    cerr<<"[WARNING] Could not read message from "<<saddr.toStringWithPort()<<": "<<e.what()<<endl;
     close(cfd);
     return;
   }
@@ -708,11 +690,11 @@ void handleTCPRequest(int fd, boost::any&) {
     } /* if (mdp.d_qtype == QType::IXFR) */
 
     for (const auto& packet : packets) {
-      char buf[2];
-      buf[0]=packet.size()/256;
-      buf[1]=packet.size()%256;
+      char sendBuf[2];
+      sendBuf[0]=packet.size()/256;
+      sendBuf[1]=packet.size()%256;
 
-      int send = writen2(cfd, buf, 2);
+      ssize_t send = writen2(cfd, sendBuf, 2);
       send += writen2(cfd, &packet[0], packet.size());
     }
     shutdown(cfd, 2);


### PR DESCRIPTION
### Short description
spotted by @rgacogne

We would read the size of the buffer on a possibly blocking call.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)