### PR TITLE
Auth ringbuffer simmaries were case sensitive & accounted delegations incorrectly

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1431,6 +1431,7 @@ fuzz_target_packetcache_SOURCES = \
 	ednsoptions.cc ednsoptions.hh \
 	misc.cc misc.hh \
 	packetcache.hh \
+	qtype.cc qtype.hh \
 	statbag.cc statbag.hh
 
 fuzz_target_packetcache_DEPENDENCIES = $(fuzz_targets_deps)

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -335,11 +335,11 @@ void declareStats(void)
   S.declare("latency","Average number of microseconds needed to answer a question", getLatency);
   S.declare("timedout-packets","Number of packets which weren't answered within timeout set");
   S.declare("security-status", "Security status based on regular polling");
-  S.declareRing("queries","UDP Queries Received");
-  S.declareRing("nxdomain-queries","Queries for non-existent records within existent domains");
-  S.declareRing("noerror-queries","Queries for existing records, but for type we don't have");
-  S.declareRing("servfail-queries","Queries that could not be answered due to backend errors");
-  S.declareRing("unauth-queries","Queries for domains that we are not authoritative for");
+  S.declareDNSNameQTypeRing("queries","UDP Queries Received");
+  S.declareDNSNameQTypeRing("nxdomain-queries","Queries for non-existent records within existent domains");
+  S.declareDNSNameQTypeRing("noerror-queries","Queries for existing records, but for type we don't have");
+  S.declareDNSNameQTypeRing("servfail-queries","Queries that could not be answered due to backend errors");
+  S.declareDNSNameQTypeRing("unauth-queries","Queries for domains that we are not authoritative for");
   S.declareRing("logmessages","Log Messages");
   S.declareComboRing("remotes","Remote server IP addresses");
   S.declareComboRing("remotes-unauth","Remote hosts querying domains for which we are not auth");
@@ -421,7 +421,7 @@ try
      if(P->d.qr)
        continue;
 
-    S.ringAccount("queries", P->qdomain.toLogString()+"/"+P->qtype.getName());
+    S.ringAccount("queries", P->qdomain, P->qtype);
     S.ringAccount("remotes",P->d_remote);
     if(logDNSQueries) {
       string remote;

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1003,7 +1003,7 @@ void PacketHandler::makeNOError(DNSPacket* p, DNSPacket* r, const DNSName& targe
   if(d_dk.isSecuredZone(sd.qname))
     addNSECX(p, r, target, wildcard, sd.qname, mode);
 
-  S.ringAccount("noerror-queries",p->qdomain.toLogString()+"/"+p->qtype.getName());
+  S.ringAccount("noerror-queries", p->qdomain, p->qtype);
 }
 
 
@@ -1561,7 +1561,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     r=p->replyPacket(); // generate an empty reply packet
     r->setRcode(RCode::ServFail);
     S.inc("servfail-packets");
-    S.ringAccount("servfail-queries",p->qdomain.toLogString());
+    S.ringAccount("servfail-queries", p->qdomain, p->qtype);
   }
   catch(PDNSException &e) {
     g_log<<Logger::Error<<"Backend reported permanent error which prevented lookup ("+e.reason+"), aborting"<<endl;
@@ -1573,7 +1573,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     r=p->replyPacket(); // generate an empty reply packet
     r->setRcode(RCode::ServFail);
     S.inc("servfail-packets");
-    S.ringAccount("servfail-queries",p->qdomain.toLogString());
+    S.ringAccount("servfail-queries", p->qdomain, p->qtype);
   }
   return r; 
 

