### PR TITLE
auth: geoip - Fix static lookup when using weighted records on multiple record types

### DIFF
--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -221,7 +221,7 @@ Using the ``weight`` attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use record attributes to define positive and non-zero weight.
-If this is given, only one record is chosen randomly based on the weight.
+If this is given, only one record per type is chosen randomly based on the weight.
 
 Probability is calculated by summing up the weights and dividing each weight with the sum.
 

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -261,24 +261,30 @@ void GeoIPBackend::initialize() {
 
     // finally fix weights
     for(auto &item: dom.records) {
-      float weight=0;
-      float sum=0;
+      map<uint16_t, float> weights;
+      map<uint16_t, float> sums;
+      map<uint16_t, GeoIPDNSResourceRecord> lasts;
       bool has_weight=false;
       // first we look for used weight
       for(const auto &rr: item.second) {
-        weight+=rr.weight;
+        weights[rr.qtype.getCode()] += rr.weight;
         if (rr.has_weight) has_weight = true;
       }
       if (has_weight) {
         // put them back as probabilities and values..
         for(auto &rr: item.second) {
-          rr.weight=static_cast<int>((static_cast<float>(rr.weight) / weight)*1000.0);
-          sum += rr.weight;
+          uint16_t rr_type = rr.qtype.getCode();
+          rr.weight=static_cast<int>((static_cast<float>(rr.weight) / weights[rr_type])*1000.0);
+          sums[rr_type] += rr.weight;
           rr.has_weight = has_weight;
+          lasts[rr_type] = rr;
         }
         // remove rounding gap
-        if (sum < 1000)
-          item.second.back().weight += (1000-sum);
+        for(auto &x: lasts) {
+          float sum = sums[x.first];
+          if (sum < 1000)
+            x.second.weight += (1000-sum);
+        }
       }
     }
 
@@ -307,15 +313,15 @@ GeoIPBackend::~GeoIPBackend() {
 
 bool GeoIPBackend::lookup_static(const GeoIPDomain &dom, const DNSName &search, const QType &qtype, const DNSName& qdomain, const std::string &ip, GeoIPNetmask &gl, bool v6) {
   const auto& i = dom.records.find(search);
-  int cumul_probability = 0;
+  map<uint16_t,int> cumul_probabilities;
   int probability_rnd = 1+(dns_random(1000)); // setting probability=0 means it never is used
 
   if (i != dom.records.end()) { // return static value
     for(const auto& rr : i->second) {
       if (rr.has_weight) {
         gl.netmask = (v6?128:32);
-        int comp = cumul_probability;
-        cumul_probability += rr.weight;
+        int comp = cumul_probabilities[rr.qtype.getCode()];
+        cumul_probabilities[rr.qtype.getCode()] += rr.weight;
         if (rr.weight == 0 || probability_rnd < comp || probability_rnd > (comp + rr.weight))
           continue;
       }

--- a/modules/geoipbackend/regression-tests/mixed-weight-resolution/command
+++ b/modules/geoipbackend/regression-tests/mixed-weight-resolution/command
@@ -1,0 +1,5 @@
+#!/bin/sh
+cleandig mixed_weight.geo.example.com A
+cleandig mixed_weight.geo.example.com TXT
+cleandig mixed_weight.geo.example.com ANY tcp
+

--- a/modules/geoipbackend/regression-tests/mixed-weight-resolution/description
+++ b/modules/geoipbackend/regression-tests/mixed-weight-resolution/description
@@ -1,0 +1,2 @@
+This test ensure we can query all available QType of a mixed weighted
+GeoIP record.

--- a/modules/geoipbackend/regression-tests/mixed-weight-resolution/expected_result
+++ b/modules/geoipbackend/regression-tests/mixed-weight-resolution/expected_result
@@ -1,0 +1,10 @@
+0	mixed_weight.geo.example.com.	IN	A	30	127.0.0.1
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='mixed_weight.geo.example.com.', qtype=A
+0	mixed_weight.geo.example.com.	IN	TXT	30	"text"
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='mixed_weight.geo.example.com.', qtype=TXT
+0	mixed_weight.geo.example.com.	IN	A	30	127.0.0.1
+0	mixed_weight.geo.example.com.	IN	TXT	30	"text"
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='mixed_weight.geo.example.com.', qtype=ANY

--- a/regression-tests/backends/geoip-master
+++ b/regression-tests/backends/geoip-master
@@ -26,6 +26,13 @@ domains:
       - ns: ns1.example.com
       - ns: ns2.example.com
       - mx: 10 mx.example.com
+    mixed_weight.geo.example.com:
+      - a:
+          content: "%ip4"
+          weight: 10
+      - txt:
+          content: text
+          weight: 10
     ip.geo.example.com:
       - a: "%ip4"
       - aaaa: "%ip6"


### PR DESCRIPTION
### Short description
Computes the record weight/probability per QType and adapt the code to avoid empty answer in a mixed-weighted-Qtype situation.

Closes #7051.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)