### PR TITLE
dnsdist: Fix warnings reported by clang's analyzer and cppcheck

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1140,7 +1140,7 @@ private:
         static_assert(std::is_class<TObject>::value || std::is_pointer<TObject>::value || std::is_union<TObject>::value , "registerFunction can only be used for a class a union or a pointer");
 
         checkTypeRegistration(mState, &typeid(TObject));
-        setTable<TRetValue(TObject&, TOtherParams...)>(mState, Registry, &typeid(TObject), 0, functionName, std::move(function));
+        setTable<TRetValue(TObject&, TOtherParams...)>(mState, Registry, &typeid(TObject), 0, functionName, function);
         
         checkTypeRegistration(mState, &typeid(TObject*));
         setTable<TRetValue(TObject*, TOtherParams...)>(mState, Registry, &typeid(TObject*), 0, functionName, [=](TObject* obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });

--- a/pdns/dnscrypt.cc
+++ b/pdns/dnscrypt.cc
@@ -713,7 +713,7 @@ int DNSCryptQuery::encryptResponse(char* response, uint16_t responseLen, uint16_
   return res;
 }
 
-int DNSCryptContext::encryptQuery(char* query, uint16_t queryLen, uint16_t querySize, const unsigned char clientPublicKey[DNSCRYPT_PUBLIC_KEY_SIZE], const DNSCryptPrivateKey& clientPrivateKey, const unsigned char clientNonce[DNSCRYPT_NONCE_SIZE / 2], bool tcp, uint16_t* encryptedResponseLen, const std::shared_ptr<DNSCryptCert> cert) const
+int DNSCryptContext::encryptQuery(char* query, uint16_t queryLen, uint16_t querySize, const unsigned char clientPublicKey[DNSCRYPT_PUBLIC_KEY_SIZE], const DNSCryptPrivateKey& clientPrivateKey, const unsigned char clientNonce[DNSCRYPT_NONCE_SIZE / 2], bool tcp, uint16_t* encryptedResponseLen, const std::shared_ptr<DNSCryptCert>& cert) const
 {
   assert(query != nullptr);
   assert(queryLen > 0);

--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -152,7 +152,7 @@ struct DNSCryptCertificatePair
 class DNSCryptQuery
 {
 public:
-  DNSCryptQuery(std::shared_ptr<DNSCryptContext> ctx): d_ctx(ctx)
+  DNSCryptQuery(const std::shared_ptr<DNSCryptContext>& ctx): d_ctx(ctx)
   {
   }
   ~DNSCryptQuery();
@@ -182,7 +182,7 @@ public:
     return d_encrypted;
   }
 
-  void setCertificatePair(std::shared_ptr<DNSCryptCertificatePair> pair)
+  void setCertificatePair(const std::shared_ptr<DNSCryptCertificatePair>& pair)
   {
     d_pair = pair;
   }
@@ -213,7 +213,7 @@ private:
   std::shared_ptr<DNSCryptCertificatePair> d_pair{nullptr};
   uint16_t d_id{0};
   uint16_t d_len{0};
-  uint16_t d_paddedLen;
+  uint16_t d_paddedLen{0};
   bool d_encrypted{false};
   bool d_valid{false};
 
@@ -246,7 +246,7 @@ public:
   std::vector<std::shared_ptr<DNSCryptCertificatePair>> getCertificates() { return certs; };
   const DNSName& getProviderName() const { return providerName; }
 
-  int encryptQuery(char* query, uint16_t queryLen, uint16_t querySize, const unsigned char clientPublicKey[DNSCRYPT_PUBLIC_KEY_SIZE], const DNSCryptPrivateKey& clientPrivateKey, const unsigned char clientNonce[DNSCRYPT_NONCE_SIZE / 2], bool tcp, uint16_t* encryptedResponseLen, const std::shared_ptr<DNSCryptCert> cert) const;
+  int encryptQuery(char* query, uint16_t queryLen, uint16_t querySize, const unsigned char clientPublicKey[DNSCRYPT_PUBLIC_KEY_SIZE], const DNSCryptPrivateKey& clientPrivateKey, const unsigned char clientNonce[DNSCRYPT_NONCE_SIZE / 2], bool tcp, uint16_t* encryptedResponseLen, const std::shared_ptr<DNSCryptCert>& cert) const;
   bool magicMatchesAPublicKey(DNSCryptQuery& query, time_t now);
   void getCertificateResponse(time_t now, const DNSName& qname, uint16_t qid, std::vector<uint8_t>& response);
 

--- a/pdns/dnsdist-dynbpf.hh
+++ b/pdns/dnsdist-dynbpf.hh
@@ -35,7 +35,7 @@
 class DynBPFFilter
 {
 public:
-  DynBPFFilter(std::shared_ptr<BPFFilter> bpf): d_bpf(bpf)
+  DynBPFFilter(std::shared_ptr<BPFFilter>& bpf): d_bpf(bpf)
   {
   }
   ~DynBPFFilter()

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -651,7 +651,7 @@ public:
 class DnstapLogAction : public DNSAction, public boost::noncopyable
 {
 public:
-  DnstapLogAction(const std::string& identity, std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(const DNSQuestion&, DnstapMessage*)> > alterFunc): d_identity(identity), d_logger(logger), d_alterFunc(alterFunc)
+  DnstapLogAction(const std::string& identity, std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSQuestion&, DnstapMessage*)> > alterFunc): d_identity(identity), d_logger(logger), d_alterFunc(alterFunc)
   {
   }
   DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
@@ -683,7 +683,7 @@ private:
 class RemoteLogAction : public DNSAction, public boost::noncopyable
 {
 public:
-  RemoteLogAction(std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(const DNSQuestion&, DNSDistProtoBufMessage*)> > alterFunc): d_logger(logger), d_alterFunc(alterFunc)
+  RemoteLogAction(std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSQuestion&, DNSDistProtoBufMessage*)> > alterFunc): d_logger(logger), d_alterFunc(alterFunc)
   {
   }
   DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
@@ -740,7 +740,7 @@ private:
 class TagAction : public DNSAction
 {
 public:
-  TagAction(const std::string tag, const std::string value): d_tag(tag), d_value(value)
+  TagAction(const std::string& tag, const std::string& value): d_tag(tag), d_value(value)
   {
   }
   DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
@@ -765,7 +765,7 @@ private:
 class DnstapLogResponseAction : public DNSResponseAction, public boost::noncopyable
 {
 public:
-  DnstapLogResponseAction(const std::string& identity, std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(const DNSResponse&, DnstapMessage*)> > alterFunc): d_identity(identity), d_logger(logger), d_alterFunc(alterFunc)
+  DnstapLogResponseAction(const std::string& identity, std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSResponse&, DnstapMessage*)> > alterFunc): d_identity(identity), d_logger(logger), d_alterFunc(alterFunc)
   {
   }
   DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
@@ -799,7 +799,7 @@ private:
 class RemoteLogResponseAction : public DNSResponseAction, public boost::noncopyable
 {
 public:
-  RemoteLogResponseAction(std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(const DNSResponse&, DNSDistProtoBufMessage*)> > alterFunc, bool includeCNAME): d_logger(logger), d_alterFunc(alterFunc), d_includeCNAME(includeCNAME)
+  RemoteLogResponseAction(std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSResponse&, DNSDistProtoBufMessage*)> > alterFunc, bool includeCNAME): d_logger(logger), d_alterFunc(alterFunc), d_includeCNAME(includeCNAME)
   {
   }
   DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
@@ -901,7 +901,7 @@ private:
 class TagResponseAction : public DNSResponseAction
 {
 public:
-  TagResponseAction(const std::string tag, const std::string value): d_tag(tag), d_value(value)
+  TagResponseAction(const std::string& tag, const std::string& value): d_tag(tag), d_value(value)
   {
   }
   DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -826,7 +826,7 @@ private:
 class TagRule : public DNSRule
 {
 public:
-  TagRule(std::string tag, boost::optional<std::string> value) : d_value(value), d_tag(tag)
+  TagRule(const std::string& tag, boost::optional<std::string> value) : d_value(value), d_tag(tag)
   {
   }
   bool matches(const DNSQuestion* dq) const override

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1443,7 +1443,7 @@ void setupLuaConfig(bool client)
 #endif
       });
 
-    g_lua.writeFunction("showTLSContexts", [client]() {
+    g_lua.writeFunction("showTLSContexts", []() {
 #ifdef HAVE_DNS_OVER_TLS
         setLuaNoSideEffect();
         try {
@@ -1467,7 +1467,7 @@ void setupLuaConfig(bool client)
 #endif
       });
 
-    g_lua.writeFunction("getTLSContext", [client](size_t index) {
+    g_lua.writeFunction("getTLSContext", [](size_t index) {
         std::shared_ptr<TLSCtx> result = nullptr;
 #ifdef HAVE_DNS_OVER_TLS
         setLuaNoSideEffect();

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -25,7 +25,7 @@ class LuaAction : public DNSAction
 {
 public:
   typedef std::function<std::tuple<int, boost::optional<string> >(DNSQuestion* dq)> func_t;
-  LuaAction(LuaAction::func_t& func) : d_func(func)
+  LuaAction(const LuaAction::func_t& func) : d_func(func)
   {}
   Action operator()(DNSQuestion* dq, string* ruleresult) const override;
   string toString() const override
@@ -40,7 +40,7 @@ class LuaResponseAction : public DNSResponseAction
 {
 public:
   typedef std::function<std::tuple<int, boost::optional<string> >(DNSResponse* dr)> func_t;
-  LuaResponseAction(LuaResponseAction::func_t& func) : d_func(func)
+  LuaResponseAction(const LuaResponseAction::func_t& func) : d_func(func)
   {}
   Action operator()(DNSResponse* dr, string* ruleresult) const override;
   string toString() const override

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -25,7 +25,7 @@ class LuaAction : public DNSAction
 {
 public:
   typedef std::function<std::tuple<int, boost::optional<string> >(DNSQuestion* dq)> func_t;
-  LuaAction(LuaAction::func_t func) : d_func(func)
+  LuaAction(LuaAction::func_t& func) : d_func(func)
   {}
   Action operator()(DNSQuestion* dq, string* ruleresult) const override;
   string toString() const override
@@ -40,7 +40,7 @@ class LuaResponseAction : public DNSResponseAction
 {
 public:
   typedef std::function<std::tuple<int, boost::optional<string> >(DNSResponse* dr)> func_t;
-  LuaResponseAction(LuaResponseAction::func_t func) : d_func(func)
+  LuaResponseAction(LuaResponseAction::func_t& func) : d_func(func)
   {}
   Action operator()(DNSResponse* dr, string* ruleresult) const override;
   string toString() const override

--- a/pdns/dnsdist-snmp.cc
+++ b/pdns/dnsdist-snmp.cc
@@ -367,7 +367,7 @@ static int backendStatTable_handler(netsnmp_mib_handler* handler,
 }
 #endif /* HAVE_NET_SNMP */
 
-bool DNSDistSNMPAgent::sendBackendStatusChangeTrap(const std::shared_ptr<DownstreamState> dss)
+bool DNSDistSNMPAgent::sendBackendStatusChangeTrap(const std::shared_ptr<DownstreamState>& dss)
 {
 #ifdef HAVE_NET_SNMP
   const string backendAddress = dss->remote.toStringWithPort();

--- a/pdns/dnsdist-snmp.hh
+++ b/pdns/dnsdist-snmp.hh
@@ -13,7 +13,7 @@ class DNSDistSNMPAgent: public SNMPAgent
 {
 public:
   DNSDistSNMPAgent(const std::string& name, const std::string& masterSocket);
-  bool sendBackendStatusChangeTrap(const std::shared_ptr<DownstreamState>);
+  bool sendBackendStatusChangeTrap(const std::shared_ptr<DownstreamState>&);
   bool sendCustomTrap(const std::string& reason);
   bool sendDNSTrap(const DNSQuestion&, const std::string& reason="");
 };

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -128,6 +128,19 @@ public:
 
 struct DynBlock
 {
+  DynBlock(): action(DNSAction::Action::None)
+  {
+  }
+
+  DynBlock(const std::string& reason_, const struct timespec& until_, const DNSName& domain_, DNSAction::Action action_): reason(reason_), until(until_), domain(domain_), action(action_)
+  {
+  }
+
+  DynBlock(const DynBlock& rhs): reason(rhs.reason), until(rhs.until), domain(rhs.domain), action(rhs.action)
+  {
+    blocks.store(rhs.blocks);
+  }
+
   DynBlock& operator=(const DynBlock& rhs)
   {
     reason=rhs.reason;
@@ -324,12 +337,10 @@ struct ClientState;
 struct IDState
 {
   IDState() : origFD(-1), sentTime(true), delayMsec(0), tempFailureTTL(boost::none) { origDest.sin4.sin_family = 0;}
-  IDState(const IDState& orig)
+  IDState(const IDState& orig): origRemote(orig.origRemote), origDest(orig.origDest)
   {
     origFD = orig.origFD;
     origID = orig.origID;
-    origRemote = orig.origRemote;
-    origDest = orig.origDest;
     delayMsec = orig.delayMsec;
     tempFailureTTL = orig.tempFailureTTL;
     age.store(orig.age.load());

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -613,7 +613,7 @@ class GnuTLSConnection: public TLSConnection
 {
 public:
 
-  GnuTLSConnection(int socket, unsigned int timeout, const gnutls_certificate_credentials_t creds, const gnutls_priority_t priorityCache, std::shared_ptr<GnuTLSTicketsKey> ticketsKey): d_ticketsKey(ticketsKey)
+  GnuTLSConnection(int socket, unsigned int timeout, const gnutls_certificate_credentials_t creds, const gnutls_priority_t priorityCache, std::shared_ptr<GnuTLSTicketsKey>& ticketsKey): d_ticketsKey(ticketsKey)
   {
     d_socket = socket;
 

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -179,9 +179,7 @@ inline bool DNSName::canonCompare(const DNSName& rhs) const
   for(;;) {
     if(ourcount == 0 && rhscount != 0)
       return true;
-    if(ourcount == 0 && rhscount == 0)
-      return false;
-    if(ourcount !=0 && rhscount == 0)
+    if(rhscount == 0)
       return false;
     ourcount--;
     rhscount--;
@@ -235,12 +233,8 @@ struct SuffixMatchTree
   SuffixMatchTree(const std::string& name="", bool endNode_=false) : d_name(name), endNode(endNode_)
   {}
 
-  SuffixMatchTree(const SuffixMatchTree& rhs)
+  SuffixMatchTree(const SuffixMatchTree& rhs): d_name(rhs.d_name), children(rhs.children), endNode(rhs.endNode), d_value(rhs.d_value)
   {
-    d_name = rhs.d_name;
-    children = rhs.children;
-    endNode = rhs.endNode;
-    d_value = rhs.d_value;
   }
   std::string d_name;
   mutable std::set<SuffixMatchTree> children;

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -199,9 +199,8 @@ DNSRecordContent::zmakermap_t& DNSRecordContent::getZmakermap()
   return zmakermap;
 }
 
-DNSRecord::DNSRecord(const DNSResourceRecord& rr)
+DNSRecord::DNSRecord(const DNSResourceRecord& rr): d_name(rr.qname)
 {
-  d_name = rr.qname;
   d_type = rr.qtype.getCode();
   d_ttl = rr.ttl;
   d_class = rr.qclass;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -349,9 +349,8 @@ public:
 	d_bits=0;
   }
   
-  Netmask(const ComboAddress& network, uint8_t bits=0xff)
+  Netmask(const ComboAddress& network, uint8_t bits=0xff): d_network(network)
   {
-    d_network = network;
     d_network.sin4.sin_port=0;
     if(bits > 128)
       bits = (network.sin4.sin_family == AF_INET) ? 32 : 128;
@@ -601,6 +600,7 @@ public:
     // see above.
     for(auto const& node: rhs._nodes)
       insert(node->first).second = node->second;
+    d_cleanup_tree = rhs.d_cleanup_tree;
     return *this;
   }
 

--- a/pdns/lock.hh
+++ b/pdns/lock.hh
@@ -118,7 +118,9 @@ public:
   TryWriteLock(TryWriteLock&& rhs)
   {
     d_lock = rhs.d_lock;
-    rhs.d_lock=0;
+    rhs.d_lock = nullptr;
+    d_havelock = rhs.d_havelock;
+    rhs.d_havelock = false;
   }
 
   
@@ -164,7 +166,9 @@ public:
   TryReadLock(TryReadLock&& rhs)
   {
     d_lock = rhs.d_lock;
-    rhs.d_lock=0;
+    rhs.d_lock = nullptr;
+    d_havelock = rhs.d_havelock;
+    rhs.d_havelock = false;
   }
 
   ~TryReadLock()

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -378,7 +378,7 @@ struct CIStringComparePOSIX
       while(a!=lhs.end()) {
           if (b==rhs.end() || std::tolower(*b,loc)<std::tolower(*a,loc)) return false;
           else if (std::tolower(*a,loc)<std::tolower(*b,loc)) return true;
-          a++;b++;
+          ++a;++b;
       }
       return (b!=rhs.end());
    }
@@ -479,18 +479,18 @@ public:
  
   bool match(string::const_iterator mi, string::const_iterator mend, string::const_iterator vi, string::const_iterator vend)
   {
-    for(;;mi++) {
+    for(;;++mi) {
       if (mi == mend) {
         return vi == vend;
       } else if (*mi == '?') {
         if (vi == vend) return false;
-        vi++;
+        ++vi;
       } else if (*mi == '*') {
-        while(*mi == '*') mi++;
+        while(*mi == '*') ++mi;
         if (mi == d_mask.end()) return true;
         while(vi != vend) {
           if (match(mi,mend,vi,vend)) return true;
-          vi++;
+          ++vi;
         }
         return false;
       } else {
@@ -501,7 +501,7 @@ public:
         } else {
           if (*mi != *vi) return false;
         }
-        vi++;
+        ++vi;
       }
     }
   }

--- a/pdns/pollmplexer.cc
+++ b/pdns/pollmplexer.cc
@@ -74,7 +74,7 @@ void PollFDMultiplexer::addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo,
 void PollFDMultiplexer::removeFD(callbackmap_t& cbmap, int fd)
 {
   if(d_inrun && d_iter->first==fd)  // trying to remove us!
-    d_iter++;
+    ++d_iter;
 
   if(!cbmap.erase(fd))
     throw FDMultiplexerException("Tried to remove unlisted fd "+std::to_string(fd)+ " from multiplexer");

--- a/pdns/statnode.cc
+++ b/pdns/statnode.cc
@@ -112,7 +112,7 @@ void StatNode::submit(std::vector<string>::const_iterator end, std::vector<strin
       labelsCount = count;
     }
     //    cerr<<"Not yet end, set our fullname to '"<<fullname<<"', recursing"<<endl;
-    end--;
+    --end;
     children[*end].submit(end, begin, fullname, rcode, remote, count+1);
   }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Mostly non-noticeable performance hints:
- pass shared pointers by reference whenever possible
- use pre-increment instead of post-increment for non-primitive types
- use initialization list instead of assigning values in the constructor's body

`LuaWrapper` moving the function variable before using it again might be a real issue though, and the locks' move constructor might have become one at some point.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
