### PR TITLE
Add support for OpenSSL 1.1.1's ed25519 and ed448 for signing and verifying

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,7 @@ PDNS_CHECK_LIBCRYPTO([
   ]
 )
 PDNS_CHECK_LIBCRYPTO_ECDSA
+PDNS_CHECK_LIBCRYPTO_EDDSA
 
 PDNS_CHECK_RAGEL([pdns/dnslabeltext.cc], [www.powerdns.com])
 PDNS_CHECK_CLOCK_GETTIME
@@ -352,11 +353,11 @@ AS_IF([test "x$libcrypto_ecdsa" = "xyes"],
   [AC_MSG_NOTICE([OpenSSL ecdsa: yes])],
   [AC_MSG_NOTICE([OpenSSL ecdsa: no])]
 )
-AS_IF([test "x$LIBSODIUM_LIBS" != "x" || test "x$LIBDECAF_LIBS" != "x"],
+AS_IF([test "x$LIBSODIUM_LIBS" != "x" || test "x$LIBDECAF_LIBS" != "x" || test "x$libcrypto_ed25519" = "xyes"],
   [AC_MSG_NOTICE([ed25519: yes])],
   [AC_MSG_NOTICE([ed25519: no])]
 )
-AS_IF([test "x$LIBDECAF_LIBS" != "x"],
+AS_IF([test "x$LIBDECAF_LIBS" != "x" || test "x$libcrypto_ed448" = "xyes"],
   [AC_MSG_NOTICE([ed448: yes])],
   [AC_MSG_NOTICE([ed448: no])]
 )

--- a/m4/pdns_check_libcrypto_eddsa.m4
+++ b/m4/pdns_check_libcrypto_eddsa.m4
@@ -25,7 +25,7 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO_EDDSA], [
   [AC_INCLUDES_DEFAULT
   #include <$ssldir/include/openssl/evp.h>])
 
-  AS_IF([test "$libcrypto_ed448" = "yes" -o "$libcrypto_ed448" = "yes"], [
+  AS_IF([test "$libcrypto_ed25519" = "yes" -o "$libcrypto_ed448" = "yes"], [
     AC_DEFINE([HAVE_LIBCRYPTO_EDDSA], [1], [define to 1 if OpenSSL EDDSA support is available.])
   ], [ : ])
 

--- a/m4/pdns_check_libcrypto_eddsa.m4
+++ b/m4/pdns_check_libcrypto_eddsa.m4
@@ -1,0 +1,36 @@
+AC_DEFUN([PDNS_CHECK_LIBCRYPTO_EDDSA], [
+  AC_REQUIRE([PDNS_CHECK_LIBCRYPTO])
+
+  # Set the environment correctly for a possibly non-default OpenSSL path that was found by/supplied to PDNS_CHECK_LIBCRYPTO
+  save_CPPFLAGS="$CPPFLAGS"
+  save_LDFLAGS="$LDFLAGS"
+  save_LIBS="$LIBS"
+
+  CPPFLAGS="$LIBCRYPTO_INCLUDES $CPPFLAGS"
+  LDFLAGS="$LIBCRYPTO_LDFLAGS $LDFLAGS"
+  LIBS="$LIBCRYPTO_LIBS $LIBS"
+
+  libcrypto_ed25519=no
+  libcrypto_ed448=no
+  AC_CHECK_DECLS([NID_ED25519], [
+    libcrypto_ed25519=yes
+    AC_DEFINE([HAVE_LIBCRYPTO_ED25519], [1], [define to 1 if OpenSSL ed25519 support is available.])
+  ], [ : ],
+  [AC_INCLUDES_DEFAULT
+  #include <$ssldir/include/openssl/evp.h>])
+  AC_CHECK_DECLS([NID_ED448], [
+    libcrypto_ed448=yes
+    AC_DEFINE([HAVE_LIBCRYPTO_ED448], [1], [define to 1 if OpenSSL ed448 support is available.])
+  ], [ : ],
+  [AC_INCLUDES_DEFAULT
+  #include <$ssldir/include/openssl/evp.h>])
+
+  AS_IF([test "$libcrypto_ed448" = "yes" -o "$libcrypto_ed448" = "yes"], [
+    AC_DEFINE([HAVE_LIBCRYPTO_EDDSA], [1], [define to 1 if OpenSSL EDDSA support is available.])
+  ], [ : ])
+
+  # Restore variables
+  CPPFLAGS="$save_CPPFLAGS"
+  LDFLAGS="$save_LDFLAGS"
+  LIBS="$save_LIBS"
+])

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -1134,20 +1134,13 @@ void OpenSSLEDDSADNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, std::m
 
 void OpenSSLEDDSADNSCryptoKeyEngine::fromPublicKeyString(const std::string& content)
 {
-  const unsigned char* raw = reinterpret_cast<const unsigned char*>(content.c_str());
-  const size_t inputLen = content.length();
-
-  int type{0};
-
-  if (inputLen == 32) {
-    type = NID_ED25519;
-  } else if (inputLen == 57) {
-    type = NID_ED448;
-  } else {
-    throw runtime_error(getName() + "could not determine EDDSA key type");
+  if (content.length() != d_len) {
+    throw runtime_error(getName() + " wrong public key length for algorithm " + std::to_string(d_algorithm));
   }
 
-  d_edkey = EVP_PKEY_new_raw_public_key(type, nullptr, raw, inputLen);
+  const unsigned char* raw = reinterpret_cast<const unsigned char*>(content.c_str());
+
+  d_edkey = EVP_PKEY_new_raw_public_key(d_id, nullptr, raw, d_len);
   if (d_edkey == nullptr) {
     throw runtime_error(getName()+" allocation of public key structure failed");
   }

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -985,7 +985,7 @@ bool OpenSSLEDDSADNSCryptoKeyEngine::checkKey() const
 
 void OpenSSLEDDSADNSCryptoKeyEngine::create(unsigned int bits)
 {
-  auto pctx = EVP_PKEY_CTX_new(d_edkey, nullptr);
+  auto pctx = EVP_PKEY_CTX_new_id(d_id, nullptr);
   if (pctx == nullptr) {
     throw runtime_error(getName()+" context initialization failed");
   }

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -930,13 +930,19 @@ public:
       throw runtime_error(getName()+" allocation of key structure failed");
     }
 
+#ifdef HAVE_LIBCRYPTO_ED25519
     if(d_algorithm == 15) {
       d_len = 32;
       d_id = NID_ED25519;
-    } else if (d_algorithm == 16) {
+    }
+#endif
+#ifdef HAVE_LIBCRYPTO_ED448
+    if (d_algorithm == 16) {
       d_len = 57;
       d_id = NID_ED448;
-    } else {
+    }
+#endif
+    if (d_len == 0) {
       EVP_PKEY_free(d_edkey);
       throw runtime_error(getName()+" unknown algorithm "+std::to_string(d_algorithm));
     }
@@ -966,8 +972,8 @@ public:
   }
 
 private:
-  size_t d_len;
-  int d_id;
+  size_t d_len{0};
+  int d_id{0};
 
   EVP_PKEY *d_edkey = nullptr;
 };
@@ -996,12 +1002,19 @@ DNSCryptoKeyEngine::storvector_t OpenSSLEDDSADNSCryptoKeyEngine::convertToISCVec
   storvector_t storvect;
   string algorithm;
 
-  if(d_algorithm == 15)
+#ifdef HAVE_LIBCRYPTO_ED25519
+  if(d_algorithm == 15) {
     algorithm = "15 (ED25519)";
-  else if(d_algorithm == 16)
+  }
+#endif
+#ifdef HAVE_LIBCRYPTO_ED448
+  if(d_algorithm == 16) {
     algorithm = "16 (ED448)";
-  else
+  }
+#endif
+  if (algorithm.empty()) {
     algorithm = " ? (?)";
+  }
 
   storvect.push_back(make_pair("Algorithm", algorithm));
 

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -1115,7 +1115,7 @@ std::string OpenSSLEDDSADNSCryptoKeyEngine::getPublicKeyString() const
   size_t len = d_len;
   buf.resize(len);
   if (EVP_PKEY_get_raw_public_key(d_edkey, reinterpret_cast<unsigned char*>(&buf.at(0)), &len) < 1) {
-    throw std::runtime_error("Unable to get public key from key struct");
+    throw std::runtime_error(getName() + " unable to get public key from key struct");
   }
   return buf;
 }

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -990,11 +990,14 @@ void OpenSSLEDDSADNSCryptoKeyEngine::create(unsigned int bits)
     throw runtime_error(getName()+" context initialization failed");
   }
   if (EVP_PKEY_keygen_init(pctx) < 1) {
+    EVP_PKEY_CTX_free(pctx);
     throw runtime_error(getName()+" keygen initialization failed");
   }
   if (EVP_PKEY_keygen(pctx, &d_edkey) < 1) {
+    EVP_PKEY_CTX_free(pctx);
     throw runtime_error(getName()+" key generation failed");
   }
+  EVP_PKEY_CTX_free(pctx);
 }
 
 DNSCryptoKeyEngine::storvector_t OpenSSLEDDSADNSCryptoKeyEngine::convertToISCVector() const

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -118,6 +118,7 @@ PDNS_CHECK_LIBCRYPTO([
   ]
 )
 PDNS_CHECK_LIBCRYPTO_ECDSA
+PDNS_CHECK_LIBCRYPTO_EDDSA
 PDNS_CHECK_LIBSODIUM
 PDNS_CHECK_LIBDECAF
 
@@ -224,13 +225,13 @@ AC_MSG_NOTICE([Features enabled])
 AC_MSG_NOTICE([----------------])
 AC_MSG_NOTICE([Lua: $LUAPC])
 AC_MSG_NOTICE([OpenSSL ECDSA: $libcrypto_ecdsa])
-AS_IF([test "x$LIBSODIUM_LIBS" != "x"],
-  [AC_MSG_NOTICE([libsodium ed25519: yes])],
-  [AC_MSG_NOTICE([libsodium ed25519: no])]
+AS_IF([test "x$LIBSODIUM_LIBS" != "x" || test "x$LIBDECAF_LIBS" != "x" || test "x$libcrypto_ed25519" = "xyes"],
+  [AC_MSG_NOTICE([ed25519: yes])],
+  [AC_MSG_NOTICE([ed25519: no])]
 )
-AS_IF([test "x$LIBDECAF_LIBS" != "x"],
-  [AC_MSG_NOTICE([libdecaf ed25519 and ed448: yes])],
-  [AC_MSG_NOTICE([libdecaf ed25519 and ed448: no])]
+AS_IF([test "x$LIBDECAF_LIBS" != "x" || test "x$libcrypto_ed448" = "xyes"],
+  [AC_MSG_NOTICE([ed448: yes])],
+  [AC_MSG_NOTICE([ed448: no])]
 )
 AS_IF([test "x$BOTAN_LIBS" != "x"],
   [AC_MSG_NOTICE([Botan gost: yes])],

--- a/pdns/recursordist/m4/pdns_check_libcrypto_eddsa.m4
+++ b/pdns/recursordist/m4/pdns_check_libcrypto_eddsa.m4
@@ -1,0 +1,1 @@
+../../../m4/pdns_check_libcrypto_eddsa.m4

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -99,7 +99,7 @@ static const struct signerParams
     false
   },
 #endif /* HAVE_LIBCRYPTO_ECDSA */
-#if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF)
+#if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED25519)
   /* ed25519 from https://github.com/CZ-NIC/knot/blob/master/src/dnssec/tests/sample_keys.h,
      also from rfc8080 section 6.1 */
   { "Algorithm: 15\n"
@@ -121,7 +121,7 @@ static const struct signerParams
     DNSSECKeeper::ED25519,
     true
   },
-#endif /* defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) */
+#endif /* defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED25519) */
 };
 
 static void checkRR(const signerParams& signer)
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(test_generic_signers)
   }
 }
 
-#ifdef HAVE_LIBDECAF
+#if defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED448)
 BOOST_AUTO_TEST_CASE(test_ed448_signer) {
     vector<std::shared_ptr<DNSRecordContent> > rrs;
     DNSName qname("example.com.");
@@ -275,6 +275,6 @@ BOOST_AUTO_TEST_CASE(test_ed448_signer) {
     // vector verified from dnskey.py as above, and confirmed with https://www.rfc-editor.org/errata_search.php?rfc=8080&eid=4935
     BOOST_CHECK_EQUAL(b64, "3cPAHkmlnxcDHMyg7vFC34l0blBhuG1qpwLmjInI8w1CMB29FkEAIJUA0amxWndkmnBZ6SKiwZSAxGILn/NBtOXft0+Gj7FSvOKxE/07+4RQvE581N3Aj/JtIyaiYVdnYtyMWbSNyGEY2213WKsJlwEA");
 }
-#endif
+#endif /* defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED448) */
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
This implements algorithm 15 and 16 support in the OpenSSL signer. It will only be used if the (as of yet unreleased) OpenSSL 1.1.1 is used.

Please review carefully.

CC: @mind04 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)