### PR TITLE
 calidns: Add an option to read ECS values from the query file, skip comments

### DIFF
--- a/docs/manpages/calidns.1.rst
+++ b/docs/manpages/calidns.1.rst
@@ -34,6 +34,8 @@ Options
 
 --ecs <SUBNET>           Add EDNS Client Subnet option to outgoing queries using random
                          addresses from the specified *SUBNET* range (IPv4 only).
+--ecs-from-file          Read IP or subnet values from the query file and add them as EDNS
+                         Client Subnet option to outgoing queries.
 --increment <NUM>        On every subsequent run, multiply the number of queries per second
                          by *NUM*. By default, this is 1.1.
 --maximum-qps <NUM>      Stop incrementing once this rate has been reached, to provide a

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -318,6 +318,9 @@ try
     vector<uint8_t> packet;
     DNSPacketWriter::optvect_t ednsOptions;
     boost::trim(line);
+    if (line.empty() || line.at(0) == '#') {
+      continue;
+    }
 
     auto fields = splitField(line, ' ');
     std::string qname = fields.first;

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -222,6 +222,7 @@ try
     ("help,h", "Show this helpful message")
     ("version", "Show the version number")
     ("ecs", po::value<string>(), "Add EDNS Client Subnet option to outgoing queries using random addresses from the specified range (IPv4 only)")
+    ("ecs-from-file", "Read IP or subnet values from the query file and add them as EDNS Client Subnet options to outgoing queries")
     ("increment", po::value<float>()->default_value(1.1),  "Set the factor to increase the QPS load per run")
     ("maximum-qps", po::value<uint32_t>(), "Stop incrementing once this rate has been reached, to provide a stable load")
     ("want-recursion", "Set the Recursion Desired flag on queries");
@@ -266,6 +267,7 @@ try
   }
 
   bool wantRecursion = g_vm.count("want-recursion");
+  bool useECSFromFile = g_vm.count("ecs-from-file");
 
   double hitrate = g_vm["hitrate"].as<double>();
   if (hitrate > 100 || hitrate < 0) {
@@ -316,14 +318,25 @@ try
     vector<uint8_t> packet;
     DNSPacketWriter::optvect_t ednsOptions;
     boost::trim(line);
-    const auto fields = splitField(line, ' ');
-    DNSPacketWriter pw(packet, DNSName(fields.first), DNSRecordContent::TypeToNumber(fields.second));
+
+    auto fields = splitField(line, ' ');
+    std::string qname = fields.first;
+    std::string qtype = fields.second;
+    std::string subnet;
+
+    if(useECSFromFile) {
+      fields = splitField(qtype, ' ');
+      qtype = fields.first;
+      subnet = fields.second;
+    }
+
+    DNSPacketWriter pw(packet, DNSName(qname), DNSRecordContent::TypeToNumber(qtype));
     pw.getHeader()->rd=wantRecursion;
     pw.getHeader()->id=random();
 
-    if(!ecsRange.empty()) {
+    if(!subnet.empty() || !ecsRange.empty()) {
       EDNSSubnetOpts opt;
-      opt.source = Netmask("0.0.0.0/32");
+      opt.source = Netmask(subnet.empty() ? "0.0.0.0/32" : subnet);
       ednsOptions.push_back(std::make_pair(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(opt)));
     }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If the `--ecs-from-file` option is used, `calidns` read an IP address or netmask from a third space-separated field in the query file, and adds it to the query as an `EDNS Client Subnet` option.
This PR also makes `calidns` ignore lines starting with a `#` in the query file, to be able to put comments in it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
