### PR TITLE
dnsdist: Add an option to use several source ports toward a backend

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -349,7 +349,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "newQPSLimiter", true, "rate, burst", "configure a QPS limiter with that rate and that burst capacity" },
   { "newRemoteLogger", true, "address:port [, timeout=2, maxQueuedEntries=100, reconnectWaitTime=1]", "create a Remote Logger object, to use with `RemoteLogAction()` and `RemoteLogResponseAction()`" },
   { "newRuleAction", true, "DNS rule, DNS action [, {uuid=\"UUID\"}]", "return a pair of DNS Rule and DNS Action, to be used with `setRules()`" },
-  { "newServer", true, "{address=\"ip:port\", qps=1000, order=1, weight=10, pool=\"abuse\", retries=5, tcpConnectTimeout=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName=\"a.root-servers.net.\", checkType=\"A\", maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source=\"address|interface name|address@interface\"}", "instantiate a server" },
+  { "newServer", true, "{address=\"ip:port\", qps=1000, order=1, weight=10, pool=\"abuse\", retries=5, tcpConnectTimeout=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName=\"a.root-servers.net.\", checkType=\"A\", maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source=\"address|interface name|address@interface\", sockets=1}", "instantiate a server" },
   { "newServerPolicy", true, "name, function", "create a policy object from a Lua function" },
   { "newSuffixMatchNode", true, "", "returns a new SuffixMatchNode" },
   { "NoRecurseAction", true, "", "strip RD bit from the question, let it go through" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -217,9 +217,13 @@ void setupLuaConfig(bool client)
 			  }
 			}
 
-			if(vars.count("sockets")) {
-			  numberOfSockets=std::stoi(boost::get<string>(vars["sockets"]));
-			}
+                        if (vars.count("sockets")) {
+                          numberOfSockets = std::stoul(boost::get<string>(vars["sockets"]));
+                          if (numberOfSockets == 0) {
+                            warnlog("Dismissing invalid number of sockets '%s', using 1 instead", boost::get<string>(vars["sockets"]));
+                            numberOfSockets = 1;
+                          }
+                        }
 
 			std::shared_ptr<DownstreamState> ret;
 			try {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -117,6 +117,7 @@ void setupLuaConfig(bool client)
 			}
 			ComboAddress sourceAddr;
 			unsigned int sourceItf = 0;
+                        size_t numberOfSockets = 1;
                         std::set<int> cpus;
 			if(auto addressStr = boost::get<string>(&pvars)) {
 			  std::shared_ptr<DownstreamState> ret;
@@ -216,6 +217,10 @@ void setupLuaConfig(bool client)
 			  }
 			}
 
+			if(vars.count("sockets")) {
+			  numberOfSockets=std::stoi(boost::get<string>(vars["sockets"]));
+			}
+
 			std::shared_ptr<DownstreamState> ret;
 			try {
 			  ComboAddress address(boost::get<string>(vars["address"]), 53);
@@ -224,7 +229,7 @@ void setupLuaConfig(bool client)
 			    errlog("Error creating new server: %s is not a valid address for a downstream server", boost::get<string>(vars["address"]));
 			    return ret;
 			  }
-			  ret=std::make_shared<DownstreamState>(address, sourceAddr, sourceItf);
+			  ret=std::make_shared<DownstreamState>(address, sourceAddr, sourceItf, numberOfSockets);
 			}
 			catch(const PDNSException& e) {
 			  g_outputBuffer="Error creating new server: "+string(e.reason);

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -268,8 +268,9 @@ Servers
                              --   "address", e.g. "192.0.2.2"
                              --   "interface name", e.g. "eth0"
                              --   "address@interface", e.g. "192.0.2.2@eth0"
-      addXPF=NUM             -- Add the client's IP address and port to the query, along with the original destination address and port,
+      addXPF=NUM,            -- Add the client's IP address and port to the query, along with the original destination address and port,
                              -- using the experimental XPF record from `draft-bellis-dnsop-xpf <https://datatracker.ietf.org/doc/draft-bellis-dnsop-xpf/>`_ and the specified option code. Default is disabled (0)
+      sockets=NUM            -- Number of sockets (and thus source ports) used toward the backend server, defaults to a single one
     })
 
   :param str server_string: A simple IP:PORT string.

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -44,11 +44,12 @@ public:
     close(d_kqueuefd);
   }
 
