### PR TITLE
rec: Ensure we don't hammer the RPZ master server

### DIFF
--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -327,8 +327,8 @@ void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine:
   while (!sr) {
     try {
       sr=loadRPZFromServer(master, zoneName, zone, defpol, maxTTL, tt, maxReceivedBytes, localAddress);
-      if(refresh) {
-        sr->d_st.refresh=refresh;
+      if(refresh == 0) {
+        refresh = sr->d_st.refresh;
       }
       zone->setSerial(sr->d_st.serial);
     }
@@ -340,7 +340,11 @@ void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine:
     }
 
     if (!sr) {
-      sleep(refresh);
+      if (refresh == 0) {
+        sleep(10);
+      } else {
+        sleep(refresh);
+      }
     }
   }
 


### PR DESCRIPTION
### Short description
Before, if the `refresh` was not set in the lua-config file's
`rpzMaster` statement, we would keep trying to get delta's the whole
time. This commit ensures we update the zone's refresh config to the
value from the AXFR'd zone (if not set in the config).

This issue has been present since #6237

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)