### PR TITLE
dnsdist: Require the right gnutls version

### DIFF
--- a/pdns/dnsdistdist/m4/dnsdist_check_gnutls.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_check_gnutls.m4
@@ -10,8 +10,8 @@ AC_DEFUN([DNSDIST_CHECK_GNUTLS], [
 
   AS_IF([test "x$enable_gnutls" != "xno"], [
     AS_IF([test "x$enable_gnutls" = "xyes" -o "x$enable_gnutls" = "xauto"], [
-      # we require gnutls_certificate_set_x509_key_file, added in 3.1.11
-      PKG_CHECK_MODULES([GNUTLS], [gnutls >= 3.1.11], [
+      # we require gnutls_memset, added in 3.4.0
+      PKG_CHECK_MODULES([GNUTLS], [gnutls >= 3.4.0], [
         [HAVE_GNUTLS=1]
         AC_DEFINE([HAVE_GNUTLS], [1], [Define to 1 if you have GnuTLS])
       ], [ : ])


### PR DESCRIPTION
### Short description
We use `gnutls_memset`, introduced in 3.4.0.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)