### PR TITLE
rec: Support multiple values for the same EDNS option in gettag

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -548,12 +548,12 @@ bool getEDNSOpts(const MOADNSParser& mdp, EDNSOpts* eo)
     for(const MOADNSParser::answers_t::value_type& val :  mdp.d_answers) {
       if(val.first.d_place == DNSResourceRecord::ADDITIONAL && val.first.d_type == QType::OPT) {
         eo->d_packetsize=val.first.d_class;
-       
+
         EDNS0Record stuff;
         uint32_t ttl=ntohl(val.first.d_ttl);
         static_assert(sizeof(EDNS0Record) == sizeof(uint32_t), "sizeof(EDNS0Record) must match sizeof(uint32_t)");
         memcpy(&stuff, &ttl, sizeof(stuff));
-        
+
         eo->d_extRCode=stuff.extRCode;
         eo->d_version=stuff.version;
         eo->d_extFlags = ntohs(stuff.extFlags);

--- a/pdns/ednsoptions.cc
+++ b/pdns/ednsoptions.cc
@@ -67,7 +67,7 @@ int getEDNSOption(char* optRR, const size_t len, uint16_t wantedOption, char ** 
 }
 
 /* extract all EDNS0 options from a pointer on the beginning rdLen of the OPT RR */
-int getEDNSOptions(const char* optRR, const size_t len, std::map<uint16_t, EDNSOptionView>& options)
+int getEDNSOptions(const char* optRR, const size_t len, EDNSOptionViewMap& options)
 {
   assert(optRR != NULL);
   size_t pos = 0;
@@ -92,10 +92,10 @@ int getEDNSOptions(const char* optRR, const size_t len, std::map<uint16_t, EDNSO
     if (optionLen > (rdLen - rdPos) || optionLen > (len - pos))
       return EINVAL;
 
-    EDNSOptionView view;
-    view.content = optRR + pos;
-    view.size = optionLen;
-    options[optionCode] = view;
+    EDNSOptionViewValue value;
+    value.content = optRR + pos;
+    value.size = optionLen;
+    options[optionCode].values.push_back(std::move(value));
 
     /* skip this option */
     pos += optionLen;

--- a/pdns/ednsoptions.hh
+++ b/pdns/ednsoptions.hh
@@ -32,14 +32,21 @@ struct EDNSOptionCode
 /* extract a specific EDNS0 option from a pointer on the beginning rdLen of the OPT RR */
 int getEDNSOption(char* optRR, size_t len, uint16_t wantedOption, char ** optionValue, size_t * optionValueSize);
 
-struct EDNSOptionView
+struct EDNSOptionViewValue
 {
   const char* content{nullptr};
   uint16_t size{0};
 };
 
+struct EDNSOptionView
+{
+  std::vector<EDNSOptionViewValue> values;
+};
+
+typedef std::map<uint16_t, EDNSOptionView> EDNSOptionViewMap;
+
 /* extract all EDNS0 options from a pointer on the beginning rdLen of the OPT RR */
-int getEDNSOptions(const char* optRR, size_t len, std::map<uint16_t, EDNSOptionView>& options);
+int getEDNSOptions(const char* optRR, size_t len, EDNSOptionViewMap& options);
 
 void generateEDNSOption(uint16_t optionCode, const std::string& payload, std::string& res);
 

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -109,8 +109,8 @@ public:
     DNSName followupName;
   };
 
-  unsigned int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const std::map<uint16_t, EDNSOptionView>&, bool tcp, std::string& requestorId, std::string& deviceId) const;
-  unsigned int gettag_ffi(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const std::map<uint16_t, EDNSOptionView>&, bool tcp, std::string& requestorId, std::string& deviceId, uint32_t& ttlCap, bool& variable) const;
+  unsigned int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const EDNSOptionViewMap&, bool tcp, std::string& requestorId, std::string& deviceId) const;
+  unsigned int gettag_ffi(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const EDNSOptionViewMap&, bool tcp, std::string& requestorId, std::string& deviceId, uint32_t& ttlCap, bool& variable) const;
 
   void maintenance() const;
   bool prerpz(DNSQuestion& dq, int& ret) const;
@@ -131,7 +131,7 @@ public:
             d_postresolve);
   }
 
