### PR TITLE
Avoid unaligned access, it hurts on e.g. sparc64

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -91,6 +91,13 @@
 union ComboAddress {
   struct sockaddr_in sin4;
   struct sockaddr_in6 sin6;
+  // struct sockaddr_in6 is *not* defined as containing two uint64_t for the
+  // address , but we like to read or write it like that.
+  // Force alignment by adding an uint64_t in the union. This makes sure
+  // the start of the struct and s6_addr gets aligned.
+  // This works because of the spot of s6_addr in struct sockaddr_in6.
+  // Needed for strict alignment architectures like sparc64.
+  uint64_t	force_align;
 
   bool operator==(const ComboAddress& rhs) const
   {

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -242,7 +242,7 @@ void UDPNameserver::bindIPv6()
 
     if( !d_additional_socket )
         g_localaddresses.push_back(locala);
-    if(::bind(s, (sockaddr*)&locala, sizeof(locala))<0) {
+    if(::bind(s, (sockaddr*)&locala, locala.getSocklen())<0) {
       close(s);
       if( errno == EADDRNOTAVAIL && ! ::arg().mustDo("local-ipv6-nonexist-fail") ) {
         g_log<<Logger::Error<<"IPv6 Address " << localname << " does not exist on this server - skipping UDP bind" << endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fix unaligned access, spotted on OpenBSD/sparc. Together with a compiler fix
make auth work on OpenBSD/sparc. See https://github.com/PowerDNS/pdns/issues/6742
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
