### PR TITLE
Added Prometheus stats support for dnsdist

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -471,7 +471,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           }
           const string label = "{pool=\"" + poolName + "\"}";
           const std::shared_ptr<ServerPool> pool = entry.second;
-          output << "dnsdist_pools_servers" << label << " " << pool->countServers(false) << "\n";
+          output << "dnsdist_pool_servers" << label << " " << pool->countServers(false) << "\n";
 
           if (pool->packetCache != nullptr) {
             const auto& cache = pool->packetCache;

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -128,7 +128,7 @@ static bool isAnAPIRequestAllowedWithWebAuth(const YaHTTP::Request& req)
 
 static bool isAStatsRequest(const YaHTTP::Request& req)
 {
-  return req.url.path == "/jsonstat" || req.url.path == "/prometheus";
+  return req.url.path == "/jsonstat" || req.url.path == "/metrics";
 }
 
 static bool compareAuthorization(const YaHTTP::Request& req, const string &expected_password, const string& expectedApiKey)
@@ -386,70 +386,98 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
         resp.status=404;
       }
     }
-    else if(req.url.path=="/prometheus") {
+    else if (req.url.path == "/metrics") {
         handleCORS(req, resp);
-        resp.status=200;
+        resp.status = 200;
 
-        ostringstream str;
-        for(const auto& e : g_stats.entries) {
-          string metricName = "dnsdist_main_" + std::get<0>(e);
-          boost::replace_all(metricName, "-", "_");
+        std::ostringstream output;
+        for (const auto& e : g_stats.entries) {
+          std::string metricName = std::get<0>(e);
+
+          // Prometheus suggest using '_' instead of '-'
+          std::string prometheusMetricName = "dnsdist_main_" + boost::replace_all_copy(metricName, "-", "_");
+
+          MetricDefinition metricDetails; 
+
+          if (!g_metricDefinitions.getMetricDetails(metricName, metricDetails)) {
+              warnlog("Do not have metric details for %s", metricName);
+              continue;
+          }
 
           // for these we have the help and types encoded in the sources:
-          str<<"# HELP "<<metricName<<' '<< std::get<3>(e)<<"\n";
-          str<<"# TYPE "<<metricName<<' '<< std::get<2>(e)<<"\n";
-          str<<metricName<<' ';
-          if(const auto& val = boost::get<DNSDistStats::stat_t*>(&std::get<1>(e)))
-            str<<(*val)->load();
+          output << "# HELP " << prometheusMetricName << " " << metricDetails.description    << "\n";
+          output << "# TYPE " << prometheusMetricName << " " << metricDetails.prometheusType << "\n";
+          output << prometheusMetricName << " ";
+
+          if (const auto& val = boost::get<DNSDistStats::stat_t*>(&std::get<1>(e)))
+            output << (*val)->load();
           else if (const auto& dval = boost::get<double*>(&std::get<1>(e)))
-            str<<**dval;
+            output << **dval;
           else
-            str<<(*boost::get<DNSDistStats::statfunction_t>(&std::get<1>(e)))(std::get<0>(e));
-          str<<"\n";
+            output << (*boost::get<DNSDistStats::statfunction_t>(&std::get<1>(e)))(std::get<0>(e));
+          
+          output << "\n";
         }
+
         const auto states = g_dstates.getCopy();
         const string statesbase = "dnsdist_main_servers_";
-        for(const auto& state : states) {
-          string serverName = state->name.empty() ? (state->remote.toString() + ":" + std::to_string(state->remote.getPort())) : state->getName();
+        
+        for (const auto& state : states) {
+          string serverName;
+           
+          if (state->name.empty())
+              serverName = state->remote.toString() + ":" + std::to_string(state->remote.getPort());
+          else
+              serverName = state->getName();
+
           boost::replace_all(serverName, ".", "_");
+
           const string label = "{server=\"" + serverName + "\"}";
-          str<<statesbase<<"queries"<<label<<' '<< state->queries.load() <<"\n";
-          str<<statesbase<<"drops"<<label<<' '<< state->reuseds.load() << "\n";
-          str<<statesbase<<"latency"<<label<<' '<< state->latencyUsec/1000.0 << "\n";
-          str<<statesbase<<"senderrors"<<label<<' '<< state->sendErrors.load() << "\n";
-          str<<statesbase<<"outstanding"<<label<<' '<< state->outstanding.load() << "\n";
+          output << statesbase << "queries"     << label << " " << state->queries.load()     << "\n";
+          output << statesbase << "drops"       << label << " " << state->reuseds.load()     << "\n";
+          output << statesbase << "latency"     << label << " " << state->latencyUsec/1000.0 << "\n";
+          output << statesbase << "senderrors"  << label << " " << state->sendErrors.load()  << "\n";
+          output << statesbase << "outstanding" << label << " " << state->outstanding.load() << "\n";
         }
-        for(const auto& front : g_frontends) {
+
+        for (const auto& front : g_frontends) {
           if (front->udpFD == -1 && front->tcpFD == -1)
             continue;
 
           string frontName = front->local.toString() + ":" + std::to_string(front->local.getPort());
           boost::replace_all(frontName, ".", "_");
           string proto = (front->udpFD >= 0 ? "udp" : "tcp");
-          str<<"dnsdist_main_frontend_queries{frontend=\""<<frontName<<"\",proto=\""<<proto<<"\"} "<< front->queries.load() << "\n";
+
+          output << "dnsdist_main_frontend_queries{frontend=\"" << frontName << "\",proto=\"" << proto
+              << "\"} " << front->queries.load() << "\n";
         }
+
         const auto localPools = g_pools.getCopy();
         const string cachebase = "dnsdist_pool_";
+        
         for (const auto& entry : localPools) {
           string poolName = entry.first;
           boost::replace_all(poolName, ".", "_");
+          
           if (poolName.empty()) {
             poolName = "_default_";
           }
           const string label = "{pool=\"" + poolName + "\"}";
           const std::shared_ptr<ServerPool> pool = entry.second;
-          str<<"dnsdist_main_pools_servers"<<label<< ' ' << pool->servers.size() <<"\n";
+          output << "dnsdist_main_pools_servers" << label << " " << pool->countServers(false) << "\n";
+
           if (pool->packetCache != nullptr) {
             const auto& cache = pool->packetCache;
-            str<<cachebase<<"cache_size"<<label << ' ' << cache->getMaxEntries() << "\n";
-            str<<cachebase<<"cache_entries"<<label << ' ' << cache->getEntriesCount() << "\n";
-            str<<cachebase<<"cache_hits"<<label << ' ' << cache->getHits() << "\n";
-            str<<cachebase<<"cache_misses"<<label << ' ' << cache->getMisses() << "\n";
-            str<<cachebase<<"cache_deferred_inserts"<<label << ' ' << cache->getDeferredInserts() << "\n";
-            str<<cachebase<<"cache_deferred_lookups"<<label << ' ' << cache->getDeferredLookups() << "\n";
-            str<<cachebase<<"cache_lookup_collisions"<<label << ' ' << cache->getLookupCollisions() << "\n";
-            str<<cachebase<<"cache_insert_collisions"<<label << ' ' << cache->getInsertCollisions() << "\n";
-            str<<cachebase<<"cache_ttl_too_shorts"<<label << ' ' << cache->getTTLTooShorts() << "\n";
+
+            output << cachebase << "cache_size"              <<label << " " << cache->getMaxEntries()       << "\n";
+            output << cachebase << "cache_entries"           <<label << " " << cache->getEntriesCount()     << "\n";
+            output << cachebase << "cache_hits"              <<label << " " << cache->getHits()             << "\n";
+            output << cachebase << "cache_misses"            <<label << " " << cache->getMisses()           << "\n";
+            output << cachebase << "cache_deferred_inserts"  <<label << " " << cache->getDeferredInserts()  << "\n";
+            output << cachebase << "cache_deferred_lookups"  <<label << " " << cache->getDeferredLookups()  << "\n";
+            output << cachebase << "cache_lookup_collisions" <<label << " " << cache->getLookupCollisions() << "\n";
+            output << cachebase << "cache_insert_collisions" <<label << " " << cache->getInsertCollisions() << "\n";
+            output << cachebase << "cache_ttl_too_shorts"    <<label << " " << cache->getTTLTooShorts()     << "\n";
           }
         }
 
@@ -457,15 +485,18 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           WriteLock wl(&g_qcount.queryLock);
           std::string qname;
           const string qnamebase = "dnsdist_querycount_queries";
+
           for(auto &record: g_qcount.records) {
             qname = record.first;
             boost::replace_all(qname, ".", "_");
-	    const string label = "{qname=\"" + qname + "\"}";
-            str<<qnamebase<<label<<' '<<record.second<<"\n";
+	    
+            const std::string label = "{qname=\"" + qname + "\"}";
+            output << qnamebase << label << " " << record.second << "\n";
           }
           g_qcount.records.clear();
         }
-        resp.body=str.str();
+
+        resp.body = output.str();
         resp.headers["Content-Type"] = "text/plain";
     }
 

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -433,7 +433,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           string serverName;
            
           if (state->name.empty())
-              serverName = state->remote.toString() + ":" + std::to_string(state->remote.getPort());
+              serverName = state->remote.toStringWithPort();
           else
               serverName = state->getName();
 

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -427,7 +427,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
         }
 
         auto states = g_dstates.getLocal();
-        const string statesbase = "dnsdist_servers_";
+        const string statesbase = "dnsdist_server_";
         
         for (const auto& state : *states) {
           string serverName;
@@ -454,7 +454,6 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
             continue;
 
           string frontName = front->local.toString() + ":" + std::to_string(front->local.getPort());
-          boost::replace_all(frontName, ".", "_");
           string proto = (front->udpFD >= 0 ? "udp" : "tcp");
 
           output << "dnsdist_frontend_queries{frontend=\"" << frontName << "\",proto=\"" << proto
@@ -466,7 +465,6 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
         
         for (const auto& entry : *localPools) {
           string poolName = entry.first;
-          boost::replace_all(poolName, ".", "_");
           
           if (poolName.empty()) {
             poolName = "_default_";

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -34,6 +34,7 @@
 #include "htmlfiles.h"
 #include "base64.hh"
 #include "gettime.hh"
+#include  <boost/format.hpp>
 
 bool g_apiReadWrite{false};
 std::string g_apiConfigDirectory;
@@ -439,7 +440,9 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
 
           boost::replace_all(serverName, ".", "_");
 
-          const string label = "{server=\"" + serverName + "\"}";
+          const std::string label = boost::str(boost::format("{server=\"%1%\",address=\"%2%\"}")
+            % serverName % state->remote.toStringWithPort());
+
           output << statesbase << "queries"     << label << " " << state->queries.load()     << "\n";
           output << statesbase << "drops"       << label << " " << state->reuseds.load()     << "\n";
           output << statesbase << "latency"     << label << " " << state->latencyUsec/1000.0 << "\n";

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -404,9 +404,16 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
               continue;
           }
 
+          std::string prometheusTypeName = g_metricDefinitions.getPrometheusStringMetricType(metricDetails.prometheusType);
+
+          if (prometheusTypeName == "") {
+              vinfolog("Unknown Prometheus type for %s", metricName);
+              continue;
+          }
+
           // for these we have the help and types encoded in the sources:
           output << "# HELP " << prometheusMetricName << " " << metricDetails.description    << "\n";
-          output << "# TYPE " << prometheusMetricName << " " << metricDetails.prometheusType << "\n";
+          output << "# TYPE " << prometheusMetricName << " " << prometheusTypeName << "\n";
           output << prometheusMetricName << " ";
 
           if (const auto& val = boost::get<DNSDistStats::stat_t*>(&std::get<1>(e)))

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -395,7 +395,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           std::string metricName = std::get<0>(e);
 
           // Prometheus suggest using '_' instead of '-'
-          std::string prometheusMetricName = "dnsdist_main_" + boost::replace_all_copy(metricName, "-", "_");
+          std::string prometheusMetricName = "dnsdist_" + boost::replace_all_copy(metricName, "-", "_");
 
           MetricDefinition metricDetails; 
 
@@ -427,7 +427,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
         }
 
         auto states = g_dstates.getLocal();
-        const string statesbase = "dnsdist_main_servers_";
+        const string statesbase = "dnsdist_servers_";
         
         for (const auto& state : *states) {
           string serverName;
@@ -457,7 +457,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           boost::replace_all(frontName, ".", "_");
           string proto = (front->udpFD >= 0 ? "udp" : "tcp");
 
-          output << "dnsdist_main_frontend_queries{frontend=\"" << frontName << "\",proto=\"" << proto
+          output << "dnsdist_frontend_queries{frontend=\"" << frontName << "\",proto=\"" << proto
               << "\"} " << front->queries.load() << "\n";
         }
 
@@ -473,7 +473,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           }
           const string label = "{pool=\"" + poolName + "\"}";
           const std::shared_ptr<ServerPool> pool = entry.second;
-          output << "dnsdist_main_pools_servers" << label << " " << pool->countServers(false) << "\n";
+          output << "dnsdist_pools_servers" << label << " " << pool->countServers(false) << "\n";
 
           if (pool->packetCache != nullptr) {
             const auto& cache = pool->packetCache;

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -490,20 +490,6 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           }
         }
 
-        {
-          ReadLock rl(&g_qcount.queryLock);
-          std::string qname;
-          const string qnamebase = "dnsdist_querycount_queries";
-
-          for(auto &record: g_qcount.records) {
-            qname = record.first;
-            boost::replace_all(qname, ".", "_");
-	    
-            const std::string label = "{qname=\"" + qname + "\"}";
-            output << qnamebase << label << " " << record.second << "\n";
-          }
-        }
-
         resp.body = output.str();
         resp.headers["Content-Type"] = "text/plain";
     }

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -400,7 +400,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           MetricDefinition metricDetails; 
 
           if (!g_metricDefinitions.getMetricDetails(metricName, metricDetails)) {
-              warnlog("Do not have metric details for %s", metricName);
+              vinfolog("Do not have metric details for %s", metricName);
               continue;
           }
 

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -445,6 +445,8 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           output << statesbase << "latency"     << label << " " << state->latencyUsec/1000.0 << "\n";
           output << statesbase << "senderrors"  << label << " " << state->sendErrors.load()  << "\n";
           output << statesbase << "outstanding" << label << " " << state->outstanding.load() << "\n";
