### PR TITLE
Tiny Recursor dnssec doc improvements

### DIFF
--- a/pdns/recursordist/docs/dnssec.rst
+++ b/pdns/recursordist/docs/dnssec.rst
@@ -45,29 +45,28 @@ What, when?
 ^^^^^^^^^^^
 The descriptions above are a bit terse, here's a table describing different scenarios with regards to the ``dnssec`` mode.
 
-+--------------+---------+---------------+---------------+---------------+---------------+
-|              | ``off`` | ``process-no- | ``process``   | ``log-fail``  | ``validate``  |
-|              |         | validate``    |               |               |               |
-+==============+=========+===============+===============+===============+===============+
-| Perform      | No      | No            | Only on +AD   | Always (logs  | Always        |
-| validation   |         |               | or +DO from   | result)       |               |
-|              |         |               | client        |               |               |
-+--------------+---------+---------------+---------------+---------------+---------------+
-| SERVFAIL on  | No      | No            | Only on +AD   | Only on +AD   | Always        |
-| bogus        |         |               | or +DO from   | or +DO from   |               |
-|              |         |               | client        | client        |               |
-+--------------+---------+---------------+---------------+---------------+---------------+
-| AD in        | Never   | Never         | Only on +AD   | Only on +AD   | Only on +AD   |
-| response on  |         |               | or +DO from   | or +DO from   | or +DO from   |
-| authenticate |         |               | client        | client        | client        |
-| d            |         |               |               |               |               |
-| data         |         |               |               |               |               |
-+--------------+---------+---------------+---------------+---------------+---------------+
-| RRSIGs/NSECs | No      | Yes           | Yes           | Yes           | Yes           |
-| in answer on |         |               |               |               |               |
-| +DO from     |         |               |               |               |               |
-| client       |         |               |               |               |               |
-+--------------+---------+---------------+---------------+---------------+---------------+
++--------------+---------+-------------------------+---------------+---------------+---------------+
+|              | ``off`` | ``process-no-validate`` | ``process``   | ``log-fail``  | ``validate``  |
++==============+=========+=========================+===============+===============+===============+
+| Perform      | No      | No                      | Only on +AD   | Always (logs  | Always        |
+| validation   |         |                         | or +DO from   | result)       |               |
+|              |         |                         | client        |               |               |
++--------------+---------+-------------------------+---------------+---------------+---------------+
+| SERVFAIL on  | No      | No                      | Only on +AD   | Only on +AD   | Always        |
+| bogus        |         |                         | or +DO from   | or +DO from   |               |
+|              |         |                         | client        | client        |               |
++--------------+---------+-------------------------+---------------+---------------+---------------+
+| AD in        | Never   | Never                   | Only on +AD   | Only on +AD   | Only on +AD   |
+| response on  |         |                         | or +DO from   | or +DO from   | or +DO from   |
+| authenticate |         |                         | client        | client        | client        |
+| d            |         |                         |               |               |               |
+| data         |         |                         |               |               |               |
++--------------+---------+-------------------------+---------------+---------------+---------------+
+| RRSIGs/NSECs | No      | Yes                     | Yes           | Yes           | Yes           |
+| in answer on |         |                         |               |               |               |
+| +DO from     |         |                         |               |               |               |
+| client       |         |                         |               |               |               |
++--------------+---------+-------------------------+---------------+---------------+---------------+
 
 **Note**: the ``dig`` tool sets the AD-bit in the query.
 This might lead to unexpected query results when testing.

--- a/pdns/recursordist/docs/dnssec.rst
+++ b/pdns/recursordist/docs/dnssec.rst
@@ -72,6 +72,9 @@ The descriptions above are a bit terse, here's a table describing different scen
 This might lead to unexpected query results when testing.
 Set ``+noad`` on the ``dig`` commandline when this is the case.
 
+**Note**: the CD-bit is honored correctly for ``process`` and
+``validate``. For ``log-fail``, failures will be logged too.
+
 Trust Anchor Management
 -----------------------
 In the PowerDNS Recursor, both positive and negative trust anchors can be configured during startup (from a persistent configuration file) and at runtime (which is volatile).


### PR DESCRIPTION
### Short description
Add note about CD.
Slightly improve 'when?' table rendering for HTML (process-no-validate is now correctly "tt").

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
