### PR TITLE
rec: Add hashed indexes to the caches, for faster retrieval

### DIFF
--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -33,7 +33,7 @@ unsigned int MemRecursorCache::bytes() const
     ret+=sizeof(struct CacheEntry);
     ret+=(unsigned int)i.d_qname.toString().length();
     for(const auto& record : i.d_records)
-      ret+= sizeof(record); // XXX WRONG we don't know the stored size! j->size();
+      ret+= sizeof(record); // XXX WRONG we don't know the stored size!
   }
   return ret;
 }

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -35,7 +35,7 @@
  * \param ne       A NegCacheEntry that is filled when there is a cache entry
  * \return         true if ne was filled out, false otherwise
  */
-bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne) {
+bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, const NegCacheEntry** ne) {
   // Never deny the root.
   if (qname.isRoot())
     return false;
@@ -51,7 +51,7 @@ bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, N
          ni->d_qtype == qtnull) {
     // We have something
     if ((uint32_t)now.tv_sec < ni->d_ttd) {
-      ne = *ni;
+      *ne = &(*ni);
       moveCacheItemToBack(d_negcache, ni);
       return true;
     }
@@ -70,7 +70,7 @@ bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, N
  * \param ne       A NegCacheEntry that is filled when there is a cache entry
  * \return         true if ne was filled out, false otherwise
  */
-bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne, bool typeMustMatch) {
+bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeval& now, const NegCacheEntry** ne, bool typeMustMatch) {
   const auto& idx = d_negcache.get<2>();
   auto range = idx.equal_range(qname);
   auto ni = range.first;
@@ -83,7 +83,7 @@ bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeva
 
       if((uint32_t) now.tv_sec < ni->d_ttd) {
         // Not expired
-        ne = *ni;
+        *ne = &(*ni);
         moveCacheItemToBack(d_negcache, firstIndexIterator);
         return true;
       }

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -71,21 +71,24 @@ bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, N
  * \return         true if ne was filled out, false otherwise
  */
 bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne, bool typeMustMatch) {
-  auto range = d_negcache.equal_range(tie(qname));
-  negcache_t::iterator ni = range.first;
+  const auto& idx = d_negcache.get<2>();
+  auto range = idx.equal_range(qname);
+  auto ni = range.first;
 
   while (ni != range.second) {
     // We have an entry
     if ((!typeMustMatch && ni->d_qtype.getCode() == 0) || ni->d_qtype == qtype) {
       // We match the QType or the whole name is denied
+      auto firstIndexIterator = d_negcache.project<0>(ni);
+
       if((uint32_t) now.tv_sec < ni->d_ttd) {
         // Not expired
         ne = *ni;
-        moveCacheItemToBack(d_negcache, ni);
+        moveCacheItemToBack(d_negcache, firstIndexIterator);
         return true;
       }
       // expired
-      moveCacheItemToFront(d_negcache, ni);
+      moveCacheItemToFront(d_negcache, firstIndexIterator);
     }
     ++ni;
   }

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -60,8 +60,8 @@ class NegCache : public boost::noncopyable {
 
     void add(const NegCacheEntry& ne);
     void updateValidationStatus(const DNSName& qname, const QType& qtype, const vState newState);
-    bool get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne, bool typeMustMatch=false);
-    bool getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne);
+    bool get(const DNSName& qname, const QType& qtype, const struct timeval& now, const NegCacheEntry** ne, bool typeMustMatch=false);
+    bool getRootNXTrust(const DNSName& qname, const struct timeval& now, const NegCacheEntry** ne);
     uint64_t count(const DNSName& qname) const;
     uint64_t count(const DNSName& qname, const QType qtype) const;
     void prune(unsigned int maxEntries);

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
 #include "dnsparser.hh"
 #include "dnsname.hh"
 #include "dns.hh"
