### PR TITLE
auth: scopeMask in the SOAData structure is unused after #5512

### DIFF
--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -844,7 +844,6 @@ bool RemoteBackend::calculateSOASerial(const DNSName& domain, const SOAData& sd,
          { "expire", static_cast<int>(sd.expire) },
          { "default_ttl", static_cast<int>(sd.default_ttl) },
          { "domain_id", static_cast<int>(sd.domain_id) },
-         { "scopeMask", sd.scopeMask }
        }}
      }}
    };

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -37,7 +37,7 @@ struct DNSRecord;
 
 struct SOAData
 {
-  SOAData() : ttl(0), serial(0), refresh(0), retry(0), expire(0), default_ttl(0), db(0), domain_id(-1), scopeMask(0) {};
+  SOAData() : ttl(0), serial(0), refresh(0), retry(0), expire(0), default_ttl(0), db(0), domain_id(-1) {};
 
   DNSName qname;
   DNSName nameserver;
@@ -50,7 +50,6 @@ struct SOAData
   uint32_t default_ttl;
   DNSBackend *db;
   int domain_id;
-  uint8_t scopeMask;
 };
 
 class RCode

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -234,7 +234,6 @@ bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd, bool unmodifiedSeria
     fillSOAData(rr.content, sd);
     sd.domain_id=rr.domain_id;
     sd.ttl=rr.ttl;
-    sd.scopeMask = rr.scopeMask;
   }
 
   if(!hits)

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -979,7 +979,6 @@ void PacketHandler::makeNXDomain(DNSPacket* p, DNSPacket* r, const DNSName& targ
   rr.domain_id=sd.domain_id;
   rr.dr.d_place=DNSResourceRecord::AUTHORITY;
   rr.auth = 1;
-  rr.scopeMask = sd.scopeMask;
   r->addRecord(rr);
 
   if(d_dk.isSecuredZone(sd.qname))


### PR DESCRIPTION
### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
