### PR TITLE
backport #6641: dnsdist: fix RPM scriptlets

### DIFF
--- a/build-scripts/build-dnsdist-rpm
+++ b/build-scripts/build-dnsdist-rpm
@@ -158,10 +158,12 @@ exit 0
 %post
 %if 0%{?el6}
 /sbin/chkconfig --add %{name}
-%elif 0%{?suse_version}
+%else
+%if 0%{?suse_version}
 %service_add_post %{name}.service
 %else
 %systemd_post %{name}.service
+%endif
 %endif
 
 %preun
@@ -171,10 +173,12 @@ if [ "\$1" -eq "0" ]; then
   /sbin/service %{name} stop > /dev/null 2>&1 || :
   /sbin/chkconfig --del %{name}
 fi
-%elif 0%{?suse_version}
+%else
+%if 0%{?suse_version}
 %service_del_preun %{name}.service
 %else
 %systemd_preun %{name}.service
+%endif
 %endif
 
 %postun
@@ -182,10 +186,12 @@ fi
 if [ "\$1" -ge "1" ] ; then
   /sbin/service %{name} condrestart >/dev/null 2>&1 || :
 fi
-%elif 0%{?suse_version}
+%else
+%if 0%{?suse_version}
 %service_del_postun %{name}.service
 %else
 %systemd_postun_with_restart %{name}.service
+%endif
 %endif
 
 %files


### PR DESCRIPTION
We used the non-existing `%elif` rpm macro ¯\\_(ツ)_/¯.

(cherry picked from commit 3e27601f900aa91c4f17ae4d24b48564fab157e4)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] checked that this code was merged to master (#6641)
