### PR TITLE
-rdynamic is for the linker

### DIFF
--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -105,8 +105,7 @@ AS_IF([test "x$LUAPC" = "x" -a "x$LUAJITPC" = "x"], [
 AS_IF([test "x$LUAJITPC" != "x"], [
   # export all symbols to be able to use the Lua FFI interface
   AC_MSG_NOTICE([Adding -rdynamic to export all symbols for the Lua FFI interface])
-  CFLAGS="$CFLAGS -rdynamic"
-  CXXFLAGS="$CXXFLAGS -rdynamic"
+  LDFLAGS="$LDFLAGS -rdynamic"
 ])
 PDNS_CHECK_LUA_HPP
 


### PR DESCRIPTION
(cherry picked from commit f1f504545f6165b794e8fe5ddd29812610c63db9)

### Short description
Backport of #6630.

I have verified that both with and without this change, `nm` shows the FFI symbols on macOS and Debian 9.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
