### PR TITLE
dnsdist: Reserve according to the _query_ ring size in exceedQueryGen

### DIFF
--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -179,7 +179,7 @@ static counts_t exceedQueryGen(unsigned int rate, int seconds, std::function<voi
 
   {
     ReadLock rl(&g_rings.queryLock);
-    counts.reserve(g_rings.respRing.size());
+    counts.reserve(g_rings.queryRing.size());
     for(const auto& c : g_rings.queryRing) {
       if(seconds && c.when < cutoff)
         continue;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Typo introduced in #6350, not a big issue since both rings should have roughly  the same size after a while.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
