### PR TITLE
dnsdist: Expose trailing data

### DIFF
--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -63,6 +63,12 @@ void setupLuaBindingsDNSQuestion()
 
       return *dq.ednsOptions;
     });
+  g_lua.registerFunction<vector<uint8_t>(DNSQuestion::*)(void)>("getTrailingData", [](const DNSQuestion& dq) {
+      const uint8_t* message = reinterpret_cast<const uint8_t*>(dq.dh);
+      const uint16_t length = getDNSPacketLength(reinterpret_cast<const char*>(message), dq.len);
+      vector<uint8_t> tail(message + length, message + dq.len);
+      return tail;
+    });
 
   g_lua.registerFunction<void(DNSQuestion::*)(std::string)>("sendTrap", [](const DNSQuestion& dq, boost::optional<std::string> reason) {
 #ifdef HAVE_NET_SNMP

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -73,7 +73,7 @@ void setupLuaBindingsDNSQuestion()
       char* message = reinterpret_cast<char*>(dq.dh);
       const uint16_t messageLen = getDNSPacketLength(message, dq.len);
       const uint16_t tailLen = tail.size();
-      if(messageLen + tailLen > dq.size) {
+      if(tailLen > (dq.size - messageLen)) {
         return false;
       }
 
@@ -154,7 +154,7 @@ void setupLuaBindingsDNSQuestion()
       char* message = reinterpret_cast<char*>(dq.dh);
       const uint16_t messageLen = getDNSPacketLength(message, dq.len);
       const uint16_t tailLen = tail.size();
-      if(messageLen + tailLen > dq.size) {
+      if(tailLen > (dq.size - messageLen)) {
         return false;
       }
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -109,13 +109,13 @@ This state can be modified from the various hooks.
 
     :returns: A table of tags, using strings as keys and values
 
-  .. method:: DNSQuestion:getTrailingData() -> table
+  .. method:: DNSQuestion:getTrailingData() -> string
 
     .. versionadded:: 1.4.0
 
     Get all data following the DNS message.
 
-    :returns: A list of 8-bit integers
+    :returns: The trailing data as a null-safe string
 
   .. method:: DNSQuestion:sendTrap(reason)
 
@@ -142,13 +142,13 @@ This state can be modified from the various hooks.
 
     :param table tags: A table of tags, using strings as keys and values
 
-  .. method:: DNSQuestion:setTrailingData(bytes) -> bool
+  .. method:: DNSQuestion:setTrailingData(tail) -> bool
 
     .. versionadded:: 1.4.0
 
     Set the data following the DNS message, overwriting anything already present.
 
-    :param table bytes: The new data as a list of 8-bit integers
+    :param string tail: The new data
     :returns: true if the operation succeeded, false otherwise
 
 .. _DNSResponse:

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -109,6 +109,14 @@ This state can be modified from the various hooks.
 
     :returns: A table of tags, using strings as keys and values
 
+  .. method:: DNSQuestion:getTrailingData() -> table
+
+    .. versionadded:: >1.3.2
+
+    Get all data following the DNS message.
+
+    :returns: A list of 8-bit integers
+
   .. method:: DNSQuestion:sendTrap(reason)
 
     .. versionadded:: 1.2.0
@@ -133,6 +141,15 @@ This state can be modified from the various hooks.
     Set an array of tags into the DNSQuestion object.
 
     :param table tags: A table of tags, using strings as keys and values
+
+  .. method:: DNSQuestion:setTrailingData(bytes) -> bool
+
+    .. versionadded:: >1.3.2
+
+    Set the data following the DNS message, overwriting anything already present.
+
+    :param table bytes: The new data as a list of 8-bit integers
+    :returns: true if the operation succeeded, false otherwise
 
 .. _DNSResponse:
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -111,7 +111,7 @@ This state can be modified from the various hooks.
 
   .. method:: DNSQuestion:getTrailingData() -> table
 
-    .. versionadded:: >1.3.2
+    .. versionadded:: 1.4.0
 
     Get all data following the DNS message.
 
@@ -144,7 +144,7 @@ This state can be modified from the various hooks.
 
   .. method:: DNSQuestion:setTrailingData(bytes) -> bool
 
-    .. versionadded:: >1.3.2
+    .. versionadded:: 1.4.0
 
     Set the data following the DNS message, overwriting anything already present.
 

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -173,7 +173,11 @@ class DNSDistTest(unittest.TestCase):
 
     @classmethod
     def UDPResponder(cls, port, fromQueue, toQueue, trailingDataResponse=False):
+        # trailingDataResponse=True means "ignore trailing data".
+        # Other values are either False (meaning "raise an exception")
+        # or are interpreted as a response RCODE for queries with trailing data.
         ignoreTrailing = trailingDataResponse is True
+
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         sock.bind(("127.0.0.1", port))
@@ -183,7 +187,7 @@ class DNSDistTest(unittest.TestCase):
             try:
                 request = dns.message.from_wire(data, ignore_trailing=ignoreTrailing)
             except dns.message.TrailingJunk as e:
-                if trailingDataResponse is False:
+                if trailingDataResponse is False or forceRcode is True:
                     raise
                 print("UDP query with trailing data, synthesizing response")
                 request = dns.message.from_wire(data, ignore_trailing=True)
@@ -200,7 +204,11 @@ class DNSDistTest(unittest.TestCase):
 
     @classmethod
     def TCPResponder(cls, port, fromQueue, toQueue, trailingDataResponse=False, multipleResponses=False):
+        # trailingDataResponse=True means "ignore trailing data".
+        # Other values are either False (meaning "raise an exception")
+        # or are interpreted as a response RCODE for queries with trailing data.
         ignoreTrailing = trailingDataResponse is True
+
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         try:
@@ -224,7 +232,7 @@ class DNSDistTest(unittest.TestCase):
             try:
                 request = dns.message.from_wire(data, ignore_trailing=ignoreTrailing)
             except dns.message.TrailingJunk as e:
-                if trailingDataResponse is False:
+                if trailingDataResponse is False or forceRcode is True:
                     raise
                 print("TCP query with trailing data, synthesizing response")
                 request = dns.message.from_wire(data, ignore_trailing=True)

--- a/regression-tests.dnsdist/test_Trailing.py
+++ b/regression-tests.dnsdist/test_Trailing.py
@@ -204,14 +204,14 @@ class TestTrailingDataToDnsdist(DNSDistTest):
     function reportTrailingHex(dq)
         local tail = dq:getTrailingData()
         local hex = string.gsub(tail, ".", function(ch)
-            return string.format("\\x2502X", string.byte(ch))
+            return string.sub(string.format("\\x2502X", string.byte(ch)), -2)
         end)
         return DNSAction.Spoof, "-0x" .. hex .. ".echoed-hex.trailing.tests.powerdns.com."
     end
     addLuaAction("echoed-hex.trailing.tests.powerdns.com.", reportTrailingHex)
 
     function replaceTrailingData_unsafe(dq)
-        local success = dq:setTrailingData("\\xB0\\x00\\x00\\xDE\\xAD.")
+        local success = dq:setTrailingData("\\xB0\\x00\\xDE\\xADB\\xF0\\x9F\\x91\\xBB\\xC3\\xBE")
         if not success then
             return DNSAction.ServFail, ""
         end
@@ -388,7 +388,7 @@ class TestTrailingDataToDnsdist(DNSDistTest):
                                     60,
                                     dns.rdataclass.IN,
                                     dns.rdatatype.CNAME,
-                                    '-0xB00000DEAD2E.echoed-hex.trailing.tests.powerdns.com.')
+                                    '-0xB000DEAD42F09F91BBC3BE.echoed-hex.trailing.tests.powerdns.com.')
         expectedResponse.answer.append(rrset)
 
         raw = query.to_wire()

--- a/regression-tests.dnsdist/test_Trailing.py
+++ b/regression-tests.dnsdist/test_Trailing.py
@@ -12,18 +12,64 @@ class TestTrailingDataToBackend(DNSDistTest):
     _testServerPort = 5360
     _config_template = """
     newServer{address="127.0.0.1:%s"}
+
+    function replaceTrailingData(dq)
+        local success = dq:setTrailingData({65, 66, 67}) -- "ABC"
+        if not success then
+            return DNSAction.ServFail, ""
+        end
+        return DNSAction.None, ""
+    end
+    addLuaAction("added.trailing.tests.powerdns.com.", replaceTrailingData)
+
+    function fillBuffer(dq)
+        local available = dq.size - dq.len
+        local tail = extendTableBy({}, available)
+        local success = dq:setTrailingData(tail)
+        if not success then
+            return DNSAction.ServFail, ""
+        end
+        return DNSAction.None, ""
+    end
+    addLuaAction("max.trailing.tests.powerdns.com.", fillBuffer)
+
+    function exceedBuffer(dq)
+        local available = dq.size - dq.len
+        local tail = extendTableBy({}, available + 1)
+        local success = dq:setTrailingData(tail)
+        if not success then
+            return DNSAction.ServFail, ""
+        end
+        return DNSAction.None, ""
+    end
+    addLuaAction("limited.trailing.tests.powerdns.com.", exceedBuffer)
+
+    function extendTableBy(t, n)
+        if n <= 1 then
+            if n == 1 then
+                t[#t + 1] = 0
+            end
+            return t
+        end
+
+        local lower = math.floor(n / 2)
+        local upper = n - lower
+        t = extendTableBy(t, lower)
+        t = extendTableBy(t, upper)
+        return t
+    end
     """
     @classmethod
     def startResponders(cls):
         print("Launching responders..")
 
-        # Respond SERVFAIL to queries with trailing data.
-        cls._UDPResponder = threading.Thread(name='UDP Responder', target=cls.UDPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue, dns.rcode.SERVFAIL])
+        # Respond REFUSED to queries with trailing data.
+        cls._UDPResponder = threading.Thread(name='UDP Responder', target=cls.UDPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue, dns.rcode.REFUSED])
         cls._UDPResponder.setDaemon(True)
         cls._UDPResponder.start()
 
