### PR TITLE
Implement a smarter dedup for filling packets in auth

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -186,13 +186,14 @@ void DNSPacket::addRecord(const DNSZoneRecord &rr)
 
   if(d_compress) {
     std::string ser = const_cast<DNSZoneRecord&>(rr).dr.d_content->serialize(rr.dr.d_name);
-    if(d_dedup.count({rr.dr.d_name, ser})) { // might be a dup
+    auto hash = boost::hash< std::pair<DNSName, std::string> >()({rr.dr.d_name, ser});
+    if(d_dedup.count(hash)) { // might be a dup
       for(auto i=d_rrs.begin();i!=d_rrs.end();++i) {
         if(rr.dr == i->dr)  // XXX SUPER SLOW
           return;
       }
     }
-    d_dedup.insert({rr.dr.d_name, ser});
+    d_dedup.insert(hash);
   }
 
   d_rrs.push_back(rr);

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -173,7 +173,6 @@ void DNSPacket::setOpcode(uint16_t opcode)
   d.opcode=opcode;
 }
 
-
 void DNSPacket::clearRecords()
 {
   d_rrs.clear();
@@ -182,21 +181,19 @@ void DNSPacket::clearRecords()
 
 void DNSPacket::addRecord(const DNSZoneRecord &rr)
 {
-  // this removes duplicates from the packet in case we are not compressing
-  // for AXFR, no such checking is performed!
+  // this removes duplicates from the packet.
+  // in case we are not compressing for AXFR, no such checking is performed!
 
-  std::string ser;
   if(d_compress) {
-    ser=const_cast<DNSZoneRecord&>(rr).dr.d_content->serialize(rr.dr.d_name);
+    std::string ser = const_cast<DNSZoneRecord&>(rr).dr.d_content->serialize(rr.dr.d_name);
     if(d_dedup.count({rr.dr.d_name, ser})) { // might be a dup
       for(auto i=d_rrs.begin();i!=d_rrs.end();++i) {
         if(rr.dr == i->dr)  // XXX SUPER SLOW
           return;
       }
     }
-  }
-  if(d_compress)
     d_dedup.insert({rr.dr.d_name, ser});
+  }
 
   d_rrs.push_back(rr);
 }
@@ -217,9 +214,7 @@ vector<DNSZoneRecord*> DNSPacket::getAPRecords()
           arrs.push_back(&*i);
         }
     }
-
   return arrs;
-
 }
 
 vector<DNSZoneRecord*> DNSPacket::getAnswerRecords()

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -175,7 +175,7 @@ private:
   string d_tsigprevious;
 
   vector<DNSZoneRecord> d_rrs; // 8
-  std::unordered_set<pair<DNSName, std::string>, boost::hash< std::pair<DNSName, std::string> >  > d_dedup;
+  std::unordered_set<size_t> d_dedup;
   string d_rawpacket; // this is where everything lives 8
   EDNSSubnetOpts d_eso;
 

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -29,7 +29,7 @@
 #include <sys/types.h>
 #include "iputils.hh"
 #include "ednssubnet.hh"
-
+#include <unordered_set>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <sys/time.h>
@@ -175,6 +175,7 @@ private:
   string d_tsigprevious;
 
   vector<DNSZoneRecord> d_rrs; // 8
+  std::unordered_set<pair<DNSName, std::string>, boost::hash< std::pair<DNSName, std::string> >  > d_dedup;
   string d_rawpacket; // this is where everything lives 8
   EDNSSubnetOpts d_eso;
 


### PR DESCRIPTION
### Short description
When we fill packets in the auth server, we check for duplicates.. in a very very slow way. With this PR, an unordered_set is used to speed up this process. 

This plot shows the time we take to fill a packet (in microseconds) with increasing number of records:
![image](https://user-images.githubusercontent.com/1223657/41292912-1f646c22-6e54-11e8-8442-34e52621a1f7.png)
This PR appears to be a speedup at all packet sizes - except for a measurement error at the first ever query. 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
