### PR TITLE
-rdynamic is for the linker

### DIFF
--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -103,8 +103,7 @@ PDNS_WITH_LUA([mandatory])
 AS_IF([test "x$LUAPC" = "xluajit"], [
   # export all symbols to be able to use the Lua FFI interface
   AC_MSG_NOTICE([Adding -rdynamic to export all symbols for the Lua FFI interface])
-  CFLAGS="$CFLAGS -rdynamic"
-  CXXFLAGS="$CXXFLAGS -rdynamic"
+  LDFLAGS="$LDFLAGS -rdynamic"
 ])
 
 PDNS_CHECK_LUA_HPP


### PR DESCRIPTION
### Short description
This moves `-rdynamic` from compiler to linker flags for the recursor. Ref #6511 

I DID NOT test if the FFI symbols are correctly exported with this patch.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
