### PR TITLE
Backport rec-4.1.x: Allocate one more stack byte to make _GLIBCXX_ASSERTIONS happy

### DIFF
--- a/pdns/mtasker.cc
+++ b/pdns/mtasker.cc
@@ -268,10 +268,10 @@ template<class Key, class Val>void MTasker<Key,Val>::makeThread(tfunc_t *start, 
   auto uc=std::make_shared<pdns_ucontext_t>();
   
   uc->uc_link = &d_kernel; // come back to kernel after dying
-  uc->uc_stack.resize (d_stacksize);
+  uc->uc_stack.resize (d_stacksize+1);
 #ifdef PDNS_USE_VALGRIND
   uc->valgrind_id = VALGRIND_STACK_REGISTER(&uc->uc_stack[0],
-                                            &uc->uc_stack[uc->uc_stack.size()]);
+                                            &uc->uc_stack[uc->uc_stack.size()-1]);
 #endif /* PDNS_USE_VALGRIND */
 
   auto& thread = d_threads[d_maxtid];

--- a/pdns/mtasker_fcontext.cc
+++ b/pdns/mtasker_fcontext.cc
@@ -216,13 +216,13 @@ pdns_makecontext
     assert (ctx.uc_link);
     assert (ctx.uc_stack.size() >= 8192);
     assert (!ctx.uc_mcontext);
-    ctx.uc_mcontext = make_fcontext (&ctx.uc_stack[ctx.uc_stack.size()],
-                                     ctx.uc_stack.size(), &threadWrapper);
+    ctx.uc_mcontext = make_fcontext (&ctx.uc_stack[ctx.uc_stack.size()-1],
+                                     ctx.uc_stack.size()-1, &threadWrapper);
     args_t args;
     args.self = &ctx;
     args.work = &start;
     /* jumping to threadwrapper */
-    notifyStackSwitch(&ctx.uc_stack[ctx.uc_stack.size()], ctx.uc_stack.size());
+    notifyStackSwitch(&ctx.uc_stack[ctx.uc_stack.size()-1], ctx.uc_stack.size()-1);
 #if BOOST_VERSION < 106100
     jump_fcontext (reinterpret_cast<fcontext_t*>(&args.prev_ctx),
                    static_cast<fcontext_t>(ctx.uc_mcontext),


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
(cherry picked from commit 5529b1b183a2b2a51784fe6ee292bdf9032e8834)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
