### PR TITLE
ixfrdist: Reduce memory usage and lock contention

### DIFF
--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -452,8 +452,11 @@ bool makeAXFRPackets(const MOADNSParser& mdp, vector<vector<uint8_t>>& packets) 
     records = g_soas[mdp.d_qname].latestAXFR;
   }
 
+  packets.reserve(packets.size() + /* SOAs */ 2 + records.size());
+
   // Initial SOA
-  packets.push_back(getSOAPacket(mdp, soa));
+  const auto soaPacket = getSOAPacket(mdp, soa);
+  packets.push_back(soaPacket);
 
   for (auto const &record : records) {
     if (record.d_type == QType::SOA) {
@@ -471,7 +474,7 @@ bool makeAXFRPackets(const MOADNSParser& mdp, vector<vector<uint8_t>>& packets) 
   }
 
   // Final SOA
-  packets.push_back(getSOAPacket(mdp, soa));
+  packets.push_back(soaPacket);
 
   return true;
 }

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -198,11 +198,11 @@ static void makeIXFRDiff(const records_t& from, const records_t& to, ixfrdiff_t&
   set_difference(to.cbegin(), to.cend(), from.cbegin(), from.cend(), back_inserter(diff.additions), from.value_comp());
   diff.oldSOA = fromSOA;
   if (fromSOA == nullptr) {
-    getSOAFromRecords(from);
+    diff.oldSOA = getSOAFromRecords(from);
   }
   diff.newSOA = toSOA;
   if (toSOA == nullptr) {
-    getSOAFromRecords(to);
+    diff.newSOA = getSOAFromRecords(to);
   }
 }
 

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -360,8 +360,10 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
         g_log<<Logger::Notice<<"Retrieved all zone data for "<<domain<<". Received "<<nrecords<<" records."<<endl;
       } catch (PDNSException &e) {
         g_log<<Logger::Warning<<"Could not retrieve AXFR for '"<<domain<<"': "<<e.reason<<endl;
+        continue;
       } catch (runtime_error &e) {
         g_log<<Logger::Warning<<"Could not retrieve AXFR for zone '"<<domain<<"': "<<e.what()<<endl;
+        continue;
       }
 
       try {

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -281,6 +281,11 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
     }
     time_t now = time(nullptr);
     for (const auto &domainConfig : g_domainConfigs) {
+
+      if (g_exiting) {
+        break;
+      }
+
       DNSName domain = domainConfig.first;
       shared_ptr<SOARecordContent> current_soa;
       const auto& zoneInfo = getCurrentZoneInfo(domain);

--- a/pdns/ixfrutils.cc
+++ b/pdns/ixfrutils.cc
@@ -105,6 +105,17 @@ uint32_t getSerialFromRecords(const records_t& records, DNSRecord& soaret)
   return 0;
 }
 
+static void writeRecords(FILE* fp, const records_t& records)
+{
+  for(const auto& r: records) {
+    fprintf(fp, "%s\t%" PRIu32 "\tIN\t%s\t%s\n",
+            r.d_name.isRoot() ? "@" :  r.d_name.toStringNoDot().c_str(),
+            r.d_ttl,
+            DNSRecordContent::NumberToType(r.d_type).c_str(),
+            r.d_content->getZoneRepresentation().c_str());
+  }
+}
+
 void writeZoneToDisk(const records_t& records, const DNSName& zone, const std::string& directory)
 {
   DNSRecord soa;
@@ -117,15 +128,11 @@ void writeZoneToDisk(const records_t& records, const DNSName& zone, const std::s
   records_t soarecord;
   soarecord.insert(soa);
   fprintf(fp, "$ORIGIN %s\n", zone.toString().c_str());
-  for(const auto& outer : {soarecord, records, soarecord} ) {
-    for(const auto& r: outer) {
-      fprintf(fp, "%s\t%" PRIu32 "\tIN\t%s\t%s\n",
-          r.d_name.isRoot() ? "@" :  r.d_name.toStringNoDot().c_str(),
-          r.d_ttl,
-          DNSRecordContent::NumberToType(r.d_type).c_str(),
-          r.d_content->getZoneRepresentation().c_str());
-    }
-  }
+
+  writeRecords(fp, soarecord);
+  writeRecords(fp, records);
+  writeRecords(fp, soarecord);
+
   fclose(fp);
   rename( (fname+".partial").c_str(), fname.c_str());
 }

--- a/pdns/ixfrutils.hh
+++ b/pdns/ixfrutils.hh
@@ -55,16 +55,3 @@ uint32_t getSerialFromRecords(const records_t& records, DNSRecord& soaret);
 void writeZoneToDisk(const records_t& records, const DNSName& zone, const std::string& directory);
 void loadZoneFromDisk(records_t& records, const string& fname, const DNSName& zone);
 void loadSOAFromDisk(const DNSName& zone, const string& fname, shared_ptr<SOARecordContent>& soa);
-
-struct ixfrdiff_t {
-  shared_ptr<SOARecordContent> oldSOA;
-  shared_ptr<SOARecordContent> newSOA;
-  vector<DNSRecord> removals;
-  vector<DNSRecord> additions;
-};
-
-struct ixfrinfo_t {
-  shared_ptr<SOARecordContent> soa; // The SOA of the latestAXFR
-  records_t latestAXFR;             // The most recent AXFR
-  vector<ixfrdiff_t> ixfrDiffs;
-};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* Avoid some copies during zone retrieval, reducing the memory usage
* Reserve memory in advance when possible to avoid reallocation
* Reduce lock contention and copy of zone information (records, diffs) when serving an actual query, by using shared pointers so we only need to hold the lock while retrieving or replacing a pointer, instead of having to hold it while copying the whole zone.   

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
