### PR TITLE
check-all-zones: find duplicate zones and SOAs

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -604,8 +604,6 @@ int checkAllZones(DNSSECKeeper &dk, bool exitOnError)
 {
   UeberBackend B("default");
   vector<DomainInfo> domainInfo;
-  struct name{};
-  struct id{};
   multi_index_container<
     DomainInfo,
     indexed_by<


### PR DESCRIPTION
### Short description
If you have duplicate zones, zone IDs or SOAs, check-all-zones will now produce errors like these:

duplicate SOA:
```
[Error] Another SOA for zone 'zeha1.example.org' (serial 2) has already been seen (serial 1).
[Error] Domain ID 99 of 'zeha1.example.org' in backend gsqlite3 has already been used by zone 'zeha1.example.org' in backend gsqlite3.
```

duplicate zone ID in different backends:
```
[Error] Another SOA for zone 'example.com' (serial 2847484148) has already been seen (serial 2847484148).
[Error] Domain ID 3 of 'example.com' in backend bind has already been used by zone 'example.com' in backend gsqlite3.
```

Fixes #6829 by means of adding checking in check-all-zones.
### Checklist
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
