### PR TITLE
Fix ./configure --help alignment

### DIFF
--- a/m4/pdns_enable_ixfrdist.m4
+++ b/m4/pdns_enable_ixfrdist.m4
@@ -1,7 +1,7 @@
 AC_DEFUN([PDNS_ENABLE_IXFRDIST], [
   AC_MSG_CHECKING([whether we will be building ixfrdist])
-  AC_ARG_ENABLE([ixfrdist], [
-    AS_HELP_STRING([--enable-ixfrdist], [if we should build and install ixfrdist @<:@default=no@:>@])
+  AC_ARG_ENABLE([ixfrdist],
+    [AS_HELP_STRING([--enable-ixfrdist], [if we should build and install ixfrdist @<:@default=no@:>@])
   ], [
     enable_ixfrdist=$enableval
   ], [

--- a/m4/pdns_with_lua.m4
+++ b/m4/pdns_with_lua.m4
@@ -1,8 +1,8 @@
 AC_DEFUN([PDNS_WITH_LUA],[
   AC_PROG_GREP()dnl Ensure we have grep
   AC_MSG_CHECKING([which Lua implementation to use])
-  AC_ARG_WITH([lua], [
-    AS_HELP_STRING([--with-lua], [select Lua implementation @<:@default=auto@:>@])
+  AC_ARG_WITH([lua],
+    [AS_HELP_STRING([--with-lua], [select Lua implementation @<:@default=auto@:>@])
   ], [
     with_lua=$withval
   ], [

--- a/m4/pdns_with_postgresql.m4
+++ b/m4/pdns_with_postgresql.m4
@@ -6,8 +6,8 @@ dnl determine the CFLAGS and LIBS
 dnl
 AC_DEFUN([PDNS_WITH_POSTGRESQL], [
   PG_CONFIG=""
-  AC_ARG_WITH([pg-config], [
-    AS_HELP_STRING([--with-pg-config=<path>], [path to pg_config])
+  AC_ARG_WITH([pg-config],
+    [AS_HELP_STRING([--with-pg-config=<path>], [path to pg_config])
   ], [
     PG_CONFIG="$withval"
     AS_IF([test "x$PG_CONFIG" = "xyes" -o ! -x "$PG_CONFIG"], [


### PR DESCRIPTION
### Short description
AS_HELP_STRING cares about whitespace preceding the call...

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
