### PR TITLE
rec: extend the validity period of signatures by a number of seconds

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3364,6 +3364,12 @@ static int serviceMain(int argc, char*argv[])
     exit(1);
   }
 
+  g_signatureInceptionSkew = ::arg().asNum("signature-inception-skew");
+  if (g_signatureInceptionSkew < 0) {
+    g_log<<Logger::Error<<"A negative value for 'signature-inception-skew' is not allowed"<<endl;
+    exit(1);
+  }
+
   g_dnssecLogBogus = ::arg().mustDo("dnssec-log-bogus");
   g_maxNSEC3Iterations = ::arg().asNum("nsec3-max-iterations");
 
@@ -3959,6 +3965,7 @@ int main(int argc, char **argv)
     ::arg().set("trace","if we should output heaps of logging. set to 'fail' to only log failing domains")="off";
     ::arg().set("dnssec", "DNSSEC mode: off/process-no-validate (default)/process/log-fail/validate")="process-no-validate";
     ::arg().set("dnssec-log-bogus", "Log DNSSEC bogus validations")="no";
+    ::arg().set("signature-inception-skew", "Allow the signture inception to be off by this number of seconds")="60";
     ::arg().set("daemon","Operate as a daemon")="no";
     ::arg().setSwitch("write-pid","Write a PID file")="yes";
     ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="6";

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1096,6 +1096,15 @@ Query example (where 192.0.2.14 is your server):
 PowerDNS can change its user and group id after binding to its socket.
 Can be used for better :doc:`security <security>`.
 
+.. _setting-signature-inception-skew:
+
+``signature-inception-skew``
+----------------------------------
+-  Integer
+-  Default: 60
+
+Allow the signture inception to be off by this number of seconds. Negative values are not allowed.
+
 .. _setting-single-socket:
 
 ``single-socket``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1100,6 +1100,8 @@ Can be used for better :doc:`security <security>`.
 
 ``signature-inception-skew``
 ----------------------------------
+.. versionadded:: 4.1.5
+
 -  Integer
 -  Default: 60
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1105,7 +1105,11 @@ Can be used for better :doc:`security <security>`.
 -  Integer
 -  Default: 60
 
-Allow the signture inception to be off by this number of seconds. Negative values are not allowed.
+Allow the signature inception to be off by this number of seconds. Negative values are not allowed.
+
+.. versionchanged:: 4.2.0
+
+    Default is now 60, was 0 before.
 
 .. _setting-single-socket:
 

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -6,6 +6,7 @@
 #include "base32.hh"
 #include "logger.hh"
 bool g_dnssecLOG{false};
+time_t g_signatureInceptionSkew{0};
 uint16_t g_maxNSEC3Iterations{0};
 
 #define LOG(x) if(g_dnssecLOG) { g_log <<Logger::Warning << x; }
@@ -676,7 +677,7 @@ static const vector<DNSName> getZoneCuts(const DNSName& begin, const DNSName& en
 
 bool isRRSIGNotExpired(const time_t now, const shared_ptr<RRSIGRecordContent> sig)
 {
-  return sig->d_siginception <= now && sig->d_sigexpire >= now;
+  return sig->d_siginception - g_signatureInceptionSkew <= now && sig->d_sigexpire >= now;
 }
 
 static bool checkSignatureWithKey(time_t now, const shared_ptr<RRSIGRecordContent> sig, const shared_ptr<DNSKEYRecordContent> key, const std::string& msg)
@@ -693,7 +694,7 @@ static bool checkSignatureWithKey(time_t now, const shared_ptr<RRSIGRecordConten
       LOG("signature by key with tag "<<sig->d_tag<<" and algorithm "<<DNSSECKeeper::algorithm2name(sig->d_algorithm)<<" was " << (result ? "" : "NOT ")<<"valid"<<endl);
     }
     else {
-      LOG("Signature is "<<((sig->d_siginception > now) ? "not yet valid" : "expired")<<" (inception: "<<sig->d_siginception<<", expiration: "<<sig->d_sigexpire<<", now: "<<now<<")"<<endl);
+      LOG("Signature is "<<((sig->d_siginception - g_signatureInceptionSkew > now) ? "not yet valid" : "expired")<<" (inception: "<<sig->d_siginception<<", inception skew: "<<g_signatureInceptionSkew<<", expiration: "<<sig->d_sigexpire<<", now: "<<now<<")"<<endl);
     }
   }
   catch(const std::exception& e) {

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -28,6 +28,7 @@
 #include "dnsrecords.hh"
  
 extern bool g_dnssecLOG;
+extern time_t g_signatureInceptionSkew;
 extern uint16_t g_maxNSEC3Iterations;
 
 // 4033 5


### PR DESCRIPTION
### Short description
There are some weird, maybe even broken, dnssec implementations out there. This pull is a workaround for the sign with inception is NOW problem. This is done by a loadbalancer vendor with a letter and a number in it's name. This is bad because only a very small time difference between signer and validator is enough for a domain to go bogus from time to time. 
This pull is adding an option to extent the signature validity by a number of seconds at inception and expire. This will increase the resilience of the validation process and avoid a number of hard to explain bogus results for high profile domains. The default is to add 60 seconds to the signature lifetime. If you think you need to increase this value check your clock. Ntp is your friend...

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
