### PR TITLE
dnsdist: DSTPortRule 

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -342,6 +342,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "DnstapLogResponseAction", true, "identity, FrameStreamLogger [, alterFunction]", "send the contents of this response to a remote or FrameStreamLogger or RemoteLogger as dnstap. `alterFunction` is a callback, receiving a DNSResponse and a DnstapMessage, that can be used to modify the dnstap message" },
   { "DropAction", true, "", "drop these packets" },
   { "DropResponseAction", true, "", "drop these packets" },
+  { "DSTPortRule", true, "port", "matches questions received to the destination port specified" },
   { "dumpStats", true, "", "print all statistics we gather" },
   { "exceedNXDOMAINs", true, "rate, seconds", "get set of addresses that exceed `rate` NXDOMAIN/s over `seconds` seconds" },
   { "dynBlockRulesGroup", true, "", "return a new DynBlockRulesGroup object" },

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -373,6 +373,10 @@ void setupLuaRules()
       return std::shared_ptr<DNSRule>(new OrRule(a));
     });
 
+  g_lua.writeFunction("DSTPortRule", [](uint16_t port) {
+      return std::shared_ptr<DNSRule>(new DSTPortRule(port));
+    });
+
   g_lua.writeFunction("TCPRule", [](bool tcp) {
       return std::shared_ptr<DNSRule>(new TCPRule(tcp));
     });

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -603,11 +603,10 @@ class DSTPortRule : public DNSRule
 public:
   DSTPortRule(uint16_t port) : d_port(port)
   {
-    d_port_htons = htons(d_port);
   }
   bool matches(const DNSQuestion* dq) const override
   {
-    return d_port_htons == dq->local->sin4.sin_port;
+    return htons(d_port) == dq->local->sin4.sin_port;
   }
   string toString() const override
   {

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -598,6 +598,26 @@ private:
   uint8_t d_opcode;
 };
 
+class DSTPortRule : public DNSRule
+{
+public:
+  DSTPortRule(uint16_t port) : d_port(port)
+  {
+    d_port_htons = htons(d_port);
+  }
+  bool matches(const DNSQuestion* dq) const override
+  {
+    return d_port_htons == dq->local->sin4.sin_port;
+  }
+  string toString() const override
+  {
+    return "dst port=="+std::to_string(d_port);
+  }
+private:
+  uint16_t d_port;
+  uint16_t d_port_htons;
+};
+
 class TCPRule : public DNSRule
 {
 public:

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -614,7 +614,6 @@ public:
   }
 private:
   uint16_t d_port;
-  uint16_t d_port_htons;
 };
 
 class TCPRule : public DNSRule

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -714,6 +714,12 @@ These ``DNSRule``\ s be one of the following items:
 
   :param bool tcp: Match TCP traffic. Default is true.
 
+.. function:: DSTPortRule(port)
+
+  Matches questions received to the destination port.
+
+  :param int port: Match destination port.
+
 .. function:: TrailingDataRule()
 
   Matches if the query has trailing data.

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -1021,6 +1021,33 @@ class TestAdvancedNMGRule(DNSDistTest):
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
         self.assertEquals(receivedResponse, expectedResponse)
 
+class TestDSTPortRule(DNSDistTest):
+
+    _config_params = ['_dnsDistPort', '_testServerPort']
+    _config_template = """
+    addAction(DSTPortRule(%d), RCodeAction(dnsdist.REFUSED))
+    newServer{address="127.0.0.1:%s"}
+    """
+
+    def testDSTPortRule(self):
+        """
+        Advanced: DSTPortRule should capture our queries
+
+        Send queries to "dstportrule.advanced.tests.powerdns.com.",
+        check that we are getting a REFUSED response.
+        """
+
+        name = 'dstportrule.advanced.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+
+        (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
+        (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
+        self.assertEquals(receivedResponse, expectedResponse)
+
 class TestAdvancedLabelsCountRule(DNSDistTest):
 
     _config_template = """


### PR DESCRIPTION
### Short description
Allows matching based on the destination port of the question. This allows one to apply more powerful rules to ports bound for DoT for instance.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
