### PR TITLE
docs: geoip-database-files has not been dropped in v4.2.0

### DIFF
--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -50,8 +50,8 @@ defaults suite you.
 ``geoip-database-files``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. deprecated:: 4.2.0
-  This setting has been removed
+.. versionchanged:: 4.2.0
+  This option has been changed since v4.2.0
 
 Comma, tab or space separated list of files to open. You can use
 `geoip-cvs-to-dat <https://github.com/dankamongmen/sprezzos-world/blob/master/packaging/geoip/debian/src/geoip-csv-to-dat.cpp>`__
@@ -68,9 +68,6 @@ Currently supported options for dat driver (legacy libGeoIP):
 Currently supported options for mmdb driver (libmaxminddb):
   - mode=mmap
   - language=en (which language to use)
-
-.. warning::
-  This option has been changed since v4.2.0
 
 .. _setting-geoip-database-cache:
 


### PR DESCRIPTION
### Short description
Remove the incorrect deprecation warning, and replace it with changed warning.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
