### PR TITLE
Backport 6130 to rec-4.1.x: Update copyright years to 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PowerDNS is copyright © 2002-2017 by PowerDNS.COM BV and lots of
+PowerDNS is copyright © 2001-2018 by PowerDNS.COM BV and lots of
 contributors, using the GNU GPLv2 license (see NOTICE for the
 exact license and exception used).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ master_doc = 'indexTOC'
 
 # General information about the project.
 project = 'PowerDNS Recursor'
-copyright = '2017, PowerDNS.COM BV'
+copyright = '2001-2018, PowerDNS.COM BV'
 author = 'PowerDNS.COM BV'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/pdns/dnsdistdist/docs/conf.py
+++ b/pdns/dnsdistdist/docs/conf.py
@@ -48,7 +48,7 @@ master_doc = 'index_TOC'
 
 # General information about the project.
 project = 'dnsdist'
-copyright = '2015-2017, PowerDNS.COM BV and its contributors'
+copyright = '2015-2018, PowerDNS.COM BV and its contributors'
 author = 'PowerDNS.COM BV and its contributors'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/pdns/recursordist/README.md
+++ b/pdns/recursordist/README.md
@@ -81,6 +81,6 @@ reported.
 
 License
 -------
-PowerDNS is copyright © 2002-2017 by PowerDNS.COM BV and lots of
+PowerDNS is copyright © 2001-2018 by PowerDNS.COM BV and lots of
 contributors, using the GNU GPLv2 license (see NOTICE for the
 exact license and exception used).

--- a/pdns/recursordist/docs/conf.py
+++ b/pdns/recursordist/docs/conf.py
@@ -51,7 +51,7 @@ master_doc = 'indexTOC'
 
 # General information about the project.
 project = 'PowerDNS Recursor'
-copyright = '2017, PowerDNS.COM BV'
+copyright = '2001-2018, PowerDNS.COM BV'
 author = 'PowerDNS.COM BV'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/pdns/version.cc
+++ b/pdns/version.cc
@@ -71,7 +71,7 @@ string productTypeApiType() {
 
 void showProductVersion()
 {
-  theL()<<Logger::Warning<<productName()<<" "<< VERSION << " (C) 2001-2017 "
+  theL()<<Logger::Warning<<productName()<<" "<< VERSION << " (C) 2001-2018 "
     "PowerDNS.COM BV" << endl;
   theL()<<Logger::Warning<<"Using "<<(sizeof(unsigned long)*8)<<"-bits mode. "
     "Built using " << compilerVersion()

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -277,7 +277,7 @@ void AuthWebServer::indexfunction(HttpRequest* req, HttpResponse* resp)
     printtable(ret,req->getvars["ring"],S.getRingTitle(req->getvars["ring"]),100);
 
   ret<<"</div></div>"<<endl;
-  ret<<"<footer class=\"row\">"<<fullVersionString()<<"<br>&copy; 2013 - 2017 <a href=\"http://www.powerdns.com/\">PowerDNS.COM BV</a>.</footer>"<<endl;
+  ret<<"<footer class=\"row\">"<<fullVersionString()<<"<br>&copy; 2013 - 2018 <a href=\"http://www.powerdns.com/\">PowerDNS.COM BV</a>.</footer>"<<endl;
   ret<<"</body></html>"<<endl;
 
   resp->body = ret.str();


### PR DESCRIPTION
Also update several years to match the data in pdns/version.cc

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
4.1.2 is still "copyright 2017". Backport #6130 to rec-4.1.x.

I don't know what I'm doing, but it shouldn't be possible for something like this to go wrong...

(Backport for auth is #6610.)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
