### PR TITLE
dnsdist: Fix detection of NoData / NXDomain answers in the cache

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -809,7 +809,7 @@ uint32_t getDNSPacketMinTTL(const char* packet, size_t length, bool* seenAuthSOA
       }
 
       /* report it if we see a SOA record in the AUTHORITY section */
-      if(dnstype == QType::SOA && dnsclass == QClass::IN && seenAuthSOA != nullptr && n >= (ntohs(dh->ancount) && n < (ntohs(dh->ancount) + ntohs(dh->nscount)))) {
+      if(dnstype == QType::SOA && dnsclass == QClass::IN && seenAuthSOA != nullptr && n >= ntohs(dh->ancount) && n < (ntohs(dh->ancount) + ntohs(dh->nscount))) {
         *seenAuthSOA = true;
       }
 

--- a/pdns/test-dnsparser_cc.cc
+++ b/pdns/test-dnsparser_cc.cc
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(test_getDNSPacketMinTTL) {
     pwR.getHeader()->qr = 1;
     pwR.commit();
 
-    pwR.startRecord(name, QType::SOA, 255, QClass::CHAOS, DNSResourceRecord::ADDITIONAL);
+    pwR.startRecord(name, QType::SOA, 255, QClass::IN, DNSResourceRecord::ADDITIONAL);
     pwR.commit();
 
     bool seenAuthSOA = false;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Checking whether the SOA record is in the right section was broken because of a misplaced parenthesis, and the unit test checking that case turned out to be broken too (wrong class) :'(
The broken check was reported by cppcheck (thanks!):

```
Comparison of a boolean expression with an integer.
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
