### PR TITLE
configure: ensure lua is setup when lua records are enabled

### DIFF
--- a/m4/pdns_with_lua_records.m4
+++ b/m4/pdns_with_lua_records.m4
@@ -9,6 +9,9 @@ AC_DEFUN([PDNS_WITH_LUA_RECORDS], [
   AC_MSG_RESULT([$enable_lua_records])
 
   AS_IF([test "x$enable_lua_records" != "xno"], [
+    AS_IF([test "x$LUAPC" = "x"],
+      AC_MSG_ERROR([LUA records need LUA. You can disable this feature with the --disable-lua-records switch or configure a proper LUA installation.])
+    )
     LIBCURL_CHECK_CONFIG("yes", "7.21.3", [ : ], [
       AC_MSG_ERROR([libcurl minimum version requirement not met. This is required for LUA records. You can disable it with the --disable-lua-records switch or use --with-libcurl to select another curl installation.])
     ])


### PR DESCRIPTION
### Short description
This will trigger an error if LUA hasn't been found and LUA records were not disabled.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
