### PR TITLE
Remove compiler warnings pointed by Aki

### DIFF
--- a/modules/ldapbackend/ldapbackend.hh
+++ b/modules/ldapbackend/ldapbackend.hh
@@ -53,7 +53,7 @@ class LdapAuthenticator;
  *  Types which aren't active are currently not supported by PDNS
  */
 
-static const char* ldap_attrany[] = {
+__attribute__ ((unused)) static const char* ldap_attrany[] = {
   "associatedDomain",
   "dNSTTL",
   "ALIASRecord",

--- a/modules/ldapbackend/powerldap.cc
+++ b/modules/ldapbackend/powerldap.cc
@@ -32,7 +32,7 @@
 
 
 PowerLDAP::SearchResult::SearchResult( int msgid, LDAP* ld )
-  : d_msgid( msgid ), d_ld( ld ), d_finished( false )
+  : d_ld( ld ), d_msgid( msgid ), d_finished( false )
 {
 }
 
@@ -449,12 +449,12 @@ const string PowerLDAP::escape( const string& str )
   for( i = str.begin(); i != str.end(); i++ )
   {
       // RFC4515 3
-      if( *i == '*' ||
-          *i == '(' ||
-          *i == ')' ||
-          *i == '\\' ||
-          *i == '\0' ||
-          *i > 127)
+      if( (unsigned char)*i == '*' ||
+          (unsigned char)*i == '(' ||
+          (unsigned char)*i == ')' ||
+          (unsigned char)*i == '\\' ||
+          (unsigned char)*i == '\0' ||
+          (unsigned char)*i > 127)
       {
           sprintf(tmp,"\\%02x", (unsigned char)*i);
 


### PR DESCRIPTION
### Short description
As @cmouse pointed out, the LDAP backend generates a fair amount of compiler warning with certain options (that I didn't think to enable, my bad).

This PR removes them.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
