### PR TITLE
The refrence for useage of RE2Rule as RegexRule is wrong

### DIFF
--- a/pdns/dnsdistdist/docs/index.rst
+++ b/pdns/dnsdistdist/docs/index.rst
@@ -10,8 +10,8 @@ A configuration to balance DNS queries to several backend servers:
 
 .. code-block:: lua
 
-   newServer({address="2001:4860:4860::8888", qps=1})
-   newServer({address="2001:4860:4860::8844", qps=1})
+   newServer({address="2620:fe::fe", qps=1})
+   newServer({address="2620:fe::9", qps=1})
    newServer({address="2620:0:ccc::2", qps=10})
    newServer({address="2620:0:ccd::2", name="dns1", qps=10})
    newServer("192.168.1.2")

--- a/pdns/dnsdistdist/docs/quickstart.rst
+++ b/pdns/dnsdistdist/docs/quickstart.rst
@@ -8,7 +8,7 @@ Running in the Foreground
 
 After :doc:`installing <install>` dnsdist, the quickest way to start experimenting is launching it on the foreground with::
 
-   dnsdist -l 127.0.0.1:5300 8.8.8.8 2001:4860:4860::8888
+   dnsdist -l 127.0.0.1:5300 9.9.9.9 2620:fe::fe
 
 This will make dnsdist listen on IP address 127.0.0.1, port 5300 and forward all queries to the two listed IP addresses, with a sensible balancing policy.
 
@@ -17,8 +17,8 @@ This will make dnsdist listen on IP address 127.0.0.1, port 5300 and forward all
 
 Here is more complete configuration, save it to ``dnsdist.conf``::
 
-  newServer({address="2001:4860:4860::8888", qps=1})
-  newServer({address="2001:4860:4860::8844", qps=1})
+  newServer({address="2620:fe::fe", qps=1})
+  newServer({address="2620:fe::9", qps=1})
   newServer({address="2620:0:ccc::2", qps=10})
   newServer({address="2620:0:ccd::2", name="dns1", qps=10})
   newServer("192.168.1.2")
@@ -29,8 +29,8 @@ The :func:`newServer` function is used to add a backend server to the configurat
 Now run dnsdist again, reading this configuration::
 
   $ dnsdist -C dnsdist.conf --local=0.0.0.0:5300
-  Marking downstream [2001:4860:4860::8888]:53 as 'up'
-  Marking downstream [2001:4860:4860::8844]:53 as 'up'
+  Marking downstream [2620:fe::fe]:53 as 'up'
+  Marking downstream [2620:fe::9]:53 as 'up'
   Marking downstream [2620:0:ccc::2]:53 as 'up'
   Marking downstream [2620:0:ccd::2]:53 as 'up'
   Marking downstream 192.168.1.2:53 as 'up'
@@ -46,8 +46,8 @@ Note that dnsdist dropped us in a prompt above, where we can get some statistics
 
   > showServers()
   #   Address                   State     Qps    Qlim Ord Wt    Queries   Drops Drate   Lat Pools
-  0   [2001:4860:4860::8888]:53    up     0.0       1   1  1          1       0   0.0   0.0
-  1   [2001:4860:4860::8844]:53    up     0.0       1   1  1          0       0   0.0   0.0
+  0   [2620:fe::fe]:53    up     0.0       1   1  1          1       0   0.0   0.0
+  1   [2620:fe::9]:53    up     0.0       1   1  1          0       0   0.0   0.0
   2   [2620:0:ccc::2]:53           up     0.0      10   1  1          0       0   0.0   0.0
   3   [2620:0:ccd::2]:53           up     0.0      10   1  1          0       0   0.0   0.0
   4   192.168.1.2:53               up     0.0       0   1  1          0       0   0.0   0.0
@@ -65,8 +65,8 @@ The final server has no limit, which we can easily test::
 
   > showServers()
   #   Address                   State     Qps    Qlim Ord Wt    Queries   Drops Drate   Lat Pools
-  0   [2001:4860:4860::8888]:53    up     1.0       1   1  1          7       0   0.0   1.6
-  1   [2001:4860:4860::8844]:53    up     1.0       1   1  1          6       0   0.0   0.6
+  0   [2620:fe::fe]:53    up     1.0       1   1  1          7       0   0.0   1.6
+  1   [2620:fe::9]:53    up     1.0       1   1  1          6       0   0.0   0.6
   2   [2620:0:ccc::2]:53           up    10.3      10   1  1         64       0   0.0   2.4
   3   [2620:0:ccd::2]:53           up    10.3      10   1  1         63       0   0.0   2.4
   4   192.168.1.2:53               up   125.8       0   1  1        671       0   0.0   0.4
@@ -85,7 +85,7 @@ To force a server down, try :attr:`Server:setDown()`::
   > getServer(0):setDown()
   > showServers()
   #   Address                   State     Qps    Qlim Ord Wt    Queries   Drops Drate   Lat Pools
-  0   [2001:4860:4860::8888]:53  DOWN     0.0       1   1  1          8       0   0.0   0.0
+  0   [2620:fe::fe]:53  DOWN     0.0       1   1  1          8       0   0.0   0.0
   ...
 
 The ``DOWN`` in all caps means it was forced down.

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -667,7 +667,7 @@ These ``DNSRule``\ s be one of the following items:
 	QNAME can be written in case insensitively PCRE formatted regex.
 	For regex to match partial QNAME queries see :func:`RegexRule`
 	
-	For an example of usage:
+	For an example of usage::
 	
 		addAction(RE2Rule("^[0-9]{4,}\\.example\\.org$"), DropAction()) -- first rule
 		addAction(RE2Rule("^example\\.[0-9a-z]\\.org$"), DropAction()) -- last rule
