### PR TITLE
[WIP] add memory limits to recursor caches

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -78,6 +78,12 @@ public:
   {
     return d_dr.d_type;
   }
+  size_t bytes() const override
+  {
+    return sizeof(*this)
+      + this->d_record.size() * sizeof(uint8_t)
+      + this->d_dr.d_name.getStorage().capacity() + 1;
+  }
 private:
   DNSRecord d_dr;
   vector<uint8_t> d_record;
@@ -526,7 +532,6 @@ try
     blob.clear();
 
   d_pos = d_startrecordpos + d_recordlen;
-  d_bytesout += d_recordlen;
 }
 catch(...)
 {
@@ -546,7 +551,6 @@ void PacketReader::xfrBlob(string& blob, int length)
   }
   else 
     blob.clear();
-  d_bytesout += length;
 }
 
 

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -526,6 +526,7 @@ try
     blob.clear();
 
   d_pos = d_startrecordpos + d_recordlen;
+  d_bytesout += d_recordlen;
 }
 catch(...)
 {
@@ -545,6 +546,7 @@ void PacketReader::xfrBlob(string& blob, int length)
   }
   else 
     blob.clear();
+  d_bytesout += length;
 }
 
 

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -146,6 +146,7 @@ public:
   void xfrText(string &text, bool multi=false, bool lenField=true)
   {
     text=getText(multi, lenField);
+    d_bytesout += text.length();
   }
 
   void xfrUnquotedText(string &text, bool lenField){

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -87,6 +87,7 @@ public:
   void xfr32BitInt(uint32_t& val)
   {
     val=get32BitInt();
+    d_bytesout += 4;
   }
 
   void xfrIP(uint32_t& val)
@@ -139,6 +140,7 @@ public:
   void xfrName(DNSName &name, bool compress=false, bool noDot=false)
   {
     name=getName();
+    d_bytesout += name.wirelength();
   }
 
   void xfrText(string &text, bool multi=false, bool lenField=true)
@@ -166,6 +168,8 @@ public:
   string getUnquotedText(bool lenField);
 
   uint16_t d_pos;
+
+  size_t d_bytesout = 0;
 
   bool eof() { return true; };
   const string getRemaining() const {
@@ -262,6 +266,8 @@ public:
   }
 
   virtual uint16_t getType() const = 0;
+
+  size_t d_size_in_bytes = 0;
 
 protected:
   typedef std::map<std::pair<uint16_t, uint16_t>, makerfunc_t* > typemap_t;

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -87,7 +87,6 @@ public:
   void xfr32BitInt(uint32_t& val)
   {
     val=get32BitInt();
-    d_bytesout += 4;
   }
 
   void xfrIP(uint32_t& val)
@@ -140,13 +139,11 @@ public:
   void xfrName(DNSName &name, bool compress=false, bool noDot=false)
   {
     name=getName();
-    d_bytesout += name.wirelength();
   }
 
   void xfrText(string &text, bool multi=false, bool lenField=true)
   {
     text=getText(multi, lenField);
-    d_bytesout += text.length();
   }
 
   void xfrUnquotedText(string &text, bool lenField){
@@ -169,8 +166,6 @@ public:
   string getUnquotedText(bool lenField);
 
   uint16_t d_pos;
-
-  size_t d_bytesout = 0;
 
   bool eof() { return true; };
   const string getRemaining() const {
@@ -223,6 +218,7 @@ public:
   static shared_ptr<DNSRecordContent> unserialize(const DNSName& qname, uint16_t qtype, const string& serialized);
 
   void doRecordCheck(const struct DNSRecord&){}
+  virtual size_t bytes() const = 0;
 
   typedef DNSRecordContent* makerfunc_t(const struct DNSRecord& dr, PacketReader& pr);  
   typedef DNSRecordContent* zmakerfunc_t(const string& str);  
@@ -268,7 +264,6 @@ public:
 
   virtual uint16_t getType() const = 0;
 
-  size_t d_size_in_bytes = 0;
 
 protected:
   typedef std::map<std::pair<uint16_t, uint16_t>, makerfunc_t* > typemap_t;

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -98,12 +98,20 @@ ARecordContent::ARecordContent(const ComboAddress& ca)
   d_ip = ca.sin4.sin_addr.s_addr;
 }
 
+size_t ARecordContent::bytes() const
+{
+  return sizeof(*this);
+}
+
 AAAARecordContent::AAAARecordContent(const ComboAddress& ca) 
 {
   d_ip6.assign((const char*)ca.sin6.sin6_addr.s6_addr, 16);
 }
 
-
+size_t AAAARecordContent::bytes() const
+{
+  return sizeof(*this);
+}
 
 ComboAddress ARecordContent::getCA(int port) const
 {
@@ -135,31 +143,114 @@ void ARecordContent::doRecordCheck(const DNSRecord& dr)
 boilerplate_conv(AAAA, QType::AAAA, conv.xfrIP6(d_ip6); );
 
 boilerplate_conv(NS, QType::NS, conv.xfrName(d_content, true));
+size_t NSRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_content.getStorage().capacity() + 1;
+}
 boilerplate_conv(PTR, QType::PTR, conv.xfrName(d_content, true));
+size_t PTRRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_content.getStorage().capacity() + 1;
+}
 boilerplate_conv(CNAME, QType::CNAME, conv.xfrName(d_content, true));
+size_t CNAMERecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_content.getStorage().capacity() + 1;
+}
 boilerplate_conv(ALIAS, QType::ALIAS, conv.xfrName(d_content, false));
+size_t ALIASRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_content.getStorage().capacity() + 1;
+}
 boilerplate_conv(DNAME, QType::DNAME, conv.xfrName(d_content));
+size_t DNAMERecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_content.getStorage().capacity() + 1;
+}
 boilerplate_conv(MB, QType::MB, conv.xfrName(d_madname, true));
+size_t MBRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_madname.getStorage().capacity() + 1;
+}
 boilerplate_conv(MG, QType::MG, conv.xfrName(d_mgmname, true));
+size_t MGRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_mgmname.getStorage().capacity() + 1;
+}
 boilerplate_conv(MR, QType::MR, conv.xfrName(d_alias, true));
+size_t MRRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_alias.getStorage().capacity() + 1;
+}
 boilerplate_conv(MINFO, QType::MINFO, conv.xfrName(d_rmailbx, true); conv.xfrName(d_emailbx, true));
+size_t MINFORecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_rmailbx.getStorage().capacity() + 1
+    + d_emailbx.getStorage().capacity() + 1;
+}
 boilerplate_conv(TXT, QType::TXT, conv.xfrText(d_text, true));
+
+size_t TXTRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_text.capacity() + 1;
+}
+
 #ifdef HAVE_LUA_RECORDS
 boilerplate_conv(LUA, QType::LUA, conv.xfrType(d_type); conv.xfrText(d_code, true));
+size_t LUARecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_code.capacity() + 1;
+}
 #endif
 boilerplate_conv(ENT, 0, );
+size_t ENTRecordContent::bytes() const
+{
+  return sizeof(*this);
+}
 boilerplate_conv(SPF, 99, conv.xfrText(d_text, true));
+size_t SPFRecordContent::bytes() const
+{
+  return sizeof(*this);
+}
 boilerplate_conv(HINFO, QType::HINFO,  conv.xfrText(d_cpu);   conv.xfrText(d_host));
+size_t HINFORecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_cpu.capacity() + 1
+    + d_host.capacity() + 1;
+}
 
 boilerplate_conv(RP, QType::RP,
                  conv.xfrName(d_mbox);   
                  conv.xfrName(d_info)
                  );
 
+size_t RPRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_mbox.getStorage().capacity() + 1
+    + d_info.getStorage().capacity() + 1;
+}
 
 boilerplate_conv(OPT, QType::OPT, 
                    conv.xfrBlob(d_data)
                  );
+size_t OPTRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_data.capacity() + 1;
+}
 
 #ifdef HAVE_LUA_RECORDS
 string LUARecordContent::getCode()
@@ -208,6 +299,14 @@ boilerplate_conv(TSIG, QType::TSIG,
                  if (size>0) conv.xfrBlobNoSpaces(d_otherData, size);
                  );
 
+size_t TSIGRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_algoName.getStorage().capacity() + 1
+    + d_mac.capacity() + 1
+    + d_otherData.capacity() +  1;
+}
+
 MXRecordContent::MXRecordContent(uint16_t preference, const DNSName& mxname):  d_preference(preference), d_mxname(mxname)
 {
 }
