### PR TITLE
document explicitly that the dnsdist 'responses' metric is actually 'backend responses'

### DIFF
--- a/pdns/dnsdistdist/docs/statistics.rst
+++ b/pdns/dnsdistdist/docs/statistics.rst
@@ -120,7 +120,9 @@ Current memory usage.
 
 responses
 ---------
-Number of responses received from backends.
+Number of responses received from backends. Note! This is not the number of
+responses sent to clients. To get that number, add 'cache-hits' and
+'responses'.
 
 rule-drop
 ---------


### PR DESCRIPTION
### Short description
The documentation was technically correct, but everyone would expect the 'questions' and 'responses' metrics to match up. Since it was documented that this was not the case, I suggest not fixing the metric, but at least to document explicitly that 'responses' measures 'responses received from backend', and how to get the number you expect (by adding up cache-hits).
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
