### PR TITLE
rec: Avoid setting a root NX unless we have AA=1

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2264,7 +2264,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
       */
       if(!wasVariable() && newtarget.empty()) {
         t_sstorage.negcache.add(ne);
-        if(s_rootNXTrust && ne.d_auth.isRoot() && auth.isRoot()) {
+        if(s_rootNXTrust && ne.d_auth.isRoot() && auth.isRoot() && lwr.d_aabit) {
           ne.d_name = ne.d_name.getLastLabel();
           t_sstorage.negcache.add(ne);
         }


### PR DESCRIPTION
### Short description
#5252 fixed part of the issue by ensuring we were talking to . and the SOA was for . (and fixed my CNAME example I was able to reproduce with).
#6112 still has issues because these conditions are still satisfied when using 8.8.8.8 under certain conditions.

By ensuring we have AA=1 this still works for cases like:
- Forwarding to a root server
- Hosting root zone ourselves in rec

and avoids all the nasty surprises you get otherwise.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
