### PR TITLE
logger: Use thread_local, move config into a function-level static variable

### DIFF
--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -36,6 +36,15 @@ thread_local Logger::PerThread Logger::t_perThread;
 
 static Logger::Config& getLoggerConfig()
 {
+  /* Since the Logger can be called very early, we need to make sure
+     that the relevant parts are initialized no matter what, which is tricky
+     because we can't easily control the initialization order, especially with
+     built-in backends.
+     t_perThread is thread_local, so it will be initialized when first accessed,
+     but we need to make sure that the rest of the config is too, and making
+     it a function-level static variable achieves that, because it will be
+     initialized the first time we enter this function at the very last.
+  */
   static Logger::Config config;
   return config;
 }

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -41,36 +41,44 @@ public:
   enum Urgency {All=32767,Alert=LOG_ALERT, Critical=LOG_CRIT, Error=LOG_ERR, Warning=LOG_WARNING,
                 Notice=LOG_NOTICE,Info=LOG_INFO, Debug=LOG_DEBUG, None=-1};
 
+  struct Config
+  {
+    string name;
+    int flags;
+    int d_facility;
+    Urgency d_loglevel{None};
+    Urgency consoleUrgency{Error};
+    bool opened{false};
+    bool d_disableSyslog{false};
+    bool d_timestamps{true};
+    bool d_prefixed{false};
+  };
+
   /** Log a message.
       \param msg Message you wish to log
       \param u Urgency of the message you wish to log
   */
   void log(const string &msg, Urgency u=Notice);
 
-  void setFacility(int f){d_facility=f;open();} //!< Choose logging facility
-  void setFlag(int f){flags|=f;open();} //!< set a syslog flag
+  void setFacility(int f); //!< Choose logging facility
+  void setFlag(int f); //!< set a syslog flag
   void setName(const string &);
 
   //! set lower limit of urgency needed for console display. Messages of this urgency, and higher, will be displayed
   void toConsole(Urgency);
   void setLoglevel( Urgency );
 
-  void disableSyslog(bool d) {
-    d_disableSyslog = d;
-  }
+  void disableSyslog(bool d);
 
-  void setTimestamps(bool t) {
-    d_timestamps = t;
-  }
+  void setTimestamps(bool t);
 
-  void setPrefixed(bool p) {
-    d_prefixed = p;
-  }
+  void setPrefixed(bool p);
 
   //! Log to a file.
   void toFile( const string & filename );
   
-  void resetFlags(){flags=0;open();} //!< zero the flags
+  void resetFlags(); //!< zero the flags
+
   /** Use this to stream to your log, like this:
       \code
       g_log<<"This is an informational message"<<endl; // logged at default loglevel (Info)
@@ -104,15 +112,6 @@ private:
   void open();
 
   static thread_local PerThread t_perThread;
-  string name;
-  int flags;
-  int d_facility;
-  Urgency d_loglevel;
-  Urgency consoleUrgency;
-  bool opened;
-  bool d_disableSyslog;
-  bool d_timestamps{true};
-  bool d_prefixed{false};
 };
 
 extern Logger g_log;

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -26,7 +26,6 @@
 #include <iostream>
 #include <sstream>
 #include <syslog.h>
-#include <pthread.h>
 
 #include "namespaces.hh"
 #include "dnsname.hh"
@@ -101,11 +100,10 @@ private:
     string d_output;
     Urgency d_urgency;
   };
-  static void initKey();
-  static void perThreadDestructor(void *);
-  PerThread* getPerThread();
+  PerThread& getPerThread();
   void open();
 
+  static thread_local PerThread t_perThread;
   string name;
   int flags;
   int d_facility;
@@ -115,8 +113,6 @@ private:
   bool d_disableSyslog;
   bool d_timestamps{true};
   bool d_prefixed{false};
-  static pthread_once_t s_once;
-  static pthread_key_t g_loggerKey;
 };
 
 extern Logger g_log;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR includes the commit from #6625 and additionally move the `Logger` configuration to a different struct kept inside a function-level static variable, making sure it's always properly initialized before being used.
The diff is not very large and should not be harder to maintain and use than the current version. It avoids relying on an undefined order of initialization that might prove a more serious issue in the future.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
