### PR TITLE
Tests output

### DIFF
--- a/regression-tests.auth-py/authtests.py
+++ b/regression-tests.auth-py/authtests.py
@@ -124,8 +124,7 @@ distributor-threads=1""".format(confdir=confdir, prefix=cls._PREFIX,
         try:
             subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print(e.output)
-            raise
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
 
     @classmethod
     def secureZone(cls, confdir, zonename, key=None):
@@ -152,8 +151,7 @@ distributor-threads=1""".format(confdir=confdir, prefix=cls._PREFIX,
         try:
             subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print(e.output)
-            raise
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
 
     @classmethod
     def generateAllAuthConfig(cls, confdir):

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -86,7 +86,10 @@ class DNSDistTest(unittest.TestCase):
 
         # validate config with --check-config, which sets client=true, possibly exposing bugs.
         testcmd = dnsdistcmd + ['--check-config']
-        output = subprocess.check_output(testcmd, close_fds=True)
+        try:
+            output = subprocess.check_output(testcmd, stderr=subprocess.STDOUT, close_fds=True)
+        except subprocess.CalledProcessError as exc:
+            raise AssertionError('dnsdist --check-config failed (%d): %s' % (exc.returncode, exc.output))
         if output != b'Configuration \'dnsdist_test.conf\' OK!\n':
             raise AssertionError('dnsdist --check-config failed: %s' % output)
 

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -1643,7 +1643,7 @@ class TestAdvancedLuaTempFailureTTL(DNSDistTest):
 
     def testTempFailureTTLBinding(self):
         """
-        Exercise dq.tempFailureTTL Lua binding
+        Advanced: Exercise dq.tempFailureTTL Lua binding
         """
         name = 'tempfailurettlbinding.advanced.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
@@ -1671,7 +1671,7 @@ class TestAdvancedEDNSOptionRule(DNSDistTest):
 
     def testDropped(self):
         """
-        A question with ECS is dropped
+        Advanced: A question with ECS is dropped
         """
 
         name = 'ednsoptionrule.advanced.tests.powerdns.com.'
@@ -1686,7 +1686,7 @@ class TestAdvancedEDNSOptionRule(DNSDistTest):
 
     def testReplied(self):
         """
-        A question without ECS is answered
+        Advanced: A question without ECS is answered
         """
 
         name = 'ednsoptionrule.advanced.tests.powerdns.com.'

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -114,6 +114,9 @@ class TestCarbon(DNSDistTest):
             self.assertTrue(value >= 1)
 
     def testCarbonServerUp(self):
+        """
+        Carbon: set up 2 carbon servers
+        """
         # wait for the carbon data to be sent
         time.sleep(self._carbonInterval + 1)
 

--- a/regression-tests.dnsdist/test_SelfAnsweredResponses.py
+++ b/regression-tests.dnsdist/test_SelfAnsweredResponses.py
@@ -15,7 +15,7 @@ class TestSelfAnsweredResponses(DNSDistTest):
 
     def testSelfAnsweredUDP(self):
         """
-        CacheHitResponse: Drop when served from the cache
+        SelfAnsweredResponses: CacheHitResponse: Drop when served from the cache
         """
         ttl = 60
         name = 'udp.selfanswered.tests.powerdns.com.'
@@ -40,7 +40,7 @@ class TestSelfAnsweredResponses(DNSDistTest):
 
     def testSelfAnsweredTCP(self):
         """
-        testSelfAnsweredTCP: Drop after exceeding QPS
+        SelfAnsweredResponses: TCP: Drop after exceeding QPS
         """
         ttl = 60
         name = 'tcp.selfanswered.tests.powerdns.com.'

--- a/regression-tests.dnsdist/test_SelfAnsweredResponses.py
+++ b/regression-tests.dnsdist/test_SelfAnsweredResponses.py
@@ -15,7 +15,7 @@ class TestSelfAnsweredResponses(DNSDistTest):
 
     def testSelfAnsweredUDP(self):
         """
-        SelfAnsweredResponses: CacheHitResponse: Drop when served from the cache
+        SelfAnsweredResponses: Drop when served from the cache
         """
         ttl = 60
         name = 'udp.selfanswered.tests.powerdns.com.'

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -345,8 +345,7 @@ distributor-threads=1""".format(confdir=confdir,
         try:
             subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print(e.output)
-            raise
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
 
     @classmethod
     def secureZone(cls, confdir, zonename, key=None):
@@ -373,8 +372,7 @@ distributor-threads=1""".format(confdir=confdir,
         try:
             subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print(e.output)
-            raise
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
 
     @classmethod
     def generateAllAuthConfig(cls, confdir):
@@ -505,8 +503,7 @@ distributor-threads=1""".format(confdir=confdir,
         try:
             subprocess.check_output(rec_controlCmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print(e.output)
-            raise
+            raise AssertionError('%s failed (%d): %s' % (rec_controlCmd, e.returncode, e.output))
 
     @classmethod
     def setUpSockets(cls):

--- a/regression-tests.recursor-dnssec/test_basicNSEC3.py
+++ b/regression-tests.recursor-dnssec/test_basicNSEC3.py
@@ -32,8 +32,7 @@ class basicNSEC3(BasicDNSSEC):
         try:
             subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print(e.output)
-            raise
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
 
         params = "1 0 100 AABBCCDDEEFF112233"
 
@@ -50,5 +49,4 @@ class basicNSEC3(BasicDNSSEC):
         try:
             subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print(e.output)
-            raise
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))


### PR DESCRIPTION
### Short description
Improve test handling

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code

### Details

* This makes the test output more consistent and thus makes it easier to figure out which test has a failure
* https://travis-ci.org/jsoref/pdns/jobs/476925140#L2811

```
ERROR
Dnstap: Send query packed in dnstap to a unix socket fstrmlogger server ... ok
Dnstap: Send query and responses packed in dnstap to a remotelogger server ... ok
DnstapExtra: Send query and responses packed in dnstap to a remotelogger server. Extra data is filled out. ... ok
Dyn Blocks (group) : Excluded from the dynamic block rules ... ok
...
XPF ... ok
======================================================================
ERROR: test suite for <class 'test_Dnstap.TestDnstapOverFrameStreamTcpLogger'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/jsoref/pdns/regression-tests.dnsdist/.venv/local/lib/python2.7/site-packages/nose/suite.py", line 209, in run
    self.setUp()
  File "/home/travis/build/jsoref/pdns/regression-tests.dnsdist/.venv/local/lib/python2.7/site-packages/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/home/travis/build/jsoref/pdns/regression-tests.dnsdist/.venv/local/lib/python2.7/site-packages/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/home/travis/build/jsoref/pdns/regression-tests.dnsdist/.venv/local/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/travis/build/jsoref/pdns/regression-tests.dnsdist/dnsdisttests.py", line 124, in setUpClass
    cls.startDNSDist(cls._shutUp)
  File "/home/travis/build/jsoref/pdns/regression-tests.dnsdist/dnsdisttests.py", line 92, in startDNSDist
    raise AssertionError('dnsdist --check-config failed (%d): %s' % (exc.returncode, exc.output))
AssertionError: dnsdist --check-config failed (1): Fatal Lua error: [string "chunk"]:4: Caught exception: fstrm with TCP support is required to build an AF_INET FrameStreamLogger
----------------------------------------------------------------------
XML: /home/travis/build/jsoref/pdns/regression-tests.dnsdist/nosetests.xml
----------------------------------------------------------------------
Ran 272 tests in 830.231s
FAILED (errors=1)
The command "DNSDISTBIN=/home/travis/dnsdist/bin/dnsdist ./runtests -v" failed and exited with 1 during .
```

This error is because the build here is trying to use xenial, and the library it needs hasn't been packaged with the modified feature for xenial.

There's still one more thing to fix in the output, namely:
`The command "DNSDISTBIN=/home/travis/dnsdist/bin/dnsdist ./runtests -v" failed and exited with 1 during .`

```
build-scripts/travis.sh:    echo -e "\n${ANSI_RED}The command \"$TRAVIS_CMD\" failed and exited with $result during $TRAVIS_STAGE.${ANSI_RESET}\n\nYour build has been stopped."
```

For whatever reason, `$TRAVIS_STAGE` is apparently ` `.