### PR TITLE
rec: fallback to std::set when boost::container::flat_set is not available

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -26,8 +26,9 @@
 #include <netdb.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
+#ifdef HAVE_BOOST_CONTAINER_FLAT_SET_HPP
 #include <boost/container/flat_set.hpp>
+#endif
 #include "ws-recursor.hh"
 #include <pthread.h>
 #include "recpacketcache.hh"
@@ -161,7 +162,11 @@ static bool g_gettagNeedsEDNSOptions{false};
 static time_t g_statisticsInterval;
 static bool g_useIncomingECS;
 std::atomic<uint32_t> g_maxCacheEntries, g_maxPacketCacheEntries;
+#ifdef HAVE_BOOST_CONTAINER_FLAT_SET_HPP
 static boost::container::flat_set<uint16_t> s_avoidUdpSourcePorts;
+#else
+static std::set<uint16_t> s_avoidUdpSourcePorts;
+#endif
 static uint16_t s_minUdpSourcePort;
 static uint16_t s_maxUdpSourcePort;
 

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -90,6 +90,10 @@ AS_IF([test "x$PROTOBUF_LIBS" != "x" -a x"$PROTOC" != "x"],
 )
 
 BOOST_REQUIRE([$boost_required_version])
+
+# Check against flat_set header that requires boost >= 1.48
+BOOST_FIND_HEADER([boost/container/flat_set.hpp])
+
 PDNS_SELECT_CONTEXT_IMPL
 
 PDNS_ENABLE_UNIT_TESTS


### PR DESCRIPTION
### Short description
See discussion https://github.com/PowerDNS/pdns/issues/6398#issuecomment-376434065

Fix #6398 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
