### PR TITLE
gmysql: Use future-proof statement for transaction isolation

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -427,7 +427,7 @@ void SMySQL::connect()
 #endif
 
     if (d_setIsolation && (retry == 1))
-      mysql_options(&d_db, MYSQL_INIT_COMMAND,"SET SESSION tx_isolation='READ-COMMITTED'");
+      mysql_options(&d_db, MYSQL_INIT_COMMAND,"SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED");
 
     mysql_options(&d_db, MYSQL_READ_DEFAULT_GROUP, d_group.c_str());
 


### PR DESCRIPTION
### Short description
`tx_isolation` has been deprecated since 5.7.20 and removed in 8.0.3, see https://bugs.mysql.com/bug.php?id=88227

This uses syntax documented all the way back to MySQL 5.0 (and also supported by 8.0).

Fixes #6632.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
