### PR TITLE
Fix maybe-uninitialized warning

### DIFF
--- a/pdns/recursordist/test-mtasker.cc
+++ b/pdns/recursordist/test-mtasker.cc
@@ -15,7 +15,7 @@ static int g_result;
 static void doSomething(void* p)
 {
   MTasker<>* mt = reinterpret_cast<MTasker<>*>(p);
-  int i=12, o;
+  int i=12, o=0;
   mt->waitEvent(i, &o);
   g_result = o;
   


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
test-mtasker.cc: In function 'void mtasker_cc::doSomething(void*)':
test-mtasker.cc:20:12: warning: 'o' may be used uninitialized in this function [-Wmaybe-uninitialized]
   g_result = o;

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
