### PR TITLE
docs: Fix ./configure example, add --disable-lua-records

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ autoreconf -vi
 To compile a very clean version, use:
 
 ```
-$ ./configure --with-modules="" --without-lua
+$ ./configure --with-modules="" --without-lua --disable-lua-records
 $ make
 # make install
 ```


### PR DESCRIPTION
The docs say:

```
When building from git, the following packages are also required: autoconf, automake,
$ autoreconf -vi
$ ./configure --with-modules="" --without-lua
$ make
```

However, that second one yields:
```
$ ./configure --with-modules="" --without-lua
...
checking for protoc... no
checking whether we will enable LUA records... yes
configure: error: LUA records need LUA. You can disable this feature with the --disable-lua-records switch or configure a proper LUA installation.
```
When adding the --disable-lua-records, the configure completes.