### PR TITLE
Implement #6173

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -337,6 +337,17 @@ Name to insert in the SOA record if none set in the backend.
 Use this soa-edit value for all zones if no
 :ref:`metadata-soa-edit` metadata value is set.
 
+
+.. _setting-default-soa-edit-api
+``default-soa-edit-api``
+------------------------
+
+- String
+- Default 
+
+Sets the default :ref:`metadata-soa-edit-api` metadata on a domain, when it is created via the API.
+
+
 .. _setting-default-soa-edit-signed:
 
 ``default-soa-edit-signed``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1523,7 +1523,7 @@ The plaintext password required for accessing the webserver.
 ------------------
 
 -  Integer
--  Default: 8001
+-  Default: 8081
 
 The port where webserver/API will listen on.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -338,15 +338,18 @@ Use this soa-edit value for all zones if no
 :ref:`metadata-soa-edit` metadata value is set.
 
 
-.. _setting-default-soa-edit-api
+.. _setting-default-soa-edit-api:
+
 ``default-soa-edit-api``
 ------------------------
 
 - String
 - Default 
 
-Sets the default :ref:`metadata-soa-edit-api` metadata on a domain, when it is created via the API.
-
+Sets the default :ref:`metadata-soa-edit-api` metadata on a domain,
+when it is created via the API. If the value is empty, no :ref:`metadata-soa-edit-api`
+will be set. If soa-edit-api is provided in the request body (of the create request), then the 
+provided soa-edit-api is used.
 
 .. _setting-default-soa-edit-signed:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1020,6 +1020,7 @@ restarts, but it may also mask configuration issues and for this reason
 it is disabled by default.
 
 .. _setting-rng:
+
 ``rng``
 -------
 
@@ -1361,14 +1362,14 @@ and :doc:`Virtual Hosting <guides/virtual-instances>` how this can differ.
 .. _setting-supermaster:
 
 ``supermaster``
-------------
+---------------
 
 -  Boolean
 -  Default: no
 
 .. versionadded:: 4.2.0
 
-Turn on supermaster support. See :ref:`supemaster-operation`.
+Turn on supermaster support. See :ref:`supermaster-operation`.
 
 .. _setting-tcp-control-address:
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -155,7 +155,7 @@ void declareArguments()
   ::arg().set("soa-retry-default","Default SOA retry")="3600";
   ::arg().set("soa-expire-default","Default SOA expire")="604800";
   ::arg().set("default-soa-edit","Default SOA-EDIT value")="";
-  ::arg().set("default-soa-edit-api","Default SOA-EDIT-API value")="DEFAULT";
+  ::arg().set("default-soa-edit-api","Default SOA-EDIT-API value")="";
   ::arg().set("default-soa-edit-signed","Default SOA-EDIT value for signed zones")="";
   ::arg().set("dnssec-key-cache-ttl","Seconds to cache DNSSEC keys from the database")="30";
   ::arg().set("domain-metadata-cache-ttl","Seconds to cache domain metadata from the database")="60";

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -155,6 +155,7 @@ void declareArguments()
   ::arg().set("soa-retry-default","Default SOA retry")="3600";
   ::arg().set("soa-expire-default","Default SOA expire")="604800";
   ::arg().set("default-soa-edit","Default SOA-EDIT value")="";
+  ::arg().set("default-soa-edit-api","Default SOA-EDIT-API value")="";
   ::arg().set("default-soa-edit-signed","Default SOA-EDIT value for signed zones")="";
   ::arg().set("dnssec-key-cache-ttl","Seconds to cache DNSSEC keys from the database")="30";
   ::arg().set("domain-metadata-cache-ttl","Seconds to cache domain metadata from the database")="60";

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -155,7 +155,7 @@ void declareArguments()
   ::arg().set("soa-retry-default","Default SOA retry")="3600";
   ::arg().set("soa-expire-default","Default SOA expire")="604800";
   ::arg().set("default-soa-edit","Default SOA-EDIT value")="";
-  ::arg().set("default-soa-edit-api","Default SOA-EDIT-API value")="";
+  ::arg().set("default-soa-edit-api","Default SOA-EDIT-API value")="DEFAULT";
   ::arg().set("default-soa-edit-signed","Default SOA-EDIT value for signed zones")="";
   ::arg().set("dnssec-key-cache-ttl","Seconds to cache DNSSEC keys from the database")="30";
   ::arg().set("domain-metadata-cache-ttl","Seconds to cache domain metadata from the database")="60";

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -568,6 +568,10 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
   if (document["kind"].is_string()) {
     di.backend->setKind(zonename, DomainInfo::stringToKind(stringFromJson(document, "kind")));
   }
+  
+  if (arg()["default-soa-edit-api"] != "" && !document["soa_edit_api"].is_string()) {
+    di.backend->setDomainMetadataOne(zonename, "SOA-EDIT-API", arg()["default-soa-edit-api"]);   
+  }
   if (document["soa_edit_api"].is_string()) {
     di.backend->setDomainMetadataOne(zonename, "SOA-EDIT-API", document["soa_edit_api"].string_value());
   }

--- a/regression-tests.api/runtests
+++ b/regression-tests.api/runtests
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# This scripts starts the API tests.
+# To run these tests, you'll need to compile pdns-auth with gsqlite3 and bind module
 
 if [ ! -d .venv ]; then
   if [ -z "$PYTHON" ]; then

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Shell-script style.
+# If you're here to figure out how to run these test, see runtests (without the .py extension)
 
 from __future__ import print_function
 import os


### PR DESCRIPTION
### Short description
This adds very simple default-soa-edit-api support, which is requested in #6173 
I'm not sure if:
- we maybe should re-use default-soa-edit
- We should check for valid input (maybe soa-edit-api should be an enum or some sort to be able to parse it and validate that it's correct)
- The docs are good. I haven't gotten them working, but wanted to submit this pull request to get a review.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled and tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

