### PR TITLE
also use dnsmasq during lmdb testing

### DIFF
--- a/regression-tests/backends/lmdb-master
+++ b/regression-tests/backends/lmdb-master
@@ -50,7 +50,7 @@ __EOF__
         $RUNWRAPPER $PDNS --daemon=no --local-address=$address --local-port=$port --config-dir=. \
             --config-name=lmdb --socket-dir=./ --no-shuffle \
             --dnsupdate=no \
-            --expand-alias=yes --resolver=8.8.8.8 \
+            --expand-alias=yes --resolver=$RESOLVERIP \
             --disable-axfr-rectify=yes --outgoing-axfr-expand-alias=yes \
             --cache-ttl=$cachettl --dname-processing $lua_prequery &
 


### PR DESCRIPTION
### Short description
After another ALIAS-related Travis failure, I discovered that LMDB testing still used 8.8.8.8.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
