### PR TITLE
dnsdist: Expose toString of various objects to Lua

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -64,6 +64,7 @@ void setupLuaBindings(bool client)
   g_lua.registerMember("name", &ServerPolicy::name);
   g_lua.registerMember("policy", &ServerPolicy::policy);
   g_lua.registerMember("isLua", &ServerPolicy::isLua);
+  g_lua.registerFunction("toString", &ServerPolicy::toString);
 
   g_lua.writeVariable("firstAvailable", ServerPolicy{"firstAvailable", firstAvailable, false});
   g_lua.writeVariable("roundrobin", ServerPolicy{"roundrobin", roundrobin, false});
@@ -187,6 +188,7 @@ void setupLuaBindings(bool client)
   g_lua.registerFunction("match", (bool (NetmaskGroup::*)(const ComboAddress&) const)&NetmaskGroup::match);
   g_lua.registerFunction("size", &NetmaskGroup::size);
   g_lua.registerFunction("clear", &NetmaskGroup::clear);
+  g_lua.registerFunction<string(NetmaskGroup::*)()>("toString", [](const NetmaskGroup& nmg ) { return "NetmaskGroup " + nmg.toString(); });
 
   /* QPSLimiter */
   g_lua.writeFunction("newQPSLimiter", [](int rate, int burst) { return QPSLimiter(rate, burst); });
@@ -302,6 +304,8 @@ void setupLuaBindings(bool client)
       throw std::runtime_error("fstrm with TCP support is required to build an AF_INET FrameStreamLogger");
 #endif /* HAVE_FSTRM */
     });
+
+  g_lua.registerFunction("toString", &RemoteLoggerInterface::toString);
 
 #ifdef HAVE_DNSCRYPT
     /* DNSCryptContext bindings */

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -610,6 +610,9 @@ struct ServerPolicy
   string name;
   policyfunc_t policy;
   bool isLua;
+  std::string toString() const {
+    return string("ServerPolicy") + (isLua ? " (Lua)" : "") + " \"" + name + "\"";
+  }
 };
 
 struct ServerPool

--- a/pdns/fstrm_logger.hh
+++ b/pdns/fstrm_logger.hh
@@ -38,7 +38,7 @@ public:
   FrameStreamLogger(int family, const std::string& address, bool connect);
   virtual ~FrameStreamLogger();
   virtual void queueData(const std::string& data) override;
-  virtual std::string toString() override
+  virtual std::string toString() const override
   {
     return "FrameStreamLogger to " + d_address;
   }

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -36,7 +36,7 @@ class RemoteLoggerInterface
 public:
   virtual ~RemoteLoggerInterface() {};
   virtual void queueData(const std::string& data) = 0;
-  virtual std::string toString() = 0;
+  virtual std::string toString() const = 0;
 };
 
 class RemoteLogger : public RemoteLoggerInterface
@@ -45,7 +45,7 @@ public:
   RemoteLogger(const ComboAddress& remote, uint16_t timeout=2, uint64_t maxQueuedEntries=100, uint8_t reconnectWaitTime=1, bool asyncConnect=false);
   virtual ~RemoteLogger();
   virtual void queueData(const std::string& data) override;
-  virtual std::string toString() override
+  virtual std::string toString() const override
   {
     return "RemoteLogger to " + d_remote.toStringWithPort();
   }


### PR DESCRIPTION
### Short description
For better introspection all creatable objects should have toString() methods. Actually many objects already have toString() implemented in C++, but then it's not hooked up to Lua.
This adds a few (easy) objects to Lua, obviously more would be better.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
