### PR TITLE
dnsdist: Add a 'rise' parameter to 'newServer()'

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -368,6 +368,10 @@ void setupLuaConfig(bool client)
 			  ret->maxCheckFailures=std::stoi(boost::get<string>(vars["maxCheckFailures"]));
 			}
 
+                        if(vars.count("rise")) {
+                          ret->minRiseSuccesses=std::stoi(boost::get<string>(vars["rise"]));
+                        }
+
                         if(vars.count("cpus")) {
                           for (const auto cpu : boost::get<vector<pair<int,string>>>(vars["cpus"])) {
                             cpus.insert(std::stoi(cpu.second));

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -711,7 +711,9 @@ struct DownstreamState
   uint16_t xpfRRCode{0};
   uint16_t checkTimeout{1000}; /* in milliseconds */
   uint8_t currentCheckFailures{0};
+  uint8_t consecutiveSuccesfulChecks{0};
   uint8_t maxCheckFailures{1};
+  uint8_t minRiseSuccesses{1};
   StopWatch sw;
   set<string> pools;
   enum class Availability { Up, Down, Auto} availability{Availability::Auto};

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -312,6 +312,7 @@ Servers
 
   .. versionchanged:: 1.3.4
     - Added ``checkTimeout`` to server_table
+    - Added ``rise`` to server_table.
 
   Add a new backend server. Call this function with either a string::
 
@@ -339,8 +340,8 @@ Servers
       checkClass=NUM,        -- Use NUM as QCLASS in the health-check query, default: DNSClass.IN
       checkName=STRING,      -- Use STRING as QNAME in the health-check query, default: "a.root-servers.net."
       checkType=STRING,      -- Use STRING as QTYPE in the health-check query, default: "A"
-      checkFunction=FUNCTION -- Use this function to dynamically set the QNAME, QTYPE and QCLASS to use in the health-check query (see :ref:`Healthcheck`)
-      checkTimeout=NUM       -- The timeout (in milliseconds) of a health-check query, default: 1000 (1s)
+      checkFunction=FUNCTION,-- Use this function to dynamically set the QNAME, QTYPE and QCLASS to use in the health-check query (see :ref:`Healthcheck`)
+      checkTimeout=NUM,      -- The timeout (in milliseconds) of a health-check query, default: 1000 (1s)
       setCD=BOOL,            -- Set the CD (Checking Disabled) flag in the health-check query, default: false
       maxCheckFailures=NUM,  -- Allow NUM check failures before declaring the backend down, default: 1
       mustResolve=BOOL,      -- Set to true when the health check MUST return a NOERROR RCODE and an answer
@@ -353,7 +354,8 @@ Servers
       addXPF=NUM,            -- Add the client's IP address and port to the query, along with the original destination address and port,
                              -- using the experimental XPF record from `draft-bellis-dnsop-xpf <https://datatracker.ietf.org/doc/draft-bellis-dnsop-xpf/>`_ and the specified option code. Default is disabled (0)
       sockets=NUM,           -- Number of sockets (and thus source ports) used toward the backend server, defaults to a single one
-      disableZeroScope       -- Disable the EDNS Client Subnet 'zero scope' feature, which does a cache lookup for an answer valid for all subnets (ECS scope of 0) before adding ECS information to the query and doing the regular lookup
+      disableZeroScope=BOOL, -- Disable the EDNS Client Subnet 'zero scope' feature, which does a cache lookup for an answer valid for all subnets (ECS scope of 0) before adding ECS information to the query and doing the regular lookup
+      rise=NUM               -- Require NUM consecutive successful checks before declaring the backend up, default: 1
     })
 
   :param str server_string: A simple IP:PORT string.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In some setups it might make sense to wait until 2 or 3 checks have succeeded before starting to use a backend, because we care about stability more than we want the backend to get back up fast.
This PR adds a new optional `rise` parameter to `newServer()`, specifying how many health checks must be successful before the backend is marked as up.

Closes #7237.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
