### PR TITLE
Make api changes do a rectify by default, add an option to disable

### DIFF
--- a/docs/domainmetadata.rst
+++ b/docs/domainmetadata.rst
@@ -56,7 +56,9 @@ This metadata item controls whether or not a zone is fully rectified on changes
 to the contents of a zone made through the :doc:`API <http-api/index>`.
 
 When the ``API-RECTIFY`` value is "1", the zone will be rectified on changes.
-Any other other value means that it will not be rectified.
+Any other other value means that it will not be rectified. If this is not set
+at all, rectifying of the zone depends on the config variable
+:ref:`setting-default-api-rectify`.
 
 .. _metadata-axfr-source:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -300,6 +300,20 @@ Debugging switch - don't use.
 
 Operate as a daemon.
 
+.. _setting-default-api-rectify:
+
+``default-api-rectify``
+-----------------------
+-  Boolean
+-  Default: yes
+
+.. versionadded:: 4.2.0
+
+The value of :ref:`metadata-api-rectify` if it is not set on the zone.
+
+.. note::
+  Pre 4.2.0 the default was always no.
+
 .. _setting-default-ksk-algorithms:
 .. _setting-default-ksk-algorithm:
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -95,6 +95,7 @@ void declareArguments()
   ::arg().set("retrieval-threads", "Number of AXFR-retrieval threads for slave operation")="2";
   ::arg().setSwitch("api", "Enable/disable the REST API (including HTTP listener)")="no";
   ::arg().set("api-key", "Static pre-shared authentication key for access to the REST API")="";
+  ::arg().setSwitch("default-api-rectify","Default API-RECTIFY value for zones")="yes";
   ::arg().setSwitch("dname-processing", "If we should support DNAME records")="no";
 
   ::arg().setCmd("help","Provide a helpful message");

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -688,6 +688,11 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
     // Rectify
     string api_rectify;
     di.backend->getDomainMetadataOne(zonename, "API-RECTIFY", api_rectify);
+    if (api_rectify.empty()) {
+      if (::arg().mustDo("default-api-rectify")) {
+        api_rectify = "1";
+      }
+    }
     if (api_rectify == "1") {
       string info;
       string error_msg;

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1632,6 +1632,60 @@ fred   IN  A      192.168.0.4
         # should return zone, SOA, ns1, ns2, sub.sub A (but not the ENT)
         self.assertEquals(len(r.json()), 5)
 
+    def test_default_api_rectify(self):
+        name = unique_zone_name()
+        search = name.split('.')[0]
+        rrsets = [
+            {
+                "name": 'a.' + name,
+                "type": "AAAA",
+                "ttl": 3600,
+                "records": [{
+                    "content": "2001:DB8::1",
+                    "disabled": False,
+                }],
+            },
+            {
+                "name": 'b.' + name,
+                "type": "AAAA",
+                "ttl": 3600,
+                "records": [{
+                    "content": "2001:DB8::2",
+                    "disabled": False,
+                }],
+            },
+        ]
+        self.create_zone(name=name, rrsets=rrsets, dnssec=True, nsec3param='1 0 1 ab')
+        dbrecs = get_db_records(name, 'AAAA')
+        self.assertIsNotNone(dbrecs[0]['ordername'])
+
+    def test_override_api_rectify(self):
+        name = unique_zone_name()
+        search = name.split('.')[0]
+        rrsets = [
+            {
+                "name": 'a.' + name,
+                "type": "AAAA",
+                "ttl": 3600,
+                "records": [{
+                    "content": "2001:DB8::1",
+                    "disabled": False,
+                }],
+            },
+            {
+                "name": 'b.' + name,
+                "type": "AAAA",
+                "ttl": 3600,
+                "records": [{
+                    "content": "2001:DB8::2",
+                    "disabled": False,
+                }],
+            },
+        ]
+        self.create_zone(name=name, rrsets=rrsets, api_rectify=False, dnssec=True, nsec3param='1 0 1 ab')
+        dbrecs = get_db_records(name, 'AAAA')
+        self.assertIsNone(dbrecs[0]['ordername'])
+
     def test_cname_at_ent_place(self):
         name, payload, zone = self.create_zone(api_rectify=True)
         rrset = {

--- a/regression-tests.api/test_helper.py
+++ b/regression-tests.api/test_helper.py
@@ -70,12 +70,12 @@ def get_auth_db():
 def get_db_records(zonename, qtype):
     with get_auth_db() as db:
         rows = db.execute("""
-            SELECT name, type, content, ttl
+            SELECT name, type, content, ttl, ordername
             FROM records
             WHERE type = ? AND domain_id = (
                 SELECT id FROM domains WHERE name = ?
             )""", (qtype, zonename.rstrip('.'))).fetchall()
-        recs = [{'name': row[0], 'type': row[1], 'content': row[2], 'ttl': row[3]} for row in rows]
+        recs = [{'name': row[0], 'type': row[1], 'content': row[2], 'ttl': row[3], 'ordername': row[4]} for row in rows]
         print("DB Records:", recs)
         return recs
 


### PR DESCRIPTION
### Short description
Previously, you had to set API-RECTIFY metadata on every zone you wanted to
have automatically rectified on changes through the API. With this change, the
default behaviour is to do a rectify, but this can globally be cahged with the
setting default-api-rectify, and overriden per zone.
It fixes #7231

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
