### PR TITLE
dnsdist: Add HELP and TYPE for dnsdist_server_ stats

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -433,6 +433,21 @@ static void connectionThread(int sock, ComboAddress remote, string password, str
 
         auto states = g_dstates.getLocal();
         const string statesbase = "dnsdist_server_";
+
+        output << "# HELP " << statesbase << "queries "     << "Amount of queries relayed to server"                               << "\n";
+        output << "# TYPE " << statesbase << "queries "     << "counter"                                                           << "\n";
+        output << "# HELP " << statesbase << "drops "       << "Amount of queries not answered by server"                          << "\n";
+        output << "# TYPE " << statesbase << "drops "       << "counter"                                                           << "\n";
+        output << "# HELP " << statesbase << "latency "     << "Server's latency when answering questions in miliseconds"          << "\n";
+        output << "# TYPE " << statesbase << "latency "     << "gauge"                                                             << "\n";
+        output << "# HELP " << statesbase << "senderrors "  << "Total number of OS snd errors while relaying queries"              << "\n";
+        output << "# TYPE " << statesbase << "senderrors "  << "counter"                                                           << "\n";
+        output << "# HELP " << statesbase << "outstanding " << "Current number of queries that are waiting for a backend response" << "\n";
+        output << "# TYPE " << statesbase << "outstanding " << "gauge"                                                             << "\n";
+        output << "# HELP " << statesbase << "order "       << "The order in which this server is picked"                          << "\n";
+        output << "# TYPE " << statesbase << "order "       << "gauge"                                                             << "\n";
+        output << "# HELP " << statesbase << "weight "      << "The weight within the order in which this server is picked"        << "\n";
+        output << "# TYPE " << statesbase << "weight "      << "gauge"                                                             << "\n";
         
         for (const auto& state : *states) {
           string serverName;


### PR DESCRIPTION
### Short description
These were missing from the output. I've put them above the for loop. According to the Open Metrics standard, metrics don't have to be directly underneath the HELP or TYPE (and only one for each metric is allowed).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)