@@ -217,10 +316,22 @@ boilerplate_conv(MX, QType::MX,
                  conv.xfrName(d_mxname, true);
                  )
 
+size_t MXRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_mxname.getStorage().capacity() + 1;
+}
+
 boilerplate_conv(KX, QType::KX, 
                  conv.xfr16BitInt(d_preference);
                  conv.xfrName(d_exchanger, false);
                  )
+
+size_t KXRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_exchanger.getStorage().capacity() + 1;
+}
 
 boilerplate_conv(IPSECKEY, QType::IPSECKEY,
    conv.xfr8BitInt(d_preference);
@@ -256,15 +367,33 @@ boilerplate_conv(IPSECKEY, QType::IPSECKEY,
    }
 ) 
 
+size_t IPSECKEYRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_gateway.getStorage().capacity() + 1
+    + d_publickey.capacity() + 1
+    + d_ip6.capacity() + 1;
+}
+
 boilerplate_conv(DHCID, 49, 
                  conv.xfrBlob(d_content);
                  )
 
+size_t DHCIDRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_content.capacity() + 1;
+}
 
 boilerplate_conv(AFSDB, QType::AFSDB, 
                  conv.xfr16BitInt(d_subtype);
                  conv.xfrName(d_hostname);
                  )
+size_t AFSDBRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_hostname.getStorage().capacity() + 1;
+}
 
 
 boilerplate_conv(NAPTR, QType::NAPTR,
@@ -272,7 +401,14 @@ boilerplate_conv(NAPTR, QType::NAPTR,
                  conv.xfrText(d_flags);        conv.xfrText(d_services);         conv.xfrText(d_regexp);
                  conv.xfrName(d_replacement);
                  )
-
+size_t NAPTRRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_replacement.getStorage().capacity() + 1
+    + d_flags.capacity() + 1
+    + d_services.capacity() + 1
+    + d_regexp.capacity() + 1;
+}
 
 SRVRecordContent::SRVRecordContent(uint16_t preference, uint16_t weight, uint16_t port, const DNSName& target) 
 : d_weight(weight), d_port(port), d_target(target), d_preference(preference)
@@ -282,6 +418,12 @@ boilerplate_conv(SRV, QType::SRV,
                  conv.xfr16BitInt(d_preference);   conv.xfr16BitInt(d_weight);   conv.xfr16BitInt(d_port);
                  conv.xfrName(d_target); 
                  )
+
+size_t SRVRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_target.getStorage().capacity() + 1;
+}
 
 SOARecordContent::SOARecordContent(const DNSName& mname, const DNSName& rname, const struct soatimes& st) 
 : d_mname(mname), d_rname(rname), d_st(st)
@@ -297,6 +439,13 @@ boilerplate_conv(SOA, QType::SOA,
                  conv.xfr32BitInt(d_st.expire);
                  conv.xfr32BitInt(d_st.minimum);
                  );
+size_t SOARecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_mname.getStorage().capacity() + 1
+    + d_rname.getStorage().capacity() + 1;
+}
+
 #undef KEY
 boilerplate_conv(KEY, QType::KEY, 
                  conv.xfr16BitInt(d_flags); 
@@ -304,6 +453,11 @@ boilerplate_conv(KEY, QType::KEY,
                  conv.xfr8BitInt(d_algorithm); 
                  conv.xfrBlob(d_certificate);
                  );
+size_t KEYRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_certificate.capacity() + 1;
+}
 
 boilerplate_conv(CERT, 37, 
                  conv.xfr16BitInt(d_type); 
@@ -313,6 +467,11 @@ boilerplate_conv(CERT, 37,
                  conv.xfr8BitInt(d_algorithm); 
                  conv.xfrBlob(d_certificate);
                  )
+size_t CERTRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_certificate.capacity() + 1;
+}
 
 boilerplate_conv(TLSA, 52, 
                  conv.xfr8BitInt(d_certusage); 
@@ -320,10 +479,21 @@ boilerplate_conv(TLSA, 52,
                  conv.xfr8BitInt(d_matchtype); 
                  conv.xfrHexBlob(d_cert, true);
                  )                 
+size_t TLSARecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_cert.capacity() + 1;
+}
                  
 boilerplate_conv(OPENPGPKEY, 61,
                  conv.xfrBlob(d_keyring);
                  )
+
+size_t OPENPGPKEYRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_keyring.capacity() + 1;
+}
 
 boilerplate_conv(SMIMEA, 53,
                  conv.xfr8BitInt(d_certusage);
@@ -331,6 +501,11 @@ boilerplate_conv(SMIMEA, 53,
                  conv.xfr8BitInt(d_matchtype);
                  conv.xfrHexBlob(d_cert, true);
                  )
+size_t SMIMEARecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_cert.capacity() + 1;
+}
 
 DSRecordContent::DSRecordContent() {}
 boilerplate_conv(DS, 43, 
@@ -339,6 +514,11 @@ boilerplate_conv(DS, 43,
                  conv.xfr8BitInt(d_digesttype); 
                  conv.xfrHexBlob(d_digest, true); // keep reading across spaces
                  )
+size_t DSRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_digest.capacity() + 1;
+}
 
 CDSRecordContent::CDSRecordContent() {}
 boilerplate_conv(CDS, 59, 
@@ -348,6 +528,12 @@ boilerplate_conv(CDS, 59,
                  conv.xfrHexBlob(d_digest, true); // keep reading across spaces
                  )
 
+size_t CDSRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_digest.capacity() + 1;
+}
+
 DLVRecordContent::DLVRecordContent() {}
 boilerplate_conv(DLV,32769 , 
                  conv.xfr16BitInt(d_tag); 
@@ -355,6 +541,11 @@ boilerplate_conv(DLV,32769 ,
                  conv.xfr8BitInt(d_digesttype); 
                  conv.xfrHexBlob(d_digest, true); // keep reading across spaces
                  )
+size_t DLVRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_digest.capacity() + 1;
+}
 
 
 boilerplate_conv(SSHFP, 44, 
@@ -362,6 +553,11 @@ boilerplate_conv(SSHFP, 44,
                  conv.xfr8BitInt(d_fptype); 
                  conv.xfrHexBlob(d_fingerprint, true);
                  )
+size_t SSHFPRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_fingerprint.capacity() + 1;
+}
 
 boilerplate_conv(RRSIG, 46, 
                  conv.xfrType(d_type); 
@@ -374,6 +570,13 @@ boilerplate_conv(RRSIG, 46,
                  conv.xfrName(d_signer);
                  conv.xfrBlob(d_signature);
                  )
+
+size_t RRSIGRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_signature.capacity() + 1
+    + d_signer.getStorage().capacity() + 1;
+}
                  
 RRSIGRecordContent::RRSIGRecordContent() {}
 
@@ -384,6 +587,11 @@ boilerplate_conv(DNSKEY, 48,
                  conv.xfrBlob(d_key);
                  )
 DNSKEYRecordContent::DNSKEYRecordContent() {}
+size_t DNSKEYRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_key.capacity() + 1;
+}
 
 boilerplate_conv(CDNSKEY, 60, 
                  conv.xfr16BitInt(d_flags); 
@@ -392,6 +600,11 @@ boilerplate_conv(CDNSKEY, 60,
                  conv.xfrBlob(d_key);
                  )
 CDNSKEYRecordContent::CDNSKEYRecordContent() {}
+size_t CDNSKEYRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_key.capacity() + 1;
+}
 
 boilerplate_conv(RKEY, 57, 
                  conv.xfr16BitInt(d_flags); 
@@ -399,6 +612,12 @@ boilerplate_conv(RKEY, 57,
                  conv.xfrBlob(d_key);
                  )
 RKEYRecordContent::RKEYRecordContent() {}
+
+size_t RKEYRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_key.capacity() + 1;
+}
 
 /* EUI48 start */
 void EUI48RecordContent::report(void) 
@@ -440,10 +659,19 @@ string EUI48RecordContent::getZoneRepresentation(bool noDot) const
     return tmp;
 }
 
+size_t EUI48RecordContent::bytes() const
+{
+  return sizeof(*this);
+}
+
 /* EUI48 end */
 
 /* EUI64 start */
 
