### PR TITLE
LuaWrapper: Disable maybe uninitialized warnings with boost optional

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -78,6 +78,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * your function to std::function (not directly std::bind or a lambda function) so the class can detect which argument types
  * it wants. These arguments may only be of basic types (int, float, etc.) or std::string.
  */
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 class LuaContext {
     struct ValueInRegistry;
     template<typename TFunctionObject, typename TFirstParamType> struct Binder;
@@ -2946,5 +2952,9 @@ struct LuaContext::Reader<std::tuple<TFirst, TOthers...>,
         return std::tuple_cat(std::tuple<TFirst>(*firstVal), std::move(*othersVal));
     }
 };
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`GCC` enables `-Wmaybe-uninitialized` by default with `-Wall`, and it reports what looks like false positives with `boost::optional` types.

See:
- https://svn.boost.org/trac10/ticket/12513
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78044

I'm not a huge fan of hiding warnings, but these are flooding my terminal causing me to miss other, legitimate, warnings, and they look like false positives to me. 
`clang` does not implement the warning and actually issue a warning if you try to hide a non-existent warning, so I had to exclude it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
