### PR TITLE
Fixed small spelling mistakes in serverselection.rst

### DIFF
--- a/pdns/dnsdistdist/docs/guides/serverselection.rst
+++ b/pdns/dnsdistdist/docs/guides/serverselection.rst
@@ -1,7 +1,7 @@
 Loadbalancing and Server Policies
 =================================
 
-:program:`dnsdist` selects the server (if there are multiple eligable) to send queries to based on the configured policy.
+:program:`dnsdist` selects the server (if there are multiple eligible) to send queries to based on the configured policy.
 Only servers that are marked as 'up', either forced so by the administrator or as the result of the last health check, might
 be selected.
 
@@ -31,7 +31,7 @@ For now this is the only policy using the QPS limit.
 A further policy, ``wrandom`` assigns queries randomly, but based on the weight parameter passed to :func:`newServer`.
 
 For example, if two servers are available, the first one with a weight of 2 and the second one with a weight of 1 (the default), the
-first one should get two thirds of the incoming queries and the second one the remaining third.
+first one should get two-thirds of the incoming queries and the second one the remaining third.
 
 ``whashed``
 ~~~~~~~~~~~


### PR DESCRIPTION
Small spelling mistakes

### Short description
Fixed two small spelling mistakes in serverselection.rst guide

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)