### PR TITLE
dnsdist: Release memory on DNS over TLS handshake failure

### DIFF
--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -258,7 +258,7 @@ public:
         try {
           handleIORequest(res, timeout);
         }
-        catch(const std::exception&) {
+        catch(...) {
           SSL_free(d_conn);
           d_conn = nullptr;
           throw;

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -636,8 +636,6 @@ public:
 
       if (file.fail()) {
         file.close();
-        safe_memory_release(d_key.data, d_key.size);
-        gnutls_free(d_key.data);
         throw std::runtime_error("Invalid GnuTLS tickets key file " + keyFile);
       }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise we leak the memory allocated to handle the `TLS` connection if the handshake doesn't succeed correctly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
