### PR TITLE
auth: Link dnspcap2protobuf against librt when needed

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1179,7 +1179,8 @@ dnspcap2protobuf_LDFLAGS = \
 dnspcap2protobuf_LDADD = \
 	$(LIBCRYPTO_LIBS) \
 	$(PROTOBUF_LIBS) \
-	$(BOOST_PROGRAM_OPTIONS_LIBS)
+	$(BOOST_PROGRAM_OPTIONS_LIBS) \
+	$(RT_LIBS)
 endif
 endif
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We correctly add `RT_LIBS` to most programs using `clock_gettime()`, directly or not, but we forgot `dnspcap2protobuf`. Should fix #6482.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