+size_t EUI64RecordContent::bytes() const
+{
+  return sizeof(*this);
+}
 void EUI64RecordContent::report(void)
 {
   regist(1, QType::EUI64, &make, &make, "EUI64");
@@ -498,6 +726,15 @@ boilerplate_conv(TKEY, QType::TKEY,
                  conv.xfr16BitInt(d_othersize);
                  if (d_othersize>0) conv.xfrBlobNoSpaces(d_other, d_othersize);
                  )
+
+size_t TKEYRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_algo.getStorage().capacity() + 1
+    + d_key.capacity() + 1
+    + d_other.capacity() + 1;
+}
+
 TKEYRecordContent::TKEYRecordContent() { d_othersize = 0; } // fix CID#1288932
 
 boilerplate_conv(URI, QType::URI,
@@ -506,11 +743,24 @@ boilerplate_conv(URI, QType::URI,
                  conv.xfrText(d_target, true, false);
                  )
 
+size_t URIRecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_target.capacity() + 1;
+}
+
 boilerplate_conv(CAA, QType::CAA,
                  conv.xfr8BitInt(d_flags);
                  conv.xfrUnquotedText(d_tag, true);
                  conv.xfrText(d_value, true, false); /* no lenField */
                 )
+
+size_t CAARecordContent::bytes() const
+{
+  return sizeof(*this)
+    + d_tag.capacity() + 1
+    + d_value.capacity() + 1;
+}
 
 static uint16_t makeTag(const std::string& data)
 {

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -41,8 +41,9 @@
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);                          \
   static DNSRecordContent* make(const string& zonedata);                                         \
   string getZoneRepresentation(bool noDot=false) const override;                                 \
+  size_t bytes() const override;                                                                 \
   void toPacket(DNSPacketWriter& pw) override;                                                   \
-  uint16_t getType() const override { return QType::RNAME; }                                   \
+  uint16_t getType() const override { return QType::RNAME; }                                     \
   template<class Convertor> void xfrPacket(Convertor& conv, bool noDot=false);
 
 class NAPTRRecordContent : public DNSRecordContent
@@ -545,6 +546,7 @@ public:
   {}
   NSECRecordContent(const string& content, const string& zone=""); //FIXME400: DNSName& zone?
 
+  size_t bytes() const override;
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& content);
   string getZoneRepresentation(bool noDot=false) const override;
@@ -566,6 +568,7 @@ public:
   {}
   NSEC3RecordContent(const string& content, const string& zone=""); //FIXME400: DNSName& zone?
 
+  size_t bytes() const override;
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& content);
   string getZoneRepresentation(bool noDot=false) const override;
@@ -595,6 +598,7 @@ public:
   {}
   NSEC3PARAMRecordContent(const string& content, const string& zone=""); // FIXME400: DNSName& zone?
 
+  size_t bytes() const override;
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& content);
   string getZoneRepresentation(bool noDot=false) const override;
@@ -620,6 +624,7 @@ public:
   {}
   LOCRecordContent(const string& content, const string& zone="");
 
+  size_t bytes() const override;
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& content);
   string getZoneRepresentation(bool noDot=false) const override;
@@ -636,29 +641,30 @@ private:
 };
 
 
-class WKSRecordContent : public DNSRecordContent
-{
-public:
-  static void report(void);
-  WKSRecordContent() 
-  {}
-  WKSRecordContent(const string& content, const string& zone=""); // FIXME400: DNSName& zone?
-
-  static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
-  static DNSRecordContent* make(const string& content);
-  string getZoneRepresentation(bool noDot=false) const override;
-  void toPacket(DNSPacketWriter& pw) override;
-
-  uint32_t d_ip{0};
-  std::bitset<65535> d_services;
-private:
-};
+//class WKSRecordContent : public DNSRecordContent
+//{
+//public:
+//  static void report(void);
+//  WKSRecordContent() 
+//  {}
+//  WKSRecordContent(const string& content, const string& zone=""); // FIXME400: DNSName& zone?
+//
+//  static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
+//  static DNSRecordContent* make(const string& content);
+//  string getZoneRepresentation(bool noDot=false) const override;
+//  void toPacket(DNSPacketWriter& pw) override;
+//
+//  uint32_t d_ip{0};
+//  std::bitset<65535> d_services;
+//private:
+//};
 
 class EUI48RecordContent : public DNSRecordContent 
 {
 public:
   EUI48RecordContent() {};
   static void report(void);
+  size_t bytes() const override;
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& zone); // FIXME400: DNSName& zone?
   string getZoneRepresentation(bool noDot=false) const override;
@@ -674,6 +680,7 @@ class EUI64RecordContent : public DNSRecordContent
 public:
   EUI64RecordContent() {};
   static void report(void);
+  size_t bytes() const override;
   static DNSRecordContent* make(const DNSRecord &dr, PacketReader& pr);
   static DNSRecordContent* make(const string& zone); // FIXME400: DNSName& zone?
   string getZoneRepresentation(bool noDot=false) const override;
@@ -730,8 +737,7 @@ RNAME##RecordContent::DNSRecordContent* RNAME##RecordContent::make(const DNSReco
 RNAME##RecordContent::RNAME##RecordContent(const DNSRecord& dr, PacketReader& pr)                  \
 {                                                                                                  \
   doRecordCheck(dr);                                                                               \
-  pr.d_bytesout = 0 ;xfrPacket(pr);                                                                                   \
-  d_size_in_bytes = pr.d_bytesout+sizeof(*this); ; /* d_size_in_bytes = dr.d_clen; */                                                               \
+  xfrPacket(pr);                                                                                   \
 }                                                                                                  \
                                                                                                    \
 RNAME##RecordContent::DNSRecordContent* RNAME##RecordContent::make(const string& zonedata)         \
@@ -769,7 +775,7 @@ RNAME##RecordContent::RNAME##RecordContent(const string& zoneData)              
 string RNAME##RecordContent::getZoneRepresentation(bool noDot) const                               \
 {                                                                                                  \
   string ret;                                                                                      \
-  RecordTextWriter rtw(ret, noDot);                                                                       \
+  RecordTextWriter rtw(ret, noDot);                                                                \
   const_cast<RNAME##RecordContent*>(this)->xfrPacket(rtw);                                         \
   return ret;                                                                                      \
 }                                                                                                  

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -731,7 +731,7 @@ RNAME##RecordContent::RNAME##RecordContent(const DNSRecord& dr, PacketReader& pr
 {                                                                                                  \
   doRecordCheck(dr);                                                                               \
   pr.d_bytesout = 0 ;xfrPacket(pr);                                                                                   \
-  d_size_in_bytes = pr.d_bytesout; ; /* d_size_in_bytes = dr.d_clen; */                                                               \
+  d_size_in_bytes = pr.d_bytesout+sizeof(*this); ; /* d_size_in_bytes = dr.d_clen; */                                                               \
 }                                                                                                  \
                                                                                                    \
 RNAME##RecordContent::DNSRecordContent* RNAME##RecordContent::make(const string& zonedata)         \

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -730,7 +730,8 @@ RNAME##RecordContent::DNSRecordContent* RNAME##RecordContent::make(const DNSReco
 RNAME##RecordContent::RNAME##RecordContent(const DNSRecord& dr, PacketReader& pr)                  \
 {                                                                                                  \
   doRecordCheck(dr);                                                                               \
-  xfrPacket(pr);                                                                                   \
+  pr.d_bytesout = 0 ;xfrPacket(pr);                                                                                   \
+  d_size_in_bytes = pr.d_bytesout; ; /* d_size_in_bytes = dr.d_clen; */                                                               \
 }                                                                                                  \
                                                                                                    \
 RNAME##RecordContent::DNSRecordContent* RNAME##RecordContent::make(const string& zonedata)         \

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -293,6 +293,9 @@ public:
   void preRemoval(const METACacheEntry&)
   {
   }
