### PR TITLE
 rec: Fix the allow-from-file test in the API regression tests

### DIFF
--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -55,6 +55,7 @@ REC_CONF_TPL = """
 auth-zones=
 forward-zones=
 forward-zones-recurse=
+allow-from-file=acl.list
 api-config-dir=%(conf_dir)s
 include-dir=%(conf_dir)s
 """
@@ -148,7 +149,7 @@ else:
     with open(conf_dir+'/example.com..conf', 'w') as conf_file:
         conf_file.write(REC_EXAMPLE_COM_CONF_TPL)
 
-    servercmd = [pdns_recursor] + common_args + ["--allow-from-file=acl.list"]
+    servercmd = [pdns_recursor] + common_args
 
 
 # Now run pdns and the tests.

--- a/regression-tests.api/test_RecursorConfig.py
+++ b/regression-tests.api/test_RecursorConfig.py
@@ -18,6 +18,8 @@ class RecursorConfig(ApiTestCase):
             headers={'content-type': 'application/json'})
         self.assert_success_json(r)
         data = r.json()
+        self.assertIn("value", data)
+        self.assertEquals(len(data["value"]), 1)
         self.assertEquals("127.0.0.1/32", data["value"][0])
 
     def test_config_allow_from_replace_error(self):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixes the issue in the API regression tests reported in https://github.com/PowerDNS/pdns/pull/6962#issuecomment-420638541 
- Really make sure that the `ACL` is updated via the `API`
- Pass the initial `allow-from-file` value from the configuration instead of the command line so it can be overridden.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
