### PR TITLE
move arg function to the testrunner

### DIFF
--- a/pdns/test-nameserver_cc.cc
+++ b/pdns/test-nameserver_cc.cc
@@ -8,16 +8,9 @@
 #include "iputils.hh"
 #include "nameserver.hh"
 #include "statbag.hh"
-#include "arguments.hh"
 #include <utility>
 
 extern vector<ComboAddress> g_localaddresses;
-
-ArgvMap &arg()
-{
-  static ArgvMap theArg;
-  return theArg;
-}
 
 BOOST_AUTO_TEST_SUITE(nameserver_cc)
 

--- a/pdns/testrunner.cc
+++ b/pdns/testrunner.cc
@@ -6,6 +6,7 @@
 #include "config.h"
 #endif
 #include <boost/test/unit_test.hpp>
+#include "arguments.hh"
 #include "auth-packetcache.hh"
 #include "auth-querycache.hh"
 #include "statbag.hh"
@@ -13,3 +14,8 @@ StatBag S;
 AuthPacketCache PC;
 AuthQueryCache QC;
 
+ArgvMap &arg()
+{
+  static ArgvMap theArg;
+  return theArg;
+}


### PR DESCRIPTION
### Short description
IT'S = IT IS => wrong

### Checklist
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
