### PR TITLE
auth: api - Check DNSNames that should be hostnames

### DIFF
--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -805,4 +805,5 @@ void reportBasicTypes();
 void reportOtherTypes();
 void reportAllTypes();
 ComboAddress getAddr(const DNSRecord& dr, uint16_t defport=0);
+void checkHostnameCorrectness(const DNSResourceRecord& rr);
 #endif 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1723,6 +1723,31 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
             if (rr.qtype.getCode() == QType::SOA && rr.qname==zonename) {
               soa_edit_done = increaseSOARecord(rr, soa_edit_api_kind, soa_edit_kind);
             }
+
+            // Check if the DNSNames that should be hostnames, are hostnames
+            if (rr.qtype.getCode() == QType::NS || rr.qtype.getCode() == QType::MX || rr.qtype.getCode() == QType::SRV) {
+              DNSName toCheck;
+              if (rr.qtype.getCode() == QType::SRV) {
+                vector<string> parts;
+                stringtok(parts, rr.getZoneRepresentation());
+                if (parts.size() == 4) toCheck = DNSName(parts[3]);
+              } else if (rr.qtype.getCode() == QType::MX) {
+                vector<string> parts;
+                stringtok(parts, rr.getZoneRepresentation());
+                if (parts.size() == 2) toCheck = DNSName(parts[1]);
+              } else {
+                toCheck = DNSName(rr.content);
+              }
+
+              if (toCheck.empty()) {
+                throw ApiException("RRset "+qname.toString()+" IN "+qtype.getName() + " unable to extract hostname from content.");
+              }
+              else if ((rr.qtype.getCode() == QType::MX || rr.qtype.getCode() == QType::SRV) && toCheck == g_rootdnsname) {
+                // allow null MX/SRV
+              } else if(!toCheck.isHostname()) {
+                throw ApiException("RRset "+qname.toString()+" IN "+qtype.getName() + " record has non-hostname content '" + toCheck.toString() + "'.");
+              }
+            }
           }
           checkDuplicateRecords(new_records);
         }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1006,7 +1006,7 @@ fred   IN  A      192.168.0.4
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
         self.assertEquals(r.status_code, 422)
-        self.assertIn('record has non-hostname content', r.json()['error'])
+        self.assertIn('non-hostname content', r.json()['error'])
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         self.assertIsNone(get_rrset(data, name, 'MX'))
 

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -985,6 +985,31 @@ fred   IN  A      192.168.0.4
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         self.assertEquals(get_rrset(data, name, 'MX')['records'], rrset['records'])
 
+    def test_zone_rr_update_invalid_mx(self):
+        name, payload, zone = self.create_zone()
+        # do a replace (= update)
+        rrset = {
+            'changetype': 'replace',
+            'name': name,
+            'type': 'MX',
+            'ttl': 3600,
+            'records': [
+                {
+                    "content": "10 mail@mx.example.org.",
+                    "disabled": False
+                }
+            ]
+        }
+        payload = {'rrsets': [rrset]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={'content-type': 'application/json'})
+        self.assertEquals(r.status_code, 422)
+        self.assertIn('record has non-hostname content', r.json()['error'])
+        data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
+        self.assertIsNone(get_rrset(data, name, 'MX'))
+
     def test_zone_rr_update_opt(self):
         name, payload, zone = self.create_zone()
         # do a replace (= update)


### PR DESCRIPTION
### Short description
This is a copy of the check done in `pdnsutil check-zone` that will trigger an API error when trying to create or update an MX record with a non hostname content.

This fix #6636 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
