### PR TITLE
Clarify documentation to reflect actual behavior of includeDirectory

### DIFF
--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -40,7 +40,7 @@ Global configuration
 
   Include configuration files from ``path``.
 
-  :param str path: The directory to load the configuration from
+  :param str path: The directory to load configuration files from. Each file must end in ``.conf``.
 
 Listen Sockets
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
### Short description
Updated the documentation of includeDirectory to reflect the fact that only .conf files will be loaded from the target directory.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
