### PR TITLE
rec: really fallback to std::set when boost::container::flat_set is not available

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3237,13 +3237,13 @@ static int serviceMain(int argc, char*argv[])
   }
 
   int port = ::arg().asNum("udp-source-port-min");
-  if(port < 1025 || port > 65535){
+  if(port < 1024 || port > 65535){
     L<<Logger::Error<<"Unable to launch, udp-source-port-min is not a valid port number"<<endl;
     exit(99); // this isn't going to fix itself either
   }
   s_minUdpSourcePort = port;
   port = ::arg().asNum("udp-source-port-max");
-  if(port < 1025 || port > 65535 || port < s_minUdpSourcePort){
+  if(port < 1024 || port > 65535 || port < s_minUdpSourcePort){
     L<<Logger::Error<<"Unable to launch, udp-source-port-max is not a valid port number or is smaller than udp-source-port-min"<<endl;
     exit(99); // this isn't going to fix itself either
   }
@@ -3253,7 +3253,7 @@ static int serviceMain(int argc, char*argv[])
   for (const auto &part : parts)
   {
     port = std::stoi(part);
-    if(port < 1025 || port > 65535){
+    if(port < 1024 || port > 65535){
       L<<Logger::Error<<"Unable to launch, udp-source-port-avoid contains an invalid port number: "<<part<<endl;
       exit(99); // this isn't going to fix itself either
     }
@@ -3577,7 +3577,7 @@ int main(int argc, char **argv)
     ::arg().set("xpf-allow-from","XPF information is only processed from these subnets")="";
     ::arg().set("xpf-rr-code","XPF option code to use")="0";
 
-    ::arg().set("udp-source-port-min", "Minimum UDP port to bind on")="1025";
+    ::arg().set("udp-source-port-min", "Minimum UDP port to bind on")="1024";
     ::arg().set("udp-source-port-max", "Maximum UDP port to bind on")="65535";
     ::arg().set("udp-source-port-avoid", "List of comma separated UDP port number to avoid")="11211";
 

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -92,7 +92,7 @@ AS_IF([test "x$PROTOBUF_LIBS" != "x" -a x"$PROTOC" != "x"],
 BOOST_REQUIRE([$boost_required_version])
 
 # Check against flat_set header that requires boost >= 1.48
-BOOST_FIND_HEADER([boost/container/flat_set.hpp])
+BOOST_FIND_HEADER([boost/container/flat_set.hpp], [AC_MSG_NOTICE([boost::container::flat_set not available, will fallback to std::set])])
 
 PDNS_SELECT_CONTEXT_IMPL
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1074,7 +1074,7 @@ May destroy performance under load.
 .. versionadded:: 4.2.0
 
 -  Integer
--  Default: 1025
+-  Default: 1024
 
 This option sets the low limit of UDP port number to bind on.
 


### PR DESCRIPTION
### Short description
Only notice if boost flat_set are not available instead of throwing an error.

The API was clear though.

Fix #6398

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
