### PR TITLE
Release memory in case of error in the OpenSSL ECDSA constructor

### DIFF
--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -616,14 +616,19 @@ public:
       d_ecgroup = EC_GROUP_new_by_curve_name(NID_secp384r1);
       d_len = 48;
     } else {
+      EC_KEY_free(d_eckey);
       throw runtime_error(getName()+" unknown algorithm "+std::to_string(d_algorithm));
     }
+
     if (d_ecgroup == NULL) {
+      EC_KEY_free(d_eckey);
       throw runtime_error(getName()+" allocation of group structure failed");
     }
 
-    ret = EC_KEY_set_group(d_eckey,d_ecgroup);
+    ret = EC_KEY_set_group(d_eckey, d_ecgroup);
     if (ret != 1) {
+      EC_KEY_free(d_eckey);
+      EC_GROUP_free(d_ecgroup);
       throw runtime_error(getName()+" setting key group failed");
     }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The current code will only fail to release the allocated memory if called with an invalid algorithm, which won't happen, or if a memory allocation fails in which case this might not matter much.
Still, it's cleaner to release the memory properly and might avoid mistakes later if we look at this code while implementing a new crypto backend.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
