### PR TITLE
Remove trailing \n from runtime_error message

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -448,7 +448,7 @@ DSRecordContent makeDSFromDNSKey(const DNSName& qname, const DNSKEYRecordContent
     dsrc.d_digest = dpk->hash(toHash);
   }
   catch(const std::exception& e) {
-    throw std::runtime_error("Asked to a DS of unknown digest type " + std::to_string(digest)+"\n");
+    throw std::runtime_error("Asked to create (C)DS record of unknown digest type " + std::to_string(digest));
   }
   
   dsrc.d_algorithm = drc.d_algorithm;


### PR DESCRIPTION
And rewrite the message a bit.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Remove trailing `\n` from `pdns/dnssecinfra.cc:makeDSFromDNSKey`'s  `std::runtime_error()` message, and rewrite the error message itself a bit.

The `\n` made syslog a bit wacky:

    pdns_server[3070]: Exception building answer packet for 779141.xyz/CDS (Asked to a DS of unknown digest type 3
    pdns_server[3070]: ) sending out servfail

I didn't test this. :grimacing: 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)