### PR TITLE
rec: Use a separate protobuf exporter thread per worker thread

### DIFF
--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -23,8 +23,17 @@
 #include "sholder.hh"
 #include "sortlist.hh"
 #include "filterpo.hh"
-#include "remote_logger.hh"
 #include "validate.hh"
+
+struct ProtobufExportConfig
+{
+  ComboAddress server;
+  uint64_t maxQueuedEntries{100};
+  uint16_t timeout{2};
+  uint16_t reconnectWaitTime{1};
+  bool asyncConnect{false};
+  bool enabled{false};
+};
 
 class LuaConfigItems 
 {
@@ -34,8 +43,12 @@ public:
   DNSFilterEngine dfe;
   map<DNSName,dsmap_t> dsAnchors;
   map<DNSName,std::string> negAnchors;
-  std::shared_ptr<RemoteLogger> protobufServer{nullptr};
-  std::shared_ptr<RemoteLogger> outgoingProtobufServer{nullptr};
+  /* we need to increment this every time the configuration
+     is reloaded, so we know if we need to reload the protobuf
+     remote loggers */
+  ProtobufExportConfig protobufExportConfig;
+  ProtobufExportConfig outgoingProtobufExportConfig;
+  uint64_t generation{0};
   uint8_t protobufMaskV4{32};
   uint8_t protobufMaskV6{128};
   bool protobufTaggedOnly{false};

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -75,7 +75,7 @@ void RemoteLogger::worker()
 void RemoteLogger::queueData(const std::string& data)
 {
   {
-    std::unique_lock<std::mutex> lock(d_writeMutex);
+    std::lock_guard<std::mutex> lock(d_writeMutex);
     if (d_writeQueue.size() >= d_maxQueuedEntries) {
       d_writeQueue.pop();
     }

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -49,6 +49,18 @@ public:
   {
     return "RemoteLogger to " + d_remote.toStringWithPort();
   }
+  void stop()
+  {
+    d_exiting = true;
+  }
+  uint64_t getGeneration() const
+  {
+    return d_generation;
+  }
+  void setGeneration(uint64_t newGeneration)
+  {
+    d_generation = newGeneration;
+  }
 private:
   void busyReconnectLoop();
   bool reconnect();
@@ -59,6 +71,7 @@ private:
   std::condition_variable d_queueCond;
   ComboAddress d_remote;
   uint64_t d_maxQueuedEntries;
+  uint64_t d_generation{0};
   int d_socket{-1};
   uint16_t d_timeout;
   uint8_t d_reconnectWaitTime;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -464,10 +464,10 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
       sendQname.makeUsLowerCase();
 
     if (d_asyncResolve) {
-      ret = d_asyncResolve(ip, sendQname, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, luaconfsLocal->outgoingProtobufServer, res, chained);
+      ret = d_asyncResolve(ip, sendQname, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, d_outgoingProtobufServer, res, chained);
     }
     else {
-      ret=asyncresolve(ip, sendQname, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, luaconfsLocal->outgoingProtobufServer, res, chained);
+      ret=asyncresolve(ip, sendQname, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, d_outgoingProtobufServer, res, chained);
     }
     if(ret < 0) {
       return ret; // transport error, nothing to learn here

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -649,6 +649,11 @@ public:
   {
     d_initialRequestId = initialRequestId;
   }
+
+  void setOutgoingProtobufServer(std::shared_ptr<RemoteLogger>& server)
+  {
+    d_outgoingProtobufServer = server;
+  }
 #endif
 
   void setAsyncCallback(asyncresolve_t func)
@@ -790,6 +795,7 @@ private:
   ostringstream d_trace;
   shared_ptr<RecursorLua4> d_pdl;
   boost::optional<Netmask> d_outgoingECSNetwork;
+  std::shared_ptr<RemoteLogger> d_outgoingProtobufServer{nullptr};
 #ifdef HAVE_PROTOBUF
   boost::optional<const boost::uuids::uuid&> d_initialRequestId;
 #endif


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Use a dedicated protobuf queue for each worker thread, instead of sharing a single one for all worker threads, leading to some contention under heavy load.
Also properly stops the existing protobuf exporter threads on a `Lua` configuration reload.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
