### PR TITLE
recheck serial when AXFR is done

### DIFF
--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -125,8 +125,17 @@ void CommunicatorClass::mainloop(void)
       while(time(0) < next) {
         rc=d_any_sem.tryWait();
 
-        if(rc)
+        if(rc) {
+          bool extraSlaveRefresh = false;
           Utility::sleep(1);
+          {
+            Lock l(&d_lock);
+            if (d_tocheck.size())
+              extraSlaveRefresh = true;
+          }
+          if (extraSlaveRefresh)
+            slaveRefresh(&P);
+        }
         else { 
           break; // something happened
         }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -802,6 +802,8 @@ int PacketHandler::processNotify(DNSPacket *p)
      if master is higher -> do stuff
   */
 
+  g_log<<Logger::Debug<<"Received NOTIFY for "<<p->qdomain<<" from "<<p->getRemote()<<endl;
+
   if(!::arg().mustDo("slave") && s_forwardNotify.empty()) {
     g_log<<Logger::Warning<<"Received NOTIFY for "<<p->qdomain<<" from "<<p->getRemote()<<" but slave support is disabled in the configuration"<<endl;
     return RCode::Refused;
@@ -868,8 +870,10 @@ int PacketHandler::processNotify(DNSPacket *p)
     }
   }
 
-  if(::arg().mustDo("slave"))
+  if(::arg().mustDo("slave")) {
+    g_log<<Logger::Debug<<"Queueing slave check for "<<p->qdomain<<endl;
     Communicator.addSlaveCheckRequest(di, p->d_remote);
+  }
   return 0;
 }
 


### PR DESCRIPTION
### Short description
When a slave receives a NOTIFY, it (if the serial check says it should) re-transfers the zone. If additional NOTIFYs come in during the transfer, those are acknowledged, even if they mean that the zone we are transferring is not the latest version. With this patch, we will recheck the serial when the transfer is done and, if necessary, do another transfer to make sure are truly up to date with the master.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
