### PR TITLE
[WIP] luawrapper: work with luajit on ARM64

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -32,12 +32,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <limits>
 #include <list>
 #include <map>
 #include <memory>
+#include <iostream>
 #include <random>
 #include <set>
 #include <stdexcept>
@@ -97,9 +99,10 @@ public:
         // setting the panic function
         lua_atpanic(mState, [](lua_State* state) -> int {
             const std::string str = lua_tostring(state, -1);
+            std::cerr<<"lua panic: "<<str<<std::endl;
             lua_pop(state, 1);
             assert(false && "lua_atpanic triggered");
-            exit(0);
+            exit(EXIT_FAILURE);
         });
 
         // opening default library if required to do so

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -480,20 +480,20 @@ public:
     template<typename TType>
     void unregisterFunction(const std::string& /*functionName*/)
     {
-        lua_pushlightuserdata(mState, const_cast<std::type_info*>(&typeid(TType)));
+        lua_pushstring(mState, typeid(TType).name());
         lua_pushnil(mState);
         lua_settable(mState, LUA_REGISTRYINDEX);
-        checkTypeRegistration(mState, &typeid(TType));
+        checkTypeRegistration(mState, typeid(TType));
         
-        lua_pushlightuserdata(mState, const_cast<std::type_info*>(&typeid(TType*)));
+        lua_pushstring(mState, typeid(TType*).name());
         lua_pushnil(mState);
         lua_settable(mState, LUA_REGISTRYINDEX);
-        checkTypeRegistration(mState, &typeid(TType*));
+        checkTypeRegistration(mState, typeid(TType*));
         
-        lua_pushlightuserdata(mState, const_cast<std::type_info*>(&typeid(std::shared_ptr<TType>)));
+        lua_pushstring(mState, typeid(std::shared_ptr<TType>).name());
         lua_pushnil(mState);
         lua_settable(mState, LUA_REGISTRYINDEX);
-        checkTypeRegistration(mState, &typeid(std::shared_ptr<TType>));
+        checkTypeRegistration(mState, typeid(std::shared_ptr<TType>));
     }
     
     /**
@@ -1084,9 +1084,9 @@ private:
     }
 
     // checks that the offsets for a type's registrations are set in the registry
-    static void checkTypeRegistration(lua_State* state, const std::type_info* type)
+    static void checkTypeRegistration(lua_State* state, const std::type_info &type)
     {
-        lua_pushlightuserdata(state, const_cast<std::type_info*>(type));
+        lua_pushstring(state, type.name());
         lua_gettable(state, LUA_REGISTRYINDEX);
         if (!lua_isnil(state, -1)) {
             lua_pop(state, 1);
@@ -1094,7 +1094,7 @@ private:
         }
         lua_pop(state, 1);
 
-        lua_pushlightuserdata(state, const_cast<std::type_info*>(type));
+        lua_pushstring(state, type.name());
         lua_newtable(state);
 
         lua_pushinteger(state, 0);
@@ -1139,14 +1139,14 @@ private:
     {
         static_assert(std::is_class<TObject>::value || std::is_pointer<TObject>::value || std::is_union<TObject>::value , "registerFunction can only be used for a class a union or a pointer");
 
-        checkTypeRegistration(mState, &typeid(TObject));
-        setTable<TRetValue(TObject&, TOtherParams...)>(mState, Registry, &typeid(TObject), 0, functionName, function);
+        checkTypeRegistration(mState, typeid(TObject));
+        setTable<TRetValue(TObject&, TOtherParams...)>(mState, Registry, typeid(TObject).name(), 0, functionName, function);
         
-        checkTypeRegistration(mState, &typeid(TObject*));
-        setTable<TRetValue(TObject*, TOtherParams...)>(mState, Registry, &typeid(TObject*), 0, functionName, [=](TObject* obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
+        checkTypeRegistration(mState, typeid(TObject*));
+        setTable<TRetValue(TObject*, TOtherParams...)>(mState, Registry, typeid(TObject*).name(), 0, functionName, [=](TObject* obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
         
-        checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject>));
-        setTable<TRetValue(std::shared_ptr<TObject>, TOtherParams...)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 0, functionName, [=](const std::shared_ptr<TObject>& obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
+        checkTypeRegistration(mState, typeid(std::shared_ptr<TObject>));
+        setTable<TRetValue(std::shared_ptr<TObject>, TOtherParams...)>(mState, Registry, typeid(std::shared_ptr<TObject>).name(), 0, functionName, [=](const std::shared_ptr<TObject>& obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
     }
     
     template<typename TFunctionType, typename TRetValue, typename TObject, typename... TOtherParams>
@@ -1154,11 +1154,11 @@ private:
     {
         registerFunctionImpl(functionName, function, tag<TObject>{}, fTypeTag);
 
-        checkTypeRegistration(mState, &typeid(TObject const*));
-        setTable<TRetValue(TObject const*, TOtherParams...)>(mState, Registry, &typeid(TObject const*), 0, functionName, [=](TObject const* obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
+        checkTypeRegistration(mState, typeid(TObject const*));
+        setTable<TRetValue(TObject const*, TOtherParams...)>(mState, Registry, typeid(TObject const*).name(), 0, functionName, [=](TObject const* obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
         
-        checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject const>));
-        setTable<TRetValue(std::shared_ptr<TObject const>, TOtherParams...)>(mState, Registry, &typeid(std::shared_ptr<TObject const>), 0, functionName, [=](const std::shared_ptr<TObject const>& obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
+        checkTypeRegistration(mState, typeid(std::shared_ptr<TObject const>));
+        setTable<TRetValue(std::shared_ptr<TObject const>, TOtherParams...)>(mState, Registry, typeid(std::shared_ptr<TObject const>).name(), 0, functionName, [=](const std::shared_ptr<TObject const>& obj, TOtherParams... rest) { assert(obj); return function(*obj, std::forward<TOtherParams>(rest)...); });
     }
 
     template<typename TFunctionType, typename TRetValue, typename TObject, typename... TOtherParams>
@@ -1191,31 +1191,31 @@ private:
     {
         static_assert(std::is_class<TObject>::value || std::is_pointer<TObject>::value, "registerMember can only be called on a class or a pointer");
         
-        checkTypeRegistration(mState, &typeid(TObject));
-        setTable<TVarType (TObject&)>(mState, Registry, &typeid(TObject), 1, name, [readFunction](TObject const& object) {
+        checkTypeRegistration(mState, typeid(TObject));
+        setTable<TVarType (TObject&)>(mState, Registry, typeid(TObject).name(), 1, name, [readFunction](TObject const& object) {
             return readFunction(object);
         });
         
-        checkTypeRegistration(mState, &typeid(TObject*));
-        setTable<TVarType (TObject*)>(mState, Registry, &typeid(TObject*), 1, name, [readFunction](TObject const* object) {
+        checkTypeRegistration(mState, typeid(TObject*));
+        setTable<TVarType (TObject*)>(mState, Registry, typeid(TObject*).name(), 1, name, [readFunction](TObject const* object) {
             assert(object);
             return readFunction(*object);
         });
         
-        checkTypeRegistration(mState, &typeid(TObject const*));
-        setTable<TVarType (TObject const*)>(mState, Registry, &typeid(TObject const*), 1, name, [readFunction](TObject const* object) {
+        checkTypeRegistration(mState, typeid(TObject const*));
+        setTable<TVarType (TObject const*)>(mState, Registry, typeid(TObject const*).name(), 1, name, [readFunction](TObject const* object) {
             assert(object);
             return readFunction(*object);
         });
         
-        checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject>));
-        setTable<TVarType (std::shared_ptr<TObject>)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 1, name, [readFunction](const std::shared_ptr<TObject>& object) {
+        checkTypeRegistration(mState, typeid(std::shared_ptr<TObject>));
+        setTable<TVarType (std::shared_ptr<TObject>)>(mState, Registry, typeid(std::shared_ptr<TObject>).name(), 1, name, [readFunction](const std::shared_ptr<TObject>& object) {
             assert(object);
             return readFunction(*object);
         });
         
-        checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject const>));
-        setTable<TVarType (std::shared_ptr<TObject const>)>(mState, Registry, &typeid(std::shared_ptr<TObject const>), 1, name, [readFunction](const std::shared_ptr<TObject const>& object) {
+        checkTypeRegistration(mState, typeid(std::shared_ptr<TObject const>));
+        setTable<TVarType (std::shared_ptr<TObject const>)>(mState, Registry, typeid(std::shared_ptr<TObject const>).name(), 1, name, [readFunction](const std::shared_ptr<TObject const>& object) {
             assert(object);
             return readFunction(*object);
         });
@@ -1226,16 +1226,16 @@ private:
     {
         registerMemberImpl<TObject,TVarType>(name, readFunction);
 
-        setTable<void (TObject&, TVarType)>(mState, Registry, &typeid(TObject), 4, name, [writeFunction_](TObject& object, const TVarType& value) {
+        setTable<void (TObject&, TVarType)>(mState, Registry, typeid(TObject).name(), 4, name, [writeFunction_](TObject& object, const TVarType& value) {
             writeFunction_(object, value);
         });
         
-        setTable<void (TObject*, TVarType)>(mState, Registry, &typeid(TObject*), 4, name, [writeFunction_](TObject* object, const TVarType& value) {
+        setTable<void (TObject*, TVarType)>(mState, Registry, typeid(TObject*).name(), 4, name, [writeFunction_](TObject* object, const TVarType& value) {
             assert(object);
             writeFunction_(*object, value);
         });
         
-        setTable<void (std::shared_ptr<TObject>, TVarType)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 4, name, [writeFunction_](std::shared_ptr<TObject> object, const TVarType& value) {
+        setTable<void (std::shared_ptr<TObject>, TVarType)>(mState, Registry, typeid(std::shared_ptr<TObject>).name(), 4, name, [writeFunction_](std::shared_ptr<TObject> object, const TVarType& value) {
             assert(object);
             writeFunction_(*object, value);
         });
@@ -1257,31 +1257,31 @@ private:
     template<typename TObject, typename TVarType, typename TReadFunction>
     void registerMemberImpl(TReadFunction readFunction)
     {
-        checkTypeRegistration(mState, &typeid(TObject));
-        setTable<TVarType (TObject const&, std::string)>(mState, Registry, &typeid(TObject), 2, [readFunction](TObject const& object, const std::string& name) {
+        checkTypeRegistration(mState, typeid(TObject));
+        setTable<TVarType (TObject const&, std::string)>(mState, Registry, typeid(TObject).name(), 2, [readFunction](TObject const& object, const std::string& name) {
             return readFunction(object, name);
         });
         
-        checkTypeRegistration(mState, &typeid(TObject*));
-        setTable<TVarType (TObject*, std::string)>(mState, Registry, &typeid(TObject*), 2, [readFunction](TObject const* object, const std::string& name) {
+        checkTypeRegistration(mState, typeid(TObject*));
+        setTable<TVarType (TObject*, std::string)>(mState, Registry, typeid(TObject*).name(), 2, [readFunction](TObject const* object, const std::string& name) {
             assert(object);
             return readFunction(*object, name);
         });
         
-        checkTypeRegistration(mState, &typeid(TObject const*));
-        setTable<TVarType (TObject const*, std::string)>(mState, Registry, &typeid(TObject const*), 2, [readFunction](TObject const* object, const std::string& name) {
+        checkTypeRegistration(mState, typeid(TObject const*));
+        setTable<TVarType (TObject const*, std::string)>(mState, Registry, typeid(TObject const*).name(), 2, [readFunction](TObject const* object, const std::string& name) {
             assert(object);
             return readFunction(*object, name);
         });
         
-        checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject>));
-        setTable<TVarType (std::shared_ptr<TObject>, std::string)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 2, [readFunction](const std::shared_ptr<TObject>& object, const std::string& name) {
+        checkTypeRegistration(mState, typeid(std::shared_ptr<TObject>));
+        setTable<TVarType (std::shared_ptr<TObject>, std::string)>(mState, Registry, typeid(std::shared_ptr<TObject>).name(), 2, [readFunction](const std::shared_ptr<TObject>& object, const std::string& name) {
             assert(object);
             return readFunction(*object, name);
         });
         
-        checkTypeRegistration(mState, &typeid(std::shared_ptr<TObject const>));
-        setTable<TVarType (std::shared_ptr<TObject const>, std::string)>(mState, Registry, &typeid(std::shared_ptr<TObject const>), 2, [readFunction](const std::shared_ptr<TObject const>& object, const std::string& name) {
+        checkTypeRegistration(mState, typeid(std::shared_ptr<TObject const>));
+        setTable<TVarType (std::shared_ptr<TObject const>, std::string)>(mState, Registry, typeid(std::shared_ptr<TObject const>).name(), 2, [readFunction](const std::shared_ptr<TObject const>& object, const std::string& name) {
             assert(object);
             return readFunction(*object, name);
         });
@@ -1292,16 +1292,16 @@ private:
     {
         registerMemberImpl<TObject,TVarType>(readFunction);
 
-        setTable<void (TObject&, std::string, TVarType)>(mState, Registry, &typeid(TObject), 5, [writeFunction_](TObject& object, const std::string& name, const TVarType& value) {
+        setTable<void (TObject&, std::string, TVarType)>(mState, Registry, typeid(TObject).name(), 5, [writeFunction_](TObject& object, const std::string& name, const TVarType& value) {
             writeFunction_(object, name, value);
         });
         
-        setTable<void (TObject*, std::string, TVarType)>(mState, Registry, &typeid(TObject*), 2, [writeFunction_](TObject* object, const std::string& name, const TVarType& value) {
+        setTable<void (TObject*, std::string, TVarType)>(mState, Registry, typeid(TObject*).name(), 2, [writeFunction_](TObject* object, const std::string& name, const TVarType& value) {
             assert(object);
             writeFunction_(*object, name, value);
         });
         
-        setTable<void (std::shared_ptr<TObject>, std::string, TVarType)>(mState, Registry, &typeid(std::shared_ptr<TObject>), 2, [writeFunction_](const std::shared_ptr<TObject>& object, const std::string& name, const TVarType& value) {
+        setTable<void (std::shared_ptr<TObject>, std::string, TVarType)>(mState, Registry, typeid(std::shared_ptr<TObject>).name(), 2, [writeFunction_](const std::shared_ptr<TObject>& object, const std::string& name, const TVarType& value) {
             assert(object);
             writeFunction_(*object, name, value);
         });
@@ -1489,7 +1489,7 @@ private:
                     assert(lua_isuserdata(lua, 1));
 
                     // searching for a handler
-                    lua_pushlightuserdata(lua, const_cast<std::type_info*>(&typeid(TType)));
+                    lua_pushstring(lua, typeid(TType).name());
                     lua_gettable(lua, LUA_REGISTRYINDEX);
                     assert(!lua_isnil(lua, -1));
                     
@@ -1535,7 +1535,7 @@ private:
                     assert(lua_isuserdata(lua, 1));
 
                     // searching for a handler
-                    lua_pushlightuserdata(lua, const_cast<std::type_info*>(&typeid(TType)));
+                    lua_pushstring(lua, typeid(TType).name());
                     lua_rawget(lua, LUA_REGISTRYINDEX);
                     assert(!lua_isnil(lua, -1));
                     
@@ -1598,7 +1598,7 @@ private:
 
 
             // writing structure for this type into the registry
-            checkTypeRegistration(state, &typeid(TType));
+            checkTypeRegistration(state, typeid(TType));
 
             // creating the object
             // lua_newuserdata allocates memory in the internals of the lua library and returns it so we can fill it
@@ -1623,7 +1623,7 @@ private:
 
             // the _typeid index of the metatable will store the type_info*
             lua_pushstring(state, "_typeid");
-            lua_pushlightuserdata(state, const_cast<std::type_info*>(&typeid(TType)));
+            lua_pushstring(state, typeid(TType).name());
             lua_settable(state, -3);
 
             // using the index function we created above
@@ -1704,12 +1704,12 @@ private:
             // retrieving its _typeid member
             lua_pushstring(state, "_typeid");
             lua_gettable(state, -2);
-            const auto storedTypeID = static_cast<const std::type_info*>(lua_touserdata(state, -1));
-            const auto typeIDToCompare = &typeid(TType);
+            const auto storedTypeID = lua_tostring(state, -1);
+            const auto typeIDToCompare = typeid(TType).name();
 
             // if wrong typeid, returning false
             lua_pop(state, 2);
-            if (storedTypeID != typeIDToCompare)
+            if (strcmp(storedTypeID, typeIDToCompare))
                 return false;
 
             return true;

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2071,6 +2071,18 @@ struct LuaContext::Pusher<LuaContext::EmptyArray_t> {
     }
 };
 
+// std::type_info* is a lightuserdata
+template<>
+struct LuaContext::Pusher<const std::type_info*> {
+    static const int minSize = 1;
+    static const int maxSize = 1;
+
+    static PushedObject push(lua_State* state, const std::type_info* ptr) noexcept {
+        lua_pushlightuserdata(state, const_cast<std::type_info*>(ptr));
+        return PushedObject{state, 1};
+    }
+};
+
 // thread
 template<>
 struct LuaContext::Pusher<LuaContext::ThreadID> {

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2067,18 +2067,6 @@ struct LuaContext::Pusher<LuaContext::EmptyArray_t> {
     }
 };
 
-// std::type_info* is a lightuserdata
-template<>
-struct LuaContext::Pusher<const std::type_info*> {
-    static const int minSize = 1;
-    static const int maxSize = 1;
-
-    static PushedObject push(lua_State* state, const std::type_info* ptr) noexcept {
-        lua_pushlightuserdata(state, const_cast<std::type_info*>(ptr));
-        return PushedObject{state, 1};
-    }
-};
-
 // thread
 template<>
 struct LuaContext::Pusher<LuaContext::ThreadID> {

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1768,24 +1768,24 @@ private:
         // this constructor will clone and hold the value at the specified index (or by default at the top of the stack) in the registry
         ValueInRegistry(lua_State* lua_, int index=-1) : lua{lua_}
         {
-            lua_pushlightuserdata(lua, this);
+            lua_pushvalue(lua, LUA_REGISTRYINDEX);
             lua_pushvalue(lua, -1 + index);
-            lua_settable(lua, LUA_REGISTRYINDEX);
+            ref = luaL_ref(lua, -2);
+            lua_pop(lua, 1);
         }
         
         // removing the function from the registry
         ~ValueInRegistry()
         {
-            lua_pushlightuserdata(lua, this);
-            lua_pushnil(lua);
-            lua_settable(lua, LUA_REGISTRYINDEX);
+            lua_pushvalue(lua, LUA_REGISTRYINDEX);
+            luaL_unref(lua, -1, ref);
+            lua_pop(lua, 1);
         }
 
         // loads the value and puts it at the top of the stack
         PushedObject pop()
         {
-            lua_pushlightuserdata(lua, this);
-            lua_gettable(lua, LUA_REGISTRYINDEX);
+            lua_rawgeti(lua, LUA_REGISTRYINDEX, ref);
             return PushedObject{lua, 1};
         }
 
@@ -1794,6 +1794,7 @@ private:
 
     private:
         lua_State* lua;
+        int ref;
     };
     
     // binds the first parameter of a function object

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2078,6 +2078,9 @@ struct LuaContext::Pusher<const std::type_info*> {
     static const int maxSize = 1;
 
     static PushedObject push(lua_State* state, const std::type_info* ptr) noexcept {
+        fprintf(stderr, "about to call lua_pushlightuserdata(state, %p)", ptr);
+        assert(false && "lua_pushlightuserdata called");
+
         lua_pushlightuserdata(state, const_cast<std::type_info*>(ptr));
         return PushedObject{state, 1};
     }


### PR DESCRIPTION
### Short description
Lua `lightuserdata` on ARM64 with LuaJIT is limited to addresses that can fit in 47 bits. This PR removes all usage of `lua_pushlightuserdata` from our copy of Luawrapper. The `ValueInRegistry` and `plain function pointer` changes are mostly harmless; the type index changes might have some performance impact.

This makes the dnsdist test suite pass on Linux/ARM64.

PRing this now for reviews and comments. If it turns out the type index changes have real performance impact, I will consider making that a compile time choice.

~When force applied to upstream Luawrapper, this breaks compilation of the `custom_types`, `movable` and `metatables` test suite components.~ Fixed in `Revert "no longer need this" `

### TODO
- [x] deal with the last remaining `lua_pushlightuserdata` call (in `template<> struct LuaContext::Pusher<const std::type_info*>`) - either make sure we never call it, or fix it. Just removing that template causes the upstream LuaWrapper failure mentioned above. I checked this box after adding an assert to that call, proving we do not rely on it.
- [x] update comments
- [ ] check performance impact of these changes

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
