### PR TITLE
dnsdist: add optional UUID column to showServers()

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -464,7 +464,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "showRules", true, "[{showUUIDs=false, truncateRuleWidth=-1}]", "show all defined rules, optionally with their UUIDs and optionally truncated to a given width" },
   { "showSelfAnsweredResponseRules", true, "[{showUUIDs=false, truncateRuleWidth=-1}]", "show all defined self-answered response rules, optionally with their UUIDs and optionally truncated to a given width" },
   { "showServerPolicy", true, "", "show name of currently operational server selection policy" },
-  { "showServers", true, "", "output all servers" },
+  { "showServers", true, "[{showUUIDs=false}]", "output all servers, optionally with their UUIDs" },
   { "showTCPStats", true, "", "show some statistics regarding TCP" },
   { "showTLSContexts", true, "", "list all the available TLS contexts" },
   { "showVersion", true, "", "show the current version" },

--- a/pdns/dnsdistdist/docs/guides/serverselection.rst
+++ b/pdns/dnsdistdist/docs/guides/serverselection.rst
@@ -48,7 +48,7 @@ The current hash algorithm is based on the qname of the query.
 
 ``chashed`` is a consistent hashing distribution policy. Identical questions with identical hashes will be distributed to the same servers. But unlike the ``whashed`` policy, this distribution will keep consistent over time. Adding or removing servers will only remap a small part of the queries.
 
-You can also set the hash perturbation value, see :func:`setWHashedPertubation`. To achieve consistent distribution over :program:`dnsdist` restarts, you will also need to explicitly set the backend's UUIDs with the ``id`` option of :func:`newServer`. You can get the current UUIDs of your backends by calling :func:`showServers`.
+You can also set the hash perturbation value, see :func:`setWHashedPertubation`. To achieve consistent distribution over :program:`dnsdist` restarts, you will also need to explicitly set the backend's UUIDs with the ``id`` option of :func:`newServer`. You can get the current UUIDs of your backends by calling :func:`showServers` with the ``showUUIDs=true`` option.
 
 ``roundrobin``
 ~~~~~~~~~~~~~~

--- a/pdns/dnsdistdist/docs/guides/serverselection.rst
+++ b/pdns/dnsdistdist/docs/guides/serverselection.rst
@@ -48,7 +48,7 @@ The current hash algorithm is based on the qname of the query.
 
 ``chashed`` is a consistent hashing distribution policy. Identical questions with identical hashes will be distributed to the same servers. But unlike the ``whashed`` policy, this distribution will keep consistent over time. Adding or removing servers will only remap a small part of the queries.
 
-You can also set the hash perturbation value, see :func:`setWHashedPertubation`.
+You can also set the hash perturbation value, see :func:`setWHashedPertubation`. To achieve consistent distribution over :program:`dnsdist` restarts, you will also need to explicitly set the backend's UUIDs with the ``id`` option of :func:`newServer`. You can get the current UUIDs of your backends by calling :func:`showServers`.
 
 ``roundrobin``
 ~~~~~~~~~~~~~~

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -321,6 +321,7 @@ Servers
 
     newServer({
       address="IP:PORT",     -- IP and PORT of the backend server (mandatory)
+      id=STRING              -- Use a pre-defined UUID instead of a random one
       qps=NUM,               -- Limit the number of queries per second to NUM, when using the `firstAvailable` policy
       order=NUM,             -- The order of this server, used by the `leastOustanding` and `firstAvailable` policies
       weight=NUM,            -- The weight of this server, used by the `wrandom`, `whashed` and `chashed` policies, default: 1
@@ -686,12 +687,16 @@ Status, Statistics and More
 
   Show a plot of the response time latency distribution
 
-.. function:: showServers()
+.. function:: showServers([options])
+
+  .. versionchanged:: 1.3.4
+    ``options`` optional parameter added
 
   This function shows all backend servers currently configured and some statistics.
   These statics have the following fields:
 
   * ``#`` - The number of the server, can be used as the argument for :func:`getServer`
+  * ``UUID`` - The UUID of the backend. Can be set with the ``id`` option of :func:`newServer`
   * ``Address`` - The IP address and port of the server
   * ``State`` - The current state of the server
   * ``Qps`` - Current number of queries per second
@@ -703,6 +708,12 @@ Status, Statistics and More
   * ``Drate`` - Number of queries dropped per second by this server
   * ``Lat`` - The latency of this server in milliseconds
   * ``Pools`` - The pools this server belongs to
+
+  :param table options: A table with key: value pairs with display options.
+
+  Options:
+
+  * ``showUUIDs=false``: bool - Whether to display the UUIDs, defaults to false.
 
 .. function:: showTCPStats()
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -321,7 +321,7 @@ Servers
 
     newServer({
       address="IP:PORT",     -- IP and PORT of the backend server (mandatory)
-      id=STRING              -- Use a pre-defined UUID instead of a random one
+      id=STRING,             -- Use a pre-defined UUID instead of a random one
       qps=NUM,               -- Limit the number of queries per second to NUM, when using the `firstAvailable` policy
       order=NUM,             -- The order of this server, used by the `leastOustanding` and `firstAvailable` policies
       weight=NUM,            -- The weight of this server, used by the `wrandom`, `whashed` and `chashed` policies, default: 1


### PR DESCRIPTION
### Short description
This adds an optional UUID column to the `showServers()` output. This PR also tries to clarify what parameters the `chashed` distribution is based on.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
