### PR TITLE
rec: Cleanup the netmask trees used for the ECS index on removals

### DIFF
--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -107,7 +107,7 @@ private:
   class ECSIndexEntry
   {
   public:
-    ECSIndexEntry(const DNSName& qname, uint16_t qtype): d_qname(qname), d_qtype(qtype)
+    ECSIndexEntry(const DNSName& qname, uint16_t qtype): d_nmt(true), d_qname(qname), d_qtype(qtype)
     {
     }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise the intermediary nodes will remain and consume memory until the tree is deleted from the index, which might never happen if we still have active entries for this specific qname and qtype.

This is not a huge issue for IPv4 entries because there is a limited number of entries in the index, but it is much more painful with IPv6 entries.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
