### PR TITLE
Enable Address (dnsdist, rec) and Undefined Behavior (dnsdist) Sanitizers in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,6 @@ env:
   - PDNS_BUILD_PRODUCT=recursor
   - PDNS_BUILD_PRODUCT=dnsdist
 
-matrix:
-  exclude:
-    - compiler: clang
-      env: PDNS_BUILD_PRODUCT=recursor
-  include:
-    - compiler: clang
-      env: PDNS_BUILD_PRODUCT=recursor COMPILER=clang++-3.6
-      addons:
-        apt:
-          packages: ['clang-3.6']
-
 before_script:
   - git describe --always --dirty=+
   - sudo rm -f /etc/apt/sources.list.d/*.list

--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -405,7 +405,7 @@ build_recursor() {
   run "rm -f pdns-recursor-*.tar.bz2"
   run "cd pdns-recursor-*"
   # Build without --enable-botan, no botan 2.x in Travis CI
-  run "CXX=${COMPILER} ./configure \
+  run "./configure \
     ${sanitizerflags} \
     --prefix=$PDNS_RECURSOR_DIR \
     --enable-libsodium \

--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -377,6 +377,7 @@ build_auth() {
   run "autoreconf -vi"
   # Build without --enable-botan, no botan 2.x in Travis CI
   run "./configure \
+    ${sanitizerflags} \
     --with-dynmodules='bind gmysql geoip gpgsql gsqlite3 ldap lua mydns opendbx pipe random remote tinydns godbc lua2' \
     --with-modules='' \
     --with-sqlite3 \
@@ -405,6 +406,7 @@ build_recursor() {
   run "cd pdns-recursor-*"
   # Build without --enable-botan, no botan 2.x in Travis CI
   run "CXX=${COMPILER} ./configure \
+    ${sanitizerflags} \
     --prefix=$PDNS_RECURSOR_DIR \
     --enable-libsodium \
     --enable-unit-tests \
@@ -421,6 +423,7 @@ build_dnsdist(){
   run "tar xf dnsdist*.tar.bz2"
   run "cd dnsdist-*"
   run "./configure \
+    ${sanitizerflags} \
     --enable-unit-tests \
     --enable-libsodium \
     --enable-dnscrypt \
@@ -611,12 +614,20 @@ run "sudo dpkg -i libsodium-dev_1.0.3-1~ppa14.04+1_amd64.deb libsodium13_1.0.3-1
 run "cd ${TRAVIS_BUILD_DIR}"
 
 compilerflags="-O1 -Werror=vla"
+sanitizerflags=""
 if [ "$CC" = "clang" ]
 then
   compilerflags="$compilerflags -Werror=string-plus-int"
+  if [ "${PDNS_BUILD_PRODUCT}" = "recursor" ]; then
+    sanitizerflags="${sanitizerflags} --enable-asan"
+  elif [ "${PDNS_BUILD_PRODUCT}" = "dnsdist" ]; then
+    sanitizerflags="${sanitizerflags} --enable-asan --enable-ubsan"
+  fi
 fi
 export CFLAGS=$compilerflags
 export CXXFLAGS=$compilerflags
+export sanitizerflags
+export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1"
 
 install_$PDNS_BUILD_PRODUCT
 

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -383,6 +383,14 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile) {
       BOOST_FAIL("Unable to read a line from the temp file");
     BOOST_CHECK_EQUAL(line, str);
   }
+
+  if (line != nullptr) {
+    /* getline() allocates a buffer then called with a nullptr,
+       then reallocates it when needed, but we need to free the
+       last allocation if any. */
+    free(line);
+  }
+
   fclose(fp);
 }
 

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile) {
   }
 
   if (line != nullptr) {
-    /* getline() allocates a buffer then called with a nullptr,
+    /* getline() allocates a buffer when called with a nullptr,
        then reallocates it when needed, but we need to free the
        last allocation if any. */
     free(line);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Enable ASAN in dnsdist and recursor builds ;
- Enable UBSAN in dnsdist's build (it fails for the rec, probably because it needs too much memory) ;
- Get rid of the special version of `clang` (`3.6`) for the recursor, Travis upgraded to `5.0.0` in the meantime ;
- Fix a memory leak in the negative cache unit tests, detected by Leak Sanitizer.

Unfortunately we are already running out of time for the authoritative builds, so no change there.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
