### PR TITLE
unbreak various things

### DIFF
--- a/build-scripts/build-auth-debian
+++ b/build-scripts/build-auth-debian
@@ -35,6 +35,7 @@ export VERSION_ID="${VERSION_ID}"
 if [ ${ID} = "ubuntu" ]; then
   if [ ${VERSION_ID} = "14.04" ]; then
     sed -i '/lib\/systemd\/system\/pdns@\?\.service/d' debian/*.install
+    sed -i '/lib\/systemd\/system\/ixfrdist@\?\.service/d' debian/*.install
   fi
   if [ $VERSION_ID} = "16.10" ];then
     sed -i 's!libzmq-dev!libzmq3-dev!' debian/control.in

--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -908,16 +908,6 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 %description backend-remote
 This package contains the remote backend for %{name}
 
-%package backend-ldap
-Summary: LDAP backend for %{name}
-Group: System Environment/Daemons
-Requires: %{name}%{?_isa} = %{version}-%{release}
-BuildRequires: openldap2-devel
-%global backends %{backends} ldap
-
-%description backend-ldap
-This package contains the LDAP backend for %{name}
-
 %package backend-lua
 Summary: Lua backend for %{name}
 Group: System Environment/Daemons
@@ -1078,11 +1068,6 @@ exit 0
 
 %files backend-remote
 %{_libdir}/%{name}/libremotebackend.so
-
-%files backend-ldap
-%{_libdir}/%{name}/libldapbackend.so
-%doc %{_defaultdocdir}/%{name}/dnsdomain2.schema
-%doc %{_defaultdocdir}/%{name}/pdns-domaininfo.schema
 
 %files backend-lua
 %{_libdir}/%{name}/libluabackend.so

--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -974,10 +974,6 @@ make install DESTDIR=%{buildroot}
 
 chmod 600 %{buildroot}%{_sysconfdir}/%{name}/pdns.conf
 
-# rename zone2ldap to pdns-zone2ldap (#1193116)
-%{__mv} %{buildroot}/%{_bindir}/zone2ldap %{buildroot}/%{_bindir}/pdns-zone2ldap
-%{__mv} %{buildroot}/%{_mandir}/man1/zone2ldap.1 %{buildroot}/%{_mandir}/man1/pdns-zone2ldap.1
-
 %check
 make %{?_smp_mflags} -C pdns check || (cat pdns/test-suite.log && false)
 
@@ -1003,7 +999,6 @@ exit 0
 %doc COPYING README
 %{_bindir}/pdns_control
 %{_bindir}/pdnsutil
-%{_bindir}/pdns-zone2ldap
 %{_bindir}/zone2sql
 %{_bindir}/zone2json
 %{_sbindir}/pdns_server
@@ -1012,7 +1007,6 @@ exit 0
 %{_mandir}/man1/pdns_server.1.gz
 %{_mandir}/man1/zone2sql.1.gz
 %{_mandir}/man1/zone2json.1.gz
-%{_mandir}/man1/pdns-zone2ldap.1.gz
 %{_mandir}/man1/pdnsutil.1.gz
 %{_unitdir}/pdns.service
 %{_unitdir}/pdns@.service

--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -1025,6 +1025,7 @@ exit 0
 %{_bindir}/dnstcpbench
 %{_bindir}/dnswasher
 %{_bindir}/dumresp
+%{_bindir}/ixfrdist
 %{_bindir}/ixplore
 %{_bindir}/pdns_notify
 %{_bindir}/nproxy
@@ -1040,12 +1041,14 @@ exit 0
 %{_mandir}/man1/dnstcpbench.1.gz
 %{_mandir}/man1/dnswasher.1.gz
 %{_mandir}/man1/dumresp.1.gz
+%{_mandir}/man1/ixfrdist.1.gz
 %{_mandir}/man1/ixplore.1.gz
 %{_mandir}/man1/pdns_notify.1.gz
 %{_mandir}/man1/nproxy.1.gz
 %{_mandir}/man1/nsec3dig.1.gz
 %{_mandir}/man1/saxfr.1.gz
 %{_mandir}/man1/sdig.1.gz
+%{_unitdir}/ixfrdist.service
 
 %files backend-mysql
 %doc modules/gmysqlbackend/schema.mysql.sql

--- a/build-scripts/debian-authoritative/pdns-server.install
+++ b/build-scripts/debian-authoritative/pdns-server.install
@@ -1,4 +1,5 @@
 usr/bin/pdns_control
+usr/bin/zone2json
 usr/bin/zone2sql
 usr/bin/pdnsutil
 usr/lib/*/pdns/libbindbackend.so*

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -2,8 +2,11 @@ MAIN_MANS = pdns_server.1 \
 	pdns_control.1 \
 	pdnsutil.1 \
 	zone2json.1 \
