### PR TITLE
rec-4.1.x: Fix compilation in handleRunningTCPQuestion without protobuf support

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1535,6 +1535,9 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
             L<<Logger::Warning<<"Error parsing a query packet for tag determination, setting tag=0: "<<e.what()<<endl;
         }
       }
+
+      const struct dnsheader* dh = (const struct dnsheader*) conn->data;
+
 #ifdef HAVE_PROTOBUF
       if(luaconfsLocal->protobufServer || luaconfsLocal->outgoingProtobufServer) {
         dc->d_requestorId = requestorId;
@@ -1542,7 +1545,6 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
         dc->d_uuid = (*t_uuidGenerator)();
       }
 
-      const struct dnsheader* dh = (const struct dnsheader*) conn->data;
       if(luaconfsLocal->protobufServer) {
         try {
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
6c4d0ab4cdb2fc73e73faba31fd8c3fe909e250a introduced a call to the Lua `ipfilter` hook that required access to the DNS header, but the corresponding variable was only declared when `protobuf` support had been enabled.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
