### PR TITLE
rec: Use the timeout passed to rec_control for sending too

### DIFF
--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -108,8 +108,16 @@ void RecursorControlChannel::connect(const string& path, const string& fname)
   }
 }
 
-void RecursorControlChannel::send(const std::string& msg, const std::string* remote)
+void RecursorControlChannel::send(const std::string& msg, const std::string* remote, unsigned int timeout)
 {
+  int ret = waitForRWData(d_fd, false, timeout, 0);
+  if(ret == 0) {
+    throw PDNSException("Timeout sending message over control channel");
+  }
+  else if(ret < 0) {
+    throw PDNSException("Error sending message over control channel:" + string(strerror(errno)));
+  }
+
   if(remote) {
     struct sockaddr_un remoteaddr;
     memset(&remoteaddr, 0, sizeof(remoteaddr));

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -44,7 +44,7 @@ public:
 
   uint64_t getStat(const std::string& name);
 
-  void send(const std::string& msg, const std::string* remote=0);
+  void send(const std::string& msg, const std::string* remote=nullptr, unsigned int timeout=5);
   std::string recv(std::string* remote=0, unsigned int timeout=5);
 
   int d_fd;

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -104,7 +104,7 @@ try
       command+=" ";
     command+=commands[i];
   }
-  rccS.send(command);
+  rccS.send(command, nullptr, arg().asNum("timeout"));
   string receive=rccS.recv(0, arg().asNum("timeout"));
   if(receive.compare(0, 7, "Unknown") == 0) {
     cerr<<receive<<endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise `rec_control` gets stuck when the queue is full. The recursor itself might also have encountered the same issue in `handleRCC()`.

Fixes #1898.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