-  virtual int run(struct timeval* tv, int timeout=500);
+  virtual int run(struct timeval* tv, int timeout=500) override;
+  virtual void getAvailableFDs(std::vector<int>& fds, int timeout) override;
 
-  virtual void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const boost::any& parameter);
-  virtual void removeFD(callbackmap_t& cbmap, int fd);
-  string getName()
+  virtual void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const boost::any& parameter) override;
+  virtual void removeFD(callbackmap_t& cbmap, int fd) override;
+  string getName() const override
   {
     return "kqueue";
   }
@@ -85,7 +86,7 @@ void KqueueFDMultiplexer::addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toD
 
   struct kevent kqevent;
   EV_SET(&kqevent, fd, (&cbmap == &d_readCallbacks) ? EVFILT_READ : EVFILT_WRITE, EV_ADD, 0,0,0);
-  
+
   if(kevent(d_kqueuefd, &kqevent, 1, 0, 0, 0) < 0) {
     cbmap.erase(fd);
     throw FDMultiplexerException("Adding fd to kqueue set: "+stringerror());
@@ -103,6 +104,22 @@ void KqueueFDMultiplexer::removeFD(callbackmap_t& cbmap, int fd)
     throw FDMultiplexerException("Removing fd from kqueue set: "+stringerror());
 }
 
+void KqueueFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
+{
+  struct timespec ts;
+  ts.tv_sec=timeout/1000;
+  ts.tv_nsec=(timeout % 1000) * 1000000;
+
+  int ret = kevent(d_kqueuefd, 0, 0, d_kevents.get(), s_maxevents, &ts);
+
+  if(ret < 0 && errno != EINTR)
+    throw FDMultiplexerException("kqueue returned error: "+stringerror());
+
+  for(int n=0; n < ret; ++n) {
+    fds.push_back(d_kevents[n].ident);
+  }
+}
+
 int KqueueFDMultiplexer::run(struct timeval* now, int timeout)
 {
   if(d_inrun) {
@@ -115,7 +132,7 @@ int KqueueFDMultiplexer::run(struct timeval* now, int timeout)
 
   int ret=kevent(d_kqueuefd, 0, 0, d_kevents.get(), s_maxevents, &ts);
   gettimeofday(now,0); // MANDATORY!
-  
+
   if(ret < 0 && errno!=EINTR)
     throw FDMultiplexerException("kqueue returned error: "+stringerror());
 

--- a/pdns/mplexer.hh
+++ b/pdns/mplexer.hh
@@ -73,6 +73,9 @@ public:
   /* timeout is in ms */
   virtual int run(struct timeval* tv, int timeout=500) = 0;
 
+  /* timeout is in ms, 0 will return immediatly, -1 will block until at least one FD is ready */
+  virtual void getAvailableFDs(std::vector<int>& fds, int timeout) = 0;
+
   //! Add an fd to the read watch list - currently an fd can only be on one list at a time!
   virtual void addReadFD(int fd, callbackfunc_t toDo, const funcparam_t& parameter=funcparam_t())
   {
@@ -132,7 +135,7 @@ public:
     return theMap;
   }
   
-  virtual std::string getName() = 0;
+  virtual std::string getName() const = 0;
 
 protected:
   typedef std::map<int, Callback> callbackmap_t;

--- a/pdns/pollmplexer.cc
+++ b/pdns/pollmplexer.cc
@@ -34,15 +34,18 @@ public:
   {
   }
 
-  virtual int run(struct timeval* tv, int timeout=500);
+  virtual int run(struct timeval* tv, int timeout=500) override;
+  virtual void getAvailableFDs(std::vector<int>& fds, int timeout) override;
 
-  virtual void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const funcparam_t& parameter);
-  virtual void removeFD(callbackmap_t& cbmap, int fd);
-  string getName()
+  virtual void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const funcparam_t& parameter) override;
+  virtual void removeFD(callbackmap_t& cbmap, int fd) override;
+
+  string getName() const override
   {
     return "poll";
   }
 private:
