### PR TITLE
prevent leak of file descriptor if running out of ports for incoming AXFR

### DIFF
--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -86,10 +86,11 @@ int makeQuerySocket(const ComboAddress& local, bool udpOrTCP, bool nonLocalBind)
   }
   else {
     // tcp, let the kernel figure out the port
-    // cerr<<"letting kernel pick TCP port"<<endl;
     ourLocal.sin4.sin_port = 0;
-    if(::bind(sock, (struct sockaddr *)&ourLocal, ourLocal.getSocklen()) < 0)
+    if(::bind(sock, (struct sockaddr *)&ourLocal, ourLocal.getSocklen()) < 0) {
+      closesocket(sock);
       throw PDNSException("Resolver binding to local TCP socket on "+ourLocal.toString()+": "+stringerror());
+    }
   }
   return sock;
 }


### PR DESCRIPTION
### Short description
In scalability tests I found the OS can run out of local ports making the call to bind() fail for the TCP socket we use to retrieve zones. If that happens we leak a filedescriptor.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
