### PR TITLE
Add syntax to dns.proto to silence compilation warning.

### DIFF
--- a/pdns/dnstap.proto
+++ b/pdns/dnstap.proto
@@ -13,6 +13,7 @@
 // with this file. If not, see:
 //
 // <http://creativecommons.org/publicdomain/zero/1.0/>.
+syntax = "proto2";
 
 package dnstap;
 


### PR DESCRIPTION
### Short description

Add syntax statement to `dnstap.proto` as suggested by the compilation warning.  This is the same default syntax statement  the the protobuf compiler falls back to.

This is just to get rid of  the jarring warning message to comes by when compiling.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
