### PR TITLE
Utility::random() and srandom() is not used anymore.

### DIFF
--- a/modules/randombackend/randombackend.cc
+++ b/modules/randombackend/randombackend.cc
@@ -22,11 +22,11 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "pdns/utility.hh"
 #include "pdns/dnsbackend.hh"
 #include "pdns/dns.hh"
 #include "pdns/dnsbackend.hh"
 #include "pdns/dnspacket.hh"
+#include "pdns/dns_random.hh"
 #include "pdns/pdnsexception.hh"
 #include "pdns/logger.hh"
 #include "pdns/version.hh"
@@ -59,7 +59,7 @@ public:
     } else if (qdomain == d_ourname) {
       if(type.getCode() == QType::A || type.getCode() == QType::ANY) {
         ostringstream os;
-        os<<Utility::random()%256<<"."<<Utility::random()%256<<"."<<Utility::random()%256<<"."<<Utility::random()%256;
+        os<<dns_random(256)<<"."<<dns_random(256)<<"."<<dns_random(256)<<"."<<dns_random(256);
         d_answer=os.str(); // our random ip address
       } else {
         d_answer="";

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1058,7 +1058,8 @@ pdns_notify_SOURCES = \
 	rcpgenerator.cc rcpgenerator.hh \
 	sillyrecords.cc \
 	statbag.cc \
-	unix_utility.cc
+	unix_utility.cc \
+	dns_random.cc
 
 pdns_notify_LDFLAGS = \
 	$(AM_LDFLAGS) \
@@ -1068,6 +1069,10 @@ pdns_notify_LDFLAGS = \
 pdns_notify_LDADD = \
 	$(LIBCRYPTO_LIBS) \
 	$(BOOST_PROGRAM_OPTIONS_LIBS)
+
+if LIBSODIUM
+pdns_notify_LDADD += $(LIBSODIUM_LIBS)
+endif
 
 dnsscope_SOURCES = \
 	arguments.cc \

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -377,7 +377,7 @@ try
 
     DNSPacketWriter pw(packet, DNSName(qname), DNSRecordContent::TypeToNumber(qtype));
     pw.getHeader()->rd=wantRecursion;
-    pw.getHeader()->id=random();
+    pw.getHeader()->id=dns_random(UINT16_MAX);
 
     if(!subnet.empty() || !ecsRange.empty()) {
       EDNSSubnetOpts opt;
@@ -454,7 +454,7 @@ try
       known.push_back(ptr);
     }
     for(;n < total; ++n) {
-      toSend.push_back(known[random()%known.size()].get());
+      toSend.push_back(known[dns_random(known.size())].get());
     }
     random_shuffle(toSend.begin(), toSend.end());
     g_recvcounter.store(0);

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -496,6 +496,8 @@ static void triggerLoadOfLibraries()
 
 void mainthread()
 {
+   Utility::srandom(time(0) ^ getpid());
+
    int newgid=0;
    if(!::arg()["setgid"].empty()) 
      newgid=Utility::makeGidNumeric(::arg()["setgid"]);      

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -496,7 +496,7 @@ static void triggerLoadOfLibraries()
 
 void mainthread()
 {
-   Utility::srandom(time(0) ^ getpid());
+   Utility::srandom();
 
    int newgid=0;
    if(!::arg()["setgid"].empty()) 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -496,9 +496,7 @@ static void triggerLoadOfLibraries()
 
 void mainthread()
 {
-   Utility::srandom(time(0) ^ getpid());
-
-   int newgid=0;      
+   int newgid=0;
    if(!::arg()["setgid"].empty()) 
      newgid=Utility::makeGidNumeric(::arg()["setgid"]);      
    int newuid=0;      

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -343,7 +343,7 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
 
       // TODO Keep track of 'down' masters
       set<ComboAddress>::const_iterator it(domainConfig.second.masters.begin());
-      std::advance(it, random() % domainConfig.second.masters.size());
+      std::advance(it, dns_random(domainConfig.second.masters.size()));
       ComboAddress master = *it;
 
       string dir = workdir + "/" + domain.toString();

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -7,6 +7,7 @@
 #include "ueberbackend.hh"
 #include <boost/format.hpp>
 #include "dnsrecords.hh"
+#include "dns_random.hh"
 
 #include "../modules/geoipbackend/geoipinterface.hh" // only for the enum
 
@@ -249,7 +250,7 @@ static ComboAddress pickrandom(const vector<ComboAddress>& ips)
   if (ips.empty()) {
     throw std::invalid_argument("The IP list cannot be empty");
   }
-  return ips[random() % ips.size()];
+  return ips[dns_random(ips.size())];
 }
 
 static ComboAddress hashed(const ComboAddress& who, const vector<ComboAddress>& ips)
@@ -273,7 +274,7 @@ static ComboAddress pickwrandom(const vector<pair<int,ComboAddress> >& wips)
     sum += i.first;
     pick.push_back({sum, i.second});
   }
-  int r = random() % sum;
+  int r = dns_random(sum);
   auto p = upper_bound(pick.begin(), pick.end(),r, [](int r, const decltype(pick)::value_type& a) { return  r < a.first;});
   return p->second;
 }
@@ -379,7 +380,7 @@ static ComboAddress pickclosest(const ComboAddress& bestwho, const vector<ComboA
     //          cout<<"    distance: "<<sqrt(dist2) * 40000.0/360<<" km"<<endl; // length of a degree
     ranked[dist2].push_back(c);
   }
-  return ranked.begin()->second[random() % ranked.begin()->second.size()];
+  return ranked.begin()->second[dns_random(ranked.begin()->second.size())];
 }
 
 static std::vector<DNSZoneRecord> lookup(const DNSName& name, uint16_t qtype, int zoneid)

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -852,7 +852,7 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
         for(const auto& nmpair : netmasks) {
           Netmask nm(nmpair.second);
           if(nm.match(bestwho)) {
-            return destinations[random() % destinations.size()].second;
+            return destinations[dns_random(destinations.size())].second;
           }
         }
       }

