### PR TITLE
 dnsdist: Refactoring to merge the UDP and TCP paths

### DIFF
--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -24,11 +24,24 @@
 
 #ifndef HAVE_DNSCRYPT
 
-class DNSCryptQuery
+/* let's just define a few types and values so that the rest of
+   the code can ignore whether DNSCrypt support is available */
+#define DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE (0)
+
+class DNSCryptContext
 {
 };
 
-#else
+class DNSCryptQuery
+{
+  DNSCryptQuery(const std::shared_ptr<DNSCryptContext>& ctx): d_ctx(ctx)
+  {
+  }
+private:
+  std::shared_ptr<DNSCryptContext> d_ctx{nullptr};
+};
+
+#else /* HAVE_DNSCRYPT */
 
 #include <memory>
 #include <string>

--- a/pdns/dnsdist-ecs.cc
+++ b/pdns/dnsdist-ecs.cc
@@ -464,9 +464,7 @@ static int removeEDNSOptionFromOptions(unsigned char* optionsStart, const uint16
 
 int removeEDNSOptionFromOPT(char* optStart, size_t* optLen, const uint16_t optionCodeToRemove)
 {
-  /* we need at least:
-     root label (1), type (2), class (2), ttl (4) + rdlen (2)*/
-  if (*optLen < 11) {
+  if (*optLen < optRecordMinimumSize) {
     return EINVAL;
   }
   const unsigned char* end = (const unsigned char*) optStart + *optLen;
@@ -490,15 +488,13 @@ int removeEDNSOptionFromOPT(char* optStart, size_t* optLen, const uint16_t optio
 
 bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const size_t optLen, const uint16_t optionCodeToFind, size_t* optContentStart, uint16_t* optContentLen)
 {
-  /* we need at least:
-   root label (1), type (2), class (2), ttl (4) + rdlen (2)*/
-  if (optLen < 11) {
+  if (optLen < optRecordMinimumSize) {
     return false;
   }
   size_t p = optStart + 9;
   uint16_t rdLen = (0x100*packet.at(p) + packet.at(p+1));
   p += sizeof(rdLen);
-  if (rdLen > (optLen - 11)) {
+  if (rdLen > (optLen - optRecordMinimumSize)) {
     return false;
   }
 
@@ -740,4 +736,32 @@ bool queryHasEDNS(const DNSQuestion& dq)
   }
 
   return false;
+}
+
+bool getEDNS0Record(const DNSQuestion& dq, EDNS0Record& edns0)
+{
+  uint16_t optStart;
+  size_t optLen = 0;
+  bool last = false;
+  const char * packet = reinterpret_cast<const char*>(dq.dh);
+  std::string packetStr(packet, dq.len);
+  int res = locateEDNSOptRR(packetStr, &optStart, &optLen, &last);
+  if (res != 0) {
+    // no EDNS OPT RR
+    return false;
+  }
+
+  if (optLen < optRecordMinimumSize) {
+    return false;
+  }
+
+  if (optStart < dq.len && packetStr.at(optStart) != 0) {
+    // OPT RR Name != '.'
+    return false;
+  }
+
+  static_assert(sizeof(EDNS0Record) == sizeof(uint32_t), "sizeof(EDNS0Record) must match sizeof(uint32_t) AKA RR TTL size");
+  // copy out 4-byte "ttl" (really the EDNS0 record), after root label (1) + type (2) + class (2).
+  memcpy(&edns0, packet + optStart + 5, sizeof edns0);
+  return true;
 }

--- a/pdns/dnsdist-ecs.hh
+++ b/pdns/dnsdist-ecs.hh
@@ -21,6 +21,9 @@
  */
 #pragma once
 
+// root label (1), type (2), class (2), ttl (4) + rdlen (2)
+static const size_t optRecordMinimumSize = 11;
+
 extern size_t g_EdnsUDPPayloadSize;
 extern uint16_t g_PayloadSizeSelfGenAnswers;
 
@@ -42,3 +45,4 @@ bool parseEDNSOptions(DNSQuestion& dq);
 
 int getEDNSZ(const DNSQuestion& dq);
 bool queryHasEDNS(const DNSQuestion& dq);
+bool getEDNS0Record(const DNSQuestion& dq, EDNS0Record& edns0);

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -245,7 +245,7 @@ static bool maxConnectionDurationReached(unsigned int maxConnectionDuration, tim
   return false;
 }
 
-void cleanupClosedTCPConnections(std::map<ComboAddress,int>& sockets)
+static void cleanupClosedTCPConnections(std::map<ComboAddress,int>& sockets)
 {
   for(auto it = sockets.begin(); it != sockets.end(); ) {
     if (isTCPSocketUsable(it->second)) {
@@ -272,11 +272,9 @@ void tcpClientThread(int pipefd)
   
   LocalHolders holders;
   auto localRespRulactions = g_resprulactions.getLocal();
-#ifdef HAVE_DNSCRYPT
   /* when the answer is encrypted in place, we need to get a copy
      of the original header before encryption to fill the ring buffer */
-  dnsheader dhCopy;
-#endif
+  dnsheader cleartextDH;
 
   map<ComboAddress,int> sockets;
   for(;;) {
@@ -297,7 +295,7 @@ void tcpClientThread(int pipefd)
     vector<uint8_t> rewrittenResponse;
     shared_ptr<DownstreamState> ds;
     size_t queriesCount = 0;
-    time_t connectionStartTime = time(NULL);
+    time_t connectionStartTime = time(nullptr);
     std::vector<char> queryBuffer;
     std::vector<char> answerBuffer;
 
@@ -343,7 +341,7 @@ void tcpClientThread(int pipefd)
 
         /* allocate a bit more memory to be able to spoof the content,
            or to add ECS without allocating a new buffer */
-        queryBuffer.resize(qlen + 512);
+        queryBuffer.resize((static_cast<size_t>(qlen) + 512) < 4096 ? (static_cast<size_t>(qlen) + 512) : 4096);
 
         char* query = &queryBuffer[0];
         handler.read(query, qlen, g_tcpRecvTimeout, remainingTime);
@@ -357,7 +355,6 @@ void tcpClientThread(int pipefd)
         gettime(&queryRealTime, true);
 
         std::shared_ptr<DNSCryptQuery> dnsCryptQuery = nullptr;
-
 #ifdef HAVE_DNSCRYPT
         auto dnsCryptResponse = checkDNSCryptQuery(*ci.cs, query, qlen, dnsCryptQuery, queryRealTime.tv_sec, true);
         if (dnsCryptResponse) {
@@ -377,22 +374,21 @@ void tcpClientThread(int pipefd)
         DNSQuestion dq(&qname, qtype, qclass, consumed, &dest, &ci.remote, dh, queryBuffer.size(), qlen, true, &queryRealTime);
         dq.dnsCryptQuery = std::move(dnsCryptQuery);
 
-        responseSender sender = [&handler](const ClientState& cs, const char* data, uint16_t dataSize, int delayMsec, const ComboAddress& dest, const ComboAddress& remote) {
-          handler.writeSizeAndMsg(data, dataSize, g_tcpSendTimeout);
-        };
+        std::shared_ptr<DownstreamState> ds{nullptr};
+        auto result = processQuery(dq, *ci.cs, holders, ds);
 
-        bool dropped = false;
-        auto ds = processQuery(dq, *ci.cs, holders, sender, dropped);
-        if (!ds) {
-          if (dropped) {
-            break;
-          }
+        if (result == ProcessQueryResult::Drop) {
+          break;
+        }
+
+        if (result == ProcessQueryResult::SendAnswer) {
+          handler.writeSizeAndMsg(reinterpret_cast<char*>(dq.dh), dq.len, g_tcpSendTimeout);
           continue;
         }
 
-        // check how that would work!!
-        char cachedResponse[4096];
-        uint16_t cachedResponseSize = sizeof cachedResponse;
+        if (result != ProcessQueryResult::PassToBackend || ds == nullptr) {
+          break;
+        }
 
 	int dsock = -1;
 	uint16_t downstreamFailures=0;
@@ -478,7 +474,7 @@ void tcpClientThread(int pipefd)
         size_t responseSize = rlen;
         uint16_t addRoom = 0;
 #ifdef HAVE_DNSCRYPT
-        if (dq.dnsCryptQuery && (UINT16_MAX - rlen) > (uint16_t) DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE) {
+        if (dq.dnsCryptQuery && (UINT16_MAX - rlen) > static_cast<uint16_t>(DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE)) {
           addRoom = DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE;
         }
 #endif
@@ -502,43 +498,36 @@ void tcpClientThread(int pipefd)
           break;
         }
         firstPacket=false;
-        bool zeroScope = false;
-        if (!fixUpResponse(&response, &responseLen, &responseSize, qname, dq.origFlags, dq.ednsAdded, dq.ecsAdded, rewrittenResponse, addRoom, dq.useZeroScope ? &zeroScope : nullptr)) {
-          break;
-        }
 
-        dh = (struct dnsheader*) response;
+        dh = reinterpret_cast<struct dnsheader*>(response);
         DNSResponse dr(&qname, qtype, qclass, consumed, &dest, &ci.remote, dh, responseSize, responseLen, true, &queryRealTime);
+        dr.origFlags = dq.origFlags;
+        dr.ecsAdded = dq.ecsAdded;
+        dr.ednsAdded = dq.ednsAdded;
+        dr.useZeroScope = dq.useZeroScope;
+        dr.packetCache = std::move(dq.packetCache);
+        dr.delayMsec = dq.delayMsec;
+        dr.skipCache = dq.skipCache;
+        dr.cacheKey = dq.cacheKey;
+        dr.cacheKeyNoECS = dq.cacheKeyNoECS;
+        dr.dnssecOK = dq.dnssecOK;
+        dr.tempFailureTTL = dq.tempFailureTTL;
+        dr.qTag = std::move(dq.qTag);
+        dr.subnet = std::move(dq.subnet);
 #ifdef HAVE_PROTOBUF
-        dr.uniqueId = dq.uniqueId;
+        dr.uniqueId = std::move(dq.uniqueId);
 #endif
-        dr.qTag = dq.qTag;
-
-        if (!processResponse(localRespRulactions, dr, &dq.delayMsec)) {
-          break;
-        }
-
-	if (dq.packetCache && !dq.skipCache) {
-          if (!dq.useZeroScope) {
-            /* if the query was not suitable for zero-scope, for
-               example because it had an existing ECS entry so the hash is
-               not really 'no ECS', so just insert it for the existing subnet
-               since:
-               - we don't have the correct hash for a non-ECS query
-               - inserting with hash computed before the ECS replacement but with
-               the subnet extracted _after_ the replacement would not work.
-            */
-            zeroScope = false;
-          }
-          // if zeroScope, pass the pre-ECS hash-key and do not pass the subnet to the cache
-          dq.packetCache->insert(zeroScope ? dq.cacheKeyNoECS : dq.cacheKey, zeroScope ? boost::none : dq.subnet, dq.origFlags, dq.dnssecOK, qname, qtype, qclass, response, responseLen, true, dh->rcode, dq.tempFailureTTL);
-	}
-
 #ifdef HAVE_DNSCRYPT
-        if (!encryptResponse(response, &responseLen, responseSize, true, dq.dnsCryptQuery, &dh, &dhCopy)) {
-          break;
+        if (dq.dnsCryptQuery) {
+          dr.dnsCryptQuery = std::move(dq.dnsCryptQuery);
         }
 #endif
+
+        memcpy(&cleartextDH, dr.dh, sizeof(cleartextDH));
+        if (!processResponse(&response, &responseLen, &responseSize, localRespRulactions, dr, addRoom, rewrittenResponse, false)) {
+          break;
+        }
+
         if (!handler.writeSizeAndMsg(response, responseLen, g_tcpSendTimeout)) {
           break;
         }
@@ -565,7 +554,7 @@ void tcpClientThread(int pipefd)
         struct timespec answertime;
         gettime(&answertime);
         unsigned int udiff = 1000000.0*DiffTime(now,answertime);
-        g_rings.insertResponse(answertime, ci.remote, qname, dq.qtype, (unsigned int)udiff, (unsigned int)responseLen, *dh, ds->remote);
+        g_rings.insertResponse(answertime, ci.remote, qname, dq.qtype, static_cast<unsigned int>(udiff), static_cast<unsigned int>(responseLen), cleartextDH, ds->remote);
 
         rewrittenResponse.clear();
       }
@@ -614,9 +603,9 @@ void tcpAcceptorThread(void* p)
       ci = std::unique_ptr<ConnectionInfo>(new ConnectionInfo);
       ci->cs = cs;
 #ifdef HAVE_ACCEPT4
-      ci->fd = accept4(cs->tcpFD, (struct sockaddr*)&remote, &remlen, SOCK_NONBLOCK);
+      ci->fd = accept4(cs->tcpFD, reinterpret_cast<struct sockaddr*>(&remote), &remlen, SOCK_NONBLOCK);
 #else
-      ci->fd = accept(cs->tcpFD, (struct sockaddr*)&remote, &remlen);
+      ci->fd = accept(cs->tcpFD, reinterpret_cast<struct sockaddr*>(&remote), &remlen);
 #endif
       if(ci->fd < 0) {
         throw std::runtime_error((boost::format("accepting new connection on socket: %s") % strerror(errno)).str());
@@ -674,7 +663,7 @@ void tcpAcceptorThread(void* p)
         }
       }
     }
-    catch(std::exception& e) {
+    catch(const std::exception& e) {
       errlog("While reading a TCP question: %s", e.what());
       if(tcpClientCountIncremented) {
         decrementTCPClientCount(remote);

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -296,16 +296,16 @@ void tcpClientThread(int pipefd)
     uint16_t qlen, rlen;
     vector<uint8_t> rewrittenResponse;
     shared_ptr<DownstreamState> ds;
-    ComboAddress dest;
-    dest.reset();
-    dest.sin4.sin_family = ci.remote.sin4.sin_family;
-    socklen_t len = dest.getSocklen();
     size_t queriesCount = 0;
     time_t connectionStartTime = time(NULL);
     std::vector<char> queryBuffer;
     std::vector<char> answerBuffer;
 
-    if (getsockname(ci.fd, (sockaddr*)&dest, &len)) {
+    ComboAddress dest;
+    dest.reset();
+    dest.sin4.sin_family = ci.remote.sin4.sin_family;
+    socklen_t socklen = dest.getSocklen();
+    if (getsockname(ci.fd, (sockaddr*)&dest, &socklen)) {
       dest = ci.cs->local;
     }
 
@@ -341,8 +341,6 @@ void tcpClientThread(int pipefd)
           break;
         }
 
-        bool ednsAdded = false;
-        bool ecsAdded = false;
         /* allocate a bit more memory to be able to spoof the content,
            or to add ECS without allocating a new buffer */
         queryBuffer.resize(qlen + 512);
@@ -350,197 +348,51 @@ void tcpClientThread(int pipefd)
         char* query = &queryBuffer[0];
         handler.read(query, qlen, g_tcpRecvTimeout, remainingTime);
 
-        /* we need this one to be accurate ("real") for the protobuf message */
-	struct timespec queryRealTime;
-	struct timespec now;
-	gettime(&now);
-	gettime(&queryRealTime, true);
+        /* we need an accurate ("real") value for the response and
+           to store into the IDS, but not for insertion into the
+           rings for example */
+        struct timespec now;
+        struct timespec queryRealTime;
+        gettime(&now);
+        gettime(&queryRealTime, true);
 
-#ifdef HAVE_DNSCRYPT
         std::shared_ptr<DNSCryptQuery> dnsCryptQuery = nullptr;
 
-        if (ci.cs->dnscryptCtx) {
-          dnsCryptQuery = std::make_shared<DNSCryptQuery>(ci.cs->dnscryptCtx);
-          uint16_t decryptedQueryLen = 0;
-          vector<uint8_t> response;
-          bool decrypted = handleDNSCryptQuery(query, qlen, dnsCryptQuery, &decryptedQueryLen, true, queryRealTime.tv_sec, response);
-
-          if (!decrypted) {
-            if (response.size() > 0) {
-              handler.writeSizeAndMsg(response.data(), response.size(), g_tcpSendTimeout);
-            }
-            break;
-          }
-          qlen = decryptedQueryLen;
-        }
-#endif
-        struct dnsheader* dh = reinterpret_cast<struct dnsheader*>(query);
-
-        if (!checkQueryHeaders(dh)) {
-          goto drop;
-        }
-
-	string poolname;
-	int delayMsec=0;
-
-	const uint16_t* flags = getFlagsFromDNSHeader(dh);
-	uint16_t origFlags = *flags;
-	uint16_t qtype, qclass;
-	unsigned int consumed = 0;
-	DNSName qname(query, qlen, sizeof(dnsheader), false, &qtype, &qclass, &consumed);
-	DNSQuestion dq(&qname, qtype, qclass, consumed, &dest, &ci.remote, dh, queryBuffer.size(), qlen, true, &queryRealTime);
-
-	if (!processQuery(holders, dq, poolname, &delayMsec, now)) {
-	  goto drop;
-	}
-
-	if(dq.dh->qr) { // something turned it into a response
-          fixUpQueryTurnedResponse(dq, origFlags);
-
-          DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, reinterpret_cast<dnsheader*>(query), dq.size, dq.len, true, &queryRealTime);
-#ifdef HAVE_PROTOBUF
-          dr.uniqueId = dq.uniqueId;
-#endif
-          dr.qTag = dq.qTag;
-
-          if (!processResponse(holders.selfAnsweredRespRulactions, dr, &delayMsec)) {
-            goto drop;
-          }
-
 #ifdef HAVE_DNSCRYPT
-          if (!encryptResponse(query, &dq.len, dq.size, true, dnsCryptQuery, nullptr, nullptr)) {
-            goto drop;
-          }
-#endif
-          handler.writeSizeAndMsg(query, dq.len, g_tcpSendTimeout);
-          ++g_stats.selfAnswered;
+        auto dnsCryptResponse = checkDNSCryptQuery(*ci.cs, query, qlen, dnsCryptQuery, queryRealTime.tv_sec, true);
+        if (dnsCryptResponse) {
+          handler.writeSizeAndMsg(reinterpret_cast<char*>(dnsCryptResponse->data()), static_cast<uint16_t>(dnsCryptResponse->size()), g_tcpSendTimeout);
           continue;
         }
-
-        std::shared_ptr<ServerPool> serverPool = getPool(*holders.pools, poolname);
-        std::shared_ptr<DNSDistPacketCache> packetCache = serverPool->packetCache;
-
-        auto policy = *(holders.policy);
-        if (serverPool->policy != nullptr) {
-          policy = *(serverPool->policy);
-        }
-        auto servers = serverPool->getServers();
-        if (policy.isLua) {
-          std::lock_guard<std::mutex> lock(g_luamutex);
-          ds = policy.policy(servers, &dq);
-        }
-        else {
-          ds = policy.policy(servers, &dq);
-        }
-
-        uint32_t cacheKeyNoECS = 0;
-        uint32_t cacheKey = 0;
-        boost::optional<Netmask> subnet;
-        char cachedResponse[4096];
-        uint16_t cachedResponseSize = sizeof cachedResponse;
-        uint32_t allowExpired = ds ? 0 : g_staleCacheEntriesTTL;
-        bool useZeroScope = false;
-
-        bool dnssecOK = false;
-        if (packetCache && !dq.skipCache) {
-          dnssecOK = (getEDNSZ(dq) & EDNS_HEADER_FLAG_DO);
-        }
-
-        if (dq.useECS && ((ds && ds->useECS) || (!ds && serverPool->getECS()))) {
-          // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
-          if (packetCache && !dq.skipCache && (!ds || !ds->disableZeroScope) && packetCache->isECSParsingEnabled()) {
-            if (packetCache->get(dq, consumed, dq.dh->id, cachedResponse, &cachedResponseSize, &cacheKeyNoECS, subnet, dnssecOK, allowExpired)) {
-              DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, (dnsheader*) cachedResponse, sizeof cachedResponse, cachedResponseSize, true, &queryRealTime);
-#ifdef HAVE_PROTOBUF
-              dr.uniqueId = dq.uniqueId;
 #endif
-              dr.qTag = dq.qTag;
 
-              if (!processResponse(holders.cacheHitRespRulactions, dr, &delayMsec)) {
-                goto drop;
-              }
-
-#ifdef HAVE_DNSCRYPT
-              if (!encryptResponse(cachedResponse, &cachedResponseSize, sizeof cachedResponse, true, dnsCryptQuery, nullptr, nullptr)) {
-                goto drop;
-              }
-#endif
-              handler.writeSizeAndMsg(cachedResponse, cachedResponseSize, g_tcpSendTimeout);
-              g_stats.cacheHits++;
-              continue;
-            }
-
-            if (!subnet) {
-              /* there was no existing ECS on the query, enable the zero-scope feature */
-              useZeroScope = true;
-            }
-          }
-
-          if (!handleEDNSClientSubnet(dq, &(ednsAdded), &(ecsAdded), g_preserveTrailingData)) {
-            vinfolog("Dropping query from %s because we couldn't insert the ECS value", ci.remote.toStringWithPort());
-            goto drop;
-          }
-        }
-
-        if (packetCache && !dq.skipCache) {
-          if (packetCache->get(dq, (uint16_t) consumed, dq.dh->id, cachedResponse, &cachedResponseSize, &cacheKey, subnet, dnssecOK, allowExpired)) {
-            DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, (dnsheader*) cachedResponse, sizeof cachedResponse, cachedResponseSize, true, &queryRealTime);
-#ifdef HAVE_PROTOBUF
-            dr.uniqueId = dq.uniqueId;
-#endif
-            dr.qTag = dq.qTag;
-
-            if (!processResponse(holders.cacheHitRespRulactions, dr, &delayMsec)) {
-              goto drop;
-            }
-
-#ifdef HAVE_DNSCRYPT
-            if (!encryptResponse(cachedResponse, &cachedResponseSize, sizeof cachedResponse, true, dnsCryptQuery, nullptr, nullptr)) {
-              goto drop;
-            }
-#endif
-            handler.writeSizeAndMsg(cachedResponse, cachedResponseSize, g_tcpSendTimeout);
-            ++g_stats.cacheHits;
-            continue;
-          }
-          ++g_stats.cacheMisses;
-        }
-
-        if(!ds) {
-          ++g_stats.noPolicy;
-
-          if (g_servFailOnNoPolicy) {
-            restoreFlags(dh, origFlags);
-            dq.dh->rcode = RCode::ServFail;
-            dq.dh->qr = true;
-
-            DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, reinterpret_cast<dnsheader*>(query), dq.size, dq.len, false, &queryRealTime);
-#ifdef HAVE_PROTOBUF
-            dr.uniqueId = dq.uniqueId;
-#endif
-            dr.qTag = dq.qTag;
-
-            if (!processResponse(holders.selfAnsweredRespRulactions, dr, &delayMsec)) {
-              goto drop;
-            }
-
-#ifdef HAVE_DNSCRYPT
-            if (!encryptResponse(query, &dq.len, dq.size, true, dnsCryptQuery, nullptr, nullptr)) {
-              goto drop;
-            }
-#endif
-            handler.writeSizeAndMsg(query, dq.len, g_tcpSendTimeout);
-
-            // no response-only statistics counter to update.
-            continue;
-          }
-
+        struct dnsheader* dh = reinterpret_cast<struct dnsheader*>(query);
+        if (!checkQueryHeaders(dh)) {
           break;
         }
 
-        if (dq.addXPF && ds->xpfRRCode != 0) {
-          addXPF(dq, ds->xpfRRCode, g_preserveTrailingData);
+        uint16_t qtype, qclass;
+        unsigned int consumed = 0;
+        DNSName qname(query, qlen, sizeof(dnsheader), false, &qtype, &qclass, &consumed);
+        DNSQuestion dq(&qname, qtype, qclass, consumed, &dest, &ci.remote, dh, queryBuffer.size(), qlen, true, &queryRealTime);
+        dq.dnsCryptQuery = std::move(dnsCryptQuery);
+
+        responseSender sender = [&handler](const ClientState& cs, const char* data, uint16_t dataSize, int delayMsec, const ComboAddress& dest, const ComboAddress& remote) {
+          handler.writeSizeAndMsg(data, dataSize, g_tcpSendTimeout);
+        };
+
+        bool dropped = false;
+        auto ds = processQuery(dq, *ci.cs, holders, sender, dropped);
+        if (!ds) {
+          if (dropped) {
+            break;
+          }
+          continue;
         }
+
+        // check how that would work!!
+        char cachedResponse[4096];
+        uint16_t cachedResponseSize = sizeof cachedResponse;
 
 	int dsock = -1;
 	uint16_t downstreamFailures=0;
@@ -558,7 +410,6 @@ void tcpClientThread(int pipefd)
 #endif /* MSG_FASTOPEN */
         }
 
-        ds->queries++;
         ds->outstanding++;
         outstanding = true;
 
@@ -619,7 +470,7 @@ void tcpClientThread(int pipefd)
           freshConn=true;
 #endif /* MSG_FASTOPEN */
           if(xfrStarted) {
-            goto drop;
+            break;
           }
           goto retry;
         }
@@ -627,7 +478,7 @@ void tcpClientThread(int pipefd)
         size_t responseSize = rlen;
         uint16_t addRoom = 0;
 #ifdef HAVE_DNSCRYPT
-        if (dnsCryptQuery && (UINT16_MAX - rlen) > (uint16_t) DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE) {
+        if (dq.dnsCryptQuery && (UINT16_MAX - rlen) > (uint16_t) DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE) {
           addRoom = DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE;
         }
 #endif
@@ -652,7 +503,7 @@ void tcpClientThread(int pipefd)
         }
         firstPacket=false;
         bool zeroScope = false;
-        if (!fixUpResponse(&response, &responseLen, &responseSize, qname, origFlags, ednsAdded, ecsAdded, rewrittenResponse, addRoom, useZeroScope ? &zeroScope : nullptr)) {
+        if (!fixUpResponse(&response, &responseLen, &responseSize, qname, dq.origFlags, dq.ednsAdded, dq.ecsAdded, rewrittenResponse, addRoom, dq.useZeroScope ? &zeroScope : nullptr)) {
           break;
         }
 
@@ -663,12 +514,12 @@ void tcpClientThread(int pipefd)
 #endif
         dr.qTag = dq.qTag;
 
-        if (!processResponse(localRespRulactions, dr, &delayMsec)) {
+        if (!processResponse(localRespRulactions, dr, &dq.delayMsec)) {
           break;
         }
 
-	if (packetCache && !dq.skipCache) {
-          if (!useZeroScope) {
+	if (dq.packetCache && !dq.skipCache) {
+          if (!dq.useZeroScope) {
             /* if the query was not suitable for zero-scope, for
                example because it had an existing ECS entry so the hash is
                not really 'no ECS', so just insert it for the existing subnet
@@ -680,12 +531,12 @@ void tcpClientThread(int pipefd)
             zeroScope = false;
           }
           // if zeroScope, pass the pre-ECS hash-key and do not pass the subnet to the cache
-          packetCache->insert(zeroScope ? cacheKeyNoECS : cacheKey, zeroScope ? boost::none : subnet, origFlags, dnssecOK, qname, qtype, qclass, response, responseLen, true, dh->rcode, dq.tempFailureTTL);
+          dq.packetCache->insert(zeroScope ? dq.cacheKeyNoECS : dq.cacheKey, zeroScope ? boost::none : dq.subnet, dq.origFlags, dq.dnssecOK, qname, qtype, qclass, response, responseLen, true, dh->rcode, dq.tempFailureTTL);
 	}
 
 #ifdef HAVE_DNSCRYPT
-        if (!encryptResponse(response, &responseLen, responseSize, true, dnsCryptQuery, &dh, &dhCopy)) {
-          goto drop;
+        if (!encryptResponse(response, &responseLen, responseSize, true, dq.dnsCryptQuery, &dh, &dhCopy)) {
+          break;
         }
 #endif
         if (!handler.writeSizeAndMsg(response, responseLen, g_tcpSendTimeout)) {
@@ -719,9 +570,11 @@ void tcpClientThread(int pipefd)
         rewrittenResponse.clear();
       }
     }
-    catch(...) {}
-
-  drop:;
+    catch(const std::exception& e) {
+      vinfolog("Got exception while handling TCP query: %s", e.what());
+    }
+    catch(...) {
+    }
 
     vinfolog("Closing TCP client connection with %s", ci.remote.toStringWithPort());
 

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -355,13 +355,11 @@ void tcpClientThread(int pipefd)
         gettime(&queryRealTime, true);
 
         std::shared_ptr<DNSCryptQuery> dnsCryptQuery = nullptr;
-#ifdef HAVE_DNSCRYPT
         auto dnsCryptResponse = checkDNSCryptQuery(*ci.cs, query, qlen, dnsCryptQuery, queryRealTime.tv_sec, true);
         if (dnsCryptResponse) {
           handler.writeSizeAndMsg(reinterpret_cast<char*>(dnsCryptResponse->data()), static_cast<uint16_t>(dnsCryptResponse->size()), g_tcpSendTimeout);
           continue;
         }
-#endif
 
         struct dnsheader* dh = reinterpret_cast<struct dnsheader*>(query);
         if (!checkQueryHeaders(dh)) {
@@ -473,11 +471,10 @@ void tcpClientThread(int pipefd)
 
         size_t responseSize = rlen;
         uint16_t addRoom = 0;
-#ifdef HAVE_DNSCRYPT
         if (dq.dnsCryptQuery && (UINT16_MAX - rlen) > static_cast<uint16_t>(DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE)) {
           addRoom = DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE;
         }
-#endif
+
         responseSize += addRoom;
         answerBuffer.resize(responseSize);
         char* response = answerBuffer.data();
@@ -517,11 +514,9 @@ void tcpClientThread(int pipefd)
 #ifdef HAVE_PROTOBUF
         dr.uniqueId = std::move(dq.uniqueId);
 #endif
-#ifdef HAVE_DNSCRYPT
         if (dq.dnsCryptQuery) {
           dr.dnsCryptQuery = std::move(dq.dnsCryptQuery);
         }
-#endif
 
         memcpy(&cleartextDH, dr.dh, sizeof(cleartextDH));
         if (!processResponse(&response, &responseLen, &responseSize, localRespRulactions, dr, addRoom, rewrittenResponse, false)) {

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -156,7 +156,7 @@ try
     hadEDNS = getEDNSUDPPayloadSizeAndZ(packet, *len, &payloadSize, &z);
   }
 
-  *len=(uint16_t) (sizeof(dnsheader)+consumed+DNS_TYPE_SIZE+DNS_CLASS_SIZE);
+  *len=static_cast<uint16_t>(sizeof(dnsheader)+consumed+DNS_TYPE_SIZE+DNS_CLASS_SIZE);
   struct dnsheader* dh = reinterpret_cast<struct dnsheader*>(packet);
   dh->ancount = dh->arcount = dh->nscount = 0;
 
@@ -537,7 +537,7 @@ try {
         char * response = packet;
         size_t responseSize = sizeof(packet);
 
-        if (got < static_cast<ssize_t>(sizeof(dnsheader)))
+        if (got < 0 || static_cast<size_t>(got) < sizeof(dnsheader))
           continue;
 
         uint16_t responseLen = static_cast<uint16_t>(got);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -268,6 +268,7 @@ static bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags)
   return addEDNSToQueryTurnedResponse(dq);
 }
 
+/* returns false if the response should be dropped, true otherwise */
 static bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope)
 {
   if (*responseLen < sizeof(dnsheader)) {
@@ -365,6 +366,7 @@ static bool fixUpResponse(char** response, uint16_t* responseLen, size_t* respon
 }
 
 #ifdef HAVE_DNSCRYPT
+/* returns false if the response should be dropped, true otherwise */
 static bool encryptResponse(char* response, uint16_t* responseLen, size_t responseSize, bool tcp, std::shared_ptr<DNSCryptQuery> dnsCryptQuery, dnsheader** dh, dnsheader* dhCopy)
 {
   if (dnsCryptQuery) {
@@ -389,6 +391,7 @@ static bool encryptResponse(char* response, uint16_t* responseLen, size_t respon
 }
 #endif /* HAVE_DNSCRYPT */
 
+/* returns false if the response should be dropped, true otherwise */
 static bool applyRulesToResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr)
 {
   DNSResponseAction::Action action=DNSResponseAction::Action::None;
@@ -424,6 +427,7 @@ static bool applyRulesToResponse(LocalStateHolder<vector<DNSDistResponseRuleActi
   return true;
 }
 
+/* returns false if the response should be dropped, true otherwise */
 bool processResponse(char** response, uint16_t* responseLen, size_t* responseSize, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, size_t addRoom, std::vector<uint8_t>& rewrittenResponse, bool muted)
 {
   if (!applyRulesToResponse(localRespRulactions, dr)) {
@@ -1005,6 +1009,7 @@ static void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent)
   }
 }
 
+/* returns false if the query should be dropped, true otherwise */
 static bool applyRulesToQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, const struct timespec& now)
 {
   g_rings.insertQuery(now, *dq.remote, *dq.qname, dq.qtype, dq.len, *dq.dh);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -249,7 +249,7 @@ bool responseContentMatches(const char* response, const uint16_t responseLen, co
   return true;
 }
 
-void restoreFlags(struct dnsheader* dh, uint16_t origFlags)
+static void restoreFlags(struct dnsheader* dh, uint16_t origFlags)
 {
   static const uint16_t rdMask = 1 << FLAGS_RD_OFFSET;
   static const uint16_t cdMask = 1 << FLAGS_CD_OFFSET;
@@ -263,7 +263,7 @@ void restoreFlags(struct dnsheader* dh, uint16_t origFlags)
   *flags |= origFlags;
 }
 
-bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags)
+static bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags)
 {
   restoreFlags(dq.dh, origFlags);
 
@@ -392,7 +392,7 @@ bool encryptResponse(char* response, uint16_t* responseLen, size_t responseSize,
 }
 #endif
 
-static bool sendUDPResponse(int origFD, char* response, uint16_t responseLen, int delayMsec, const ComboAddress& origDest, const ComboAddress& origRemote)
+static bool sendUDPResponse(int origFD, const char* response, uint16_t responseLen, int delayMsec, const ComboAddress& origDest, const ComboAddress& origRemote)
 {
   if(delayMsec && g_delay) {
     DelayedPacket dp{origFD, string(response,responseLen), origRemote, origDest};
@@ -416,7 +416,7 @@ static bool sendUDPResponse(int origFD, char* response, uint16_t responseLen, in
 }
 
 
-static int pickBackendSocketForSending(DownstreamState* state)
+static int pickBackendSocketForSending(std::shared_ptr<DownstreamState>& state)
 {
   return state->sockets[state->socketsOffset++ % state->sockets.size()];
 }
@@ -962,9 +962,9 @@ static void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent)
   }
 }
 
-bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int* delayMsec, const struct timespec& now)
+static bool applyRulesToQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, const struct timespec& now)
 {
-  g_rings.insertQuery(now,*dq.remote,*dq.qname,dq.qtype,dq.len,*dq.dh);
+  g_rings.insertQuery(now, *dq.remote, *dq.qname, dq.qtype, dq.len, *dq.dh);
 
   if(g_qcount.enabled) {
     string qname = (*dq.qname).toString(".");
@@ -1146,7 +1146,7 @@ bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int*
         break;
         /* non-terminal actions follow */
       case DNSAction::Action::Delay:
-        *delayMsec = static_cast<int>(pdns_stou(ruleresult)); // sorry
+        dq.delayMsec = static_cast<int>(pdns_stou(ruleresult)); // sorry
         break;
       case DNSAction::Action::None:
         /* fall-through */
@@ -1198,7 +1198,7 @@ bool processResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& local
   return true;
 }
 
-static ssize_t udpClientSendRequestToBackend(DownstreamState* ss, const int sd, const char* request, const size_t requestLen, bool healthCheck=false)
+static ssize_t udpClientSendRequestToBackend(const std::shared_ptr<DownstreamState>& ss, const int sd, const char* request, const size_t requestLen, bool healthCheck=false)
 {
   ssize_t result;
 
@@ -1262,7 +1262,7 @@ static bool isUDPQueryAcceptable(ClientState& cs, LocalHolders& holders, const s
 }
 
 #ifdef HAVE_DNSCRYPT
-static bool checkDNSCryptQuery(const ClientState& cs, const char* query, uint16_t& len, std::shared_ptr<DNSCryptQuery>& dnsCryptQuery, const ComboAddress& dest, const ComboAddress& remote, time_t now)
+boost::optional<std::vector<uint8_t>> checkDNSCryptQuery(const ClientState& cs, const char* query, uint16_t& len, std::shared_ptr<DNSCryptQuery>& dnsCryptQuery, time_t now, bool tcp)
 {
   if (cs.dnscryptCtx) {
     vector<uint8_t> response;
@@ -1270,18 +1270,18 @@ static bool checkDNSCryptQuery(const ClientState& cs, const char* query, uint16_
 
     dnsCryptQuery = std::make_shared<DNSCryptQuery>(cs.dnscryptCtx);
 
-    bool decrypted = handleDNSCryptQuery(const_cast<char*>(query), len, dnsCryptQuery, &decryptedQueryLen, false, now, response);
+    bool decrypted = handleDNSCryptQuery(const_cast<char*>(query), len, dnsCryptQuery, &decryptedQueryLen, tcp, now, response);
 
     if (!decrypted) {
       if (response.size() > 0) {
-        sendUDPResponse(cs.udpFD, reinterpret_cast<char*>(response.data()), static_cast<uint16_t>(response.size()), 0, dest, remote);
+        return response;
       }
-      return false;
+      throw std::runtime_error("Unable to decrypt DNSCrypt query, dropping.");
     }
 
     len = decryptedQueryLen;
   }
-  return true;
+  return boost::none;
 }
 #endif /* HAVE_DNSCRYPT */
 
@@ -1319,34 +1319,27 @@ static void queueResponse(const ClientState& cs, const char* response, uint16_t 
 }
 #endif /* defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE) */
 
-static int sendAndEncryptUDPResponse(LocalHolders& holders, ClientState& cs, const DNSQuestion& dq, char* response, uint16_t responseLen, std::shared_ptr<DNSCryptQuery>& dnsCryptQuery, int delayMsec, const ComboAddress& dest, struct mmsghdr* responsesVect, unsigned int* queuedResponses, struct iovec* respIOV, char* respCBuf, bool cacheHit)
+static int sendResponse(LocalHolders& holders, ClientState& cs, DNSQuestion& dq, char* response, uint16_t responseLen, bool cacheHit, responseSender sender)
 {
-  DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, reinterpret_cast<dnsheader*>(response), dq.size, responseLen, false, dq.queryTime);
+  DNSResponse dr(dq.qname, dq.qtype, dq.qclass, dq.consumed, dq.local, dq.remote, reinterpret_cast<dnsheader*>(response), dq.size, responseLen, dq.tcp, dq.queryTime);
+
 #ifdef HAVE_PROTOBUF
   dr.uniqueId = dq.uniqueId;
 #endif
   dr.qTag = dq.qTag;
 
-  if (!processResponse(cacheHit ? holders.cacheHitRespRulactions : holders.selfAnsweredRespRulactions, dr, &delayMsec)) {
+  if (!processResponse(cacheHit ? holders.cacheHitRespRulactions : holders.selfAnsweredRespRulactions, dr, &dq.delayMsec)) {
     return -1;
   }
 
   if (!cs.muted) {
 #ifdef HAVE_DNSCRYPT
-    if (!encryptResponse(response, &responseLen, dq.size, false, dnsCryptQuery, nullptr, nullptr)) {
+    if (!encryptResponse(response, &responseLen, dq.size, dq.tcp, dq.dnsCryptQuery, nullptr, nullptr)) {
       return -1;
     }
 #endif
-#if defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE)
-    if (delayMsec == 0 && responsesVect != nullptr) {
-      queueResponse(cs, response, responseLen, dest, *dq.remote, responsesVect[*queuedResponses], respIOV, respCBuf);
-      (*queuedResponses)++;
-    }
-    else
-#endif /* defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE) */
-      {
-        sendUDPResponse(cs.udpFD, response, responseLen, delayMsec, dest, *dq.remote);
-      }
+
+    sender(cs, response, responseLen, dq.delayMsec, *dq.local, *dq.remote);
   }
 
   if (cacheHit) {
@@ -1354,6 +1347,124 @@ static int sendAndEncryptUDPResponse(LocalHolders& holders, ClientState& cs, con
   }
   doLatencyStats(0);  // we're not going to measure this
   return 0;
+}
+
+/* returns nullptr if the query has been taken care of (cache-hit, self-answered or discarded) and a backend it should be sent to otherwise */
+std::shared_ptr<DownstreamState> processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& holders, responseSender sender, bool& dropped)
+{
+  const uint16_t queryId = ntohs(dq.dh->id);
+
+  try {
+    /* we need an accurate ("real") value for the response and
+       to store into the IDS, but not for insertion into the
+       rings for example */
+    struct timespec now;
+    gettime(&now);
+
+    string poolname;
+
+    if (!applyRulesToQuery(holders, dq, poolname, now)) {
+      dropped = true;
+      return nullptr;
+    }
+
+    if(dq.dh->qr) { // something turned it into a response
+      fixUpQueryTurnedResponse(dq, dq.origFlags);
+
+      if (!cs.muted) {
+        char* response = reinterpret_cast<char*>(dq.dh);
+        uint16_t responseLen = dq.len;
+
+        sendResponse(holders, cs, dq, response, responseLen, false, sender);
+
+        ++g_stats.selfAnswered;
+      }
+
+      return nullptr;
+    }
+
+    std::shared_ptr<DownstreamState> ss{nullptr};
+    std::shared_ptr<ServerPool> serverPool = getPool(*holders.pools, poolname);
+    dq.packetCache = serverPool->packetCache;
+    auto policy = *(holders.policy);
+    if (serverPool->policy != nullptr) {
+      policy = *(serverPool->policy);
+    }
+    auto servers = serverPool->getServers();
+    if (policy.isLua) {
+      std::lock_guard<std::mutex> lock(g_luamutex);
+      ss = policy.policy(servers, &dq);
+    }
+    else {
+      ss = policy.policy(servers, &dq);
+    }
+
+    uint16_t cachedResponseSize = dq.size;
+    uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
+
+    if (dq.packetCache && !dq.skipCache) {
+      dq.dnssecOK = (getEDNSZ(dq) & EDNS_HEADER_FLAG_DO);
+    }
+
+    if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
+      // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
+      if (dq.packetCache && !dq.skipCache && (!ss || !ss->disableZeroScope) && dq.packetCache->isECSParsingEnabled()) {
+        if (dq.packetCache->get(dq, dq.consumed, dq.dh->id, reinterpret_cast<char*>(dq.dh), &cachedResponseSize, &dq.cacheKeyNoECS, dq.subnet, dq.dnssecOK, allowExpired)) {
+          sendResponse(holders, cs, dq, reinterpret_cast<char*>(dq.dh), cachedResponseSize, true, sender);
+          return nullptr;
+        }
+
+        if (!dq.subnet) {
+          /* there was no existing ECS on the query, enable the zero-scope feature */
+          dq.useZeroScope = true;
+        }
+      }
+
+      if (!handleEDNSClientSubnet(dq, &(dq.ednsAdded), &(dq.ecsAdded), g_preserveTrailingData)) {
+        vinfolog("Dropping query from %s because we couldn't insert the ECS value", dq.remote->toStringWithPort());
+        dropped = true;
+        return nullptr;
+      }
+    }
+
+    if (dq.packetCache && !dq.skipCache) {
+      if (dq.packetCache->get(dq, dq.consumed, dq.dh->id, reinterpret_cast<char*>(dq.dh), &cachedResponseSize, &dq.cacheKey, dq.subnet, dq.dnssecOK, allowExpired)) {
+        sendResponse(holders, cs, dq, reinterpret_cast<char*>(dq.dh), cachedResponseSize, true, sender);
+        return nullptr;
+      }
+      ++g_stats.cacheMisses;
+    }
+
+    if(!ss) {
+      ++g_stats.noPolicy;
+
+      if (g_servFailOnNoPolicy && !cs.muted) {
+        char* response = reinterpret_cast<char*>(dq.dh);
+        uint16_t responseLen = dq.len;
+        restoreFlags(dq.dh, dq.origFlags);
+
+        dq.dh->rcode = RCode::ServFail;
+        dq.dh->qr = true;
+
+        sendResponse(holders, cs, dq, response, responseLen, false, sender);
+        // no response-only statistics counter to update.
+      }
+      vinfolog("%s query for %s|%s from %s, no policy applied", g_servFailOnNoPolicy ? "ServFailed" : "Dropped", dq.qname->toString(), QType(dq.qtype).getName(), dq.remote->toStringWithPort());
+      return nullptr;
+    }
+
+    if (dq.addXPF && ss->xpfRRCode != 0) {
+      addXPF(dq, ss->xpfRRCode, g_preserveTrailingData);
+    }
+
+    ss->queries++;
+    return ss;
+  }
+  catch(const std::exception& e){
+    vinfolog("Got an error while parsing a %s query from %s, id %d: %s", (dq.tcp ? "TCP" : "UDP"), dq.remote->toStringWithPort(), queryId, e.what());
+    dropped = true;
+  }
+  return nullptr;
 }
 
 static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct msghdr* msgh, const ComboAddress& remote, ComboAddress& dest, char* query, uint16_t len, size_t queryBufferSize, struct mmsghdr* responsesVect, unsigned int* queuedResponses, struct iovec* respIOV, char* respCBuf)
@@ -1377,7 +1488,9 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     std::shared_ptr<DNSCryptQuery> dnsCryptQuery = nullptr;
 
 #ifdef HAVE_DNSCRYPT
-    if (!checkDNSCryptQuery(cs, query, len, dnsCryptQuery, dest, remote, queryRealTime.tv_sec)) {
+    auto dnsCryptResponse = checkDNSCryptQuery(cs, query, len, dnsCryptQuery, queryRealTime.tv_sec, false);
+    if (dnsCryptResponse) {
+      sendUDPResponse(cs.udpFD, reinterpret_cast<char*>(dnsCryptResponse->data()), static_cast<uint16_t>(dnsCryptResponse->size()), 0, dest, remote);
       return;
     }
 #endif
@@ -1389,117 +1502,29 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
       return;
     }
 
-    string poolname;
-    int delayMsec = 0;
-    const uint16_t * flags = getFlagsFromDNSHeader(dh);
-    const uint16_t origFlags = *flags;
     uint16_t qtype, qclass;
     unsigned int consumed = 0;
     DNSName qname(query, len, sizeof(dnsheader), false, &qtype, &qclass, &consumed);
     DNSQuestion dq(&qname, qtype, qclass, consumed, dest.sin4.sin_family != 0 ? &dest : &cs.local, &remote, dh, queryBufferSize, len, false, &queryRealTime);
-    bool dnssecOK = false;
+    dq.dnsCryptQuery = std::move(dnsCryptQuery);
 
-    if (!processQuery(holders, dq, poolname, &delayMsec, now))
-    {
-      return;
-    }
-
-    if(dq.dh->qr) { // something turned it into a response
-      fixUpQueryTurnedResponse(dq, origFlags);
-
-      if (!cs.muted) {
-        char* response = query;
-        uint16_t responseLen = dq.len;
-
-        sendAndEncryptUDPResponse(holders, cs, dq, response, responseLen, dnsCryptQuery, delayMsec, dest, responsesVect, queuedResponses, respIOV, respCBuf, false);
-
-        ++g_stats.selfAnswered;
-      }
-
-      return;
-    }
-
-    DownstreamState* ss = nullptr;
-    std::shared_ptr<ServerPool> serverPool = getPool(*holders.pools, poolname);
-    std::shared_ptr<DNSDistPacketCache> packetCache = serverPool->packetCache;
-    auto policy = *(holders.policy);
-    if (serverPool->policy != nullptr) {
-      policy = *(serverPool->policy);
-    }
-    auto servers = serverPool->getServers();
-    if (policy.isLua) {
-      std::lock_guard<std::mutex> lock(g_luamutex);
-      ss = policy.policy(servers, &dq).get();
-    }
-    else {
-      ss = policy.policy(servers, &dq).get();
-    }
-
-    bool ednsAdded = false;
-    bool ecsAdded = false;
-    uint32_t cacheKeyNoECS = 0;
-    uint32_t cacheKey = 0;
-    boost::optional<Netmask> subnet;
-    uint16_t cachedResponseSize = dq.size;
-    uint32_t allowExpired = ss ? 0 : g_staleCacheEntriesTTL;
-    bool useZeroScope = false;
-
-    if (packetCache && !dq.skipCache) {
-      dnssecOK = (getEDNSZ(dq) & EDNS_HEADER_FLAG_DO);
-    }
-
-    if (dq.useECS && ((ss && ss->useECS) || (!ss && serverPool->getECS()))) {
-      // we special case our cache in case a downstream explicitly gave us a universally valid response with a 0 scope
-      if (packetCache && !dq.skipCache && (!ss || !ss->disableZeroScope) && packetCache->isECSParsingEnabled()) {
-        if (packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKeyNoECS, subnet, dnssecOK, allowExpired)) {
-          sendAndEncryptUDPResponse(holders, cs, dq, query, cachedResponseSize, dnsCryptQuery, delayMsec, dest, responsesVect, queuedResponses, respIOV, respCBuf, true);
-          return;
-        }
-
-        if (!subnet) {
-          /* there was no existing ECS on the query, enable the zero-scope feature */
-          useZeroScope = true;
-        }
-      }
-
-      if (!handleEDNSClientSubnet(dq, &(ednsAdded), &(ecsAdded), g_preserveTrailingData)) {
-        vinfolog("Dropping query from %s because we couldn't insert the ECS value", remote.toStringWithPort());
+    responseSender sender = [&responsesVect, &queuedResponses, &respIOV, &respCBuf](const ClientState& cs, const char* data, uint16_t dataSize, int delayMsec, const ComboAddress& dest, const ComboAddress& remote) -> void {
+#if defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE)
+      if (delayMsec == 0 && responsesVect != nullptr) {
+        queueResponse(cs, data, dataSize, dest, remote, responsesVect[*queuedResponses], respIOV, respCBuf);
+        (*queuedResponses)++;
         return;
       }
-    }
+#endif /* defined(HAVE_RECVMMSG) && defined(HAVE_SENDMMSG) && defined(MSG_WAITFORONE) */
+      sendUDPResponse(cs.udpFD, data, dataSize, delayMsec, dest, remote);
+    };
 
-    if (packetCache && !dq.skipCache) {
-      if (packetCache->get(dq, consumed, dh->id, query, &cachedResponseSize, &cacheKey, subnet, dnssecOK, allowExpired)) {
-        sendAndEncryptUDPResponse(holders, cs, dq, query, cachedResponseSize, dnsCryptQuery, delayMsec, dest, responsesVect, queuedResponses, respIOV, respCBuf, true);
-        return;
-      }
-      ++g_stats.cacheMisses;
-    }
+    bool dropped = false;
+    auto ss = processQuery(dq, cs, holders, sender, dropped);
 
-    if(!ss) {
-      ++g_stats.noPolicy;
-
-      if (g_servFailOnNoPolicy && !cs.muted) {
-        char* response = query;
-        uint16_t responseLen = dq.len;
-        restoreFlags(dh, origFlags);
-
-        dq.dh->rcode = RCode::ServFail;
-        dq.dh->qr = true;
-
-        sendAndEncryptUDPResponse(holders, cs, dq, response, responseLen, dnsCryptQuery, delayMsec, dest, responsesVect, queuedResponses, respIOV, respCBuf, false);
-
-        // no response-only statistics counter to update.
-      }
-      vinfolog("%s query for %s|%s from %s, no policy applied", g_servFailOnNoPolicy ? "ServFailed" : "Dropped", dq.qname->toString(), QType(dq.qtype).getName(), remote.toStringWithPort());
+    if (!ss) {
       return;
     }
-
-    if (dq.addXPF && ss->xpfRRCode != 0) {
-      addXPF(dq, ss->xpfRRCode, g_preserveTrailingData);
-    }
-
-    ss->queries++;
 
     unsigned int idOffset = (ss->idOffset++) % ss->idStates.size();
     IDState* ids = &ss->idStates[idOffset];
@@ -1519,22 +1544,22 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     ids->origID = dh->id;
     ids->origRemote = remote;
     ids->sentTime.set(queryRealTime);
-    ids->qname = qname;
+    ids->qname = std::move(qname);
     ids->qtype = dq.qtype;
     ids->qclass = dq.qclass;
-    ids->delayMsec = delayMsec;
+    ids->delayMsec = dq.delayMsec;
     ids->tempFailureTTL = dq.tempFailureTTL;
-    ids->origFlags = origFlags;
-    ids->cacheKey = cacheKey;
-    ids->cacheKeyNoECS = cacheKeyNoECS;
-    ids->subnet = subnet;
+    ids->origFlags = dq.origFlags;
+    ids->cacheKey = dq.cacheKey;
+    ids->cacheKeyNoECS = dq.cacheKeyNoECS;
+    ids->subnet = dq.subnet;
     ids->skipCache = dq.skipCache;
-    ids->packetCache = packetCache;
-    ids->ednsAdded = ednsAdded;
-    ids->ecsAdded = ecsAdded;
-    ids->useZeroScope = useZeroScope;
+    ids->packetCache = dq.packetCache;
+    ids->ednsAdded = dq.ednsAdded;
+    ids->ecsAdded = dq.ecsAdded;
+    ids->useZeroScope = dq.useZeroScope;
     ids->qTag = dq.qTag;
-    ids->dnssecOK = dnssecOK;
+    ids->dnssecOK = dq.dnssecOK;
 
     /* If we couldn't harvest the real dest addr, still
        write down the listening addr since it will be useful
@@ -1551,10 +1576,10 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
       ids->destHarvested = false;
     }
 #ifdef HAVE_DNSCRYPT
-    ids->dnsCryptQuery = dnsCryptQuery;
+    ids->dnsCryptQuery = std::move(dq.dnsCryptQuery);
 #endif
 #ifdef HAVE_PROTOBUF
-    ids->uniqueId = dq.uniqueId;
+    ids->uniqueId = std::move(dq.uniqueId);
 #endif
 
     dh->id = idOffset;
@@ -1721,12 +1746,12 @@ uint16_t getRandomDNSID()
 #endif
 }
 
-static bool upCheck(DownstreamState& ds)
+static bool upCheck(const shared_ptr<DownstreamState>& ds)
 try
 {
-  DNSName checkName = ds.checkName;
-  uint16_t checkType = ds.checkType.getCode();
-  uint16_t checkClass = ds.checkClass;
+  DNSName checkName = ds->checkName;
+  uint16_t checkType = ds->checkType.getCode();
+  uint16_t checkClass = ds->checkClass;
   dnsheader checkHeader;
   memset(&checkHeader, 0, sizeof(checkHeader));
 
@@ -1734,13 +1759,13 @@ try
   checkHeader.id = getRandomDNSID();
 
   checkHeader.rd = true;
-  if (ds.setCD) {
+  if (ds->setCD) {
     checkHeader.cd = true;
   }
 
-  if (ds.checkFunction) {
+  if (ds->checkFunction) {
     std::lock_guard<std::mutex> lock(g_luamutex);
-    auto ret = ds.checkFunction(checkName, checkType, checkClass, &checkHeader);
+    auto ret = ds->checkFunction(checkName, checkType, checkClass, &checkHeader);
     checkName = std::get<0>(ret);
     checkType = std::get<1>(ret);
     checkClass = std::get<2>(ret);
@@ -1751,31 +1776,31 @@ try
   dnsheader * requestHeader = dpw.getHeader();
   *requestHeader = checkHeader;
 
-  Socket sock(ds.remote.sin4.sin_family, SOCK_DGRAM);
+  Socket sock(ds->remote.sin4.sin_family, SOCK_DGRAM);
   sock.setNonBlocking();
-  if (!IsAnyAddress(ds.sourceAddr)) {
+  if (!IsAnyAddress(ds->sourceAddr)) {
     sock.setReuseAddr();
-    sock.bind(ds.sourceAddr);
+    sock.bind(ds->sourceAddr);
   }
-  sock.connect(ds.remote);
-  ssize_t sent = udpClientSendRequestToBackend(&ds, sock.getHandle(), (char*)&packet[0], packet.size(), true);
+  sock.connect(ds->remote);
+  ssize_t sent = udpClientSendRequestToBackend(ds, sock.getHandle(), (char*)&packet[0], packet.size(), true);
   if (sent < 0) {
     int ret = errno;
     if (g_verboseHealthChecks)
-      infolog("Error while sending a health check query to backend %s: %d", ds.getNameWithAddr(), ret);
+      infolog("Error while sending a health check query to backend %s: %d", ds->getNameWithAddr(), ret);
     return false;
   }
 
-  int ret = waitForRWData(sock.getHandle(), true, /* ms to seconds */ ds.checkTimeout / 1000, /* remaining ms to us */ (ds.checkTimeout % 1000) * 1000);
+  int ret = waitForRWData(sock.getHandle(), true, /* ms to seconds */ ds->checkTimeout / 1000, /* remaining ms to us */ (ds->checkTimeout % 1000) * 1000);
   if(ret < 0 || !ret) { // error, timeout, both are down!
     if (ret < 0) {
       ret = errno;
       if (g_verboseHealthChecks)
-        infolog("Error while waiting for the health check response from backend %s: %d", ds.getNameWithAddr(), ret);
+        infolog("Error while waiting for the health check response from backend %s: %d", ds->getNameWithAddr(), ret);
     }
     else {
       if (g_verboseHealthChecks)
-        infolog("Timeout while waiting for the health check response from backend %s", ds.getNameWithAddr());
+        infolog("Timeout while waiting for the health check response from backend %s", ds->getNameWithAddr());
     }
     return false;
   }
@@ -1785,9 +1810,9 @@ try
   sock.recvFrom(reply, from);
 
   /* we are using a connected socket but hey.. */
-  if (from != ds.remote) {
+  if (from != ds->remote) {
     if (g_verboseHealthChecks)
-      infolog("Invalid health check response received from %s, expecting one from %s", from.toStringWithPort(), ds.remote.toStringWithPort());
+      infolog("Invalid health check response received from %s, expecting one from %s", from.toStringWithPort(), ds->remote.toStringWithPort());
     return false;
   }
 
@@ -1795,31 +1820,31 @@ try
 
   if (reply.size() < sizeof(*responseHeader)) {
     if (g_verboseHealthChecks)
-      infolog("Invalid health check response of size %d from backend %s, expecting at least %d", reply.size(), ds.getNameWithAddr(), sizeof(*responseHeader));
+      infolog("Invalid health check response of size %d from backend %s, expecting at least %d", reply.size(), ds->getNameWithAddr(), sizeof(*responseHeader));
     return false;
   }
 
   if (responseHeader->id != requestHeader->id) {
     if (g_verboseHealthChecks)
-      infolog("Invalid health check response id %d from backend %s, expecting %d", responseHeader->id, ds.getNameWithAddr(), requestHeader->id);
+      infolog("Invalid health check response id %d from backend %s, expecting %d", responseHeader->id, ds->getNameWithAddr(), requestHeader->id);
     return false;
   }
 
   if (!responseHeader->qr) {
     if (g_verboseHealthChecks)
-      infolog("Invalid health check response from backend %s, expecting QR to be set", ds.getNameWithAddr());
+      infolog("Invalid health check response from backend %s, expecting QR to be set", ds->getNameWithAddr());
     return false;
   }
 
   if (responseHeader->rcode == RCode::ServFail) {
     if (g_verboseHealthChecks)
-      infolog("Backend %s responded to health check with ServFail", ds.getNameWithAddr());
+      infolog("Backend %s responded to health check with ServFail", ds->getNameWithAddr());
     return false;
   }
 
-  if (ds.mustResolve && (responseHeader->rcode == RCode::NXDomain || responseHeader->rcode == RCode::Refused)) {
+  if (ds->mustResolve && (responseHeader->rcode == RCode::NXDomain || responseHeader->rcode == RCode::Refused)) {
     if (g_verboseHealthChecks)
-      infolog("Backend %s responded to health check with %s while mustResolve is set", ds.getNameWithAddr(), responseHeader->rcode == RCode::NXDomain ? "NXDomain" : "Refused");
+      infolog("Backend %s responded to health check with %s while mustResolve is set", ds->getNameWithAddr(), responseHeader->rcode == RCode::NXDomain ? "NXDomain" : "Refused");
     return false;
   }
 
@@ -1829,7 +1854,7 @@ try
 
   if (receivedName != checkName || receivedType != checkType || receivedClass != checkClass) {
     if (g_verboseHealthChecks)
-      infolog("Backend %s responded to health check with an invalid qname (%s vs %s), qtype (%s vs %s) or qclass (%d vs %d)", ds.getNameWithAddr(), receivedName.toLogString(), checkName.toLogString(), QType(receivedType).getName(), QType(checkType).getName(), receivedClass, checkClass);
+      infolog("Backend %s responded to health check with an invalid qname (%s vs %s), qtype (%s vs %s) or qclass (%d vs %d)", ds->getNameWithAddr(), receivedName.toLogString(), checkName.toLogString(), QType(receivedType).getName(), QType(checkType).getName(), receivedClass, checkClass);
     return false;
   }
 
@@ -1838,13 +1863,13 @@ try
 catch(const std::exception& e)
 {
   if (g_verboseHealthChecks)
-    infolog("Error checking the health of backend %s: %s", ds.getNameWithAddr(), e.what());
+    infolog("Error checking the health of backend %s: %s", ds->getNameWithAddr(), e.what());
   return false;
 }
 catch(...)
 {
   if (g_verboseHealthChecks)
-    infolog("Unknown exception while checking the health of backend %s", ds.getNameWithAddr());
+    infolog("Unknown exception while checking the health of backend %s", ds->getNameWithAddr());
   return false;
 }
 
@@ -1958,7 +1983,7 @@ static void healthChecksThread()
         continue;
       dss->lastCheck = 0;
       if(dss->availability==DownstreamState::Availability::Auto) {
-        bool newState=upCheck(*dss);
+        bool newState=upCheck(dss);
         if (newState) {
           /* check succeeded */
           dss->currentCheckFailures = 0;
@@ -2803,7 +2828,7 @@ try
 
   for(auto& dss : g_dstates.getCopy()) { // it is a copy, but the internal shared_ptrs are the real deal
     if(dss->availability==DownstreamState::Availability::Auto) {
-      bool newState=upCheck(*dss);
+      bool newState=upCheck(dss);
       warnlog("Marking downstream %s as '%s'", dss->getNameWithAddr(), newState ? "up" : "down");
       dss->upStatus = newState;
     }

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -94,9 +94,7 @@ string g_outputBuffer;
 
 vector<std::tuple<ComboAddress, bool, bool, int, string, std::set<int>>> g_locals;
 std::vector<std::shared_ptr<TLSFrontend>> g_tlslocals;
-#ifdef HAVE_DNSCRYPT
 std::vector<std::tuple<ComboAddress,std::shared_ptr<DNSCryptContext>,bool, int, string, std::set<int> >> g_dnsCryptLocals;
-#endif
 #ifdef HAVE_EBPF
 shared_ptr<BPFFilter> g_defaultBPFFilter;
 std::vector<std::shared_ptr<DynBPFFilter> > g_dynBPFFilters;
@@ -389,7 +387,7 @@ static bool encryptResponse(char* response, uint16_t* responseLen, size_t respon
   }
   return true;
 }
-#endif
+#endif /* HAVE_DNSCRYPT */
 
 static bool applyRulesToResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr)
 {
@@ -459,7 +457,7 @@ bool processResponse(char** response, uint16_t* responseLen, size_t* responseSiz
       return false;
     }
   }
-#endif
+#endif /* HAVE_DNSCRYPT */
 
   return true;
 }
@@ -513,11 +511,7 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
 try {
   setThreadName("dnsdist/respond");
   auto localRespRulactions = g_resprulactions.getLocal();
-#ifdef HAVE_DNSCRYPT
   char packet[4096 + DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE];
-#else
-  char packet[4096];
-#endif
   static_assert(sizeof(packet) <= UINT16_MAX, "Packet size should fit in a uint16_t");
   /* when the answer is encrypted in place, we need to get a copy
      of the original header before encryption to fill the ring buffer */
@@ -597,12 +591,10 @@ try {
 #ifdef HAVE_PROTOBUF
         dr.uniqueId = std::move(ids->uniqueId);
 #endif
-#ifdef HAVE_DNSCRYPT
         if (ids->dnsCryptQuery) {
           addRoom = DNSCRYPT_MAX_RESPONSE_PADDING_AND_MAC_SIZE;
           dr.dnsCryptQuery = std::move(ids->dnsCryptQuery);
         }
-#endif
 
         memcpy(&cleartextDH, dr.dh, sizeof(cleartextDH));
         if (!processResponse(&response, &responseLen, &responseSize, localRespRulactions, dr, addRoom, rewrittenResponse, ids->cs && ids->cs->muted)) {
@@ -1277,10 +1269,10 @@ static bool isUDPQueryAcceptable(ClientState& cs, LocalHolders& holders, const s
   return true;
 }
 
-#ifdef HAVE_DNSCRYPT
 boost::optional<std::vector<uint8_t>> checkDNSCryptQuery(const ClientState& cs, const char* query, uint16_t& len, std::shared_ptr<DNSCryptQuery>& dnsCryptQuery, time_t now, bool tcp)
 {
   if (cs.dnscryptCtx) {
+#ifdef HAVE_DNSCRYPT
     vector<uint8_t> response;
     uint16_t decryptedQueryLen = 0;
 
@@ -1296,10 +1288,10 @@ boost::optional<std::vector<uint8_t>> checkDNSCryptQuery(const ClientState& cs, 
     }
 
     len = decryptedQueryLen;
+#endif /* HAVE_DNSCRYPT */
   }
   return boost::none;
 }
-#endif /* HAVE_DNSCRYPT */
 
 bool checkQueryHeaders(const struct dnsheader* dh)
 {
@@ -1353,13 +1345,13 @@ static bool prepareOutgoingResponse(LocalHolders& holders, ClientState& cs, DNSQ
   /* in case a rule changed it */
   dq.delayMsec = dr.delayMsec;
 
-  if (!cs.muted) {
 #ifdef HAVE_DNSCRYPT
+  if (!cs.muted) {
     if (!encryptResponse(reinterpret_cast<char*>(dq.dh), &dq.len, dq.size, dq.tcp, dq.dnsCryptQuery, nullptr, nullptr)) {
       return false;
     }
-#endif
   }
+#endif /* HAVE_DNSCRYPT */
 
   if (cacheHit) {
     ++g_stats.cacheHits;
@@ -1507,13 +1499,11 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     gettime(&queryRealTime, true);
 
     std::shared_ptr<DNSCryptQuery> dnsCryptQuery = nullptr;
-#ifdef HAVE_DNSCRYPT
     auto dnsCryptResponse = checkDNSCryptQuery(cs, query, len, dnsCryptQuery, queryRealTime.tv_sec, false);
     if (dnsCryptResponse) {
       sendUDPResponse(cs.udpFD, reinterpret_cast<char*>(dnsCryptResponse->data()), static_cast<uint16_t>(dnsCryptResponse->size()), 0, dest, remote);
       return;
     }
-#endif
 
     struct dnsheader* dh = reinterpret_cast<struct dnsheader*>(query);
     queryId = ntohs(dh->id);
@@ -1599,9 +1589,9 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
       ids->origDest = cs.local;
       ids->destHarvested = false;
     }
-#ifdef HAVE_DNSCRYPT
+
     ids->dnsCryptQuery = std::move(dq.dnsCryptQuery);
-#endif
+
 #ifdef HAVE_PROTOBUF
     ids->uniqueId = std::move(dq.uniqueId);
 #endif
@@ -2604,7 +2594,6 @@ try
     tcpBindsCount++;
   }
 
-#ifdef HAVE_DNSCRYPT
   for(auto& dcLocal : g_dnsCryptLocals) {
     ClientState* cs = new ClientState;
     cs->local = std::get<0>(dcLocal);
@@ -2706,7 +2695,6 @@ try
     g_frontends.push_back(cs);
     tcpBindsCount++;
   }
-#endif
 
   for(auto& frontend : g_tlslocals) {
     ClientState* cs = new ClientState;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -530,9 +530,7 @@ struct IDState
   ComboAddress origDest;                                      // 28
   StopWatch sentTime;                                         // 16
   DNSName qname;                                              // 80
-#ifdef HAVE_DNSCRYPT
   std::shared_ptr<DNSCryptQuery> dnsCryptQuery{nullptr};
-#endif
 #ifdef HAVE_PROTOBUF
   boost::optional<boost::uuids::uuid> uniqueId;
 #endif
@@ -576,9 +574,7 @@ struct ClientState
 {
   std::set<int> cpus;
   ComboAddress local;
-#ifdef HAVE_DNSCRYPT
   std::shared_ptr<DNSCryptContext> dnscryptCtx{nullptr};
-#endif
   shared_ptr<TLSFrontend> tlsFrontend;
   std::atomic<uint64_t> queries{0};
   int udpFD{-1};
@@ -1041,13 +1037,9 @@ bool processResponse(char** response, uint16_t* responseLen, size_t* responseSiz
 
 bool checkQueryHeaders(const struct dnsheader* dh);
 
-#ifdef HAVE_DNSCRYPT
 extern std::vector<std::tuple<ComboAddress, std::shared_ptr<DNSCryptContext>, bool, int, std::string, std::set<int> > > g_dnsCryptLocals;
-
 int handleDNSCryptQuery(char* packet, uint16_t len, std::shared_ptr<DNSCryptQuery> query, uint16_t* decryptedQueryLen, bool tcp, time_t now, std::vector<uint8_t>& response);
-
 boost::optional<std::vector<uint8_t>> checkDNSCryptQuery(const ClientState& cs, const char* query, uint16_t& len, std::shared_ptr<DNSCryptQuery>& dnsCryptQuery, time_t now, bool tcp);
-#endif
 
 bool addXPF(DNSQuestion& dq, uint16_t optionCode);
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1037,15 +1037,13 @@ bool getLuaNoSideEffect(); // set if there were only explicit declarations of _n
 void resetLuaSideEffect(); // reset to indeterminate state
 
 bool responseContentMatches(const char* response, const uint16_t responseLen, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote, unsigned int& consumed);
-bool processResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, int* delayMsec);
-bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope);
+bool processResponse(char** response, uint16_t* responseLen, size_t* responseSize, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, size_t addRoom, std::vector<uint8_t>& rewrittenResponse, bool muted);
 
 bool checkQueryHeaders(const struct dnsheader* dh);
 
 #ifdef HAVE_DNSCRYPT
 extern std::vector<std::tuple<ComboAddress, std::shared_ptr<DNSCryptContext>, bool, int, std::string, std::set<int> > > g_dnsCryptLocals;
 
-bool encryptResponse(char* response, uint16_t* responseLen, size_t responseSize, bool tcp, std::shared_ptr<DNSCryptQuery> dnsCryptQuery, dnsheader** dh, dnsheader* dhCopy);
 int handleDNSCryptQuery(char* packet, uint16_t len, std::shared_ptr<DNSCryptQuery> query, uint16_t* decryptedQueryLen, bool tcp, time_t now, std::vector<uint8_t>& response);
 
 boost::optional<std::vector<uint8_t>> checkDNSCryptQuery(const ClientState& cs, const char* query, uint16_t& len, std::shared_ptr<DNSCryptQuery>& dnsCryptQuery, time_t now, bool tcp);
@@ -1064,6 +1062,6 @@ extern bool g_addEDNSToSelfGeneratedResponses;
 
 static const size_t s_udpIncomingBufferSize{1500};
 
-typedef std::function<void(const ClientState& cs, const char* data, uint16_t dataSize, int delayMsec, const ComboAddress& dest, const ComboAddress& remote)> responseSender;
-std::shared_ptr<DownstreamState> processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& holders, responseSender sender, bool& dropped);
+enum class ProcessQueryResult { Drop, SendAnswer, PassToBackend };
+ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend);
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -61,33 +61,47 @@ typedef std::unordered_map<string, string> QTag;
 struct DNSQuestion
 {
   DNSQuestion(const DNSName* name, uint16_t type, uint16_t class_, unsigned int consumed_, const ComboAddress* lc, const ComboAddress* rem, struct dnsheader* header, size_t bufferSize, uint16_t queryLen, bool isTcp, const struct timespec* queryTime_):
-    qname(name), qtype(type), qclass(class_), local(lc), remote(rem), dh(header), size(bufferSize), consumed(consumed_), len(queryLen), ecsPrefixLength(rem->sin4.sin_family == AF_INET ? g_ECSSourcePrefixV4 : g_ECSSourcePrefixV6), tempFailureTTL(boost::none), tcp(isTcp), queryTime(queryTime_), ecsOverride(g_ECSOverride) { }
+    qname(name), local(lc), remote(rem), dh(header), queryTime(queryTime_), size(bufferSize), consumed(consumed_), tempFailureTTL(boost::none), qtype(type), qclass(class_), len(queryLen), ecsPrefixLength(rem->sin4.sin_family == AF_INET ? g_ECSSourcePrefixV4 : g_ECSSourcePrefixV6), tcp(isTcp), ecsOverride(g_ECSOverride) {
+    const uint16_t* flags = getFlagsFromDNSHeader(dh);
+    origFlags = *flags;
+  }
 
 #ifdef HAVE_PROTOBUF
   boost::optional<boost::uuids::uuid> uniqueId;
 #endif
   Netmask ecs;
-  const DNSName* qname;
-  const uint16_t qtype;
-  const uint16_t qclass;
-  const ComboAddress* local;
-  const ComboAddress* remote;
+  boost::optional<Netmask> subnet;
+  const DNSName* qname{nullptr};
+  const ComboAddress* local{nullptr};
+  const ComboAddress* remote{nullptr};
   std::shared_ptr<QTag> qTag{nullptr};
   std::shared_ptr<std::map<uint16_t, EDNSOptionView> > ednsOptions;
-  struct dnsheader* dh;
+  std::shared_ptr<DNSCryptQuery> dnsCryptQuery{nullptr};
+  std::shared_ptr<DNSDistPacketCache> packetCache{nullptr};
+  struct dnsheader* dh{nullptr};
+  const struct timespec* queryTime{nullptr};
   size_t size;
   unsigned int consumed{0};
+  int delayMsec{0};
+  boost::optional<uint32_t> tempFailureTTL;
+  uint32_t cacheKeyNoECS;
+  uint32_t cacheKey;
+  const uint16_t qtype;
+  const uint16_t qclass;
   uint16_t len;
   uint16_t ecsPrefixLength;
+  uint16_t origFlags;
   uint8_t ednsRCode{0};
-  boost::optional<uint32_t> tempFailureTTL;
   const bool tcp;
-  const struct timespec* queryTime;
   bool skipCache{false};
   bool ecsOverride;
   bool useECS{true};
   bool addXPF{true};
   bool ecsSet{false};
+  bool ecsAdded{false};
+  bool ednsAdded{false};
+  bool useZeroScope{false};
+  bool dnssecOK{false};
 };
 
 struct DNSResponse : DNSQuestion
@@ -1023,11 +1037,9 @@ bool getLuaNoSideEffect(); // set if there were only explicit declarations of _n
 void resetLuaSideEffect(); // reset to indeterminate state
 
 bool responseContentMatches(const char* response, const uint16_t responseLen, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote, unsigned int& consumed);
-bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int* delayMsec, const struct timespec& now);
 bool processResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, int* delayMsec);
-bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags);
 bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope);
-void restoreFlags(struct dnsheader* dh, uint16_t origFlags);
+
 bool checkQueryHeaders(const struct dnsheader* dh);
 
 #ifdef HAVE_DNSCRYPT
@@ -1035,6 +1047,8 @@ extern std::vector<std::tuple<ComboAddress, std::shared_ptr<DNSCryptContext>, bo
 
 bool encryptResponse(char* response, uint16_t* responseLen, size_t responseSize, bool tcp, std::shared_ptr<DNSCryptQuery> dnsCryptQuery, dnsheader** dh, dnsheader* dhCopy);
 int handleDNSCryptQuery(char* packet, uint16_t len, std::shared_ptr<DNSCryptQuery> query, uint16_t* decryptedQueryLen, bool tcp, time_t now, std::vector<uint8_t>& response);
+
+boost::optional<std::vector<uint8_t>> checkDNSCryptQuery(const ClientState& cs, const char* query, uint16_t& len, std::shared_ptr<DNSCryptQuery>& dnsCryptQuery, time_t now, bool tcp);
 #endif
 
 bool addXPF(DNSQuestion& dq, uint16_t optionCode);
@@ -1049,3 +1063,7 @@ extern DNSDistSNMPAgent* g_snmpAgent;
 extern bool g_addEDNSToSelfGeneratedResponses;
 
 static const size_t s_udpIncomingBufferSize{1500};
+
+typedef std::function<void(const ClientState& cs, const char* data, uint16_t dataSize, int delayMsec, const ComboAddress& dest, const ComboAddress& remote)> responseSender;
+std::shared_ptr<DownstreamState> processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& holders, responseSender sender, bool& dropped);
+

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -863,30 +863,10 @@ public:
       return false;
     }
 
-    uint16_t optStart;
-    size_t optLen = 0;
-    bool last = false;
-    const char * packet = reinterpret_cast<const char*>(dq->dh);
-    std::string packetStr(packet, dq->len);
-    int res = locateEDNSOptRR(packetStr, &optStart, &optLen, &last);
-    if (res != 0) {
-      // no EDNS OPT RR
-      return d_extrcode == 0;
-    }
-
-    // root label (1), type (2), class (2), ttl (4) + rdlen (2)
-    if (optLen < 11) {
-      return false;
-    }
-
-    if (optStart < dq->len && packet[optStart] != 0) {
-      // OPT RR Name != '.'
-      return false;
-    }
     EDNS0Record edns0;
-    static_assert(sizeof(EDNS0Record) == sizeof(uint32_t), "sizeof(EDNS0Record) must match sizeof(uint32_t) AKA RR TTL size");
-    // copy out 4-byte "ttl" (really the EDNS0 record), after root label (1) + type (2) + class (2).
-    memcpy(&edns0, packet + optStart + 5, sizeof edns0);
+    if (!getEDNS0Record(*dq, edns0)) {
+      return false;
+    }
 
     return d_extrcode == edns0.extRCode;
   }
@@ -907,30 +887,10 @@ public:
   }
   bool matches(const DNSQuestion* dq) const override
   {
-    uint16_t optStart;
-    size_t optLen = 0;
-    bool last = false;
-    const char * packet = reinterpret_cast<const char*>(dq->dh);
-    std::string packetStr(packet, dq->len);
-    int res = locateEDNSOptRR(packetStr, &optStart, &optLen, &last);
-    if (res != 0) {
-      // no EDNS OPT RR
-      return false;
-    }
-
-    // root label (1), type (2), class (2), ttl (4) + rdlen (2)
-    if (optLen < 11) {
-      return false;
-    }
-
-    if (optStart < dq->len && packetStr.at(optStart) != 0) {
-      // OPT RR Name != '.'
-      return false;
-    }
     EDNS0Record edns0;
-    static_assert(sizeof(EDNS0Record) == sizeof(uint32_t), "sizeof(EDNS0Record) must match sizeof(uint32_t) AKA RR TTL size");
-    // copy out 4-byte "ttl" (really the EDNS0 record), after root label (1) + type (2) + class (2).
-    memcpy(&edns0, packet + optStart + 5, sizeof edns0);
+    if (!getEDNS0Record(*dq, edns0)) {
+      return false;
+    }
 
     return d_version < edns0.version;
   }
@@ -961,8 +921,7 @@ public:
       return false;
     }
 
-    // root label (1), type (2), class (2), ttl (4) + rdlen (2)
-    if (optLen < 11) {
+    if (optLen < optRecordMinimumSize) {
       return false;
     }
 

--- a/pdns/dnsdistdist/test-dnsdistrules_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrules_cc.cc
@@ -22,7 +22,8 @@ BOOST_AUTO_TEST_CASE(test_MaxQPSIPRule) {
   uint16_t qclass = QClass::IN;
   ComboAddress lc("127.0.0.1:53");
   ComboAddress rem("192.0.2.1:42");
-  struct dnsheader* dh = nullptr;
+  struct dnsheader dh;
+  memset(&dh, 0, sizeof(dh));
   size_t bufferSize = 0;
   size_t queryLen = 0;
   bool isTcp = false;
@@ -32,7 +33,7 @@ BOOST_AUTO_TEST_CASE(test_MaxQPSIPRule) {
   /* the internal QPS limiter does not use the real time */
   gettime(&expiredTime);
 
-  DNSQuestion dq(&qname, qtype, qclass, qname.wirelength(), &lc, &rem, dh, bufferSize, queryLen, isTcp, &queryRealTime);
+  DNSQuestion dq(&qname, qtype, qclass, qname.wirelength(), &lc, &rem, &dh, bufferSize, queryLen, isTcp, &queryRealTime);
 
   for (size_t idx = 0; idx < maxQPS; idx++) {
     /* let's use different source ports, it shouldn't matter */

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -1433,8 +1433,7 @@ BOOST_AUTO_TEST_CASE(test_isEDNSOptionInOpt) {
       return false;
     }
 
-    // root label (1), type (2), class (2), ttl (4) + rdlen (2)
-    if (optLen < 11) {
+    if (optLen < optRecordMinimumSize) {
       return false;
     }
 

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -137,7 +137,7 @@ class TestCarbon(DNSDistTest):
         for line in data1.splitlines():
             if expectedStart in line:
                 parts = line.split(b' ')
-                if 'servers-up' in line:
+                if b'servers-up' in line:
                     self.assertEquals(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
                     self.assertEquals(int(parts[1]), 2)
@@ -160,7 +160,7 @@ class TestCarbon(DNSDistTest):
         for line in data2.splitlines():
             if expectedStart in line:
                 parts = line.split(b' ')
-                if 'servers-up' in line:
+                if b'servers-up' in line:
                     self.assertEquals(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
                     self.assertEquals(int(parts[1]), 2)

--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -4,7 +4,11 @@ import json
 import requests
 import time
 import dns
-from dnsdisttests import DNSDistTest, range
+from dnsdisttests import DNSDistTest
+try:
+  range = xrange
+except NameError:
+  pass
 
 class DynBlocksTest(DNSDistTest):
 

--- a/regression-tests.dnsdist/test_EDNSOptions.py
+++ b/regression-tests.dnsdist/test_EDNSOptions.py
@@ -105,7 +105,7 @@ class TestEDNSOptions(EDNSOptionsBase):
         EDNS Options: Cookie
         """
         name = 'cookie.ednsoptions.tests.powerdns.com.'
-        eco = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        eco = cookiesoption.CookiesOption(b'deadbeef', b'deadbeef')
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[eco])
         response = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name,
@@ -192,7 +192,7 @@ class TestEDNSOptions(EDNSOptionsBase):
         EDNS Options: Cookie + ECS6
         """
         name = 'cookie-ecs6.ednsoptions.tests.powerdns.com.'
-        eco = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        eco = cookiesoption.CookiesOption(b'deadbeef', b'deadbeef')
         ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[ecso,eco])
         response = dns.message.make_response(query)
@@ -222,9 +222,9 @@ class TestEDNSOptions(EDNSOptionsBase):
         EDNS Options: Two Cookies + ECS6
         """
         name = 'multiplecookies-ecs6.ednsoptions.tests.powerdns.com.'
-        eco1 = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        eco1 = cookiesoption.CookiesOption(b'deadbeef', b'deadbeef')
         ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
-        eco2 = cookiesoption.CookiesOption('deadc0de', 'deadc0de')
+        eco2 = cookiesoption.CookiesOption(b'deadc0de', b'deadc0de')
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[eco1, ecso, eco2])
         response = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name,
@@ -294,7 +294,7 @@ class TestEDNSOptionsAddingECS(EDNSOptionsBase):
         EDNS Options: Cookie (adding ECS)
         """
         name = 'cookie.ednsoptions-ecs.tests.powerdns.com.'
-        eco = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        eco = cookiesoption.CookiesOption(b'deadbeef', b'deadbeef')
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[eco])
         ecso = clientsubnetoption.ClientSubnetOption('127.0.0.1', 24)
         expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, options=[eco,ecso], payload=512)
@@ -387,7 +387,7 @@ class TestEDNSOptionsAddingECS(EDNSOptionsBase):
         EDNS Options: Cookie + ECS6 (adding ECS)
         """
         name = 'cookie-ecs6.ednsoptions-ecs.tests.powerdns.com.'
-        eco = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        eco = cookiesoption.CookiesOption(b'deadbeef', b'deadbeef')
         ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[ecso,eco])
         ecsoResponse = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128, scope=56)
@@ -419,9 +419,9 @@ class TestEDNSOptionsAddingECS(EDNSOptionsBase):
         EDNS Options: Two Cookies + ECS6
         """
         name = 'multiplecookies-ecs6.ednsoptions.tests.powerdns.com.'
-        eco1 = cookiesoption.CookiesOption('deadbeef', 'deadbeef')
+        eco1 = cookiesoption.CookiesOption(b'deadbeef', b'deadbeef')
         ecso = clientsubnetoption.ClientSubnetOption('2001:DB8::1', 128)
-        eco2 = cookiesoption.CookiesOption('deadc0de', 'deadc0de')
+        eco2 = cookiesoption.CookiesOption(b'deadc0de', b'deadc0de')
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[eco1, ecso, eco2])
         response = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name,

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -188,7 +188,7 @@ class TestProtobuf(DNSDistTest):
         self.assertEquals(msg.id, query.id)
         self.assertTrue(msg.HasField('inBytes'))
         self.assertTrue(msg.HasField('serverIdentity'))
-        self.assertEquals(msg.serverIdentity, self._protobufServerID)
+        self.assertEquals(msg.serverIdentity, self._protobufServerID.encode('utf-8'))
 
         if normalQueryResponse:
           # compare inBytes with length of query/response
@@ -291,7 +291,7 @@ class TestProtobuf(DNSDistTest):
         self.assertEquals(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.CNAME, name, 3600)
-        self.assertEquals(rr.rdata, target)
+        self.assertEquals(rr.rdata.decode('utf-8'), target)
         rr = msg.response.rrs[1]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, target, 3600)
         self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
@@ -319,7 +319,7 @@ class TestProtobuf(DNSDistTest):
         self.assertEquals(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.CNAME, name, 3600)
-        self.assertEquals(rr.rdata, target)
+        self.assertEquals(rr.rdata.decode('utf-8'), target)
         rr = msg.response.rrs[1]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, target, 3600)
         self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')

--- a/regression-tests.dnsdist/test_TCPKeepAlive.py
+++ b/regression-tests.dnsdist/test_TCPKeepAlive.py
@@ -2,7 +2,12 @@
 import struct
 import time
 import dns
-from dnsdisttests import DNSDistTest, range
+from dnsdisttests import DNSDistTest
+
+try:
+  range = xrange
+except NameError:
+  pass
 
 class TestTCPKeepAlive(DNSDistTest):
     """

--- a/regression-tests.dnsdist/test_TCPLimits.py
+++ b/regression-tests.dnsdist/test_TCPLimits.py
@@ -2,7 +2,12 @@
 import struct
 import time
 import dns
-from dnsdisttests import DNSDistTest, range
+from dnsdisttests import DNSDistTest
+
+try:
+  range = xrange
+except NameError:
+  pass
 
 class TestTCPLimits(DNSDistTest):
 
@@ -106,9 +111,10 @@ class TestTCPLimits(DNSDistTest):
                 # sleeping for only one second keeps us below the
                 # idle timeout (setTCPRecvTimeout())
                 time.sleep(1)
-                conn.send('A')
+                conn.send(b'A')
                 count = count + 1
-            except:
+            except Exception as e:
+                print("Exception: %s!" % (e))
                 break
 
         end = time.time()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR refactors the handling of queries and responses a bit so that the existing code for the UDP and TCP paths can be merged into one. This reduces code duplication and will make it easier to add another processing path in the future, like DoH or a more scalable TCP/DoT stack.
It also removes a bit of code duplication in the rules, and create empty objects for the DNSCrypt-related classes when support is disabled, so that we can mostly ignore whether it's enabled in most parts of the code.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
