### PR TITLE
Improved Lua records - Added all selector, and backupSelector fallbacks

### DIFF
--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -46,7 +46,7 @@ Record creation functions
 
   Various options can be set in the ``options`` parameter:
 
-  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed'.
+  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none'.
   - ``source``: Source IP address to check from
 
 
@@ -56,16 +56,14 @@ Record creation functions
   ``url``. In addition, multiple groups of IP addresses can be supplied. The
   first set with a working (available) IP address is used.
 
-  If all addresses are down, as usual, a random element from all sets is
-  returned.
-
   :param string url: The url to retrieve.
   :param addresses: List of lists of IP addresses to check the URL on.
   :param options: Table of options for this specific check, see below.
 
   Various options can be set in the ``options`` parameter:
 
-  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed'.
+  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none'.
+  - ``defaultSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none'.
   - ``source``: Source IP address to check from
   - ``stringmatch``: check ``url`` for this string, only declare 'up' if found
 

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -46,8 +46,8 @@ Record creation functions
 
   Various options can be set in the ``options`` parameter:
 
-  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none' (default to 'random').
-  - ``backupSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none' (default to 'random').
+  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all' (default to 'random').
+  - ``backupSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all' (default to 'random').
   - ``source``: Source IP address to check from
 
 
@@ -65,8 +65,8 @@ Record creation functions
 
   Various options can be set in the ``options`` parameter:
 
-  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none' (default to 'random').
-  - ``backupSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none' (default to 'random').
+  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all' (default to 'random').
+  - ``backupSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all' (default to 'random').
   - ``source``: Source IP address to check from
   - ``stringmatch``: check ``url`` for this string, only declare 'up' if found
 

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -46,7 +46,8 @@ Record creation functions
 
   Various options can be set in the ``options`` parameter:
 
-  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none'.
+  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none' (default to 'random').
+  - ``backupSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none' (default to 'random').
   - ``source``: Source IP address to check from
 
 
@@ -54,7 +55,9 @@ Record creation functions
 
   More sophisticated test that attempts an actual http(s) connection to
   ``url``. In addition, multiple groups of IP addresses can be supplied. The
-  first set with a working (available) IP address is used.
+  first set with a working (available) IP address is used. URL is considered up if
+  HTTP response code is 200 and optionally if the content matches ``stringmatch``
+  option.
 
   :param string url: The url to retrieve.
   :param addresses: List of lists of IP addresses to check the URL on.
@@ -62,8 +65,8 @@ Record creation functions
 
   Various options can be set in the ``options`` parameter:
 
-  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none'.
-  - ``defaultSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none'.
+  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none' (default to 'random').
+  - ``backupSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all', 'none' (default to 'random').
   - ``source``: Source IP address to check from
   - ``stringmatch``: check ``url`` for this string, only declare 'up' if found
 

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -405,23 +405,44 @@ static std::vector<DNSZoneRecord> lookup(const DNSName& name, uint16_t qtype, in
   return ret;
 }
 
-static ComboAddress useSelector(const boost::optional<std::unordered_map<string, string>>& options, const ComboAddress& bestwho, const vector<ComboAddress>& candidates)
+static std::string getOptionValue(const boost::optional<std::unordered_map<string, string>>& options, const std::string &name, const std::string &defaultValue)
 {
-  string selector="random";
+  string selector=defaultValue;
   if(options) {
-    if(options->count("selector"))
-      selector=options->find("selector")->second;
+    if(options->count(name))
+      selector=options->find(name)->second;
+  }
+  return selector;
+}
+
+static vector<ComboAddress> useSelector(const std::string &selector, const ComboAddress& bestwho, const vector<ComboAddress>& candidates)
+{
+  vector<ComboAddress> ret;
+
+  if(selector=="none")
+    return ret;
+  else if(selector=="all")
+    return candidates;
+  else if(selector=="random")
+    ret.emplace_back(pickrandom(candidates));
+  else if(selector=="pickclosest")
+    ret.emplace_back(pickclosest(bestwho, candidates));
+  else if(selector=="hashed")
+    ret.emplace_back(hashed(bestwho, candidates));
+  else {
+    g_log<<Logger::Warning<<"LUA Record called with unknown selector '"<<selector<<"'"<<endl;
+    ret.emplace_back(pickrandom(candidates));
   }
 
-  if(selector=="random")
-    return pickrandom(candidates);
-  else if(selector=="pickclosest")
-    return pickclosest(bestwho, candidates);
-  else if(selector=="hashed")
-    return hashed(bestwho, candidates);
+  return ret;
+}
 
