### PR TITLE
dnsdist: Add support for rotating certificates and keys

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -362,6 +362,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "getServer", true, "n", "returns server with index n" },
   { "getServers", true, "", "returns a table with all defined servers" },
   { "getTLSContext", true, "n", "returns the TLS context with index n" },
+  { "getTLSFrontend", true, "n", "returns the TLS frontend with index n" },
   { "inClientStartup", true, "", "returns true during console client parsing of configuration" },
   { "grepq", true, "Netmask|DNS Name|100ms|{\"::1\", \"powerdns.com\", \"100ms\"} [, n]", "shows the last n queries and responses matching the specified client address or range (Netmask), or the specified DNS Name, or slower than 100ms" },
   { "leastOutstanding", false, "", "Send traffic to downstream server with least outstanding queries, with the lowest 'order', and within that the lowest recent latency"},

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1513,6 +1513,10 @@ void setupLuaConfig(bool client)
           if (vars->count("numberOfTicketsKeys")) {
             frontend->d_numberOfTicketsKeys = std::stoi(boost::get<const string>((*vars)["numberOfTicketsKeys"]));
           }
+
+          if (vars->count("disableTickets")) {
+            frontend->d_disableTickets = boost::get<bool>((*vars)["disableTickets"]);
+          }
         }
 
         try {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1514,8 +1514,8 @@ void setupLuaConfig(bool client)
             frontend->d_numberOfTicketsKeys = std::stoi(boost::get<const string>((*vars)["numberOfTicketsKeys"]));
           }
 
-          if (vars->count("disableTickets")) {
-            frontend->d_disableTickets = boost::get<bool>((*vars)["disableTickets"]);
+          if (vars->count("sessionTickets")) {
+            frontend->d_enableTickets = boost::get<bool>((*vars)["sessionTickets"]);
           }
         }
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1615,9 +1615,11 @@ void setupLuaConfig(bool client)
       });
 
     g_lua.registerFunction<void(std::shared_ptr<TLSFrontend>::*)(boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles)>("loadNewCertificatesAndKeys", [](std::shared_ptr<TLSFrontend>& frontend, boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles) {
+#ifdef HAVE_DNS_OVER_TLS
         if (loadTLSCertificateAndKeys(frontend, certFiles, keyFiles)) {
           frontend->setupTLS();
         }
+#endif
       });
 }
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -106,6 +106,41 @@ static void parseLocalBindVars(boost::optional<localbind_t> vars, bool& doTCP, b
   }
 }
 
+#ifdef HAVE_DNS_OVER_TLS
+static bool loadTLSCertificateAndKeys(shared_ptr<TLSFrontend>& frontend, boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles)
+{
+  if (certFiles.type() == typeid(std::string) && keyFiles.type() == typeid(std::string)) {
+    auto certFile = boost::get<std::string>(certFiles);
+    auto keyFile = boost::get<std::string>(keyFiles);
+    frontend->d_certKeyPairs.clear();
+    frontend->d_certKeyPairs.push_back({certFile, keyFile});
+  }
+  else if (certFiles.type() == typeid(std::vector<std::pair<int,std::string>>) && keyFiles.type() == typeid(std::vector<std::pair<int,std::string>>))
+  {
+    auto certFilesVect = boost::get<std::vector<std::pair<int,std::string>>>(certFiles);
+    auto keyFilesVect = boost::get<std::vector<std::pair<int,std::string>>>(keyFiles);
+    if (certFilesVect.size() == keyFilesVect.size()) {
+      frontend->d_certKeyPairs.clear();
+      for (size_t idx = 0; idx < certFilesVect.size(); idx++) {
+        frontend->d_certKeyPairs.push_back({certFilesVect.at(idx).second, keyFilesVect.at(idx).second});
+      }
+    }
+    else {
+      errlog("Error, mismatching number of certificates and keys in call to addTLSLocal()!");
+      g_outputBuffer="Error, mismatching number of certificates and keys in call to addTLSLocal()!";
+      return false;
+    }
+  }
+  else {
+    errlog("Error, mismatching number of certificates and keys in call to addTLSLocal()!");
+    g_outputBuffer="Error, mismatching number of certificates and keys in call to addTLSLocal()!";
+    return false;
+  }
+
+  return true;
+}
+#endif /* HAVE_DNS_OVER_TLS */
+
 void setupLuaConfig(bool client)
 {
   typedef std::unordered_map<std::string, boost::variant<bool, std::string, vector<pair<int, std::string> >, DownstreamState::checkfunc_t > > newserver_t;
@@ -1451,29 +1486,7 @@ void setupLuaConfig(bool client)
         }
         shared_ptr<TLSFrontend> frontend = std::make_shared<TLSFrontend>();
 
