### PR TITLE
On incoming NOTIFY load our serial from backend to have it available …

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -887,7 +887,7 @@ int PacketHandler::processNotify(DNSPacket *p)
   // Domain verification
   //
   DomainInfo di;
-  if(!B.getDomainInfo(p->qdomain, di, false) || !di.backend) {
+  if(!B.getDomainInfo(p->qdomain, di, true) || !di.backend) {
     if(::arg().mustDo("supermaster")) {
       g_log<<Logger::Warning<<"Received NOTIFY for "<<p->qdomain<<" from "<<p->getRemote()<<" for which we are not authoritative, trying supermaster"<<endl;
       return trySuperMaster(p, p->getTSIGKeyname());
@@ -921,7 +921,7 @@ int PacketHandler::processNotify(DNSPacket *p)
   }
 
   if(::arg().mustDo("slave")) {
-    g_log<<Logger::Debug<<"Queueing slave check for "<<p->qdomain<<endl;
+    g_log<<Logger::Debug<<"Queueing slave check for "<<p->qdomain<<", our serial is "<<di.serial<<endl;
     Communicator.addSlaveCheckRequest(di, p->d_remote);
   }
   return 0;


### PR DESCRIPTION
### Short description
On incoming NOTIFY load our serial from backend to have it available during slave-check.

Also log ourserial to ease debugging.

Fixes #6821 
### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
