### PR TITLE
bindbackend: refuse launch suffixes

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -659,6 +659,8 @@ configuration item names change: e.g. ``gmysql-host`` is available to
 configure the ``host`` setting of the first or main instance, and
 ``gmysql-server2-host`` for the second one.
 
+Running multiple instances of the bind backend is not allowed.
+
 .. _setting-load-modules:
 
 ``load-modules``

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1357,12 +1357,20 @@ class Bind2Factory : public BackendFactory
 
       DNSBackend *make(const string &suffix="")
       {
+         assertEmptySuffix(suffix);
          return new Bind2Backend(suffix);
       }
       
       DNSBackend *makeMetadataOnly(const string &suffix="")
       {
+        assertEmptySuffix(suffix);
         return new Bind2Backend(suffix, false);
+      }
+   private:
+      void assertEmptySuffix(const string &suffix)
+      {
+        if(suffix.length())
+          throw PDNSException("launch= suffixes are not supported on the bindbackend");
       }
 };
 


### PR DESCRIPTION
### Short description
In #6308, a bug is reported with a config containing this line:

```
launch=gsqlite3:api,bind:main,bind:dnsadmin,bind:eec,bind:jobstuff,bind:nzrb
```

However, that is invalid setup, as the bindbackend shares data between instances without respecting the suffix.

This PR makes such setups fail early so surprises are avoided.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
