### PR TITLE
rec: Respect the AXFR timeout while connecting to the RPZ server

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -338,10 +338,7 @@ int waitForRWData(int fd, bool waitForRead, int seconds, int useconds, bool* err
     pfd.events=POLLOUT;
 
   ret = poll(&pfd, 1, seconds * 1000 + useconds/1000);
-  if ( ret == -1 ) {
-    errno = ETIMEDOUT; // ???
-  }
-  else if (ret > 0) {
+  if (ret > 0) {
     if (error && (pfd.revents & POLLERR)) {
       *error = true;
     }

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -362,7 +362,8 @@ AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
                              const DNSName& domain,
                              const TSIGTriplet& tt, 
                              const ComboAddress* laddr,
-                             size_t maxReceivedBytes)
+                             size_t maxReceivedBytes,
+                             uint16_t timeout)
   : d_tsigVerifier(tt, remote, d_trc), d_receivedBytes(0), d_maxReceivedBytes(maxReceivedBytes)
 {
   ComboAddress local;
@@ -382,7 +383,7 @@ AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
       throw ResolverException("Error creating socket for AXFR request to "+d_remote.toStringWithPort());
     d_buf = shared_array<char>(new char[65536]);
     d_remote = remote; // mostly for error reporting
-    this->connect();
+    this->connect(timeout);
     d_soacount = 0;
   
     vector<uint8_t> packet;
@@ -415,7 +416,7 @@ AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
       throw ResolverException("Partial write on AXFR request to "+d_remote.toStringWithPort());
     }
   
-    int res = waitForData(d_sock, 10, 0);
+    int res = waitForData(d_sock, timeout, 0);
     
     if(!res)
       throw ResolverException("Timeout waiting for answer from "+d_remote.toStringWithPort()+" during AXFR");
@@ -504,7 +505,7 @@ void AXFRRetriever::timeoutReadn(uint16_t bytes, uint16_t timeoutsec)
   }
 }
 
-void AXFRRetriever::connect()
+void AXFRRetriever::connect(uint16_t timeout)
 {
   setNonBlocking( d_sock );
 
@@ -525,7 +526,7 @@ void AXFRRetriever::connect()
   if(!err)
     goto done;
 
-  err=waitForRWData(d_sock, false, 10, 0); // wait for writeability
+  err=waitForRWData(d_sock, false, timeout, 0); // wait for writeability
   
   if(!err) {
     try {
@@ -542,7 +543,7 @@ void AXFRRetriever::connect()
     throw ResolverException("Timeout connecting to server");
   }
   else if(err < 0) {
-    throw ResolverException("Error connecting: "+string(strerror(err)));
+    throw ResolverException("Error connecting: "+string(strerror(errno)));
   }
   else {
     Utility::socklen_t len=sizeof(err);

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -85,12 +85,13 @@ class AXFRRetriever : public boost::noncopyable
                   const DNSName& zone,
                   const TSIGTriplet& tt = TSIGTriplet(),
                   const ComboAddress* laddr = NULL,
-                  size_t maxReceivedBytes=0);
+                  size_t maxReceivedBytes=0,
+                  uint16_t timeout=10);
     ~AXFRRetriever();
     int getChunk(Resolver::res_t &res, vector<DNSRecord>* records=0, uint16_t timeout=10);
   
   private:
-    void connect();
+    void connect(uint16_t timeout);
     int getLength(uint16_t timeout);
     void timeoutReadn(uint16_t bytes, uint16_t timeoutsec=10);
 

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -300,11 +300,11 @@ void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine:
       setRPZZoneNewState(polName, sr->d_st.serial, zone->size(), true);
     }
     catch(const std::exception& e) {
-      g_log<<Logger::Warning<<"Unable to load RPZ zone '"<<zoneName<<"' from '"<<master<<"': '"<<e.what()<<"'. (Will try again in "<<refresh<<" seconds...)"<<endl;
+      g_log<<Logger::Warning<<"Unable to load RPZ zone '"<<zoneName<<"' from '"<<master<<"': '"<<e.what()<<"'. (Will try again in "<<(refresh > 0 ? refresh : 10)<<" seconds...)"<<endl;
       incRPZFailedTransfers(polName);
     }
     catch(const PDNSException& e) {
-      g_log<<Logger::Warning<<"Unable to load RPZ zone '"<<zoneName<<"' from '"<<master<<"': '"<<e.reason<<"'. (Will try again in "<<refresh<<" seconds...)"<<endl;
+      g_log<<Logger::Warning<<"Unable to load RPZ zone '"<<zoneName<<"' from '"<<master<<"': '"<<e.reason<<"'. (Will try again in "<<(refresh > 0 ? refresh : 10)<<" seconds...)"<<endl;
       incRPZFailedTransfers(polName);
     }
 

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -185,7 +185,7 @@ shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const
   if (local == ComboAddress())
     local = getQueryLocalAddress(master.sin4.sin_family, 0);
 
-  AXFRRetriever axfr(master, zoneName, tt, &local, maxReceivedBytes);
+  AXFRRetriever axfr(master, zoneName, tt, &local, maxReceivedBytes, axfrTimeout);
   unsigned int nrecords=0;
   Resolver::res_t nop;
   vector<DNSRecord> chunk;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The initial `AXFR` query to a `RPZ` server was using a hard-coded ten seconds timeout regardless of the `axfrTimeout` setting.
We also messed up error reporting in `waitForRWData()` when `poll` returns `-1`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