-        # Respond SERVFAIL to queries with trailing data.
-        cls._TCPResponder = threading.Thread(name='TCP Responder', target=cls.TCPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue, dns.rcode.SERVFAIL])
+        # Respond REFUSED to queries with trailing data.
+        cls._TCPResponder = threading.Thread(name='TCP Responder', target=cls.TCPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue, dns.rcode.REFUSED])
         cls._TCPResponder.setDaemon(True)
         cls._TCPResponder.start()
 
@@ -42,7 +88,7 @@ class TestTrailingDataToBackend(DNSDistTest):
                                     '127.0.0.1')
         response.answer.append(rrset)
         expectedResponse = dns.message.make_response(query)
-        expectedResponse.set_rcode(dns.rcode.SERVFAIL)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
 
         raw = query.to_wire()
         raw = raw + b'A'* 20
@@ -58,16 +104,118 @@ class TestTrailingDataToBackend(DNSDistTest):
             self.assertEquals(receivedQuery, query)
             self.assertEquals(receivedResponse, expectedResponse)
 
+    def testTrailingCapacity(self):
+        """
+        Trailing data: Fill buffer
+
+        """
+        name = 'max.trailing.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            # (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+            # (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEquals(receivedQuery, query)
+            self.assertEquals(receivedResponse, expectedResponse)
+
+    def testTrailingLimited(self):
+        """
+        Trailing data: Reject buffer overflows
+
+        """
+        name = 'limited.trailing.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.SERVFAIL)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            # (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+            # (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+            (_, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedResponse)
+            self.assertEquals(receivedResponse, expectedResponse)
+
+    def testTrailingAdded(self):
+        """
+        Trailing data: Add
+
+        """
+        name = 'added.trailing.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.REFUSED)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            # (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+            # (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEquals(receivedQuery, query)
+            self.assertEquals(receivedResponse, expectedResponse)
+
 class TestTrailingDataToDnsdist(DNSDistTest):
     _config_template = """
     newServer{address="127.0.0.1:%s"}
+
+    addAction(AndRule({QNameRule("dropped.trailing.tests.powerdns.com."), TrailingDataRule()}), DropAction())
+
+    function removeTrailingData(dq)
+        local success = dq:setTrailingData({})
+        if not success then
+            return DNSAction.ServFail, ""
+        end
+        return DNSAction.None, ""
+    end
+    addLuaAction("removed.trailing.tests.powerdns.com.", removeTrailingData)
+
     function reportTrailingData(dq)
         local tailBytes = dq:getTrailingData()
         local tailChars = string.char(unpack(tailBytes))
-        return DNSAction.Spoof, tailChars .. ".echoed.trailing.tests.powerdns.com."
+        return DNSAction.Spoof, "-" .. tailChars .. ".echoed.trailing.tests.powerdns.com."
     end
-    addAction(AndRule({QNameRule("dropped.trailing.tests.powerdns.com."), TrailingDataRule()}), DropAction())
     addLuaAction("echoed.trailing.tests.powerdns.com.", reportTrailingData)
+
+    function replaceTrailingData(dq)
+        local success = dq:setTrailingData({65, 66, 67}) -- "ABC"
+        if not success then
+            return DNSAction.ServFail, ""
+        end
+        return DNSAction.None, ""
+    end
+    addLuaAction("replaced.trailing.tests.powerdns.com.", replaceTrailingData)
+    addLuaAction("replaced.trailing.tests.powerdns.com.", reportTrailingData)
     """
 
     def testTrailingDropped(self):
