### PR TITLE
dnsdist: Add the ability to dump a summary of the cache content

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -160,6 +160,7 @@ bool DNSDistPacketCache::get(const DNSQuestion& dq, uint16_t consumed, uint16_t 
 {
   std::string dnsQName(dq.qname->toDNSString());
   uint32_t key = getKey(dnsQName, consumed, (const unsigned char*)dq.dh, dq.len, dq.tcp);
+
   if (keyOut)
     *keyOut = key;
 
@@ -382,4 +383,36 @@ string DNSDistPacketCache::toString()
 uint64_t DNSDistPacketCache::getEntriesCount()
 {
   return getSize();
+}
+
+uint64_t DNSDistPacketCache::dump(int fd)
+{
+  FILE * fp = fdopen(dup(fd), "w");
+  if (fp == nullptr) {
+    return 0;
+  }
+
+  fprintf(fp, "; dnsdist's packet cache dump follows\n;\n");
+
+  uint64_t count = 0;
+  time_t now = time(nullptr);
+  for (uint32_t shardIndex = 0; shardIndex < d_shardCount; shardIndex++) {
+    ReadLock w(&d_shards.at(shardIndex).d_lock);
+    auto& map = d_shards[shardIndex].d_map;
+
+    for(const auto entry : map) {
+      const CacheValue& value = entry.second;
+      count++;
+
+      try {
+        fprintf(fp, "%s %" PRId64 " %s ; key %" PRIu32 ", length %" PRIu16 ", tcp %d, added %" PRIu64 "\n", value.qname.toString().c_str(), static_cast<int64_t>(value.validity - now), QType(value.qtype).getName().c_str(), entry.first, value.len, value.tcp, value.added);
+      }
+      catch(...) {
+        fprintf(fp, "; error printing '%s'\n", value.qname.empty() ? "EMPTY" : value.qname.toString().c_str());
+      }
+    }
+  }
+
+  fclose(fp);
+  return count;
 }

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -50,6 +50,7 @@ public:
   uint64_t getMaxEntries() const { return d_maxEntries; }
   uint64_t getTTLTooShorts() const { return d_ttlTooShorts; }
   uint64_t getEntriesCount();
+  uint64_t dump(int fd);
 
   static uint32_t getMinTTL(const char* packet, uint16_t length);
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -526,6 +526,14 @@ See :doc:`../guides/cache` for a how to.
 
   Represents a cache that can be part of :class:`ServerPool`.
 
+  .. method:: PacketCache:dump(fname)
+
+    .. versionadded:: 1.3.1
+
+    Dump a summary of the cache entries to a file.
+
+    :param str fname: The path to a file where the cache summary should be dumped. Note that if the target file already exists, it will not be overwritten.
+
   .. method:: PacketCache:expunge(n)
 
     Remove entries from the cache, leaving at most ``n`` entries


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The new feature writes a summary of the packet cache content to a file, dumping for each entry:
- qname
- remaining TTL
- qtype
-  computed hash
- response's length
- TCP or UDP
- the timestamp of when the entry was added to the cache. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
