### PR TITLE
dnsdist: fix RPM scriptlets

### DIFF
--- a/build-scripts/build-dnsdist-rpm
+++ b/build-scripts/build-dnsdist-rpm
@@ -172,37 +172,43 @@ exit 0
 
 
 %post
-%if 0%{?el6}
+%if 0%{?rhel} < 7
 if [ -x /sbin/initctl ]; then
    /sbin/initctl reload-configuration
 fi
-%elif 0%{?suse_version}
+%else
+%if 0%{?suse_version}
 %service_add_post %{name}.service
 %else
 %systemd_post %{name}.service
 %endif
+%endif
 
 %preun
-%if 0%{?el6}
+%if 0%{?rhel} < 7
 if [ \$1 -eq 0 ] ; then
     # This is package removal, not upgrade
     /sbin/stop %{name} >/dev/null 2>&1 || :
 fi
-%elif 0%{?suse_version}
+%else
+%if 0%{?suse_version}
 %service_del_preun %{name}.service
 %else
 %systemd_preun %{name}.service
 %endif
+%endif
 
 %postun
-%if 0%{?el6}
+%if 0%{?rhel} < 7
 if [ -x /sbin/initctl ] && /sbin/initctl status %{name} 2>/dev/null | grep -q 'running' ; then
   /sbin/initctl stop %{name} > /dev/null 2>&1 || :
 fi
-%elif 0%{?suse_version}
+%else
+%if 0%{?suse_version}
 %service_del_postun %{name}.service
 %else
 %systemd_postun_with_restart %{name}.service
+%endif
 %endif
 
 %files


### PR DESCRIPTION
### Short description
We used the non-existing `%elif` rpm macro ¯\\_(ツ)_/¯. Which broke upgrades and removals on EL6. Unfortunately, this is broken in already released packages, so the only solution we can offer is:

> Please use `yum --setopt=tsflags=noscripts remove dnsdist` and reinstall

Once we have released a new version with this fix.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)