### PR TITLE
Revert EDNS0Record to a trivial type

### DIFF
--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -134,8 +134,8 @@ struct dnsrecordheader
 
 struct EDNS0Record
 {
-  uint8_t extRCode{0}, version{0};
-  uint16_t extFlags{0};
+  uint8_t extRCode, version;
+  uint16_t extFlags;
 } GCCPACKATTRIBUTE;
 
 static_assert(sizeof(EDNS0Record) == 4, "EDNS0Record size must be 4");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Adding brace initializers makes it non-trivial, which does not seem
like a very good idea for a packed structure.
gcc 8.1.0 complains with:

```
warning: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘struct EDNS0Record’ from an array of ‘uint32_t’ {aka ‘unsigned int’} [-Wclass-memaccess]
         memcpy(&stuff, &ttl, sizeof(stuff));
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
