### PR TITLE
Remove VLAs

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -369,7 +369,7 @@ install_dnsdist() {
 build_auth() {
   run "autoreconf -vi"
   # Build without --enable-botan, no botan 2.x in Travis CI
-  run "CFLAGS='-O1' CXXFLAGS='-O1' ./configure \
+  run "CFLAGS='-O1 -Werror=vla' CXXFLAGS='-O1 -Werror=vla' ./configure \
     --with-dynmodules='bind gmysql geoip gpgsql gsqlite3 ldap lua mydns opendbx pipe random remote tinydns godbc lua2' \
     --with-modules='' \
     --with-sqlite3 \
@@ -396,7 +396,7 @@ build_recursor() {
   run "rm -f pdns-recursor-*.tar.bz2"
   run "cd pdns-recursor-*"
   # Build without --enable-botan, no botan 2.x in Travis CI
-  run "CFLAGS='-O1' CXXFLAGS='-O1' CXX=${COMPILER} ./configure \
+  run "CFLAGS='-O1 -Werror=vla' CXXFLAGS='-O1 -Werror=vla' CXX=${COMPILER} ./configure \
     --prefix=$PDNS_RECURSOR_DIR \
     --enable-libsodium \
     --enable-unit-tests \
@@ -412,7 +412,7 @@ build_dnsdist(){
   run "cd pdns/dnsdistdist"
   run "tar xf dnsdist*.tar.bz2"
   run "cd dnsdist-*"
-  run "CFLAGS='-O1' CXXFLAGS='-O1' ./configure \
+  run "CFLAGS='-O1 -Werror=vla' CXXFLAGS='-O1 -Werror=vla' ./configure \
     --enable-unit-tests \
     --enable-libsodium \
     --enable-dnscrypt \

--- a/modules/pipebackend/coprocess.cc
+++ b/modules/pipebackend/coprocess.cc
@@ -45,13 +45,13 @@ CoProcess::CoProcess(const string &command,int timeout, int infd, int outfd)
   vector <string> v;
   split(v, command, is_any_of(" "));
 
-  const char *argv[v.size()+1];
+  std::vector<const char *>argv(v.size()+1);
   argv[v.size()]=0;
 
   for (size_t n = 0; n < v.size(); n++)
     argv[n]=v[n].c_str();
   // we get away with not copying since nobody resizes v 
-  launch(argv, timeout, infd, outfd);
+  launch(&argv.at(0), timeout, infd, outfd);
 }
 
 void CoProcess::launch(const char **argv, int timeout, int infd, int outfd)

--- a/modules/pipebackend/coprocess.cc
+++ b/modules/pipebackend/coprocess.cc
@@ -51,7 +51,7 @@ CoProcess::CoProcess(const string &command,int timeout, int infd, int outfd)
   for (size_t n = 0; n < v.size(); n++)
     argv[n]=v[n].c_str();
   // we get away with not copying since nobody resizes v 
-  launch(&argv.at(0), timeout, infd, outfd);
+  launch(argv.data(), timeout, infd, outfd);
 }
 
 void CoProcess::launch(const char **argv, int timeout, int infd, int outfd)

--- a/modules/remotebackend/pipeconnector.cc
+++ b/modules/remotebackend/pipeconnector.cc
@@ -107,7 +107,7 @@ void PipeConnector::launch() {
 
     // stdin & stdout are now connected, fire up our coprocess!
 
-    if(execv(argv[0], const_cast<char * const *>(&argv[0]))<0) // now what
+    if(execv(argv[0], const_cast<char * const *>(argv.data()))<0) // now what
       exit(123);
 
     /* not a lot we can do here. We shouldn't return because that will leave a forked process around.

--- a/modules/remotebackend/pipeconnector.cc
+++ b/modules/remotebackend/pipeconnector.cc
@@ -64,7 +64,7 @@ void PipeConnector::launch() {
   std::vector <std::string> v;
   split(v, command, is_any_of(" "));
 
-  const char *argv[v.size()+1];
+  std::vector<const char *>argv(v.size()+1);
   argv[v.size()]=0;
 
   for (size_t n = 0; n < v.size(); n++)
@@ -107,7 +107,7 @@ void PipeConnector::launch() {
 
     // stdin & stdout are now connected, fire up our coprocess!
 
-    if(execv(argv[0], const_cast<char * const *>(argv))<0) // now what
+    if(execv(argv[0], const_cast<char * const *>(&argv[0]))<0) // now what
       exit(123);
 
     /* not a lot we can do here. We shouldn't return because that will leave a forked process around.

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -366,6 +366,8 @@ try
   int diff;
   bool logDNSQueries = ::arg().mustDo("log-dns-queries");
   shared_ptr<UDPNameserver> NS;
+  std::string buffer;
+  buffer.resize(DNSPacket::s_udpTruncationThreshold);
 
   // If we have SO_REUSEPORT then create a new port for all receiver threads
   // other than the first one.
@@ -379,7 +381,7 @@ try
   }
 
   for(;;) {
-    if(!(P=NS->receive(&question))) { // receive a packet         inline
+    if(!(P=NS->receive(&question, buffer))) { // receive a packet         inline
       continue;                    // packet was broken, try again
     }
 

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -271,6 +271,7 @@ void* tcpClientThread(int pipefd)
     size_t queriesCount = 0;
     time_t connectionStartTime = time(NULL);
     std::vector<char> queryBuffer;
+    std::vector<char> answerBuffer;
 
     if (getsockname(ci.fd, (sockaddr*)&dest, &len)) {
       dest = ci.cs->local;
@@ -559,9 +560,9 @@ void* tcpClientThread(int pipefd)
         }
 #endif
         responseSize += addRoom;
-        char answerbuffer[responseSize];
-        readn2WithTimeout(dsock, answerbuffer, rlen, ds->tcpRecvTimeout);
-        char* response = answerbuffer;
+        answerBuffer.resize(responseSize);
+        char* response = &answerBuffer.at(0);
+        readn2WithTimeout(dsock, response, rlen, ds->tcpRecvTimeout);
         uint16_t responseLen = rlen;
         if (outstanding) {
           /* might be false for {A,I}XFR */

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -561,7 +561,7 @@ void* tcpClientThread(int pipefd)
 #endif
         responseSize += addRoom;
         answerBuffer.resize(responseSize);
-        char* response = &answerBuffer.at(0);
+        char* response = answerBuffer.data();
         readn2WithTimeout(dsock, response, rlen, ds->tcpRecvTimeout);
         uint16_t responseLen = rlen;
         if (outstanding) {

--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -250,7 +250,7 @@ try
   }
 
 
-  pthread_t workers[numworkers];
+  std::vector<pthread_t> workers(numworkers);
 
   FILE* fp;
   if(!g_vm.count("file"))

--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -169,6 +169,7 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
   vector<DNSRecord> records;
   size_t receivedBytes = 0;
   int8_t ixfrInProgress = -2;
+  std::string reply;
 
   for(;;) {
     // IXFR end
@@ -186,18 +187,18 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
     if (maxReceivedBytes > 0 && (maxReceivedBytes - receivedBytes) < (size_t) len)
       throw std::runtime_error("Reached the maximum number of received bytes in an IXFR delta for zone '"+zone.toLogString()+"' from master "+master.toStringWithPort());
 
-    char reply[len]; 
-    readn2(s.getHandle(), reply, len);
+    reply.resize(len);
+    readn2(s.getHandle(), &reply.at(0), len);
     receivedBytes += len;
 
-    MOADNSParser mdp(false, string(reply, len));
+    MOADNSParser mdp(false, reply);
     if(mdp.d_header.rcode) 
       throw std::runtime_error("Got an error trying to IXFR zone '"+zone.toLogString()+"' from master '"+master.toStringWithPort()+"': "+RCode::to_s(mdp.d_header.rcode));
 
     //    cout<<"Got a response, rcode: "<<mdp.d_header.rcode<<", got "<<mdp.d_answers.size()<<" answers"<<endl;
 
     if(!tt.algo.empty()) { // TSIG verify message
-      tsigVerifier.check(std::string(reply, len), mdp);
+      tsigVerifier.check(reply, mdp);
     }
 
     for(auto& r: mdp.d_answers) {

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -362,8 +362,8 @@ int waitForMultiData(const set<int>& fds, const int seconds, const int useconds,
     }
   }
 
-  struct pollfd pfds[realFDs.size()];
-  memset(&pfds[0], 0, realFDs.size()*sizeof(struct pollfd));
+  std::vector<struct pollfd> pfds(realFDs.size());
+  memset(&pfds.at(0), 0, realFDs.size()*sizeof(struct pollfd));
   int ctr = 0;
   for (const auto& fd : realFDs) {
     pfds[ctr].fd = fd;
@@ -373,9 +373,9 @@ int waitForMultiData(const set<int>& fds, const int seconds, const int useconds,
 
   int ret;
   if(seconds >= 0)
-    ret = poll(pfds, realFDs.size(), seconds * 1000 + useconds/1000);
+    ret = poll(&pfds.at(0), realFDs.size(), seconds * 1000 + useconds/1000);
   else
-    ret = poll(pfds, realFDs.size(), -1);
+    ret = poll(&pfds.at(0), realFDs.size(), -1);
   if(ret <= 0)
     return ret;
 

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -363,7 +363,7 @@ int waitForMultiData(const set<int>& fds, const int seconds, const int useconds,
   }
 
   std::vector<struct pollfd> pfds(realFDs.size());
-  memset(&pfds.at(0), 0, realFDs.size()*sizeof(struct pollfd));
+  memset(pfds.data(), 0, realFDs.size()*sizeof(struct pollfd));
   int ctr = 0;
   for (const auto& fd : realFDs) {
     pfds[ctr].fd = fd;
@@ -373,9 +373,9 @@ int waitForMultiData(const set<int>& fds, const int seconds, const int useconds,
 
   int ret;
   if(seconds >= 0)
-    ret = poll(&pfds.at(0), realFDs.size(), seconds * 1000 + useconds/1000);
+    ret = poll(pfds.data(), realFDs.size(), seconds * 1000 + useconds/1000);
   else
-    ret = poll(&pfds.at(0), realFDs.size(), -1);
+    ret = poll(pfds.data(), realFDs.size(), -1);
   if(ret <= 0)
     return ret;
 

--- a/pdns/nameserver.hh
+++ b/pdns/nameserver.hh
@@ -81,7 +81,7 @@ class UDPNameserver
 {
 public:
   UDPNameserver( bool additional_socket = false );  //!< Opens the socket
-  DNSPacket *receive(DNSPacket *prefilled=0); //!< call this in a while or for(;;) loop to get packets
+  DNSPacket *receive(DNSPacket *prefilled, std::string& buffer); //!< call this in a while or for(;;) loop to get packets
   void send(DNSPacket *); //!< send a DNSPacket. Will call DNSPacket::truncate() if over 512 bytes
   inline bool canReusePort() {
 #ifdef SO_REUSEPORT

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -388,14 +388,14 @@ std::string OpenSSLRSADNSCryptoKeyEngine::getPubKeyHash() const
     throw runtime_error(getName()+" failed to init hash context for generating the public key hash");
   }
 
-  int len = BN_bn2bin(e, &tmp.at(0));
-  res = SHA1_Update(&ctx, &tmp.at(0), len);
+  int len = BN_bn2bin(e, tmp.data());
+  res = SHA1_Update(&ctx, tmp.data(), len);
   if (res != 1) {
     throw runtime_error(getName()+" failed to update hash context for generating the public key hash");
   }
 
-  len = BN_bn2bin(n, &tmp.at(0));
-  res = SHA1_Update(&ctx, &tmp.at(0), len);
+  len = BN_bn2bin(n, tmp.data());
+  res = SHA1_Update(&ctx, tmp.data(), len);
   if (res != 1) {
     throw runtime_error(getName()+" failed to update hash context for generating the public key hash");
   }

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -294,9 +294,13 @@ DNSCryptoKeyEngine::storvector_t OpenSSLRSADNSCryptoKeyEngine::convertToISCVecto
   storvect.push_back(make_pair("Algorithm", algorithm));
 
   for(outputs_t::value_type value :  outputs) {
-    unsigned char tmp[BN_num_bytes(value.second)];
-    int len = BN_bn2bin(value.second, tmp);
-    storvect.push_back(make_pair(value.first, string((char*) tmp, len)));
+    std::string tmp;
+    tmp.resize(BN_num_bytes(value.second));
+    int len = BN_bn2bin(value.second, reinterpret_cast<unsigned char*>(&tmp.at(0)));
+    if (len >= 0) {
+      tmp.resize(len);
+      storvect.push_back(make_pair(value.first, tmp));
+    }
   }
 
   return storvect;
@@ -344,15 +348,17 @@ std::string OpenSSLRSADNSCryptoKeyEngine::sign(const std::string& msg) const
 {
   string hash = this->hash(msg);
   int hashKind = hashSizeToKind(hash.size());
-  unsigned char signature[RSA_size(d_key)];
+  std::string signature;
+  signature.resize(RSA_size(d_key));
   unsigned int signatureLen = 0;
 
-  int res = RSA_sign(hashKind, (unsigned char*) hash.c_str(), hash.length(), signature, &signatureLen, d_key);
+  int res = RSA_sign(hashKind, reinterpret_cast<unsigned char*>(&hash.at(0)), hash.length(), reinterpret_cast<unsigned char*>(&signature.at(0)), &signatureLen, d_key);
   if (res != 1) {
     throw runtime_error(getName()+" failed to generate signature");
   }
 
-  return string((char*) signature, signatureLen);
+  signature.resize(signatureLen);
+  return signature;
 }
 
 
@@ -371,7 +377,8 @@ std::string OpenSSLRSADNSCryptoKeyEngine::getPubKeyHash() const
 {
   const BIGNUM *n, *e, *d;
   RSA_get0_key(d_key, &n, &e, &d);
-  unsigned char tmp[std::max(BN_num_bytes(e), BN_num_bytes(n))];
+  std::vector<unsigned char> tmp;
+  tmp.resize(std::max(BN_num_bytes(e), BN_num_bytes(n)));
   unsigned char hash[SHA_DIGEST_LENGTH];
   SHA_CTX ctx;
 
@@ -381,14 +388,14 @@ std::string OpenSSLRSADNSCryptoKeyEngine::getPubKeyHash() const
     throw runtime_error(getName()+" failed to init hash context for generating the public key hash");
   }
 
-  int len = BN_bn2bin(e, tmp);
-  res = SHA1_Update(&ctx, tmp, len);
+  int len = BN_bn2bin(e, &tmp.at(0));
+  res = SHA1_Update(&ctx, &tmp.at(0), len);
   if (res != 1) {
     throw runtime_error(getName()+" failed to update hash context for generating the public key hash");
   }
 
-  len = BN_bn2bin(n, tmp);
-  res = SHA1_Update(&ctx, tmp, len);
+  len = BN_bn2bin(n, &tmp.at(0));
+  res = SHA1_Update(&ctx, &tmp.at(0), len);
   if (res != 1) {
     throw runtime_error(getName()+" failed to update hash context for generating the public key hash");
   }
@@ -407,9 +414,10 @@ std::string OpenSSLRSADNSCryptoKeyEngine::getPublicKeyString() const
   const BIGNUM *n, *e, *d;
   RSA_get0_key(d_key, &n, &e, &d);
   string keystring;
-  unsigned char tmp[std::max(BN_num_bytes(e), BN_num_bytes(n))];
+  std::string tmp;
+  tmp.resize(std::max(BN_num_bytes(e), BN_num_bytes(n)));
 
-  int len = BN_bn2bin(e, tmp);
+  int len = BN_bn2bin(e, reinterpret_cast<unsigned char*>(&tmp.at(0)));
   if (len < 255) {
     keystring.assign(1, (char) (unsigned int) len);
   } else {
@@ -418,10 +426,10 @@ std::string OpenSSLRSADNSCryptoKeyEngine::getPublicKeyString() const
     tempLen = htons(tempLen);
     keystring.append((char*)&tempLen, 2);
   }
-  keystring.append((char *) tmp, len);
+  keystring.append(&tmp.at(0), len);
 
-  len = BN_bn2bin(n, tmp);
-  keystring.append((char *) tmp, len);
+  len = BN_bn2bin(n, reinterpret_cast<unsigned char*>(&tmp.at(0)));
+  keystring.append(&tmp.at(0), len);
 
   return keystring;
 }
@@ -688,14 +696,15 @@ DNSCryptoKeyEngine::storvector_t OpenSSLECDSADNSCryptoKeyEngine::convertToISCVec
     throw runtime_error(getName()+" private key not set");
   }
 
-  unsigned char tmp[BN_num_bytes(key)];
-  int len = BN_bn2bin(key, tmp);
+  std::string tmp;
+  tmp.resize(BN_num_bytes(key));
+  int len = BN_bn2bin(key, reinterpret_cast<unsigned char*>(&tmp.at(0)));
 
   string prefix;
   if (d_len - len)
     prefix.append(d_len - len, 0x00);
 
-  storvect.push_back(make_pair("PrivateKey", prefix + string((char*) tmp, sizeof(tmp))));
+  storvect.push_back(make_pair("PrivateKey", prefix + tmp));
 
   return storvect;
 }
@@ -728,19 +737,20 @@ std::string OpenSSLECDSADNSCryptoKeyEngine::sign(const std::string& msg) const
   }
 
   string ret;
-  unsigned char tmp[d_len];
+  std::string tmp;
+  tmp.resize(d_len);
 
   const BIGNUM *pr, *ps;
   ECDSA_SIG_get0(signature, &pr, &ps);
-  int len = BN_bn2bin(pr, tmp);
+  int len = BN_bn2bin(pr, reinterpret_cast<unsigned char*>(&tmp.at(0)));
   if (d_len - len)
     ret.append(d_len - len, 0x00);
-  ret.append(string((char*) tmp, len));
+  ret.append(&tmp.at(0), len);
 
-  len = BN_bn2bin(ps, tmp);
+  len = BN_bn2bin(ps, reinterpret_cast<unsigned char*>(&tmp.at(0)));
   if (d_len - len)
     ret.append(d_len - len, 0x00);
-  ret.append(string((char*) tmp, len));
+  ret.append(&tmp.at(0), len);
 
   ECDSA_SIG_free(signature);
 
@@ -800,9 +810,10 @@ std::string OpenSSLECDSADNSCryptoKeyEngine::getPubKeyHash() const
 
 std::string OpenSSLECDSADNSCryptoKeyEngine::getPublicKeyString() const
 {
-  unsigned char binaryPoint[(d_len * 2) + 1];
+  std::string binaryPoint;
+  binaryPoint.resize((d_len * 2) + 1);
 
-  int ret = EC_POINT_point2oct(d_ecgroup, EC_KEY_get0_public_key(d_eckey), POINT_CONVERSION_UNCOMPRESSED, binaryPoint, sizeof(binaryPoint), d_ctx);
+  int ret = EC_POINT_point2oct(d_ecgroup, EC_KEY_get0_public_key(d_eckey), POINT_CONVERSION_UNCOMPRESSED, reinterpret_cast<unsigned char*>(&binaryPoint.at(0)), binaryPoint.size(), d_ctx);
   if (ret == 0) {
     throw runtime_error(getName()+" exporting point to binary failed");
   }
@@ -810,7 +821,8 @@ std::string OpenSSLECDSADNSCryptoKeyEngine::getPublicKeyString() const
   /* we skip the first byte as the other backends use
      raw field elements, as opposed to the format described in
      SEC1: "2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion" */
-  return string((const char *)(binaryPoint + 1), sizeof(binaryPoint) - 1);
+  binaryPoint.erase(0, 1);
+  return binaryPoint;
 }
 
 

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -672,8 +672,8 @@ CK_RV Pkcs11Slot::HuntSlot(const string& tokenId, CK_SLOT_ID &slotId, _CK_SLOT_I
   }
 
   // get the actual slot ids
-  CK_SLOT_ID slotIds[slots];
-  err = functions->C_GetSlotList(CK_FALSE, slotIds, &slots);
+  std::vector<CK_SLOT_ID> slotIds(slots);
+  err = functions->C_GetSlotList(CK_FALSE, &slotIds.at(0), &slots);
   if (err) {
     L<<Logger::Warning<<"C_GetSlotList(CK_FALSE, slotIds, &slots) = " << err << std::endl;
     return err;

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -673,7 +673,7 @@ CK_RV Pkcs11Slot::HuntSlot(const string& tokenId, CK_SLOT_ID &slotId, _CK_SLOT_I
 
   // get the actual slot ids
   std::vector<CK_SLOT_ID> slotIds(slots);
-  err = functions->C_GetSlotList(CK_FALSE, &slotIds.at(0), &slots);
+  err = functions->C_GetSlotList(CK_FALSE, slotIds.data(), &slots);
   if (err) {
     L<<Logger::Warning<<"C_GetSlotList(CK_FALSE, slotIds, &slots) = " << err << std::endl;
     return err;

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -675,8 +675,8 @@ int PacketHandler::forwardPacket(const string &msgPrefix, DNSPacket *p, DomainIn
     }
     size_t packetLen = lenBuf[0]*256+lenBuf[1];
 
-    char buf[packetLen];
-    recvRes = recv(sock, &buf, packetLen, 0);
+    buffer.resize(packetLen);
+    recvRes = recv(sock, &buffer.at(0), packetLen, 0);
     if (recvRes < 0) {
       L<<Logger::Error<<msgPrefix<<"Could not receive data (dnspacket) from master at "<<remote.toStringWithPort()<<", error:"<<stringerror()<<endl;
       try {
@@ -695,7 +695,7 @@ int PacketHandler::forwardPacket(const string &msgPrefix, DNSPacket *p, DomainIn
     }
 
     try {
-      MOADNSParser mdp(false, buf, static_cast<unsigned int>(recvRes));
+      MOADNSParser mdp(false, buffer.data(), static_cast<unsigned int>(recvRes));
       L<<Logger::Info<<msgPrefix<<"Forward update message to "<<remote.toStringWithPort()<<", result was RCode "<<mdp.d_header.rcode<<endl;
       return mdp.d_header.rcode;
     }

--- a/pdns/sodcrypto.cc
+++ b/pdns/sodcrypto.cc
@@ -62,7 +62,7 @@ std::string sodDecryptSym(const std::string& msg, const std::string& key, Sodium
 
   decrypted.resize(msg.length() - crypto_secretbox_MACBYTES);
 
-  if (crypto_secretbox_open_easy(reinterpret_cast<unsigned char*>(&decrypted.at(0)),
+  if (crypto_secretbox_open_easy(reinterpret_cast<unsigned char*>(const_cast<char *>(decrypted.data())),
                                  reinterpret_cast<const unsigned char*>(msg.c_str()),
                                  msg.length(),
                                  nonce.value,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Variable-length arrays are not supported by the C++ standard, and make it very easy to forget how big the array is, which is an issue with small stacks.
In most cases we were already copying the content of the `VLA` to a string or a vector right away anyhow, so we might actually see a gain.
This PR also adds `-Werror=vla` on Travis so we don't use `VLA` by mistake in the future.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
