### PR TITLE
auth-api: restrict creation of OPT and TSIG rrsets

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -306,7 +306,7 @@ static Json::object getZoneInfo(const DomainInfo& di, DNSSECKeeper *dk) {
   vector<string> masters;
   for(const auto& m : di.masters)
     masters.push_back(m.toStringWithPortExcept(53));
-  
+
   return Json::object {
     // id is the canonical lookup key, which doesn't actually match the name (in some cases)
     { "id", zoneId },
@@ -462,6 +462,12 @@ void productServerStatisticsFetch(map<string,string>& out)
   out["uptime"] = std::to_string(time(0) - s_starttime);
 }
 
+static void validateGatheredRRType(const DNSResourceRecord& rr) {
+  if (rr.qtype.getCode() == QType::OPT || rr.qtype.getCode() == QType::TSIG) {
+    throw ApiException("RRset "+rr.qname.toString()+" IN "+rr.qtype.getName()+": invalid type given");
+  }
+}
+
 static void gatherRecords(const Json container, const DNSName& qname, const QType qtype, const int ttl, vector<DNSResourceRecord>& new_records, vector<DNSResourceRecord>& new_ptrs) {
   UeberBackend B;
   DNSResourceRecord rr;
@@ -469,6 +475,8 @@ static void gatherRecords(const Json container, const DNSName& qname, const QTyp
   rr.qtype = qtype;
   rr.auth = 1;
   rr.ttl = ttl;
+
+  validateGatheredRRType(rr);
   for(auto record : container["records"].array_items()) {
     string content = stringFromJson(record, "content");
     rr.disabled = boolFromJson(record, "disabled");
@@ -1181,6 +1189,7 @@ static void gatherRecordsFromZone(const std::string& zonestring, vector<DNSResou
         continue;
       if(rr.qtype.getCode() == QType::SOA)
         seenSOA=true;
+      validateGatheredRRType(rr);
 
       new_records.push_back(rr);
     }
@@ -1645,10 +1654,6 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
         // we only validate for REPLACE, as DELETE can be used to "fix" out of zone records.
         if (!qname.isPartOf(zonename) && qname != zonename)
           throw ApiException("RRset "+qname.toString()+" IN "+qtype.getName()+": Name is out of zone");
-
-        if (qtype.getCode() == QType::OPT || qtype.getCode() == QType::TSIG) {
-          throw ApiException("RRset "+qname.toString()+" IN "+stringFromJson(rrset, "type")+": invalid type given");
-        }
 
         bool replace_records = rrset["records"].is_array();
         bool replace_comments = rrset["comments"].is_array();

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1646,6 +1646,10 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
         if (!qname.isPartOf(zonename) && qname != zonename)
           throw ApiException("RRset "+qname.toString()+" IN "+qtype.getName()+": Name is out of zone");
 
+        if (qtype.getCode() == QType::OPT || qtype.getCode() == QType::TSIG) {
+          throw ApiException("RRset "+qname.toString()+" IN "+stringFromJson(rrset, "type")+": invalid type given");
+        }
+
         bool replace_records = rrset["records"].is_array();
         bool replace_comments = rrset["comments"].is_array();
 

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -938,6 +938,29 @@ fred   IN  A      192.168.0.4
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         self.assertEquals(get_rrset(data, name, 'MX')['records'], rrset['records'])
 
+    def test_zone_rr_update_opt(self):
+        name, payload, zone = self.create_zone()
+        # do a replace (= update)
+        rrset = {
+            'changetype': 'replace',
+            'name': name,
+            'type': 'OPT',
+            'ttl': 3600,
+            'records': [
+                {
+                    "content": "9",
+                    "disabled": False
+                }
+            ]
+        }
+        payload = {'rrsets': [rrset]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(r.status_code, 422)
+        self.assertIn('OPT: invalid type given', r.json()['error'])
+
     def test_zone_rr_update_multiple_rrsets(self):
         name, payload, zone = self.create_zone()
         rrset1 = {


### PR DESCRIPTION
### Short description
OPT and TSIG rrsets are already ignored in incoming AXFR. This restricts creation of such records through the authoritative API and fix #6441 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
