### PR TITLE
[do not merge] apply ALIAS scopemask after chasing

### DIFF
--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -88,7 +88,7 @@ void DNSProxy::go()
 }
 
 //! look up qname target with r->qtype, plonk it in the answer section of 'r' with name aname
-bool DNSProxy::completePacket(DNSPacket *r, const DNSName& target,const DNSName& aname)
+bool DNSProxy::completePacket(DNSPacket *r, const DNSName& target,const DNSName& aname, const uint8_t scopeMask)
 {
   if(r->d_tcp) {
     vector<DNSZoneRecord> ips;
@@ -106,6 +106,7 @@ bool DNSProxy::completePacket(DNSPacket *r, const DNSName& target,const DNSName&
     for (auto &ip : ips)
     {
       ip.dr.d_name = aname;
+      ip.scopeMask = scopeMask;
       r->addRecord(ip);
     }
 
@@ -132,6 +133,7 @@ bool DNSProxy::completePacket(DNSPacket *r, const DNSName& target,const DNSName&
     ce.anyLocal = r->d_anyLocal;
     ce.complete = r;
     ce.aname=aname;
+    ce.anameScopeMask = scopeMask;
     d_conntrack[id]=ce;
   }
 
@@ -247,6 +249,7 @@ void DNSProxy::mainloop(void)
 	      if(j->first.d_type == i->second.qtype || (i->second.qtype == QType::ANY && (j->first.d_type == QType::A || j->first.d_type == QType::AAAA))) {
                 DNSZoneRecord dzr;
 		dzr.dr.d_name=i->second.aname;
+		dzr.scopeMask=i->second.anameScopeMask;
 		dzr.dr.d_type = j->first.d_type;
 		dzr.dr.d_ttl=j->first.d_ttl;
 		dzr.dr.d_place= j->first.d_place;

--- a/pdns/dnsproxy.hh
+++ b/pdns/dnsproxy.hh
@@ -54,7 +54,7 @@ public:
   DNSProxy(const string &ip); //!< creates socket
   ~DNSProxy(); //<! dtor for DNSProxy
   void go(); //!< launches the actual thread
-  bool completePacket(DNSPacket *r, const DNSName& target,const DNSName& aname);
+  bool completePacket(DNSPacket *r, const DNSName& target,const DNSName& aname, const uint8_t scopeMask);
 
   void mainloop();                  //!< this is the main loop that receives reply packets and sends them out again
   static void *launchhelper(void *p)
@@ -71,6 +71,7 @@ private:
     DNSName qname;
     DNSPacket* complete;
     DNSName aname;
+    uint8_t anameScopeMask;
     ComboAddress remote;
     uint16_t id;
     uint16_t qtype;

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1119,6 +1119,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
   vector<DNSZoneRecord> rrset;
   bool weDone=0, weRedirected=0, weHaveUnauth=0;
   DNSName haveAlias;
+  uint8_t aliasScopeMask;
 
   DNSPacket *r=0;
   bool noCache=false;
@@ -1353,6 +1354,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     B.lookup(QType(QType::ANY), target, p, sd.domain_id);
     rrset.clear();
     haveAlias.trimToLabels(0);
+    aliasScopeMask = 0;
     weDone = weRedirected = weHaveUnauth =  false;
     
     while(B.get(rr)) {
@@ -1409,6 +1411,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
           continue;
         }
         haveAlias=getRR<ALIASRecordContent>(rr.dr)->d_content;
+        aliasScopeMask=rr.scopeMask;
       }
 
       // Filter out all SOA's and add them in later
@@ -1440,7 +1443,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
 
     if(!haveAlias.empty() && (!weDone || p->qtype.getCode() == QType::ANY)) {
       DLOG(g_log<<Logger::Warning<<"Found nothing that matched for '"<<target<<"', but did get alias to '"<<haveAlias<<"', referring"<<endl);
-      DP->completePacket(r, haveAlias, target);
+      DP->completePacket(r, haveAlias, target, aliasScopeMask);
       return 0;
     }
 


### PR DESCRIPTION
### Short description
Before this patch, the scopebits on an ALIAS result from a backend would be thrown away. With this patch, we pass the scopebits down into the dnsproxy so it can apply it to the resulting A/AAAA records.

Related: #5469 

Should this be configurable?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