+  vector<struct pollfd> preparePollFD() const;
 };
 
 static FDMultiplexer* make()
@@ -77,9 +80,40 @@ void PollFDMultiplexer::removeFD(callbackmap_t& cbmap, int fd)
     throw FDMultiplexerException("Tried to remove unlisted fd "+std::to_string(fd)+ " from multiplexer");
 }
 
-bool pollfdcomp(const struct pollfd& a, const struct pollfd& b)
+vector<struct pollfd> PollFDMultiplexer::preparePollFD() const
 {
-  return a.fd < b.fd;
+  vector<struct pollfd> pollfds;
+  pollfds.reserve(d_readCallbacks.size() + d_writeCallbacks.size());
+
+  struct pollfd pollfd;
+  for(const auto& cb : d_readCallbacks) {
+    pollfd.fd = cb.first;
+    pollfd.events = POLLIN;
+    pollfds.push_back(pollfd);
+  }
+
+  for(const auto& cb : d_writeCallbacks) {
+    pollfd.fd = cb.first;
+    pollfd.events = POLLOUT;
+    pollfds.push_back(pollfd);
+  }
+
+  return pollfds;
+}
+
+void PollFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
+{
+  auto pollfds = preparePollFD();
+  int ret = poll(&pollfds[0], pollfds.size(), timeout);
+
+  if (ret < 0 && errno != EINTR)
+    throw FDMultiplexerException("poll returned error: " + stringerror());
+
+  for(const auto& pollfd : pollfds) {
+    if (pollfd.revents == POLLIN || pollfd.revents == POLLOUT) {
+      fds.push_back(pollfd.fd);
+    }
+  }
 }
 
 int PollFDMultiplexer::run(struct timeval* now, int timeout)
@@ -87,21 +121,8 @@ int PollFDMultiplexer::run(struct timeval* now, int timeout)
   if(d_inrun) {
     throw FDMultiplexerException("FDMultiplexer::run() is not reentrant!\n");
   }
-  
-  vector<struct pollfd> pollfds;
-  
-  struct pollfd pollfd;
-  for(callbackmap_t::const_iterator i=d_readCallbacks.begin(); i != d_readCallbacks.end(); ++i) {
-    pollfd.fd = i->first;
-    pollfd.events = POLLIN;
-    pollfds.push_back(pollfd);
-  }
 
-  for(callbackmap_t::const_iterator i=d_writeCallbacks.begin(); i != d_writeCallbacks.end(); ++i) {
-    pollfd.fd = i->first;
-    pollfd.events = POLLOUT;
-    pollfds.push_back(pollfd);
-  }
+  auto pollfds = preparePollFD();
 
   int ret=poll(&pollfds[0], pollfds.size(), timeout);
   gettimeofday(now, 0); // MANDATORY!
@@ -112,17 +133,17 @@ int PollFDMultiplexer::run(struct timeval* now, int timeout)
   d_iter=d_readCallbacks.end();
   d_inrun=true;
 
-  for(unsigned int n = 0; n < pollfds.size(); ++n) {  
-    if(pollfds[n].revents == POLLIN) {
-      d_iter=d_readCallbacks.find(pollfds[n].fd);
+  for(const auto& pollfd : pollfds) {
+    if(pollfd.revents == POLLIN) {
+      d_iter=d_readCallbacks.find(pollfd.fd);
     
       if(d_iter != d_readCallbacks.end()) {
         d_iter->second.d_callback(d_iter->first, d_iter->second.d_parameter);
         continue; // so we don't refind ourselves as writable!
       }
     }
-    else if(pollfds[n].revents == POLLOUT) {
-      d_iter=d_writeCallbacks.find(pollfds[n].fd);
+    else if(pollfd.revents == POLLOUT) {
+      d_iter=d_writeCallbacks.find(pollfd.fd);
     
       if(d_iter != d_writeCallbacks.end()) {
         d_iter->second.d_callback(d_iter->first, d_iter->second.d_parameter);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is very useful if the backend is distributing queries based only on (source IP, source port, destination IP, destination port), which is for example the case of PowerDNS Recursor with several
threads, `reuseport` set and `pdns-distribute-queries` not set.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
