### PR TITLE
Make recursor & dnsdist communicate (ECS) 'variable' status

### DIFF
--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -53,6 +53,7 @@ public:
   uint64_t getTTLTooShorts() const { return d_ttlTooShorts; }
   uint64_t getEntriesCount();
   uint64_t dump(int fd);
+  bool isECSParsingEnabled() const { return d_parseECS; }
 
   static uint32_t getMinTTL(const char* packet, uint16_t length, bool* seenNoDataSOA);
   static uint32_t getKey(const std::string& qname, uint16_t consumed, const unsigned char* packet, uint16_t packetLen, bool tcp);

--- a/pdns/dnsdist-ecs.cc
+++ b/pdns/dnsdist-ecs.cc
@@ -488,7 +488,7 @@ int removeEDNSOptionFromOPT(char* optStart, size_t* optLen, const uint16_t optio
   return 0;
 }
 
-bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const size_t optLen, const uint16_t optionCodeToFind)
+bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const size_t optLen, const uint16_t optionCodeToFind, size_t* optContentStart, uint16_t* optContentLen)
 {
   /* we need at least:
    root label (1), type (2), class (2), ttl (4) + rdlen (2)*/
@@ -508,10 +508,20 @@ bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const s
     p += sizeof(optionCode);
     const uint16_t optionLen = 0x100*packet.at(p) + packet.at(p+1);
     p += sizeof(optionLen);
+
     if ((p + optionLen) > rdEnd) {
       return false;
     }
+
     if (optionCode == optionCodeToFind) {
+      if (optContentStart != nullptr) {
+        *optContentStart = p;
+      }
+
+      if (optContentLen != nullptr) {
+        *optContentLen = optionLen;
+      }
+
       return true;
     }
     p += optionLen;
@@ -731,4 +741,3 @@ bool queryHasEDNS(const DNSQuestion& dq)
 
   return false;
 }
-

--- a/pdns/dnsdist-ecs.hh
+++ b/pdns/dnsdist-ecs.hh
@@ -31,7 +31,7 @@ void generateECSOption(const ComboAddress& source, string& res, uint16_t ECSPref
 int removeEDNSOptionFromOPT(char* optStart, size_t* optLen, const uint16_t optionCodeToRemove);
 int rewriteResponseWithoutEDNSOption(const std::string& initialPacket, const uint16_t optionCodeToSkip, vector<uint8_t>& newContent);
 int getEDNSOptionsStart(const char* packet, const size_t offset, const size_t len, uint16_t* optRDPosition, size_t * remaining);
-bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const size_t optLen, const uint16_t optionCodeToFind);
+bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const size_t optLen, const uint16_t optionCodeToFind, size_t* optContentStart = nullptr, uint16_t* optContentLen = nullptr);
 bool addEDNS(dnsheader* dh, uint16_t& len, const size_t size, bool dnssecOK, uint16_t payloadSize);
 bool addEDNSToQueryTurnedResponse(DNSQuestion& dq);
 
@@ -42,4 +42,3 @@ bool parseEDNSOptions(DNSQuestion& dq);
 
 int getEDNSZ(const DNSQuestion& dq);
 bool queryHasEDNS(const DNSQuestion& dq);
-

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -348,6 +348,10 @@ void setupLuaConfig(bool client)
 			  ret->useECS=boost::get<bool>(vars["useClientSubnet"]);
 			}
 
