### PR TITLE
pdns-recursor: avoid a memory leak in catch-all exception handler

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1590,6 +1590,7 @@ static void startDoResolve(void *p)
   }
   catch(...) {
     g_log<<Logger::Error<<"Any other exception in a resolver context "<< makeLoginfo(dc) <<endl;
+    delete dc;
   }
 
   g_stats.maxMThreadStackUsage = max(MT->getMaxStackUsage(), g_stats.maxMThreadStackUsage);


### PR DESCRIPTION
This commit prevents a leak of DNSComboWriter in the catch-all exception
handler.
