### PR TITLE
reflect accurate old value of webserver-allow-from

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1527,7 +1527,7 @@ IP Address for webserver/API to listen on.
 
 .. versionchanged:: 4.1.0
 
-    Default is now 127.0.0.1,::1, was 0.0.0.0,::/0 before.
+    Default is now 127.0.0.1,::1, was 0.0.0.0/0,::/0 before.
 
 Webserver/API access is only allowed from these subnets.
 


### PR DESCRIPTION
### Short description
Modified the previous value of webserver-allow-from to correctly reflect the change introduced [here](https://github.com/PowerDNS/pdns/commit/be3e14771236c0476713d7d55aa2d60622a799e2).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
