### PR TITLE
recursor 4.1: Add pdnslog to Lua configuration scripts

### DIFF
--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -96,6 +96,21 @@ void loadRecursorLuaConfig(const std::string& fname, bool checkOnly)
 
   auto luaconfsLocal = g_luaconfs.getLocal();
 
+  // pdnslog here is compatible with pdnslog in lua-base4.cc.
+  Lua.writeFunction("pdnslog", [](const std::string& msg, boost::optional<int> loglevel) { L << (Logger::Urgency)loglevel.get_value_or(Logger::Warning) << msg<<endl; });
+  std::unordered_map<string, std::unordered_map<string, int>> pdns_table;
+  pdns_table["loglevels"] = std::unordered_map<string, int>{
+    {"Alert", LOG_ALERT},
+    {"Critical", LOG_CRIT},
+    {"Debug", LOG_DEBUG},
+    {"Emergency", LOG_EMERG},
+    {"Info", LOG_INFO},
+    {"Notice", LOG_NOTICE},
+    {"Warning", LOG_WARNING},
+    {"Error", LOG_ERR}
+  };
+  Lua.writeVariable("pdns", pdns_table);
+
   Lua.writeFunction("clearSortlist", [&lci]() { lci.sortlist.clear(); });
   
   /* we can get: "1.2.3.4"


### PR DESCRIPTION
### Short description
In Debian I want to ship a default Lua config file, which will modify the default behaviour (rgd. root keys). As such I want to clearly note this in the startup log. Therefore, add pdnslog.

Targets 4.1. master is in #6848.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] ***NOT YET MERGED into master!***