### PR TITLE
dnsdist: allow known exception types to be converted to string

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -44,6 +44,21 @@ void setupLuaBindings(bool client)
       g_outputBuffer+="\n";
     });
 
+  /* Exceptions */
+  g_lua.registerFunction<string(std::exception_ptr::*)()>("__tostring", [](const std::exception_ptr& eptr) {
+      try {
+        if (eptr) {
+          std::rethrow_exception(eptr);
+        }
+      } catch(const std::exception& e) {
+        return string(e.what());
+      } catch(const PDNSException& e) {
+        return e.reason;
+      } catch(...) {
+        return string("Unknown exception");
+      }
+      return string("No exception");
+    });
   /* ServerPolicy */
   g_lua.writeFunction("newServerPolicy", [](string name, policyfunc_t policy) { return ServerPolicy{name, policy, true};});
   g_lua.registerMember("name", &ServerPolicy::name);


### PR DESCRIPTION
### Short description
This tries to improve Lua error reporting, see #6535. Exceptions thrown in a Lua subroutine can be printed:
```
x = newNMG()
res, err = pcall(function() x:addMask('banana') end)
if not res then
   print("An error has been thrown: ", err)
end
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
