### PR TITLE
switch travis to luajit; lower luajit required version to 2.0.2

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -588,7 +588,7 @@ test_repo(){
 # Add botan 2.x when available in Travis CI
 run "sudo apt-get -qq --no-install-recommends install \
   libboost-all-dev \
-  liblua5.1-dev \
+  libluajit-5.1-dev \
   libedit-dev \
   libprotobuf-dev \
   pandoc\

--- a/m4/pdns_with_lua.m4
+++ b/m4/pdns_with_lua.m4
@@ -21,7 +21,7 @@ AC_DEFUN([PDNS_WITH_LUA],[
   ])
 
   LUAPC=""
-  luajit_min_version='2.0.3'
+  luajit_min_version='2.0.2'
   lua_min_version='5.1'
 
   AS_IF([test "x$with_lua" != "xno"], [


### PR DESCRIPTION
### Short description
This brings Travis closer in line with what we actually ship. Lowering the LuaJIT requirement from 2.0.3 to 2.0.2 has been tested in Travis and on buildbot with no observable ill effects.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
