### PR TITLE
rec: Add an optional stack cache to MTasker

### DIFF
--- a/pdns/mtasker.hh
+++ b/pdns/mtasker.hh
@@ -25,6 +25,7 @@
 #include <queue>
 #include <vector>
 #include <map>
+#include <stack>
 #include <time.h>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -49,7 +50,10 @@ struct KeyTag {};
 
 template<class EventKey=int, class EventVal=int> class MTasker
 {
+  typedef std::unique_ptr<std::vector<char, lazy_allocator<char>>> pdns_mtasker_stack_t;
+
 private:
+  std::stack<pdns_mtasker_stack_t> d_freeStacks;
   pdns_ucontext_t d_kernel;
   std::queue<int> d_runQueue;
   std::queue<int> d_zombiesQueue;
@@ -71,6 +75,7 @@ private:
   int d_tid;
   int d_maxtid;
   size_t d_stacksize;
+  size_t d_maxFreeStacks;
 
   EventVal d_waitval;
   enum waitstatusenum {Error=-1,TimeOut=0,Answer} d_waitstatus;
@@ -110,7 +115,7 @@ public:
       This limit applies solely to the stack, the heap is not limited in any way. If threads need to allocate a lot of data,
       the use of new/delete is suggested. 
    */
-  MTasker(size_t stacksize=16*8192) : d_tid(0), d_maxtid(0), d_stacksize(stacksize), d_waitstatus(Error)
+  MTasker(size_t stacksize=16*8192, size_t maxFreeStacks=0) : d_tid(0), d_maxtid(0), d_stacksize(stacksize), d_maxFreeStacks(maxFreeStacks), d_waitstatus(Error)
   {
     initMainStackBounds();
   }

--- a/pdns/mtasker_context.hh
+++ b/pdns/mtasker_context.hh
@@ -29,12 +29,21 @@
 
 struct pdns_ucontext_t {
     pdns_ucontext_t ();
+    pdns_ucontext_t (std::unique_ptr<std::vector<char, lazy_allocator<char>>>&& stack);
     pdns_ucontext_t (pdns_ucontext_t const&) = delete;
     pdns_ucontext_t& operator= (pdns_ucontext_t const&) = delete;
     ~pdns_ucontext_t ();
 
+    std::vector<char, lazy_allocator<char>>& getStack()
+    {
+        if (uc_stack_ptr) {
+          return *uc_stack_ptr;
+        }
+        return uc_stack;
+    }
     void* uc_mcontext;
     pdns_ucontext_t* uc_link;
+    std::unique_ptr<std::vector<char, lazy_allocator<char>>> uc_stack_ptr{nullptr};
     std::vector<char, lazy_allocator<char>> uc_stack;
     std::exception_ptr exception;
 #ifdef PDNS_USE_VALGRIND

--- a/pdns/mtasker_fcontext.cc
+++ b/pdns/mtasker_fcontext.cc
@@ -164,7 +164,14 @@ threadWrapper (transfer_t const t) {
 }
 
 pdns_ucontext_t::pdns_ucontext_t
-(): uc_mcontext(nullptr), uc_link(nullptr) {
+(): uc_mcontext(nullptr), uc_link(nullptr), uc_stack_ptr(nullptr) {
+#ifdef PDNS_USE_VALGRIND
+  valgrind_id = 0;
+#endif /* PDNS_USE_VALGRIND */
+}
+
+pdns_ucontext_t::pdns_ucontext_t
+(std::unique_ptr<std::vector<char, lazy_allocator<char>>>&& stack): uc_mcontext(nullptr), uc_link(nullptr), uc_stack_ptr(std::move(stack)) {
 #ifdef PDNS_USE_VALGRIND
   valgrind_id = 0;
 #endif /* PDNS_USE_VALGRIND */
@@ -214,15 +221,16 @@ void
 pdns_makecontext
 (pdns_ucontext_t& ctx, boost::function<void(void)>& start) {
     assert (ctx.uc_link);
-    assert (ctx.uc_stack.size() >= 8192);
+    auto& stack = ctx.getStack();
+    assert (stack.size() >= 8192);
     assert (!ctx.uc_mcontext);
-    ctx.uc_mcontext = make_fcontext (&ctx.uc_stack[ctx.uc_stack.size()],
-                                     ctx.uc_stack.size(), &threadWrapper);
+    ctx.uc_mcontext = make_fcontext (&stack[stack.size()],
+                                     stack.size(), &threadWrapper);
     args_t args;
     args.self = &ctx;
     args.work = &start;
     /* jumping to threadwrapper */
-    notifyStackSwitch(&ctx.uc_stack[ctx.uc_stack.size()], ctx.uc_stack.size());
+    notifyStackSwitch(&stack[stack.size()], stack.size());
 #if BOOST_VERSION < 106100
     jump_fcontext (reinterpret_cast<fcontext_t*>(&args.prev_ctx),
                    static_cast<fcontext_t>(ctx.uc_mcontext),

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3413,7 +3413,7 @@ try
     t_servfailqueryring->set_capacity(ringsize);
   }
 
-  MT=std::unique_ptr<MTasker<PacketID,string> >(new MTasker<PacketID,string>(::arg().asNum("stack-size")));
+  MT=std::unique_ptr<MTasker<PacketID,string> >(new MTasker<PacketID,string>(::arg().asNum("stack-size"), ::arg().asNum("mtasker-stacks-cache-size")));
 
 #ifdef HAVE_PROTOBUF
   /* start protobuf export threads if needed */
@@ -3546,6 +3546,7 @@ int main(int argc, char **argv)
 
   try {
     ::arg().set("stack-size","stack size per mthread")="200000";
+    ::arg().set("mtasker-stacks-cache-size", "maximum number of free mthread stacks to keep in cache")="0";
     ::arg().set("soa-minimum-ttl","Don't change")="0";
     ::arg().set("no-shuffle","Don't change")="off";
     ::arg().set("local-port","port to listen on")="53";

--- a/pdns/recursordist/docs/performance.rst
+++ b/pdns/recursordist/docs/performance.rst
@@ -32,6 +32,16 @@ If ``SO_REUSEPORT`` support is available and :ref:`setting-reuseport` is set to 
 .. versionadded:: 4.1.0
    The :ref:`setting-cpu-map` parameter can be used to pin worker threads to specific CPUs, in order to keep caches as warm as possible and optimize memory access on NUMA systems.
 
+MTasker and MThreads
+--------------------
+
+PowerDNS Recursor uses a cooperative multitasking in userspace called ``MTasker``, based either on ``boost::context`` if available, or on ``System V ucontexts`` otherwise. For maximum performance, please make sure that your system supports ``boost::context``, as the alternative has been known to be quite slower.
+
+The maximum number of simultaneous MTasker threads, called ``MThreads``, can be tuned via :ref:`setting-max-mthreads`, as the default value of 2048 might not be enough for large-scale installations.
+
+When a ``MThread`` is started, a new stack is dynamically allocated for it on the heap. The size of those stacks can be configured via the :ref:`setting-stack-size` parameter, whose default value is 200k which should be enough in most cases.
+Modern memory allocators should be quite good at keeping released stacks around for a while in per-thread free list, making the allocation of a new stack very cheap. Still on older allocators, it might be helpful to maintain that free list directly inside the recursor, to make sure that the allocation stays cheap. This can be done via the :ref:`setting-mtasker-stacks-cache-size` setting, which configures the number of released stacks the recursor will keep in cache, ready to be reused again. The only trade-off of enabling this cache should be a slightly increased memory consumption, equals to the number of stacks specified by :ref:`setting-mtasker-stacks-cache-size` multiplied by the size of one stack, itself specified via :ref:`setting-stack-size`.
+
 Performance tips
 ----------------
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -779,6 +779,19 @@ This setting artificially raises all TTLs to be at least this long.
 While this is a gross hack, and violates RFCs, under conditions of DoS, it may enable you to continue serving your customers.
 Can be set at runtime using ``rec_control set-minimum-ttl 3600``.
 
+.. _setting-mtasker-stacks-cache-size:
+
+``mtasker-stacks-cache-size``
+------------------------
+.. versionadded:: 4.2.0
+
+-  Integer
+-  Default: 0 (disabled)
+
+This setting enables a cache for the stacks used by the recursor. When enabled, stacks are put into a free-list when
+a context is released until the number of available stacks reaches the configured value, and new contexts will reuse
+available stacks before allocating new ones.
+
 .. _setting-network-timeout:
 
 ``network-timeout``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -782,7 +782,7 @@ Can be set at runtime using ``rec_control set-minimum-ttl 3600``.
 .. _setting-mtasker-stacks-cache-size:
 
 ``mtasker-stacks-cache-size``
-------------------------
+-----------------------------
 .. versionadded:: 4.2.0
 
 -  Integer
@@ -885,6 +885,7 @@ If ``SO_REUSEPORT`` support is available, allows multiple processes to open a li
 Since 4.1.0, when ``pdns-distributes-queries`` is set to false and ``reuseport`` is enabled, every thread will open a separate listening socket to let the kernel distribute the incoming queries, avoiding any thundering herd issue as well as the distributor thread being a bottleneck, thus leading to much higher performance on multi-core boxes.
 
 .. _setting-rng:
+
 ``rng``
 -------
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The stack cache is disabled by default and can be enabled by setting `mtasker-stacks-cache-size` to a non-zero value. When the cache is enabled the internal vector is not used, and a new one is
dynamically allocated instead, to be able to store it into a per-MTasker free list when the context is released and then reuse it for a new context later.
Otherwise there should be no noticeable overhead.

Ideally the allocator should have a per-thread cache and save us the trouble. While it seems to be the case on recent (>= 2.26) glibc, it looks like older versions don't have a per-thread free-list, or at least not for so large objects. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
