### PR TITLE
avoid interleaved access to B (via d_dk)

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1340,13 +1340,6 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
 
     DLOG(g_log<<"Got no referrals, trying ANY"<<endl);
 
-    // see what we get..
-    B.lookup(QType(QType::ANY), target, p, sd.domain_id);
-    rrset.clear();
-    haveAlias.trimToLabels(0);
-    weDone = weRedirected = weHaveUnauth =  false;
-
-
 #ifdef HAVE_LUA_RECORDS
     if(!doLua) {
       string val;
@@ -1354,6 +1347,12 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
       doLua = (val=="1");
     }
 #endif
+
+    // see what we get..
+    B.lookup(QType(QType::ANY), target, p, sd.domain_id);
+    rrset.clear();
+    haveAlias.trimToLabels(0);
+    weDone = weRedirected = weHaveUnauth =  false;
     
     while(B.get(rr)) {
 #ifdef HAVE_LUA_RECORDS


### PR DESCRIPTION
### Short description
Before this patch, the meta lookup would interfere with the already-started `B.lookup`. This caused failures with odbc/MSSQL.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
