### PR TITLE
dnsdist: Fix building when DNSCrypt support is not enabled

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1029,9 +1029,9 @@ void setupLuaConfig(bool client)
 #endif
     });
 
+#ifdef HAVE_DNSCRYPT
   g_lua.writeFunction("generateDNSCryptCertificate", [](const std::string& providerPrivateKeyFile, const std::string& certificateFile, const std::string privateKeyFile, uint32_t serial, time_t begin, time_t end, boost::optional<DNSCryptExchangeVersion> version) {
       setLuaNoSideEffect();
-#ifdef HAVE_DNSCRYPT
       DNSCryptPrivateKey privateKey;
       DNSCryptCert cert;
 
@@ -1045,10 +1045,8 @@ void setupLuaConfig(bool client)
         errlog(e.what());
         g_outputBuffer="Error: "+string(e.what())+"\n";
       }
-#else
-      g_outputBuffer="Error: DNSCrypt support is not enabled.\n";
-#endif
     });
+#endif
 
   g_lua.writeFunction("showPools", []() {
       setLuaNoSideEffect();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The build was failing because the `DNSCryptExchangeVersion` type was not defined.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
