### PR TITLE
Travis dangling symlinks

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -384,6 +384,10 @@ install_dnsdist() {
   run "sudo chmod 0755 /var/agentx"
 }
 
+check_for_dangling_symlinks() {
+  run '! find -L . -name missing-sources -prune -o ! -name pubsuffix.cc -type l | grep .'
+}
+
 build_auth() {
   run "autoreconf -vi"
   run "./configure \
@@ -422,6 +426,9 @@ build_ixfrdist() {
 
 build_recursor() {
   export PDNS_RECURSOR_DIR=$HOME/pdns_recursor
+  run "cd pdns/recursordist"
+  check_for_dangling_symlinks
+  run "cd ../.."
   # distribution build
   run "./build-scripts/dist-recursor"
   run "cd pdns/recursordist"
@@ -442,6 +449,9 @@ build_recursor() {
 }
 
 build_dnsdist(){
+  run "cd pdns/dnsdistdist"
+  check_for_dangling_symlinks
+  run "cd ../.."
   run "./build-scripts/dist-dnsdist"
   run "cd pdns/dnsdistdist"
   run "tar xf dnsdist*.tar.bz2"


### PR DESCRIPTION
### Short description
Yak: recursor and dnsdist rely on symlinks into the 'main' pdns source tree. Travis should check for dangling symlinks.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
