### PR TITLE
rec: use native QType in lua scripting

### DIFF
--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -228,7 +228,7 @@ void BaseLua4::prepareContext() {
           }});
 
   for(const auto& n : QType::names)
-    d_pd.push_back({n.first, n.second});
+    d_pd.push_back({n.first, QType(n.second)});
 
   d_lw->registerMember("tv_sec", &timeval::tv_sec);
   d_lw->registerMember("tv_usec", &timeval::tv_usec);

--- a/pdns/lua-base4.hh
+++ b/pdns/lua-base4.hh
@@ -29,5 +29,5 @@ protected:
   virtual void postPrepareContext() = 0;
   virtual void postLoad() = 0;
   typedef vector<pair<string, int> > in_t;
-  vector<pair<string, boost::variant<int, in_t, struct timeval* > > > d_pd;
+  vector<pair<string, boost::variant<int, in_t, struct timeval*, QType > > > d_pd;
 };

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -60,11 +60,11 @@ public:
 
   struct DNSQuestion
   {
-    DNSQuestion(const ComboAddress& rem, const ComboAddress& loc, const DNSName& query, uint16_t type, bool tcp, bool& variable_, bool& wantsRPZ_): qname(query), qtype(type), local(loc), remote(rem), isTcp(tcp), variable(variable_), wantsRPZ(wantsRPZ_)
+    DNSQuestion(const ComboAddress& rem, const ComboAddress& loc, const DNSName& query, uint16_t type, bool tcp, bool& variable_, bool& wantsRPZ_): qname(query), qtype(QType(type)), local(loc), remote(rem), isTcp(tcp), variable(variable_), wantsRPZ(wantsRPZ_)
     {
     }
     const DNSName& qname;
-    const uint16_t qtype;
+    const QType qtype;
     const ComboAddress& local;
     const ComboAddress& remote;
     const struct dnsheader* dh{nullptr};
@@ -82,8 +82,8 @@ public:
     bool& wantsRPZ;
     unsigned int tag{0};
 
-    void addAnswer(uint16_t type, const std::string& content, boost::optional<int> ttl, boost::optional<string> name);
-    void addRecord(uint16_t type, const std::string& content, DNSResourceRecord::Place place, boost::optional<int> ttl, boost::optional<string> name);
+    void addAnswer(const QType& type, const std::string& content, boost::optional<int> ttl, boost::optional<string> name);
+    void addRecord(const QType& type, const std::string& content, DNSResourceRecord::Place place, boost::optional<int> ttl, boost::optional<string> name);
     vector<pair<int,DNSRecord> > getRecords() const;
     boost::optional<dnsheader> getDH() const;
     vector<pair<uint16_t, string> > getEDNSOptions() const;
@@ -109,7 +109,7 @@ public:
     DNSName followupName;
   };
 
-  unsigned int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const EDNSOptionViewMap&, bool tcp, std::string& requestorId, std::string& deviceId) const;
+  unsigned int gettag(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, const QType& qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const EDNSOptionViewMap&, bool tcp, std::string& requestorId, std::string& deviceId) const;
   unsigned int gettag_ffi(const ComboAddress& remote, const Netmask& ednssubnet, const ComboAddress& local, const DNSName& qname, uint16_t qtype, std::vector<std::string>* policyTags, LuaContext::LuaObject& data, const EDNSOptionViewMap&, bool tcp, std::string& requestorId, std::string& deviceId, uint32_t& ttlCap, bool& variable) const;
 
   void maintenance() const;
@@ -131,7 +131,7 @@ public:
             d_postresolve);
   }
 
