### PR TITLE
dnsdist: don't test or show unneeded TLS libs

### DIFF
--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -52,10 +52,12 @@ AC_SUBST([YAHTTP_LIBS], ['$(top_builddir)/ext/yahttp/yahttp/libyahttp.la'])
 PDNS_WITH_LUA([mandatory])
 PDNS_CHECK_LUA_HPP
 
+AM_CONDITIONAL([HAVE_GNUTLS], [false])
+AM_CONDITIONAL([HAVE_LIBSSL], [false])
 DNSDIST_ENABLE_DNS_OVER_TLS
-DNSDIST_WITH_GNUTLS
-DNSDIST_WITH_LIBSSL
 AS_IF([test "x$enable_dns_over_tls" != "xno"], [
+  DNSDIST_WITH_GNUTLS
+  DNSDIST_WITH_LIBSSL
   AS_IF([test "$HAVE_LIBSSL" = "1"], [
     # we need libcrypto if libssl is enabled
     PDNS_CHECK_LIBCRYPTO
@@ -160,16 +162,15 @@ AS_IF([test "x$NET_SNMP_LIBS" != "x"],
   [AC_MSG_NOTICE([SNMP: yes])],
   [AC_MSG_NOTICE([SNMP: no])]
 )
-AS_IF([test "x$enable_dns_over_tls" != "xno"],
-  [AC_MSG_NOTICE([DNS over TLS: yes])],
+AS_IF([test "x$enable_dns_over_tls" != "xno"], [
+  AC_MSG_NOTICE([DNS over TLS: yes])
+  AS_IF([test "x$GNUTLS_LIBS" != "x"],
+    [AC_MSG_NOTICE([GnuTLS: yes])],
+    [AC_MSG_NOTICE([GnuTLS: no])])
+  AS_IF([test "x$LIBSSL_LIBS" != "x"],
+    [AC_MSG_NOTICE([OpenSSL: yes])],
+    [AC_MSG_NOTICE([OpenSSL: no])])
+  ],
   [AC_MSG_NOTICE([DNS over TLS: no])]
-)
-AS_IF([test "x$GNUTLS_LIBS" != "x"],
-  [AC_MSG_NOTICE([GnuTLS: yes])],
-  [AC_MSG_NOTICE([GnuTLS: no])]
-)
-AS_IF([test "x$LIBSSL_LIBS" != "x"],
-  [AC_MSG_NOTICE([OpenSSL: yes])],
-  [AC_MSG_NOTICE([OpenSSL: no])]
 )
 AC_MSG_NOTICE([])


### PR DESCRIPTION
### Short description
This shaves a yak that @Habbie had. No longer check for OpenSSL or gnutls when DoT is disabled. This PR also does not show the detection of TLS libraries anymore when DoT is not enabled.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)