### PR TITLE
add namespace and instance variable to carbon key

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -185,6 +185,8 @@ Seconds to store packets in the :ref:`packet-cache`.
 -  String
 -  Default: pdns
 
+.. versionadded:: 4.2.0
+
 Set the namespace or first string of the metric key. Be careful not to include
 any dots in this setting, unless you know what you are doing.
 See :ref:`metricscarbon`
@@ -208,6 +210,8 @@ you are doing. See :ref:`metricscarbon`
 
 -  String
 -  Default: auth
+
+.. versionadded:: 4.2.0
 
 Set the instance or third string of the metric key. Be careful not to include
 any dots in this setting, unless you know what you are doing.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -177,6 +177,18 @@ Also AXFR a zone from a master with a lower serial.
 
 Seconds to store packets in the :ref:`packet-cache`.
 
+.. _setting-carbon-namespace:
+
+``carbon-namespace``
+--------------------
+
+-  String
+-  Default: pdns
+
+Set the namespace or first string of the metric key. Be careful not to include
+any dots in this setting, unless you know what you are doing.
+See :ref:`metricscarbon`
+
 .. _setting-carbon-ourname:
 
 ``carbon-ourname``
@@ -188,6 +200,18 @@ Seconds to store packets in the :ref:`packet-cache`.
 If sending carbon updates, if set, this will override our hostname. Be
 careful not to include any dots in this setting, unless you know what
 you are doing. See :ref:`metricscarbon`
+
+.. _setting-carbon-instance:
+
+``carbon-instance``
+-------------------
+
+-  String
+-  Default: auth
+
+Set the instance or third string of the metric key. Be careful not to include
+any dots in this setting, unless you know what you are doing.
+See :ref:`metricscarbon`
 
 .. _setting-carbon-server:
 

--- a/pdns/auth-carbon.cc
+++ b/pdns/auth-carbon.cc
@@ -37,9 +37,6 @@ try
   extern StatBag S;
 
   string namespace_name=arg()["carbon-namespace"];
-  if(namespace_name.empty()) {
-    namespace_name="pdns";
-  }
   string hostname=arg()["carbon-ourname"];
   if(hostname.empty()) {
     char tmp[80];
@@ -51,9 +48,6 @@ try
     boost::replace_all(hostname, ".", "_");
   }
   string instance_name=arg()["carbon-instancename"];
-  if(instance_name.empty()) {
-    instance_name="auth";
-  }
 
   vector<string> carbonServers;
   stringtok(carbonServers, arg()["carbon-server"], ", ");

