### PR TITLE
dnsdist: Remove the useless 'void*' return type of threads

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -37,7 +37,7 @@ uint64_t uptimeOfProcess(const std::string& str)
   return time(0) - s_start;
 }
 
-void* carbonDumpThread()
+void carbonDumpThread()
 try
 {
   setThreadName("dnsdist/carbon");
@@ -162,20 +162,16 @@ try
       }
     }
   }
-  return 0;
 }
 catch(std::exception& e)
 {
   errlog("Carbon thread died: %s", e.what());
-  return 0;
 }
 catch(PDNSException& e)
 {
   errlog("Carbon thread died, PDNSException: %s", e.reason);
-  return 0;
 }
 catch(...)
 {
   errlog("Carbon thread died");
-  return 0;
 }

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -132,7 +132,7 @@ static std::map<ComboAddress,size_t,ComboAddress::addressOnlyLessThan> tcpClient
 bool g_useTCPSinglePipe{false};
 std::atomic<uint16_t> g_downstreamTCPCleanupInterval{60};
 
-void* tcpClientThread(int pipefd);
+void tcpClientThread(int pipefd);
 
 static void decrementTCPClientCount(const ComboAddress& client)
 {
@@ -260,7 +260,7 @@ void cleanupClosedTCPConnections(std::map<ComboAddress,int>& sockets)
 
 std::shared_ptr<TCPClientCollection> g_tcpclientthreads;
 
-void* tcpClientThread(int pipefd)
+void tcpClientThread(int pipefd)
 {
   /* we get launched with a pipe on which we receive file descriptors from clients that we own
      from that point on */
@@ -688,13 +688,12 @@ void* tcpClientThread(int pipefd)
       lastTCPCleanup = time(nullptr);
     }
   }
-  return 0;
 }
 
 /* spawn as many of these as required, they call Accept on a socket on which they will accept queries, and 
    they will hand off to worker threads & spawn more of them if required
 */
-void* tcpAcceptorThread(void* p)
+void tcpAcceptorThread(void* p)
 {
   setThreadName("dnsdist/tcpAcce");
   ClientState* cs = (ClientState*) p;
@@ -785,6 +784,4 @@ void* tcpAcceptorThread(void* p)
     }
     catch(...){}
   }
-
-  return 0;
 }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -427,7 +427,7 @@ static void pickBackendSocketsReadyForReceiving(const std::shared_ptr<Downstream
 }
 
 // listens on a dedicated socket, lobs answers from downstream servers to original requestors
-void* responderThread(std::shared_ptr<DownstreamState> dss)
+void responderThread(std::shared_ptr<DownstreamState> dss)
 try {
   setThreadName("dnsdist/respond");
   auto localRespRulactions = g_resprulactions.getLocal();
@@ -565,22 +565,18 @@ try {
       vinfolog("Got an error in UDP responder thread while parsing a response from %s, id %d: %s", dss->remote.toStringWithPort(), queryId, e.what());
     }
   }
-  return nullptr;
 }
 catch(const std::exception& e)
 {
   errlog("UDP responder thread died because of exception: %s", e.what());
-  return nullptr;
 }
 catch(const PDNSException& e)
 {
   errlog("UDP responder thread died because of PowerDNS exception: %s", e.reason);
-  return nullptr;
 }
 catch(...)
 {
   errlog("UDP responder thread died because of an exception: %s", "unknown");
-  return nullptr;
 }
 
 bool DownstreamState::reconnect()
@@ -1643,7 +1639,7 @@ static void MultipleMessagesUDPClientThread(ClientState* cs, LocalHolders& holde
 #endif /* defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE) */
 
 // listens to incoming queries, sends out to downstream servers, noting the intended return path
-static void* udpClientThread(ClientState* cs)
+static void udpClientThread(ClientState* cs)
 try
 {
   setThreadName("dnsdist/udpClie");
@@ -1685,23 +1681,18 @@ try
       processUDPQuery(*cs, holders, &msgh, remote, dest, packet, static_cast<uint16_t>(got), s_udpIncomingBufferSize, nullptr, nullptr, nullptr, nullptr);
     }
   }
-
-  return nullptr;
 }
 catch(const std::exception &e)
 {
   errlog("UDP client thread died because of exception: %s", e.what());
-  return nullptr;
 }
 catch(const PDNSException &e)
 {
   errlog("UDP client thread died because of PowerDNS exception: %s", e.reason);
-  return nullptr;
 }
 catch(...)
 {
   errlog("UDP client thread died because of an exception: %s", "unknown");
-  return nullptr;
 }
 
 uint16_t getRandomDNSID()
@@ -1844,7 +1835,7 @@ uint64_t g_maxTCPClientThreads{10};
 std::atomic<uint16_t> g_cacheCleaningDelay{60};
 std::atomic<uint16_t> g_cacheCleaningPercentage{100};
 
-void* maintThread()
+void maintThread()
 {
   setThreadName("dnsdist/main");
   int interval = 1;
@@ -1888,10 +1879,9 @@ void* maintThread()
 
     // ponder pruning g_dynblocks of expired entries here
   }
-  return nullptr;
 }
 
-static void* secPollThread()
+static void secPollThread()
 {
   setThreadName("dnsdist/secpoll");
 
@@ -1903,10 +1893,9 @@ static void* secPollThread()
     }
     sleep(g_secPollInterval);
   }
-  return 0;
 }
 
-static void* healthChecksThread()
+static void healthChecksThread()
 {
   setThreadName("dnsdist/healthC");
 
@@ -1995,7 +1984,6 @@ static void* healthChecksThread()
       }
     }
   }
-  return nullptr;
 }
 
 static void bindAny(int af, int sock)

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -51,7 +51,7 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
-void* carbonDumpThread();
+void carbonDumpThread();
 uint64_t uptimeOfProcess(const std::string& str);
 
 extern uint16_t g_ECSSourcePrefixV4;
@@ -759,7 +759,7 @@ using servers_t =vector<std::shared_ptr<DownstreamState>>;
 
 template <class T> using NumberedVector = std::vector<std::pair<unsigned int, T> >;
 
-void* responderThread(std::shared_ptr<DownstreamState> state);
+void responderThread(std::shared_ptr<DownstreamState> state);
 extern std::mutex g_luamutex;
 extern LuaContext g_lua;
 extern std::string g_outputBuffer; // locking for this is ok, as locked by g_luamutex
@@ -1006,7 +1006,7 @@ void setWebserverCustomHeaders(const boost::optional<std::map<std::string, std::
 void dnsdistWebserverThread(int sock, const ComboAddress& local);
 bool getMsgLen32(int fd, uint32_t* len);
 bool putMsgLen32(int fd, uint32_t len);
-void* tcpAcceptorThread(void* p);
+void tcpAcceptorThread(void* p);
 
 void setLuaNoSideEffect(); // if nothing has been declared, set that there are no side effects
 void setLuaSideEffect();   // set to report a side effect, cancelling all _no_ side effect calls


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
