### PR TITLE
 auth-4.1.x: Prevent more than one CNAME/SOA record in the same RRset

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -471,7 +471,7 @@ static void validateGatheredRRType(const DNSResourceRecord& rr) {
 }
 
 static void gatherRecords(const Json container, const DNSName& qname, const QType qtype, const int ttl, vector<DNSResourceRecord>& new_records, vector<DNSResourceRecord>& new_ptrs) {
-  static const std::set<uint16_t> onlyOneEntryTypes = { QType::CNAME, QType::SOA};
+  static const std::set<uint16_t> onlyOneEntryTypes = { QType::CNAME, QType::SOA };
   UeberBackend B;
   DNSResourceRecord rr;
   rr.qname = qname;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -471,6 +471,7 @@ static void validateGatheredRRType(const DNSResourceRecord& rr) {
 }
 
 static void gatherRecords(const Json container, const DNSName& qname, const QType qtype, const int ttl, vector<DNSResourceRecord>& new_records, vector<DNSResourceRecord>& new_ptrs) {
+  static const std::set<uint16_t> onlyOneEntryTypes = { QType::CNAME, QType::SOA};
   UeberBackend B;
   DNSResourceRecord rr;
   rr.qname = qname;
@@ -479,7 +480,12 @@ static void gatherRecords(const Json container, const DNSName& qname, const QTyp
   rr.ttl = ttl;
 
   validateGatheredRRType(rr);
-  for(auto record : container["records"].array_items()) {
+  const auto& items = container["records"].array_items();
+  if (onlyOneEntryTypes.count(qtype.getCode()) != 0 && items.size() > 1) {
+    throw ApiException("RRset for "+rr.qname.toString()+"/"+rr.qtype.getName()+" has more than one record");
+  }
+
+  for(const auto& record : items) {
     string content = stringFromJson(record, "content");
     rr.disabled = boolFromJson(record, "disabled");
 

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1201,6 +1201,30 @@ fred   IN  A      192.168.0.4
         self.assertEquals(r.status_code, 422)
         self.assertIn('Conflicts with pre-existing CNAME RRset', r.json()['error'])
 
+    def test_rrset_multiple_cnames(self):
+        name, payload, zone = self.create_zone()
+        rrset = {
+            'changetype': 'replace',
+            'name': 'sub.'+name,
+            'type': 'CNAME',
+            'ttl': 3600,
+            'records': [
+                {
+                    "content": "01.example.org.",
+                    "disabled": False
+                },
+                {
+                    "content": "02.example.org.",
+                    "disabled": False
+                }
+            ]
+        }
+        payload = {'rrsets': [rrset]}
+        r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
+                               headers={'content-type': 'application/json'})
+        self.assertEquals(r.status_code, 422)
+        self.assertIn('/CNAME has more than one record', r.json()['error'])
+
     def test_create_zone_with_leading_space(self):
         # Actual regression.
         name, payload, zone = self.create_zone()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #7278 to rel/auth-4.1.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
