### PR TITLE
Make NOD and Boost FS conditional for compilation based on configure flag

### DIFF
--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -11,8 +11,12 @@ AM_CPPFLAGS += \
 AM_CXXFLAGS = \
 	-DSYSCONFDIR=\"$(sysconfdir)\" \
 	-DPKGLIBDIR=\"$(pkglibdir)\" \
-	-DLOCALSTATEDIR=\"$(socketdir)\" \
+	-DLOCALSTATEDIR=\"$(socketdir)\"
+
+if NOD_ENABLED
+AM_CXXFLAGS += \
 	-DNODCACHEDIR=\"$(nodcachedir)\"
+endif
 
 AM_LDFLAGS = \
 	$(PROGRAM_LDFLAGS) \
@@ -123,7 +127,6 @@ pdns_recursor_SOURCES = \
 	mtasker_context.cc mtasker_context.hh \
 	namespaces.hh \
 	negcache.hh negcache.cc \
-	nod.hh nod.cc \
 	nsecrecords.cc \
 	opensslsigners.cc opensslsigners.hh \
 	packetcache.hh \
@@ -185,13 +188,20 @@ pdns_recursor_LDADD = \
 	$(NET_SNMP_LIBS) \
 	$(SYSTEMD_LIBS) \
 	$(RT_LIBS) \
-	$(BOOST_FILESYSTEM_LIBS) \
 	$(BOOST_SYSTEM_LIBS) \
 	$(PROBDS_LIBS)
 
 pdns_recursor_LDFLAGS = $(AM_LDFLAGS) \
 	$(LIBCRYPTO_LDFLAGS) $(BOOST_CONTEXT_LDFLAGS) \
-	$(BOOST_FILESYSTEM_LDFLAGS) $(BOOST_SYSTEM_LDFLAGS)
+	$(BOOST_SYSTEM_LDFLAGS)
+
+if NOD_ENABLED
+pdns_recursor_SOURCES += nod.hh nod.cc
+pdns_recursor_LDADD += \
+	$(BOOST_FILESYSTEM_LIBS)
+pdns_recursor_LDFLAGS += \
+	$(BOOST_FILESYSTEM_LDFLAGS)
+endif
 
 testrunner_SOURCES = \
 	arguments.cc \
@@ -219,7 +229,6 @@ testrunner_SOURCES = \
 	mtasker_context.cc \
 	negcache.hh negcache.cc \
 	namespaces.hh \
-	nod.hh nod.cc \
 	nsecrecords.cc \
 	pdnsexception.hh \
 	opensslsigners.cc opensslsigners.hh \
@@ -252,7 +261,6 @@ testrunner_SOURCES = \
 	test-mtasker.cc \
 	test-nmtree.cc \
 	test-negcache_cc.cc \
-	test-nod_cc.cc \
 	test-rcpgenerator_cc.cc \
 	test-recpacketcache_cc.cc \
 	test-recursorcache_cc.cc \
@@ -273,7 +281,6 @@ testrunner_LDFLAGS = \
 	$(BOOST_CONTEXT_LDFLAGS) \
 	$(BOOST_UNIT_TEST_FRAMEWORK_LDFLAGS) \
 	$(LIBCRYPTO_LDFLAGS) \
-	$(BOOST_FILESYSTEM_LDFLAGS) \
 	$(BOOST_SYSTEM_LDFLAGS)
 
 testrunner_LDADD = \
@@ -281,9 +288,18 @@ testrunner_LDADD = \
 	$(BOOST_UNIT_TEST_FRAMEWORK_LIBS) \
 	$(LIBCRYPTO_LIBS) \
 	$(RT_LIBS) \
-	$(BOOST_FILESYSTEM_LIBS) \
 	$(BOOST_SYSTEM_LIBS) \
 	$(PROBDS_LIBS)
+
+if NOD_ENABLED
+testrunner_SOURCES +=   nod.hh nod.cc \
+			test-nod_cc.cc
+
+testrunner_LDADD += \
+	$(BOOST_FILESYSTEM_LIBS)
+testrunner_LDFLAGS += \
+	$(BOOST_FILESYSTEM_LDFLAGS)
+endif
 
 if BOTAN
 pdns_recursor_SOURCES += \

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -78,8 +78,11 @@ AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
   fi
 ])
 
-BOOST_FILESYSTEM
-AS_IF([test -z "$BOOST_FILESYSTEM_LIBS"], [ AC_MSG_ERROR([Boost filesystem library is not installed])])
+AS_IF([test "x$NOD_ENABLED" != "xn"],
+  [
+  BOOST_FILESYSTEM
+  AS_IF([test -z "$BOOST_FILESYSTEM_LIBS"], [ AC_MSG_ERROR([Boost filesystem library is not installed])])],
+  [])
 
 PDNS_CHECK_CLOCK_GETTIME
 

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -78,12 +78,6 @@ AC_DEFUN([PDNS_SELECT_CONTEXT_IMPL], [
   fi
 ])
 
-AS_IF([test "x$NOD_ENABLED" != "xn"],
-  [
-  BOOST_FILESYSTEM
-  AS_IF([test -z "$BOOST_FILESYSTEM_LIBS"], [ AC_MSG_ERROR([Boost filesystem library is not installed])])],
-  [])
-
 PDNS_CHECK_CLOCK_GETTIME
 
 boost_required_version=1.35
@@ -145,6 +139,12 @@ AC_ARG_WITH([socketdir],
 )
 
 PDNS_ENABLE_NOD
+
+AM_COND_IF([NOD_ENABLED],
+  [
+  BOOST_FILESYSTEM
+  AS_IF([test -z "$BOOST_FILESYSTEM_LIBS"], [ AC_MSG_ERROR([Boost filesystem library is not installed])])],
+  [])
 
 AC_SUBST([nodcachedir])
 nodcachedir='${prefix}/var/lib/pdns-recursor'
@@ -248,7 +248,7 @@ AS_IF([test "x$systemd" != "xn"],
   [AC_MSG_NOTICE([systemd: yes])],
   [AC_MSG_NOTICE([systemd: no])]
 )
-AS_IF([test "x$NOD_ENABLED" != "xn"],
+AM_COND_IF([NOD_ENABLED],
   [AC_MSG_NOTICE([nod: yes])],
   [AC_MSG_NOTICE([nod: no])]
 )

--- a/pdns/recursordist/m4/pdns_enable_nod.m4
+++ b/pdns/recursordist/m4/pdns_enable_nod.m4
@@ -13,5 +13,7 @@ AC_DEFUN([PDNS_ENABLE_NOD],[
     [AC_DEFINE([NOD_ENABLED], [1], [Define to 1 if nod is enabled])]
   )
 
+  AM_CONDITIONAL([NOD_ENABLED], [test "x$enable_nod" != "xno"])
+
   AC_MSG_RESULT([$enable_nod])
 ])


### PR DESCRIPTION
### Short description
Newly Observed Domain support is configured via a configure option, however the compilation was still including the NOD source files and requiring boost filesystem.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
