### PR TITLE
dnsdist: Check that SO_ATTACH_BPF is defined before enabling eBPF

### DIFF
--- a/m4/pdns_with_ebpf.m4
+++ b/m4/pdns_with_ebpf.m4
@@ -20,12 +20,19 @@ AC_DEFUN([PDNS_WITH_EBPF],[
   AM_CONDITIONAL([HAVE_EBPF], [test x"$bpf_headers" = "xyes" ])
   AS_IF([test x"$bpf_headers" = "xyes" ],
     [AC_CHECK_DECL(BPF_FUNC_tail_call,
-      [ AC_DEFINE([HAVE_EBPF], [1], [Define if using eBPF.]) ],
+      [ AC_CHECK_DECL(SO_ATTACH_BPF,
+        [ AC_DEFINE([HAVE_EBPF], [1], [Define if using eBPF.]) ],
+        [ AS_IF([test "x$with_ebpf" = "xyes"], [
+          AC_MSG_ERROR([EBPF support requested but SO_ATTACH_BPF not found])
+        ])],
+        [#include <sys/socket.h>
+        ]
+      )],
       [ AS_IF([test "x$with_ebpf" = "xyes"], [
-          AC_MSG_ERROR([EBPF support requested but BPF_FUNC_tail_call not found in the eBPF headers])
-        ])
-      ],
-      [#include <linux/bpf.h>]
+        AC_MSG_ERROR([EBPF support requested but BPF_FUNC_tail_call not found in the eBPF headers])
+      ])],
+      [#include <linux/bpf.h>
+      ]
     )]
   )
 ])


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It turns out that RH decided to backport only the tracing subsystem part of eBPF as a "Technology Preview" in the RHEL / Centos 7.6 kernel, so most of the eBPF stuff is present but not what is needed
to use the networking parts.

With this change, eBPF support is disabled when `SO_ATTACH_BPF` is missing since we can't attach our filter to a socket without that anyway. Tested on CentOS 7.6 and Arch.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
