### PR TITLE
API export function output change to add IN to the output

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1460,6 +1460,7 @@ static void apiServerZoneExport(HttpRequest* req, HttpResponse* resp) {
     ss <<
       rr.qname.toString() << "\t" <<
       rr.ttl << "\t" <<
+      "IN" << "\t" <<
       rr.qtype.getName() << "\t" <<
       makeApiRecordContent(rr.qtype, rr.content) <<
       endl;

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -828,9 +828,9 @@ fred   IN  A      192.168.0.4
         self.assert_success_json(r)
         data = r.json()
         self.assertIn('zone', data)
-        expected_data = [name + '\t3600\tNS\tns1.foo.com.',
-                         name + '\t3600\tNS\tns2.foo.com.',
-                         name + '\t3600\tSOA\ta.misconfigured.powerdns.server. hostmaster.' + name +
+        expected_data = [name + '\t3600\tIN\tNS\tns1.foo.com.',
+                         name + '\t3600\tIN\tNS\tns2.foo.com.',
+                         name + '\t3600\tIN\tSOA\ta.misconfigured.powerdns.server. hostmaster.' + name +
                          ' 0 10800 3600 604800 3600']
         self.assertEquals(data['zone'].strip().split('\n'), expected_data)
 
@@ -842,9 +842,9 @@ fred   IN  A      192.168.0.4
             headers={'accept': '*/*'}
         )
         data = r.text.strip().split("\n")
-        expected_data = [name + '\t3600\tNS\tns1.foo.com.',
-                         name + '\t3600\tNS\tns2.foo.com.',
-                         name + '\t3600\tSOA\ta.misconfigured.powerdns.server. hostmaster.' + name +
+        expected_data = [name + '\t3600\tIN\tNS\tns1.foo.com.',
+                         name + '\t3600\tIN\tNS\tns2.foo.com.',
+                         name + '\t3600\tIN\tSOA\ta.misconfigured.powerdns.server. hostmaster.' + name +
                          ' 0 10800 3600 604800 3600']
         self.assertEquals(data, expected_data)
 


### PR DESCRIPTION
### Short description
The default API output exports zone in AXFR format without IN in the records. This just adds IN to the output string.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
