### PR TITLE
auth: Link dnspcap2protobuf against librt when needed

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1119,7 +1119,8 @@ dnspcap2protobuf_LDFLAGS = \
 dnspcap2protobuf_LDADD = \
 	$(LIBCRYPTO_LIBS) \
 	$(PROTOBUF_LIBS) \
-	$(BOOST_PROGRAM_OPTIONS_LIBS)
+	$(BOOST_PROGRAM_OPTIONS_LIBS) \
+	$(RT_LIBS)
 endif
 endif
 


### PR DESCRIPTION
(cherry picked from commit 4a4fcdcbfb3eaefd231a44ca56d21aa9ec7bb9d5)

### Short description
backport of #6487 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
