### PR TITLE
 dnsdist: Fix reconnection handling

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -345,6 +345,8 @@ void setupLuaConfig(bool client)
                         g_pools.setState(localPools);
 
 			if (ret->connected) {
+			  ret->threadStarted.test_and_set();
+
 			  if(g_launchWork) {
 			    g_launchWork->push_back([ret,cpus]() {
                               ret->tid = thread(responderThread, ret);

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -501,6 +501,7 @@ struct DownstreamState
 
   std::vector<int> sockets;
   std::mutex socketsLock;
+  std::mutex connectLock;
   std::unique_ptr<FDMultiplexer> mplexer{nullptr};
   std::thread tid;
   ComboAddress remote;
@@ -544,8 +545,10 @@ struct DownstreamState
   bool useECS{false};
   bool setCD{false};
   std::atomic<bool> connected{false};
+  std::atomic_flag threadStarted;
   bool tcpFastOpen{false};
   bool ipBindAddrNoPort{true};
+
   bool isUp() const
   {
     if(availability == Availability::Down)
@@ -580,7 +583,7 @@ struct DownstreamState
       status = (upStatus ? "up" : "down");
     return status;
   }
-  void reconnect();
+  bool reconnect();
 };
 using servers_t =vector<std::shared_ptr<DownstreamState>>;
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The first issue was that we closed the socket toward the backend if the first connection attempt failed, but tried to reconnect without reopening it, as reported by Aleš Rygl on the mailing-list [1].
The second issue is that we would close and reconnect the backend socket on some error codes even if the error was occurring on the health check socket, which is a separate one.
This PR also makes sure we don't try to reconnect from the healthcheck and responder threads at the same time, and that we don't accidentally start the same responder thread twice.

[1]: https://mailman.powerdns.com/pipermail/dnsdist/2018-May/000425.html
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
