### PR TITLE
[WIP] Make recursor & dnsdist communicate (ECS) 'variable' status

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1415,8 +1415,6 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
     
     if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
-      uint16_t cachedResponseSize = dq.size;
-      uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
       boost::optional<Netmask> subnet;
       if (packetCache && !dq.skipCache && packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKeyNoECS, subnet, allowExpired)) {
         goto sendIt;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -269,7 +269,7 @@ bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags)
   return addEDNSToQueryTurnedResponse(dq);
 }
 
-bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom)
+bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope)
 {
   struct dnsheader* dh = (struct dnsheader*) *response;
 
@@ -297,8 +297,11 @@ bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize,
 
     const std::string responseStr(*response, *responseLen);
     int res = locateEDNSOptRR(responseStr, &optStart, &optLen, &last);
-
+    
     if (res == 0) {
+      if(zeroScope)
+        *zeroScope = optLen > 18 && !responseStr.at(optStart + 18);
+
       if (ednsAdded) {
         /* we added the entire OPT RR,
            therefore we need to remove it entirely */
@@ -511,12 +514,13 @@ try {
           addRoom = DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE;
         }
 #endif
-        if (!fixUpResponse(&response, &responseLen, &responseSize, ids->qname, ids->origFlags, ids->ednsAdded, ids->ecsAdded, rewrittenResponse, addRoom)) {
+        bool zeroScope=false;
+        if (!fixUpResponse(&response, &responseLen, &responseSize, ids->qname, ids->origFlags, ids->ednsAdded, ids->ecsAdded, rewrittenResponse, addRoom, &zeroScope)) {
           continue;
         }
 
         if (ids->packetCache && !ids->skipCache) {
-          ids->packetCache->insert(ids->cacheKey, ids->subnet, ids->origFlags, ids->qname, ids->qtype, ids->qclass, response, responseLen, false, dh->rcode, ids->tempFailureTTL);
+          ids->packetCache->insert(zeroScope ? ids->cacheKeyNoECS : ids->cacheKey, ids->subnet, ids->origFlags, ids->qname, ids->qtype, ids->qclass, response, responseLen, false, dh->rcode, ids->tempFailureTTL);
         }
 
         if (ids->cs && !ids->cs->muted) {
@@ -1404,19 +1408,29 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
 
     bool ednsAdded = false;
     bool ecsAdded = false;
+    uint32_t cacheKeyNoECS = 0;
+    uint32_t cacheKey = 0;
+    boost::optional<Netmask> subnet;
+    uint16_t cachedResponseSize = dq.size;
+    uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
+    
     if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
+      uint16_t cachedResponseSize = dq.size;
+      uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
+      boost::optional<Netmask> subnet;
+      if (packetCache && !dq.skipCache && packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKeyNoECS, subnet, allowExpired)) {
+        goto sendIt;
+      }
+      
       if (!handleEDNSClientSubnet(dq, &(ednsAdded), &(ecsAdded))) {
         vinfolog("Dropping query from %s because we couldn't insert the ECS value", remote.toStringWithPort());
         return;
       }
     }
 
-    uint32_t cacheKey = 0;
-    boost::optional<Netmask> subnet;
     if (packetCache && !dq.skipCache) {
-      uint16_t cachedResponseSize = dq.size;
-      uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
       if (packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKey, subnet, allowExpired)) {
+      sendIt:;
         DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, reinterpret_cast<dnsheader*>(query), dq.size, cachedResponseSize, false, &queryRealTime);
 #ifdef HAVE_PROTOBUF
         dr.uniqueId = dq.uniqueId;
@@ -1527,6 +1541,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     ids->tempFailureTTL = dq.tempFailureTTL;
     ids->origFlags = origFlags;
     ids->cacheKey = cacheKey;
+    ids->cacheKeyNoECS = cacheKeyNoECS;
     ids->subnet = subnet;
     ids->skipCache = dq.skipCache;
     ids->packetCache = packetCache;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1306,6 +1306,41 @@ static void queueResponse(const ClientState& cs, const char* response, uint16_t 
 }
 #endif /* defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE) */
 
+static int sendAndEncryptUDPResponse(LocalHolders& holders, ClientState& cs, const DNSQuestion& dq, char* query, uint16_t cachedResponseSize, const struct timespec& queryRealTime, int delayMsec, const ComboAddress& dest, const ComboAddress& remote, struct mmsghdr* responsesVect, unsigned int* queuedResponses, struct iovec* respIOV, char* respCBuf)
+{
+  DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, reinterpret_cast<dnsheader*>(query), dq.size, cachedResponseSize, false, &queryRealTime);
+#ifdef HAVE_PROTOBUF
+  dr.uniqueId = dq.uniqueId;
+#endif
+  dr.qTag = dq.qTag;
+  
+  if (!processResponse(holders.cacheHitRespRulactions, dr, &delayMsec)) {
+    return -1;
+  }
+  
+  if (!cs.muted) {
+#ifdef HAVE_DNSCRYPT
+    if (!encryptResponse(query, &cachedResponseSize, dq.size, false, dnsCryptQuery, nullptr, nullptr)) {
+      return -1;
+    }
+#endif
+#if defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE)
+    if (delayMsec == 0 && responsesVect != nullptr) {
+      queueResponse(cs, query, cachedResponseSize, dest, remote, responsesVect[*queuedResponses], respIOV, respCBuf);
+      (*queuedResponses)++;
+    }
+    else
+#endif /* defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE) */
+      {
+        sendUDPResponse(cs.udpFD, query, cachedResponseSize, delayMsec, dest, remote);
+      }
+  }
+  
+  g_stats.cacheHits++;
+  doLatencyStats(0);  // we're not going to measure this
+  return 0;
+}
+
 static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct msghdr* msgh, const ComboAddress& remote, ComboAddress& dest, char* query, uint16_t len, size_t queryBufferSize, struct mmsghdr* responsesVect, unsigned int* queuedResponses, struct iovec* respIOV, char* respCBuf)
 {
   assert(responsesVect == nullptr || (queuedResponses != nullptr && respIOV != nullptr && respCBuf != nullptr));
@@ -1420,7 +1455,8 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
       // we special case our cache in case a downstream explicitly gave us a universally valid resposne with a 0 scope
       if (packetCache && !dq.skipCache && packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKeyNoECS, subnet, allowExpired)) {
-        goto sendIt;
+        sendAndEncryptUDPResponse(holders, cs, dq, query, cachedResponseSize, queryRealTime, delayMsec, dest, remote, responsesVect, queuedResponses, respIOV, respCBuf);
+        return;
       }
       
       if (!handleEDNSClientSubnet(dq, &(ednsAdded), &(ecsAdded))) {
@@ -1431,37 +1467,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
 
     if (packetCache && !dq.skipCache) {
       if (packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKey, subnet, allowExpired)) {
-      sendIt:;
-        DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, reinterpret_cast<dnsheader*>(query), dq.size, cachedResponseSize, false, &queryRealTime);
-#ifdef HAVE_PROTOBUF
-        dr.uniqueId = dq.uniqueId;
-#endif
-        dr.qTag = dq.qTag;
-
-        if (!processResponse(holders.cacheHitRespRulactions, dr, &delayMsec)) {
-          return;
-        }
-
-        if (!cs.muted) {
-#ifdef HAVE_DNSCRYPT
-          if (!encryptResponse(query, &cachedResponseSize, dq.size, false, dnsCryptQuery, nullptr, nullptr)) {
-            return;
-          }
-#endif
-#if defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE)
-          if (delayMsec == 0 && responsesVect != nullptr) {
-            queueResponse(cs, query, cachedResponseSize, dest, remote, responsesVect[*queuedResponses], respIOV, respCBuf);
-            (*queuedResponses)++;
-          }
-          else
-#endif /* defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE) */
-          {
-            sendUDPResponse(cs.udpFD, query, cachedResponseSize, delayMsec, dest, remote);
-          }
-        }
-
-        g_stats.cacheHits++;
-        doLatencyStats(0);  // we're not going to measure this
+        sendAndEncryptUDPResponse(holders, cs, dq, query, cachedResponseSize, queryRealTime, delayMsec, dest, remote, responsesVect, queuedResponses, respIOV, respCBuf);
         return;
       }
       g_stats.cacheMisses++;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1415,7 +1415,6 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
     
     if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
-      boost::optional<Netmask> subnet;
       if (packetCache && !dq.skipCache && packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKeyNoECS, subnet, allowExpired)) {
         goto sendIt;
       }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -299,8 +299,10 @@ bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize,
     int res = locateEDNSOptRR(responseStr, &optStart, &optLen, &last);
     
     if (res == 0) {
-      if(zeroScope)
-        *zeroScope = optLen > 18 && !responseStr.at(optStart + 18);
+      if(zeroScope) { // this finds if an EDNS scope was set, and if it is 0
+        *zeroScope = optLen > 18 && !responseStr.at(optStart + 18) && !responseStr.at(optStart + 11) && responseStr.at(optStart + 12) ==8;
+      }
+      // this test only detects a /0 if ECS is the first option
 
       if (ednsAdded) {
         /* we added the entire OPT RR,

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -522,7 +522,8 @@ try {
         }
 
         if (ids->packetCache && !ids->skipCache) {
-          ids->packetCache->insert(zeroScope ? ids->cacheKeyNoECS : ids->cacheKey, ids->subnet, ids->origFlags, ids->qname, ids->qtype, ids->qclass, response, responseLen, false, dh->rcode, ids->tempFailureTTL);
+          // if zeroScope, pass the pre-ECS hash-key and do not pass the subnet to the cache
+          ids->packetCache->insert(zeroScope ? ids->cacheKeyNoECS : ids->cacheKey, zeroScope ? boost::none : ids->subnet, ids->origFlags, ids->qname, ids->qtype, ids->qclass, response, responseLen, false, dh->rcode, ids->tempFailureTTL);
         }
 
         if (ids->cs && !ids->cs->muted) {
@@ -1417,6 +1418,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
     
     if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
+      // we special case our cache in case a downstream explicitly gave us a universally valid resposne with a 0 scope
       if (packetCache && !dq.skipCache && packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKeyNoECS, subnet, allowExpired)) {
         goto sendIt;
       }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -417,7 +417,8 @@ public:
   {
     auto delta = d_prev.udiffAndSet();
 
-    d_tokens += 1.0 * rate * (delta/1000000.0);
+    if(delta > 0.0) // time, frequently, does go backwards..
+      d_tokens += 1.0 * rate * (delta/1000000.0);
 
     if(d_tokens > burst) {
       d_tokens = burst;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -522,7 +522,8 @@ struct IDState
   std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
   std::shared_ptr<QTag> qTag{nullptr};
   const ClientState* cs{nullptr};
-  uint32_t cacheKey;                                          // 8
+  uint32_t cacheKey;                                          // 4
+  uint32_t cacheKeyNoECS;                                     // 4
   uint16_t age;                                               // 4
   uint16_t qtype;                                             // 2
   uint16_t qclass;                                            // 2
@@ -997,7 +998,7 @@ bool responseContentMatches(const char* response, const uint16_t responseLen, co
 bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int* delayMsec, const struct timespec& now);
 bool processResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, int* delayMsec);
 bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags);
-bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom);
+bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope=0);
 void restoreFlags(struct dnsheader* dh, uint16_t origFlags);
 bool checkQueryHeaders(const struct dnsheader* dh);
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1402,6 +1402,7 @@ static void startDoResolve(void *p)
   sendit:;
 
     if(g_useIncomingECS && haveEDNS && !sr.wasVariable()) {
+      //      cerr<<"Stuffing in a 0 scope because answer is static"<<endl;
       EDNSSubnetOpts eo;
       eo.source = dc->d_ednssubnet.source;
       ComboAddress sa;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1401,6 +1401,17 @@ static void startDoResolve(void *p)
     }
   sendit:;
 
+    if(g_useIncomingECS && haveEDNS && !sr.wasVariable()) {
+      EDNSSubnetOpts eo;
+      eo.source = dc->d_ednssubnet.source;
+      ComboAddress sa;
+      memset(&sa, 0, sizeof(sa));
+      sa.sin4.sin_family = eo.source.getNetwork().sin4.sin_family;
+      eo.scope = Netmask(sa, 0);
+
+      returnedEdnsOptions.push_back(make_pair(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(eo)));
+    }
+
     if (haveEDNS) {
       /* we try to add the EDNS OPT RR even for truncated answers,
          as rfc6891 states:

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1401,7 +1401,7 @@ static void startDoResolve(void *p)
     }
   sendit:;
 
-    if(g_useIncomingECS && dc->d_ecsFound && !sr.wasVariable()) {
+    if(g_useIncomingECS && dc->d_ecsFound && (!sr.wasVariable() && !variableAnswer)) {
       //      cerr<<"Stuffing in a 0 scope because answer is static"<<endl;
       EDNSSubnetOpts eo;
       eo.source = dc->d_ednssubnet.source;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1454,6 +1454,9 @@ static void startDoResolve(void *p)
       if(sendmsg(dc->d_socket, &msgh, 0) < 0 && g_logCommonErrors) 
         g_log<<Logger::Warning<<"Sending UDP reply to client "<<dc->getRemote()<<" failed with: "<<strerror(errno)<<endl;
 
+      if(variableAnswer || sr.wasVariable()) {
+	g_stats.variableResponses++;
+      }
       if(!SyncRes::s_nopacketcache && !variableAnswer && !sr.wasVariable() ) {
         t_packetCache->insertResponsePacket(dc->d_tag, dc->d_qhash, dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_mdp.d_qclass,
                                             string((const char*)&*packet.begin(), packet.size()),

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1401,12 +1401,12 @@ static void startDoResolve(void *p)
     }
   sendit:;
 
-    if(g_useIncomingECS && haveEDNS && !sr.wasVariable()) {
+    if(g_useIncomingECS && dc->d_ecsFound && !sr.wasVariable()) {
       //      cerr<<"Stuffing in a 0 scope because answer is static"<<endl;
       EDNSSubnetOpts eo;
       eo.source = dc->d_ednssubnet.source;
       ComboAddress sa;
-      memset(&sa, 0, sizeof(sa));
+      sa.reset();
       sa.sin4.sin_family = eo.source.getNetwork().sin4.sin_family;
       eo.scope = Netmask(sa, 0);
 
@@ -1455,7 +1455,7 @@ static void startDoResolve(void *p)
         g_log<<Logger::Warning<<"Sending UDP reply to client "<<dc->getRemote()<<" failed with: "<<strerror(errno)<<endl;
 
       if(variableAnswer || sr.wasVariable()) {
-	g_stats.variableResponses++;
+        g_stats.variableResponses++;
       }
       if(!SyncRes::s_nopacketcache && !variableAnswer && !sr.wasVariable() ) {
         t_packetCache->insertResponsePacket(dc->d_tag, dc->d_qhash, dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_mdp.d_qclass,

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -110,6 +110,7 @@ static const oid policyResultCustomOID[] = { RECURSOR_STATS_OID, 91 };
 static const oid queryPipeFullDropsOID[] = { RECURSOR_STATS_OID, 92 };
 static const oid truncatedDropsOID[] = { RECURSOR_STATS_OID, 93 };
 static const oid emptyQueriesOID[] = { RECURSOR_STATS_OID, 94 };
+static const oid variableResponsesOID[] = { RECURSOR_STATS_OID, 95 };
 
 static std::unordered_map<oid, std::string> s_statsMap;
 
@@ -224,6 +225,7 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   registerCounter64Stat("query-pipe-full-drops", queryPipeFullDropsOID, OID_LENGTH(queryPipeFullDropsOID));
   registerCounter64Stat("truncated-drops", truncatedDropsOID, OID_LENGTH(truncatedDropsOID));
   registerCounter64Stat("empty-queries", emptyQueriesOID, OID_LENGTH(emptyQueriesOID));
+  registerCounter64Stat("variable-responses", variableResponsesOID, OID_LENGTH(variableResponsesOID));
   registerCounter64Stat("answers0-1", answers01OID, OID_LENGTH(answers01OID));
   registerCounter64Stat("answers1-10", answers110OID, OID_LENGTH(answers110OID));
   registerCounter64Stat("answers10-100", answers10100OID, OID_LENGTH(answers10100OID));

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -990,6 +990,7 @@ void registerAllStats()
   addGetStat("edns-ping-matches", &g_stats.ednsPingMatches);
   addGetStat("edns-ping-mismatches", &g_stats.ednsPingMismatches);
   addGetStat("dnssec-queries", &g_stats.dnssecQueries);
+  addGetStat("variable-responses", &g_stats.variableResponses);
 
   addGetStat("noping-outqueries", &g_stats.noPingOutQueries);
   addGetStat("noedns-outqueries", &g_stats.noEdnsOutQueries);

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -782,6 +782,14 @@ emptyQueries OBJECT-TYPE
         "Number of queries dropped because they had a QD count of 0"
     ::= { stats 94 }
 
+variableResponses OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of variable responses"
+    ::= { stats 95 }
+
 ---
 --- Traps / Notifications
 ---

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -464,6 +464,14 @@ number of CPU milliseconds spent in 'user' mode
 
 .. _stat-x-our-latency:
 
+variable-responses
+^^^^^^^^^^^^^
+.. versionadded:: 4.2
+
+Reponses that were marked as 'variable'. This could be because of EDNS
+Client Subnet or Lua rules that indicate this variable status (dependent on
+time or who is asking, for example).
+
 x-our-latency
 ^^^^^^^^^^^^^
 .. versionadded:: 4.1

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -933,6 +933,7 @@ struct RecursorStats
   std::atomic<uint64_t> emptyQueriesCount;
   time_t startupTime;
   std::atomic<uint64_t> dnssecQueries;
+  std::atomic<uint64_t> variableResponses;
   unsigned int maxMThreadStackUsage;
   std::atomic<uint64_t> dnssecValidations; // should be the sum of all dnssecResult* stats
   std::map<vState, std::atomic<uint64_t> > dnssecResults;


### PR DESCRIPTION
### Short description
DO NOT MERGE - code works, but needs review
When recursor uses EDNS Client Subnet, a minority of domain names start getting variable answers depending on who is asking. The recursor cache is aware of how this works. However, when the recursor hides behind dnsdist, the dnsdist cache is not aware of which domains are variable or not. 

With this PR, when the recursor is configured to 'use-incoming-edns-subnet', it will add a /0 ECS scope to responses that are _not_ variable.

Meanwhile with this PR, dnsdist learns that /0 answers from backends are invariant, and uses these for anyone who asks, independent of source address. The details are described more fully in this gist: https://gist.github.com/ahupowerdns/cebbddb1cee967c4c6b31176c213dcb8

This code has been tested in production and positively zooms. 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
