### PR TITLE
rec: Skip NS records in authority/additional sections of NXD / NODATA

### DIFF
--- a/pdns/test-common.hh
+++ b/pdns/test-common.hh
@@ -6,23 +6,29 @@ static inline std::shared_ptr<DNSRecordContent> getRecordContent(uint16_t type, 
 {
   std::shared_ptr<DNSRecordContent> result = nullptr;
 
-  if (type == QType::NS) {
-    result = std::make_shared<NSRecordContent>(DNSName(content));
+  try {
+    if (type == QType::NS) {
+      result = std::make_shared<NSRecordContent>(DNSName(content));
+    }
+    else if (type == QType::A) {
+      result = std::make_shared<ARecordContent>(ComboAddress(content));
+    }
+    else if (type == QType::AAAA) {
+      result = std::make_shared<AAAARecordContent>(ComboAddress(content));
+    }
+    else if (type == QType::CNAME) {
+      result = std::make_shared<CNAMERecordContent>(DNSName(content));
+    }
+    else if (type == QType::OPT) {
+      result = std::make_shared<OPTRecordContent>();
+    }
+    else {
+      result = DNSRecordContent::mastermake(type, QClass::IN, content);
+    }
   }
-  else if (type == QType::A) {
-    result = std::make_shared<ARecordContent>(ComboAddress(content));
-  }
-  else if (type == QType::AAAA) {
-    result = std::make_shared<AAAARecordContent>(ComboAddress(content));
-  }
-  else if (type == QType::CNAME) {
-    result = std::make_shared<CNAMERecordContent>(DNSName(content));
-  }
-  else if (type == QType::OPT) {
-    result = std::make_shared<OPTRecordContent>();
-  }
-  else {
-    result = DNSRecordContent::mastermake(type, QClass::IN, content);
+  catch(...) {
+    cerr<<"Error in getRecordContent() while parsing content '" << content <<"' for type "<<QType(type).getName()<<endl;
+    throw;
   }
 
   return result;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
These records are quite susceptible to fragmentation poisoning.
Based on a suggestion by Tsunehiko Suzuki (thanks!).

Note that Unbound introduced the same change in 1.8.2:
- NLnetLabs/unbound@f7e9913
- NLnetLabs/unbound@7458729

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
