### PR TITLE
add TCP support for ALIAS

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -515,7 +515,6 @@ void mainthread()
   AuthWebServer webserver;
   Utility::dropUserPrivs(newuid);
 
-  // We need to start the Recursor Proxy before doing secpoll, see issue #2453
   if(::arg().mustDo("resolver")){
     DP=new DNSProxy(::arg()["resolver"]);
     DP->go();

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -33,7 +33,6 @@
 #include "statbag.hh"
 #include "dns_random.hh"
 #include "stubresolver.hh"
-#include "tcpreceiver.hh"
 #include "arguments.hh"
 
 extern StatBag S;
@@ -87,8 +86,6 @@ void DNSProxy::go()
   pthread_t tid;
   pthread_create(&tid,0,&launchhelper,this);
 }
-
-extern TCPNameserver *TN;
 
 //! look up qname aname with r->qtype, plonk it in the answer section of 'r' with name target
 bool DNSProxy::completePacket(DNSPacket *r, const DNSName& target,const DNSName& aname)

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -85,38 +85,6 @@ void DNSProxy::go()
   pthread_create(&tid,0,&launchhelper,this);
 }
 
-/** returns false if p->remote is not allowed to recurse via us */
-bool DNSProxy::sendPacket(DNSPacket *p)
-{
-  uint16_t id;
-  {
-    Lock l(&d_lock);
-    id=getID_locked();
-
-    ConntrackEntry ce;
-    ce.id       = p->d.id;
-    ce.remote = p->d_remote;
-    ce.outsock  = p->getSocket();
-    ce.created  = time( NULL );
-    ce.qtype = p->qtype.getCode();
-    ce.qname = p->qdomain;
-    ce.anyLocal = p->d_anyLocal;
-    ce.complete=0;
-    d_conntrack[id]=ce;
-  }
-  p->d.id=id^d_xor;
-  p->commitD();
-  
-  const string& buffer = p->getString();
-  
-  if(send(d_sock,buffer.c_str(), buffer.length() , 0)<0) { // zoom
-    L<<Logger::Error<<"Unable to send a packet to our recursing backend: "<<stringerror()<<endl;
-  }
-  (*d_resquestions)++;
-  return true;
-
-}
-
 //! look up qname aname with r->qtype, plonk it in the answer section of 'r' with name target
 bool DNSProxy::completePacket(DNSPacket *r, const DNSName& target,const DNSName& aname)
 {

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -94,7 +94,6 @@ extern TCPNameserver *TN;
 bool DNSProxy::completePacket(DNSPacket *r, const DNSName& target,const DNSName& aname)
 {
   if(r->d_tcp) {
-    cerr<<"qtype="<<r->qtype.getCode()<<endl;
     vector<DNSZoneRecord> ips;
     int ret1 = 0, ret2 = 0;
 

--- a/pdns/dnsproxy.hh
+++ b/pdns/dnsproxy.hh
@@ -54,7 +54,6 @@ public:
   DNSProxy(const string &ip); //!< creates socket
   ~DNSProxy(); //<! dtor for DNSProxy
   void go(); //!< launches the actual thread
-  bool sendPacket(DNSPacket *p);    //!< send out a packet and make a conntrack entry to we can send back the answer
   bool completePacket(DNSPacket *r, const DNSName& target,const DNSName& aname);
 
   void mainloop();                  //!< this is the main loop that receives reply packets and sends them out again


### PR DESCRIPTION
### Short description
The dnsproxy does not support TCP. For questions that come in over TCP that rely on ALIAS expansion, this PR short circuits the request via the stub resolver, instead of the proxy.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
