### PR TITLE
recursor: Add options to tune udp source ports

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <boost/container/flat_set.hpp>
 #include "ws-recursor.hh"
 #include <pthread.h>
 #include "recpacketcache.hh"
@@ -60,7 +61,6 @@
 #include <boost/shared_array.hpp>
 #include <boost/function.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/container/flat_set.hpp>
 #ifdef MALLOC_TRACE
 #include "malloctrace.hh"
 #endif
@@ -3207,25 +3207,25 @@ static int serviceMain(int argc, char*argv[])
     g_snmpAgent->run();
   }
 
-  int port = ::arg().asNum("min-udp-source-port");
+  int port = ::arg().asNum("udp-source-port-min");
   if(port < 1025 || port > 65535){
-    L<<Logger::Error<<"Unable to launch, min-udp-source-port is not a valid port number"<<endl;
+    L<<Logger::Error<<"Unable to launch, udp-source-port-min is not a valid port number"<<endl;
     exit(99); // this isn't going to fix itself either
   }
   s_minUdpSourcePort = port;
-  port = ::arg().asNum("max-udp-source-port");
+  port = ::arg().asNum("udp-source-port-max");
   if(port < 1025 || port > 65535 || port < s_minUdpSourcePort){
-    L<<Logger::Error<<"Unable to launch, max-udp-source-port is not a valid port number or is smaller than min-udp-source-port"<<endl;
+    L<<Logger::Error<<"Unable to launch, udp-source-port-max is not a valid port number or is smaller than udp-source-port-min"<<endl;
     exit(99); // this isn't going to fix itself either
   }
   s_maxUdpSourcePort = port;
   std::vector<string> parts {};
-  stringtok(parts, ::arg()["avoid-udp-source-port"], ", ");
+  stringtok(parts, ::arg()["udp-source-port-avoid"], ", ");
   for (const auto &part : parts)
   {
     port = std::stoi(part);
     if(port < 1025 || port > 65535){
-      L<<Logger::Error<<"Unable to launch, avoid-udp-source-port contains an invalid port number: "<<part<<endl;
+      L<<Logger::Error<<"Unable to launch, udp-source-port-avoid contains an invalid port number: "<<part<<endl;
       exit(99); // this isn't going to fix itself either
     }
     s_avoidUdpSourcePorts.insert(port);
@@ -3548,9 +3548,9 @@ int main(int argc, char **argv)
     ::arg().set("xpf-allow-from","XPF information is only processed from these subnets")="";
     ::arg().set("xpf-rr-code","XPF option code to use")="0";
 
-    ::arg().set("min-udp-source-port", "Minimum UDP port to bind on")="1025";
-    ::arg().set("max-udp-source-port", "Maximum UDP port to bind on")="65535";
-    ::arg().set("avoid-udp-source-port", "List of comma separated UDP port number to avoid")="11211";
+    ::arg().set("udp-source-port-min", "Minimum UDP port to bind on")="1025";
+    ::arg().set("udp-source-port-max", "Maximum UDP port to bind on")="65535";
+    ::arg().set("udp-source-port-avoid", "List of comma separated UDP port number to avoid")="11211";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print version string");

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -60,6 +60,7 @@
 #include <boost/shared_array.hpp>
 #include <boost/function.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/container/flat_set.hpp>
 #ifdef MALLOC_TRACE
 #include "malloctrace.hh"
 #endif
@@ -160,6 +161,9 @@ static bool g_gettagNeedsEDNSOptions{false};
 static time_t g_statisticsInterval;
 static bool g_useIncomingECS;
 std::atomic<uint32_t> g_maxCacheEntries, g_maxPacketCacheEntries;
+static boost::container::flat_set<uint16_t> s_avoidUdpSourcePorts;
+static uint16_t s_minUdpSourcePort;
+static uint16_t s_maxUdpSourcePort;
 
 RecursorControlChannel s_rcc; // only active in thread 0
 RecursorStats g_stats;
@@ -516,8 +520,12 @@ public:
 
       if(tries==1)  // fall back to kernel 'random'
         port = 0;
-      else
-        port = 1025 + dns_random(64510);
+      else {
+        do {
+          port = s_minUdpSourcePort + dns_random(s_maxUdpSourcePort - s_minUdpSourcePort + 1);
+        }
+        while (s_avoidUdpSourcePorts.count(port));
+      }
 
       sin=getQueryLocalAddress(family, port); // does htons for us
 
@@ -3199,6 +3207,30 @@ static int serviceMain(int argc, char*argv[])
     g_snmpAgent->run();
   }
 
