### PR TITLE
rec: Document addRecord

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -150,6 +150,16 @@ The DNSQuestion object contains at least the following fields:
      :param int ttl: The TTL in seconds for this record
      :param DNSName name: The name of this record, defaults to :attr:`DNSQuestion.qname`
 
+  .. method:: DNSQuestion:addRecord(type, content, place, [ttl, name])
+
+     Add a record of ``type`` with ``content`` in section ``place``.
+
+     :param int type: The type of record to add, can be ``pdns.AAAA`` etc.
+     :param str content: The content of the record, will be parsed into wireformat based on the ``type``
+     :param int place: The section to place the record, see :attr:`DNSRecord.place`
+     :param int ttl: The TTL in seconds for this record
+     :param DNSName name: The name of this record, defaults to :attr:`DNSQuestion.qname`
+
   .. method:: DNSQuestion:addPolicyTag(tag)
 
      Add a policy tag.

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -147,7 +147,7 @@ The DNSQuestion object contains at least the following fields:
 
      :param int type: The type of record to add, can be ``pdns.AAAA`` etc.
      :param str content: The content of the record, will be parsed into wireformat based on the ``type``
-     :param int ttl: The TTL in seconds for this record
+     :param int ttl: The TTL in seconds for this record, defaults to 3600
      :param DNSName name: The name of this record, defaults to :attr:`DNSQuestion.qname`
 
   .. method:: DNSQuestion:addRecord(type, content, place, [ttl, name])
@@ -157,7 +157,7 @@ The DNSQuestion object contains at least the following fields:
      :param int type: The type of record to add, can be ``pdns.AAAA`` etc.
      :param str content: The content of the record, will be parsed into wireformat based on the ``type``
      :param int place: The section to place the record, see :attr:`DNSRecord.place`
-     :param int ttl: The TTL in seconds for this record
+     :param int ttl: The TTL in seconds for this record, defaults to 3600
      :param DNSName name: The name of this record, defaults to :attr:`DNSQuestion.qname`
 
   .. method:: DNSQuestion:addPolicyTag(tag)


### PR DESCRIPTION
### Short description
Document the more generic addRecord that addAnswer uses.

This lets you place data at different places, eg, additional section.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)