### PR TITLE
Documentation for Reverse DNS functions, using Lua with generic SQL, plus README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,23 @@ When building from git, the following packages are also required:
 apt install autoconf automake ragel bison flex
 ```
 
-then generate the configure file:
+For Ubuntu 18.04 (Bionic Beaver), the following packages should be installed:
+
+```sh
+apt install libcurl4-openssl-dev luajit lua-yaml-dev libyaml-cpp-dev libtolua-dev lua5.3 autoconf automake ragel bison flex g++ libboost-all-dev libtool make pkg-config libssl-dev virtualenv lua-yaml-dev libyaml-cpp-dev libluajit-5.1-dev libcurl4 gawk
+# For DNSSEC ed25519 (algorithm 15) support with --enable-libsodium
+apt install libsodium-dev
+# If using the gmysql (Generic MySQL) backend
+apt install default-libmysqlclient-dev
+# If using the gpgsql (Generic PostgreSQL) backend
+apt install postgresql-server-dev-10
+# If using --enable-systemd (will create the service scripts so it can be managed with systemctl/service)
+apt install libsystemd0 libsystemd-dev
+# If using the geoip backend
+apt install libmaxminddb-dev libmaxminddb0 libgeoip1 libgeoip-dev
+```
+
+Then generate the configure file:
 
 ```sh
 autoreconf -vi
@@ -61,6 +77,8 @@ make
 
 This generates a PowerDNS Authoritative Server binary with no modules built in.
 
+See https://doc.powerdns.com/authoritative/backends/index.html for a list of available modules.
+
 When `./configure` is run without `--with-modules`, the bind and gmysql module are
 built-in by default and the pipe-backend is compiled for runtime loading.
 
@@ -72,7 +90,7 @@ To add multiple modules, try:
 
 Note that you will need the development headers for PostgreSQL as well in this case.
 
-See https://doc.powerdns.com/md/appendix/compiling-powerdns/ for more details.
+See https://doc.powerdns.com/authoritative/appendices/compiling.html for more details.
 
 If you run into C++11-related symbol trouble, please try passing `CPPFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0` (or 1) to `./configure` to make sure you are compatible with the installed dependencies.
 
@@ -83,6 +101,82 @@ See the README in pdns/recursordist.
 Compiling dnsdist
 -----------------
 See the README in pdns/dnsdistdist.
