### PR TITLE
dnsdist: Allow NoRecurse for use in dynamic blocks or lua rules

### DIFF
--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -36,7 +36,8 @@ void setupLuaVars()
       {"NoOp",(int)DNSAction::Action::NoOp},
       {"Delay", (int)DNSAction::Action::Delay},
       {"Truncate", (int)DNSAction::Action::Truncate},
-      {"ServFail", (int)DNSAction::Action::ServFail}
+      {"ServFail", (int)DNSAction::Action::ServFail},
+      {"NoRecurse", (int)DNSAction::Action::NoRecurse}
     });
 
   g_lua.writeVariable("DNSResponseAction", std::unordered_map<string,int>{

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1050,12 +1050,12 @@ instance_name ? *instance_name : "main" ,
 
   g_lua.writeFunction("setDynBlocksAction", [](DNSAction::Action action) {
       if (!g_configurationDone) {
-        if (action == DNSAction::Action::Drop || action == DNSAction::Action::NoOp || action == DNSAction::Action::Nxdomain || action == DNSAction::Action::Refused || action == DNSAction::Action::Truncate) {
+        if (action == DNSAction::Action::Drop || action == DNSAction::Action::NoOp || action == DNSAction::Action::Nxdomain || action == DNSAction::Action::Refused || action == DNSAction::Action::Truncate || action == DNSAction::Action::NoRecurse) {
           g_dynBlockAction = action;
         }
         else {
-          errlog("Dynamic blocks action can only be Drop, NoOp, NXDomain, Refused or Truncate!");
-          g_outputBuffer="Dynamic blocks action can only be Drop, NoOp, NXDomain, Refused or Truncate!\n";
+          errlog("Dynamic blocks action can only be Drop, NoOp, NXDomain, Refused, Truncate or NoRecurse!");
+          g_outputBuffer="Dynamic blocks action can only be Drop, NoOp, NXDomain, Refused, Truncate or NoRecurse!\n";
         }
       } else {
         g_outputBuffer="Dynamic blocks action cannot be altered at runtime!\n";

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1007,6 +1007,11 @@ bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int*
           vinfolog("Query from %s for %s over TCP *not* truncated because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
         }
         break;
+      case DNSAction::Action::NoRecurse:
+        updateBlockStats();
+        vinfolog("Query from %s setting rd=0 because of dynamic block", dq.remote->toStringWithPort());
+        dq.dh->rd = false;
+        return true;
       default:
         updateBlockStats();
         vinfolog("Query from %s dropped because of dynamic block", dq.remote->toStringWithPort());
@@ -1057,6 +1062,11 @@ bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int*
           vinfolog("Query from %s for %s over TCP *not* truncated because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
         }
         break;
+      case DNSAction::Action::NoRecurse:
+        updateBlockStats();
+        vinfolog("Query from %s setting rd=0 because of dynamic block", dq.remote->toStringWithPort());
+        dq.dh->rd = false;
+        return true;
       default:
         updateBlockStats();
         vinfolog("Query from %s for %s dropped because of dynamic block", dq.remote->toStringWithPort(), dq.qname->toString());
@@ -1121,6 +1131,10 @@ bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int*
       case DNSAction::Action::None:
         /* fall-through */
       case DNSAction::Action::NoOp:
+        break;
+      case DNSAction::Action::NoRecurse:
+        dq.dh->rd = false;
+        return true;
         break;
       }
     }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -111,7 +111,7 @@ struct DNSResponse : DNSQuestion
 class DNSAction
 {
 public:
-  enum class Action { Drop, Nxdomain, Refused, Spoof, Allow, HeaderModify, Pool, Delay, Truncate, ServFail, None, NoOp };
+  enum class Action { Drop, Nxdomain, Refused, Spoof, Allow, HeaderModify, Pool, Delay, Truncate, ServFail, None, NoOp, NoRecurse };
   static std::string typeToString(const Action& action)
   {
     switch(action) {
@@ -138,6 +138,8 @@ public:
     case Action::None:
     case Action::NoOp:
       return "Do nothing";
+    case Action::NoRecurse:
+      return "Set rd=0";
     }
 
     return "Unknown";

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -801,7 +801,7 @@ Dynamic Blocks
     ``DNSAction.NXDomain`` action added.
 
   Set which action is performed when a query is blocked.
-  Only DNSAction.Drop (the default), DNSAction.NoOp, DNSAction.NXDomain, DNSAction.Refused and DNSAction.Truncate are supported.
+  Only DNSAction.Drop (the default), DNSAction.NoOp, DNSAction.NXDomain, DNSAction.Refused, DNSAction.Truncate and DNSAction.NoRecurse are supported.
 
 .. _exceedfuncs:
 

--- a/pdns/dnsdistdist/docs/reference/constants.rst
+++ b/pdns/dnsdistdist/docs/reference/constants.rst
@@ -107,6 +107,7 @@ These constants represent an Action that can be returned from the functions invo
  * ``DNSAction.ServFail``: return a response with a ServFail rcode
  * ``DNSAction.Spoof``: spoof the response using the supplied IPv4 (A), IPv6 (AAAA) or string (CNAME) value
  * ``DNSAction.Truncate``: truncate the response
+ * ``DNSAction.NoRecurse``: set rd=0 on the query
 
 
 .. _DNSResponseAction:


### PR DESCRIPTION
### Short description
We can do NoRecurseAction() but not similar actions within a Lua rule nor as a dynamic block action.

This is potentially silly, please just close if it doesn't make sense to be doing - notably it's somewhat confusing because the query is put into the query ring before actions so it makes things like grepq look a bit weird.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
