### PR TITLE
dnsdist: Speed up the processing of large ring buffers

### DIFF
--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -24,10 +24,10 @@
 
 #include "statnode.hh"
 
-static std::unordered_map<int, vector<boost::variant<string,double>>> getGenResponses(unsigned int top, boost::optional<int> labels, std::function<bool(const Rings::Response&)> pred)
+static std::unordered_map<unsigned int, vector<boost::variant<string,double>>> getGenResponses(unsigned int top, boost::optional<int> labels, std::function<bool(const Rings::Response&)> pred)
 {
   setLuaNoSideEffect();
-  map<DNSName, int> counts;
+  map<DNSName, unsigned int> counts;
   unsigned int total=0;
   {
     std::lock_guard<std::mutex> lock(g_rings.respMutex);
@@ -53,7 +53,7 @@ static std::unordered_map<int, vector<boost::variant<string,double>>> getGenResp
     }
   }
   //      cout<<"Looked at "<<total<<" responses, "<<counts.size()<<" different ones"<<endl;
-  vector<pair<int, DNSName>> rcounts;
+  vector<pair<unsigned int, DNSName>> rcounts;
   rcounts.reserve(counts.size());
   for(const auto& c : counts)
     rcounts.push_back(make_pair(c.second, c.first.makeLowerCase()));
@@ -63,7 +63,7 @@ static std::unordered_map<int, vector<boost::variant<string,double>>> getGenResp
          return b.first < a.first;
        });
 
-  std::unordered_map<int, vector<boost::variant<string,double>>> ret;
+  std::unordered_map<unsigned int, vector<boost::variant<string,double>>> ret;
   unsigned int count=1, rest=0;
   for(const auto& rc : rcounts) {
     if(count==top+1)
@@ -75,20 +75,19 @@ static std::unordered_map<int, vector<boost::variant<string,double>>> getGenResp
   return ret;
 }
 
-static map<ComboAddress,int> filterScore(const map<ComboAddress, unsigned int,ComboAddress::addressOnlyLessThan >& counts,
-				  double delta, int rate)
+static void filterScore(map<ComboAddress, unsigned int,ComboAddress::addressOnlyLessThan >& counts,
+                        double delta, unsigned int rate)
 {
-  std::multimap<unsigned int,ComboAddress> score;
-  for(const auto& e : counts)
-    score.insert({e.second, e.first});
-
-  map<ComboAddress,int> ret;
-
   double lim = delta*rate;
-  for(auto s = score.crbegin(); s != score.crend() && s->first > lim; ++s) {
-    ret[s->second]=s->first;
+  for(auto iter = counts.begin(); iter != counts.end();) {
+    if (iter->second <= lim) {
+      iter = counts.erase(iter);
+    }
+    else {
+      iter++;
+    }
   }
-  return ret;
+
 }
 
 
@@ -103,23 +102,23 @@ static void statNodeRespRing(statvisitor_t visitor, unsigned int seconds)
     cutoff.tv_sec -= seconds;
   }
 
-  std::lock_guard<std::mutex> lock(g_rings.respMutex);
-
   StatNode root;
