### PR TITLE
rec: print the actual name of the failing file

### DIFF
--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -430,7 +430,7 @@ std::shared_ptr<SyncRes::domainmap_t> parseAuthAndForwards()
     
     ifstream ifs(fname.c_str());
     if(!ifs) {
-      g_log<<Logger::Warning<<"Could not open /etc/hosts for reading"<<endl;
+      g_log<<Logger::Warning<<"Could not open "<<fname<<" for reading"<<endl;
     }
     else {
       string searchSuffix = ::arg()["export-etc-hosts-search-suffix"];


### PR DESCRIPTION
### Short description
If `etc-hosts-file` is set, but it cannot be opened, we claim we cannot open `/etc/hosts`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
