### PR TITLE
Rec: Set socket buf size for control socket.

### DIFF
--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -42,9 +42,9 @@ static void setSocketBuffer(int fd, int optname, uint32_t size)
 
   if (psize > size)
     return;
-
-  if (setsockopt(fd, SOL_SOCKET, optname, (const void*)&size, sizeof(size)) < 0 )
-    throw PDNSException("Unable to raise socket buffer size: "+stringerror());
+  
+  // failure to raise is not fatal
+  setsockopt(fd, SOL_SOCKET, optname, (const void*)&size, sizeof(size));
 }
 
 

--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -54,6 +54,12 @@ int RecursorControlChannel::listen(const string& fname)
   if(bind(d_fd, (sockaddr*)&d_local,sizeof(d_local))<0) 
     throw PDNSException("Unable to bind to controlsocket '"+fname+"': "+stringerror());
 
+  // receive buf should be size of max datagram plus address size
+  int bufsz = 60*1024;
+  setsockopt(d_fd, SOL_SOCKET, SO_SNDBUF, &bufsz, sizeof(bufsz));
+  bufsz = 64*1024;
+  setsockopt(d_fd, SOL_SOCKET, SO_RCVBUF, &bufsz, sizeof(bufsz));
+  
   return d_fd;
 }
 
@@ -99,6 +105,12 @@ void RecursorControlChannel::connect(const string& path, const string& fname)
 	unlink(d_local.sun_path);
       throw PDNSException("Unable to connect to remote '"+string(remote.sun_path)+"': "+stringerror());
     }
+
+    // receive buf should be size of max datagram plus address size
+    int bufsz = 60*1024;
+    setsockopt(d_fd, SOL_SOCKET, SO_SNDBUF, &bufsz, sizeof(bufsz));
+    bufsz = 64*1024;
+    setsockopt(d_fd, SOL_SOCKET, SO_RCVBUF, &bufsz, sizeof(bufsz));
 
   } catch (...) {
     close(d_fd);


### PR DESCRIPTION
Fixes #5745 without changing settings for all processes.

### Short description
<!-- Some systems have small buffer sizes for locall domain sockets.  This sets the buf sizes
without need for local system config changes -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
