### PR TITLE
Allow compiling against MySQL 8 client header files

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -32,6 +32,11 @@
 #include "pdns/namespaces.hh"
 #include "pdns/lock.hh"
 
+#if MYSQL_VERSION_ID >= 80000
+// Need to keep this for compatibility with MySQL < 8.0.0, which used typedef char my_bool;
+typedef bool my_bool;
+#endif
+
 bool SMySQL::s_dolog;
 pthread_mutex_t SMySQL::s_myinitlock = PTHREAD_MUTEX_INITIALIZER;
 


### PR DESCRIPTION
### Short description
MySQL 8 has removed the `my_bool` typedef. Just switching to `bool` would break compatibility with the 5.x headers.

### Checklist
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
