### PR TITLE
API docs: fix zone axfr-retrieve description

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -221,8 +221,8 @@ paths:
 
   '/servers/{server_id}/zones/{zone_id}/axfr-retrieve':
     put:
-      summary: Send a DNS NOTIFY to all slaves.
-      description: 'Fails when zone kind is not Master or Slave, or master and slave are disabled in the configuration. Only works for Slave if renotify is on. Clients MUST NOT send a body.'
+      summary: Retrieve slave zone from its master.
+      description: 'Fails when zone kind is not Slave, or slave is disabled in the configuration. Clients MUST NOT send a body.'
       operationId: axfrRetrieveZone
       tags:
         - zones


### PR DESCRIPTION
### Short description

I found some copy-paste oversight in the api docs, and corrected it based on the man page for "pdns_control retrieve" (which I assume does the same thing). I also used the axfr-retrieve api endpoint with pdns 4.1.3, it works as expected :)

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
