### PR TITLE
Add rec statistics about ECS response sizes, API endpoint to get a specific stat

### DIFF
--- a/docs/common/api/endpoint-statistics.rst
+++ b/docs/common/api/endpoint-statistics.rst
@@ -1,7 +1,7 @@
 Statistics endpoint
 ===================
 
-.. http:get:: /api/v1/servers/:server_id/statistics
+.. http:get:: /api/v1/servers/:server_id/statistics?statistic=:statistic
 
   Query PowerDNS internal statistics.
   Returns a list of :json:object:`StatisticItem` elements.
@@ -9,6 +9,10 @@ Statistics endpoint
   The names and meaning of these items are described :ref:`here <metricnames>`.
 
   :param server_id: The name of the server
+
+  .. versionadded:: 4.2.0
+
+  :query statistic: If set to the name of a specific statistic, only this value is returned. If no statistic with that name exists, the response has a 422 status and an error message
 
   **Example response:**
 

--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -399,6 +399,14 @@ paths:
           required: true
           description: The id of the server to retrieve
           type: string
+        - name: statistic
+          in: query
+          required: false
+          type: string
+          description: |
+            When set to the name of a specific statistic, only this value is returned.
+            If no statistic with that name exists, the response has a 422 status and an error message.
+
       responses:
         '200':
           description: List of Statistic Items
@@ -408,6 +416,8 @@ paths:
             - $ref: '#/definitions/StatisticItem'
             - $ref: '#/definitions/MapStatisticItem'
             - $ref: '#/definitions/RingStatisticItem'
+        '422':
+          description: 'Returned when a non-existing statistic name has been requested. Contains an error message'
 
   '/servers/{server_id}/search-data':
     get:

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3857,10 +3857,10 @@ static int serviceMain(int argc, char*argv[])
   g_tcpMaxQueriesPerConn=::arg().asNum("max-tcp-queries-per-connection");
   s_maxUDPQueriesPerRound=::arg().asNum("max-udp-queries-per-round");
 
