### PR TITLE
dnsdist: default set "Connection: close" header for web requests

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -194,7 +194,6 @@ static void addSecurityHeaders(YaHTTP::Response& resp, const boost::optional<std
     { "X-Permitted-Cross-Domain-Policies", "none" },
     { "X-XSS-Protection", "1; mode=block" },
     { "Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'" },
-    { "Connection", "close" },
   };
 
   for (const auto& h : headers) {
@@ -275,6 +274,8 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
 
     addCustomHeaders(resp, customHeaders);
     addSecurityHeaders(resp, customHeaders);
+    /* indicate that the connection will be closed after completion of the response */
+    resp.headers["Connection"] = "close";
 
     /* no need to send back the API key if any */
     resp.headers.erase("X-API-Key");

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -194,6 +194,7 @@ static void addSecurityHeaders(YaHTTP::Response& resp, const boost::optional<std
     { "X-Permitted-Cross-Domain-Policies", "none" },
     { "X-XSS-Protection", "1; mode=block" },
     { "Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'" },
+    { "Connection", "close" },
   };
 
   for (const auto& h : headers) {

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -21,7 +21,6 @@ By default, our web server sends some security-related headers::
    X-Permitted-Cross-Domain-Policies: none
    X-XSS-Protection: 1; mode=block
    Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'
-   Connection: close
 
 You can override those headers, or add custom headers by using the last parameter to :func:`webserver`.
 For example, to remove the X-Frame-Options header and add a X-Custom one:

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -21,6 +21,7 @@ By default, our web server sends some security-related headers::
    X-Permitted-Cross-Domain-Policies: none
    X-XSS-Protection: 1; mode=block
    Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'
+   Connection: close
 
 You can override those headers, or add custom headers by using the last parameter to :func:`webserver`.
 For example, to remove the X-Frame-Options header and add a X-Custom one:
@@ -64,6 +65,7 @@ URL Endpoints
 
       HTTP/1.1 200 OK
       Transfer-Encoding: chunked
+      Connection: close
       Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'
       Content-Type: application/json
       X-Content-Type-Options: nosniff
@@ -86,6 +88,7 @@ URL Endpoints
 
       HTTP/1.1 200 OK
       Transfer-Encoding: chunked
+      Connection: close
       Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'
       Content-Type: application/json
       X-Content-Type-Options: nosniff


### PR DESCRIPTION
### Short description
Default add the `Connection: close` header to dnsdist http responses to indicate that the connection will be closed after completion of the response.

Fix #6532 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