--- a/pdns/notify.cc
+++ b/pdns/notify.cc
@@ -24,6 +24,7 @@
 #endif
 #include <bitset>
 #include "dnsparser.hh"
+#include "dns_random.hh"
 #include "iputils.hh"
 #include <boost/program_options.hpp>
 
@@ -112,7 +113,7 @@ try
     }
     vector<uint8_t> outpacket;
     DNSPacketWriter pw(outpacket, DNSName(argv[2]), QType::SOA, 1, Opcode::Notify);
-    pw.getHeader()->id = random();
+    pw.getHeader()->id = dns_random(UINT16_MAX);
 
     if(send(sock, &outpacket[0], outpacket.size(), 0) < 0) {
       cerr<<"Unable to send notify to "<<addr.toStringWithPort()<<": "+stringerror()<<endl;

--- a/pdns/notify.cc
+++ b/pdns/notify.cc
@@ -60,6 +60,8 @@ int main(int argc, char** argv)
 try
 {
   set<ComboAddress> addrs;
+  ::arg().set("rng")="auto";
+  ::arg().set("entropy-source")="/dev/urandom";
 
   for(int n=1 ; n < argc; ++n) {
     if ((string) argv[n] == "--help") {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4158,6 +4158,7 @@ int main(int argc, char **argv)
   g_argc = argc;
   g_argv = argv;
   g_stats.startupTime=time(0);
+  Utility::srandom();
   versionSetProduct(ProductRecursor);
   reportBasicTypes();
   reportOtherTypes();

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -200,7 +200,7 @@ void dbBench(const std::string& fname)
   dt.set();
   unsigned int hits=0, misses=0;
   for(; n < 10000; ++n) {
-    DNSName domain(domains[random() % domains.size()]);
+    DNSName domain(domains[dns_random(domains.size())]);
     B.lookup(QType(QType::NS), domain);
     while(B.get(rr)) {
       hits++;
@@ -1319,7 +1319,7 @@ void testSpeed(DNSSECKeeper& dk, const DNSName& zone, const string& remote, int 
   DTime dt;
   dt.set();
   for(unsigned int n=0; n < 100000; ++n) {
-    rnd = random();
+    rnd = dns_random(UINT32_MAX);
     snprintf(tmp, sizeof(tmp), "%d.%d.%d.%d", 
       octets[0], octets[1], octets[2], octets[3]);
     rr.content=tmp;

--- a/pdns/test-recpacketcache_cc.cc
+++ b/pdns/test-recpacketcache_cc.cc
@@ -5,6 +5,7 @@
 #include "config.h"
 #endif
 #include <boost/test/unit_test.hpp>
+#include "arguments.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
 #include "dns_random.hh"
@@ -23,6 +24,9 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimple) {
   uint32_t qhash=0;
   uint32_t ttd=3600;
   BOOST_CHECK_EQUAL(rpc.size(), 0);
+
+  ::arg().set("rng")="auto";
+  ::arg().set("entropy-source")="/dev/urandom";
 
   DNSName qname("www.powerdns.com");
   vector<uint8_t> packet;
@@ -95,6 +99,9 @@ BOOST_AUTO_TEST_CASE(test_recPacketCache_Tags) {
   uint32_t temphash=0;
   uint32_t ttd=3600;
   BOOST_CHECK_EQUAL(rpc.size(), 0);
+
+  ::arg().set("rng")="auto";
+  ::arg().set("entropy-source")="/dev/urandom";
 
   DNSName qname("www.powerdns.com");
   vector<uint8_t> packet;

--- a/pdns/test-recpacketcache_cc.cc
+++ b/pdns/test-recpacketcache_cc.cc
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimple) {
   DNSPacketWriter pw(packet, qname, QType::A);
   pw.getHeader()->rd=true;
   pw.getHeader()->qr=false;
-  pw.getHeader()->id=random();
+  pw.getHeader()->id=dns_random(UINT16_MAX);
   string qpacket((const char*)&packet[0], packet.size());
   pw.startRecord(qname, QType::A, ttd);
 
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimple) {
 
   pw2.getHeader()->rd=true;
   pw2.getHeader()->qr=false;
-  pw2.getHeader()->id=random();
+  pw2.getHeader()->id=dns_random(UINT16_MAX);
   qpacket.assign((const char*)&packet[0], packet.size());
 
   found = rpc.getResponsePacket(tag, qpacket, time(nullptr), &fpacket, &age, &qhash);
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCache_Tags) {
   DNSPacketWriter pw(packet, qname, QType::A);
   pw.getHeader()->rd=true;
   pw.getHeader()->qr=false;
-  pw.getHeader()->id=random();
+  pw.getHeader()->id=dns_random(UINT16_MAX);
   string qpacket(reinterpret_cast<const char*>(&packet[0]), packet.size());
   pw.startRecord(qname, QType::A, ttd);
 

--- a/pdns/unix_utility.cc
+++ b/pdns/unix_utility.cc
@@ -213,19 +213,6 @@ int Utility::makeUidNumeric(const string &username)
 }
 
 
-// Returns a random number.
-long int Utility::random( void )
-{
-  return rand();
-}
-
-// Sets the random seed.
-void Utility::srandom( unsigned int seed )
-{
-  ::srandom(seed);
-}
-
-
 // Writes a vector.
 int Utility::writev(int socket, const iovec *vector, size_t count )
 {

--- a/pdns/unix_utility.cc
+++ b/pdns/unix_utility.cc
@@ -212,6 +212,11 @@ int Utility::makeUidNumeric(const string &username)
   return newuid;
 }
 
+// Sets the random seed.
+void Utility::srandom( unsigned int seed )
+{
+  ::srandom(seed);
+}
 
 // Writes a vector.
 int Utility::writev(int socket, const iovec *vector, size_t count )

--- a/pdns/unix_utility.cc
+++ b/pdns/unix_utility.cc
@@ -213,9 +213,11 @@ int Utility::makeUidNumeric(const string &username)
 }
 
 // Sets the random seed.
-void Utility::srandom( unsigned int seed )
+void Utility::srandom(void)
 {
-  ::srandom(seed);
+  struct timeval tv;
+  gettimeofday(&tv, 0);
+  ::srandom(tv.tv_sec ^ tv.tv_usec ^ getpid());
 }
 
 // Writes a vector.

--- a/pdns/utility.hh
+++ b/pdns/utility.hh
@@ -129,6 +129,9 @@ public:
   //! Writes a vector.
   static int writev( Utility::sock_t socket, const iovec *vector, size_t count );
 
+  //! Sets the random seed.
+  static void srandom( unsigned int seed );
+  
   //! Drops the program's group privileges.
   static void dropGroupPrivs( int uid, int gid );
 

--- a/pdns/utility.hh
+++ b/pdns/utility.hh
@@ -130,8 +130,8 @@ public:
   static int writev( Utility::sock_t socket, const iovec *vector, size_t count );
 
   //! Sets the random seed.
-  static void srandom( unsigned int seed );
-  
+  static void srandom(void);
+
   //! Drops the program's group privileges.
   static void dropGroupPrivs( int uid, int gid );
 

--- a/pdns/utility.hh
+++ b/pdns/utility.hh
@@ -128,11 +128,6 @@ public:
 
   //! Writes a vector.
   static int writev( Utility::sock_t socket, const iovec *vector, size_t count );
-  //! Returns a random number.
-  static long int random( void );
-
-  //! Sets the random seed.
-  static void srandom( unsigned int seed );
 
   //! Drops the program's group privileges.
   static void dropGroupPrivs( int uid, int gid );


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Eliminate rand() and srand() usage. These are really bad random generators and should not be used. Leaving usage of random() alone.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