--- a/pdns/responsestats-auth.cc
+++ b/pdns/responsestats-auth.cc
@@ -24,9 +24,9 @@ void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP) {
 
   if(p.d.aa) {
     if (p.d.rcode==RCode::NXDomain)
-      S.ringAccount("nxdomain-queries",p.qdomain.toLogString()+"/"+p.qtype.getName());
+      S.ringAccount("nxdomain-queries", p.qdomain, p.qtype);
   } else if (p.d.rcode == RCode::Refused) {
-    S.ringAccount("unauth-queries",p.qdomain.toLogString()+"/"+p.qtype.getName());
+    S.ringAccount("unauth-queries", p.qdomain, p.qtype);
     S.ringAccount("remotes-unauth",p.d_remote);
   }
 

--- a/pdns/responsestats-auth.cc
+++ b/pdns/responsestats-auth.cc
@@ -25,7 +25,7 @@ void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP) {
   if(p.d.aa) {
     if (p.d.rcode==RCode::NXDomain)
       S.ringAccount("nxdomain-queries",p.qdomain.toLogString()+"/"+p.qtype.getName());
-  } else if (p.isEmpty()) {
+  } else if (p.d.rcode == RCode::Refused) {
     S.ringAccount("unauth-queries",p.qdomain.toLogString()+"/"+p.qtype.getName());
     S.ringAccount("remotes-unauth",p.d_remote);
   }

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -589,6 +589,7 @@ struct ParsePacketTest
 
   void operator()() const
   {
+#if 0
     MOADNSParser mdp(false, (const char*)&*d_packet.begin(), d_packet.size());
     typedef map<pair<DNSName, QType>, set<DNSResourceRecord>, TCacheComp > tcache_t;
     tcache_t tcache;
@@ -609,7 +610,7 @@ struct ParsePacketTest
       lwr.d_result.push_back(rr);
     }
 
-
+#endif
   }
   const vector<uint8_t>& d_packet;
   std::string d_name;

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -807,6 +807,20 @@ struct StatRingDNSNameQTypeToStringTest
   QType d_type;
 };
 
+struct StatRingDNSNameQTypeTest
+{
+  explicit StatRingDNSNameQTypeTest(const DNSName &name, const QType type) : d_name(name), d_type(type) {}
+
+  string getName() const { return "StatRing test with DNSName and QType"; }
+
+  void operator()() const {
+    S.ringAccount("testring", d_name, d_type);
+  };
+
+  DNSName d_name;
+  QType d_type;
+};
+
 
 
 int main(int argc, char** argv)
@@ -897,6 +911,9 @@ try
 
   S.declareRing("testring", "Just some ring where we'll account things");
   doRun(StatRingDNSNameQTypeToStringTest(DNSName("example.com"), QType(1)));
+
+  S.declareDNSNameQTypeRing("testring", "Just some ring where we'll account things");
+  doRun(StatRingDNSNameQTypeTest(DNSName("example.com"), QType(1)));
 #endif
 
   cerr<<"Total runs: " << g_totalRuns<<endl;

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -588,7 +588,6 @@ struct ParsePacketTest
 
   void operator()() const
   {
-#if 0
     MOADNSParser mdp(false, (const char*)&*d_packet.begin(), d_packet.size());
     typedef map<pair<DNSName, QType>, set<DNSResourceRecord>, TCacheComp > tcache_t;
     tcache_t tcache;
@@ -609,7 +608,7 @@ struct ParsePacketTest
       lwr.d_result.push_back(rr);
     }
 
-#endif
+
   }
   const vector<uint8_t>& d_packet;
   std::string d_name;

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -793,6 +793,20 @@ struct NOPTest
 
 };
 
+struct StatRingDNSNameQTypeToStringTest
+{
+  explicit StatRingDNSNameQTypeToStringTest(const DNSName &name, const QType type) : d_name(name), d_type(type) {}
+
+  string getName() const { return "StatRing test with DNSName and QType to string"; }
+
+  void operator()() const {
+    S.ringAccount("testring", d_name.toLogString()+"/"+d_type.getName());
+  };
+
+  DNSName d_name;
+  QType d_type;
+};
+
 
 
 int main(int argc, char** argv)
@@ -877,6 +891,13 @@ try
 
   doRun(DNSNameParseTest());
   doRun(DNSNameRootTest());
+
+#ifndef RECURSOR
+  S.doRings();
+
+  S.declareRing("testring", "Just some ring where we'll account things");
+  doRun(StatRingDNSNameQTypeToStringTest(DNSName("example.com"), QType(1)));
+#endif
 
   cerr<<"Total runs: " << g_totalRuns<<endl;
 

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -814,7 +814,7 @@ struct StatRingDNSNameQTypeTest
   string getName() const { return "StatRing test with DNSName and QType"; }
 
   void operator()() const {
-    S.ringAccount("testring", d_name, d_type);
+    S.ringAccount("testringdnsname", d_name, d_type);
   };
 
   DNSName d_name;
@@ -912,7 +912,7 @@ try
   S.declareRing("testring", "Just some ring where we'll account things");
   doRun(StatRingDNSNameQTypeToStringTest(DNSName("example.com"), QType(1)));
 
-  S.declareDNSNameQTypeRing("testring", "Just some ring where we'll account things");
+  S.declareDNSNameQTypeRing("testringdnsname", "Just some ring where we'll account things");
   doRun(StatRingDNSNameQTypeTest(DNSName("example.com"), QType(1)));
 #endif
 

