### PR TITLE
luawrapper: report caught std::exception as lua_error

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2366,9 +2366,15 @@ private:
             lua_pushstring(state, ex.luaType.c_str());
             lua_pushstring(state, " to ");
             lua_pushstring(state, ex.destination.name());
-            lua_concat(state, 4);
+            lua_concat(state, 5);
             luaError(state);
 
+        } catch (const std::exception& e) {
+          luaL_where(state, 1);
+          lua_pushstring(state, "Caught exception: ");
+          lua_pushstring(state, e.what());
+          lua_concat(state, 3);
+          luaError(state);
         } catch (...) {
             Pusher<std::exception_ptr>::push(state, std::current_exception()).release();
             luaError(state);


### PR DESCRIPTION
### Short description
This allows uncaught `std::exception` to be better reported with reason information.

See #6541 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