@@ -90,7 +91,10 @@ class NegCache : public boost::noncopyable {
             CanonDNSNameCompare, std::less<QType>
           >
         >,
-        sequenced<>
+        sequenced<>,
+        hashed_non_unique <
+          member<NegCacheEntry, DNSName, &NegCacheEntry::d_name>
+        >
       >
     > negcache_t;
 

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -57,13 +57,13 @@ BOOST_AUTO_TEST_CASE(test_get_entry) {
 
   BOOST_CHECK_EQUAL(cache.size(), 1);
 
-  NegCache::NegCacheEntry ne;
-  bool ret = cache.get(qname, QType(1), now, ne);
+  const NegCache::NegCacheEntry* ne = nullptr;
+  bool ret = cache.get(qname, QType(1), now, &ne);
 
   BOOST_CHECK(ret);
-  BOOST_CHECK_EQUAL(ne.d_name, qname);
-  BOOST_CHECK_EQUAL(ne.d_qtype.getName(), QType(0).getName());
-  BOOST_CHECK_EQUAL(ne.d_auth, auth);
+  BOOST_CHECK_EQUAL(ne->d_name, qname);
+  BOOST_CHECK_EQUAL(ne->d_qtype.getName(), QType(0).getName());
+  BOOST_CHECK_EQUAL(ne->d_auth, auth);
 }
 
 BOOST_AUTO_TEST_CASE(test_get_entry_exact_type) {
@@ -81,10 +81,11 @@ BOOST_AUTO_TEST_CASE(test_get_entry_exact_type) {
 
   BOOST_CHECK_EQUAL(cache.size(), 1);
 
-  NegCache::NegCacheEntry ne;
-  bool ret = cache.get(qname, QType(1), now, ne, true);
+  const NegCache::NegCacheEntry* ne = nullptr;
+  bool ret = cache.get(qname, QType(1), now, &ne, true);
 
   BOOST_CHECK_EQUAL(ret, false);
+  BOOST_CHECK(ne == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(test_get_NODATA_entry) {
@@ -99,17 +100,18 @@ BOOST_AUTO_TEST_CASE(test_get_NODATA_entry) {
 
   BOOST_CHECK_EQUAL(cache.size(), 1);
 
-  NegCache::NegCacheEntry ne;
-  bool ret = cache.get(qname, QType(1), now, ne);
+  const NegCache::NegCacheEntry* ne = nullptr;
+  bool ret = cache.get(qname, QType(1), now, &ne);
 
   BOOST_CHECK(ret);
-  BOOST_CHECK_EQUAL(ne.d_name, qname);
-  BOOST_CHECK_EQUAL(ne.d_qtype.getName(), QType(1).getName());
-  BOOST_CHECK_EQUAL(ne.d_auth, auth);
+  BOOST_CHECK_EQUAL(ne->d_name, qname);
+  BOOST_CHECK_EQUAL(ne->d_qtype.getName(), QType(1).getName());
+  BOOST_CHECK_EQUAL(ne->d_auth, auth);
 
-  NegCache::NegCacheEntry ne2;
-  ret = cache.get(qname, QType(16), now, ne2);
+  const NegCache::NegCacheEntry* ne2 = nullptr;
+  ret = cache.get(qname, QType(16), now, &ne2);
   BOOST_CHECK_EQUAL(ret, false);
+  BOOST_CHECK(ne2 == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(test_getRootNXTrust_entry) {
@@ -124,13 +126,13 @@ BOOST_AUTO_TEST_CASE(test_getRootNXTrust_entry) {
 
   BOOST_CHECK_EQUAL(cache.size(), 1);
 
-  NegCache::NegCacheEntry ne;
-  bool ret = cache.getRootNXTrust(qname, now, ne);
+  const NegCache::NegCacheEntry* ne = nullptr;
+  bool ret = cache.getRootNXTrust(qname, now, &ne);
 
   BOOST_CHECK(ret);
-  BOOST_CHECK_EQUAL(ne.d_name, qname);
-  BOOST_CHECK_EQUAL(ne.d_qtype.getName(), QType(0).getName());
-  BOOST_CHECK_EQUAL(ne.d_auth, auth);
+  BOOST_CHECK_EQUAL(ne->d_name, qname);
+  BOOST_CHECK_EQUAL(ne->d_qtype.getName(), QType(0).getName());
+  BOOST_CHECK_EQUAL(ne->d_auth, auth);
 }
 
 BOOST_AUTO_TEST_CASE(test_add_and_get_expired_entry) {
@@ -146,15 +148,13 @@ BOOST_AUTO_TEST_CASE(test_add_and_get_expired_entry) {
 
   BOOST_CHECK_EQUAL(cache.size(), 1);
 
-  NegCache::NegCacheEntry ne;
+  const NegCache::NegCacheEntry* ne = nullptr;
 
   now.tv_sec += 1000;
-  bool ret = cache.get(qname, QType(1), now, ne);
+  bool ret = cache.get(qname, QType(1), now, &ne);
 
   BOOST_CHECK_EQUAL(ret, false);
-  BOOST_CHECK_EQUAL(ne.d_name, DNSName());
-  BOOST_CHECK_EQUAL(ne.d_auth, DNSName());
-  BOOST_CHECK(ne.authoritySOA.records.empty());
+  BOOST_CHECK(ne == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(test_getRootNXTrust_expired_entry) {
@@ -170,15 +170,13 @@ BOOST_AUTO_TEST_CASE(test_getRootNXTrust_expired_entry) {
 
   BOOST_CHECK_EQUAL(cache.size(), 1);
 
-  NegCache::NegCacheEntry ne;
+  const NegCache::NegCacheEntry* ne = nullptr;
 
   now.tv_sec += 1000;
-  bool ret = cache.getRootNXTrust(qname, now, ne);
+  bool ret = cache.getRootNXTrust(qname, now, &ne);
 
   BOOST_CHECK_EQUAL(ret, false);
-  BOOST_CHECK_EQUAL(ne.d_name, DNSName());
-  BOOST_CHECK_EQUAL(ne.d_auth, DNSName());
-  BOOST_CHECK(ne.authoritySOA.records.empty());
+  BOOST_CHECK(ne == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(test_add_updated_entry) {
@@ -196,12 +194,12 @@ BOOST_AUTO_TEST_CASE(test_add_updated_entry) {
 
   BOOST_CHECK_EQUAL(cache.size(), 1);
 
-  NegCache::NegCacheEntry ne;
-  bool ret = cache.get(qname, QType(1), now, ne);
+  const NegCache::NegCacheEntry* ne = nullptr;
+  bool ret = cache.get(qname, QType(1), now, &ne);
 
   BOOST_CHECK(ret);
-  BOOST_CHECK_EQUAL(ne.d_name, qname);
-  BOOST_CHECK_EQUAL(ne.d_auth, auth2);
+  BOOST_CHECK_EQUAL(ne->d_name, qname);
+  BOOST_CHECK_EQUAL(ne->d_auth, auth2);
 }
 
 BOOST_AUTO_TEST_CASE(test_getRootNXTrust) {
@@ -217,12 +215,12 @@ BOOST_AUTO_TEST_CASE(test_getRootNXTrust) {
   cache.add(genNegCacheEntry(qname, auth, now));
   cache.add(genNegCacheEntry(qname2, auth2, now));
 
-  NegCache::NegCacheEntry ne;
-  bool ret = cache.getRootNXTrust(qname, now, ne);
+  const NegCache::NegCacheEntry* ne = nullptr;
+  bool ret = cache.getRootNXTrust(qname, now, &ne);
 
   BOOST_CHECK(ret);
-  BOOST_CHECK_EQUAL(ne.d_name, qname2);
-  BOOST_CHECK_EQUAL(ne.d_auth, auth2);
+  BOOST_CHECK_EQUAL(ne->d_name, qname2);
+  BOOST_CHECK_EQUAL(ne->d_auth, auth2);
 }
 
 BOOST_AUTO_TEST_CASE(test_getRootNXTrust_full_domain_only) {
@@ -238,10 +236,11 @@ BOOST_AUTO_TEST_CASE(test_getRootNXTrust_full_domain_only) {
   cache.add(genNegCacheEntry(qname, auth, now));
   cache.add(genNegCacheEntry(qname2, auth2, now, 1)); // Add the denial for COM|A
 
-  NegCache::NegCacheEntry ne;
-  bool ret = cache.getRootNXTrust(qname, now, ne);
+  const NegCache::NegCacheEntry* ne = nullptr;
+  bool ret = cache.getRootNXTrust(qname, now, &ne);
 
   BOOST_CHECK_EQUAL(ret, false);
+  BOOST_CHECK(ne == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(test_prune) {
@@ -288,22 +287,20 @@ BOOST_AUTO_TEST_CASE(test_wipe_single) {
   cache.wipe(auth);
   BOOST_CHECK_EQUAL(cache.size(), 400);
 
-  NegCache::NegCacheEntry ne2;
-  bool ret = cache.get(auth, QType(1), now, ne2);
+  const NegCache::NegCacheEntry* ne2 = nullptr;
+  bool ret = cache.get(auth, QType(1), now, &ne2);
 
   BOOST_CHECK_EQUAL(ret, false);
-  BOOST_CHECK_EQUAL(ne2.d_auth, DNSName());
-  BOOST_CHECK_EQUAL(ne2.d_name, DNSName());
+  BOOST_CHECK(ne2 == nullptr);
 
   cache.wipe(DNSName("1.powerdns.com"));
   BOOST_CHECK_EQUAL(cache.size(), 399);
 
-  NegCache::NegCacheEntry ne3;
-  ret = cache.get(auth, QType(1), now, ne3);
+  const NegCache::NegCacheEntry* ne3 = nullptr;
+  ret = cache.get(auth, QType(1), now, &ne3);
 
   BOOST_CHECK_EQUAL(ret, false);
-  BOOST_CHECK_EQUAL(ne3.d_auth, DNSName());
-  BOOST_CHECK_EQUAL(ne3.d_name, DNSName());
+  BOOST_CHECK(ne3 == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(test_wipe_subtree) {
@@ -369,8 +366,7 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile) {
   cache.add(genNegCacheEntry(DNSName("www1.powerdns.com"), DNSName("powerdns.com"), now));
   cache.add(genNegCacheEntry(DNSName("www2.powerdns.com"), DNSName("powerdns.com"), now));
 
-  FILE* fp;
-  fp = tmpfile();
+  FILE* fp = tmpfile();
   if (!fp)
     BOOST_FAIL("Temporary file could not be opened");
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -9003,15 +9003,15 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity) {
   BOOST_CHECK_EQUAL(queriesCount, 4);
 
   /* check that the entry has not been negatively cached for longer than the RRSIG validity */
-  NegCache::NegCacheEntry ne;
+  const NegCache::NegCacheEntry* ne = nullptr;
   BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
-  BOOST_CHECK_EQUAL(ne.d_ttd, now + 1);
-  BOOST_CHECK_EQUAL(ne.d_validationState, Secure);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.signatures.size(), 1);
+  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), &ne), true);
+  BOOST_CHECK_EQUAL(ne->d_ttd, now + 1);
+  BOOST_CHECK_EQUAL(ne->d_validationState, Secure);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.signatures.size(), 1);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.signatures.size(), 1);
 
   /* again, to test the cache */
   ret.clear();
@@ -9639,14 +9639,14 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure) {
   BOOST_REQUIRE_EQUAL(ret.size(), 4);
   BOOST_CHECK_EQUAL(queriesCount, 1);
   /* check that the entry has not been negatively cached */
-  NegCache::NegCacheEntry ne;
+  const NegCache::NegCacheEntry* ne = nullptr;
   BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
-  BOOST_CHECK_EQUAL(ne.d_validationState, Indeterminate);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.signatures.size(), 1);
+  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), &ne), true);
+  BOOST_CHECK_EQUAL(ne->d_validationState, Indeterminate);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.signatures.size(), 1);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.signatures.size(), 1);
 
   ret.clear();
   /* second one _does_ require validation */
@@ -9657,12 +9657,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure) {
   BOOST_REQUIRE_EQUAL(ret.size(), 4);
   BOOST_CHECK_EQUAL(queriesCount, 4);
   BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
-  BOOST_CHECK_EQUAL(ne.d_validationState, Secure);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.signatures.size(), 1);
+  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), &ne), true);
+  BOOST_CHECK_EQUAL(ne->d_validationState, Secure);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.signatures.size(), 1);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.signatures.size(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure_ds) {
@@ -9775,14 +9775,14 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_insecure) {
   BOOST_REQUIRE_EQUAL(ret.size(), 1);
   BOOST_CHECK_EQUAL(queriesCount, 1);
   /* check that the entry has not been negatively cached */
-  NegCache::NegCacheEntry ne;
+  const NegCache::NegCacheEntry* ne = nullptr;
   BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
-  BOOST_CHECK_EQUAL(ne.d_validationState, Indeterminate);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 0);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.records.size(), 0);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.signatures.size(), 0);
+  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), &ne), true);
+  BOOST_CHECK_EQUAL(ne->d_validationState, Indeterminate);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.signatures.size(), 0);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.records.size(), 0);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.signatures.size(), 0);
 
   ret.clear();
   /* second one _does_ require validation */
