### PR TITLE
Remove very-long-txt from "to sql" for mydns test

### DIFF
--- a/regression-tests/backends/mydns-master
+++ b/regression-tests/backends/mydns-master
@@ -11,7 +11,7 @@ case $context in
 		mysql --user="$MYDNSUSER" --password="$MYDNSPASSWD" --host="$MYDNSHOST" \
 			"$MYDNSDB" < ../modules/mydnsbackend/schema.mydns.sql
 
-		tosql mydns | grep -v 'double\.example\.com' | mysql --user="$MYDNSUSER" --password="$MYDNSPASSWD" --host="$MYDNSHOST" \
+		tosql mydns | grep -v 'double\.example\.com' | grep -v 'very-long-txt\.test\.com' | mysql --user="$MYDNSUSER" --password="$MYDNSPASSWD" --host="$MYDNSHOST" \
 			"$MYDNSDB"
 
 		cat > pdns-mydns.conf << __EOF__


### PR DESCRIPTION

### Short description
The MyDNS database doesn't support more data then 128 chars, this simply filters out the data import. The very-long-txt test was already excluded using fail.mydns file.

### Checklist
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
