### PR TITLE
Fix compilation and use of getrandom() when available

### DIFF
--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -40,7 +40,7 @@
 #include <openssl/rand.h>
 #endif
 #if defined(HAVE_GETRANDOM)
-#include <linux/random.h>
+#include <sys/random.h>
 #endif
 
 static enum DNS_RNG {
@@ -131,7 +131,7 @@ static void dns_random_setup(void)
 #if defined(HAVE_KISS_RNG)
   } else if (rng == "kiss") {
     chosen_rng = RNG_KISS;
-    L<<Logger::Warning<<"kiss rng should not be used in production environment"<<std::endl;
+    g_log<<Logger::Warning<<"kiss rng should not be used in production environment"<<std::endl;
 #endif
   } else {
     throw PDNSException("Unsupported rng '" + rng + "'");
@@ -152,7 +152,7 @@ static void dns_random_setup(void)
     // some systems define getrandom but it does not really work, e.g. because it's
     // not present in kernel.
     if (getrandom(buf, sizeof(buf), 0) == -1) {
-       L<<Logger::Warning<<"getrandom() failed: "<<strerror(errno)<<", falling back to " + rdev<<std::endl;
+       g_log<<Logger::Warning<<"getrandom() failed: "<<strerror(errno)<<", falling back to " + rdev<<std::endl;
        chosen_rng = RNG_URANDOM;
     }
   }
@@ -261,7 +261,7 @@ unsigned int dns_random(unsigned int upper_bound) {
 #if defined(HAVE_GETRANDOM) && !defined(USE_URANDOM_ONLY)
       unsigned int num=0;
       while(num < min) {
-        if (getrandom(&num, sizeof(num), 0) != 0)
+        if (getrandom(&num, sizeof(num), 0) != sizeof(num))
           throw PDNSException("getrandom() failed: " + std::string(strerror(errno)));
       }
       return num % upper_bound;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* `getrandom()` is declared in `sys/random.h`, not `linux/random.h`, contrary to what some man pages say
* `L` has been replaced by `g_log`
* `getrandom()` returns the number of bytes when everything goes well

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