+          output << statesbase << "order"       << label << " " << state->order              << "\n";
+          output << statesbase << "weight"      << label << " " << state->weight             << "\n";
         }
 
         for (const auto& front : g_frontends) {

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -419,10 +419,10 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           output << "\n";
         }
 
-        const auto states = g_dstates.getCopy();
+        auto states = g_dstates.getLocal();
         const string statesbase = "dnsdist_main_servers_";
         
-        for (const auto& state : states) {
+        for (const auto& state : *states) {
           string serverName;
            
           if (state->name.empty())
@@ -452,10 +452,10 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
               << "\"} " << front->queries.load() << "\n";
         }
 
-        const auto localPools = g_pools.getCopy();
+        auto localPools = g_pools.getLocal();
         const string cachebase = "dnsdist_pool_";
         
-        for (const auto& entry : localPools) {
+        for (const auto& entry : *localPools) {
           string poolName = entry.first;
           boost::replace_all(poolName, ".", "_");
           

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -491,7 +491,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
         }
 
         {
-          WriteLock wl(&g_qcount.queryLock);
+          ReadLock rl(&g_qcount.queryLock);
           std::string qname;
           const string qnamebase = "dnsdist_querycount_queries";
 
@@ -502,7 +502,6 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
             const std::string label = "{qname=\"" + qname + "\"}";
             output << qnamebase << label << " " << record.second << "\n";
           }
-          g_qcount.records.clear();
         }
 
         resp.body = output.str();

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -80,6 +80,8 @@ using std::thread;
 bool g_verbose;
 
 struct DNSDistStats g_stats;
+MetricDefinitionStorage g_metricDefinitions;
+
 uint16_t g_maxOutstanding{10240};
 bool g_verboseHealthChecks{false};
 uint32_t g_staleCacheEntriesTTL{0};

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -262,7 +262,75 @@ struct DNSDistStats
   };
 };
 
