### PR TITLE
Backport rec-4.1.x: Fix warnings reported by GCC 8.1.0

### DIFF
--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -216,7 +216,7 @@ class RemoteBackend : public DNSBackend
         string val = asString(value);
         if (val == "0") return false;
         if (val == "1") return true;
-      } catch (JsonException) {};
+      } catch (const JsonException&) {};
       throw JsonException("Json value not convertible to boolean");
     };
 

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -275,7 +275,7 @@ private:
         struct addrinfo* address = res;
         do {
           if (address->ai_addrlen <= sizeof(remote)) {
-            memcpy(&remote, address->ai_addr, address->ai_addrlen);
+            remote.setSockaddr(address->ai_addr, address->ai_addrlen);
             addresses->push_back(remote.toString());
           }
         } while((address = address->ai_next));

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -100,7 +100,7 @@ bool DNSSECKeeper::addKey(const DNSName& name, bool setSEPBit, int algorithm, in
   shared_ptr<DNSCryptoKeyEngine> dpk(DNSCryptoKeyEngine::make(algorithm));
   try{
     dpk->create(bits);
-  } catch (std::runtime_error error){
+  } catch (const std::runtime_error& error){
     throw runtime_error("The algorithm does not support the given bit size.");
   }
   dspk.setKey(dpk);

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -255,7 +255,7 @@ void* tcpClientThread(int pipefd)
     vector<uint8_t> rewrittenResponse;
     shared_ptr<DownstreamState> ds;
     ComboAddress dest;
-    memset(&dest, 0, sizeof(dest));
+    dest.reset();
     dest.sin4.sin_family = ci.remote.sin4.sin_family;
     socklen_t len = dest.getSocklen();
     size_t queriesCount = 0;

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -116,7 +116,7 @@ ComboAddress ARecordContent::getCA(int port) const
 ComboAddress AAAARecordContent::getCA(int port) const
 {
   ComboAddress ret;
-  memset(&ret, 0, sizeof(ret));
+  ret.reset();
 
   ret.sin4.sin_family=AF_INET6;
   ret.sin6.sin6_port = htons(port);

--- a/pdns/ednssubnet.cc
+++ b/pdns/ednssubnet.cc
@@ -57,7 +57,7 @@ bool getEDNSSubnetOptsFromString(const char* options, unsigned int len, EDNSSubn
       return false;
     if(octetsin > sizeof(address.sin4.sin_addr.s_addr))
       return false;
-    memset(&address, 0, sizeof(address));
+    address.reset();
     address.sin4.sin_family = AF_INET;
     if(octetsin > 0)
       memcpy(&address.sin4.sin_addr.s_addr, options+sizeof(esow), octetsin);
@@ -66,7 +66,8 @@ bool getEDNSSubnetOptsFromString(const char* options, unsigned int len, EDNSSubn
       return false;
     if(octetsin > sizeof(address.sin6.sin6_addr.s6_addr))
       return false;
-    memset(&address, 0, sizeof(address));
+
+    address.reset();
     address.sin4.sin_family = AF_INET6;
     if(octetsin > 0)
       memcpy(&address.sin6.sin6_addr.s6_addr, options+sizeof(esow), octetsin);

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -145,7 +145,7 @@ bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv)
 }
 bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destination)
 {
-  memset(destination, 0, sizeof(*destination));
+  destination->reset();
   const struct cmsghdr* cmsg;
   for (cmsg = CMSG_FIRSTHDR(msgh); cmsg != NULL; cmsg = CMSG_NXTHDR(const_cast<struct msghdr*>(msgh), const_cast<struct cmsghdr*>(cmsg))) {
 #if defined(IP_PKTINFO)

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -282,6 +282,12 @@ union ComboAddress {
     return ntohs(sin4.sin_port);
   }
 
+  void reset()
+  {
+    memset(&sin4, 0, sizeof(sin4));
+    memset(&sin6, 0, sizeof(sin6));
+  }
+
 };
 
 /** This exception is thrown by the Netmask class and by extension by the NetmaskGroup class */

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -720,7 +720,7 @@ int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret)
       port = pdns_stou(addr.substr(pos+2));
       portSet = true;
     }
-    catch(std::out_of_range) {
+    catch(const std::out_of_range&) {
       return -1;
     }
   }

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -111,8 +111,8 @@ void UDPNameserver::bindIPv4()
   
     if(!setNonBlocking(s))
       throw PDNSException("Unable to set UDP socket to non-blocking: "+stringerror());
-  
-    memset(&locala,0,sizeof(locala));
+
+    locala.reset();
     locala.sin4.sin_family=AF_INET;
 
     if(localname=="0.0.0.0")

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1480,7 +1480,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       dc->d_tcp=true;
       dc->setRemote(&conn->d_remote);
       ComboAddress dest;
-      memset(&dest, 0, sizeof(dest));
+      dest.reset();
       dest.sin4.sin_family = conn->d_remote.sin4.sin_family;
       socklen_t len = dest.getSocklen();
       getsockname(conn->getFD(), (sockaddr*)&dest, &len); // if this fails, we're ok with it
@@ -1876,7 +1876,7 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
 	struct timeval tv={0,0};
 	HarvestTimestamp(&msgh, &tv);
 	ComboAddress dest;
-	memset(&dest, 0, sizeof(dest)); // this makes sure we ignore this address if not returned by recvmsg above
+	dest.reset(); // this makes sure we ignore this address if not returned by recvmsg above
         auto loc = rplookup(g_listenSocketsAddresses, fd);
 	if(HarvestDestinationAddress(&msgh, &dest)) {
           // but.. need to get port too
@@ -1935,7 +1935,7 @@ static void makeTCPServerSockets(unsigned int threadId)
 
     ComboAddress sin;
 
-    memset((char *)&sin,0, sizeof(sin));
+    sin.reset();
     sin.sin4.sin_family = AF_INET;
     if(!IpToU32(st.host, (uint32_t*)&sin.sin4.sin_addr.s_addr)) {
       sin.sin6.sin6_family = AF_INET6;
@@ -2021,7 +2021,7 @@ static void makeUDPServerSockets(unsigned int threadId)
 
     ComboAddress sin;
 
-    memset(&sin, 0, sizeof(sin));
+    sin.reset();
     sin.sin4.sin_family = AF_INET;
     if(!IpToU32(st.host.c_str() , (uint32_t*)&sin.sin4.sin_addr.s_addr)) {
       sin.sin6.sin6_family = AF_INET6;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -821,7 +821,7 @@ struct PacketID
 {
   PacketID() : id(0), type(0), sock(0), inNeeded(0), inIncompleteOkay(false), outPos(0), nearMisses(0), fd(-1)
   {
-    memset(&remote, 0, sizeof(remote));
+    remote.reset();
   }
 
   uint16_t id;  // wait for a specific id/remote pair

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -60,8 +60,8 @@ BOOST_AUTO_TEST_CASE(test_ComboAddress) {
 
 BOOST_AUTO_TEST_CASE(test_ComboAddressCompare) {
   ComboAddress a, b;
-  memset(&a, 0, sizeof(a));
-  memset(&b, 0, sizeof(b));
+  a.reset();
+  b.reset();
   BOOST_CHECK(!(a<b));
   BOOST_CHECK(!(a>b));
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fix warnings reported by GCC 8.1.0:
- polymorphic exceptions caught by value
- ComboAddress objects manipulated via `memset()`

(cherry picked from commit d38e2ba97a78aa9dfc894fc4e13a6f3a410dd31a)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
