### PR TITLE
Update dns64.rst

### DIFF
--- a/pdns/recursordist/docs/dns64.rst
+++ b/pdns/recursordist/docs/dns64.rst
@@ -24,4 +24,4 @@ To setup DNS64, with both forward and reverse records, create the following Lua 
 Where fe80::21b::77ff:0:0 is your "Pref64" translation prefix and the "ip6.arpa" string is the reversed form of this Pref64 address.
 Now ensure your script gets loaded by specifying it with :ref:`lua-dns-script=dns64.lua <setting-lua-dns-script>`.
 
-To enhance DNS64, see the `Lua scripting <lua-scripting/index>` documentation.
+To enhance DNS64, see the :doc:`lua-scripting/index` documentation.


### PR DESCRIPTION
Provide the same link below as in the middle of the document. Currently renders as "To enhance DNS64, see the Lua scripting <lua-scripting/index> documentation." with no actual link on https://doc.powerdns.com/recursor/dns64.html
