### PR TITLE
Fix syntax error for replace-rrset

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2236,7 +2236,7 @@ try
   }
   else if(cmds[0] == "replace-rrset") {
     if(cmds.size() < 5) {
-      cerr<<"Syntax: pdnsutil replace-record ZONE name type [ttl] \"content\" [\"content\"...]"<<endl;
+      cerr<<"Syntax: pdnsutil replace-rrset ZONE name type [ttl] \"content\" [\"content\"...]"<<endl;
       return 0;
     }
     exit(addOrReplaceRecord(false , cmds));


### PR DESCRIPTION
Make `replace-rrset` tell the user to use the `replace-rrset` command, rather than `replace-record`.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Replaces the `replace-record` command to `replace-rrset` in the syntax help for the `replace-rrset` command.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
