### PR TITLE
dnsdist: show droprate in API output

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -414,7 +414,8 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           {"pools", pools},
           {"latency", (double)(a->latencyUsec/1000.0)},
           {"queries", (double)a->queries},
-          {"sendErrors", (double)a->sendErrors}
+          {"sendErrors", (double)a->sendErrors},
+          {"dropRate", (double)a->dropRate}
         };
 
         /* sending a latency for a DOWN server doesn't make sense */

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -220,6 +220,7 @@ JSON Objects
   :property integer sendErrors: Number of network errors while sending a query to this server
   :property string state: The state of the server (e.g. "DOWN" or "up")
   :property integer weight: The weight assigned to this server
+  :property float dropRate: The amount of packets dropped per second by this server
 
 .. json:object:: StatisticItem
 


### PR DESCRIPTION
### Short description
It seems that `dropRate` was not shown when getting server statistics. It can be handy to have them.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)