### PR TITLE
Remove some misunderstanding of adding several masters in slave zones

### DIFF
--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -151,12 +151,10 @@ create-zone *ZONE*
     Create an empty zone named *ZONE*.
 create-slave-zone *ZONE* *MASTER* [*MASTER*]..
     Create a new slave zone *ZONE* with masters *MASTER*. All *MASTER*\ s
-    need to to be IP addresses with an optional port.
-    Master addressess is to be seperated by spaces
+    need to to be IP addresses with an optional port. Master addressess is to be seperated by spaces
 change-slave-zone-master *ZONE* *MASTER* [*MASTER*]..
     Change the masters for slave zone *ZONE* to new masters *MASTER*. All
-    *MASTER*\ s need to to be IP addresses with an optional port.
-    Master addressess is to be seperated by spaces
+    *MASTER*\ s need to to be IP addresses with an optional port. Master addressess is to be seperated by spaces
 check-all-zones
     Check all zones for correctness.
 check-zone *ZONE*

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -154,7 +154,7 @@ create-slave-zone *ZONE* *MASTER* [*MASTER*]..
     need to to be IP addresses with an optional port. Master addressess is to be seperated by spaces
 change-slave-zone-master *ZONE* *MASTER* [*MASTER*]..
     Change the masters for slave zone *ZONE* to new masters *MASTER*. All
-    *MASTER*\ s need to to be IP addresses with an optional port. Master addressess is to be seperated by spaces
+    *MASTER*\ s need to to be space-separated IP addresses with an optional port.
 check-all-zones
     Check all zones for correctness.
 check-zone *ZONE*

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -152,9 +152,11 @@ create-zone *ZONE*
 create-slave-zone *ZONE* *MASTER* [*MASTER*]..
     Create a new slave zone *ZONE* with masters *MASTER*. All *MASTER*\ s
     need to to be IP addresses with an optional port.
+    Master addressess is to be seperated by spaces
 change-slave-zone-master *ZONE* *MASTER* [*MASTER*]..
     Change the masters for slave zone *ZONE* to new masters *MASTER*. All
     *MASTER*\ s need to to be IP addresses with an optional port.
+    Master addressess is to be seperated by spaces
 check-all-zones
     Check all zones for correctness.
 check-zone *ZONE*

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -151,7 +151,7 @@ create-zone *ZONE*
     Create an empty zone named *ZONE*.
 create-slave-zone *ZONE* *MASTER* [*MASTER*]..
     Create a new slave zone *ZONE* with masters *MASTER*. All *MASTER*\ s
-    need to to be IP addresses with an optional port. Master addressess is to be seperated by spaces
+    need to to be space-separated IP addresses with an optional port.
 change-slave-zone-master *ZONE* *MASTER* [*MASTER*]..
     Change the masters for slave zone *ZONE* to new masters *MASTER*. All
     *MASTER*\ s need to to be space-separated IP addresses with an optional port.


### PR DESCRIPTION
Trying to remove some misunderstanding of how several masters are added by adding the "Master addressess is to be seperated by spaces" to avoid misunderstanding as noted in the IRC by me.

Reason
I understood that by this is MASTER OR [master in array]

Coz: Seen inconsistent to "@Habbie this is what unix commands are documented like
@Habbie  in every project
@Habbie over the last 30 years"

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