-  typedef std::function<std::tuple<unsigned int,boost::optional<std::unordered_map<int,string> >,boost::optional<LuaContext::LuaObject>,boost::optional<std::string>,boost::optional<std::string> >(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const EDNSOptionViewMap&, bool)> gettag_t;
+  typedef std::function<std::tuple<unsigned int,boost::optional<std::unordered_map<int,string> >,boost::optional<LuaContext::LuaObject>,boost::optional<std::string>,boost::optional<std::string> >(ComboAddress, Netmask, ComboAddress, DNSName, QType, const EDNSOptionViewMap&, bool)> gettag_t;
   gettag_t d_gettag; // public so you can query if we have this hooked
   typedef std::function<boost::optional<LuaContext::LuaObject>(pdns_ffi_param_t*)> gettag_ffi_t;
   gettag_ffi_t d_gettag_ffi;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1692,7 +1692,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
                 dc->d_tag = t_pdl->gettag_ffi(dc->d_source, dc->d_ednssubnet.source, dc->d_destination, qname, qtype, &dc->d_policyTags, dc->d_data, ednsOptions, true, requestorId, deviceId, dc->d_ttlCap, dc->d_variable);
               }
               else if (t_pdl->d_gettag) {
-                dc->d_tag = t_pdl->gettag(dc->d_source, dc->d_ednssubnet.source, dc->d_destination, qname, qtype, &dc->d_policyTags, dc->d_data, ednsOptions, true, requestorId, deviceId);
+                dc->d_tag = t_pdl->gettag(dc->d_source, dc->d_ednssubnet.source, dc->d_destination, qname, QType(qtype), &dc->d_policyTags, dc->d_data, ednsOptions, true, requestorId, deviceId);
               }
             }
             catch(const std::exception& e)  {
@@ -1886,7 +1886,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
               ctag = t_pdl->gettag_ffi(source, ednssubnet.source, destination, qname, qtype, &policyTags, data, ednsOptions, false, requestorId, deviceId, ttlCap, variable);
             }
             else if (t_pdl->d_gettag) {
-              ctag = t_pdl->gettag(source, ednssubnet.source, destination, qname, qtype, &policyTags, data, ednsOptions, false, requestorId, deviceId);
+              ctag = t_pdl->gettag(source, ednssubnet.source, destination, qname, QType(qtype), &policyTags, data, ednsOptions, false, requestorId, deviceId);
             }
           }
           catch(const std::exception& e)  {

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -17,7 +17,11 @@ The DNSQuestion object contains at least the following fields:
 
   .. attribute:: DNSQuestion.qtype
 
-      Type this query is for as an integer, can be compared against ``pdns.A``, ``pdns.AAAA``.
+     .. versionchanged:: 4.2.0
+
+       The qtype parameter is now a QType instead of an int
+
+      Type this query is for as an QType, can be compared against ``pdns.A``, ``pdns.AAAA``.
 
   .. attribute:: DNSQuestion.rcode
 

--- a/pdns/recursordist/docs/lua-scripting/hooks.rst
+++ b/pdns/recursordist/docs/lua-scripting/hooks.rst
@@ -56,6 +56,10 @@ Interception Functions
 .. function:: gettag(remote, ednssubnet, localip, qname, qtype, ednsoptions, tcp) -> int
               gettag(remote, ednssubnet, localip, qname, qtype, ednsoptions) -> int
 
+    .. versionchanged:: 4.2.0
+
+      The qtype parameter is now a QType instead of an int.
+
     .. versionchanged:: 4.1.0
 
       The ``tcp`` parameter was added.
@@ -78,7 +82,7 @@ Interception Functions
     :param Netmask ednssubnet: The EDNS Client subnet that was extracted from the packet
     :param ComboAddress localip: The IP address the query was received on
     :param DNSName qname: The domain name the query is for
-    :param int qtype: The query type of the query
+    :param QType qtype: The query type of the query
     :param ednsoptions: A table whose keys are EDNS option codes and values are :class:`EDNSOptionView` objects. This table is empty unless the :ref:`setting-gettag-needs-edns-options` option is set.
     :param bool tcp: Added in 4.1.0, a boolean indicating whether the query was received over UDP (false) or TCP (true).
 

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -65,7 +65,7 @@ class GettagRecursorTest(RecursorTest):
 
       -- test that tags are passed to other hooks
       table.insert(tags, qname:toString())
-      table.insert(tags, 'gettag-qtype-'..qtype)
+      table.insert(tags, 'gettag-qtype-'..qtype:getName())
 
       return 0, tags, data
     end
@@ -134,7 +134,7 @@ class GettagRecursorTest(RecursorTest):
         name = 'gettag.lua.'
         expected = [
             dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.1'),
-            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [ name, 'gettag-qtype-1'])
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [ name, 'gettag-qtype-A'])
             ]
         query = dns.message.make_query(name, 'A', want_dnssec=True)
         query.flags |= dns.flags.CD
@@ -145,7 +145,7 @@ class GettagRecursorTest(RecursorTest):
         name = 'gettag-tcpa.lua.'
         expected = [
             dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.1'),
-            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [ name, 'gettag-qtype-1', 'gettag-tcp'])
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [ name, 'gettag-qtype-A', 'gettag-tcp'])
             ]
         query = dns.message.make_query(name, 'A', want_dnssec=True)
         query.flags |= dns.flags.CD
@@ -156,7 +156,7 @@ class GettagRecursorTest(RecursorTest):
         name = 'gettag-aaaa.lua.'
         expected = [
             dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'AAAA', '2001:db8::1'),
-            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [ name, 'gettag-qtype-28'])
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [ name, 'gettag-qtype-AAAA'])
             ]
         query = dns.message.make_query(name, 'AAAA', want_dnssec=True)
         query.flags |= dns.flags.CD
@@ -170,7 +170,7 @@ class GettagRecursorTest(RecursorTest):
         ecso = clientsubnetoption.ClientSubnetOption(subnet, subnetMask)
         expected = [
             dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.1'),
-            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [name, 'gettag-qtype-1', 'edns-subnet-' + subnet + '/' + str(subnetMask),
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [name, 'gettag-qtype-A', 'edns-subnet-' + subnet + '/' + str(subnetMask),
                                                                          'ednsoption-8-count-1', 'ednsoption-8-total-len-8']),
             ]
         query = dns.message.make_query(name, 'A', want_dnssec=True, options=[ecso])
@@ -188,7 +188,7 @@ class GettagRecursorTest(RecursorTest):
 
         expected = [
             dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.1'),
-            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [name, 'gettag-qtype-1', 'edns-subnet-' + subnet + '/' + str(subnetMask),
+            dns.rrset.from_text_list(name, 0, dns.rdataclass.IN, 'TXT', [name, 'gettag-qtype-A', 'edns-subnet-' + subnet + '/' + str(subnetMask),
                                                                          'ednsoption-10-count-2', 'ednsoption-10-total-len-32',
                                                                          'ednsoption-8-count-1', 'ednsoption-8-total-len-8'
                                                                         ]),


### PR DESCRIPTION
### Short description
qtype.getName() and qtype.getCode() is now possible without type casting.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
