### PR TITLE
Add operator<<(long long) to be able to log time_t.

### DIFF
--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -222,6 +222,16 @@ Logger& Logger::operator<<(unsigned long i)
   return *this;
 }
 
+Logger& Logger::operator<<(long long i)
+{
+  ostringstream tmp;
+  tmp<<i;
+
+  *this<<tmp.str();
+
+  return *this;
+}
+
 Logger& Logger::operator<<(unsigned long long i)
 {
   ostringstream tmp;

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -86,6 +86,7 @@ public:
   Logger& operator<<(unsigned int);   //!< log an unsigned int
   Logger& operator<<(long);   //!< log an unsigned int
   Logger& operator<<(unsigned long);   //!< log an unsigned int
+  Logger& operator<<(long long);   //!< log a 64 bit int
   Logger& operator<<(unsigned long long);   //!< log an unsigned 64 bit int
   Logger& operator<<(const DNSName&); 
   Logger& operator<<(const ComboAddress&); //!< log an address


### PR DESCRIPTION
On some systems time_t is defined as long long so that it is at least 64 bit on 32 bit and 64 bit architectures.

This prevents

slavecommunicator.cc:902:151: error: use of overloaded operator '<<' is
      ambiguous (with operand types 'Logger' and 'time_t' (aka 'long long'))
