### PR TITLE
Fix replying from ANY address for non-standard port

### DIFF
--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -112,10 +112,12 @@ void UDPNameserver::bindIPv4()
     if(!setNonBlocking(s))
       throw PDNSException("Unable to set UDP socket to non-blocking: "+stringerror());
 
-    locala.reset();
-    locala.sin4.sin_family=AF_INET;
+    locala=ComboAddress(localname, ::arg().asNum("local-port"));
 
-    if(localname=="0.0.0.0")
+    if(locala.sin4.sin_family != AF_INET)
+      throw PDNSException("Attempting to bind IPv4 socket to IPv6 address");
+
+    if(IsAnyAddress(locala))
       setsockopt(s, IPPROTO_IP, GEN_IP_PKTINFO, &one, sizeof(one));
 
     if (!setSocketTimestamps(s))
@@ -130,9 +132,6 @@ void UDPNameserver::bindIPv4()
     if( ::arg().mustDo("non-local-bind") )
 	Utility::setBindAny(AF_INET, s);
 
-    locala=ComboAddress(localname, ::arg().asNum("local-port"));
-    if(locala.sin4.sin_family != AF_INET) 
-      throw PDNSException("Attempting to bind IPv4 socket to IPv6 address");
 
     if( !d_additional_socket )
         g_localaddresses.push_back(locala);


### PR DESCRIPTION
### Short description
Previously we would only recognize 0.0.0.0 as 'any' and not 0.0.0.0:5300 or even 0.0.0.0:53.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