+
+Building the HTML documentation
+-------------------------------
+
+The HTML documentation (as seen [on the PowerDNS docs site](https://doc.powerdns.com/authoritative/)) is built from ReStructured Text (rst) files located in `docs`. They are compiled into HTML files using [Sphinx](http://www.sphinx-doc.org/en/master/index.html), a documentation generator tool which is built in Python.
+
+**Using a normal Python installation**
+
+For those simply contributing to the documentation, this avoids needing to install the various build
+tools and other dependencies.
+
+Install Python 2.7 or Python 3 (preferable) if you don't yet have it installed. On some operating
+systems you may also have to install `python3-pip` or similarly named.
+
+Ubuntu 16.04 / 18.04
+
+```sh
+apt update
+apt install python3 python3-pip python3-venv
+```
+
+macOS (using homebrew)
+
+```sh
+brew install python3
+```
+
+Update your `pip` and install/update `virtualenv` to avoid problems:
+
+```sh
+# for python2, use "pip" instead of "pip3"
+pip3 install -U pip
+pip3 install -U virtualenv
+```
+
+Enter the repository's `docs` folder, set up the virtualenv, and install the requirements
+
+```sh
+cd docs
+# for python2, use "virtualenv .venv" instead
+python3 -m venv .venv
+source .venv/bin/activate
+# The virtualenv may use an older pip, so upgrade it again
+pip3 install -U pip setuptools setuptools-git
+# Now you can install the requirements
+pip3 install -r requirements.txt
+```
+
+Finally, you can build the documentation:
+
+```sh
+sphinx-build . html-docs
+```
+
+Note: If your shell has problems finding sphinx-build, try using `.venv/bin/sphinx-build` instead.
+
+The HTML documentation is now available in `html-docs`.
+
+**Using the build tools**
+
+This method is preferable for those who already have a working build environment for PowerDNS.
+
+Install the dependencies under "COMPILING", and run autoreconf if you haven't already:
+
+```sh
+autoreconf -vi
+```
+
+Enter the `docs` folder, and use make to build the HTML docs.
+
+```
+cd docs
+make html-docs
+```
+
+The HTML documentation will now be available in `html-docs`.
 
 Solaris Notes
 -------------

--- a/docs/lua-records.rst
+++ b/docs/lua-records.rst
@@ -188,7 +188,7 @@ Record creation functions
 
   Various options can be set in the ``options`` parameter:
 
-  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'closest', 'random', 'hashed'.
+  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed'.
   - ``source``: Source IP address to check from
 
 
@@ -207,7 +207,7 @@ Record creation functions
 
   Various options can be set in the ``options`` parameter:
 
-  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'closest', 'random', 'hashed'.
+  - ``selector``: used to pick the IP address from list of viable candidates. Choices include 'pickclosest', 'random', 'hashed'.
   - ``source``: Source IP address to check from
   - ``stringmatch``: check ``url`` for this string, only declare 'up' if found
 
@@ -305,6 +305,144 @@ Record creation functions
   :param weightparams: table of weight, IP addresses.
 
   See :func:`pickwhashed` for an example.
+
+Reverse DNS functions
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+  **WARNING**: The reverse DNS functions are under active development. **They may**
+  **not be safe for production use.** The syntax of these functions may change at any
+  time.
+
+.. function:: createReverse(format)
+
+  Used for generating default hostnames from IPv4 wildcard reverse DNS records, e.g. *.0.0.127.in-addr.arpa 
+  
+  See :func:`createReverse6` for IPv6 records (ip6.arpa)
+  See :func:`createForward` for creating the A records to a wildcard record such as *.static.example.com
+  
+  Returns a formatted hostname based on the format string passed.
+
+  :param format: A hostname string to format, for example ``%1%.%2%.%3%.%4%.static.example.com``.
+  
+  Formatting options::
+   
+   - ``%1%`` to ``%4%`` are individual octets
+     - Example record query: ``1.0.0.127.in-addr.arpa``
+       - ``%1%`` = 127
+       - ``%2%`` = 0
+       - ``%3%`` = 0
+       - ``%4%`` = 1
+   - ``%5%`` joins the four decimal octets together with dashes
+     - Example: ``%5%.static.example.com`` is equivalent to ``%1%-%2%-%3%-%4%.static.example.com``
+   - ``%6%`` converts each octet from decimal to hexadecimal and joins them together
+     - Example: A query for ``15.0.0.127.static.example.com`` - ``%6`` would be `7f00000f` (127 is 7f, and 15 is 0f in hexadecimal)
+  
+  **NOTE:** At the current time, only forward dotted format works with :func:`createForward` (i.e. 127.0.0.1.static.example.com)
+  
+  Example records::
+  
+    *.0.0.127.in-addr.arpa IN    LUA    PTR "createReverse('%1%.%2%.%3%.%4%.static.example.com')"
+    *.1.0.127.in-addr.arpa IN    LUA    PTR "createReverse('%5%.static.example.com')"
+    *.2.0.127.in-addr.arpa IN    LUA    PTR "createReverse('%6%.static.example.com')"
+ 
+  When queried::
+  
+    # -x is syntactic sugar to request the PTR record for an IPv4/v6 address such as 127.0.0.5
+    # Equivalent to dig PTR 5.0.0.127.in-addr.arpa
+    $ dig +short -x 127.0.0.5 @ns1.example.com
+    127.0.0.5.static.example.com.
+    $ dig +short -x 127.0.1.5 @ns1.example.com
+    127-0-0-5.static.example.com.
+    $ dig +short -x 127.0.2.5 @ns1.example.com
+    7f000205.static.example.com.
+
+.. function:: createForward()
+  
+  Used to generate the reverse DNS domains made from :func:`createReverse`
+  
+  Generates an A record for a dotted or hexadecimal IPv4 domain (e.g. 127.0.0.1.static.example.com)
+  
+  It does not take any parameters, it simply interprets the zone record to find the IP address.
+  
+  An example record for zone ``static.example.com``::
+    
+    *.static.example.com    IN    LUA    A "createForward()"
+  
+  **NOTE:** At the current time, only forward dotted format works for this function (i.e. 127.0.0.1.static.example.com)
+  
+  When queried::
+  
+    $ dig +short A 127.0.0.5.static.example.com @ns1.example.com
+    127.0.0.5
+  
+.. function:: createReverse6(format)
+
+  Used for generating default hostnames from IPv6 wildcard reverse DNS records, e.g. *.1.0.0.2.ip6.arpa 
+  
+  **For simplicity purposes, only small sections of IPv6 rDNS domains are used in most parts of this guide,**
+  **as a full ip6.arpa record is around 80 characters long, e.g. ``1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.0.0.0.a.0.0.0.1.0.0.2.ip6.arpa``**
+  
+  See :func:`createReverse` for IPv4 records (in-addr.arpa)
+  See :func:`createForward6` for creating the AAAA records to a wildcard record such as *.static.example.com
+  
+  Returns a formatted hostname based on the format string passed.
+
+  :param format: A hostname string to format, for example ``%33%.static6.example.com``.
+  
+  Formatting options::
+   
+   - ``%1%`` to ``%32%`` are individual characters (nibbles)
+     - Example record query: ``1.0.0.2.ip6.arpa``
+       - ``%1%`` = 2
+       - ``%2%`` = 0
+       - ``%3%`` = 0
+       - ``%4%`` = 1
+   - ``%33%`` converts the compressed address format into a dashed format, e.g. ``2001:a::1`` to ``2001-a--1``
+   - ``%34%`` to ``%41%`` represent the 8 uncompressed 2-byte chunks
+     - Example: A query for 2001:a:b::123
+       - ``%34%`` - returns ``2001`` (chunk 1)
+       - ``%35%`` - returns ``000a`` (chunk 2)
+       - ``%41%`` - returns ``0123`` (chunk 8)
+  
+  **NOTE:** At the current time, only forward dotted format works with :func:`createForward` (i.e. 1.0.0.2.static.example.com)
+  
+  Example records::
+  
+    *.1.0.0.2.ip6.arpa IN    LUA    PTR "createReverse('%33%.static6.example.com')"
+    *.2.0.0.2.ip6.arpa IN    LUA    PTR "createReverse('%34%.%35%.static6.example.com')"
+ 
+  When queried::
+  
+    # -x is syntactic sugar to request the PTR record for an IPv4/v6 address such as 2001::1
+    # Equivalent to dig PTR 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.0.0.0.a.0.0.0.1.0.0.2.ip6.arpa
+    # readable version:     1.0.0.0 .0.0.0.0 .0.0.0.0 .0.0.0.0 .0.0.0.0 .b.0.0.0 .a.0.0.0 .1.0.0.2 .ip6.arpa
+    
+    $ dig +short -x 2001:a:b::1 @ns1.example.com
+    2001-a-b--1.static6.example.com.
+    
+    $ dig +short -x 2002:a:b::1 @ns1.example.com
+    2002.000a.static6.example.com
+
+.. function:: createForward6()
+  
+  Used to generate the reverse DNS domains made from :func:`createReverse6`
+  
+  Generates an AAAA record for a dashed compressed IPv6 domain (e.g. 2001-a-b--1.static6.example.com)
+  
+  It does not take any parameters, it simply interprets the zone record to find the IP address.
+  
+  An example record for zone ``static.example.com``::
+    
+    *.static6.example.com    IN    LUA    AAAA "createForward6()"
+  
+  **NOTE:** At the current time, only dashed compressed format works for this function (i.e. 2001-a-b--1.static6.example.com)
+  
+  When queried::
+  
+    $ dig +short AAAA 2001-a-b--1.static6.example.com @ns1.example.com
+    2001:a:b::1
+
 
 Helper functions
 ~~~~~~~~~~~~~~~~

--- a/docs/lua-records.rst
+++ b/docs/lua-records.rst
@@ -309,36 +309,38 @@ Record creation functions
 Reverse DNS functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note::
-  **WARNING**: The reverse DNS functions are under active development. **They may**
+.. warning::
+  The reverse DNS functions are under active development. **They may**
   **not be safe for production use.** The syntax of these functions may change at any
   time.
 
 .. function:: createReverse(format)
 
-  Used for generating default hostnames from IPv4 wildcard reverse DNS records, e.g. *.0.0.127.in-addr.arpa 
+  Used for generating default hostnames from IPv4 wildcard reverse DNS records, e.g. ``*.0.0.127.in-addr.arpa`` 
   
   See :func:`createReverse6` for IPv6 records (ip6.arpa)
-  See :func:`createForward` for creating the A records to a wildcard record such as *.static.example.com
+
+  See :func:`createForward` for creating the A records on a wildcard record such as ``*.static.example.com``
   
   Returns a formatted hostname based on the format string passed.
 
   :param format: A hostname string to format, for example ``%1%.%2%.%3%.%4%.static.example.com``.
   
-  Formatting options::
-   
-   - ``%1%`` to ``%4%`` are individual octets
-     - Example record query: ``1.0.0.127.in-addr.arpa``
-       - ``%1%`` = 127
-       - ``%2%`` = 0
-       - ``%3%`` = 0
-       - ``%4%`` = 1
-   - ``%5%`` joins the four decimal octets together with dashes
-     - Example: ``%5%.static.example.com`` is equivalent to ``%1%-%2%-%3%-%4%.static.example.com``
-   - ``%6%`` converts each octet from decimal to hexadecimal and joins them together
-     - Example: A query for ``15.0.0.127.static.example.com`` - ``%6`` would be `7f00000f` (127 is 7f, and 15 is 0f in hexadecimal)
-  
-  **NOTE:** At the current time, only forward dotted format works with :func:`createForward` (i.e. 127.0.0.1.static.example.com)
+  **Formatting options:**
+
+    - ``%1%`` to ``%4%`` are individual octets
+        - Example record query: ``1.0.0.127.in-addr.arpa`` 
+        - ``%1%`` = 127
+        - ``%2%`` = 0
+        - ``%3%`` = 0
+        - ``%4%`` = 1
+    - ``%5%`` joins the four decimal octets together with dashes
+        - Example: ``%5%.static.example.com`` is equivalent to ``%1%-%2%-%3%-%4%.static.example.com``
+    - ``%6%`` converts each octet from decimal to hexadecimal and joins them together
+        - Example: A query for ``15.0.0.127.in-addr.arpa`` 
+        - ``%6`` would be ``7f00000f`` (127 is 7f, and 15 is 0f in hexadecimal)
+
+  **NOTE:** At the current time, only forward dotted format works with :func:`createForward` (i.e. ``127.0.0.1.static.example.com``)
   
   Example records::
   
@@ -369,7 +371,7 @@ Reverse DNS functions
     
     *.static.example.com    IN    LUA    A "createForward()"
   
-  **NOTE:** At the current time, only forward dotted format works for this function (i.e. 127.0.0.1.static.example.com)
+  **NOTE:** At the current time, only forward dotted format works for this function (i.e. ``127.0.0.1.static.example.com``)
   
   When queried::
   
@@ -378,34 +380,35 @@ Reverse DNS functions
   
 .. function:: createReverse6(format)
 
-  Used for generating default hostnames from IPv6 wildcard reverse DNS records, e.g. *.1.0.0.2.ip6.arpa 
+  Used for generating default hostnames from IPv6 wildcard reverse DNS records, e.g. ``*.1.0.0.2.ip6.arpa``
   
   **For simplicity purposes, only small sections of IPv6 rDNS domains are used in most parts of this guide,**
-  **as a full ip6.arpa record is around 80 characters long, e.g. ``1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.0.0.0.a.0.0.0.1.0.0.2.ip6.arpa``**
+  **as a full ip6.arpa record is around 80 characters long**
   
   See :func:`createReverse` for IPv4 records (in-addr.arpa)
-  See :func:`createForward6` for creating the AAAA records to a wildcard record such as *.static.example.com
+
+  See :func:`createForward6` for creating the AAAA records on a wildcard record such as ``*.static.example.com``
   
   Returns a formatted hostname based on the format string passed.
 
   :param format: A hostname string to format, for example ``%33%.static6.example.com``.
   
-  Formatting options::
+  Formatting options:
    
-   - ``%1%`` to ``%32%`` are individual characters (nibbles)
-     - Example record query: ``1.0.0.2.ip6.arpa``
-       - ``%1%`` = 2
-       - ``%2%`` = 0
-       - ``%3%`` = 0
-       - ``%4%`` = 1
-   - ``%33%`` converts the compressed address format into a dashed format, e.g. ``2001:a::1`` to ``2001-a--1``
-   - ``%34%`` to ``%41%`` represent the 8 uncompressed 2-byte chunks
-     - Example: A query for 2001:a:b::123
-       - ``%34%`` - returns ``2001`` (chunk 1)
-       - ``%35%`` - returns ``000a`` (chunk 2)
-       - ``%41%`` - returns ``0123`` (chunk 8)
+    - ``%1%`` to ``%32%`` are individual characters (nibbles)
+        - **Example PTR record query:** ``a.0.0.0.1.0.0.2.ip6.arpa``
+        - ``%1%`` = 2
+        - ``%2%`` = 0
+        - ``%3%`` = 0
+        - ``%4%`` = 1
+    - ``%33%`` converts the compressed address format into a dashed format, e.g. ``2001:a::1`` to ``2001-a--1``
+    - ``%34%`` to ``%41%`` represent the 8 uncompressed 2-byte chunks
+        - **Example:** PTR query for ``2001:a:b::123``
+        - ``%34%`` - returns ``2001`` (chunk 1)
+        - ``%35%`` - returns ``000a`` (chunk 2)
+        - ``%41%`` - returns ``0123`` (chunk 8)
   
-  **NOTE:** At the current time, only forward dotted format works with :func:`createForward` (i.e. 1.0.0.2.static.example.com)
+  **NOTE:** At the current time, only dashed compressed format works for this function (i.e. ``2001-a-b--1.static6.example.com``)
   
   Example records::
   
@@ -428,7 +431,7 @@ Reverse DNS functions
   
   Used to generate the reverse DNS domains made from :func:`createReverse6`
   
-  Generates an AAAA record for a dashed compressed IPv6 domain (e.g. 2001-a-b--1.static6.example.com)
+  Generates an AAAA record for a dashed compressed IPv6 domain (e.g. ``2001-a-b--1.static6.example.com``)
   
   It does not take any parameters, it simply interprets the zone record to find the IP address.
   
@@ -436,7 +439,7 @@ Reverse DNS functions
     
     *.static6.example.com    IN    LUA    AAAA "createForward6()"
   
-  **NOTE:** At the current time, only dashed compressed format works for this function (i.e. 2001-a-b--1.static6.example.com)
+  **NOTE:** At the current time, only dashed compressed format works for this function (i.e. ``2001-a-b--1.static6.example.com``)
   
   When queried::
   

--- a/docs/lua-records.rst
+++ b/docs/lua-records.rst
@@ -59,7 +59,7 @@ addresses.
 ``pickclosest`` and ifportup can be combined as follows::
 
   www    IN    LUA    A    ("ifportup(443, {'192.0.2.1', '192.0.2.2', '198.51.100.1'}"
-                            ", {selector='closest'})                                 ")
+                            ", {selector='pickclosest'})                                 ")
 
 This will pick from the viable IP addresses the one deemed closest to the user.                         
 

--- a/docs/lua-records.rst
+++ b/docs/lua-records.rst
@@ -63,6 +63,40 @@ addresses.
 
 This will pick from the viable IP addresses the one deemed closest to the user.                         
 
+Using LUA Records with Generic SQL backends
+-------------------------------------------
+
+It's possible to use Lua records with the Generic SQL backends such as gmysql and gpgsql.
+
+Be aware that due to the fact that Lua records uses both double and single quotes, you will
+need to appropriately escape them in INSERT/UPDATE queries.
+
+Here is an example from the previous section (``pickclosest``) which should work 
+for both **MySQL** and **PostgreSQL**::
+
+    -- Create the zone example.com
+    INSERT INTO domains (id, name, type) VALUES (1, 'example.com', 'NATIVE');
+
+    -- Enable Lua records for the zone (if not enabled globally)
+    INSERT INTO domainmetadata (domain_id, kind, content) 
+    VALUES (1, 'ENABLE-LUA-RECORD', 1);
+
+    -- Create a pickClosest() Lua A record.
+    -- Double single quotes are used to escape single quotes in both MySQL and PostgreSQL
+    INSERT INTO records (domain_id, name, type, content, ttl)
+    VALUES (
+      1, 
+      'www.example.com',
+      'LUA', 
+      'A "pickclosest({''192.0.2.1'',''192.0.2.2'',''198.51.100.1''})"',
+      600
+    );
+
+The above queries create a zone ``example.com``, enable Lua records for the zone using ``ENABLE-LUA-RECORD``,
+and finally insert a LUA A record for the ``www`` subdomain using the previous pickclosest example.
+
+See `Details & Security`_ for more information about enabling Lua records, and the risks involved.
+
 Record format
 -------------
 .. note::


### PR DESCRIPTION
### Short description
Documentation for Reverse DNS functions, using Lua with generic SQL, plus README improvements

Big thanks to @ahupowerdns for helping me out with the reverse DNS functions :)

**Documentation (`docs`) changes**

 - Documented previously undocumented/uncommented Lua functions with in depth examples
   - `createForward` 
   - `createReverse`
   - `createForward6`
   - `createReverse6`
 - Added a section for using Lua records with generic SQL backends, including an example set of SQL INSERT queries which work on both MySQL and PostgreSQL (and maybe others)
 - Corrected `closest` to `pickclosest` in several areas, as it was incorrect

**README.md changes**

 - Added packages required to build PowerDNS on Ubuntu 18.04
 - Added build instructions for Sphinx docs (the `docs` folder), as PowerDNS sorely needs more documentation contributors
 - Added link to list of backends, so people know where to find the list of modules they can use
 - Fixed link to point to 4.1 docs instead of 4.0

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
