### PR TITLE
logger: Use a function-level static var for the logger object

### DIFF
--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -31,8 +31,22 @@ extern StatBag S;
 #include "lock.hh"
 #include "namespaces.hh"
 
-Logger g_log("", LOG_DAEMON);
 thread_local Logger::PerThread Logger::t_perThread;
+
+Logger& getLogger()
+{
+  /* Since the Logger can be called very early, we need to make sure
+     that the relevant parts are initialized no matter what, which is tricky
+     because we can't easily control the initialization order, especially with
+     built-in backends.
+     t_perThread is thread_local, so it will be initialized when first accessed,
+     but we need to make sure that the object itself is initialized, and making
+     it a function-level static variable achieves that, because it will be
+     initialized the first time we enter this function at the very last.
+  */
+  static Logger log("", LOG_DAEMON);
+  return log;
+}
 
 void Logger::log(const string &msg, Urgency u)
 {

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -115,7 +115,9 @@ private:
   bool d_prefixed{false};
 };
 
-extern Logger g_log;
+Logger& getLogger();
+
+#define g_log getLogger()
 
 #ifdef VERBOSELOG
 #define DLOG(x) x

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -26,7 +26,6 @@
 #include <iostream>
 #include <sstream>
 #include <syslog.h>
-#include <pthread.h>
 
 #include "namespaces.hh"
 #include "dnsname.hh"
@@ -101,11 +100,10 @@ private:
     string d_output;
     Urgency d_urgency;
   };
-  static void initKey();
-  static void perThreadDestructor(void *);
-  PerThread* getPerThread();
+  PerThread& getPerThread();
   void open();
 
+  static thread_local PerThread t_perThread;
   string name;
   int flags;
   int d_facility;
@@ -115,8 +113,6 @@ private:
   bool d_disableSyslog;
   bool d_timestamps{true};
   bool d_prefixed{false};
-  static pthread_once_t s_once;
-  static pthread_key_t g_loggerKey;
 };
 
 extern Logger g_log;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR includes the commit from #6625, replaces #6639. I don't like the macro trick at all but I don't see any other way to make sure that the `Logger` object is correctly initialized before any use. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
