### PR TITLE
 dnsdist: Mark the remote member of DownstreamState as const

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1074,7 +1074,8 @@ static ssize_t udpClientSendRequestToBackend(DownstreamState* ss, const int sd, 
     struct msghdr msgh;
     struct iovec iov;
     char cbuf[256];
-    fillMSGHdr(&msgh, &iov, cbuf, sizeof(cbuf), const_cast<char*>(request), requestLen, &ss->remote);
+    ComboAddress remote(ss->remote);
+    fillMSGHdr(&msgh, &iov, cbuf, sizeof(cbuf), const_cast<char*>(request), requestLen, &remote);
     addCMsgSrcAddr(&msgh, cbuf, &ss->sourceAddr, ss->sourceItf);
     result = sendmsg(sd, &msgh, 0);
   }
@@ -1688,7 +1689,15 @@ try
   }
 
   string reply;
-  sock.recvFrom(reply, ds.remote);
+  ComboAddress from;
+  sock.recvFrom(reply, from);
+
+  /* we are using a connected socket but hey.. */
+  if (from != ds.remote) {
+    if (g_verboseHealthChecks)
+      infolog("Invalid health check response received from %s, expecting one from %s", from.toStringWithPort(), ds.remote.toStringWithPort());
+    return false;
+  }
 
   const dnsheader * responseHeader = reinterpret_cast<const dnsheader *>(reply.c_str());
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -433,10 +433,10 @@ class TCPClientCollection {
   std::atomic<uint64_t> d_numthreads{0};
   std::atomic<uint64_t> d_pos{0};
   std::atomic<uint64_t> d_queued{0};
-  uint64_t d_maxthreads{0};
+  const uint64_t d_maxthreads{0};
   std::mutex d_mutex;
   int d_singlePipe[2];
-  bool d_useSinglePipe;
+  const bool d_useSinglePipe;
 public:
 
   TCPClientCollection(size_t maxThreads, bool useSinglePipe=false): d_maxthreads(maxThreads), d_singlePipe{-1,-1}, d_useSinglePipe(useSinglePipe)
@@ -506,7 +506,7 @@ struct DownstreamState
   const ComboAddress remote;
   QPSLimiter qps;
   vector<IDState> idStates;
-  ComboAddress sourceAddr;
+  const ComboAddress sourceAddr;
   checkfunc_t checkFunction;
   DNSName checkName{"a.root-servers.net."};
   QType checkType{QType::A};
@@ -531,7 +531,7 @@ struct DownstreamState
   int tcpConnectTimeout{5};
   int tcpRecvTimeout{30};
   int tcpSendTimeout{30};
-  unsigned int sourceItf{0};
+  const unsigned int sourceItf{0};
   uint16_t retries{5};
   uint16_t xpfRRCode{0};
   uint8_t currentCheckFailures{0};

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -503,7 +503,7 @@ struct DownstreamState
   std::mutex socketsLock;
   std::unique_ptr<FDMultiplexer> mplexer{nullptr};
   std::thread tid;
-  ComboAddress remote;
+  const ComboAddress remote;
   QPSLimiter qps;
   vector<IDState> idStates;
   ComboAddress sourceAddr;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
While investigating #6664, I noticed that we pass the `remote` member to functions that could alter it, like `Socket::recvFrom()`. At the moment I don't see how it could have led to having a different port in the end, since we use a connected socket, but it's still not very clean.
As there is no reason to alter `remote` and some other members after the object construction, this PR marks them as `const` so we are prevented from passing them to a function that might alter their content.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
