### PR TITLE
Rename rtr to rte since it's an rte...

### DIFF
--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -760,8 +760,8 @@ RNAME##RecordContent::RNAME##RecordContent(const string& zoneData)              
     RecordTextReader rtr(zoneData);                                                                \
     xfrPacket(rtr);                                                                                \
   }                                                                                                \
-  catch(RecordTextException& rtr) {                                                                \
-    throw MOADNSException("Parsing record content (try 'pdnsutil check-zone'): "+string(rtr.what()));  \
+  catch(RecordTextException& rte) {                                                                \
+    throw MOADNSException("Parsing record content (try 'pdnsutil check-zone'): "+string(rte.what()));  \
   }        											   \
 }                                                                                                  \
                                                                                                    \

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -762,7 +762,7 @@ RNAME##RecordContent::RNAME##RecordContent(const string& zoneData)              
   }                                                                                                \
   catch(RecordTextException& rte) {                                                                \
     throw MOADNSException("Parsing record content (try 'pdnsutil check-zone'): "+string(rte.what()));  \
-  }        											   \
+  }                                                                                                \
 }                                                                                                  \
                                                                                                    \
 string RNAME##RecordContent::getZoneRepresentation(bool noDot) const                               \


### PR DESCRIPTION
### Short description
This variable is confusingly named

### Checklist
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
