### PR TITLE
rec: Add the possibility to preload RPZ from file, dump updates to a file

### DIFF
--- a/pdns/recursordist/docs/lua-config/rpz.rst
+++ b/pdns/recursordist/docs/lua-config/rpz.rst
@@ -112,6 +112,37 @@ axfrTimeout
 The timeout in seconds of the total initial AXFR transaction.
 20 by default.
 
+dumpFile
+^^^^^^^^
+.. versionadded:: 4.2.0
+
+A path to a file where the recursor will dump the latest version of the RPZ zone after
+each successful update. This can be used to keep track of changes in the RPZ zone, or
+to speed up the initial loading of the zone via the `seedFile`_ parameter.
+The format of the generated zone file is the same than the one used with :func:`rpzFile`,
+and can also be generated via:
+
+  rec_control dump-rpz *zone-name* *output-file*
+
+
+seedFile
+^^^^^^^^
+.. versionadded:: 4.2.0
+
+A path to a file containing an existing dump of the RPZ zone. The recursor will try to load
+the zone from this file on startup, then immediately do an IXFR to retrieve any updates.
+If the file does not exist or is not valid, the normal process of doing a full AXFR will
+be used instead.
+This option allows a faster startup by loading an existing zone from a file instead
+of retrieving it from the network, then retrieving only the needed updates via IXFR.
+The format of the zone file is the same than the one used with :func:`rpzFile`, and can
+for example be generated via:
+
+  rec_control dump-rpz *zone-name* *output-file*
+
+It is also possible to use the `dumpFile`_ parameter in order to dump the latest version
+of the RPZ zone after each update.
+
 Policy Actions
 --------------
 

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -287,7 +287,57 @@ static void setRPZZoneNewState(const std::string& zone, uint32_t serial, uint64_
   stats->d_numberOfRecords = numberOfRecords;
 }
 
-void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, std::shared_ptr<DNSFilterEngine::Zone> zone, const uint16_t axfrTimeout, std::shared_ptr<SOARecordContent> sr, uint64_t configGeneration)
+static bool dumpZoneToDisk(const DNSName& zoneName, const std::shared_ptr<DNSFilterEngine::Zone>& newZone, const std::string& dumpZoneFileName)
+{
+  std::string temp = dumpZoneFileName + "XXXXXX";
+  int fd = mkstemp(&temp.at(0));
+  if (fd < 0) {
+    g_log<<Logger::Warning<<"Unable to open a file to dump the content of the RPZ zone "<<zoneName.toLogString()<<endl;
+    return false;
+  }
+
+  FILE * fp = fdopen(fd, "w+");
+  if (fp == nullptr) {
+    close(fd);
+    g_log<<Logger::Warning<<"Unable to open a file pointer to dump the content of the RPZ zone "<<zoneName.toLogString()<<endl;
+    return false;
+  }
+
+  fd = -1;
+
+  try {
+    newZone->dump(fp);
+  }
+  catch(const std::exception& e) {
+    g_log<<Logger::Warning<<"Error while dumping the content of the RPZ zone "<<zoneName.toLogString()<<": "<<e.what()<<endl;
+    fclose(fp);
+    return false;
+  }
+
+  if (fflush(fp) != 0) {
+    g_log<<Logger::Warning<<"Error while flushing the content of the RPZ zone "<<zoneName.toLogString()<<" to the dump file: "<<strerror(errno)<<endl;
+    return false;
+  }
+
+  if (fsync(fileno(fp)) != 0) {
+    g_log<<Logger::Warning<<"Error while syncing the content of the RPZ zone "<<zoneName.toLogString()<<" to the dump file: "<<strerror(errno)<<endl;
+    return false;
+  }
+
+  if (fclose(fp) != 0) {
+    g_log<<Logger::Warning<<"Error while writing the content of the RPZ zone "<<zoneName.toLogString()<<" to the dump file: "<<strerror(errno)<<endl;
+    return false;
+  }
+
+  if (rename(temp.c_str(), dumpZoneFileName.c_str()) != 0) {
+    g_log<<Logger::Warning<<"Error while moving the content of the RPZ zone "<<zoneName.toLogString()<<" to the dump file: "<<strerror(errno)<<endl;
+    return false;
+  }
+
+  return true;
+}
+
+void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, std::shared_ptr<DNSFilterEngine::Zone> zone, const uint16_t axfrTimeout, std::shared_ptr<SOARecordContent> sr, std::string dumpZoneFileName, uint64_t configGeneration)
 {
   bool isPreloaded = sr != nullptr;
   uint32_t refresh = zone->getRefresh();
@@ -304,6 +354,10 @@ void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine:
       }
       zone->setSerial(sr->d_st.serial);
       setRPZZoneNewState(polName, sr->d_st.serial, zone->size(), true);
