### PR TITLE
add option send-signed-notify to send NOTIFYs without TSIG signature

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1260,7 +1260,7 @@ Number of AXFR slave threads to start.
 If yes, outgoing NOTIFYs will be signed if a TSIG key is configured for the zone.
 If there are multiple TSIG keys configured for a domain, PowerDNS will use the
 first one retrieved from the backend, which may not be the correct one for the
-respective slave. Hence, in setups with mutliple slaves with different TSIG keys
+respective slave. Hence, in setups with multiple slaves with different TSIG keys
 it may be required to send NOTIFYs unsigned.
 
 .. _setting-setgid:

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1249,6 +1249,20 @@ resolvers.
 
 Number of AXFR slave threads to start.
 
+.. _setting-send-signed-notify:
+
+``send-signed-notify``
+----------
+
+-  Boolean
+-  Default: yes
+
+If yes, outgoing NOTIFYs will be signed if a TSIG key is configured for the zone.
+If there are multiple TSIG keys configured for a domain, PowerDNS will use the
+first one retrieved from the backend, which may not be the correct one for the
+respective slave. Hence, in setups with mutliple slaves with different TSIG keys
+it may be required to send NOTIFYs unsigned.
+
 .. _setting-setgid:
 
 ``setgid``

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -74,6 +74,7 @@ void declareArguments()
   ::arg().setSwitch("dnsupdate","Enable/Disable DNS update (RFC2136) support. Default is no.")="no";
   ::arg().setSwitch("write-pid","Write a PID file")="yes";
   ::arg().set("allow-dnsupdate-from","A global setting to allow DNS updates from these IP ranges.")="127.0.0.0/8,::1";
+  ::arg().setSwitch("send-signed-notify","Send TSIG secured NOTIFY if TSIG key is configured for a domain")="yes";
   ::arg().set("allow-unsigned-notify","Allow unsigned notifications for TSIG secured domains")="yes"; //FIXME: change to 'no' later
   ::arg().set("allow-unsigned-supermaster", "Allow supermasters to create zones without TSIG signed NOTIFY")="yes";
   ::arg().setSwitch("forward-dnsupdate","A global setting to allow DNS update packages that are for a Slave domain, to be forwarded to the master.")="yes";

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -232,7 +232,7 @@ void CommunicatorClass::sendNotification(int sock, const DNSName& domain, const 
   string tsigsecret64;
   string tsigsecret;
 
-  if (B.getDomainMetadata(domain, "TSIG-ALLOW-AXFR", meta) && meta.size() > 0) {
+  if (::arg().mustDo("send-signed-notify") && B.getDomainMetadata(domain, "TSIG-ALLOW-AXFR", meta) && meta.size() > 0) {
     tsigkeyname = DNSName(meta[0]);
   }
 


### PR DESCRIPTION
### Short description
If there are multiple TSIG keys configured for a domain, PowerDNS will use the
first one retrieved from the backend, which may not be the correct one for the
respective slave. Hence, in setups with multiple slaves with different TSIG keys
it may be required to send NOTIFYs unsigned.
 
### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
