### PR TITLE
Split PDNS_ENABLE_UNIT_TESTS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,7 @@ AS_IF([test "$boost_cv_lib_program_options" = "no"], [
   AC_MSG_ERROR([Boost Program Options library not found])
 ])
 PDNS_ENABLE_UNIT_TESTS
+PDNS_ENABLE_BACKEND_UNIT_TESTS
 PDNS_ENABLE_REPRODUCIBLE
 
 PDNS_WITH_SQLITE3

--- a/m4/pdns_enable_backend_unit_tests.m4
+++ b/m4/pdns_enable_backend_unit_tests.m4
@@ -1,0 +1,18 @@
+AC_DEFUN([PDNS_ENABLE_BACKEND_UNIT_TESTS], [
+  AC_MSG_CHECKING([whether to enable backend unit test building])
+  AC_ARG_ENABLE([backend-unit-tests],
+    AS_HELP_STRING([--enable-backend-unit-tests],
+      [enable backend unit test building @<:@default=no@:>@]),
+    [enable_backend_unit_tests=$enableval],
+    [enable_backend_unit_tests=no]
+  )
+  AC_MSG_RESULT([$enable_backend_unit_tests])
+  AM_CONDITIONAL([BACKEND_UNIT_TESTS], [test "x$enable_backend_unit_tests" != "xno"])
+
+  AS_IF([test "x$enable_backend_unit_tests" != "xno"], [
+     BOOST_TEST([mt])
+     AS_IF([test "$boost_cv_lib_unit_test_framework" = "no"], [
+       AC_MSG_ERROR([Boost Unit Test library not found])
+     ])
+   ])
+])

--- a/m4/pdns_enable_unit_tests.m4
+++ b/m4/pdns_enable_unit_tests.m4
@@ -9,17 +9,7 @@ AC_DEFUN([PDNS_ENABLE_UNIT_TESTS], [
   AC_MSG_RESULT([$enable_unit_tests])
   AM_CONDITIONAL([UNIT_TESTS], [test "x$enable_unit_tests" != "xno"])
 
-  AC_MSG_CHECKING([whether to enable backend unit test building])
-  AC_ARG_ENABLE([backend-unit-tests],
-    AS_HELP_STRING([--enable-backend-unit-tests],
-      [enable backend unit test building @<:@default=no@:>@]),
-    [enable_backend_unit_tests=$enableval],
-    [enable_backend_unit_tests=no]
-  )
-  AC_MSG_RESULT([$enable_backend_unit_tests])
-  AM_CONDITIONAL([BACKEND_UNIT_TESTS], [test "x$enable_backend_unit_tests" != "xno"])
-
-  AS_IF([test "x$enable_unit_tests" != "xno" || test "x$enable_backend_unit_tests" != "xno"], [
+  AS_IF([test "x$enable_unit_tests" != "xno"], [
      BOOST_TEST([mt])
      AS_IF([test "$boost_cv_lib_unit_test_framework" = "no"], [
        AC_MSG_ERROR([Boost Unit Test library not found])


### PR DESCRIPTION
Split `PDNS_ENABLE_UNIT_TESTS` so recursor, dnsdist dont have meaningless `--enable-backend-unit-tests`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