@@ -675,7 +675,7 @@ These ``DNSRule``\ s be one of the following items:
 	The first example will match any query to the domain example.org starting
 	 with a number 4 (four) or more times and if the query is true, drop the query.
 
-	Shown examples for first rule:
+	Shown examples for first rule::
 
 		12345.example.org -- will be matched by the first rule and query dropped
 		54321.example.org -- will be matched by the first rule and query dropped
@@ -685,7 +685,7 @@ These ``DNSRule``\ s be one of the following items:
 	The second example will match any query starting with example.
 	 with a subset of any letter or number any number of times and ending in .org
 
-	Shown examples for last rule:
+	Shown examples for last rule::
 
 		example.123abc.org -- will match the last rule and query dropped
 		example.abc321.org -- will match the last rule and query dropped

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -700,13 +700,20 @@ These ``DNSRule``\ s be one of the following items:
 
 .. function:: RE2Rule(regex)
 
+	Where RegexRule accept any match the RE2Rule require a full query match against the regex.
   Matches the query name against the supplied regex using the RE2 engine.
 
-  For an example of usage, see :func:`RegexRule`.
+  For an example of usage.
+
+    addAction(RE2Rule("[0-9]{5,}"), DelayAction(750)) -- milliseconds
+    addAction(RE2Rule("^[0-9]{4,}\\.example$"), DropAction())
+
+  Versus a RegexRule, RE2Rule will not match any query for a domain name with 5 or more consecutive digits in it, as it recuire a full match.
+  The second rule will match with RE2Rule and drops anything with more than 4 consecutive digits in the beginning within a .EXAMPLE domain.
 
   :note: Only available when dnsdist was built with libre2 support.
 
-  :param str regex: The regular expression to match the QNAME.
+  :param str regex: The regular expression to match the full QNAME.
 
 .. function:: SuffixMatchNodeRule(smn[, quiet])
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -661,6 +661,46 @@ These ``DNSRule``\ s be one of the following items:
 
   Matches queries with the RD flag set.
 
+.. function:: RE2Rule(regex)
+
+	RE2Rule are used to match a ''full query string'' where parts of the 
+	QNAME can be written in case insensitively PCRE formatted regex.
+	For regex to match partial QNAME queries see :func:`RegexRule`
+	
+	For an example of usage:
+	
+		addAction(RE2Rule("^[0-9]{4,}\\.example\\.org$"), DropAction()) -- first rule
+		addAction(RE2Rule("^example\\.[0-9a-z]\\.org$"), DropAction()) -- last rule
+
+	The first example will match any query to the domain example.org starting
+	 with a number 4 (four) or more times and if the query is true, drop the query.
+
+	Shown examples for first rule:
+
+		12345.example.org -- will be matched by the first rule and query dropped
+		54321.example.org -- will be matched by the first rule and query dropped
+		4321.abc.example.org -- will *not* match first rule and the query will proceed
+		123.example.org -- will *not* match first rule and the query will proceed
+
+	The second example will match any query starting with example.
+	 with a subset of any letter or number any number of times and ending in .org
+
+	Shown examples for last rule:
+
+		example.123abc.org -- will match the last rule and query dropped
+		example.abc321.org -- will match the last rule and query dropped
+		example.123.adc.org -- will *not* match first rule and the query will proceed
+		example.abc.321.org -- will *not* match first rule and the query will proceed
+
+    :quick-notes:
+    - case insensitively.
+    - match full QNAME queries
+
+  :note: Only available when dnsdist was built with libre2 support.
+
+  :param str regex: The regular expression to match full QNAME query.
+  :param str regex: case insensitively PCRE formatted
+
 .. function:: RegexRule(regex)
 
   Matches the query name against the ``regex``.
@@ -673,8 +713,8 @@ These ``DNSRule``\ s be one of the following items:
   This delays any query for a domain name with 5 or more consecutive digits in it.
   The second rule drops anything with more than 4 consecutive digits within a .EXAMPLE domain.
 
-  Note that the query name is presented without a trailing dot to the regex.
-  The regex is applied case insensitively.
+  :Note: that the query name is presented without a trailing dot to the regex.
+  - The regex is applied case insensitively.
 
   :param string regex: A regular expression to match the traffic on
 
@@ -697,23 +737,6 @@ These ``DNSRule``\ s be one of the following items:
   :param int qtype: The QTYPE to match on
   :param int minCount: The minimum number of entries
   :param int maxCount: The maximum number of entries
-
-.. function:: RE2Rule(regex)
-
-	Where RegexRule accept any match the RE2Rule require a full query match against the regex.
-  Matches the query name against the supplied regex using the RE2 engine.
-
-  For an example of usage.
-
-    addAction(RE2Rule("[0-9]{5,}"), DelayAction(750)) -- milliseconds
-    addAction(RE2Rule("^[0-9]{4,}\\.example$"), DropAction())
-
-  Versus a RegexRule, RE2Rule will not match any query for a domain name with 5 or more consecutive digits in it, as it recuire a full match.
-  The second rule will match with RE2Rule and drops anything with more than 4 consecutive digits in the beginning within a .EXAMPLE domain.
-
-  :note: Only available when dnsdist was built with libre2 support.
-
-  :param str regex: The regular expression to match the full QNAME.
 
 .. function:: SuffixMatchNodeRule(smn[, quiet])
 


### PR DESCRIPTION
1. Consider as draft from a late friday night
2. Work in progress
3. Would defiantly like some help to formulate this

4. It turns out that having RE2Rule to reference to RegexRule is wrong, as the big difrence is that RE2Rule need to match the full QUERY string vs. RegexRule only need partial match

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
