### PR TITLE
Unique DNS Responses

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -114,6 +114,7 @@ class PDNSPBConnHandler(object):
                 if rr.HasField('class'):
                     rrclass = getattr(rr, 'class')
                 rrtype = rr.type
+                rrudr = rr.udr
                 if (rrclass == 1 or rrclass == 255) and rr.HasField('rdata'):
                     if rrtype == 1:
                         rdatastr = socket.inet_ntop(socket.AF_INET, rr.rdata)
@@ -122,11 +123,12 @@ class PDNSPBConnHandler(object):
                     elif rrtype == 28:
                         rdatastr = socket.inet_ntop(socket.AF_INET6, rr.rdata)
 
-                print("\t - %d, %d, %s, %d, %s" % (rrclass,
+                print("\t - %d, %d, %s, %d, %s, %d" % (rrclass,
                                                    rrtype,
                                                    rr.name,
                                                    rr.ttl,
-                                                   rdatastr))
+                                                   rdatastr,
+                                                   rrudr))
 
     def printSummary(self, msg, typestr):
         datestr = datetime.datetime.fromtimestamp(msg.timeSec).strftime('%Y-%m-%d %H:%M:%S')
@@ -168,9 +170,10 @@ class PDNSPBConnHandler(object):
 
         deviceId = binascii.hexlify(bytearray(msg.deviceId))
         requestorId = msg.requestorId
+        nod = msg.newlyObservedDomain
 
         print('[%s] %s of size %d: %s%s -> %s (%s), id: %d, uuid: %s%s '
-                  'requestorid: %s deviceid: %s serverid: %s' % (datestr,
+                  'requestorid: %s deviceid: %s serverid: %s nod: %d' % (datestr,
                                                     typestr,
                                                     msg.inBytes,
                                                     ipfromstr,
@@ -182,7 +185,8 @@ class PDNSPBConnHandler(object):
                                                     initialrequestidstr,
                                                     requestorId,
                                                     deviceId,
-                                                    serveridstr))
+                                                    serveridstr,
+                                                    nod))
 
     def getRequestorSubnet(self, msg):
         requestorstr = None

--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -111,10 +111,12 @@ class PDNSPBConnHandler(object):
             for rr in response.rrs:
                 rrclass = 1
                 rdatastr = ''
+                rrudr = 0
                 if rr.HasField('class'):
                     rrclass = getattr(rr, 'class')
                 rrtype = rr.type
-                rrudr = rr.udr
+                if rr.HasField('udr'):
+                    rrudr = rr.udr
                 if (rrclass == 1 or rrclass == 255) and rr.HasField('rdata'):
                     if rrtype == 1:
                         rdatastr = socket.inet_ntop(socket.AF_INET, rr.rdata)
@@ -170,7 +172,9 @@ class PDNSPBConnHandler(object):
 
         deviceId = binascii.hexlify(bytearray(msg.deviceId))
         requestorId = msg.requestorId
