### PR TITLE
geoipbackend: Add libmaxminddb-devel dependency for CentOS

### DIFF
--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -166,6 +166,7 @@ Group: System Environment/Daemons
 Requires: %{name}%{?_isa} = %{version}-%{release}
 BuildRequires: yaml-cpp-devel
 BuildRequires: geoip-devel
+BuildRequires: libmaxminddb-devel
 %global backends %{backends} geoip
 
 %description backend-geoip
@@ -196,7 +197,7 @@ This package contains the ixfrdist program.
 %if 0%{?rhel} == 6
 %setup -n %{name}-%{getenv:BUILDER_VERSION}
 %else
-%autosetup -p1 -n %{name}-%{getenv:BUILDER_VERSION} 
+%autosetup -p1 -n %{name}-%{getenv:BUILDER_VERSION}
 %endif
 
 %build


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

### Short description
```
Distributor caught fatal exception: libmaxminddb support not compiled in
```