### PR TITLE
rec: Drop queries truncated because they were larger than our buffer

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2011,6 +2011,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
 static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
 {
   ssize_t len;
+  static const size_t maxIncomingQuerySize = 512;
   static thread_local std::string data;
   ComboAddress fromaddr;
   struct msghdr msgh;
@@ -2018,7 +2019,7 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
   char cbuf[256];
   bool firstQuery = true;
 
-  data.resize(1500);
+  data.resize(maxIncomingQuerySize);
   fromaddr.sin6.sin6_family=AF_INET6; // this makes sure fromaddr is big enough
   fillMSGHdr(&msgh, &iov, cbuf, sizeof(cbuf), &data[0], data.size(), &fromaddr);
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2035,6 +2035,14 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       return;
     }
 
+    if (msgh.msg_flags & MSG_TRUNC) {
+      g_stats.truncatedDrops++;
+      if (!g_quiet) {
+        g_log<<Logger::Error<<"Ignoring truncated query from "<<fromaddr.toString()<<endl;
+      }
+      return;
+    }
+
     if(t_remotes)
       t_remotes->push_back(fromaddr);
 

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -108,6 +108,7 @@ static const oid policyResultNodataOID[] = { RECURSOR_STATS_OID, 89 };
 static const oid policyResultTruncateOID[] = { RECURSOR_STATS_OID, 90 };
 static const oid policyResultCustomOID[] = { RECURSOR_STATS_OID, 91 };
 static const oid queryPipeFullDropsOID[] = { RECURSOR_STATS_OID, 92 };
+static const oid truncatedDropsOID[] = { RECURSOR_STATS_OID, 93 };
 
 static std::unordered_map<oid, std::string> s_statsMap;
 
@@ -220,6 +221,7 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   registerCounter64Stat("server-parse-errors", serverParseErrorsOID, OID_LENGTH(serverParseErrorsOID));
   registerCounter64Stat("too-old-drops", tooOldDropsOID, OID_LENGTH(tooOldDropsOID));
   registerCounter64Stat("query-pipe-full-drops", queryPipeFullDropsOID, OID_LENGTH(queryPipeFullDropsOID));
+  registerCounter64Stat("truncated-drops", truncatedDropsOID, OID_LENGTH(truncatedDropsOID));
   registerCounter64Stat("answers0-1", answers01OID, OID_LENGTH(answers01OID));
   registerCounter64Stat("answers1-10", answers110OID, OID_LENGTH(answers110OID));
   registerCounter64Stat("answers10-100", answers10100OID, OID_LENGTH(answers10100OID));

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -870,6 +870,7 @@ void registerAllStats()
   addGetStat("client-parse-errors", &g_stats.clientParseError);
   addGetStat("server-parse-errors", &g_stats.serverParseError);
   addGetStat("too-old-drops", &g_stats.tooOldDrops);
+  addGetStat("truncated-drops", &g_stats.truncatedDrops);
   addGetStat("query-pipe-full-drops", &g_stats.queryPipeFullDrops);
 
   addGetStat("answers0-1", &g_stats.answers0_1);

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -766,6 +766,14 @@ queryPipeFullDrops OBJECT-TYPE
         "Number of queries dropped because the query distribution pipe was full"
     ::= { stats 92 }
 
+truncatedDrops OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of queries dropped because they were larger than 1500 bytes"
+    ::= { stats 93 }
+
 ---
 --- Traps / Notifications
 ---
@@ -900,6 +908,7 @@ recGroup OBJECT-GROUP
         policyResultTruncate,
         policyResultCustom,
         queryPipeFullDrops,
+        truncatedDrops,
         trapReason
     }
     STATUS current

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -771,7 +771,7 @@ truncatedDrops OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-        "Number of queries dropped because they were larger than 1500 bytes"
+        "Number of queries dropped because they were larger than 512 bytes"
     ::= { stats 93 }
 
 ---

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -430,7 +430,7 @@ truncated-drops
 ^^^^^^^^^^^^^^^
 .. versionadded:: 4.2
 
-questions dropped because they were larger than 1500 bytes
+questions dropped because they were larger than 512 bytes
 
 unauthorized-tcp
 ^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -426,6 +426,12 @@ too-old-drops
 ^^^^^^^^^^^^^
 questions dropped that were too old
 
+truncated-drops
+^^^^^^^^^^^^^^^
+.. versionadded:: 4.2
+
+questions dropped because they were larger than 1500 bytes
+
 unauthorized-tcp
 ^^^^^^^^^^^^^^^^
 number of TCP questions denied because of   allow-from restrictions

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -905,6 +905,7 @@ struct RecursorStats
   std::atomic<uint64_t> clientParseError;
   std::atomic<uint64_t> serverParseError;
   std::atomic<uint64_t> tooOldDrops;
+  std::atomic<uint64_t> truncatedDrops;
   std::atomic<uint64_t> queryPipeFullDrops;
   std::atomic<uint64_t> unexpectedCount;
   std::atomic<uint64_t> caseMismatchCount;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Incoming queries larger than our buffer (1500 bytes) are truncated by the kernel, so let's not even try to parse them.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
