### PR TITLE
dnsdist: add setConsoleOutputMaxMsgSize function

### DIFF
--- a/pdns/dnsdist-console.hh
+++ b/pdns/dnsdist-console.hh
@@ -43,6 +43,7 @@ extern const std::vector<ConsoleKeyword> g_consoleKeywords;
 extern std::string g_consoleKey; // in theory needs locking
 extern bool g_logConsoleConnections;
 extern bool g_consoleEnabled;
+extern uint32_t g_consoleOutputMsgMaxSize;
 
 void doClient(ComboAddress server, const std::string& command);
 void doConsole();

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1469,6 +1469,10 @@ void setupLuaConfig(bool client)
       g_logConsoleConnections = enabled;
     });
 
+  g_lua.writeFunction("setConsoleOutputMaxMsgSize", [](uint32_t size) {
+      g_consoleOutputMsgMaxSize = size;
+    });
+
   g_lua.writeFunction("setUDPMultipleMessagesVectorSize", [](size_t vSize) {
       if (g_configurationDone) {
         errlog("setUDPMultipleMessagesVectorSize() cannot be used at runtime!");

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -776,30 +776,3 @@ void* tcpAcceptorThread(void* p)
 
   return 0;
 }
-
-bool getMsgLen32(int fd, uint32_t* len)
-try
-{
-  uint32_t raw;
-  size_t ret = readn2(fd, &raw, sizeof raw);
-  if(ret != sizeof raw)
-    return false;
-  *len = ntohl(raw);
-  if(*len > 10000000) // arbitrary 10MB limit
-    return false;
-  return true;
-}
-catch(...) {
-   return false;
-}
-
-bool putMsgLen32(int fd, uint32_t len)
-try
-{
-  uint32_t raw = htonl(len);
-  size_t ret = writen2(fd, &raw, sizeof raw);
-  return ret==sizeof raw;
-}
-catch(...) {
-  return false;
-}

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -203,6 +203,14 @@ Control Socket, Console and Webserver
 
   Test the crypto code, will report errors when something is not ok.
 
+.. function:: setConsoleOutputMaxMsgSize(size)
+
+  .. versionadded:: 1.3.3
+
+  Set the maximum size in bytes of a single console message, default set to 10 MB.
+
+  :param int size: The new maximum size.
+
 Webserver
 ~~~~~~~~~
 


### PR DESCRIPTION
`setConsoleOutputMaxMsgSize` lets you tune the maximum size of a console message.

Fix #7084

For the record, I moved `{get,put}MsgLen32` in `dnsdist-console.cc` as both were not used anywhere else anymore.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
