### PR TITLE
docs: auth config settings: explain loglevel value

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -811,7 +811,8 @@ Do not pass names like 'local0'!
 -  Integer
 -  Default: 4
 
-Amount of logging. Higher is more. Do not set below 3
+Amount of logging. Higher is more. Do not set below 3. Corresponds to "syslog" level values,
+e.g. error = 3, warning = 4, notice = 5, info = 6
 
 .. _setting-log-dns-queries:
 


### PR DESCRIPTION
### Short description

It wasn't obvious to me, initially, that the loglevel values correspond to the libc syslog values (which you can often find in `/usr/include/sys/syslog.h`). Perhaps this was because I immediately disabled syslog output in favor of only stdout (which is captured by docker in my case).

Though, this is a subjective thing, and it does seem somewhat obvious to me now ...

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
