### PR TITLE
our recursor lua policy override example did not work

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/hooks.rst
+++ b/pdns/recursordist/docs/lua-scripting/hooks.rst
@@ -272,13 +272,14 @@ Example script
     myDomain = newDN("example.com")
 
     myNetblock = newNMG()
-    myNetblock:addMasks("192.0.2.0/24")
+    myNetblock:addMasks({"192.0.2.0/24"})
 
     function preresolve(dq)
       if dq.qname:isPartOf(myDomain) and dq.appliedPolicy.policyKind ~= pdns.policykinds.NoAction then
         pdnslog("Not blocking our own domain!")
         dq.appliedPolicy.policyKind = pdns.policykinds.NoAction
       end
+      return false
     end
 
     function postresolve(dq)
@@ -294,6 +295,7 @@ Example script
           end
         end
       end
+      return false
     end
 
 .. _snmp:


### PR DESCRIPTION
### Short description
Fix an example Lua script from the documentation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
