### PR TITLE
Fix up the BIND config files on upgrade

### DIFF
--- a/builder-support/debian/authoritative/debian-jessie/pdns-backend-bind.postinst
+++ b/builder-support/debian/authoritative/debian-jessie/pdns-backend-bind.postinst
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+fix_bind_conf() {
+  cp /etc/powerdns/pdns.d/bind.conf /etc/powerdns/pdns.d/bind.conf.dpkg-bak
+  echo "Moving /etc/powerdns/pdns.d/${1} to /etc/powerdns/pdns.d/bind.conf"
+  mv -f /etc/powerdns/pdns.d/${1} /etc/powerdns/pdns.d/bind.conf
+
+  # Update all references from /etc/powerdns/bindbackend.conf to /etc/powerdns/named.conf
+  # as we're moving that file.
+  sed -i 's,/etc/powerdns/bindbackend.conf\(\s*\|$\),/etc/powerdns/named.conf\1,' /etc/powerdns/pdns.d/bind.conf
+}
+
 case "$1" in
     configure)
         chown pdns:pdns /var/lib/powerdns/zones.slave.d || :
@@ -11,6 +21,39 @@ case "$1" in
         if test -e $BINDCONF && grep "^bind-supermaster-config=$SUPERMASTERCONF" $BINDCONF >/dev/null 2>&1; then
             touch $SUPERMASTERCONF
             chown pdns:pdns $SUPERMASTERCONF
+        fi
+
+        # Older versions had the BIND backend configured in other files.
+        # If these files were not removed by the pdns-server package postinst,
+        # that means they were changed by user. Move them into the right places
+        # so the BIND backend keeps working on an upgrade.
+        if [ -z "$2" ]; then
+          # This is a new install. It is possible that it is _part_ of an upgrade from
+          # an installation that did not have the pdns-backend-bind package but the
+          # bind backend in the pdns-server package. Let's do the needful and move
+          # files to keep the bind bindbackend functional.
+          if [ -e "/etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak" ]; then
+            # This file was modified by the user, and moved by the installation of pdns-server
+            cp /etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak /etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak2
+            fix_bind_conf pdns.simplebind.conf.dpkg-bak
+          fi
+
+          if [ -e "/etc/powerdns/pdns.d/pdns.simplebind.conf" ]; then
+            # The previous package was one from repo.powerdns.com that did not put
+            # this file under ufc control
+            cp /etc/powerdns/pdns.d/pdns.simplebind.conf /etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak2
+            fix_bind_conf pdns.simplebind.conf
+          fi
+
+          # Now let's move this out of the way
+          if [ -e "/etc/powerdns/bindbackend.conf" ]; then
+            # This file was modified by the user (if not, it was removed by the installation
+            # of pdns-server), so make sure this file is not lost
+            cp /etc/powerdns/bindbackend.conf /etc/powerdns/bindbackend.conf.dpkg-bak
+            cp /etc/powerdns/named.conf /etc/powerdns/named.conf.dpkg-bak
+            echo "Moving /etc/powerdns/bindbackend.conf to /etc/powerdns/named.conf"
+            mv -f /etc/powerdns/bindbackend.conf /etc/powerdns/named.conf
+          fi
         fi
     ;;
 

--- a/builder-support/debian/authoritative/debian-stretch/pdns-backend-bind.postinst
+++ b/builder-support/debian/authoritative/debian-stretch/pdns-backend-bind.postinst
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+fix_bind_conf() {
+  cp /etc/powerdns/pdns.d/bind.conf /etc/powerdns/pdns.d/bind.conf.dpkg-bak
+  echo "Moving /etc/powerdns/pdns.d/${1} to /etc/powerdns/pdns.d/bind.conf"
+  mv -f /etc/powerdns/pdns.d/${1} /etc/powerdns/pdns.d/bind.conf
+
+  # Update all references from /etc/powerdns/bindbackend.conf to /etc/powerdns/named.conf
+  # as we're moving that file.
+  sed -i 's,/etc/powerdns/bindbackend.conf\(\s*\|$\),/etc/powerdns/named.conf\1,' /etc/powerdns/pdns.d/bind.conf
+}
+
 case "$1" in
     configure)
         chown pdns:pdns /var/lib/powerdns/zones.slave.d || :
@@ -11,6 +21,39 @@ case "$1" in
         if test -e $BINDCONF && grep "^bind-supermaster-config=$SUPERMASTERCONF" $BINDCONF >/dev/null 2>&1; then
             touch $SUPERMASTERCONF
             chown pdns:pdns $SUPERMASTERCONF
