### PR TITLE
rather than crash, sheepishly report no file/linenum

### DIFF
--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -268,7 +268,10 @@ string ZoneParserTNG::getLineOfFile()
 
 pair<string,int> ZoneParserTNG::getLineNumAndFile()
 {
-  return {d_filestates.top().d_filename, d_filestates.top().d_lineno};
+  if (d_filestates.empty())
+    return {"", 0};
+  else
+    return {d_filestates.top().d_filename, d_filestates.top().d_lineno};
 }
 
 bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)


### PR DESCRIPTION
### Short description
Before this commit, you could crash pdnsutil edit-zone this way:
1) run pdnsutil edit-zone example.org
2) add a line saying: IN TXT ("
3) exit editor

I suspect other consumers of the zone file parser could also crash this way.

After this commit, we don't crash but we fail to report the line number.
There is room for more improvement here.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
