### PR TITLE
Dynamic blocks were being created with the wrong duration

### DIFF
--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -203,7 +203,7 @@ private:
       blocks = g_dynblockNMG.getCopy();
     }
     struct timespec until = now;
-    until.tv_sec += rule.d_seconds;
+    until.tv_sec += rule.d_blockDuration;
     unsigned int count = 0;
     const auto& got = blocks->lookup(Netmask(requestor));
     bool expired = false;
@@ -225,7 +225,7 @@ private:
     DynBlock db{rule.d_blockReason, until, DNSName(), rule.d_action};
     db.blocks = count;
     if (!got || expired) {
-      warnlog("Inserting dynamic block for %s for %d seconds: %s", requestor.toString(), rule.d_seconds, rule.d_blockReason);
+      warnlog("Inserting dynamic block for %s for %d seconds: %s", requestor.toString(), rule.d_blockDuration, rule.d_blockReason);
     }
     blocks->insert(Netmask(requestor)).second = db;
     updated = true;


### PR DESCRIPTION
Dynamic blocks were being created with the wrong duration the detection interval was being used.

### Short description
Fixes the duration as set at the creation of dynamic blocks from rules.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
