### PR TITLE
do not leak requests for addzone.com to the Internet

### DIFF
--- a/regression-tests/tests/00dnssec-grabkeys/command
+++ b/regression-tests/tests/00dnssec-grabkeys/command
@@ -2,9 +2,9 @@
 rm -f trustedkeys
 rm -f unbound-host.conf
 
-for zone in $(grep 'zone ' named.conf  | cut -f2 -d\")
+for zone in $(grep 'zone ' named.conf  | cut -f2 -d\") addzone.com
 do
-	if [ "${zone: 0:16}" != "secure-delegated" ] && [ "$zone" != "stest.com" ]
+	if [ "${zone: 0:16}" != "secure-delegated" ] && [ "$zone" != "stest.com" ] && [ "$zone" != "addzone.com" ]
 	then
 		drill -p $port -o rd -D dnskey $zone @$nameserver | grep $'DNSKEY\t257' | grep -v 'RRSIG' | grep -v '^;' | grep -v AwEAAarTiHhPgvD28WCN8UBXcEcf8f >> trustedkeys
 	fi


### PR DESCRIPTION
### Short description
Because addzone.com is not in the regression testing named.conf, unbound does not know that it is a special name for which requests should be directed at PowerDNS.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
