### PR TITLE
auth: geoip - forbid 0 as weight value

### DIFF
--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -220,7 +220,7 @@ These placeholders disable caching for the record completely:
 Using the ``weight`` attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can use record attributes to define weight.
+You can use record attributes to define positive and non-zero weight.
 If this is given, only one record is chosen randomly based on the weight.
 
 Probability is calculated by summing up the weights and dividing each weight with the sum.

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -150,9 +150,9 @@ void GeoIPBackend::initialize() {
                rr.content = content;
              } else if (attr == "weight") {
                rr.weight = iter->second.as<int>();
-               if (rr.weight < 0) {
-                 g_log<<Logger::Error<<"Weight cannot be negative for " << rr.qname << endl;
-                 throw PDNSException(string("Weight cannot be negative for ") + rr.qname.toLogString());
+               if (rr.weight <= 0) {
+                 g_log<<Logger::Error<<"Weight must be positive for " << rr.qname << endl;
+                 throw PDNSException(string("Weight must be positive for ") + rr.qname.toLogString());
                }
                rr.has_weight = true;
              } else if (attr == "ttl") {


### PR DESCRIPTION
### Short description
In the case where the weight of all records is set to zero, former code was trying to compute probability by dividing by 0.

Another motivation to forbid the use of the "zero" weight is that the desired behavior was not clear.

This has been asked by @rgacogne in #7219 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)