+        fi
+
+        # Older versions had the BIND backend configured in other files.
+        # If these files were not removed by the pdns-server package postinst,
+        # that means they were changed by user. Move them into the right places
+        # so the BIND backend keeps working on an upgrade.
+        if [ -z "$2" ]; then
+          # This is a new install. It is possible that it is _part_ of an upgrade from
+          # an installation that did not have the pdns-backend-bind package but the
+          # bind backend in the pdns-server package. Let's do the needful and move
+          # files to keep the bind bindbackend functional.
+          if [ -e "/etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak" ]; then
+            # This file was modified by the user, and moved by the installation of pdns-server
+            cp /etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak /etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak2
+            fix_bind_conf pdns.simplebind.conf.dpkg-bak
+          fi
+
+          if [ -e "/etc/powerdns/pdns.d/pdns.simplebind.conf" ]; then
+            # The previous package was one from repo.powerdns.com that did not put
+            # this file under ufc control
+            cp /etc/powerdns/pdns.d/pdns.simplebind.conf /etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak2
+            fix_bind_conf pdns.simplebind.conf
+          fi
+
+          # Now let's move this out of the way
+          if [ -e "/etc/powerdns/bindbackend.conf" ]; then
+            # This file was modified by the user (if not, it was removed by the installation
+            # of pdns-server), so make sure this file is not lost
+            cp /etc/powerdns/bindbackend.conf /etc/powerdns/bindbackend.conf.dpkg-bak
+            cp /etc/powerdns/named.conf /etc/powerdns/named.conf.dpkg-bak
+            echo "Moving /etc/powerdns/bindbackend.conf to /etc/powerdns/named.conf"
+            mv -f /etc/powerdns/bindbackend.conf /etc/powerdns/named.conf
+          fi
         fi
     ;;
 

--- a/builder-support/debian/authoritative/ubuntu-trusty/pdns-backend-bind.postinst
+++ b/builder-support/debian/authoritative/ubuntu-trusty/pdns-backend-bind.postinst
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+fix_bind_conf() {
+  cp /etc/powerdns/pdns.d/bind.conf /etc/powerdns/pdns.d/bind.conf.dpkg-bak
+  echo "Moving /etc/powerdns/pdns.d/${1} to /etc/powerdns/pdns.d/bind.conf"
+  mv -f /etc/powerdns/pdns.d/${1} /etc/powerdns/pdns.d/bind.conf
+
+  # Update all references from /etc/powerdns/bindbackend.conf to /etc/powerdns/named.conf
+  # as we're moving that file.
+  sed -i 's,/etc/powerdns/bindbackend.conf\(\s*\|$\),/etc/powerdns/named.conf\1,' /etc/powerdns/pdns.d/bind.conf
+}
+
 case "$1" in
     configure)
         chown pdns:pdns /var/lib/powerdns/zones.slave.d || :
@@ -11,6 +21,39 @@ case "$1" in
         if test -e $BINDCONF && grep "^bind-supermaster-config=$SUPERMASTERCONF" $BINDCONF >/dev/null 2>&1; then
             touch $SUPERMASTERCONF
             chown pdns:pdns $SUPERMASTERCONF
+        fi
+
+        # Older versions had the BIND backend configured in other files.
+        # If these files were not removed by the pdns-server package postinst,
+        # that means they were changed by user. Move them into the right places
+        # so the BIND backend keeps working on an upgrade.
+        if [ -z "$2" ]; then
+          # This is a new install. It is possible that it is _part_ of an upgrade from
+          # an installation that did not have the pdns-backend-bind package but the
+          # bind backend in the pdns-server package. Let's do the needful and move
+          # files to keep the bind bindbackend functional.
+          if [ -e "/etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak" ]; then
+            # This file was modified by the user, and moved by the installation of pdns-server
+            cp /etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak /etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak2
+            fix_bind_conf pdns.simplebind.conf.dpkg-bak
+          fi
+
+          if [ -e "/etc/powerdns/pdns.d/pdns.simplebind.conf" ]; then
+            # The previous package was one from repo.powerdns.com that did not put
+            # this file under ufc control
+            cp /etc/powerdns/pdns.d/pdns.simplebind.conf /etc/powerdns/pdns.d/pdns.simplebind.conf.dpkg-bak2
+            fix_bind_conf pdns.simplebind.conf
+          fi
+
+          # Now let's move this out of the way
+          if [ -e "/etc/powerdns/bindbackend.conf" ]; then
+            # This file was modified by the user (if not, it was removed by the installation
+            # of pdns-server), so make sure this file is not lost
+            cp /etc/powerdns/bindbackend.conf /etc/powerdns/bindbackend.conf.dpkg-bak
+            cp /etc/powerdns/named.conf /etc/powerdns/named.conf.dpkg-bak
+            echo "Moving /etc/powerdns/bindbackend.conf to /etc/powerdns/named.conf"
+            mv -f /etc/powerdns/bindbackend.conf /etc/powerdns/named.conf
+          fi
         fi
     ;;
 


### PR DESCRIPTION
### Short description
Tested on Xenial, upgrading from 4.0.0~alpha2, 4.0.5 and 4.1.4, with an edited simplebind.conf, bindbackend.conf and both edited.

Also tested upgrades on Bionic, Jessie and Stretch.

cc @zeha for a review 

Fixes #7065

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)