### PR TITLE
rec: Revert 'Keep the EDNS status of a server on FormErr with EDNS'

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -479,7 +479,12 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
       return ret;
     }
     else if(mode==EDNSStatus::UNKNOWN || mode==EDNSStatus::EDNSOK || mode == EDNSStatus::EDNSIGNORANT ) {
-      if(!res->d_haveEDNS && (res->d_rcode == RCode::FormErr || res->d_rcode == RCode::NotImp)) {
+      /* So, you might be tempted to treat the presence of EDNS in a response as meaning that the
+         server does understand EDNS, and thus prevent a downgrade to no EDNS.
+         It turns out that you can't because there are a lot of crappy servers out there,
+         so you have to treat a FormErr as 'I have no idea what this EDNS thing is' no matter what.
+      */
+      if(res->d_rcode == RCode::FormErr || res->d_rcode == RCode::NotImp) {
 	//	cerr<<"Downgrading to NOEDNS because of "<<RCode::to_s(res->d_rcode)<<" for query to "<<ip.toString()<<" for '"<<domain<<"'"<<endl;
         mode = EDNSStatus::NOEDNS;
         continue;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