-  g_log<<Logger::Warning<<"LUA Record called with unknown selector '"<<selector<<"'"<<endl;
-  return pickrandom(candidates);
+static vector<string> convIpListToString(const vector<ComboAddress> &comboAddresses)
+{
+  vector<string> ret;
+  for (ComboAddress c : comboAddresses)
+    ret.emplace_back(c.toString());
+  return ret;
 }
 
 static vector<ComboAddress> convIplist(const iplist_t& src)
@@ -672,9 +693,9 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
         // if no IP is available, use selector on the whole set
         candidates = std::move(unavailables);
       }
-      ComboAddress res=useSelector(options, bestwho, candidates);
 
-      return res.toString();
+      vector<ComboAddress> res = useSelector(getOptionValue(options, "selector", "random"), bestwho, candidates);
+      return convIpListToString(res);
     });
 
   lua.writeFunction("ifurlup", [&bestwho](const std::string& url,
@@ -704,20 +725,20 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
           }
         }
         if(!available.empty()) {
-          ComboAddress res=useSelector(options, bestwho, available);
-
-          return res.toString();
+          vector<ComboAddress> res = useSelector(getOptionValue(options, "selector", "random"), bestwho, available);
+          return convIpListToString(res);
         }
       }
 
-      // All units down, return a single, random record
+      // All units down, apply defaultSelector on all candidates
       vector<ComboAddress> ret{};
       for(const auto& unit : candidates) {
         ret.insert(ret.end(), unit.begin(), unit.end());
       }
 
-      return pickrandom(ret).toString();
-                    });
+      vector<ComboAddress> res = useSelector(getOptionValue(options, "defaultSelector", "random"), bestwho, ret);
+      return convIpListToString(res);
+    });
 
 
   /* idea: we have policies on vectors of ComboAddresses, like

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -440,8 +440,11 @@ static vector<ComboAddress> useSelector(const std::string &selector, const Combo
 static vector<string> convIpListToString(const vector<ComboAddress> &comboAddresses)
 {
   vector<string> ret;
-  for (ComboAddress c : comboAddresses)
+
+  for (const auto& c : comboAddresses) {
     ret.emplace_back(c.toString());
+  }
+
   return ret;
 }
 
@@ -449,8 +452,9 @@ static vector<ComboAddress> convIplist(const iplist_t& src)
 {
   vector<ComboAddress> ret;
 
-  for(const auto& ip : src)
+  for(const auto& ip : src) {
     ret.emplace_back(ip.second);
+  }
 
   return ret;
 }
@@ -459,8 +463,9 @@ static vector<pair<int, ComboAddress> > convWIplist(std::unordered_map<int, wipl
 {
   vector<pair<int,ComboAddress> > ret;
 
-  for(const auto& i : src)
+  for(const auto& i : src) {
     ret.emplace_back(atoi(i.second.at(1).c_str()), ComboAddress(i.second.at(2)));
+  }
 
   return ret;
 }

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -419,9 +419,7 @@ static vector<ComboAddress> useSelector(const std::string &selector, const Combo
 {
   vector<ComboAddress> ret;
 
-  if(selector=="none")
-    return ret;
-  else if(selector=="all")
+  if(selector=="all")
     return candidates;
   else if(selector=="random")
     ret.emplace_back(pickrandom(candidates));


### PR DESCRIPTION
### Short description

Fixes -3 and -4 of #6892

This PR adds a `backupSelector` parameter to the `ifportup` and `ifurlup` methods. This is used to be able to customize the selector used when no candidate is declared as UP (instead of the default `random` one). This also adds the `all` selector that can be used to return all candidates.

### Checklist

I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

What do you think ? ;-)