-	zone2ldap.1 \
 	zone2sql.1
+
+if LDAP
+MAIN_MANS += zone2ldap.1
+endif
 
 MANPAGES_INSTALL = $(MAIN_MANS)
 MANPAGES_DIST = $(MAIN_MANS)

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -6,9 +6,7 @@ MAIN_MANS = pdns_server.1 \
 
 MANPAGES_INSTALL = $(MAIN_MANS)
 
-MAIN_MANS += zone2ldap.1
-
-MANPAGES_DIST = $(MAIN_MANS)
+MANPAGES_DIST = $(MAIN_MANS) zone2ldap.1
 
 if LDAP
 MANPAGES_INSTALL += zone2ldap.1

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -4,12 +4,15 @@ MAIN_MANS = pdns_server.1 \
 	zone2json.1 \
 	zone2sql.1
 
-if LDAP
-MAIN_MANS += zone2ldap.1
-endif
-
 MANPAGES_INSTALL = $(MAIN_MANS)
+
+MAIN_MANS += zone2ldap.1
+
 MANPAGES_DIST = $(MAIN_MANS)
+
+if LDAP
+MANPAGES_INSTALL += zone2ldap.1
+endif
 
 MANPAGES_TARGET_TOOLS = calidns.1 \
 	dnsgram.1 \

--- a/modules/luabackend/lua_functions.cc
+++ b/modules/luabackend/lua_functions.cc
@@ -136,12 +136,12 @@ int l_dnspacket (lua_State *lua) {
 int l_logger (lua_State *lua) {
 //    assert(lua == lb->lua);
 
-    lua_getfield(lua, LUA_REGISTRYINDEX, "__LUABACKEND");
-    LUABackend* lb = (LUABackend*)lua_touserdata(lua, -1);
-
     int i = lua_gettop(lua);
     if (i < 1)
-	return 0;
+        return 0;
+
+    lua_getfield(lua, LUA_REGISTRYINDEX, "__LUABACKEND");
+    LUABackend* lb = (LUABackend*)lua_touserdata(lua, -1);
 
     int log_level = 0;
     stringstream s;

--- a/modules/luabackend/test2/pdns-luabackend.lua
+++ b/modules/luabackend/test2/pdns-luabackend.lua
@@ -168,7 +168,7 @@ function get()
 	logger(log_debug, "(l_get) begin")
 	while rrsetidx < rrsetsize do
 		rrsetidx = rrsetidx + 1
-		logger(log_debug, "(l_get) rrset ", rrsetidx, " : ", rrset[rrsetidx])
+		logger(log_debug, "(l_get) rrset ", rrsetidx)
 		return rrset[rrsetidx]
 	end
 	logger(log_debug, "(l_get) done")

--- a/modules/luabackend/test2/pdns_control
+++ b/modules/luabackend/test2/pdns_control
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-
-../../../pdns/pdns_control --config-dir=./ --socket-dir=./ $@
+PDNSCONTROL=${PDNSCONTROL:-${PWD}/../../../pdns/pdns_control}
+$PDNSCONTROL --config-dir=./ --socket-dir=./ $@

--- a/modules/luabackend/test2/runtest.pl
+++ b/modules/luabackend/test2/runtest.pl
@@ -8,7 +8,9 @@ use 5.10.0; # somewhat sane minimum?
 # standard perl
 use Test::More;
 
-my $sdig = 'timeout 3 ../../../pdns/sdig 127.0.0.1 5300';
+my $sdigpath = '../../../pdns/sdig';
+if (defined($ENV{SDIG})) { $sdigpath = $ENV{SDIG} }
+my $sdig = "timeout 3 $sdigpath 127.0.0.1 5300";
 
 exit main(@ARGV);
 

--- a/regression-tests.recursor/comments-in-forward-zones-file/command
+++ b/regression-tests.recursor/comments-in-forward-zones-file/command
@@ -1,2 +1,2 @@
 #!/bin/sh
-curl -s -H 'X-API-Key: secret' 127.0.0.1:8082/api/v1/servers/localhost/zones | jq '.[] | select(.kind=="Forwarded")' | sort | sed 's/,$//'
+curl -s -H 'X-API-Key: secret' 127.0.0.1:8082/api/v1/servers/localhost/zones | jq '.[] | select(.kind=="Forwarded")' | LC_ALL=C sort | sed 's/,$//'

--- a/regression-tests.recursor/comments-in-forward-zones-file/expected_result
+++ b/regression-tests.recursor/comments-in-forward-zones-file/expected_result
@@ -1,20 +1,20 @@
-  ]
-  ]
-{
-{
-}
-}
     "8.8.8.8:53"
     "8.8.8.8:53"
