### PR TITLE
Enforce style const MOADNSException &mde

### DIFF
--- a/pdns/dnsdemog.cc
+++ b/pdns/dnsdemog.cc
@@ -81,7 +81,7 @@ try
           cout <<", "<< ntohs(dh->arcount) <<");\n";
 
         }
-        catch(MOADNSException& mde) {
+        catch(const MOADNSException &mde) {
           //        cerr<<"error parsing packet: "<<mde.what()<<endl;
           continue;
         }

--- a/pdns/dnsgram.cc
+++ b/pdns/dnsgram.cc
@@ -194,7 +194,7 @@ try
             lastreport = pr.d_pheader.ts;
           }          
         }
-        catch(MOADNSException& mde) {
+        catch(const MOADNSException &mde) {
           //        cerr<<"error parsing packet: "<<mde.what()<<endl;
           parseErrors++;
           continue;

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -444,7 +444,7 @@ try
 	measureResultAndClean(iter);
       }
     }
-    catch(MOADNSException &e)
+    catch(const MOADNSException &mde)
     {
       s_wednserrors++;
     }
@@ -684,10 +684,10 @@ static bool sendPacketFromPR(PcapPacketReader& pr, const ComboAddress& remote, i
       }
     }
   }
-  catch(MOADNSException &e)
+  catch(const MOADNSException &mde)
   {
     if(!g_quiet)
-      cerr<<"Error parsing packet: "<<e.what()<<endl;
+      cerr<<"Error parsing packet: "<<mde.what()<<endl;
     s_idmanager.releaseID(qd.d_assignedID);  // not added to qids for cleanup
     s_origdnserrors++;
   }

--- a/pdns/dnsscan.cc
+++ b/pdns/dnsscan.cc
@@ -90,8 +90,8 @@ try
           counts[mdp.d_qtype]++;
 
       }
-      catch(MOADNSException &e) {
-        cout<<"Error from remote "<<pr.getSource().toString()<<": "<<e.what()<<"\n";
+      catch(const MOADNSException &mde) {
+        cout<<"Error from remote "<<pr.getSource().toString()<<": "<<mde.what()<<"\n";
         //        sock.sendTo(string(pr.d_payload, pr.d_payload + pr.d_len), remote);
       }
     }

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -321,7 +321,7 @@ try
 
         
 	}
-	catch(MOADNSException& mde) {
+	catch(const MOADNSException &mde) {
 	  if(verbose)
 	    cout<<"error parsing packet: "<<mde.what()<<endl;
 	  if(pw)

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -854,8 +854,8 @@ static void tcpWorker(int tid) {
       } /* if (mdp.d_qtype == QType::IXFR) */
 
       shutdown(cfd, 2);
-    } catch (MOADNSException &e) {
-      g_log<<Logger::Warning<<prefix<<"Could not parse DNS packet from "<<saddr.toStringWithPort()<<": "<<e.what()<<endl;
+    } catch (const MOADNSException &mde) {
+      g_log<<Logger::Warning<<prefix<<"Could not parse DNS packet from "<<saddr.toStringWithPort()<<": "<<mde.what()<<endl;
     } catch (runtime_error &e) {
       g_log<<Logger::Warning<<prefix<<"Could not write reply to "<<saddr.toStringWithPort()<<": "<<e.what()<<endl;
     }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1570,8 +1570,8 @@ static void startDoResolve(void *p)
     g_log<<Logger::Error<<"startDoResolve problem "<<makeLoginfo(dc)<<": "<<ae.reason<<endl;
     delete dc;
   }
-  catch(MOADNSException& e) {
-    g_log<<Logger::Error<<"DNS parser error "<<makeLoginfo(dc) <<": "<<dc->d_mdp.d_qname<<", "<<e.what()<<endl;
+  catch(const MOADNSException &mde) {
+    g_log<<Logger::Error<<"DNS parser error "<<makeLoginfo(dc) <<": "<<dc->d_mdp.d_qname<<", "<<mde.what()<<endl;
     delete dc;
   }
   catch(std::exception& e) {
@@ -1747,7 +1747,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       try {
         dc=new DNSComboWriter(conn->data, g_now);
       }
-      catch(MOADNSException &mde) {
+      catch(const MOADNSException &mde) {
         g_stats.clientParseError++;
         if(g_logCommonErrors)
           g_log<<Logger::Error<<"Unable to parse packet from TCP client "<< conn->d_remote.toStringWithPort() <<endl;
@@ -2255,7 +2255,7 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
           }
         }
       }
-      catch(const MOADNSException& mde) {
+      catch(const MOADNSException &mde) {
         g_stats.clientParseError++;
         if(g_logCommonErrors) {
           g_log<<Logger::Error<<"Unable to parse packet from remote UDP client "<<fromaddr.toString() <<": "<<mde.what()<<endl;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -600,8 +600,8 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote)
       di.backend->abortTransaction();
     }
   }
-  catch(MOADNSException &re) {
-    g_log<<Logger::Error<<"Unable to parse record during incoming AXFR of '"<<domain<<"' (MOADNSException): "<<re.what()<<endl;
+  catch(const MOADNSException &mde) {
+    g_log<<Logger::Error<<"Unable to parse record during incoming AXFR of '"<<domain<<"' (MOADNSException): "<<mde.what()<<endl;
     if(di.backend && transaction) {
       g_log<<Logger::Error<<"Aborting possible open transaction for domain '"<<domain<<"' AXFR"<<endl;
       di.backend->abortTransaction();


### PR DESCRIPTION
### Short description
There were a number of styles for this exception object.
This enforces a single style (const, space before &).

I hope to write a wrapper for MOADNSException which includes the zone / record name...
It will be easier if this object is consistently named/typed...

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
