### PR TITLE
auth-4.1.x: Use a realistic RSA key size for testing rsasha256 via the API

### DIFF
--- a/regression-tests.api/test_cryptokeys.py
+++ b/regression-tests.api/test_cryptokeys.py
@@ -111,7 +111,7 @@ class Cryptokeys(ApiTestCase):
 
     # Test POST to add a key with specific name and bits
     def test_post_specific_name_bits(self):
-        self.post_helper(algo="rsasha256", bits=256)
+        self.post_helper(algo="rsasha256", bits=2048)
 
     # Test POST to add a key with specific name
     def test_post_specific_name(self):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to request the creation of a 256-bit `RSA` key, which `OpenSSL` refuses from 1.1.1 onward. 1.1.0 used to accept everything larger than 16 bits (!) but in 1.1.1 512 (`RSA_MIN_MODULUS_BITS`) is the minimum.
We already changed this in master in https://github.com/PowerDNS/pdns/pull/6139, among other things.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
