### PR TITLE
calidns: Add quiet, minimum-success-rate options to use from a script

### DIFF
--- a/docs/manpages/calidns.1.rst
+++ b/docs/manpages/calidns.1.rst
@@ -40,4 +40,5 @@ Options
                          by *NUM*. By default, this is 1.1.
 --maximum-qps <NUM>      Stop incrementing once this rate has been reached, to provide a
                          stable load.
+--plot-file <FILE>       Write results to the specified file.
 --want-recursion         Set this flag to send queries with the Recursion Desired flag set.

--- a/docs/manpages/calidns.1.rst
+++ b/docs/manpages/calidns.1.rst
@@ -43,4 +43,6 @@ Options
 --minimum-success-rate <NUM>   Stop the test as soon as the success rate drops below this value,
                                in percent.
 --plot-file <FILE>             Write results to the specified file.
+--quiet                        Whether to run quietly, outputting only the maximum QPS reached.
+                               This option is mostly useful when used with --minimum-success-rate.
 --want-recursion               Set this flag to send queries with the Recursion Desired flag set.

--- a/docs/manpages/calidns.1.rst
+++ b/docs/manpages/calidns.1.rst
@@ -32,13 +32,15 @@ This is similar to Alexa top 1 million list.
 Options
 -------
 
---ecs <SUBNET>           Add EDNS Client Subnet option to outgoing queries using random
-                         addresses from the specified *SUBNET* range (IPv4 only).
---ecs-from-file          Read IP or subnet values from the query file and add them as EDNS
-                         Client Subnet option to outgoing queries.
---increment <NUM>        On every subsequent run, multiply the number of queries per second
-                         by *NUM*. By default, this is 1.1.
---maximum-qps <NUM>      Stop incrementing once this rate has been reached, to provide a
-                         stable load.
---plot-file <FILE>       Write results to the specified file.
---want-recursion         Set this flag to send queries with the Recursion Desired flag set.
+--ecs <SUBNET>                 Add EDNS Client Subnet option to outgoing queries using random
+                               addresses from the specified *SUBNET* range (IPv4 only).
+--ecs-from-file                Read IP or subnet values from the query file and add them as EDNS
+                               Client Subnet option to outgoing queries.
+--increment <NUM>              On every subsequent run, multiply the number of queries per second
+                               by *NUM*. By default, this is 1.1.
+--maximum-qps <NUM>            Stop incrementing once this rate has been reached, to provide a
+                               stable load.
+--minimum-success-rate <NUM>   Stop the test as soon as the success rate drops below this value,
+                               in percent.
+--plot-file <FILE>             Write results to the specified file.
+--want-recursion               Set this flag to send queries with the Recursion Desired flag set.

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -227,6 +227,7 @@ try
     ("maximum-qps", po::value<uint32_t>(), "Stop incrementing once this rate has been reached, to provide a stable load")
     ("minimum-success-rate", po::value<double>()->default_value(0), "Stop the test as soon as the success rate drops below this value, in percent")
     ("plot-file", po::value<string>(), "Write results to the specific file")
+    ("quiet", "Whether to run quietly, outputting only the maximum QPS reached. This option is mostly useful when used with --minimum-success-rate")
     ("want-recursion", "Set the Recursion Desired flag on queries");
   po::options_description alloptions;
   po::options_description hidden("hidden options");
@@ -269,6 +270,7 @@ try
   }
 
   bool wantRecursion = g_vm.count("want-recursion");
+  bool beQuiet = g_vm.count("quiet");
   bool useECSFromFile = g_vm.count("ecs-from-file");
 
   double hitrate = g_vm["hitrate"].as<double>();
@@ -303,7 +305,9 @@ try
           return EXIT_FAILURE;
         }
 
-        cout<<"Adding ECS option to outgoing queries with random addresses from the "<<ecsRange.toString()<<" range"<<endl;
+        if (!beQuiet) {
+          cout<<"Adding ECS option to outgoing queries with random addresses from the "<<ecsRange.toString()<<" range"<<endl;
+        }
       }
     }
     catch (const NetmaskException& e) {
@@ -366,7 +370,9 @@ try
     unknown.emplace_back(std::make_shared<vector<uint8_t>>(packet));
   }
   random_shuffle(unknown.begin(), unknown.end());
-  cout<<"Generated "<<unknown.size()<<" ready to use queries"<<endl;
+  if (!beQuiet) {
+    cout<<"Generated "<<unknown.size()<<" ready to use queries"<<endl;
+  }
   
   vector<Socket*> sockets;
   ComboAddress dest;
