### PR TITLE
auth: Fix the default value of max-signature-cache-entries in the doc

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -945,7 +945,7 @@ situation hopeless and respawn.
 -------------------------------
 
 -  Integer
--  Default: 2^64 (on 64-bit systems)
+-  Default: 2^31-1 (on most systems), 2^63-1 (on ILP64 systems)
 
 Maximum number of signatures cache entries
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
