### PR TITLE
Add dnspcap2calidns, to convert PCAP to the calidns format

### DIFF
--- a/build-scripts/build-auth-rpm
+++ b/build-scripts/build-auth-rpm
@@ -451,6 +451,7 @@ fi
 %files tools
 %{_bindir}/calidns
 %{_bindir}/dnsgram
+%{_bindir}/dnspcap2calidns
 %{_bindir}/dnsreplay
 %{_bindir}/dnsscan
 %{_bindir}/dnsscope
@@ -465,6 +466,7 @@ fi
 %{_bindir}/sdig
 %{_mandir}/man1/calidns.1.gz
 %{_mandir}/man1/dnsgram.1.gz
+%{_mandir}/man1/dnspcap2calidns.1.gz
 %{_mandir}/man1/dnsreplay.1.gz
 %{_mandir}/man1/dnsscan.1.gz
 %{_mandir}/man1/dnsscope.1.gz
@@ -774,6 +776,7 @@ exit 0
 %{_bindir}/calidns
 %{_bindir}/dnsbulktest
 %{_bindir}/dnsgram
+%{_bindir}/dnspcap2calidns
 %{_bindir}/dnspcap2protobuf
 %{_bindir}/dnsreplay
 %{_bindir}/dnsscan
@@ -791,6 +794,7 @@ exit 0
 %{_mandir}/man1/calidns.1.gz
 %{_mandir}/man1/dnsbulktest.1.gz
 %{_mandir}/man1/dnsgram.1.gz
+%{_mandir}/man1/dnspcap2calidns.1.gz
 %{_mandir}/man1/dnspcap2protobuf.1.gz
 %{_mandir}/man1/dnsreplay.1.gz
 %{_mandir}/man1/dnsscan.1.gz
@@ -1055,6 +1059,7 @@ exit 0
 %{_bindir}/calidns
 %{_bindir}/dnsbulktest
 %{_bindir}/dnsgram
+%{_bindir}/dnspcap2calidns
 %{_bindir}/dnsreplay
 %{_bindir}/dnsscan
 %{_bindir}/dnsscope
@@ -1071,6 +1076,7 @@ exit 0
 %{_mandir}/man1/calidns.1.gz
 %{_mandir}/man1/dnsbulktest.1.gz
 %{_mandir}/man1/dnsgram.1.gz
+%{_mandir}/man1/dnspcap2calidns.1.gz
 %{_mandir}/man1/dnsreplay.1.gz
 %{_mandir}/man1/dnsscan.1.gz
 %{_mandir}/man1/dnsscope.1.gz

--- a/build-scripts/debian-authoritative/pdns-tools.install
+++ b/build-scripts/debian-authoritative/pdns-tools.install
@@ -1,6 +1,7 @@
 usr/bin/calidns
 usr/bin/dnsbulktest
 usr/bin/dnsgram
+usr/bin/dnspcap2calidns
 usr/bin/dnspcap2protobuf
 usr/bin/dnsreplay
 usr/bin/dnsscan

--- a/build-scripts/debian-authoritative/pdns-tools.manpages
+++ b/build-scripts/debian-authoritative/pdns-tools.manpages
@@ -1,6 +1,7 @@
 debian/tmp/usr/share/man/man1/calidns.1
 debian/tmp/usr/share/man/man1/dnsbulktest.1
 debian/tmp/usr/share/man/man1/dnsgram.1
