### PR TITLE
dnsdist: allow web API calls to trigger Lua code

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -780,7 +780,13 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
         std::lock_guard<std::mutex> lock(g_luamutex);
         auto f = g_lua.readVariable<boost::optional<std::function<std::string (const std::string &)> > >("webcall");
         if(f) {
-          resp.body = (*f)(req.body);
+          try {
+            resp.body = (*f)(req.body);
+          }
+          catch(std::exception &e) {
+            resp.status = 500;
+            resp.body = e.what();
+          }
         }
       }
     }


### PR DESCRIPTION
### Short description
Given this config:

```
webserver('127.0.0.1:8083', 'secret', 'apisecret')
setAPIWritable(true)

function webcall(s) 
	print("got webcall", s)
	return string.format('you said: %s', s)
end
```

This works:

```
$ curl -X POST --data 'hi' -H 'X-API-Key: apisecret' http://127.0.0.1:8083/api/v1/servers/localhost/luahandler
you said: hi
```

Obviously this needs error handling, and perhaps some serialisation (how hard would it be to get JSON in and out without importing a JSON parser into Lua?).

For now I am posting this for discussion. The power and flexibility offered by this extension should be obvious; most API feature requests could be diverted to this feature until we flesh out a real API for the important functions. @rgacogne has called the idea 'a can of worms', and given the foot shooting ability we are offering here, it is obvious he is right.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
