### PR TITLE
make check-zone error on rows that have content but shouldn't

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -299,13 +299,13 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
     records=*suppliedrecords;
 
   for(auto rr : records) { // we modify this
-    if(!rr.qtype.getCode()) {
-      if(rr.content.length()) {
-        cout<<"[Error] ENT (or unknown type) has content: "<<rr.qname<<" IN " <<rr.qtype.getName()<< " '" << rr.content<<"'"<<endl;
-        numerrors++;
-      }
-      continue;
-    }
+    // if(!rr.qtype.getCode()) {
+    //   if(rr.content.length()) {
+    //     cout<<"[Error] ENT (or unknown type) has content: "<<rr.qname<<" IN " <<rr.qtype.getName()<< " '" << rr.content<<"'"<<endl;
+    //     numerrors++;
+    //   }
+    //   continue;
+    // }
 
     numrecords++;
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -299,8 +299,13 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
     records=*suppliedrecords;
 
   for(auto rr : records) { // we modify this
-    if(!rr.qtype.getCode())
+    if(!rr.qtype.getCode()) {
+      if(rr.content.length()) {
+        cout<<"[Error] ENT (or unknown type) has content: "<<rr.qname<<" IN " <<rr.qtype.getName()<< " '" << rr.content<<"'"<<endl;
+        numerrors++;
+      }
       continue;
+    }
 
     numrecords++;
 


### PR DESCRIPTION
### Short description
With this PR, pdnsutil will error about leftover MBOXFW records (as requested in #6064), and any other unknown records stored in the database.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
