### PR TITLE
rec-4.1.x: avoid a memory leak in catch-all exception handler

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1344,6 +1344,7 @@ static void startDoResolve(void *p)
   }
   catch(...) {
     L<<Logger::Error<<"Any other exception in a resolver context "<< makeLoginfo(dc) <<endl;
+    delete dc;
   }
 
   g_stats.maxMThreadStackUsage = max(MT->getMaxStackUsage(), g_stats.maxMThreadStackUsage);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This commit prevents a leak of DNSComboWriter in the catch-all exception
handler, which could be triggered by an `ImmediateServFailException` while invoking `followCNAMERecords`, `getFakeAAAARecords` or `getFakePTRRecords` from a `Lua` hook.

(cherry picked from commit cbb097d8581dbb27d81be3a3022a96b8ad08e295)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
