### PR TITLE
dnsdist: Add a 'creationOrder' field to rules

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -1004,11 +1004,12 @@ static void addAction(GlobalStateHolder<vector<T> > *someRulActions, luadnsrule_
   setLuaSideEffect();
 
   boost::uuids::uuid uuid;
-  parseRuleParams(params, uuid);
+  uint64_t creationOrder;
+  parseRuleParams(params, uuid, creationOrder);
 
   auto rule=makeRule(var);
-  someRulActions->modify([rule, action, uuid](vector<T>& rulactions){
-      rulactions.push_back({rule, action, uuid});
+  someRulActions->modify([rule, action, uuid, creationOrder](vector<T>& rulactions){
+      rulactions.push_back({rule, action, uuid, creationOrder});
     });
 }
 
@@ -1016,10 +1017,11 @@ void setupLuaActions()
 {
   g_lua.writeFunction("newRuleAction", [](luadnsrule_t dnsrule, std::shared_ptr<DNSAction> action, boost::optional<luaruleparams_t> params) {
       boost::uuids::uuid uuid;
-      parseRuleParams(params, uuid);
+      uint64_t creationOrder;
+      parseRuleParams(params, uuid, creationOrder);
 
       auto rule=makeRule(dnsrule);
-      DNSDistRuleAction ra({rule, action, uuid});
+      DNSDistRuleAction ra({rule, action, uuid, creationOrder});
       return std::make_shared<DNSDistRuleAction>(ra);
     });
 

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -68,8 +68,10 @@ static boost::uuids::uuid makeRuleID(std::string& id)
   return gen(id);
 }
 
-void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid& uuid)
+void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid& uuid, uint64_t& creationOrder)
 {
+  static uint64_t s_creationOrder = 0;
+
   string uuidStr;
 
   if (params) {
@@ -79,6 +81,7 @@ void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid
   }
 
   uuid = makeRuleID(uuidStr);
+  creationOrder = s_creationOrder++;
 }
 
 typedef std::unordered_map<std::string, boost::variant<bool, int, std::string, std::vector<std::pair<int,int> > > > ruleparams_t;
@@ -101,11 +104,11 @@ static void showRules(GlobalStateHolder<vector<T> > *someRulActions, boost::opti
 
   auto rules = someRulActions->getLocal();
   if (showUUIDs) {
-    boost::format fmt("%-3d %-38s %9d %-56s %s\n");
-    g_outputBuffer += (fmt % "#" % "UUID" % "Matches" % "Rule" % "Action").str();
+    boost::format fmt("%-3d %-38s %9d %9d %-56s %s\n");
+    g_outputBuffer += (fmt % "#" % "UUID" % "Cr. Order" % "Matches" % "Rule" % "Action").str();
     for(const auto& lim : *rules) {
       string name = lim.d_rule->toString().substr(0, truncateRuleWidth);
-      g_outputBuffer += (fmt % num % boost::uuids::to_string(lim.d_id) % lim.d_rule->d_matches % name % lim.d_action->toString()).str();
+      g_outputBuffer += (fmt % num % boost::uuids::to_string(lim.d_id) % lim.d_creationOrder % lim.d_rule->d_matches % name % lim.d_action->toString()).str();
       ++num;
     }
   }

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -80,7 +80,7 @@ private:
 typedef boost::variant<string, vector<pair<int, string>>, std::shared_ptr<DNSRule>, DNSName, vector<pair<int, DNSName> > > luadnsrule_t;
 std::shared_ptr<DNSRule> makeRule(const luadnsrule_t& var);
 typedef std::unordered_map<std::string, boost::variant<std::string> > luaruleparams_t;
-void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid& uuid);
+void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid& uuid, uint64_t& creationOrder);
 
 typedef NetmaskTree<DynBlock> nmts_t;
 

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -231,6 +231,7 @@ static json11::Json::array someResponseRulesToJson(GlobalStateHolder<vector<T>>*
   for(const auto& a : *localResponseRules) {
     Json::object rule{
       {"id", num++},
+      {"creationOrder", (double)a.d_creationOrder},
       {"uuid", boost::uuids::to_string(a.d_id)},
       {"matches", (double)a.d_rule->d_matches},
       {"rule", a.d_rule->toString()},
@@ -589,6 +590,7 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
       for(const auto& a : *localRules) {
 	Json::object rule{
           {"id", num++},
+          {"creationOrder", (double)a.d_creationOrder},
           {"uuid", boost::uuids::to_string(a.d_id)},
           {"matches", (double)a.d_rule->d_matches},
           {"rule", a.d_rule->toString()},

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -896,6 +896,7 @@ struct DNSDistRuleAction
   std::shared_ptr<DNSRule> d_rule;
   std::shared_ptr<DNSAction> d_action;
   boost::uuids::uuid d_id;
+  uint64_t d_creationOrder;
 };
 
 struct DNSDistResponseRuleAction
@@ -903,6 +904,7 @@ struct DNSDistResponseRuleAction
   std::shared_ptr<DNSRule> d_rule;
   std::shared_ptr<DNSResponseAction> d_action;
   boost::uuids::uuid d_id;
+  uint64_t d_creationOrder;
 };
 
 extern GlobalStateHolder<SuffixMatchTree<DynBlock>> g_dynblockSMT;

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -78,21 +78,15 @@ class TestAPIBasics(DNSDistTest):
 
         self.assertEquals(content['daemon_type'], 'dnsdist')
 
-        rule_groups = ['response-rules', 'cache-hit-response-rules', 'self-answered-response-rules']
-        for key in ['version', 'acl', 'local', 'rules', 'servers', 'frontends', 'pools'] + rule_groups:
+        rule_groups = ['response-rules', 'cache-hit-response-rules', 'self-answered-response-rules', 'rules']
+        for key in ['version', 'acl', 'local', 'servers', 'frontends', 'pools'] + rule_groups:
             self.assertIn(key, content)
-
-        for rule in content['rules']:
-            for key in ['id', 'matches', 'rule', 'action', 'uuid']:
-                self.assertIn(key, rule)
-            for key in ['id', 'matches']:
-                self.assertTrue(rule[key] >= 0)
 
         for rule_group in rule_groups:
             for rule in content[rule_group]:
-                for key in ['id', 'matches', 'rule', 'action', 'uuid']:
+                for key in ['id', 'creationOrder', 'matches', 'rule', 'action', 'uuid']:
                     self.assertIn(key, rule)
-                for key in ['id', 'matches']:
+                for key in ['id', 'creationOrder', 'matches']:
                     self.assertTrue(rule[key] >= 0)
 
         for server in content['servers']:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Closes #6909.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