-        if (certFiles.type() == typeid(std::string) && keyFiles.type() == typeid(std::string)) {
-          auto certFile = boost::get<std::string>(certFiles);
-          auto keyFile = boost::get<std::string>(keyFiles);
-          frontend->d_certKeyPairs.push_back({certFile, keyFile});
-        }
-        else if (certFiles.type() == typeid(std::vector<std::pair<int,std::string>>) && keyFiles.type() == typeid(std::vector<std::pair<int,std::string>>))
-        {
-          auto certFilesVect = boost::get<std::vector<std::pair<int,std::string>>>(certFiles);
-          auto keyFilesVect = boost::get<std::vector<std::pair<int,std::string>>>(keyFiles);
-          if (certFilesVect.size() == keyFilesVect.size()) {
-            for (size_t idx = 0; idx < certFilesVect.size(); idx++) {
-              frontend->d_certKeyPairs.push_back({certFilesVect.at(idx).second, keyFilesVect.at(idx).second});
-            }
-          }
-          else {
-            errlog("Error, mismatching number of certificates and keys in call to addTLSLocal()!");
-            g_outputBuffer="Error, mismatching number of certificates and keys in call to addTLSLocal()!";
-            return;
-          }
-        }
-        else {
-          errlog("Error, mismatching number of certificates and keys in call to addTLSLocal()!");
-          g_outputBuffer="Error, mismatching number of certificates and keys in call to addTLSLocal()!";
+        if (!loadTLSCertificateAndKeys(frontend, certFiles, keyFiles)) {
           return;
         }
 
@@ -1562,6 +1575,29 @@ void setupLuaConfig(bool client)
         return result;
       });
 
