### PR TITLE
SOA-check: reject nxdomain response and check label of RR against qname

### DIFF
--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -271,6 +271,9 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
   if(mdp.d_qtype != QType::SOA)
     throw ResolverException("Query to '" + remote->toStringWithPort() + "' for SOA of '" + domain->toLogString() + "' returned wrong record type");
 
+  if(mdp.d_header.rcode != 0)
+    throw ResolverException("Query to '" + remote->toStringWithPort() + "' for SOA of '" + domain->toLogString() + "' returned Rcode " + RCode::to_s(mdp.d_header.rcode));
+
   *theirInception = *theirExpire = 0;
   bool gotSOA=false;
   for(const MOADNSParser::answers_t::value_type& drc :  mdp.d_answers) {

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -277,14 +277,14 @@ bool Resolver::tryGetSOASerial(DNSName *domain, ComboAddress* remote, uint32_t *
   *theirInception = *theirExpire = 0;
   bool gotSOA=false;
   for(const MOADNSParser::answers_t::value_type& drc :  mdp.d_answers) {
-    if(drc.first.d_type == QType::SOA) {
+    if(drc.first.d_type == QType::SOA && drc.first.d_name == *domain) {
       shared_ptr<SOARecordContent> src=getRR<SOARecordContent>(drc.first);
       if (src) {
         *theirSerial=src->d_st.serial;
         gotSOA = true;
       }
     }
-    if(drc.first.d_type == QType::RRSIG) {
+    if(drc.first.d_type == QType::RRSIG && drc.first.d_name == *domain) {
       shared_ptr<RRSIGRecordContent> rrc=getRR<RRSIGRecordContent>(drc.first);
       if(rrc && rrc->d_type == QType::SOA) {
         *theirInception= std::max(*theirInception, rrc->d_siginception);


### PR DESCRIPTION
Without these patches, PowerDNS even parses NXDOMAIN responses and falsely uses
wrong SOA records, i.e. the SOA record of a parent zone in authority section
when answering with NXDOMAIN.

Patch 1: ignore NXDOMAIN responses
Patch 2: only use SOA RR if the name of the RR matches the qname

### Short description
Fixes https://github.com/PowerDNS/pdns/issues/7058
It does not add all sanity checks, but it fixes issue 1 and 3. For issue 2 I do not found a solution as it seems all reponse sections (answer, authority, additional) are treated equally by the parser. Anyway, fixing issue 1+3 is sufficient.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
