### PR TITLE
dnsdist: Fix return-type detection with boost 1.69's tribool

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -75,7 +75,10 @@ void setLuaSideEffect()
 
 bool getLuaNoSideEffect()
 {
-  return g_noLuaSideEffect==true;
+  if (g_noLuaSideEffect) {
+    return true;
+  }
+  return false;
 }
 
 void resetLuaSideEffect()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Hopefully fixes #7091, although I did not test against the development version of Boost.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
