### PR TITLE
[dnsdist] Fix wrong version numbering of new features

### DIFF
--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -650,7 +650,7 @@ These ``DNSRule``\ s be one of the following items:
 
 .. function:: EDNSOptionRule(optcode)
 
-  .. versionadded:: 1.4.0
+  .. versionadded:: 1.3.3
 
   Matches queries or responses with the specified EDNS option present.
   ``optcode`` is specified as an integer, or a constant such as `EDNSOptionCode.ECS`.


### PR DESCRIPTION
### Short description
dnsdist version 1.4.0 is not released yet

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
