### PR TITLE
Get rid of some allocs/copies in DNS parsing

### DIFF
--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -232,12 +232,7 @@ bool TinyDNSBackend::get(DNSResourceRecord &rr)
     }
 
 
-    vector<uint8_t> bytes;
-    const char *sval = val.c_str();
-    unsigned int len = val.size();
-    bytes.resize(len);
-    copy(sval, sval+len, bytes.begin());
-    PacketReader pr(bytes);
+    PacketReader pr(val, 0);
     rr.qtype = QType(pr.get16BitInt());
 
     if(d_isAxfr || d_qtype.getCode() == QType::ANY || rr.qtype == d_qtype) {
@@ -298,7 +293,7 @@ bool TinyDNSBackend::get(DNSResourceRecord &rr)
         DNSRecord dr;
         dr.d_class = 1;
         dr.d_type = rr.qtype.getCode();
-        dr.d_clen = val.size()-pr.d_pos;
+        dr.d_clen = val.size()-pr.getPosition();
 
         auto drc = DNSRecordContent::mastermake(dr, pr);
         rr.content = drc->getZoneRepresentation();

--- a/pdns/dnsdist-ecs.hh
+++ b/pdns/dnsdist-ecs.hh
@@ -21,10 +21,10 @@
  */
 #pragma once
 
-int rewriteResponseWithoutEDNS(const char * packet, size_t len, vector<uint8_t>& newContent);
-int locateEDNSOptRR(char * packet, size_t len, char ** optStart, size_t * optLen, bool * last);
+int rewriteResponseWithoutEDNS(const std::string& initialPacket, vector<uint8_t>& newContent);
+int locateEDNSOptRR(const std::string& packet, uint16_t * optStart, size_t * optLen, bool * last);
 bool handleEDNSClientSubnet(char * packet, size_t packetSize, unsigned int consumed, uint16_t * len, bool* ednsAdded, bool* ecsAdded, const ComboAddress& remote, bool overrideExisting, uint16_t ecsPrefixLength);
 void generateOptRR(const std::string& optRData, string& res);
 int removeEDNSOptionFromOPT(char* optStart, size_t* optLen, const uint16_t optionCodeToRemove);
-int rewriteResponseWithoutEDNSOption(const char * packet, const size_t len, const uint16_t optionCodeToSkip, vector<uint8_t>& newContent);
+int rewriteResponseWithoutEDNSOption(const std::string& initialPacket, const uint16_t optionCodeToSkip, vector<uint8_t>& newContent);
 int getEDNSOptionsStart(char* packet, const size_t offset, const size_t len, char ** optRDLen, size_t * remaining);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -273,7 +273,7 @@ bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize,
   }
 
   if (ednsAdded || ecsAdded) {
-    uint16_t optStart = NULL;
+    uint16_t optStart;
     size_t optLen = 0;
     bool last = false;
 

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -109,7 +109,7 @@ shared_ptr<DNSRecordContent> DNSRecordContent::unserialize(const DNSName& qname,
 
   struct dnsrecordheader drh;
   drh.d_type=htons(qtype);
-  drh.d_class=htons(1);
+  drh.d_class=htons(QClass::IN);
   drh.d_ttl=0;
   drh.d_clen=htons(serialized.size());
 
@@ -221,12 +221,12 @@ DNSResourceRecord DNSResourceRecord::fromWire(const DNSRecord& d) {
   return rr;
 }
 
-void MOADNSParser::init(bool query, const char *packet, unsigned int len)
+void MOADNSParser::init(bool query, const std::string& packet)
 {
-  if(len < sizeof(dnsheader))
+  if (packet.size() < sizeof(dnsheader))
     throw MOADNSException("Packet shorter than minimal header");
   
-  memcpy(&d_header, packet, sizeof(dnsheader));
+  memcpy(&d_header, packet.data(), sizeof(dnsheader));
 
   if(d_header.opcode != Opcode::Query && d_header.opcode != Opcode::Notify && d_header.opcode != Opcode::Update)
     throw MOADNSException("Can't parse non-query packet with opcode="+ std::to_string(d_header.opcode));
@@ -238,15 +238,10 @@ void MOADNSParser::init(bool query, const char *packet, unsigned int len)
 
   if (query && (d_header.qdcount > 1))
     throw MOADNSException("Query with QD > 1 ("+std::to_string(d_header.qdcount)+")");
-
-  uint16_t contentlen=len-sizeof(dnsheader);
-
-  d_content.resize(contentlen);
-  copy(packet+sizeof(dnsheader), packet+len, d_content.begin());
   
   unsigned int n=0;
 
-  PacketReader pr(d_content);
+  PacketReader pr(packet);
   bool validPacket=false;
   try {
     d_qtype = d_qclass = 0; // sometimes replies come in with no question, don't present garbage then
@@ -272,7 +267,7 @@ void MOADNSParser::init(bool query, const char *packet, unsigned int len)
       else 
         dr.d_place=DNSResourceRecord::ADDITIONAL;
 
-      unsigned int recordStartPos=pr.d_pos;
+      unsigned int recordStartPos=pr.getPosition();
 
       DNSName name=pr.getName();
 
@@ -295,7 +290,7 @@ void MOADNSParser::init(bool query, const char *packet, unsigned int len)
         dr.d_content=DNSRecordContent::mastermake(dr, pr, d_header.opcode);
       }
 
-      d_answers.push_back(make_pair(dr, pr.d_pos));
+      d_answers.push_back(make_pair(dr, pr.getPosition() - sizeof(dnsheader)));
 
       /* XXX: XPF records should be allowed after TSIG as soon as the actual XPF option code has been assigned:
          if (dr.d_place == DNSResourceRecord::ADDITIONAL && seenTSIG && dr.d_type != QType::XPF)
@@ -310,18 +305,18 @@ void MOADNSParser::init(bool query, const char *packet, unsigned int len)
           throw MOADNSException("Packet ("+d_qname.toLogString()+"|#"+std::to_string(d_qtype)+") has a TSIG record in an invalid position.");
         }
         seenTSIG = true;
-        d_tsigPos = recordStartPos + sizeof(struct dnsheader);
+        d_tsigPos = recordStartPos;
       }
     }
 
 #if 0
-    if(pr.d_pos!=contentlen) {
-      throw MOADNSException("Packet ("+d_qname+"|#"+std::to_string(d_qtype)+") has trailing garbage ("+ std::to_string(pr.d_pos) + " < " + 
-                            std::to_string(contentlen) + ")");
+    if(pr.getPosition()!=packet.size()) {
+      throw MOADNSException("Packet ("+d_qname+"|#"+std::to_string(d_qtype)+") has trailing garbage ("+ std::to_string(pr.getPosition()) + " < " +
+                            std::to_string(packet.size()) + ")");
     }
 #endif
   }
-  catch(std::out_of_range &re) {
+  catch(const std::out_of_range &re) {
     if(validPacket && d_header.tc) { // don't sweat it over truncated packets, but do adjust an, ns and arcount
       if(n < d_header.ancount) {
         d_header.ancount=n; d_header.nscount = d_header.arcount = 0;
@@ -334,7 +329,7 @@ void MOADNSParser::init(bool query, const char *packet, unsigned int len)
       }
     }
     else {
-      throw MOADNSException("Error parsing packet of "+std::to_string(len)+" bytes (rd="+
+      throw MOADNSException("Error parsing packet of "+std::to_string(packet.size())+" bytes (rd="+
                             std::to_string(d_header.rd)+
                             "), out of bounds: "+string(re.what()));
     }
@@ -383,29 +378,29 @@ void PacketReader::copyRecord(unsigned char* dest, uint16_t len)
 void PacketReader::xfr48BitInt(uint64_t& ret)
 {
   ret=0;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   ret<<=8;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   ret<<=8;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   ret<<=8;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   ret<<=8;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   ret<<=8;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
 }
 
 uint32_t PacketReader::get32BitInt()
 {
   uint32_t ret=0;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   ret<<=8;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   ret<<=8;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   ret<<=8;
-  ret+=d_content.at(d_pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   
   return ret;
 }
@@ -413,15 +408,10 @@ uint32_t PacketReader::get32BitInt()
 
 uint16_t PacketReader::get16BitInt()
 {
-  return get16BitInt(d_content, d_pos);
-}
-
-uint16_t PacketReader::get16BitInt(const vector<unsigned char>&content, uint16_t& pos)
-{
   uint16_t ret=0;
-  ret+=content.at(pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   ret<<=8;
-  ret+=content.at(pos++);
+  ret+=static_cast<uint8_t>(d_content.at(d_pos++));
   
   return ret;
 }
@@ -435,10 +425,8 @@ DNSName PacketReader::getName()
 {
   unsigned int consumed;
   try {
-    DNSName dn((const char*) d_content.data() - 12, d_content.size() + 12, d_pos + sizeof(dnsheader), true /* uncompress */, 0 /* qtype */, 0 /* qclass */, &consumed, sizeof(dnsheader));
+    DNSName dn((const char*) d_content.data(), d_content.size(), d_pos, true /* uncompress */, 0 /* qtype */, 0 /* qclass */, &consumed, sizeof(dnsheader));
     
-    // the -12 fakery is because we don't have the header in 'd_content', but we do need to get 
-    // the internal offsets to work
     d_pos+=consumed;
     return dn;
   }
@@ -482,7 +470,7 @@ string PacketReader::getText(bool multi, bool lenField)
     }
     uint16_t labellen;
     if(lenField)
