### PR TITLE
dnsdist: add consistent hash builtin policy

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -461,6 +461,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "unregisterDynBPFFilter", true, "DynBPFFilter", "unregister this dynamic BPF filter" },
   { "webserver", true, "address:port, password [, apiKey [, customHeaders ]])", "launch a webserver with stats on that address with that password" },
   { "whashed", false, "", "Weighted hashed ('sticky') distribution over available servers, based on the server 'weight' parameter" },
+  { "chashed", false, "", "Consistent hashed ('sticky') distribution over available servers, also based on the server 'weight' parameter" },
   { "wrandom", false, "", "Weighted random over available servers, based on the server 'weight' parameter" },
 };
 

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -70,6 +70,7 @@ void setupLuaBindings(bool client)
   g_lua.writeVariable("roundrobin", ServerPolicy{"roundrobin", roundrobin, false});
   g_lua.writeVariable("wrandom", ServerPolicy{"wrandom", wrandom, false});
   g_lua.writeVariable("whashed", ServerPolicy{"whashed", whashed, false});
+  g_lua.writeVariable("chashed", ServerPolicy{"chashed", chashed, false});
   g_lua.writeVariable("leastOutstanding", ServerPolicy{"leastOutstanding", leastOutstanding, false});
 
   /* ServerPool */

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -115,7 +115,10 @@ void setupLuaBindings(bool client)
   g_lua.registerFunction("getName", &DownstreamState::getName);
   g_lua.registerFunction("getNameWithAddr", &DownstreamState::getNameWithAddr);
   g_lua.registerMember("upStatus", &DownstreamState::upStatus);
-  g_lua.registerMember("weight", &DownstreamState::weight);
+  g_lua.registerMember<int (DownstreamState::*)>("weight",
+    [](const DownstreamState& s) -> int {return s.weight;},
+    [](DownstreamState& s, int newWeight) {s.setWeight(newWeight);}
+  );
   g_lua.registerMember("order", &DownstreamState::order);
   g_lua.registerMember("name", &DownstreamState::name);
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -237,7 +237,7 @@ void setupLuaConfig(bool client)
 			      return ret;
 			    }
 
-			    ret->weight=weightVal;
+			    ret->setWeight(weightVal);
 			  }
 			  catch(std::exception& e) {
 			    // std::stoi will throw an exception if the string isn't in a value int range
@@ -278,7 +278,7 @@ void setupLuaConfig(bool client)
 			}
 
                         if (vars.count("id")) {
-                          ret->id = boost::lexical_cast<boost::uuids::uuid>(boost::get<string>(vars["id"]));
+                          ret->setId(boost::lexical_cast<boost::uuids::uuid>(boost::get<string>(vars["id"])));
                         }
 
 			if(vars.count("checkName")) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -44,6 +44,7 @@
 #include "sodcrypto.hh"
 
 #include <boost/logic/tribool.hpp>
+#include <boost/lexical_cast.hpp>
 
 #ifdef HAVE_SYSTEMD
 #include <systemd/sd-daemon.h>
@@ -275,6 +276,10 @@ void setupLuaConfig(bool client)
 			if(vars.count("name")) {
 			  ret->name=boost::get<string>(vars["name"]);
 			}
