### PR TITLE
dnsdist: Fix the documentation for MaxQPSRule()

### DIFF
--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -495,10 +495,10 @@ These ``DNSRule``\ s be one of the following items:
 
 .. function:: MaxQPSRule(qps)
 
-  Matches traffic exceeding this qps limit. If e.g. this is set to 50, starting at the 51st query of the current second traffic is matched.
+  Matches traffic **not** exceeding this qps limit. If e.g. this is set to 50, starting at the 51st query of the current second traffic stops being matched.
   This can be used to enforce a global QPS limit.
 
-  :param int qps: The number of queries per second allowed, above this number traffic is matched
+  :param int qps: The number of queries per second allowed, above this number the traffic is **not** matched anymore
 
 .. function:: NetmaskGroupRule(nmg[, src])
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Contrary to `MaxQPSIPRule()`, `MaxQPSRule()` matches the traffic below the QPS limit, not above.
We should deprecated one of those two and replace it with a new selector whose behavior is consistent with the other one.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
