### PR TITLE
rec: Add a new max-udp-queries-per-round setting

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3646,7 +3646,7 @@ int main(int argc, char **argv)
     ::arg().set("max-qperq", "Maximum outgoing queries per query")="50";
     ::arg().set("max-total-msec", "Maximum total wall-clock time per query in milliseconds, 0 for unlimited")="7000";
     ::arg().set("max-recursion-depth", "Maximum number of internal recursion calls per query, 0 for unlimited")="40";
-    ::arg().set("max-udp-queries-per-round", "Maximum number of UDP queries processed per round, before returning back to normal processing")="10000";
+    ::arg().set("max-udp-queries-per-round", "Maximum number of UDP queries processed per recvmsg() round, before returning back to normal processing")="10000";
 
     ::arg().set("include-dir","Include *.conf files from this directory")="";
     ::arg().set("security-poll-suffix","Domain name from which to query security update notifications")="secpoll.powerdns.com.";

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -768,6 +768,18 @@ Maximum number of DNS queries in a TCP connection.
 
 Total maximum number of milliseconds of wallclock time the server may use to answer a single query.
 
+.. _setting-max-udp-queries-per-round:
+
+``max-udp-queries-per-round``
+----------------------------------
+.. versionadded:: 4.2.0
+
+-  Integer
+-  Default: 10000
+
+Maximum number of DNS queries processed in a single round after being woken up by the multiplexer, before
+returning back to normal processing to handle other events.
+
 .. _setting-minimum-ttl-override:
 
 ``minimum-ttl-override``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -777,8 +777,11 @@ Total maximum number of milliseconds of wallclock time the server may use to ans
 -  Integer
 -  Default: 10000
 
-Maximum number of DNS queries processed in a single round after being woken up by the multiplexer, before
-returning back to normal processing to handle other events.
+Under heavy load the recursor might be busy processing incoming UDP queries for a long while before there is no more of these, and might therefore
+neglect scheduling new ``mthreads``, handling responses from authoritative servers or responding to :doc:`rec_control <manpages/rec_control.1>`
+requests.
+This setting caps the maximum number of incoming UDP DNS queries processed in a single round of looping on ``recvmsg()`` after being woken up by the multiplexer, before
+returning back to normal processing and handling other events.
 
 .. _setting-minimum-ttl-override:
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This new setting limits the number of `UDP` queries we attempt to handle after being woken up by the multiplexer and before returning back to process other events.
Before this, we could end up trying to process queries after queries and almost never return from `handleNewUDPQuestion()` to process new events, meaning we could eventually end up never scheduling new `mthreads` or handle responses from authoritative servers for a long time, only sending responses for packetcache hits and creating new `mthreads`.

This would also make `rec_control` seem unresponsive and return with:
```
Fatal: Timeout waiting for answer from control channel
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
