### PR TITLE
cast usec, avoids a build failure on macOS/Darwin

### DIFF
--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -125,7 +125,7 @@ void visitor(const StatNode* node, const StatNode::Stat& selfstat, const StatNod
 
 const struct timeval operator-(const struct pdns_timeval& lhs, const struct pdns_timeval& rhs)
 {
-  struct timeval a{lhs.tv_sec, lhs.tv_usec}, b{rhs.tv_sec, rhs.tv_usec};
+  struct timeval a{lhs.tv_sec, static_cast<suseconds_t>(lhs.tv_usec)}, b{rhs.tv_sec, static_cast<suseconds_t>(rhs.tv_usec)};
   return operator-(a,b);
 }
 


### PR DESCRIPTION
### Short description
Before:
```
  CXX      dnsscope.o
dnsscope.cc:128:32: error: non-constant-expression cannot be narrowed from type 'uint32_t' (aka 'unsigned int') to '__darwin_suseconds_t' (aka 'int') in initializer list [-Wc++11-narrowing]
  struct timeval a{lhs.tv_sec, lhs.tv_usec}, b{rhs.tv_sec, rhs.tv_usec};
                               ^~~~~~~~~~~
dnsscope.cc:128:32: note: insert an explicit cast to silence this issue
  struct timeval a{lhs.tv_sec, lhs.tv_usec}, b{rhs.tv_sec, rhs.tv_usec};
                               ^~~~~~~~~~~
                               static_cast<__darwin_suseconds_t>( )
dnsscope.cc:128:60: error: non-constant-expression cannot be narrowed from type 'uint32_t' (aka 'unsigned int') to '__darwin_suseconds_t' (aka 'int') in initializer list [-Wc++11-narrowing]
  struct timeval a{lhs.tv_sec, lhs.tv_usec}, b{rhs.tv_sec, rhs.tv_usec};
                                                           ^~~~~~~~~~~
dnsscope.cc:128:60: note: insert an explicit cast to silence this issue
  struct timeval a{lhs.tv_sec, lhs.tv_usec}, b{rhs.tv_sec, rhs.tv_usec};
                                                           ^~~~~~~~~~~
                                                           static_cast<__darwin_suseconds_t>( )
2 errors generated.
```


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
