### PR TITLE
Tell people to use --with-modules=... when they use --without-mysql

### DIFF
--- a/m4/pdns_with_mysql.m4
+++ b/m4/pdns_with_mysql.m4
@@ -2,6 +2,12 @@ AC_DEFUN([PDNS_WITH_MYSQL],[
   AC_ARG_WITH([mysql],
     [AS_HELP_STRING([--with-mysql=<path>], [root directory path of MySQL installation])],
     [
+      if test "$withval" = "no"; then
+        modules_without_gmysql=$(echo $modules|sed -e 's/gmysql//;s/  */ /g;')
+        dynmodules_without_gmysql=$(echo $dynmodules|sed -e 's/gmysql//;s/  */ /g;')
+        AC_MSG_ERROR([instead of --without-mysql try --with-modules="$modules_without_gmysql" --with-dyn-modules="$dynmodules_without_gmysql"])
+      fi
+
       MYSQL_LIBS_check="$withval/lib/mysql $with_mysql/lib"
       MYSQL_CFLAGS_check="$withval/include/mysql"
       MYSQL_config_check="$withval/bin/mysql_config"


### PR DESCRIPTION
closes #5140

### Short description
Detect `--without-mysql` and suggest `--with-modules="bind random" --with-dyn-modules="pipe"`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

fwiw, this isn't my preference, I'd rather we just remove `gmysql` from `modules` when someone uses `--without-mysql`, but...

```sh
$ ./configure --without-mysql --with-libcrypto=/usr/local/opt/openssl 2>&1|tail -5
checking for arc4random... yes
checking whether to enable verbose logging... no
checking whether to enable PKCS11 support... no
checking whether to enable experimental GSS-TSIG support... no
configure: error: instead of --without-mysql try --with-modules="bind random" --with-dyn-modules="pipe"
```