### PR TITLE
add "enable-notification-warning" option to make logging of warnings …

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -554,16 +554,16 @@ Enables EDNS subnet processing, for backends that support it.
 
 Enable globally the LUA records feature
 
-.. _setting-enable-notification-warning:
+.. _setting-enable-no-notification-targets-warning:
 
-``enable-notification-warning``
+``enable-no-notification-targets-warning``
 --------------------------
 
 -  Boolean
 -  Default: yes
 
-By default PowerDNS will log a warning if all NOTIFYs were suppressed due to
-`only-notify` and there were no explict ALSO-NOTIFYs. This warning can be suppressed by
+By default PowerDNS will log a warning if all outgoing NOTIFYs were suppressed due to
+`only-notify` and there were no explicit ALSO-NOTIFYs. This warning can be suppressed by
 setting this option to `no`.
 
 .. _setting-entropy-source:

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -554,6 +554,18 @@ Enables EDNS subnet processing, for backends that support it.
 
 Enable globally the LUA records feature
 
+.. _setting-enable-notification-warning:
+
+``enable-notification-warning``
+--------------------------
+
+-  Boolean
+-  Default: yes
+
+By default PowerDNS will log a warning if all NOTIFYs were suppressed due to
+`only-notify` and there were no explict ALSO-NOTIFYs. This warning can be suppressed by
+setting this option to `no`.
+
 .. _setting-entropy-source:
 
 ``entropy-source``

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -118,7 +118,7 @@ void declareArguments()
   ::arg().set("allow-axfr-ips","Allow zonetransfers only to these subnets")="127.0.0.0/8,::1";
   ::arg().set("only-notify", "Only send AXFR NOTIFY to these IP addresses or netmasks")="0.0.0.0/0,::/0";
   ::arg().set("also-notify", "When notifying a domain, also notify these nameservers")="";
-  ::arg().set("enable-notification-warning","Enable the logging of warnings if all NOTIFYs were suppressed")="yes";
+  ::arg().set("enable-no-notification-targets-warning","Enable the logging of warnings if all NOTIFYs were suppressed")="yes";
   ::arg().set("allow-notify-from","Allow AXFR NOTIFY from these IP ranges. If empty, drop all incoming notifies.")="0.0.0.0/0,::/0";
   ::arg().set("slave-cycle-interval","Schedule slave freshness checks once every .. seconds")="60";
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -118,6 +118,7 @@ void declareArguments()
   ::arg().set("allow-axfr-ips","Allow zonetransfers only to these subnets")="127.0.0.0/8,::1";
   ::arg().set("only-notify", "Only send AXFR NOTIFY to these IP addresses or netmasks")="0.0.0.0/0,::/0";
   ::arg().set("also-notify", "When notifying a domain, also notify these nameservers")="";
+  ::arg().set("enable-notification-warning","Enable the logging of warnings if all NOTIFYs were suppressed")="yes";
   ::arg().set("allow-notify-from","Allow AXFR NOTIFY from these IP ranges. If empty, drop all incoming notifies.")="0.0.0.0/0,::/0";
   ::arg().set("slave-cycle-interval","Schedule slave freshness checks once every .. seconds")="60";
 

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -96,7 +96,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
     }
   }
 
-  if (!hasQueuedItem && ::arg().mustDo("enable-notification-warning")) {
+  if (!hasQueuedItem && ::arg().mustDo("enable-no-notification-targets-warning")) {
     g_log<<Logger::Warning<<"Request to queue notification for domain '"<<di.zone<<"' was processed, but no valid nameservers or ALSO-NOTIFYs found. Not notifying!"<<endl;
   }
 }

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -96,8 +96,9 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
     }
   }
 
-  if (!hasQueuedItem)
+  if (!hasQueuedItem && ::arg().mustDo("enable-notification-warning")) {
     g_log<<Logger::Warning<<"Request to queue notification for domain '"<<di.zone<<"' was processed, but no valid nameservers or ALSO-NOTIFYs found. Not notifying!"<<endl;
+  }
 }
 
 


### PR DESCRIPTION
…configureable

### Short description
By default PowerDNS will log a warning if all NOTIFYs were suppressed due to
`only-notify` and there were no explict ALSO-NOTIFYs. This warning can be suppressed by
setting this option to `no`


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x ] compiled this code
- [ ] tested this code
- [x ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
