### PR TITLE
dnsdist: Add option to set interval between health checks

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -289,6 +289,10 @@ void setupLuaConfig(bool client)
 			  ret->retries=std::stoi(boost::get<string>(vars["retries"]));
 			}
 
+			if(vars.count("checkInterval")) {
+			  ret->checkInterval=static_cast<unsigned int>(std::stoul(boost::get<string>(vars["checkInterval"])));
+			}
+
 			if(vars.count("tcpConnectTimeout")) {
 			  ret->tcpConnectTimeout=std::stoi(boost::get<string>(vars["tcpConnectTimeout"]));
 			}

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1947,6 +1947,9 @@ static void* healthChecksThread()
 
     auto states = g_dstates.getLocal(); // this points to the actual shared_ptrs!
     for(auto& dss : *states) {
+      if(++dss->lastCheck < dss->checkInterval)
+        continue;
+      dss->lastCheck = 0;
       if(dss->availability==DownstreamState::Availability::Auto) {
         bool newState=upCheck(*dss);
         if (newState) {

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -698,6 +698,8 @@ struct DownstreamState
   int tcpConnectTimeout{5};
   int tcpRecvTimeout{30};
   int tcpSendTimeout{30};
+  unsigned int checkInterval{1};
+  unsigned int lastCheck{0};
   const unsigned int sourceItf{0};
   uint16_t retries{5};
   uint16_t xpfRRCode{0};

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -339,6 +339,7 @@ Servers
       checkFunction=FUNCTION -- Use this function to dynamically set the QNAME, QTYPE and QCLASS to use in the health-check query (see :ref:`Healthcheck`)
       setCD=BOOL,            -- Set the CD (Checking Disabled) flag in the health-check query, default: false
       maxCheckFailures=NUM,  -- Allow NUM check failures before declaring the backend down, default: 1
+      checkInterval=NUM      -- The time in seconds between health checks
       mustResolve=BOOL,      -- Set to true when the health check MUST return a NOERROR RCODE and an answer
       useClientSubnet=BOOL,  -- Add the client's IP address in the EDNS Client Subnet option when forwarding the query to this backend
       source=STRING,         -- The source address or interface to use for queries to this backend, by default this is left to the kernel's address selection


### PR DESCRIPTION
### Short description
Add option 'checkInterval' for newServer() to set the interval between
health checks.

### Checklist
I have:
- [yes] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [yes] compiled this code
- [yes] tested this code
- [yes] included documentation (including possible behaviour changes)
- [yes] documented the code
- [no] added or modified regression test(s)
- [no] added or modified unit test(s)

Hi,
this is a small patch to allow users to set the interval between health checks for each server.
Did a quick test on my setup which worked as expected.
I hope I did not forget any documentation?

Best regards