### PR TITLE
Disable parallel build for docs

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -63,6 +63,15 @@ endif # if !HAVE_MANPAGES
 	.venv/bin/pip install -U pip setuptools setuptools-git
 	.venv/bin/pip install -r requirements.txt
 
+.NOTPARALLEL: \
+	all-docs \
+	upload-docs \
+	html-docs \
+	$(MANPAGES_DIST) \
+	latex/PowerDNS-Authoritative.pdf \
+	PowerDNS-Authoritative.pdf \
+	html-docs.tar.bz2
+
 html-docs: common/** manpages/** .venv *.rst
 	.venv/bin/python -msphinx -b html . html-docs
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -72,6 +72,10 @@ endif # if !HAVE_MANPAGES
 	PowerDNS-Authoritative.pdf \
 	html-docs.tar.bz2
 
+clean-local:
+	rm -f latex/PowerDNS-Authoritative.pdf $(MANPAGES_DIST) html-docs.tar.bz2
+	rm -rf mans
+
 html-docs: common/** manpages/** .venv *.rst
 	.venv/bin/python -msphinx -b html . html-docs
 


### PR DESCRIPTION
### Short description
Fixes the docs subdir to not use parallel build even if `-j` is used.  Also adds `clean` target support.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
