### PR TITLE
fix el6 recursor build by disabling protobuf support

### DIFF
--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -31,10 +31,13 @@ BuildRequires: systemd-devel
 BuildRequires: libatomic
 %endif
 
-BuildRequires: openssl-devel
-BuildRequires: net-snmp-devel
+%if 0%{?rhel} >= 7
 BuildRequires: protobuf-compiler
 BuildRequires: protobuf-devel
+%endif
+
+BuildRequires: openssl-devel
+BuildRequires: net-snmp-devel
 BuildRequires: libsodium-devel
 
 Requires(pre): shadow-utils
@@ -62,16 +65,17 @@ package if you need a dns cache for your network.
 %configure \
     --sysconfdir=%{_sysconfdir}/%{name} \
     --enable-libsodium \
-    --with-protobuf \
     --with-netsnmp \
     --disable-silent-rules \
     --disable-static \
     --enable-unit-tests \
 %if 0%{?rhel} == 6
+    --without-protobuf \
     --with-boost=/usr/include/boost148 LIBRARY_PATH=/usr/lib64/boost148
 
 make %{?_smp_mflags} LIBRARY_PATH=/usr/lib64/boost148
 %else
+    --with-protobuf \
     --with-lua=%{lua_implementation} \
     --enable-systemd --with-systemd=%{_unitdir}
 


### PR DESCRIPTION
### Short description
Recent changes (around the NOD work) broke our compatibility with the old Protobuf version of EL6, so we're dropping support.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
