### PR TITLE
timestamp TTL limiting from djbdns tdlookup.c

### DIFF
--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -285,6 +285,8 @@ bool TinyDNSBackend::get(DNSResourceRecord &rr)
             continue;
           }
           rr.ttl = timestamp - now;
+          if (rr.ttl <= 2.0) rr.ttl = 2.0;
+          if (rr.ttl >= 3600.0) rr.ttl = 3600.0;
         } else if (now <= timestamp) {
           continue;
         }


### PR DESCRIPTION
### Short description
Fixes issue #7439 - timestamp feature which generated huge TTLs for long in the future expiry dates. Calculations are clamped in the original djbdns code, this clamping was missing in pdns tinydnsbackend.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
