### PR TITLE
WIP dnsdist: Allow removing incoming ECS data

### DIFF
--- a/pdns/dnsdist-ecs.hh
+++ b/pdns/dnsdist-ecs.hh
@@ -21,9 +21,18 @@
  */
 #pragma once
 
+enum class ECSOverrideMethod {
+  keep              = 0,
+  useClientAddr     = 1,
+  remove            = 2,
+};
+namespace std {
+  string to_string(ECSOverrideMethod value);
+}
+
 int rewriteResponseWithoutEDNS(const char * packet, size_t len, vector<uint8_t>& newContent);
 int locateEDNSOptRR(char * packet, size_t len, char ** optStart, size_t * optLen, bool * last);
-bool handleEDNSClientSubnet(char * packet, size_t packetSize, unsigned int consumed, uint16_t * len, bool* ednsAdded, bool* ecsAdded, const ComboAddress& remote, bool overrideExisting, uint16_t ecsPrefixLength);
+bool handleEDNSClientSubnet(char * packet, size_t packetSize, unsigned int consumed, uint16_t * len, bool* ednsAdded, bool* ecsAdded, const ComboAddress& remote, ECSOverrideMethod overrideExisting, uint16_t ecsPrefixLength);
 void generateOptRR(const std::string& optRData, string& res);
 int removeEDNSOptionFromOPT(char* optStart, size_t* optLen, const uint16_t optionCodeToRemove);
 int rewriteResponseWithoutEDNSOption(const char * packet, const size_t len, const uint16_t optionCodeToSkip, vector<uint8_t>& newContent);

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -41,7 +41,18 @@ void setupLuaBindingsDNSQuestion()
   g_lua.registerMember<bool (DNSQuestion::*)>("tcp", [](const DNSQuestion& dq) -> bool { return dq.tcp; }, [](DNSQuestion& dq, bool newTcp) { (void) newTcp; });
   g_lua.registerMember<bool (DNSQuestion::*)>("skipCache", [](const DNSQuestion& dq) -> bool { return dq.skipCache; }, [](DNSQuestion& dq, bool newSkipCache) { dq.skipCache = newSkipCache; });
   g_lua.registerMember<bool (DNSQuestion::*)>("useECS", [](const DNSQuestion& dq) -> bool { return dq.useECS; }, [](DNSQuestion& dq, bool useECS) { dq.useECS = useECS; });
-  g_lua.registerMember<bool (DNSQuestion::*)>("ecsOverride", [](const DNSQuestion& dq) -> bool { return dq.ecsOverride; }, [](DNSQuestion& dq, bool ecsOverride) { dq.ecsOverride = ecsOverride; });
+  g_lua.registerMember<ECSOverrideMethod (DNSQuestion::*)>("ecsOverride",
+      [](const DNSQuestion& dq) -> ECSOverrideMethod {
+        return dq.ecsOverride;
+      },
+      [](DNSQuestion& dq, boost::variant<ECSOverrideMethod, bool>  ecsOverride) {
+        if (bool* boolValue = boost::get<bool>(&ecsOverride)) {
+          dq.ecsOverride = *boolValue ? ECSOverrideMethod::useClientAddr : ECSOverrideMethod::keep;
+        } else {
+          dq.ecsOverride = boost::get<ECSOverrideMethod>(ecsOverride);
+        }
+      }
+    );
   g_lua.registerMember<uint16_t (DNSQuestion::*)>("ecsPrefixLength", [](const DNSQuestion& dq) -> uint16_t { return dq.ecsPrefixLength; }, [](DNSQuestion& dq, uint16_t newPrefixLength) { dq.ecsPrefixLength = newPrefixLength; });
   g_lua.registerMember<boost::optional<uint32_t> (DNSQuestion::*)>("tempFailureTTL",
       [](const DNSQuestion& dq) -> boost::optional<uint32_t> {

--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -102,4 +102,10 @@ void setupLuaVars()
         { "VERSION2", DNSCryptExchangeVersion::VERSION2 },
     });
 #endif
+
+  g_lua.writeVariable("ECSOverrideMethod", std::unordered_map<string,int>{
+      {std::to_string(ECSOverrideMethod::keep),            (int)ECSOverrideMethod::keep             },
+      {std::to_string(ECSOverrideMethod::useClientAddr),   (int)ECSOverrideMethod::useClientAddr    },
+      {std::to_string(ECSOverrideMethod::remove),          (int)ECSOverrideMethod::remove           }
+    });
 }

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -816,7 +816,13 @@ void setupLuaConfig(bool client)
 
   g_lua.writeFunction("setECSSourcePrefixV6", [](uint16_t prefix) { g_ECSSourcePrefixV6=prefix; });
 
-  g_lua.writeFunction("setECSOverride", [](bool override) { g_ECSOverride=override; });
+  g_lua.writeFunction("setECSOverride", [](boost::variant<ECSOverrideMethod, bool> ecsOverride) {
+    if (bool* boolValue = boost::get<bool>(&ecsOverride)) {
+      g_ECSOverride = *boolValue ? ECSOverrideMethod::useClientAddr : ECSOverrideMethod::keep;
+    } else {
+      g_ECSOverride = boost::get<ECSOverrideMethod>(ecsOverride);
+    }
+  });
 
   g_lua.writeFunction("showDynBlocks", []() {
       setLuaNoSideEffect();

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -553,7 +553,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
       std::vector<std::pair<std::string, configentry_t> > configEntries {
         { "acl", g_ACL.getLocal()->toString() },
         { "control-socket", g_serverControl.toStringWithPort() },
-        { "ecs-override", g_ECSOverride },
+        { "ecs-override", std::to_string(g_ECSOverride) },
         { "ecs-source-prefix-v4", (double) g_ECSSourcePrefixV4 },
         { "ecs-source-prefix-v6", (double)  g_ECSSourcePrefixV6 },
         { "fixup-case", g_fixupCase },

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -35,6 +35,7 @@
 #include "sholder.hh"
 #include "dnscrypt.hh"
 #include "dnsdist-cache.hh"
+#include "dnsdist-ecs.hh"
 #include "gettime.hh"
 #include "dnsdist-dynbpf.hh"
 #include "bpf-filter.hh"
@@ -51,7 +52,7 @@ uint64_t uptimeOfProcess(const std::string& str);
 
 extern uint16_t g_ECSSourcePrefixV4;
 extern uint16_t g_ECSSourcePrefixV6;
-extern bool g_ECSOverride;
+extern ECSOverrideMethod g_ECSOverride;
 
 extern thread_local boost::uuids::random_generator t_uuidGenerator;
 
@@ -79,7 +80,7 @@ struct DNSQuestion
   const bool tcp;
   const struct timespec* queryTime;
   bool skipCache{false};
-  bool ecsOverride;
+  ECSOverrideMethod ecsOverride{ECSOverrideMethod::keep};
   bool useECS{true};
   bool addXPF{true};
 };


### PR DESCRIPTION
### Short description
If a client included EDNS Client Subnet data in a query, there was no way in dnsdist to get rid of that data. This turns ECSOverrideAction into a multi-purpose tool.

WIP: tests are probably broken, need to add tests for new format, and need tests for `remove`

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
