### PR TITLE
[WIP] auth API, DNSSEC (key) caching

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -57,12 +57,12 @@ bool DNSSECKeeper::doesDNSSEC()
   return d_keymetadb->doesDNSSEC();
 }
 
-bool DNSSECKeeper::isSecuredZone(const DNSName& zone) 
+bool DNSSECKeeper::isSecuredZone(const DNSName& zone, bool useCache)
 {
   if(isPresigned(zone))
     return true;
 
-  keyset_t keys = getKeys(zone); // does the cache
+  keyset_t keys = getKeys(zone, useCache);
 
   for(keyset_t::value_type& val :  keys) {
     if(val.second.active) {

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -182,7 +182,7 @@ public:
       delete d_keymetadb;
   }
   bool doesDNSSEC();
-  bool isSecuredZone(const DNSName& zone);
+  bool isSecuredZone(const DNSName& zone, bool useCache = true);
   static uint64_t dbdnssecCacheSizes(const std::string& str);
   keyset_t getEntryPoints(const DNSName& zname);
   keyset_t getKeys(const DNSName& zone, bool useCache = true);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -644,7 +644,7 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
   }
   catch (const JsonException&) {}
 
-  bool isDNSSECZone = dk.isSecuredZone(zonename);
+  bool isDNSSECZone = dk.isSecuredZone(zonename, false);
 
   if (dnssecInJSON) {
     if (dnssecDocVal) {


### PR DESCRIPTION
### Short description
#7407 demonstrates our DNSSEC key cache persisting over domain deletion, and thereby preventing the correct setup of DNSSEC when immediately adding that domain again.

This PR mitigates the specific symptom. It's obvious that the key cache shouldn't have held on to those keys when the domain was deleted, so there is more work to be done here.

Please feel free to push (if you have access) or PR (if you don't) to this branch.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
