### PR TITLE
Use a bitset for NSEC(3) records with lots of types

### DIFF
--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -720,25 +720,6 @@ public:
 private:
 };
 
-
-class WKSRecordContent : public DNSRecordContent
-{
-public:
-  static void report(void);
-  WKSRecordContent() 
-  {}
-  WKSRecordContent(const string& content, const string& zone=""); // FIXME400: DNSName& zone?
-
-  static std::shared_ptr<DNSRecordContent> make(const DNSRecord &dr, PacketReader& pr);
-  static std::shared_ptr<DNSRecordContent> make(const string& content);
-  string getZoneRepresentation(bool noDot=false) const override;
-  void toPacket(DNSPacketWriter& pw) override;
-
-  uint32_t d_ip{0};
-  std::bitset<65535> d_services;
-private:
-};
-
 class EUI48RecordContent : public DNSRecordContent 
 {
 public:

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -545,6 +545,28 @@ public:
 class NSECBitmap
 {
 public:
+  NSECBitmap(): d_bitset(nullptr)
+  {
+  }
+  NSECBitmap(const NSECBitmap& rhs): d_set(rhs.d_set)
+  {
+    if (rhs.d_bitset) {
+      d_bitset = std::unique_ptr<std::bitset<nbTypes>>(new std::bitset<nbTypes>(*(rhs.d_bitset)));
+    }
+  }
+  NSECBitmap& operator=(const NSECBitmap& rhs)
+  {
+    d_set = rhs.d_set;
+
+    if (rhs.d_bitset) {
+      d_bitset = std::unique_ptr<std::bitset<nbTypes>>(new std::bitset<nbTypes>(*(rhs.d_bitset)));
+    }
+
+    return *this;
+  }
+  NSECBitmap(NSECBitmap&& rhs): d_bitset(std::move(rhs.d_bitset)), d_set(std::move(rhs.d_set))
+  {
+  }
   bool isSet(uint16_t type) const
   {
     if (d_bitset) {
@@ -625,6 +647,10 @@ public:
   {
     d_bitmap.set(type);
   }
+  void set(const NSECBitmap& bitmap)
+  {
+    d_bitmap = bitmap;
+  }
   size_t numberOfTypesSet() const
   {
     return d_bitmap.count();
@@ -664,6 +690,10 @@ public:
   void set(uint16_t type)
   {
     d_bitmap.set(type);
+  }
+  void set(const NSECBitmap& bitmap)
+  {
+    d_bitmap = bitmap;
   }
   size_t numberOfTypesSet() const
   {

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -580,10 +580,13 @@ public:
   void toPacket(DNSPacketWriter& pw);
   std::string getZoneRepresentation() const;
 
+  static constexpr size_t const nbTypes = 65536;
+
 private:
+
   void migrateToBitSet()
   {
-    d_bitset = std::unique_ptr<std::bitset<65536>>(new std::bitset<65536>());
+    d_bitset = std::unique_ptr<std::bitset<nbTypes>>(new std::bitset<nbTypes>());
     for (const auto& type : d_set) {
       d_bitset->set(type);
     }
@@ -594,7 +597,7 @@ private:
      when there are a lot of them.
      So we start with the set, but allocate and switch to a bitset
      if the number of covered types increases a lot */
-  std::unique_ptr<std::bitset<65536>> d_bitset;
+  std::unique_ptr<std::bitset<nbTypes>> d_bitset;
   std::set<uint16_t> d_set;
 };
 

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -542,6 +542,62 @@ public:
   struct soatimes d_st;
 };
 
+class NSECBitmap
+{
+public:
+  bool isSet(uint16_t type) const
+  {
+    if (d_bitset) {
+      return d_bitset->test(type);
+    }
+    return d_set.count(type);
+  }
+  void set(uint16_t type)
+  {
+    if (!d_bitset) {
+      if (d_set.size() >= 200) {
+        migrateToBitSet();
+      }
+    }
+    if (d_bitset) {
+      d_bitset->set(type);
+    }
+    else {
+      d_set.insert(type);
+    }
+  }
+  size_t count() const
+  {
+    if (d_bitset) {
+      return d_bitset->count();
+    }
+    else {
+      return d_set.size();
+    }
+  }
+
+  void fromPacket(PacketReader& pr);
+  void toPacket(DNSPacketWriter& pw);
+  std::string getZoneRepresentation() const;
+
+private:
+  void migrateToBitSet()
+  {
+    d_bitset = std::unique_ptr<std::bitset<65536>>(new std::bitset<65536>());
+    for (const auto& type : d_set) {
+      d_bitset->set(type);
+    }
+    d_set.clear();
+  }
+  /* using a dynamic set is very efficient for a small number of
+     types covered (~200), but uses a lot of memory (up to 3MB)
+     when there are a lot of them.
+     So we start with the set, but allocate and switch to a bitset
+     if the number of covered types increases a lot */
+  std::unique_ptr<std::bitset<65536>> d_bitset;
+  std::set<uint16_t> d_set;
+};
+
 class NSECRecordContent : public DNSRecordContent
 {
 public:
@@ -558,9 +614,22 @@ public:
   {
     return QType::NSEC;
   }
+  bool isSet(uint16_t type) const
+  {
+    return d_bitmap.isSet(type);
+  }
+  void set(uint16_t type)
+  {
+    d_bitmap.set(type);
+  }
+  size_t numberOfTypesSet() const
+  {
+    return d_bitmap.count();
+  }
+
   DNSName d_next;
-  std::set<uint16_t> d_set;
 private:
+  NSECBitmap d_bitmap;
 };
 
 class NSEC3RecordContent : public DNSRecordContent
@@ -580,15 +649,26 @@ public:
   uint16_t d_iterations{0};
   string d_salt;
   string d_nexthash;
-  std::set<uint16_t> d_set;
 
   uint16_t getType() const override
   {
     return QType::NSEC3;
   }
-
+  bool isSet(uint16_t type) const
+  {
+    return d_bitmap.isSet(type);
+  }
+  void set(uint16_t type)
+  {
+    d_bitmap.set(type);
+  }
+  size_t numberOfTypesSet() const
+  {
+    return d_bitmap.count();
+  }
 
 private:
+  NSECBitmap d_bitmap;
 };
 
 

--- a/pdns/nsec3dig.cc
+++ b/pdns/nsec3dig.cc
@@ -171,15 +171,18 @@ try
     {
       // cerr<<"got nsec3 ["<<i->first.d_name<<"]"<<endl;
       // cerr<<i->first.d_content->getZoneRepresentation()<<endl;
-      NSEC3RecordContent r = dynamic_cast<NSEC3RecordContent&> (*(i->first.d_content));
+      const auto r = std::dynamic_pointer_cast<NSEC3RecordContent>(i->first.d_content);
+      if (!r) {
+        continue;
+      }
       // nsec3.insert(new nsec3()
       // cerr<<toBase32Hex(r.d_nexthash)<<endl;
       vector<string> parts;
       string sname=i->first.d_name.toString();
       boost::split(parts, sname /* FIXME400 */, boost::is_any_of("."));
-      nsec3s.insert(make_pair(toLower(parts[0]), toBase32Hex(r.d_nexthash)));
-      nsec3salt = r.d_salt;
-      nsec3iters = r.d_iterations;
+      nsec3s.insert(make_pair(toLower(parts[0]), toBase32Hex(r->d_nexthash)));
+      nsec3salt = r->d_salt;
+      nsec3iters = r->d_iterations;
     }
     else
     {

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -24,6 +24,140 @@
 #endif
 #include "dnsrecords.hh"
 
+class NSECBitmapGenerator
+{
+public:
+  NSECBitmapGenerator(DNSPacketWriter& pw_): pw(pw_)
+  {
+  }
+  void set(uint16_t type)
+  {
+    uint16_t bit = type % 256;
+    int window = static_cast<int>(type / 256);
+
+    if (window != oldWindow) {
+      if (oldWindow > -1) {
+        res[0] = static_cast<unsigned char>(oldWindow);
+        res[1] = static_cast<unsigned char>(len);
+        tmp.assign(res, res+len+2);
+        pw.xfrBlob(tmp);
+      }
+      memset(res, 0, 34);
+      oldWindow = window;
+    }
+    res[2+bit/8] |= 1 << (7-(bit%8));
+    len=1+bit/8;
+  }
+
+  void finish()
+  {
+    res[0] = static_cast<unsigned char>(oldWindow);
+    res[1] = static_cast<unsigned char>(len);
+    if (len) {
+      tmp.assign(res, res+len+2);
+      pw.xfrBlob(tmp);
+    }
+  }
+
+private:
+  DNSPacketWriter& pw;
+  /* one byte for the window,
+     one for the length,
+     then the maximum of 32 bytes */
+  uint8_t res[34];
+  int oldWindow{-1};
+  int len{0};
+  string tmp;
+};
+
+void NSECBitmap::toPacket(DNSPacketWriter& pw)
+{
+  NSECBitmapGenerator nbg(pw);
+  if (d_bitset) {
+    size_t count = d_bitset->count();
+    size_t found = 0;
+    for(size_t idx = 0; idx < 65535 && found < count; ++idx){
+      if (!d_bitset->test(idx)) {
+        continue;
+      }
+      found++;
+      nbg.set(idx);
+    }
+  }
+  else {
+    for (const auto& type : d_set) {
+      nbg.set(type);
+    }
+  }
+
+  nbg.finish();
+}
+
+void NSECBitmap::fromPacket(PacketReader& pr)
+{
+  string bitmap;
+  pr.xfrBlob(bitmap);
+
+  // 00 06 20 00 00 00 00 03  -> NS RRSIG NSEC  ( 2, 46, 47 ) counts from left
+  if(bitmap.empty()) {
+    return;
+  }
+
+  if(bitmap.size() < 2) {
+    throw MOADNSException("NSEC record with impossibly small bitmap");
+  }
+  
+  for(unsigned int n = 0; n+1 < bitmap.size();) {
+    unsigned int window=static_cast<unsigned char>(bitmap[n++]);
+    unsigned int blen=static_cast<unsigned char>(bitmap[n++]);
+
+    // end if zero padding and ensure packet length
+    if(window == 0 && blen == 0) {
+      break;
+    }
+
+    if(n + blen > bitmap.size()) {
+      throw MOADNSException("NSEC record with bitmap length > packet length");
+    }
+
+    for(unsigned int k=0; k < blen; k++) {
+      uint8_t val=bitmap[n++];
+      for(int bit = 0; bit < 8 ; ++bit , val>>=1) {
+        if(val & 1) {
+          set((7-bit) + 8*(k) + 256*window);
+        }
+      }
+    }
+  }
+}
+
+string NSECBitmap::getZoneRepresentation() const
+{
+  string ret;
+
+  if (d_bitset) {
+    size_t count = d_bitset->count();
+    size_t found = 0;
+    for(size_t idx = 0; idx < 65535 && found < count; ++idx) {
+      if (!d_bitset->test(idx)) {
+        continue;
+      }
+      found++;
+
+      ret+=" ";
+      ret+=DNSRecordContent::NumberToType(idx);
+    }
+  }
+  else {
+    for(const auto& type : d_set) {
+      ret+=" ";
+      ret+=DNSRecordContent::NumberToType(type);
+    }
+  }
+
+  return ret;
+}
+
 void NSECRecordContent::report(void)
 {
   regist(1, 47, &make, &make, "NSEC");
@@ -34,7 +168,7 @@ std::shared_ptr<DNSRecordContent> NSECRecordContent::make(const string& content)
   return std::make_shared<NSECRecordContent>(content);
 }
 
-NSECRecordContent::NSECRecordContent(const string& content, const string& zone) 
+NSECRecordContent::NSECRecordContent(const string& content, const string& zone)
 {
   RecordTextReader rtr(content, DNSName(zone));
   rtr.xfrName(d_next);
@@ -42,76 +176,23 @@ NSECRecordContent::NSECRecordContent(const string& content, const string& zone)
   while(!rtr.eof()) {
     uint16_t type;
     rtr.xfrType(type);
-    d_set.insert(type);
+    set(type);
   }
 }
 
-void NSECRecordContent::toPacket(DNSPacketWriter& pw) 
+void NSECRecordContent::toPacket(DNSPacketWriter& pw)
 {
   pw.xfrName(d_next);
-
-  uint8_t res[34];
-  set<uint16_t>::const_iterator i;
-  int oldWindow = -1;
-  int window = 0;
-  int len = 0;
-  string tmp;
-
-  for(i=d_set.begin(); i != d_set.end(); ++i){
-    uint16_t bit = (*i)%256;
-    window = static_cast<int>((*i) / 256); 
-
-    if (window != oldWindow) {
-      if (oldWindow > -1) {
-          res[0] = static_cast<unsigned char>(oldWindow);
-          res[1] = static_cast<unsigned char>(len);
-          tmp.assign(res, res+len+2);
-          pw.xfrBlob(tmp);
-      }
-      memset(res, 0, 34);
-      oldWindow = window;
-    }
-    res[2+bit/8] |= 1 << (7-(bit%8));
-    len=1+bit/8;
-  }
-
-  res[0] = static_cast<unsigned char>(window);
-  res[1] = static_cast<unsigned char>(len);
-  tmp.assign(res, res+len+2);
-  pw.xfrBlob(tmp);
+  d_bitmap.toPacket(pw);
 }
 
 std::shared_ptr<NSECRecordContent::DNSRecordContent> NSECRecordContent::make(const DNSRecord &dr, PacketReader& pr)
 {
   auto ret=std::make_shared<NSECRecordContent>();
   pr.xfrName(ret->d_next);
-  string bitmap;
-  pr.xfrBlob(bitmap);
- 
-  // 00 06 20 00 00 00 00 03  -> NS RRSIG NSEC  ( 2, 46, 47 ) counts from left
-  if(bitmap.empty())
-    return ret;
 
-  if(bitmap.size() < 2)
-    throw MOADNSException("NSEC record with impossibly small bitmap");
-  
-  for(unsigned int n = 0; n+1 < bitmap.size();) {
-    unsigned int window=static_cast<unsigned char>(bitmap[n++]);
-    unsigned int blen=static_cast<unsigned char>(bitmap[n++]);
+  ret->d_bitmap.fromPacket(pr);
 
-    // end if zero padding and ensure packet length
-    if(window == 0 && blen == 0) break;
-    if(n + blen > bitmap.size())
-      throw MOADNSException("NSEC record with bitmap length > packet length");
-
-    for(unsigned int k=0; k < blen; k++) {
-      uint8_t val=bitmap[n++];
-      for(int bit = 0; bit < 8 ; ++bit , val>>=1)
-        if(val & 1) {
-          ret->d_set.insert((7-bit) + 8*(k) + 256*window);
-        }
-      }
-  }
   return ret;
 }
 
@@ -120,13 +201,8 @@ string NSECRecordContent::getZoneRepresentation(bool noDot) const
   string ret;
   RecordTextWriter rtw(ret);
   rtw.xfrName(d_next);
-  
-  for(set<uint16_t>::const_iterator i=d_set.begin(); i!=d_set.end(); ++i) {
-    ret+=" ";
-    ret+=NumberToType(*i);
-  }
-  
-  return ret;
+
+  return ret + d_bitmap.getZoneRepresentation();
 }
 
 ////// begin of NSEC3
@@ -154,7 +230,7 @@ NSEC3RecordContent::NSEC3RecordContent(const string& content, const string& zone
   while(!rtr.eof()) {
     uint16_t type;
     rtr.xfrType(type);
-    d_set.insert(type);
+    set(type);
   }
 }
 
@@ -168,39 +244,8 @@ void NSEC3RecordContent::toPacket(DNSPacketWriter& pw)
 
   pw.xfr8BitInt(d_nexthash.length());
   pw.xfrBlob(d_nexthash);
-  
-  uint8_t res[34];
-  set<uint16_t>::const_iterator i;
-  int oldWindow = -1;
-  int window = 0;
-  int len = 0;
-  string tmp;
 
-  for(i=d_set.begin(); i != d_set.end(); ++i){
-    uint16_t bit = (*i)%256;
-    window = static_cast<int>((*i) / 256);
-
-    if (window != oldWindow) {
-      if (oldWindow > -1) {
-          res[0] = static_cast<unsigned char>(oldWindow);
-          res[1] = static_cast<unsigned char>(len);
-          tmp.assign(res, res+len+2);
-          pw.xfrBlob(tmp);
-      }
-      memset(res, 0, 34);
-      oldWindow = window;
-    }
-    res[2+bit/8] |= 1 << (7-(bit%8));
-    len=1+bit/8;
-  }
-
-  res[0] = static_cast<unsigned char>(window);
-  res[1] = static_cast<unsigned char>(len);
-
-  if (len) {
-    tmp.assign(res, res+len+2);
-    pw.xfrBlob(tmp);
-  }
+  d_bitmap.toPacket(pw);
 }
 
 std::shared_ptr<NSEC3RecordContent::DNSRecordContent> NSEC3RecordContent::make(const DNSRecord &dr, PacketReader& pr)
@@ -215,35 +260,8 @@ std::shared_ptr<NSEC3RecordContent::DNSRecordContent> NSEC3RecordContent::make(c
 
   pr.xfr8BitInt(len);
   pr.xfrBlob(ret->d_nexthash, len);
-  
-  string bitmap;
-  pr.xfrBlob(bitmap);
-  
-  // 00 06 20 00 00 00 00 03  -> NS RRSIG NSEC  ( 2, 46, 47 ) counts from left
-  
-  if(bitmap.empty())
-    return ret;
 
-  if(bitmap.size() < 2)
-    throw MOADNSException("NSEC3 record with impossibly small bitmap");
-
-  for(unsigned int n = 0; n+1 < bitmap.size();) {
-    unsigned int window=static_cast<unsigned char>(bitmap[n++]);
-    unsigned int innerlen=static_cast<unsigned char>(bitmap[n++]);
-    
-    // end if zero padding and ensure packet length
-    if(window == 0&&innerlen == 0) break;
-    if(n+innerlen>bitmap.size())
-      throw MOADNSException("NSEC record with bitmap length > packet length");
-
-    for(unsigned int k=0; k < innerlen; k++) {
-      uint8_t val=bitmap[n++];
-      for(int bit = 0; bit < 8 ; ++bit , val>>=1)
-        if(val & 1) {
-          ret->d_set.insert((7-bit) + 8*(k) + 256*window);
-        }
-      }
-  }
+  ret->d_bitmap.fromPacket(pr);
   return ret;
 }
 
@@ -257,12 +275,8 @@ string NSEC3RecordContent::getZoneRepresentation(bool noDot) const
 
   rtw.xfrHexBlob(d_salt);
   rtw.xfrBase32HexBlob(d_nexthash);
-  for(set<uint16_t>::const_iterator i=d_set.begin(); i!=d_set.end(); ++i) {
-    ret+=" ";
-    ret+=NumberToType(*i);
-  }
-  
-  return ret;
+
+  return ret + d_bitmap.getZoneRepresentation();
 }
 
 

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -76,7 +76,7 @@ void NSECBitmap::toPacket(DNSPacketWriter& pw)
   if (d_bitset) {
     size_t count = d_bitset->count();
     size_t found = 0;
-    for(size_t idx = 0; idx < 65535 && found < count; ++idx){
+    for(size_t idx = 0; idx < nbTypes && found < count; ++idx){
       if (!d_bitset->test(idx)) {
         continue;
       }
@@ -138,7 +138,7 @@ string NSECBitmap::getZoneRepresentation() const
   if (d_bitset) {
     size_t count = d_bitset->count();
     size_t found = 0;
-    for(size_t idx = 0; idx < 65535 && found < count; ++idx) {
+    for(size_t idx = 0; idx < nbTypes && found < count; ++idx) {
       if (!d_bitset->test(idx)) {
         continue;
       }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -484,19 +484,19 @@ void PacketHandler::emitNSEC(DNSPacket *r, const SOAData& sd, const DNSName& nam
   NSECRecordContent nrc;
   nrc.d_next = next;
 
-  nrc.d_set.insert(QType::NSEC);
-  nrc.d_set.insert(QType::RRSIG);
+  nrc.set(QType::NSEC);
+  nrc.set(QType::RRSIG);
   if(sd.qname == name) {
-    nrc.d_set.insert(QType::SOA); // 1dfd8ad SOA can live outside the records table
-    nrc.d_set.insert(QType::DNSKEY);
+    nrc.set(QType::SOA); // 1dfd8ad SOA can live outside the records table
+    nrc.set(QType::DNSKEY);
     string publishCDNSKEY;
     d_dk.getFromMeta(name, "PUBLISH-CDNSKEY", publishCDNSKEY);
     if (publishCDNSKEY == "1")
-      nrc.d_set.insert(QType::CDNSKEY);
+      nrc.set(QType::CDNSKEY);
     string publishCDS;
     d_dk.getFromMeta(name, "PUBLISH-CDS", publishCDS);
     if (! publishCDS.empty())
-      nrc.d_set.insert(QType::CDS);
+      nrc.set(QType::CDS);
   }
 
   DNSZoneRecord rr;
@@ -505,17 +505,17 @@ void PacketHandler::emitNSEC(DNSPacket *r, const SOAData& sd, const DNSName& nam
   while(B.get(rr)) {
 #ifdef HAVE_LUA_RECORDS   
     if(rr.dr.d_type == QType::LUA)
-      nrc.d_set.insert(getRR<LUARecordContent>(rr.dr)->d_type);
+      nrc.set(getRR<LUARecordContent>(rr.dr)->d_type);
     else
 #endif
       if(rr.dr.d_type == QType::NS || rr.auth)
-      nrc.d_set.insert(rr.dr.d_type);
+      nrc.set(rr.dr.d_type);
   }
 
   rr.dr.d_name = name;
   rr.dr.d_ttl = sd.default_ttl;
   rr.dr.d_type = QType::NSEC;
-  rr.dr.d_content = std::make_shared<NSECRecordContent>(nrc);
+  rr.dr.d_content = std::make_shared<NSECRecordContent>(std::move(nrc));
   rr.dr.d_place = (mode == 5 ) ? DNSResourceRecord::ANSWER: DNSResourceRecord::AUTHORITY;
   rr.auth = true;
 
@@ -535,38 +535,40 @@ void PacketHandler::emitNSEC3(DNSPacket *r, const SOAData& sd, const NSEC3PARAMR
 
   if(!name.empty()) {
     if (sd.qname == name) {
-      n3rc.d_set.insert(QType::SOA); // 1dfd8ad SOA can live outside the records table
-      n3rc.d_set.insert(QType::NSEC3PARAM);
-      n3rc.d_set.insert(QType::DNSKEY);
+      n3rc.set(QType::SOA); // 1dfd8ad SOA can live outside the records table
+      n3rc.set(QType::NSEC3PARAM);
+      n3rc.set(QType::DNSKEY);
       string publishCDNSKEY;
       d_dk.getFromMeta(name, "PUBLISH-CDNSKEY", publishCDNSKEY);
       if (publishCDNSKEY == "1")
-        n3rc.d_set.insert(QType::CDNSKEY);
+        n3rc.set(QType::CDNSKEY);
       string publishCDS;
       d_dk.getFromMeta(name, "PUBLISH-CDS", publishCDS);
       if (! publishCDS.empty())
-        n3rc.d_set.insert(QType::CDS);
+        n3rc.set(QType::CDS);
     }
 
     B.lookup(QType(QType::ANY), name, NULL, sd.domain_id);
     while(B.get(rr)) {
 #ifdef HAVE_LUA_RECORDS
       if(rr.dr.d_type == QType::LUA)
-        n3rc.d_set.insert(getRR<LUARecordContent>(rr.dr)->d_type);
+        n3rc.set(getRR<LUARecordContent>(rr.dr)->d_type);
       else
 #endif
         if(rr.dr.d_type && (rr.dr.d_type == QType::NS || rr.auth)) // skip empty non-terminals
-        n3rc.d_set.insert(rr.dr.d_type);
+        n3rc.set(rr.dr.d_type);
     }
   }
 
-  if (n3rc.d_set.size() && !(n3rc.d_set.size() == 1 && n3rc.d_set.count(QType::NS)))
-    n3rc.d_set.insert(QType::RRSIG);
+  const auto numberOfTypesSet = n3rc.numberOfTypesSet();
+  if (numberOfTypesSet != 0 && !(numberOfTypesSet == 1 && n3rc.isSet(QType::NS))) {
+    n3rc.set(QType::RRSIG);
+  }
 
   rr.dr.d_name = DNSName(toBase32Hex(namehash))+sd.qname;
   rr.dr.d_ttl = sd.default_ttl;
   rr.dr.d_type=QType::NSEC3;
-  rr.dr.d_content=std::make_shared<NSEC3RecordContent>(n3rc);
+  rr.dr.d_content=std::make_shared<NSEC3RecordContent>(std::move(n3rc));
   rr.dr.d_place = (mode == 5 ) ? DNSResourceRecord::ANSWER: DNSResourceRecord::AUTHORITY;
   rr.auth = true;
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -343,13 +343,15 @@ static void addNSECRecordToLW(const DNSName& domain, const DNSName& next, const 
 {
   NSECRecordContent nrc;
   nrc.d_next = next;
-  nrc.d_set = types;
+  for (const auto& type : types) {
+    nrc.set(type);
+  }
 
   DNSRecord rec;
   rec.d_name = domain;
   rec.d_ttl = ttl;
   rec.d_type = QType::NSEC;
-  rec.d_content = std::make_shared<NSECRecordContent>(nrc);
+  rec.d_content = std::make_shared<NSECRecordContent>(std::move(nrc));
   rec.d_place = DNSResourceRecord::AUTHORITY;
 
   records.push_back(rec);
@@ -363,13 +365,15 @@ static void addNSEC3RecordToLW(const DNSName& hashedName, const std::string& has
   nrc.d_iterations = iterations;
   nrc.d_salt = salt;
   nrc.d_nexthash = hashedNext;
-  nrc.d_set = types;
+  for (const auto& type : types) {
+    nrc.set(type);
+  }
 
   DNSRecord rec;
   rec.d_name = hashedName;
   rec.d_ttl = ttl;
   rec.d_type = QType::NSEC3;
-  rec.d_content = std::make_shared<NSEC3RecordContent>(nrc);
+  rec.d_content = std::make_shared<NSEC3RecordContent>(std::move(nrc));
   rec.d_place = DNSResourceRecord::AUTHORITY;
 
   records.push_back(rec);

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -200,7 +200,7 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
     } else if (zs.optOutFlag != (ns3rc.d_flags & 1))
       throw PDNSException("Zones with a mixture of Opt-Out NSEC3 RRs and non-Opt-Out NSEC3 RRs are not supported.");
     zs.optOutFlag = ns3rc.d_flags & 1;
-    if (ns3rc.d_set.count(QType::NS) && !(rr.qname==domain)) {
+    if (ns3rc.isSet(QType::NS) && !(rr.qname==domain)) {
       DNSName hashPart = rr.qname.makeRelative(domain);
       zs.secured.insert(hashPart);
     }

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -8,6 +8,8 @@
 
 #include <boost/tuple/tuple.hpp>
 #include <boost/scoped_ptr.hpp>
+
+#include "base32.hh"
 #include "dnsrecords.hh"
 
 namespace {
@@ -455,6 +457,103 @@ BOOST_AUTO_TEST_CASE(test_nsec_records_in) {
     MOADNSParser parser(false, reinterpret_cast<const char*>(packet.data()), packet.size());
 
     BOOST_CHECK_THROW(MOADNSParser failParser(false, reinterpret_cast<const char*>(packet.data()), packet.size()-1), MOADNSException);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_nsec_records_types) {
+
+  {
+    auto validNSEC = DNSRecordContent::mastermake(QType::NSEC, QClass::IN, "host.example.com. A MX RRSIG NSEC TYPE1234");
+    auto nsecContent = std::dynamic_pointer_cast<NSECRecordContent>(validNSEC);
+    BOOST_REQUIRE(nsecContent);
+
+    for (const auto type : { QType::A, QType::MX, QType::RRSIG, QType::NSEC, static_cast<QType::typeenum>(1234) }) {
+      BOOST_CHECK(nsecContent->isSet(type));
+    }
+    BOOST_CHECK_EQUAL(nsecContent->isSet(QType::NSEC3), false);
+    BOOST_CHECK_EQUAL(nsecContent->numberOfTypesSet(), 5);
+  }
+
+  {
+    auto nsecContent = std::make_shared<NSECRecordContent>();
+    BOOST_CHECK_EQUAL(nsecContent->numberOfTypesSet(), 0);
+    BOOST_CHECK_EQUAL(nsecContent->isSet(QType::NSEC3), false);
+
+    for (size_t idx = 0; idx < 65536; idx++) {
+      nsecContent->set(idx);
+    }
+    BOOST_CHECK_EQUAL(nsecContent->isSet(QType::NSEC3), true);
+    BOOST_CHECK_EQUAL(nsecContent->numberOfTypesSet(), 65536);
+    for (size_t idx = 0; idx < 65536; idx++) {
+      BOOST_CHECK(nsecContent->isSet(idx));
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_nsec3_records_types) {
+
+  {
+    auto validNSEC3 = DNSRecordContent::mastermake(QType::NSEC3, QClass::IN, "1 1 12 aabbccdd 2vptu5timamqttgl4luu9kg21e0aor3s A MX RRSIG NSEC3 TYPE1234");
+    auto nsec3Content = std::dynamic_pointer_cast<NSEC3RecordContent>(validNSEC3);
+    BOOST_REQUIRE(nsec3Content);
+
+    for (const auto type : { QType::A, QType::MX, QType::RRSIG, QType::NSEC3, static_cast<QType::typeenum>(1234) }) {
+      BOOST_CHECK(nsec3Content->isSet(type));
+    }
+    BOOST_CHECK_EQUAL(nsec3Content->isSet(QType::NSEC), false);
+    BOOST_CHECK_EQUAL(nsec3Content->numberOfTypesSet(), 5);
+  }
+
+  {
+    auto nsec3Content = std::make_shared<NSEC3RecordContent>();
+    BOOST_CHECK_EQUAL(nsec3Content->numberOfTypesSet(), 0);
+    BOOST_CHECK_EQUAL(nsec3Content->isSet(QType::NSEC), false);
+
+    for (size_t idx = 0; idx < 65536; idx++) {
+      nsec3Content->set(idx);
+    }
+    BOOST_CHECK_EQUAL(nsec3Content->isSet(QType::NSEC), true);
+    BOOST_CHECK_EQUAL(nsec3Content->numberOfTypesSet(), 65536);
+    for (size_t idx = 0; idx < 65536; idx++) {
+      BOOST_CHECK(nsec3Content->isSet(idx));
+    }
+  }
+
+  {
+    DNSName qname("powerdns.com.");
+    /* check that we can have a NSEC3 with 0 types covered */
+    const std::string salt = "aabbccdd";
+    const std::string hash =  "2vptu5timamqttgl4luu9kg21e0aor3s";
+    const std::string str = "1 1 12 " + salt + " " + hash;
+    auto validNSEC3=DNSRecordContent::mastermake(QType::NSEC3, QClass::IN, str);
+
+    vector<uint8_t> packet;
+    DNSPacketWriter writer(packet, qname, QType::NSEC3, QClass::IN, 0);
+    writer.getHeader()->qr = 1;
+    writer.startRecord(qname, QType::NSEC3, 100, QClass::IN, DNSResourceRecord::ANSWER);
+    validNSEC3->toPacket(writer);
+    writer.commit();
+
+    static const size_t expectedSize = sizeof(dnsheader) + qname.wirelength() + 2 /* QType */ + 2 /* QClass */
+      + 2 /* name pointer */ + 2 /* QType */ + 2 /* QClass */
+      + 2 /* rd length */ + 1 /* hash algo */ + 1 /* flags */ + 2 /*iterations */ + 1 /* salt length */ + salt.size()
+      + 1 /* hash length */ + fromBase32Hex(hash).size();
+    BOOST_CHECK_EQUAL(packet.size(), expectedSize);
+
+    MOADNSParser parser(false, reinterpret_cast<const char*>(packet.data()), packet.size());
+    BOOST_REQUIRE_EQUAL(parser.d_answers.size(), 1);
+    const auto& record = parser.d_answers.at(0).first;
+    BOOST_REQUIRE(record.d_type == QType::NSEC3);
+    BOOST_REQUIRE(record.d_class == QClass::IN);
+    auto content = std::dynamic_pointer_cast<NSEC3RecordContent>(record.d_content);
+    BOOST_REQUIRE(content);
+    BOOST_CHECK_EQUAL(content->numberOfTypesSet(), 0);
+    for (size_t idx = 0; idx < 65536; idx++) {
+      BOOST_CHECK_EQUAL(content->isSet(idx), false);
+    }
+    auto str2 = content->getZoneRepresentation();
+    boost::to_lower(str2);
+    BOOST_CHECK_EQUAL(str2, str);
   }
 }
 

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -493,30 +493,39 @@ BOOST_AUTO_TEST_CASE(test_nsec_records_types) {
 BOOST_AUTO_TEST_CASE(test_nsec3_records_types) {
 
   {
-    auto validNSEC3 = DNSRecordContent::mastermake(QType::NSEC3, QClass::IN, "1 1 12 aabbccdd 2vptu5timamqttgl4luu9kg21e0aor3s A MX RRSIG NSEC3 TYPE1234");
+    const std::string str = "1 1 12 aabbccdd 2vptu5timamqttgl4luu9kg21e0aor3s a mx rrsig nsec3 type1234 type65535";
+    auto validNSEC3 = DNSRecordContent::mastermake(QType::NSEC3, QClass::IN, str);
     auto nsec3Content = std::dynamic_pointer_cast<NSEC3RecordContent>(validNSEC3);
     BOOST_REQUIRE(nsec3Content);
 
-    for (const auto type : { QType::A, QType::MX, QType::RRSIG, QType::NSEC3, static_cast<QType::typeenum>(1234) }) {
+    for (const auto type : { QType::A, QType::MX, QType::RRSIG, QType::NSEC3, static_cast<QType::typeenum>(1234), static_cast<QType::typeenum>(65535) }) {
       BOOST_CHECK(nsec3Content->isSet(type));
     }
     BOOST_CHECK_EQUAL(nsec3Content->isSet(QType::NSEC), false);
-    BOOST_CHECK_EQUAL(nsec3Content->numberOfTypesSet(), 5);
+    BOOST_CHECK_EQUAL(nsec3Content->numberOfTypesSet(), 6);
+    auto str2 = nsec3Content->getZoneRepresentation();
+    boost::to_lower(str2);
+    BOOST_CHECK_EQUAL(str2, str);
   }
 
   {
-    auto nsec3Content = std::make_shared<NSEC3RecordContent>();
+    std::string str = "1 1 12 aabbccdd 2vptu5timamqttgl4luu9kg21e0aor3s";
+    auto nsec3Content = std::make_shared<NSEC3RecordContent>(str);
     BOOST_CHECK_EQUAL(nsec3Content->numberOfTypesSet(), 0);
     BOOST_CHECK_EQUAL(nsec3Content->isSet(QType::NSEC), false);
 
     for (size_t idx = 0; idx < 65536; idx++) {
       nsec3Content->set(idx);
+      str += " " + toLower(DNSRecordContent::NumberToType(idx));
     }
     BOOST_CHECK_EQUAL(nsec3Content->isSet(QType::NSEC), true);
     BOOST_CHECK_EQUAL(nsec3Content->numberOfTypesSet(), 65536);
     for (size_t idx = 0; idx < 65536; idx++) {
       BOOST_CHECK(nsec3Content->isSet(idx));
     }
+    auto str2 = nsec3Content->getZoneRepresentation();
+    boost::to_lower(str2);
+    BOOST_CHECK_EQUAL(str2, str);
   }
 
   {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`NSEC` and `NSEC3` records content classes are currently storing the types they cover in a `std::set<uint16_t>`. While this is efficient for most cases because there are relatively few types covered, it uses a lot of memory for a very large number of types, up to ~3 MB.
This PR switches from a `std::set<uint16_t>` to a `std::bitset` once we reach 200 types, turning the memory usage to ~8k, which is roughly the size that the regular set uses for this number of elements.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