@@ -107,6 +255,35 @@ class TestTrailingDataToDnsdist(DNSDistTest):
             (_, receivedResponse) = sender(raw, response, rawQuery=True)
             self.assertEquals(receivedResponse, None)
 
+    def testTrailingRemoved(self):
+        """
+        Trailing data: Remove
+
+        """
+        name = 'removed.trailing.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+
+        raw = query.to_wire()
+        raw = raw + b'A'* 20
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            # (receivedQuery, receivedResponse) = self.sendUDPQuery(raw, response, rawQuery=True)
+            # (receivedQuery, receivedResponse) = self.sendTCPQuery(raw, response, rawQuery=True)
+            (receivedQuery, receivedResponse) = sender(raw, response, rawQuery=True)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEquals(receivedQuery, query)
+            self.assertEquals(receivedResponse, response)
+
     def testTrailingRead(self):
         """
         Trailing data: Count
@@ -121,7 +298,36 @@ class TestTrailingDataToDnsdist(DNSDistTest):
                                     60,
                                     dns.rdataclass.IN,
                                     dns.rdatatype.CNAME,
-                                    'TrailingData.echoed.trailing.tests.powerdns.com.')
+                                    '-TrailingData.echoed.trailing.tests.powerdns.com.')
+        expectedResponse.answer.append(rrset)
+
+        raw = query.to_wire()
+        raw = raw + b'TrailingData'
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            # (receivedQuery, receivedResponse) = self.sendUDPQuery(raw, response, rawQuery=True)
+            # (receivedQuery, receivedResponse) = self.sendTCPQuery(raw, response, rawQuery=True)
+            (_, receivedResponse) = sender(raw, response, rawQuery=True)
+            self.assertTrue(receivedResponse)
+            expectedResponse.flags = receivedResponse.flags
+            self.assertEquals(receivedResponse, expectedResponse)
+
+    def testTrailingReplaced(self):
+        """
+        Trailing data: Replace
+
+        """
+        name = 'replaced.trailing.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        response.set_rcode(dns.rcode.SERVFAIL)
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.CNAME,
+                                    '-ABC.echoed.trailing.tests.powerdns.com.')
         expectedResponse.answer.append(rrset)
 
         raw = query.to_wire()

--- a/regression-tests.dnsdist/test_Trailing.py
+++ b/regression-tests.dnsdist/test_Trailing.py
@@ -3,7 +3,7 @@ import threading
 import dns
 from dnsdisttests import DNSDistTest
 
-class TestTrailing(DNSDistTest):
+class TestTrailingDataToBackend(DNSDistTest):
 
     # this test suite uses a different responder port
     # because, contrary to the other ones, its
@@ -12,26 +12,64 @@ class TestTrailing(DNSDistTest):
     _testServerPort = 5360
     _config_template = """
     newServer{address="127.0.0.1:%s"}
