### PR TITLE
Added option to specify multiple backup pools for any pool for dnsdist

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1477,6 +1477,20 @@ void setupLuaConfig(bool client)
       g_pools.setState(localPools);
     });
 
+  g_lua.writeFunction("addPoolBackupPool", [](string pool, string backupPool) {
+      setLuaSideEffect();
+      auto localPools = g_pools.getCopy();
+      addBackupPool(localPools, pool, backupPool);
+      g_pools.setState(localPools);
+    });
+
+  g_lua.writeFunction("showPoolBackupPool", [](string pool) {
+      setLuaSideEffect();
+      auto localPools = g_pools.getCopy();
+      auto poolObj = getPool(localPools, pool);
+      g_outputBuffer = boost::algorithm::join(poolObj->backupPools, ",")+"\n";
+    });
+
   g_lua.writeFunction("showPoolServerPolicy", [](string pool) {
       setLuaSideEffect();
       auto localPools = g_pools.getCopy();

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -808,6 +808,11 @@ struct ServerPool
 
   std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
   std::shared_ptr<ServerPolicy> policy{nullptr};
+  std::vector<std::string> backupPools;
+
+  void addBackupPool(const std::string& poolName) {
+    backupPools.push_back(poolName);
+  }
 
   size_t countServers(bool upOnly)
   {
@@ -876,6 +881,7 @@ private:
 };
 using pools_t=map<std::string,std::shared_ptr<ServerPool>>;
 void setPoolPolicy(pools_t& pools, const string& poolName, std::shared_ptr<ServerPolicy> policy);
+void addBackupPool(pools_t& pools, const string& poolName, const std::string& backupPool);
 void addServerToPool(pools_t& pools, const string& poolName, std::shared_ptr<DownstreamState> server);
 void removeServerFromPool(pools_t& pools, const string& poolName, std::shared_ptr<DownstreamState> server);
 


### PR DESCRIPTION
### Short description

It's second attempt to implement backup pool. Previous one was: https://github.com/PowerDNS/pdns/pull/6935 

I Implemented option to specify any number of backup pools for specific pool.

It can be enabled using following Lua commands
```
addPoolBackupPool("", "backup1")
addPoolBackupPool("", "backup2")
showPoolBackupPool("")
```

dnsdist uses backup server only when all other servers in specified pool are dead. It's not used during normal operations.

All load balancing policies supported. But be careful with round robin: https://github.com/PowerDNS/pdns/issues/6936 

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
