### PR TITLE
dnsdist: Fix a sign comparison warning on armv7l

### DIFF
--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -98,7 +98,7 @@ public:
   }
   bool isValid(time_t now) const
   {
-    return ntohl(getTSStart()) <= now && now <= ntohl(getTSEnd());
+    return ntohl(getTSStart()) <= static_cast<uint32_t>(now) && static_cast<uint32_t>(now) <= ntohl(getTSEnd());
   }
   unsigned char magic[DNSCRYPT_CERT_MAGIC_SIZE];
   unsigned char esVersion[2];


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`time_t` is signed there.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
