### PR TITLE
dnsdist: Fix duration false positive in the dynblock regression tests

### DIFF
--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -29,7 +29,7 @@ class DynBlocksTest(DNSDistTest):
             self.assertIn(key, values)
 
         self.assertEqual(values['reason'], reason)
-        self.assertGreater(values['seconds'], minSeconds)
+        self.assertGreaterEqual(values['seconds'], minSeconds)
         self.assertLessEqual(values['seconds'], maxSeconds)
         self.assertGreaterEqual(values['blocks'], minBlocks)
         self.assertLessEqual(values['blocks'], maxBlocks)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The number of remaining seconds might also be equal to the minimum value.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
