### PR TITLE
make lock test pass on macOS

### DIFF
--- a/pdns/test-lock_hh.cc
+++ b/pdns/test-lock_hh.cc
@@ -41,8 +41,17 @@ BOOST_AUTO_TEST_CASE(test_pdns_lock)
   for(auto& pp : g_locks)
     wlocks.emplace_back(&*pp);
 
-  TryReadLock trl(&*g_locks[0]);
-  BOOST_CHECK(!trl.gotIt());
+  // on macOS, this TryReadLock throws (EDEADLK) instead of simply failing
+  // so we catch the exception and consider that success for this test
+  bool gotit = false;
+  try {
+    TryReadLock trl(&*g_locks[0]);
+    gotit = trl.gotIt();
+  }
+  catch(const PDNSException &e) {
+    gotit = false;
+  }
+  BOOST_CHECK(!gotit);
 
   wlocks.clear();
   TryReadLock trl2(&*g_locks[0]);


### PR DESCRIPTION
### Short description
With this change, auth `make check` passes on macOS.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
