### PR TITLE
rec: Move carbon/webserver/control/stats handling to a separate thread

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2462,13 +2462,14 @@ void broadcastFunction(const pipefunc_t& func)
       unixDie("write to thread pipe returned wrong size or error");
     }
 
-    string* resp;
+    string* resp = nullptr;
     if(read(tps.readFromThread, &resp, sizeof(resp)) != sizeof(resp))
       unixDie("read from thread pipe returned wrong size or error");
 
     if(resp) {
 //      cerr <<"got response: " << *resp << endl;
       delete resp;
+      resp = nullptr;
     }
   }
 }
@@ -2585,7 +2586,7 @@ template<class T> T broadcastAccFunction(const boost::function<T*()>& func)
       unixDie("write to thread pipe returned wrong size or error");
     }
 
-    T* resp;
+    T* resp = nullptr;
     if(read(tps.readFromThread, &resp, sizeof(resp)) != sizeof(resp))
       unixDie("read from thread pipe returned wrong size or error");
 
@@ -2593,6 +2594,7 @@ template<class T> T broadcastAccFunction(const boost::function<T*()>& func)
       //~ cerr <<"got response: " << *resp << endl;
       ret += *resp;
       delete resp;
+      resp = nullptr;
     }
   }
   return ret;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2581,7 +2581,6 @@ template<class T> T broadcastAccFunction(const boost::function<T*()>& func)
   if (t_id != s_handlerThreadID) {
     g_log<<Logger::Error<<"broadcastFunction has been called by a worker ("<<t_id<<")"<<endl;
     exit(1);
-
   }
 
   T ret=T();

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -132,6 +132,9 @@ struct ThreadPipeSet
   int readQueriesToThread;
 };
 
+static const int s_handlerThreadID = -1;
+static const int s_distributorThreadID = 0;
+
 typedef vector<int> tcpListenSockets_t;
 typedef map<int, ComboAddress> listenSocketsAddresses_t; // is shared across all threads right now
 typedef vector<pair<int, function< void(int, any&) > > > deferredAdd_t;
@@ -2356,13 +2359,13 @@ static void houseKeeping(void *)
         last_rootupdate=now.tv_sec;
     }
 
