### PR TITLE
travis auth: install dnsmasq, configure it on 127.0.0.53

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -328,6 +328,19 @@ install_auth() {
     faketime"
   run "sudo touch /etc/authbind/byport/53"
   run "sudo chmod 755 /etc/authbind/byport/53"
+
+  # Install dnsmasq to make lookups more robust
+  run "sudo apt-get -qq --no-install-recommends install \
+    dnsmasq"
+  run 'echo listen-address=127.0.0.53 | sudo tee /etc/dnsmasq.d/local.conf'
+  run 'echo bind-interfaces | sudo tee -a /etc/dnsmasq.d/local.conf'
+
+  ## WARNING
+  ## after this dnsmasq restart, DNS lookups will fail for a few seconds.
+  run 'sudo service dnsmasq restart'
+  run "sudo resolvconf --disable-updates"
+  run 'echo nameserver 127.0.0.53 | sudo tee /etc/resolv.conf'
+  run "export RESOLVERIP=127.0.0.53"
 }
 
 install_ixfrdist() {

--- a/regression-tests/backends/gsql-common
+++ b/regression-tests/backends/gsql-common
@@ -37,7 +37,7 @@ gsql_master()
 
 	$RUNWRAPPER $PDNS --daemon=no --local-address=$address --local-port=$port --config-dir=. \
 		--config-name=$backend --socket-dir=./ --no-shuffle \
-		--dnsupdate=yes --resolver=8.8.8.8 --outgoing-axfr-expand-alias=yes \
+		--dnsupdate=yes --resolver=$RESOLVERIP --outgoing-axfr-expand-alias=yes \
 		--expand-alias=yes \
 		--cache-ttl=$cachettl --dname-processing \
 		--disable-axfr-rectify=yes $lua_prequery &

--- a/regression-tests/backends/ldap-master
+++ b/regression-tests/backends/ldap-master
@@ -28,7 +28,7 @@ __EOF__
 			--config-name=ldap --socket-dir=./ --no-shuffle \
 			--query-logging --dnsupdate=yes \
       --expand-alias=yes --outgoing-axfr-expand-alias=yes \
-      --resolver=8.8.8.8 \
+      --resolver=$RESOLVERIP \
 			--cache-ttl=$cachettl --dname-processing $lua_prequery &
 
 		skipreasons="nodnssec noent nodyndns nometa noaxfr"

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -16,6 +16,7 @@ export ZONE2SQL=${ZONE2SQL:-${PWD}/../pdns/zone2sql}
 export ZONE2LDAP=${ZONE2LDAP:-${PWD}/../pdns/zone2ldap}
 export PDNSUTIL=${PDNSUTIL:-${PWD}/../pdns/pdnsutil}
 export PDNSCONTROL=${PDNSCONTROL:-${PWD}/../pdns/pdns_control}
+export RESOLVERIP=${RESOLVERIP:-8.8.8.8}
 
 
 ALGORITHM=${ALGORITHM:="hmac-md5"}


### PR DESCRIPTION
### Short description
This introduces some local caching, and, I hope, a bit of retrying on ALIAS lookups, because we don't do that internally.

I considered hardcoding the google-public-dns-a.google.com./8.8.8.8 record we use for testing, but I'd like to see if just adding dnsmasq as a layer improves the situation without hardcoding anything. If it turns out we do need to add that static record, it will be just one extra item around line 336 of `build-scripts/travis.sh` at that time.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
