### PR TITLE
auth: make --enable-lua-records switch plural

### DIFF
--- a/docs/lua-records/index.rst
+++ b/docs/lua-records/index.rst
@@ -21,8 +21,8 @@ tiny (or larger) `Lua <https://www.lua.org>`_ statements.
   interoperability, and strive to turn this functionality into a broadly
   supported standard.
 
-To enable this feature, either set 'enable-lua-record' in the configuration,
-or set the 'ENABLE-LUA-RECORD' per-zone metadata item to 1.
+To enable this feature, either set 'enable-lua-records' in the configuration,
+or set the 'ENABLE-LUA-RECORDS' per-zone metadata item to 1.
 
 In addition, to benefit from the geographical features, make sure the PowerDNS
 launch statement includes the ``geoip`` backend.
@@ -79,7 +79,7 @@ for both **MySQL** and **PostgreSQL**::
 
     -- Enable Lua records for the zone (if not enabled globally)
     INSERT INTO domainmetadata (domain_id, kind, content) 
-    VALUES (1, 'ENABLE-LUA-RECORD', 1);
+    VALUES (1, 'ENABLE-LUA-RECORDS', 1);
 
     -- Create a pickClosest() Lua A record.
     -- Double single quotes are used to escape single quotes in both MySQL and PostgreSQL
@@ -92,7 +92,7 @@ for both **MySQL** and **PostgreSQL**::
       600
     );
 
-The above queries create a zone ``example.com``, enable Lua records for the zone using ``ENABLE-LUA-RECORD``,
+The above queries create a zone ``example.com``, enable Lua records for the zone using ``ENABLE-LUA-RECORDS``,
 and finally insert a LUA A record for the ``www`` subdomain using the previous pickclosest example.
 
 See `Details & Security`_ for more information about enabling Lua records, and the risks involved.
@@ -110,7 +110,7 @@ again for configuration scripts. The query type is then followed by the
 actual Lua snippet.
 
 LUA records can have TTL settings, and these will be honoured. In addition,
-LUA record output can be DNSSEC signed like any other record, but see below
+LUA records output can be DNSSEC signed like any other record, but see below
 for further details.
 
 More powerful example
@@ -181,7 +181,7 @@ LUA records themselves can not be queried however, as this would allow third par
 they do not need to see.
 
 A non-supporting DNS server will also serve a zone with LUA records, but
-they will not function, and will in fact leak the contents of the LUA record.
+they will not function, and will in fact leak the content of the LUA records.
 
 .. note::
   Under NO circumstances serve LUA records from zones from untrusted sources!
@@ -193,9 +193,9 @@ possible to combine pre-signed DNSSEC zone and LUA records. In other words,
 the signing key must be available on the server creating answers based on
 LUA records.
 
-Note that to protect operators, support for the LUA record must be enabled
-explicitly, either globally (``enable-lua-record``) or per zone
-(``ENABLE-LUA-RECORD`` = 1).
+Note that to protect operators, support for LUA records must be enabled
+explicitly, either globally (``enable-lua-records``) or per zone
+(``ENABLE-LUA-RECORDS`` = 1).
 
 Reference
 ---------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -736,15 +736,15 @@ Disable this if the process supervisor timestamps these lines already.
 .. note::
   The systemd unit file supplied with the source code already disables timestamp printing
 
-.. _setting-lua-record-exec-limit:
+.. _setting-lua-records-exec-limit:
 
-``lua-record-exec-limit``
+``lua-records-exec-limit``
 -----------------------------
 
 -  Integer
 -  Default: 1000
 
-Limit LUA record scripts to ``lua-record-exec-limit`` instructions.
+Limit LUA records scripts to ``lua-records-exec-limit`` instructions.
 Setting this to any value less than or equal to 0 will set no limit.
 
 .. _setting-non-local-bind:

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -213,8 +213,8 @@ void declareArguments()
   ::arg().setSwitch("outgoing-axfr-expand-alias", "Expand ALIAS records during outgoing AXFR")="no";
   ::arg().setSwitch("8bit-dns", "Allow 8bit dns queries")="no";
 #ifdef HAVE_LUA_RECORDS
-  ::arg().setSwitch("enable-lua-record", "Process LUA record for all zones (metadata overrides this)")="no";
-  ::arg().set("lua-record-exec-limit", "LUA record scripts execution limit (instructions count). Values <= 0 mean no limit")="1000";
+  ::arg().setSwitch("enable-lua-records", "Process LUA records for all zones (metadata overrides this)")="no";
+  ::arg().set("lua-records-exec-limit", "LUA records scripts execution limit (instructions count). Values <= 0 mean no limit")="1000";
 #endif
   ::arg().setSwitch("axfr-lower-serial", "Also AXFR a zone from a master with a lower serial")="no";
 
@@ -508,8 +508,8 @@ void mainthread()
    g_anyToTcp = ::arg().mustDo("any-to-tcp");
    g_8bitDNS = ::arg().mustDo("8bit-dns");
 #ifdef HAVE_LUA_RECORDS
-   g_doLuaRecord = ::arg().mustDo("enable-lua-record");
-   g_luaRecordExecLimit = ::arg().asNum("lua-record-exec-limit");
+   g_doLuaRecord = ::arg().mustDo("enable-lua-records");
+   g_luaRecordExecLimit = ::arg().asNum("lua-records-exec-limit");
 #endif
 
    DNSPacket::s_udpTruncationThreshold = std::max(512, ::arg().asNum("udp-truncation-threshold"));

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -360,7 +360,7 @@ bool PacketHandler::getBestWildcard(DNSPacket *p, SOAData& sd, const DNSName &ta
   bool doLua=g_doLuaRecord;
   if(!doLua) {
     string val;
-    d_dk.getFromMeta(sd.qname, "ENABLE-LUA-RECORD", val);
+    d_dk.getFromMeta(sd.qname, "ENABLE-LUA-RECORDS", val);
     doLua = (val=="1");
   }
 #endif
@@ -1341,7 +1341,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
 #ifdef HAVE_LUA_RECORDS
     if(!doLua) {
       string val;
-      d_dk.getFromMeta(sd.qname, "ENABLE-LUA-RECORD", val);
+      d_dk.getFromMeta(sd.qname, "ENABLE-LUA-RECORDS", val);
       doLua = (val=="1");
     }
 #endif

--- a/regression-tests.auth-py/authtests.py
+++ b/regression-tests.auth-py/authtests.py
@@ -177,7 +177,7 @@ distributor-threads=1""".format(confdir=confdir, prefix=cls._PREFIX,
         authcmd.append('--local-address=%s' % ipaddress)
         authcmd.append('--local-port=%s' % cls._authPort)
         authcmd.append('--loglevel=9')
-        authcmd.append('--enable-lua-record')
+        authcmd.append('--enable-lua-records')
         print(' '.join(authcmd))
 
         logFile = os.path.join(confdir, 'pdns.log')


### PR DESCRIPTION
### Short description
This PR standardize LUA records spelling to the plural form.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
