### PR TITLE
dnsdist: reorder headers to fix OpenBSD build

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -22,9 +22,12 @@
 
 #include <dirent.h>
 #include <fstream>
-#include <net/if.h>
-#include <sys/types.h>
+
+// for OpenBSD, sys/socket.h needs to come before net/if.h
 #include <sys/socket.h>
+#include <net/if.h>
+
+#include <sys/types.h>
 #include <sys/stat.h>
 #include <thread>
 


### PR DESCRIPTION
### Short description
OpenBSD requires `sys/socket.h` to come before `net/if.h`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
