### PR TITLE
ixfrdist: Fix TTL, optimize the construction of answers

### DIFF
--- a/docs/manpages/ixfrdist.yml.5.rst
+++ b/docs/manpages/ixfrdist.yml.5.rst
@@ -59,6 +59,10 @@ Options
   Increase this when the network to the authoritative servers is slow or the domains are very large and you experience timeouts.
   Defaults to 20.
 
+:compress:
+  Whether record compression should be enabled, leading to smaller answers at the cost of an increased CPU and memory usage.
+  Defaults to false.
+
 :work-dir:
   The directory where the domain data is stored.
   When not set, the current working directory is used.

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -497,7 +497,7 @@ static bool sendPacketOverTCP(int fd, const std::vector<uint8_t>& packet)
 
 static bool addRecordToWriter(DNSPacketWriter& pw, const DNSName& zoneName, const DNSRecord& record)
 {
-  pw.startRecord(record.d_name + zoneName, record.d_type);
+  pw.startRecord(record.d_name + zoneName, record.d_type, record.d_ttl);
   record.d_content->toPacket(pw);
   if (pw.size() > 65535) {
     pw.rollback();

--- a/pdns/ixfrdist.example.yml
+++ b/pdns/ixfrdist.example.yml
@@ -35,6 +35,11 @@ acl:
 #
 axfr-timeout: 20
 
+# Whether record compression should be enabled, leading to smaller answers
+# at the cost of an increased CPU and memory usage. Defaults to false.
+#
+compress: false
+
 # Amount of older copies/IXFR diffs to keep for every domain. This is set to
 # 20 by default or when unset.
 #


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* Don't override the original `TTL` in our `AXFR`/`IXFR` responses ;
* Group as many records as possible inside one `DNS` message, and send a message as soon as it is ready, so we can reduce the memory usage by not keeping all outgoing messages in memory, and send a lower number of messages ;
* Add an option to compress record while building the answer, off by default.

This PR could use a good review before merging.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
