### PR TITLE
Restore the existing behaviour of Socket::connect() with a 0 timeout

### DIFF
--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -61,6 +61,10 @@ int SConnectWithTimeout(int sockfd, const ComboAddress& remote, int timeout)
   if(ret < 0) {
     int savederrno = errno;
     if (savederrno == EINPROGRESS) {
+      if (timeout <= 0) {
+        return ret;
+      }
+
       /* we wait until the connection has been established */
       bool error = false;
       bool disconnected = false;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
73ba5999186da82b444472170f7e0ce312ce536b rightly removed the code duplication between `Socket::connect()` and `SConnectWithTimeout()`.
Unfortunately the two codes had different behaviours when connecting in non-blocking mode with a timeout value of zero. The first one just returned the socket descriptor on `EINPROGRESS`, rightly
assuming that a value of 0 for the timeout meant not to wait for the connection to established, while `SConnectWithTimeout()` did not handle that special case, because it was never called with a value
of 0 for the timeout duration.

This, for example, made the recursor fail to contact any host over `TCP`.

We need to investigate why our regression tests did not catch this!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
