### PR TITLE
fix off-by-one in mvRule counting

### DIFF
--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -168,7 +168,7 @@ static void mvRule(GlobalStateHolder<vector<T> > *someRespRulActions, unsigned i
   }
   auto subject = rules[from];
   rules.erase(rules.begin()+from);
-  if(to == rules.size())
+  if(to > rules.size())
     rules.push_back(subject);
   else {
     if(from < to)


### PR DESCRIPTION
### Short description
This makes `mvRule(0,x)` work where x is the highest rule number.

Maybe we want a test for this?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
