### PR TITLE
dnsdist: expose secpoll status

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -462,6 +462,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "showResponseLatency", true, "", "show a plot of the response time latency distribution" },
   { "showResponseRules", true, "[{showUUIDs=false, truncateRuleWidth=-1}]", "show all defined response rules, optionally with their UUIDs and optionally truncated to a given width" },
   { "showRules", true, "[{showUUIDs=false, truncateRuleWidth=-1}]", "show all defined rules, optionally with their UUIDs and optionally truncated to a given width" },
+  { "showSecurityStatus", true, "", "Show the security status"},
   { "showSelfAnsweredResponseRules", true, "[{showUUIDs=false, truncateRuleWidth=-1}]", "show all defined self-answered response rules, optionally with their UUIDs and optionally truncated to a given width" },
   { "showServerPolicy", true, "", "show name of currently operational server selection policy" },
   { "showServers", true, "", "output all servers" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1268,6 +1268,11 @@ instance_name ? *instance_name : "main" ,
       g_outputBuffer = "dnsdist " + std::string(VERSION) + "\n";
     });
 
+  g_lua.writeFunction("showSecurityStatus", []() {
+      setLuaNoSideEffect();
+      g_outputBuffer = std::to_string(g_stats.securityStatus) + "\n";
+    });
+
 #ifdef HAVE_EBPF
   g_lua.writeFunction("setDefaultBPFFilter", [](std::shared_ptr<BPFFilter> bpf) {
       if (g_configurationDone) {

--- a/pdns/dnsdist-snmp.cc
+++ b/pdns/dnsdist-snmp.cc
@@ -47,6 +47,7 @@ static const oid fdUsageOID[] = { DNSDIST_STATS_OID, 34 };
 static const oid dynBlockedOID[] = { DNSDIST_STATS_OID, 35 };
 static const oid dynBlockedNMGSizeOID[] = { DNSDIST_STATS_OID, 36 };
 static const oid ruleServFailOID[] = { DNSDIST_STATS_OID, 37 };
+static const oid securityStatusOID[] = { DNSDIST_STATS_OID, 38 };
 
 static std::unordered_map<oid, DNSDistStats::entry_t> s_statsMap;
 
@@ -580,6 +581,7 @@ DNSDistSNMPAgent::DNSDistSNMPAgent(const std::string& name, const std::string& m
   registerGauge64Stat("cpuSysMSec", cpuSysMSecOID, OID_LENGTH(cpuSysMSecOID), &getCPUTimeSystem);
   registerGauge64Stat("fdUsage", fdUsageOID, OID_LENGTH(fdUsageOID), &getOpenFileDescriptors);
   registerGauge64Stat("dynBlockedNMGSize", dynBlockedNMGSizeOID, OID_LENGTH(dynBlockedNMGSizeOID), [](const std::string&) { return g_dynblockNMG.getLocal()->size(); });
+  registerGauge64Stat("securityStatus", securityStatusOID, OID_LENGTH(securityStatusOID), [](const std::string&) { return g_stats.securityStatus.load(); });
 
 
   netsnmp_table_registration_info* table_info = SNMP_MALLOC_TYPEDEF(netsnmp_table_registration_info);

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -227,10 +227,11 @@ struct DNSDistStats
   stat_t cacheHits{0};
   stat_t cacheMisses{0};
   stat_t latency0_1{0}, latency1_10{0}, latency10_50{0}, latency50_100{0}, latency100_1000{0}, latencySlow{0};
+  stat_t securityStatus{0};
 
   double latencyAvg100{0}, latencyAvg1000{0}, latencyAvg10000{0}, latencyAvg1000000{0};
   typedef std::function<uint64_t(const std::string&)> statfunction_t;
-  typedef boost::variant<stat_t*, double*, statfunction_t> entry_t;
+  typedef boost::variant<stat_t*, double*, statfunction_t, uint64_t*> entry_t;
   std::vector<std::pair<std::string, entry_t>> entries{
     {"responses", &responses},
     {"servfail-responses", &servfailResponses},
@@ -267,7 +268,8 @@ struct DNSDistStats
     {"cpu-sys-msec", getCPUTimeSystem},
     {"fd-usage", getOpenFileDescriptors},
     {"dyn-blocked", &dynBlocked},
-    {"dyn-block-nmg-size", [](const std::string&) { return g_dynblockNMG.getLocal()->size(); }}
+    {"dyn-block-nmg-size", [](const std::string&) { return g_dynblockNMG.getLocal()->size(); }},
+    {"security-status", &securityStatus}
   };
 };
 
@@ -357,6 +359,7 @@ struct MetricDefinitionStorage {
     { "fd-usage",               MetricDefinition(PrometheusMetricType::gauge,   "Number of currently used file descriptors")},
     { "dyn-blocked",            MetricDefinition(PrometheusMetricType::counter, "Number of queries dropped because of a dynamic block")},
     { "dyn-block-nmg-size",     MetricDefinition(PrometheusMetricType::gauge,   "Number of dynamic blocks entries") },
+    { "security-status",        MetricDefinition(PrometheusMetricType::gauge,   "Security status of this software. 0=unknown, 1=OK, 2=upgrade recommended, 3=upgrade mandatory") },
   };
 };
 

--- a/pdns/dnsdistdist/DNSDIST-MIB.txt
+++ b/pdns/dnsdistdist/DNSDIST-MIB.txt
@@ -326,6 +326,14 @@ ruleServFail OBJECT-TYPE
 	"Number of ServFail responses returned because of a rule"
     ::= { stats 37 }
 
+securityStatus OBJECT-TYPE
+    SYNTAX CounterBasedGauge64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+	"Security status of this software. 0=unknown, 1=OK, 2=upgrade recommended, 3=upgrade mandatory"
+    ::= { stats 38 }
+
 backendStatTable OBJECT-TYPE
     SYNTAX SEQUENCE OF BackendStatEntry
     MAX-ACCESS not-accessible
@@ -670,6 +678,7 @@ dnsdistGroup OBJECT-GROUP
         fdUsage,
         dynBlocked,
         dynBlockNMGSize,
+        securityStatus,
         backendName,
         backendLatency,
         backendWeight,

--- a/pdns/dnsdistdist/dnsdist-secpoll.cc
+++ b/pdns/dnsdistdist/dnsdist-secpoll.cc
@@ -220,6 +220,7 @@ void doSecPoll(const std::string& suffix)
       errlog("PowerDNS DNSDist Security Update Mandatory: %s", securityMessage);
     }
 
+    g_stats.securityStatus = securityStatus;
     g_secPollDone = true;
     return;
   }

