### PR TITLE
make rec_control respect include-dir; closes #6536

### DIFF
--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -66,10 +66,7 @@ static void initArguments(int argc, char** argv)
   
   cleanSlashes(configname);
 
-  if(!::arg().preParseFile(configname.c_str(), "socket-dir", ""))
-    cerr<<"Warning: unable to parse configuration file '"<<configname<<"'"<<endl;
-  if(!::arg().preParseFile(configname.c_str(), "chroot", ""))
-    cerr<<"Warning: unable to parse configuration file '"<<configname<<"'"<<endl;
+  arg().laxFile(configname.c_str());
 
   arg().laxParse(argc,argv);   // make sure the commandline wins
 


### PR DESCRIPTION
### Short description
By invoking the full file parser instead of doing two runs looking for specific keys, the include-dir logic is allowed to run.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
