### PR TITLE
simplify log message to avoid compile error

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1447,7 +1447,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     }
 
     if(rrset.empty()) {
-      DLOG(g_log<<"checking qtype.getCode() ["<<(p->qtype.getCode())<<"] against QType::DS ["<<(QType::DS)<<"]"<<endl);
+      DLOG(g_log<<"checking if qtype is DS"<<endl);
       if(p->qtype.getCode() == QType::DS)
       {
         DLOG(g_log<<"DS query found no direct result, trying referral now"<<endl);


### PR DESCRIPTION
### Short description
Under `--enable-verbose-logging`, this line would break on printing `QType::DS`. By simplifying the message, we avoid this problem.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