-        nod = msg.newlyObservedDomain
+        nod = 0
+        if (msg.HasField('newlyObservedDomain')):
+            nod = msg.newlyObservedDomain
 
         print('[%s] %s of size %d: %s%s -> %s (%s), id: %d, uuid: %s%s '
                   'requestorid: %s deviceid: %s serverid: %s nod: %d' % (datestr,

--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -70,6 +70,7 @@ message PBDNSMessage {
       optional uint32 class = 3;
       optional uint32 ttl = 4;
       optional bytes rdata = 5;
+      optional bool  udr = 6;                   // True if this is the first time this RR has been seen for this question
     }
     optional uint32 rcode = 1;
     repeated DNSRR rrs = 2;
@@ -85,4 +86,5 @@ message PBDNSMessage {
   optional string requestorId = 15;             // Username of the requestor
   optional bytes initialRequestId = 16;         // UUID of the incoming query that initiated this outgoing query or incoming response
   optional bytes deviceId = 17;     		// Device ID of the requestor (could be mac address IP address or e.g. IMEI)
+  optional bool  newlyObservedDomain = 18;      // True if the domain has not been seen before
 }

--- a/pdns/nod.hh
+++ b/pdns/nod.hh
@@ -22,6 +22,7 @@
 #pragma once
 #include <atomic>
 #include <mutex>
+#include <thread>
 #include "dnsname.hh"
 #include "stable-bloom.hh"
 
@@ -31,18 +32,48 @@ namespace nod {
   const uint8_t num_dec = 10;
   const unsigned int snapshot_interval_default = 600;
   const std::string bf_suffix = "bf";
+  const std::string sbf_prefix = "sbf";
 
-  // This class is not designed to be shared between threads
+  // Theses classes are not designed to be shared between threads
   // Use a new instance per-thread, e.g. using thread local storage
   // Synchronization (at the class level) is still needed for reading from
   // and writing to the cache dir
   // Synchronization (at the instance level) is needed when snapshotting
+  class PersistentSBF {
+  public:
+    bool init(bool ignore_pid=false);
+    void setPrefix(const std::string& prefix) { d_prefix = prefix; } // Added to filenames in cachedir
+    void setCacheDir(const std::string& cachedir);
+    bool snapshotCurrent(std::thread::id tid); // Write the current file out to disk
+    void add(const std::string& data) { 
+      // The only time this should block is when snapshotting
+      std::lock_guard<std::mutex> lock(d_sbf_mutex);
+      d_sbf.add(data); 
+    }
+    bool test(const std::string& data) { return d_sbf.test(data); }
+    bool testAndAdd(const std::string& data) { 
+      // The only time this should block is when snapshotting
+      std::lock_guard<std::mutex> lock(d_sbf_mutex);
+      return d_sbf.testAndAdd(data); 
+    }
+  private:
+    bool d_init{false};
+    bf::stableBF d_sbf{fp_rate, num_cells, num_dec}; // Stable Bloom Filter
+    std::string d_cachedir;
+    std::string d_prefix = sbf_prefix;
+    std::mutex d_sbf_mutex; // Per-instance mutex for snapshots
+    static std::mutex d_cachedir_mutex; // One mutex for all instances of this class
+  };
+
   class NODDB {
   public:
     NODDB() {}
     // Set ignore_pid to true if you don't mind loading files
     // created by the current process
-    bool init(bool ignore_pid=false); // Initialize the NODDB
+    bool init(bool ignore_pid=false) { 
+      d_psbf.setPrefix("nod");
+      return d_psbf.init(ignore_pid); 
+    }
     bool isNewDomain(const std::string& domain); // Returns true if newly observed domain
     bool isNewDomain(const DNSName& dname); // As above
     bool isNewDomainWithParent(const std::string& domain, std::string& observed); // Returns true if newly observed domain, in which case "observed" contains the parent domain which *was* observed (or "" if domain is . or no parent domains observed)
@@ -50,20 +81,36 @@ namespace nod {
     void addDomain(const DNSName& dname); // You need to add this to refresh frequently used domains
     void addDomain(const std::string& domain); // As above
     void setSnapshotInterval(unsigned int secs) { d_snapshot_interval = secs; }
-    void setCacheDir(const std::string& cachedir);
-    bool snapshotCurrent(); // Write the current file out to disk
-    bool pruneCacheFiles(); // Remove oldest cache files
-    static void startHousekeepingThread(std::shared_ptr<NODDB> noddbp) {
-      noddbp->housekeepingThread();
+    void setCacheDir(const std::string& cachedir) { d_psbf.setCacheDir(cachedir); }
+    bool snapshotCurrent(std::thread::id tid) { return d_psbf.snapshotCurrent(tid); }
+    static void startHousekeepingThread(std::shared_ptr<NODDB> noddbp, std::thread::id tid) {
+      noddbp->housekeepingThread(tid);
     }
   private:
-    void housekeepingThread();
-    bool d_init{false};
-    bf::stableBF d_sbf{fp_rate, num_cells, num_dec}; // Stable Bloom Filter
-    unsigned int d_snapshot_interval{snapshot_interval_default}; // Number seconds between snapshots
-    std::string d_cachedir;
-    std::mutex d_sbf_mutex; // Per-instance mutex for snapshots
-    static std::mutex d_cachedir_mutex; // One mutex for all instances of this class
+    PersistentSBF d_psbf;
+    unsigned int d_snapshot_interval{snapshot_interval_default}; // Number seconds between snapshots    
+    void housekeepingThread(std::thread::id tid);
+  };
+
+  class UniqueResponseDB {
+  public:
+    UniqueResponseDB() {}
+    bool init(bool ignore_pid=false) {
+      d_psbf.setPrefix("udr");
+      return d_psbf.init(ignore_pid); 
+    }
+    bool isUniqueResponse(const std::string& response);
+    void addResponse(const std::string& response);
+    void setSnapshotInterval(unsigned int secs) { d_snapshot_interval = secs; }
+    void setCacheDir(const std::string& cachedir) { d_psbf.setCacheDir(cachedir); }
+    bool snapshotCurrent(std::thread::id tid) { return d_psbf.snapshotCurrent(tid); }
+    static void startHousekeepingThread(std::shared_ptr<UniqueResponseDB> udrdbp, std::thread::id tid) {
+      udrdbp->housekeepingThread(tid);
+    }
+  private:
+    PersistentSBF d_psbf;
+    unsigned int d_snapshot_interval{snapshot_interval_default}; // Number seconds between snapshots    
+    void housekeepingThread(std::thread::id tid); 
   };
 
 }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1469,6 +1469,10 @@ static void startDoResolve(void *p)
       }
 #endif /* NOD_ENABLED */
       protobufLogResponse(t_protobufServer, *pbMessage);
+#ifdef NOD_ENABLED
+      pbMessage->setNOD(false);
+      pbMessage->clearUDR();
+#endif /* NOD_ENABLED */
     }
 #endif
     if(!dc->d_tcp) {
@@ -2099,10 +2103,6 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
         pbMessage->setQueryTime(g_now.tv_sec, g_now.tv_usec);
         pbMessage->setRequestorId(requestorId);
         pbMessage->setDeviceId(deviceId);
-#ifdef NOD_ENABLED
-	pbMessage->setNOD(false);
-	pbMessage->clearUDR();
-#endif
         protobufLogResponse(t_protobufServer, *pbMessage);
       }
 #endif /* HAVE_PROTOBUF */

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3305,7 +3305,8 @@ static void setCPUMap(const std::map<unsigned int, std::set<int> >& cpusMap, uns
 static void setupNODThread()
 {
   if (g_nodEnabled) {
-    t_nodDBp = std::make_shared<nod::NODDB>();
+    uint32_t num_cells = ::arg().asNum("new-domain-db-size");
+    t_nodDBp = std::make_shared<nod::NODDB>(num_cells);
     try {
       t_nodDBp->setCacheDir(::arg()["new-domain-history-dir"]);
     }
@@ -3321,7 +3322,8 @@ static void setupNODThread()
     t.detach();
   }
   if (g_udrEnabled) {
-    t_udrDBp = std::make_shared<nod::UniqueResponseDB>();
+    uint32_t num_cells = ::arg().asNum("unique-response-db-size");
+    t_udrDBp = std::make_shared<nod::UniqueResponseDB>(num_cells);
     try {
       t_udrDBp->setCacheDir(::arg()["unique-response-history-dir"]);
     }
@@ -4137,9 +4139,11 @@ int main(int argc, char **argv)
     ::arg().set("new-domain-lookup", "Perform a DNS lookup newly observed domains as a subdomain of the configured domain")="";
     ::arg().set("new-domain-history-dir", "Persist new domain tracking data here to persist between restarts")=string(NODCACHEDIR)+"/nod";
     ::arg().set("new-domain-whitelist", "List of domains (and implicitly all subdomains) which will never be considered a new domain")="";
+    ::arg().set("new-domain-db-size", "Size of the DB used to track new domains in terms of number of cells. Defaults to 67108864")="67108864";
     ::arg().set("unique-response-tracking", "Track unique responses (tuple of query name, type and RR).")="no";
     ::arg().set("unique-response-log", "Log unique responses")="yes";
     ::arg().set("unique-response-history-dir", "Persist unique response tracking data here to persist between restarts")=string(NODCACHEDIR)+"/udr";
+    ::arg().set("unique-response-db-size", "Size of the DB used to track unique responses in terms of number of cells. Defaults to 67108864")="67108864";
 #endif /* NOD_ENABLED */
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print version string");

--- a/pdns/rec-protobuf.cc
+++ b/pdns/rec-protobuf.cc
@@ -2,7 +2,32 @@
 #include "config.h"
 #include "rec-protobuf.hh"
 
+#ifdef NOD_ENABLED
+void RecProtoBufMessage::setNOD(bool nod)
+{
+#ifdef HAVE_PROTOBUF
+  d_message.set_newlyobserveddomain(nod);
+#endif /* HAVE_PROTOBUF */  
+}
+
+void RecProtoBufMessage::clearUDR() 
+{
+#ifdef HAVE_PROTOBUF
+  auto response = d_message.mutable_response();
+  const int count = response->rrs_size();
+  for (int idx = 0; idx < count; idx++) {
+    auto rr = response->mutable_rrs(idx);
+    rr->set_udr(false);
+  }
+#endif /* HAVE_PROTOBUF */
+}
+#endif /* NOD_ENABLED */
+
+#ifdef NOD_ENABLED
+void RecProtoBufMessage::addRR(const DNSRecord& record, const std::set<uint16_t>& exportTypes, bool udr)
+#else
 void RecProtoBufMessage::addRR(const DNSRecord& record, const std::set<uint16_t>& exportTypes)
+#endif /* NOD_ENABLED */
 {
 #ifdef HAVE_PROTOBUF
   PBDNSMessage_DNSResponse* response = d_message.mutable_response();
@@ -27,6 +52,9 @@ void RecProtoBufMessage::addRR(const DNSRecord& record, const std::set<uint16_t>
   pbRR->set_type(record.d_type);
   pbRR->set_class_(record.d_class);
   pbRR->set_ttl(record.d_ttl);
+#ifdef NOD_ENABLED
+  pbRR->set_udr(udr);
+#endif
 
   switch(record.d_type) {
   case QType::A:

--- a/pdns/rec-protobuf.cc
+++ b/pdns/rec-protobuf.cc
@@ -179,6 +179,39 @@ void RecProtoBufMessage::setPolicyTags(const std::vector<std::string>& policyTag
 #endif /* HAVE_PROTOBUF */
 }
 
+void RecProtoBufMessage::addPolicyTag(const std::string& policyTag)
+{
+#ifdef HAVE_PROTOBUF
+  PBDNSMessage_DNSResponse* response = d_message.mutable_response();
+  if (response) {
+    response->add_tags(policyTag);
+  }
+#endif
+}
+
+void RecProtoBufMessage::removePolicyTag(const std::string& policyTag)
+{
+#ifdef HAVE_PROTOBUF
+  PBDNSMessage_DNSResponse* response = d_message.mutable_response();
+  if (response) {
+    const int count = response->tags_size();
+    int keep = 0;
+    for (int idx = 0; idx < count; ++idx) {
+      auto tagp = response->mutable_tags(idx);
+      if (tagp->compare(policyTag) == 0) {        
+      }
+      else {
+        if (keep < idx) {
+          response->mutable_tags()->SwapElements(idx, keep);
+        }
+        ++keep;
+      }
+    }
+    response->mutable_tags()->DeleteSubrange(keep, count - keep);
+  }  
+#endif
+}
+
 std::string RecProtoBufMessage::getAppliedPolicy() const
 {
   std::string result;

--- a/pdns/rec-protobuf.hh
+++ b/pdns/rec-protobuf.hh
@@ -43,7 +43,13 @@ public:
 #endif /* HAVE_PROTOBUF */
 
   void addRRs(const std::vector<DNSRecord>& records, const std::set<uint16_t>& exportTypes);
+#ifdef NOD_ENABLED
+  void setNOD(bool nod);
+  void addRR(const DNSRecord& record, const std::set<uint16_t>& exportTypes, bool udr=false);
+  void clearUDR();
+#else
   void addRR(const DNSRecord& record, const std::set<uint16_t>& exportTypes);
+#endif /* NOD_ENABLED */
   void setAppliedPolicy(const std::string& policy);
   void setAppliedPolicyType(const DNSFilterEngine::PolicyType& policyType);
   void setPolicyTags(const std::vector<std::string>& policyTags);

--- a/pdns/rec-protobuf.hh
+++ b/pdns/rec-protobuf.hh
@@ -53,6 +53,8 @@ public:
   void setAppliedPolicy(const std::string& policy);
   void setAppliedPolicyType(const DNSFilterEngine::PolicyType& policyType);
   void setPolicyTags(const std::vector<std::string>& policyTags);
+  void addPolicyTag(const std::string& policyTag);
+  void removePolicyTag(const std::string& policyTag);
   std::string getAppliedPolicy() const;
   std::vector<std::string> getPolicyTags() const;
 };

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -917,6 +917,16 @@ considered a new domain. One use-case for the whitelist is to never
 reveal details of internal subdomains via the new-domain-lookup
 feature.
 
+.. _setting-new-domain-pb-tag:
+
+``new-domain-pb-tag``
+------------------------
+- String
+- Default: pnds-nod
+
+If protobuf is configured, then this tag will be added to all protobuf response messages when
+a new domain is observed. 
+
 .. _setting-unique-response-tracking:
 
 ``unique-response-tracking``
@@ -978,6 +988,16 @@ synchronized to disk every 10 minutes, and is also initialized from
 disk on startup. This ensures that previously observed responses are
 preserved across recursor restarts. If you change the 
 unique-response-db-size, you must remove any files from this directory.
+
+.. _setting-unique-response-pb-tag:
+
+``unique-response-pb-tag``
+------------------------
+- String
+- Default: pnds-udr
+
+If protobuf is configured, then this tag will be added to all protobuf response messages when
+a unique DNS response is observed. 
 
 .. _setting-network-timeout:
 

--- a/pdns/recursordist/test-nod_cc.cc
+++ b/pdns/recursordist/test-nod_cc.cc
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(test_basic) {
     BOOST_CHECK_EQUAL(newnod.isNewDomain(new_domain2), true);
     BOOST_CHECK_EQUAL(newnod.isNewDomain(new_domain1), false);
     BOOST_CHECK_EQUAL(newnod.isNewDomain(new_domain2), false);
-    BOOST_CHECK_EQUAL(newnod.snapshotCurrent(), true);
+    BOOST_CHECK_EQUAL(newnod.snapshotCurrent(std::this_thread::get_id()), true);
   }
   {
     NODDB newnod;


### PR DESCRIPTION
### Short description
This PR extends the work on Newly Observed Domains by adding support for Unique DNS Responses; these are never-seen-before triplets of (qname, qtype, RR(rrname, rrtype, rrdata)). These are used by folks to detect potential evilness, such as fast-flux DNS.

Completely new to this PR is the ability to pass the NOD and UDR status via Protobuf. These are only set in the Response Protobuf packet. Protobuf responses from the packet cache have these flags cleared, as we only want to indicate this once. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)