@@ -9792,12 +9792,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_insecure) {
   BOOST_CHECK_EQUAL(sr->getValidationState(), Insecure);
   BOOST_REQUIRE_EQUAL(ret.size(), 1);
   BOOST_CHECK_EQUAL(queriesCount, 1);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
-  BOOST_CHECK_EQUAL(ne.d_validationState, Insecure);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 0);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.records.size(), 0);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.signatures.size(), 0);
+  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), &ne), true);
+  BOOST_CHECK_EQUAL(ne->d_validationState, Insecure);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.signatures.size(), 0);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.records.size(), 0);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.signatures.size(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus) {
@@ -9852,14 +9852,14 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus) {
   BOOST_CHECK_EQUAL(sr->getValidationState(), Indeterminate);
   BOOST_REQUIRE_EQUAL(ret.size(), 2);
   BOOST_CHECK_EQUAL(queriesCount, 1);
-  NegCache::NegCacheEntry ne;
+  const NegCache::NegCacheEntry* ne = nullptr;
   BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
-  BOOST_CHECK_EQUAL(ne.d_validationState, Indeterminate);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.records.size(), 0);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.signatures.size(), 0);
+  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), &ne), true);
+  BOOST_CHECK_EQUAL(ne->d_validationState, Indeterminate);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.signatures.size(), 1);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.records.size(), 0);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.signatures.size(), 0);
 
   ret.clear();
   /* second one _does_ require validation */
