### PR TITLE
configure: Fix lua2 check for lua existence

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,8 +238,8 @@ AM_CONDITIONAL([SQLITE3], [test "x$needsqlite3" = "xyes"])
 for a in $modules; do
   AC_MSG_CHECKING([whether we can build module "${a}"])
   AS_IF([test "x$a" = "xlua2"], [
-     AS_IF([test "x$with_lua" != "xyes"],
-           AC_MSG_ERROR([Cannot build lua2 module without lua]),[])
+     AS_IF([test "x$LUAPC" = "x"],
+           AC_MSG_ERROR([Cannot build lua2 module without lua (with_lua=$with_lua)]),[])
   ])
   if [[ -d "$srcdir/modules/${a}backend" ]]; then
     AC_MSG_RESULT([yes])


### PR DESCRIPTION
### Short description
Fix lua2 check for Lua existence. Seems with_lua can be auto too, so check if LUAPC is empty instead.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)