### PR TITLE
rec api: add subtree option to the cache flush endpoint

### DIFF
--- a/pdns/recursordist/docs/http-api/endpoint-cache.rst
+++ b/pdns/recursordist/docs/http-api/endpoint-cache.rst
@@ -7,7 +7,10 @@ Cache manipulation endpoint
 
   :query server_id: The name of the server
   :query domain: The domainname to flush for
-  :query subtree: If set to `true`, also flush the whole subtree (default=`false`)
+
+  .. versionadded:: 4.1.3
+
+  :query subtree: If set to `true`, also flush the whole subtree (default = `false`)
 
   **Example Response:**
 

--- a/pdns/recursordist/docs/http-api/endpoint-cache.rst
+++ b/pdns/recursordist/docs/http-api/endpoint-cache.rst
@@ -7,6 +7,7 @@ Cache manipulation endpoint
 
   :query server_id: The name of the server
   :query domain: The domainname to flush for
+  :query subtree: If set to `true`, also flush the whole subtree (default=`false`)
 
   **Example Response:**
 

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -373,7 +373,7 @@ static void apiServerCacheFlush(HttpRequest* req, HttpResponse* resp) {
     throw HttpMethodNotAllowedException();
 
   DNSName canon = apiNameToDNSName(req->getvars["domain"]);
-  bool subtree = (req->getvars["subtree"].compare("true") == 0);
+  bool subtree = (req->getvars.count("subtree") > 0 && req->getvars["subtree"].compare("true") == 0);
 
   int count = broadcastAccFunction<uint64_t>(boost::bind(pleaseWipeCache, canon, subtree));
   count += broadcastAccFunction<uint64_t>(boost::bind(pleaseWipePacketCache, canon, subtree));

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -373,10 +373,11 @@ static void apiServerCacheFlush(HttpRequest* req, HttpResponse* resp) {
     throw HttpMethodNotAllowedException();
 
   DNSName canon = apiNameToDNSName(req->getvars["domain"]);
+  bool subtree = (req->getvars["subtree"].compare("true") == 0);
 
-  int count = broadcastAccFunction<uint64_t>(boost::bind(pleaseWipeCache, canon, false));
-  count += broadcastAccFunction<uint64_t>(boost::bind(pleaseWipePacketCache, canon, false));
-  count += broadcastAccFunction<uint64_t>(boost::bind(pleaseWipeAndCountNegCache, canon, false));
+  int count = broadcastAccFunction<uint64_t>(boost::bind(pleaseWipeCache, canon, subtree));
+  count += broadcastAccFunction<uint64_t>(boost::bind(pleaseWipePacketCache, canon, subtree));
+  count += broadcastAccFunction<uint64_t>(boost::bind(pleaseWipeAndCountNegCache, canon, subtree));
   resp->setBody(Json::object {
     { "count", count },
     { "result", "Flushed cache." }

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -185,6 +185,8 @@ test_env.update({
     'DAEMON': daemon,
     'SQLITE_DB': SQLITE_DB,
     'PDNSUTIL_CMD': ' '.join(PDNSUTIL_CMD),
+    'SDIG': sdig,
+    'DNSPORT': str(DNSPORT)
 })
 
 try:

--- a/regression-tests.api/test_Cache.py
+++ b/regression-tests.api/test_Cache.py
@@ -1,4 +1,5 @@
 from test_helper import ApiTestCase, is_auth, is_recursor, sdig
+import unittest
 
 
 class Servers(ApiTestCase):
@@ -9,6 +10,7 @@ class Servers(ApiTestCase):
         data = r.json()
         self.assertIn('count', data)
 
+    @unittest.skipIf(not is_recursor(), "Not applicable")
     def test_flush_count(self):
         sdig("ns1.example.com", 'A')
         r = self.session.put(self.url("/api/v1/servers/localhost/cache/flush?domain=ns1.example.com."))
@@ -17,6 +19,7 @@ class Servers(ApiTestCase):
         self.assertIn('count', data)
         self.assertEquals(1, data['count'])
 
+    @unittest.skipIf(not is_recursor(), "Not applicable")
     def test_flush_subtree(self):
         sdig("ns1.example.com", 'A')
         sdig("ns2.example.com", 'A')

--- a/regression-tests.api/test_Cache.py
+++ b/regression-tests.api/test_Cache.py
@@ -1,4 +1,4 @@
-from test_helper import ApiTestCase, is_auth, is_recursor
+from test_helper import ApiTestCase, is_auth, is_recursor, sdig
 
 
 class Servers(ApiTestCase):
@@ -8,6 +8,28 @@ class Servers(ApiTestCase):
         self.assert_success_json(r)
         data = r.json()
         self.assertIn('count', data)
+
+    def test_flush_count(self):
+        sdig("ns1.example.com", 'A')
+        r = self.session.put(self.url("/api/v1/servers/localhost/cache/flush?domain=ns1.example.com."))
+        self.assert_success_json(r)
+        data = r.json()
+        self.assertIn('count', data)
+        self.assertEquals(1, data['count'])
+
+    def test_flush_subtree(self):
+        sdig("ns1.example.com", 'A')
+        sdig("ns2.example.com", 'A')
+        r = self.session.put(self.url("/api/v1/servers/localhost/cache/flush?domain=example.com.&subtree=false"))
+        self.assert_success_json(r)
+        data = r.json()
+        self.assertIn('count', data)
+        self.assertEquals(1, data['count'])
+        r = self.session.put(self.url("/api/v1/servers/localhost/cache/flush?domain=example.com.&subtree=true"))
+        self.assert_success_json(r)
+        data = r.json()
+        self.assertIn('count', data)
+        self.assertEquals(2, data['count'])
 
     def test_flush_root(self):
         r = self.session.put(self.url("/api/v1/servers/localhost/cache/flush?domain=."))

--- a/regression-tests.api/test_helper.py
+++ b/regression-tests.api/test_helper.py
@@ -11,11 +11,11 @@ if sys.version_info[0] == 2:
 else:
     from urllib.parse import urljoin
 
-
 DAEMON = os.environ.get('DAEMON', 'authoritative')
 PDNSUTIL_CMD = os.environ.get('PDNSUTIL_CMD', 'NOT_SET BUT_THIS MIGHT_BE_A_LIST').split(' ')
 SQLITE_DB = os.environ.get('SQLITE_DB', 'pdns.sqlite3')
-
+SDIG = os.environ.get('SDIG', 'sdig')
+DNSPORT = os.environ.get('DNSPORT', '53')
 
 class ApiTestCase(unittest.TestCase):
 
@@ -86,7 +86,12 @@ def pdnsutil(subcommand, *args):
     except subprocess.CalledProcessError as except_inst:
         raise RuntimeError("pdnsutil %s %s failed: %s" % (command, args, except_inst.output.decode('ascii', errors='replace')))
 
-
 def pdnsutil_rectify(zonename):
     """Run pdnsutil rectify-zone on the given zone."""
     pdnsutil('rectify-zone', zonename)
+
+def sdig(*args):
+    try:
+        return subprocess.check_call([SDIG, '127.0.0.1', str(DNSPORT)] + list(args))
+    except subprocess.CalledProcessError as except_inst:
+        raise RuntimeError("sdig %s %s failed: %s" % (command, args, except_inst.output.decode('ascii', errors='replace')))


### PR DESCRIPTION
### Short description
This adds support for the `subtree` parameter to the cache flush API endpoint.
```
/api/v1/servers/localhost/cache/flush?domain=example.com.&subtree=true
```

Fix #6550 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
