### PR TITLE
dnsreplay: Bail out on a too small outgoing buffer

### DIFF
--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -595,7 +595,7 @@ static void addECSOption(char* packet, const size_t& packetSize, uint16_t* len, 
 
   uint16_t arcount = ntohs(dh->arcount);
   /* does it fit in the existing buffer? */
-  if (packetSize - *len > EDNSRR.size()) {
+  if (packetSize > *len && packetSize - *len > EDNSRR.size()) {
     arcount++;
     dh->arcount = htons(arcount);
     memcpy(packet + *len, EDNSRR.c_str(), EDNSRR.size());


### PR DESCRIPTION
### Short description
dnsreplay: Bail out on a too small outgoing buffer

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