+  int port = ::arg().asNum("min-udp-source-port");
+  if(port < 1025 || port > 65535){
+    L<<Logger::Error<<"Unable to launch, min-udp-source-port is not a valid port number"<<endl;
+    exit(99); // this isn't going to fix itself either
+  }
+  s_minUdpSourcePort = port;
+  port = ::arg().asNum("max-udp-source-port");
+  if(port < 1025 || port > 65535 || port < s_minUdpSourcePort){
+    L<<Logger::Error<<"Unable to launch, max-udp-source-port is not a valid port number or is smaller than min-udp-source-port"<<endl;
+    exit(99); // this isn't going to fix itself either
+  }
+  s_maxUdpSourcePort = port;
+  std::vector<string> parts {};
+  stringtok(parts, ::arg()["avoid-udp-source-port"], ", ");
+  for (const auto &part : parts)
+  {
+    port = std::stoi(part);
+    if(port < 1025 || port > 65535){
+      L<<Logger::Error<<"Unable to launch, avoid-udp-source-port contains an invalid port number: "<<part<<endl;
+      exit(99); // this isn't going to fix itself either
+    }
+    s_avoidUdpSourcePorts.insert(port);
+  }
+
   const auto cpusMap = parseCPUMap();
   if(g_numThreads == 1) {
     L<<Logger::Warning<<"Operating unthreaded"<<endl;
@@ -3515,6 +3547,10 @@ int main(int argc, char **argv)
 
     ::arg().set("xpf-allow-from","XPF information is only processed from these subnets")="";
     ::arg().set("xpf-rr-code","XPF option code to use")="0";
+
+    ::arg().set("min-udp-source-port", "Minimum UDP port to bind on")="1025";
+    ::arg().set("max-udp-source-port", "Maximum UDP port to bind on")="65535";
+    ::arg().set("avoid-udp-source-port", "List of comma separated UDP port number to avoid")="11211";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print version string");

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1067,6 +1067,48 @@ Spawn this number of threads on startup.
 If turned on, output impressive heaps of logging.
 May destroy performance under load.
 
+.. _setting-udp-source-port-min:
+
+``udp-source-port-min``
+-----------------------
+.. versionadded:: 4.2.0
+
+-  Integer
+-  Default: 1025
+
+This option sets the low limit of UDP port number to bind on.
+
+In combination with `udp-source-port-max`_ it configures the UDP
+port range to use. Port numbers are randomized within this range on
+initialization, and exceptions can be configured with `udp-source-port-avoid`_
+
+.. _setting-udp-source-port-max:
+
+``udp-source-port-max``
+-----------------------
+.. versionadded:: 4.2.0
+
+-  Integer
+-  Default: 65535
+
+This option sets the maximum limit of UDP port number to bind on.
+
+See `udp-source-port-min`_.
+
+.. _setting-udp-source-port-avoid:
+
+``udp-source-port-avoid``
+-------------------------
+.. versionadded:: 4.2.0
+
+-  String
+-  Default: 11211
+
+A list of comma-separated UDP port numbers to avoid when binding.
+Ex: `5300,11211`
+
+See `udp-source-port-min`_.
+
 .. _setting-udp-truncation-threshold:
 
 ``udp-truncation-threshold``


### PR DESCRIPTION
Add min-udp-source-port, max-udp-source-port and avoid-udp-source-port variables to tune the range of ports we use

This should address #6321 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
