### PR TITLE
Packages: add dnsdist.install for Ubuntu Trusty

### DIFF
--- a/builder-support/debian/dnsdist/ubuntu-trusty/dnsdist.install
+++ b/builder-support/debian/dnsdist/ubuntu-trusty/dnsdist.install
@@ -1,0 +1,1 @@
+usr/bin/dnsdist


### PR DESCRIPTION
### Short description
It seems that the debhelper version in trusty needs this to package the binary

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)