### PR TITLE
dnsdist: export Prometheus metric about number of alive servers in pool

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -475,6 +475,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
           const string label = "{pool=\"" + poolName + "\"}";
           const std::shared_ptr<ServerPool> pool = entry.second;
           output << "dnsdist_pool_servers" << label << " " << pool->countServers(false) << "\n";
+          output << "dnsdist_pool_active_servers" << label << " " << pool->countServers(true) << "\n";
 
           if (pool->packetCache != nullptr) {
             const auto& cache = pool->packetCache;


### PR DESCRIPTION
### Short description

I added number of alive servers in pool for Prometheus. That's very useful for monitoring purposes.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
