### PR TITLE
switch python to pyenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,18 @@ env:
   - PDNS_BUILD_PRODUCT=dnsdist
   - PDNS_BUILD_PRODUCT=ixfrdist
 
+cache:
+  - pip
+  - directories:
+    - $HOME/.pyenv_cache
+
+before_install:
+  - |
+      PYENV_VERSION='2.7.13' PYENV_VERSION_STRING='Python 2.7.13'
+      wget https://github.com/praekeltfoundation/travis-pyenv/releases/download/0.4.0/setup-pyenv.sh
+      source setup-pyenv.sh
+      rm setup-pyenv.sh
+
 before_script:
   - git describe --always --dirty=+
   - sudo rm -f /etc/apt/sources.list.d/*.list

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
   - directories:
     - $HOME/.pyenv_cache
 
+# this block can go if we ever upgrade the underlying Ubuntu
 before_install:
   - |
       PYENV_VERSION='2.7.13' PYENV_VERSION_STRING='Python 2.7.13'


### PR DESCRIPTION
### Short description
From the [Yak-list](https://github.com/PowerDNS/pdns/wiki/Yak-list):
> figure out Travis/python/SSL warnings and do something about them

This switches from using system python to using a `.travis.yml` specified python which gets installed via `pyenv` using https://github.com/praekeltfoundation/travis-pyenv.

The old output:
```sh

make[2]: Entering directory `/home/travis/build/PowerDNS/pdns/codedocs'
make[2]: Leaving directory `/home/travis/build/PowerDNS/pdns/codedocs'
 (cd docs && make  top_distdir=../pdns-0.0..0.HEAD.gebba82f803 distdir=../pdns-0.0..0.HEAD.gebba82f803/docs \
     am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
make[2]: Entering directory `/home/travis/build/PowerDNS/pdns/docs'
virtualenv .venv
New python executable in /home/travis/build/PowerDNS/pdns/docs/.venv/bin/python
Installing setuptools, pip, wheel...done.
.venv/bin/pip install -U pip setuptools setuptools-git
/home/travis/build/PowerDNS/pdns/docs/.venv/local/lib/python2.7/site-packages/pip/_vendor/urllib3/util/ssl_.py:369: SNIMissingWarning: An HTTPS request has been made, but the SNI (Server Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  SNIMissingWarning
/home/travis/build/PowerDNS/pdns/docs/.venv/local/lib/python2.7/site-packages/pip/_vendor/urllib3/util/ssl_.py:160: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecurePlatformWarning
```

New output:
```sh
make[2]: Entering directory `/home/travis/build/jsoref/pdns/codedocs'
make[2]: Leaving directory `/home/travis/build/jsoref/pdns/codedocs'
 (cd docs && make  top_distdir=../pdns-0.0..0.HEAD.g4d0486f63b distdir=../pdns-0.0..0.HEAD.g4d0486f63b/docs \
     am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
make[2]: Entering directory `/home/travis/build/jsoref/pdns/docs'
virtualenv .venv
New python executable in /home/travis/build/jsoref/pdns/docs/.venv/bin/python2.7
Also creating executable in /home/travis/build/jsoref/pdns/docs/.venv/bin/python
Installing setuptools, pip, wheel...done.
.venv/bin/pip install -U pip setuptools setuptools-git
Requirement already up-to-date: pip in ./.venv/lib/python2.7/site-packages (18.1)
Requirement already up-to-date: setuptools in ./.venv/lib/python2.7/site-packages (40.4.3)
Collecting setuptools-git
  Downloading https://files.pythonhosted.org/packages/05/97/dd99fa9c0d9627a7b3c103a00f1566d8193aca8d473884ed258cca82b06f/setuptools_git-1.2-py2.py3-none-any.whl
Installing collected packages: setuptools-git
Successfully installed setuptools-git-1.2
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
