### PR TITLE
Be smarter about trimming whitespace when creating records from ASCII

### DIFF
--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -39,7 +39,7 @@ RecordTextReader::RecordTextReader(const string& str, const DNSName& zone) : d_s
 {
    /* remove whitespace */
    if(!d_string.empty() && ( dns_isspace(*d_string.begin()) || dns_isspace(*d_string.rbegin()) ))
-     boost::trim_if(d_string, boost::algorithm::is_space());
+     boost::trim_if(d_string, dns_isspace);
    d_end = d_string.size();
 }
 

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -38,7 +38,8 @@
 RecordTextReader::RecordTextReader(const string& str, const DNSName& zone) : d_string(str), d_zone(zone), d_pos(0)
 {
    /* remove whitespace */
-   boost::trim_if(d_string, boost::algorithm::is_space());
+   if(!d_string.empty() && ( dns_isspace(*d_string.begin()) || dns_isspace(*d_string.rbegin()) ))
+     boost::trim_if(d_string, boost::algorithm::is_space());
    d_end = d_string.size();
 }
 


### PR DESCRIPTION
In ff7ac440afdae4370e12a1b9eb21d4b1389a861f we added trimming of whitespace,
so you could turn " 1.2.3.4 " into an A record 0x01020304. This commit made us more flexible
but also six times slower in some microbenchmarks.

This commit restores the old performance which shaves double digits percentages of time from many
benchmarks in 'speedtest', while making "make-a record" six times faster again.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
