### PR TITLE
auth: fix el6 build with default boost

### DIFF
--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -23,7 +23,9 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#if HAVE_BOOST_GE_148
 #include "histog.hh"
+#endif
 
 #include "statbag.hh"
 #include "dnspcap.hh"
@@ -138,8 +140,10 @@ try
     ("rd", po::value<bool>(), "If set to true, only process RD packets, to false only non-RD, unset: both")
     ("ipv4", po::value<bool>()->default_value(true), "Process IPv4 packets")
     ("ipv6", po::value<bool>()->default_value(true), "Process IPv6 packets")
+#if HAVE_BOOST_GE_148
     ("log-histogram", "Write a log-histogram to file 'log-histogram'")
     ("full-histogram", po::value<double>(), "Write a log-histogram to file 'full-histogram' with this millisecond bin size")
+#endif
     ("load-stats,l", po::value<string>()->default_value(""), "if set, emit per-second load statistics (questions, answers, outstanding)")
     ("no-servfail-stats", "Don't include servfails in response time stats")
     ("servfail-tree", "Figure out subtrees that generate servfails")
@@ -431,6 +435,7 @@ try
   cout.precision(4);
   sum=0;
 
+#if HAVE_BOOST_GE_148
   if(g_vm.count("log-histogram")) {
     string fname = g_vm["stats-dir"].as<string>()+"/log-histogram";
     ofstream loglog(fname);
@@ -447,6 +452,7 @@ try
       throw runtime_error("Unable to write statistics to "+fname);
     writeFullHistogramFile(cumul, g_vm["full-histogram"].as<double>(), loglog);
   }
+#endif
 
   
   sum=0;


### PR DESCRIPTION
### Short description
Disable the histograms in dnsscope for boost versions below 1.48

### Checklist
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code on el6
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
