### PR TITLE
Recursor: allow basic auth for some statistics APIs

### DIFF
--- a/pdns/recursordist/html/index.html
+++ b/pdns/recursordist/html/index.html
@@ -22,9 +22,7 @@
 <!-- ========================= CONTENT ========================= -->
 
 <div class="topbar">
-    <label>API Key: <input type="password" id="password" value=""></label>
-    <button>Submit</button><!-- Just a trick to make the user click outside of the input field -->
-    <span id="connection-status" style="display:none">No server connection or incorrect key</span>
+    <span id="connection-status" style="display:none">No server connection</span>
     <span id="connection-error"></span>
 </div>
 

--- a/pdns/recursordist/html/local.js
+++ b/pdns/recursordist/html/local.js
@@ -21,12 +21,6 @@ $(document).ready(function () {
         $('#' + name).html(h);
     };
 
-    var password = $("#password").val();
-    $("#password").change(function (e) {
-        password = $("#password").val();
-        update();
-    });
-
     var qpsgraph = new Rickshaw.Graph({
         element: document.getElementById("qpschart"),
         width: 400,
@@ -70,7 +64,6 @@ $(document).ready(function () {
 
     var jsonstatParams = function (command, name, filtered) {
         var d = {
-            'api-key': password,
             'command': command,
             'name': name
         };
@@ -159,7 +152,7 @@ $(document).ready(function () {
 
     function update() {
         $.ajax({
-            url: 'api/v1/servers/localhost/statistics?api-key=' + password,
+            url: 'api/v1/servers/localhost/statistics',
             type: 'GET',
             dataType: 'json',
             success: function (adata, x, y) {
@@ -216,7 +209,7 @@ $(document).ready(function () {
 
         if (!version) {
             $.ajax({
-                url: 'api/v1/servers/localhost?api-key=' + password, type: 'GET', dataType: 'json',
+                url: 'api/v1/servers/localhost', type: 'GET', dataType: 'json',
                 success: function (data) {
                     version = "PowerDNS " + data["daemon_type"] + " " + data["version"];
                 }

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -158,16 +158,10 @@ public:
   virtual ~WebServer() { };
 
   void setApiKey(const string &apikey) {
-    if (d_registerApiHandlerCalled) {
-      throw PDNSException("registerApiHandler has been called, can not change apikey");
-    }
     d_apikey = apikey;
   }
 
   void setPassword(const string &password) {
-    if (d_registerWebHandlerCalled) {
-      throw PDNSException("registerWebHandler has been called, can not change password");
-    }
     d_webserverPassword = password;
   }
 
@@ -233,10 +227,9 @@ protected:
   std::shared_ptr<Server> d_server;
 
   std::string d_apikey;
-  bool d_registerApiHandlerCalled{false};
-
+  void apiWrapper(WebServer::HandlerFunction handler, HttpRequest* req, HttpResponse* resp);
   std::string d_webserverPassword;
-  bool d_registerWebHandlerCalled{false};
+  void webWrapper(WebServer::HandlerFunction handler, HttpRequest* req, HttpResponse* resp);
 
   NetmaskGroup d_acl;
 

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -176,7 +176,7 @@ public:
   void handleRequest(HttpRequest& request, HttpResponse& resp) const;
 
   typedef boost::function<void(HttpRequest* req, HttpResponse* resp)> HandlerFunction;
-  void registerApiHandler(const string& url, HandlerFunction handler);
+  void registerApiHandler(const string& url, HandlerFunction handler, bool allowPassword=false);
   void registerWebHandler(const string& url, HandlerFunction handler);
 
   enum class LogLevel : uint8_t {
@@ -227,7 +227,7 @@ protected:
   std::shared_ptr<Server> d_server;
 
   std::string d_apikey;
-  void apiWrapper(WebServer::HandlerFunction handler, HttpRequest* req, HttpResponse* resp);
+  void apiWrapper(WebServer::HandlerFunction handler, HttpRequest* req, HttpResponse* resp, bool allowPassword);
   std::string d_webserverPassword;
   void webWrapper(WebServer::HandlerFunction handler, HttpRequest* req, HttpResponse* resp);
 

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -467,16 +467,16 @@ RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
   d_ws->bind();
 
   // legacy dispatch
-  d_ws->registerApiHandler("/jsonstat", boost::bind(&RecursorWebServer::jsonstat, this, _1, _2));
+  d_ws->registerApiHandler("/jsonstat", boost::bind(&RecursorWebServer::jsonstat, this, _1, _2), true);
   d_ws->registerApiHandler("/api/v1/servers/localhost/cache/flush", &apiServerCacheFlush);
   d_ws->registerApiHandler("/api/v1/servers/localhost/config/allow-from", &apiServerConfigAllowFrom);
   d_ws->registerApiHandler("/api/v1/servers/localhost/config", &apiServerConfig);
   d_ws->registerApiHandler("/api/v1/servers/localhost/rpzstatistics", &apiServerRPZStats);
   d_ws->registerApiHandler("/api/v1/servers/localhost/search-data", &apiServerSearchData);
-  d_ws->registerApiHandler("/api/v1/servers/localhost/statistics", &apiServerStatistics);
+  d_ws->registerApiHandler("/api/v1/servers/localhost/statistics", &apiServerStatistics, true);
   d_ws->registerApiHandler("/api/v1/servers/localhost/zones/<id>", &apiServerZoneDetail);
   d_ws->registerApiHandler("/api/v1/servers/localhost/zones", &apiServerZones);
-  d_ws->registerApiHandler("/api/v1/servers/localhost", &apiServerDetail);
+  d_ws->registerApiHandler("/api/v1/servers/localhost", &apiServerDetail, true);
   d_ws->registerApiHandler("/api/v1/servers", &apiServer);
   d_ws->registerApiHandler("/api", &apiDiscovery);
 

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -20,6 +20,7 @@ SQLITE_DB = 'pdns.sqlite3'
 WEBPORT = 5556
 DNSPORT = 5300
 APIKEY = '1234567890abcdefghijklmnopq-key'
+WEBPASSWORD = 'something'
 PDNSUTIL_CMD = [os.environ.get("PDNSUTIL", "../pdns/pdnsutil"), "--config-dir=."]
 
 NAMED_CONF_TPL = """
@@ -103,7 +104,8 @@ pdns_recursor = os.environ.get("PDNSRECURSOR", "../pdns/recursordist/pdns_recurs
 common_args = [
     "--daemon=no", "--socket-dir=.", "--config-dir=.",
     "--local-address=127.0.0.1", "--local-port="+str(DNSPORT),
-    "--webserver=yes", "--webserver-port="+str(WEBPORT), "--webserver-address=127.0.0.1", "--webserver-password=something",
+    "--webserver=yes", "--webserver-port="+str(WEBPORT), "--webserver-address=127.0.0.1",
+    "--webserver-password="+WEBPASSWORD,
     "--api-key="+APIKEY
 ]
 
@@ -188,6 +190,7 @@ returncode = 0
 test_env = {}
 test_env.update(os.environ)
 test_env.update({
+    'WEBPASSWORD': WEBPASSWORD,
     'WEBPORT': str(WEBPORT),
     'APIKEY': APIKEY,
     'DAEMON': daemon,

--- a/regression-tests.api/test_Basics.py
+++ b/regression-tests.api/test_Basics.py
@@ -10,6 +10,10 @@ class TestBasics(ApiTestCase):
         r = requests.get(self.url("/api/v1/servers/localhost"))
         self.assertEquals(r.status_code, requests.codes.unauthorized)
 
+    def test_index_html(self):
+        r = requests.get(self.url("/"), auth=('admin', self.server_web_password))
+        self.assertEquals(r.status_code, requests.codes.ok)
+
     def test_split_request(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)

--- a/regression-tests.api/test_Servers.py
+++ b/regression-tests.api/test_Servers.py
@@ -1,3 +1,5 @@
+import requests
+import unittest
 from test_helper import ApiTestCase, is_auth, is_recursor
 
 
@@ -68,3 +70,9 @@ class Servers(ApiTestCase):
         r = self.session.get(self.url("/api/v1/servers/localhost/statistics?statistic=uptimeAAAA"))
         self.assertEquals(r.status_code, 422)
         self.assertIn("Unknown statistic name", r.json()['error'])
+
+    @unittest.skipIf(is_auth(), "Not applicable")
+    def test_read_statistics_using_password(self):
+        r = requests.get(self.url("/api/v1/servers/localhost/statistics"), auth=('admin', self.server_web_password))
+        self.assertEquals(r.status_code, requests.codes.ok)
+        self.assert_success_json(r)

--- a/regression-tests.api/test_helper.py
+++ b/regression-tests.api/test_helper.py
@@ -25,6 +25,7 @@ class ApiTestCase(unittest.TestCase):
         self.server_address = '127.0.0.1'
         self.server_port = int(os.environ.get('WEBPORT', '5580'))
         self.server_url = 'http://%s:%s/' % (self.server_address, self.server_port)
+        self.server_web_password = os.environ.get('WEBPASSWORD', 'MISSING')
         self.session = requests.Session()
         self.session.headers = {'X-API-Key': os.environ.get('APIKEY', 'changeme-key'), 'Origin': 'http://%s:%s' % (self.server_address, self.server_port)}
 

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -57,6 +57,7 @@ class TestAPIBasics(DNSDistTest):
             url = 'http://127.0.0.1:' + str(self._webServerPort) + path
             r = requests.get(url, headers=headers, timeout=self._webTimeout)
             self.assertEquals(r.status_code, 401)
+
     def testBasicAuthOnly(self):
         """
         API: Basic Authentication Only


### PR DESCRIPTION
### Short description
Removes need for API key on builtin webserver pages.

Fixes #5942.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
