### PR TITLE
backport #6360: use mirror for dnsperf

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -261,7 +261,7 @@ install_auth() {
     alien\
     fakeroot"
   run "cd .."
-  run "wget ftp://ftp.nominum.com/pub/nominum/dnsperf/2.0.0.0/dnsperf-2.0.0.0-1-rhel-6-x86_64.tar.gz"
+  run "wget https://downloads.powerdns.com/tmp/dnsperf-2.0.0.0-1-rhel-6-x86_64.tar.gz"
   run "tar xzvf dnsperf-2.0.0.0-1-rhel-6-x86_64.tar.gz"
   run "fakeroot alien --to-deb dnsperf-2.0.0.0-1/dnsperf-2.0.0.0-1.el6.x86_64.rpm"
   run "sudo dpkg -i dnsperf_2.0.0.0-2_amd64.deb"


### PR DESCRIPTION
(cherry picked from commit 0e62797ed1cc33cbc44cbbc58d69da400cec85b1)

### Short description
The nominum FTP site is unreliable/slow.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
