### PR TITLE
Move UUID generators to a common function, fix boost 1.69.0 warning

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1219,7 +1219,8 @@ dnspcap2protobuf_SOURCES = \
 	sillyrecords.cc \
 	statbag.cc \
 	unix_utility.cc \
-	utility.hh
+	utility.hh \
+	uuid-utils.hh uuid-utils.cc
 
 nodist_dnspcap2protobuf_SOURCES=dnsmessage.pb.cc dnsmessage.pb.h
 

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -758,7 +758,7 @@ public:
   {
 #ifdef HAVE_PROTOBUF
     if (!dq->uniqueId) {
-      dq->uniqueId = t_uuidGenerator();
+      dq->uniqueId = getUniqueID();
     }
 
     DNSDistProtoBufMessage message(*dq);
@@ -878,7 +878,7 @@ public:
   {
 #ifdef HAVE_PROTOBUF
     if (!dr->uniqueId) {
-      dr->uniqueId = t_uuidGenerator();
+      dr->uniqueId = getUniqueID();
     }
 
     DNSDistProtoBufMessage message(*dr, d_includeCNAME);

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -61,11 +61,10 @@ std::shared_ptr<DNSRule> makeRule(const luadnsrule_t& var)
 static boost::uuids::uuid makeRuleID(std::string& id)
 {
   if (id.empty()) {
-    return t_uuidGenerator();
+    return getUniqueID();
   }
 
-  boost::uuids::string_generator gen;
-  return gen(id);
+  return getUniqueID(id);
 }
 
 void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid& uuid, uint64_t& creationOrder)
@@ -128,8 +127,7 @@ static void rmRule(GlobalStateHolder<vector<T> > *someRulActions, boost::variant
   setLuaSideEffect();
   auto rules = someRulActions->getCopy();
   if (auto str = boost::get<std::string>(&id)) {
-    boost::uuids::string_generator gen;
-    const auto uuid = gen(*str);
+    const auto uuid = getUniqueID(*str);
     if (rules.erase(std::remove_if(rules.begin(),
                                     rules.end(),
                                     [uuid](const T& a) { return a.d_id == uuid; }),

--- a/pdns/dnsdist-protobuf.cc
+++ b/pdns/dnsdist-protobuf.cc
@@ -28,12 +28,12 @@
 #ifdef HAVE_PROTOBUF
 #include "dnsmessage.pb.h"
 
-DNSDistProtoBufMessage::DNSDistProtoBufMessage(const DNSQuestion& dq): DNSProtoBufMessage(Query, dq.uniqueId ? *dq.uniqueId : t_uuidGenerator(), dq.remote, dq.local, *dq.qname, dq.qtype, dq.qclass, dq.dh->id, dq.tcp, dq.len)
+DNSDistProtoBufMessage::DNSDistProtoBufMessage(const DNSQuestion& dq): DNSProtoBufMessage(Query, dq.uniqueId ? *dq.uniqueId : getUniqueID(), dq.remote, dq.local, *dq.qname, dq.qtype, dq.qclass, dq.dh->id, dq.tcp, dq.len)
 {
   setQueryTime(dq.queryTime->tv_sec, dq.queryTime->tv_nsec / 1000);
 };
 
-DNSDistProtoBufMessage::DNSDistProtoBufMessage(const DNSResponse& dr, bool includeCNAME): DNSProtoBufMessage(Response, dr.uniqueId ? *dr.uniqueId : t_uuidGenerator(), dr.remote, dr.local, *dr.qname, dr.qtype, dr.qclass, dr.dh->id, dr.tcp, dr.len)
+DNSDistProtoBufMessage::DNSDistProtoBufMessage(const DNSResponse& dr, bool includeCNAME): DNSProtoBufMessage(Response, dr.uniqueId ? *dr.uniqueId : getUniqueID(), dr.remote, dr.local, *dr.qname, dr.qtype, dr.qclass, dr.dh->id, dr.tcp, dr.len)
 {
   setQueryTime(dr.queryTime->tv_sec, dr.queryTime->tv_nsec / 1000);
   setResponseCode(dr.dh->rcode);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -64,8 +64,6 @@
 #include "sstuff.hh"
 #include "threadname.hh"
 
-thread_local boost::uuids::random_generator t_uuidGenerator;
-
 /* Known sins:
 
    Receiver is currently single threaded
@@ -702,7 +700,7 @@ void DownstreamState::setWeight(int newWeight)
 DownstreamState::DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf_, size_t numberOfSockets): remote(remote_), sourceAddr(sourceAddr_), sourceItf(sourceItf_)
 {
   pthread_rwlock_init(&d_lock, nullptr);
-  id = t_uuidGenerator();
+  id = getUniqueID();
   threadStarted.clear();
 
   mplexer = std::unique_ptr<FDMultiplexer>(FDMultiplexer::getMultiplexerSilent());

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -47,10 +47,7 @@
 #include "mplexer.hh"
 #include "sholder.hh"
 #include "tcpiohandler.hh"
-
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
+#include "uuid-utils.hh"
 
 void carbonDumpThread();
 uint64_t uptimeOfProcess(const std::string& str);
@@ -58,8 +55,6 @@ uint64_t uptimeOfProcess(const std::string& str);
 extern uint16_t g_ECSSourcePrefixV4;
 extern uint16_t g_ECSSourcePrefixV6;
 extern bool g_ECSOverride;
-
-extern thread_local boost::uuids::random_generator t_uuidGenerator;
 
 typedef std::unordered_map<string, string> QTag;
 

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -142,6 +142,7 @@ dnsdist_SOURCES = \
 	statnode.cc statnode.hh \
 	tcpiohandler.cc tcpiohandler.hh \
 	threadname.hh threadname.cc \
+	uuid-utils.hh uuid-utils.cc \
 	xpf.cc xpf.hh \
 	ext/luawrapper/include/LuaContext.hpp \
 	ext/json11/json11.cpp \

--- a/pdns/dnsdistdist/uuid-utils.cc
+++ b/pdns/dnsdistdist/uuid-utils.cc
@@ -1,0 +1,1 @@
+../uuid-utils.cc

--- a/pdns/dnsdistdist/uuid-utils.hh
+++ b/pdns/dnsdistdist/uuid-utils.hh
@@ -1,0 +1,1 @@
+../uuid-utils.hh

--- a/pdns/dnspcap2protobuf.cc
+++ b/pdns/dnspcap2protobuf.cc
@@ -23,7 +23,6 @@
 #include "config.h"
 #endif
 #include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
 
 #include "iputils.hh"
 #include "misc.hh"
@@ -32,6 +31,7 @@
 #include "dnspcap.hh"
 #include "dnsparser.hh"
 #include "protobuf.hh"
+#include "uuid-utils.hh"
 
 #include "statbag.hh"
 StatBag S;
@@ -75,7 +75,6 @@ try {
     ind=atoi(argv[3]);
 
   std::map<uint16_t,std::pair<boost::uuids::uuid,struct timeval> > ids;
-  boost::uuids::random_generator uuidGenerator;
   try {
     while (pr.getUDPPacket()) {
       const dnsheader* dh=(dnsheader*)pr.d_payload;
@@ -104,7 +103,7 @@ try {
       if (!dh->qr) {
         queryTime.tv_sec = pr.d_pheader.ts.tv_sec;
         queryTime.tv_usec = pr.d_pheader.ts.tv_usec;
-        uniqueId = uuidGenerator();
+        uniqueId = getUniqueID();
         ids[dh->id] = std::make_pair(uniqueId, queryTime);
       }
       else {
@@ -115,7 +114,7 @@ try {
           hasQueryTime = true;
         }
         else {
-          uniqueId = uuidGenerator();
+          uniqueId = getUniqueID();
         }
       }
 

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -50,6 +50,8 @@
 
 #ifdef HAVE_PROTOBUF
 
+#include "uuid-utils.hh"
+
 static void logOutgoingQuery(const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, boost::optional<const boost::uuids::uuid&> initialRequestId, const boost::uuids::uuid& uuid, const ComboAddress& ip, const DNSName& domain, int type, uint16_t qid, bool doTCP, size_t bytes, boost::optional<Netmask>& srcmask)
 {
   if(!outgoingLoggers)
@@ -160,7 +162,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
   const struct timeval queryTime = *now;
 
   if (outgoingLoggers) {
-    uuid = (*t_uuidGenerator)();
+    uuid = getUniqueID();
     logOutgoingQuery(outgoingLoggers, context ? context->d_initialRequestId : boost::none, uuid, ip, domain, type, qid, doTCP, vpacket.size(), srcmask);
   }
 #endif

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -102,6 +102,10 @@
 
 #include "namespaces.hh"
 
+#ifdef HAVE_PROTOBUF
+#include "uuid-utils.hh"
+#endif
+
 #include "xpf.hh"
 
 typedef map<ComboAddress, uint32_t, ComboAddress::addressOnlyLessThan> tcpClientCounts_t;
@@ -124,9 +128,6 @@ thread_local FDMultiplexer* t_fdm{nullptr};
 thread_local std::unique_ptr<addrringbuf_t> t_remotes, t_servfailremotes, t_largeanswerremotes, t_bogusremotes;
 thread_local std::unique_ptr<boost::circular_buffer<pair<DNSName, uint16_t> > > t_queryring, t_servfailqueryring, t_bogusqueryring;
 thread_local std::shared_ptr<NetmaskGroup> t_allowFrom;
-#ifdef HAVE_PROTOBUF
-thread_local std::unique_ptr<boost::uuids::random_generator> t_uuidGenerator;
-#endif
 #ifdef NOD_ENABLED
 thread_local std::shared_ptr<nod::NODDB> t_nodDBp;
 thread_local std::shared_ptr<nod::UniqueResponseDB> t_udrDBp;
@@ -1942,7 +1943,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       if(t_protobufServers || t_outgoingProtobufServers) {
         dc->d_requestorId = requestorId;
         dc->d_deviceId = deviceId;
-        dc->d_uuid = (*t_uuidGenerator)();
+        dc->d_uuid = getUniqueID();
       }
 
       if(t_protobufServers) {
@@ -2077,10 +2078,10 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
   boost::uuids::uuid uniqueId;
   auto luaconfsLocal = g_luaconfs.getLocal();
   if (checkProtobufExport(luaconfsLocal)) {
-    uniqueId = (*t_uuidGenerator)();
+    uniqueId = getUniqueID();
     needECS = true;
   } else if (checkOutgoingProtobufExport(luaconfsLocal)) {
-    uniqueId = (*t_uuidGenerator)();
+    uniqueId = getUniqueID();
   }
   logQuery = t_protobufServers && luaconfsLocal->protobufExportConfig.logQueries;
   bool logResponse = t_protobufServers && luaconfsLocal->protobufExportConfig.logResponses;
@@ -3932,9 +3933,6 @@ try
 
   t_packetCache = std::unique_ptr<RecursorPacketCache>(new RecursorPacketCache());
 
-#ifdef HAVE_PROTOBUF
-  t_uuidGenerator = std::unique_ptr<boost::uuids::random_generator>(new boost::uuids::random_generator());
-#endif
   g_log<<Logger::Warning<<"Done priming cache with root hints"<<endl;
 
 #ifdef NOD_ENABLED

--- a/pdns/protobuf.hh
+++ b/pdns/protobuf.hh
@@ -31,7 +31,6 @@
 
 #ifdef HAVE_PROTOBUF
 #include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
 #include "dnsmessage.pb.h"
 #endif /* HAVE_PROTOBUF */
 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -362,6 +362,10 @@ testrunner_LDADD += $(PROTOBUF_LIBS)
 testrunner$(OBJEXT): dnsmessage.pb.cc
 
 endif
+
+pdns_recursor_SOURCES += \
+	uuid-utils.hh uuid-utils.cc
+
 endif
 
 rec_control_SOURCES = \

--- a/pdns/recursordist/uuid-utils.cc
+++ b/pdns/recursordist/uuid-utils.cc
@@ -1,0 +1,1 @@
+../uuid-utils.cc

--- a/pdns/recursordist/uuid-utils.hh
+++ b/pdns/recursordist/uuid-utils.hh
@@ -1,0 +1,1 @@
+../uuid-utils.hh

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -56,7 +56,6 @@
 
 #ifdef HAVE_PROTOBUF
 #include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
 #endif
 
 class RecursorLua4;
@@ -1016,7 +1015,3 @@ void doCarbonDump(void*);
 void primeHints(void);
 
 extern __thread struct timeval g_now;
-
-#ifdef HAVE_PROTOBUF
-extern thread_local std::unique_ptr<boost::uuids::random_generator> t_uuidGenerator;
-#endif

--- a/pdns/uuid-utils.cc
+++ b/pdns/uuid-utils.cc
@@ -19,32 +19,29 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#pragma once
 
-#include <cstddef>
-#include <string>
+#include "uuid-utils.hh"
 
-#include "config.h"
+// see https://github.com/boostorg/random/issues/49
+#if BOOST_VERSION == 106900
+#ifndef BOOST_PENDING_INTEGER_LOG2_HPP
+#define BOOST_PENDING_INTEGER_LOG2_HPP
+#include <boost/integer/integer_log2.hpp>
+#endif /* BOOST_PENDING_INTEGER_LOG2_HPP */
+#endif /* BOOST_VERSION */
 
-#include "dnsname.hh"
-#include "iputils.hh"
+#include <boost/uuid/uuid_generators.hpp>
 
-#ifdef HAVE_PROTOBUF
-#include <boost/uuid/uuid.hpp>
-#include "dnstap.pb.h"
-#endif /* HAVE_PROTOBUF */
+thread_local boost::uuids::random_generator t_uuidGenerator;
 
-class DnstapMessage
+boost::uuids::uuid getUniqueID()
 {
-public:
-  DnstapMessage(const std::string& identity, const ComboAddress* requestor, const ComboAddress* responder, bool isTCP, const char* packet, const size_t len, const struct timespec* queryTime, const struct timespec* responseTime);
-  void serialize(std::string& data) const;
-  std::string toDebugString() const;
+  return t_uuidGenerator();
+}
 
-  void setExtra(const std::string& extra);
+boost::uuids::uuid getUniqueID(const std::string& str)
+{
+  boost::uuids::string_generator gen;
+  return gen(str);
+}
 
-#ifdef HAVE_PROTOBUF
-protected:
-  dnstap::Dnstap proto_message;
-#endif /* HAVE_PROTOBUF */
-};

--- a/pdns/uuid-utils.hh
+++ b/pdns/uuid-utils.hh
@@ -21,30 +21,8 @@
  */
 #pragma once
 
-#include <cstddef>
-#include <string>
-
-#include "config.h"
-
-#include "dnsname.hh"
-#include "iputils.hh"
-
-#ifdef HAVE_PROTOBUF
 #include <boost/uuid/uuid.hpp>
-#include "dnstap.pb.h"
-#endif /* HAVE_PROTOBUF */
+#include <boost/uuid/uuid_io.hpp>
 
-class DnstapMessage
-{
-public:
-  DnstapMessage(const std::string& identity, const ComboAddress* requestor, const ComboAddress* responder, bool isTCP, const char* packet, const size_t len, const struct timespec* queryTime, const struct timespec* responseTime);
-  void serialize(std::string& data) const;
-  std::string toDebugString() const;
-
-  void setExtra(const std::string& extra);
-
-#ifdef HAVE_PROTOBUF
-protected:
-  dnstap::Dnstap proto_message;
-#endif /* HAVE_PROTOBUF */
-};
+boost::uuids::uuid getUniqueID();
+boost::uuids::uuid getUniqueID(const std::string& str);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Without this fix, compiling against boost 1.69.0 results in a lot of occurrences of the following warning:
```
In file included from /usr/include/boost/random/detail/integer_log2.hpp:19,
                 from /usr/include/boost/random/detail/large_arithmetic.hpp:19,
                 from /usr/include/boost/random/detail/const_mod.hpp:23,
                 from /usr/include/boost/random/detail/seed_impl.hpp:26,
                 from /usr/include/boost/random/mersenne_twister.hpp:30,
                 from /usr/include/boost/uuid/random_generator.hpp:17,
                 from /usr/include/boost/uuid/uuid_generators.hpp:17,
                 from protobuf.hh:34,
                 from protobuf.cc:4:
/usr/include/boost/pending/integer_log2.hpp:7:59: note: #pragma message: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead.
 BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
```

A fix has been merged upstream and the warning will be gone in the upcoming 1.70.0, but 1.69.0 might be there for a long time if it's shipped in any LTS:

https://github.com/boostorg/random/issues/49

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
