### PR TITLE
only parse resolv.conf once - this avoids race conditions

### DIFF
--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -30,8 +30,6 @@ void AuthLua4::postLoad()
 #include "ext/luawrapper/include/LuaContext.hpp"
 
 void AuthLua4::postPrepareContext() {
-  stubParseResolveConf();
-
   d_lw->writeFunction("resolve", [](const std::string& qname, uint16_t qtype) {
       std::vector<DNSZoneRecord> ret;
       std::unordered_map<int, DNSResourceRecord> luaResult;

--- a/pdns/stubresolver.cc
+++ b/pdns/stubresolver.cc
@@ -94,6 +94,8 @@ static void parseLocalResolvConf()
  * First, parse the `resolver` configuration option for IP addresses to use.
  * If that doesn't work, parse /etc/resolv.conf and add those nameservers to
  * s_resolversForStub.
+ *
+ * mainthread() calls this so you don't have to.
  */
 void stubParseResolveConf()
 {


### PR DESCRIPTION
### Short description
@goestreicher ran into crashes because AuthLua4 again tells us to parse resolv.conf (and add the results to a global vector). This PR fixes that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
