### PR TITLE
fix documentation for out-of-zone-additional-processing

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1064,7 +1064,7 @@ always receive AXFR NOTIFYs.
 
 Do out of zone additional processing. This means that if a malicious
 user adds a '.com' zone to your server, it is not used for other domains
-and will not contaminate answers. Do not enable this setting if you run
+and will not contaminate answers. Do not disable this setting if you run
 a public DNS service with untrusted users.
 
 The docs had previously indicated that the default was "no", but the


### PR DESCRIPTION
### Short description
The documentation for `out-of-zone-additional-processing` (default: `yes` ) currently states 'Do not **enable** this setting if you run a public DNS service with untrusted users.'
However, as the default is `yes` this should probably read "do not **disable** this setting"

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
