### PR TITLE
auth: fix handling of user-defined axfr filters return values

### DIFF
--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -272,7 +272,7 @@ Consider the following simple example:
            if record:qtype() == pdns.HINFO then
               resp = {}
               resp[1] = {
-                qname   = record:qname:toString(),
+                qname   = record:qname():toString(),
                 qtype   = pdns.TXT,
                 ttl     = 99,
                 content = "Hello Ahu!"
@@ -281,7 +281,7 @@ Consider the following simple example:
            end
 
            -- Grab each _tstamp TXT record and add a time stamp
-           if record:qtype() == pdns.TXT and string.starts(record:qname:toString(), "_tstamp.") then
+           if record:qtype() == pdns.TXT and string.starts(record:qname():toString(), "_tstamp.") then
               resp = {}
               resp[1] = {
                 qname   = record:qname():toString(),
@@ -296,7 +296,7 @@ Consider the following simple example:
            if record:qtype() == pdns.A then
               resp = {}
               resp[1] = {
-                qname   = record:qname:toString(),
+                qname   = record:qname():toString(),
                 qtype   = pdns.TXT,
                 ttl     = 99,
                 content = "Hello Ahu, again!"

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -113,10 +113,17 @@ bool AuthLua4::axfrfilter(const ComboAddress& remote, const DNSName& zone, const
 
   ret = d_axfr_filter(remote, zone, in);
   rcode = std::get<0>(ret);
-  if (rcode < 0)
+  if (rcode < 0) {
+    // no modification, handle normally
     return false;
-  else if (rcode == 1)
+  }
+  else if (rcode == 0) {
+    // replace the matching record by the filtered record(s)
+  }
+  else if (rcode == 1) {
+    // append the filtered record(s) after the matching record
     out.push_back(in);
+  }
   else
     throw PDNSException("Cannot understand return code "+std::to_string(rcode)+" in axfr filter response");
 


### PR DESCRIPTION
### Short description
Also fix a typo in the example of the auth documentation about axfr filters.

Fix #6228 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
