### PR TITLE
dnsdist: Nodes in NMG are now ordered, fix the API regression tests

### DIFF
--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -178,7 +178,11 @@ class TestAPIBasics(DNSDistTest):
 
         self.assertEquals(content['name'], 'allow-from')
         self.assertEquals(content['type'], 'ConfigSetting')
-        self.assertEquals(content['value'], ["127.0.0.1/32", "::1/128"])
+        acl = content['value']
+        expectedACL = ["127.0.0.1/32", "::1/128"]
+        acl.sort()
+        expectedACL.sort()
+        self.assertEquals(acl, expectedACL)
 
     def testServersLocalhostConfigAllowFromPut(self):
         """
@@ -333,7 +337,11 @@ class TestAPIWritable(DNSDistTest):
         self.assertEquals(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
-        self.assertEquals(content['value'], ["127.0.0.1/32", "::1/128"])
+        acl = content['value']
+        expectedACL = ["127.0.0.1/32", "::1/128"]
+        acl.sort()
+        expectedACL.sort()
+        self.assertEquals(acl, expectedACL)
 
         newACL = ["192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24"]
         payload = json.dumps({"name": "allow-from",


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This ACL test was relying on a specific ordering since https://github.com/PowerDNS/pdns/pull/6962 which is not guaranteed to be true.
Thanks to @neilcook for reporting this!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
