### PR TITLE
Backport 6302: ixfrdist: Also respect the AXFR timeout for the chunk's length

### DIFF
--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -452,7 +452,7 @@ int AXFRRetriever::getChunk(Resolver::res_t &res, vector<DNSRecord>* records, ui
     return false;
 
   // d_sock is connected and is about to spit out a packet
-  int len=getLength();
+  int len=getLength(timeout);
   if(len<0)
     throw ResolverException("EOF trying to read axfr chunk from remote TCP client");
 
@@ -567,9 +567,9 @@ void AXFRRetriever::connect()
   // d_sock now connected
 }
 
-int AXFRRetriever::getLength()
+int AXFRRetriever::getLength(uint16_t timeout)
 {
-  timeoutReadn(2);
+  timeoutReadn(2, timeout);
   return (unsigned char)d_buf[0]*256+(unsigned char)d_buf[1];
 }
 

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -94,7 +94,7 @@ class AXFRRetriever : public boost::noncopyable
   
   private:
     void connect();
-    int getLength();
+    int getLength(uint16_t timeout);
     void timeoutReadn(uint16_t bytes, uint16_t timeoutsec=10);
 
     shared_array<char> d_buf;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to apply the default timeout of 10s to retrieve the chunk's length even if we were passed a different one.

(cherry picked from commit b726c12720f31a6cdd94a06ccb3a427a96f19669)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
