### PR TITLE
Allow running "brew bundle" to fetch deps on macOS

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,14 @@
+# Use "brew bundle" to install these.
+# You still need 'PKG_CONFIG_PATH=/usr/local/opt/libedit/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig' for ./configure.
+brew 'autoconf'
+brew 'automake'
+brew 'libedit'
+brew 'libsodium'
+brew 'libtool'
+brew 'lua'
+brew 'openssl'
+brew 'pkg-config'
+brew 'protobuf'
+brew 'python'
+brew 'ragel'
+brew 'sqlite'


### PR DESCRIPTION
### Short description
This should reduce the time required to hunt down common dependencies on macOS, to get a build with most features enabled.

The various DBs are excluded though.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
