### PR TITLE
Use mmap for stack allocation, adding the MAP_STACK flag on OpenBSD.

### DIFF
--- a/pdns/lazy_allocator.hh
+++ b/pdns/lazy_allocator.hh
@@ -25,6 +25,13 @@
 #include <cstddef>
 #include <utility>
 #include <type_traits>
+#include <new>
+#include <sys/mman.h>
+
+// On OpenBSD mem used as stack should be marked MAP_STACK
+#if !defined(MAP_STACK)
+#define MAP_STACK 0
+#endif
 
 template <typename T>
 struct lazy_allocator {
@@ -36,17 +43,16 @@ struct lazy_allocator {
 
     pointer
     allocate (size_type const n) {
-        return static_cast<pointer>(::operator new (n * sizeof(value_type)));
+        void *p = mmap(NULL, n * sizeof(value_type),
+          PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_STACK, -1, 0);
+        if (p == MAP_FAILED)
+          throw std::bad_alloc();
+        return static_cast<pointer>(p);
     }
 
     void
     deallocate (pointer const ptr, size_type const n) noexcept {
-#if defined(__cpp_sized_deallocation) &&  (__cpp_sized_deallocation >= 201309)
-        ::operator delete (ptr, n * sizeof(value_type));
-#else
-        (void) n;
-        ::operator delete (ptr);
-#endif
+        munmap(ptr, n * sizeof(value_type));
     }
 
     void construct (T*) const noexcept {}


### PR DESCRIPTION
### Short description
On a userland to kernel transition OpenBSD checks if the stack
pointer points to a piece of mem marked MAP_STACK to prevent a large
class of exploits. Since we setup out own stack we must use mmap
on OpenBSD, and we might do that on other systems as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
