### PR TITLE
Initialize some missed qtypes

### DIFF
--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -175,6 +175,7 @@ private:
       qtype_insert("MB", 7);
       qtype_insert("MG", 8);
       qtype_insert("MR", 9);
+      qtype_insert("WKS", 11);
       qtype_insert("PTR", 12);
       qtype_insert("HINFO", 13);
       qtype_insert("MINFO", 14);
@@ -203,6 +204,7 @@ private:
       qtype_insert("NSEC3", 50);
       qtype_insert("NSEC3PARAM", 51);
       qtype_insert("TLSA", 52);
+      qtype_insert("SMIMEA", 53);
       qtype_insert("RKEY", 57);
       qtype_insert("CDS", 59);
       qtype_insert("CDNSKEY", 60);


### PR DESCRIPTION
### Short description
Fixes #6685

It's not clear to me why these lines were missing.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
