### PR TITLE
changelog: fix dup of #6312 in 4.1.3, was in 4.1.2

### DIFF
--- a/docs/changelog/4.1.rst
+++ b/docs/changelog/4.1.rst
@@ -23,12 +23,6 @@ Changelogs for 4.1.x
     pdnsutil: use new domain in b2bmigrate (Aki Tuomi)
 
   .. change::
-    :tags: Improvements
-    :pullreq: 6545, 6312
-
-    Lower 'packet too short' loglevel
-
-  .. change::
     :tags: Bug Fixes
     :pullreq: 6370
     :tickets: 6228


### PR DESCRIPTION
### Short description

The "packet too short" log level change is present in both the 4.1.3 and 4.1.2 sections (around line 77). I confirmed it was in the 4.1.2 release via https://github.com/PowerDNS/pdns/commits/auth-4.1.2

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
