### PR TITLE
rec-4.1.x: Add -rdynamic to C{,XX}FLAGS when we build with LuaJIT

### DIFF
--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -102,6 +102,12 @@ AS_IF([test "x$with_luajit" = "xno"], [
 AS_IF([test "x$LUAPC" = "x" -a "x$LUAJITPC" = "x"], [
   AC_MSG_ERROR([Neither Lua nor LuaJIT found, Lua support is not optional])
 ])
+AS_IF([test "x$LUAJITPC" != "x"], [
+  # export all symbols to be able to use the Lua FFI interface
+  AC_MSG_NOTICE([Adding -rdynamic to export all symbols for the Lua FFI interface])
+  CFLAGS="$CFLAGS -rdynamic"
+  CXXFLAGS="$CXXFLAGS -rdynamic"
+])
 PDNS_CHECK_LUA_HPP
 
 PDNS_ENABLE_VERBOSE_LOGGING


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We need that to get the FFI symbols exported.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
