### PR TITLE
#3814 - Add question for to increase-soa after non SOA edit

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -919,6 +919,10 @@ int editZone(DNSSECKeeper& dk, const DNSName &zone) {
     str<<"\033[0;32m+"<< d.d_name <<" "<<d.d_ttl<<" IN "<<DNSRecordContent::NumberToType(d.d_type)<<" "<<d.d_content->getZoneRepresentation(true)<<"\033[0m"<<endl;
     changed[{d.d_name,d.d_type}]+=str.str();
   }
+  cout<<"Detected the following changes:"<<endl;
+  for(const auto& c : changed) {
+    cout<<c.second;
+  }
   if (changed.size() > 0) {
     if (changed.find({zone, QType::SOA}) == changed.end()) {
       cout<<endl<<"You have not updated the SOA record! Would you like to increase-serial?"<<endl;
@@ -959,12 +963,8 @@ int editZone(DNSSECKeeper& dk, const DNSName &zone) {
           break;
       }
     }
-    cout<<"Detected the following changes:"<<endl;
-    for(const auto& c : changed) {
-      cout<<c.second;
-    }
   }
- reAsk2:;
+  reAsk2:;
   if(changed.empty()) {
     cout<<endl<<"No changes to apply."<<endl;
     return(EXIT_SUCCESS);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -919,10 +919,50 @@ int editZone(DNSSECKeeper& dk, const DNSName &zone) {
     str<<"\033[0;32m+"<< d.d_name <<" "<<d.d_ttl<<" IN "<<DNSRecordContent::NumberToType(d.d_type)<<" "<<d.d_content->getZoneRepresentation(true)<<"\033[0m"<<endl;
     changed[{d.d_name,d.d_type}]+=str.str();
   }
-  if (changed.size() > 0)
+  if (changed.size() > 0) {
+    if (changed.find({zone, QType::SOA}) == changed.end()) {
+      cout<<endl<<"You have not updated the SOA record! Would you like to increase-serial?"<<endl;
+      cout<<"(y)es - increase serial, (n)o - leave SOA record as is, (e)dit your changes, (q)uit:"<<endl;
+      int c = read1char();
+      switch(c) {
+        case 'y':
+          {
+            DNSRecord oldSoaDR = grouped[{zone, QType::SOA}].at(0); // there should be only one SOA record, so we can use .at(0);
+            ostringstream str;
+            str<<"\033[0;31m-"<< oldSoaDR.d_name <<" "<<oldSoaDR.d_ttl<<" IN "<<DNSRecordContent::NumberToType(oldSoaDR.d_type)<<" "<<oldSoaDR.d_content->getZoneRepresentation(true)<<"\033[0m"<<endl;
+
+            SOAData sd;
+            B.getSOAUncached(zone, sd);
+            // TODO: do we need to check for presigned? here or maybe even all the way before edit-zone starts?
+
+            string soaEditKind;
+            dk.getSoaEdit(zone, soaEditKind);
+
+            DNSResourceRecord rr;
+            makeIncreasedSOARecord(sd, "SOA-EDIT-INCREASE", soaEditKind, rr);
+            DNSRecord dr(rr);
+            str<<"\033[0;32m+"<< dr.d_name <<" "<<dr.d_ttl<<" IN "<<DNSRecordContent::NumberToType(dr.d_type)<<" "<<dr.d_content->getZoneRepresentation(true)<<"\033[0m"<<endl;
+
+            changed[{dr.d_name, dr.d_type}]+=str.str();
+            grouped[{dr.d_name, dr.d_type}].at(0) = dr;
+          }
+        break;
+        case 'q':
+          return EXIT_FAILURE;
+          break;
+        case 'e':
+          goto editAgain;
+          break;
+        case 'n':
+        default:
+          goto reAsk2;
+          break;
+      }
+    }
     cout<<"Detected the following changes:"<<endl;
-  for(const auto& c : changed) {
-    cout<<c.second;
+    for(const auto& c : changed) {
+      cout<<c.second;
+    }
   }
  reAsk2:;
   if(changed.empty()) {


### PR DESCRIPTION
### Short description
First stab at #3814.
Simple implementation that does simple SOA change detection. Should work for most people
who just want to let increase-serial do the work.

Logic to increase serial is not centralized and it does not detect if the SERIAL has changed in the SOA. It just looks for a change of the SOA record in general.

I'm happy to also look at the rework of the increase-serial in general, but will need some guidance on that...

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