+debian/tmp/usr/share/man/man1/dnspcap2calidns.1
 debian/tmp/usr/share/man/man1/dnspcap2protobuf.1
 debian/tmp/usr/share/man/man1/dnsreplay.1
 debian/tmp/usr/share/man/man1/dnsscan.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,6 +170,7 @@ descriptions = {
     'calidns': 'A DNS recursor testing tool',
     'dnsbulktest': 'A debugging tool for intermittent resolver failures',
     'dnsgram': 'A debugging tool for intermittent resolver failures',
+    'dnspcap2calidns': 'A tool to convert PCAPs of DNS traffic to calidns input',
     'dnspcap2protobuf': 'A tool to convert PCAPs of DNS traffic to PowerDNS Protobuf',
     'dnsreplay': 'A PowerDNS nameserver debugging tool',
     'dnsscan': 'List the amount of queries per qtype in a pcap',

--- a/docs/manpages/dnspcap2calidns.1.rst
+++ b/docs/manpages/dnspcap2calidns.1.rst
@@ -1,0 +1,23 @@
+dnspcap2calidns
+================
+
+Synopsis
+--------
+
+:program:`dnspcap2calidns` *PCAPFILE* *OUTFILE*
+
+Description
+-----------
+
+:program:`dnspcap2calidns` reads the PCAP file *PCAPFILE* for DNS queries and
+writes these to *OUTFILE* in the format understood by :program:`calidns`
+
+Options
+-------
+
+--help           Show a summary of options.
+--version        Display the version of dnspcap2calidns
+
+See also
+--------
+:manpage:`calidns(1)`

--- a/pdns/.gitignore
+++ b/pdns/.gitignore
@@ -24,6 +24,7 @@
 /dnsdemog
 /dnsdist
 /dnsgram
+/dnspcap2calidns
 /dnspcap2protobuf
 /dnsscan
 /dnsscope

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -88,6 +88,7 @@ bin_PROGRAMS = \
 if TOOLS
 bin_PROGRAMS += \
 	dnsgram \
+	dnspcap2calidns \
 	dnsreplay \
 	dnsscan \
 	dnsscope \
@@ -120,6 +121,7 @@ EXTRA_PROGRAMS = \
 	dnsbulktest \
 	dnsdemog \
 	dnsgram \
+	dnspcap2calidns \
 	dnsreplay \
 	dnsscan \
 	dnsscope \
@@ -1148,6 +1150,38 @@ dnsdemog_LDFLAGS = \
 
 dnsdemog_LDADD = \
 	$(LIBCRYPTO_LIBS)
+
+dnspcap2calidns_SOURCES = \
+	base32.cc \
+	base64.cc base64.hh \
+	dnslabeltext.cc \
+	dnsname.cc dnsname.hh \
+	dnsparser.cc dnsparser.hh \
+	dnspcap.cc dnspcap.hh \
+	dnspcap2calidns.cc \
+	dnsrecords.cc \
+	dnswriter.cc dnswriter.hh \
+	ednsoptions.cc ednsoptions.hh \
+	ednssubnet.cc ednssubnet.hh \
+	iputils.cc \
+	logger.cc \
+	misc.cc \
+	nsecrecords.cc \
+	qtype.cc \
+	rcpgenerator.cc rcpgenerator.hh \
+	sillyrecords.cc \
+	statbag.cc \
+	unix_utility.cc \
+	utility.hh
+
+dnspcap2calidns_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(LIBCRYPTO_LDFLAGS) \
+	$(BOOST_PROGRAM_OPTIONS_LDFLAGS)
+
+dnspcap2calidns_LDADD = \
+	$(LIBCRYPTO_LIBS) \
+	$(BOOST_PROGRAM_OPTIONS_LIBS)
 
 if HAVE_PROTOBUF
 if HAVE_PROTOC

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -170,9 +170,9 @@ void declareArguments()
   ::arg().set("default-ttl","Seconds a result is valid if not set otherwise")="3600";
   ::arg().set("max-tcp-connections","Maximum number of TCP connections")="20";
   ::arg().set("max-tcp-connections-per-client","Maximum number of simultaneous TCP connections per client")="0";
-  ::arg().set("max-tcp-transactions-per-conn")="0";
-  ::arg().set("max-tcp-connection-duration")="0";
-  ::arg().set("tcp-idle-timeout")="5";
+  ::arg().set("max-tcp-transactions-per-conn","Maximum number of subsequent queries per TCP connection")="0";
+  ::arg().set("max-tcp-connection-duration","Maximum time in seconds that a TCP DNS connection is allowed to stay open.")="0";
+  ::arg().set("tcp-idle-timeout","Maximum time in seconds that a TCP DNS connection is allowed to stay open while being idle")="5";
 
   ::arg().setSwitch("no-shuffle","Set this to prevent random shuffling of answers - for regression testing")="off";
 

--- a/pdns/dnspcap2calidns.cc
+++ b/pdns/dnspcap2calidns.cc
@@ -1,0 +1,121 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <fstream>
+
+#include "iputils.hh"
+#include "misc.hh"
+#include "dns.hh"
+#include "dnspcap.hh"
+#include "dnsparser.hh"
+
+#include "statbag.hh"
+StatBag S;
+
+static void usage()
+{
+  cerr<<"This program reads DNS queries from a PCAP file and outputs them in the calidns format."<<endl;
+  cerr<<"Usage: dnspcap2calidns PCAPFILE OUTFILE"<<endl;
+}
+
+int main(int argc, char **argv)
+{
+  try {
+    for(int n=1 ; n < argc; ++n) {
+      if ((string) argv[n] == "--help") {
+        usage();
+        return EXIT_SUCCESS;
+      }
+
+      if ((string) argv[n] == "--version") {
+        cerr<<"dnspcap2calidns "<<VERSION<<endl;
+        return EXIT_SUCCESS;
+      }
+    }
+
+    if(argc < 3) {
+      usage();
+      exit(EXIT_FAILURE);
+    }
+
+
+    PcapPacketReader pr(argv[1]);
+    ofstream fp(argv[2]);
+
+    if (!fp) {
+      cerr<<"Error opening output file "<<argv[2]<<": "<<strerror(errno)<<endl;
+      exit(EXIT_FAILURE);
+    }
+
+    try {
+      while (pr.getUDPPacket()) {
+        if (pr.d_len < sizeof(dnsheader)) {
+          continue;
+        }
+
+        const dnsheader* dh=reinterpret_cast<const dnsheader*>(pr.d_payload);
+        if (!dh->qdcount) {
+          continue;
+        }
+
+        if (!dh->rd) {
+          continue;
+        }
+
+        if (dh->qr) {
+          continue;
+        }
+
+        uint16_t qtype, qclass;
+        DNSName qname;
+        try {
+          qname=DNSName(reinterpret_cast<const char*>(pr.d_payload), pr.d_len, sizeof(dnsheader), false, &qtype, &qclass);
+        }
+        catch(const std::exception& e) {
+          cerr<<"Error while parsing qname: "<<e.what()<<endl;
+          continue;
+        }
+
+        const ComboAddress requestor = pr.getSource();
+
+        fp << qname << " " << QType(qtype).getName() << " " << requestor.toString() << endl;
+      }
+    }
+    catch (const std::exception& e) {
+      cerr<<"Error while parsing the PCAP file: "<<e.what()<<endl;
+      fp.close();
+      exit(EXIT_FAILURE);
+    }
+
+    fp.flush();
+    fp.close();
+  }
+  catch(const std::exception& e) {
+    cerr<<"Error opening PCAP file: "<<e.what()<<endl;
+    exit(EXIT_FAILURE);
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This tool generates a list of queries (qname, qtype, source) in the `calidns` format from a `PCAP`.

This PR lacks documentation.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
