### PR TITLE
dnsdist did not set TCP_NODELAY, causing needless latency

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -716,7 +716,7 @@ void* tcpAcceptorThread(void* p)
         continue;
       }
 #endif
-      SSetsockopt(ci->fd, SOL_TCP, TCP_NODELAY, 1); // disable NAGLE
+      setTCPNoDelay(ci->fd);  // disable NAGLE
       if(g_maxTCPQueuedConnections > 0 && g_tcpclientthreads->getQueuedCount() >= g_maxTCPQueuedConnections) {
         close(ci->fd);
         delete ci;

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -32,6 +32,7 @@
 #include "threadname.hh"
 #include <thread>
 #include <atomic>
+#include <netinet/tcp.h>
 
 using std::thread;
 using std::atomic;
@@ -715,7 +716,7 @@ void* tcpAcceptorThread(void* p)
         continue;
       }
 #endif
-
+      SSetsockopt(ci->fd, SOL_TCP, TCP_NODELAY, 1); // disable NAGLE
       if(g_maxTCPQueuedConnections > 0 && g_tcpclientthreads->getQueuedCount() >= g_maxTCPQueuedConnections) {
         close(ci->fd);
         delete ci;


### PR DESCRIPTION
Winfried and others noted that our TLS responses were super slow. This turned out to be caused by the Nagle
algorithm which we failed to disable. https://en.wikipedia.org/wiki/Nagle%27s_algorithm

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
