### PR TITLE
fix 4.0 changelog that wrongly said SOA-EDIT=EPOCH was deprecated

### DIFF
--- a/docs/changelog/4.0.rst
+++ b/docs/changelog/4.0.rst
@@ -404,7 +404,7 @@ Important changes:
 
 -  Crypto++ and mbedTLS support is dropped, these are replaced by
    OpenSSL
--  The INCEPTION, INCEPTION-WEEK and EPOCH SOA-EDIT metadata values are
+-  The INCEPTION and INCEPTION-WEEK SOA-EDIT metadata values are
    marked as deprecated and will be removed in 4.1
 
 The final release has the following bug fixes compared to rc2:


### PR DESCRIPTION
closes #7384

### Short description
EPOCH was never supposed to be deprecated, and it is not going away. This PR removes that mention from the 4.0 changelog as it confused people.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
