### PR TITLE
settings.rst: Fix name of enable-lua-record

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -578,9 +578,9 @@ disables caching.
 
 Enables EDNS subnet processing, for backends that support it.
 
-.. _setting-enable-lua-records:
+.. _setting-enable-lua-record:
 
-``enable-lua-records``
+``enable-lua-record``
 ----------------------
 
 -  Boolean


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

It's singular `enable-lua-record`, not plural `enable-lua-records`.

https://github.com/PowerDNS/pdns/blob/269a485b1e634f0bc17b263cb063eb15850cd3aa/pdns/common_startup.cc#L216

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)