### PR TITLE
backport: avoid concurrent records/comments iteration from running out of sync

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -402,7 +402,8 @@ static void fillZone(const DNSName& zonename, HttpResponse* resp, bool doRRSets)
     auto cit = comments.begin();
 
     while (rit != records.end() || cit != comments.end()) {
-      if (cit == comments.end() || (rit != records.end() && (cit->qname.toString() <= rit->qname.toString() || cit->qtype < rit->qtype || cit->qtype == rit->qtype))) {
+      // if you think this should be rit < cit instead of cit < rit, note the b < a instead of a < b in the sort comparison functions above
+      if (cit == comments.end() || (rit != records.end() && (rit->qname == cit->qname ? (cit->qtype < rit->qtype || cit->qtype == rit->qtype) : cit->qname < rit->qname))) {
         current_qname = rit->qname;
         current_qtype = rit->qtype;
         ttl = rit->ttl;


### PR DESCRIPTION
(cherry picked from commit 5481c77c8917ef3097d37e0da8a450a01b09f3de)

This backports #6780 to auth-4.1.x.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