+  size_t bytes(){
+    return 0;
+  }
 };
 
 class DNSPacket;

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -211,6 +211,8 @@ void NSEC3RecordContent::toPacket(DNSPacketWriter& pw)
 NSEC3RecordContent::DNSRecordContent* NSEC3RecordContent::make(const DNSRecord &dr, PacketReader& pr) 
 {
   NSEC3RecordContent* ret=new NSEC3RecordContent();
+
+  pr.d_bytesout = 0;
   pr.xfr8BitInt(ret->d_algorithm);
   pr.xfr8BitInt(ret->d_flags);
   pr.xfr16BitInt(ret->d_iterations);
@@ -220,7 +222,8 @@ NSEC3RecordContent::DNSRecordContent* NSEC3RecordContent::make(const DNSRecord &
 
   pr.xfr8BitInt(len);
   pr.xfrBlob(ret->d_nexthash, len);
-  
+  ret->d_size_in_bytes = pr.d_bytesout;
+
   string bitmap;
   pr.xfrBlob(bitmap);
   
@@ -246,6 +249,7 @@ NSEC3RecordContent::DNSRecordContent* NSEC3RecordContent::make(const DNSRecord &
       for(int bit = 0; bit < 8 ; ++bit , val>>=1)
         if(val & 1) {
           ret->d_set.insert((7-bit) + 8*(k) + 256*window);
+          ret->d_size_in_bytes += 2 + 2*sizeof(void*);
         }
       }
   }

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -84,7 +84,11 @@ void NSECRecordContent::toPacket(DNSPacketWriter& pw)
 NSECRecordContent::DNSRecordContent* NSECRecordContent::make(const DNSRecord &dr, PacketReader& pr) 
 {
   NSECRecordContent* ret=new NSECRecordContent();
+
+  pr.d_bytesout = 0;
   pr.xfrName(ret->d_next);
+  ret->d_size_in_bytes = pr.d_bytesout;
+
   string bitmap;
   pr.xfrBlob(bitmap);
  
@@ -109,6 +113,7 @@ NSECRecordContent::DNSRecordContent* NSECRecordContent::make(const DNSRecord &dr
       for(int bit = 0; bit < 8 ; ++bit , val>>=1)
         if(val & 1) {
           ret->d_set.insert((7-bit) + 8*(k) + 256*window);
+          ret->d_size_in_bytes += 2 + 2*sizeof(void*);
         }
       }
   }

--- a/pdns/protobuf.cc
+++ b/pdns/protobuf.cc
@@ -278,6 +278,17 @@ std::string DNSProtoBufMessage::toDebugString() const
 #endif /* HAVE_PROTOBUF */
 }
 
+size_t DNSProtoBufMessage::byteSize() const
+{
+#ifdef HAVE_PROTOBUF
+    // https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.message#Message.SpaceUsed.details
+  return d_message.SpaceUsedLong();
+//  return d_message.ByteSize();
+#else
+    return 0;
+#endif /* HAVE_PROTOBUF */
+}
+
 #ifdef HAVE_PROTOBUF
 
 void DNSProtoBufMessage::setUUID(const boost::uuids::uuid& uuid)

--- a/pdns/protobuf.cc
+++ b/pdns/protobuf.cc
@@ -282,7 +282,7 @@ size_t DNSProtoBufMessage::byteSize() const
 {
 #ifdef HAVE_PROTOBUF
     // https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.message#Message.SpaceUsed.details
-  return d_message.SpaceUsedLong();
+  return d_message.SpaceUsed();
 //  return d_message.ByteSize();
 #else
     return 0;

--- a/pdns/protobuf.hh
+++ b/pdns/protobuf.hh
@@ -73,6 +73,7 @@ public:
   std::string toDebugString() const;
   void addTag(const std::string& strValue);
   void addRR(const DNSName& qame, uint16_t utype, uint16_t uClass, uint32_t uTTl, const std::string& strBlob);
+  size_t byteSize() const;
 
 #ifdef HAVE_PROTOBUF
   DNSProtoBufMessage(DNSProtoBufMessage::DNSProtoBufMessageType type, const boost::uuids::uuid& uuid, const ComboAddress* requestor, const ComboAddress* responder, const DNSName& domain, int qtype, uint16_t qclass, uint16_t qid, bool isTCP, size_t bytes);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -624,6 +624,15 @@ string setMaxCacheEntries(T begin, T end)
 }
 
 template<typename T>
+string setMaxCacheMBytes(T begin, T end)
+{
+  if(end-begin != 1)
+    return "Need to supply new cache size in mbytes\n";
+  g_maxCacheBytes = pdns_stou(*begin)*1024*1024;
+  return "New max cache size in bytes: " + std::to_string(g_maxCacheBytes) + "\n";
+}
+
+template<typename T>
 string setMaxPacketCacheEntries(T begin, T end)
 {
   if(end-begin != 1) 
@@ -632,6 +641,14 @@ string setMaxPacketCacheEntries(T begin, T end)
   return "New max packetcache entries: " + std::to_string(g_maxPacketCacheEntries) + "\n";
 }
 
+template<typename T>
+string setMaxPacketCacheMBytes(T begin, T end)
+{
+  if(end-begin != 1)
+    return "Need to supply new packet cache size in mbytes\n";
+  g_maxPacketCacheBytes = pdns_stou(*begin)*1024*1024;
+  return "New max packetcache size in bytes: " + std::to_string(g_maxPacketCacheBytes) + "\n";
+}
 
 static uint64_t getSysTimeMsec()
 {
@@ -847,7 +864,9 @@ void registerAllStats()
   addGetStat("cache-misses", doGetCacheMisses); 
   addGetStat("cache-entries", doGetCacheSize);
   addGetStat("max-cache-entries", []() { return g_maxCacheEntries.load(); });
+  addGetStat("max-cache-mbytes", []() { return g_maxCacheBytes.load()/1024/1024; });
   addGetStat("max-packetcache-entries", []() { return g_maxPacketCacheEntries.load();}); 
+  addGetStat("max-packetcache-mbytes", []() { return g_maxPacketCacheBytes.load()/1024/1024;});
   addGetStat("cache-bytes", doGetCacheBytes); 
   
   addGetStat("packetcache-hits", doGetPacketCacheHits);
@@ -1389,10 +1408,16 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
   if(cmd=="set-max-cache-entries") {
     return setMaxCacheEntries(begin, end);
   }
+  if(cmd=="set-max-cache-mbytes") {
+    return setMaxCacheMBytes(begin, end);
+  }
   if(cmd=="set-max-packetcache-entries") {
     return setMaxPacketCacheEntries(begin, end);
   }
-  
+  if(cmd=="set-max-packetcache-mbytes") {
+    return setMaxPacketCacheMBytes(begin, end);
+  }
+ 
   if(cmd=="set-minimum-ttl") {
     return setMinimumTTL(begin, end);
   }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -715,9 +715,20 @@ uint64_t* pleaseGetNegCacheSize()
   return new uint64_t(tmp);
 }
 
+uint64_t* pleaseGetNegCacheBytes()
+{
+  uint64_t tmp=(SyncRes::getNegCacheBytes());
+  return new uint64_t(tmp);
+}
+
 uint64_t getNegCacheSize()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetNegCacheSize);
+}
+
+uint64_t getNegCacheBytes()
+{
+  return broadcastAccFunction<uint64_t>(pleaseGetNegCacheBytes);
 }
 
 uint64_t* pleaseGetFailedHostsSize()
@@ -932,6 +943,7 @@ void registerAllStats()
   addGetStat("max-mthread-stack", &g_stats.maxMThreadStackUsage);
   
   addGetStat("negcache-entries", boost::bind(getNegCacheSize));
+  addGetStat("negcache-bytes", boost::bind(getNegCacheBytes));
   addGetStat("throttle-entries", boost::bind(getThrottleSize)); 
 
   addGetStat("nsspeeds-entries", boost::bind(getNsSpeedsSize));

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -114,8 +114,6 @@ map<string,string> getAllStatsMap()
   }
 
   for(const auto& the64bitmembers :  d_get64bitmembers) { 
-    if(the64bitmembers.first == "cache-bytes" || the64bitmembers.first=="packetcache-bytes")
-      continue; // too slow for 'get-all'
     ret.insert(make_pair(the64bitmembers.first, std::to_string(the64bitmembers.second())));
   }
   Lock l(&d_dynmetricslock);

--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -212,6 +212,7 @@ void RecursorPacketCache::doPruneTo(unsigned int maxCached)
 
 uint64_t RecursorPacketCache::doDump(int fd)
 {
+  size_t bytes=0;
   FILE* fp=fdopen(dup(fd), "w");
   if(!fp) { // dup probably failed
     return 0;
@@ -223,6 +224,7 @@ uint64_t RecursorPacketCache::doDump(int fd)
   time_t now=time(0);
   for(auto i=sidx.cbegin(); i != sidx.cend(); ++i) {
     count++;
+    bytes+=i->d_bytes;
     try {
       fprintf(fp, "%s %" PRId64 " %s  ; tag %d size=%zu\n", i->d_name.toString().c_str(), static_cast<int64_t>(i->d_ttd - now), DNSRecordContent::NumberToType(i->d_type).c_str(), i->d_tag, i->d_bytes);
     }
@@ -230,6 +232,7 @@ uint64_t RecursorPacketCache::doDump(int fd)
       fprintf(fp, "; error printing '%s'\n", i->d_name.empty() ? "EMPTY" : i->d_name.toString().c_str());
     }
   }
+  fprintf(fp, "; running size=%zu, actual size=%zu\n;\n;\n", d_bytes, bytes);
   fclose(fp);
   return count;
 

--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -191,12 +191,12 @@ void RecursorPacketCache::insertResponsePacket(unsigned int tag, uint32_t qhash,
   }
 }
 
