### PR TITLE
Make sure that the systemd binaries are available during the build

### DIFF
--- a/builder-support/debian/authoritative/debian-jessie/control
+++ b/builder-support/debian/authoritative/debian-jessie/control
@@ -39,6 +39,7 @@ Build-Depends: autoconf,
                po-debconf,
                protobuf-compiler,
                ragel,
+               systemd [linux-any],
                unixodbc-dev (>= 2.3.1)
 Homepage: http://www.powerdns.com/
 

--- a/builder-support/debian/authoritative/debian-stretch/control
+++ b/builder-support/debian/authoritative/debian-stretch/control
@@ -40,6 +40,7 @@ Build-Depends: autoconf,
                po-debconf,
                protobuf-compiler,
                ragel,
+               systemd [linux-any],
                unixodbc-dev (>= 2.3.1)
 Homepage: http://www.powerdns.com/
 

--- a/builder-support/debian/dnsdist/debian-jessie/control
+++ b/builder-support/debian/dnsdist/debian-jessie/control
@@ -16,7 +16,8 @@ Build-Depends: debhelper (>= 9~),
                libsystemd-dev [linux-any],
                pkg-config,
                protobuf-compiler,
-               ragel
+               ragel,
+               systemd [linux-any]
 Standards-Version: 4.1.0
 Homepage: http://dnsdist.org
 Vcs-Git: https://anonscm.debian.org/git/pkg-dns/dnsdist.git

--- a/builder-support/debian/dnsdist/debian-stretch/control
+++ b/builder-support/debian/dnsdist/debian-stretch/control
@@ -17,7 +17,8 @@ Build-Depends: debhelper (>= 10~),
                libsystemd-dev [linux-any],
                pkg-config,
                protobuf-compiler,
-               ragel
+               ragel,
+               systemd [linux-any]
 Standards-Version: 4.1.0
 Homepage: http://dnsdist.org
 Vcs-Git: https://anonscm.debian.org/git/pkg-dns/dnsdist.git

--- a/builder-support/debian/recursor/debian-jessie/control
+++ b/builder-support/debian/recursor/debian-jessie/control
@@ -16,7 +16,8 @@ Build-Depends: debhelper (>= 9~),
                libsystemd-dev [linux-any],
                pkg-config,
                protobuf-compiler,
-               ragel
+               ragel,
+               systemd [linux-any]
 Homepage: https://www.powerdns.com/
 
 Package: pdns-recursor

--- a/builder-support/debian/recursor/debian-stretch/control
+++ b/builder-support/debian/recursor/debian-stretch/control
@@ -15,7 +15,8 @@ Build-Depends: debhelper (>= 10~),
                libsystemd-dev [linux-any],
                pkg-config,
                protobuf-compiler,
-               ragel
+               ragel,
+               systemd [linux-any]
 Vcs-Git: https://anonscm.debian.org/git/pkg-dns/pdns-recursor.git
 Vcs-Browser: https://anonscm.debian.org/cgit/pkg-dns/pdns-recursor.git
 Homepage: https://www.powerdns.com/

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -20,6 +20,7 @@ BuildRequires: re2-devel
 %if 0%{?suse_version}
 BuildRequires: boost-devel
 BuildRequires: lua-devel
+BuildRequires: systemd
 BuildRequires: systemd-units
 BuildRequires: systemd-devel
 %endif
@@ -39,6 +40,7 @@ BuildRequires: net-snmp-devel
 BuildRequires: protobuf-compiler
 BuildRequires: protobuf-devel
 BuildRequires: re2-devel
+BuildRequires: systemd
 BuildRequires: systemd-devel
 BuildRequires: systemd-units
 %endif

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -23,6 +23,7 @@ Requires(post): systemd-sysv
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units
+BuildRequires: systemd
 BuildRequires: systemd-units
 BuildRequires: systemd-devel
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise the detection of systemd's sandboxing features does not work properly, since it uses `systemctl` to determine the version of systemd.
A better option might be to use `pkg-config --modversion systemd` to retrieve the version but that's a fix for a later time.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