-    if (t_id == -1) {
+    if (t_id == s_handlerThreadID) {
       if(g_statisticsInterval > 0 && now.tv_sec - last_stat >= g_statisticsInterval) {
 	doStats();
 	last_stat=time(0);
       }
     }
-    else if(!t_id) {
+    else if(t_id == s_distributorThreadID) {
 
       if(now.tv_sec - last_secpoll >= 3600) {
 	try {
@@ -2435,7 +2438,7 @@ struct ThreadMSG
 void broadcastFunction(const pipefunc_t& func, bool skipSelf)
 {
   /* This function might be called by the worker with t_id 0 during startup */
-  if (t_id != -1 && t_id != 0) {
+  if (t_id != s_handlerThreadID && t_id != s_distributorThreadID) {
     g_log<<Logger::Error<<"broadcastFunction() has been called by a worker ("<<t_id<<")"<<endl;
     exit(1);
   }
@@ -2470,7 +2473,7 @@ void broadcastFunction(const pipefunc_t& func, bool skipSelf)
 
 void distributeAsyncFunction(const string& packet, const pipefunc_t& func)
 {
-  if (t_id != 0) {
+  if (t_id != s_distributorThreadID) {
     g_log<<Logger::Error<<"distributeAsyncFunction() has been called by a worker ("<<t_id<<")"<<endl;
     exit(1);
   }
@@ -2562,7 +2565,7 @@ vector<pair<DNSName, uint16_t> >& operator+=(vector<pair<DNSName, uint16_t> >&a,
 
 template<class T> T broadcastAccFunction(const boost::function<T*()>& func, bool skipSelf)
 {
-  if (t_id != -1) {
+  if (t_id != s_handlerThreadID) {
     g_log<<Logger::Error<<"broadcastFunction has been called by a worker ("<<t_id<<")"<<endl;
     exit(1);
 
@@ -3378,7 +3381,7 @@ static int serviceMain(int argc, char*argv[])
   }
 
   /* This thread handles the web server, carbon, statistics and the control channel */
-  std::thread handlerThread(recursorThread, -1, false);
+  std::thread handlerThread(recursorThread, s_handlerThreadID, false);
 
   const auto cpusMap = parseCPUMap();
 
@@ -3490,7 +3493,7 @@ try
       }
     }
     else {
-      if(!g_weDistributeQueries || !t_id) { // if we distribute queries, only t_id = 0 listens
+      if(!g_weDistributeQueries || t_id == s_distributorThreadID) { // if we distribute queries, only t_id = 0 listens
         for(deferredAdd_t::const_iterator i = deferredAdds[0].cbegin(); i != deferredAdds[0].cend(); ++i) {
           t_fdm->addReadFD(i->first, i->second);
         }
@@ -3546,7 +3549,7 @@ try
     t_fdm->run(&g_now);
     // 'run' updates g_now for us
 
-    if(worker && (!g_weDistributeQueries || !t_id)) { // if pdns distributes queries, only tid 0 should do this
+    if(worker && (!g_weDistributeQueries || t_id == s_distributorThreadID)) { // if pdns distributes queries, only tid 0 should do this
       if(listenOnTCP) {
 	if(TCPConnection::getCurrentConnections() > maxTcpClients) {  // shutdown, too many connections
 	  for(tcpListenSockets_t::iterator i=g_tcpListenSockets.begin(); i != g_tcpListenSockets.end(); ++i)

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2491,7 +2491,7 @@ void distributeAsyncFunction(const string& packet, const pipefunc_t& func)
   unsigned int hash = hashQuestion(packet.c_str(), packet.length(), g_disthashseed);
   unsigned int target = 1 + (hash % (g_pipes.size()-1));
 
-  if(target == 0) {
+  if(target == static_cast<unsigned int>(s_distributorThreadID)) {
     g_log<<Logger::Error<<"distributeAsyncFunction() tried to assign a query to the distributor"<<endl;
     exit(1);
   }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -101,7 +101,7 @@
 typedef map<ComboAddress, uint32_t, ComboAddress::addressOnlyLessThan> tcpClientCounts_t;
 
 static thread_local std::shared_ptr<RecursorLua4> t_pdl;
-static thread_local unsigned int t_id;
+static thread_local int t_id;
 static thread_local std::shared_ptr<Regex> t_traceRegex;
 static thread_local std::unique_ptr<tcpClientCounts_t> t_tcpClientCounts;
 #ifdef HAVE_PROTOBUF
@@ -283,7 +283,7 @@ ArgvMap &arg()
 
 unsigned int getRecursorThreadId()
 {
-  return t_id;
+  return static_cast<unsigned int>(t_id);
 }
 
 int getMTaskerTID()
@@ -2356,11 +2356,13 @@ static void houseKeeping(void *)
         last_rootupdate=now.tv_sec;
     }
 
-    if(!t_id) {
+    if (t_id == -1) {
       if(g_statisticsInterval > 0 && now.tv_sec - last_stat >= g_statisticsInterval) {
 	doStats();
 	last_stat=time(0);
       }
+    }
+    else if(!t_id) {
 
       if(now.tv_sec - last_secpoll >= 3600) {
 	try {
@@ -2432,7 +2434,13 @@ struct ThreadMSG
 
 void broadcastFunction(const pipefunc_t& func, bool skipSelf)
 {
-  unsigned int n = 0;
+  /* This function might be called by the worker with t_id 0 during startup */
+  if (t_id != -1 && t_id != 0) {
+    g_log<<Logger::Error<<"broadcastFunction() has been called by a worker ("<<t_id<<")"<<endl;
+    exit(1);
+  }
+
+  int n = 0;
   for(ThreadPipeSet& tps : g_pipes)
   {
     if(n++ == t_id) {
@@ -2462,13 +2470,19 @@ void broadcastFunction(const pipefunc_t& func, bool skipSelf)
 
 void distributeAsyncFunction(const string& packet, const pipefunc_t& func)
 {
+  if (t_id != 0) {
+    g_log<<Logger::Error<<"distributeAsyncFunction() has been called by a worker ("<<t_id<<")"<<endl;
+    exit(1);
+  }
+
   unsigned int hash = hashQuestion(packet.c_str(), packet.length(), g_disthashseed);
   unsigned int target = 1 + (hash % (g_pipes.size()-1));
 
-  if(target == t_id) {
-    func();
-    return;
+  if(target == 0) {
+    g_log<<Logger::Error<<"distributeAsyncFunction() tried to assign a query to the distributor"<<endl;
+    exit(1);
   }
+
   ThreadPipeSet& tps = g_pipes[target];
   ThreadMSG* tmsg = new ThreadMSG();
   tmsg->func = func;
@@ -2548,22 +2562,15 @@ vector<pair<DNSName, uint16_t> >& operator+=(vector<pair<DNSName, uint16_t> >&a,
 
 template<class T> T broadcastAccFunction(const boost::function<T*()>& func, bool skipSelf)
 {
-  unsigned int n = 0;
+  if (t_id != -1) {
+    g_log<<Logger::Error<<"broadcastFunction has been called by a worker ("<<t_id<<")"<<endl;
+    exit(1);
+
+  }
+
   T ret=T();
   for(ThreadPipeSet& tps : g_pipes)
   {
-    if(n++ == t_id) {
-      if(!skipSelf) {
-        T* resp = (T*)func(); // don't write to ourselves!
-        if(resp) {
-          //~ cerr <<"got direct: " << *resp << endl;
-          ret += *resp;
-          delete resp;
-        }
-      }
-      continue;
-    }
-
     ThreadMSG* tmsg = new ThreadMSG();
     tmsg->func = boost::bind(voider<T>, func);
     tmsg->wantAnswer = true;
@@ -2886,7 +2893,7 @@ static void checkOrFixFDS()
   }
 }
 
-static void* recursorThread(void*);
+static void* recursorThread(int tid, bool worker);
 
 static void* pleaseSupplantACLs(std::shared_ptr<NetmaskGroup> ng)
 {
@@ -3370,36 +3377,39 @@ static int serviceMain(int argc, char*argv[])
     s_avoidUdpSourcePorts.insert(port);
   }
 
+  /* This thread handles the web server, carbon, statistics and the control channel */
+  std::thread handlerThread(recursorThread, -1, false);
+
   const auto cpusMap = parseCPUMap();
+
+  std::vector<std::thread> workers(g_numThreads);
   if(g_numThreads == 1) {
     g_log<<Logger::Warning<<"Operating unthreaded"<<endl;
 #ifdef HAVE_SYSTEMD
     sd_notify(0, "READY=1");
 #endif
     setCPUMap(cpusMap, 0, pthread_self());
-    recursorThread(0);
+    recursorThread(0, true);
   }
   else {
-    pthread_t tid;
     g_log<<Logger::Warning<<"Launching "<< g_numThreads <<" threads"<<endl;
     for(unsigned int n=0; n < g_numThreads; ++n) {
-      pthread_create(&tid, 0, recursorThread, (void*)(long)n);
+      workers[n] = std::thread(recursorThread, n, true);
 
-      setCPUMap(cpusMap, n, tid);
+      setCPUMap(cpusMap, n, workers[n].native_handle());
     }
-    void* res;
 #ifdef HAVE_SYSTEMD
     sd_notify(0, "READY=1");
 #endif
-    pthread_join(tid, &res);
+    workers.back().join();
   }
   return 0;
 }
 
-static void* recursorThread(void* ptr)
+static void* recursorThread(int n, bool worker)
 try
 {
-  t_id=(int) (long) ptr;
+  t_id=n;
   SyncRes tmp(g_now); // make sure it allocates tsstorage before we do anything, like primeHints or so..
   SyncRes::setDomainMap(g_initialDomainMap);
   t_allowFrom = g_initialAllowFrom;
@@ -3456,7 +3466,8 @@ try
   PacketID pident;
 
   t_fdm=getMultiplexer();
-  if(!t_id) {
+
+  if(!worker) {
     if(::arg().mustDo("webserver")) {
       g_log<<Logger::Warning << "Enabling web server" << endl;
       try {
@@ -3469,25 +3480,27 @@ try
     }
     g_log<<Logger::Error<<"Enabled '"<< t_fdm->getName() << "' multiplexer"<<endl;
   }
-
-  t_fdm->addReadFD(g_pipes[t_id].readToThread, handlePipeRequest);
-  t_fdm->addReadFD(g_pipes[t_id].readQueriesToThread, handlePipeRequest);
-
-  if(g_useOneSocketPerThread) {
-    for(deferredAdd_t::const_iterator i = deferredAdds[t_id].cbegin(); i != deferredAdds[t_id].cend(); ++i) {
-      t_fdm->addReadFD(i->first, i->second);
-    }
-  }
   else {
-    if(!g_weDistributeQueries || !t_id) { // if we distribute queries, only t_id = 0 listens
-      for(deferredAdd_t::const_iterator i = deferredAdds[0].cbegin(); i != deferredAdds[0].cend(); ++i) {
+    t_fdm->addReadFD(g_pipes[t_id].readToThread, handlePipeRequest);
+    t_fdm->addReadFD(g_pipes[t_id].readQueriesToThread, handlePipeRequest);
+
+    if(g_useOneSocketPerThread) {
+      for(deferredAdd_t::const_iterator i = deferredAdds[t_id].cbegin(); i != deferredAdds[t_id].cend(); ++i) {
         t_fdm->addReadFD(i->first, i->second);
+      }
+    }
+    else {
+      if(!g_weDistributeQueries || !t_id) { // if we distribute queries, only t_id = 0 listens
+        for(deferredAdd_t::const_iterator i = deferredAdds[0].cbegin(); i != deferredAdds[0].cend(); ++i) {
+          t_fdm->addReadFD(i->first, i->second);
+        }
       }
     }
   }
 
   registerAllStats();
-  if(!t_id) {
+
+  if(!worker) {
     t_fdm->addReadFD(s_rcc.d_fd, handleRCC); // control channel
   }
 
@@ -3519,13 +3532,13 @@ try
 
     counter++;
 
-    if(!t_id && statsWanted) {
+    if(!worker && statsWanted) {
       doStats();
     }
 
     Utility::gettimeofday(&g_now, 0);
 
-    if(!t_id && (g_now.tv_sec - last_carbon >= carbonInterval)) {
+    if(!worker && (g_now.tv_sec - last_carbon >= carbonInterval)) {
       MT->makeThread(doCarbonDump, 0);
       last_carbon = g_now.tv_sec;
     }
@@ -3533,7 +3546,7 @@ try
     t_fdm->run(&g_now);
     // 'run' updates g_now for us
 
-    if(!g_weDistributeQueries || !t_id) { // if pdns distributes queries, only tid 0 should do this
+    if(worker && (!g_weDistributeQueries || !t_id)) { // if pdns distributes queries, only tid 0 should do this
       if(listenOnTCP) {
 	if(TCPConnection::getCurrentConnections() > maxTcpClients) {  // shutdown, too many connections
 	  for(tcpListenSockets_t::iterator i=g_tcpListenSockets.begin(); i != g_tcpListenSockets.end(); ++i)

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2435,7 +2435,7 @@ struct ThreadMSG
   bool wantAnswer;
 };
 
-void broadcastFunction(const pipefunc_t& func, bool skipSelf)
+void broadcastFunction(const pipefunc_t& func)
 {
   /* This function might be called by the worker with t_id 0 during startup */
   if (t_id != s_handlerThreadID && t_id != s_distributorThreadID) {
@@ -2443,12 +2443,14 @@ void broadcastFunction(const pipefunc_t& func, bool skipSelf)
     exit(1);
   }
 
+  // call the function ourselves, to update the ACL or domain maps for example
+  func();
+
   int n = 0;
   for(ThreadPipeSet& tps : g_pipes)
   {
     if(n++ == t_id) {
-      if(!skipSelf)
-        func(); // don't write to ourselves!
+      func(); // don't write to ourselves!
       continue;
     }
 
@@ -2563,7 +2565,7 @@ vector<pair<DNSName, uint16_t> >& operator+=(vector<pair<DNSName, uint16_t> >&a,
 }
 
 
-template<class T> T broadcastAccFunction(const boost::function<T*()>& func, bool skipSelf)
+template<class T> T broadcastAccFunction(const boost::function<T*()>& func)
 {
   if (t_id != s_handlerThreadID) {
     g_log<<Logger::Error<<"broadcastFunction has been called by a worker ("<<t_id<<")"<<endl;
@@ -2596,10 +2598,10 @@ template<class T> T broadcastAccFunction(const boost::function<T*()>& func, bool
   return ret;
 }
 
-template string broadcastAccFunction(const boost::function<string*()>& fun, bool skipSelf); // explicit instantiation
-template uint64_t broadcastAccFunction(const boost::function<uint64_t*()>& fun, bool skipSelf); // explicit instantiation
-template vector<ComboAddress> broadcastAccFunction(const boost::function<vector<ComboAddress> *()>& fun, bool skipSelf); // explicit instantiation
-template vector<pair<DNSName,uint16_t> > broadcastAccFunction(const boost::function<vector<pair<DNSName, uint16_t> > *()>& fun, bool skipSelf); // explicit instantiation
+template string broadcastAccFunction(const boost::function<string*()>& fun); // explicit instantiation
+template uint64_t broadcastAccFunction(const boost::function<uint64_t*()>& fun); // explicit instantiation
+template vector<ComboAddress> broadcastAccFunction(const boost::function<vector<ComboAddress> *()>& fun); // explicit instantiation
+template vector<pair<DNSName,uint16_t> > broadcastAccFunction(const boost::function<vector<pair<DNSName, uint16_t> > *()>& fun); // explicit instantiation
 
 static void handleRCC(int fd, FDMultiplexer::funcparam_t& var)
 {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -979,12 +979,12 @@ std::string reloadAuthAndForwards();
 ComboAddress parseIPAndPort(const std::string& input, uint16_t port);
 ComboAddress getQueryLocalAddress(int family, uint16_t port);
 typedef boost::function<void*(void)> pipefunc_t;
-void broadcastFunction(const pipefunc_t& func, bool skipSelf = false);
+void broadcastFunction(const pipefunc_t& func);
 void distributeAsyncFunction(const std::string& question, const pipefunc_t& func);
 
 int directResolve(const DNSName& qname, const QType& qtype, int qclass, vector<DNSRecord>& ret);
 
-template<class T> T broadcastAccFunction(const boost::function<T*()>& func, bool skipSelf=false);
+template<class T> T broadcastAccFunction(const boost::function<T*()>& func);
 
 std::shared_ptr<SyncRes::domainmap_t> parseAuthAndForwards();
 uint64_t* pleaseGetNsSpeedsSize();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This makes sure that no worker or distributor thread will get blocked while waiting for a response from another thread, for example while gathering stats or executing a command coming from the control
channel.

This PR needs a serious review, don't merge blindly!

It might also need some documentation update.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
