### PR TITLE
dnsdist: Refuse console connection without a proper key set

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -86,7 +86,6 @@ static bool sendMessageToServer(int fd, const std::string& line, SodiumNonce& re
   putMsgLen32(fd, static_cast<uint32_t>(msgLen));
 
   if (!msg.empty()) {
-    cerr << "sending message of size " << msgLen << endl;
     writen2(fd, msg);
   }
 

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -79,7 +79,7 @@ static bool sendMessageToServer(int fd, const std::string& line, SodiumNonce& re
   string msg = sodEncryptSym(line, g_consoleKey, writingNonce);
   const auto msgLen = msg.length();
   if (msgLen > std::numeric_limits<uint32_t>::max()) {
-    cout << "Encrypted essage is too long to be sent to the server, "<< std::to_string(msgLen) << " > " << std::numeric_limits<uint32_t>::max() << endl;
+    cout << "Encrypted message is too long to be sent to the server, "<< std::to_string(msgLen) << " > " << std::numeric_limits<uint32_t>::max() << endl;
     return true;
   }
 

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -42,6 +42,7 @@ GlobalStateHolder<NetmaskGroup> g_consoleACL;
 vector<pair<struct timeval, string> > g_confDelta;
 std::string g_consoleKey;
 bool g_logConsoleConnections{true};
+bool g_consoleEnabled{false};
 
 // MUST BE CALLED UNDER A LOCK - right now the LuaLock
 static void feedConfigDelta(const std::string& line)
@@ -73,10 +74,56 @@ static string historyFile(const bool &ignoreHOME = false)
   return ret;
 }
 
+static bool sendMessageToServer(int fd, const std::string& line, SodiumNonce& readingNonce, SodiumNonce& writingNonce, const bool outputEmptyLine)
+{
+  string msg = sodEncryptSym(line, g_consoleKey, writingNonce);
+  const auto msgLen = msg.length();
+  if (msgLen > std::numeric_limits<uint32_t>::max()) {
+    cout << "Encrypted essage is too long to be sent to the server, "<< std::to_string(msgLen) << " > " << std::numeric_limits<uint32_t>::max() << endl;
+    return true;
+  }
+
+  putMsgLen32(fd, static_cast<uint32_t>(msgLen));
+
+  if (!msg.empty()) {
+    cerr << "sending message of size " << msgLen << endl;
+    writen2(fd, msg);
+  }
+
+  uint32_t len;
+  if(!getMsgLen32(fd, &len)) {
+    cout << "Connection closed by the server." << endl;
+    return false;
+  }
+
+  if (len == 0) {
+    if (outputEmptyLine) {
+      cout << endl;
+    }
+
+    return true;
+  }
+
+  boost::scoped_array<char> resp(new char[len]);
+  readn2(fd, resp.get(), len);
+  msg.assign(resp.get(), len);
+  msg = sodDecryptSym(msg, g_consoleKey, readingNonce);
+  cout << msg;
+  cout.flush();
+
+  return true;
+}
+
 void doClient(ComboAddress server, const std::string& command)
 {
-  if(g_verbose)
+  if (!sodIsValidKey(g_consoleKey)) {
+    cerr << "The currently configured console key is not valid, please configure a valid key using the setKey() directive" << endl;
+    return;
+  }
+
+  if(g_verbose) {
     cout<<"Connecting to "<<server.toStringWithPort()<<endl;
+  }
 
   int fd=socket(server.sin4.sin_family, SOCK_STREAM, 0);
   if (fd < 0) {
@@ -93,25 +140,18 @@ void doClient(ComboAddress server, const std::string& command)
   readingNonce.merge(ours, theirs);
   writingNonce.merge(theirs, ours);
 
-  if(!command.empty()) {
-    string msg=sodEncryptSym(command, g_consoleKey, writingNonce);
-    putMsgLen32(fd, (uint32_t) msg.length());
-    if(!msg.empty())
-      writen2(fd, msg);
-    uint32_t len;
-    if(getMsgLen32(fd, &len)) {
-      if (len > 0) {
-        boost::scoped_array<char> resp(new char[len]);
-        readn2(fd, resp.get(), len);
-        msg.assign(resp.get(), len);
-        msg=sodDecryptSym(msg, g_consoleKey, readingNonce);
-        cout<<msg;
-        cout.flush();
-      }
-    }
-    else {
-      cout << "Connection closed by the server." << endl;
-    }
+  /* try sending an empty message, the server should send an empty
+     one back. If it closes the connection instead, we are probably
+     having a key mismatch issue. */
+  if (!sendMessageToServer(fd, "", readingNonce, writingNonce, false)) {
+    cerr<<"The server closed the connection right away, likely indicating a key mismatch. Please check your setKey() directive."<<endl;
+    close(fd);
+    return;
+  }
+
+  if (!command.empty()) {
+    sendMessageToServer(fd, command, readingNonce, writingNonce, false);
+
     close(fd);
     return; 
   }
@@ -150,25 +190,8 @@ void doClient(ComboAddress server, const std::string& command)
     if(line.empty())
       continue;
 
-    string msg=sodEncryptSym(line, g_consoleKey, writingNonce);
-    putMsgLen32(fd, (uint32_t) msg.length());
-    writen2(fd, msg);
-    uint32_t len;
-    if(!getMsgLen32(fd, &len)) {
-      cout << "Connection closed by the server." << endl;
+    if (!sendMessageToServer(fd, line, readingNonce, writingNonce, true)) {
       break;
-    }
-
-    if (len > 0) {
-      boost::scoped_array<char> resp(new char[len]);
-      readn2(fd, resp.get(), len);
-      msg.assign(resp.get(), len);
-      msg=sodDecryptSym(msg, g_consoleKey, readingNonce);
-      cout<<msg;
-      cout.flush();
-    }
-    else {
-      cout<<endl;
     }
   }
   close(fd);
@@ -529,8 +552,9 @@ try
 
     boost::scoped_array<char> msg(new char[len]);
     readn2(fd, msg.get(), len);
-    
+
     string line(msg.get(), len);
+
     line = sodDecryptSym(line, g_consoleKey, readingNonce);
     //    cerr<<"Have decrypted line: "<<line<<endl;
     string response;
@@ -642,6 +666,12 @@ try
   infolog("Accepting control connections on %s", local.toStringWithPort());
 
   while ((sock = SAccept(fd, client)) >= 0) {
+
+    if (!sodIsValidKey(g_consoleKey)) {
+      vinfolog("Control connection from %s dropped because we don't have a valid key configured, please configure one using setKey()", client.toStringWithPort());
+      close(sock);
+      continue;
+    }
 
     if (!localACL->match(client)) {
       vinfolog("Control connection from %s dropped because of ACL", client.toStringWithPort());

--- a/pdns/dnsdist-console.hh
+++ b/pdns/dnsdist-console.hh
@@ -42,6 +42,7 @@ extern GlobalStateHolder<NetmaskGroup> g_consoleACL;
 extern const std::vector<ConsoleKeyword> g_consoleKeywords;
 extern std::string g_consoleKey; // in theory needs locking
 extern bool g_logConsoleConnections;
+extern bool g_consoleEnabled;
 
 void doClient(ComboAddress server, const std::string& command);
 void doConsole();

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -611,6 +611,13 @@ void setupLuaConfig(bool client)
 	return;
       }
 
+      g_consoleEnabled = true;
+#ifdef HAVE_LIBSODIUM
+      if (g_configurationDone && g_consoleKey.empty()) {
+        warnlog("Warning, the console has been enabled via 'controlSocket()' but no key has been set with 'setKey()' so all connections will fail until a key has been set");
+      }
+#endif
+
       try {
 	int sock = SSocket(local.sin4.sin_family, SOCK_STREAM, 0);
 	SSetsockopt(sock, SOL_SOCKET, SO_REUSEADDR, 1);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -81,7 +81,6 @@ bool g_verbose;
 
 struct DNSDistStats g_stats;
 uint16_t g_maxOutstanding{10240};
-bool g_console;
 bool g_verboseHealthChecks{false};
 uint32_t g_staleCacheEntriesTTL{0};
 bool g_syslog{true};
@@ -2062,7 +2061,6 @@ try
   signal(SIGPIPE, SIG_IGN);
   signal(SIGCHLD, SIG_IGN);
   openlog("dnsdist", LOG_PID, LOG_DAEMON);
-  g_console=true;
 
 #ifdef HAVE_LIBSODIUM
   if (sodium_init() == -1) {
@@ -2549,6 +2547,7 @@ try
   }
 
   warnlog("dnsdist %s comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it according to the terms of the GPL version 2", VERSION);
+
   vector<string> vec;
   std::string acls;
   g_ACL.getLocal()->toStringVector(&vec);
@@ -2568,6 +2567,12 @@ try
     acls += entry;
   }
   infolog("Console ACL allowing connections from: %s", acls.c_str());
+
+#ifdef HAVE_LIBSODIUM
+  if (g_consoleEnabled && g_consoleKey.empty()) {
+    warnlog("Warning, the console has been enabled via 'controlSocket()' but no key has been set with 'setKey()' so all connections will fail until a key has been set");
+  }
+#endif
 
   uid_t newgid=0;
   gid_t newuid=0;

--- a/pdns/dnsdistdist/docs/guides/console.rst
+++ b/pdns/dnsdistdist/docs/guides/console.rst
@@ -11,14 +11,16 @@ The console can be enabled with :func:`controlSocket`:
 
   controlSocket('192.0.2.53:5199')
 
-Enabling the console without encryption enabled is not recommended. To enable encryption, first generate a key with :func:`makeKey`::
+Enabling the console without encryption enabled is not recommended. Note that encryption requires building dnsdist with libsodium support enabled.
+
+Once you have a libsodium-enabled dnsdist, the first step to enable encryption is to generate a key with :func:`makeKey`::
 
   $ ./dnsdist -l 127.0.0.1:5300
   [..]
   > makeKey()
   setKey("ENCODED KEY")
 
-Add the generated :func:`setKey` line to your dnsdist configuration file, along with a :func:`controlSocket`:
+Then add the generated :func:`setKey` line to your dnsdist configuration file, along with a :func:`controlSocket`:
 
 .. code-block:: lua
 
@@ -37,8 +39,6 @@ Alternatively, you can specify the address and key on the client commandline::
 .. warning::
 
   This will leak the key into your shell's history and is **not** recommended.
-
-Note that encryption requires building dnsdist with libsodium support enabled.
 
 Since 1.3.0, dnsdist supports restricting which client can connect to the console with an ACL:
 

--- a/pdns/dnsdistdist/docs/guides/console.rst
+++ b/pdns/dnsdistdist/docs/guides/console.rst
@@ -11,7 +11,7 @@ The console can be enabled with :func:`controlSocket`:
 
   controlSocket('192.0.2.53:5199')
 
-Exposing the console to the network without encryption enabled is not recommended. To enable encryption, first generate a key with :func:`makeKey`::
+Enabling the console without encryption enabled is not recommended. To enable encryption, first generate a key with :func:`makeKey`::
 
   $ ./dnsdist -l 127.0.0.1:5300
   [..]
@@ -48,4 +48,6 @@ Since 1.3.0, dnsdist supports restricting which client can connect to the consol
   setConsoleACL('192.0.2.0/24')
 
 The default value is '127.0.0.1', restricting the use of the console to local users. Please make sure that encryption is enabled
-before using :func:`addConsoleACL` or :func:`setConsoleACL` to allow connection from remote clients.
+before using :func:`addConsoleACL` or :func:`setConsoleACL` to allow connection from remote clients. Even if the console is
+restricted to local users, the use of encryption is still strongly advised to prevent unauthorized local users from connecting to
+the console.

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -155,7 +155,8 @@ Control Socket, Console and Webserver
 
   Bind to ``addr`` and listen for a connection for the console. Since 1.3.0 only connections from local users are allowed
   by default, :func:`addConsoleACL` and :func:`setConsoleACL` can be used to enable remote connections. Please make sure
-  that encryption has been enabled with :func:`setKey` before doing so.
+  that encryption has been enabled with :func:`setKey` before doing so. Enabling encryption is also strongly advised for
+  local connections, since not enabling it allows any local user to connect to the console.
 
   :param str address: An IP address with optional port. By default, the port is 5199.
 

--- a/pdns/dolog.hh
+++ b/pdns/dolog.hh
@@ -36,7 +36,7 @@
           warnlog("Query took %d milliseconds", 1232.4); // yes, %d
           errlog("Unable to bind to %s: %s", ca.toStringWithPort(), strerr(errno));
 
-   If bool g_console is true, will log to stdout. Will syslog in any case with LOG_INFO,
+   Will log to stdout. Will syslog in any case with LOG_INFO,
    LOG_WARNING, LOG_ERR respectively. If g_verbose=false, vinfolog is a noop.
    More generically, dolog(someiostream, "Hello %s", stream) will log to someiostream
 
@@ -67,7 +67,6 @@ void dolog(std::ostream& os, const char* s, T value, Args... args)
   }    
 }
 
-extern bool g_console;
 extern bool g_verbose;
 extern bool g_syslog;
 
@@ -78,8 +77,7 @@ void genlog(int level, const char* s, Args... args)
   dolog(str, s, args...);
   if(g_syslog)
     syslog(level, "%s", str.str().c_str());
-  if(g_console) 
-    std::cout<<str.str()<<std::endl;
+  std::cout<<str.str()<<std::endl;
 }
 
 

--- a/pdns/sodcrypto.cc
+++ b/pdns/sodcrypto.cc
@@ -38,8 +38,17 @@ string newKey()
   return "\""+Base64Encode(key)+"\"";
 }
 
+bool sodIsValidKey(const std::string& key)
+{
+  return key.size() == crypto_secretbox_KEYBYTES;
+}
+
 std::string sodEncryptSym(const std::string& msg, const std::string& key, SodiumNonce& nonce)
 {
+  if (!sodIsValidKey(key)) {
+    throw std::runtime_error("Invalid encryption key of size " + std::to_string(key.size()) + ", use setKey() to set a valid key");
+  }
+
   std::string ciphertext;
   ciphertext.resize(msg.length() + crypto_secretbox_MACBYTES);
   crypto_secretbox_easy(reinterpret_cast<unsigned char*>(&ciphertext.at(0)),
@@ -60,6 +69,10 @@ std::string sodDecryptSym(const std::string& msg, const std::string& key, Sodium
     throw std::runtime_error("Could not decrypt message of size " + std::to_string(msg.length()));
   }
 
+  if (!sodIsValidKey(key)) {
+    throw std::runtime_error("Invalid decryption key of size " + std::to_string(key.size()) + ", use setKey() to set a valid key");
+  }
+
   decrypted.resize(msg.length() - crypto_secretbox_MACBYTES);
 
   if (crypto_secretbox_open_easy(reinterpret_cast<unsigned char*>(const_cast<char *>(decrypted.data())),
@@ -67,7 +80,7 @@ std::string sodDecryptSym(const std::string& msg, const std::string& key, Sodium
                                  msg.length(),
                                  nonce.value,
                                  reinterpret_cast<const unsigned char*>(key.c_str())) != 0) {
-    throw std::runtime_error("Could not decrypt message");
+    throw std::runtime_error("Could not decrypt message, please check that the key configured with setKey() is correct");
   }
 
   nonce.increment();
@@ -88,6 +101,10 @@ string newKey()
   return "\"plaintext\"";
 }
 
+bool sodIsValidKey(const std::string& key)
+{
+  return true;
+}
 
 #endif
 

--- a/pdns/sodcrypto.hh
+++ b/pdns/sodcrypto.hh
@@ -70,3 +70,4 @@ std::string newKeypair();
 std::string sodEncryptSym(const std::string& msg, const std::string& key, SodiumNonce&);
 std::string sodDecryptSym(const std::string& msg, const std::string& key, SodiumNonce&);
 std::string newKey();
+bool sodIsValidKey(const std::string& key);

--- a/pdns/test-dnscrypt_cc.cc
+++ b/pdns/test-dnscrypt_cc.cc
@@ -31,7 +31,6 @@
 #include <unistd.h>
 
 bool g_verbose{true};
-bool g_console{true};
 bool g_syslog{true};
 
 BOOST_AUTO_TEST_SUITE(dnscrypt_cc)

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -37,7 +37,6 @@
 
 BOOST_AUTO_TEST_SUITE(dnsdist_cc)
 
-bool g_console{true};
 bool g_syslog{true};
 bool g_verbose{true};
 

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -458,6 +458,9 @@ class DNSDistTest(unittest.TestCase):
         sock.send(struct.pack("!I", len(msg)))
         sock.send(msg)
         data = sock.recv(4)
+        if not data:
+            raise socket.error("Got EOF while reading the response size")
+
         (responseLen,) = struct.unpack("!I", data)
         data = sock.recv(responseLen)
         response = cls._decryptConsole(data, readingNonce)

--- a/regression-tests.dnsdist/test_Console.py
+++ b/regression-tests.dnsdist/test_Console.py
@@ -41,3 +41,20 @@ class TestConsoleNotAllowed(DNSDistTest):
         Console: Not allowed by the ACL
         """
         self.assertRaises(SocketError, self.sendConsoleCommand, 'showVersion()')
+
+class TestConsoleNoKey(DNSDistTest):
+
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
+
+    _config_params = ['_consolePort', '_testServerPort']
+    _config_template = """
+    controlSocket("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%d"}
+    """
+
+    def testConsoleAllowed(self):
+        """
+        Console: No key, the connection should not be allowed
+        """
+        self.assertRaises(SocketError, self.sendConsoleCommand, 'showVersion()')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixes #6683 and explicitly prevents the situation from #6709, which was working in some cases because of a very brittle side-effect.
This PR should add a few words to the documentation to clarify that the use of encryption is also strongly recommended for local connections.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
