### PR TITLE
logger: Use a function-level static var for the logger object

### DIFF
--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -34,7 +34,20 @@ extern StatBag S;
 pthread_once_t Logger::s_once;
 pthread_key_t Logger::g_loggerKey;
 
-Logger g_log("", LOG_DAEMON);
+Logger& getLogger()
+{
+  /* Since the Logger can be called very early, we need to make sure
+     that the relevant parts are initialized no matter what, which is tricky
+     because we can't easily control the initialization order, especially with
+     built-in backends.
+     t_perThread is thread_local, so it will be initialized when first accessed,
+     but we need to make sure that the object itself is initialized, and making
+     it a function-level static variable achieves that, because it will be
+     initialized the first time we enter this function at the very last.
+  */
+  static Logger log("", LOG_DAEMON);
+  return log;
+}
 
 void Logger::log(const string &msg, Urgency u)
 {

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -119,7 +119,9 @@ private:
   static pthread_key_t g_loggerKey;
 };
 
-extern Logger g_log;
+Logger& getLogger();
+
+#define g_log getLogger()
 
 #ifdef VERBOSELOG
 #define DLOG(x) x


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is the same commit than in #6689, ie making the `Logger` object a function-level static variable to make sure it's properly initialized. It fixes the crash reported in #6624 without adding a new one like the use of `thread_local` proposed in #6689 and #6625.
This should restore the behavior we had before the move to `g_log`, but is not perfect: @tih reports that the recursor still crashes a bit later on `NetBSD/arm32`, apparently because of an issue regarding the initialization of non-`POD` `unique_ptr`.
I still think using `thread_local` instead of `pthread_get_specific()` makes sense, so I'd be more interested in merging #6689 than this PR but I'm opening it so we can discuss that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
