### PR TITLE
Fix the dns_random unit tests, test all available backends

### DIFF
--- a/pdns/dns_random.hh
+++ b/pdns/dns_random.hh
@@ -22,7 +22,7 @@
 #ifndef PDNS_DNS_RANDOM
 #define PDNS_DNS_RANDOM
 
-void dns_random_init(const std::string& data = "");
+void dns_random_init(const std::string& data = "", bool force_reinit = false);
 unsigned int dns_random(unsigned int n);
 
 #endif

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -190,7 +190,7 @@ testrunner_SOURCES = \
 	base32.cc \
 	base64.cc base64.hh \
 	dns.cc dns.hh \
-	dns_random_urandom.cc dns_random.hh \
+	dns_random.cc dns_random.hh \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dnsparser.hh dnsparser.cc \

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -165,6 +165,8 @@ static void init(bool debug=false)
   g_maxNSEC3Iterations = 2500;
 
   ::arg().set("version-string", "string reported on version.pdns or version.bind")="PowerDNS Unit Tests";
+  ::arg().set("rng")="auto";
+  ::arg().set("entropy-source")="/dev/urandom";
 }
 
 static void initSR(std::unique_ptr<SyncRes>& sr, bool dnssec=false, bool debug=false, time_t fakeNow=0)

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -15,6 +15,7 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
 
+#include "arguments.hh"
 #include "dns_random.hh"
 #include "namespaces.hh"
 
@@ -33,9 +34,12 @@ typedef accumulator_set<
 
 BOOST_AUTO_TEST_SUITE(test_dns_random_hh)
 
