### PR TITLE
 dnsdist: Add a negative TTL option to the packet cache

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1296,6 +1296,7 @@ testrunner_SOURCES = \
 	test-distributor_hh.cc \
 	test-dns_random_hh.cc \
 	test-dnsname_cc.cc \
+	test-dnsparser_cc.cc \
 	test-dnsparser_hh.cc \
 	test-dnsrecords_cc.cc \
 	test-iputils_hh.cc \

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -30,7 +30,7 @@ struct DNSQuestion;
 class DNSDistPacketCache : boost::noncopyable
 {
 public:
-  DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL=86400, uint32_t minTTL=0, uint32_t tempFailureTTL=60, uint32_t staleTTL=60, bool dontAge=false, uint32_t shards=1, bool deferrableInsertLock=true);
+  DNSDistPacketCache(size_t maxEntries, uint32_t maxTTL=86400, uint32_t minTTL=0, uint32_t tempFailureTTL=60, uint32_t maxNegativeTTL=3600, uint32_t staleTTL=60, bool dontAge=false, uint32_t shards=1, bool deferrableInsertLock=true);
   ~DNSDistPacketCache();
 
   void insert(uint32_t key, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp, uint8_t rcode, boost::optional<uint32_t> tempFailureTTL);
@@ -51,7 +51,7 @@ public:
   uint64_t getTTLTooShorts() const { return d_ttlTooShorts; }
   uint64_t getEntriesCount();
 
-  static uint32_t getMinTTL(const char* packet, uint16_t length);
+  static uint32_t getMinTTL(const char* packet, uint16_t length, bool* seenNoDataSOA);
 
 private:
 
@@ -110,6 +110,7 @@ private:
   uint32_t d_shardCount;
   uint32_t d_maxTTL;
   uint32_t d_tempFailureTTL;
+  uint32_t d_maxNegativeTTL;
   uint32_t d_minTTL;
   uint32_t d_staleTTL;
   bool d_dontAge;

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -212,8 +212,8 @@ void setupLuaBindings(bool client)
 #endif /* HAVE_EBPF */
 
   /* PacketCache */
