### PR TITLE
Keep track of what destinations are causing the most timeouts

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -116,7 +116,7 @@ thread_local std::unique_ptr<MT_t> MT; // the big MTasker
 thread_local std::unique_ptr<MemRecursorCache> t_RC;
 thread_local std::unique_ptr<RecursorPacketCache> t_packetCache;
 thread_local FDMultiplexer* t_fdm{nullptr};
-thread_local std::unique_ptr<addrringbuf_t> t_remotes, t_servfailremotes, t_largeanswerremotes, t_bogusremotes, t_timeouts;
+thread_local std::unique_ptr<addrringbuf_t> t_remotes, t_servfailremotes, t_largeanswerremotes, t_bogusremotes;
 thread_local std::unique_ptr<boost::circular_buffer<pair<DNSName, uint16_t> > > t_queryring, t_servfailqueryring, t_bogusqueryring;
 thread_local std::shared_ptr<NetmaskGroup> t_allowFrom;
 #ifdef HAVE_PROTOBUF

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -116,7 +116,7 @@ thread_local std::unique_ptr<MT_t> MT; // the big MTasker
 thread_local std::unique_ptr<MemRecursorCache> t_RC;
 thread_local std::unique_ptr<RecursorPacketCache> t_packetCache;
 thread_local FDMultiplexer* t_fdm{nullptr};
-thread_local std::unique_ptr<addrringbuf_t> t_remotes, t_servfailremotes, t_largeanswerremotes, t_bogusremotes;
+thread_local std::unique_ptr<addrringbuf_t> t_remotes, t_servfailremotes, t_largeanswerremotes, t_bogusremotes, t_timeouts;
 thread_local std::unique_ptr<boost::circular_buffer<pair<DNSName, uint16_t> > > t_queryring, t_servfailqueryring, t_bogusqueryring;
 thread_local std::shared_ptr<NetmaskGroup> t_allowFrom;
 #ifdef HAVE_PROTOBUF
@@ -3755,6 +3755,8 @@ try
     t_bogusremotes->set_capacity(ringsize);
     t_largeanswerremotes = std::unique_ptr<addrringbuf_t>(new addrringbuf_t());
     t_largeanswerremotes->set_capacity(ringsize);
+    t_timeouts = std::unique_ptr<addrringbuf_t>(new addrringbuf_t());
+    t_timeouts->set_capacity(ringsize);
 
     t_queryring = std::unique_ptr<boost::circular_buffer<pair<DNSName, uint16_t> > >(new boost::circular_buffer<pair<DNSName, uint16_t> >());
     t_queryring->set_capacity(ringsize);

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -73,6 +73,7 @@ std::vector<ComboAddress>* pleaseGetRemotes();
 std::vector<ComboAddress>* pleaseGetServfailRemotes();
 std::vector<ComboAddress>* pleaseGetBogusRemotes();
 std::vector<ComboAddress>* pleaseGetLargeAnswerRemotes();
+std::vector<ComboAddress>* pleaseGetTimeouts();
 DNSName getRegisteredName(const DNSName& dom);
 std::atomic<unsigned long>* getDynMetric(const std::string& str);
 optional<uint64_t> getStatByName(const std::string& name);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1100,6 +1100,18 @@ vector<ComboAddress>* pleaseGetLargeAnswerRemotes()
   return ret;
 }
 
