### PR TITLE
rec: Fix some warnings reported by GCC

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -127,7 +127,6 @@ shared_ptr<DNSCryptoKeyEngine> DNSCryptoKeyEngine::makeFromISCString(DNSKEYRecor
 
 std::string DNSCryptoKeyEngine::convertToISC() const
 {
-  typedef map<string, string> stormap_t;
   storvector_t stormap = this->convertToISCVector();
   ostringstream ret;
   ret<<"Private-key-format: v1.2\n";

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -179,10 +179,10 @@ void BaseLua4::prepareContext() {
   d_lw->registerFunction<boost::optional<ComboAddress>(DNSRecord::*)()>("getCA", [](const DNSRecord& dr) {
       boost::optional<ComboAddress> ret;
 
-      if(auto rec = std::dynamic_pointer_cast<ARecordContent>(dr.d_content))
-        ret=rec->getCA(53);
-      else if(auto rec = std::dynamic_pointer_cast<AAAARecordContent>(dr.d_content))
-        ret=rec->getCA(53);
+      if(auto arec = std::dynamic_pointer_cast<ARecordContent>(dr.d_content))
+        ret=arec->getCA(53);
+      else if(auto aaaarec = std::dynamic_pointer_cast<AAAARecordContent>(dr.d_content))
+        ret=aaaarec->getCA(53);
       return ret;
     });
   d_lw->registerFunction<void(DNSRecord::*)(const std::string&)>("changeContent", [](DNSRecord& dr, const std::string& newContent) { dr.d_content = shared_ptr<DNSRecordContent>(DNSRecordContent::mastermake(dr.d_type, 1, newContent)); });

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -351,7 +351,7 @@ int waitForRWData(int fd, bool waitForRead, int seconds, int useconds, bool* err
 }
 
 // returns -1 in case of error, 0 if no data is available, 1 if there is. In the first two cases, errno is set
-int waitForMultiData(const set<int>& fds, const int seconds, const int useconds, int* fd) {
+int waitForMultiData(const set<int>& fds, const int seconds, const int useconds, int* fdOut) {
   set<int> realFDs;
   for (const auto& fd : fds) {
     if (fd >= 0 && realFDs.count(fd) == 0) {
@@ -384,7 +384,7 @@ int waitForMultiData(const set<int>& fds, const int seconds, const int useconds,
   }
   set<int>::const_iterator it(pollinFDs.begin());
   advance(it, random() % pollinFDs.size());
-  *fd = *it;
+  *fdOut = *it;
   return 1;
 }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2022,7 +2022,7 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
   fromaddr.sin6.sin6_family=AF_INET6; // this makes sure fromaddr is big enough
   fillMSGHdr(&msgh, &iov, cbuf, sizeof(cbuf), &data[0], data.size(), &fromaddr);
 
-  for(size_t counter = 0; counter < s_maxUDPQueriesPerRound; counter++)
+  for(size_t queriesCounter = 0; queriesCounter < s_maxUDPQueriesPerRound; queriesCounter++)
   if((len=recvmsg(fd, &msgh, 0)) >= 0) {
 
     firstQuery = false;

--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -115,7 +115,7 @@ void RecursorControlChannel::send(const std::string& msg, const std::string* rem
     memset(&remoteaddr, 0, sizeof(remoteaddr));
   
     remoteaddr.sun_family=AF_UNIX;
-    strncpy(remoteaddr.sun_path, remote->c_str(), sizeof(remoteaddr.sun_path));
+    strncpy(remoteaddr.sun_path, remote->c_str(), sizeof(remoteaddr.sun_path)-1);
     remoteaddr.sun_path[sizeof(remoteaddr.sun_path)-1] = '\0';
 
     if(::sendto(d_fd, msg.c_str(), msg.length(), 0, (struct sockaddr*) &remoteaddr, sizeof(remoteaddr) ) < 0)

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -320,10 +320,8 @@ int MemRecursorCache::doWipeCache(const DNSName& name, bool sub, uint16_t qtype)
 {
   int count=0;
   d_cachecachevalid=false;
-  pair<cache_t::iterator, cache_t::iterator> range;
 
   if(!sub) {
-    pair<ecsIndex_t::iterator, ecsIndex_t::iterator> ecsIndexRange;
     auto& idx = d_cache.get<NameOnlyHashedTag>();
     auto range = idx.equal_range(name);
     for(auto& i=range.first; i != range.second; ) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Shadowed variables
- One warning about `strncpy()`, we always NULL-terminate the string anyway, but let's make the compiler happy.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
