### PR TITLE
Fixed typos around DNS64 lua docs

### DIFF
--- a/pdns/recursordist/docs/dns64.rst
+++ b/pdns/recursordist/docs/dns64.rst
@@ -21,7 +21,7 @@ To setup DNS64, with both forward and reverse records, create the following Lua 
 .. literalinclude:: ../contrib/dns64.lua
     :language: lua
 
-Where fe80::21b::77ff:0:0 is your "Pref64" translation prefix and the "ip6.arpa" string is the reversed form of this Pref64 address.
+Where fe80::21b:77ff:0:0 is your "Pref64" translation prefix and the "ip6.arpa" string is the reversed form of this Pref64 address.
 Now ensure your script gets loaded by specifying it with :ref:`lua-dns-script=dns64.lua <setting-lua-dns-script>`.
 
 To enhance DNS64, see the :doc:`lua-scripting/index` documentation.

--- a/pdns/recursordist/docs/lua-scripting/hooks.rst
+++ b/pdns/recursordist/docs/lua-scripting/hooks.rst
@@ -173,7 +173,7 @@ DNS64
 -----
 
 The ``getFakeAAAARecords`` and ``getFakePTRRecords`` followupFunctions
-can be used to implement DNS64. See :doc:`dns64` for more information.
+can be used to implement DNS64. See :doc:`../dns64` for more information.
 
 To get fake AAAA records for DNS64 usage, set dq.followupFunction to
 ``getFakeAAAARecords``, dq.followupPrefix to e.g. "64:ff9b::" and

--- a/pdns/recursordist/docs/lua-scripting/hooks.rst
+++ b/pdns/recursordist/docs/lua-scripting/hooks.rst
@@ -173,8 +173,7 @@ DNS64
 -----
 
 The ``getFakeAAAARecords`` and ``getFakePTRRecords`` followupFunctions
-can be used to implement DNS64. See `DNS64 support in the PowerDNS
-Recursor <dns64.md>`__ for more information.
+can be used to implement DNS64. See :doc:`dns64` for more information.
 
 To get fake AAAA records for DNS64 usage, set dq.followupFunction to
 ``getFakeAAAARecords``, dq.followupPrefix to e.g. "64:ff9b::" and


### PR DESCRIPTION
### Short description
A few typos in the documentation fixed.
* typo in ipv6 address explaining the example
* old 404 link back to the dns64 doc from the hooks doc

### Checklist
Please check my syntax. I've never have touched `rst` before. :-)

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
