### PR TITLE
Backport 6574 to 4.1.x: rec: Add _raw versions for qname / ComboAddresses to the FFI API

### DIFF
--- a/pdns/lua-recursor4-ffi.hh
+++ b/pdns/lua-recursor4-ffi.hh
@@ -30,12 +30,16 @@ extern "C" {
   } pdns_ednsoption_t;
 
   const char* pdns_ffi_param_get_qname(pdns_ffi_param_t* ref) __attribute__ ((visibility ("default")));
+  void pdns_ffi_param_get_qname_raw(pdns_ffi_param_t* ref, const char** qname, size_t* qnameSize) __attribute__ ((visibility ("default")));
   uint16_t pdns_ffi_param_get_qtype(const pdns_ffi_param_t* ref) __attribute__ ((visibility ("default")));
   const char* pdns_ffi_param_get_remote(pdns_ffi_param_t* ref) __attribute__ ((visibility ("default")));
+  void pdns_ffi_param_get_remote_raw(pdns_ffi_param_t* ref, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
   uint16_t pdns_ffi_param_get_remote_port(const pdns_ffi_param_t* ref) __attribute__ ((visibility ("default")));
   const char* pdns_ffi_param_get_local(pdns_ffi_param_t* ref) __attribute__ ((visibility ("default")));
+  void pdns_ffi_param_get_local_raw(pdns_ffi_param_t* ref, const void** addr, size_t* addrSize) __attribute__ ((visibility ("default")));
   uint16_t pdns_ffi_param_get_local_port(const pdns_ffi_param_t* ref) __attribute__ ((visibility ("default")));
   const char* pdns_ffi_param_get_edns_cs(pdns_ffi_param_t* ref) __attribute__ ((visibility ("default")));
+  void pdns_ffi_param_get_edns_cs_raw(pdns_ffi_param_t* ref, const void** net, size_t* netSize) __attribute__ ((visibility ("default")));
   uint8_t pdns_ffi_param_get_edns_cs_source_mask(const pdns_ffi_param_t* ref) __attribute__ ((visibility ("default")));
 
   // returns the length of the resulting 'out' array. 'out' is not set if the length is 0

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -749,6 +749,13 @@ const char* pdns_ffi_param_get_qname(pdns_ffi_param_t* ref)
   return ref->qnameStr->c_str();
 }
 
+void pdns_ffi_param_get_qname_raw(pdns_ffi_param_t* ref, const char** qname, size_t* qnameSize)
+{
+  const auto& storage = ref->qname.getStorage();
+  *qname = storage.data();
+  *qnameSize = storage.size();
+}
+
 uint16_t pdns_ffi_param_get_qtype(const pdns_ffi_param_t* ref)
 {
   return ref->qtype;
@@ -763,6 +770,23 @@ const char* pdns_ffi_param_get_remote(pdns_ffi_param_t* ref)
   return ref->remoteStr->c_str();
 }
 
+static void pdns_ffi_comboaddress_to_raw(const ComboAddress& ca, const void** addr, size_t* addrSize)
+{
+  if (ca.isIPv4()) {
+    *addr = &ca.sin4.sin_addr.s_addr;
+    *addrSize = sizeof(ca.sin4.sin_addr.s_addr);
+  }
+  else {
+    *addr = &ca.sin6.sin6_addr.s6_addr;
+    *addrSize = sizeof(ca.sin6.sin6_addr.s6_addr);
+  }
+}
+
+void pdns_ffi_param_get_remote_raw(pdns_ffi_param_t* ref, const void** addr, size_t* addrSize)
+{
+  pdns_ffi_comboaddress_to_raw(ref->remote, addr, addrSize);
+}
+
 uint16_t pdns_ffi_param_get_remote_port(const pdns_ffi_param_t* ref)
 {
   return ref->remote.getPort();
@@ -775,6 +799,11 @@ const char* pdns_ffi_param_get_local(pdns_ffi_param_t* ref)
   }
 
   return ref->localStr->c_str();
+}
+
+void pdns_ffi_param_get_local_raw(pdns_ffi_param_t* ref, const void** addr, size_t* addrSize)
+{
+  pdns_ffi_comboaddress_to_raw(ref->local, addr, addrSize);
 }
 
 uint16_t pdns_ffi_param_get_local_port(const pdns_ffi_param_t* ref)
@@ -793,6 +822,17 @@ const char* pdns_ffi_param_get_edns_cs(pdns_ffi_param_t* ref)
   }
 
   return ref->ednssubnetStr->c_str();
+}
+
+void pdns_ffi_param_get_edns_cs_raw(pdns_ffi_param_t* ref, const void** net, size_t* netSize)
+{
+  if (ref->ednssubnet.empty()) {
+    *net = nullptr;
+    *netSize = 0;
+    return;
+  }
+
+  pdns_ffi_comboaddress_to_raw(ref->ednssubnet.getNetwork(), net, netSize);
 }
 
 uint8_t pdns_ffi_param_get_edns_cs_source_mask(const pdns_ffi_param_t* ref)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
(cherry picked from commit aedec560c6494e838d92e9a8106d5ff87367eb83)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
