### PR TITLE
Removed master-zone-query from documentation; fixes #6818

### DIFF
--- a/docs/backends/generic-sql.rst
+++ b/docs/backends/generic-sql.rst
@@ -340,7 +340,6 @@ On slaves
 ~~~~~~~~~
 
 -  ``info-all-slaves-query``: Called to retrieve all slave domains.
--  ``master-zone-query``: Called to determine the master of a zone.
 -  ``update-lastcheck-query``: Called to update the last time a slave
    domain was successfully checked for freshness.
 -  ``update-master-query``: Called to update the master address of a


### PR DESCRIPTION
### Short description

Removing "master-zone-query" from documentation as this function has been removed. Fixes #6818 

### Checklist

I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
