### PR TITLE
dnsdist: Support DNSAction.Allow in DynBlocks for testing purposes

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -936,12 +936,23 @@ void setupLuaConfig(bool client)
 
   g_lua.writeFunction("setDynBlocksAction", [](DNSAction::Action action) {
       if (!g_configurationDone) {
-        if (action == DNSAction::Action::Drop || action == DNSAction::Action::Refused || action == DNSAction::Action::Truncate) {
-          g_dynBlockAction = action;
-        }
-        else {
-          errlog("Dynamic blocks action can only be Drop, Refused or Truncate!");
-          g_outputBuffer="Dynamic blocks action can only be Drop, Refused or Truncate!\n";
+        switch(action) {
+          case DNSAction::Action::Allow: 
+            g_dynBlockAction = action;
+            break;
+          case DNSAction::Action::Drop:
+            g_dynBlockAction = action;
+            break;
+          case DNSAction::Action::Refused:
+            g_dynBlockAction = action;
+            break;
+          case DNSAction::Action::Truncate:
+            g_dynBlockAction = action;
+            break;
+          default:
+            errlog("Dynamic blocks action can only be Allow, Drop, Refused or Truncate!");
+            g_outputBuffer="Dynamic blocks action can only be Allow, Drop, Refused or Truncate!\n";
+            break;
         }
       } else {
         g_outputBuffer="Dynamic blocks action cannot be altered at runtime!\n";

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -938,14 +938,8 @@ void setupLuaConfig(bool client)
       if (!g_configurationDone) {
         switch(action) {
           case DNSAction::Action::Allow: 
-            g_dynBlockAction = action;
-            break;
           case DNSAction::Action::Drop:
-            g_dynBlockAction = action;
-            break;
           case DNSAction::Action::Refused:
-            g_dynBlockAction = action;
-            break;
           case DNSAction::Action::Truncate:
             g_dynBlockAction = action;
             break;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -911,31 +911,34 @@ bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int*
       if (action == DNSAction::Action::None) {
         action = g_dynBlockAction;
       }
-      if (action == DNSAction::Action::Refused) {
+      switch (action) {
+      case DNSAction::Action::Allow:
+        return true;
+        break;
+      case DNSAction::Action::Refused:
         vinfolog("Query from %s refused because of dynamic block", dq.remote->toStringWithPort());
         updateBlockStats();
-      
         dq.dh->rcode = RCode::Refused;
         dq.dh->qr=true;
         return true;
-      }
-      else if (action == DNSAction::Action::Truncate) {
+        break;
+      case DNSAction::Action::Truncate:
         if(!dq.tcp) {
           updateBlockStats();
           vinfolog("Query from %s truncated because of dynamic block", dq.remote->toStringWithPort());
           dq.dh->tc = true;
           dq.dh->qr = true;
           return true;
-        }
-        else {
+          break;
+        } else {
           vinfolog("Query from %s for %s over TCP *not* truncated because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
+          break;
         }
-
-      }
-      else {
+      default:
         updateBlockStats();
         vinfolog("Query from %s dropped because of dynamic block", dq.remote->toStringWithPort());
         return false;
+        break;
       }
     }
   }
@@ -951,31 +954,35 @@ bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int*
       if (action == DNSAction::Action::None) {
         action = g_dynBlockAction;
       }
-      if (action == DNSAction::Action::Refused) {
-        vinfolog("Query from %s for %s refused because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
-        updateBlockStats();
 
+      switch (action) {
+      case DNSAction::Action::Allow:
+        return true;
+        break;
+      case DNSAction::Action::Refused:
+        vinfolog("Query from %s refused because of dynamic block", dq.remote->toStringWithPort());
+        updateBlockStats();
         dq.dh->rcode = RCode::Refused;
         dq.dh->qr=true;
         return true;
-      }
-      else if (action == DNSAction::Action::Truncate) {
+        break;
+      case DNSAction::Action::Truncate:
         if(!dq.tcp) {
           updateBlockStats();
-      
-          vinfolog("Query from %s for %s truncated because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
+          vinfolog("Query from %s truncated because of dynamic block", dq.remote->toStringWithPort());
           dq.dh->tc = true;
           dq.dh->qr = true;
           return true;
-        }
-        else {
+          break;
+        } else {
           vinfolog("Query from %s for %s over TCP *not* truncated because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
+          break;
         }
-      }
-      else {
+      default:
         updateBlockStats();
-        vinfolog("Query from %s for %s dropped because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
+        vinfolog("Query from %s dropped because of dynamic block", dq.remote->toStringWithPort());
         return false;
+        break;
       }
     }
   }

--- a/pdns/dnsdistdist/docs/guides/dynblocks.rst
+++ b/pdns/dnsdistdist/docs/guides/dynblocks.rst
@@ -23,6 +23,8 @@ For example, to send a REFUSED code instead of droppping the query::
 
   setDynBlocksAction(DNSAction.Refused)
 
+Please see the documentation for :func:`setDynBlocksAction` to confirm which actions are supported.
+
 .. _DynBlockRulesGroup:
 
 DynBlockRulesGroup

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -728,6 +728,8 @@ Dynamic Blocks
   :param int seconds: The number of seconds this block to expire
   :param int action: The action to take when the dynamic block matches, see :ref:`here <DNSAction>`. (default to the one set with :func:`setDynBlocksAction`)
 
+  Please see the documentation for :func:`setDynBlocksAction` to confirm which actions are supported by the action paramater.
+
 .. function:: clearDynBlocks()
 
   Remove all current dynamic blocks.
@@ -739,7 +741,8 @@ Dynamic Blocks
 .. function:: setDynBlocksAction(action)
 
   Set which action is performed when a query is blocked.
-  Only DNSAction.Drop (the default), DNSAction.Refused and DNSAction.Truncate are supported.
+
+  Only DNSAction.Allow (for testing), DNSAction.Drop (the default), DNSAction.Refused and DNSAction.Truncate are currently supported.
 
 .. _exceedfuncs:
 

--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -498,6 +498,27 @@ class TestDynBlockGroupQPSRefused(DynBlocksTest):
         name = 'qraterefused.group.dynblocks.tests.powerdns.com.'
         self.doTestQRateRCode(name, dns.rcode.REFUSED)
 
+class TestDynBlockQPSActionAllow(DynBlocksTest):
+
+    _dynBlockQPS = 10
+    _dynBlockPeriod = 2
+    _dynBlockDuration = 5
+    _config_params = ['_dynBlockQPS', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort']
+    _config_template = """
+    function maintenance()
+	    addDynBlocks(exceedQRate(%d, %d), "Exceeded query rate", %d, DNSAction.Allow)
+    end
+    setDynBlocksAction(DNSAction.Drop)
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testDynBlocksQRate(self):
+        """
+        Dyn Blocks: QRate allow (action)
+        """
+        name = 'qrateactionallow.dynblocks.tests.powerdns.com.'
+        self.doTestQRate(name)
+
 class TestDynBlockQPSActionRefused(DynBlocksTest):
 
     _dynBlockQPS = 10


### PR DESCRIPTION
### Short description
Supports DNSAction.Allow in DynBlocks for testing purposes, based on discussion in the IRC channel on 31/05. Also makes documentation more verbose.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
