### PR TITLE
auth-bindbackend: only compare ips in isMaster()

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1211,10 +1211,16 @@ bool Bind2Backend::isMaster(const DNSName& name, const string &ip)
   if(bbd.d_kind != DomainInfo::Slave)
     return false;
 
-  for(vector<string>::const_iterator iter = bbd.d_masters.begin(); iter != bbd.d_masters.end(); ++iter)
-    if(*iter==ip)
-      return true;
-  
+  for(vector<string>::const_iterator iter = bbd.d_masters.begin(); iter != bbd.d_masters.end(); ++iter) {
+    try {
+      const ComboAddress caMaster(*iter);
+      if(ip == caMaster.toString()) {
+        return true;
+      }
+    }
+    catch(...) {}
+  }
+
   return false;
 }
 


### PR DESCRIPTION
### Short description
This fix is in a different form already present on master (part of #6021)

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] checked that this code was merged to master