+// Keeps additional information about metrics
+struct MetricDefinition {
+  MetricDefinition(std::string description, std::string prometheusType) {
+    this->description = description;
+    this->prometheusType = prometheusType;
+  }
+ 
+  MetricDefinition() = default;
 
+  // Metric description
+  std::string description;
+  // Metric type for Prometheus
+  std::string prometheusType;
+};
+
+struct MetricDefinitionStorage {
+  // Return metric definition by name
+  bool getMetricDetails(std::string metricName, MetricDefinition& metric) {
+  auto metricDetailsIter = metrics.find(metricName);
+
+  if (metricDetailsIter == metrics.end()) {
+    return false;
+  }
+
+  metric = metricDetailsIter->second;
+    return true;
+  };
+
+  std::map<std::string, MetricDefinition> metrics = {
+    { "responses",              MetricDefinition("counter", "Number of responses received from backends") },
+    { "servfail-responses",     MetricDefinition("counter", "Number of SERVFAIL answers received from backends") },
+    { "queries",                MetricDefinition("counter", "Number of received queries")},
+    { "acl-drops",              MetricDefinition("counter", "Number of packets dropped because of the ACL")},
+    { "rule-drop",              MetricDefinition("counter", "Number of queries dropped because of a rule")},
+    { "rule-nxdomain",          MetricDefinition("counter", "Number of NXDomain answers returned because of a rule")},
+    { "rule-refused",           MetricDefinition("counter", "Number of Refused answers returned because of a rule")},
+    { "rule-servfail",          MetricDefinition("counter", "Number of SERVFAIL answers received because of a rule")},
+    { "self-answered",          MetricDefinition("counter", "Number of self-answered responses")},
+    { "downstream-timeouts",    MetricDefinition("counter", "Number of queries not answered in time by a backend")},
+    { "downstream-send-errors", MetricDefinition("counter", "Number of errors when sending a query to a backend")},
+    { "trunc-failures",         MetricDefinition("counter", "Number of errors encountered while truncating an answer")},
+    { "no-policy",              MetricDefinition("counter", "Number of queries dropped because no server was available")},
+    { "latency0-1",             MetricDefinition("counter", "Number of queries answered in less than 1ms")},
+    { "latency1-10",            MetricDefinition("counter", "Number of queries answered in 1-10 ms")},
+    { "latency10-50",           MetricDefinition("counter", "Number of queries answered in 10-50 ms")},
+    { "latency50-100",          MetricDefinition("counter", "Number of queries answered in 50-100 ms")},
+    { "latency100-1000",        MetricDefinition("counter", "Number of queries answered in 100-1000 ms")},
+    { "latency-slow",           MetricDefinition("counter", "Number of queries answered in more than 1 second")},
+    { "latency-avg100",         MetricDefinition("gauge",   "Average response latency in microseconds of the last 100 packets")},
+    { "latency-avg1000",        MetricDefinition("gauge",   "Average response latency in microseconds of the last 1000 packets")},
+    { "latency-avg10000",       MetricDefinition("gauge",   "Average response latency in microseconds of the last 10000 packets")},
+    { "latency-avg1000000",     MetricDefinition("gauge",   "Average response latency in microseconds of the last 1000000 packets")},
+    { "uptime",                 MetricDefinition("gauge",   "Uptime of the dnsdist process in seconds")},
+    { "real-memory-usage",      MetricDefinition("gauge",   "Current memory usage in bytes")},
+    { "noncompliant-queries",   MetricDefinition("counter", "Number of queries dropped as non-compliant")},
+    { "noncompliant-responses", MetricDefinition("counter", "Number of answers from a backend dropped as non-compliant")},
+    { "rdqueries",              MetricDefinition("counter", "Number of received queries with the recursion desired bit set")},
+    { "empty-queries",          MetricDefinition("counter", "Number of empty queries received from clients")},
+    { "cache-hits",             MetricDefinition("counter", "Number of times an answer was retrieved from cache")},
+    { "cache-misses",           MetricDefinition("counter", "Number of times an answer not found in the cache")},
+    { "cpu-user-msec",          MetricDefinition("counter", "Milliseconds spent by dnsdist in the user state")},
+    { "cpu-sys-msec",           MetricDefinition("counter", "Milliseconds spent by dnsdist in the system state")},
+    { "fd-usage",               MetricDefinition("gauge",   "Number of currently used file descriptors")},
+    { "dyn-blocked",            MetricDefinition("counter", "Number of queries dropped because of a dynamic block")},
+    { "dyn-block-nmg-size",     MetricDefinition("gauge",   "Number of dynamic blocks entries") },
+  };
+};
+
+extern MetricDefinitionStorage g_metricDefinitions;
 extern struct DNSDistStats g_stats;
 void doLatencyStats(double udiff);
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -346,8 +346,7 @@ struct MetricDefinitionStorage {
     { "cpu-user-msec",          MetricDefinition(PrometheusMetricType::counter, "Milliseconds spent by dnsdist in the user state")},
     { "cpu-sys-msec",           MetricDefinition(PrometheusMetricType::counter, "Milliseconds spent by dnsdist in the system state")},
     { "fd-usage",               MetricDefinition(PrometheusMetricType::gauge,   "Number of currently used file descriptors")},
-    { "dyn-blocked",            MetricDefinition(PrometheusMetricType::counter
-            , "Number of queries dropped because of a dynamic block")},
+    { "dyn-blocked",            MetricDefinition(PrometheusMetricType::counter, "Number of queries dropped because of a dynamic block")},
     { "dyn-block-nmg-size",     MetricDefinition(PrometheusMetricType::gauge,   "Number of dynamic blocks entries") },
   };
 };

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -262,11 +262,17 @@ struct DNSDistStats
   };
 };
 
