### PR TITLE
lualang.org -> lua.org

### DIFF
--- a/pdns/dnsdistdist/docs/index.rst
+++ b/pdns/dnsdistdist/docs/index.rst
@@ -4,7 +4,7 @@ dnsdist Overview
 dnsdist is a highly DNS-, DoS- and abuse-aware loadbalancer.
 Its goal in life is to route traffic to the best server, delivering top performance to legitimate users while shunting or blocking abusive traffic.
 
-dnsdist is dynamic, its configuration language is `Lua <http://lualang.org>`_ and it can be can be changed at runtime, and its statistics can be queried from a console-like interface or an HTTP API.
+dnsdist is dynamic, its configuration language is `Lua <http://lua.org>`_ and it can be can be changed at runtime, and its statistics can be queried from a console-like interface or an HTTP API.
 
 A configuration to balance DNS queries to several backend servers:
 


### PR DESCRIPTION
lualang.org appears dead, lua.org appears alive