### PR TITLE
 make negcache-tests-dotted-cname test portable between Python versions

### DIFF
--- a/regression-tests.nobackend/negcache-tests-dotted-cname/command
+++ b/regression-tests.nobackend/negcache-tests-dotted-cname/command
@@ -7,7 +7,7 @@ fi
 port=5501
 rm -f pdns*.pid
 
-$PDNS --daemon=no --local-port=$port --socket-dir=./          \
+PYTHONUNBUFFERED=1 $PDNS --daemon=no --local-port=$port --socket-dir=./          \
 	--no-shuffle --launch=bind,pipe --bind-config=negcache-tests-dotted-cname/named.conf   \
 	--pipe-command=negcache-tests-dotted-cname/pipe.py \
 	--cache-ttl=60 --no-config --module-dir=../regression-tests/modules &

--- a/regression-tests.nobackend/negcache-tests-dotted-cname/pipe.py
+++ b/regression-tests.nobackend/negcache-tests-dotted-cname/pipe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7 -u
+#!/usr/bin/env python -u
 
 import sys
 

--- a/regression-tests.nobackend/negcache-tests-dotted-cname/pipe.py
+++ b/regression-tests.nobackend/negcache-tests-dotted-cname/pipe.py
@@ -1,32 +1,32 @@
-#!/usr/bin/python2 -u
+#!/usr/bin/env python2.7 -u
 
 import sys
 
 line = sys.stdin.readline()
 # TOLO
-print 'OK\tTest backend firing up'
+print('OK\tTest backend firing up')
 
 while True:
     line = sys.stdin.readline()
     items = line.split('\t')
     sys.stderr.write(line)
     if len(items) < 6:
-        print 'LOG\tGot an unparseable line'
-        print 'LOG\t%s' % line
-        print 'END'
+        print('LOG\tGot an unparseable line')
+        print('LOG\t%s' % line)
+        print('END')
         continue
 
     what, qname, qclass, qtype, id, ip = items
 
     if qtype in ['SOA', 'ANY'] and qname == 'example2.com':
-        print 'DATA\t%s\t%s\tSOA\t300\t-1\tns1.example.com ahu.example.com 2008080300 1800 3600 604800 3600' % (qname, qclass)
+        print('DATA\t%s\t%s\tSOA\t300\t-1\tns1.example.com ahu.example.com 2008080300 1800 3600 604800 3600' % (qname, qclass))
 
     if qtype in ['NS', 'ANY'] and qname == 'example2.com':
-        print 'DATA\t%s\t%s\tNS\t3600\t-1\tns1.example.com' % (qname, qclass)
-        print 'DATA\t%s\t%s\tNS\t3600\t-1\tns2.example.com' % (qname, qclass)
+        print('DATA\t%s\t%s\tNS\t3600\t-1\tns1.example.com' % (qname, qclass))
+        print('DATA\t%s\t%s\tNS\t3600\t-1\tns2.example.com' % (qname, qclass))
 
     if qtype in ['A', 'ANY'] and qname.endswith('example2.com'):
         # We were asked a specific record
-        print 'DATA\t%s\t%s\tCNAME\t3600\t-1\twww.example.com.' % (qname, qclass)
+        print('DATA\t%s\t%s\tCNAME\t3600\t-1\twww.example.com.' % (qname, qclass))
 
-    print 'END'
+    print('END')

--- a/regression-tests.nobackend/negcache-tests-dotted-cname/pipe.py
+++ b/regression-tests.nobackend/negcache-tests-dotted-cname/pipe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -u
+#!/usr/bin/env python
 
 import sys
 


### PR DESCRIPTION
### Short description
This test failed on my Mac. I hope this PR makes the test work on more systems while not breaking it on a lot of systems.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
