### PR TITLE
Dnsscope off-by-one + domain-filter

### DIFF
--- a/docs/manpages/dnsscope.1.rst
+++ b/docs/manpages/dnsscope.1.rst
@@ -23,6 +23,7 @@ INFILE
                                        flag set. By default, we process all DNS packets in *INFILE*.
 --ipv4=<state>                         Process IPv4 packets. On by default, disable with **--ipv4 false**.
 --ipv6=<state>                         Process IPv6 packets. On by default, disable with **--ipv6 false**.
+-f, --filter-name=<domain>             Only process packets within this domain 
 --full-histogram <msec>                Write out histogram with specified bin-size to 'full-histogram'
 --log-histogram                        Write out a log-histogram of response times to 'log-histogram'
 --no-servfail-stats                    Remove servfail responses from latency statistics

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -458,9 +458,8 @@ try
   sum=0;
   double lastperc=0, perc=0;
   uint64_t lastsum=0;
-  for(cumul_t::const_iterator i=cumul.begin(); i!=cumul.end(); ++i) {
-    sum+=i->second;
 
+  for(cumul_t::const_iterator i=cumul.begin(); i!=cumul.end(); ++i) {
     for(done_t::iterator j=done.begin(); j!=done.end(); ++j) {
       if(!j->second && i->first > j->first) {
         j->second=true;
@@ -476,7 +475,24 @@ try
         lastsum=sum;
       }
     }
+    sum+=i->second;
   }
+
+  for(auto j = done.begin(); j != done.end(); ++j) {
+    if(!j->second) {
+      perc=sum*100.0/totpairs;
+      if(j->first < 1024)
+        cout<< perc <<"% of questions answered within " << j->first << " usec (";
+      else
+        cout<< perc <<"% of questions answered within " << j->first/1000.0 << " msec (";
+      
+      cout<<perc-lastperc<<"%)\n";
+      lastperc=sum*100.0/totpairs;
+      lastsum=sum;
+      break;
+    }
+  }
+  
   cout<< (totpairs-lastsum)<<" responses ("<<((totpairs-lastsum)*100.0/answers) <<"%) older than "<< (done.rbegin()->first/1000000.0) <<" seconds"<<endl;
   if(totpairs)
     cout<<"Average non-late response time: "<<tottime/totpairs<<" usec"<<endl;

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -144,6 +144,7 @@ try
     ("log-histogram", "Write a log-histogram to file 'log-histogram'")
     ("full-histogram", po::value<double>(), "Write a log-histogram to file 'full-histogram' with this millisecond bin size")
 #endif
+    ("filter-name,f", po::value<string>(), "Do statistics only for queries within this domain")
     ("load-stats,l", po::value<string>()->default_value(""), "if set, emit per-second load statistics (questions, answers, outstanding)")
     ("no-servfail-stats", "Don't include servfails in response time stats")
     ("servfail-tree", "Figure out subtrees that generate servfails")
@@ -176,6 +177,11 @@ try
     cout << desc << endl;
     exit(0);
   }
+
+  DNSName filtername;
+  if(g_vm.count("filter-name"))
+    filtername = DNSName(g_vm["filter-name"].as<string>());
+  uint32_t nameMismatch = 0;
 
   StatNode root;
 
@@ -245,7 +251,12 @@ try
 	    rdFilterMismatch++;
 	    continue;
 	  }
-
+          
+          if(!filtername.empty() && !qname.isPartOf(filtername)) {
+            nameMismatch++;
+            continue;
+          }
+          
 	  if(!header.qr) {
             uint16_t udpsize, z;
             if(getEDNSUDPPayloadSizeAndZ((const char*)pr.d_payload, pr.d_len, &udpsize, &z)) {
@@ -390,6 +401,8 @@ try
   cout<<nonDNSIP<<" non-DNS UDP, "<<dnserrors<<" dns decoding errors, "<<parsefail<<" packets failed to parse"<<endl;
   cout<<"Ignored fragment packets: "<<fragmented<<endl;
   cout<<"Dropped DNS packets based on recursion-desired filter: "<<rdFilterMismatch<<endl;
+  if(!filtername.empty())
+    cout <<"Dropped DNS packets because not part of '"<<filtername<<"': "<<nameMismatch << endl;
   cout<<"DNS IPv4: "<<ipv4DNSPackets<<" packets, IPv6: "<<ipv6DNSPackets<<" packets"<<endl;
   cout<<"Questions: "<<queries<<", answers: "<<answers<<endl;
   cout<<"Reuses of same state entry: "<<reuses<<endl;


### PR DESCRIPTION
### Short description
dnsscope miscounted its statistics, assigning '101 usec' to the <100 usec bin. Secondly, it neglected to process the last latency bin, causing it to spuriously report very late packets.

Add `-f,--filter-name` option to dnsscope to limit processing to queries within a certain domain

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
