### PR TITLE
auth: docs - increase latex maximum list depth

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,6 +135,7 @@ htmlhelp_basename = 'PowerDNSAuthoritativedoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
+    'maxlistdepth' : '8',
     # The paper size ('letterpaper' or 'a4paper').
     #
     'papersize': 'a4paper',


### PR DESCRIPTION
This fixes `LaTeX Error: Too deeply nested` while generating auth docs.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)