+
+                        if (vars.count("id")) {
+                          ret->id = boost::lexical_cast<boost::uuids::uuid>(boost::get<string>(vars["id"]));
+                        }
 
 			if(vars.count("checkName")) {
 			  ret->checkName=DNSName(boost::get<string>(vars["checkName"]));

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -649,6 +649,10 @@ void DownstreamState::setId(const boost::uuids::uuid& newId)
 
 void DownstreamState::setWeight(int newWeight)
 {
+  if (newWeight < 1) {
+    errlog("Error setting server's weight: downstream weight value must be greater than 0.");
+    return ;
+  }
   weight = newWeight;
   if (!hashes.empty()) {
     hash();

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -624,6 +624,29 @@ bool DownstreamState::reconnect()
 
   return connected;
 }
+void DownstreamState::hash()
+{
+  auto w = weight;
+  hashes.clear();
+  while (w > 0) {
+    std::string uuid = boost::str(boost::format("%s-%d") % id % w);
+    unsigned int wshash = burtleCI((const unsigned char*)uuid.c_str(), uuid.size(), g_hashperturb);
+    hashes.insert(wshash);
+    --w;
+  }
+}
+
+void DownstreamState::setId(const boost::uuids::uuid& newId)
+{
+  id = newId;
+  hash();
+}
+
+void DownstreamState::setWeight(int newWeight)
+{
+  weight = newWeight;
+  hash();
+}
 
 DownstreamState::DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf_, size_t numberOfSockets): remote(remote_), sourceAddr(sourceAddr_), sourceItf(sourceItf_)
 {
@@ -636,6 +659,7 @@ DownstreamState::DownstreamState(const ComboAddress& remote_, const ComboAddress
   for (auto& fd : sockets) {
     fd = -1;
   }
+  hash();
 
   if (!IsAnyAddress(remote)) {
     reconnect();
@@ -737,17 +761,6 @@ shared_ptr<DownstreamState> chashed(const NumberedServerVector& servers, const D
 
   for (const auto& d: servers) {
     if (d.second->isUp()) {
-      if (d.second->hashes.empty()) {
-        // computes server's points
-        // @todo check if server's weight can change over time
-        auto w = d.second->weight;
-        while (w > 0) {
-          std::string uuid = boost::str(boost::format("%s-%d") % d.second->id % w);
-          unsigned int wshash = burtleCI((const unsigned char*)uuid.c_str(), uuid.size(), g_hashperturb);
-          d.second->hashes.insert(wshash);
-          --w;
-        }
-      }
       for (const auto& h: d.second->hashes) {
         // put server's hashes on the circle
         circle.insert(std::make_pair(h, d.second));

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -618,6 +618,9 @@ struct DownstreamState
     return status;
   }
   bool reconnect();
+  void hash();
+  void setId(const boost::uuids::uuid& newId);
+  void setWeight(int newWeight);
 };
 using servers_t =vector<std::shared_ptr<DownstreamState>>;
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -518,7 +518,7 @@ extern std::shared_ptr<TCPClientCollection> g_tcpclientthreads;
 
 struct DownstreamState
 {
-  typedef std::function<std::tuple<DNSName, uint16_t, uint16_t>(const DNSName&, uint16_t, uint16_t, dnsheader*)> checkfunc_t;
+   typedef std::function<std::tuple<DNSName, uint16_t, uint16_t>(const DNSName&, uint16_t, uint16_t, dnsheader*)> checkfunc_t;
 
   DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf, size_t numberOfSockets);
   DownstreamState(const ComboAddress& remote_): DownstreamState(remote_, ComboAddress(), 0, 1) {}
@@ -531,7 +531,8 @@ struct DownstreamState
       }
     }
   }
-
+  boost::uuids::uuid id;
+  std::set<unsigned int> hashes;
   std::vector<int> sockets;
   std::mutex socketsLock;
   std::mutex connectLock;
@@ -846,6 +847,7 @@ std::shared_ptr<DownstreamState> firstAvailable(const NumberedServerVector& serv
 std::shared_ptr<DownstreamState> leastOutstanding(const NumberedServerVector& servers, const DNSQuestion* dq);
 std::shared_ptr<DownstreamState> wrandom(const NumberedServerVector& servers, const DNSQuestion* dq);
 std::shared_ptr<DownstreamState> whashed(const NumberedServerVector& servers, const DNSQuestion* dq);
+std::shared_ptr<DownstreamState> chashed(const NumberedServerVector& servers, const DNSQuestion* dq);
 std::shared_ptr<DownstreamState> roundrobin(const NumberedServerVector& servers, const DNSQuestion* dq);
 int getEDNSZ(const char* packet, unsigned int len);
 uint16_t getEDNSOptionCode(const char * packet, size_t len);

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -533,6 +533,7 @@ struct DownstreamState
   }
   boost::uuids::uuid id;
   std::set<unsigned int> hashes;
+  mutable pthread_rwlock_t d_lock;
   std::vector<int> sockets;
   std::mutex socketsLock;
   std::mutex connectLock;

--- a/pdns/dnsdistdist/docs/guides/serverselection.rst
+++ b/pdns/dnsdistdist/docs/guides/serverselection.rst
@@ -43,6 +43,13 @@ The current hash algorithm is based on the qname of the query.
 
   Set the hash perturbation value to be used in the whashed policy instead of a random one, allowing to have consistent whashed results on different instances.
 
+``chashed``
+~~~~~~~~~~~
+
+``chashed`` is a consistent hashing distribution policy. Identical questions with identical hashes will be distributed to the same servers. But unlike the ``whashed`` policy, this distribution will keep consistent over time. Adding or removing servers will only remap a small part of the queries.
+
+You can also set the hash perturbation value, see :func:`setWHashedPertubation`.
+
 ``roundrobin``
 ~~~~~~~~~~~~~~
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -296,7 +296,7 @@ Servers
       address="IP:PORT",     -- IP and PORT of the backend server (mandatory)
       qps=NUM,               -- Limit the number of queries per second to NUM, when using the `firstAvailable` policy
       order=NUM,             -- The order of this server, used by the `leastOustanding` and `firstAvailable` policies
-      weight=NUM,            -- The weight of this server, used by the `wrandom` and `whashed` policies, default: 1
+      weight=NUM,            -- The weight of this server, used by the `wrandom`, `whashed` and `chashed` policies, default: 1
                              -- Supported values are a minimum of 1, and a maximum of 2147483647.
       pool=STRING|{STRING},  -- The pools this server belongs to (unset or empty string means default pool) as a string or table of strings
       retries=NUM,           -- The number of TCP connection attempts to the backend, for a given query


### PR DESCRIPTION
### Short description
This adds a new load balancing policy that is based on consistent hashing. Unlike the ``whashed`` policy, this distribution will keep consistent over time. Adding or removing servers will only remap a small part of the queries.

For the record, this also adds a`uuid` field to the `DownstreamState` class.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
