### PR TITLE
Use a cache able soa record for the serial check caused by a notify

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -884,7 +884,7 @@ int PacketHandler::processNotify(DNSPacket *p)
   // Domain verification
   //
   DomainInfo di;
-  if(!B.getDomainInfo(p->qdomain, di, true) || !di.backend) {
+  if(!B.getDomainInfo(p->qdomain, di, false) || !di.backend) {
     if(::arg().mustDo("supermaster")) {
       g_log<<Logger::Warning<<"Received NOTIFY for "<<p->qdomain<<" from "<<p->getRemote()<<" for which we are not authoritative, trying supermaster"<<endl;
       return trySuperMaster(p, p->getTSIGKeyname());
@@ -918,7 +918,7 @@ int PacketHandler::processNotify(DNSPacket *p)
   }
 
   if(::arg().mustDo("slave")) {
-    g_log<<Logger::Debug<<"Queueing slave check for "<<p->qdomain<<", our serial is "<<di.serial<<endl;
+    g_log<<Logger::Debug<<"Queueing slave check for "<<p->qdomain<<endl;
     Communicator.addSlaveCheckRequest(di, p->d_remote);
   }
   return 0;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -756,7 +756,6 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
         requeue.insert(di);
       }
       else {
-        g_log<<Logger::Debug<<"Got NOTIFY for "<<di.zone<<", going to check SOA serial, our serial is "<<di.serial<<endl;
         // We received a NOTIFY for a zone. This means at least one of the zone's master server is working.
         // Therefore we delete the zone from the list of failed slave-checks to allow immediate checking.
         const auto wasFailedDomain = d_failedSlaveRefresh.find(di.zone);


### PR DESCRIPTION
### Short description
Use a cache able soa record for the serial check caused by notify.
Ps. the cache is cleared after every axfr, so this is fine

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
