### PR TITLE
recursor: Add pdnslog to Lua configuration scripts

### DIFF
--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -132,6 +132,21 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
   auto luaconfsLocal = g_luaconfs.getLocal();
   lci.generation = luaconfsLocal->generation + 1;
 
+  // pdnslog here is compatible with pdnslog in lua-base4.cc.
+  Lua.writeFunction("pdnslog", [](const std::string& msg, boost::optional<int> loglevel) { g_log << (Logger::Urgency)loglevel.get_value_or(Logger::Warning) << msg<<endl; });
+  std::unordered_map<string, std::unordered_map<string, int>> pdns_table;
+  pdns_table["loglevels"] = std::unordered_map<string, int>{
+    {"Alert", LOG_ALERT},
+    {"Critical", LOG_CRIT},
+    {"Debug", LOG_DEBUG},
+    {"Emergency", LOG_EMERG},
+    {"Info", LOG_INFO},
+    {"Notice", LOG_NOTICE},
+    {"Warning", LOG_WARNING},
+    {"Error", LOG_ERR}
+  };
+  Lua.writeVariable("pdns", pdns_table);
+
   Lua.writeFunction("clearSortlist", [&lci]() { lci.sortlist.clear(); });
   
   /* we can get: "1.2.3.4"

--- a/pdns/recursordist/docs/lua-config/index.rst
+++ b/pdns/recursordist/docs/lua-config/index.rst
@@ -9,3 +9,5 @@ Since version 4.0.0, the PowerDNS Recursor supports additional configuration opt
     sortlist
     protobuf
     rpz
+
+In addition, :func:`pdnslog` together with ``pdns.loglevels`` is also supported in the Lua configuration file.


### PR DESCRIPTION
### Short description
As a distro maintainer, I'd like to ship a default Lua config file that also logs something, so users can know that they are not running the default empty configuration.

I intend to carry this as a 4.1 patch in Debian.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
