### PR TITLE
check-zone: allow null MX, SRV

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -449,7 +449,9 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
 
       if (toCheck.empty())
         cout<<"[Warning] "<<rr.qtype.getName()<<" record in zone '"<<zone<<"': unable to extract hostname from content."<<endl;
-      else if(!toCheck.isHostname()) {
+      else if ((rr.qtype.getCode() == QType::MX || rr.qtype.getCode() == QType::SRV) && toCheck == g_rootdnsname) {
+        // allow null MX/SRV
+      } else if(!toCheck.isHostname()) {
         cout<<"[Warning] "<<rr.qtype.getName()<<" record in zone '"<<zone<<"' has non-hostname content '"<<toCheck.toString()<<"'."<<endl;
         numwarnings++;
       }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -447,8 +447,10 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
         toCheck = DNSName(rr.content);
       }
 
-      if (toCheck.empty())
+      if (toCheck.empty()) {
         cout<<"[Warning] "<<rr.qtype.getName()<<" record in zone '"<<zone<<"': unable to extract hostname from content."<<endl;
+        numwarnings++;
+      }
       else if ((rr.qtype.getCode() == QType::MX || rr.qtype.getCode() == QType::SRV) && toCheck == g_rootdnsname) {
         // allow null MX/SRV
       } else if(!toCheck.isHostname()) {


### PR DESCRIPTION
### Short description
As detailed in #6800, `pdnsutil check-zone` wrongly warns about RFC7505 null MX records. This PR remedies that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
