### PR TITLE
Zero out qtype response numbers in our statistics

### DIFF
--- a/pdns/responsestats.cc
+++ b/pdns/responsestats.cc
@@ -19,6 +19,8 @@ ResponseStats::ResponseStats() :   d_qtypecounters(new std::atomic<unsigned long
   for(int n=200; n < 65000 ; n+=200)
     d_sizecounters.push_back(make_pair(n,0));
   d_sizecounters.push_back(make_pair(std::numeric_limits<uint16_t>::max(),0));
+  for(unsigned int n =0 ; n < 65535; ++n)
+    d_qtypecounters[n] = 0;
 }
 
 ResponseStats g_rs;


### PR DESCRIPTION
Although you might think otherwise, and I frequently do, atomic counters do not get zero-initialized.
With this PR, we do this by hand. This makes valgrind usable again on auth.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
