### PR TITLE
build-scripts: Use correct example file for lua2

### DIFF
--- a/build-scripts/debian-authoritative/pdns-backend-lua2.examples
+++ b/build-scripts/debian-authoritative/pdns-backend-lua2.examples
@@ -1,1 +1,1 @@
-debian/config/pdns.local.lua.conf
+debian/config/pdns.local.lua2.conf


### PR DESCRIPTION
### Short description
The example file in debian packages was wrong.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)