### PR TITLE
dnsdist: Add support for more than one TLS certificate

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -301,7 +301,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "addCacheHitResponseAction", true, "DNS rule, DNS response action [, {uuid=\"UUID\"}]", "add a cache hit response rule" },
   { "addResponseAction", true, "DNS rule, DNS response action [, {uuid=\"UUID\"}]", "add a response rule" },
   { "addSelfAnsweredResponseAction", true, "DNS rule, DNS response action [, {uuid=\"UUID\"}]", "add a self-answered response rule" },
-  { "addTLSLocal", true, "addr, certFile, keyFile[,params]", "listen to incoming DNS over TLS queries on the specified address using the specified certificate and key. The last parameter is a table" },
+  { "addTLSLocal", true, "addr, certFile(s), keyFile(s) [,params]", "listen to incoming DNS over TLS queries on the specified address using the specified certificate (or list of) and key (or list of). The last parameter is a table" },
   { "AllowAction", true, "", "let these packets go through" },
   { "AllowResponseAction", true, "", "let these packets go through" },
   { "AllRule", true, "", "matches all traffic" },

--- a/pdns/dnsdistdist/docs/guides/dns-over-tls.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-tls.rst
@@ -10,3 +10,9 @@ Adding a listen port for DNS-over-TLS can be done with the :func:`addTLSLocal` f
   addTLSLocal('192.0.2.55', '/etc/ssl/certs/example.com.pem', '/etc/ssl/private/example.com.key')
 
 This will make :program:`dnsdist` listen on 192.0.2.55:853 on TCP and UDP and will use the provided certificate and key to provide the TLS connection.
+
+In order to support multiple certificates and keys, for example an ECDSA and an RSA one, the following syntax may be used instead::
+
+  addTLSLocal('192.0.2.55', {'/etc/ssl/certs/example.com.rsa.pem', '/etc/ssl/certs/example.com.ecdsa.pem'}, {'/etc/ssl/private/example.com.rsa.key', '/etc/ssl/private/example.com.ecdsa.key'})
+
+The certificate chain to present will then be selected based on the algorithms advertised by the client.

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -86,16 +86,18 @@ Listen Sockets
                                   higher than 0 to enable TCP Fast Open when available.
                                   Default is 0.
 
-.. function:: addTLSLocal(address, certFile, keyFile[, options])
+.. function:: addTLSLocal(address, certFile(s), keyFile(s) [, options])
 
   .. versionadded:: 1.3.0
+  .. versionchanged:: 1.3.1
+    ``certFile(s)`` and ``keyFile(s)`` parameters accept a list of files.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
   :param str address: The IP Address with an optional port to listen on.
                       The default port is 853.
-  :param str certFile: The path to a X.509 certificate file in PEM format.
-  :param str keyFile: The path to the private key file corresponding to the certificate.
+  :param str certFile(s): The path to a X.509 certificate file in PEM format, or a list of paths to such files.
+  :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones.
   :param table options: A table with key: value pairs with listen options.
 
   Options:

--- a/pdns/dnsdistdist/tcpiohandler.hh
+++ b/pdns/dnsdistdist/tcpiohandler.hh
@@ -128,9 +128,8 @@ public:
   }
 
   std::set<int> d_cpus;
+  std::vector<std::pair<std::string, std::string>> d_certKeyPairs;
   ComboAddress d_addr;
-  std::string d_certFile;
-  std::string d_keyFile;
   std::string d_ciphers;
   std::string d_provider;
   std::string d_interface;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
To be able to present an ECDSA certificate to clients supporting it and a RSA one to those who don't.
Closes #6450.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
