### PR TITLE
dnsdist: Work around a false positive in statNodeRespRing()

### DIFF
--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -99,10 +99,8 @@ static void statNodeRespRing(statvisitor_t visitor, unsigned int seconds)
 {
   struct timespec cutoff, now;
   gettime(&now);
-  if (seconds) {
-    cutoff = now;
-    cutoff.tv_sec -= seconds;
-  }
+  cutoff = now;
+  cutoff.tv_sec -= seconds;
 
   StatNode root;
   {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Debian Jessie's compiler reports that `cutoff` might be used uninitialized in `statNodeRespRing()`. This is a false positive, but let's just initialize it no matter what so the compiler stops whining.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