@@ -401,13 +407,17 @@ try
 
   for(qps=qpsstart;;) {
     double seconds=1;
-    cout<<"Aiming at "<<qps<< "qps (RD="<<wantRecursion<<") for "<<seconds<<" seconds at cache hitrate "<<100.0*hitrate<<"%";
+    if (!beQuiet) {
+      cout<<"Aiming at "<<qps<< "qps (RD="<<wantRecursion<<") for "<<seconds<<" seconds at cache hitrate "<<100.0*hitrate<<"%";
+    }
     unsigned int misses=(1-hitrate)*qps*seconds;
     unsigned int total=qps*seconds;
     if (misses == 0) {
       misses = 1;
     }
-    cout<<", need "<<misses<<" misses, "<<total<<" queries, have "<<unknown.size()<<" unknown left!"<<endl;
+    if (!beQuiet) {
+      cout<<", need "<<misses<<" misses, "<<total<<" queries, have "<<unknown.size()<<" unknown left!"<<endl;
+    }
 
     if (misses > unknown.size()) {
       cerr<<"Not enough queries remaining (need at least "<<misses<<" and got "<<unknown.size()<<", please add more to the query file), exiting."<<endl;
@@ -434,14 +444,18 @@ try
     
     const auto udiff = dt.udiffNoReset();
     const auto realqps=toSend.size()/(udiff/1000000.0);
-    cout<<"Achieved "<<realqps<<" qps over "<< udiff/1000000.0<<" seconds"<<endl;
+    if (!beQuiet) {
+      cout<<"Achieved "<<realqps<<" qps over "<< udiff/1000000.0<<" seconds"<<endl;
+    }
     
     usleep(50000);
     const auto received = g_recvcounter.load();
     const auto udiffReceived = dt.udiff();
     const auto realReceivedQPS = received/(udiffReceived/1000000.0);
     double perc=received*100.0/toSend.size();
-    cout<<"Received "<<received<<" packets over "<< udiffReceived/1000000.0<<" seconds ("<<perc<<"%, adjusted received rate "<<realReceivedQPS<<" qps)"<<endl;
+     if (!beQuiet) {
+       cout<<"Received "<<received<<" packets over "<< udiffReceived/1000000.0<<" seconds ("<<perc<<"%, adjusted received rate "<<realReceivedQPS<<" qps)"<<endl;
+     }
 
     if (plot) {
       plot<<qps<<" "<<realqps<<" "<<perc<<" "<<received/(udiff/1000000.0)<<" " << 8*g_recvbytes.load()/(udiff/1000000.0)<<endl;
@@ -456,8 +470,13 @@ try
     }
 
     if (minimumSuccessRate > 0.0 && perc < minimumSuccessRate) {
-      cout<<"The latest success rate ("<<perc<<") dropped below the minimum success rate of "<<minimumSuccessRate<<", stopping."<<endl;
-      cout<<"The final rate reached before failing was "<<bestQPS<<" qps (best rate at 100% was "<<bestPerfectQPS<<" qps)"<<endl;
+      if (beQuiet) {
+        cout<<bestQPS<<endl;
+      }
+      else {
+        cout<<"The latest success rate ("<<perc<<") dropped below the minimum success rate of "<<minimumSuccessRate<<", stopping."<<endl;
+        cout<<"The final rate reached before failing was "<<bestQPS<<" qps (best rate at 100% was "<<bestPerfectQPS<<" qps)"<<endl;
+      }
       break;
     }
 

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -314,6 +314,9 @@ try
   string line;
   reportAllTypes();
   vector<std::shared_ptr<vector<uint8_t> > > unknown, known;
+  std::vector<std::string> fields;
+  fields.reserve(3);
+
   while(getline(ifs, line)) {
     vector<uint8_t> packet;
     DNSPacketWriter::optvect_t ednsOptions;
@@ -322,15 +325,19 @@ try
       continue;
     }
 
-    auto fields = splitField(line, ' ');
-    std::string qname = fields.first;
-    std::string qtype = fields.second;
+    fields.clear();
+    stringtok(fields, line, "\t ");
+    if ((useECSFromFile && fields.size() < 3) || fields.size() < 2) {
+      cerr<<"Skipping invalid line '"<<line<<", it does not contain enough values"<<endl;
+      continue;
+    }
+
+    const std::string& qname = fields.at(0);
+    const std::string& qtype = fields.at(1);
     std::string subnet;
 
-    if(useECSFromFile) {
-      fields = splitField(qtype, ' ');
-      qtype = fields.first;
-      subnet = fields.second;
+    if (useECSFromFile) {
+      subnet = fields.at(2);
     }
 
     DNSPacketWriter pw(packet, DNSName(qname), DNSRecordContent::TypeToNumber(qtype));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Add an option to stop once we drop below a minimum rate, as well as a `quiet` option so I can start `calidns` from a script and it just outputs the maximum QPS reached before we dropped below 99.9%, for example
- Accept lines with an ECS value even if we don't use it, so we can use a file with ECS information more easily
- Only write a 'plot' file when asked to, because I keep finding those files on my filesystem :)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
