### PR TITLE
rec: dump edns harder

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -189,6 +189,11 @@ static uint64_t* pleaseDump(int fd)
   return new uint64_t(t_RC->doDump(fd) + dumpNegCache(SyncRes::t_sstorage.negcache, fd) + t_packetCache->doDump(fd));
 }
 
+static uint64_t* pleaseDumpEDNSMap(int fd)
+{
+  return new uint64_t(SyncRes::doEDNSDump(fd));
+}
+
 static uint64_t* pleaseDumpNSSpeeds(int fd)
 {
   return new uint64_t(SyncRes::doDumpNSSpeeds(fd));
@@ -264,10 +269,14 @@ string doDumpEDNSStatus(T begin, T end)
   int fd=open(fname.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0660);
   if(fd < 0) 
     return "Error opening dump file for writing: "+string(strerror(errno))+"\n";
+  uint64_t total = 0;
+  try {
+    total = broadcastAccFunction<uint64_t>(boost::bind(pleaseDumpEDNSMap, fd));
+  }
+  catch(...){}
 
-  SyncRes::doEDNSDumpAndClose(fd);
-
-  return "done\n";
+  close(fd);
+  return "dumped "+std::to_string(total)+" records\n";
 }
 
 template<typename T>

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -350,18 +350,21 @@ bool SyncRes::doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSR
   return doOOBResolve(iter->second, qname, qtype, ret, res);
 }
 
-void SyncRes::doEDNSDumpAndClose(int fd)
+uint64_t SyncRes::doEDNSDump(int fd)
 {
-  FILE* fp=fdopen(fd, "w");
+  FILE* fp=fdopen(dup(fd), "w");
   if (!fp) {
-    return;
+    return 0;
   }
-  fprintf(fp,"IP Address\tMode\tMode last updated at\n");
+  uint64_t count = 0;
+
+  fprintf(fp,"; edns from thread follows\n;\n");
   for(const auto& eds : t_sstorage.ednsstatus) {
+    count++;
     fprintf(fp, "%s\t%d\t%s", eds.first.toString().c_str(), (int)eds.second.mode, ctime(&eds.second.modeSetAt));
   }
-
   fclose(fp);
+  return count;
 }
 
 uint64_t SyncRes::doDumpNSSpeeds(int fd)

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -399,7 +399,7 @@ public:
   {
     s_lm = lm;
   }
-  static void doEDNSDumpAndClose(int fd);
+  static uint64_t doEDNSDump(int fd);
   static uint64_t doDumpNSSpeeds(int fd);
   static uint64_t doDumpThrottleMap(int fd);
   static int getRootNS(struct timeval now, asyncresolve_t asyncCallback);


### PR DESCRIPTION
### Short description
We need to troll all the threads to get the data, not just tid=1 (I think) - otherwise it just prints the root priming info and secpoll and nothing more useful.

Now produces data such as:
```
; edns from thread follows
;
199.9.14.201	1	Tue Oct 16 02:05:27 2018
; edns from thread follows
;
216.239.32.10	2	Tue Oct 16 02:05:40 2018
216.239.34.10	2	Tue Oct 16 02:05:40 2018
216.239.36.10	2	Tue Oct 16 02:05:40 2018
216.239.38.10	2	Tue Oct 16 02:05:40 2018
192.43.172.30	1	Tue Oct 16 02:05:40 2018
199.9.14.201	1	Tue Oct 16 02:05:27 2018
192.5.5.241	1	Tue Oct 16 02:05:40 2018
; edns from thread follows
;
142.103.1.1	1	Tue Oct 16 02:08:42 2018
198.41.0.4	1	Tue Oct 16 02:05:27 2018
216.239.32.10	2	Tue Oct 16 02:05:40 2018
216.239.34.10	2	Tue Oct 16 02:05:40 2018
216.239.36.10	2	Tue Oct 16 02:05:40 2018
216.239.38.10	2	Tue Oct 16 02:05:40 2018
192.42.93.30	1	Tue Oct 16 02:05:40 2018
199.7.83.42	1	Tue Oct 16 02:08:42 2018
198.97.190.53	1	Tue Oct 16 02:05:40 2018
199.253.250.68	1	Tue Oct 16 02:08:42 2018
```

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
