### PR TITLE
pdnsutil: occlusion and auth check improvements

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -487,12 +487,6 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
         numwarnings++;
       }
     }
-
-    if(!suppliedrecords && rr.auth == 0 && rr.qtype.getCode()!=QType::NS && rr.qtype.getCode()!=QType::A && rr.qtype.getCode()!=QType::AAAA)
-    {
-      cout<<"[Error] Following record is auth=0, run pdnsutil rectify-zone?: "<<rr.qname<<" IN " <<rr.qtype.getName()<< " " << rr.content<<endl;
-      numerrors++;
-    }
   }
 
   for(auto &i: cnames) {
@@ -537,7 +531,7 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
   for( const auto &qname : checkOcclusion ) {
     for( const auto &rr : records ) {
       if( qname.first == rr.qname && ((( rr.qtype == QType::NS || rr.qtype == QType::DS ) && qname.second == QType::NS ) || ( rr.qtype == QType::DNAME && qname.second == QType::DNAME ) ) ) {
-          continue;
+        continue;
       }
       if( rr.qname.isPartOf( qname.first ) ) {
         if( qname.second == QType::DNAME || ( rr.qtype != QType::ENT && rr.qtype.getCode() != QType::A && rr.qtype.getCode() != QType::AAAA ) ) {
@@ -551,6 +545,42 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
           numwarnings++;
         }
       }
+    }
+  }
+
+  bool ok, ds_ns, done;
+  for( const auto &rr : records ) {
+    ok = ( rr.auth == 1 );
+    ds_ns = false;
+    done = (suppliedrecords || !sd.db->doesDNSSEC());
+    for( const auto &qname : checkOcclusion ) {
+      if( qname.second == QType::NS ) {
+        if( qname.first == rr.qname ) {
+          ds_ns = true;
+        }
+        if ( done ) {
+          continue;
+        }
+        if( rr.auth == 0 ) {
+          if( rr.qname.isPartOf( qname.first ) && ( qname.first != rr.qname || rr.qtype != QType::DS ) ) {
+            ok = done = true;
+          }
+          if( rr.qtype == QType::ENT && qname.first.isPartOf( rr.qname ) ) {
+            ok = done = true;
+          }
+        } else if( rr.qname.isPartOf( qname.first ) && ( ( qname.first != rr.qname || rr.qtype != QType::DS ) || rr.qtype == QType::NS ) ) {
+          ok = false;
+          done = true;
+        }
+      }
+    }
+    if( ! ds_ns && rr.qtype.getCode() == QType::DS && rr.qname != zone ) {
+      cout << "[Warning] DS record without a delegation '" << rr.qname<<"'." << endl;
+      numwarnings++;
+    }
+    if( ! ok && ! suppliedrecords ) {
+      cout << "[Error] Following record is auth=" << rr.auth << ", run pdnsutil rectify-zone?: " << rr.qname << " IN " << rr.qtype.getName() << " " << rr.content << endl;
+      numerrors++;
     }
   }
 


### PR DESCRIPTION
### Short description
The occlusion check was ignoring NS, DNAME and DS records.
The auth check was incomplete (only for records with auth == 0)
Add DS at delegation check

Fixes #6622

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
