### PR TITLE
document undocumented config vars

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -165,9 +165,9 @@ void declareArguments()
   ::arg().set("default-ttl","Seconds a result is valid if not set otherwise")="3600";
   ::arg().set("max-tcp-connections","Maximum number of TCP connections")="20";
   ::arg().set("max-tcp-connections-per-client","Maximum number of simultaneous TCP connections per client")="0";
-  ::arg().set("max-tcp-transactions-per-conn")="0";
-  ::arg().set("max-tcp-connection-duration")="0";
-  ::arg().set("tcp-idle-timeout")="5";
+  ::arg().set("max-tcp-transactions-per-conn","Maximum number of subsequent queries per TCP connection")="0";
+  ::arg().set("max-tcp-connection-duration","Maximum time in seconds that a TCP DNS connection is allowed to stay open.")="0";
+  ::arg().set("tcp-idle-timeout","Maximum time in seconds that a TCP DNS connection is allowed to stay open while being idle")="5";
 
   ::arg().setSwitch("no-shuffle","Set this to prevent random shuffling of answers - for regression testing")="off";
 


### PR DESCRIPTION
configuration variables without a help string do not show up in --help and
pdns_control current-config

(cherry picked from commit 69a1b753a31ffa29315f40d4d2074f92ff896b96)

### Short description
Backport of #6539 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