+
+      if (!dumpZoneFileName.empty()) {
+        dumpZoneToDisk(zoneName, zone, dumpZoneFileName);
+      }
     }
     catch(const std::exception& e) {
       g_log<<Logger::Warning<<"Unable to load RPZ zone '"<<zoneName<<"' from '"<<master<<"': '"<<e.what()<<"'. (Will try again in "<<(refresh > 0 ? refresh : 10)<<" seconds...)"<<endl;
@@ -423,5 +477,9 @@ void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine:
     g_luaconfs.modify([zoneIdx, &newZone](LuaConfigItems& lci) {
                         lci.dfe.setZone(zoneIdx, newZone);
                       });
+
+    if (!dumpZoneFileName.empty()) {
+      dumpZoneToDisk(zoneName, newZone, dumpZoneFileName);
+    }
   }
 }

--- a/pdns/rpzloader.hh
+++ b/pdns/rpzloader.hh
@@ -29,7 +29,7 @@ extern bool g_logRPZChanges;
 std::shared_ptr<SOARecordContent> loadRPZFromFile(const std::string& fname, std::shared_ptr<DNSFilterEngine::Zone> zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL);
 std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zoneName, std::shared_ptr<DNSFilterEngine::Zone> zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, const uint16_t axfrTimeout);
 void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngine::Zone> zone, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL);
-void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, std::shared_ptr<DNSFilterEngine::Zone> zone, const uint16_t axfrTimeout, shared_ptr<SOARecordContent> sr, uint64_t configGeneration);
+void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, std::shared_ptr<DNSFilterEngine::Zone> zone, const uint16_t axfrTimeout, shared_ptr<SOARecordContent> sr, std::string dumpZoneFileName, uint64_t configGeneration);
 
 struct rpzStats
 {

--- a/pdns/rpzloader.hh
+++ b/pdns/rpzloader.hh
@@ -26,10 +26,10 @@
 
 extern bool g_logRPZChanges;
 
-void loadRPZFromFile(const std::string& fname, std::shared_ptr<DNSFilterEngine::Zone> zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL);
+std::shared_ptr<SOARecordContent> loadRPZFromFile(const std::string& fname, std::shared_ptr<DNSFilterEngine::Zone> zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL);
 std::shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master, const DNSName& zoneName, std::shared_ptr<DNSFilterEngine::Zone> zone, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, const uint16_t axfrTimeout);
 void RPZRecordToPolicy(const DNSRecord& dr, std::shared_ptr<DNSFilterEngine::Zone> zone, bool addOrRemove, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL);
-void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t polZone, const TSIGTriplet &tt, size_t maxReceivedBytes, const ComboAddress& localAddress, std::shared_ptr<DNSFilterEngine::Zone> zone, uint16_t axfrTimeout, uint64_t configGeneration);
+void RPZIXFRTracker(const ComboAddress& master, boost::optional<DNSFilterEngine::Policy> defpol, uint32_t maxTTL, size_t zoneIdx, const TSIGTriplet& tt, size_t maxReceivedBytes, const ComboAddress& localAddress, std::shared_ptr<DNSFilterEngine::Zone> zone, const uint16_t axfrTimeout, shared_ptr<SOARecordContent> sr, uint64_t configGeneration);
 
 struct rpzStats
 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* Add `seedFile` to load `RPZ` zones from a file, then update via `IXFR`
* Add `dumpFile` so the latest version of the zone is dumped to a file after a successful `IXFR`

Need documentation, and ideally regression tests.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