@@ -9869,12 +9869,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus) {
   BOOST_CHECK_EQUAL(sr->getValidationState(), Bogus);
   BOOST_REQUIRE_EQUAL(ret.size(), 2);
   BOOST_CHECK_EQUAL(queriesCount, 4);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
-  BOOST_CHECK_EQUAL(ne.d_validationState, Bogus);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1);
-  BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.records.size(), 0);
-  BOOST_CHECK_EQUAL(ne.DNSSECRecords.signatures.size(), 0);
+  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), &ne), true);
+  BOOST_CHECK_EQUAL(ne->d_validationState, Bogus);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.records.size(), 1);
+  BOOST_CHECK_EQUAL(ne->authoritySOA.signatures.size(), 1);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.records.size(), 0);
+  BOOST_CHECK_EQUAL(ne->DNSSECRecords.signatures.size(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_lowercase_outgoing) {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -776,9 +776,9 @@ private:
   vState validateRecordsWithSigs(unsigned int depth, const DNSName& qname, const QType& qtype, const DNSName& name, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth);
   vState getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int depth);
-  dState getDenialValidationState(NegCache::NegCacheEntry& ne, const vState state, const dState expectedState, bool referralToUnsigned);
-  void updateDenialValidationState(NegCache::NegCacheEntry& ne, vState& state, const dState denialState, const dState expectedState, bool allowOptOut);
-  void computeNegCacheValidationStatus(NegCache::NegCacheEntry& ne, const DNSName& qname, const QType& qtype, const int res, vState& state, unsigned int depth);
+  dState getDenialValidationState(const NegCache::NegCacheEntry& ne, const vState state, const dState expectedState, bool referralToUnsigned);
+  void updateDenialValidationState(vState& neValidationState, const DNSName& neName, vState& state, const dState denialState, const dState expectedState, bool allowOptOut);
+  void computeNegCacheValidationStatus(const NegCache::NegCacheEntry* ne, const DNSName& qname, const QType& qtype, const int res, vState& state, unsigned int depth);
   vState getTA(const DNSName& zone, dsmap_t& ds);
   bool haveExactValidationStatus(const DNSName& domain);
   vState getValidationStatus(const DNSName& subdomain, bool allowIndeterminate=true);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Most of the lookups in the query (positive) and negative caches are done on the exact name only, and doing so using a hash is much more faster than using canonical ordering.
In both cases we still need canonical ordering to be able to wipe a domain and its subtree from the cache efficiently, but regular retrieval (cachecache, get()) doesn't.

Pros:
- Faster retrieval: ~8x faster

Cons:
- Increased memory usage: ~10% overhead worst case (entries with only one small record)
- Slower insertion: 1.08x slower

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