+vector<ComboAddress>* pleaseGetTimeouts()
+{
+  vector<ComboAddress>* ret = new vector<ComboAddress>();
+  if(!t_timeouts)
+    return ret;
+  ret->reserve(t_timeouts->size());
+  for(const ComboAddress& ca :  *t_timeouts) {
+    ret->push_back(ca);
+  }
+  return ret;
+}
+
 string doGenericTopRemotes(pleaseremotefunc_t func)
 {
   typedef map<ComboAddress, int, ComboAddress::addressOnlyLessThan> counts_t;
@@ -1275,6 +1287,7 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
 "top-queries                      show top queries\n"
 "top-pub-queries                  show top queries grouped by public suffix list\n"
 "top-remotes                      show top remotes\n"
+"top-timeouts                     show top downstream timeouts"
 "top-servfail-queries             show top queries receiving servfail answers\n"
 "top-bogus-queries                show top queries validating as bogus\n"
 "top-pub-servfail-queries         show top queries receiving servfail answers grouped by public suffix list\n"
@@ -1411,6 +1424,9 @@ string RecursorControlParser::getAnswer(const string& question, RecursorControlP
 
   if(cmd=="top-largeanswer-remotes")
     return doGenericTopRemotes(pleaseGetLargeAnswerRemotes);
+
+  if(cmd=="top-timeouts")
+    return doGenericTopRemotes(pleaseGetTimeouts);
 
 
   if(cmd=="current-queries")

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -237,6 +237,10 @@ top-bogus-remotes
     Shows the top-20 most active remote hosts causing bogus responses.
     Statistics are over the last 'stats-ringbuffer-entries' queries.
 
+top-timeouts
+    Shows the top-20 most active downstream timeout destinations.
+    Statistics are over the last 'stats-ringbuffer-entries' queries.
+
 trace-regex *REGEX*
     Emit resolution trace for matching queries. Empty regex to disable trace.
 

--- a/pdns/recursordist/html/index.html
+++ b/pdns/recursordist/html/index.html
@@ -66,6 +66,7 @@
             <div class="stats-table" id="remotering"></div>
             <div class="stats-table" id="servfailremotering"></div>
             <div class="stats-table" id="bogusremotering"></div>
+            <div class="stats-table" id="timeouts"></div>
         </div>
     </div>
 
@@ -168,6 +169,21 @@
         <tr>
             <th>Number</th>
             <th>Bogus remote</th>
+        </tr>
+        {{#each rows}}
+        <tr>
+            <td>{{0}}</td>
+            <td>{{1}}</td>
+        </tr>
+        {{/each}}
+    </table>
+</script>
+
+<script id="timeouts-template" type="text/x-handlebars-template">
+    <table class="two-col">
+        <tr>
+            <th>Number</th>
+            <th>Downstream timeouts</th>
         </tr>
         {{#each rows}}
         <tr>

--- a/pdns/recursordist/html/local.js
+++ b/pdns/recursordist/html/local.js
@@ -137,6 +137,11 @@ $(document).ready(function () {
                 var rows = makeRingRows(data);
                 render('bogusremotering', {rows: rows});
             });
+        $.getJSON('jsonstat', jsonstatParams('get-remote-ring', 'timeouts', false),
+            function (data) {
+                var rows = makeRingRows(data);
+                render('timeouts', {rows: rows});
+            });
     }
 
     var connectionOK = function (ok, o) {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2484,6 +2484,8 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
       else {
         // timeout
         t_sstorage.throttle.throttle(d_now.tv_sec, boost::make_tuple(remoteIP, qname, qtype.getCode()), 10, 5);
+        if(t_timeouts)
+          t_timeouts->push_back(remoteIP);
       }
     }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -37,6 +37,7 @@
 #include "validate-recursor.hh"
 
 thread_local SyncRes::ThreadLocalStorage SyncRes::t_sstorage;
+thread_local std::unique_ptr<addrringbuf_t> t_timeouts;
 
 std::unordered_set<DNSName> SyncRes::s_delegationOnly;
 std::unique_ptr<NetmaskGroup> SyncRes::s_dontQuery{nullptr};
@@ -2455,6 +2456,9 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
         s_outgoing4timeouts++;
       else
         s_outgoing6timeouts++;
+
+      if(t_timeouts)
+        t_timeouts->push_back(remoteIP);
     }
     else if(resolveret == -2) {
       /* OS resource limit reached */
@@ -2484,8 +2488,6 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
       else {
         // timeout
         t_sstorage.throttle.throttle(d_now.tv_sec, boost::make_tuple(remoteIP, qname, qtype.getCode()), 10, 5);
-        if(t_timeouts)
-          t_timeouts->push_back(remoteIP);
       }
     }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -963,7 +963,7 @@ public:
 };
 
 typedef boost::circular_buffer<ComboAddress> addrringbuf_t;
-extern thread_local std::unique_ptr<addrringbuf_t> t_servfailremotes, t_largeanswerremotes, t_remotes, t_bogusremotes;
+extern thread_local std::unique_ptr<addrringbuf_t> t_servfailremotes, t_largeanswerremotes, t_remotes, t_bogusremotes, t_timeouts;
 
 extern thread_local std::unique_ptr<boost::circular_buffer<pair<DNSName,uint16_t> > > t_queryring, t_servfailqueryring, t_bogusqueryring;
 extern thread_local std::shared_ptr<NetmaskGroup> t_allowFrom;

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -540,6 +540,8 @@ void RecursorWebServer::jsonstat(HttpRequest* req, HttpResponse *resp)
       queries=broadcastAccFunction<vector<ComboAddress> >(pleaseGetBogusRemotes);
     else if(req->getvars["name"]=="large-answer-remotes")
       queries=broadcastAccFunction<vector<ComboAddress> >(pleaseGetLargeAnswerRemotes);
+    else if(req->getvars["name"]=="timeouts")
+      queries=broadcastAccFunction<vector<ComboAddress> >(pleaseGetTimeouts);
 
     typedef map<ComboAddress,unsigned int,ComboAddress::addressOnlyLessThan> counts_t;
     counts_t counts;


### PR DESCRIPTION
### Short description
Keep track of what downstreams are causing the most timeouts. Useful for troubleshooting network connectivity issues rather than trolling servfails and manual testing.

- [ ] not really remotes so should split that out in ws/api
- [ ] the naming timeouts could probably be improved, suggestions?

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
