### PR TITLE
add +nocookie to the dig examples

### DIFF
--- a/pdns/dnsdistdist/docs/quickstart.rst
+++ b/pdns/dnsdistdist/docs/quickstart.rst
@@ -39,7 +39,7 @@ Now run dnsdist again, reading this configuration::
 
 You can now send queries to port 5300, and get answers::
 
-  $ dig -t aaaa powerdns.com @127.0.0.1 -p 5300 +short
+  $ dig -t aaaa powerdns.com @127.0.0.1 -p 5300 +short +nocookie
   2001:888:2000:1d::2
 
 Note that dnsdist dropped us in a prompt above, where we can get some statistics::
@@ -59,7 +59,7 @@ Here we also see our configuration. 5 downstream servers have been configured, o
 
 The final server has no limit, which we can easily test::
 
-  $ for a in {0..1000}; do dig powerdns.com @127.0.0.1 -p 5300 +noall > /dev/null; done
+  $ for a in {0..1000}; do dig powerdns.com @127.0.0.1 -p 5300 +noall +nocookie > /dev/null; done
 
 ::
 


### PR DESCRIPTION
added the +nocookie to the dig examples.

Reason, as you are setting up new software your mind is full, and who think of dig is sending DNS cookies? So for the quick copy/paste the cache test should also be possible with no errors.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
