### PR TITLE
recursor tests: replace awk command by perl

### DIFF
--- a/build-scripts/test-recursor
+++ b/build-scripts/test-recursor
@@ -46,7 +46,7 @@ sleep 3
 svstat configs/*
 ## prints the logs of supervised processes reported as running for less than 3 secs
 for config in configs/* ; do
-    secs=$(svstat ${config} | perl -pe 's!.+(\d+) seconds!\1!')
+    secs=$(svstat ${config} | perl -pe 's!.* (\d+) seconds!\1!')
     if [ -n "${secs}" ] && [ ${secs} -lt 3 ] ; then
         echo "-----------------"
         echo "Logs of ${config}"

--- a/build-scripts/test-recursor
+++ b/build-scripts/test-recursor
@@ -46,7 +46,7 @@ sleep 3
 svstat configs/*
 ## prints the logs of supervised processes reported as running for less than 3 secs
 for config in configs/* ; do
-    secs=$(svstat ${config} | awk 'match($0, /([0-9]+) seconds/, r) { print r[1] }')
+    secs=$(svstat ${config} | perl -pe 's!.+(\d+) seconds!\1!')
     if [ -n "${secs}" ] && [ ${secs} -lt 3 ] ; then
         echo "-----------------"
         echo "Logs of ${config}"


### PR DESCRIPTION
### Short description
Looks like mawk `match()` has a slightly different signature/behaviour than gawk. This replaces awk usage by perl.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
