### PR TITLE
Fix attempt to restrict/speed-up additional processing to auth zone

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -456,7 +456,7 @@ int PacketHandler::doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, c
       else
         continue;
 
-      B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), lookup, p, sd.domain_id);
+      B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), lookup, p, soadata.domain_id);
 
       while(B.get(rr)) {
         if(rr.dr.d_type != QType::A && rr.dr.d_type!=QType::AAAA)


### PR DESCRIPTION
When doing additional processing, an attempt is made to restrict the lookup
to the zone we are answering from.  Sadly, we use the domain_id of an
optional getSOA lookup, a lookup that frequently does not happen.

Fixing this shaves 20-40 microseconds from a referral when serving the root.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