+// Metric types for Prometheus
+enum class PrometheusMetricType: int {
+    counter = 1,
+    gauge = 2
+};
+
 // Keeps additional information about metrics
 struct MetricDefinition {
-  MetricDefinition(const std::string& description, const std::string& prometheusType) {
-    this->description = description;
+  MetricDefinition(PrometheusMetricType prometheusType, const std::string& description) {
     this->prometheusType = prometheusType;
+    this->description = description;
   }
  
   MetricDefinition() = default;
@@ -274,7 +280,7 @@ struct MetricDefinition {
   // Metric description
   std::string description;
   // Metric type for Prometheus
-  std::string prometheusType;
+  PrometheusMetricType prometheusType;
 };
 
 struct MetricDefinitionStorage {
@@ -290,43 +296,59 @@ struct MetricDefinitionStorage {
     return true;
   };
 
+  // Return string representation of Prometheus metric type
+  std::string getPrometheusStringMetricType(PrometheusMetricType metricType) {
+    switch (metricType) { 
+      case PrometheusMetricType::counter:
+        return "counter";
+        break;
+      case PrometheusMetricType::gauge:
+        return "gauge";
+        break;
+      default:
+        return "";
+        break;
+    }
+  };
+
   std::map<std::string, MetricDefinition> metrics = {
-    { "responses",              MetricDefinition("counter", "Number of responses received from backends") },
-    { "servfail-responses",     MetricDefinition("counter", "Number of SERVFAIL answers received from backends") },
-    { "queries",                MetricDefinition("counter", "Number of received queries")},
-    { "acl-drops",              MetricDefinition("counter", "Number of packets dropped because of the ACL")},
-    { "rule-drop",              MetricDefinition("counter", "Number of queries dropped because of a rule")},
-    { "rule-nxdomain",          MetricDefinition("counter", "Number of NXDomain answers returned because of a rule")},
-    { "rule-refused",           MetricDefinition("counter", "Number of Refused answers returned because of a rule")},
-    { "rule-servfail",          MetricDefinition("counter", "Number of SERVFAIL answers received because of a rule")},
-    { "self-answered",          MetricDefinition("counter", "Number of self-answered responses")},
-    { "downstream-timeouts",    MetricDefinition("counter", "Number of queries not answered in time by a backend")},
-    { "downstream-send-errors", MetricDefinition("counter", "Number of errors when sending a query to a backend")},
-    { "trunc-failures",         MetricDefinition("counter", "Number of errors encountered while truncating an answer")},
-    { "no-policy",              MetricDefinition("counter", "Number of queries dropped because no server was available")},
-    { "latency0-1",             MetricDefinition("counter", "Number of queries answered in less than 1ms")},
-    { "latency1-10",            MetricDefinition("counter", "Number of queries answered in 1-10 ms")},
-    { "latency10-50",           MetricDefinition("counter", "Number of queries answered in 10-50 ms")},
-    { "latency50-100",          MetricDefinition("counter", "Number of queries answered in 50-100 ms")},
-    { "latency100-1000",        MetricDefinition("counter", "Number of queries answered in 100-1000 ms")},
-    { "latency-slow",           MetricDefinition("counter", "Number of queries answered in more than 1 second")},
-    { "latency-avg100",         MetricDefinition("gauge",   "Average response latency in microseconds of the last 100 packets")},
-    { "latency-avg1000",        MetricDefinition("gauge",   "Average response latency in microseconds of the last 1000 packets")},
-    { "latency-avg10000",       MetricDefinition("gauge",   "Average response latency in microseconds of the last 10000 packets")},
-    { "latency-avg1000000",     MetricDefinition("gauge",   "Average response latency in microseconds of the last 1000000 packets")},
-    { "uptime",                 MetricDefinition("gauge",   "Uptime of the dnsdist process in seconds")},
-    { "real-memory-usage",      MetricDefinition("gauge",   "Current memory usage in bytes")},
-    { "noncompliant-queries",   MetricDefinition("counter", "Number of queries dropped as non-compliant")},
-    { "noncompliant-responses", MetricDefinition("counter", "Number of answers from a backend dropped as non-compliant")},
-    { "rdqueries",              MetricDefinition("counter", "Number of received queries with the recursion desired bit set")},
-    { "empty-queries",          MetricDefinition("counter", "Number of empty queries received from clients")},
-    { "cache-hits",             MetricDefinition("counter", "Number of times an answer was retrieved from cache")},
-    { "cache-misses",           MetricDefinition("counter", "Number of times an answer not found in the cache")},
-    { "cpu-user-msec",          MetricDefinition("counter", "Milliseconds spent by dnsdist in the user state")},
-    { "cpu-sys-msec",           MetricDefinition("counter", "Milliseconds spent by dnsdist in the system state")},
-    { "fd-usage",               MetricDefinition("gauge",   "Number of currently used file descriptors")},
-    { "dyn-blocked",            MetricDefinition("counter", "Number of queries dropped because of a dynamic block")},
-    { "dyn-block-nmg-size",     MetricDefinition("gauge",   "Number of dynamic blocks entries") },
+    { "responses",              MetricDefinition(PrometheusMetricType::counter, "Number of responses received from backends") },
+    { "servfail-responses",     MetricDefinition(PrometheusMetricType::counter, "Number of SERVFAIL answers received from backends") },
+    { "queries",                MetricDefinition(PrometheusMetricType::counter, "Number of received queries")},
+    { "acl-drops",              MetricDefinition(PrometheusMetricType::counter, "Number of packets dropped because of the ACL")},
+    { "rule-drop",              MetricDefinition(PrometheusMetricType::counter, "Number of queries dropped because of a rule")},
+    { "rule-nxdomain",          MetricDefinition(PrometheusMetricType::counter, "Number of NXDomain answers returned because of a rule")},
+    { "rule-refused",           MetricDefinition(PrometheusMetricType::counter, "Number of Refused answers returned because of a rule")},
+    { "rule-servfail",          MetricDefinition(PrometheusMetricType::counter, "Number of SERVFAIL answers received because of a rule")},
+    { "self-answered",          MetricDefinition(PrometheusMetricType::counter, "Number of self-answered responses")},
+    { "downstream-timeouts",    MetricDefinition(PrometheusMetricType::counter, "Number of queries not answered in time by a backend")},
+    { "downstream-send-errors", MetricDefinition(PrometheusMetricType::counter, "Number of errors when sending a query to a backend")},
+    { "trunc-failures",         MetricDefinition(PrometheusMetricType::counter, "Number of errors encountered while truncating an answer")},
+    { "no-policy",              MetricDefinition(PrometheusMetricType::counter, "Number of queries dropped because no server was available")},
+    { "latency0-1",             MetricDefinition(PrometheusMetricType::counter, "Number of queries answered in less than 1ms")},
+    { "latency1-10",            MetricDefinition(PrometheusMetricType::counter, "Number of queries answered in 1-10 ms")},
+    { "latency10-50",           MetricDefinition(PrometheusMetricType::counter, "Number of queries answered in 10-50 ms")},
+    { "latency50-100",          MetricDefinition(PrometheusMetricType::counter, "Number of queries answered in 50-100 ms")},
+    { "latency100-1000",        MetricDefinition(PrometheusMetricType::counter, "Number of queries answered in 100-1000 ms")},
+    { "latency-slow",           MetricDefinition(PrometheusMetricType::counter, "Number of queries answered in more than 1 second")},
+    { "latency-avg100",         MetricDefinition(PrometheusMetricType::gauge,   "Average response latency in microseconds of the last 100 packets")},
+    { "latency-avg1000",        MetricDefinition(PrometheusMetricType::gauge,   "Average response latency in microseconds of the last 1000 packets")},
+    { "latency-avg10000",       MetricDefinition(PrometheusMetricType::gauge,   "Average response latency in microseconds of the last 10000 packets")},
+    { "latency-avg1000000",     MetricDefinition(PrometheusMetricType::gauge,   "Average response latency in microseconds of the last 1000000 packets")},
+    { "uptime",                 MetricDefinition(PrometheusMetricType::gauge,   "Uptime of the dnsdist process in seconds")},
+    { "real-memory-usage",      MetricDefinition(PrometheusMetricType::gauge,   "Current memory usage in bytes")},
+    { "noncompliant-queries",   MetricDefinition(PrometheusMetricType::counter, "Number of queries dropped as non-compliant")},
+    { "noncompliant-responses", MetricDefinition(PrometheusMetricType::counter, "Number of answers from a backend dropped as non-compliant")},
+    { "rdqueries",              MetricDefinition(PrometheusMetricType::counter, "Number of received queries with the recursion desired bit set")},
+    { "empty-queries",          MetricDefinition(PrometheusMetricType::counter, "Number of empty queries received from clients")},
+    { "cache-hits",             MetricDefinition(PrometheusMetricType::counter, "Number of times an answer was retrieved from cache")},
+    { "cache-misses",           MetricDefinition(PrometheusMetricType::counter, "Number of times an answer not found in the cache")},
+    { "cpu-user-msec",          MetricDefinition(PrometheusMetricType::counter, "Milliseconds spent by dnsdist in the user state")},
+    { "cpu-sys-msec",           MetricDefinition(PrometheusMetricType::counter, "Milliseconds spent by dnsdist in the system state")},
+    { "fd-usage",               MetricDefinition(PrometheusMetricType::gauge,   "Number of currently used file descriptors")},
+    { "dyn-blocked",            MetricDefinition(PrometheusMetricType::counter
+            , "Number of queries dropped because of a dynamic block")},
+    { "dyn-block-nmg-size",     MetricDefinition(PrometheusMetricType::gauge,   "Number of dynamic blocks entries") },
   };
 };
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -264,7 +264,7 @@ struct DNSDistStats
 
 // Keeps additional information about metrics
 struct MetricDefinition {
-  MetricDefinition(std::string description, std::string prometheusType) {
+  MetricDefinition(const std::string& description, const std::string& prometheusType) {
     this->description = description;
     this->prometheusType = prometheusType;
   }

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -99,7 +99,7 @@ URL Endpoints
 
   :query command: one of ``stats``, ``dynblocklist`` or ``ebpfblocklist``
 
-.. http:get:: /prometheus
+.. http:get:: /metrics
 
   Get statistics from dnsdist in `Prometheus <https://prometheus.io>`_ format.
 
@@ -107,7 +107,7 @@ URL Endpoints
 
    .. sourcecode:: http
 
-      GET /prometheus
+      GET /metrics
 
   **Example response**:
    .. sourcecode:: http
@@ -271,7 +271,7 @@ URL Endpoints
       job_name: dnsdist
       scrape_interval: 10s
       scrape_timeout: 2s
-      metrics_path: /prometheus
+      metrics_path: /metrics
       basic_auth:
         username: dontcare
         password: yoursecret

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -99,6 +99,184 @@ URL Endpoints
 
   :query command: one of ``stats``, ``dynblocklist`` or ``ebpfblocklist``
 
+.. http:get:: /prometheus
+
+  Get statistics from dnsdist in `Prometheus <https://prometheus.io>`_ format.
+
+  **Example request**:
+
+   .. sourcecode:: http
+
+      GET /prometheus
+
+  **Example response**:
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Transfer-Encoding: chunked
+      Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type: text/plain
+      X-Content-Type-Options: nosniff
+      X-Frame-Options: deny
+      X-Permitted-Cross-Domain-Policies: none
+      X-Xss-Protection: 1; mode=block
+
+
+      # HELP dnsdist_main_responses Number of responses received from backends
+      # TYPE dnsdist_main_responses counter
+      dnsdist_main_responses 0
+      # HELP dnsdist_main_servfail_responses Number of SERVFAIL answers received from backends
+      # TYPE dnsdist_main_servfail_responses counter
+      dnsdist_main_servfail_responses 0
+      # HELP dnsdist_main_queries Number of received queries
+      # TYPE dnsdist_main_queries counter
+      dnsdist_main_queries 0
+      # HELP dnsdist_main_acl_drops Number of packets dropped because of the ACL
+      # TYPE dnsdist_main_acl_drops counter
+      dnsdist_main_acl_drops 0
+      # HELP dnsdist_main_rule_drop Number of queries dropped because of a rule
+      # TYPE dnsdist_main_rule_drop counter
+      dnsdist_main_rule_drop 0
+      # HELP dnsdist_main_rule_nxdomain Number of NXDomain answers returned because of a rule
+      # TYPE dnsdist_main_rule_nxdomain counter
+      dnsdist_main_rule_nxdomain 0
+      # HELP dnsdist_main_rule_refused Number of Refused answers returned because of a rule
+      # TYPE dnsdist_main_rule_refused counter
+      dnsdist_main_rule_refused 0
+      # HELP dnsdist_main_rule_servfail Number of SERVFAIL answers received because of a rule
+      # TYPE dnsdist_main_rule_servfail counter
+      dnsdist_main_rule_servfail 0
+      # HELP dnsdist_main_self_answered Number of self-answered responses
+      # TYPE dnsdist_main_self_answered counter
+      dnsdist_main_self_answered 0
+      # HELP dnsdist_main_downstream_timeouts Number of queries not answered in time by a backend
+      # TYPE dnsdist_main_downstream_timeouts counter
+      dnsdist_main_downstream_timeouts 0
+      # HELP dnsdist_main_downstream_send_errors Number of errors when sending a query to a backend
+      # TYPE dnsdist_main_downstream_send_errors counter
+      dnsdist_main_downstream_send_errors 0
+      # HELP dnsdist_main_trunc_failures Number of errors encountered while truncating an answer
+      # TYPE dnsdist_main_trunc_failures counter
+      dnsdist_main_trunc_failures 0
+      # HELP dnsdist_main_no_policy Number of queries dropped because no server was available
+      # TYPE dnsdist_main_no_policy counter
+      dnsdist_main_no_policy 0
+      # HELP dnsdist_main_latency0_1 Number of queries answered in less than 1ms
+      # TYPE dnsdist_main_latency0_1 counter
+      dnsdist_main_latency0_1 0
+      # HELP dnsdist_main_latency1_10 Number of queries answered in 1-10 ms
+      # TYPE dnsdist_main_latency1_10 counter
+      dnsdist_main_latency1_10 0
+      # HELP dnsdist_main_latency10_50 Number of queries answered in 10-50 ms
+      # TYPE dnsdist_main_latency10_50 counter
+      dnsdist_main_latency10_50 0
+      # HELP dnsdist_main_latency50_100 Number of queries answered in 50-100 ms
+      # TYPE dnsdist_main_latency50_100 counter
+      dnsdist_main_latency50_100 0
+      # HELP dnsdist_main_latency100_1000 Number of queries answered in 100-1000 ms
+      # TYPE dnsdist_main_latency100_1000 counter
+      dnsdist_main_latency100_1000 0
+      # HELP dnsdist_main_latency_slow Number of queries answered in more than 1 second
+      # TYPE dnsdist_main_latency_slow counter
+      dnsdist_main_latency_slow 0
+      # HELP dnsdist_main_latency_avg100 Average response latency in microseconds of the last 100 packets
+      # TYPE dnsdist_main_latency_avg100 gauge
+      dnsdist_main_latency_avg100 0
+      # HELP dnsdist_main_latency_avg1000 Average response latency in microseconds of the last 1000 packets
+      # TYPE dnsdist_main_latency_avg1000 gauge
+      dnsdist_main_latency_avg1000 0
+      # HELP dnsdist_main_latency_avg10000 Average response latency in microseconds of the last 10000 packets
+      # TYPE dnsdist_main_latency_avg10000 gauge
+      dnsdist_main_latency_avg10000 0
+      # HELP dnsdist_main_latency_avg1000000 Average response latency in microseconds of the last 1000000 packets
+      # TYPE dnsdist_main_latency_avg1000000 gauge
+      dnsdist_main_latency_avg1000000 0
+      # HELP dnsdist_main_uptime Uptime of the dnsdist process in seconds
+      # TYPE dnsdist_main_uptime gauge
+      dnsdist_main_uptime 42
+      # HELP dnsdist_main_real_memory_usage Current memory usage in bytes
+      # TYPE dnsdist_main_real_memory_usage gauge
+      dnsdist_main_real_memory_usage 11292672
+      # HELP dnsdist_main_noncompliant_queries Number of queries dropped as non-compliant
+      # TYPE dnsdist_main_noncompliant_queries counter
+      dnsdist_main_noncompliant_queries 0
+      # HELP dnsdist_main_noncompliant_responses Number of answers from a backend dropped as non-compliant
+      # TYPE dnsdist_main_noncompliant_responses counter
+      dnsdist_main_noncompliant_responses 0
+      # HELP dnsdist_main_rdqueries Number of received queries with the recursion desired bit set
+      # TYPE dnsdist_main_rdqueries counter
+      dnsdist_main_rdqueries 0
+      # HELP dnsdist_main_empty_queries Number of empty queries received from clients
+      # TYPE dnsdist_main_empty_queries counter
+      dnsdist_main_empty_queries 0
+      # HELP dnsdist_main_cache_hits Number of times an answer was retrieved from cache
+      # TYPE dnsdist_main_cache_hits counter
+      dnsdist_main_cache_hits 0
+      # HELP dnsdist_main_cache_misses Number of times an answer not found in the cache
+      # TYPE dnsdist_main_cache_misses counter
+      dnsdist_main_cache_misses 0
+      # HELP dnsdist_main_cpu_user_msec Milliseconds spent by dnsdist in the user state
+      # TYPE dnsdist_main_cpu_user_msec counter
+      dnsdist_main_cpu_user_msec 58
+      # HELP dnsdist_main_cpu_sys_msec Milliseconds spent by dnsdist in the system state
+      # TYPE dnsdist_main_cpu_sys_msec counter
+      dnsdist_main_cpu_sys_msec 35
+      # HELP dnsdist_main_fd_usage Number of currently used file descriptors
+      # TYPE dnsdist_main_fd_usage gauge
+      dnsdist_main_fd_usage 18
+      # HELP dnsdist_main_dyn_blocked Number of queries dropped because of a dynamic block
+      # TYPE dnsdist_main_dyn_blocked counter
+      dnsdist_main_dyn_blocked 0
+      # HELP dnsdist_main_dyn_block_nmg_size Number of dynamic blocks entries
+      # TYPE dnsdist_main_dyn_block_nmg_size gauge
+      dnsdist_main_dyn_block_nmg_size 0
+      dnsdist_main_servers_queries{server="9_9_9_9:53"} 0
+      dnsdist_main_servers_drops{server="9_9_9_9:53"} 0
+      dnsdist_main_servers_latency{server="9_9_9_9:53"} 0
+      dnsdist_main_servers_senderrors{server="9_9_9_9:53"} 0
+      dnsdist_main_servers_outstanding{server="9_9_9_9:53"} 0
+      dnsdist_main_servers_queries{server="8_8_8_8:53"} 0
+      dnsdist_main_servers_drops{server="8_8_8_8:53"} 0
+      dnsdist_main_servers_latency{server="8_8_8_8:53"} 0
+      dnsdist_main_servers_senderrors{server="8_8_8_8:53"} 0
+      dnsdist_main_servers_outstanding{server="8_8_8_8:53"} 0
+      dnsdist_main_servers_queries{server="::1:53"} 0
+      dnsdist_main_servers_drops{server="::1:53"} 0
+      dnsdist_main_servers_latency{server="::1:53"} 0
+      dnsdist_main_servers_senderrors{server="::1:53"} 0
+      dnsdist_main_servers_outstanding{server="::1:53"} 0
+      dnsdist_main_servers_queries{server="194_109_6_66:53"} 0
+      dnsdist_main_servers_drops{server="194_109_6_66:53"} 0
+      dnsdist_main_servers_latency{server="194_109_6_66:53"} 0
+      dnsdist_main_servers_senderrors{server="194_109_6_66:53"} 0
+      dnsdist_main_servers_outstanding{server="194_109_6_66:53"} 0
+      dnsdist_main_frontend_queries{frontend="127_0_0_1:5300",proto="udp"} 0
+      dnsdist_main_frontend_queries{frontend="127_0_0_1:5300",proto="tcp"} 0
+      dnsdist_main_pools_servers{pool="_default_"} 4
+      dnsdist_pool_cache_size{pool="_default_"} 1000
+      dnsdist_pool_cache_entries{pool="_default_"} 0
+      dnsdist_pool_cache_hits{pool="_default_"} 0
+      dnsdist_pool_cache_misses{pool="_default_"} 0
+      dnsdist_pool_cache_deferred_inserts{pool="_default_"} 0
+      dnsdist_pool_cache_deferred_lookups{pool="_default_"} 0
+      dnsdist_pool_cache_lookup_collisions{pool="_default_"} 0
+      dnsdist_pool_cache_insert_collisions{pool="_default_"} 0
+      dnsdist_pool_cache_ttl_too_shorts{pool="_default_"} 0
+
+  **Example prometheus configuration**:
+
+   This is just the scrape job description, for details see the prometheus documentation.
+
+   .. sourcecode:: yaml
+      job_name: dnsdist
+      scrape_interval: 10s
+      scrape_timeout: 2s
+      metrics_path: /prometheus
+      basic_auth:
+        username: dontcare
+        password: yoursecret
+
+
 .. http:get:: /api/v1/servers/localhost
 
   Get a quick overview of several parameters.

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -255,7 +255,6 @@ URL Endpoints
       dnsdist_pool_cache_lookup_collisions{pool="_default_"} 0
       dnsdist_pool_cache_insert_collisions{pool="_default_"} 0
       dnsdist_pool_cache_ttl_too_shorts{pool="_default_"} 0
-      dnsdist_querycount_queries{qname="kernel_org_"} 1
 
   **Example prometheus configuration**:
 

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -129,7 +129,7 @@ URL Endpoints
       dnsdist_servfail_responses 0
       # HELP dnsdist_queries Number of received queries
       # TYPE dnsdist_queries counter
-      dnsdist_queries 1
+      dnsdist_queries 0
       # HELP dnsdist_acl_drops Number of packets dropped because of the ACL
       # TYPE dnsdist_acl_drops counter
       dnsdist_acl_drops 0
@@ -159,7 +159,7 @@ URL Endpoints
       dnsdist_trunc_failures 0
       # HELP dnsdist_no_policy Number of queries dropped because no server was available
       # TYPE dnsdist_no_policy counter
-      dnsdist_no_policy 1
+      dnsdist_no_policy 0
       # HELP dnsdist_latency0_1 Number of queries answered in less than 1ms
       # TYPE dnsdist_latency0_1 counter
       dnsdist_latency0_1 0
@@ -192,10 +192,10 @@ URL Endpoints
       dnsdist_latency_avg1000000 0
       # HELP dnsdist_uptime Uptime of the dnsdist process in seconds
       # TYPE dnsdist_uptime gauge
-      dnsdist_uptime 15
+      dnsdist_uptime 39
       # HELP dnsdist_real_memory_usage Current memory usage in bytes
       # TYPE dnsdist_real_memory_usage gauge
-      dnsdist_real_memory_usage 10268672
+      dnsdist_real_memory_usage 10276864
       # HELP dnsdist_noncompliant_queries Number of queries dropped as non-compliant
       # TYPE dnsdist_noncompliant_queries counter
       dnsdist_noncompliant_queries 0
@@ -204,7 +204,7 @@ URL Endpoints
       dnsdist_noncompliant_responses 0
       # HELP dnsdist_rdqueries Number of received queries with the recursion desired bit set
       # TYPE dnsdist_rdqueries counter
-      dnsdist_rdqueries 1
+      dnsdist_rdqueries 0
       # HELP dnsdist_empty_queries Number of empty queries received from clients
       # TYPE dnsdist_empty_queries counter
       dnsdist_empty_queries 0
@@ -213,13 +213,13 @@ URL Endpoints
       dnsdist_cache_hits 0
       # HELP dnsdist_cache_misses Number of times an answer not found in the cache
       # TYPE dnsdist_cache_misses counter
-      dnsdist_cache_misses 1
+      dnsdist_cache_misses 0
       # HELP dnsdist_cpu_user_msec Milliseconds spent by dnsdist in the user state
       # TYPE dnsdist_cpu_user_msec counter
-      dnsdist_cpu_user_msec 8
+      dnsdist_cpu_user_msec 28
       # HELP dnsdist_cpu_sys_msec Milliseconds spent by dnsdist in the system state
       # TYPE dnsdist_cpu_sys_msec counter
-      dnsdist_cpu_sys_msec 20
+      dnsdist_cpu_sys_msec 32
       # HELP dnsdist_fd_usage Number of currently used file descriptors
       # TYPE dnsdist_fd_usage gauge
       dnsdist_fd_usage 17
@@ -229,27 +229,27 @@ URL Endpoints
       # HELP dnsdist_dyn_block_nmg_size Number of dynamic blocks entries
       # TYPE dnsdist_dyn_block_nmg_size gauge
       dnsdist_dyn_block_nmg_size 0
-      dnsdist_servers_queries{server="1_1_1_1"} 0
-      dnsdist_servers_drops{server="1_1_1_1"} 0
-      dnsdist_servers_latency{server="1_1_1_1"} 0
-      dnsdist_servers_senderrors{server="1_1_1_1"} 0
-      dnsdist_servers_outstanding{server="1_1_1_1"} 0
-      dnsdist_servers_order{server="1_1_1_1"} 1
-      dnsdist_servers_weight{server="1_1_1_1"} 1
-      dnsdist_servers_queries{server="1_0_0_1"} 0
-      dnsdist_servers_drops{server="1_0_0_1"} 0
-      dnsdist_servers_latency{server="1_0_0_1"} 0
-      dnsdist_servers_senderrors{server="1_0_0_1"} 0
-      dnsdist_servers_outstanding{server="1_0_0_1"} 0
-      dnsdist_servers_order{server="1_0_0_1"} 1
-      dnsdist_servers_weight{server="1_0_0_1"} 2
-      dnsdist_frontend_queries{frontend="127_0_0_1:1153",proto="udp"} 0
-      dnsdist_frontend_queries{frontend="127_0_0_1:1153",proto="tcp"} 1
-      dnsdist_pools_servers{pool="_default_"} 2
+      dnsdist_server_queries{server="1_1_1_1",address="1.1.1.1:53"} 0
+      dnsdist_server_drops{server="1_1_1_1",address="1.1.1.1:53"} 0
+      dnsdist_server_latency{server="1_1_1_1",address="1.1.1.1:53"} 0
+      dnsdist_server_senderrors{server="1_1_1_1",address="1.1.1.1:53"} 0
+      dnsdist_server_outstanding{server="1_1_1_1",address="1.1.1.1:53"} 0
+      dnsdist_server_order{server="1_1_1_1",address="1.1.1.1:53"} 1
+      dnsdist_server_weight{server="1_1_1_1",address="1.1.1.1:53"} 1
+      dnsdist_server_queries{server="1_0_0_1",address="1.0.0.1:53"} 0
+      dnsdist_server_drops{server="1_0_0_1",address="1.0.0.1:53"} 0
+      dnsdist_server_latency{server="1_0_0_1",address="1.0.0.1:53"} 0
+      dnsdist_server_senderrors{server="1_0_0_1",address="1.0.0.1:53"} 0
+      dnsdist_server_outstanding{server="1_0_0_1",address="1.0.0.1:53"} 0
+      dnsdist_server_order{server="1_0_0_1",address="1.0.0.1:53"} 1
+      dnsdist_server_weight{server="1_0_0_1",address="1.0.0.1:53"} 2
+      dnsdist_frontend_queries{frontend="127.0.0.1:1153",proto="udp"} 0
+      dnsdist_frontend_queries{frontend="127.0.0.1:1153",proto="tcp"} 0
+      dnsdist_pool_servers{pool="_default_"} 2
       dnsdist_pool_cache_size{pool="_default_"} 200000
       dnsdist_pool_cache_entries{pool="_default_"} 0
       dnsdist_pool_cache_hits{pool="_default_"} 0
-      dnsdist_pool_cache_misses{pool="_default_"} 1
+      dnsdist_pool_cache_misses{pool="_default_"} 0
       dnsdist_pool_cache_deferred_inserts{pool="_default_"} 0
       dnsdist_pool_cache_deferred_lookups{pool="_default_"} 0
       dnsdist_pool_cache_lookup_collisions{pool="_default_"} 0

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -121,147 +121,141 @@ URL Endpoints
       X-Permitted-Cross-Domain-Policies: none
       X-Xss-Protection: 1; mode=block
 
-
-      # HELP dnsdist_main_responses Number of responses received from backends
-      # TYPE dnsdist_main_responses counter
-      dnsdist_main_responses 0
-      # HELP dnsdist_main_servfail_responses Number of SERVFAIL answers received from backends
-      # TYPE dnsdist_main_servfail_responses counter
-      dnsdist_main_servfail_responses 0
-      # HELP dnsdist_main_queries Number of received queries
-      # TYPE dnsdist_main_queries counter
-      dnsdist_main_queries 0
-      # HELP dnsdist_main_acl_drops Number of packets dropped because of the ACL
-      # TYPE dnsdist_main_acl_drops counter
-      dnsdist_main_acl_drops 0
-      # HELP dnsdist_main_rule_drop Number of queries dropped because of a rule
-      # TYPE dnsdist_main_rule_drop counter
-      dnsdist_main_rule_drop 0
-      # HELP dnsdist_main_rule_nxdomain Number of NXDomain answers returned because of a rule
-      # TYPE dnsdist_main_rule_nxdomain counter
-      dnsdist_main_rule_nxdomain 0
-      # HELP dnsdist_main_rule_refused Number of Refused answers returned because of a rule
-      # TYPE dnsdist_main_rule_refused counter
-      dnsdist_main_rule_refused 0
-      # HELP dnsdist_main_rule_servfail Number of SERVFAIL answers received because of a rule
-      # TYPE dnsdist_main_rule_servfail counter
-      dnsdist_main_rule_servfail 0
-      # HELP dnsdist_main_self_answered Number of self-answered responses
-      # TYPE dnsdist_main_self_answered counter
-      dnsdist_main_self_answered 0
-      # HELP dnsdist_main_downstream_timeouts Number of queries not answered in time by a backend
-      # TYPE dnsdist_main_downstream_timeouts counter
-      dnsdist_main_downstream_timeouts 0
-      # HELP dnsdist_main_downstream_send_errors Number of errors when sending a query to a backend
-      # TYPE dnsdist_main_downstream_send_errors counter
-      dnsdist_main_downstream_send_errors 0
-      # HELP dnsdist_main_trunc_failures Number of errors encountered while truncating an answer
-      # TYPE dnsdist_main_trunc_failures counter
-      dnsdist_main_trunc_failures 0
-      # HELP dnsdist_main_no_policy Number of queries dropped because no server was available
-      # TYPE dnsdist_main_no_policy counter
-      dnsdist_main_no_policy 0
-      # HELP dnsdist_main_latency0_1 Number of queries answered in less than 1ms
-      # TYPE dnsdist_main_latency0_1 counter
-      dnsdist_main_latency0_1 0
-      # HELP dnsdist_main_latency1_10 Number of queries answered in 1-10 ms
-      # TYPE dnsdist_main_latency1_10 counter
-      dnsdist_main_latency1_10 0
-      # HELP dnsdist_main_latency10_50 Number of queries answered in 10-50 ms
-      # TYPE dnsdist_main_latency10_50 counter
-      dnsdist_main_latency10_50 0
-      # HELP dnsdist_main_latency50_100 Number of queries answered in 50-100 ms
-      # TYPE dnsdist_main_latency50_100 counter
-      dnsdist_main_latency50_100 0
-      # HELP dnsdist_main_latency100_1000 Number of queries answered in 100-1000 ms
-      # TYPE dnsdist_main_latency100_1000 counter
-      dnsdist_main_latency100_1000 0
-      # HELP dnsdist_main_latency_slow Number of queries answered in more than 1 second
-      # TYPE dnsdist_main_latency_slow counter
-      dnsdist_main_latency_slow 0
-      # HELP dnsdist_main_latency_avg100 Average response latency in microseconds of the last 100 packets
-      # TYPE dnsdist_main_latency_avg100 gauge
-      dnsdist_main_latency_avg100 0
-      # HELP dnsdist_main_latency_avg1000 Average response latency in microseconds of the last 1000 packets
-      # TYPE dnsdist_main_latency_avg1000 gauge
-      dnsdist_main_latency_avg1000 0
-      # HELP dnsdist_main_latency_avg10000 Average response latency in microseconds of the last 10000 packets
-      # TYPE dnsdist_main_latency_avg10000 gauge
-      dnsdist_main_latency_avg10000 0
-      # HELP dnsdist_main_latency_avg1000000 Average response latency in microseconds of the last 1000000 packets
-      # TYPE dnsdist_main_latency_avg1000000 gauge
-      dnsdist_main_latency_avg1000000 0
-      # HELP dnsdist_main_uptime Uptime of the dnsdist process in seconds
-      # TYPE dnsdist_main_uptime gauge
-      dnsdist_main_uptime 42
-      # HELP dnsdist_main_real_memory_usage Current memory usage in bytes
-      # TYPE dnsdist_main_real_memory_usage gauge
-      dnsdist_main_real_memory_usage 11292672
-      # HELP dnsdist_main_noncompliant_queries Number of queries dropped as non-compliant
-      # TYPE dnsdist_main_noncompliant_queries counter
-      dnsdist_main_noncompliant_queries 0
-      # HELP dnsdist_main_noncompliant_responses Number of answers from a backend dropped as non-compliant
-      # TYPE dnsdist_main_noncompliant_responses counter
-      dnsdist_main_noncompliant_responses 0
-      # HELP dnsdist_main_rdqueries Number of received queries with the recursion desired bit set
-      # TYPE dnsdist_main_rdqueries counter
-      dnsdist_main_rdqueries 0
-      # HELP dnsdist_main_empty_queries Number of empty queries received from clients
-      # TYPE dnsdist_main_empty_queries counter
-      dnsdist_main_empty_queries 0
-      # HELP dnsdist_main_cache_hits Number of times an answer was retrieved from cache
-      # TYPE dnsdist_main_cache_hits counter
-      dnsdist_main_cache_hits 0
-      # HELP dnsdist_main_cache_misses Number of times an answer not found in the cache
-      # TYPE dnsdist_main_cache_misses counter
-      dnsdist_main_cache_misses 0
-      # HELP dnsdist_main_cpu_user_msec Milliseconds spent by dnsdist in the user state
-      # TYPE dnsdist_main_cpu_user_msec counter
-      dnsdist_main_cpu_user_msec 58
-      # HELP dnsdist_main_cpu_sys_msec Milliseconds spent by dnsdist in the system state
-      # TYPE dnsdist_main_cpu_sys_msec counter
-      dnsdist_main_cpu_sys_msec 35
-      # HELP dnsdist_main_fd_usage Number of currently used file descriptors
-      # TYPE dnsdist_main_fd_usage gauge
-      dnsdist_main_fd_usage 18
-      # HELP dnsdist_main_dyn_blocked Number of queries dropped because of a dynamic block
-      # TYPE dnsdist_main_dyn_blocked counter
-      dnsdist_main_dyn_blocked 0
-      # HELP dnsdist_main_dyn_block_nmg_size Number of dynamic blocks entries
-      # TYPE dnsdist_main_dyn_block_nmg_size gauge
-      dnsdist_main_dyn_block_nmg_size 0
-      dnsdist_main_servers_queries{server="9_9_9_9:53"} 0
-      dnsdist_main_servers_drops{server="9_9_9_9:53"} 0
-      dnsdist_main_servers_latency{server="9_9_9_9:53"} 0
-      dnsdist_main_servers_senderrors{server="9_9_9_9:53"} 0
-      dnsdist_main_servers_outstanding{server="9_9_9_9:53"} 0
-      dnsdist_main_servers_queries{server="8_8_8_8:53"} 0
-      dnsdist_main_servers_drops{server="8_8_8_8:53"} 0
-      dnsdist_main_servers_latency{server="8_8_8_8:53"} 0
-      dnsdist_main_servers_senderrors{server="8_8_8_8:53"} 0
-      dnsdist_main_servers_outstanding{server="8_8_8_8:53"} 0
-      dnsdist_main_servers_queries{server="::1:53"} 0
-      dnsdist_main_servers_drops{server="::1:53"} 0
-      dnsdist_main_servers_latency{server="::1:53"} 0
-      dnsdist_main_servers_senderrors{server="::1:53"} 0
-      dnsdist_main_servers_outstanding{server="::1:53"} 0
-      dnsdist_main_servers_queries{server="194_109_6_66:53"} 0
-      dnsdist_main_servers_drops{server="194_109_6_66:53"} 0
-      dnsdist_main_servers_latency{server="194_109_6_66:53"} 0
-      dnsdist_main_servers_senderrors{server="194_109_6_66:53"} 0
-      dnsdist_main_servers_outstanding{server="194_109_6_66:53"} 0
-      dnsdist_main_frontend_queries{frontend="127_0_0_1:5300",proto="udp"} 0
-      dnsdist_main_frontend_queries{frontend="127_0_0_1:5300",proto="tcp"} 0
-      dnsdist_main_pools_servers{pool="_default_"} 4
-      dnsdist_pool_cache_size{pool="_default_"} 1000
+      # HELP dnsdist_responses Number of responses received from backends
+      # TYPE dnsdist_responses counter
+      dnsdist_responses 0
+      # HELP dnsdist_servfail_responses Number of SERVFAIL answers received from backends
+      # TYPE dnsdist_servfail_responses counter
+      dnsdist_servfail_responses 0
+      # HELP dnsdist_queries Number of received queries
+      # TYPE dnsdist_queries counter
+      dnsdist_queries 1
+      # HELP dnsdist_acl_drops Number of packets dropped because of the ACL
+      # TYPE dnsdist_acl_drops counter
+      dnsdist_acl_drops 0
+      # HELP dnsdist_rule_drop Number of queries dropped because of a rule
+      # TYPE dnsdist_rule_drop counter
+      dnsdist_rule_drop 0
+      # HELP dnsdist_rule_nxdomain Number of NXDomain answers returned because of a rule
+      # TYPE dnsdist_rule_nxdomain counter
+      dnsdist_rule_nxdomain 0
+      # HELP dnsdist_rule_refused Number of Refused answers returned because of a rule
+      # TYPE dnsdist_rule_refused counter
+      dnsdist_rule_refused 0
+      # HELP dnsdist_rule_servfail Number of SERVFAIL answers received because of a rule
+      # TYPE dnsdist_rule_servfail counter
+      dnsdist_rule_servfail 0
+      # HELP dnsdist_self_answered Number of self-answered responses
+      # TYPE dnsdist_self_answered counter
+      dnsdist_self_answered 0
+      # HELP dnsdist_downstream_timeouts Number of queries not answered in time by a backend
+      # TYPE dnsdist_downstream_timeouts counter
+      dnsdist_downstream_timeouts 0
+      # HELP dnsdist_downstream_send_errors Number of errors when sending a query to a backend
+      # TYPE dnsdist_downstream_send_errors counter
+      dnsdist_downstream_send_errors 0
+      # HELP dnsdist_trunc_failures Number of errors encountered while truncating an answer
+      # TYPE dnsdist_trunc_failures counter
+      dnsdist_trunc_failures 0
+      # HELP dnsdist_no_policy Number of queries dropped because no server was available
+      # TYPE dnsdist_no_policy counter
+      dnsdist_no_policy 1
+      # HELP dnsdist_latency0_1 Number of queries answered in less than 1ms
+      # TYPE dnsdist_latency0_1 counter
+      dnsdist_latency0_1 0
+      # HELP dnsdist_latency1_10 Number of queries answered in 1-10 ms
+      # TYPE dnsdist_latency1_10 counter
+      dnsdist_latency1_10 0
+      # HELP dnsdist_latency10_50 Number of queries answered in 10-50 ms
+      # TYPE dnsdist_latency10_50 counter
+      dnsdist_latency10_50 0
+      # HELP dnsdist_latency50_100 Number of queries answered in 50-100 ms
+      # TYPE dnsdist_latency50_100 counter
+      dnsdist_latency50_100 0
+      # HELP dnsdist_latency100_1000 Number of queries answered in 100-1000 ms
+      # TYPE dnsdist_latency100_1000 counter
+      dnsdist_latency100_1000 0
+      # HELP dnsdist_latency_slow Number of queries answered in more than 1 second
+      # TYPE dnsdist_latency_slow counter
+      dnsdist_latency_slow 0
+      # HELP dnsdist_latency_avg100 Average response latency in microseconds of the last 100 packets
+      # TYPE dnsdist_latency_avg100 gauge
+      dnsdist_latency_avg100 0
+      # HELP dnsdist_latency_avg1000 Average response latency in microseconds of the last 1000 packets
+      # TYPE dnsdist_latency_avg1000 gauge
+      dnsdist_latency_avg1000 0
+      # HELP dnsdist_latency_avg10000 Average response latency in microseconds of the last 10000 packets
+      # TYPE dnsdist_latency_avg10000 gauge
+      dnsdist_latency_avg10000 0
+      # HELP dnsdist_latency_avg1000000 Average response latency in microseconds of the last 1000000 packets
+      # TYPE dnsdist_latency_avg1000000 gauge
+      dnsdist_latency_avg1000000 0
+      # HELP dnsdist_uptime Uptime of the dnsdist process in seconds
+      # TYPE dnsdist_uptime gauge
+      dnsdist_uptime 15
+      # HELP dnsdist_real_memory_usage Current memory usage in bytes
+      # TYPE dnsdist_real_memory_usage gauge
+      dnsdist_real_memory_usage 10268672
+      # HELP dnsdist_noncompliant_queries Number of queries dropped as non-compliant
+      # TYPE dnsdist_noncompliant_queries counter
+      dnsdist_noncompliant_queries 0
+      # HELP dnsdist_noncompliant_responses Number of answers from a backend dropped as non-compliant
+      # TYPE dnsdist_noncompliant_responses counter
+      dnsdist_noncompliant_responses 0
+      # HELP dnsdist_rdqueries Number of received queries with the recursion desired bit set
+      # TYPE dnsdist_rdqueries counter
+      dnsdist_rdqueries 1
+      # HELP dnsdist_empty_queries Number of empty queries received from clients
+      # TYPE dnsdist_empty_queries counter
+      dnsdist_empty_queries 0
+      # HELP dnsdist_cache_hits Number of times an answer was retrieved from cache
+      # TYPE dnsdist_cache_hits counter
+      dnsdist_cache_hits 0
+      # HELP dnsdist_cache_misses Number of times an answer not found in the cache
+      # TYPE dnsdist_cache_misses counter
+      dnsdist_cache_misses 1
+      # HELP dnsdist_cpu_user_msec Milliseconds spent by dnsdist in the user state
+      # TYPE dnsdist_cpu_user_msec counter
+      dnsdist_cpu_user_msec 8
+      # HELP dnsdist_cpu_sys_msec Milliseconds spent by dnsdist in the system state
+      # TYPE dnsdist_cpu_sys_msec counter
+      dnsdist_cpu_sys_msec 20
+      # HELP dnsdist_fd_usage Number of currently used file descriptors
+      # TYPE dnsdist_fd_usage gauge
+      dnsdist_fd_usage 17
+      # HELP dnsdist_dyn_blocked Number of queries dropped because of a dynamic block
+      # TYPE dnsdist_dyn_blocked counter
+      dnsdist_dyn_blocked 0
+      # HELP dnsdist_dyn_block_nmg_size Number of dynamic blocks entries
+      # TYPE dnsdist_dyn_block_nmg_size gauge
+      dnsdist_dyn_block_nmg_size 0
+      dnsdist_servers_queries{server="1_1_1_1"} 0
+      dnsdist_servers_drops{server="1_1_1_1"} 0
+      dnsdist_servers_latency{server="1_1_1_1"} 0
+      dnsdist_servers_senderrors{server="1_1_1_1"} 0
+      dnsdist_servers_outstanding{server="1_1_1_1"} 0
+      dnsdist_servers_order{server="1_1_1_1"} 1
+      dnsdist_servers_weight{server="1_1_1_1"} 1
+      dnsdist_servers_queries{server="1_0_0_1"} 0
+      dnsdist_servers_drops{server="1_0_0_1"} 0
+      dnsdist_servers_latency{server="1_0_0_1"} 0
+      dnsdist_servers_senderrors{server="1_0_0_1"} 0
+      dnsdist_servers_outstanding{server="1_0_0_1"} 0
+      dnsdist_servers_order{server="1_0_0_1"} 1
+      dnsdist_servers_weight{server="1_0_0_1"} 2
+      dnsdist_frontend_queries{frontend="127_0_0_1:1153",proto="udp"} 0
+      dnsdist_frontend_queries{frontend="127_0_0_1:1153",proto="tcp"} 1
+      dnsdist_pools_servers{pool="_default_"} 2
+      dnsdist_pool_cache_size{pool="_default_"} 200000
       dnsdist_pool_cache_entries{pool="_default_"} 0
       dnsdist_pool_cache_hits{pool="_default_"} 0
-      dnsdist_pool_cache_misses{pool="_default_"} 0
+      dnsdist_pool_cache_misses{pool="_default_"} 1
       dnsdist_pool_cache_deferred_inserts{pool="_default_"} 0
       dnsdist_pool_cache_deferred_lookups{pool="_default_"} 0
       dnsdist_pool_cache_lookup_collisions{pool="_default_"} 0
       dnsdist_pool_cache_insert_collisions{pool="_default_"} 0
       dnsdist_pool_cache_ttl_too_shorts{pool="_default_"} 0
+      dnsdist_querycount_queries{qname="kernel_org_"} 1
 
   **Example prometheus configuration**:
 


### PR DESCRIPTION
### Short description

My patch based on https://github.com/PowerDNS/pdns/pull/6343 prepared by @giganteous 

I made number of changes for it:
- Ported code to current master branch
- Introduced class which stores meta information about metrics (metric type, description). I do not like idea about mixing atomic counters and meta fields with big text blobs and I divided them
- Slightly changed code formatting
- Changed endpoint to /metrics as suggested by @dannyk81 
- Tested code and it works quite well for my case

### Checklist
I have:
- [*] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [*] compiled this code
- [*] tested this code
- [*] included documentation (including possible behaviour changes)
- [*] documented the code
- [] added or modified regression test(s)
- [] added or modified unit test(s)

Thank you!