-    addAction(AndRule({QTypeRule(dnsdist.AAAA), TrailingDataRule()}), DropAction())
     """
     @classmethod
     def startResponders(cls):
         print("Launching responders..")
 
-        cls._UDPResponder = threading.Thread(name='UDP Responder', target=cls.UDPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue, True])
+        # Respond SERVFAIL to queries with trailing data.
+        cls._UDPResponder = threading.Thread(name='UDP Responder', target=cls.UDPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue, dns.rcode.SERVFAIL])
         cls._UDPResponder.setDaemon(True)
         cls._UDPResponder.start()
 
-        cls._TCPResponder = threading.Thread(name='TCP Responder', target=cls.TCPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue, True])
+        # Respond SERVFAIL to queries with trailing data.
+        cls._TCPResponder = threading.Thread(name='TCP Responder', target=cls.TCPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue, dns.rcode.SERVFAIL])
         cls._TCPResponder.setDaemon(True)
         cls._TCPResponder.start()
 
-    def testTrailingAllowed(self):
+    def testTrailingPassthrough(self):
         """
-        Trailing: Allowed
+        Trailing data: Pass through
 
         """
-        name = 'allowed.trailing.tests.powerdns.com.'
+        name = 'passthrough.trailing.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+        expectedResponse = dns.message.make_response(query)
+        expectedResponse.set_rcode(dns.rcode.SERVFAIL)
+
+        raw = query.to_wire()
+        raw = raw + b'A'* 20
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            # (receivedQuery, receivedResponse) = self.sendUDPQuery(raw, response, rawQuery=True)
+            # (receivedQuery, receivedResponse) = self.sendTCPQuery(raw, response, rawQuery=True)
+            (receivedQuery, receivedResponse) = sender(raw, response, rawQuery=True)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEquals(receivedQuery, query)
+            self.assertEquals(receivedResponse, expectedResponse)
+
+class TestTrailingDataToDnsdist(DNSDistTest):
+    _config_template = """
+    newServer{address="127.0.0.1:%s"}
+    addAction(AndRule({QNameRule("dropped.trailing.tests.powerdns.com."), TrailingDataRule()}), DropAction())
+    """
+
+    def testTrailingDropped(self):
+        """
+        Trailing data: Drop query
+
+        """
+        name = 'dropped.trailing.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
         response = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name,
@@ -43,32 +81,22 @@ class TestTrailing(DNSDistTest):
 
         raw = query.to_wire()
         raw = raw + b'A'* 20
-        (receivedQuery, receivedResponse) = self.sendUDPQuery(raw, response, rawQuery=True)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
 
-        (receivedQuery, receivedResponse) = self.sendTCPQuery(raw, response, rawQuery=True)
-        self.assertTrue(receivedQuery)
-        self.assertTrue(receivedResponse)
-        receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
 
-    def testTrailingDropped(self):
-        """
-        Trailing: dropped
+            # Verify that queries with no trailing data make it through.
+            # (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
+            # (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
+            (receivedQuery, receivedResponse) = sender(query, response)
+            self.assertTrue(receivedQuery)
+            self.assertTrue(receivedResponse)
+            receivedQuery.id = query.id
+            self.assertEquals(query, receivedQuery)
+            self.assertEquals(response, receivedResponse)
 
-        """
-        name = 'dropped.trailing.tests.powerdns.com.'
-        query = dns.message.make_query(name, 'AAAA', 'IN')
-
-        raw = query.to_wire()
-        raw = raw + b'A'* 20
-
-        (_, receivedResponse) = self.sendUDPQuery(raw, response=None, rawQuery=True)
-        self.assertEquals(receivedResponse, None)
-        (_, receivedResponse) = self.sendTCPQuery(raw, response=None, rawQuery=True)
-        self.assertEquals(receivedResponse, None)
+            # Verify that queries with trailing data don't make it through.
+            # (_, receivedResponse) = self.sendUDPQuery(raw, response, rawQuery=True)
+            # (_, receivedResponse) = self.sendTCPQuery(raw, response, rawQuery=True)
+            (_, receivedResponse) = sender(raw, response, rawQuery=True)
+            self.assertEquals(receivedResponse, None)


### PR DESCRIPTION
### Short description
Expose data following a DNS message to Lua for both reading and writing.
Fixes #6846.

Incorporates #6897 ([diff from that base](https://github.com/gibson042/pdns/compare/2018-08-trailing-data-tests...2018-08-trailing-data)).

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)