### PR TITLE
Document that BIND backend hosted zones can't be altered from the API

### DIFF
--- a/docs/backends/bind.rst
+++ b/docs/backends/bind.rst
@@ -9,6 +9,7 @@ Bind zone file backend
 * DNSSEC: Yes
 * Disabled data: No
 * Comments: No
+* API: Read-only
 * Module name: bind
 * Launch: ``bind``
 
@@ -20,6 +21,8 @@ The BindBackend parses a Bind-style ``named.conf`` and extracts
 information about zones from it. It makes no attempt to honour other
 configuration flags, which you should configure (when available) using
 the PowerDNS native configuration.
+
+**note**: Because this backend retrieves its configuration from a text file and not a database, the HTTP API is unable to process changes for this backend. This effectively makes the API read-only for zones hosted by the BIND backend.  
 
 Configuration Parameters
 ------------------------


### PR DESCRIPTION
### Short description
Document that BIND backend hosted zones can't be altered from the API
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
