### PR TITLE
Add Rcode response statistics on API

### DIFF
--- a/docs/changelog/4.2.rst
+++ b/docs/changelog/4.2.rst
@@ -881,3 +881,10 @@ Changelogs for 4.2.x
     :tickets: 6028
 
     Forbid label compression in ALIAS wire format.
+
+  .. change::
+    :tags: Improvements
+    :pullreq: 7359
+    :tickets: 7357
+
+    API: Add response-by-qtype and response-by-rcode on /statistics endpoint

--- a/docs/http-api/statistics.rst
+++ b/docs/http-api/statistics.rst
@@ -9,6 +9,19 @@ Endpoints
 
 Objects
 -------
+
+The Statistics endpoint returns an array of objects that can be StatisticItem, MapStatisticItem or RingStatisticItem :
+
 .. openapi:: swagger/authoritative-api-swagger.yaml
   :definitions: StatisticItem
 
+.. openapi:: swagger/authoritative-api-swagger.yaml
+  :definitions: MapStatisticItem
+
+.. openapi:: swagger/authoritative-api-swagger.yaml
+  :definitions: RingStatisticItem
+
+Both MapStatisticItem and RingStatisticItem objects contains an array of SimpleStatisticItem
+
+.. openapi:: swagger/authoritative-api-swagger.yaml
+  :definitions: SimpleStatisticItem

--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -389,7 +389,7 @@ paths:
   '/servers/{server_id}/statistics':
     get:
       summary: 'Query statistics.'
-      description: 'Query PowerDNS internal statistics. Returns a list of BaseStatisticItem derived elements.'
+      description: 'Query PowerDNS internal statistics.'
       operationId: getStats
       tags:
         - stats
@@ -405,10 +405,6 @@ paths:
           schema:
             type: array
             items:
-            # these can be commented because the swagger code generator fails on them
-            # and replaced with
-            # type: string
-            # or something like that
             - $ref: '#/definitions/StatisticItem'
             - $ref: '#/definitions/MapStatisticItem'
             - $ref: '#/definitions/RingStatisticItem'
@@ -1064,69 +1060,62 @@ definitions:
         type: string
         description: 'The value of setting name'
 
-  BaseStatisticItem:
-    title: BaseStatisticItem
+  SimpleStatisticItem:
+    title: SimpleStatisticItem
+    type: object
     properties:
       name:
-        type: string
-        description: 'The name of this item (e.g. ‘uptime’)'
+          type: string
+          description: 'Item name'
+      value:
+          type: string
+          description: 'Item value'
 
   StatisticItem:
     title: StatisticItem
-    allOf:
-    - $ref: "#/definitions/BaseStatisticItem"
-    - properties:
-        type:
-          enum: [StatisticItem]
-          description: 'set to "StatisticItem"'
-        value:
-          type: string
-          description: 'The value of item'
+    properties:
+      name:
+        type: string
+        description: 'Item name'
+      type:
+        type: string
+        description: 'set to "StatisticItem"'
+      value:
+        type: string
+        description: 'Item value'
 
   MapStatisticItem:
     title: MapStatisticItem
-    allOf:
-    - $ref: "#/definitions/BaseStatisticItem"
-    - properties:
-        type:
-          enum: [MapStatisticItem]
-          description: 'set to "MapStatisticItem"'
-        value:
-          type: array
-          description: 'named statistic values'
-          items:
-            type: array
-            properties:
-              name:
-                type: string
-                description: 'item name'
-              value:
-                type: string
-                description: 'item value'
+    properties:
+      name:
+        type: string
+        description: 'Item name'
+      type:
+        type: string
+        description: 'Set to "MapStatisticItem"'
+      value:
+        type: array
+        description: 'Named values'
+        items:
+          $ref: '#/definitions/SimpleStatisticItem'
 
   RingStatisticItem:
     title: RingStatisticItem
-    allOf:
-    - $ref: "#/definitions/BaseStatisticItem"
-    - properties:
-        type:
-          enum: [RingStatisticItem]
-          description: 'set to "RingStatisticItem"'
-        size:
-          type: integer
-          description: 'for RingStatisticItem objects, the size of the ring'
-        value:
-          type: array
-          description: 'named ring statistic values'
-          items:
-            type: array
-            properties:
-              name:
-                type: string
-                description: 'item name'
-              value:
-                type: string
-                description: 'item value'
+    properties:
+      name:
+        type: string
+        description: 'Item name'
+      type:
+        type: string
+        description: 'Set to "RingStatisticItem"'
+      size:
+        type: integer
+        description: 'Ring size'
+      value:
+        type: array
+        description: 'Named values'
+        items:
+          $ref: '#/definitions/SimpleStatisticItem'
 
   SearchResultZone:
     title: SearchResultZone

