### PR TITLE
rec: Count a lookup into an internal auth zone as a cache miss

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1288,7 +1288,12 @@ static void startDoResolve(void *p)
 
     }
 
-    sr.d_outqueries ? t_RC->cacheMisses++ : t_RC->cacheHits++;
+    if (sr.d_outqueries || sr.d_authzonequeries) {
+      t_RC->cacheMisses++;
+    }
+    else {
+      t_RC->cacheHits++;
+    }
 
     if(spent < 0.001)
       g_stats.answers0_1++;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -39,32 +39,27 @@
 #include "namespaces.hh"
 pthread_mutex_t g_carbon_config_lock=PTHREAD_MUTEX_INITIALIZER;
 
-map<string, const uint32_t*> d_get32bitpointers;
-map<string, const uint64_t*> d_get64bitpointers;
-map<string, const std::atomic<uint64_t>*> d_getatomics;
-map<string, function< uint64_t() > >  d_get64bitmembers;
-pthread_mutex_t d_dynmetricslock = PTHREAD_MUTEX_INITIALIZER;
-map<string, std::atomic<unsigned long>* > d_dynmetrics;
-void addGetStat(const string& name, const uint32_t* place)
+static map<string, const uint32_t*> d_get32bitpointers;
+static map<string, const uint64_t*> d_get64bitpointers;
+static map<string, const std::atomic<uint64_t>*> d_getatomics;
+static map<string, function< uint64_t() > >  d_get64bitmembers;
+static pthread_mutex_t d_dynmetricslock = PTHREAD_MUTEX_INITIALIZER;
+static map<string, std::atomic<unsigned long>* > d_dynmetrics;
+
+static void addGetStat(const string& name, const uint32_t* place)
 {
   d_get32bitpointers[name]=place;
 }
-void addGetStat(const string& name, const uint64_t* place)
-{
-  d_get64bitpointers[name]=place;
-}
 
-void addGetStat(const string& name, const std::atomic<uint64_t>* place)
+static void addGetStat(const string& name, const std::atomic<uint64_t>* place)
 {
   d_getatomics[name]=place;
 }
 
-
-void addGetStat(const string& name, function<uint64_t ()> f ) 
+static void addGetStat(const string& name, function<uint64_t ()> f )
 {
   d_get64bitmembers[name]=f;
 }
-
 
 std::atomic<unsigned long>* getDynMetric(const std::string& str)
 {
@@ -930,6 +925,7 @@ void registerAllStats()
   addGetStat("outgoing-timeouts", &SyncRes::s_outgoingtimeouts);
   addGetStat("outgoing4-timeouts", &SyncRes::s_outgoing4timeouts);
   addGetStat("outgoing6-timeouts", &SyncRes::s_outgoing6timeouts);
+  addGetStat("auth-zone-queries", &SyncRes::s_authzonequeries);
   addGetStat("tcp-outqueries", &SyncRes::s_tcpoutqueries);
   addGetStat("all-outqueries", &SyncRes::s_outqueries);
   addGetStat("ipv6-outqueries", &g_stats.ipv6queries);

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -144,6 +144,10 @@ auth6-answers100-1000
 ^^^^^^^^^^^^^^^^^^^^^
 counts the number of queries answered by auth6s within 1 second (4.0)
 
+auth-zone-queries
+^^^^^^^^^^^^^^^^^
+counts the number of queries to locally hosted authoritative zones (:ref:`setting-auth-zones`) since starting
+
 cache-bytes
 ^^^^^^^^^^^
 size of the cache in bytes

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -57,6 +57,7 @@ unsigned int SyncRes::s_packetcachettl;
 unsigned int SyncRes::s_packetcacheservfailttl;
 unsigned int SyncRes::s_serverdownmaxfails;
 unsigned int SyncRes::s_serverdownthrottletime;
+std::atomic<uint64_t> SyncRes::s_authzonequeries;
 std::atomic<uint64_t> SyncRes::s_queries;
 std::atomic<uint64_t> SyncRes::s_outgoingtimeouts;
 std::atomic<uint64_t> SyncRes::s_outgoing4timeouts;
@@ -323,6 +324,7 @@ int SyncRes::AuthDomain::getRecords(const DNSName& qname, uint16_t qtype, std::v
 bool SyncRes::doOOBResolve(const AuthDomain& domain, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int& res)
 {
   d_authzonequeries++;
+  s_authzonequeries++;
 
   res = domain.getRecords(qname, qtype.getCode(), ret);
   return true;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -320,8 +320,10 @@ int SyncRes::AuthDomain::getRecords(const DNSName& qname, uint16_t qtype, std::v
   return result;
 }
 
-bool SyncRes::doOOBResolve(const AuthDomain& domain, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int& res) const
+bool SyncRes::doOOBResolve(const AuthDomain& domain, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int& res)
 {
+  d_authzonequeries++;
+
   res = domain.getRecords(qname, qtype.getCode(), ret);
   return true;
 }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -107,7 +107,7 @@ static void accountAuthLatency(int usec, int family)
 }
 
 
-SyncRes::SyncRes(const struct timeval& now) :  d_outqueries(0), d_tcpoutqueries(0), d_throttledqueries(0), d_timeouts(0), d_unreachables(0),
+SyncRes::SyncRes(const struct timeval& now) :  d_authzonequeries(0), d_outqueries(0), d_tcpoutqueries(0), d_throttledqueries(0), d_timeouts(0), d_unreachables(0),
 					       d_totUsec(0), d_now(now),
 					       d_cacheonly(false), d_doDNSSEC(false), d_doEDNS0(false), d_lm(s_lm)
                                                  

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -697,6 +697,7 @@ public:
 
   std::unordered_map<std::string,bool> d_discardedPolicies;
   DNSFilterEngine::Policy d_appliedPolicy;
+  unsigned int d_authzonequeries;
   unsigned int d_outqueries;
   unsigned int d_tcpoutqueries;
   unsigned int d_throttledqueries;
@@ -736,7 +737,7 @@ private:
   bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state);
 
   int doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state);
-  bool doOOBResolve(const AuthDomain& domain, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int& res) const;
+  bool doOOBResolve(const AuthDomain& domain, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int& res);
   bool doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res);
   domainmap_t::const_iterator getBestAuthZone(DNSName* qname) const;
   bool doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state, bool wasAuthZone);

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -669,6 +669,7 @@ public:
   static std::atomic<uint64_t> s_outgoing6timeouts;
   static std::atomic<uint64_t> s_throttledqueries;
   static std::atomic<uint64_t> s_dontqueries;
+  static std::atomic<uint64_t> s_authzonequeries;
   static std::atomic<uint64_t> s_outqueries;
   static std::atomic<uint64_t> s_tcpoutqueries;
   static std::atomic<uint64_t> s_nodelegated;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We only considered a query a cache miss if we had to do at least one outgoing query, but having to look up into one of the internally hosted zone (auth-zones) should count as a cache miss too.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
