### PR TITLE
Remove Flake8 from lgtm.yml

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -35,11 +35,3 @@ extraction:
   python:
     python_setup:
       version: 3
-    after_prepare:
-      - python3 -m pip install --upgrade --user flake8
-    before_index:
-      - python3 -m flake8 --version  # flake8 3.6.0 on CPython 3.6.5 on Linux
-      # stop the build if there are Python syntax errors or undefined names
-      - python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-      # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-      - python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
LGTM.com performs its own checks by running queries over source code (all queries are [open source on GitHub](https://github.com/semmle/ql)). It does not show alerts that are generated by Flake.

Unfortunately the provided Flake commands actually return an error, which means that LGTM's Python analysis fails:
```
[2019-01-05 07:31:29] [build] ++ python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
[2019-01-05 07:31:35] [build] ./regression-tests.recursor-dnssec/test_ECS.py:521:99: F821 undefined name 'cls'
[2019-01-05 07:31:35] [build]             additional = dns.rrset.from_text('ns1.ecs-echo.example.', 15, dns.rdataclass.IN, 'A', cls._PREFIX + '.21')
[2019-01-05 07:31:35] [build]
```

(https://lgtm.com/projects/g/PowerDNS/pdns/logs/rev/3a0387f7429710a21af7abcc745c71d6932e14be/lang:python/stage:Build%20child%20(3a0387f))
