### PR TITLE
Backup server type for dnsdist

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -341,6 +341,10 @@ void setupLuaConfig(bool client)
 			  ret->mustResolve=boost::get<bool>(vars["mustResolve"]);
 			}
 
+			if(vars.count("backup")) {
+			  ret->backup=boost::get<bool>(vars["backup"]);
+			}
+
 			if(vars.count("useClientSubnet")) {
 			  ret->useECS=boost::get<bool>(vars["useClientSubnet"]);
 			}

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -721,13 +721,33 @@ shared_ptr<DownstreamState> leastOutstanding(const NumberedServerVector& servers
   /* so you might wonder, why do we go through this trouble? The data on which we sort could change during the sort,
      which would suck royally and could even lead to crashes. So first we snapshot on what we sort, and then we sort */
   poss.reserve(servers.size());
+
+  // If we have backup server we will use it when we do not have any other servers alive
+  shared_ptr<DownstreamState> backup;
+
   for(auto& d : servers) {
+    // We do not use servers marked as backup during normal operations
+    if (d.second->isBackup()) {
+      // We allow only single backup server
+      if (backup == nullptr) {
+        backup = d.second;
+      }
+      continue;
+    }
+
     if(d.second->isUp()) {
       poss.push_back({make_tuple(d.second->outstanding.load(), d.second->order, d.second->latencyUsec), d.second});
     }
   }
-  if(poss.empty())
+  if(poss.empty()) {
+    // If we have backup server, let's use it
+    if (backup != nullptr) {
+        return backup;
+    }
+
     return shared_ptr<DownstreamState>();
+  }
+
   nth_element(poss.begin(), poss.begin(), poss.end(), [](const decltype(poss)::value_type& a, const decltype(poss)::value_type& b) { return a.first < b.first; });
   return poss.begin()->second;
 }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -707,6 +707,21 @@ struct DownstreamState
   bool tcpFastOpen{false};
   bool ipBindAddrNoPort{true};
 
+  // Use this server only if other servers down
+  bool backup{false};
+
+  bool isBackup() {
+    return backup;
+  }
+
+  void setBackup() {
+    backup = true;
+  }
+
+  void unsetBackup() {
+    backup = false;
+  }
+
   bool isUp() const
   {
     if(availability == Availability::Down)

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -316,7 +316,7 @@ Servers
       setCD=BOOL,            -- Set the CD (Checking Disabled) flag in the health-check query, default: false
       maxCheckFailures=NUM,  -- Allow NUM check failures before declaring the backend down, default: 1
       mustResolve=BOOL,      -- Set to true when the health check MUST return a NOERROR RCODE and an answer
-      backup=BOOL,           -- When set to true, it means that server should be used only when all other servers are down (supported only for wrandom, whashed, roundrobin, leastOutstanding, firstAvailable policies). Health status for backup server is ignored
+      backup=BOOL,           -- When set to true, it means that server should be used only when all other servers are down. Health status for backup server is ignored
       useClientSubnet=BOOL,  -- Add the client's IP address in the EDNS Client Subnet option when forwarding the query to this backend
       source=STRING,         -- The source address or interface to use for queries to this backend, by default this is left to the kernel's address selection
                              -- The following formats are supported:

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -316,7 +316,7 @@ Servers
       setCD=BOOL,            -- Set the CD (Checking Disabled) flag in the health-check query, default: false
       maxCheckFailures=NUM,  -- Allow NUM check failures before declaring the backend down, default: 1
       mustResolve=BOOL,      -- Set to true when the health check MUST return a NOERROR RCODE and an answer
-      backup=BOOL,           -- When set to true, it means that server should be used only when all other servers are down (supported only for wrandom, whashed, roundrobin, leastOutstanding policies). Health status for backup server is ignored
+      backup=BOOL,           -- When set to true, it means that server should be used only when all other servers are down (supported only for wrandom, whashed, roundrobin, leastOutstanding, firstAvailable policies). Health status for backup server is ignored
       useClientSubnet=BOOL,  -- Add the client's IP address in the EDNS Client Subnet option when forwarding the query to this backend
       source=STRING,         -- The source address or interface to use for queries to this backend, by default this is left to the kernel's address selection
                              -- The following formats are supported:

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -316,6 +316,7 @@ Servers
       setCD=BOOL,            -- Set the CD (Checking Disabled) flag in the health-check query, default: false
       maxCheckFailures=NUM,  -- Allow NUM check failures before declaring the backend down, default: 1
       mustResolve=BOOL,      -- Set to true when the health check MUST return a NOERROR RCODE and an answer
+      backup=BOOL,           -- When set to true, it means that server should be used only when all other servers are down (supported only for wrandom and whashed policies)
       useClientSubnet=BOOL,  -- Add the client's IP address in the EDNS Client Subnet option when forwarding the query to this backend
       source=STRING,         -- The source address or interface to use for queries to this backend, by default this is left to the kernel's address selection
                              -- The following formats are supported:

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -316,7 +316,7 @@ Servers
       setCD=BOOL,            -- Set the CD (Checking Disabled) flag in the health-check query, default: false
       maxCheckFailures=NUM,  -- Allow NUM check failures before declaring the backend down, default: 1
       mustResolve=BOOL,      -- Set to true when the health check MUST return a NOERROR RCODE and an answer
-      backup=BOOL,           -- When set to true, it means that server should be used only when all other servers are down (supported only for wrandom and whashed policies)
+      backup=BOOL,           -- When set to true, it means that server should be used only when all other servers are down (supported only for wrandom, whashed, roundrobin policies)
       useClientSubnet=BOOL,  -- Add the client's IP address in the EDNS Client Subnet option when forwarding the query to this backend
       source=STRING,         -- The source address or interface to use for queries to this backend, by default this is left to the kernel's address selection
                              -- The following formats are supported:

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -316,7 +316,7 @@ Servers
       setCD=BOOL,            -- Set the CD (Checking Disabled) flag in the health-check query, default: false
       maxCheckFailures=NUM,  -- Allow NUM check failures before declaring the backend down, default: 1
       mustResolve=BOOL,      -- Set to true when the health check MUST return a NOERROR RCODE and an answer
-      backup=BOOL,           -- When set to true, it means that server should be used only when all other servers are down (supported only for wrandom, whashed, roundrobin policies)
+      backup=BOOL,           -- When set to true, it means that server should be used only when all other servers are down (supported only for wrandom, whashed, roundrobin, leastOutstanding policies). Health status for backup server is ignored
       useClientSubnet=BOOL,  -- Add the client's IP address in the EDNS Client Subnet option when forwarding the query to this backend
       source=STRING,         -- The source address or interface to use for queries to this backend, by default this is left to the kernel's address selection
                              -- The following formats are supported:


### PR DESCRIPTION
### Short description

Implemented backup server type for dnsdist. dnsdist uses backup server only when all other servers are dead. It's not used during normal operations. Only single backup server allowed.

It supported and tested for wrandom and whashed policies only.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

