### PR TITLE
dnsdist: Optionally add ECS for cache lookup when all backends are down

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -68,6 +68,8 @@ void setupLuaBindings(bool client)
         pool->packetCache = nullptr;
       }
     });
+  g_lua.registerFunction("getECS", &ServerPool::getECS);
+  g_lua.registerFunction("setECS", &ServerPool::setECS);
 
   /* DownstreamState */
   g_lua.registerFunction<void(DownstreamState::*)(int)>("setQPS", [](DownstreamState& s, int lim) { s.qps = lim ? QPSLimiter(lim, lim) : QPSLimiter(); });

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -401,7 +401,7 @@ void* tcpClientThread(int pipefd)
           ds = policy.policy(servers, &dq);
         }
 
-        if (dq.useECS && ds && ds->useECS) {
+        if (dq.useECS && ((ds && ds->useECS) || (!ds && serverPool->getECS()))) {
           uint16_t newLen = dq.len;
           if (!handleEDNSClientSubnet(query, dq.size, consumed, &newLen, &ednsAdded, &ecsAdded, ci.remote, dq.ecsOverride, dq.ecsPrefixLength)) {
             vinfolog("Dropping query from %s because we couldn't insert the ECS value", ci.remote.toStringWithPort());

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1348,7 +1348,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
 
     bool ednsAdded = false;
     bool ecsAdded = false;
-    if (dq.useECS && ss && ss->useECS) {
+    if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
       if (!handleEDNSClientSubnet(query, dq.size, consumed, &dq.len, &(ednsAdded), &(ecsAdded), remote, dq.ecsOverride, dq.ecsPrefixLength)) {
         vinfolog("Dropping query from %s because we couldn't insert the ECS value", remote.toStringWithPort());
         return;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -657,6 +657,16 @@ struct ServerPool
 
   const std::shared_ptr<DNSDistPacketCache> getCache() const { return packetCache; };
 
+  bool getECS() const
+  {
+    return d_useECS;
+  }
+
+  void setECS(bool useECS)
+  {
+    d_useECS = useECS;
+  }
+
   std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
   std::shared_ptr<ServerPolicy> policy{nullptr};
 
@@ -723,6 +733,7 @@ struct ServerPool
 private:
   NumberedVector<shared_ptr<DownstreamState>> d_servers;
   pthread_rwlock_t d_lock;
+  bool d_useECS{false};
 };
 using pools_t=map<std::string,std::shared_ptr<ServerPool>>;
 void setPoolPolicy(pools_t& pools, const string& poolName, std::shared_ptr<ServerPolicy> policy);

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -421,6 +421,13 @@ Pools are automatically created when a server is added to a pool (with :func:`ne
 
     Returns the :class:`PacketCache` for this pool or nil.
 
+  .. method:: ServerPool:getECS()
+
+    .. versionadded:: 1.3.0
+
+    Whether dnsdist will add EDNS Client Subnet information to the query before looking up into the cache,
+    when all servers from this pool are down. For more information see :meth:`ServerPool:setECS`.
+
   .. method:: ServerPool:setCache(cache)
 
     Adds ``cache`` as the pool's cache.
@@ -430,6 +437,16 @@ Pools are automatically created when a server is added to a pool (with :func:`ne
   .. method:: ServerPool:unsetCache()
 
     Removes the cache from this pool.
+
+  .. method:: ServerPool:setECS()
+
+    .. versionadded:: 1.3.0
+
+    Set to true if dnsdist should add EDNS Client Subnet information to the query before looking up into the cache,
+    when all servers from this pool are down. If at least one server is up, the preference of the
+    selected server is used, this parameter is only useful if all the backends in this pool are down
+    and have EDNS Client Subnet enabled, since the queries in the cache will have been inserted with
+    ECS information. Default is false.
 
 PacketCache
 ~~~~~~~~~~~


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Add an option so that we add `ECS` information to the query before looking up the cache, even if no backend has been selected. This is useful when all backends in a pool use `ECS`, causing the cached entries to be hashed with `ECS` information.
Fixes #6098.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