-  g_lua.writeFunction("newPacketCache", [](size_t maxEntries, boost::optional<uint32_t> maxTTL, boost::optional<uint32_t> minTTL, boost::optional<uint32_t> tempFailTTL, boost::optional<uint32_t> staleTTL, boost::optional<bool> dontAge, boost::optional<size_t> numberOfShards, boost::optional<bool> deferrableInsertLock) {
-      return std::make_shared<DNSDistPacketCache>(maxEntries, maxTTL ? *maxTTL : 86400, minTTL ? *minTTL : 0, tempFailTTL ? *tempFailTTL : 60, staleTTL ? *staleTTL : 60, dontAge ? *dontAge : false, numberOfShards ? *numberOfShards : 1, deferrableInsertLock ? *deferrableInsertLock : true);
+  g_lua.writeFunction("newPacketCache", [](size_t maxEntries, boost::optional<uint32_t> maxTTL, boost::optional<uint32_t> minTTL, boost::optional<uint32_t> tempFailTTL, boost::optional<uint32_t> staleTTL, boost::optional<bool> dontAge, boost::optional<size_t> numberOfShards, boost::optional<bool> deferrableInsertLock, boost::optional<uint32_t> maxNegativeTTL) {
+      return std::make_shared<DNSDistPacketCache>(maxEntries, maxTTL ? *maxTTL : 86400, minTTL ? *minTTL : 0, tempFailTTL ? *tempFailTTL : 60, maxNegativeTTL ? *maxNegativeTTL : 3600, staleTTL ? *staleTTL : 60, dontAge ? *dontAge : false, numberOfShards ? *numberOfShards : 1, deferrableInsertLock ? *deferrableInsertLock : true);
     });
   g_lua.registerFunction("toString", &DNSDistPacketCache::toString);
   g_lua.registerFunction("isFull", &DNSDistPacketCache::isFull);

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -214,10 +214,11 @@ testrunner_SOURCES = \
 	base64.hh \
 	dns.hh \
 	test-base64_cc.cc \
+	test-dnscrypt_cc.cc \
 	test-dnsdist_cc.cc \
 	test-dnsdistpacketcache_cc.cc \
 	test-dnsdistrings_cc.cc \
-	test-dnscrypt_cc.cc \
+	test-dnsparser_cc.cc \
 	test-iputils_hh.cc \
 	dnsdist.hh \
 	dnsdist-cache.cc dnsdist-cache.hh \

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -506,10 +506,13 @@ PacketCache
 A Pool can have a packet cache to answer queries directly in stead of going to the backend.
 See :doc:`../guides/cache` for a how to.
 
-.. function:: newPacketCache(maxEntries[, maxTTL=86400[, minTTL=0[, temporaryFailureTTL=60[, staleTTL=60[, dontAge=false[, numberOfShards=1[, deferrableInsertLock=true]]]]]]]) -> PacketCache
+.. function:: newPacketCache(maxEntries[, maxTTL=86400[, minTTL=0[, temporaryFailureTTL=60[, staleTTL=60[, dontAge=false[, numberOfShards=1[, deferrableInsertLock=true[, maxNegativeTTL=3600]]]]]]]) -> PacketCache
 
   .. versionchanged:: 1.3.0
     ``numberOfShards`` and ``deferrableInsertLock`` parameters added.
+
+  .. versionchanged:: 1.3.1
+    ``maxNegativeTTL`` parameter added.
 
   Creates a new :class:`PacketCache` with the settings specified.
 
@@ -521,6 +524,7 @@ See :doc:`../guides/cache` for a how to.
   :param bool dontAge: Don't reduce TTLs when serving from the cache. Use this when :program:`dnsdist` fronts a cluster of authoritative servers
   :param int numberOfShards: Number of shards to divide the cache into, to reduce lock contention
   :param bool deferrableInsertLock: Whether the cache should give up insertion if the lock is held by another thread, or simply wait to get the lock
+  :param bool maxNegativeTTL: Cache a NXDomain or NoData answer from the backend for at most this amount of seconds, even if the TTL of the SOA record is higher
 
 .. class:: PacketCache
 

--- a/pdns/dnsdistdist/test-dnsparser_cc.cc
+++ b/pdns/dnsdistdist/test-dnsparser_cc.cc
@@ -1,0 +1,1 @@
+../test-dnsparser_cc.cc

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -399,7 +399,7 @@ string simpleCompress(const string& label, const string& root="");
 void ageDNSPacket(char* packet, size_t length, uint32_t seconds);
 void ageDNSPacket(std::string& packet, uint32_t seconds);
 void editDNSPacketTTL(char* packet, size_t length, std::function<uint32_t(uint8_t, uint16_t, uint16_t, uint32_t)> visitor);
-uint32_t getDNSPacketMinTTL(const char* packet, size_t length);
+uint32_t getDNSPacketMinTTL(const char* packet, size_t length, bool* seenAuthSOA=nullptr);
 uint32_t getDNSPacketLength(const char* packet, size_t length);
 uint16_t getRecordsOfTypeCount(const char* packet, size_t length, uint8_t section, uint16_t type);
 

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -142,7 +142,7 @@ void DNSPacketWriter::xfr48BitInt(uint64_t val)
 
 void DNSPacketWriter::xfr32BitInt(uint32_t val)
 {
-  int rval=htonl(val);
+  uint32_t rval=htonl(val);
   uint8_t* ptr=reinterpret_cast<uint8_t*>(&rval);
   d_content.insert(d_content.end(), ptr, ptr+4);
 }

--- a/pdns/test-dnsparser_cc.cc
+++ b/pdns/test-dnsparser_cc.cc
@@ -1,0 +1,461 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <boost/test/unit_test.hpp>
+
+#include "dnsparser.hh"
+
+BOOST_AUTO_TEST_SUITE(test_dnsparser_cc)
+
+BOOST_AUTO_TEST_CASE(test_editDNSPacketTTL) {
+
+  auto generatePacket = [](uint32_t ttl) {
+    DNSName name("powerdns.com.");
+    ComboAddress v4("1.2.3.4");
+    ComboAddress v6("2001:db8::1");
+
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+
+    /* record we want to see altered */
+    pwR.startRecord(name, QType::A, ttl, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    /* same record but different TTL (yeah, don't do that but it's just a test) */
+    pwR.startRecord(name, QType::A, 100, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    /* different type */
+    pwR.startRecord(name, QType::AAAA, 42, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP6(std::string(reinterpret_cast<const char*>(v6.sin6.sin6_addr.s6_addr), 16));
+    pwR.commit();
+
+    /* different class */
+    pwR.startRecord(name, QType::A, 42, QClass::CHAOS, DNSResourceRecord::ANSWER);
+    pwR.commit();
+
+    /* different section */
+    pwR.startRecord(name, QType::A, 42, QClass::IN, DNSResourceRecord::AUTHORITY);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    return packet;
+  };
+
+  auto firstPacket = generatePacket(42);
+  auto expectedAlteredPacket = generatePacket(84);
+
+  size_t called = 0;
+  editDNSPacketTTL(reinterpret_cast<char*>(firstPacket.data()), firstPacket.size(), [&called](uint8_t section, uint16_t class_, uint16_t type, uint32_t ttl) {
+
+      called++;
+
+      /* only updates the TTL of IN/A, in answer, with an existing ttl of 42 */
+      if (section == 1 && class_ == QClass::IN && type == QType::A && ttl == 42) {
+        return 84;
+      }
+      return 0;
+    });
+
+  /* check that we have been for all records */
+  BOOST_CHECK_EQUAL(called, 5);
+
+  BOOST_REQUIRE_EQUAL(firstPacket.size(), expectedAlteredPacket.size());
+  for (size_t idx = 0; idx < firstPacket.size(); idx++) {
+    BOOST_CHECK_EQUAL(firstPacket.at(idx), expectedAlteredPacket.at(idx));
+  }
+  BOOST_CHECK(firstPacket == expectedAlteredPacket);
+
+  /* now call it with a truncated packet, missing the last TTL and rdata,
+     we should only be called 4 times but everything else should be fine. */
+  called = 0;
+  editDNSPacketTTL(reinterpret_cast<char*>(firstPacket.data()), firstPacket.size() - sizeof(uint32_t) - /* rdata length */ sizeof (uint16_t) - /* IPv4 payload in rdata */ 4, [&called](uint8_t section, uint16_t class_, uint16_t type, uint32_t ttl) {
+
+      called++;
+
+      /* only updates the TTL of IN/A, in answer, with an existing ttl of 42 */
+      if (section == 1 && class_ == QClass::IN && type == QType::A && ttl == 42) {
+        return 84;
+      }
+      return 0;
+    });
+
+  /* check that we have been for all records */
+  BOOST_CHECK_EQUAL(called, 4);
+  BOOST_CHECK(firstPacket == expectedAlteredPacket);
+}
+
+BOOST_AUTO_TEST_CASE(test_ageDNSPacket) {
+
+  auto generatePacket = [](uint32_t ttl) {
+    DNSName name("powerdns.com.");
+    ComboAddress v4("1.2.3.4");
+    ComboAddress v6("2001:db8::1");
+
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+
+    /* record we want to see altered */
+    pwR.startRecord(name, QType::A, ttl, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    return packet;
+  };
+
+  auto firstPacket = generatePacket(3600);
+  auto expectedAlteredPacket = generatePacket(1800);
+
+  ageDNSPacket(reinterpret_cast<char*>(firstPacket.data()), firstPacket.size(), 1800);
+
+  BOOST_REQUIRE_EQUAL(firstPacket.size(), expectedAlteredPacket.size());
+  for (size_t idx = 0; idx < firstPacket.size(); idx++) {
+    BOOST_CHECK_EQUAL(firstPacket.at(idx), expectedAlteredPacket.at(idx));
+  }
+  BOOST_CHECK(firstPacket == expectedAlteredPacket);
+
+  /* now call it with a truncated packet, missing the last TTL and rdata,
+     the packet should not be altered. */
+  ageDNSPacket(reinterpret_cast<char*>(firstPacket.data()), firstPacket.size() - sizeof(uint32_t) - /* rdata length */ sizeof (uint16_t) - /* IPv4 payload in rdata */ 4 - /* size of OPT record */ 11, 900);
+
+  BOOST_CHECK(firstPacket == expectedAlteredPacket);
+
+  /* now remove more than the remaining TTL, not that while TTL are,
+     per rfc1035 errata, "a 32 bit unsigned integer" so we should be
+     able to expect unsigned overflow to apply, but rfc2181 specifies
+     a maximum of "2^31 - 1". */
+  ageDNSPacket(reinterpret_cast<char*>(firstPacket.data()), firstPacket.size(), 1801);
+
+  uint32_t ttl = std::numeric_limits<uint32_t>::max();
+
+  expectedAlteredPacket = generatePacket(ttl);
+  BOOST_REQUIRE_EQUAL(firstPacket.size(), expectedAlteredPacket.size());
+  for (size_t idx = 0; idx < firstPacket.size(); idx++) {
+    BOOST_CHECK_EQUAL(firstPacket.at(idx), expectedAlteredPacket.at(idx));
+  }
+  BOOST_CHECK(firstPacket == expectedAlteredPacket);
+}
+
+BOOST_AUTO_TEST_CASE(test_getDNSPacketMinTTL) {
+
+  const DNSName name("powerdns.com.");
+  const ComboAddress v4("1.2.3.4");
+  const ComboAddress v6("2001:db8::1");
+
+  {
+    /* no records */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size(), nullptr);
+    BOOST_CHECK_EQUAL(result, std::numeric_limits<uint32_t>::max());
+  }
+
+  {
+    /* only one record, not an OPT one */
+    uint32_t ttl = 42;
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, ttl, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size(), nullptr);
+    BOOST_CHECK_EQUAL(result, ttl);
+  }
+
+  {
+    /* only one record, an OPT one */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size(), nullptr);
+    BOOST_CHECK_EQUAL(result, std::numeric_limits<uint32_t>::max());
+  }
+
+  {
+    /* records with different TTLs, should return the lower */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 257, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 255, QClass::IN, DNSResourceRecord::AUTHORITY);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 256, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size(), nullptr);
+    BOOST_CHECK_EQUAL(result, 255);
+  }
+
+  {
+    /* SOA record in answer, seenAuthSOA should not be set */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::SOA, 257, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 255, QClass::IN, DNSResourceRecord::AUTHORITY);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 256, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    bool seenAuthSOA = false;
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size(), &seenAuthSOA);
+    BOOST_CHECK_EQUAL(result, 255);
+    BOOST_CHECK_EQUAL(seenAuthSOA, false);
+  }
+
+  {
+    /* one SOA record in auth, seenAuthSOA should be set */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 255, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::SOA, 257, QClass::IN, DNSResourceRecord::AUTHORITY);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 256, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    bool seenAuthSOA = false;
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size(), &seenAuthSOA);
+    BOOST_CHECK_EQUAL(result, 255);
+    BOOST_CHECK_EQUAL(seenAuthSOA, true);
+  }
+
+  {
+    /* one SOA record of the wrong qclass in auth, seenAuthSOA should not be set */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 257, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::SOA, 255, QClass::CHAOS, DNSResourceRecord::AUTHORITY);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 256, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    bool seenAuthSOA = false;
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size(), &seenAuthSOA);
+    BOOST_CHECK_EQUAL(result, 255);
+    BOOST_CHECK_EQUAL(seenAuthSOA, false);
+  }
+
+  {
+    /* one A record in auth, seenAuthSOA should not be set */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 257, QClass::IN, DNSResourceRecord::AUTHORITY);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    bool seenAuthSOA = false;
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size(), &seenAuthSOA);
+    BOOST_CHECK_EQUAL(result, 257);
+    BOOST_CHECK_EQUAL(seenAuthSOA, false);
+  }
+
+  {
+    /* one SOA record in additional, seenAuthSOA should not be set */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::SOA, 255, QClass::CHAOS, DNSResourceRecord::ADDITIONAL);
+    pwR.commit();
+
+    bool seenAuthSOA = false;
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size(), &seenAuthSOA);
+    BOOST_CHECK_EQUAL(result, 255);
+    BOOST_CHECK_EQUAL(seenAuthSOA, false);
+  }
+
+  {
+    /* truncated packet, no exception should be raised */
+    /* one SOA record in auth, seenAuthSOA should be set */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 255, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::SOA, 257, QClass::IN, DNSResourceRecord::AUTHORITY);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 254, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    bool seenAuthSOA = false;
+    auto result = getDNSPacketMinTTL(reinterpret_cast<char*>(packet.data()), packet.size() - sizeof(uint32_t) - /* rdata length */ sizeof (uint16_t) - /* IPv4 payload in rdata */ 4, &seenAuthSOA);
+    BOOST_CHECK_EQUAL(result, 255);
+    BOOST_CHECK_EQUAL(seenAuthSOA, true);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_getDNSPacketLength) {
+
+  const DNSName name("powerdns.com.");
+  const ComboAddress v4("1.2.3.4");
+  const ComboAddress v6("2001:db8::1");
+
+  {
+    /* no records */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    auto result = getDNSPacketLength(reinterpret_cast<char*>(packet.data()), packet.size());
+    BOOST_CHECK_EQUAL(result, packet.size());
+  }
+
+  {
+    /* several records */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 255, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::SOA, 257, QClass::IN, DNSResourceRecord::AUTHORITY);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 256, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    auto result = getDNSPacketLength(reinterpret_cast<char*>(packet.data()), packet.size());
+    BOOST_CHECK_EQUAL(result, packet.size());
+  }
+
+  {
+    /* trailing data */
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 255, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::SOA, 257, QClass::IN, DNSResourceRecord::AUTHORITY);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 256, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+    auto realSize = packet.size();
+    packet.resize(realSize + 512);
+    auto result = getDNSPacketLength(reinterpret_cast<char*>(packet.data()), packet.size());
+    BOOST_CHECK_EQUAL(result, realSize);
+  }
+
+}
+
+BOOST_AUTO_TEST_CASE(test_getRecordsOfTypeCount) {
+  const DNSName name("powerdns.com.");
+  const ComboAddress v4("1.2.3.4");
+  const ComboAddress v6("2001:db8::1");
+
+  {
+    vector<uint8_t> packet;
+    DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+    pwR.getHeader()->qr = 1;
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 255, QClass::IN, DNSResourceRecord::ANSWER);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::SOA, 257, QClass::IN, DNSResourceRecord::AUTHORITY);
+    pwR.commit();
+
+    pwR.startRecord(name, QType::A, 256, QClass::IN, DNSResourceRecord::ADDITIONAL);
+    pwR.xfrIP(v4.sin4.sin_addr.s_addr);
+    pwR.commit();
+
+    pwR.addOpt(4096, 0, 0);
+    pwR.commit();
+
+     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 0, QType::A), 1);
+     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 0, QType::SOA), 0);
+     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 1, QType::A), 1);
+     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 1, QType::SOA), 0);
+     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 2, QType::A), 0);
+     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 2, QType::SOA), 1);
+     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 3, QType::A), 1);
+     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 3, QType::SOA), 0);
+
+     BOOST_CHECK_EQUAL(getRecordsOfTypeCount(reinterpret_cast<char*>(packet.data()), packet.size(), 4, QType::SOA), 0);
+}
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
So it's possible to cap the `TTL` of `NODATA` and `NXDOMAIN` answers.
Also fixes a bug in the `editTTLs()` feature, where the wrong section was passed to the callback.

Closes #6579.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
