### PR TITLE
dnsdist: Update deprecated syntax used in dist configuration file

### DIFF
--- a/pdns/dnsdistconf.lua
+++ b/pdns/dnsdistconf.lua
@@ -44,7 +44,7 @@ addAction("192.168.1.0/24", PoolAction("abuse"))
 
 -- send the queries for the "com" suffix to the "abuse"
 -- pool, but only up to 100 qps
-addAction("com.", QPSPoolRule(100, "abuse"))
+addAction("com.", QPSPoolAction(100, "abuse"))
 
 -- declare a Lua action function, routing NAPTR queries
 -- to the abuse pool


### PR DESCRIPTION
### Short description
Update deprecated syntax used in dist configuration file
See https://dnsdist.org/rules-actions.html?highlight=qpspoolrule#addQPSPoolRule
fix #6347 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master