### PR TITLE
Add parameters to swagger API definition for creating zone

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -93,6 +93,12 @@ paths:
           description: '“true” (default) or “false”, whether to include the “rrsets” in the response Zone object.'
           type: boolean
           default: true
+        - name: zone_struct
+          description: The zone struct to patch with
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/Zone'
       responses:
         '201':
           description: A zone
@@ -368,6 +374,10 @@ paths:
           schema:
             type: array
             items:
+            # these can be commented because the swagger code generator fails on them
+            # and replaced with
+            # type: string
+            # or something like that
             - $ref: '#/definitions/StatisticItem'
             - $ref: '#/definitions/MapStatisticItem'
             - $ref: '#/definitions/RingStatisticItem'
@@ -864,7 +874,7 @@ definitions:
       account:
         type: string
         description: 'Name of an account that added the comment'
-      modifided_at:
+      modified_at:
         type: integer
         description: 'Timestamp of the last change to the comment'
 


### PR DESCRIPTION
### Short description
This adds a missing parameter to swagger documentation -- as defined, you couldn't create a zone with a client. It also fixes a typo in the `Comment` definition.

Finally, I added some comments about an issue I have actually using this to generate a client. The main swagger code generator fails on the current definition for querying statistics, and I need to comment those lines out in my client project, but perhaps other people are having other experiences.

I'm a happy pdns user for years and am happily implementing a new client tool to use the REST API instead of inserting right into the database. Thanks for all your work on this!

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
