### PR TITLE
added :excludeRange and :includeRange methods to DynBPFFilter class

### DIFF
--- a/pdns/dnsdist-dynbpf.cc
+++ b/pdns/dnsdist-dynbpf.cc
@@ -28,6 +28,11 @@ bool DynBPFFilter::block(const ComboAddress& addr, const struct timespec& until)
   bool inserted = false;
   std::unique_lock<std::mutex> lock(d_mutex);
 
+  if (d_excludedSubnets.match(addr)) {
+    /* do not add a block for excluded subnets */
+    return inserted;
+  }
+
   const container_t::iterator it = d_entries.find(addr);
   if (it != d_entries.end()) {
     if (it->d_until < until) {

--- a/pdns/dnsdist-dynbpf.hh
+++ b/pdns/dnsdist-dynbpf.hh
@@ -41,6 +41,14 @@ public:
   ~DynBPFFilter()
   {
   }
+  void excludeRange(const Netmask& range)
+  {
+    d_excludedSubnets.addMask(range);
+  }
+  void includeRange(const Netmask& range)
+  {
+    d_excludedSubnets.addMask(range, false);
+  }
   /* returns true if the addr wasn't already blocked, false otherwise */
   bool block(const ComboAddress& addr, const struct timespec& until);
   void purgeExpired(const struct timespec& now);
@@ -63,6 +71,7 @@ private:
   container_t d_entries;
   std::mutex d_mutex;
   std::shared_ptr<BPFFilter> d_bpf;
+  NetmaskGroup d_excludedSubnets;
 };
 
 #endif /* HAVE_EBPF */

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -544,5 +544,27 @@ void setupLuaBindings(bool client)
           dbpf->purgeExpired(now);
         }
     });
+
+    g_lua.registerFunction<void(std::shared_ptr<DynBPFFilter>::*)(boost::variant<std::string, std::vector<std::pair<int, std::string>>>)>("excludeRange", [](std::shared_ptr<DynBPFFilter> dbpf, boost::variant<std::string, std::vector<std::pair<int, std::string>>> ranges) {
+      if (ranges.type() == typeid(std::vector<std::pair<int, std::string>>)) {
+        for (const auto& range : *boost::get<std::vector<std::pair<int, std::string>>>(&ranges)) {
+          dbpf->excludeRange(Netmask(range.second));
+        }
+      }
+      else {
+        dbpf->excludeRange(Netmask(*boost::get<std::string>(&ranges)));
+      }
+    });
+
+    g_lua.registerFunction<void(std::shared_ptr<DynBPFFilter>::*)(boost::variant<std::string, std::vector<std::pair<int, std::string>>>)>("includeRange", [](std::shared_ptr<DynBPFFilter> dbpf, boost::variant<std::string, std::vector<std::pair<int, std::string>>> ranges) {
+      if (ranges.type() == typeid(std::vector<std::pair<int, std::string>>)) {
+        for (const auto& range : *boost::get<std::vector<std::pair<int, std::string>>>(&ranges)) {
+          dbpf->includeRange(Netmask(range.second));
+        }
+      }
+      else {
+        dbpf->includeRange(Netmask(*boost::get<std::string>(&ranges)));
+      }
+    });
 #endif /* HAVE_EBPF */
 }

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -514,7 +514,7 @@ See :doc:`../guides/cache` for a how to.
     ``numberOfShards`` and ``deferrableInsertLock`` parameters added.
 
   .. versionchanged:: 1.3.1
-    ``maxNegativeTTL`` and ``parseECS` parameters added.
+    ``maxNegativeTTL`` and ``parseECS`` parameters added.
 
   Creates a new :class:`PacketCache` with the settings specified.
 
@@ -933,7 +933,7 @@ TLSContext
     :param str ticketsKeysFile: The path to a file from where TLS tickets keys should be loaded.
 
 TLSFrontend
-~~~~~~~~~~
+~~~~~~~~~~~
 
 .. class:: TLSFrontend
 

--- a/pdns/dnsdistdist/docs/reference/ebpf.rst
+++ b/pdns/dnsdistdist/docs/reference/ebpf.rst
@@ -95,3 +95,18 @@ These are all the functions, objects and methods related to the :doc:`../advance
 
   Represents an dynamic eBPF filter, allowing the use of ephemeral rules to an existing eBPF filter.
 
+  .. method:: DynBPFFilter:excludeRange(netmasks)
+
+    .. versionadded:: 1.3.3
+
+    Exclude this range, or list of ranges, meaning that no dynamic block will ever be inserted for clients in that range. Default to empty, meaning rules are applied to all ranges. When used in combination with :meth:`DynBPFFilter:includeRange`, the more specific entry wins.
+
+    :param int netmasks: A netmask, or list of netmasks, as strings, like for example "192.0.2.1/24"
+
+  .. method:: DynBPFFilter:includeRange(netmasks)
+
+    .. versionadded:: 1.3.3
+
+    Include this range, or list of ranges, meaning that rules will be applied to this range. When used in combination with :meth:`DynBPFFilter:excludeRange`, the more specific entry wins.
+
+    :param int netmasks: A netmask, or list of netmasks, as strings, like for example "192.0.2.1/24"

--- a/pdns/dnsdistdist/docs/reference/ebpf.rst
+++ b/pdns/dnsdistdist/docs/reference/ebpf.rst
@@ -74,10 +74,6 @@ These are all the functions, objects and methods related to the :doc:`../advance
 
     Print the block tables.
 
-  .. method:: BPFFilter:purgeExpired()
-
-    Remove the expired ephemeral rules associated with this filter.
-
   .. method:: BPFFilter:unblock(address)
 
     Unblock this address.
@@ -94,6 +90,10 @@ These are all the functions, objects and methods related to the :doc:`../advance
 .. class:: DynBPFFilter
 
   Represents an dynamic eBPF filter, allowing the use of ephemeral rules to an existing eBPF filter.
+
+  .. method:: DynBPFFilter:purgeExpired()
+
+    Remove the expired ephemeral rules associated with this filter.
 
   .. method:: DynBPFFilter:excludeRange(netmasks)
 


### PR DESCRIPTION
### Short description
Wanting to move from `DynBlockRulesGroup ` to `DynBPFFilter`, I found the `excludeRange` and `includeRange` methods missing, while the rest of the functionality between both ways of dynamically blocking was rather identical. So, I added them.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
