### PR TITLE
Add Metric "server-up" Count to Carbon Reporting

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -112,6 +112,7 @@ try
           const string base = "dnsdist." + hostname + ".main.pools." + poolName + ".";
           const std::shared_ptr<ServerPool> pool = entry.second;
           str<<base<<"servers" << " " << pool->servers.size() << " " << now << "\r\n";
+          str<<base<<"servers-up" << " " << pool->countServersUp() << " " << now << "\r\n";
           if (pool->packetCache != nullptr) {
             const auto& cache = pool->packetCache;
             str<<base<<"cache-size" << " " << cache->getMaxEntries() << " " << now << "\r\n";

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -648,12 +648,12 @@ struct ServerPool
   std::shared_ptr<ServerPolicy> policy{nullptr};
 
   int countServersUp() {
-    int upFound = 0;
-    for(unsigned idx=0; idx<servers.size(); idx++) {
-      if ( std::get<1>(servers[idx])->isUp() ) {
+    size_t upFound = 0;
+    for (const auto& server : servers) {
+      if (std::get<1>(server)->isUp() ) {
         upFound++;
-      }
-    }
+      };
+    };
     return upFound;
   };
 };

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -90,12 +90,12 @@ struct DNSResponse : DNSQuestion
     DNSQuestion(name, type, class_, lc, rem, header, bufferSize, responseLen, isTcp, queryTime_) { }
 };
 
-/* so what could you do: 
-   drop, 
-   fake up nxdomain, 
-   provide actual answer, 
-   allow & and stop processing, 
-   continue processing, 
+/* so what could you do:
+   drop,
+   fake up nxdomain,
+   provide actual answer,
+   allow & and stop processing,
+   continue processing,
    modify header:    (servfail|refused|notimp), set TC=1,
    send to pool */
 
@@ -172,7 +172,7 @@ struct DNSDistStats
   stat_t cacheHits{0};
   stat_t cacheMisses{0};
   stat_t latency0_1{0}, latency1_10{0}, latency10_50{0}, latency50_100{0}, latency100_1000{0}, latencySlow{0};
-  
+
   double latencyAvg100{0}, latencyAvg1000{0}, latencyAvg10000{0}, latencyAvg1000000{0};
   typedef std::function<uint64_t(const std::string&)> statfunction_t;
   typedef boost::variant<stat_t*, double*, statfunction_t> entry_t;
@@ -187,7 +187,7 @@ struct DNSDistStats
     {"rule-servfail", &ruleServFail},
     {"self-answered", &selfAnswered},
     {"downstream-timeouts", &downstreamTimeouts},
-    {"downstream-send-errors", &downstreamSendErrors}, 
+    {"downstream-send-errors", &downstreamSendErrors},
     {"trunc-failures", &truncFail},
     {"no-policy", &noPolicy},
     {"latency0-1", &latency0_1},
@@ -211,7 +211,7 @@ struct DNSDistStats
     {"cpu-user-msec", getCPUTimeUser},
     {"cpu-sys-msec", getCPUTimeSystem},
     {"fd-usage", getOpenFileDescriptors},
-    {"dyn-blocked", &dynBlocked}, 
+    {"dyn-blocked", &dynBlocked},
     {"dyn-block-nmg-size", [](const std::string&) { return g_dynblockNMG.getLocal()->size(); }}
   };
 };
@@ -229,21 +229,21 @@ struct StopWatch
   struct timespec d_start{0,0};
   bool d_needRealTime{false};
 