--- a/pdns/auth-carbon.cc
+++ b/pdns/auth-carbon.cc
@@ -36,6 +36,10 @@ try
 {
   extern StatBag S;
 
+  string namespace_name=arg()["carbon-namespace"];
+  if(namespace_name.empty()) {
+    namespace_name="pdns";
+  }
   string hostname=arg()["carbon-ourname"];
   if(hostname.empty()) {
     char tmp[80];
@@ -45,6 +49,10 @@ try
     if(p) *p=0;
     hostname=tmp;
     boost::replace_all(hostname, ".", "_");
+  }
+  string instance_name=arg()["carbon-instancename"];
+  if(instance_name.empty()) {
+    instance_name="auth";
   }
 
   vector<string> carbonServers;
@@ -61,7 +69,7 @@ try
     ostringstream str;
     time_t now=time(0);
     for(const string& entry : entries) {
-      str<<"pdns."<<hostname<<".auth."<<entry<<' '<<S.read(entry)<<' '<<now<<"\r\n";
+      str<<namespace_name<<'.'<<hostname<<'.'<<instance_name<<'.'<<entry<<' '<<S.read(entry)<<' '<<now<<"\r\n";
     }
     msg = str.str();
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -154,9 +154,9 @@ void declareArguments()
   ::arg().setSwitch("do-ipv6-additional-processing", "Do AAAA additional processing")="yes";
   ::arg().setSwitch("query-logging","Hint backends that queries should be logged")="no";
 
-  ::arg().set("carbon-namespace", "If set overwrites the first part of the carbon string)=");
+  ::arg().set("carbon-namespace", "If set overwrites the first part of the carbon string")="pdns";
   ::arg().set("carbon-ourname", "If set, overrides our reported hostname for carbon stats")="";
-  ::arg().set("carbon-instancename", "If set overwrites the the instance name default)=");
+  ::arg().set("carbon-instancename", "If set overwrites the the instance name default")="auth";
   ::arg().set("carbon-server", "If set, send metrics in carbon (graphite) format to this server IP address")="";
   ::arg().set("carbon-interval", "Number of seconds between carbon (graphite) updates")="30";
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -154,7 +154,9 @@ void declareArguments()
   ::arg().setSwitch("do-ipv6-additional-processing", "Do AAAA additional processing")="yes";
   ::arg().setSwitch("query-logging","Hint backends that queries should be logged")="no";
 
+  ::arg().set("carbon-namespace", "If set overwrites the first part of the carbon string)=");
   ::arg().set("carbon-ourname", "If set, overrides our reported hostname for carbon stats")="";
+  ::arg().set("carbon-instancename", "If set overwrites the the instance name default)=");
   ::arg().set("carbon-server", "If set, send metrics in carbon (graphite) format to this server IP address")="";
   ::arg().set("carbon-interval", "Number of seconds between carbon (graphite) updates")="30";
 

--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -93,7 +93,7 @@ try
         for(const auto& state : *states) {
           string serverName = state->name.empty() ? (state->remote.toString() + ":" + std::to_string(state->remote.getPort())) : state->getName();
           boost::replace_all(serverName, ".", "_");
-          const string base = instance_name + "." + hostname + "." + instance_name + ".servers." + serverName + ".";
+          const string base = namespace_name + "." + hostname + "." + instance_name + ".servers." + serverName + ".";
           str<<base<<"queries" << ' ' << state->queries.load() << " " << now << "\r\n";
           str<<base<<"drops" << ' ' << state->reuseds.load() << " " << now << "\r\n";
           str<<base<<"latency" << ' ' << (state->availability != DownstreamState::Availability::Down ? state->latencyUsec/1000.0 : 0) << " " << now << "\r\n";

--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -54,6 +54,10 @@ try
 
     for (const auto& conf : *localCarbon) {
       const auto& server = conf.server;
+      std::string namespace_name = conf.namespace_name;
+      if(namespace_name.empty()) {
+        namespace_name="dnsdist";
+      }
       std::string hostname = conf.ourname;
       if(hostname.empty()) {
         char tmp[80];
@@ -64,6 +68,10 @@ try
         hostname=tmp;
         boost::replace_all(hostname, ".", "_");
       }
+      std::string instance_name = conf.instance_name;
+      if(instance_name.empty()) {
+        instance_name="main";
+      }
 
       try {
         Socket s(server.sin4.sin_family, SOCK_STREAM);
@@ -72,7 +80,7 @@ try
         ostringstream str;
         time_t now=time(0);
         for(const auto& e : g_stats.entries) {
-          str<<"dnsdist."<<hostname<<".main."<<e.first<<' ';
+          str<<namespace_name<<"."<<hostname<<"."<<instance_name<<"."<<e.first<<' ';
           if(const auto& val = boost::get<DNSDistStats::stat_t*>(&e.second))
             str<<(*val)->load();
           else if (const auto& dval = boost::get<double*>(&e.second))
@@ -85,7 +93,7 @@ try
         for(const auto& state : *states) {
           string serverName = state->name.empty() ? (state->remote.toString() + ":" + std::to_string(state->remote.getPort())) : state->getName();
           boost::replace_all(serverName, ".", "_");
-          const string base = "dnsdist." + hostname + ".main.servers." + serverName + ".";
+          const string base = instance_name + "." + hostname + "." + instance_name + ".servers." + serverName + ".";
           str<<base<<"queries" << ' ' << state->queries.load() << " " << now << "\r\n";
           str<<base<<"drops" << ' ' << state->reuseds.load() << " " << now << "\r\n";
           str<<base<<"latency" << ' ' << (state->availability != DownstreamState::Availability::Down ? state->latencyUsec/1000.0 : 0) << " " << now << "\r\n";
@@ -98,7 +106,7 @@ try
 
           string frontName = front->local.toString() + ":" + std::to_string(front->local.getPort()) +  (front->udpFD >= 0 ? "_udp" : "_tcp");
           boost::replace_all(frontName, ".", "_");
-          const string base = "dnsdist." + hostname + ".main.frontends." + frontName + ".";
+          const string base = namespace_name + "." + hostname + "." + instance_name + ".frontends." + frontName + ".";
           str<<base<<"queries" << ' ' << front->queries.load() << " " << now << "\r\n";
         }
         auto localPools = g_pools.getLocal();
@@ -108,7 +116,7 @@ try
           if (poolName.empty()) {
             poolName = "_default_";
           }
-          const string base = "dnsdist." + hostname + ".main.pools." + poolName + ".";
+          const string base = namespace_name + "." + hostname + "." + instance_name + ".pools." + poolName + ".";
           const std::shared_ptr<ServerPool> pool = entry.second;
           str<<base<<"servers" << " " << pool->countServers(false) << " " << now << "\r\n";
           str<<base<<"servers-up" << " " << pool->countServers(true) << " " << now << "\r\n";

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -610,10 +610,16 @@ void setupLuaConfig(bool client)
     });
 
   g_lua.writeFunction("carbonServer", [](const std::string& address, boost::optional<string> ourName,
-					 boost::optional<unsigned int> interval) {
+					 boost::optional<unsigned int> interval, boost::optional<string> namespace_name,
+           boost::optional<string> instance_name) {
                         setLuaSideEffect();
 			auto ours = g_carbon.getCopy();
-			ours.push_back({ComboAddress(address, 2003), ourName ? *ourName : "", interval ? *interval : 30});
+			ours.push_back({
+          ComboAddress(address, 2003),
+          namespace_name ? *namespace_name : "dnsdist",
+          ourName ? *ourName : "", 
+instance_name ? *instance_name : "main" ,
+          interval ? *interval : 30, });
 			g_carbon.setState(ours);
 		      });
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -874,7 +874,9 @@ void removeServerFromPool(pools_t& pools, const string& poolName, std::shared_pt
 struct CarbonConfig
 {
   ComboAddress server;
+  std::string namespace_name;
   std::string ourname;
+  std::string instance_name;
   unsigned int interval;
 };
 

--- a/pdns/dnsdistdist/docs/guides/carbon.rst
+++ b/pdns/dnsdistdist/docs/guides/carbon.rst
@@ -6,9 +6,9 @@ Setting up a carbon export
 
 To emit metrics to Graphite, or any other software supporting the Carbon protocol, use::
 
-  carbonServer('ip-address-of-carbon-server', 'ourname', 30)
+  carbonServer('ip-address-of-carbon-server', 'ourname', 30, 'dnsdist', 'main')
 
-Where ``ourname`` can be used to override your hostname, and ``30`` is the reporting interval in seconds. The last two arguments can be omitted.
+Where ``ourname`` can be used to override your hostname, and ``30`` is the reporting interval in seconds. ``dnsdist`` and ``main`` are used as namespace and instance variables. For querycount statistics these two variables are currently ignored. The last four arguments can be omitted.
 The latest version of `PowerDNS Metronome <https://github.com/ahupowerdns/metronome>`_ comes with attractive graphs for dnsdist by default.
 
 Query counters

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -14,17 +14,24 @@ void doCarbonDump(void*)
 try
 {
   string hostname;
+  string instance_name;
+  string namespace_name;
   vector<string> carbonServers;
 
   {
     Lock l(&g_carbon_config_lock);
     stringtok(carbonServers, arg()["carbon-server"], ", ");
+    namespace_name=arg()["carbon-namespace"];
     hostname=arg()["carbon-ourname"];
+    instance_name=arg()["carbon-instance"];
   }
 
   if(carbonServers.empty())
     return;
 
+  if(namespace_name.empty()) {
+    namespace_name="pdns";
+  }
   if(hostname.empty()) {
     char tmp[80];
     memset(tmp, 0, sizeof(tmp));
@@ -34,6 +41,9 @@ try
 
     hostname=tmp;
     boost::replace_all(hostname, ".", "_");    
+  }
+  if(instance_name.empty()) {
+    instance_name="recursor";
   }
 
   registerAllStats();
@@ -53,7 +63,7 @@ try
       time_t now=time(0);
       
       for(const all_t::value_type& val :  all) {
-        str<<"pdns."<<hostname<<".recursor."<<val.first<<' '<<val.second<<' '<<now<<"\r\n";
+        str<<namespace_name<<'.'<<hostname<<'.'<<instance_name<<'.'<<val.first<<' '<<val.second<<' '<<now<<"\r\n";
       }
       msg = str.str();
     }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -396,6 +396,20 @@ string doSetCarbonServer(T begin, T end)
   if(begin != end) {
     ::arg().set("carbon-ourname")=*begin;
     ret+="set carbon-ourname to '"+*begin+"'\n";
+  } else {
+    return ret;
+  }
+  ++begin;
+  if(begin != end) {
+    ::arg().set("carbon-namespace")=*begin;
+    ret+="set carbon-namespace to '"+*begin+"'\n";
+  } else {
+    return ret;
+  }
+  ++begin;
+  if(begin != end) {
+    ::arg().set("carbon-instance")=*begin;
+    ret+="set carbon-instance to '"+*begin+"'\n";
   }
   return ret;
 }

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -140,6 +140,8 @@ See :doc:`metrics`.
 
 ``carbon-namespace``
 --------------------
+.. versionadded:: 4.2.0
+
 -  String
 
 Change the namespace or first string of the metric key. The default is pdns.
@@ -158,6 +160,8 @@ See :ref:`metricscarbon`.
 
 ``carbon-instance``
 --------------------
+.. versionadded:: 4.2.0
+
 -  String
 
 Change the instance or third string of the metric key. The default is recursor.

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -136,6 +136,14 @@ DNSSEC is not supported. Example:
 If sending carbon updates, this is the interval between them in seconds.
 See :doc:`metrics`.
 
+.. _setting-carbon-namespace:
+
+``carbon-namespace``
+--------------------
+-  String
+
+Change the namespace or first string of the metric key. The default is pdns.
+
 .. _setting-carbon-ourname:
 
 ``carbon-ourname``
@@ -145,6 +153,14 @@ See :doc:`metrics`.
 If sending carbon updates, if set, this will override our hostname.
 Be careful not to include any dots in this setting, unless you know what you are doing.
 See :ref:`metricscarbon`.
+
+.. _setting-carbon-instance:
+
+``carbon-instance``
+--------------------
+-  String
+
+Change the instance or third string of the metric key. The default is recursor.
 
 .. _setting-carbon-server:
 


### PR DESCRIPTION
### Short description
This pull request adds two variables to carbon keys, namespace and instance. It is related to #6941 and #2362.

In environments with multiple pdns instances the predefined keys limit the way to distinguish between each of these instances. With namespace and instance made variable it is now possible to add the team, location, instance name or role into the metric name and therefore group them together for example with the database.

The documentation was updated for what is implemented at the moment. Everything is kept backwards compatible to avoid problems for current users upgrading.
But there are two parts where I do not know how to keep it backwards compatible.

1. In pdns/dnsdist-carbon.cc#143 the querycount metric is not per host and the instance is replaced with qname. Is it okay to replace only the namespace with the variable or should we break here and make querycount a per host key under the instance variable?

2. In pdns/rec_channel_rec.cc#385 the function set-carbon-server currently has no option to set additional variables. Should we add namespace and instance as extra parameters and make them optional or should new functions be provided to set each variable?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)