### PR TITLE
reject duplicate RRsets in patchZone

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1642,14 +1642,15 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
       apiCheckQNameAllowedCharacters(qname.toString());
       QType qtype;
       qtype = stringFromJson(rrset, "type");
-      if(seen.count({qname, qtype}))
-      {
-        throw ApiException("Duplicate RRset "+qname.toString()+" IN "+stringFromJson(rrset, "type"));
-      }
-      seen.insert({qname, qtype});
       if (qtype.getCode() == 0) {
         throw ApiException("RRset "+qname.toString()+" IN "+stringFromJson(rrset, "type")+": unknown type given");
       }
+
+      if(seen.count({qname, qtype}))
+      {
+        throw ApiException("Duplicate RRset "+qname.toString()+" IN "+qtype.getName());
+      }
+      seen.insert({qname, qtype});
 
       if (changetype == "DELETE") {
         // delete all matching qname/qtype RRs (and, implicitly comments).

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1022,6 +1022,40 @@ fred   IN  A      192.168.0.4
         self.assertEquals(r.status_code, 422)
         self.assertIn('Duplicate record in RRset', r.json()['error'])
 
+    def test_zone_rr_update_duplicate_rrset(self):
+        name, payload, zone = self.create_zone()
+        rrset1 = {
+            'changetype': 'replace',
+            'name': name,
+            'type': 'NS',
+            'ttl': 3600,
+            'records': [
+                {
+                    "content": "ns9999.example.com.",
+                    "disabled": False
+                }
+            ]
+        }
+        rrset2 = {
+            'changetype': 'replace',
+            'name': name,
+            'type': 'NS',
+            'ttl': 3600,
+            'records': [
+                {
+                    "content": "ns9998.example.com.",
+                    "disabled": False
+                }
+            ]
+        }
+        payload = {'rrsets': [rrset1, rrset2]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(r.status_code, 422)
+        self.assertIn('Duplicate RRset', r.json()['error'])
+
     def test_zone_rr_delete(self):
         name, payload, zone = self.create_zone()
         # do a delete of all NS records (these are created with the zone)


### PR DESCRIPTION
### Short description
We frequently get users who pass two identical RRsets, each holding one record, with different content. The user might then be confused to only see the second one ending up in the zone. Erroring out early should avoid confusion.

Comments welcome. ~~Still needs a test.~~

Suggested by @hlindqvist 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
