### PR TITLE
dnsdist: add EDNSOptionRule

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -404,6 +404,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "QTypeRule", true, "qtype", "matches queries with the specified qtype" },
   { "RCodeRule", true, "rcode", "matches responses with the specified rcode" },
   { "ERCodeRule", true, "rcode", "matches responses with the specified extended rcode (EDNS0)" },
+  { "EDNSOptionRule", true, "optcode", "matches queries with the specified EDNS0 option present" },
   { "sendCustomTrap", true, "str", "send a custom `SNMP` trap from Lua, containing the `str` string"},
   { "setACL", true, "{netmask, netmask}", "replace the ACL set with these netmasks. Use `setACL({})` to reset the list, meaning no one can use us" },
   { "setAPIWritable", true, "bool, dir", "allow modifications via the API. if `dir` is set, it must be a valid directory where the configuration files will be written by the API" },

--- a/pdns/dnsdist-ecs.hh
+++ b/pdns/dnsdist-ecs.hh
@@ -28,3 +28,4 @@ void generateOptRR(const std::string& optRData, string& res);
 int removeEDNSOptionFromOPT(char* optStart, size_t* optLen, const uint16_t optionCodeToRemove);
 int rewriteResponseWithoutEDNSOption(const std::string& initialPacket, const uint16_t optionCodeToSkip, vector<uint8_t>& newContent);
 int getEDNSOptionsStart(char* packet, const size_t offset, const size_t len, char ** optRDLen, size_t * remaining);
+bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const size_t optLen, const uint16_t optionCodeToFind);

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -417,6 +417,10 @@ void setupLuaRules()
       return std::shared_ptr<DNSRule>(new ERCodeRule(rcode));
     });
 
+  g_lua.writeFunction("EDNSOptionRule", [](uint16_t optcode) {
+      return std::shared_ptr<DNSRule>(new EDNSOptionRule(optcode));
+    });
+
   g_lua.writeFunction("showRules", [](boost::optional<ruleparams_t> vars) {
       showRules(&g_rulactions, vars);
     });

--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "dnsdist.hh"
+#include "ednsoptions.hh"
 
 void setupLuaVars()
 {
@@ -70,17 +71,17 @@ void setupLuaVars()
     });
 
   g_lua.writeVariable("EDNSOptionCode", std::unordered_map<string,int>{
-      {"NSID",          3 },
-      {"DAU",           5 },
-      {"DHU",           6 },
-      {"N3U",           7 },
-      {"ECS",           8 },
-      {"EXPIRE",        9 },
-      {"COOKIE",       10 },
-      {"TCPKEEPALIVE", 11 },
-      {"PADDING",      12 },
-      {"CHAIN",        13 },
-      {"KEYTAG",       14 }
+      {"NSID",         EDNSOptionCode::NSID },
+      {"DAU",          EDNSOptionCode::DAU },
+      {"DHU",          EDNSOptionCode::DHU },
+      {"N3U",          EDNSOptionCode::N3U },
+      {"ECS",          EDNSOptionCode::ECS },
+      {"EXPIRE",       EDNSOptionCode::EXPIRE },
+      {"COOKIE",       EDNSOptionCode::COOKIE },
+      {"TCPKEEPALIVE", EDNSOptionCode::TCPKEEPALIVE },
+      {"PADDING",      EDNSOptionCode::PADDING },
+      {"CHAIN",        EDNSOptionCode::CHAIN },
+      {"KEYTAG",       EDNSOptionCode::KEYTAG }
     });
 
   vector<pair<string, int> > rcodes = {{"NOERROR",  RCode::NoError  },

--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -69,6 +69,20 @@ void setupLuaVars()
       {"Additional",3 }
     });
 
+  g_lua.writeVariable("EDNSOptionCode", std::unordered_map<string,int>{
+      {"NSID",          3 },
+      {"DAU",           5 },
+      {"DHU",           6 },
+      {"N3U",           7 },
+      {"ECS",           8 },
+      {"EXPIRE",        9 },
+      {"COOKIE",       10 },
+      {"TCPKEEPALIVE", 11 },
+      {"PADDING",      12 },
+      {"CHAIN",        13 },
+      {"KEYTAG",       14 }
+    });
+
   vector<pair<string, int> > rcodes = {{"NOERROR",  RCode::NoError  },
                                        {"FORMERR",  RCode::FormErr  },
                                        {"SERVFAIL", RCode::ServFail },

--- a/pdns/dnsdistdist/docs/reference/constants.rst
+++ b/pdns/dnsdistdist/docs/reference/constants.rst
@@ -58,6 +58,26 @@ RCodes below and including ``BADVERS`` are extended RCodes that can only be matc
 
 Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 
+
+.. _EDNSOptionCode:
+
+EDNSOptionCode
+--------------
+
+- ``EDNSOptionCode.DHU``
+- ``EDNSOptionCode.ECS``
+- ``EDNSOptionCode.N3U``
+- ``EDNSOptionCode.DAU``
+- ``EDNSOptionCode.TCPKEEPALIVE``
+- ``EDNSOptionCode.COOKIE``
+- ``EDNSOptionCode.PADDING``
+- ``EDNSOptionCode.KEYTAG``
+- ``EDNSOptionCode.NSID``
+- ``EDNSOptionCode.CHAIN``
+- ``EDNSOptionCode.EXPIRE``
+
+Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-11
+
 .. _DNSSection:
 
 DNS Section

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -638,6 +638,13 @@ These ``DNSRule``\ s be one of the following items:
 
   :param int rcode: The RCODE to match on
 
+.. function:: EDNSOptionRule(optcode)
+
+  .. versionadded:: 1.4.0
+
+  Matches queries or responses with the specified EDNS option present.
+  ``optcode`` is specified as an integer.
+
 .. function:: RDRule()
 
   .. versionadded:: 1.2.0

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -643,7 +643,7 @@ These ``DNSRule``\ s be one of the following items:
   .. versionadded:: 1.4.0
 
   Matches queries or responses with the specified EDNS option present.
-  ``optcode`` is specified as an integer.
+  ``optcode`` is specified as an integer, or a constant such as `EDNSOptionCode.ECS`.
 
 .. function:: RDRule()
 

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -1628,7 +1628,7 @@ class TestAdvancedEDNSOptionRule(DNSDistTest):
 
     _config_template = """
     newServer{address="127.0.0.1:%s"}
-    addAction(EDNSOptionRule(8), DropAction())
+    addAction(EDNSOptionRule(EDNSOptionCode.ECS), DropAction())
     """
 
     def testDropped(self):


### PR DESCRIPTION
### Short description
This adds `EDNSOptionRule`, used as follows (8 is edns-client-subnet):
```
warnlog(string.format("Script starting %s", "up!"))

newServer({address="8.8.8.8", pool="g1"})
newServer({address="8.8.4.4", pool="g2"})

addAction(EDNSOptionRule(8), PoolAction("g1"))
addAction(AllRule(), PoolAction("g2"))

getServer(0):setUp()
getServer(1):setUp()
```

Needs:
- [x] tests
- [x] documentation
- [ ] a good review of the pointer mangling that I cargo culted from another function in dnsdist-ecs.cc

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