-  blacklistStats(StatComponent::API, ::arg()["blacklisted-stats-api"]);
-  blacklistStats(StatComponent::Carbon, ::arg()["blacklisted-stats-carbon"]);
-  blacklistStats(StatComponent::RecControl, ::arg()["blacklisted-stats-rec-control"]);
-  blacklistStats(StatComponent::SNMP, ::arg()["blacklisted-stats-snmp"]);
+  blacklistStats(StatComponent::API, ::arg()["stats-api-blacklist"]);
+  blacklistStats(StatComponent::Carbon, ::arg()["stats-carbon-blacklist"]);
+  blacklistStats(StatComponent::RecControl, ::arg()["stats-rec-control-blacklist"]);
+  blacklistStats(StatComponent::SNMP, ::arg()["stats-snmp-blacklist"]);
 
   if (::arg().mustDo("snmp-agent")) {
     g_snmpAgent = std::make_shared<RecursorSNMPAgent>("recursor", ::arg()["snmp-master-socket"]);
@@ -4292,10 +4292,10 @@ int main(int argc, char **argv)
     for (size_t idx = 0; idx < 128; idx++) {
       defaultBlacklistedStats += ", ecs-v6-response-bits-" + std::to_string(idx + 1);
     }
-    ::arg().set("blacklisted-stats-api", "List of statistics that are disabled when retrieving the complete list of statistics via the API")=defaultBlacklistedStats;
-    ::arg().set("blacklisted-stats-carbon", "List of statistics that are prevented from being exported via Carbon")=defaultBlacklistedStats;
-    ::arg().set("blacklisted-stats-rec-control", "List of statistics that are prevented from being exported via rec_control get-all")=defaultBlacklistedStats;
-    ::arg().set("blacklisted-stats-snmp", "List of statistics that are prevented from being exported via SNMP")=defaultBlacklistedStats;
+    ::arg().set("stats-api-blacklist", "List of statistics that are disabled when retrieving the complete list of statistics via the API")=defaultBlacklistedStats;
+    ::arg().set("stats-carbon-blacklist", "List of statistics that are prevented from being exported via Carbon")=defaultBlacklistedStats;
+    ::arg().set("stats-rec-control-blacklist", "List of statistics that are prevented from being exported via rec_control get-all")=defaultBlacklistedStats;
+    ::arg().set("stats-snmp-blacklist", "List of statistics that are prevented from being exported via SNMP")=defaultBlacklistedStats;
 
     ::arg().set("tcp-fast-open", "Enable TCP Fast Open support on the listening sockets, using the supplied numerical value as the queue size")="0";
     ::arg().set("nsec3-max-iterations", "Maximum number of iterations allowed for an NSEC3 record")="2500";

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3652,6 +3652,7 @@ static int serviceMain(int argc, char*argv[])
 
   SyncRes::s_ecsipv4limit = ::arg().asNum("ecs-ipv4-bits");
   SyncRes::s_ecsipv6limit = ::arg().asNum("ecs-ipv6-bits");
+  SyncRes::clearECSStats();
 
   if (!::arg().isEmpty("ecs-scope-zero-address")) {
     ComboAddress scopeZero(::arg()["ecs-scope-zero-address"]);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3857,7 +3857,7 @@ static int serviceMain(int argc, char*argv[])
   s_maxUDPQueriesPerRound=::arg().asNum("max-udp-queries-per-round");
 
   if (::arg().mustDo("snmp-agent")) {
-    g_snmpAgent = std::make_shared<RecursorSNMPAgent>("recursor", ::arg()["snmp-master-socket"]);
+    g_snmpAgent = std::make_shared<RecursorSNMPAgent>("recursor", ::arg()["snmp-master-socket"], ::arg().mustDo("snmp-enable-expensive-stats"));
     g_snmpAgent->run();
   }
 
@@ -4278,6 +4278,7 @@ int main(int argc, char **argv)
 
     ::arg().setSwitch("snmp-agent", "If set, register as an SNMP agent")="no";
     ::arg().set("snmp-master-socket", "If set and snmp-agent is set, the socket to use to register to the SNMP master")="";
+    ::arg().setSwitch("snmp-enable-expensive-stats", "If set and snmp-agent is set, even statistics whose reporting can have an impact on production will be enabled")="no";
 
     ::arg().set("tcp-fast-open", "Enable TCP Fast Open support on the listening sockets, using the supplied numerical value as the queue size")="0";
     ::arg().set("nsec3-max-iterations", "Maximum number of iterations allowed for an NSEC3 record")="2500";

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -57,7 +57,7 @@ try
  
     if(msg.empty()) {
       typedef map<string,string> all_t;
-      all_t all=getAllStatsMap();
+      all_t all=getAllStatsMap(StatComponent::Carbon);
       
       ostringstream str;
       time_t now=time(0);

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -164,7 +164,7 @@ static int handleDisabledCounter64Stats(netsnmp_mib_handler* handler,
   return RecursorSNMPAgent::setCounter64Value(requests, 0);
 }
 
-static void registerCounter64Stat(const std::string& name, const oid statOID[], size_t statOIDLength, bool expensiveStats)
+static void registerCounter64Stat(const std::string& name, const oid statOID[], size_t statOIDLength)
 {
   if (statOIDLength != OID_LENGTH(questionsOID)) {
     g_log<<Logger::Error<<"Invalid OID for SNMP Counter64 statistic "<<name<<endl;
@@ -178,7 +178,7 @@ static void registerCounter64Stat(const std::string& name, const oid statOID[], 
 
   s_statsMap[statOID[statOIDLength - 1]] = name.c_str();
   netsnmp_register_scalar(netsnmp_create_handler_registration(name.c_str(),
-                                                              (expensiveStats || !isStatExpensive(name)) ? handleCounter64Stats : handleDisabledCounter64Stats,
+                                                              isStatBlacklisted(StatComponent::SNMP, name) ? handleCounter64Stats : handleDisabledCounter64Stats,
                                                               statOID,
                                                               statOIDLength,
                                                               HANDLER_CAN_RONLY));
@@ -213,112 +213,112 @@ bool RecursorSNMPAgent::sendCustomTrap(const std::string& reason)
 }
 
 
-RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string& masterSocket, bool enableExpensiveStatistics): SNMPAgent(name, masterSocket)
+RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string& masterSocket): SNMPAgent(name, masterSocket)
 {
 #ifdef HAVE_NET_SNMP
   /* This is done so that the statistics maps are
      initialized. */
   registerAllStats();
 
-  registerCounter64Stat("questions", questionsOID, OID_LENGTH(questionsOID), enableExpensiveStatistics);
-  registerCounter64Stat("ipv6-questions", ipv6QuestionsOID, OID_LENGTH(ipv6QuestionsOID), enableExpensiveStatistics);
-  registerCounter64Stat("tcp-questions", tcpQuestionsOID, OID_LENGTH(tcpQuestionsOID), enableExpensiveStatistics);
-  registerCounter64Stat("cache-hits", cacheHitsOID, OID_LENGTH(cacheHitsOID), enableExpensiveStatistics);
-  registerCounter64Stat("cache-misses", cacheMissesOID, OID_LENGTH(cacheMissesOID), enableExpensiveStatistics);
-  registerCounter64Stat("cache-entries", cacheEntriesOID, OID_LENGTH(cacheEntriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("cache-bytes", cacheBytesOID, OID_LENGTH(cacheBytesOID), enableExpensiveStatistics);
-  registerCounter64Stat("packetcache-hits", packetcacheHitsOID, OID_LENGTH(packetcacheHitsOID), enableExpensiveStatistics);
-  registerCounter64Stat("packetcache-misses", packetcacheMissesOID, OID_LENGTH(packetcacheMissesOID), enableExpensiveStatistics);
-  registerCounter64Stat("packetcache-entries", packetcacheEntriesOID, OID_LENGTH(packetcacheEntriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("packetcache-bytes", packetcacheBytesOID, OID_LENGTH(packetcacheBytesOID), enableExpensiveStatistics);
-  registerCounter64Stat("malloc-bytes", mallocBytesOID, OID_LENGTH(mallocBytesOID), enableExpensiveStatistics);
-  registerCounter64Stat("servfail-answers", servfailAnswersOID, OID_LENGTH(servfailAnswersOID), enableExpensiveStatistics);
-  registerCounter64Stat("nxdomain-answers", nxdomainAnswersOID, OID_LENGTH(nxdomainAnswersOID), enableExpensiveStatistics);
-  registerCounter64Stat("noerror-answers", noerrorAnswersOID, OID_LENGTH(noerrorAnswersOID), enableExpensiveStatistics);
-  registerCounter64Stat("unauthorized-udp", unauthorizedUdpOID, OID_LENGTH(unauthorizedUdpOID), enableExpensiveStatistics);
-  registerCounter64Stat("unauthorized-tcp", unauthorizedTcpOID, OID_LENGTH(unauthorizedTcpOID), enableExpensiveStatistics);
-  registerCounter64Stat("tcp-client-overflow", tcpClientOverflowOID, OID_LENGTH(tcpClientOverflowOID), enableExpensiveStatistics);
-  registerCounter64Stat("client-parse-errors", clientParseErrorsOID, OID_LENGTH(clientParseErrorsOID), enableExpensiveStatistics);
-  registerCounter64Stat("server-parse-errors", serverParseErrorsOID, OID_LENGTH(serverParseErrorsOID), enableExpensiveStatistics);
-  registerCounter64Stat("too-old-drops", tooOldDropsOID, OID_LENGTH(tooOldDropsOID), enableExpensiveStatistics);
-  registerCounter64Stat("query-pipe-full-drops", queryPipeFullDropsOID, OID_LENGTH(queryPipeFullDropsOID), enableExpensiveStatistics);
-  registerCounter64Stat("truncated-drops", truncatedDropsOID, OID_LENGTH(truncatedDropsOID), enableExpensiveStatistics);
-  registerCounter64Stat("empty-queries", emptyQueriesOID, OID_LENGTH(emptyQueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("variable-responses", variableResponsesOID, OID_LENGTH(variableResponsesOID), enableExpensiveStatistics);
-  registerCounter64Stat("answers0-1", answers01OID, OID_LENGTH(answers01OID), enableExpensiveStatistics);
-  registerCounter64Stat("answers1-10", answers110OID, OID_LENGTH(answers110OID), enableExpensiveStatistics);
-  registerCounter64Stat("answers10-100", answers10100OID, OID_LENGTH(answers10100OID), enableExpensiveStatistics);
-  registerCounter64Stat("answers100-1000", answers1001000OID, OID_LENGTH(answers1001000OID), enableExpensiveStatistics);
-  registerCounter64Stat("answers-slow", answersSlowOID, OID_LENGTH(answersSlowOID), enableExpensiveStatistics);
-  registerCounter64Stat("auth4-answers0-1", auth4Answers01OID, OID_LENGTH(auth4Answers01OID), enableExpensiveStatistics);
-  registerCounter64Stat("auth4-answers1-10", auth4Answers110OID, OID_LENGTH(auth4Answers110OID), enableExpensiveStatistics);
-  registerCounter64Stat("auth4-answers10-100", auth4Answers10100OID, OID_LENGTH(auth4Answers10100OID), enableExpensiveStatistics);
-  registerCounter64Stat("auth4-answers100-1000", auth4Answers1001000OID, OID_LENGTH(auth4Answers1001000OID), enableExpensiveStatistics);
-  registerCounter64Stat("auth4-answers-slow", auth4AnswersslowOID, OID_LENGTH(auth4AnswersslowOID), enableExpensiveStatistics);
-  registerCounter64Stat("auth6-answers0-1", auth6Answers01OID, OID_LENGTH(auth6Answers01OID), enableExpensiveStatistics);
-  registerCounter64Stat("auth6-answers1-10", auth6Answers110OID, OID_LENGTH(auth6Answers110OID), enableExpensiveStatistics);
-  registerCounter64Stat("auth6-answers10-100", auth6Answers10100OID, OID_LENGTH(auth6Answers10100OID), enableExpensiveStatistics);
-  registerCounter64Stat("auth6-answers100-1000", auth6Answers1001000OID, OID_LENGTH(auth6Answers1001000OID), enableExpensiveStatistics);
-  registerCounter64Stat("auth6-answers-slow", auth6AnswersSlowOID, OID_LENGTH(auth6AnswersSlowOID), enableExpensiveStatistics);
-  registerCounter64Stat("qa-latency", qaLatencyOID, OID_LENGTH(qaLatencyOID), enableExpensiveStatistics);
-  registerCounter64Stat("unexpected-packets", unexpectedPacketsOID, OID_LENGTH(unexpectedPacketsOID), enableExpensiveStatistics);
-  registerCounter64Stat("case-mismatches", caseMismatchesOID, OID_LENGTH(caseMismatchesOID), enableExpensiveStatistics);
-  registerCounter64Stat("spoof-prevents", spoofPreventsOID, OID_LENGTH(spoofPreventsOID), enableExpensiveStatistics);
-  registerCounter64Stat("nsset-invalidations", nssetInvalidationsOID, OID_LENGTH(nssetInvalidationsOID), enableExpensiveStatistics);
-  registerCounter64Stat("resource-limits", resourceLimitsOID, OID_LENGTH(resourceLimitsOID), enableExpensiveStatistics);
-  registerCounter64Stat("over-capacity-drops", overCapacityDropsOID, OID_LENGTH(overCapacityDropsOID), enableExpensiveStatistics);
-  registerCounter64Stat("policy-drops", policyDropsOID, OID_LENGTH(policyDropsOID), enableExpensiveStatistics);
-  registerCounter64Stat("no-packet-error", noPacketErrorOID, OID_LENGTH(noPacketErrorOID), enableExpensiveStatistics);
-  registerCounter64Stat("dlg-only-drops", dlgOnlyDropsOID, OID_LENGTH(dlgOnlyDropsOID), enableExpensiveStatistics);
-  registerCounter64Stat("ignored-packets", ignoredPacketsOID, OID_LENGTH(ignoredPacketsOID), enableExpensiveStatistics);
-  registerCounter64Stat("max-mthread-stack", maxMthreadStackOID, OID_LENGTH(maxMthreadStackOID), enableExpensiveStatistics);
-  registerCounter64Stat("negcache-entries", negcacheEntriesOID, OID_LENGTH(negcacheEntriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("throttle-entries", throttleEntriesOID, OID_LENGTH(throttleEntriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("nsspeeds-entries", nsspeedsEntriesOID, OID_LENGTH(nsspeedsEntriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("failed-host-entries", failedHostEntriesOID, OID_LENGTH(failedHostEntriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("concurrent-queries", concurrentQueriesOID, OID_LENGTH(concurrentQueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("security-status", securityStatusOID, OID_LENGTH(securityStatusOID), enableExpensiveStatistics);
-  registerCounter64Stat("outgoing-timeouts", outgoingTimeoutsOID, OID_LENGTH(outgoingTimeoutsOID), enableExpensiveStatistics);
-  registerCounter64Stat("outgoing4-timeouts", outgoing4TimeoutsOID, OID_LENGTH(outgoing4TimeoutsOID), enableExpensiveStatistics);
-  registerCounter64Stat("outgoing6-timeouts", outgoing6TimeoutsOID, OID_LENGTH(outgoing6TimeoutsOID), enableExpensiveStatistics);
-  registerCounter64Stat("tcp-outqueries", tcpOutqueriesOID, OID_LENGTH(tcpOutqueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("all-outqueries", allOutqueriesOID, OID_LENGTH(allOutqueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("ipv6-outqueries", ipv6OutqueriesOID, OID_LENGTH(ipv6OutqueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("throttled-outqueries", throttledOutqueriesOID, OID_LENGTH(throttledOutqueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("dont-outqueries", dontOutqueriesOID, OID_LENGTH(dontOutqueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("unreachables", unreachablesOID, OID_LENGTH(unreachablesOID), enableExpensiveStatistics);
-  registerCounter64Stat("chain-resends", chainResendsOID, OID_LENGTH(chainResendsOID), enableExpensiveStatistics);
-  registerCounter64Stat("tcp-clients", tcpClientsOID, OID_LENGTH(tcpClientsOID), enableExpensiveStatistics);
+  registerCounter64Stat("questions", questionsOID, OID_LENGTH(questionsOID));
+  registerCounter64Stat("ipv6-questions", ipv6QuestionsOID, OID_LENGTH(ipv6QuestionsOID));
+  registerCounter64Stat("tcp-questions", tcpQuestionsOID, OID_LENGTH(tcpQuestionsOID));
+  registerCounter64Stat("cache-hits", cacheHitsOID, OID_LENGTH(cacheHitsOID));
+  registerCounter64Stat("cache-misses", cacheMissesOID, OID_LENGTH(cacheMissesOID));
+  registerCounter64Stat("cache-entries", cacheEntriesOID, OID_LENGTH(cacheEntriesOID));
+  registerCounter64Stat("cache-bytes", cacheBytesOID, OID_LENGTH(cacheBytesOID));
+  registerCounter64Stat("packetcache-hits", packetcacheHitsOID, OID_LENGTH(packetcacheHitsOID));
+  registerCounter64Stat("packetcache-misses", packetcacheMissesOID, OID_LENGTH(packetcacheMissesOID));
+  registerCounter64Stat("packetcache-entries", packetcacheEntriesOID, OID_LENGTH(packetcacheEntriesOID));
+  registerCounter64Stat("packetcache-bytes", packetcacheBytesOID, OID_LENGTH(packetcacheBytesOID));
+  registerCounter64Stat("malloc-bytes", mallocBytesOID, OID_LENGTH(mallocBytesOID));
+  registerCounter64Stat("servfail-answers", servfailAnswersOID, OID_LENGTH(servfailAnswersOID));
+  registerCounter64Stat("nxdomain-answers", nxdomainAnswersOID, OID_LENGTH(nxdomainAnswersOID));
+  registerCounter64Stat("noerror-answers", noerrorAnswersOID, OID_LENGTH(noerrorAnswersOID));
+  registerCounter64Stat("unauthorized-udp", unauthorizedUdpOID, OID_LENGTH(unauthorizedUdpOID));
+  registerCounter64Stat("unauthorized-tcp", unauthorizedTcpOID, OID_LENGTH(unauthorizedTcpOID));
+  registerCounter64Stat("tcp-client-overflow", tcpClientOverflowOID, OID_LENGTH(tcpClientOverflowOID));
+  registerCounter64Stat("client-parse-errors", clientParseErrorsOID, OID_LENGTH(clientParseErrorsOID));
+  registerCounter64Stat("server-parse-errors", serverParseErrorsOID, OID_LENGTH(serverParseErrorsOID));
+  registerCounter64Stat("too-old-drops", tooOldDropsOID, OID_LENGTH(tooOldDropsOID));
+  registerCounter64Stat("query-pipe-full-drops", queryPipeFullDropsOID, OID_LENGTH(queryPipeFullDropsOID));
+  registerCounter64Stat("truncated-drops", truncatedDropsOID, OID_LENGTH(truncatedDropsOID));
+  registerCounter64Stat("empty-queries", emptyQueriesOID, OID_LENGTH(emptyQueriesOID));
+  registerCounter64Stat("variable-responses", variableResponsesOID, OID_LENGTH(variableResponsesOID));
+  registerCounter64Stat("answers0-1", answers01OID, OID_LENGTH(answers01OID));
+  registerCounter64Stat("answers1-10", answers110OID, OID_LENGTH(answers110OID));
+  registerCounter64Stat("answers10-100", answers10100OID, OID_LENGTH(answers10100OID));
+  registerCounter64Stat("answers100-1000", answers1001000OID, OID_LENGTH(answers1001000OID));
+  registerCounter64Stat("answers-slow", answersSlowOID, OID_LENGTH(answersSlowOID));
+  registerCounter64Stat("auth4-answers0-1", auth4Answers01OID, OID_LENGTH(auth4Answers01OID));
+  registerCounter64Stat("auth4-answers1-10", auth4Answers110OID, OID_LENGTH(auth4Answers110OID));
+  registerCounter64Stat("auth4-answers10-100", auth4Answers10100OID, OID_LENGTH(auth4Answers10100OID));
+  registerCounter64Stat("auth4-answers100-1000", auth4Answers1001000OID, OID_LENGTH(auth4Answers1001000OID));
+  registerCounter64Stat("auth4-answers-slow", auth4AnswersslowOID, OID_LENGTH(auth4AnswersslowOID));
+  registerCounter64Stat("auth6-answers0-1", auth6Answers01OID, OID_LENGTH(auth6Answers01OID));
+  registerCounter64Stat("auth6-answers1-10", auth6Answers110OID, OID_LENGTH(auth6Answers110OID));
+  registerCounter64Stat("auth6-answers10-100", auth6Answers10100OID, OID_LENGTH(auth6Answers10100OID));
+  registerCounter64Stat("auth6-answers100-1000", auth6Answers1001000OID, OID_LENGTH(auth6Answers1001000OID));
+  registerCounter64Stat("auth6-answers-slow", auth6AnswersSlowOID, OID_LENGTH(auth6AnswersSlowOID));
+  registerCounter64Stat("qa-latency", qaLatencyOID, OID_LENGTH(qaLatencyOID));
+  registerCounter64Stat("unexpected-packets", unexpectedPacketsOID, OID_LENGTH(unexpectedPacketsOID));
+  registerCounter64Stat("case-mismatches", caseMismatchesOID, OID_LENGTH(caseMismatchesOID));
+  registerCounter64Stat("spoof-prevents", spoofPreventsOID, OID_LENGTH(spoofPreventsOID));
+  registerCounter64Stat("nsset-invalidations", nssetInvalidationsOID, OID_LENGTH(nssetInvalidationsOID));
+  registerCounter64Stat("resource-limits", resourceLimitsOID, OID_LENGTH(resourceLimitsOID));
+  registerCounter64Stat("over-capacity-drops", overCapacityDropsOID, OID_LENGTH(overCapacityDropsOID));
+  registerCounter64Stat("policy-drops", policyDropsOID, OID_LENGTH(policyDropsOID));
+  registerCounter64Stat("no-packet-error", noPacketErrorOID, OID_LENGTH(noPacketErrorOID));
+  registerCounter64Stat("dlg-only-drops", dlgOnlyDropsOID, OID_LENGTH(dlgOnlyDropsOID));
+  registerCounter64Stat("ignored-packets", ignoredPacketsOID, OID_LENGTH(ignoredPacketsOID));
+  registerCounter64Stat("max-mthread-stack", maxMthreadStackOID, OID_LENGTH(maxMthreadStackOID));
+  registerCounter64Stat("negcache-entries", negcacheEntriesOID, OID_LENGTH(negcacheEntriesOID));
+  registerCounter64Stat("throttle-entries", throttleEntriesOID, OID_LENGTH(throttleEntriesOID));
+  registerCounter64Stat("nsspeeds-entries", nsspeedsEntriesOID, OID_LENGTH(nsspeedsEntriesOID));
+  registerCounter64Stat("failed-host-entries", failedHostEntriesOID, OID_LENGTH(failedHostEntriesOID));
+  registerCounter64Stat("concurrent-queries", concurrentQueriesOID, OID_LENGTH(concurrentQueriesOID));
+  registerCounter64Stat("security-status", securityStatusOID, OID_LENGTH(securityStatusOID));
+  registerCounter64Stat("outgoing-timeouts", outgoingTimeoutsOID, OID_LENGTH(outgoingTimeoutsOID));
+  registerCounter64Stat("outgoing4-timeouts", outgoing4TimeoutsOID, OID_LENGTH(outgoing4TimeoutsOID));
+  registerCounter64Stat("outgoing6-timeouts", outgoing6TimeoutsOID, OID_LENGTH(outgoing6TimeoutsOID));
+  registerCounter64Stat("tcp-outqueries", tcpOutqueriesOID, OID_LENGTH(tcpOutqueriesOID));
+  registerCounter64Stat("all-outqueries", allOutqueriesOID, OID_LENGTH(allOutqueriesOID));
+  registerCounter64Stat("ipv6-outqueries", ipv6OutqueriesOID, OID_LENGTH(ipv6OutqueriesOID));
+  registerCounter64Stat("throttled-outqueries", throttledOutqueriesOID, OID_LENGTH(throttledOutqueriesOID));
+  registerCounter64Stat("dont-outqueries", dontOutqueriesOID, OID_LENGTH(dontOutqueriesOID));
+  registerCounter64Stat("unreachables", unreachablesOID, OID_LENGTH(unreachablesOID));
+  registerCounter64Stat("chain-resends", chainResendsOID, OID_LENGTH(chainResendsOID));
+  registerCounter64Stat("tcp-clients", tcpClientsOID, OID_LENGTH(tcpClientsOID));
 #ifdef __linux__
-  registerCounter64Stat("udp-recvbuf-errors", udpRecvbufErrorsOID, OID_LENGTH(udpRecvbufErrorsOID), enableExpensiveStatistics);
-  registerCounter64Stat("udp-sndbuf-errors", udpSndbufErrorsOID, OID_LENGTH(udpSndbufErrorsOID), enableExpensiveStatistics);
-  registerCounter64Stat("udp-noport-errors", udpNoportErrorsOID, OID_LENGTH(udpNoportErrorsOID), enableExpensiveStatistics);
-  registerCounter64Stat("udp-in-errors", udpinErrorsOID, OID_LENGTH(udpinErrorsOID), enableExpensiveStatistics);
+  registerCounter64Stat("udp-recvbuf-errors", udpRecvbufErrorsOID, OID_LENGTH(udpRecvbufErrorsOID));
+  registerCounter64Stat("udp-sndbuf-errors", udpSndbufErrorsOID, OID_LENGTH(udpSndbufErrorsOID));
+  registerCounter64Stat("udp-noport-errors", udpNoportErrorsOID, OID_LENGTH(udpNoportErrorsOID));
+  registerCounter64Stat("udp-in-errors", udpinErrorsOID, OID_LENGTH(udpinErrorsOID));
 #endif /* __linux__ */
-  registerCounter64Stat("edns-ping-matches", ednsPingMatchesOID, OID_LENGTH(ednsPingMatchesOID), enableExpensiveStatistics);
-  registerCounter64Stat("edns-ping-mismatches", ednsPingMismatchesOID, OID_LENGTH(ednsPingMismatchesOID), enableExpensiveStatistics);
-  registerCounter64Stat("dnssec-queries", dnssecQueriesOID, OID_LENGTH(dnssecQueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("dnssec-authentic-data-queries", dnssecAuthenticDataQueriesOID, OID_LENGTH(dnssecAuthenticDataQueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("dnssec-check-disabled-queries", dnssecCheckDisabledQueriesOID, OID_LENGTH(dnssecCheckDisabledQueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("noping-outqueries", nopingOutqueriesOID, OID_LENGTH(nopingOutqueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("noedns-outqueries", noednsOutqueriesOID, OID_LENGTH(noednsOutqueriesOID), enableExpensiveStatistics);
-  registerCounter64Stat("uptime", uptimeOID, OID_LENGTH(uptimeOID), enableExpensiveStatistics);
-  registerCounter64Stat("real-memory-usage", realMemoryUsageOID, OID_LENGTH(realMemoryUsageOID), enableExpensiveStatistics);
-  registerCounter64Stat("fd-usage", fdUsageOID, OID_LENGTH(fdUsageOID), enableExpensiveStatistics);
-  registerCounter64Stat("user-msec", userMsecOID, OID_LENGTH(userMsecOID), enableExpensiveStatistics);
-  registerCounter64Stat("sys-msec", sysMsecOID, OID_LENGTH(sysMsecOID), enableExpensiveStatistics);
-  registerCounter64Stat("dnssec-validations", dnssecValidationsOID, OID_LENGTH(dnssecValidationsOID), enableExpensiveStatistics);
-  registerCounter64Stat("dnssec-result-insecure", dnssecResultInsecureOID, OID_LENGTH(dnssecResultInsecureOID), enableExpensiveStatistics);
-  registerCounter64Stat("dnssec-result-secure", dnssecResultSecureOID, OID_LENGTH(dnssecResultSecureOID), enableExpensiveStatistics);
-  registerCounter64Stat("dnssec-result-bogus", dnssecResultBogusOID, OID_LENGTH(dnssecResultBogusOID), enableExpensiveStatistics);
-  registerCounter64Stat("dnssec-result-indeterminate", dnssecResultIndeterminateOID, OID_LENGTH(dnssecResultIndeterminateOID), enableExpensiveStatistics);
-  registerCounter64Stat("dnssec-result-nta", dnssecResultNtaOID, OID_LENGTH(dnssecResultNtaOID), enableExpensiveStatistics);
-  registerCounter64Stat("policy-result-noaction", policyResultNoactionOID, OID_LENGTH(policyResultNoactionOID), enableExpensiveStatistics);
-  registerCounter64Stat("policy-result-drop", policyResultDropOID, OID_LENGTH(policyResultDropOID), enableExpensiveStatistics);
-  registerCounter64Stat("policy-result-nxdomain", policyResultNxdomainOID, OID_LENGTH(policyResultNxdomainOID), enableExpensiveStatistics);
-  registerCounter64Stat("policy-result-nodata", policyResultNodataOID, OID_LENGTH(policyResultNodataOID), enableExpensiveStatistics);
-  registerCounter64Stat("policy-result-truncate", policyResultTruncateOID, OID_LENGTH(policyResultTruncateOID), enableExpensiveStatistics);
-  registerCounter64Stat("policy-result-custom", policyResultCustomOID, OID_LENGTH(policyResultCustomOID), enableExpensiveStatistics);
-  registerCounter64Stat("special-memory-usage", specialMemoryUsageOID, OID_LENGTH(specialMemoryUsageOID), enableExpensiveStatistics);
+  registerCounter64Stat("edns-ping-matches", ednsPingMatchesOID, OID_LENGTH(ednsPingMatchesOID));
+  registerCounter64Stat("edns-ping-mismatches", ednsPingMismatchesOID, OID_LENGTH(ednsPingMismatchesOID));
+  registerCounter64Stat("dnssec-queries", dnssecQueriesOID, OID_LENGTH(dnssecQueriesOID));
+  registerCounter64Stat("dnssec-authentic-data-queries", dnssecAuthenticDataQueriesOID, OID_LENGTH(dnssecAuthenticDataQueriesOID));
+  registerCounter64Stat("dnssec-check-disabled-queries", dnssecCheckDisabledQueriesOID, OID_LENGTH(dnssecCheckDisabledQueriesOID));
+  registerCounter64Stat("noping-outqueries", nopingOutqueriesOID, OID_LENGTH(nopingOutqueriesOID));
+  registerCounter64Stat("noedns-outqueries", noednsOutqueriesOID, OID_LENGTH(noednsOutqueriesOID));
+  registerCounter64Stat("uptime", uptimeOID, OID_LENGTH(uptimeOID));
+  registerCounter64Stat("real-memory-usage", realMemoryUsageOID, OID_LENGTH(realMemoryUsageOID));
+  registerCounter64Stat("fd-usage", fdUsageOID, OID_LENGTH(fdUsageOID));
+  registerCounter64Stat("user-msec", userMsecOID, OID_LENGTH(userMsecOID));
+  registerCounter64Stat("sys-msec", sysMsecOID, OID_LENGTH(sysMsecOID));
+  registerCounter64Stat("dnssec-validations", dnssecValidationsOID, OID_LENGTH(dnssecValidationsOID));
+  registerCounter64Stat("dnssec-result-insecure", dnssecResultInsecureOID, OID_LENGTH(dnssecResultInsecureOID));
+  registerCounter64Stat("dnssec-result-secure", dnssecResultSecureOID, OID_LENGTH(dnssecResultSecureOID));
+  registerCounter64Stat("dnssec-result-bogus", dnssecResultBogusOID, OID_LENGTH(dnssecResultBogusOID));
+  registerCounter64Stat("dnssec-result-indeterminate", dnssecResultIndeterminateOID, OID_LENGTH(dnssecResultIndeterminateOID));
+  registerCounter64Stat("dnssec-result-nta", dnssecResultNtaOID, OID_LENGTH(dnssecResultNtaOID));
+  registerCounter64Stat("policy-result-noaction", policyResultNoactionOID, OID_LENGTH(policyResultNoactionOID));
+  registerCounter64Stat("policy-result-drop", policyResultDropOID, OID_LENGTH(policyResultDropOID));
+  registerCounter64Stat("policy-result-nxdomain", policyResultNxdomainOID, OID_LENGTH(policyResultNxdomainOID));
+  registerCounter64Stat("policy-result-nodata", policyResultNodataOID, OID_LENGTH(policyResultNodataOID));
+  registerCounter64Stat("policy-result-truncate", policyResultTruncateOID, OID_LENGTH(policyResultTruncateOID));
+  registerCounter64Stat("policy-result-custom", policyResultCustomOID, OID_LENGTH(policyResultCustomOID));
+  registerCounter64Stat("special-memory-usage", specialMemoryUsageOID, OID_LENGTH(specialMemoryUsageOID));
 #endif /* HAVE_NET_SNMP */
 }

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -148,21 +148,37 @@ static int handleCounter64Stats(netsnmp_mib_handler* handler,
   }
 }
 
-static void registerCounter64Stat(const char* name, const oid statOID[], size_t statOIDLength)
+static int handleDisabledCounter64Stats(netsnmp_mib_handler* handler,
+                                        netsnmp_handler_registration* reginfo,
+                                        netsnmp_agent_request_info* reqinfo,
+                                        netsnmp_request_info* requests)
+{
+  if (reqinfo->mode != MODE_GET) {
+    return SNMP_ERR_GENERR;
+  }
+
+  if (reginfo->rootoid_len != OID_LENGTH(questionsOID) + 1) {
+    return SNMP_ERR_GENERR;
+  }
+
+  return RecursorSNMPAgent::setCounter64Value(requests, 0);
+}
+
+static void registerCounter64Stat(const std::string& name, const oid statOID[], size_t statOIDLength, bool expensiveStats)
 {
   if (statOIDLength != OID_LENGTH(questionsOID)) {
-    g_log<<Logger::Error<<"Invalid OID for SNMP Counter64 statistic "<<std::string(name)<<endl;
+    g_log<<Logger::Error<<"Invalid OID for SNMP Counter64 statistic "<<name<<endl;
     return;
   }
 
   if (s_statsMap.find(statOID[statOIDLength - 1]) != s_statsMap.end()) {
-    g_log<<Logger::Error<<"OID for SNMP Counter64 statistic "<<std::string(name)<<" has already been registered"<<endl;
+    g_log<<Logger::Error<<"OID for SNMP Counter64 statistic "<<name<<" has already been registered"<<endl;
     return;
   }
 
-  s_statsMap[statOID[statOIDLength - 1]] = name;
-  netsnmp_register_scalar(netsnmp_create_handler_registration(name,
-                                                              handleCounter64Stats,
+  s_statsMap[statOID[statOIDLength - 1]] = name.c_str();
+  netsnmp_register_scalar(netsnmp_create_handler_registration(name.c_str(),
+                                                              (expensiveStats || !isStatExpensive(name)) ? handleCounter64Stats : handleDisabledCounter64Stats,
                                                               statOID,
                                                               statOIDLength,
                                                               HANDLER_CAN_RONLY));
@@ -197,113 +213,112 @@ bool RecursorSNMPAgent::sendCustomTrap(const std::string& reason)
 }
 
 
-RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string& masterSocket): SNMPAgent(name, masterSocket)
+RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string& masterSocket, bool enableExpensiveStatistics): SNMPAgent(name, masterSocket)
 {
 #ifdef HAVE_NET_SNMP
   /* This is done so that the statistics maps are
      initialized. */
   registerAllStats();
 
-  registerCounter64Stat("questions", questionsOID, OID_LENGTH(questionsOID));
-  registerCounter64Stat("ipv6-questions", ipv6QuestionsOID, OID_LENGTH(ipv6QuestionsOID));
-  registerCounter64Stat("tcp-questions", tcpQuestionsOID, OID_LENGTH(tcpQuestionsOID));
-  registerCounter64Stat("cache-hits", cacheHitsOID, OID_LENGTH(cacheHitsOID));
-  registerCounter64Stat("cache-misses", cacheMissesOID, OID_LENGTH(cacheMissesOID));
-  registerCounter64Stat("cache-entries", cacheEntriesOID, OID_LENGTH(cacheEntriesOID));
-  registerCounter64Stat("cache-bytes", cacheBytesOID, OID_LENGTH(cacheBytesOID));
-  registerCounter64Stat("packetcache-hits", packetcacheHitsOID, OID_LENGTH(packetcacheHitsOID));
-  registerCounter64Stat("packetcache-misses", packetcacheMissesOID, OID_LENGTH(packetcacheMissesOID));
-  registerCounter64Stat("packetcache-entries", packetcacheEntriesOID, OID_LENGTH(packetcacheEntriesOID));
-  registerCounter64Stat("packetcache-bytes", packetcacheBytesOID, OID_LENGTH(packetcacheBytesOID));
-  registerCounter64Stat("malloc-bytes", mallocBytesOID, OID_LENGTH(mallocBytesOID));
-  registerCounter64Stat("servfail-answers", servfailAnswersOID, OID_LENGTH(servfailAnswersOID));
-  registerCounter64Stat("nxdomain-answers", nxdomainAnswersOID, OID_LENGTH(nxdomainAnswersOID));
-  registerCounter64Stat("noerror-answers", noerrorAnswersOID, OID_LENGTH(noerrorAnswersOID));
-  registerCounter64Stat("unauthorized-udp", unauthorizedUdpOID, OID_LENGTH(unauthorizedUdpOID));
-  registerCounter64Stat("unauthorized-tcp", unauthorizedTcpOID, OID_LENGTH(unauthorizedTcpOID));
-  registerCounter64Stat("tcp-client-overflow", tcpClientOverflowOID, OID_LENGTH(tcpClientOverflowOID));
-  registerCounter64Stat("client-parse-errors", clientParseErrorsOID, OID_LENGTH(clientParseErrorsOID));
-  registerCounter64Stat("server-parse-errors", serverParseErrorsOID, OID_LENGTH(serverParseErrorsOID));
-  registerCounter64Stat("too-old-drops", tooOldDropsOID, OID_LENGTH(tooOldDropsOID));
-  registerCounter64Stat("query-pipe-full-drops", queryPipeFullDropsOID, OID_LENGTH(queryPipeFullDropsOID));
-  registerCounter64Stat("truncated-drops", truncatedDropsOID, OID_LENGTH(truncatedDropsOID));
-  registerCounter64Stat("empty-queries", emptyQueriesOID, OID_LENGTH(emptyQueriesOID));
-  registerCounter64Stat("variable-responses", variableResponsesOID, OID_LENGTH(variableResponsesOID));
-  registerCounter64Stat("answers0-1", answers01OID, OID_LENGTH(answers01OID));
-  registerCounter64Stat("answers1-10", answers110OID, OID_LENGTH(answers110OID));
-  registerCounter64Stat("answers10-100", answers10100OID, OID_LENGTH(answers10100OID));
-  registerCounter64Stat("answers100-1000", answers1001000OID, OID_LENGTH(answers1001000OID));
-  registerCounter64Stat("answers-slow", answersSlowOID, OID_LENGTH(answersSlowOID));
-  registerCounter64Stat("auth4-answers0-1", auth4Answers01OID, OID_LENGTH(auth4Answers01OID));
-  registerCounter64Stat("auth4-answers1-10", auth4Answers110OID, OID_LENGTH(auth4Answers110OID));
-  registerCounter64Stat("auth4-answers10-100", auth4Answers10100OID, OID_LENGTH(auth4Answers10100OID));
-  registerCounter64Stat("auth4-answers100-1000", auth4Answers1001000OID, OID_LENGTH(auth4Answers1001000OID));
-  registerCounter64Stat("auth4-answers-slow", auth4AnswersslowOID, OID_LENGTH(auth4AnswersslowOID));
-  registerCounter64Stat("auth6-answers0-1", auth6Answers01OID, OID_LENGTH(auth6Answers01OID));
-  registerCounter64Stat("auth6-answers1-10", auth6Answers110OID, OID_LENGTH(auth6Answers110OID));
-  registerCounter64Stat("auth6-answers10-100", auth6Answers10100OID, OID_LENGTH(auth6Answers10100OID));
-  registerCounter64Stat("auth6-answers100-1000", auth6Answers1001000OID, OID_LENGTH(auth6Answers1001000OID));
-  registerCounter64Stat("auth6-answers-slow", auth6AnswersSlowOID, OID_LENGTH(auth6AnswersSlowOID));
-  registerCounter64Stat("qa-latency", qaLatencyOID, OID_LENGTH(qaLatencyOID));
-  registerCounter64Stat("unexpected-packets", unexpectedPacketsOID, OID_LENGTH(unexpectedPacketsOID));
-  registerCounter64Stat("case-mismatches", caseMismatchesOID, OID_LENGTH(caseMismatchesOID));
-  registerCounter64Stat("spoof-prevents", spoofPreventsOID, OID_LENGTH(spoofPreventsOID));
-  registerCounter64Stat("nsset-invalidations", nssetInvalidationsOID, OID_LENGTH(nssetInvalidationsOID));
-  registerCounter64Stat("resource-limits", resourceLimitsOID, OID_LENGTH(resourceLimitsOID));
-  registerCounter64Stat("over-capacity-drops", overCapacityDropsOID, OID_LENGTH(overCapacityDropsOID));
-  registerCounter64Stat("policy-drops", policyDropsOID, OID_LENGTH(policyDropsOID));
-  registerCounter64Stat("no-packet-error", noPacketErrorOID, OID_LENGTH(noPacketErrorOID));
-  registerCounter64Stat("dlg-only-drops", dlgOnlyDropsOID, OID_LENGTH(dlgOnlyDropsOID));
-  registerCounter64Stat("ignored-packets", ignoredPacketsOID, OID_LENGTH(ignoredPacketsOID));
-  registerCounter64Stat("max-mthread-stack", maxMthreadStackOID, OID_LENGTH(maxMthreadStackOID));
-  registerCounter64Stat("negcache-entries", negcacheEntriesOID, OID_LENGTH(negcacheEntriesOID));
-  registerCounter64Stat("throttle-entries", throttleEntriesOID, OID_LENGTH(throttleEntriesOID));
-  registerCounter64Stat("nsspeeds-entries", nsspeedsEntriesOID, OID_LENGTH(nsspeedsEntriesOID));
-  registerCounter64Stat("failed-host-entries", failedHostEntriesOID, OID_LENGTH(failedHostEntriesOID));
-  registerCounter64Stat("concurrent-queries", concurrentQueriesOID, OID_LENGTH(concurrentQueriesOID));
-  registerCounter64Stat("security-status", securityStatusOID, OID_LENGTH(securityStatusOID));
-  registerCounter64Stat("outgoing-timeouts", outgoingTimeoutsOID, OID_LENGTH(outgoingTimeoutsOID));
-  registerCounter64Stat("outgoing4-timeouts", outgoing4TimeoutsOID, OID_LENGTH(outgoing4TimeoutsOID));
-  registerCounter64Stat("outgoing6-timeouts", outgoing6TimeoutsOID, OID_LENGTH(outgoing6TimeoutsOID));
-  registerCounter64Stat("tcp-outqueries", tcpOutqueriesOID, OID_LENGTH(tcpOutqueriesOID));
-  registerCounter64Stat("all-outqueries", allOutqueriesOID, OID_LENGTH(allOutqueriesOID));
-  registerCounter64Stat("ipv6-outqueries", ipv6OutqueriesOID, OID_LENGTH(ipv6OutqueriesOID));
-  registerCounter64Stat("throttled-outqueries", throttledOutqueriesOID, OID_LENGTH(throttledOutqueriesOID));
-  registerCounter64Stat("dont-outqueries", dontOutqueriesOID, OID_LENGTH(dontOutqueriesOID));
-  registerCounter64Stat("unreachables", unreachablesOID, OID_LENGTH(unreachablesOID));
-  registerCounter64Stat("chain-resends", chainResendsOID, OID_LENGTH(chainResendsOID));
-  registerCounter64Stat("tcp-clients", tcpClientsOID, OID_LENGTH(tcpClientsOID));
+  registerCounter64Stat("questions", questionsOID, OID_LENGTH(questionsOID), enableExpensiveStatistics);
+  registerCounter64Stat("ipv6-questions", ipv6QuestionsOID, OID_LENGTH(ipv6QuestionsOID), enableExpensiveStatistics);
+  registerCounter64Stat("tcp-questions", tcpQuestionsOID, OID_LENGTH(tcpQuestionsOID), enableExpensiveStatistics);
+  registerCounter64Stat("cache-hits", cacheHitsOID, OID_LENGTH(cacheHitsOID), enableExpensiveStatistics);
+  registerCounter64Stat("cache-misses", cacheMissesOID, OID_LENGTH(cacheMissesOID), enableExpensiveStatistics);
+  registerCounter64Stat("cache-entries", cacheEntriesOID, OID_LENGTH(cacheEntriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("cache-bytes", cacheBytesOID, OID_LENGTH(cacheBytesOID), enableExpensiveStatistics);
+  registerCounter64Stat("packetcache-hits", packetcacheHitsOID, OID_LENGTH(packetcacheHitsOID), enableExpensiveStatistics);
+  registerCounter64Stat("packetcache-misses", packetcacheMissesOID, OID_LENGTH(packetcacheMissesOID), enableExpensiveStatistics);
+  registerCounter64Stat("packetcache-entries", packetcacheEntriesOID, OID_LENGTH(packetcacheEntriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("packetcache-bytes", packetcacheBytesOID, OID_LENGTH(packetcacheBytesOID), enableExpensiveStatistics);
+  registerCounter64Stat("malloc-bytes", mallocBytesOID, OID_LENGTH(mallocBytesOID), enableExpensiveStatistics);
+  registerCounter64Stat("servfail-answers", servfailAnswersOID, OID_LENGTH(servfailAnswersOID), enableExpensiveStatistics);
+  registerCounter64Stat("nxdomain-answers", nxdomainAnswersOID, OID_LENGTH(nxdomainAnswersOID), enableExpensiveStatistics);
+  registerCounter64Stat("noerror-answers", noerrorAnswersOID, OID_LENGTH(noerrorAnswersOID), enableExpensiveStatistics);
+  registerCounter64Stat("unauthorized-udp", unauthorizedUdpOID, OID_LENGTH(unauthorizedUdpOID), enableExpensiveStatistics);
+  registerCounter64Stat("unauthorized-tcp", unauthorizedTcpOID, OID_LENGTH(unauthorizedTcpOID), enableExpensiveStatistics);
+  registerCounter64Stat("tcp-client-overflow", tcpClientOverflowOID, OID_LENGTH(tcpClientOverflowOID), enableExpensiveStatistics);
+  registerCounter64Stat("client-parse-errors", clientParseErrorsOID, OID_LENGTH(clientParseErrorsOID), enableExpensiveStatistics);
+  registerCounter64Stat("server-parse-errors", serverParseErrorsOID, OID_LENGTH(serverParseErrorsOID), enableExpensiveStatistics);
+  registerCounter64Stat("too-old-drops", tooOldDropsOID, OID_LENGTH(tooOldDropsOID), enableExpensiveStatistics);
+  registerCounter64Stat("query-pipe-full-drops", queryPipeFullDropsOID, OID_LENGTH(queryPipeFullDropsOID), enableExpensiveStatistics);
+  registerCounter64Stat("truncated-drops", truncatedDropsOID, OID_LENGTH(truncatedDropsOID), enableExpensiveStatistics);
+  registerCounter64Stat("empty-queries", emptyQueriesOID, OID_LENGTH(emptyQueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("variable-responses", variableResponsesOID, OID_LENGTH(variableResponsesOID), enableExpensiveStatistics);
+  registerCounter64Stat("answers0-1", answers01OID, OID_LENGTH(answers01OID), enableExpensiveStatistics);
+  registerCounter64Stat("answers1-10", answers110OID, OID_LENGTH(answers110OID), enableExpensiveStatistics);
+  registerCounter64Stat("answers10-100", answers10100OID, OID_LENGTH(answers10100OID), enableExpensiveStatistics);
+  registerCounter64Stat("answers100-1000", answers1001000OID, OID_LENGTH(answers1001000OID), enableExpensiveStatistics);
+  registerCounter64Stat("answers-slow", answersSlowOID, OID_LENGTH(answersSlowOID), enableExpensiveStatistics);
+  registerCounter64Stat("auth4-answers0-1", auth4Answers01OID, OID_LENGTH(auth4Answers01OID), enableExpensiveStatistics);
+  registerCounter64Stat("auth4-answers1-10", auth4Answers110OID, OID_LENGTH(auth4Answers110OID), enableExpensiveStatistics);
+  registerCounter64Stat("auth4-answers10-100", auth4Answers10100OID, OID_LENGTH(auth4Answers10100OID), enableExpensiveStatistics);
+  registerCounter64Stat("auth4-answers100-1000", auth4Answers1001000OID, OID_LENGTH(auth4Answers1001000OID), enableExpensiveStatistics);
+  registerCounter64Stat("auth4-answers-slow", auth4AnswersslowOID, OID_LENGTH(auth4AnswersslowOID), enableExpensiveStatistics);
+  registerCounter64Stat("auth6-answers0-1", auth6Answers01OID, OID_LENGTH(auth6Answers01OID), enableExpensiveStatistics);
+  registerCounter64Stat("auth6-answers1-10", auth6Answers110OID, OID_LENGTH(auth6Answers110OID), enableExpensiveStatistics);
+  registerCounter64Stat("auth6-answers10-100", auth6Answers10100OID, OID_LENGTH(auth6Answers10100OID), enableExpensiveStatistics);
+  registerCounter64Stat("auth6-answers100-1000", auth6Answers1001000OID, OID_LENGTH(auth6Answers1001000OID), enableExpensiveStatistics);
+  registerCounter64Stat("auth6-answers-slow", auth6AnswersSlowOID, OID_LENGTH(auth6AnswersSlowOID), enableExpensiveStatistics);
+  registerCounter64Stat("qa-latency", qaLatencyOID, OID_LENGTH(qaLatencyOID), enableExpensiveStatistics);
+  registerCounter64Stat("unexpected-packets", unexpectedPacketsOID, OID_LENGTH(unexpectedPacketsOID), enableExpensiveStatistics);
+  registerCounter64Stat("case-mismatches", caseMismatchesOID, OID_LENGTH(caseMismatchesOID), enableExpensiveStatistics);
+  registerCounter64Stat("spoof-prevents", spoofPreventsOID, OID_LENGTH(spoofPreventsOID), enableExpensiveStatistics);
+  registerCounter64Stat("nsset-invalidations", nssetInvalidationsOID, OID_LENGTH(nssetInvalidationsOID), enableExpensiveStatistics);
+  registerCounter64Stat("resource-limits", resourceLimitsOID, OID_LENGTH(resourceLimitsOID), enableExpensiveStatistics);
+  registerCounter64Stat("over-capacity-drops", overCapacityDropsOID, OID_LENGTH(overCapacityDropsOID), enableExpensiveStatistics);
+  registerCounter64Stat("policy-drops", policyDropsOID, OID_LENGTH(policyDropsOID), enableExpensiveStatistics);
+  registerCounter64Stat("no-packet-error", noPacketErrorOID, OID_LENGTH(noPacketErrorOID), enableExpensiveStatistics);
+  registerCounter64Stat("dlg-only-drops", dlgOnlyDropsOID, OID_LENGTH(dlgOnlyDropsOID), enableExpensiveStatistics);
+  registerCounter64Stat("ignored-packets", ignoredPacketsOID, OID_LENGTH(ignoredPacketsOID), enableExpensiveStatistics);
+  registerCounter64Stat("max-mthread-stack", maxMthreadStackOID, OID_LENGTH(maxMthreadStackOID), enableExpensiveStatistics);
+  registerCounter64Stat("negcache-entries", negcacheEntriesOID, OID_LENGTH(negcacheEntriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("throttle-entries", throttleEntriesOID, OID_LENGTH(throttleEntriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("nsspeeds-entries", nsspeedsEntriesOID, OID_LENGTH(nsspeedsEntriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("failed-host-entries", failedHostEntriesOID, OID_LENGTH(failedHostEntriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("concurrent-queries", concurrentQueriesOID, OID_LENGTH(concurrentQueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("security-status", securityStatusOID, OID_LENGTH(securityStatusOID), enableExpensiveStatistics);
+  registerCounter64Stat("outgoing-timeouts", outgoingTimeoutsOID, OID_LENGTH(outgoingTimeoutsOID), enableExpensiveStatistics);
+  registerCounter64Stat("outgoing4-timeouts", outgoing4TimeoutsOID, OID_LENGTH(outgoing4TimeoutsOID), enableExpensiveStatistics);
+  registerCounter64Stat("outgoing6-timeouts", outgoing6TimeoutsOID, OID_LENGTH(outgoing6TimeoutsOID), enableExpensiveStatistics);
+  registerCounter64Stat("tcp-outqueries", tcpOutqueriesOID, OID_LENGTH(tcpOutqueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("all-outqueries", allOutqueriesOID, OID_LENGTH(allOutqueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("ipv6-outqueries", ipv6OutqueriesOID, OID_LENGTH(ipv6OutqueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("throttled-outqueries", throttledOutqueriesOID, OID_LENGTH(throttledOutqueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("dont-outqueries", dontOutqueriesOID, OID_LENGTH(dontOutqueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("unreachables", unreachablesOID, OID_LENGTH(unreachablesOID), enableExpensiveStatistics);
+  registerCounter64Stat("chain-resends", chainResendsOID, OID_LENGTH(chainResendsOID), enableExpensiveStatistics);
+  registerCounter64Stat("tcp-clients", tcpClientsOID, OID_LENGTH(tcpClientsOID), enableExpensiveStatistics);
 #ifdef __linux__
-  registerCounter64Stat("udp-recvbuf-errors", udpRecvbufErrorsOID, OID_LENGTH(udpRecvbufErrorsOID));
-  registerCounter64Stat("udp-sndbuf-errors", udpSndbufErrorsOID, OID_LENGTH(udpSndbufErrorsOID));
-  registerCounter64Stat("udp-noport-errors", udpNoportErrorsOID, OID_LENGTH(udpNoportErrorsOID));
-  registerCounter64Stat("udp-in-errors", udpinErrorsOID, OID_LENGTH(udpinErrorsOID));
+  registerCounter64Stat("udp-recvbuf-errors", udpRecvbufErrorsOID, OID_LENGTH(udpRecvbufErrorsOID), enableExpensiveStatistics);
+  registerCounter64Stat("udp-sndbuf-errors", udpSndbufErrorsOID, OID_LENGTH(udpSndbufErrorsOID), enableExpensiveStatistics);
+  registerCounter64Stat("udp-noport-errors", udpNoportErrorsOID, OID_LENGTH(udpNoportErrorsOID), enableExpensiveStatistics);
+  registerCounter64Stat("udp-in-errors", udpinErrorsOID, OID_LENGTH(udpinErrorsOID), enableExpensiveStatistics);
 #endif /* __linux__ */
-  registerCounter64Stat("edns-ping-matches", ednsPingMatchesOID, OID_LENGTH(ednsPingMatchesOID));
-  registerCounter64Stat("edns-ping-mismatches", ednsPingMismatchesOID, OID_LENGTH(ednsPingMismatchesOID));
-  registerCounter64Stat("dnssec-queries", dnssecQueriesOID, OID_LENGTH(dnssecQueriesOID));
-  registerCounter64Stat("dnssec-authentic-data-queries", dnssecAuthenticDataQueriesOID, OID_LENGTH(dnssecAuthenticDataQueriesOID));
-  registerCounter64Stat("dnssec-check-disabled-queries", dnssecCheckDisabledQueriesOID, OID_LENGTH(dnssecCheckDisabledQueriesOID));
-  registerCounter64Stat("noping-outqueries", nopingOutqueriesOID, OID_LENGTH(nopingOutqueriesOID));
-  registerCounter64Stat("noedns-outqueries", noednsOutqueriesOID, OID_LENGTH(noednsOutqueriesOID));
-  registerCounter64Stat("uptime", uptimeOID, OID_LENGTH(uptimeOID));
-  registerCounter64Stat("real-memory-usage", realMemoryUsageOID, OID_LENGTH(realMemoryUsageOID));
-  registerCounter64Stat("fd-usage", fdUsageOID, OID_LENGTH(fdUsageOID));
-  registerCounter64Stat("user-msec", userMsecOID, OID_LENGTH(userMsecOID));
-  registerCounter64Stat("sys-msec", sysMsecOID, OID_LENGTH(sysMsecOID));
-  registerCounter64Stat("dnssec-validations", dnssecValidationsOID, OID_LENGTH(dnssecValidationsOID));
-  registerCounter64Stat("dnssec-result-insecure", dnssecResultInsecureOID, OID_LENGTH(dnssecResultInsecureOID));
-  registerCounter64Stat("dnssec-result-secure", dnssecResultSecureOID, OID_LENGTH(dnssecResultSecureOID));
-  registerCounter64Stat("dnssec-result-bogus", dnssecResultBogusOID, OID_LENGTH(dnssecResultBogusOID));
-  registerCounter64Stat("dnssec-result-indeterminate", dnssecResultIndeterminateOID, OID_LENGTH(dnssecResultIndeterminateOID));
-  registerCounter64Stat("dnssec-result-nta", dnssecResultNtaOID, OID_LENGTH(dnssecResultNtaOID));
-  registerCounter64Stat("policy-result-noaction", policyResultNoactionOID, OID_LENGTH(policyResultNoactionOID));
-  registerCounter64Stat("policy-result-drop", policyResultDropOID, OID_LENGTH(policyResultDropOID));
-  registerCounter64Stat("policy-result-nxdomain", policyResultNxdomainOID, OID_LENGTH(policyResultNxdomainOID));
-  registerCounter64Stat("policy-result-nodata", policyResultNodataOID, OID_LENGTH(policyResultNodataOID));
-  registerCounter64Stat("policy-result-truncate", policyResultTruncateOID, OID_LENGTH(policyResultTruncateOID));
-  registerCounter64Stat("policy-result-custom", policyResultCustomOID, OID_LENGTH(policyResultCustomOID));
-  registerCounter64Stat("special-memory-usage", specialMemoryUsageOID, OID_LENGTH(specialMemoryUsageOID));
-
+  registerCounter64Stat("edns-ping-matches", ednsPingMatchesOID, OID_LENGTH(ednsPingMatchesOID), enableExpensiveStatistics);
+  registerCounter64Stat("edns-ping-mismatches", ednsPingMismatchesOID, OID_LENGTH(ednsPingMismatchesOID), enableExpensiveStatistics);
+  registerCounter64Stat("dnssec-queries", dnssecQueriesOID, OID_LENGTH(dnssecQueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("dnssec-authentic-data-queries", dnssecAuthenticDataQueriesOID, OID_LENGTH(dnssecAuthenticDataQueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("dnssec-check-disabled-queries", dnssecCheckDisabledQueriesOID, OID_LENGTH(dnssecCheckDisabledQueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("noping-outqueries", nopingOutqueriesOID, OID_LENGTH(nopingOutqueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("noedns-outqueries", noednsOutqueriesOID, OID_LENGTH(noednsOutqueriesOID), enableExpensiveStatistics);
+  registerCounter64Stat("uptime", uptimeOID, OID_LENGTH(uptimeOID), enableExpensiveStatistics);
+  registerCounter64Stat("real-memory-usage", realMemoryUsageOID, OID_LENGTH(realMemoryUsageOID), enableExpensiveStatistics);
+  registerCounter64Stat("fd-usage", fdUsageOID, OID_LENGTH(fdUsageOID), enableExpensiveStatistics);
+  registerCounter64Stat("user-msec", userMsecOID, OID_LENGTH(userMsecOID), enableExpensiveStatistics);
+  registerCounter64Stat("sys-msec", sysMsecOID, OID_LENGTH(sysMsecOID), enableExpensiveStatistics);
+  registerCounter64Stat("dnssec-validations", dnssecValidationsOID, OID_LENGTH(dnssecValidationsOID), enableExpensiveStatistics);
+  registerCounter64Stat("dnssec-result-insecure", dnssecResultInsecureOID, OID_LENGTH(dnssecResultInsecureOID), enableExpensiveStatistics);
+  registerCounter64Stat("dnssec-result-secure", dnssecResultSecureOID, OID_LENGTH(dnssecResultSecureOID), enableExpensiveStatistics);
+  registerCounter64Stat("dnssec-result-bogus", dnssecResultBogusOID, OID_LENGTH(dnssecResultBogusOID), enableExpensiveStatistics);
+  registerCounter64Stat("dnssec-result-indeterminate", dnssecResultIndeterminateOID, OID_LENGTH(dnssecResultIndeterminateOID), enableExpensiveStatistics);
+  registerCounter64Stat("dnssec-result-nta", dnssecResultNtaOID, OID_LENGTH(dnssecResultNtaOID), enableExpensiveStatistics);
+  registerCounter64Stat("policy-result-noaction", policyResultNoactionOID, OID_LENGTH(policyResultNoactionOID), enableExpensiveStatistics);
+  registerCounter64Stat("policy-result-drop", policyResultDropOID, OID_LENGTH(policyResultDropOID), enableExpensiveStatistics);
+  registerCounter64Stat("policy-result-nxdomain", policyResultNxdomainOID, OID_LENGTH(policyResultNxdomainOID), enableExpensiveStatistics);
+  registerCounter64Stat("policy-result-nodata", policyResultNodataOID, OID_LENGTH(policyResultNodataOID), enableExpensiveStatistics);
+  registerCounter64Stat("policy-result-truncate", policyResultTruncateOID, OID_LENGTH(policyResultTruncateOID), enableExpensiveStatistics);
+  registerCounter64Stat("policy-result-custom", policyResultCustomOID, OID_LENGTH(policyResultCustomOID), enableExpensiveStatistics);
+  registerCounter64Stat("special-memory-usage", specialMemoryUsageOID, OID_LENGTH(specialMemoryUsageOID), enableExpensiveStatistics);
 #endif /* HAVE_NET_SNMP */
 }

--- a/pdns/rec-snmp.hh
+++ b/pdns/rec-snmp.hh
@@ -10,7 +10,7 @@ class RecursorSNMPAgent;
 class RecursorSNMPAgent: public SNMPAgent
 {
 public:
-  RecursorSNMPAgent(const std::string& name, const std::string& masterSocket);
+  RecursorSNMPAgent(const std::string& name, const std::string& masterSocket, bool enableExpensiveStatistics);
   bool sendCustomTrap(const std::string& reason);
 };
 

--- a/pdns/rec-snmp.hh
+++ b/pdns/rec-snmp.hh
@@ -10,7 +10,7 @@ class RecursorSNMPAgent;
 class RecursorSNMPAgent: public SNMPAgent
 {
 public:
-  RecursorSNMPAgent(const std::string& name, const std::string& masterSocket, bool enableExpensiveStatistics);
+  RecursorSNMPAgent(const std::string& name, const std::string& masterSocket);
   bool sendCustomTrap(const std::string& reason);
 };
 

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -64,7 +64,9 @@ public:
   std::string getAnswer(const std::string& question, func_t** func);
 };
 
-std::map<std::string, std::string> getAllStatsMap();
+enum class StatComponent { API, Carbon, RecControl, SNMP };
+
+std::map<std::string, std::string> getAllStatsMap(StatComponent component);
 extern pthread_mutex_t g_carbon_config_lock;
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetQueryRing();
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetServfailQueryRing();
@@ -77,6 +79,9 @@ std::vector<ComboAddress>* pleaseGetTimeouts();
 DNSName getRegisteredName(const DNSName& dom);
 std::atomic<unsigned long>* getDynMetric(const std::string& str);
 optional<uint64_t> getStatByName(const std::string& name);
-bool isStatExpensive(const std::string& name);
+bool isStatBlacklisted(StatComponent component, const std::string& name);
+void blacklistStat(StatComponent component, const string& name);
+void blacklistStats(StatComponent component, const string& stats);
+
 void registerAllStats();
 

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -19,8 +19,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#ifndef PDNS_REC_CHANNEL
-#define PDNS_REC_CHANNEL
+
+#pragma once
+
 #include <string>
 #include <map>
 #include <vector>
@@ -76,5 +77,6 @@ std::vector<ComboAddress>* pleaseGetTimeouts();
 DNSName getRegisteredName(const DNSName& dom);
 std::atomic<unsigned long>* getDynMetric(const std::string& str);
 optional<uint64_t> getStatByName(const std::string& name);
+bool isStatExpensive(const std::string& name);
 void registerAllStats();
-#endif 
+

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -40,7 +40,6 @@
 pthread_mutex_t g_carbon_config_lock=PTHREAD_MUTEX_INITIALIZER;
 
 static map<string, const uint32_t*> d_get32bitpointers;
-static map<string, const uint64_t*> d_get64bitpointers;
 static map<string, const std::atomic<uint64_t>*> d_getatomics;
 static map<string, function< uint64_t() > >  d_get64bitmembers;
 static pthread_mutex_t d_dynmetricslock = PTHREAD_MUTEX_INITIALIZER;
@@ -79,8 +78,6 @@ static optional<uint64_t> get(const string& name)
 
   if(d_get32bitpointers.count(name))
     return *d_get32bitpointers.find(name)->second;
-  if(d_get64bitpointers.count(name))
-    return *d_get64bitpointers.find(name)->second;
   if(d_getatomics.count(name))
     return d_getatomics.find(name)->second->load();
   if(d_get64bitmembers.count(name))
@@ -105,9 +102,6 @@ map<string,string> getAllStatsMap()
   
   for(const auto& the32bits :  d_get32bitpointers) {
     ret.insert(make_pair(the32bits.first, std::to_string(*the32bits.second)));
-  }
-  for(const auto& the64bits :  d_get64bitpointers) {
-    ret.insert(make_pair(the64bits.first, std::to_string(*the64bits.second)));
   }
   for(const auto& atomic :  d_getatomics) {
     ret.insert(make_pair(atomic.first, std::to_string(atomic.second->load())));
@@ -138,7 +132,7 @@ string getAllStats()
 }
 
 template<typename T>
-string doGet(T begin, T end)
+static string doGet(T begin, T end)
 {
   string ret;
 
@@ -153,7 +147,7 @@ string doGet(T begin, T end)
 }
 
 template<typename T>
-string doGetParameter(T begin, T end)
+string static doGetParameter(T begin, T end)
 {
   string ret;
   string parm;
@@ -206,7 +200,7 @@ static uint64_t* pleaseDumpThrottleMap(int fd)
 }
 
 template<typename T>
-string doDumpNSSpeeds(T begin, T end)
+static string doDumpNSSpeeds(T begin, T end)
 {
   T i=begin;
   string fname;
@@ -237,7 +231,7 @@ string doDumpNSSpeeds(T begin, T end)
 }
 
 template<typename T>
-string doDumpCache(T begin, T end)
+static string doDumpCache(T begin, T end)
 {
   T i=begin;
   string fname;
@@ -259,7 +253,7 @@ string doDumpCache(T begin, T end)
 }
 
 template<typename T>
-string doDumpEDNSStatus(T begin, T end)
+static string doDumpEDNSStatus(T begin, T end)
 {
   T i=begin;
   string fname;
@@ -281,7 +275,7 @@ string doDumpEDNSStatus(T begin, T end)
 }
 
 template<typename T>
-string doDumpRPZ(T begin, T end)
+static string doDumpRPZ(T begin, T end)
 {
   T i=begin;
 
@@ -320,7 +314,7 @@ string doDumpRPZ(T begin, T end)
 }
 
 template<typename T>
-string doDumpThrottleMap(T begin, T end)
+static string doDumpThrottleMap(T begin, T end)
 {
   T i=begin;
   string fname;
@@ -360,7 +354,7 @@ uint64_t* pleaseWipeAndCountNegCache(const DNSName& canon, bool subtree)
 
 
 template<typename T>
-string doWipeCache(T begin, T end)
+static string doWipeCache(T begin, T end)
 {
   vector<pair<DNSName, bool> > toWipe;
   for(T i=begin; i != end; ++i) {
@@ -391,7 +385,7 @@ string doWipeCache(T begin, T end)
 }
 
 template<typename T>
-string doSetCarbonServer(T begin, T end)
+static string doSetCarbonServer(T begin, T end)
 {
   Lock l(&g_carbon_config_lock);
   if(begin==end) {
@@ -424,7 +418,7 @@ string doSetCarbonServer(T begin, T end)
 }
 
 template<typename T>
-string doSetDnssecLogBogus(T begin, T end)
+static string doSetDnssecLogBogus(T begin, T end)
 {
   if(checkDNSSECDisabled())
     return "DNSSEC is disabled in the configuration, not changing the Bogus logging setting\n";
@@ -454,7 +448,7 @@ string doSetDnssecLogBogus(T begin, T end)
 }
 
 template<typename T>
-string doAddNTA(T begin, T end)
+static string doAddNTA(T begin, T end)
 {
   if(checkDNSSECDisabled())
     return "DNSSEC is disabled in the configuration, not adding a Negative Trust Anchor\n";
@@ -492,7 +486,7 @@ string doAddNTA(T begin, T end)
 }
 
 template<typename T>
-string doClearNTA(T begin, T end)
+static string doClearNTA(T begin, T end)
 {
   if(checkDNSSECDisabled())
     return "DNSSEC is disabled in the configuration, not removing a Negative Trust Anchor\n";
@@ -558,7 +552,7 @@ static string getNTAs()
 }
 
 template<typename T>
-string doAddTA(T begin, T end)
+static string doAddTA(T begin, T end)
 {
   if(checkDNSSECDisabled())
     return "DNSSEC is disabled in the configuration, not adding a Trust Anchor\n";
@@ -603,7 +597,7 @@ string doAddTA(T begin, T end)
 }
 
 template<typename T>
-string doClearTA(T begin, T end)
+static string doClearTA(T begin, T end)
 {
   if(checkDNSSECDisabled())
     return "DNSSEC is disabled in the configuration, not removing a Trust Anchor\n";
@@ -666,7 +660,7 @@ static string getTAs()
 }
 
 template<typename T>
-string setMinimumTTL(T begin, T end)
+static string setMinimumTTL(T begin, T end)
 {
   if(end-begin != 1) 
     return "Need to supply new minimum TTL number\n";
@@ -675,7 +669,7 @@ string setMinimumTTL(T begin, T end)
 }
 
 template<typename T>
-string setMaxCacheEntries(T begin, T end)
+static string setMaxCacheEntries(T begin, T end)
 {
   if(end-begin != 1) 
     return "Need to supply new cache size\n";
@@ -684,7 +678,7 @@ string setMaxCacheEntries(T begin, T end)
 }
 
 template<typename T>
-string setMaxPacketCacheEntries(T begin, T end)
+static string setMaxPacketCacheEntries(T begin, T end)
 {
   if(end-begin != 1) 
     return "Need to supply new packet cache size\n";
@@ -709,7 +703,7 @@ static uint64_t getUserTimeMsec()
 
 static uint64_t calculateUptime()
 {
-  return time(0) - g_stats.startupTime;
+  return time(nullptr) - g_stats.startupTime;
 }
 
 static string* pleaseGetCurrentQueries()
@@ -762,17 +756,18 @@ uint64_t* pleaseGetNegCacheSize()
   return new uint64_t(tmp);
 }
 
-uint64_t getNegCacheSize()
+static uint64_t getNegCacheSize()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetNegCacheSize);
 }
 
-uint64_t* pleaseGetFailedHostsSize()
+static uint64_t* pleaseGetFailedHostsSize()
 {
   uint64_t tmp=(SyncRes::getThrottledServersSize());
   return new uint64_t(tmp);
 }
-uint64_t getFailedHostsSize()
+
+static uint64_t getFailedHostsSize()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetFailedHostsSize);
 }
@@ -782,7 +777,7 @@ uint64_t* pleaseGetNsSpeedsSize()
   return new uint64_t(SyncRes::getNSSpeedsSize());
 }
 
-uint64_t getNsSpeedsSize()
+static uint64_t getNsSpeedsSize()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetNsSpeedsSize);
 }
@@ -802,24 +797,22 @@ uint64_t* pleaseGetCacheSize()
   return new uint64_t(t_RC ? t_RC->size() : 0);
 }
 
-uint64_t* pleaseGetCacheBytes()
+static uint64_t* pleaseGetCacheBytes()
 {
   return new uint64_t(t_RC ? t_RC->bytes() : 0);
 }
 
-
-uint64_t doGetCacheSize()
+static uint64_t doGetCacheSize()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetCacheSize);
 }
 
-uint64_t doGetAvgLatencyUsec()
+static uint64_t doGetAvgLatencyUsec()
 {
   return (uint64_t) g_stats.avgLatencyUsec;
 }
 
-
-uint64_t doGetCacheBytes()
+static uint64_t doGetCacheBytes()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetCacheBytes);
 }
@@ -829,7 +822,7 @@ uint64_t* pleaseGetCacheHits()
   return new uint64_t(t_RC ? t_RC->cacheHits : 0);
 }
 
-uint64_t doGetCacheHits()
+static uint64_t doGetCacheHits()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetCacheHits);
 }
@@ -839,55 +832,52 @@ uint64_t* pleaseGetCacheMisses()
   return new uint64_t(t_RC ? t_RC->cacheMisses : 0);
 }
 
-uint64_t doGetCacheMisses()
+static uint64_t doGetCacheMisses()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetCacheMisses);
 }
-
 
 uint64_t* pleaseGetPacketCacheSize()
 {
   return new uint64_t(t_packetCache ? t_packetCache->size() : 0);
 }
 
-uint64_t* pleaseGetPacketCacheBytes()
+static uint64_t* pleaseGetPacketCacheBytes()
 {
   return new uint64_t(t_packetCache ? t_packetCache->bytes() : 0);
 }
 
-
-uint64_t doGetPacketCacheSize()
+static uint64_t doGetPacketCacheSize()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetPacketCacheSize);
 }
 
-uint64_t doGetPacketCacheBytes()
+static uint64_t doGetPacketCacheBytes()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetPacketCacheBytes);
 }
-
 
 uint64_t* pleaseGetPacketCacheHits()
 {
   return new uint64_t(t_packetCache ? t_packetCache->d_hits : 0);
 }
 
-uint64_t doGetPacketCacheHits()
+static uint64_t doGetPacketCacheHits()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetPacketCacheHits);
 }
 
-uint64_t* pleaseGetPacketCacheMisses()
+static uint64_t* pleaseGetPacketCacheMisses()
 {
   return new uint64_t(t_packetCache ? t_packetCache->d_misses : 0);
 }
 
-uint64_t doGetPacketCacheMisses()
+static uint64_t doGetPacketCacheMisses()
 {
   return broadcastAccFunction<uint64_t>(pleaseGetPacketCacheMisses);
 }
 
-uint64_t doGetMallocated()
+static uint64_t doGetMallocated()
 {
   // this turned out to be broken
 /*  struct mallinfo mi = mallinfo();
@@ -979,13 +969,13 @@ void registerAllStats()
   addGetStat("empty-queries", &g_stats.emptyQueriesCount);
   addGetStat("max-mthread-stack", &g_stats.maxMThreadStackUsage);
   
-  addGetStat("negcache-entries", boost::bind(getNegCacheSize));
-  addGetStat("throttle-entries", boost::bind(getThrottleSize)); 
+  addGetStat("negcache-entries", getNegCacheSize);
+  addGetStat("throttle-entries", getThrottleSize);
 
-  addGetStat("nsspeeds-entries", boost::bind(getNsSpeedsSize));
-  addGetStat("failed-host-entries", boost::bind(getFailedHostsSize));
+  addGetStat("nsspeeds-entries", getNsSpeedsSize);
+  addGetStat("failed-host-entries", getFailedHostsSize);
 
-  addGetStat("concurrent-queries", boost::bind(getConcurrentQueries)); 
+  addGetStat("concurrent-queries", getConcurrentQueries);
   addGetStat("security-status", &g_security_status);
   addGetStat("outgoing-timeouts", &SyncRes::s_outgoingtimeouts);
   addGetStat("outgoing4-timeouts", &SyncRes::s_outgoing4timeouts);

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -236,6 +236,14 @@ ecs-responses
 ^^^^^^^^^^^^^
 number of responses received from authoritative servers with an EDNS Client Subnet option we used (since 4.1)
 
+ecs-v4-response-bits-*
+^^^^^^^^^^^^^^^^^^^^^^
+number of responses received from authoritative servers with an IPv4 EDNS Client Subnet option we used, of this subnet size (1 to 32). Added in 4.2.0.
+
+ecs-v6-response-bits-*
+^^^^^^^^^^^^^^^^^^^^^^
+number of responses received from authoritative servers with an IPv6 EDNS Client Subnet option we used, of this subnet size (1 to 128). Added in 4.2.0.
+
 edns-ping-matches
 ^^^^^^^^^^^^^^^^^
 number of servers that sent a valid EDNS PING   response

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -238,11 +238,15 @@ number of responses received from authoritative servers with an EDNS Client Subn
 
 ecs-v4-response-bits-*
 ^^^^^^^^^^^^^^^^^^^^^^
-number of responses received from authoritative servers with an IPv4 EDNS Client Subnet option we used, of this subnet size (1 to 32). Added in 4.2.0.
+.. versionadded:: 4.2.0
+
+number of responses received from authoritative servers with an IPv4 EDNS Client Subnet option we used, of this subnet size (1 to 32).
 
 ecs-v6-response-bits-*
 ^^^^^^^^^^^^^^^^^^^^^^
-number of responses received from authoritative servers with an IPv6 EDNS Client Subnet option we used, of this subnet size (1 to 128). Added in 4.2.0.
+.. versionadded:: 4.2.0
+
+number of responses received from authoritative servers with an IPv6 EDNS Client Subnet option we used, of this subnet size (1 to 128).
 
 edns-ping-matches
 ^^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -126,6 +126,46 @@ DNSSEC is not supported. Example:
 
     auth-zones=example.org=/var/zones/example.org, powerdns.com=/var/zones/powerdns.com
 
+.. _setting-blacklisted-stats-api:
+
+``blacklisted-stats-api``
+-------------------------
+.. versionadded:: 4.2.0
+
+-  String
+-  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+
+A list of comma-separated statistic names, that are disabled when retrieving the complete list of statistics via the API for performance reasons.
+These statistics can still be retrieved individually by specifically asking for it.
+
+``blacklisted-stats-carbon``
+---------------------------
+.. versionadded:: 4.2.0
+
+-  String
+-  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+
+A list of comma-separated statistic names, that are prevented from being exported via carbon for performance reasons.
+
+``blacklisted-stats-rec-control``
+---------------------------------
+.. versionadded:: 4.2.0
+
+-  String
+-  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+
+A list of comma-separated statistic names, that are disabled when retrieving the complete list of statistics via `rec_control get-all`, for performance reasons.
+These statistics can still be retrieved individually.
+
+``blacklisted-stats-snmp``
+--------------------------
+.. versionadded:: 4.2.0
+
+-  String
+-  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+
+A list of comma-separated statistic names, that are prevented from being exported via SNMP, for performance reasons.
+
 .. _setting-carbon-interval:
 
 ``carbon-interval``
@@ -1224,17 +1264,6 @@ Use only a single socket for outgoing queries.
 -  Default: no
 
 If set to true and PowerDNS has been compiled with SNMP support, it will register as an SNMP agent to provide statistics and be able to send traps.
-
-.. _setting-snmp-enable-expensive-stats:
-
-``snmp-enable-expensive-stats``
-----------------------
-.. versionadded:: 4.2.0
-
--  Boolean
--  Default: no
-
-If set and snmp-agent is set, even statistics whose reporting can have an impact on production will be enabled
 
 .. _setting-snmp-master-socket:
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -126,46 +126,6 @@ DNSSEC is not supported. Example:
 
     auth-zones=example.org=/var/zones/example.org, powerdns.com=/var/zones/powerdns.com
 
-.. _setting-blacklisted-stats-api:
-
-``blacklisted-stats-api``
--------------------------
-.. versionadded:: 4.2.0
-
--  String
--  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
-
-A list of comma-separated statistic names, that are disabled when retrieving the complete list of statistics via the API for performance reasons.
-These statistics can still be retrieved individually by specifically asking for it.
-
-``blacklisted-stats-carbon``
----------------------------
-.. versionadded:: 4.2.0
-
--  String
--  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
-
-A list of comma-separated statistic names, that are prevented from being exported via carbon for performance reasons.
-
-``blacklisted-stats-rec-control``
----------------------------------
-.. versionadded:: 4.2.0
-
--  String
--  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
-
-A list of comma-separated statistic names, that are disabled when retrieving the complete list of statistics via `rec_control get-all`, for performance reasons.
-These statistics can still be retrieved individually.
-
-``blacklisted-stats-snmp``
---------------------------
-.. versionadded:: 4.2.0
-
--  String
--  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
-
-A list of comma-separated statistic names, that are prevented from being exported via SNMP, for performance reasons.
-
 .. _setting-carbon-interval:
 
 ``carbon-interval``
@@ -1322,6 +1282,41 @@ Size of the stack per thread.
 Interval between logging statistical summary on recursor performance.
 Use 0 to disable.
 
+.. _setting-stats-api-blacklist:
+
+``stats-api-blacklist``
+-----------------------
+.. versionadded:: 4.2.0
+
+-  String
+-  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+
+A list of comma-separated statistic names, that are disabled when retrieving the complete list of statistics via the API for performance reasons.
+These statistics can still be retrieved individually by specifically asking for it.
+
+.. _setting-stats-carbon-blacklist:
+
+``stats-carbon-blacklist``
+--------------------------
+.. versionadded:: 4.2.0
+
+-  String
+-  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+
+A list of comma-separated statistic names, that are prevented from being exported via carbon for performance reasons.
+
+.. _setting-stats-rec-control-blacklist:
+
+``stats-rec-control-blacklist``
+-------------------------------
+.. versionadded:: 4.2.0
+
+-  String
+-  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+
+A list of comma-separated statistic names, that are disabled when retrieving the complete list of statistics via `rec_control get-all`, for performance reasons.
+These statistics can still be retrieved individually.
+
 .. _setting-stats-ringbuffer-entries:
 
 ``stats-ringbuffer-entries``
@@ -1331,6 +1326,17 @@ Use 0 to disable.
 
 Number of entries in the remotes ringbuffer, which keeps statistics on who is querying your server.
 Can be read out using ``rec_control top-remotes``.
+
+.. _setting-stats-snmp-blacklist:
+
+``stats-snmp-blacklist``
+------------------------
+.. versionadded:: 4.2.0
+
+-  String
+-  Default: "cache-bytes, packetcache-bytes, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+
+A list of comma-separated statistic names, that are prevented from being exported via SNMP, for performance reasons.
 
 .. _setting-tcp-fast-open:
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1225,6 +1225,17 @@ Use only a single socket for outgoing queries.
 
 If set to true and PowerDNS has been compiled with SNMP support, it will register as an SNMP agent to provide statistics and be able to send traps.
 
+.. _setting-snmp-enable-expensive-stats:
+
+``snmp-enable-expensive-stats``
+----------------------
+.. versionadded:: 4.2.0
+
+-  Boolean
+-  Default: no
+
+If set and snmp-agent is set, even statistics whose reporting can have an impact on production will be enabled
+
 .. _setting-snmp-master-socket:
 
 ``snmp-master-socket``

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -72,6 +72,9 @@ std::atomic<uint64_t> SyncRes::s_nodelegated;
 std::atomic<uint64_t> SyncRes::s_unreachables;
 std::atomic<uint64_t> SyncRes::s_ecsqueries;
 std::atomic<uint64_t> SyncRes::s_ecsresponses;
+std::map<uint8_t, std::atomic<uint64_t>> SyncRes::s_ecsResponsesBySubnetSize4;
+std::map<uint8_t, std::atomic<uint64_t>> SyncRes::s_ecsResponsesBySubnetSize6;
+
 uint8_t SyncRes::s_ecsipv4limit;
 uint8_t SyncRes::s_ecsipv6limit;
 bool SyncRes::s_doIPv6;
@@ -2700,6 +2703,14 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
     if(ednsmask) {
       s_ecsresponses++;
       LOG(prefix<<qname<<": Received EDNS Client Subnet Mask "<<ednsmask->toString()<<" on response"<<endl);
+      if (ednsmask->getBits() > 0) {
+        if (ednsmask->isIpv4()) {
+          ++SyncRes::s_ecsResponsesBySubnetSize4.at(ednsmask->getBits()-1);
+        }
+        else {
+          ++SyncRes::s_ecsResponsesBySubnetSize6.at(ednsmask->getBits()-1);
+        }
+      }
     }
   }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -558,6 +558,20 @@ public:
     s_ecsScopeZero.source = scopeZeroMask;
   }
 
+  static void clearECSStats()
+  {
+    s_ecsqueries.store(0);
+    s_ecsresponses.store(0);
+
+    for (size_t idx = 0; idx < 32; idx++) {
+      SyncRes::s_ecsResponsesBySubnetSize4[idx].store(0);
+    }
+
+    for (size_t idx = 0; idx < 128; idx++) {
+      SyncRes::s_ecsResponsesBySubnetSize6[idx].store(0);
+    }
+  }
+
   explicit SyncRes(const struct timeval& now);
 
   int beginResolve(const DNSName &qname, const QType &qtype, uint16_t qclass, vector<DNSRecord>&ret);
@@ -686,6 +700,8 @@ public:
   static std::atomic<uint64_t> s_unreachables;
   static std::atomic<uint64_t> s_ecsqueries;
   static std::atomic<uint64_t> s_ecsresponses;
+  static std::map<uint8_t, std::atomic<uint64_t>> s_ecsResponsesBySubnetSize4;
+  static std::map<uint8_t, std::atomic<uint64_t>> s_ecsResponsesBySubnetSize6;
 
   static string s_serverID;
   static unsigned int s_minimumTTL;

--- a/pdns/ws-api.hh
+++ b/pdns/ws-api.hh
@@ -41,5 +41,6 @@ DNSName apiNameToDNSName(const string& name);
 
 // To be provided by product code.
 void productServerStatisticsFetch(std::map<string,string>& out);
+boost::optional<uint64_t> productServerStatisticsFetch(const std::string& name);
 
 #endif /* PDNS_WSAPI_HH */

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -503,6 +503,17 @@ void productServerStatisticsFetch(map<string,string>& out)
   out["uptime"] = std::to_string(time(0) - s_starttime);
 }
 
+boost::optional<uint64_t> productServerStatisticsFetch(const std::string& name)
+{
+  try {
+    // ::read() calls ::exists() which throws a PDNSException when the key does not exist
+    return S.read(name);
+  }
+  catch(...) {
+    return boost::none;
+  }
+}
+
 static void validateGatheredRRType(const DNSResourceRecord& rr) {
   if (rr.qtype.getCode() == QType::OPT || rr.qtype.getCode() == QType::TSIG) {
     throw ApiException("RRset "+rr.qname.toString()+" IN "+rr.qtype.getName()+": invalid type given");

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -52,6 +52,11 @@ void productServerStatisticsFetch(map<string,string>& out)
   out.swap(stats);
 }
 
+boost::optional<uint64_t> productServerStatisticsFetch(const std::string& name)
+{
+  return getStatByName(name);
+}
+
 static void apiWriteConfigFile(const string& filebasename, const string& content)
 {
   if (::arg()["api-config-dir"].empty()) {

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -48,7 +48,7 @@ using json11::Json;
 
 void productServerStatisticsFetch(map<string,string>& out)
 {
-  map<string,string> stats = getAllStatsMap();
+  map<string,string> stats = getAllStatsMap(StatComponent::API);
   out.swap(stats);
 }
 

--- a/regression-tests.api/test_Servers.py
+++ b/regression-tests.api/test_Servers.py
@@ -57,3 +57,14 @@ class Servers(ApiTestCase):
             self.assertIn('60', [e['name'] for e in respsize_stats])
             self.assertIn('example.com/A', [e['name'] for e in queries_stats])
             self.assertIn('No Error', [e['name'] for e in rcode_stats])
+
+    def test_read_one_statistic(self):
+        r = self.session.get(self.url("/api/v1/servers/localhost/statistics?statistic=uptime"))
+        self.assert_success_json(r)
+        data = r.json()
+        self.assertIn('uptime', [e['name'] for e in data])
+
+    def test_read_one_non_existent_statistic(self):
+        r = self.session.get(self.url("/api/v1/servers/localhost/statistics?statistic=uptimeAAAA"))
+        self.assertEquals(r.status_code, 422)
+        self.assertIn("Unknown statistic name", r.json()['error'])


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR:
- adds statistics about ECS response sizes in the recursor, closing #7498 ;
- adds an API endpoint to request a specific statistic only, in the recursor and the auth, even if it is otherwise excluded from the list of all statistics ;
- disable the polling of expensive statistics (cache-bytes, packetcache-bytes) via SNMP by default ;
- make the list of metrics that are excluded from either the list of all statistics (API, rec-control) or completely (Carbon, SNMP) configurable per retrieval method.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