-uint64_t RecursorPacketCache::size()
+uint64_t RecursorPacketCache::size() const
 {
   return d_packetCache.size();
 }
 
-uint64_t RecursorPacketCache::bytes()
+uint64_t RecursorPacketCache::bytes() const
 {
   return d_bytes;
 }

--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -201,9 +201,9 @@ uint64_t RecursorPacketCache::bytes()
   return d_bytes;
 }
 
-void RecursorPacketCache::doPruneTo(unsigned int maxCached)
+void RecursorPacketCache::doPruneTo(unsigned int maxCached, size_t maxBytes)
 {
-  pruneCollection(*this, d_packetCache, maxCached);
+  pruneCollection(*this, d_packetCache, maxCached, maxBytes);
 }
 
 uint64_t RecursorPacketCache::doDump(int fd)

--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -198,11 +198,7 @@ uint64_t RecursorPacketCache::size()
 
 uint64_t RecursorPacketCache::bytes()
 {
-  uint64_t sum=0;
-  for(const auto& e :  d_packetCache) {
-    sum += sizeof(e) + e.d_packet.length() + 4;
-  }
-  return sum;
+  return d_bytes;
 }
 
 void RecursorPacketCache::doPruneTo(unsigned int maxCached)

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -57,7 +57,7 @@ public:
   bool getResponsePacket(unsigned int tag, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, uint32_t* qhash, RecProtoBufMessage* protobufMessage);
   void insertResponsePacket(unsigned int tag, uint32_t qhash, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::string& responsePacket, time_t now, uint32_t ttl);
   void insertResponsePacket(unsigned int tag, uint32_t qhash, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::string& responsePacket, time_t now, uint32_t ttl, const boost::optional<RecProtoBufMessage>& protobufMessage);
-  void doPruneTo(unsigned int maxSize=250000);
+  void doPruneTo(unsigned int maxSize, size_t maxBytes);
   uint64_t doDump(int fd);
   int doWipePacketCache(const DNSName& name, uint16_t qtype=0xffff, bool subtree=false);
   

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -92,6 +92,7 @@ private:
     {
       return d_ttd;
     }
+    mutable ssize_t d_bytes=0;
   };
 
   typedef multi_index_container<
@@ -107,9 +108,11 @@ private:
 
   bool checkResponseMatches(std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, RecProtoBufMessage* protobufMessage);
 
+  ssize_t d_bytes=0;
 public:
   void preRemoval(const Entry& entry)
   {
+    d_bytes -= entry.d_bytes;
   }
 };
 

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -57,7 +57,7 @@ public:
   bool getResponsePacket(unsigned int tag, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, uint32_t* qhash, RecProtoBufMessage* protobufMessage);
   void insertResponsePacket(unsigned int tag, uint32_t qhash, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::string& responsePacket, time_t now, uint32_t ttl);
   void insertResponsePacket(unsigned int tag, uint32_t qhash, const DNSName& qname, uint16_t qtype, uint16_t qclass, const std::string& responsePacket, time_t now, uint32_t ttl, const boost::optional<RecProtoBufMessage>& protobufMessage);
-  void doPruneTo(unsigned int maxSize, size_t maxBytes);
+  void doPruneTo(unsigned int maxCached, size_t maxBytes);
   uint64_t doDump(int fd);
   int doWipePacketCache(const DNSName& name, uint16_t qtype=0xffff, bool subtree=false);
   
@@ -92,7 +92,7 @@ private:
     {
       return d_ttd;
     }
-    mutable ssize_t d_bytes=0;
+    mutable size_t d_bytes=0;
   };
 
   typedef multi_index_container<
@@ -108,7 +108,7 @@ private:
 
   bool checkResponseMatches(std::pair<packetCache_t::index<HashTag>::type::iterator, packetCache_t::index<HashTag>::type::iterator> range, const std::string& queryPacket, const DNSName& qname, uint16_t qtype, uint16_t qclass, time_t now, std::string* responsePacket, uint32_t* age, RecProtoBufMessage* protobufMessage);
 