-  for(const auto& c : g_rings.respRing) {
-    if (now < c.when)
-      continue;
+  {
+    std::lock_guard<std::mutex> lock(g_rings.respMutex);
+    for(const auto& c : g_rings.respRing) {
+      if (now < c.when)
+        continue;
 
-    if (seconds && c.when < cutoff)
-      continue;
+      if (seconds && c.when < cutoff)
+        continue;
 
-    root.submit(c.name, c.dh.rcode, c.requestor);
+      root.submit(c.name, c.dh.rcode, c.requestor);
+    }
   }
+
   StatNode::Stat node;
-
-  root.visit([&visitor](const StatNode* node_, const StatNode::Stat& self, const StatNode::Stat& children) {
+  root.visit([visitor](const StatNode* node_, const StatNode::Stat& self, const StatNode::Stat& children) {
       visitor(*node_, self, children);},  node);
-
 }
 
 static vector<pair<unsigned int, std::unordered_map<string,string> > > getRespRing(boost::optional<int> rcode)
@@ -142,7 +141,7 @@ static vector<pair<unsigned int, std::unordered_map<string,string> > > getRespRi
 }
 
 typedef   map<ComboAddress, unsigned int,ComboAddress::addressOnlyLessThan > counts_t;
-static map<ComboAddress,int> exceedRespGen(int rate, int seconds, std::function<void(counts_t&, const Rings::Response&)> T)
+static counts_t exceedRespGen(unsigned int rate, int seconds, std::function<void(counts_t&, const Rings::Response&)> T)
 {
   counts_t counts;
   struct timespec cutoff, mintime, now;
@@ -150,22 +149,26 @@ static map<ComboAddress,int> exceedRespGen(int rate, int seconds, std::function<
   cutoff = mintime = now;
   cutoff.tv_sec -= seconds;
 
-  std::lock_guard<std::mutex> lock(g_rings.respMutex);
-  for(const auto& c : g_rings.respRing) {
-    if(seconds && c.when < cutoff)
-      continue;
-    if(now < c.when)
-      continue;
+  {
+    std::lock_guard<std::mutex> lock(g_rings.respMutex);
+    for(const auto& c : g_rings.respRing) {
+      if(seconds && c.when < cutoff)
+        continue;
+      if(now < c.when)
+        continue;
 
-    T(counts, c);
-    if(c.when < mintime)
-      mintime = c.when;
+      T(counts, c);
+      if(c.when < mintime)
+        mintime = c.when;
+    }
   }
+
   double delta = seconds ? seconds : DiffTime(now, mintime);
-  return filterScore(counts, delta, rate);
+  filterScore(counts, delta, rate);
+  return counts;
 }
 
-static map<ComboAddress,int> exceedQueryGen(int rate, int seconds, std::function<void(counts_t&, const Rings::Query&)> T)
+static counts_t exceedQueryGen(unsigned int rate, int seconds, std::function<void(counts_t&, const Rings::Query&)> T)
 {
   counts_t counts;
   struct timespec cutoff, mintime, now;
@@ -173,22 +176,26 @@ static map<ComboAddress,int> exceedQueryGen(int rate, int seconds, std::function
   cutoff = mintime = now;
   cutoff.tv_sec -= seconds;
 
-  ReadLock rl(&g_rings.queryLock);
-  for(const auto& c : g_rings.queryRing) {
-    if(seconds && c.when < cutoff)
-      continue;
-    if(now < c.when)
-      continue;
-    T(counts, c);
-    if(c.when < mintime)
-      mintime = c.when;
+  {
+    ReadLock rl(&g_rings.queryLock);
+    for(const auto& c : g_rings.queryRing) {
+      if(seconds && c.when < cutoff)
+        continue;
+      if(now < c.when)
+        continue;
+      T(counts, c);
+      if(c.when < mintime)
+        mintime = c.when;
+    }
   }
+
   double delta = seconds ? seconds : DiffTime(now, mintime);
-  return filterScore(counts, delta, rate);
+  filterScore(counts, delta, rate);
+  return counts;
 }
 
 
-static map<ComboAddress,int> exceedRCode(int rate, int seconds, int rcode)
+static counts_t exceedRCode(unsigned int rate, int seconds, int rcode)
 {
   return exceedRespGen(rate, seconds, [rcode](counts_t& counts, const Rings::Response& r)
 		   {
@@ -197,7 +204,7 @@ static map<ComboAddress,int> exceedRCode(int rate, int seconds, int rcode)
 		   });
 }
 
-static map<ComboAddress,int> exceedRespByterate(int rate, int seconds)
+static counts_t exceedRespByterate(unsigned int rate, int seconds)
 {
   return exceedRespGen(rate, seconds, [](counts_t& counts, const Rings::Response& r)
 		   {
@@ -210,7 +217,7 @@ void setupLuaInspection()
   g_lua.writeFunction("topClients", [](boost::optional<unsigned int> top_) {
       setLuaNoSideEffect();
       auto top = top_.get_value_or(10);
-      map<ComboAddress, int,ComboAddress::addressOnlyLessThan > counts;
+      map<ComboAddress, unsigned int,ComboAddress::addressOnlyLessThan > counts;
       unsigned int total=0;
       {
         ReadLock rl(&g_rings.queryLock);
@@ -219,7 +226,7 @@ void setupLuaInspection()
           total++;
         }
       }
-      vector<pair<int, ComboAddress>> rcounts;
+      vector<pair<unsigned int, ComboAddress>> rcounts;
       rcounts.reserve(counts.size());
       for(const auto& c : counts)
 	rcounts.push_back(make_pair(c.second, c.first));
@@ -241,7 +248,7 @@ void setupLuaInspection()
 
   g_lua.writeFunction("getTopQueries", [](unsigned int top, boost::optional<int> labels) {
       setLuaNoSideEffect();
-      map<DNSName, int> counts;
+      map<DNSName, unsigned int> counts;
       unsigned int total=0;
       if(!labels) {
 	ReadLock rl(&g_rings.queryLock);
@@ -260,7 +267,7 @@ void setupLuaInspection()
 	}
       }
       // cout<<"Looked at "<<total<<" queries, "<<counts.size()<<" different ones"<<endl;
-      vector<pair<int, DNSName>> rcounts;
+      vector<pair<unsigned int, DNSName>> rcounts;
       rcounts.reserve(counts.size());
       for(const auto& c : counts)
 	rcounts.push_back(make_pair(c.second, c.first.makeLowerCase()));
@@ -270,7 +277,7 @@ void setupLuaInspection()
 	     return b.first < a.first;
 	   });
 
-      std::unordered_map<int, vector<boost::variant<string,double>>> ret;
+      std::unordered_map<unsigned int, vector<boost::variant<string,double>>> ret;
       unsigned int count=1, rest=0;
       for(const auto& rc : rcounts) {
 	if(count==top+1)

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -114,7 +114,7 @@ static void statNodeRespRing(statvisitor_t visitor, unsigned int seconds)
       if (seconds && c.when < cutoff)
         continue;
 
-      root.submit(c.name, c.dh.rcode, c.requestor);
+      root.submit(c.name, c.dh.rcode, boost::none);
     }
   }
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -821,7 +821,7 @@ void setupLuaConfig(bool client)
     });
 
   g_lua.writeFunction("addDynBlocks",
-                      [](const map<ComboAddress,int>& m, const std::string& msg, boost::optional<int> seconds, boost::optional<DNSAction::Action> action) {
+                      [](const map<ComboAddress,unsigned int, ComboAddress::addressOnlyLessThan>& m, const std::string& msg, boost::optional<int> seconds, boost::optional<DNSAction::Action> action) {
                            setLuaSideEffect();
 			   auto slow = g_dynblockNMG.getCopy();
 			   struct timespec until, now;

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -821,7 +821,7 @@ void setupLuaConfig(bool client)
     });
 
   g_lua.writeFunction("addDynBlocks",
-                      [](const map<ComboAddress,unsigned int, ComboAddress::addressOnlyLessThan>& m, const std::string& msg, boost::optional<int> seconds, boost::optional<DNSAction::Action> action) {
+                      [](const std::unordered_map<ComboAddress,unsigned int, ComboAddress::addressOnlyHash, ComboAddress::addressOnlyEqual>& m, const std::string& msg, boost::optional<int> seconds, boost::optional<DNSAction::Action> action) {
                            setLuaSideEffect();
 			   auto slow = g_dynblockNMG.getCopy();
 			   struct timespec until, now;

--- a/pdns/statnode.cc
+++ b/pdns/statnode.cc
@@ -39,10 +39,10 @@ void  StatNode::visit(visitor_t visitor, Stat &newstat, unsigned int depth) cons
   childstat.nxdomains += s.nxdomains;
   childstat.servfails += s.servfails;
   childstat.drops += s.drops;
-  childstat.remotes = s.remotes;
+//  childstat.remotes = s.remotes;
   
-  Stat selfstat(childstat);
 
+  Stat selfstat(childstat);
 
   for(const children_t::value_type& child :  children) {
     child.second.visit(visitor, childstat, depth+8);
@@ -107,7 +107,7 @@ void StatNode::submit(deque<string>& labels, const std::string& domain, int rcod
       s.servfails++;
     else if(rcode==3)
       s.nxdomains++;
-    s.remotes[remote]++;
+//    s.remotes[remote]++;
   }
   else {
     if (fullname.empty()) {

--- a/pdns/statnode.cc
+++ b/pdns/statnode.cc
@@ -41,8 +41,7 @@ void  StatNode::visit(visitor_t visitor, Stat &newstat, unsigned int depth) cons
   childstat.drops += s.drops;
   childstat.remotes = s.remotes;
   
-
-  Stat selfstat;
+  Stat selfstat(childstat);
 
   for(const children_t::value_type& child :  children) {
     child.second.visit(visitor, childstat, depth+8);

--- a/pdns/statnode.cc
+++ b/pdns/statnode.cc
@@ -39,10 +39,10 @@ void  StatNode::visit(visitor_t visitor, Stat &newstat, unsigned int depth) cons
   childstat.nxdomains += s.nxdomains;
   childstat.servfails += s.servfails;
   childstat.drops += s.drops;
-//  childstat.remotes = s.remotes;
+  childstat.remotes = s.remotes;
   
 
-  Stat selfstat(childstat);
+  Stat selfstat;
 
   for(const children_t::value_type& child :  children) {
     child.second.visit(visitor, childstat, depth+8);
@@ -54,7 +54,7 @@ void  StatNode::visit(visitor_t visitor, Stat &newstat, unsigned int depth) cons
 }
 
 
-void StatNode::submit(const DNSName& domain, int rcode, const ComboAddress& remote)
+void StatNode::submit(const DNSName& domain, int rcode, boost::optional<const ComboAddress&> remote)
 {
   //  cerr<<"FIRST submit called on '"<<domain<<"'"<<endl;
   std::vector<string> tmp = domain.getRawLabels();
@@ -72,7 +72,7 @@ void StatNode::submit(const DNSName& domain, int rcode, const ComboAddress& remo
    www.powerdns.com. 
 */
 
-void StatNode::submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const std::string& domain, int rcode, const ComboAddress& remote, unsigned int count)
+void StatNode::submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const std::string& domain, int rcode, boost::optional<const ComboAddress&> remote, unsigned int count)
 {
   //  cerr<<"Submit called for domain='"<<domain<<"': ";
   //  for(const std::string& n :  labels) 
@@ -102,7 +102,10 @@ void StatNode::submit(std::vector<string>::const_iterator end, std::vector<strin
       s.servfails++;
     else if(rcode==3)
       s.nxdomains++;
-//    s.remotes[remote]++;
+
+    if (remote) {
+      s.remotes[*remote]++;
+    }
   }
   else {
     if (fullname.empty()) {

--- a/pdns/statnode.hh
+++ b/pdns/statnode.hh
@@ -32,7 +32,7 @@ public:
   struct Stat
   {
     Stat() : queries(0), noerrors(0), nxdomains(0), servfails(0), drops(0){}
-    int queries, noerrors, nxdomains, servfails, drops;
+    uint64_t queries, noerrors, nxdomains, servfails, drops;
 
     Stat& operator+=(const Stat& rhs) {
       queries+=rhs.queries;

--- a/pdns/statnode.hh
+++ b/pdns/statnode.hh
@@ -29,7 +29,7 @@ class StatNode
 {
 public:
 
-  struct Stat 
+  struct Stat
   {
     Stat() : queries(0), noerrors(0), nxdomains(0), servfails(0), drops(0){}
     int queries, noerrors, nxdomains, servfails, drops;
@@ -41,13 +41,13 @@ public:
       servfails+=rhs.servfails;
       drops+=rhs.drops;
 
-      for(const remotes_t::value_type& rem :  rhs.remotes) {
-	remotes[rem.first]+=rem.second;
-      }
+      //for(const remotes_t::value_type& rem :  rhs.remotes) {
+      //  remotes[rem.first]+=rem.second;
+      //}
       return *this;
     }
-    typedef std::map<ComboAddress,int,ComboAddress::addressOnlyLessThan> remotes_t;
-    remotes_t remotes;
+    //typedef std::map<ComboAddress,int,ComboAddress::addressOnlyLessThan> remotes_t;
+    //remotes_t remotes;
   };
 
   Stat s;
@@ -56,12 +56,13 @@ public:
   unsigned int labelsCount{0};
 
   void submit(const DNSName& domain, int rcode, const ComboAddress& remote);
-  void submit(std::deque<std::string>& labels, const std::string& domain, int rcode, const ComboAddress& remote, unsigned int count);
 
   Stat print(unsigned int depth=0, Stat newstat=Stat(), bool silent=false) const;
   typedef boost::function<void(const StatNode*, const Stat& selfstat, const Stat& childstat)> visitor_t;
   void visit(visitor_t visitor, Stat& newstat, unsigned int depth=0) const;
   typedef std::map<std::string,StatNode, CIStringCompare> children_t;
   children_t children;
-  
+
+private:
+  void submit(std::deque<std::string>& labels, const std::string& domain, int rcode, const ComboAddress& remote, unsigned int count);
 };

--- a/pdns/statnode.hh
+++ b/pdns/statnode.hh
@@ -64,5 +64,5 @@ public:
   children_t children;
 
 private:
-  void submit(std::deque<std::string>& labels, const std::string& domain, int rcode, const ComboAddress& remote, unsigned int count);
+  void submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const std::string& domain, int rcode, const ComboAddress& remote, unsigned int count);
 };

--- a/pdns/statnode.hh
+++ b/pdns/statnode.hh
@@ -41,13 +41,13 @@ public:
       servfails+=rhs.servfails;
       drops+=rhs.drops;
 
-      //for(const remotes_t::value_type& rem :  rhs.remotes) {
-      //  remotes[rem.first]+=rem.second;
-      //}
+      for(const remotes_t::value_type& rem : rhs.remotes) {
+        remotes[rem.first]+=rem.second;
+      }
       return *this;
     }
-    //typedef std::map<ComboAddress,int,ComboAddress::addressOnlyLessThan> remotes_t;
-    //remotes_t remotes;
+    typedef std::map<ComboAddress,int,ComboAddress::addressOnlyLessThan> remotes_t;
+    remotes_t remotes;
   };
 
   Stat s;
@@ -55,7 +55,7 @@ public:
   std::string fullname;
   unsigned int labelsCount{0};
 
-  void submit(const DNSName& domain, int rcode, const ComboAddress& remote);
+  void submit(const DNSName& domain, int rcode, boost::optional<const ComboAddress&> remote);
 
   Stat print(unsigned int depth=0, Stat newstat=Stat(), bool silent=false) const;
   typedef boost::function<void(const StatNode*, const Stat& selfstat, const Stat& childstat)> visitor_t;
@@ -64,5 +64,5 @@ public:
   children_t children;
 
 private:
-  void submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const std::string& domain, int rcode, const ComboAddress& remote, unsigned int count);
+  void submit(std::vector<string>::const_iterator end, std::vector<string>::const_iterator begin, const std::string& domain, int rcode, boost::optional<const ComboAddress&> remote, unsigned int count);
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- We kept track of the remote addresses for each `StatNode` entry, copying them around several times, while we never used them in `dnsdist` (`dnsscope` does)
- The `exceed*` functions (or more precisely the `filterScore()` one) sorted their return based on the score. We didn't used that (undocumented) property, and it led to unneeded copy of entire maps
- Use a `reserve()`'d `unordered_map` instead of a `map` for `exceed*` operations

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
