### PR TITLE
Add metrics to ixfrdist

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -419,6 +419,7 @@ build_ixfrdist() {
     --enable-unit-tests \
     --disable-dependency-tracking \
     --disable-silent-rules"
+  run "make -C ext -k -j3"
   run "cd pdns"
   run "make -k -j3 ixfrdist"
   run "cd .."

--- a/docs/manpages/ixfrdist.yml.5.rst
+++ b/docs/manpages/ixfrdist.yml.5.rst
@@ -99,6 +99,15 @@ Options
   :master: IP address of the server to transfer this domain from.
            Mandatory.
 
+:webserver-address:
+  IP address to listen on for the built-in webserver.
+  When not set, no webserver is started.
+
+:webserver-acl:
+  A list of networks that are allowed to access the :program:`ixfrdist` webserver.
+  Entries without a netmask will be interpreted as a single address.
+  By default, this list is set to ``127.0.0.0/8`` and ``::1/128``.
+
 See also
 --------
 

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -622,6 +622,8 @@ ixfrdist_SOURCES = \
 	ixfr.cc ixfr.hh \
 	ixfrdist.cc \
 	ixfrutils.cc ixfrutils.hh \
+	ixfrdist-stats.hh \
+	ixfrdist-web.hh ixfrdist-web.cc \
 	logger.cc logger.hh\
 	misc.cc misc.hh \
 	mplexer.hh \
@@ -635,11 +637,16 @@ ixfrdist_SOURCES = \
 	statbag.cc \
 	threadname.hh threadname.cc \
 	tsigverifier.cc tsigverifier.hh \
-	unix_utility.cc zoneparser-tng.cc
+	unix_utility.cc \
+	webserver.hh webserver.cc \
+	zoneparser-tng.cc
+
 
 ixfrdist_LDADD = \
 	$(BOOST_PROGRAM_OPTIONS_LIBS) \
+	$(JSON11_LIBS) \
 	$(LIBCRYPTO_LIBS) \
+	$(YAHTTP_LIBS) \
 	$(YAML_LIBS)
 
 ixfrdist_LDFLAGS = \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -622,7 +622,7 @@ ixfrdist_SOURCES = \
 	ixfr.cc ixfr.hh \
 	ixfrdist.cc \
 	ixfrutils.cc ixfrutils.hh \
-	ixfrdist-stats.hh \
+	ixfrdist-stats.hh ixfrdist-stats.cc \
 	ixfrdist-web.hh ixfrdist-web.cc \
 	logger.cc logger.hh\
 	misc.cc misc.hh \

--- a/pdns/ixfrdist-stats.cc
+++ b/pdns/ixfrdist-stats.cc
@@ -1,0 +1,108 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "ixfrdist-stats.hh"
+
+std::string ixfrdistStats::getStats() {
+  std::stringstream stats;
+  const std::string prefix = "ixfrdist_";
+
+  stats<<"# HELP "<<prefix<<"uptime_seconds The uptime of the process"<<std::endl;
+  stats<<"# TYPE "<<prefix<<"uptime_seconds gauge"<<std::endl;
+  stats<<prefix<<"uptime_seconds "<<time(nullptr) - progStats.startTime<<std::endl;
+
+  stats<<"# HELP "<<prefix<<"domains The amount of configured domains"<<std::endl;
+  stats<<"# TYPE "<<prefix<<"domains gauge"<<std::endl;
+  stats<<prefix<<"domains "<<domainStats.size()<<std::endl;
+
+  uint64_t numSOAChecks{0}, numSOAChecksFailed{0}, numSOAinQueries{0}, numIXFRinQueries{0}, numAXFRinQueries{0}, numAXFRFailures{0}, numIXFRFailures{0};
+  bool helpAdded{false};
+  for (auto const &d : domainStats) {
+    if (!helpAdded) {
+      stats<<"# HELP "<<prefix<<"soa_serial The SOA serial number of a domain"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"soa_serial gauge"<<std::endl;
+    }
+    if(d.second.haveZone)
+      stats<<prefix<<"soa_serial{domain="<<d.first<<"} "<<d.second.currentSOA<<std::endl;
+    else
+      stats<<prefix<<"soa_serial{domain="<<d.first<<"} NaN"<<std::endl;
+
+    if (!helpAdded) {
+      stats<<"# HELP "<<prefix<<"soa_checks Number of times a SOA check at the master was attempted"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"soa_checks counter"<<std::endl;
+    }
+    stats<<prefix<<"soa_checks{domain="<<d.first<<"} "<<d.second.numSOAChecks<<std::endl;
+    numSOAChecks += d.second.numSOAChecks;
+
+    if (!helpAdded) {
+      stats<<"# HELP "<<prefix<<"soa_checks_failed Number of times a SOA check at the master failed"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"soa_checks_failed counter"<<std::endl;
+    }
+    stats<<prefix<<"soa_checks_failed{domain="<<d.first<<"} "<<d.second.numSOAChecksFailed<<std::endl;
+    numSOAChecksFailed += d.second.numSOAChecksFailed;
+
+    if (!helpAdded) {
+      stats<<"# HELP "<<prefix<<"soa_inqueries Number of times a SOA query was received"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"soa_inqueries counter"<<std::endl;
+    }
+    stats<<prefix<<"soa_inqueries{domain="<<d.first<<"} "<<d.second.numSOAinQueries<<std::endl;
+    numSOAinQueries += d.second.numSOAinQueries;
+
+    if (!helpAdded) {
+      stats<<"# HELP "<<prefix<<"axfr_inqueries Number of times an AXFR query was received"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"axfr_inqueries counter"<<std::endl;
+    }
+    stats<<prefix<<"axfr_inqueries{domain="<<d.first<<"} "<<d.second.numAXFRinQueries<<std::endl;
+    numAXFRinQueries += d.second.numAXFRinQueries;
+
+    if (!helpAdded) {
+      stats<<"# HELP "<<prefix<<"axfr_failures Number of times an AXFR query was not properly answered"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"axfr_failures counter"<<std::endl;
+    }
+    stats<<prefix<<"axfr_failures{domain="<<d.first<<"} "<<d.second.numAXFRFailures<<std::endl;
+    numAXFRFailures += d.second.numAXFRFailures;
+
+    if (!helpAdded) {
+      stats<<"# HELP "<<prefix<<"ixfr_inqueries Number of times an IXFR query was received"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"ixfr_inqueries counter"<<std::endl;
+    }
+    stats<<prefix<<"ixfr_inqueries{domain="<<d.first<<"} "<<d.second.numIXFRinQueries<<std::endl;
+    numIXFRinQueries += d.second.numIXFRinQueries;
+
+    if (!helpAdded) {
+      stats<<"# HELP "<<prefix<<"ixfr_failures Number of times an IXFR query was not properly answered"<<std::endl;
+      stats<<"# TYPE "<<prefix<<"ixfr_failures counter"<<std::endl;
+    }
+    stats<<prefix<<"ixfr_failures{domain="<<d.first<<"} "<<d.second.numIXFRFailures<<std::endl;
+    numIXFRFailures += d.second.numIXFRFailures;
+    helpAdded = true;
+  }
+
+  stats<<prefix<<"soa_checks "<<numSOAChecks<<std::endl;
+  stats<<prefix<<"soa_checks_failed "<<numSOAChecksFailed<<std::endl;
+  stats<<prefix<<"soa_inqueries "<<numSOAinQueries<<std::endl;
+  stats<<prefix<<"axfr_inqueries "<<numAXFRinQueries<<std::endl;
+  stats<<prefix<<"ixfr_inqueries "<<numIXFRinQueries<<std::endl;
+  stats<<prefix<<"axfr_failures "<<numAXFRFailures<<std::endl;
+  stats<<prefix<<"ixfr_failures "<<numIXFRFailures<<std::endl;
+  return stats.str();
+}

--- a/pdns/ixfrdist-stats.hh
+++ b/pdns/ixfrdist-stats.hh
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "dnsname.hh"
+#include "pdnsexception.hh"
 
 class ixfrdistStats {
   public:
@@ -35,29 +36,30 @@ class ixfrdistStats {
     std::string getStats();
 
     void setSOASerial(const DNSName& d, const uint32_t serial) {
-      domainStats[d].currentSOA = serial;
-      domainStats[d].haveZone = true;
+      auto stat = getRegisteredDomain(d);
+      stat->second.currentSOA = serial;
+      stat->second.haveZone = true;
     }
     void incrementSOAChecks(const DNSName& d, const uint64_t amount = 1) {
-      domainStats[d].numSOAChecks += amount;
+      getRegisteredDomain(d)->second.numSOAChecks += amount;
     }
     void incrementSOAChecksFailed(const DNSName& d, const uint64_t amount = 1) {
-      domainStats[d].numSOAChecksFailed += amount;
+      getRegisteredDomain(d)->second.numSOAChecksFailed += amount;
     }
     void incrementSOAinQueries(const DNSName& d, const uint64_t amount = 1) {
-      domainStats[d].numSOAinQueries += amount;
+      getRegisteredDomain(d)->second.numSOAinQueries += amount;
     }
     void incrementAXFRinQueries(const DNSName& d, const uint64_t amount = 1) {
-      domainStats[d].numAXFRinQueries += amount;
+      getRegisteredDomain(d)->second.numAXFRinQueries += amount;
     }
     void incrementIXFRinQueries(const DNSName& d, const uint64_t amount = 1) {
-      domainStats[d].numIXFRinQueries += amount;
+      getRegisteredDomain(d)->second.numIXFRinQueries += amount;
     }
     void incrementAXFRFailures(const DNSName& d, const uint64_t amount = 1) {
-      domainStats[d].numAXFRFailures += amount;
+      getRegisteredDomain(d)->second.numAXFRFailures += amount;
     }
     void incrementIXFRFailures(const DNSName& d, const uint64_t amount = 1) {
-      domainStats[d].numIXFRFailures += amount;
+      getRegisteredDomain(d)->second.numIXFRFailures += amount;
     }
     void registerDomain(const DNSName& d) {
       domainStats[d].haveZone = false;
@@ -85,4 +87,12 @@ class ixfrdistStats {
 
     std::map<DNSName, perDomainStat> domainStats;
     programStats progStats;
+
+    std::map<DNSName, perDomainStat>::iterator getRegisteredDomain(const DNSName& d) {
+      auto ret = domainStats.find(d);
+      if (ret == domainStats.end()) {
+        throw PDNSException("Domain '" + d.toLogString() + "' not defined in the statistics map");
+      }
+      return ret;
+    };
 };

--- a/pdns/ixfrdist-stats.hh
+++ b/pdns/ixfrdist-stats.hh
@@ -1,0 +1,126 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+#include <atomic>
+#include <map>
+#include <string>
+
+#include "dnsname.hh"
+
+class ixfrdistStats {
+  public:
+    ixfrdistStats() {
+      progStats.startTime = time(nullptr);
+    }
+
+    std::string getStats() {
+      std::stringstream stats;
+      const std::string prefix = "ixfrdist_";
+
+      stats<<"# TYPE "<<prefix<<"uptime_seconds gauge"<<std::endl;
+      stats<<prefix<<"uptime_seconds "<<time(nullptr) - progStats.startTime<<std::endl;
+      stats<<"# TYPE "<<prefix<<"domains gauge"<<std::endl;
+      stats<<prefix<<"domains "<<domainStats.size()<<std::endl;
+
+      uint64_t numSOAinQueries{0}, numIXFRinQueries{0}, numAXFRinQueries{0}, numAXFRFailures{0}, numIXFRFailures{0};
+      for (auto const &d : domainStats) {
+        if(d.second.haveZone)
+          stats<<prefix<<"soa_serial{domain="<<d.first<<"} "<<d.second.currentSOA<<std::endl;
+        else
+          stats<<prefix<<"soa_serial{domain="<<d.first<<"} NaN"<<std::endl;
+
+        stats<<prefix<<"soa_inqueries{domain="<<d.first<<"} "<<d.second.numSOAinQueries<<std::endl;
+        numSOAinQueries += d.second.numSOAinQueries;
+
+        stats<<prefix<<"axfr_inqueries{domain="<<d.first<<"} "<<d.second.numAXFRinQueries<<std::endl;
+        numAXFRinQueries += d.second.numAXFRinQueries;
+
+        stats<<prefix<<"ixfr_inqueries{domain="<<d.first<<"} "<<d.second.numIXFRinQueries<<std::endl;
+        numIXFRinQueries += d.second.numIXFRinQueries;
+
+        stats<<prefix<<"axfr_failures{domain="<<d.first<<"} "<<d.second.numAXFRFailures<<std::endl;
+        numAXFRFailures += d.second.numAXFRFailures;
+
+        stats<<prefix<<"ixfr_failures{domain="<<d.first<<"} "<<d.second.numIXFRFailures<<std::endl;
+        numIXFRFailures += d.second.numIXFRFailures;
+      }
+
+      stats<<prefix<<"soa_inqueries "<<numSOAinQueries<<std::endl;
+      stats<<prefix<<"axfr_inqueries "<<numAXFRinQueries<<std::endl;
+      stats<<prefix<<"ixfr_inqueries "<<numIXFRinQueries<<std::endl;
+      stats<<prefix<<"axfr_failures "<<numAXFRFailures<<std::endl;
+      stats<<prefix<<"ixfr_failures "<<numIXFRFailures<<std::endl;
+      return stats.str();
+    }
+
+    void setSOASerial(const DNSName& d, const uint32_t serial) {
+      domainStats[d].currentSOA = serial;
+      domainStats[d].haveZone = true;
+    }
+    void incrementSOAChecks(const DNSName& d, const uint64_t amount = 1) {
+      domainStats[d].numSOAChecks += amount;
+    }
+    void incrementSOAChecksFailed(const DNSName& d, const uint64_t amount = 1) {
+      domainStats[d].numSOAChecksFailed += amount;
+    }
+    void incrementSOAinQueries(const DNSName& d, const uint64_t amount = 1) {
+      domainStats[d].numSOAinQueries += amount;
+    }
+    void incrementAXFRQueries(const DNSName& d, const uint64_t amount = 1) {
+      domainStats[d].numAXFRinQueries += amount;
+    }
+    void incrementIXFRQueries(const DNSName& d, const uint64_t amount = 1) {
+      domainStats[d].numIXFRinQueries += amount;
+    }
+    void incrementAXFRFailures(const DNSName& d, const uint64_t amount = 1) {
+      domainStats[d].numAXFRFailures += amount;
+    }
+    void incrementIXFRFailures(const DNSName& d, const uint64_t amount = 1) {
+      domainStats[d].numIXFRFailures += amount;
+    }
+    void registerDomain(const DNSName& d) {
+      domainStats[d].haveZone = false;
+    }
+  private:
+    class perDomainStat {
+      public:
+        bool                  haveZone;
+        std::atomic<uint32_t> currentSOA; // NOTE: this will wrongly be zero for unavailable zones
+
+        std::atomic<uint32_t> numSOAChecks;
+        std::atomic<uint32_t> numSOAChecksFailed;
+
+        std::atomic<uint64_t> numSOAinQueries;
+        std::atomic<uint64_t> numIXFRinQueries;
+        std::atomic<uint64_t> numAXFRinQueries;
+
+        std::atomic<uint64_t> numAXFRFailures;
+        std::atomic<uint64_t> numIXFRFailures;
+    };
+    class programStats {
+      public:
+        time_t startTime;
+    };
+
+    std::map<DNSName, perDomainStat> domainStats;
+    programStats progStats;
+};

--- a/pdns/ixfrdist-stats.hh
+++ b/pdns/ixfrdist-stats.hh
@@ -32,53 +32,7 @@ class ixfrdistStats {
       progStats.startTime = time(nullptr);
     }
 
-    std::string getStats() {
-      std::stringstream stats;
-      const std::string prefix = "ixfrdist_";
-
-      stats<<"# TYPE "<<prefix<<"uptime_seconds gauge"<<std::endl;
-      stats<<prefix<<"uptime_seconds "<<time(nullptr) - progStats.startTime<<std::endl;
-      stats<<"# TYPE "<<prefix<<"domains gauge"<<std::endl;
-      stats<<prefix<<"domains "<<domainStats.size()<<std::endl;
-
-      uint64_t numSOAChecks{0}, numSOAChecksFailed{0}, numSOAinQueries{0}, numIXFRinQueries{0}, numAXFRinQueries{0}, numAXFRFailures{0}, numIXFRFailures{0};
-      for (auto const &d : domainStats) {
-        if(d.second.haveZone)
-          stats<<prefix<<"soa_serial{domain="<<d.first<<"} "<<d.second.currentSOA<<std::endl;
-        else
-          stats<<prefix<<"soa_serial{domain="<<d.first<<"} NaN"<<std::endl;
-
-        stats<<prefix<<"soa_checks{domain="<<d.first<<"} "<<d.second.numSOAChecks<<std::endl;
-        numSOAChecks += d.second.numSOAChecks;
-
-        stats<<prefix<<"soa_checks_failed{domain="<<d.first<<"} "<<d.second.numSOAChecksFailed<<std::endl;
-        numSOAChecksFailed += d.second.numSOAChecksFailed;
-
-        stats<<prefix<<"soa_inqueries{domain="<<d.first<<"} "<<d.second.numSOAinQueries<<std::endl;
-        numSOAinQueries += d.second.numSOAinQueries;
-
-        stats<<prefix<<"axfr_inqueries{domain="<<d.first<<"} "<<d.second.numAXFRinQueries<<std::endl;
-        numAXFRinQueries += d.second.numAXFRinQueries;
-
-        stats<<prefix<<"ixfr_inqueries{domain="<<d.first<<"} "<<d.second.numIXFRinQueries<<std::endl;
-        numIXFRinQueries += d.second.numIXFRinQueries;
-
-        stats<<prefix<<"axfr_failures{domain="<<d.first<<"} "<<d.second.numAXFRFailures<<std::endl;
-        numAXFRFailures += d.second.numAXFRFailures;
-
-        stats<<prefix<<"ixfr_failures{domain="<<d.first<<"} "<<d.second.numIXFRFailures<<std::endl;
-        numIXFRFailures += d.second.numIXFRFailures;
-      }
-
-      stats<<prefix<<"soa_checks "<<numSOAChecks<<std::endl;
-      stats<<prefix<<"soa_checks_failed "<<numSOAChecksFailed<<std::endl;
-      stats<<prefix<<"soa_inqueries "<<numSOAinQueries<<std::endl;
-      stats<<prefix<<"axfr_inqueries "<<numAXFRinQueries<<std::endl;
-      stats<<prefix<<"ixfr_inqueries "<<numIXFRinQueries<<std::endl;
-      stats<<prefix<<"axfr_failures "<<numAXFRFailures<<std::endl;
-      stats<<prefix<<"ixfr_failures "<<numIXFRFailures<<std::endl;
-      return stats.str();
-    }
+    std::string getStats();
 
     void setSOASerial(const DNSName& d, const uint32_t serial) {
       domainStats[d].currentSOA = serial;

--- a/pdns/ixfrdist-stats.hh
+++ b/pdns/ixfrdist-stats.hh
@@ -41,12 +41,18 @@ class ixfrdistStats {
       stats<<"# TYPE "<<prefix<<"domains gauge"<<std::endl;
       stats<<prefix<<"domains "<<domainStats.size()<<std::endl;
 
-      uint64_t numSOAinQueries{0}, numIXFRinQueries{0}, numAXFRinQueries{0}, numAXFRFailures{0}, numIXFRFailures{0};
+      uint64_t numSOAChecks{0}, numSOAChecksFailed{0}, numSOAinQueries{0}, numIXFRinQueries{0}, numAXFRinQueries{0}, numAXFRFailures{0}, numIXFRFailures{0};
       for (auto const &d : domainStats) {
         if(d.second.haveZone)
           stats<<prefix<<"soa_serial{domain="<<d.first<<"} "<<d.second.currentSOA<<std::endl;
         else
           stats<<prefix<<"soa_serial{domain="<<d.first<<"} NaN"<<std::endl;
+
+        stats<<prefix<<"soa_checks{domain="<<d.first<<"} "<<d.second.numSOAChecks<<std::endl;
+        numSOAChecks += d.second.numSOAChecks;
+
+        stats<<prefix<<"soa_checks_failed{domain="<<d.first<<"} "<<d.second.numSOAChecksFailed<<std::endl;
+        numSOAChecksFailed += d.second.numSOAChecksFailed;
 
         stats<<prefix<<"soa_inqueries{domain="<<d.first<<"} "<<d.second.numSOAinQueries<<std::endl;
         numSOAinQueries += d.second.numSOAinQueries;
@@ -64,6 +70,8 @@ class ixfrdistStats {
         numIXFRFailures += d.second.numIXFRFailures;
       }
 
+      stats<<prefix<<"soa_checks "<<numSOAChecks<<std::endl;
+      stats<<prefix<<"soa_checks_failed "<<numSOAChecksFailed<<std::endl;
       stats<<prefix<<"soa_inqueries "<<numSOAinQueries<<std::endl;
       stats<<prefix<<"axfr_inqueries "<<numAXFRinQueries<<std::endl;
       stats<<prefix<<"ixfr_inqueries "<<numIXFRinQueries<<std::endl;
@@ -85,10 +93,10 @@ class ixfrdistStats {
     void incrementSOAinQueries(const DNSName& d, const uint64_t amount = 1) {
       domainStats[d].numSOAinQueries += amount;
     }
-    void incrementAXFRQueries(const DNSName& d, const uint64_t amount = 1) {
+    void incrementAXFRinQueries(const DNSName& d, const uint64_t amount = 1) {
       domainStats[d].numAXFRinQueries += amount;
     }
-    void incrementIXFRQueries(const DNSName& d, const uint64_t amount = 1) {
+    void incrementIXFRinQueries(const DNSName& d, const uint64_t amount = 1) {
       domainStats[d].numIXFRinQueries += amount;
     }
     void incrementAXFRFailures(const DNSName& d, const uint64_t amount = 1) {
@@ -110,8 +118,8 @@ class ixfrdistStats {
         std::atomic<uint32_t> numSOAChecksFailed;
 
         std::atomic<uint64_t> numSOAinQueries;
-        std::atomic<uint64_t> numIXFRinQueries;
         std::atomic<uint64_t> numAXFRinQueries;
+        std::atomic<uint64_t> numIXFRinQueries;
 
         std::atomic<uint64_t> numAXFRFailures;
         std::atomic<uint64_t> numIXFRFailures;

--- a/pdns/ixfrdist-web.cc
+++ b/pdns/ixfrdist-web.cc
@@ -1,0 +1,52 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "ixfrdist-web.hh"
+#include <thread>
+#include "threadname.hh"
+#include "ixfrdist-stats.hh"
+
+string doGetStats();
+
+IXFRDistWebServer::IXFRDistWebServer(const ComboAddress &listenAddress) {
+  // TODO wrap in smart pointer
+  d_ws = new WebServer(listenAddress.toString() , listenAddress.getPort());
+  d_ws->bind();
+}
+
+void IXFRDistWebServer::go() {
+  // std::thread wt(IXFRDistWebServer::webThread);
+  d_ws->registerWebHandler("/metrics", boost::bind(&IXFRDistWebServer::getMetrics, this, _1, _2));
+  d_ws->go();
+  // wt.detach();
+}
+
+void IXFRDistWebServer::webThread() {
+  setThreadName("ixfrdist/web");
+}
+
+void IXFRDistWebServer::getMetrics(HttpRequest* req, HttpResponse* resp) {
+  if(req->method != "GET")
+    throw HttpMethodNotAllowedException();
+
+  resp->body = doGetStats();
+  resp->status = 200;
+}

--- a/pdns/ixfrdist-web.cc
+++ b/pdns/ixfrdist-web.cc
@@ -28,8 +28,7 @@
 string doGetStats();
 
 IXFRDistWebServer::IXFRDistWebServer(const ComboAddress &listenAddress, const NetmaskGroup &acl) {
-  // TODO wrap in smart pointer
-  d_ws = new WebServer(listenAddress.toString() , listenAddress.getPort());
+  d_ws = std::unique_ptr<WebServer>(new WebServer(listenAddress.toString(), listenAddress.getPort()));
   d_ws->setACL(acl);
   d_ws->registerWebHandler("/metrics", boost::bind(&IXFRDistWebServer::getMetrics, this, _1, _2));
   d_ws->bind();

--- a/pdns/ixfrdist-web.cc
+++ b/pdns/ixfrdist-web.cc
@@ -50,5 +50,6 @@ void IXFRDistWebServer::getMetrics(HttpRequest* req, HttpResponse* resp) {
     throw HttpMethodNotAllowedException();
 
   resp->body = doGetStats();
+  resp->headers["Content-Type"] = "text/plain; version=0.0.4"; // https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
   resp->status = 200;
 }

--- a/pdns/ixfrdist-web.cc
+++ b/pdns/ixfrdist-web.cc
@@ -31,18 +31,13 @@ IXFRDistWebServer::IXFRDistWebServer(const ComboAddress &listenAddress, const Ne
   // TODO wrap in smart pointer
   d_ws = new WebServer(listenAddress.toString() , listenAddress.getPort());
   d_ws->setACL(acl);
+  d_ws->registerWebHandler("/metrics", boost::bind(&IXFRDistWebServer::getMetrics, this, _1, _2));
   d_ws->bind();
 }
 
 void IXFRDistWebServer::go() {
-  // std::thread wt(IXFRDistWebServer::webThread);
-  d_ws->registerWebHandler("/metrics", boost::bind(&IXFRDistWebServer::getMetrics, this, _1, _2));
-  d_ws->go();
-  // wt.detach();
-}
-
-void IXFRDistWebServer::webThread() {
   setThreadName("ixfrdist/web");
+  d_ws->go();
 }
 
 void IXFRDistWebServer::getMetrics(HttpRequest* req, HttpResponse* resp) {

--- a/pdns/ixfrdist-web.cc
+++ b/pdns/ixfrdist-web.cc
@@ -22,13 +22,15 @@
 #include "ixfrdist-web.hh"
 #include <thread>
 #include "threadname.hh"
+#include "iputils.hh"
 #include "ixfrdist-stats.hh"
 
 string doGetStats();
 
-IXFRDistWebServer::IXFRDistWebServer(const ComboAddress &listenAddress) {
+IXFRDistWebServer::IXFRDistWebServer(const ComboAddress &listenAddress, const NetmaskGroup &acl) {
   // TODO wrap in smart pointer
   d_ws = new WebServer(listenAddress.toString() , listenAddress.getPort());
+  d_ws->setACL(acl);
   d_ws->bind();
 }
 

--- a/pdns/ixfrdist-web.hh
+++ b/pdns/ixfrdist-web.hh
@@ -30,7 +30,7 @@ class IXFRDistWebServer
     void go();
 
   private:
-    WebServer *d_ws;
+    std::unique_ptr<WebServer> d_ws;
 
     // All endpoints
     void getMetrics(HttpRequest* req, HttpResponse* resp);

--- a/pdns/ixfrdist-web.hh
+++ b/pdns/ixfrdist-web.hh
@@ -22,7 +22,6 @@
 #pragma once
 #include "webserver.hh"
 #include "iputils.hh"
-//#include "ixfrdist-stats.hh"
 
 class IXFRDistWebServer
 {
@@ -32,7 +31,6 @@ class IXFRDistWebServer
 
   private:
     WebServer *d_ws;
-    void webThread();
 
     // All endpoints
     void getMetrics(HttpRequest* req, HttpResponse* resp);

--- a/pdns/ixfrdist-web.hh
+++ b/pdns/ixfrdist-web.hh
@@ -1,0 +1,39 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+#include "webserver.hh"
+#include "iputils.hh"
+//#include "ixfrdist-stats.hh"
+
+class IXFRDistWebServer
+{
+  public:
+    explicit IXFRDistWebServer(const ComboAddress &listenAddress);
+    void go();
+
+  private:
+    WebServer *d_ws;
+    void webThread();
+
+    // All endpoints
+    void getMetrics(HttpRequest* req, HttpResponse* resp);
+};

--- a/pdns/ixfrdist-web.hh
+++ b/pdns/ixfrdist-web.hh
@@ -27,7 +27,7 @@
 class IXFRDistWebServer
 {
   public:
-    explicit IXFRDistWebServer(const ComboAddress &listenAddress);
+    explicit IXFRDistWebServer(const ComboAddress &listenAddress, const NetmaskGroup &acl);
     void go();
 
   private:

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -309,7 +309,6 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
   g_log<<Logger::Notice<<"Update Thread started"<<endl;
 
   while (true) {
-    cout<<g_stats.getStats()<<endl;
     if (g_exiting) {
       g_log<<Logger::Notice<<"UpdateThread stopped"<<endl;
       break;

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -1255,8 +1255,8 @@ int main(int argc, char** argv) {
       }
     }
 
-    auto ws = IXFRDistWebServer(config["webserver-address"].as<ComboAddress>(), wsACL);
-    std::thread (&IXFRDistWebServer::go, ws).detach();
+    // Launch the webserver!
+    std::thread(&IXFRDistWebServer::go, IXFRDistWebServer(config["webserver-address"].as<ComboAddress>(), wsACL)).detach();
   }
 
   int newuid = 0;

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -43,6 +43,7 @@
 #include "misc.hh"
 #include "iputils.hh"
 #include "logger.hh"
+#include "ixfrdist-stats.hh"
 #include <yaml-cpp/yaml.h>
 
 /* BEGIN Needed because of deeper dependencies */
@@ -136,6 +137,8 @@ static bool g_exiting = false;
 
 static NetmaskGroup g_acl;
 static bool g_compress = false;
+
+static ixfrdistStats g_stats;
 
 static void handleSignal(int signum) {
   g_log<<Logger::Notice<<"Got "<<strsignal(signum)<<" signal";
@@ -232,6 +235,7 @@ static void updateCurrentZoneInfo(const DNSName& domain, std::shared_ptr<ixfrinf
 {
   std::lock_guard<std::mutex> guard(g_soas_mutex);
   g_soas[domain] = newInfo;
+  g_stats.setSOASerial(domain, newInfo->soa->d_st.serial);
 }
 
 void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& axfrTimeout, const uint16_t& soaRetry) {
@@ -278,6 +282,7 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
   g_log<<Logger::Notice<<"Update Thread started"<<endl;
 
   while (true) {
+    cout<<g_stats.getStats()<<endl;
     if (g_exiting) {
       g_log<<Logger::Notice<<"UpdateThread stopped"<<endl;
       break;
@@ -1109,6 +1114,7 @@ int main(int argc, char** argv) {
     set<ComboAddress> s;
     s.insert(domain["master"].as<ComboAddress>());
     g_domainConfigs[domain["domain"].as<DNSName>()].masters = s;
+    g_stats.registerDomain(domain["domain"].as<DNSName>());
   }
 
   for (const auto &addr : config["acl"].as<vector<string>>()) {

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -108,7 +108,7 @@ struct ixfrdiff_t {
 };
 
 struct ixfrinfo_t {
-  shared_ptr<SOARecordContent> soa; // The SOA of the latestAXFR
+  shared_ptr<SOARecordContent> soa; // The SOA of the latest AXFR
   records_t latestAXFR;             // The most recent AXFR
   vector<std::shared_ptr<ixfrdiff_t>> ixfrDiffs;
 };
@@ -625,7 +625,7 @@ static bool handleIXFR(int fd, const ComboAddress& destination, const MOADNSPars
     /* RFC 1995 Section 2
      *    If an IXFR query with the same or newer version number than that of
      *    the server is received, it is replied to with a single SOA record of
-     *    the server's current version, just as in AXFR.
+     *    the server's current version.
      */
     vector<uint8_t> packet;
     bool ret = makeSOAPacket(mdp, packet);
@@ -1252,7 +1252,7 @@ int main(int argc, char** argv) {
       break;
     }
   }
-  g_log<<Logger::Debug<<"Waiting for al threads to stop"<<endl;
+  g_log<<Logger::Debug<<"Waiting for all threads to stop"<<endl;
   g_tcpHandlerCV.notify_all();
   ut.join();
   for (auto &t : tcpHandlers) {

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -1108,7 +1108,7 @@ static bool parseAndCheckConfig(const string& configpath, YAML::Node& config) {
       config["webserver-acl"].as<vector<Netmask>>();
     }
     catch (const runtime_error &e) {
-      g_log<<Logger::Error<<"Unable to read 'webserver-address' value: "<<e.what()<<endl;
+      g_log<<Logger::Error<<"Unable to read 'webserver-acl' value: "<<e.what()<<endl;
       retval = false;
     }
   }

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -1257,7 +1257,7 @@ int main(int argc, char** argv) {
     }
 
     auto ws = IXFRDistWebServer(config["webserver-address"].as<ComboAddress>(), wsACL);
-    ws.go();
+    std::thread (&IXFRDistWebServer::go, ws).detach();
   }
 
   int newuid = 0;

--- a/pdns/ixfrdist.example.yml
+++ b/pdns/ixfrdist.example.yml
@@ -71,6 +71,10 @@ tcp-in-threads: 10
 #
 # gid: ixfrdist
 
+# The IP address and port where the webserver should listen
+#
+webserver-address: 127.0.0.1:8080
+
 # The domains to redistribute, the 'master' and 'domains' keys are mandatory.
 # When no port is specified, 53 is used. When specifying ports for IPv6, use the
 # "bracket" notation:

--- a/pdns/ixfrdist.example.yml
+++ b/pdns/ixfrdist.example.yml
@@ -75,6 +75,13 @@ tcp-in-threads: 10
 #
 webserver-address: 127.0.0.1:8080
 
+# The IP address(masks) that allowed to access the webserver. When not set,
+# it defaults to 127.0.0.0/8, ::1/128
+#
+webserver-acl:
+  - 127.0.0.0/8
+  - ::1/128
+
 # The domains to redistribute, the 'master' and 'domains' keys are mandatory.
 # When no port is specified, 53 is used. When specifying ports for IPv6, use the
 # "bracket" notation:

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -175,11 +175,9 @@ void WebServer::registerApiHandler(const string& url, HandlerFunction handler) {
   d_registerApiHandlerCalled = true;
 }
 
-static void webWrapper(WebServer::HandlerFunction handler, HttpRequest* req, HttpResponse* resp) {
-  const string& web_password = arg()["webserver-password"];
-
-  if (!web_password.empty()) {
-    bool auth_ok = req->compareAuthorization(web_password);
+static void webWrapper(WebServer::HandlerFunction handler, HttpRequest* req, HttpResponse* resp, const string &password) {
+  if (!password.empty()) {
+    bool auth_ok = req->compareAuthorization(password);
     if (!auth_ok) {
       g_log<<Logger::Debug<<"HTTP Request \"" << req->url.path << "\": Web Authentication failed" << endl;
       throw HttpUnauthorizedException("Basic");
@@ -190,7 +188,7 @@ static void webWrapper(WebServer::HandlerFunction handler, HttpRequest* req, Htt
 }
 
 void WebServer::registerWebHandler(const string& url, HandlerFunction handler) {
-  HandlerFunction f = boost::bind(&webWrapper, handler, _1, _2);
+  HandlerFunction f = boost::bind(&webWrapper, handler, _1, _2, d_webserverPassword);
   registerBareHandler(url, f);
 }
 

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -144,6 +144,14 @@ class WebServer : public boost::noncopyable
 public:
   WebServer(const string &listenaddress, int port);
   virtual ~WebServer() { };
+
+  void setApiKey(const string &apikey) {
+    if (d_registerApiHandlerCalled) {
+      throw PDNSException("registerApiHandler has been called, can not change apikey");
+    }
+    d_apikey = apikey;
+  }
+
   void bind();
   void go();
 
@@ -165,6 +173,9 @@ protected:
   int d_port;
   string d_password;
   std::shared_ptr<Server> d_server;
+
+  std::string d_apikey;
+  bool d_registerApiHandlerCalled{false};
 };
 
 #endif /* WEBSERVER_HH */

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -152,6 +152,13 @@ public:
     d_apikey = apikey;
   }
 
+  void setPassword(const string &password) {
+    if (d_registerWebHandlerCalled) {
+      throw PDNSException("registerWebHandler has been called, can not change password");
+    }
+    d_webserverPassword = password;
+  }
+
   void bind();
   void go();
 
@@ -176,6 +183,9 @@ protected:
 
   std::string d_apikey;
   bool d_registerApiHandlerCalled{false};
+
+  std::string d_webserverPassword;
+  bool d_registerWebHandlerCalled{false};
 };
 
 #endif /* WEBSERVER_HH */

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -159,6 +159,10 @@ public:
     d_webserverPassword = password;
   }
 
+  void setACL(const NetmaskGroup &nmg) {
+    d_acl = nmg;
+  }
+
   void bind();
   void go();
 
@@ -186,6 +190,8 @@ protected:
 
   std::string d_webserverPassword;
   bool d_registerWebHandlerCalled{false};
+
+  NetmaskGroup d_acl;
 };
 
 #endif /* WEBSERVER_HH */

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -64,6 +64,11 @@ AuthWebServer::AuthWebServer()
     d_ws = new WebServer(arg()["webserver-address"], arg().asNum("webserver-port"));
     d_ws->setApiKey(arg()["api-key"]);
     d_ws->setPassword(arg()["webserver-password"]);
+
+    NetmaskGroup acl;
+    acl.toMasks(::arg()["webserver-allow-from"]);
+    d_ws->setACL(acl);
+
     d_ws->bind();
   }
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -63,6 +63,7 @@ AuthWebServer::AuthWebServer()
   if(arg().mustDo("webserver") || arg().mustDo("api")) {
     d_ws = new WebServer(arg()["webserver-address"], arg().asNum("webserver-port"));
     d_ws->setApiKey(arg()["api-key"]);
+    d_ws->setPassword(arg()["webserver-password"]);
     d_ws->bind();
   }
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -62,6 +62,7 @@ AuthWebServer::AuthWebServer()
   d_tid = 0;
   if(arg().mustDo("webserver") || arg().mustDo("api")) {
     d_ws = new WebServer(arg()["webserver-address"], arg().asNum("webserver-port"));
+    d_ws->setApiKey(arg()["api-key"]);
     d_ws->bind();
   }
 }

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -451,6 +451,7 @@ RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
 
   d_ws = new AsyncWebServer(fdm, arg()["webserver-address"], arg().asNum("webserver-port"));
   d_ws->setApiKey(arg()["api-key"]);
+  d_ws->setPassword(arg()["webserver-password"]);
   d_ws->bind();
 
   // legacy dispatch

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -450,6 +450,7 @@ RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
   registerAllStats();
 
   d_ws = new AsyncWebServer(fdm, arg()["webserver-address"], arg().asNum("webserver-port"));
+  d_ws->setApiKey(arg()["api-key"]);
   d_ws->bind();
 
   // legacy dispatch

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -452,6 +452,11 @@ RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
   d_ws = new AsyncWebServer(fdm, arg()["webserver-address"], arg().asNum("webserver-port"));
   d_ws->setApiKey(arg()["api-key"]);
   d_ws->setPassword(arg()["webserver-password"]);
+
+  NetmaskGroup acl;
+  acl.toMasks(::arg()["webserver-allow-from"]);
+  d_ws->setACL(acl);
+
   d_ws->bind();
 
   // legacy dispatch

--- a/regression-tests.ixfrdist/requirements.txt
+++ b/regression-tests.ixfrdist/requirements.txt
@@ -1,3 +1,4 @@
 dnspython
 nose
 git+https://github.com/PowerDNS/xfrserver.git@0.1
+requests

--- a/regression-tests.ixfrdist/test_Stats.py
+++ b/regression-tests.ixfrdist/test_Stats.py
@@ -1,0 +1,117 @@
+from ixfrdisttests import IXFRDistTest
+from xfrserver.xfrserver import AXFRServer
+import time
+import requests
+
+zones = {
+    1: """
+$ORIGIN example.
+@        86400   SOA    foo bar 1 2 3 4 5
+@        4242    NS     ns1.example.
+@        4242    NS     ns2.example.
+ns1.example.    4242    A       192.0.2.1
+ns2.example.    4242    A       192.0.2.2
+"""}
+
+xfrServerPort = 4244
+xfrServer = AXFRServer(xfrServerPort, zones)
+
+class IXFRDistStatsTest(IXFRDistTest):
+    """
+    This test makes sure we have statistics in ixfrdist
+    """
+
+    webserver_address = '127.0.0.1:8080'
+
+    _config_params = ['_ixfrDistPort', 'webserver_address']
+
+    _config_template = """
+listen:
+  - '127.0.0.1:%d'
+acl:
+  - '127.0.0.0/8'
+axfr-timeout: 20
+keep: 20
+tcp-in-threads: 1
+work-dir: 'ixfrdist.dir'
+failed-soa-retry: 3
+webserver-address: %s
+"""
+
+    _config_domains = {'example': '127.0.0.1:' + str(xfrServerPort)}
+
+    metric_prog_stats = ["ixfrdist_uptime_seconds", "ixfrdist_domains"]
+    metric_domain_stats = ["ixfrdist_soa_serial", "ixfrdist_soa_checks",
+                           "ixfrdist_soa_checks_failed",
+                           "ixfrdist_soa_inqueries",
+                           "ixfrdist_axfr_inqueries", "ixfrdist_axfr_failures",
+                           "ixfrdist_ixfr_inqueries", "ixfrdist_ixfr_failures"]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.startIXFRDist()
+        cls.setUpSockets()
+        time.sleep(3)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tearDownIXFRDist()
+
+    def test_program_stats_exist(self):
+        res = requests.get('http://{}/metrics'.format(self.webserver_address))
+        self.assertEqual(res.status_code, 200)
+        for line in res.text.splitlines():
+            if line[0] == "#":
+                continue
+            if "{" in line:
+                continue
+            self.assertIn(line.split(" ")[0],
+                          self.metric_prog_stats + self.metric_domain_stats)
+
+    def test_registered(self):
+        res = requests.get('http://{}/metrics'.format(self.webserver_address))
+        self.assertEqual(res.status_code, 200)
+        for line in res.text.splitlines():
+            if line.startswith('ixfrdist_domains'):
+                self.assertEqual(line, 'ixfrdist_domains 1')
+                continue
+            if line[0] == "#":
+                continue
+            if "{" not in line:
+                continue
+            self.assertIn('{domain=example}', line)
+            self.assertIn(line.split("{")[0], self.metric_domain_stats)
+
+    def test_metrics_have_help(self):
+        res = requests.get('http://{}/metrics'.format(self.webserver_address))
+        self.assertEqual(res.status_code, 200)
+        for s in self.metric_prog_stats + self.metric_domain_stats:
+            self.assertIn('# HELP {}'.format(s), res.text)
+
+    def test_metrics_have_type(self):
+        res = requests.get('http://{}/metrics'.format(self.webserver_address))
+        self.assertEqual(res.status_code, 200)
+        for s in self.metric_prog_stats + self.metric_domain_stats:
+            self.assertIn('# TYPE {}'.format(s), res.text)
+
+    def test_missing_metrics(self):
+        all_metrics = set()
+
+        res = requests.get('http://{}/metrics'.format(self.webserver_address))
+        self.assertEqual(res.status_code, 200)
+
+        for line in res.text.splitlines():
+            if line[0] == "#":
+                all_metrics.add(line.split(" ")[2])
+                continue
+            if "{" in line:
+                all_metrics.add(line.split("{")[0])
+                continue
+            all_metrics.add(line.split(" ")[0])
+
+        should_have_metrics = set(self.metric_prog_stats +
+                                  self.metric_domain_stats)
+
+        unknown_metrics = all_metrics - should_have_metrics
+
+        self.assertSetEqual(unknown_metrics, set())


### PR DESCRIPTION
### Short description
This PR adds prometheus statistics to ixfrdist. It also refactors the `WebServer` class somewhat to make it more reusable (like for ixfrdist :smile:).

I've opened this PR early for comments on the code and to get some more ideas for statistics.

ToDo:

- [x] Add tests for the statistics

Future work:

- Make the webserver PW/API-key runtime-configable
- Add an API to ixfrdist

CC: @atosatto

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)