### PR TITLE
add incremental slave-check backoff also for failed AXFR 

### DIFF
--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -109,7 +109,12 @@ back on checking the domain for
 :ref:`setting-soa-retry-default` seconds
 between checks. With default settings, this means that PowerDNS will
 back off for 1, then 2, then 3 etc. minutes, to a maximum of 60 minutes
-between checks.
+between checks. The same hold back algorithm is also applied if the zone
+transfer fails due to problems on the master, i.e. if zone transfer is
+not allowed.
+
+Receiving a NOTIFY immediately clears the back off period for the
+respective domain to allow immediately freshness checks for this domain.
 
 .. warning::
   Slave support is OFF by default, turn it on by adding

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -615,17 +615,20 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote)
     }
   }
   catch(ResolverException &re) {
-    // The AXFR probably failed due to a problem on the master server. If SOA-checks against this master
-    // still succeed, we would constantly try to AXFR the zone. To avoid this, we add the zone to the list of
-    // failed slave-checks. This will suspend slave-checks (and subsequent AXFR) for this zone for some time.
-    uint64_t newCount = 1;
-    time_t now = time(0);
-    const auto failedEntry = d_failedSlaveRefresh.find(domain);
-    if (failedEntry != d_failedSlaveRefresh.end())
-      newCount = d_failedSlaveRefresh[domain].first + 1;
-    time_t nextCheck = now + std::min(newCount * d_tickinterval, (uint64_t)::arg().asNum("soa-retry-default"));
-    d_failedSlaveRefresh[domain] = {newCount, nextCheck};
-    g_log<<Logger::Error<<"Unable to AXFR zone '"<<domain<<"' from remote '"<<remote<<"' (resolver): "<<re.reason<<" (This was the "<<(newCount == 1 ? "first" : std::to_string(newCount) + "th")<<" time. Excluding zone from slave-checks until "<<nextCheck<<")"<<endl;
+    {
+      Lock l(&d_lock);
+      // The AXFR probably failed due to a problem on the master server. If SOA-checks against this master
+      // still succeed, we would constantly try to AXFR the zone. To avoid this, we add the zone to the list of
+      // failed slave-checks. This will suspend slave-checks (and subsequent AXFR) for this zone for some time.
+      uint64_t newCount = 1;
+      time_t now = time(0);
+      const auto failedEntry = d_failedSlaveRefresh.find(domain);
+      if (failedEntry != d_failedSlaveRefresh.end())
+        newCount = d_failedSlaveRefresh[domain].first + 1;
+      time_t nextCheck = now + std::min(newCount * d_tickinterval, (uint64_t)::arg().asNum("soa-retry-default"));
+      d_failedSlaveRefresh[domain] = {newCount, nextCheck};
+      g_log<<Logger::Error<<"Unable to AXFR zone '"<<domain<<"' from remote '"<<remote<<"' (resolver): "<<re.reason<<" (This was the "<<(newCount == 1 ? "first" : std::to_string(newCount) + "th")<<" time. Excluding zone from slave-checks until "<<nextCheck<<")"<<endl;
+    }
     if(di.backend && transaction) {
       g_log<<Logger::Error<<"Aborting possible open transaction for domain '"<<domain<<"' AXFR"<<endl;
       di.backend->abortTransaction();

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -615,7 +615,17 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote)
     }
   }
   catch(ResolverException &re) {
-    g_log<<Logger::Error<<"Unable to AXFR zone '"<<domain<<"' from remote '"<<remote<<"' (resolver): "<<re.reason<<endl;
+    // The AXFR probably failed due to a problem on the master server. If SOA-checks against this master
+    // still succeed, we would constantly try to AXFR the zone. To avoid this, we add the zone to the list of
+    // failed slave-checks. This will suspend slave-checks (and subsequent AXFR) for this zone for some time.
+    uint64_t newCount = 1;
+    time_t now = time(0);
+    const auto failedEntry = d_failedSlaveRefresh.find(domain);
+    if (failedEntry != d_failedSlaveRefresh.end())
+      newCount = d_failedSlaveRefresh[domain].first + 1;
+    time_t nextCheck = now + std::min(newCount * d_tickinterval, (uint64_t)::arg().asNum("soa-retry-default"));
+    d_failedSlaveRefresh[domain] = {newCount, nextCheck};
+    g_log<<Logger::Error<<"Unable to AXFR zone '"<<domain<<"' from remote '"<<remote<<"' (resolver): "<<re.reason<<" (This was the "<<(newCount == 1 ? "first" : std::to_string(newCount) + "th")<<" time. Excluding zone from slave-checks until "<<nextCheck<<")"<<endl;
     if(di.backend && transaction) {
       g_log<<Logger::Error<<"Aborting possible open transaction for domain '"<<domain<<"' AXFR"<<endl;
       di.backend->abortTransaction();


### PR DESCRIPTION
### Short description
If SOA-checks against a master with failing AXFR still succeed, we would
constantly try to AXFR the zone. To avoid this, we add the zone to the list
of failed slave-checks to suspend slave-checks (and subsequent AXFR) for
this zone for some time.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