+    g_lua.writeFunction("getTLSFrontend", [](size_t index) {
+        std::shared_ptr<TLSFrontend> result = nullptr;
+#ifdef HAVE_DNS_OVER_TLS
+        setLuaNoSideEffect();
+        try {
+          if (index < g_tlslocals.size()) {
+            result = g_tlslocals.at(index);
+          }
+          else {
+            errlog("Error: trying to get TLS frontend with index %zu but we only have %zu\n", index, g_tlslocals.size());
+            g_outputBuffer="Error: trying to get TLS frontend with index " + std::to_string(index) + " but we only have " + std::to_string(g_tlslocals.size()) + "\n";
+          }
+        }
+        catch(const std::exception& e) {
+          g_outputBuffer="Error: "+string(e.what())+"\n";
+          errlog("Error: %s\n", string(e.what()));
+        }
+#else
+        g_outputBuffer="DNS over TLS support is not present!\n";
+#endif
+        return result;
+      });
+
     g_lua.registerFunction<void(std::shared_ptr<TLSCtx>::*)()>("rotateTicketsKey", [](std::shared_ptr<TLSCtx> ctx) {
         if (ctx != nullptr) {
           ctx->rotateTicketsKey(time(nullptr));
@@ -1571,6 +1607,12 @@ void setupLuaConfig(bool client)
     g_lua.registerFunction<void(std::shared_ptr<TLSCtx>::*)(const std::string&)>("loadTicketsKeys", [](std::shared_ptr<TLSCtx> ctx, const std::string& file) {
         if (ctx != nullptr) {
           ctx->loadTicketsKeys(file);
+        }
+      });
+
+    g_lua.registerFunction<void(std::shared_ptr<TLSFrontend>::*)(boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles)>("loadNewCertificatesAndKeys", [](std::shared_ptr<TLSFrontend>& frontend, boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles) {
+        if (loadTLSCertificateAndKeys(frontend, certFiles, keyFiles)) {
+          frontend->setupTLS();
         }
       });
 }

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -616,6 +616,12 @@ Status, Statistics and More
 
   Return the TLSContext object for the context of index ``idx``.
 
+.. function:: getTLSFrontend(idx)
+
+  .. versionadded:: 1.3.1
+
+  Return the TLSFrontend object for the TLS bind of index ``idx``.
+
 .. function:: grepq(selector[, num])
               grepq(selectors[, num])
 
@@ -890,3 +896,19 @@ TLSContext
      Load new tickets keys from the selected file, replacing the existing ones. These keys should be rotated often and never written to persistent storage to preserve forward secrecy. The default is to generate a random key. The OpenSSL provider supports several tickets keys to be able to decrypt existing sessions after the rotation, while the GnuTLS provider only supports one key.
 
     :param str ticketsKeysFile: The path to a file from where TLS tickets keys should be loaded.
+
+TLSFrontend
+~~~~~~~~~~
+
+.. class:: TLSFrontend
+
+  .. versionadded:: 1.3.1
+
+  This object represents the configuration of a listening frontend for DNS over TLS queries. To each frontend is associated a TLSContext.
+
+  .. method:: TLSContext:loadNewCertificatesAndKeys(certFile(s), keyFile(s))
+
+     Create and switch to a new TLS context using the same options than were passed to the corresponding `addTLSLocal()` directive, but loading new certificates and keys from the selected files, replacing the existing ones.
+
+  :param str certFile(s): The path to a X.509 certificate file in PEM format, or a list of paths to such files.
+  :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones.

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -91,6 +91,7 @@ Listen Sockets
   .. versionadded:: 1.3.0
   .. versionchanged:: 1.3.1
     ``certFile(s)`` and ``keyFile(s)`` parameters accept a list of files.
+    ``disableTickets`` option added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
@@ -112,6 +113,7 @@ Listen Sockets
   * ``numberOfTicketsKeys``: int - The maximum number of tickets keys to keep in memory at the same time, if the provider supports it (GnuTLS doesn't, OpenSSL does). Only one key is marked as active and used to encrypt new tickets while the remaining ones can still be used to decrypt existing tickets after a rotation. Default to 5.
   * ``ticketKeyFile``: str - The path to a file from where TLS tickets keys should be loaded, to support RFC 5077. These keys should be rotated often and never written to persistent storage to preserve forward secrecy. The default is to generate a random key. The OpenSSL provider supports several tickets keys to be able to decrypt existing sessions after the rotation, while the GnuTLS provider only supports one key.
   * ``ticketsKeysRotationDelay``: int - Set the delay before the TLS tickets key is rotated, in seconds. Default is 43200 (12h).
+  * ``dibaleTickets``: bool - Disable the use of session resumption via session tickets. Default is false, meaning tickets are enabled.
 
 .. function:: setLocal(address[, options])
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -91,7 +91,7 @@ Listen Sockets
   .. versionadded:: 1.3.0
   .. versionchanged:: 1.3.1
     ``certFile(s)`` and ``keyFile(s)`` parameters accept a list of files.
-    ``disableTickets`` option added.
+    ``sessionTickets`` option added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
@@ -113,7 +113,7 @@ Listen Sockets
   * ``numberOfTicketsKeys``: int - The maximum number of tickets keys to keep in memory at the same time, if the provider supports it (GnuTLS doesn't, OpenSSL does). Only one key is marked as active and used to encrypt new tickets while the remaining ones can still be used to decrypt existing tickets after a rotation. Default to 5.
   * ``ticketKeyFile``: str - The path to a file from where TLS tickets keys should be loaded, to support RFC 5077. These keys should be rotated often and never written to persistent storage to preserve forward secrecy. The default is to generate a random key. The OpenSSL provider supports several tickets keys to be able to decrypt existing sessions after the rotation, while the GnuTLS provider only supports one key.
   * ``ticketsKeysRotationDelay``: int - Set the delay before the TLS tickets key is rotated, in seconds. Default is 43200 (12h).
-  * ``disableTickets``: bool - Disable the use of session resumption via session tickets. Default is false, meaning tickets are enabled.
+  * ``sessionTickets``: bool - Whether session resumption via session tickets is enabled. Default is true, meaning tickets are enabled.
 
 .. function:: setLocal(address[, options])
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -113,7 +113,7 @@ Listen Sockets
   * ``numberOfTicketsKeys``: int - The maximum number of tickets keys to keep in memory at the same time, if the provider supports it (GnuTLS doesn't, OpenSSL does). Only one key is marked as active and used to encrypt new tickets while the remaining ones can still be used to decrypt existing tickets after a rotation. Default to 5.
   * ``ticketKeyFile``: str - The path to a file from where TLS tickets keys should be loaded, to support RFC 5077. These keys should be rotated often and never written to persistent storage to preserve forward secrecy. The default is to generate a random key. The OpenSSL provider supports several tickets keys to be able to decrypt existing sessions after the rotation, while the GnuTLS provider only supports one key.
   * ``ticketsKeysRotationDelay``: int - Set the delay before the TLS tickets key is rotated, in seconds. Default is 43200 (12h).
-  * ``dibaleTickets``: bool - Disable the use of session resumption via session tickets. Default is false, meaning tickets are enabled.
+  * ``disableTickets``: bool - Disable the use of session resumption via session tickets. Default is false, meaning tickets are enabled.
 
 .. function:: setLocal(address[, options])
 

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -363,7 +363,7 @@ public:
   {
     d_ticketsKeyRotationDelay = fe.d_ticketsKeyRotationDelay;
 
-    static const int sslOptions =
+    int sslOptions =
       SSL_OP_NO_SSLv2 |
       SSL_OP_NO_SSLv3 |
       SSL_OP_NO_COMPRESSION |
@@ -371,6 +371,10 @@ public:
       SSL_OP_SINGLE_DH_USE |
       SSL_OP_SINGLE_ECDH_USE |
       SSL_OP_CIPHER_SERVER_PREFERENCE;
+
+    if (fe.d_disableTickets) {
+      sslOptions |= SSL_OP_NO_TICKET;
+    }
 
     if (s_users.fetch_add(1) == 0) {
       ERR_load_crypto_strings();
@@ -646,15 +650,16 @@ class GnuTLSConnection: public TLSConnection
 {
 public:
 
-  GnuTLSConnection(int socket, unsigned int timeout, const gnutls_certificate_credentials_t creds, const gnutls_priority_t priorityCache, std::shared_ptr<GnuTLSTicketsKey>& ticketsKey): d_ticketsKey(ticketsKey)
+  GnuTLSConnection(int socket, unsigned int timeout, const gnutls_certificate_credentials_t creds, const gnutls_priority_t priorityCache, std::shared_ptr<GnuTLSTicketsKey>& ticketsKey, bool disableTickets): d_ticketsKey(ticketsKey)
   {
+    unsigned int sslOptions = GNUTLS_SERVER;
+#ifdef GNUTLS_NO_SIGNAL
+    sslOptions |= GNUTLS_NO_SIGNAL;
+#endif
+
     d_socket = socket;
 
-    if (gnutls_init(&d_conn, GNUTLS_SERVER
-#ifdef GNUTLS_NO_SIGNAL
-                    | GNUTLS_NO_SIGNAL
-#endif
-          ) != GNUTLS_E_SUCCESS) {
+    if (gnutls_init(&d_conn, sslOptions) != GNUTLS_E_SUCCESS) {
       throw std::runtime_error("Error creating TLS connection");
     }
 
@@ -668,7 +673,7 @@ public:
       throw std::runtime_error("Error setting ciphers to TLS connection");
     }
 
-    if (d_ticketsKey) {
+    if (!disableTickets && d_ticketsKey) {
       const gnutls_datum_t& key = d_ticketsKey->getKey();
       if (gnutls_session_ticket_enable_server(d_conn, &key) != GNUTLS_E_SUCCESS) {
         gnutls_deinit(d_conn);
@@ -774,7 +779,7 @@ private:
 class GnuTLSIOCtx: public TLSCtx
 {
 public:
-  GnuTLSIOCtx(const TLSFrontend& fe)
+  GnuTLSIOCtx(const TLSFrontend& fe): d_disableTickets(fe.d_disableTickets)
   {
     int rc = 0;
     d_ticketsKeyRotationDelay = fe.d_ticketsKeyRotationDelay;
@@ -833,11 +838,15 @@ public:
   {
     handleTicketsKeyRotation(now);
 
-    return std::unique_ptr<GnuTLSConnection>(new GnuTLSConnection(socket, timeout, d_creds, d_priorityCache, d_ticketsKey));
+    return std::unique_ptr<GnuTLSConnection>(new GnuTLSConnection(socket, timeout, d_creds, d_priorityCache, d_ticketsKey, d_disableTickets));
   }
 
   void rotateTicketsKey(time_t now) override
   {
+    if (d_disableTickets) {
+      return;
+    }
+
     auto newKey = std::make_shared<GnuTLSTicketsKey>();
     d_ticketsKey = newKey;
     if (d_ticketsKeyRotationDelay > 0) {
@@ -847,6 +856,10 @@ public:
 
   void loadTicketsKeys(const std::string& file) override
   {
+    if (d_disableTickets) {
+      return;
+    }
+
     auto newKey = std::make_shared<GnuTLSTicketsKey>(file);
     d_ticketsKey = newKey;
     if (d_ticketsKeyRotationDelay > 0) {
@@ -863,6 +876,7 @@ private:
   gnutls_certificate_credentials_t d_creds{nullptr};
   gnutls_priority_t d_priorityCache{nullptr};
   std::shared_ptr<GnuTLSTicketsKey> d_ticketsKey{nullptr};
+  bool d_disableTickets{false};
 };
 
 #endif /* HAVE_GNUTLS */

--- a/pdns/dnsdistdist/tcpiohandler.hh
+++ b/pdns/dnsdistdist/tcpiohandler.hh
@@ -139,7 +139,7 @@ public:
   int d_tcpFastOpenQueueSize{0};
   uint8_t d_numberOfTicketsKeys{5};
   bool d_reusePort{false};
-  bool d_disableTickets{false};
+  bool d_enableTickets{true};
 
 private:
   std::shared_ptr<TLSCtx> d_ctx{nullptr};

--- a/pdns/dnsdistdist/tcpiohandler.hh
+++ b/pdns/dnsdistdist/tcpiohandler.hh
@@ -139,6 +139,7 @@ public:
   int d_tcpFastOpenQueueSize{0};
   uint8_t d_numberOfTicketsKeys{5};
   bool d_reusePort{false};
+  bool d_disableTickets{false};
 
 private:
   std::shared_ptr<TLSCtx> d_ctx{nullptr};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds support for switching to a new set of DoT certificates and keys without restarting dnsdist. It also adds an option to completely disable TLS session resumption via tickets.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
