### PR TITLE
Add return 0 for correct exit of set-kind and set-account

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2379,6 +2379,7 @@ try
   else if(cmds[0]=="set-kind") {
     if(cmds.size() != 3) {
       cerr<<"Syntax: pdnsutil set-kind ZONE KIND"<<endl;
+      return 0;
     }
     DNSName zone(cmds[1]);
     auto kind=DomainInfo::stringToKind(cmds[2]);
@@ -2387,6 +2388,7 @@ try
   else if(cmds[0]=="set-account") {
     if(cmds.size() != 3) {
       cerr<<"Syntax: pdnsutil set-account ZONE ACCOUNT"<<endl;
+      return 0;
     }
     DNSName zone(cmds[1]);
     exit(setZoneAccount(zone, cmds[2]));


### PR DESCRIPTION


### Short description
Fixes #6471

### Checklist
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