-  void start() {  
+  void start() {
     if(gettime(&d_start, d_needRealTime) < 0)
       unixDie("Getting timestamp");
-    
+
   }
 
   void set(const struct timespec& from) {
     d_start = from;
   }
-  
+
   double udiff() const {
     struct timespec now;
     if(gettime(&now, d_needRealTime) < 0)
       unixDie("Getting timestamp");
-    
+
     return 1000000.0*(now.tv_sec - d_start.tv_sec) + (now.tv_nsec - d_start.tv_nsec)/1000.0;
   }
 
@@ -251,7 +251,7 @@ struct StopWatch
     struct timespec now;
     if(gettime(&now, d_needRealTime) < 0)
       unixDie("Getting timestamp");
-    
+
     auto ret= 1000000.0*(now.tv_sec - d_start.tv_sec) + (now.tv_nsec - d_start.tv_nsec)/1000.0;
     d_start = now;
     return ret;
@@ -291,7 +291,7 @@ public:
     if(d_passthrough)
       return true;
     auto delta = d_prev.udiffAndSet();
-  
+
     d_tokens += 1.0*d_rate * (delta/1000000.0);
 
     if(d_tokens > d_burst)
@@ -306,7 +306,7 @@ public:
     else
       d_blocked++;
 
-    return ret; 
+    return ret;
   }
 private:
   bool d_passthrough{true};
