### PR TITLE
Fix reorder warning: field 'd_rname' will be initialized after field 'd_st'

### DIFF
--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -517,9 +517,9 @@ public:
   includeboilerplate(SOA)
   SOARecordContent(const DNSName& mname, const DNSName& rname, const struct soatimes& st);
 
-  struct soatimes d_st;
   DNSName d_mname;
   DNSName d_rname;
+  struct soatimes d_st;
 };
 
 class NSECRecordContent : public DNSRecordContent


### PR DESCRIPTION
### Short description
Warning from clang: Apple LLVM version 9.1.0 (clang-902.0.39.1)

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