-      labellen=d_content.at(d_pos++);
+      labellen=static_cast<uint8_t>(d_content.at(d_pos++));
     else
       labellen=d_recordlen - (d_pos - d_startrecordpos);
     
@@ -504,7 +492,7 @@ string PacketReader::getUnquotedText(bool lenField)
 {
   uint16_t stop_at;
   if(lenField)
-    stop_at = (uint8_t)d_content.at(d_pos) + d_pos + 1;
+    stop_at = static_cast<uint8_t>(d_content.at(d_pos)) + d_pos + 1;
   else
     stop_at = d_recordlen;
 

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -68,8 +68,8 @@ class MOADNSParser;
 class PacketReader
 {
 public:
-  PacketReader(const vector<uint8_t>& content) 
-    : d_pos(0), d_startrecordpos(0), d_content(content)
+  PacketReader(const std::string& content, uint16_t initialPos=sizeof(dnsheader))
+    : d_pos(initialPos), d_startrecordpos(initialPos), d_content(content)
   {
     if(content.size() > std::numeric_limits<uint16_t>::max())
       throw std::out_of_range("packet too large");
@@ -155,8 +155,6 @@ public:
   void xfrBlob(string& blob, int length);
   void xfrHexBlob(string& blob, bool keepReading=false);
 
-  static uint16_t get16BitInt(const vector<unsigned char>&content, uint16_t& pos);
-
   void getDnsrecordheader(struct dnsrecordheader &ah);
   void copyRecord(vector<unsigned char>& dest, uint16_t len);
   void copyRecord(unsigned char* dest, uint16_t len);
@@ -165,18 +163,28 @@ public:
   string getText(bool multi, bool lenField);
   string getUnquotedText(bool lenField);
 
-  uint16_t d_pos;
 
   bool eof() { return true; };
   const string getRemaining() const {
     return "";
   };
 
+  uint16_t getPosition() const
+  {
+    return d_pos;
+  }
+
+  void skip(uint16_t n)
+  {
+    d_pos += n;
+  }
+
 private:
+  uint16_t d_pos;
   uint16_t d_startrecordpos; // needed for getBlob later on
   uint16_t d_recordlen;      // ditto
   uint16_t not_used; // Aligns the whole class on 8-byte boundries
-  const vector<uint8_t>& d_content;
+  const std::string& d_content;
 };
 
 struct DNSRecord;
@@ -356,15 +364,15 @@ class MOADNSParser : public boost::noncopyable
 {
 public:
   //! Parse from a string
-  MOADNSParser(bool query, const string& buffer)  : d_tsigPos(0)
+  MOADNSParser(bool query, const string& buffer): d_tsigPos(0)
   {
-    init(query, buffer.c_str(), (unsigned int)buffer.size());
+    init(query, buffer);
   }
 
   //! Parse from a pointer and length
   MOADNSParser(bool query, const char *packet, unsigned int len) : d_tsigPos(0)
   {
-    init(query, packet, len);
+    init(query, std::string(packet, len));
   }
 
   DNSName d_qname;
@@ -377,21 +385,12 @@ public:
   //! All answers contained in this packet (everything *but* the question section)
   answers_t d_answers;
 
-  shared_ptr<PacketReader> getPacketReader(uint16_t offset)
-  {
-    shared_ptr<PacketReader> pr(new PacketReader(d_content));
-    pr->d_pos=offset;
-    return pr;
-  }
-
   uint16_t getTSIGPos() const
   {
     return d_tsigPos;
   }
 private:
-  void getDnsrecordheader(struct dnsrecordheader &ah);
-  void init(bool query, const char *packet, unsigned int len);
-  vector<uint8_t> d_content;
+  void init(bool query, const std::string& packet);
   uint16_t d_tsigPos;
 };
 

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -170,7 +170,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
 
     // sleep until we see an answer to this, interface to mtasker
     
-    ret=arecvfrom(const_cast<char *>(buf.data()), buf.size(), 0, ip, &len, qid,
+    ret=arecvfrom(buf, 0, ip, &len, qid,
                   domain, type, queryfd, now);
   }
   else {
@@ -248,7 +248,8 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
       // unexpected count has already been done @ pdns_recursor.cc
       goto out;
     }
-    
+
+    lwr->d_records.reserve(mdp.d_answers.size());
     for(const auto& a : mdp.d_answers)
       lwr->d_records.push_back(a.first);
 

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -94,7 +94,8 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
 {
   size_t len;
   size_t bufsize=g_outgoingEDNSBufsize;
-  scoped_array<unsigned char> buf(new unsigned char[bufsize]);
+  std::string buf;
+  buf.resize(bufsize);
   vector<uint8_t> vpacket;
   //  string mapped0x20=dns0x20(domain);
   uint16_t qid = dns_random(0xffff);
@@ -169,7 +170,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
 
     // sleep until we see an answer to this, interface to mtasker
     
-    ret=arecvfrom(reinterpret_cast<char *>(buf.get()), bufsize, 0, ip, &len, qid,
+    ret=arecvfrom(const_cast<char *>(buf.data()), buf.size(), 0, ip, &len, qid,
                   domain, type, queryfd, now);
   }
   else {
@@ -204,12 +205,8 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
       if(!(ret > 0))
         return ret;
       
-      if(len > bufsize) {
-        bufsize=len;
-        scoped_array<unsigned char> narray(new unsigned char[bufsize]);
-        buf.swap(narray);
-      }
-      memcpy(buf.get(), packet.c_str(), len);
+      buf.resize(len);
+      memcpy(const_cast<char*>(buf.data()), packet.c_str(), len);
 
       ret=1;
     }
@@ -225,10 +222,11 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
   if(ret <= 0) // includes 'timeout'
     return ret;
 
+  buf.resize(len);
   lwr->d_records.clear();
   try {
     lwr->d_tcbit=0;
-    MOADNSParser mdp(false, (const char*)buf.get(), len);
+    MOADNSParser mdp(false, buf);
     lwr->d_aabit=mdp.d_header.aa;
     lwr->d_tcbit=mdp.d_header.tc;
     lwr->d_rcode=mdp.d_header.rcode;

--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -45,7 +45,7 @@
 
 int asendto(const char *data, size_t len, int flags, const ComboAddress& ip, uint16_t id,
             const DNSName& domain, uint16_t qtype,  int* fd);
-int arecvfrom(char *data, size_t len, int flags, const ComboAddress& ip, size_t *d_len, uint16_t id,
+int arecvfrom(std::string& packet, int flags, const ComboAddress& ip, size_t *d_len, uint16_t id,
               const DNSName& domain, uint16_t qtype, int fd, struct timeval* now);
 
 class LWResException : public PDNSException

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -234,11 +234,11 @@ bool g_logRPZChanges{false};
 
 //! used to send information to a newborn mthread
 struct DNSComboWriter {
-  DNSComboWriter(const std::string& query, const struct timeval& now): d_mdp(true, query.c_str(), query.size()), d_now(now)
+  DNSComboWriter(const std::string& query, const struct timeval& now): d_mdp(true, query), d_now(now)
   {
   }
 
-  DNSComboWriter(const std::string& query, const struct timeval& now, std::vector<std::string>&& policyTags, LuaContext::LuaObject&& data): d_mdp(true, query.c_str(), query.size()), d_now(now), d_policyTags(std::move(policyTags)), d_data(std::move(data))
+  DNSComboWriter(const std::string& query, const struct timeval& now, std::vector<std::string>&& policyTags, LuaContext::LuaObject&& data): d_mdp(true, query), d_now(now), d_policyTags(std::move(policyTags)), d_data(std::move(data))
   {
   }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -659,7 +659,7 @@ int asendto(const char *data, size_t len, int flags,
 }
 
 // -1 is error, 0 is timeout, 1 is success
-int arecvfrom(char *data, size_t len, int flags, const ComboAddress& fromaddr, size_t *d_len,
+int arecvfrom(std::string& packet, int flags, const ComboAddress& fromaddr, size_t *d_len,
               uint16_t id, const DNSName& domain, uint16_t qtype, int fd, struct timeval* now)
 {
   static optional<unsigned int> nearMissLimit;
@@ -673,7 +673,6 @@ int arecvfrom(char *data, size_t len, int flags, const ComboAddress& fromaddr, s
   pident.type = qtype;
   pident.remote=fromaddr;
 
-  string packet;
   int ret=MT->waitEvent(pident, &packet, g_networkTimeoutMsec, now);
 
   if(ret > 0) {
@@ -681,7 +680,7 @@ int arecvfrom(char *data, size_t len, int flags, const ComboAddress& fromaddr, s
       return -1;
 
     *d_len=packet.size();
-    memcpy(data,packet.c_str(),min(len,*d_len));
+
     if(*nearMissLimit && pident.nearMisses > *nearMissLimit) {
       g_log<<Logger::Error<<"Too many ("<<pident.nearMisses<<" > "<<*nearMissLimit<<") bogus answers for '"<<domain<<"' from "<<fromaddr.toString()<<", assuming spoof attempt."<<endl;
       g_stats.spoofCount++;

--- a/pdns/protobuf.cc
+++ b/pdns/protobuf.cc
@@ -147,9 +147,8 @@ void DNSProtoBufMessage::addRRsFromPacket(const char* packet, const size_t len, 
   if (!response)
     return;
 
-  vector<uint8_t> content(len - sizeof(dnsheader));
-  copy(packet + sizeof(dnsheader), packet + len, content.begin());
-  PacketReader pr(content);
+  std::string packetStr(packet, len);
+  PacketReader pr(packetStr);
 
   size_t idx = 0;
   DNSName rrname;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -940,6 +940,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
 
         DNSRecord dr=*j;
         dr.d_ttl-=d_now.tv_sec;
+        ret.reserve(ret.size() + 1 + signatures.size() + authorityRecs.size());
         ret.push_back(dr);
 
         for(const auto& signature : signatures) {
@@ -1210,6 +1211,8 @@ bool SyncRes::doCacheCheck(const DNSName &qname, const DNSName& authname, bool w
         expired=true;
       }
     }
+
+    ret.reserve(ret.size() + signatures.size() + authorityRecs.size());
 
     for(const auto& signature : signatures) {
       DNSRecord dr;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -940,12 +940,13 @@ public:
   {
     return d_fd;
   }
+
+  std::string data;
+  const ComboAddress d_remote;
+  size_t queriesCount{0};
   enum stateenum {BYTE0, BYTE1, GETQUESTION, DONE} state{BYTE0};
   uint16_t qlen{0};
   uint16_t bytesread{0};
-  const ComboAddress d_remote;
-  char data[65535]; // damn
-  size_t queriesCount{0};
 
   static unsigned int getCurrentConnections() { return s_currentConnections; }
 private:

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(removeEDNSWhenFirst) {
   pw.commit();
 
   vector<uint8_t> newResponse;
-  int res = rewriteResponseWithoutEDNS((const char *) response.data(), response.size(), newResponse);
+  int res = rewriteResponseWithoutEDNS(std::string((const char *) response.data(), response.size()), newResponse);
   BOOST_CHECK_EQUAL(res, 0);
 
   unsigned int consumed = 0;
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(removeEDNSWhenIntermediary) {
   pw.commit();
 
   vector<uint8_t> newResponse;
-  int res = rewriteResponseWithoutEDNS((const char *) response.data(), response.size(), newResponse);
+  int res = rewriteResponseWithoutEDNS(std::string((const char *) response.data(), response.size()), newResponse);
   BOOST_CHECK_EQUAL(res, 0);
 
   unsigned int consumed = 0;
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(removeEDNSWhenLast) {
   pw.commit();
 
   vector<uint8_t> newResponse;
-  int res = rewriteResponseWithoutEDNS((const char *) response.data(), response.size(), newResponse);
+  int res = rewriteResponseWithoutEDNS(std::string((const char *) response.data(), response.size()), newResponse);
 
   BOOST_CHECK_EQUAL(res, 0);
 
@@ -394,18 +394,18 @@ BOOST_AUTO_TEST_CASE(removeECSWhenOnlyOption) {
   pw.addOpt(512, 0, 0, opts);
   pw.commit();
 
-  char * optStart = NULL;
+  uint16_t optStart;
   size_t optLen = 0;
   bool last = false;
 
-  int res = locateEDNSOptRR((char *) response.data(), response.size(), &optStart, &optLen, &last);
+  int res = locateEDNSOptRR(std::string((char *) response.data(), response.size()), &optStart, &optLen, &last);
   BOOST_CHECK_EQUAL(res, 0);
   BOOST_CHECK_EQUAL(last, true);
 
   size_t responseLen = response.size();
   size_t existingOptLen = optLen;
   BOOST_CHECK(existingOptLen < responseLen);
-  res = removeEDNSOptionFromOPT(optStart, &optLen, EDNSOptionCode::ECS);
+  res = removeEDNSOptionFromOPT(reinterpret_cast<char *>(response.data()) + optStart, &optLen, EDNSOptionCode::ECS);
   BOOST_CHECK_EQUAL(res, 0);
   BOOST_CHECK_EQUAL(optLen, existingOptLen - (origECSOptionStr.size() + 4));
   responseLen -= (existingOptLen - optLen);
@@ -446,18 +446,18 @@ BOOST_AUTO_TEST_CASE(removeECSWhenFirstOption) {
   pw.addOpt(512, 0, 0, opts);
   pw.commit();
 
-  char * optStart = NULL;
+  uint16_t optStart;
   size_t optLen = 0;
   bool last = false;
 
-  int res = locateEDNSOptRR((char *) response.data(), response.size(), &optStart, &optLen, &last);
+  int res = locateEDNSOptRR(std::string((char *) response.data(), response.size()), &optStart, &optLen, &last);
   BOOST_CHECK_EQUAL(res, 0);
   BOOST_CHECK_EQUAL(last, true);
 
   size_t responseLen = response.size();
   size_t existingOptLen = optLen;
   BOOST_CHECK(existingOptLen < responseLen);
-  res = removeEDNSOptionFromOPT(optStart, &optLen, EDNSOptionCode::ECS);
+  res = removeEDNSOptionFromOPT(reinterpret_cast<char *>(response.data()) + optStart, &optLen, EDNSOptionCode::ECS);
   BOOST_CHECK_EQUAL(res, 0);
   BOOST_CHECK_EQUAL(optLen, existingOptLen - (origECSOptionStr.size() + 4));
   responseLen -= (existingOptLen - optLen);
@@ -502,18 +502,18 @@ BOOST_AUTO_TEST_CASE(removeECSWhenIntermediaryOption) {
   pw.addOpt(512, 0, 0, opts);
   pw.commit();
 
-  char * optStart = NULL;
+  uint16_t optStart;
   size_t optLen = 0;
   bool last = false;
 
-  int res = locateEDNSOptRR((char *) response.data(), response.size(), &optStart, &optLen, &last);
+  int res = locateEDNSOptRR(std::string((char *) response.data(), response.size()), &optStart, &optLen, &last);
   BOOST_CHECK_EQUAL(res, 0);
   BOOST_CHECK_EQUAL(last, true);
 
   size_t responseLen = response.size();
   size_t existingOptLen = optLen;
   BOOST_CHECK(existingOptLen < responseLen);
-  res = removeEDNSOptionFromOPT(optStart, &optLen, EDNSOptionCode::ECS);
+  res = removeEDNSOptionFromOPT(reinterpret_cast<char *>(response.data()) + optStart, &optLen, EDNSOptionCode::ECS);
   BOOST_CHECK_EQUAL(res, 0);
   BOOST_CHECK_EQUAL(optLen, existingOptLen - (origECSOptionStr.size() + 4));
   responseLen -= (existingOptLen - optLen);
@@ -554,18 +554,18 @@ BOOST_AUTO_TEST_CASE(removeECSWhenLastOption) {
   pw.addOpt(512, 0, 0, opts);
   pw.commit();
 
-  char * optStart = NULL;
+  uint16_t optStart;
   size_t optLen = 0;
   bool last = false;
 
-  int res = locateEDNSOptRR((char *) response.data(), response.size(), &optStart, &optLen, &last);
+  int res = locateEDNSOptRR(std::string((char *) response.data(), response.size()), &optStart, &optLen, &last);
   BOOST_CHECK_EQUAL(res, 0);
   BOOST_CHECK_EQUAL(last, true);
 
   size_t responseLen = response.size();
   size_t existingOptLen = optLen;
   BOOST_CHECK(existingOptLen < responseLen);
-  res = removeEDNSOptionFromOPT(optStart, &optLen, EDNSOptionCode::ECS);
+  res = removeEDNSOptionFromOPT(reinterpret_cast<char *>(response.data()) + optStart, &optLen, EDNSOptionCode::ECS);
   BOOST_CHECK_EQUAL(res, 0);
   BOOST_CHECK_EQUAL(optLen, existingOptLen - (origECSOptionStr.size() + 4));
   responseLen -= (existingOptLen - optLen);
@@ -602,7 +602,7 @@ BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenOnlyOption) {
   pw.commit();
 
   vector<uint8_t> newResponse;
-  int res = rewriteResponseWithoutEDNSOption((const char *) response.data(), response.size(), EDNSOptionCode::ECS, newResponse);
+  int res = rewriteResponseWithoutEDNSOption(std::string((const char *) response.data(), response.size()), EDNSOptionCode::ECS, newResponse);
   BOOST_CHECK_EQUAL(res, 0);
 
   BOOST_CHECK_EQUAL(newResponse.size(), response.size() - (origECSOptionStr.size() + 4));
@@ -644,7 +644,7 @@ BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenFirstOption) {
   pw.commit();
 
   vector<uint8_t> newResponse;
-  int res = rewriteResponseWithoutEDNSOption((const char *) response.data(), response.size(), EDNSOptionCode::ECS, newResponse);
+  int res = rewriteResponseWithoutEDNSOption(std::string((const char *) response.data(), response.size()), EDNSOptionCode::ECS, newResponse);
   BOOST_CHECK_EQUAL(res, 0);
 
   BOOST_CHECK_EQUAL(newResponse.size(), response.size() - (origECSOptionStr.size() + 4));
@@ -688,7 +688,7 @@ BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenIntermediaryOption) {
   pw.commit();
 
   vector<uint8_t> newResponse;
-  int res = rewriteResponseWithoutEDNSOption((const char *) response.data(), response.size(), EDNSOptionCode::ECS, newResponse);
+  int res = rewriteResponseWithoutEDNSOption(std::string((const char *) response.data(), response.size()), EDNSOptionCode::ECS, newResponse);
   BOOST_CHECK_EQUAL(res, 0);
 
   BOOST_CHECK_EQUAL(newResponse.size(), response.size() - (origECSOptionStr.size() + 4));
@@ -730,7 +730,7 @@ BOOST_AUTO_TEST_CASE(rewritingWithoutECSWhenLastOption) {
   pw.commit();
 
   vector<uint8_t> newResponse;
-  int res = rewriteResponseWithoutEDNSOption((const char *) response.data(), response.size(), EDNSOptionCode::ECS, newResponse);
+  int res = rewriteResponseWithoutEDNSOption(std::string((const char *) response.data(), response.size()), EDNSOptionCode::ECS, newResponse);
   BOOST_CHECK_EQUAL(res, 0);
 
   BOOST_CHECK_EQUAL(newResponse.size(), response.size() - (origECSOptionStr.size() + 4));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR:
- Prevents an allocation and copy of the `DNS` query or response passed to `MOADNSParser`, and get rid of the weird `-12` dance (auth, rec) ;
- Makes `PacketReader` accepts a `string` instead of a `vector<uint18_t>` so we don't need to allocate a vector and copy our data to it (auth, rec, dnsdist) ;
- Removes a useless copy of the response in `arecvfrom()` (rec) ;
- Removes some string allocations and copies during `EDNS` processing (dnsdist) ;
- replaces a fixed 65k buffer allocated for every `TCP` connection by a dynamically allocated one (rec).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