-  ssize_t d_bytes=0;
+  size_t d_bytes=0;
 public:
   void preRemoval(const Entry& entry)
   {

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -63,8 +63,8 @@ public:
   
   void prune();
   uint64_t d_hits, d_misses;
-  uint64_t size();
-  uint64_t bytes();
+  uint64_t size() const;
+  uint64_t bytes() const;
 
 private:
   struct HashTag {};

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -32,8 +32,12 @@ unsigned int MemRecursorCache::bytes() const
   for(cache_t::const_iterator i=d_cache.begin(); i!=d_cache.end(); ++i) {
     ret+=sizeof(struct CacheEntry);
     ret+=(unsigned int)i->d_qname.toString().length();
-    for(auto j=i->d_records.begin(); j!= i->d_records.end(); ++j)
+    cerr<<i->d_qname.toString()<<"/"<<QType(i->d_qtype).getName()<<": ";
+    for(auto j=i->d_records.begin(); j!= i->d_records.end(); ++j) {
       ret+= sizeof(*j); // XXX WRONG we don't know the stored size! j->size();
+      cerr<<(*j)->getZoneRepresentation()<<"="<<(*j)->d_size_in_bytes<<" ";
+    }
+    cerr<<endl;
   }
   return ret;
 }

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -450,7 +450,7 @@ uint64_t MemRecursorCache::doDump(int fd)
     for(const auto j : i.d_records) {
       count++;
       try {
-        fprintf(fp, "%s %" PRId64 " IN %s %s ; (%s) auth=%i size=%zu %s\n", i.d_qname.toString().c_str(), static_cast<int64_t>(i.d_ttd - now), DNSRecordContent::NumberToType(i.d_qtype).c_str(), j->getZoneRepresentation().c_str(), vStates[i.d_state], i.d_auth, j->d_size_in_bytes, i.d_netmask.empty() ? "" : i.d_netmask.toString().c_str());
+        fprintf(fp, "%s %" PRId64 " IN %s %s ; (%s) auth=%i size=%zu/%zu %s\n", i.d_qname.toString().c_str(), static_cast<int64_t>(i.d_ttd - now), DNSRecordContent::NumberToType(i.d_qtype).c_str(), j->getZoneRepresentation().c_str(), vStates[i.d_state], i.d_auth, j->d_size_in_bytes, i.d_bytes, i.d_netmask.empty() ? "" : i.d_netmask.toString().c_str());
       }
       catch(...) {
         fprintf(fp, "; error printing '%s'\n", i.d_qname.empty() ? "EMPTY" : i.d_qname.toString().c_str());
@@ -459,7 +459,7 @@ uint64_t MemRecursorCache::doDump(int fd)
     for(const auto &sig : i.d_signatures) {
       count++;
       try {
-        fprintf(fp, "%s %" PRId64 " IN RRSIG %s ; %s\n", i.d_qname.toString().c_str(), static_cast<int64_t>(i.d_ttd - now), sig->getZoneRepresentation().c_str(), i.d_netmask.empty() ? "" : i.d_netmask.toString().c_str());
+        fprintf(fp, "%s %" PRId64 " IN RRSIG %s ; size=%zu/%zu %s\n", i.d_qname.toString().c_str(), static_cast<int64_t>(i.d_ttd - now), sig->getZoneRepresentation().c_str(), sig->d_size_in_bytes, i.d_bytes, i.d_netmask.empty() ? "" : i.d_netmask.toString().c_str());
       }
       catch(...) {
         fprintf(fp, "; error printing '%s'\n", i.d_qname.empty() ? "EMPTY" : i.d_qname.toString().c_str());

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -315,6 +315,9 @@ void MemRecursorCache::replace(time_t now, const DNSName &qname, const QType& qt
     ce.d_bytes += i.d_content->d_size_in_bytes;
   }
 
+  for(const auto i : signatures) {
+    ce.d_bytes += i->d_size_in_bytes;
+  }
   if (!isNew) {
     moveCacheItemToBack(d_cache, stored);
   }

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -437,6 +437,7 @@ bool MemRecursorCache::updateValidationStatus(time_t now, const DNSName &qname, 
 
 uint64_t MemRecursorCache::doDump(int fd)
 {
+  size_t bytes=0;
   FILE* fp=fdopen(dup(fd), "w");
   if(!fp) { // dup probably failed
     return 0;
@@ -447,6 +448,7 @@ uint64_t MemRecursorCache::doDump(int fd)
   uint64_t count=0;
   time_t now=time(0);
   for(const auto i : sidx) {
+    bytes += i.d_bytes;
     for(const auto j : i.d_records) {
       count++;
       try {
@@ -466,6 +468,7 @@ uint64_t MemRecursorCache::doDump(int fd)
       }
     }
   }
+  fprintf(fp, "; running size=%zu, actual size=%zu\n;\n;\n", d_bytes, bytes);
   fclose(fp);
   return count;
 }

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -344,7 +344,7 @@ int MemRecursorCache::doWipeCache(const DNSName& name, bool sub, uint16_t qtype)
 	break;
       if(iter->d_qtype == qtype || qtype == 0xffff) {
 	count++;
-        d_bytes -= iter->d_bytes;
+	d_bytes -= iter->d_bytes;
 	d_cache.erase(iter++);
       }
       else 

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -286,7 +286,7 @@ void MemRecursorCache::replace(time_t now, const DNSName &qname, const QType& qt
       ce.d_auth = false;  // new data won't be auth
     }
   }
-  ce.d_bytes=qname.wirelength();
+  ce.d_bytes=sizeof(ce)+qname.wirelength();
 
   // refuse any attempt to *raise* the TTL of auth NS records, as it would make it possible
   // for an auth to keep a "ghost" zone alive forever, even after the delegation is gone from

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -460,10 +460,10 @@ uint64_t MemRecursorCache::doDump(int fd)
   return count;
 }
 
-void MemRecursorCache::doPrune(unsigned int keep)
+void MemRecursorCache::doPrune(unsigned int keep, size_t maxBytes)
 {
   d_cachecachevalid=false;
 
-  pruneCollection(*this, d_cache, keep);
+  pruneCollection(*this, d_cache, keep, maxBytes);
 }
 

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -305,6 +305,9 @@ void MemRecursorCache::replace(time_t now, const DNSName &qname, const QType& qt
   for(const auto i : signatures) {
     ce.d_bytes += i->d_size_in_bytes;
   }
+  for(const auto i : authorityRecs) {
+    ce.d_bytes += sizeof(i) + i->d_name.wirelength() + i->d_content->d_size_in_bytes;
+  }
   if (!isNew) {
     moveCacheItemToBack(d_cache, stored);
   }

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -27,20 +27,7 @@ size_t MemRecursorCache::ecsIndexSize() const
 // this function is too slow to poll!
 unsigned int MemRecursorCache::bytes() const
 {
-  unsigned int ret=0;
-
-  for(cache_t::const_iterator i=d_cache.begin(); i!=d_cache.end(); ++i) {
-    ret+=sizeof(struct CacheEntry);
-    ret+=(unsigned int)i->d_qname.toString().length();
-    // cerr<<i->d_qname.toString()<<"/"<<QType(i->d_qtype).getName()<<": ";
-    for(auto j=i->d_records.begin(); j!= i->d_records.end(); ++j) {
-      ret+= sizeof(*j); // XXX WRONG we don't know the stored size! j->size();
-      // cerr<<(*j)->getZoneRepresentation()<<"="<<(*j)->d_size_in_bytes<<" ";
-    }
-    // cerr<<endl;
-  }
-  cerr<<"running size in bytes: "<<d_bytes<<endl;
-  return ret;
+  return d_bytes;
 }
 
 int32_t MemRecursorCache::handleHit(cache_t::iterator entry, const DNSName& qname, const ComboAddress& who, vector<DNSRecord>* res, vector<std::shared_ptr<RRSIGRecordContent>>* signatures, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs, bool* variable, vState* state, bool* wasAuth)

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -162,7 +162,6 @@ bool MemRecursorCache::entryMatches(cache_t::const_iterator& entry, uint16_t qt,
 // returns -1 for no hits
 int32_t MemRecursorCache::get(time_t now, const DNSName &qname, const QType& qt, bool requireAuth, vector<DNSRecord>* res, const ComboAddress& who, vector<std::shared_ptr<RRSIGRecordContent>>* signatures, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs, bool* variable, vState* state, bool* wasAuth)
 {
-  time_t ttd=0;
   //  cerr<<"looking up "<< qname<<"|"+qt.getName()<<"\n";
   if(res) {
     res->clear();
@@ -202,6 +201,7 @@ int32_t MemRecursorCache::get(time_t now, const DNSName &qname, const QType& qt,
   auto entries = getEntries(qname, qt);
 
   if(entries.first!=entries.second) {
+    time_t ttd=0;
     for(cache_t::const_iterator i=entries.first; i != entries.second; ++i) {
 
       if (i->d_ttd <= now) {

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -285,7 +285,7 @@ void MemRecursorCache::replace(time_t now, const DNSName &qname, const QType& qt
   }
 
   if(auth) {
-    ce.d_bytes=qname.wirelength(); //weird, this is the same as above
+    ce.d_bytes=sizeof(ce)+qname.wirelength(); //weird, this is the same as above
     ce.d_auth = true;
   }
 

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -59,7 +59,7 @@ public:
 
   void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs, bool auth, boost::optional<Netmask> ednsmask=boost::none, vState state=Indeterminate);
 
-  void doPrune(unsigned int keep, size_t maxBytes);
+  void doPrune(unsigned int keep, size_t maxBytes = 0);
   uint64_t doDump(int fd);
 
   int doWipeCache(const DNSName& name, bool sub, uint16_t qtype=0xffff);

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -173,6 +173,7 @@ private:
   > ecsIndex_t;
 
   cache_t d_cache;
+  size_t d_bytes=0;
   ecsIndex_t d_ecsIndex;
   pair<cache_t::iterator, cache_t::iterator> d_cachecache;
   DNSName d_cachedqname;
@@ -186,6 +187,7 @@ private:
 public:
   void preRemoval(const CacheEntry& entry)
   {
+    d_bytes -= entry.d_bytes;
     if (entry.d_netmask.empty()) {
       return;
     }

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -59,7 +59,7 @@ public:
 
   void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs, bool auth, boost::optional<Netmask> ednsmask=boost::none, vState state=Indeterminate);
 
-  void doPrune(unsigned int keep);
+  void doPrune(unsigned int keep, size_t maxBytes);
   uint64_t doDump(int fd);
 
   int doWipeCache(const DNSName& name, bool sub, uint16_t qtype=0xffff);

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -92,6 +92,7 @@ private:
     time_t d_ttd;
     uint16_t d_qtype;
     bool d_auth;
+    size_t d_bytes=0;
   };
 
   /* The ECS Index (d_ecsIndex) keeps track of whether there is any ECS-specific

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -192,6 +192,7 @@ void NegCache::clear() {
  * Perform some cleanup in the cache, removing stale entries
  *
  * \param maxEntries The maximum number of entries that may exist in the cache.
+ * \param maxBytes 
  */
 void NegCache::prune(unsigned int maxEntries, size_t maxBytes) {
   pruneCollection(*this, d_negcache, maxEntries, maxBytes, 200);

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -100,18 +100,19 @@ bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeva
 void NegCache::add(NegCacheEntry& ne) {
   ne.d_bytes = sizeof(ne);
   for (const auto& rec : ne.DNSSECRecords.records) {
-    ne.d_bytes+=rec.d_content->d_size_in_bytes;
+    ne.d_bytes+=rec.d_content->bytes();
   }
   for (const auto& sig : ne.DNSSECRecords.signatures) {
-    ne.d_bytes+=sig.d_content->d_size_in_bytes;
+    ne.d_bytes+=sig.d_content->bytes();
   }
   for (const auto& rec : ne.authoritySOA.records) {
-    ne.d_bytes+=rec.d_content->d_size_in_bytes;
+    ne.d_bytes+=rec.d_content->bytes();
   }
   for (const auto& sig : ne.authoritySOA.signatures) {
-    ne.d_bytes+=sig.d_content->d_size_in_bytes;
+    ne.d_bytes+=sig.d_content->bytes();
   }
-
+  ne.d_bytes += ne.d_name.getStorage().capacity() + 1
+    + ne.d_auth.getStorage().capacity() + 1;
   auto ret = d_negcache.insert(ne);
   if(!ret.second) { // insert was refused, we need to replace
     d_bytes -= ret.first->d_bytes;
@@ -215,16 +216,16 @@ uint64_t NegCache::dumpToFile(FILE* fp) {
     bytes+=ne.d_bytes;
     fprintf(fp, "%s %" PRId64 " IN %s VIA %s ; (%s) size=%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), ne.d_qtype.getName().c_str(), ne.d_auth.toString().c_str(), vStates[ne.d_validationState], ne.d_bytes);
     for (const auto& rec : ne.DNSSECRecords.records) {
-      fprintf(fp, " %s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->d_size_in_bytes, ne.d_bytes);
+      fprintf(fp, " %s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->bytes(), ne.d_bytes);
     }
     for (const auto& sig : ne.DNSSECRecords.signatures) {
-      fprintf(fp, "  %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
+      fprintf(fp, "  %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->bytes(), ne.d_bytes);
     }
     for (const auto& rec : ne.authoritySOA.records) {
-      fprintf(fp, "   %s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->d_size_in_bytes, ne.d_bytes);
+      fprintf(fp, "   %s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->bytes(), ne.d_bytes);
     }
     for (const auto& sig : ne.authoritySOA.signatures) {
-      fprintf(fp, "    %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
+      fprintf(fp, "    %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->bytes(), ne.d_bytes);
     }
   }
   fprintf(fp, "; running size=%zu, actual size=%zu\n;\n;\n", d_bytes, bytes);

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -199,11 +199,13 @@ void NegCache::prune(unsigned int maxEntries) {
 uint64_t NegCache::dumpToFile(FILE* fp) {
   uint64_t ret(0);
   struct timeval now;
+  size_t bytes = 0;
   Utility::gettimeofday(&now, nullptr);
 
   negcache_sequence_t& sidx = d_negcache.get<1>();
   for(const NegCacheEntry& ne : sidx) {
     ret++;
+    bytes+=ne.d_bytes;
     fprintf(fp, "%s %" PRId64 " IN %s VIA %s ; (%s) size=%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), ne.d_qtype.getName().c_str(), ne.d_auth.toString().c_str(), vStates[ne.d_validationState], ne.d_bytes);
     for (const auto& rec : ne.DNSSECRecords.records) {
       fprintf(fp, "%s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->d_size_in_bytes, ne.d_bytes);
@@ -212,5 +214,7 @@ uint64_t NegCache::dumpToFile(FILE* fp) {
       fprintf(fp, "%s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
     }
   }
+  fprintf(fp, "; running size=%zu, actual size=%zu\n;\n;\n", d_bytes, bytes);
+
   return ret;
 }

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -187,8 +187,8 @@ void NegCache::clear() {
  *
  * \param maxEntries The maximum number of entries that may exist in the cache.
  */
-void NegCache::prune(unsigned int maxEntries) {
-  pruneCollection(*this, d_negcache, maxEntries, 200);
+void NegCache::prune(unsigned int maxEntries, size_t maxBytes) {
+  pruneCollection(*this, d_negcache, maxEntries, maxBytes, 200);
 }
 
 /*!

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -214,16 +214,16 @@ uint64_t NegCache::dumpToFile(FILE* fp) {
     bytes+=ne.d_bytes;
     fprintf(fp, "%s %" PRId64 " IN %s VIA %s ; (%s) size=%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), ne.d_qtype.getName().c_str(), ne.d_auth.toString().c_str(), vStates[ne.d_validationState], ne.d_bytes);
     for (const auto& rec : ne.DNSSECRecords.records) {
-      fprintf(fp, "%s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->d_size_in_bytes, ne.d_bytes);
-    }
-    for (const auto& sig : ne.DNSSECRecords.signatures) {
-      fprintf(fp, " %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
-    }
-    for (const auto& rec : ne.authoritySOA.records) {
       fprintf(fp, " %s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->d_size_in_bytes, ne.d_bytes);
     }
+    for (const auto& sig : ne.DNSSECRecords.signatures) {
+      fprintf(fp, "  %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
+    }
+    for (const auto& rec : ne.authoritySOA.records) {
+      fprintf(fp, "   %s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->d_size_in_bytes, ne.d_bytes);
+    }
     for (const auto& sig : ne.authoritySOA.signatures) {
-      fprintf(fp, " %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
+      fprintf(fp, "    %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
     }
   }
   fprintf(fp, "; running size=%zu, actual size=%zu\n;\n;\n", d_bytes, bytes);

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -105,6 +105,12 @@ void NegCache::add(NegCacheEntry& ne) {
   for (const auto& sig : ne.DNSSECRecords.signatures) {
     ne.d_bytes+=sig.d_content->d_size_in_bytes;
   }
+  for (const auto& rec : ne.authoritySOA.records) {
+    ne.d_bytes+=rec.d_content->d_size_in_bytes;
+  }
+  for (const auto& sig : ne.authoritySOA.signatures) {
+    ne.d_bytes+=sig.d_content->d_size_in_bytes;
+  }
 
   auto ret = d_negcache.insert(ne);
   if(!ret.second) { // insert was refused, we need to replace
@@ -211,7 +217,13 @@ uint64_t NegCache::dumpToFile(FILE* fp) {
       fprintf(fp, "%s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->d_size_in_bytes, ne.d_bytes);
     }
     for (const auto& sig : ne.DNSSECRecords.signatures) {
-      fprintf(fp, "%s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
+      fprintf(fp, " %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
+    }
+    for (const auto& rec : ne.authoritySOA.records) {
+      fprintf(fp, " %s %" PRId64 " IN %s %s ; (%s) size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStates[ne.d_validationState], rec.d_content->d_size_in_bytes, ne.d_bytes);
+    }
+    for (const auto& sig : ne.authoritySOA.signatures) {
+      fprintf(fp, " %s %" PRId64 " IN RRSIG %s ; size=%zu/%zu\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str(), sig.d_content->d_size_in_bytes, ne.d_bytes);
     }
   }
   fprintf(fp, "; running size=%zu, actual size=%zu\n;\n;\n", d_bytes, bytes);

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -64,7 +64,7 @@ class NegCache : public boost::noncopyable {
     bool getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne);
     uint64_t count(const DNSName& qname) const;
     uint64_t count(const DNSName& qname, const QType qtype) const;
-    void prune(unsigned int maxEntries);
+    void prune(unsigned int maxEntries, size_t maxBytes);
     void clear();
     uint64_t dumpToFile(FILE* fd);
     uint64_t wipe(const DNSName& name, bool subtree = false);
@@ -72,6 +72,10 @@ class NegCache : public boost::noncopyable {
     uint64_t size() {
       return d_negcache.size();
     };
+
+    size_t bytes() {
+      return d_bytes;
+    }
 
     void preRemoval(const NegCacheEntry& entry)
     {

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -64,7 +64,7 @@ class NegCache : public boost::noncopyable {
     bool getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne);
     uint64_t count(const DNSName& qname) const;
     uint64_t count(const DNSName& qname, const QType qtype) const;
-    void prune(unsigned int maxEntries, size_t maxBytes);
+    void prune(unsigned int maxEntries, size_t maxBytes = 0);
     void clear();
     uint64_t dumpToFile(FILE* fd);
     uint64_t wipe(const DNSName& name, bool subtree = false);

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -74,6 +74,7 @@ class NegCache : public boost::noncopyable {
     };
 
     size_t bytes() const {
+      // TODO move d_bytes calc from NegCache::add to there w/ caching ?
       return d_bytes;
     }
 

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -52,12 +52,13 @@ class NegCache : public boost::noncopyable {
       recordsAndSignatures authoritySOA;  // The upstream SOA record and RRSIGs
       recordsAndSignatures DNSSECRecords; // The upstream NSEC(3) and RRSIGs
       mutable vState d_validationState{Indeterminate};
+      ssize_t d_bytes=0;
       uint32_t getTTD() const {
         return d_ttd;
       };
     };
 
-    void add(const NegCacheEntry& ne);
+    void add(NegCacheEntry& ne);
     void updateValidationStatus(const DNSName& qname, const QType& qtype, const vState newState);
     bool get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne, bool typeMustMatch=false);
     bool getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne);
@@ -74,6 +75,7 @@ class NegCache : public boost::noncopyable {
 
     void preRemoval(const NegCacheEntry& entry)
     {
+      d_bytes -= entry.d_bytes;
     }
 
   private:
@@ -99,4 +101,6 @@ class NegCache : public boost::noncopyable {
 
     // Stores the negative cache entries
     negcache_t d_negcache;
+
+    ssize_t d_bytes;
 };

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -52,7 +52,7 @@ class NegCache : public boost::noncopyable {
       recordsAndSignatures authoritySOA;  // The upstream SOA record and RRSIGs
       recordsAndSignatures DNSSECRecords; // The upstream NSEC(3) and RRSIGs
       mutable vState d_validationState{Indeterminate};
-      ssize_t d_bytes=0;
+      size_t d_bytes=0;
       uint32_t getTTD() const {
         return d_ttd;
       };
@@ -66,7 +66,7 @@ class NegCache : public boost::noncopyable {
     uint64_t count(const DNSName& qname, const QType qtype) const;
     void prune(unsigned int maxEntries, size_t maxBytes = 0);
     void clear();
-    uint64_t dumpToFile(FILE* fd);
+    uint64_t dumpToFile(FILE* fp);
     uint64_t wipe(const DNSName& name, bool subtree = false);
 
     uint64_t size() const {
@@ -106,5 +106,5 @@ class NegCache : public boost::noncopyable {
     // Stores the negative cache entries
     negcache_t d_negcache;
 
-    ssize_t d_bytes;
+    size_t d_bytes;
 };

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -69,11 +69,11 @@ class NegCache : public boost::noncopyable {
     uint64_t dumpToFile(FILE* fd);
     uint64_t wipe(const DNSName& name, bool subtree = false);
 
-    uint64_t size() {
+    uint64_t size() const {
       return d_negcache.size();
     };
 
-    size_t bytes() {
+    size_t bytes() const {
       return d_bytes;
     }
 

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -372,16 +372,16 @@ BOOST_AUTO_TEST_CASE(test_clear) {
 BOOST_AUTO_TEST_CASE(test_dumpToFile) {
   NegCache cache;
   vector<string> expected;
-  expected.push_back("www1.powerdns.com. 600 IN TYPE0 VIA powerdns.com. ; (Indeterminate) size=176\n");
-  expected.push_back(" www1.powerdns.com. 600 IN NSEC deadbeef. ; (Indeterminate) size=0/176\n");
-  expected.push_back("  www1.powerdns.com. 600 IN RRSIG NSEC 5 3 600 20370101000000 20370101000000 24567 dummy. data ; size=0/176\n");
-  expected.push_back("   www1.powerdns.com. 600 IN SOA ns1. hostmaster. 1 2 3 4 5 ; (Indeterminate) size=0/176\n");
-  expected.push_back("    www1.powerdns.com. 600 IN RRSIG SOA 5 3 600 20370101000000 20370101000000 24567 dummy. data ; size=0/176\n");
-  expected.push_back("www2.powerdns.com. 600 IN TYPE0 VIA powerdns.com. ; (Indeterminate) size=176\n");
-  expected.push_back(" www2.powerdns.com. 600 IN NSEC deadbeef. ; (Indeterminate) size=0/176\n");
-  expected.push_back("  www2.powerdns.com. 600 IN RRSIG NSEC 5 3 600 20370101000000 20370101000000 24567 dummy. data ; size=0/176\n");
-  expected.push_back("   www2.powerdns.com. 600 IN SOA ns1. hostmaster. 1 2 3 4 5 ; (Indeterminate) size=0/176\n");
-  expected.push_back("    www2.powerdns.com. 600 IN RRSIG SOA 5 3 600 20370101000000 20370101000000 24567 dummy. data ; size=0/176\n");
+
+  expected.push_back("www1.powerdns.com. 600 IN TYPE0 VIA powerdns.com. ; (Indeterminate) size=705\n");
+  expected.push_back(" www1.powerdns.com. 600 IN NSEC deadbeef. ; (Indeterminate) size=103/705\n");
+  expected.push_back("  www1.powerdns.com. 600 IN RRSIG NSEC 5 3 600 20370101000000 20370101000000 24567 dummy. data ; size=127/705\n");
+  expected.push_back("   www1.powerdns.com. 600 IN SOA ns1. hostmaster. 1 2 3 4 5 ; (Indeterminate) size=126/705\n");
+  expected.push_back("    www1.powerdns.com. 600 IN RRSIG SOA 5 3 600 20370101000000 20370101000000 24567 dummy. data ; size=127/705\n");
+  expected.push_back("www2.powerdns.com. 600 IN TYPE0 VIA powerdns.com. ; (Indeterminate) size=705\n");
+  expected.push_back(" www2.powerdns.com. 600 IN NSEC deadbeef. ; (Indeterminate) size=103/705\n");
+  expected.push_back("  www2.powerdns.com. 600 IN RRSIG NSEC 5 3 600 20370101000000 20370101000000 24567 dummy. data ; size=127/705\n");
+  expected.push_back("   www2.powerdns.com. 600 IN SOA ns1. hostmaster. 1 2 3 4 5 ; (Indeterminate) size=126/705\n");
 
   struct timeval now;
   Utility::gettimeofday(&now, 0);
@@ -401,7 +401,6 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile) {
   rewind(fp);
   char *line = nullptr;
   size_t len = 0;
-
   for (const auto& str : expected) {
     ssize_t read = getline(&line, &len, fp);
     if (read == -1)

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -401,10 +401,9 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile) {
   rewind(fp);
   char *line = nullptr;
   size_t len = 0;
-  ssize_t read;
 
   for (const auto& str : expected) {
-    read = getline(&line, &len, fp);
+    ssize_t read = getline(&line, &len, fp);
     if (read == -1)
       BOOST_FAIL("Unable to read a line from the temp file");
     BOOST_CHECK_EQUAL(line, str);

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -153,6 +153,10 @@ latlon2ul(const char **latlonstrptr, int *which)
   return (retval);
 }
 
+size_t LOCRecordContent::bytes() const
+{
+  return sizeof(*this);
+}
 void LOCRecordContent::report(void)
 {
   regist(1, QType::LOC, &make, &make, "LOC");

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -528,9 +528,9 @@ public:
     return t_sstorage.negcache.size();
   }
 
-  static void pruneNegCache(unsigned int maxEntries)
+  static void pruneNegCache(unsigned int maxEntries, size_t maxBytes)
   {
-    t_sstorage.negcache.prune(maxEntries);
+    t_sstorage.negcache.prune(maxEntries, maxBytes);
   }
 
   static uint64_t wipeNegCache(const DNSName& name, bool subtree = false)
@@ -971,6 +971,7 @@ extern RecursorStats g_stats;
 extern unsigned int g_numThreads;
 extern uint16_t g_outgoingEDNSBufsize;
 extern std::atomic<uint32_t> g_maxCacheEntries, g_maxPacketCacheEntries;
+extern std::atomic<size_t> g_maxCacheBytes, g_maxPacketCacheBytes;
 extern bool g_lowercaseOutgoing;
 
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -528,6 +528,11 @@ public:
     return t_sstorage.negcache.size();
   }
 
+  static uint64_t getNegCacheBytes()
+  {
+    return t_sstorage.negcache.bytes();
+  }
+
   static void pruneNegCache(unsigned int maxEntries, size_t maxBytes)
   {
     t_sstorage.negcache.prune(maxEntries, maxBytes);

--- a/pdns/test-recpacketcache_cc.cc
+++ b/pdns/test-recpacketcache_cc.cc
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimple) {
 
   rpc.insertResponsePacket(tag, qhash, qname, QType::A, QClass::IN, rpacket, time(0), ttd);
   BOOST_CHECK_EQUAL(rpc.size(), 1);
-  rpc.doPruneTo(0);
+  rpc.doPruneTo(0, 0);
   BOOST_CHECK_EQUAL(rpc.size(), 0);
   rpc.insertResponsePacket(tag, qhash, qname, QType::A, QClass::IN, rpacket, time(0), ttd);
   BOOST_CHECK_EQUAL(rpc.size(), 1);
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCache_Tags) {
   BOOST_CHECK_EQUAL(rpc.size(), 2);
 
   /* remove all responses from the cache */
-  rpc.doPruneTo(0);
+  rpc.doPruneTo(0, 0);
   BOOST_CHECK_EQUAL(rpc.size(), 0);
 
   /* reinsert both */


### PR DESCRIPTION
### Short description
This adds -bytes limits to the three recursor caches, in addition to the existing -entries limits. Cache pruning has been extended to make sure caches stay below both limits. 'bytes' reporting has been reinstated in `rec-control get_all` as that has become cheap.

TODO:
- [ ] make sure all xfr* methods, and all specific implementations of type conversion (like I did for NSEC/NSEC3) account for their usage
- [ ] measure against actual memory usage, then adjust the fudge factors (easily recognised by their use of `sizeof`); for this, it would be nice if we actually had a 'real memory usage' metric
- [ ] document
- [ ] make tests pass again
- [ ] expose `max-negcache-[bytes|entries]` metrics
- [ ] account for ECS
- [ ] add new metrics to SNMP?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
