### PR TITLE
auth: error on DNSSEC default misconfiguration

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -557,33 +557,41 @@ void mainthread()
   }
   catch(...) {}
 
-  // Some sanity checking on default key settings
-  bool hadKeyError = false;
-  for (const string& algotype : {"ksk", "zsk"}) {
-    int algo, size;
-    if (::arg()["default-"+algotype+"-algorithm"].empty())
-      continue;
-    algo = DNSSECKeeper::shorthand2algorithm(::arg()["default-"+algotype+"-algorithm"]);
-    size = ::arg().asNum("default-"+algotype+"-size");
-    if (algo == -1) {
-      g_log<<Logger::Error<<"Error: default-"<<algotype<<"-algorithm set to unknown algorithm: "<<::arg()["default-"+algotype+"-algorithm"]<<endl;
-      hadKeyError = true;
+  {
+    // Some sanity checking on default key settings
+    bool hadKeyError = false;
+    int kskAlgo{0}, zskAlgo{0};
+    for (const string& algotype : {"ksk", "zsk"}) {
+      int algo, size;
+      if (::arg()["default-"+algotype+"-algorithm"].empty())
+        continue;
+      algo = DNSSECKeeper::shorthand2algorithm(::arg()["default-"+algotype+"-algorithm"]);
+      size = ::arg().asNum("default-"+algotype+"-size");
+      if (algo == -1) {
+        g_log<<Logger::Error<<"Error: default-"<<algotype<<"-algorithm set to unknown algorithm: "<<::arg()["default-"+algotype+"-algorithm"]<<endl;
+        hadKeyError = true;
+      }
+      else if (algo <= 10 && size == 0) {
+        g_log<<Logger::Error<<"Error: default-"<<algotype<<"-algorithm is set to an algorithm ("<<::arg()["default-"+algotype+"-algorithm"]<<") that requires a non-zero default-"<<algotype<<"-size!"<<endl;
+        hadKeyError = true;
+      }
+      if (algotype == "ksk") {
+        kskAlgo = algo;
+      } else {
+        zskAlgo = algo;
+      }
     }
-    else if (algo <= 10 && size == 0) {
-      g_log<<Logger::Error<<"Error: default-"<<algotype<<"-algorithm is set to an algorithm ("<<::arg()["default-"+algotype+"-algorithm"]<<") that requires a non-zero default-"<<algotype<<"-size!"<<endl;
-      hadKeyError = true;
+    if (hadKeyError) {
+      exit(1);
     }
-  }
-  if (hadKeyError) {
-    exit(1);
-  }
-  if (::arg()["default-ksk-algorithm"].empty() && !::arg()["default-zsk-algorithm"].empty()) {
-    g_log<<Logger::Error<<"Error: default-zsk-algorithm is set, but default-ksk-algorithm is not set."<<endl;
-    exit(1);
-  }
-  if (!::arg()["default-zsk-algorithm"].empty() && ::arg()["default-zsk-algorithm"] != ::arg()["default-ksk-algorithm"]) {
-    g_log<<Logger::Error<<"Error: default-zsk-algorithm ("<<::arg()["default-zsk-algorithm"]<<"), when set, can not be different from default-ksk-algorithm ("<<::arg()["default-ksk-algorithm"]<<")."<<endl;
-    exit(1);
+    if (kskAlgo == 0 && zskAlgo != 0) {
+      g_log<<Logger::Error<<"Error: default-zsk-algorithm is set, but default-ksk-algorithm is not set."<<endl;
+      exit(1);
+    }
+    if (zskAlgo != 0 && zskAlgo != kskAlgo) {
+      g_log<<Logger::Error<<"Error: default-zsk-algorithm ("<<::arg()["default-zsk-algorithm"]<<"), when set, can not be different from default-ksk-algorithm ("<<::arg()["default-ksk-algorithm"]<<")."<<endl;
+      exit(1);
+    }
   }
 
   // NOW SAFE TO CREATE THREADS!

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -558,16 +558,32 @@ void mainthread()
   catch(...) {}
 
   // Some sanity checking on default key settings
+  bool hadKeyError = false;
   for (const string& algotype : {"ksk", "zsk"}) {
     int algo, size;
     if (::arg()["default-"+algotype+"-algorithm"].empty())
       continue;
     algo = DNSSECKeeper::shorthand2algorithm(::arg()["default-"+algotype+"-algorithm"]);
     size = ::arg().asNum("default-"+algotype+"-size");
-    if (algo == -1)
-      g_log<<Logger::Warning<<"Warning: default-"<<algotype<<"-algorithm set to unknown algorithm: "<<::arg()["default-"+algotype+"-algorithm"]<<endl;
-    else if (algo <= 10 && size == 0)
-      g_log<<Logger::Warning<<"Warning: default-"<<algotype<<"-algorithm is set to an algorithm ("<<::arg()["default-"+algotype+"-algorithm"]<<") that requires a non-zero default-"<<algotype<<"-size!"<<endl;
+    if (algo == -1) {
+      g_log<<Logger::Error<<"Error: default-"<<algotype<<"-algorithm set to unknown algorithm: "<<::arg()["default-"+algotype+"-algorithm"]<<endl;
+      hadKeyError = true;
+    }
+    else if (algo <= 10 && size == 0) {
+      g_log<<Logger::Error<<"Error: default-"<<algotype<<"-algorithm is set to an algorithm ("<<::arg()["default-"+algotype+"-algorithm"]<<") that requires a non-zero default-"<<algotype<<"-size!"<<endl;
+      hadKeyError = true;
+    }
+  }
+  if (hadKeyError) {
+    exit(1);
+  }
+  if (::arg()["default-ksk-algorithm"].empty() && !::arg()["default-zsk-algorithm"].empty()) {
+    g_log<<Logger::Error<<"Error: default-zsk-algorithm is set, but default-ksk-algorithm is not set."<<endl;
+    exit(1);
+  }
+  if (!::arg()["default-zsk-algorithm"].empty() && ::arg()["default-zsk-algorithm"] != ::arg()["default-ksk-algorithm"]) {
+    g_log<<Logger::Error<<"Error: default-zsk-algorithm ("<<::arg()["default-zsk-algorithm"]<<"), when set, can not be different from default-ksk-algorithm ("<<::arg()["default-ksk-algorithm"]<<")."<<endl;
+    exit(1);
   }
 
   // NOW SAFE TO CREATE THREADS!


### PR DESCRIPTION
### Short description
This commit ensures `pdns_server` does not start when there is a
misconfiguration in default-[kz]sk-algorithm:

 * Either is set to an unknown algorithm
 * When using RSA, key size is unset
 * zsk is set but ksk is not
 * zsk is not set to the same as the ksk

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)