-  "id": "forward-zones-test2.non-existing.powerdns.com."
   "id": "forward-zones-test.non-existing.powerdns.com."
+  "id": "forward-zones-test2.non-existing.powerdns.com."
   "kind": "Forwarded"
   "kind": "Forwarded"
-  "name": "forward-zones-test2.non-existing.powerdns.com."
   "name": "forward-zones-test.non-existing.powerdns.com."
+  "name": "forward-zones-test2.non-existing.powerdns.com."
   "recursion_desired": false
   "recursion_desired": false
   "servers": [
   "servers": [
-  "url": "/api/v1/servers/localhost/zones/forward-zones-test2.non-existing.powerdns.com."
   "url": "/api/v1/servers/localhost/zones/forward-zones-test.non-existing.powerdns.com."
+  "url": "/api/v1/servers/localhost/zones/forward-zones-test2.non-existing.powerdns.com."
+  ]
+  ]
+{
+{
+}
+}

--- a/regression-tests/runtests
+++ b/regression-tests/runtests
@@ -22,7 +22,7 @@ spectest=$1
 [ -z $spectest ] && spectest=""
 
 for prog in $SDIG $SAXFR $NOTIFY $NSEC3DIG; do
-  if `echo $prog | grep -q '../pdns'`; then
+  if `echo $prog | grep -q '\.\./pdns'`; then
     ${MAKE} -C ../pdns ${prog##*../pdns/} || exit
   fi
 done

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -209,7 +209,7 @@ __EOF__
 fi
 
 for prog in $SDIG $SAXFR $NOTIFY $NSEC3DIG; do
-  if `echo $prog | grep -q '../pdns'`; then
+  if `echo $prog | grep -q '\.\./pdns'`; then
     ${MAKE} -C ../pdns ${prog##*../pdns/} || exit
   fi
 done


### PR DESCRIPTION
### Short description
This PR collects fixes for various failures currently happening on our builders.

### Identified issues
- [x] [build-auth-sles-12](https://builder.powerdns.com/#/builders/67/builds/1280): krb5.h missing (now worked around by dropping the ldap backend but RPM claims zone2ldap somehow still gets installed but then, of course, not packaged)
- [x] [build-auth-sles-12](https://builder.powerdns.com/#/builders/67/builds/1285): ixfrdist not packaged
- [x] [test-rec-debian-jessie](https://builder.powerdns.com/#/builders/54/builds/1588): `dpkg: error processing archive /var/cache/apt/archives/pdns-tools_0.0.2121ga87dae3-1pdns.jessie_amd64.deb (--unpack): trying to overwrite '/lib/systemd/system/pdns.service', which is also in package pdns-server 0.0.2121ga87dae3-1pdns.jessie` (also confirmed on stretch)
- [x] [test-auth-debian-jessie](https://builder.powerdns.com/#/builders/45/builds/1776): missing `/usr/bin/sdig`
- [x] [test-auth-debian-jessie](https://builder.powerdns.com/#/builders/45/builds/1776): missing `/usr/bin/zone2json`
- [x] [build-auth-ubuntu-trusty](https://builder.powerdns.com/#/builders/57/builds/1726): `cp: cannot stat 'debian/tmp/lib/systemd/system/ixfrdist.service': No such file or directory`
- [x] [test-rec-debian-jessie](https://builder.powerdns.com/#/builders/54/builds/1595): JSON key ordering issues in `comments-in-forward-zones-file` test
- [ ] [test-auth-debian-jessie](https://builder.powerdns.com/#/builders/45/builds/1776): missing `jq`
- [ ] [test-auth-debian-jessie](https://builder.powerdns.com/#/builders/45/builds/1781): jdnssec-verifyzone: `Exception in thread "main" java.lang.UnsupportedClassVersionError: com/verisignlabs/dnssec/cl/VerifyZone : Unsupported major.minor version 52.0`. Proposed fix: `apt-get -t jessie-backports install openjdk-8-jre`; also should switch to @mind04's build of jdnssec
- [ ] [test-auth-debian-jessie](https://builder.powerdns.com/#/builders/45/builds/1781): `Failed test ./tests/ent-asterisk` - presumably the unbound version is not what our tests expect
- [ ] ~[test-rec-debian-jessie](https://builder.powerdns.com/#/builders/54/builds/1589): `tar (child): cannot run bzip2: No such file or directory`~ ~appears to be spurious/random, perhaps due to us running two image versions side by side~ the docker image `debian-jessie-test-recursor` on `buildbot-worker3.powerdns.com` is lacking `bzip2`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