--- a/pdns/responsestats-auth.cc
+++ b/pdns/responsestats-auth.cc
@@ -52,5 +52,5 @@ void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP) {
     }
   }
 
-  submitResponse(p.qtype.getCode(), buf.length(), udpOrTCP);
+  submitResponse(p.qtype.getCode(), buf.length(), p.d.rcode, udpOrTCP);
 }

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -30,12 +30,15 @@ public:
 
   void submitResponse(DNSPacket &p, bool udpOrTCP);
   void submitResponse(uint16_t qtype, uint16_t respsize, bool udpOrTCP);
+  void submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rcode, bool udpOrTCP);
   map<uint16_t, uint64_t> getQTypeResponseCounts();
   map<uint16_t, uint64_t> getSizeResponseCounts();
+  map<uint8_t, uint64_t> getRCodeResponseCounts();
   string getQTypeReport();
 
 private:
   boost::scoped_array<std::atomic<unsigned long>> d_qtypecounters;
+  boost::scoped_array<std::atomic<unsigned long>> d_rcodecounters;
   typedef vector<pair<uint16_t, uint64_t> > sizecounters_t;
   sizecounters_t d_sizecounters;
 };

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -165,6 +165,7 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp) {
 
   auto resp_qtype_stats = g_rs.getQTypeResponseCounts();
   auto resp_size_stats = g_rs.getSizeResponseCounts();
+  auto resp_rcode_stats = g_rs.getRCodeResponseCounts();
 
   Json::array doc;
   for(const auto& item : general_stats) {
@@ -188,7 +189,7 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp) {
 
     doc.push_back(Json::object {
       { "type", "MapStatisticItem" },
-      { "name", "queries-by-qtype" },
+      { "name", "response-by-qtype" },
       { "value", values },
     });
   }
@@ -208,6 +209,24 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp) {
     doc.push_back(Json::object {
       { "type", "MapStatisticItem" },
       { "name", "response-sizes" },
+      { "value", values },
+    });
+  }
+
+  {
+    Json::array values;
+    for(const auto& item : resp_rcode_stats) {
+      if (item.second == 0)
+        continue;
+      values.push_back(Json::object {
+        { "name", RCode::to_s(item.first) },
+        { "value", std::to_string(item.second) },
+      });
+    }
+
+    doc.push_back(Json::object {
+      { "type", "MapStatisticItem" },
+      { "name", "response-by-rcode" },
       { "value", values },
     });
   }

--- a/regression-tests.api/test_Servers.py
+++ b/regression-tests.api/test_Servers.py
@@ -43,14 +43,17 @@ class Servers(ApiTestCase):
         self.assertIn('uptime', [e['name'] for e in data])
         if is_auth():
             print(data)
-            qtype_stats, respsize_stats, queries_stats = None, None, None
+            qtype_stats, respsize_stats, queries_stats, rcode_stats = None, None, None, None
             for elem in data:
-                if elem['type'] == 'MapStatisticItem' and elem['name'] == 'queries-by-qtype':
+                if elem['type'] == 'MapStatisticItem' and elem['name'] == 'response-by-qtype':
                     qtype_stats = elem['value']
                 elif elem['type'] == 'MapStatisticItem' and elem['name'] == 'response-sizes':
                     respsize_stats = elem['value']
                 elif elem['type'] == 'RingStatisticItem' and elem['name'] == 'queries':
                     queries_stats = elem['value']
+                elif elem['type'] == 'MapStatisticItem' and elem['name'] == 'response-by-rcode':
+                    rcode_stats = elem['value']
             self.assertIn('A', [e['name'] for e in qtype_stats])
             self.assertIn('60', [e['name'] for e in respsize_stats])
             self.assertIn('example.com/A', [e['name'] for e in queries_stats])
+            self.assertIn('No Error', [e['name'] for e in rcode_stats])


### PR DESCRIPTION
- Add new statistic variable about rcode responses
- Add metrics about RCode on statistics API entrypoint
- Rename queries-by-qtype as response-by-qtype on API stats because it's calculated on response side

### Short description
Following Issue #7357, new statistic counter about rcode responses, published on the API on statistics entrypoint

Point to discuss : Name of variables.
On /statistics entrypoint, I've renamed queries-by-qtype as response-by-qtype, and named my new variable as response-by-rcode, because all of the work is made on responsestats.cc before sending the response. It's confusing to call the metrics as « queries » because it supposes that the metrics is measured when the querie cames and not before sending the response.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
