### PR TITLE
dnsbackend: Make isMaster a const

### DIFF
--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -87,7 +87,7 @@ struct DomainInfo
       return DomainInfo::Native;
   }
 
-  const bool isMaster(const ComboAddress& ip)
+  bool isMaster(const ComboAddress& ip) const
   {
     for( const auto& master: masters) {
       if(ComboAddress::addressOnlyEqual()(ip, master))


### PR DESCRIPTION
### Short description
The const keyword fell to wrong side of the function, so move it where it belongs to.

Broken in a2dfc9ea78614a9eef514a612117e507d70d4664

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)