### PR TITLE
Fix default webserver port in documentation

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1626,7 +1626,7 @@ The plaintext password required for accessing the webserver.
 ------------------
 
 -  Integer
--  Default: 8001
+-  Default: 8081
 
 The port where webserver/API will listen on.
 


### PR DESCRIPTION
### Short description
The default webserver port is 8081, not 8001. This is correct in other parts of the documentation but not on the settings page.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

