### PR TITLE
dnsdist: remove -d flag after #6394

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2082,9 +2082,9 @@ try
   string optstring;
   for(;;) {
 #ifdef HAVE_LIBSODIUM
-    int c=getopt_long(argc, argv, "a:hcde:C:k:l:vp:g:u:V", longopts, &longindex);
+    int c=getopt_long(argc, argv, "a:hce:C:k:l:vp:g:u:V", longopts, &longindex);
 #else
-    int c=getopt_long(argc, argv, "a:hcde:C:l:vp:g:u:V", longopts, &longindex);
+    int c=getopt_long(argc, argv, "a:hce:C:l:vp:g:u:V", longopts, &longindex);
 #endif
     if(c==-1)
       break;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2082,9 +2082,9 @@ try
   string optstring;
   for(;;) {
 #ifdef HAVE_LIBSODIUM
-    int c=getopt_long(argc, argv, "a:hce:C:k:l:vp:g:u:V", longopts, &longindex);
+    int c=getopt_long(argc, argv, "a:hce:C:k:l:v:g:u:V", longopts, &longindex);
 #else
-    int c=getopt_long(argc, argv, "a:hce:C:l:vp:g:u:V", longopts, &longindex);
+    int c=getopt_long(argc, argv, "a:hce:C:l:v:g:u:V", longopts, &longindex);
 #endif
     if(c==-1)
       break;


### PR DESCRIPTION
### Short description
#6394 forgot to remove this, leading to a silent non-daemonized startup when passing `-d`.

Question: should the `switch` block have a `default:` that complains loudly?

Question: is `-s` missing intentionally even if we use it as the key to match `--supervised`?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
