### PR TITLE
dnsdist: Unbreak addBPFFilterDynBlocks()

### DIFF
--- a/pdns/dnsdist-lua2.cc
+++ b/pdns/dnsdist-lua2.cc
@@ -1232,7 +1232,7 @@ void moreLua(bool client)
         }
     });
 
-    g_lua.writeFunction("addBPFFilterDynBlocks", [](const map<ComboAddress,int>& m, std::shared_ptr<DynBPFFilter> dynbpf, boost::optional<int> seconds) {
+    g_lua.writeFunction("addBPFFilterDynBlocks", [](const counts_t& m, std::shared_ptr<DynBPFFilter> dynbpf, boost::optional<int> seconds) {
         setLuaSideEffect();
         struct timespec until, now;
         clock_gettime(CLOCK_MONOTONIC, &now);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The `exceed*()` functions return a different kind of map since 2e32ba8d17631d3c32f6a29922fba0dfd724ba3a and I forgot to update `addBPFFilterDynBlocks()` 
 accordingly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
