### PR TITLE
pdnsutil.1 & settings: Add Ed25519 and Ed448, document ECC keysizes, remove old algos

### DIFF
--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -43,6 +43,8 @@ algorithms are supported:
 -  gost
 -  ecdsa256
 -  ecdsa384
+-  ed25519
+-  ed448
 
 activate-zone-key *ZONE* *KEY-ID*
     Activate a key with id *KEY-ID* within a zone called *ZONE*.
@@ -69,7 +71,9 @@ generate-zone-key {**KSK**,\ **ZSK**} [*ALGORITHM*] [*KEYBITS*]
     Generate a ZSK or KSK to stdout with specified algorithm and bits
     and print it on STDOUT. If *ALGORITHM* is not set, RSASHA512 is
     used. If *KEYBITS* is not set, an appropriate keysize is selected
-    for *ALGORITHM*.
+    for *ALGORITHM*. Each ECC-based algorithm supports only one valid
+    *KEYBITS* value: For GOST, ECDSA256, and ED25519, it is 256; for
+    ECDSA384, it is 384; and for ED448, it is 456.
 import-zone-key *ZONE* *FILE* {**KSK**,\ **ZSK**}
     Import from *FILE* a full (private) key for zone called *ZONE*. The
     format used is compatible with BIND and NSD/LDNS. **KSK** or **ZSK**

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -40,7 +40,6 @@ algorithms are supported:
 -  rsasha1
 -  rsasha256
 -  rsasha512
--  gost
 -  ecdsa256
 -  ecdsa384
 -  ed25519
@@ -72,8 +71,8 @@ generate-zone-key {**KSK**,\ **ZSK**} [*ALGORITHM*] [*KEYBITS*]
     and print it on STDOUT. If *ALGORITHM* is not set, RSASHA512 is
     used. If *KEYBITS* is not set, an appropriate keysize is selected
     for *ALGORITHM*. Each ECC-based algorithm supports only one valid
-    *KEYBITS* value: For GOST, ECDSA256, and ED25519, it is 256; for
-    ECDSA384, it is 384; and for ED448, it is 456.
+    *KEYBITS* value: For ECDSA256 and ED25519, it is 256; for ECDSA384,
+    it is 384; and for ED448, it is 456.
 import-zone-key *ZONE* *FILE* {**KSK**,\ **ZSK**}
     Import from *FILE* a full (private) key for zone called *ZONE*. The
     format used is compatible with BIND and NSD/LDNS. **KSK** or **ZSK**

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -291,7 +291,6 @@ to enable DNSSEC. Must be one of:
 * rsasha1
 * rsasha256
 * rsasha512
-* ecc-gost
 * ecdsa256 (ECDSA P-256 with SHA256)
 * ecdsa384 (ECDSA P-384 with SHA384)
 * ed25519
@@ -384,7 +383,6 @@ to enable DNSSEC. Must be one of:
 * rsasha1
 * rsasha256
 * rsasha512
-* ecc-gost
 * ecdsa256 (ECDSA P-256 with SHA256)
 * ecdsa384 (ECDSA P-384 with SHA384)
 * ed25519

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -288,10 +288,6 @@ The algorithm that should be used for the KSK when running
 :doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
 to enable DNSSEC. Must be one of:
 
-* rsamd5
-* dh
-* dsa
-* ecc
 * rsasha1
 * rsasha256
 * rsasha512
@@ -299,6 +295,7 @@ to enable DNSSEC. Must be one of:
 * ecdsa256 (ECDSA P-256 with SHA256)
 * ecdsa384 (ECDSA P-384 with SHA384)
 * ed25519
+* ed448
 
 .. note::
   Actual supported algorithms depend on the crypto-libraries
@@ -384,10 +381,6 @@ The algorithm that should be used for the ZSK when running
 :doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
 to enable DNSSEC. Must be one of:
 
-* rsamd5
-* dh
-* dsa
-* ecc
 * rsasha1
 * rsasha256
 * rsasha512
@@ -395,6 +388,7 @@ to enable DNSSEC. Must be one of:
 * ecdsa256 (ECDSA P-256 with SHA256)
 * ecdsa384 (ECDSA P-384 with SHA384)
 * ed25519
+* ed448
 
 .. note::
   Actual supported algorithms depend on the crypto-libraries


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In `pdnsutil.1`:

* Add Ed25519 and Ed448 to the list of DNSSEC algorithms
* Since ECC algorithms only support one valid key size, document what it is.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)