--- a/pdns/statbag.cc
+++ b/pdns/statbag.cc
@@ -218,7 +218,7 @@ vector<pair<T, unsigned int> >StatRing<T,Comp>::get() const
 
 void StatBag::declareRing(const string &name, const string &help, unsigned int size)
 {
-  d_rings[name]=StatRing<string>(size);
+  d_rings[name]=StatRing<string, CIStringCompare>(size);
   d_rings[name].setHelp(help);
 }
 
@@ -288,9 +288,9 @@ string StatBag::getRingTitle(const string &name)
 vector<string>StatBag::listRings()
 {
   vector<string> ret;
-  for(map<string,StatRing<string> >::const_iterator i=d_rings.begin();i!=d_rings.end();++i)
+  for(auto i=d_rings.begin();i!=d_rings.end();++i)
     ret.push_back(i->first);
-  for(map<string,StatRing<SComboAddress> >::const_iterator i=d_comborings.begin();i!=d_comborings.end();++i)
+  for(auto i=d_comborings.begin();i!=d_comborings.end();++i)
     ret.push_back(i->first);
 
   return ret;
@@ -301,5 +301,5 @@ bool StatBag::ringExists(const string &name)
   return d_rings.count(name) || d_comborings.count(name);
 }
 
-template class StatRing<std::string>;
+template class StatRing<std::string, CIStringCompare>;
 template class StatRing<SComboAddress>;

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -66,6 +66,7 @@ class StatBag
   map<string, string> d_keyDescrips;
   map<string,StatRing<string, CIStringCompare> >d_rings;
   map<string,StatRing<SComboAddress> >d_comborings;
+  map<string,StatRing<std::tuple<DNSName, QType> > >d_dnsnameqtyperings;
   typedef boost::function<uint64_t(const std::string&)> func_t;
   typedef map<string, func_t> funcstats_t;
   funcstats_t d_funcstats;
@@ -79,6 +80,7 @@ public:
 
   void declareRing(const string &name, const string &title, unsigned int size=10000);
   void declareComboRing(const string &name, const string &help, unsigned int size=10000);
+  void declareDNSNameQTypeRing(const string &name, const string &help, unsigned int size=10000);
   vector<pair<string, unsigned int> >getRing(const string &name);
   string getRingTitle(const string &name);
   void ringAccount(const char* name, const string &item)
@@ -96,6 +98,14 @@ public:
       if(!d_comborings.count(name))
 	throw runtime_error("Attempting to account to non-existent comboring '"+std::string(name)+"'");
       d_comborings[name].account(item);
+    }
+  }
+  void ringAccount(const char* name, const DNSName &dnsname, const QType &qtype)
+  {
+    if(d_doRings) {
+      if(!d_dnsnameqtyperings.count(name))
+	throw runtime_error("Attempting to account to non-existent dnsname+qtype ring '"+std::string(name)+"'");
+      d_dnsnameqtyperings[name].account(std::make_tuple(dnsname, qtype));
     }
   }
 

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -64,7 +64,7 @@ class StatBag
 {
   map<string, AtomicCounter *> d_stats;
   map<string, string> d_keyDescrips;
-  map<string,StatRing<string> >d_rings;
+  map<string,StatRing<string, CIStringCompare> >d_rings;
   map<string,StatRing<SComboAddress> >d_comborings;
   typedef boost::function<uint64_t(const std::string&)> func_t;
   typedef map<string, func_t> funcstats_t;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -282,9 +282,10 @@ void AuthWebServer::indexfunction(HttpRequest* req, HttpResponse* resp)
 
   ret<<"Total queries: "<<S.read("udp-queries")<<". Question/answer latency: "<<S.read("latency")/1000.0<<"ms</p><br>"<<endl;
   if(req->getvars["ring"].empty()) {
-    vector<string>entries=S.listRings();
-    for(vector<string>::const_iterator i=entries.begin();i!=entries.end();++i)
-      printtable(ret,*i,S.getRingTitle(*i));
+    auto entries = S.listRings();
+    for(const auto &i: entries) {
+      printtable(ret, i, S.getRingTitle(i));
+    }
 
     printvars(ret);
     if(arg().mustDo("webserver-print-arguments"))


### PR DESCRIPTION
### Short description
When we previously summarised a ringbuffer we would do so case sensitively. In addition, packetcached delegations were put in the rings for queries for domains we are not auth for.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