+			if(vars.count("disableZeroScope")) {
+			  ret->disableZeroScope=boost::get<bool>(vars["disableZeroScope"]);
+			}
+
 			if(vars.count("ipBindAddrNoPort")) {
 			  ret->ipBindAddrNoPort=boost::get<bool>(vars["ipBindAddrNoPort"]);
 			}

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -448,7 +448,7 @@ void tcpClientThread(int pipefd)
 
         if (dq.useECS && ((ds && ds->useECS) || (!ds && serverPool->getECS()))) {
           // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
-          if (packetCache && !dq.skipCache && !ds->disableZeroScope && packetCache->isECSParsingEnabled()) {
+          if (packetCache && !dq.skipCache && (!ds || !ds->disableZeroScope) && packetCache->isECSParsingEnabled()) {
             if (packetCache->get(dq, consumed, dq.dh->id, cachedResponse, &cachedResponseSize, &cacheKeyNoECS, subnet, dnssecOK, allowExpired)) {
               DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, (dnsheader*) cachedResponse, sizeof cachedResponse, cachedResponseSize, true, &queryRealTime);
 #ifdef HAVE_PROTOBUF

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -433,21 +433,56 @@ void tcpClientThread(int pipefd)
           ds = policy.policy(servers, &dq);
         }
 
+        uint32_t cacheKeyNoECS = 0;
+        uint32_t cacheKey = 0;
+        boost::optional<Netmask> subnet;
+        char cachedResponse[4096];
+        uint16_t cachedResponseSize = sizeof cachedResponse;
+        uint32_t allowExpired = ds ? 0 : g_staleCacheEntriesTTL;
+        bool useZeroScope = false;
+
+        bool dnssecOK = false;
+        if (packetCache && !dq.skipCache) {
+          dnssecOK = (getEDNSZ(dq) & EDNS_HEADER_FLAG_DO);
+        }
+
         if (dq.useECS && ((ds && ds->useECS) || (!ds && serverPool->getECS()))) {
+          // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
+          if (packetCache && !dq.skipCache && !ds->disableZeroScope && packetCache->isECSParsingEnabled()) {
+            if (packetCache->get(dq, consumed, dq.dh->id, cachedResponse, &cachedResponseSize, &cacheKeyNoECS, subnet, dnssecOK, allowExpired)) {
+              DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, (dnsheader*) cachedResponse, sizeof cachedResponse, cachedResponseSize, true, &queryRealTime);
+#ifdef HAVE_PROTOBUF
+              dr.uniqueId = dq.uniqueId;
+#endif
+              dr.qTag = dq.qTag;
+
+              if (!processResponse(holders.cacheHitRespRulactions, dr, &delayMsec)) {
+                goto drop;
+              }
+
+#ifdef HAVE_DNSCRYPT
+              if (!encryptResponse(cachedResponse, &cachedResponseSize, sizeof cachedResponse, true, dnsCryptQuery, nullptr, nullptr)) {
+                goto drop;
+              }
+#endif
+              handler.writeSizeAndMsg(cachedResponse, cachedResponseSize, g_tcpSendTimeout);
+              g_stats.cacheHits++;
+              continue;
+            }
+
+            if (!subnet) {
+              /* there was no existing ECS on the query, enable the zero-scope feature */
+              useZeroScope = true;
+            }
+          }
+
           if (!handleEDNSClientSubnet(dq, &(ednsAdded), &(ecsAdded), g_preserveTrailingData)) {
             vinfolog("Dropping query from %s because we couldn't insert the ECS value", ci.remote.toStringWithPort());
             goto drop;
           }
         }
 
-        uint32_t cacheKey = 0;
-        boost::optional<Netmask> subnet;
-        bool dnssecOK = false;
         if (packetCache && !dq.skipCache) {
-          char cachedResponse[4096];
-          uint16_t cachedResponseSize = sizeof cachedResponse;
-          uint32_t allowExpired = ds ? 0 : g_staleCacheEntriesTTL;
-          dnssecOK = (getEDNSZ(dq) & EDNS_HEADER_FLAG_DO);
           if (packetCache->get(dq, (uint16_t) consumed, dq.dh->id, cachedResponse, &cachedResponseSize, &cacheKey, subnet, dnssecOK, allowExpired)) {
             DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, (dnsheader*) cachedResponse, sizeof cachedResponse, cachedResponseSize, true, &queryRealTime);
 #ifdef HAVE_PROTOBUF
@@ -616,7 +651,8 @@ void tcpClientThread(int pipefd)
           break;
         }
         firstPacket=false;
-        if (!fixUpResponse(&response, &responseLen, &responseSize, qname, origFlags, ednsAdded, ecsAdded, rewrittenResponse, addRoom)) {
+        bool zeroScope = false;
+        if (!fixUpResponse(&response, &responseLen, &responseSize, qname, origFlags, ednsAdded, ecsAdded, rewrittenResponse, addRoom, useZeroScope ? &zeroScope : nullptr)) {
           break;
         }
 
@@ -632,7 +668,19 @@ void tcpClientThread(int pipefd)
         }
 
 	if (packetCache && !dq.skipCache) {
-	  packetCache->insert(cacheKey, subnet, origFlags, dnssecOK, qname, qtype, qclass, response, responseLen, true, dh->rcode, dq.tempFailureTTL);
+          if (!useZeroScope) {
+            /* if the query was not suitable for zero-scope, for
+               example because it had an existing ECS entry so the hash is
+               not really 'no ECS', so just insert it for the existing subnet
+               since:
+               - we don't have the correct hash for a non-ECS query
+               - inserting with hash computed before the ECS replacement but with
+               the subnet extracted _after_ the replacement would not work.
+            */
+            zeroScope = false;
+          }
+          // if zeroScope, pass the pre-ECS hash-key and do not pass the subnet to the cache
+          packetCache->insert(zeroScope ? cacheKeyNoECS : cacheKey, zeroScope ? boost::none : subnet, origFlags, dnssecOK, qname, qtype, qclass, response, responseLen, true, dh->rcode, dq.tempFailureTTL);
 	}
 
 #ifdef HAVE_DNSCRYPT

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1451,7 +1451,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
 
     if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
       // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
-      if (packetCache && !dq.skipCache && !ss->disableZeroScope && packetCache->isECSParsingEnabled()) {
+      if (packetCache && !dq.skipCache && (!ss || !ss->disableZeroScope) && packetCache->isECSParsingEnabled()) {
         if (packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKeyNoECS, subnet, dnssecOK, allowExpired)) {
           sendAndEncryptUDPResponse(holders, cs, dq, query, cachedResponseSize, dnsCryptQuery, delayMsec, dest, responsesVect, queuedResponses, respIOV, respCBuf, true);
           return;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1417,8 +1417,6 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
         dnssecOK = (getEDNSZ(dq) & EDNS_HEADER_FLAG_DO);
       }
 
-      uint16_t cachedResponseSize = dq.size;
-      uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
       boost::optional<Netmask> subnet;
       if (packetCache && !dq.skipCache && packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKeyNoECS, subnet, dnssecOK, allowExpired)) {
         goto sendIt;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -301,8 +301,10 @@ bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize,
     int res = locateEDNSOptRR(responseStr, &optStart, &optLen, &last);
 
     if (res == 0) {
-      if(zeroScope)
-        *zeroScope = optLen > 18 && !responseStr.at(optStart + 18);
+      if(zeroScope) { // this finds if an EDNS scope was set, and if it is 0
+        *zeroScope = optLen > 18 && !responseStr.at(optStart + 18) && !responseStr.at(optStart + 11) && responseStr.at(optStart + 12) ==8;
+      }
+      // this test only detects a /0 if ECS is the first option
 
       if (ednsAdded) {
         /* we added the entire OPT RR,

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1411,13 +1411,12 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     boost::optional<Netmask> subnet;
     uint16_t cachedResponseSize = dq.size;
     uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
-    
-    if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
-      if (packetCache && !dq.skipCache) {
-        dnssecOK = (getEDNSZ(dq) & EDNS_HEADER_FLAG_DO);
-      }
 
-      boost::optional<Netmask> subnet;
+    if (packetCache && !dq.skipCache) {
+      dnssecOK = (getEDNSZ(dq) & EDNS_HEADER_FLAG_DO);
+    }
+
+    if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
       if (packetCache && !dq.skipCache && packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKeyNoECS, subnet, dnssecOK, allowExpired)) {
         goto sendIt;
       }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -528,7 +528,8 @@ struct IDState
   std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
   std::shared_ptr<QTag> qTag{nullptr};
   const ClientState* cs{nullptr};
-  uint32_t cacheKey;                                          // 8
+  uint32_t cacheKey;                                          // 4
+  uint32_t cacheKeyNoECS;                                     // 4
   uint16_t age;                                               // 4
   uint16_t qtype;                                             // 2
   uint16_t qclass;                                            // 2
@@ -1019,7 +1020,7 @@ bool responseContentMatches(const char* response, const uint16_t responseLen, co
 bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int* delayMsec, const struct timespec& now);
 bool processResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, int* delayMsec);
 bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags);
-bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom);
+bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope=0);
 void restoreFlags(struct dnsheader* dh, uint16_t origFlags);
 bool checkQueryHeaders(const struct dnsheader* dh);
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -543,6 +543,7 @@ struct IDState
   bool skipCache{false};
   bool destHarvested{false}; // if true, origDest holds the original dest addr, otherwise the listening addr
   bool dnssecOK{false};
+  bool useZeroScope;
 };
 
 typedef std::unordered_map<string, unsigned int> QueryCountRecords;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -423,7 +423,8 @@ public:
   {
     auto delta = d_prev.udiffAndSet();
 
-    d_tokens += 1.0 * rate * (delta/1000000.0);
+    if(delta > 0.0) // time, frequently, does go backwards..
+      d_tokens += 1.0 * rate * (delta/1000000.0);
 
     if(d_tokens > burst) {
       d_tokens = burst;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -718,6 +718,7 @@ struct DownstreamState
   bool upStatus{false};
   bool useECS{false};
   bool setCD{false};
+  bool disableZeroScope{false};
   std::atomic<bool> connected{false};
   std::atomic_flag threadStarted;
   bool tcpFastOpen{false};
@@ -1022,7 +1023,7 @@ bool responseContentMatches(const char* response, const uint16_t responseLen, co
 bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int* delayMsec, const struct timespec& now);
 bool processResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, int* delayMsec);
 bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags);
-bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope=0);
+bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope);
 void restoreFlags(struct dnsheader* dh, uint16_t origFlags);
 bool checkQueryHeaders(const struct dnsheader* dh);
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -349,7 +349,8 @@ Servers
                              --   "address@interface", e.g. "192.0.2.2@eth0"
       addXPF=NUM,            -- Add the client's IP address and port to the query, along with the original destination address and port,
                              -- using the experimental XPF record from `draft-bellis-dnsop-xpf <https://datatracker.ietf.org/doc/draft-bellis-dnsop-xpf/>`_ and the specified option code. Default is disabled (0)
-      sockets=NUM            -- Number of sockets (and thus source ports) used toward the backend server, defaults to a single one
+      sockets=NUM,           -- Number of sockets (and thus source ports) used toward the backend server, defaults to a single one
+      disableZeroScope       -- Disable the EDNS Client Subnet 'zero scope' feature, which does a cache lookup for an answer valid for all subnets (ECS scope of 0) before adding ECS information to the query and doing the regular lookup
     })
 
   :param str server_string: A simple IP:PORT string.

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1486,7 +1486,7 @@ static void startDoResolve(void *p)
     }
   sendit:;
 
-    if(g_useIncomingECS && dc->d_ecsFound && (!sr.wasVariable() && !variableAnswer)) {
+    if(g_useIncomingECS && dc->d_ecsFound && !sr.wasVariable() && !variableAnswer) {
       //      cerr<<"Stuffing in a 0 scope because answer is static"<<endl;
       EDNSSubnetOpts eo;
       eo.source = dc->d_ednssubnet.source;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1486,6 +1486,17 @@ static void startDoResolve(void *p)
     }
   sendit:;
 
+    if(g_useIncomingECS && haveEDNS && !sr.wasVariable()) {
+      EDNSSubnetOpts eo;
+      eo.source = dc->d_ednssubnet.source;
+      ComboAddress sa;
+      memset(&sa, 0, sizeof(sa));
+      sa.sin4.sin_family = eo.source.getNetwork().sin4.sin_family;
+      eo.scope = Netmask(sa, 0);
+
+      returnedEdnsOptions.push_back(make_pair(EDNSOptionCode::ECS, makeEDNSSubnetOptsString(eo)));
+    }
+
     if (haveEDNS) {
       /* we try to add the EDNS OPT RR even for truncated answers,
          as rfc6891 states:

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1487,6 +1487,7 @@ static void startDoResolve(void *p)
   sendit:;
 
     if(g_useIncomingECS && haveEDNS && !sr.wasVariable()) {
+      //      cerr<<"Stuffing in a 0 scope because answer is static"<<endl;
       EDNSSubnetOpts eo;
       eo.source = dc->d_ednssubnet.source;
       ComboAddress sa;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1486,12 +1486,12 @@ static void startDoResolve(void *p)
     }
   sendit:;
 
-    if(g_useIncomingECS && haveEDNS && !sr.wasVariable()) {
+    if(g_useIncomingECS && dc->d_ecsFound && !sr.wasVariable()) {
       //      cerr<<"Stuffing in a 0 scope because answer is static"<<endl;
       EDNSSubnetOpts eo;
       eo.source = dc->d_ednssubnet.source;
       ComboAddress sa;
-      memset(&sa, 0, sizeof(sa));
+      sa.reset();
       sa.sin4.sin_family = eo.source.getNetwork().sin4.sin_family;
       eo.scope = Netmask(sa, 0);
 
@@ -1568,7 +1568,7 @@ static void startDoResolve(void *p)
         g_log<<Logger::Warning<<"Sending UDP reply to client "<<dc->getRemote()<<" failed with: "<<strerror(errno)<<endl;
 
       if(variableAnswer || sr.wasVariable()) {
-	g_stats.variableResponses++;
+        g_stats.variableResponses++;
       }
       if(!SyncRes::s_nopacketcache && !variableAnswer && !sr.wasVariable() ) {
         t_packetCache->insertResponsePacket(dc->d_tag, dc->d_qhash, std::move(dc->d_query), dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_mdp.d_qclass,

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1567,6 +1567,9 @@ static void startDoResolve(void *p)
       if(sendmsg(dc->d_socket, &msgh, 0) < 0 && g_logCommonErrors) 
         g_log<<Logger::Warning<<"Sending UDP reply to client "<<dc->getRemote()<<" failed with: "<<strerror(errno)<<endl;
 
+      if(variableAnswer || sr.wasVariable()) {
+	g_stats.variableResponses++;
+      }
       if(!SyncRes::s_nopacketcache && !variableAnswer && !sr.wasVariable() ) {
         t_packetCache->insertResponsePacket(dc->d_tag, dc->d_qhash, std::move(dc->d_query), dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_mdp.d_qclass,
                                             string((const char*)&*packet.begin(), packet.size()),

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1486,7 +1486,7 @@ static void startDoResolve(void *p)
     }
   sendit:;
 
-    if(g_useIncomingECS && dc->d_ecsFound && !sr.wasVariable()) {
+    if(g_useIncomingECS && dc->d_ecsFound && (!sr.wasVariable() && !variableAnswer)) {
       //      cerr<<"Stuffing in a 0 scope because answer is static"<<endl;
       EDNSSubnetOpts eo;
       eo.source = dc->d_ednssubnet.source;

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -112,6 +112,7 @@ static const oid truncatedDropsOID[] = { RECURSOR_STATS_OID, 93 };
 static const oid emptyQueriesOID[] = { RECURSOR_STATS_OID, 94 };
 static const oid dnssecAuthenticDataQueriesOID[] = { RECURSOR_STATS_OID, 95 };
 static const oid dnssecCheckDisabledQueriesOID[] = { RECURSOR_STATS_OID, 96 };
+static const oid variableResponsesOID[] = { RECURSOR_STATS_OID, 97 };
 
 static std::unordered_map<oid, std::string> s_statsMap;
 
@@ -226,6 +227,7 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   registerCounter64Stat("query-pipe-full-drops", queryPipeFullDropsOID, OID_LENGTH(queryPipeFullDropsOID));
   registerCounter64Stat("truncated-drops", truncatedDropsOID, OID_LENGTH(truncatedDropsOID));
   registerCounter64Stat("empty-queries", emptyQueriesOID, OID_LENGTH(emptyQueriesOID));
+  registerCounter64Stat("variable-responses", variableResponsesOID, OID_LENGTH(variableResponsesOID));
   registerCounter64Stat("answers0-1", answers01OID, OID_LENGTH(answers01OID));
   registerCounter64Stat("answers1-10", answers110OID, OID_LENGTH(answers110OID));
   registerCounter64Stat("answers10-100", answers10100OID, OID_LENGTH(answers10100OID));

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1013,8 +1013,11 @@ void registerAllStats()
   addGetStat("edns-ping-matches", &g_stats.ednsPingMatches);
   addGetStat("edns-ping-mismatches", &g_stats.ednsPingMismatches);
   addGetStat("dnssec-queries", &g_stats.dnssecQueries);
+
   addGetStat("dnssec-authentic-data-queries", &g_stats.dnssecAuthenticDataQueries);
   addGetStat("dnssec-check-disabled-queries", &g_stats.dnssecCheckDisabledQueries);
+
+  addGetStat("variable-responses", &g_stats.variableResponses);
 
   addGetStat("noping-outqueries", &g_stats.noPingOutQueries);
   addGetStat("noedns-outqueries", &g_stats.noEdnsOutQueries);

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -801,6 +801,14 @@ dnssecCheckDisabledQueries OBJECT-TYPE
         "Number of queries received with the CD bit set"
     ::= { stats 96 }
 
+variableResponses OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of variable responses"
+    ::= { stats 97 }
+
 ---
 --- Traps / Notifications
 ---
@@ -938,7 +946,8 @@ recGroup OBJECT-GROUP
         truncatedDrops,
         emptyQueries,
         dnssecAuthenticDataQueries,
-        dnssecCheckDisabledQueries
+        dnssecCheckDisabledQueries,
+        variableResponses,
         trapReason
     }
     STATUS current

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -477,7 +477,7 @@ number of CPU milliseconds spent in 'user' mode
 .. _stat-x-our-latency:
 
 variable-responses
-^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 .. versionadded:: 4.2
 
 Reponses that were marked as 'variable'. This could be because of EDNS

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -476,6 +476,14 @@ number of CPU milliseconds spent in 'user' mode
 
 .. _stat-x-our-latency:
 
+variable-responses
+^^^^^^^^^^^^^
+.. versionadded:: 4.2
+
+Reponses that were marked as 'variable'. This could be because of EDNS
+Client Subnet or Lua rules that indicate this variable status (dependent on
+time or who is asking, for example).
+
 x-our-latency
 ^^^^^^^^^^^^^
 .. versionadded:: 4.1

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -932,6 +932,7 @@ struct RecursorStats
   std::atomic<uint64_t> dnssecQueries;
   std::atomic<uint64_t> dnssecAuthenticDataQueries;
   std::atomic<uint64_t> dnssecCheckDisabledQueries;
+  std::atomic<uint64_t> variableResponses;
   unsigned int maxMThreadStackUsage;
   std::atomic<uint64_t> dnssecValidations; // should be the sum of all dnssecResult* stats
   std::map<vState, std::atomic<uint64_t> > dnssecResults;

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -1831,8 +1831,6 @@ class TestCachingScopeZero(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, scopedResponse)
             receivedQuery.id = expectedQuery.id
             self.checkMessageEDNSWithECS(expectedQuery, receivedQuery)
-            print(receivedResponse)
-            print(expectedResponse)
             self.checkMessageEDNSWithECS(receivedResponse, expectedResponse)
 
         # it should still have been cached, though, so the next query should be a hit


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Rebase of #7035 + some additional fixes.

DO NOT MERGE - code works, but needs review
When recursor uses EDNS Client Subnet, a minority of domain names start getting variable answers depending on who is asking. The recursor cache is aware of how this works. However, when the recursor hides behind dnsdist, the dnsdist cache is not aware of which domains are variable or not.

With this PR, when the recursor is configured to 'use-incoming-edns-subnet', it will add a /0 ECS scope to responses that are not variable.

Meanwhile with this PR, dnsdist learns that /0 answers from backends are invariant, and uses these for anyone who asks, independent of source address. The details are described more fully in this gist: https://gist.github.com/ahupowerdns/cebbddb1cee967c4c6b31176c213dcb8

This code has been tested in production and positively zooms.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
