### PR TITLE
dnsscope: Fix boost's version detection, build with histograms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,9 @@ BOOST_REQUIRE([1.35])
 # Boost accumulators, as used by dnsbulktest and dnstcpbench, need 1.48+
 # to be compatible with C++11
 AM_CONDITIONAL([HAVE_BOOST_GE_148], [test "$boost_major_version" -ge 148])
+AS_IF([test "$boost_major_version" -ge 148], [
+  AC_DEFINE(HAVE_BOOST_GE_148, [1], [Define to 1 if you have boost >= 1.48])
+])
 
 BOOST_PROGRAM_OPTIONS([mt])
 AS_IF([test "$boost_cv_lib_program_options" = "no"], [

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -989,7 +989,6 @@ dnsreplay_SOURCES = \
 	dnswriter.cc dnswriter.hh \
 	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
-	histog.hh \
 	iputils.cc \
 	logger.cc \
 	misc.cc \
@@ -1081,6 +1080,7 @@ dnsscope_SOURCES = \
 	dnsrecords.cc \
 	dnsscope.cc \
 	dnswriter.cc dnswriter.hh \
+	histog.hh \
 	logger.cc \
 	misc.cc \
 	nsecrecords.cc \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`dnsscope` requires Boost 1.48+ for its histogram feature, but the version check was relying on a automake variable that was not defined in `config.h` and thus the feature was never enabled.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
