### PR TITLE
Add expungeByNames function to expunge multiple names at once

### DIFF
--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -38,6 +38,7 @@ public:
   void purgeExpired(size_t upTo=0);
   void expunge(size_t upTo=0);
   void expungeByName(const DNSName& name, uint16_t qtype=QType::ANY, bool suffixMatch=false);
+  void expungeByNames(const std::vector<DNSName> names, uint16_t qtype=QType::ANY, bool suffixMatch=false);
   bool isFull();
   string toString();
   uint64_t getSize();

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -236,6 +236,19 @@ void setupLuaBindings(bool client)
                   cache->expungeByName(dname, qtype ? *qtype : QType::ANY, suffixMatch ? *suffixMatch : false);
                 }
     });
+  g_lua.registerFunction<void(std::shared_ptr<DNSDistPacketCache>::*)(const std::vector<std::pair<int,DNSName>> dnames, boost::optional<uint16_t> qtype, boost::optional<bool> suffixMatch)>("expungeByName", [](
+              std::shared_ptr<DNSDistPacketCache> cache,
+              const std::vector<std::pair<int, DNSName>> dnames,
+              boost::optional<uint16_t> qtype,
+              boost::optional<bool> suffixMatch) {
+                if (cache) {
+                  std::vector<DNSName> names;
+                  for (auto dname : dnames) {
+                    names.push_back(dname.second);
+                  }
+                  cache->expungeByNames(names, qtype ? *qtype : QType::ANY, suffixMatch ? *suffixMatch : false);
+                }
+    });
   g_lua.registerFunction<void(std::shared_ptr<DNSDistPacketCache>::*)()>("printStats", [](const std::shared_ptr<DNSDistPacketCache> cache) {
       if (cache) {
         g_outputBuffer="Entries: " + std::to_string(cache->getEntriesCount()) + "/" + std::to_string(cache->getMaxEntries()) + "\n";


### PR DESCRIPTION
### Short description
This adds an expungeByNames function alongside expungeByName allowing expunging of multiple names in one command. Solves #7157 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
