### PR TITLE
pdns-recursor: properly handle exceptions thrown from lua-recursor4

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2902,7 +2902,26 @@ int directResolve(const DNSName& qname, const QType& qtype, int qclass, vector<D
   gettimeofday(&now, 0);
 
   SyncRes sr(now);
-  int res = sr.beginResolve(qname, QType(qtype), qclass, ret); 
+  int res = -1;
+  try {
+    res = sr.beginResolve(qname, QType(qtype), qclass, ret);
+  }
+  catch(const PDNSException& e) {
+    g_log<<Logger::Error<<"Failed to resolve "<<qname.toLogString()<<", got pdns exception: "<<e.reason<<endl;
+    ret.clear();
+  }
+  catch(const ImmediateServFailException& e) {
+    g_log<<Logger::Error<<"Failed to resolve "<<qname.toLogString()<<", got ImmediateServFailException: "<<e.reason<<endl;
+    ret.clear();
+  }
+  catch(const std::exception& e) {
+    g_log<<Logger::Error<<"Failed to resolve "<<qname.toLogString()<<", got STL error: "<<e.what()<<endl;
+    ret.clear();
+  }
+  catch(...) {
+    g_log<<Logger::Error<<"Failed to resolve "<<qname.toLogString()<<", got an exception"<<endl;
+    ret.clear();
+  }
   
   return res;
 }


### PR DESCRIPTION
directResolve function is used by lua-recursor4 in various callbacks. As
a result an exception thrown from this function is caught in generic
exception handlers at the end of startDoResolve (pdns_recursor).
Specifically, ImmediateServFailException is caught in the catch-all
exception handler, which obscures the origin of the error.

This commit adds handling of all exceptions inside directResolve and
converts them to error code (-1). This way, an exception in this
function is handled properly in startDoResolve and ServFail is sent
downstream.

To clarify, in case of exception the return DNSRecord vector is cleared
to make sure that old behavior is preserved, when in case of exception
the vector was not referenced in any way.