### PR TITLE
Add a PoolAvailableRule to easily add backup pools

### DIFF
--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -440,6 +440,12 @@ void setupLuaRules()
       return std::shared_ptr<TimedIPSetRule>(new TimedIPSetRule());
     });
 
+  g_lua.writeFunction("PoolAvailableRule", [](std::string poolname) {
+    setLuaSideEffect();
+    auto localPools = g_pools.getCopy();
+    return std::shared_ptr<DNSRule>(new PoolAvailableRule(localPools, poolname));
+  });
+
   g_lua.registerFunction<void(std::shared_ptr<TimedIPSetRule>::*)()>("clear", [](std::shared_ptr<TimedIPSetRule> tisr) {
       tisr->clear();
     });

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -441,9 +441,7 @@ void setupLuaRules()
     });
 
   g_lua.writeFunction("PoolAvailableRule", [](std::string poolname) {
-    setLuaSideEffect();
-    auto localPools = g_pools.getCopy();
-    return std::shared_ptr<DNSRule>(new PoolAvailableRule(localPools, poolname));
+    return std::shared_ptr<DNSRule>(new PoolAvailableRule(poolname));
   });
 
   g_lua.registerFunction<void(std::shared_ptr<TimedIPSetRule>::*)()>("clear", [](std::shared_ptr<TimedIPSetRule> tisr) {

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -995,14 +995,13 @@ private:
 class PoolAvailableRule : public DNSRule
 {
 public:
-  PoolAvailableRule(pools_t& pools, const std::string& poolname) : d_poolname(poolname)
+  PoolAvailableRule(const std::string& poolname) : d_pools(&g_pools), d_poolname(poolname)
   {
-    d_pool = getPool(pools, poolname);
   }
 
   bool matches(const DNSQuestion* dq) const override
   {
-    return (d_pool->countServers(true) > 0);
+    return (getPool(*d_pools, d_poolname)->countServers(true) > 0);
   }
 
   string toString() const override
@@ -1010,6 +1009,6 @@ public:
     return "pool '" + d_poolname + "' is available";
   }
 private:
+  mutable LocalStateHolder<pools_t> d_pools;
   std::string d_poolname;
-  std::shared_ptr<ServerPool> d_pool;
 };

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -991,3 +991,25 @@ private:
   boost::optional<std::string> d_value;
   std::string d_tag;
 };
+
+class PoolAvailableRule : public DNSRule
+{
+public:
+  PoolAvailableRule(pools_t& pools, const std::string& poolname) : d_poolname(poolname)
+  {
+    d_pool = getPool(pools, poolname);
+  }
+
+  bool matches(const DNSQuestion* dq) const override
+  {
+    return (d_pool->countServers(true) > 0);
+  }
+
+  string toString() const override
+  {
+    return "pool '" + d_poolname + "' is available";
+  }
+private:
+  std::string d_poolname;
+  std::shared_ptr<ServerPool> d_pool;
+};

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -512,6 +512,16 @@ Functions for manipulating Self-Answered Response Rules:
 
   Move the last self answered response rule to the first position.
 
+Function for pool related rules
+
+.. function:: PoolAvailableRule(poolname)
+
+  .. versionadded:: 1.3.3
+
+  Check whether a pool has any servers available to handle queries
+
+  :param string poolname: Pool to check
+
 .. _RulesIntro:
 
 Matching Packets (Selectors)


### PR DESCRIPTION
### Short description
This adds the PoolAvailableRule. Can be used to apply different pools based on availability.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified unit test(s)
