### PR TITLE
ixfrdist: Preserve the correct TTL for SOA records

### DIFF
--- a/pdns/ixfrutils.cc
+++ b/pdns/ixfrutils.cc
@@ -166,7 +166,7 @@ void loadZoneFromDisk(records_t& records, const string& fname, const DNSName& zo
  * Load the zone `zone` from `fname` and put the first found SOA into `soa`
  * Does NOT check for nullptr
  */
-void loadSOAFromDisk(const DNSName& zone, const string& fname, shared_ptr<SOARecordContent>& soa)
+void loadSOAFromDisk(const DNSName& zone, const string& fname, shared_ptr<SOARecordContent>& soa, uint32_t& soaTTL)
 {
   ZoneParserTNG zpt(fname, zone);
   DNSResourceRecord rr;
@@ -174,6 +174,7 @@ void loadSOAFromDisk(const DNSName& zone, const string& fname, shared_ptr<SOARec
   while(zpt.get(rr)) {
     if (rr.qtype == QType::SOA) {
       soa = getRR<SOARecordContent>(DNSRecord(rr));
+      soaTTL = rr.ttl;
       return;
     }
   }

--- a/pdns/ixfrutils.hh
+++ b/pdns/ixfrutils.hh
@@ -54,4 +54,4 @@ uint32_t getSerialsFromDir(const std::string& dir);
 uint32_t getSerialFromRecords(const records_t& records, DNSRecord& soaret);
 void writeZoneToDisk(const records_t& records, const DNSName& zone, const std::string& directory);
 void loadZoneFromDisk(records_t& records, const string& fname, const DNSName& zone);
-void loadSOAFromDisk(const DNSName& zone, const string& fname, shared_ptr<SOARecordContent>& soa);
+void loadSOAFromDisk(const DNSName& zone, const string& fname, shared_ptr<SOARecordContent>& soa, uint32_t& soaTTL);

--- a/regression-tests.ixfrdist/test_IXFR.py
+++ b/regression-tests.ixfrdist/test_IXFR.py
@@ -106,6 +106,14 @@ class IXFRDistBasicTest(IXFRDistTest):
 
         # answers[1].sort(key=lambda rrset: (rrset.name, rrset.rdtype))
         self.assertEqual(answers, expected)
+        # check the TTLs
+        answerPos = 0
+        for expectedAnswer in expected:
+            pos = 0
+            for rec in expectedAnswer:
+                self.assertEquals(rec.ttl, answers[answerPos][pos].ttl)
+                pos = pos + 1
+            answerPos = answerPos + 1
 
     def test_a_XFR(self):
         self.waitUntilCorrectSerialIsLoaded(1)
@@ -124,6 +132,11 @@ class IXFRDistBasicTest(IXFRDistTest):
 
         response = self.sendUDPQuery(query)
         self.assertEquals(expected, response)
+        # check the TTLs
+        pos = 0
+        for rec in expected.answer:
+            self.assertEquals(rec.ttl, response.answer[pos].ttl)
+            pos = pos + 1
 
     def test_b_UDP_SOA_not_loaded(self):
         query = dns.message.make_query('example2.', 'SOA')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`ixfrdist` was arbitrarily using a TTL of `3600` for `SOA` records.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
