### PR TITLE
Add Basic Auth support to changelog-from-pr.py

### DIFF
--- a/build-scripts/changelog-from-pr.py
+++ b/build-scripts/changelog-from-pr.py
@@ -4,10 +4,13 @@ import requests
 import sys
 import argparse
 import re
+import getpass
 
 argp = argparse.ArgumentParser()
 argp.add_argument('--oneline', action='store_true',
                   help='Make one-lined changelog entries (for 4.0 and older)')
+argp.add_argument('--username',
+                  help='Use the specified username for Basic Authentication to the GitHub API, allowing an higher rate limit')
 argp.add_argument('pullrequest', metavar='PULL_REQUEST', nargs='+',
                   help='Make changelogs for these Pull Request #\'s')
 arguments = argp.parse_args()
@@ -15,12 +18,17 @@ arguments = argp.parse_args()
 ticket_regex = re.compile(r'(?:[Cc]loses|[Ff]ixes)? #(\d+)')
 
 out = ''
+httpAuth = None
+if arguments.username:
+    password = getpass.getpass("GitHub password for '" + arguments.username + "': ")
+    httpAuth = requests.auth.HTTPBasicAuth(arguments.username, password)
+
 for pr in arguments.pullrequest:
     if pr[0] == '#':
         pr = pr[1:]
     try:
         res = requests.get('https://api.github.com/repos/PowerDNS/pdns/pulls/'
-                           '{}'.format(pr))
+                           '{}'.format(pr), auth=httpAuth)
         pr_info = res.json()
     except (requests.exceptions.HTTPError, ValueError) as e:
         print(e)
@@ -41,9 +49,9 @@ for pr in arguments.pullrequest:
 
     if pr_info['user']['login'].lower() not in ['ahupowerdns', 'habbie',
                                                 'pieterlexis', 'rgacogne',
-                                                'aerique']:
+                                                'aerique', 'chbruyand']:
         try:
-            user_info = requests.get(pr_info['user']['url']).json()
+            user_info = requests.get(pr_info['user']['url'], auth=httpAuth).json()
         except (requests.exceptions.HTTPError, ValueError) as e:
             print(e)
             sys.exit(1)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
GitHub's API rate limiting is quite aggressive, but is more permissive for authenticated users.
This PR allows authenticating via username and password, but you can also submit a personal access token instead of a password if, for example, you have 2-factors authentication enabled on your account.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
