### PR TITLE
update data.cdb hash after merge of #6377

### DIFF
--- a/regression-tests.nobackend/tinydns-data-check/expected_result
+++ b/regression-tests.nobackend/tinydns-data-check/expected_result
@@ -11,4 +11,4 @@ a63dc120391d9df0003f2ec4f461a6af  ../regression-tests/zones/secure-delegated.dns
 b1f775045fa2cf0a3b91aa834af06e49  ../regression-tests/zones/stest.com
 a98864b315f16bcf49ce577426063c42  ../regression-tests/zones/cdnskey-cds-test.com
 9aeed2c26d0c3ba3baf22dfa9568c451  ../regression-tests/zones/2.0.192.in-addr.arpa
-fedfd1e91ef52143c9b3430925bd3881  ../modules/tinydnsbackend/data.cdb
+3cfc26fade6f3c30da8e18ca33b03498  ../modules/tinydnsbackend/data.cdb


### PR DESCRIPTION
### Short description
For unexplained reasons, #6377 was green on Travis even though the hash in this test was wrong. Master then went red. This PR should fix that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
