### PR TITLE
split compile/test in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,8 @@
 <!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
 I have:
 - [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
-- [ ] compiled and tested this code
+- [ ] compiled this code
+- [ ] tested this code
 - [ ] included documentation (including possible behaviour changes)
 - [ ] documented the code
 - [ ] added or modified regression test(s)


### PR DESCRIPTION
### Short description
A PR submitter may have checked that code compiles, but may not have had time to (sufficiently) test. This has happened to me a few times this week already. With this change, those two situations can be indicated separately.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled and tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
