### PR TITLE
Don't copy unitialized values of SuffixMatchTree

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -233,8 +233,11 @@ struct SuffixMatchTree
   SuffixMatchTree(const std::string& name="", bool endNode_=false) : d_name(name), endNode(endNode_)
   {}
 
-  SuffixMatchTree(const SuffixMatchTree& rhs): d_name(rhs.d_name), children(rhs.children), endNode(rhs.endNode), d_value(rhs.d_value)
+  SuffixMatchTree(const SuffixMatchTree& rhs): d_name(rhs.d_name), children(rhs.children), endNode(rhs.endNode)
   {
+    if (endNode) {
+      d_value = rhs.d_value;
+    }
   }
   std::string d_name;
   mutable std::set<SuffixMatchTree> children;
@@ -266,8 +269,7 @@ struct SuffixMatchTree
       d_value=value;
     }
     else if(labels.size()==1) {
-      SuffixMatchTree newChild(*labels.begin(), true);
-      auto res=children.insert(newChild);
+      auto res=children.emplace(*labels.begin(), true);
       if(!res.second) {
         // we might already have had the node as an
         // intermediary one, but it's now an end node
@@ -278,8 +280,7 @@ struct SuffixMatchTree
       res.first->d_value = value;
     }
     else {
-      SuffixMatchTree newnode(*labels.rbegin(), false);
-      auto res=children.insert(newnode);
+      auto res=children.emplace(*labels.rbegin(), false);
       labels.pop_back();
       res.first->add(labels, value);
     }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Entries that are not `endNode`s are basically place-holder and don't have a valid value, so we shouldn't attempt to copy the value when we duplicate a node, or the whole tree.
Among other possible issues it triggers the Undefined Behavior Sanitizer:

```
dnsname.hh:236:126: runtime error: load of value 165, which is not a valid value for type 'bool'
``` 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