@@ -397,7 +397,7 @@ struct Rings {
 
   std::unordered_map<int, vector<boost::variant<string,double> > > getTopBandwidth(unsigned int numentries);
   size_t numDistinctRequestors();
-  void setCapacity(size_t newCapacity) 
+  void setCapacity(size_t newCapacity)
   {
     {
       WriteLock wl(&queryLock);
@@ -646,6 +646,16 @@ struct ServerPool
   NumberedVector<shared_ptr<DownstreamState>> servers;
   std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
   std::shared_ptr<ServerPolicy> policy{nullptr};
+
+  int countServersUp() {
+    int upFound = 0;
+    for(unsigned idx=0; idx<servers.size(); idx++) {
+      if ( std::get<1>(servers[idx])->isUp() ) {
+        upFound++;
+      }
+    }
+    return upFound;
+  };
 };
 using pools_t=map<std::string,std::shared_ptr<ServerPool>>;
 void setPoolPolicy(pools_t& pools, const string& poolName, std::shared_ptr<ServerPolicy> policy);

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -647,7 +647,7 @@ struct ServerPool
   std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
   std::shared_ptr<ServerPolicy> policy{nullptr};
 
-  const size_t countServersUp() {
+  size_t countServersUp() const {
     size_t upFound = 0;
     for (const auto& server : servers) {
       if (std::get<1>(server)->isUp() ) {

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -647,7 +647,7 @@ struct ServerPool
   std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
   std::shared_ptr<ServerPolicy> policy{nullptr};
 
-  int countServersUp() {
+  const size_t countServersUp() {
     size_t upFound = 0;
     for (const auto& server : servers) {
       if (std::get<1>(server)->isUp() ) {

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -7,10 +7,6 @@ from dnsdisttests import DNSDistTest, Queue
 
 class TestCarbon(DNSDistTest):
 
-    _serverCount = 3
-    _serverUpCount = 2
-    _toResponderQueue1 = Queue()
-    _fromResponderQueue1 = Queue()
     _carbonServer1Port = 8000
     _carbonServer1Name = "carbonname1"
     _carbonServer2Port = 8001
@@ -141,13 +137,13 @@ class TestCarbon(DNSDistTest):
                 if 'servers-up' in line:
                     self.assertEquals(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
-                    self.assertEquals(int(parts[1]), self._serverUpCount)
+                    self.assertEquals(int(parts[1]), 2)
                     self.assertTrue(parts[2].isdigit())
                     self.assertTrue(int(parts[2]) <= int(after))
                 else:
                     self.assertEquals(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
-                    self.assertEquals(int(parts[1]), self._serverCount)
+                    self.assertEquals(int(parts[1]), 3)
                     self.assertTrue(parts[2].isdigit())
                     self.assertTrue(int(parts[2]) <= int(after))
 
@@ -164,12 +160,12 @@ class TestCarbon(DNSDistTest):
                 if 'servers-up' in line:
                     self.assertEquals(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
-                    self.assertEquals(int(parts[1]), self._serverUpCount)
+                    self.assertEquals(int(parts[1]), 2)
                     self.assertTrue(parts[2].isdigit())
                     self.assertTrue(int(parts[2]) <= int(after))
                 else:
                     self.assertEquals(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
-                    self.assertEquals(int(parts[1]), self._serverCount)
+                    self.assertEquals(int(parts[1]), 3)
                     self.assertTrue(parts[2].isdigit())
                     self.assertTrue(int(parts[2]) <= int(after))

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -7,6 +7,12 @@ from dnsdisttests import DNSDistTest, Queue
 
 class TestCarbon(DNSDistTest):
 
+    _serverCount = 3
+    _serverUpCount = 2
+    _baseUDPPort = 5350
+    _serverTemplate = """newServer{address="127.0.0.1:%s"}"""
+    _toResponderQueue1 = Queue()
+    _fromResponderQueue1 = Queue()
     _carbonServer1Port = 8000
     _carbonServer1Name = "carbonname1"
     _carbonServer2Port = 8001
@@ -15,7 +21,8 @@ class TestCarbon(DNSDistTest):
     _carbonQueue2 = Queue()
     _carbonInterval = 2
     _carbonCounters = {}
-    _config_params = ['_carbonServer1Port', '_carbonServer1Name', '_carbonInterval', '_carbonServer2Port', '_carbonServer2Name', '_carbonInterval']
+    _config_params = ['_carbonServer1Port', '_carbonServer1Name', '_carbonInterval',
+                      '_carbonServer2Port', '_carbonServer2Name', '_carbonInterval']
     _config_template = """
     carbonServer("127.0.0.1:%s", "%s", %s)
     carbonServer("127.0.0.1:%s", "%s", %s)
@@ -55,7 +62,13 @@ class TestCarbon(DNSDistTest):
         sock.close()
 
     @classmethod
+    def UDPResponder(cls, port, fromQueue, toQueue):
+        DNSDistTest.UDPResponder.im_func(cls, port, fromQueue, toQueue)
+
+    @classmethod
     def startResponders(cls):
+        cls.startUDPResponders(cls._serverCount, cls._serverUpCount)
+
         cls._CarbonResponder1 = threading.Thread(name='Carbon Responder 1', target=cls.CarbonResponder, args=[cls._carbonServer1Port])
         cls._CarbonResponder1.setDaemon(True)
         cls._CarbonResponder1.start()
@@ -63,6 +76,30 @@ class TestCarbon(DNSDistTest):
         cls._CarbonResponder2 = threading.Thread(name='Carbon Responder 2', target=cls.CarbonResponder, args=[cls._carbonServer2Port])
         cls._CarbonResponder2.setDaemon(True)
         cls._CarbonResponder2.start()
+
+    @classmethod
+    def startUDPResponders(cls, servers, servers_up):
+        if servers < servers_up:
+            print('startUDPResponders failed: servers cannot be less than servers_up')
+            sys.exit(1)
+
+        serverCollectionTemplate = b''
+
+        # set up a number of UDP servers
+        # metric: dnsdist.{CARBON_SERVER_NAME}.main.pools._default_.servers {SERVERS} {TIME}
+        for num in xrange(0, servers):
+            ns = str(cls._baseUDPPort+num)
+            serverCollectionTemplate += cls._serverTemplate % ns
+
+        cls._config_template += serverCollectionTemplate
+
+        # add a specific amount to the response queue marking them 'up'
+        # metric: dnsdist.{CARBON_SERVER_NAME}.main.pools._default_.servers-up {SERVERS_UP} {TIME}
+        for num in xrange(0, servers_up):
+            port = cls._baseUDPPort+num
+            cls._UDPResponder = threading.Thread(name='UDP Responder 1', target=cls.UDPResponder, args=[port, cls._toResponderQueue1, cls._fromResponderQueue1])
+            cls._UDPResponder.setDaemon(True)
+            cls._UDPResponder.start()
 
     def testCarbon(self):
         """
@@ -105,3 +142,60 @@ class TestCarbon(DNSDistTest):
         for key in self._carbonCounters:
             value = self._carbonCounters[key]
             self.assertTrue(value >= 1)
+
+    def testCarbonServerUp(self):
+        # wait for the carbon data to be sent
+        time.sleep(self._carbonInterval + 1)
+
+        # first server
+        self.assertFalse(self._carbonQueue1.empty())
+        data1 = self._carbonQueue1.get(False)
+        # second server
+        self.assertFalse(self._carbonQueue2.empty())
+        data2 = self._carbonQueue2.get(False)
+        after = time.time()
+
+        # check the first carbon server got both servers and
+        # servers-up metrics and that they are the same as
+        # configured in the class definition
+        self.assertTrue(data1)
+        self.assertTrue(len(data1.splitlines()) > 1)
+        expectedStart = b"dnsdist.%s.main.pools._default_.servers" % self._carbonServer1Name.encode('UTF-8')
+        for line in data1.splitlines():
+            if expectedStart in line:
+                parts = line.split(b' ')
+                if 'servers-up' in line:
+                    self.assertEquals(len(parts), 3)
+                    self.assertTrue(parts[1].isdigit())
+                    self.assertEquals(int(parts[1]), self._serverUpCount)
+                    self.assertTrue(parts[2].isdigit())
+                    self.assertTrue(int(parts[2]) <= int(after))
+                else:
+                    self.assertEquals(len(parts), 3)
+                    self.assertTrue(parts[1].isdigit())
+                    self.assertEquals(int(parts[1]), self._serverCount)
+                    self.assertTrue(parts[2].isdigit())
+                    self.assertTrue(int(parts[2]) <= int(after))
+
+        # check the second carbon server got both servers and
+        # servers-up metrics and that they are the same as
+        # configured in the class definition and the same as
+        # the first carbon server
+        self.assertTrue(data2)
+        self.assertTrue(len(data2.splitlines()) > 1)
+        expectedStart = b"dnsdist.%s.main.pools._default_.servers" % self._carbonServer2Name.encode('UTF-8')
+        for line in data2.splitlines():
+            if expectedStart in line:
+                parts = line.split(b' ')
+                if 'servers-up' in line:
+                    self.assertEquals(len(parts), 3)
+                    self.assertTrue(parts[1].isdigit())
+                    self.assertEquals(int(parts[1]), self._serverUpCount)
+                    self.assertTrue(parts[2].isdigit())
+                    self.assertTrue(int(parts[2]) <= int(after))
+                else:
+                    self.assertEquals(len(parts), 3)
+                    self.assertTrue(parts[1].isdigit())
+                    self.assertEquals(int(parts[1]), self._serverCount)
+                    self.assertTrue(parts[2].isdigit())
+                    self.assertTrue(int(parts[2]) <= int(after))


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds a metric (`servers-up`) to be pushed to carbon for servers in a pool which are in a state of `UP`. There already existed a metric for `servers` but that did not offer insight into the health of a `ServerPool`, rather was just a count for the total list of downstreams irrespective of their `State`. There did not appear to be an open issue/request for this.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

Proposed Metric:
```
dnsdist.carbonname1.main.pools._default_.servers-up 2 1520457187
```

Regression Test Output:
```
$ DNSDISTBIN=../pdns/dnsdistdist/dnsdist ./runtests test_Carbon.py
Generating a 2048 bit RSA private key
.......................................................................+++
...............................................+++
writing new private key to 'ca.key'
-----
Generating a 2048 bit RSA private key
.........................................................................+++
.......................................................+++
writing new private key to 'server.key'
-----
Signature ok
subject=/CN=tls.tests.dnsdist.org/OU=PowerDNS.com BV/C=NL
Getting CA Private Key
..
----------------------------------------------------------------------
Ran 2 tests in 12.345s

OK
```