### PR TITLE
LUA records: Add "useragent" option to `ifurlup` and set a default

### DIFF
--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -69,7 +69,7 @@ Record creation functions
   - ``backupSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all' (default to 'random').
   - ``source``: Source IP address to check from
   - ``stringmatch``: check ``url`` for this string, only declare 'up' if found
-  - ``useragent``: Set the HTTP "User-Agent" header in the requests. By default it is set to "PowerDNS Authoritative Server/" plus the version number
+  - ``useragent``: Set the HTTP "User-Agent" header in the requests. By default it is set to "PowerDNS Authoritative Server"
 
   An example of IP address sets:
 

--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -69,6 +69,7 @@ Record creation functions
   - ``backupSelector``: used to pick the IP address from list of all candidates if all addresses are down. Choices include 'pickclosest', 'random', 'hashed', 'all' (default to 'random').
   - ``source``: Source IP address to check from
   - ``stringmatch``: check ``url`` for this string, only declare 'up' if found
+  - ``useragent``: Set the HTTP "User-Agent" header in the requests. By default it is set to "PowerDNS Authoritative Server/" plus the version number
 
   An example of IP address sets:
 

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -185,7 +185,7 @@ void IsUpOracle::checkURLThread(ComboAddress rem, std::string url, const opts_t&
   setDown(rem, url, opts);
   for(bool first=true;;first=false) {
     try {
-      string useragent = productName() + "/" + getPDNSVersion();
+      string useragent = productName();
       if (opts.count("useragent")) {
         useragent = opts.at("useragent");
       }

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1,3 +1,4 @@
+#include "version.hh"
 #include "ext/luawrapper/include/LuaContext.hpp"
 #include "lua-auth4.hh"
 #include <thread>
@@ -184,7 +185,11 @@ void IsUpOracle::checkURLThread(ComboAddress rem, std::string url, const opts_t&
   setDown(rem, url, opts);
   for(bool first=true;;first=false) {
     try {
-      MiniCurl mc;
+      string useragent = productName() + "/" + getPDNSVersion();
+      if (opts.count("useragent")) {
+        useragent = opts.at("useragent");
+      }
+      MiniCurl mc(useragent);
 
       string content;
       if(opts.count("source")) {

--- a/pdns/minicurl.cc
+++ b/pdns/minicurl.cc
@@ -26,9 +26,12 @@
 #include <curl/curl.h>
 #include <stdexcept>
 
-MiniCurl::MiniCurl()
+MiniCurl::MiniCurl(const string& useragent)
 {
   d_curl = curl_easy_init();
+  if (d_curl != nullptr) {
+    curl_easy_setopt(d_curl, CURLOPT_USERAGENT, useragent.c_str());
+  }
 }
 
 MiniCurl::~MiniCurl()

--- a/pdns/minicurl.hh
+++ b/pdns/minicurl.hh
@@ -31,7 +31,7 @@
 class MiniCurl
 {
 public:
-  MiniCurl();
+  MiniCurl(const string& useragent="MiniCurl/0.0");
   ~MiniCurl();
   MiniCurl& operator=(const MiniCurl&) = delete;
   std::string getURL(const std::string& str, const ComboAddress* rem=0, const ComboAddress* src=0);


### PR DESCRIPTION
### Short description
This PR adds the "useragent" option to the `ifurlup` function for LUA records. By default, it sets the User-Agent to "PowerDNS Authoritative Server/$VERSION":

```
GET / HTTP/1.1
Host: 127.0.0.1:8000
User-Agent: PowerDNS Authoritative Server/0.0.16019.0.LUArecorduseragent.g63dfa8dfc7.dirty
Accept: */*
```

Closes #7393 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)