-  typedef std::function<std::tuple<unsigned int,boost::optional<std::unordered_map<int,string> >,boost::optional<LuaContext::LuaObject>,boost::optional<std::string>,boost::optional<std::string> >(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const std::map<uint16_t, EDNSOptionView>&, bool)> gettag_t;
+  typedef std::function<std::tuple<unsigned int,boost::optional<std::unordered_map<int,string> >,boost::optional<LuaContext::LuaObject>,boost::optional<std::string>,boost::optional<std::string> >(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const EDNSOptionViewMap&, bool)> gettag_t;
   gettag_t d_gettag; // public so you can query if we have this hooked
   typedef std::function<boost::optional<LuaContext::LuaObject>(pdns_ffi_param_t*)> gettag_ffi_t;
   gettag_ffi_t d_gettag_ffi;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1521,7 +1521,7 @@ static void makeControlChannelSocket(int processNum=-1)
 }
 
 static void getQNameAndSubnet(const std::string& question, DNSName* dnsname, uint16_t* qtype, uint16_t* qclass,
-                              bool& foundECS, EDNSSubnetOpts* ednssubnet, std::map<uint16_t, EDNSOptionView>* options,
+                              bool& foundECS, EDNSSubnetOpts* ednssubnet, EDNSOptionViewMap* options,
                               bool& foundXPF, ComboAddress* xpfSource, ComboAddress* xpfDest)
 {
   const bool lookForXPF = xpfSource != nullptr && g_xpfRRCode != 0;
@@ -1569,9 +1569,9 @@ static void getQNameAndSubnet(const std::string& question, DNSName* dnsname, uin
         int res = getEDNSOptions(reinterpret_cast<const char*>(&question.at(pos -sizeof(drh->d_clen))), questionLen - pos + (sizeof(drh->d_clen)), *options);
         if (res == 0) {
           const auto& it = options->find(EDNSOptionCode::ECS);
-          if (it != options->end() && it->second.content != nullptr && it->second.size > 0) {
+          if (it != options->end() && !it->second.values.empty() && it->second.values.at(0).content != nullptr && it->second.values.at(0).size > 0) {
             EDNSSubnetOpts eso;
-            if(getEDNSSubnetOptsFromString(it->second.content, it->second.size, &eso)) {
+            if(getEDNSSubnetOptsFromString(it->second.values.at(0).content, it->second.values.at(0).size, &eso)) {
               *ednssubnet=eso;
               foundECS = true;
             }
@@ -1673,7 +1673,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       if(needECS || needXPF || (t_pdl && (t_pdl->d_gettag_ffi || t_pdl->d_gettag))) {
 
         try {
-          std::map<uint16_t, EDNSOptionView> ednsOptions;
+          EDNSOptionViewMap ednsOptions;
           bool xpfFound = false;
           dc->d_ecsParsed = true;
           dc->d_ecsFound = false;
@@ -1863,7 +1863,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
 
     if(needECS || needXPF || (t_pdl && (t_pdl->d_gettag || t_pdl->d_gettag_ffi))) {
       try {
-        std::map<uint16_t, EDNSOptionView> ednsOptions;
+        EDNSOptionViewMap ednsOptions;
         bool xpfFound = false;
 
         ecsFound = false;

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -259,12 +259,22 @@ The EDNSOptionView Class
 
 .. class:: EDNSOptionView
 
-  An object that represents a single EDNS option
+  An object that represents the values of a single EDNS option
+
+  .. method:: EDNSOptionView:count()
+     .. versionadded:: 4.2.0
+
+    The number of values for this EDNS option.
+
+  .. method:: EDNSOptionView:getValues()
+     .. versionadded:: 4.2.0
+
+    Return a table of NULL-safe strings values for this EDNS option.
 
   .. attribute:: EDNSOptionView.size
 
-    The size in bytes of the EDNS option.
+    The size in bytes of the first value of this EDNS option.
 
   .. method:: EDNSOptionView:getContent()
 
-    Returns a NULL-safe string object of the EDNS option's content
+    Returns a NULL-safe string object of the first value of this EDNS option.

--- a/pdns/recursordist/test-ednsoptions_cc.cc
+++ b/pdns/recursordist/test-ednsoptions_cc.cc
@@ -87,26 +87,30 @@ BOOST_AUTO_TEST_CASE(test_getEDNSOptions) {
   BOOST_REQUIRE_EQUAL(query.at(pos), 0);
   BOOST_REQUIRE(query.at(pos+2) == QType::OPT);
 
-  std::map<uint16_t, EDNSOptionView> options;
+  EDNSOptionViewMap options;
   int res = getEDNSOptions(reinterpret_cast<char*>(query.data())+pos+9, questionLen - pos - 9, options);
   BOOST_REQUIRE_EQUAL(res, 0);
 
-  /* 3 EDNS options but two of them are EDNS Cookie, so we only keep one */
+  /* 3 EDNS options but two of them are EDNS Cookie, so we only have two entries in the map */
   BOOST_CHECK_EQUAL(options.size(), 2);
 
   auto it = options.find(EDNSOptionCode::ECS);
   BOOST_REQUIRE(it != options.end());
-  BOOST_REQUIRE(it->second.content != nullptr);
-  BOOST_REQUIRE_GT(it->second.size, 0);
+  BOOST_REQUIRE_EQUAL(it->second.values.size(), 1);
+  BOOST_REQUIRE(it->second.values.at(0).content != nullptr);
+  BOOST_REQUIRE_GT(it->second.values.at(0).size, 0);
 
   EDNSSubnetOpts eso;
-  BOOST_REQUIRE(getEDNSSubnetOptsFromString(it->second.content, it->second.size, &eso));
+  BOOST_REQUIRE(getEDNSSubnetOptsFromString(it->second.values.at(0).content, it->second.values.at(0).size, &eso));
   BOOST_CHECK(eso.source == ecs);
 
   it = options.find(EDNSOptionCode::COOKIE);
   BOOST_REQUIRE(it != options.end());
-  BOOST_REQUIRE(it->second.content != nullptr);
-  BOOST_REQUIRE_GT(it->second.size, 0);
+  BOOST_REQUIRE_EQUAL(it->second.values.size(), 2);
+  BOOST_REQUIRE(it->second.values.at(0).content != nullptr);
+  BOOST_REQUIRE_GT(it->second.values.at(0).size, 0);
+  BOOST_REQUIRE(it->second.values.at(1).content != nullptr);
+  BOOST_REQUIRE_GT(it->second.values.at(1).size, 0);
 }
 
 static void checkECSOptionValidity(const std::string& sourceStr, uint8_t sourceMask, uint8_t scopeMask)

--- a/regression-tests.recursor-dnssec/cookiesoption.py
+++ b/regression-tests.recursor-dnssec/cookiesoption.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python2
+
+import dns
+import dns.edns
+import dns.flags
+import dns.message
+import dns.query
+
+class CookiesOption(dns.edns.Option):
+    """Implementation of draft-ietf-dnsop-cookies-09.
+    """
+
+    def __init__(self, client, server):
+        super(CookiesOption, self).__init__(10)
+
+        if len(client) != 8:
+            raise Exception('invalid client cookie length')
+
+        if server is not None and len(server) != 0 and (len(server) < 8 or len(server) > 32):
+            raise Exception('invalid server cookie length')
+
+        self.client = client
+        self.server = server
+
+    def to_wire(self, file):
+        """Create EDNS packet as defined in draft-ietf-dnsop-cookies-09."""
+
+        file.write(self.client)
+        if self.server and len(self.server) > 0:
+            file.write(self.server)
+
+    def from_wire(cls, otype, wire, current, olen):
+        """Read EDNS packet as defined in draft-ietf-dnsop-cookies-09.
+
+        Returns:
+            An instance of CookiesOption based on the EDNS packet
+        """
+
+        data = wire[current:current + olen]
+        if len(data) != 8 and (len(data) < 16 or len(data) > 40):
+            raise Exception('Invalid EDNS Cookies option')
+
+        client = data[:8]
+        if len(data) > 8:
+            server = data[8:]
+        else:
+            server = None
+
+        return cls(client, server)
+
+    from_wire = classmethod(from_wire)
+
+    def __repr__(self):
+        return '%s(%s, %s)' % (
+            self.__class__.__name__,
+            self.client,
+            self.server
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, CookiesOption):
+            return False
+        if self.client != other.client:
+            return False
+        if self.server != other.server:
+            return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+dns.edns._type_to_class[0x000A] = CookiesOption
+

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -42,6 +42,7 @@ disable-syslog=yes
 """
     _config_params = []
     _lua_config_file = None
+    _lua_dns_script_file = None
     _roothints = """
 .                        3600 IN NS  ns.root.
 ns.root.                 3600 IN A   %s.8
@@ -444,10 +445,15 @@ distributor-threads=1""".format(confdir=confdir,
                 luaconfpath = os.path.join(confdir, 'conffile.lua')
                 with open(luaconfpath, 'w') as luaconf:
                     if cls._root_DS:
-                        luaconf.write("addDS('.', '%s')" % cls._root_DS)
+                        luaconf.write("addDS('.', '%s')\n" % cls._root_DS)
                     if cls._lua_config_file:
                         luaconf.write(cls._lua_config_file)
                 conf.write("lua-config-file=%s\n" % luaconfpath)
+            if cls._lua_dns_script_file:
+                luascriptpath = os.path.join(confdir, 'dnsscript.lua')
+                with open(luascriptpath, 'w') as luascript:
+                    luascript.write(cls._lua_dns_script_file)
+                conf.write("lua-dns-script=%s\n" % luascriptpath)
             if cls._roothints:
                 roothintspath = os.path.join(confdir, 'root.hints')
                 with open(roothintspath, 'w') as roothints:

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -1,0 +1,207 @@
+import clientsubnetoption
+import cookiesoption
+import dns
+import os
+
+from recursortests import RecursorTest
+
+class GettagRecursorTest(RecursorTest):
+    _confdir = 'LuaGettag'
+    _config_template = """
+    log-common-errors=yes
+    gettag-needs-edns-options=yes
+    """
+    _lua_dns_script_file = """
+    function gettag(remote, ednssubnet, localip, qname, qtype, ednsoptions, tcp)
+
+      local tags = {}
+      local data = {}
+
+      -- make sure we can pass data around to the other hooks
+      data['canary'] = 'from-gettag'
+
+      -- test that the remote addr is valid
+      if remote:toString() ~= '127.0.0.1' then
+        pdnslog("invalid remote")
+        table.insert(tags, 'invalid remote '..remote:toString())
+        return 1, tags, data
+      end
+
+      -- test that the local addr is valid
+      if localip:toString() ~= '127.0.0.1' then
+        pdnslog("invalid local")
+        table.insert(tags, 'invalid local '..localip:toString())
+        return 1, tags, data
+      end
+
+      if not ednssubnet:empty() then
+         table.insert(tags, 'edns-subnet-'..ednssubnet:toString())
+      end
+
+      for k,v in pairs(ednsoptions) do
+        table.insert(tags, 'ednsoption-'..k..'-count-'..v:count())
+        local len = 0
+        local values = v:getValues()
+        for j,l in pairs(values) do
+          len = len + l:len()
+
+          -- check that the old interface (before 4.2.0) still works
+          if j == 0 then
+            if l:len() ~= v.size then
+              table.insert(tags, 'size obtained via the old edns option interface does not match')
+            end
+            value = v:getContent()
+            if value ~= l then
+              table.insert(tags, 'content obtained via the old edns option interface does not match')
+            end
+          end
+        end
+        table.insert(tags, 'ednsoption-'..k..'-total-len-'..len)
+      end
+
+      if tcp then
+        table.insert(tags, 'gettag-tcp')
+      end
+
+      -- test that tags are passed to other hooks
+      table.insert(tags, qname:toString())
+      table.insert(tags, 'gettag-qtype-'..qtype)
+
+      return 0, tags, data
+    end
+
+    function preresolve(dq)
+
+      -- test that we are getting the tags set by gettag()
+      -- and also getting the correct qname
+      local found = false
+      for _, tag in pairs(dq:getPolicyTags()) do
+        if dq.qname:equal(tag) then
+          found = true
+        end
+        dq:addAnswer(pdns.TXT, '"'..tag..'"')
+      end
+
+      if not found then
+        pdnslog("not valid tag found")
+        dq.rcode = pdns.REFUSED
+        return true
+      end
+
+      if dq.data['canary'] ~= 'from-gettag' then
+        pdnslog("did not get any data from gettag")
+        dq.rcode = pdns.REFUSED
+        return true
+      end
+
+      if dq.qtype == pdns.A then
+        dq:addAnswer(pdns.A, '192.0.2.1')
+      elseif dq.qtype == pdns.AAAA then
+        dq:addAnswer(pdns.AAAA, '2001:db8::1')
+      end
+
+      return true
+    end
+    """
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.setUpSockets()
+        confdir = os.path.join('configs', cls._confdir)
+        cls.createConfigDir(confdir)
+        cls.generateRecursorConfig(confdir)
+        cls.startRecursor(confdir, cls._recursorPort)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tearDownRecursor()
+
+    def assertResponseMatches(self, query, expectedRRs, response):
+        expectedResponse = dns.message.make_response(query)
+
+        if query.flags & dns.flags.RD:
+            expectedResponse.flags |= dns.flags.RA
+        if query.flags & dns.flags.CD:
+            expectedResponse.flags |= dns.flags.CD
+
+        expectedResponse.answer = expectedRRs
+        print(expectedResponse)
+        print(response)
+        self.assertEquals(response, expectedResponse)
+
+    def testA(self):
+        name = 'gettag.lua.'
+        expected = [
+            dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.1'),
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [ name, 'gettag-qtype-1'])
+            ]
+        query = dns.message.make_query(name, 'A', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.assertResponseMatches(query, expected, res)
+
+    def testTCPA(self):
+        name = 'gettag-tcpa.lua.'
+        expected = [
+            dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.1'),
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [ name, 'gettag-qtype-1', 'gettag-tcp'])
+            ]
+        query = dns.message.make_query(name, 'A', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendTCPQuery(query)
+        self.assertResponseMatches(query, expected, res)
+
+    def testAAAA(self):
+        name = 'gettag-aaaa.lua.'
+        expected = [
+            dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'AAAA', '2001:db8::1'),
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [ name, 'gettag-qtype-28'])
+            ]
+        query = dns.message.make_query(name, 'AAAA', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.assertResponseMatches(query, expected, res)
+
+    def testSubnet(self):
+        name = 'gettag-subnet.lua.'
+        subnet = '192.0.2.255'
+        subnetMask = 32
+        ecso = clientsubnetoption.ClientSubnetOption(subnet, subnetMask)
+        expected = [
+            dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.1'),
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [name, 'gettag-qtype-1', 'edns-subnet-' + subnet + '/' + str(subnetMask),
+                                                                         'ednsoption-8-count-1', 'ednsoption-8-total-len-8']),
+            ]
+        query = dns.message.make_query(name, 'A', want_dnssec=True, options=[ecso])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.assertResponseMatches(query, expected, res)
+
+    def testEDNSOptions(self):
+        name = 'gettag-ednsoptions.lua.'
+        subnet = '192.0.2.255'
+        subnetMask = 32
+        ecso = clientsubnetoption.ClientSubnetOption(subnet, subnetMask)
+        eco1 = cookiesoption.CookiesOption(b'deadbeef', b'deadbeef')
+        eco2 = cookiesoption.CookiesOption(b'deadc0de', b'deadc0de')
+
+        expected = [
+            dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.1'),
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [name, 'gettag-qtype-1', 'edns-subnet-' + subnet + '/' + str(subnetMask),
+                                                                         'ednsoption-10-count-2', 'ednsoption-10-total-len-32',
+                                                                         'ednsoption-8-count-1', 'ednsoption-8-total-len-8'
+                                                                        ]),
+            ]
+        query = dns.message.make_query(name, 'A', want_dnssec=True, options=[eco1,ecso,eco2])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.assertResponseMatches(query, expected, res)
+
+# TODO:
+# - postresolve
+# - preoutquery
+# - ipfilter
+# - prerpz
+# - nxdomain
+# - nodata


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds support for retrieving multiple values for the same `EDNS` option in the recursor, not breaking the existing API. The regular interface does not support more than one value, so it will keep returning only the first value for a given option, while two new methods make it possible to retrieve all the values:
- `EDNSOptionView:count()`
- `EDNSOptionView:getValues()`

The `FFI` interface already supported returning more than one value so support for multiple values has been transparently added to it.

This PR also adds several regression tests for the Lua interface.
 
Closes #6307.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
