### PR TITLE
dnsdist: Fix documentation of DNSQuestion.len

### DIFF
--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -25,7 +25,7 @@ This state can be modified from the various hooks.
 
   .. attribute:: DNSQuestion.len
 
-    The length of the :attr:`qname <DNSQuestion.qname>`.
+    The length of the data starting at :attr:`DNSQuestion.dh`, including any trailing bytes following the DNS message.
 
   .. attribute:: DNSQuestion.localaddr
 


### PR DESCRIPTION
### Short description
Updates the documentation of `DNSQuestion.len` for accuracy. It was falsely reported to be the length of just the qname, which misled me as both a user and a developer.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)