### PR TITLE
rec: Support exporting more record types via protobuf

### DIFF
--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -211,6 +211,10 @@ class SPFRecordContent : public DNSRecordContent
 {
 public:
   includeboilerplate(SPF)
+  const std::string& getText() const
+  {
+    return d_text;
+  }
 
 private:
   string d_text;
@@ -240,6 +244,7 @@ class PTRRecordContent : public DNSRecordContent
 public:
   includeboilerplate(PTR)
   explicit PTRRecordContent(const DNSName& content) : d_content(content){}
+  const DNSName& getContent() const { return d_content; }
 private:
   DNSName d_content;
 };

--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -68,5 +68,5 @@ public:
   bool d_haveEDNS{false};
 };
 
-int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<RemoteLogger>& outgoingLogger, LWResult* res, bool* chained);
+int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<RemoteLogger>& outgoingLogger, const std::set<uint16_t>& exportTypes, LWResult* res, bool* chained);
 #endif // PDNS_LWRES_HH

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1010,11 +1010,9 @@ static void startDoResolve(void *p)
       logResponse = t_protobufServer && luaconfsLocal->protobufExportConfig.logResponses;
       Netmask requestorNM(dc->d_source, dc->d_source.sin4.sin_family == AF_INET ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
       const ComboAddress& requestor = requestorNM.getMaskedNetwork();
-      pbMessage = RecProtoBufMessage(RecProtoBufMessage::Response);
+      pbMessage = RecProtoBufMessage(RecProtoBufMessage::Response, dc->d_uuid, &requestor, &dc->d_destination, dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_mdp.d_qclass, dc->d_mdp.d_header.id, dc->d_tcp, 0);
       pbMessage->setServerIdentity(SyncRes::s_serverID);
-      pbMessage->update(dc->d_uuid, &requestor, &dc->d_destination, dc->d_tcp, dc->d_mdp.d_header.id);
       pbMessage->setEDNSSubnet(dc->d_ednssubnet.source, dc->d_ednssubnet.source.isIpv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
-      pbMessage->setQuestion(dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_mdp.d_qclass);
     }
 #endif /* HAVE_PROTOBUF */
 
@@ -1392,8 +1390,8 @@ static void startDoResolve(void *p)
         needCommit = true;
 
 #ifdef HAVE_PROTOBUF
-        if(t_protobufServer && (i->d_type == QType::A || i->d_type == QType::AAAA || i->d_type == QType::CNAME)) {
-          pbMessage->addRR(*i);
+        if(t_protobufServer) {
+          pbMessage->addRR(*i, luaconfsLocal->protobufExportConfig.exportTypes);
         }
 #endif
       }

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -82,7 +82,7 @@ static void parseRPZParameters(const std::unordered_map<string,boost::variant<ui
 }
 
 #if HAVE_PROTOBUF
-typedef std::unordered_map<std::string, boost::variant<bool, uint64_t, std::string> > protobufOptions_t;
+typedef std::unordered_map<std::string, boost::variant<bool, uint64_t, std::string, std::vector<std::pair<int,std::string> > > > protobufOptions_t;
 
 static void parseProtobufOptions(boost::optional<protobufOptions_t> vars, ProtobufExportConfig& config)
 {
@@ -116,6 +116,28 @@ static void parseProtobufOptions(boost::optional<protobufOptions_t> vars, Protob
 
   if (vars->count("logResponses")) {
     config.logResponses = boost::get<bool>((*vars)["logResponses"]);
+  }
+
+  if (vars->count("exportTypes")) {
+    config.exportTypes.clear();
+
+    auto types =  boost::get<std::vector<std::pair<int, std::string>>>((*vars)["exportTypes"]);
+    for (const auto& pair : types) {
+      const auto type = pair.second;
+      bool found = false;
+
+      for (const auto& entry : QType::names) {
+        if (entry.first == type) {
+          found = true;
+          config.exportTypes.insert(entry.second);
+          break;
+        }
+      }
+
+      if (!found) {
+        throw std::runtime_error("Unknown QType '" + type + "' in protobuf's export types");
+      }
+    }
   }
 }
 #endif /* HAVE_PROTOBUF */

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -20,6 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
+#include <set>
+
 #include "sholder.hh"
 #include "sortlist.hh"
 #include "filterpo.hh"
@@ -27,6 +29,7 @@
 
 struct ProtobufExportConfig
 {
+  std::set<uint16_t> exportTypes = { QType::A, QType::AAAA, QType::CNAME };
   ComboAddress server;
   uint64_t maxQueuedEntries{100};
   uint16_t timeout{2};

--- a/pdns/rec-protobuf.hh
+++ b/pdns/rec-protobuf.hh
@@ -42,8 +42,8 @@ public:
   }
 #endif /* HAVE_PROTOBUF */
 
-  void addRRs(const std::vector<DNSRecord>& records);
-  void addRR(const DNSRecord& record);
+  void addRRs(const std::vector<DNSRecord>& records, const std::set<uint16_t>& exportTypes);
+  void addRR(const DNSRecord& record, const std::set<uint16_t>& exportTypes);
   void setAppliedPolicy(const std::string& policy);
   void setAppliedPolicyType(const DNSFilterEngine::PolicyType& policyType);
   void setPolicyTags(const std::vector<std::string>& policyTags);

--- a/pdns/recursordist/docs/lua-config/protobuf.rst
+++ b/pdns/recursordist/docs/lua-config/protobuf.rst
@@ -30,6 +30,7 @@ Protobuf export to a server is enabled using the ``protobufServer()`` directive:
   * ``asyncConnect``: bool - When set to false (default) the first connection to the server during startup will block up to ``timeout`` seconds, otherwise the connection is done in a separate thread, after the first message has been queued
   * ``logQueries=true``: bool - Whether to export queries
   * ``logResponses=true``: bool - Whether to export responses
+  * ``exportTypes={'A', 'AAAA', 'CNAME'}``: list of strings - The list of record types found in the answer section to export. Only A, AAAA, CNAME, MX, NS, PTR, SPF, SRV and TXT are currently supported
 
 .. function:: protobufServer(server [[[[[[[, timeout=2], maxQueuedEntries=100], reconnectWaitTime=1], maskV4=32], maskV6=128], asyncConnect=false], taggedOnly=false])
 
@@ -74,6 +75,7 @@ While :func:`protobufServer` only exports the queries sent to the recursor from 
   * ``asyncConnect``: bool - When set to false (default) the first connection to the server during startup will block up to ``timeout`` seconds, otherwise the connection is done in a separate thread, after the first message has been queued
   * ``logQueries=true``: bool - Whether to export queries
   * ``logResponses=true``: bool - Whether to export responses
+  * ``exportTypes={'A', 'AAAA', 'CNAME'}``: list of strings - The list of record types found in the answer section to export. Only A, AAAA, CNAME, MX, NS, PTR, SPF, SRV and TXT are currently supported
 
 .. function:: outgoingProtobufServer(server [[[[, timeout=2], maxQueuedEntries=100], reconnectWaitTime=1], asyncConnect=false])
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -485,10 +485,10 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
       sendQname.makeUsLowerCase();
 
     if (d_asyncResolve) {
-      ret = d_asyncResolve(ip, sendQname, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, d_outgoingProtobufServer, res, chained);
+      ret = d_asyncResolve(ip, sendQname, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, res, chained);
     }
     else {
-      ret=asyncresolve(ip, sendQname, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, d_outgoingProtobufServer, res, chained);
+      ret=asyncresolve(ip, sendQname, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, d_outgoingProtobufServer, luaconfsLocal->outgoingProtobufExportConfig.exportTypes, res, chained);
     }
     if(ret < 0) {
       return ret; // transport error, nothing to learn here

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -274,7 +274,7 @@ class SyncRes : public boost::noncopyable
 {
 public:
   enum LogMode { LogNone, Log, Store};
-  typedef std::function<int(const ComboAddress& ip, const DNSName& qdomain, int qtype, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, std::shared_ptr<RemoteLogger> outgoingLogger, LWResult *lwr, bool* chained)> asyncresolve_t;
+  typedef std::function<int(const ComboAddress& ip, const DNSName& qdomain, int qtype, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult *lwr, bool* chained)> asyncresolve_t;
 
   struct EDNSStatus
   {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Several users have reported the need to export the content of of more record types found in responses. This pull request adds support for optionally exporting the content of `MX`, `NS`, `PTR`,  `SPF`, `SRV` and `TXT` record types, in addition to the existing `A`, `AAAA` and `CNAME`. The implementation is limited to those types because it special cases them.
An other option would be to implement all `xfr*()` methods to be able to get the "wire version" of all types.  If we decided to go that road, I think it might make sense to extract the `xfr*()`methods from `DNSPacketWriter` into a `DNSRecordWriter` implementing all `xfr*()` methods, that would be called by `DNSPacketWriter` but could also be used from the protobuf logger.

This PR is based on #6698 and will need a rebase after it has been merged.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
