### PR TITLE
LUA: report nested exception

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -896,7 +896,16 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
         ret.push_back(DNSRecordContent::mastermake(qtype, QClass::IN, content ));
     }
   } catch(std::exception &e) {
-    g_log<<Logger::Error<<"Lua record reported: "<<e.what()<<endl;
+    g_log<<Logger::Error<<"Lua record reported: "<<e.what();
+    try {
+      std::rethrow_if_nested(e);
+      g_log<<endl;
+    } catch(const std::exception& ne) {
+      g_log << ": " << ne.what() << std::endl;
+    }
+    catch(const PDNSException& ne) {
+      g_log << ": " << ne.reason << std::endl;
+    }
     throw ;
   }
 


### PR DESCRIPTION
### Short description
Before:
```
Jan 25 12:53:43 Lua record reported: Exception thrown by a callback function called by Lua
```
After:
```
Jan 25 19:42:24 Lua record reported: Exception thrown by a callback function called by Lua: Unable to convert presentation address '10.0.0.0/8'
```

Ideally this would also return a backtrace, but this is a start.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
