### PR TITLE
docs: link to 4.1 gsql schemas

### DIFF
--- a/docs/backends/generic-mysql.rst
+++ b/docs/backends/generic-mysql.rst
@@ -126,4 +126,6 @@ server. A value of 0 will disable the timeout. Default: 10
 Default Schema
 --------------
 
+This is the 4.2 schema. Please find `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gmysqlbackend/schema.mysql.sql>`_.
+
 .. literalinclude:: ../../modules/gmysqlbackend/schema.mysql.sql

--- a/docs/backends/generic-odbc.rst
+++ b/docs/backends/generic-odbc.rst
@@ -111,6 +111,8 @@ For convenience, a schema for MS SQL Server has been created: (Note:
 This schema can also be found in the PowerDNS source as
 ``modules/godbcbackend/schema.mssql.sql``).
 
+This is the schema for 4.2. For 4.1, please find `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/godbcbackend/schema.mssql.sql>`_.
+
 .. literalinclude:: ../../modules/godbcbackend/schema.mssql.sql
 
 Load this into the database as follows:

--- a/docs/backends/generic-oracle.rst
+++ b/docs/backends/generic-oracle.rst
@@ -17,6 +17,8 @@ The Generic Oracle Backend is a :doc:`generic-sql`. The default setup conforms t
 following schema, which you should add to an Oracle database. You may
 need or want to add ``namespace`` statements.
 
+Below, you will find the schema for 4.2. If you are using 4.1 or earlier, please find `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/goraclebackend/schema.goracle.sql>`_.
+
 .. literalinclude:: ../../modules/goraclebackend/schema.goracle.sql
 
 This schema contains all elements needed for master, slave and

--- a/docs/backends/generic-postgresql.rst
+++ b/docs/backends/generic-postgresql.rst
@@ -94,4 +94,6 @@ Default: "".
 Default schema
 --------------
 
+This is the 4.2 schema. Please find `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gpgsqlbackend/schema.pgsql.sql>`_.
+
 .. literalinclude:: ../../modules/gpgsqlbackend/schema.pgsql.sql

--- a/docs/backends/generic-sqlite3.rst
+++ b/docs/backends/generic-sqlite3.rst
@@ -33,7 +33,8 @@ Setting up the database
 ------------------------
 
 Before you can use this backend you first have to set it up and fill it
-with data. The default setup conforms to the following schema:
+with data. The default setup conforms to the following schema in 4.2.
+If you have not upgraded to 4.2, please use `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gsqlite3backend/schema.sqlite3.sql>`_.
 
 .. literalinclude:: ../../modules/gsqlite3backend/schema.sqlite3.sql
 


### PR DESCRIPTION
### Short description
For 4.2, the `change_date` column was removed. This means that the schemas as currently shown in the docs break 4.1 installs. With this PR, we link to the 4.1 schemas for users who have not upgraded yet.

Closes #7254.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