--- a/pdns/dnsdistdist/docs/statistics.rst
+++ b/pdns/dnsdistdist/docs/statistics.rst
@@ -153,6 +153,17 @@ rule-servfail
 -------------
 Number of ServFail answers returned because of a rule.
 
+security-status
+---------------
+.. versionadded:: 1.3.4
+
+The security status of :program:`dnsdist`. This is regularly polled.
+
+ * 0 = Unknown status or unreleased version
+ * 1 = OK
+ * 2 = Upgrade recommended
+ * 3 = Upgrade required (most likely because there is a known security issue)
+
 self-answered
 -------------
 Number of self-answered responses.

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -233,7 +233,7 @@ class TestAPIBasics(DNSDistTest):
                     'latency-avg1000000', 'uptime', 'real-memory-usage', 'noncompliant-queries',
                     'noncompliant-responses', 'rdqueries', 'empty-queries', 'cache-hits',
                     'cache-misses', 'cpu-user-msec', 'cpu-sys-msec', 'fd-usage', 'dyn-blocked',
-                    'dyn-block-nmg-size', 'rule-servfail']
+                    'dyn-block-nmg-size', 'rule-servfail', 'security-status']
 
         for key in expected:
             self.assertIn(key, values)


### PR DESCRIPTION
### Short description
This PR adds the security status to the SNMP, carbon and prometheus statistics. It also adds a `showSecurityStatus` function.

Closes #7194

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)