### PR TITLE
docs: Add extra LF to settings.rst to squash sphinx warning

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -887,6 +887,7 @@ If ``SO_REUSEPORT`` support is available, allows multiple processes to open a li
 Since 4.1.0, when ``pdns-distributes-queries`` is set to false and ``reuseport`` is enabled, every thread will open a separate listening socket to let the kernel distribute the incoming queries, avoiding any thundering herd issue as well as the distributor thread being a bottleneck, thus leading to much higher performance on multi-core boxes.
 
 .. _setting-rng:
+
 ``rng``
 -------
 


### PR DESCRIPTION
Compiling resursor shows this warning:
```
updating environment: 75 added, 0 changed, 0 removed                           
reading sources... [100%] upgrade                                                                                                                                                       
pdns/recursordist/docs/settings.rst:890: WARNING: Explicit markup ends without a blank line; unexpected unindent.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
writing... rec_control.1 { } pdns_recursor.1 { reading sources... [100%] upgrade                                                                                                        }                                              
build succeeded, 1 warnings.

The manual pages are in ..
The name of the builder is: man
pdns/recursordist/docs/settings.rst:890: WARNING: Explicit markup ends without a blank line; unexpected unindent.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
writing... rec_control.1 { } pdns_recursor.1 { } 
build succeeded, 1 warnings.

The manual pages are in ..
The name of the builder is: manmake[2]: Leaving directory 'pdns/recursordist'
```
Adding the missing LF on line 890 should fix things.