### PR TITLE
move includes around to avoid boost L conflict

### DIFF
--- a/pdns/protobuf.cc
+++ b/pdns/protobuf.cc
@@ -1,6 +1,5 @@
 
 #include "gettime.hh"
-#include "dnsparser.hh"
 #include "protobuf.hh"
 #include "dnsparser.hh"
 #include "gettime.hh"

--- a/pdns/protobuf.hh
+++ b/pdns/protobuf.hh
@@ -26,14 +26,14 @@
 
 #include "config.h"
 
-#include "dnsname.hh"
-#include "iputils.hh"
-
 #ifdef HAVE_PROTOBUF
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include "dnsmessage.pb.h"
 #endif /* HAVE_PROTOBUF */
+
+#include "dnsname.hh"
+#include "iputils.hh"
 
 class DNSProtoBufMessage
 {


### PR DESCRIPTION
### Short description

This avoids errors like 
```
/usr/local/include/boost/function_types/components.hpp:139:35: error: expected a qualified name after 'typename'
    template<typename T, typename L>
                                  ^
./dns.hh:228:11: note: expanded from macro 'L'
#define L theL()
```

This is an alternative to #6516. It does not preclude later merging of #6516.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
