### PR TITLE
auth: Use MySQL's transaction_isolation instead of tx_isolation

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -426,8 +426,13 @@ void SMySQL::connect()
     mysql_options(&d_db, MYSQL_SET_CHARSET_NAME, MYSQL_AUTODETECT_CHARSET_NAME);
 #endif
 
-    if (d_setIsolation && (retry == 1))
+    if (d_setIsolation && (retry == 1)) {
+#if MYSQL_VERSION_ID >= 50720
+      mysql_options(&d_db, MYSQL_INIT_COMMAND,"SET SESSION transaction_isolation='READ-COMMITTED'");
+#else
       mysql_options(&d_db, MYSQL_INIT_COMMAND,"SET SESSION tx_isolation='READ-COMMITTED'");
+#endif /* MYSQL_VERSION_ID >= 50720 */
+    }
 
     mysql_options(&d_db, MYSQL_READ_DEFAULT_GROUP, d_group.c_str());
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`tx_isolation` has been deprecated since 5.7.20 and removed in 8.0.3, see https://bugs.mysql.com/bug.php?id=88227

Fixes #6632.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
