### PR TITLE
API: Remove ENTs when "replacing" new records

### DIFF
--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1526,6 +1526,41 @@ fred   IN  A      192.168.0.4
         # should return zone, SOA, ns1, ns2, sub.sub A (but not the ENT)
         self.assertEquals(len(r.json()), 5)
 
+    def test_cname_at_ent_place(self):
+        name, payload, zone = self.create_zone(api_rectify=True)
+        rrset = {
+            'changetype': 'replace',
+            'name': 'sub2.sub1.' + name,
+            'type': "A",
+            'ttl': 3600,
+            'records': [{
+                'content': "4.3.2.1",
+                'disabled': False,
+            }],
+        }
+        payload = {'rrsets': [rrset]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + zone['id']),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(r.status_code, 204)
+        rrset = {
+            'changetype': 'replace',
+            'name': 'sub1.' + name,
+            'type': "CNAME",
+            'ttl': 3600,
+            'records': [{
+                'content': "www.example.org.",
+                'disabled': False,
+            }],
+        }
+        payload = {'rrsets': [rrset]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + zone['id']),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(r.status_code, 204)
+
     def test_rrset_parameter_post_false(self):
         name = unique_zone_name()
         payload = {


### PR DESCRIPTION
### Short description
When creating new records with the API, TYPE0 records are now removed. Also takes care of the CNAME check.

Fixes #6645.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
