### PR TITLE
Use a template to log basic types

### DIFF
--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -184,64 +184,6 @@ Logger& Logger::operator<<(const char *s)
   return *this;
 }
 
-Logger& Logger::operator<<(int i)
-{
-  ostringstream tmp;
-  tmp<<i;
-
-  *this<<tmp.str();
-
-  return *this;
-}
-
-Logger& Logger::operator<<(double i)
-{
-  ostringstream tmp;
-  tmp<<i;
-  *this<<tmp.str();
-  return *this;
-}
-
-Logger& Logger::operator<<(unsigned int i)
-{
-  ostringstream tmp;
-  tmp<<i;
-
-  *this<<tmp.str();
-
-  return *this;
-}
-
-Logger& Logger::operator<<(unsigned long i)
-{
-  ostringstream tmp;
-  tmp<<i;
-
-  *this<<tmp.str();
-
-  return *this;
-}
-
-Logger& Logger::operator<<(unsigned long long i)
-{
-  ostringstream tmp;
-  tmp<<i;
-
-  *this<<tmp.str();
-
-  return *this;
-}
-
-Logger& Logger::operator<<(long i)
-{
-  ostringstream tmp;
-  tmp<<i;
-
-  *this<<tmp.str();
-
-  return *this;
-}
-
 Logger& Logger::operator<<(ostream & (&)(ostream &))
 {
   PerThread* pt =getPerThread();

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -81,15 +81,17 @@ public:
   */
   Logger& operator<<(const char *s);
   Logger& operator<<(const string &s);   //!< log a string
-  Logger& operator<<(int);   //!< log an int
-  Logger& operator<<(double);   //!< log a double
-  Logger& operator<<(unsigned int);   //!< log an unsigned int
-  Logger& operator<<(long);   //!< log an unsigned int
-  Logger& operator<<(unsigned long);   //!< log an unsigned int
-  Logger& operator<<(unsigned long long);   //!< log an unsigned 64 bit int
   Logger& operator<<(const DNSName&); 
   Logger& operator<<(const ComboAddress&); //!< log an address
   Logger& operator<<(Urgency);    //!< set the urgency, << style
+
+  // Using const & since otherwise SyncRes:: values induce (illegal) copies
+  template<typename T> Logger & operator<<(const T & i) {
+	ostringstream tmp;
+	tmp<<i;
+	*this<<tmp.str();
+	return *this;
+  }
 
   Logger& operator<<(std::ostream & (&)(std::ostream &)); //!< this is to recognise the endl, and to commit the log
 


### PR DESCRIPTION
### Short description
<!-- This modifies the logging of basic types to use a template. This will let the compiler
figure out potential conflicts between e.g. time_t and long long. Tested on debian with gcc and OpenBSD (clang).
-->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