+BOOST_AUTO_TEST_CASE(test_dns_random_auto_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
 
+  ::arg().set("rng")="auto";
+  ::arg().set("entropy-source")="/dev/urandom";
 
-BOOST_AUTO_TEST_CASE(test_dns_random_average) {
+  dns_random_init("", true);
 
   acc_t acc;
 
@@ -44,11 +48,152 @@ BOOST_AUTO_TEST_CASE(test_dns_random_average) {
   }
   BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
   BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
-  
 
   // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
 
+BOOST_AUTO_TEST_CASE(test_dns_random_urandom_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+
+  ::arg().set("rng")="urandom";
+  ::arg().set("entropy-source")="/dev/urandom";
+
+  dns_random_init("", true);
+
+  acc_t acc;
+
+  for(unsigned int n=0; n < 100000; ++n)  {
+    acc(dns_random(100000)/100000.0);
+  }
+  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
+  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
+
+  // please add covariance tests, chi-square, Kolmogorov-Smirnov
+}
+
+BOOST_AUTO_TEST_CASE(test_dns_random_garbage, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+
+  ::arg().set("rng")="garbage";
+  ::arg().set("entropy-source")="/dev/urandom";
+
+  BOOST_CHECK_THROW(dns_random_init("", true), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(test_dns_random_uninit) {
+
+  /* should still work without the explicit call to dns_random_init() */
+  ::arg().set("rng")="auto";
+  ::arg().set("entropy-source")="/dev/urandom";
+
+  acc_t acc;
+
+  for(unsigned int n=0; n < 100000; ++n)  {
+    acc(dns_random(100000)/100000.0);
+  }
+  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
+  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
+
+  // please add covariance tests, chi-square, Kolmogorov-Smirnov
+}
+
+#if defined(HAVE_GETRANDOM)
+BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+
+  ::arg().set("rng")="getrandom";
+  ::arg().set("entropy-source")="/dev/urandom";
+
+  dns_random_init("", true);
+
+  acc_t acc;
+
+  for(unsigned int n=0; n < 100000; ++n)  {
+    acc(dns_random(100000)/100000.0);
+  }
+  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
+  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
+
+  // please add covariance tests, chi-square, Kolmogorov-Smirnov
+}
+#endif
+
+#if defined(HAVE_ARC4RANDOM)
+BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+
+  ::arg().set("rng")="arc4random";
+  ::arg().set("entropy-source")="/dev/urandom";
+
+  dns_random_init("", true);
+
+  acc_t acc;
+
+  for(unsigned int n=0; n < 100000; ++n)  {
+    acc(dns_random(100000)/100000.0);
+  }
+  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
+  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
+
+  // please add covariance tests, chi-square, Kolmogorov-Smirnov
+}
+#endif
+
+#if defined(HAVE_RANDOMBYTES_STIR)
+BOOST_AUTO_TEST_CASE(test_dns_random_sodium_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+
+  ::arg().set("rng")="sodium";
+  ::arg().set("entropy-source")="/dev/urandom";
+
+  dns_random_init("", true);
+
+  acc_t acc;
+
+  for(unsigned int n=0; n < 100000; ++n)  {
+    acc(dns_random(100000)/100000.0);
+  }
+  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
+  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
+
+  // please add covariance tests, chi-square, Kolmogorov-Smirnov
+}
+#endif
+
+#if defined(HAVE_RAND_BYTES)
+BOOST_AUTO_TEST_CASE(test_dns_random_openssl_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+
+  ::arg().set("rng")="openssl";
+  ::arg().set("entropy-source")="/dev/urandom";
+
+  dns_random_init("", true);
+
+  acc_t acc;
+
+  for(unsigned int n=0; n < 100000; ++n)  {
+    acc(dns_random(100000)/100000.0);
+  }
+  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
+  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
+
+  // please add covariance tests, chi-square, Kolmogorov-Smirnov
+}
+#endif
+
+#if defined(HAVE_KISS_RNG)
+BOOST_AUTO_TEST_CASE(test_dns_random_kiss_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+
+  ::arg().set("rng")="kiss";
+  ::arg().set("entropy-source")="/dev/urandom";
+
+  dns_random_init("", true);
+
+  acc_t acc;
+
+  for(unsigned int n=0; n < 100000; ++n)  {
+    acc(dns_random(100000)/100000.0);
+  }
+  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
+  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
+
+  // please add covariance tests, chi-square, Kolmogorov-Smirnov
+}
+#endif
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -34,7 +34,7 @@ typedef accumulator_set<
 
 BOOST_AUTO_TEST_SUITE(test_dns_random_hh)
 
-BOOST_AUTO_TEST_CASE(test_dns_random_auto_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+BOOST_AUTO_TEST_CASE(test_dns_random_auto_average) {
 
   ::arg().set("rng")="auto";
   ::arg().set("entropy-source")="/dev/urandom";
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(test_dns_random_auto_average, * boost::unit_test::depends_o
   // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
 
-BOOST_AUTO_TEST_CASE(test_dns_random_urandom_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+BOOST_AUTO_TEST_CASE(test_dns_random_urandom_average) {
 
   ::arg().set("rng")="urandom";
   ::arg().set("entropy-source")="/dev/urandom";
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(test_dns_random_urandom_average, * boost::unit_test::depend
   // please add covariance tests, chi-square, Kolmogorov-Smirnov
 }
 
-BOOST_AUTO_TEST_CASE(test_dns_random_garbage, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+BOOST_AUTO_TEST_CASE(test_dns_random_garbage) {
 
   ::arg().set("rng")="garbage";
   ::arg().set("entropy-source")="/dev/urandom";
@@ -78,25 +78,8 @@ BOOST_AUTO_TEST_CASE(test_dns_random_garbage, * boost::unit_test::depends_on("te
   BOOST_CHECK_THROW(dns_random_init("", true), std::runtime_error);
 }
 
-BOOST_AUTO_TEST_CASE(test_dns_random_uninit) {
-
-  /* should still work without the explicit call to dns_random_init() */
-  ::arg().set("rng")="auto";
-  ::arg().set("entropy-source")="/dev/urandom";
-
-  acc_t acc;
-
-  for(unsigned int n=0; n < 100000; ++n)  {
-    acc(dns_random(100000)/100000.0);
-  }
-  BOOST_CHECK_CLOSE(0.5, median(acc), 2.0); // within 2%
-  BOOST_CHECK_CLOSE(0.5, mean(acc), 2.0);
-
-  // please add covariance tests, chi-square, Kolmogorov-Smirnov
-}
-
 #if defined(HAVE_GETRANDOM)
-BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average) {
 
   ::arg().set("rng")="getrandom";
   ::arg().set("entropy-source")="/dev/urandom";
@@ -116,7 +99,7 @@ BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average, * boost::unit_test::depe
 #endif
 
 #if defined(HAVE_ARC4RANDOM)
-BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average) {
 
   ::arg().set("rng")="arc4random";
   ::arg().set("entropy-source")="/dev/urandom";
@@ -136,7 +119,7 @@ BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average, * boost::unit_test::depe
 #endif
 
 #if defined(HAVE_RANDOMBYTES_STIR)
-BOOST_AUTO_TEST_CASE(test_dns_random_sodium_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+BOOST_AUTO_TEST_CASE(test_dns_random_sodium_average) {
 
   ::arg().set("rng")="sodium";
   ::arg().set("entropy-source")="/dev/urandom";
@@ -156,7 +139,7 @@ BOOST_AUTO_TEST_CASE(test_dns_random_sodium_average, * boost::unit_test::depends
 #endif
 
 #if defined(HAVE_RAND_BYTES)
-BOOST_AUTO_TEST_CASE(test_dns_random_openssl_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+BOOST_AUTO_TEST_CASE(test_dns_random_openssl_average) {
 
   ::arg().set("rng")="openssl";
   ::arg().set("entropy-source")="/dev/urandom";
@@ -176,7 +159,7 @@ BOOST_AUTO_TEST_CASE(test_dns_random_openssl_average, * boost::unit_test::depend
 #endif
 
 #if defined(HAVE_KISS_RNG)
-BOOST_AUTO_TEST_CASE(test_dns_random_kiss_average, * boost::unit_test::depends_on("test_dns_random_hh/test_dns_random_uninit")) {
+BOOST_AUTO_TEST_CASE(test_dns_random_kiss_average) {
 
   ::arg().set("rng")="kiss";
   ::arg().set("entropy-source")="/dev/urandom";


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Don't force the use of the `urandom` backend in the unit tests
- Raise a `runtime_error` instead of a `PDNSException` since it was the existing behavior and it makes more sense anyway
- Test all available backends by allowing to force the re-initialization

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
