### PR TITLE
dnsdist: create RemoteLoggers in client mode, but avoid connecting

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -266,29 +266,20 @@ void setupLuaBindings(bool client)
 
   /* RemoteLogger */
   g_lua.writeFunction("newRemoteLogger", [client](const std::string& remote, boost::optional<uint16_t> timeout, boost::optional<uint64_t> maxQueuedEntries, boost::optional<uint8_t> reconnectWaitTime) {
-      if (client) {
-        return std::shared_ptr<RemoteLoggerInterface>();
-      }
-      return std::shared_ptr<RemoteLoggerInterface>(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? *maxQueuedEntries : 100, reconnectWaitTime ? *reconnectWaitTime : 1));
+      return std::shared_ptr<RemoteLoggerInterface>(new RemoteLogger(ComboAddress(remote), timeout ? *timeout : 2, maxQueuedEntries ? *maxQueuedEntries : 100, reconnectWaitTime ? *reconnectWaitTime : 1, client));
     });
 
   g_lua.writeFunction("newFrameStreamUnixLogger", [client](const std::string& address) {
-      if (client) {
-        return std::shared_ptr<RemoteLoggerInterface>();
-      }
 #ifdef HAVE_FSTRM
-      return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_UNIX, address));
+      return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_UNIX, address, !client));
 #else
       throw std::runtime_error("fstrm support is required to build an AF_UNIX FrameStreamLogger");
 #endif /* HAVE_FSTRM */
     });
 
   g_lua.writeFunction("newFrameStreamTcpLogger", [client](const std::string& address) {
-      if (client) {
-        return std::shared_ptr<RemoteLoggerInterface>();
-      }
 #if defined(HAVE_FSTRM) && defined(HAVE_FSTRM_TCP_WRITER_INIT)
-      return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_INET, address));
+      return std::shared_ptr<RemoteLoggerInterface>(new FrameStreamLogger(AF_INET, address, !client));
 #else
       throw std::runtime_error("fstrm with TCP support is required to build an AF_INET FrameStreamLogger");
 #endif /* HAVE_FSTRM */

--- a/pdns/fstrm_logger.hh
+++ b/pdns/fstrm_logger.hh
@@ -35,7 +35,7 @@
 class FrameStreamLogger : public RemoteLoggerInterface, boost::noncopyable
 {
 public:
-  FrameStreamLogger(int family, const std::string& address);
+  FrameStreamLogger(int family, const std::string& address, bool connect);
   virtual ~FrameStreamLogger();
   virtual void queueData(const std::string& data) override;
   virtual std::string toString() override

--- a/pdns/recursordist/docs/lua-config/protobuf.rst
+++ b/pdns/recursordist/docs/lua-config/protobuf.rst
@@ -21,7 +21,7 @@ Protobuf export to a server is enabled using the ``protobufServer()`` directive:
   :param int maskV4: network mask to apply to the client IPv4 addresses, for anonymization purposes. The default of 32 means no anonymization.
   :param int maskV6: Same as maskV4, but for IPv6. Defaults to 128.
   :param bool taggedOnly: Only entries with a policy or a policy tag set will be sent.
-  :param bool asyncConnect: When set to false (default) the first connection to the server during startup will block up to ``timeout`` seconds, otherwise the connection is done in a separate thread.
+  :param bool asyncConnect: When set to false (default) the first connection to the server during startup will block up to ``timeout`` seconds, otherwise the connection is done in a separate thread, after the first message has been queued..
 
 Logging outgoing queries and responses
 --------------------------------------
@@ -34,7 +34,7 @@ While :func:`protobufServer` only exports the queries sent to the recursor from 
   :param int timeout: Time in seconds to wait when sending a message
   :param int maxQueuedEntries: How many entries will be kept in memory if the server becomes unreachable
   :param int reconnectWaitTime: How long to wait, in seconds, between two reconnection attempts
-  :param bool asyncConnect: When set to false (default) the first connection to the server during startup will block up to ``timeout`` seconds, otherwise the connection is done in a separate thread.
+  :param bool asyncConnect: When set to false (default) the first connection to the server during startup will block up to ``timeout`` seconds, otherwise the connection is done in a separate thread, after the first message has been queued..
 
 Protobol Buffers Definition
 ---------------------------

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -41,10 +41,6 @@ void RemoteLogger::busyReconnectLoop()
 
 void RemoteLogger::worker()
 {
-  if (d_asyncConnect) {
-    busyReconnectLoop();
-  }
-
   while(true) {
     std::string data;
     {

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -70,6 +70,12 @@ class DNSDistTest(unittest.TestCase):
             dnsdistcmd.extend(['--acl', acl])
         print(' '.join(dnsdistcmd))
 
+        # validate config with --check-config, which sets client=true, possibly exposing bugs.
+        testcmd = dnsdistcmd + ['--check-config']
+        output = subprocess.check_output(testcmd, close_fds=True)
+        if output != b'Configuration \'dnsdist_test.conf\' OK!\n':
+            raise AssertionError('dnsdist --check-config failed: %s' % output)
+
         if shutUp:
             with open(os.devnull, 'w') as fdDevNull:
                 cls._dnsdist = subprocess.Popen(dnsdistcmd, close_fds=True, stdout=fdDevNull)


### PR DESCRIPTION
### Short description
Fixes a nullptr deref under --check-config, found by Quad9.

To make this work, RemoteLogger with asyncConnect now waits for the first message before  connecting. FrameStreamLogger created in client mode will not create its IO Thread, making logging impossible.

All tests will now run --check-config on their generated configuration files before running, so errors like this one should be caught by the tests.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
