### PR TITLE
DNSNameSet and QNameSetRule

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -389,6 +389,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "newServer", true, "{address=\"ip:port\", qps=1000, order=1, weight=10, pool=\"abuse\", retries=5, tcpConnectTimeout=5, tcpSendTimeout=30, tcpRecvTimeout=30, checkName=\"a.root-servers.net.\", checkType=\"A\", maxCheckFailures=1, mustResolve=false, useClientSubnet=true, source=\"address|interface name|address@interface\", sockets=1}", "instantiate a server" },
   { "newServerPolicy", true, "name, function", "create a policy object from a Lua function" },
   { "newSuffixMatchNode", true, "", "returns a new SuffixMatchNode" },
+  { "newDNSNameSet", true, "", "returns a new DNSNameSet" },
   { "NoRecurseAction", true, "", "strip RD bit from the question, let it go through" },
   { "PoolAction", true, "poolname", "set the packet into the specified pool" },
   { "printDNSCryptProviderFingerprint", true, "\"/path/to/providerPublic.key\"", "display the fingerprint of the provided resolver public key" },

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -180,7 +180,7 @@ void setupLuaBindings(bool client)
   /* DNSNameSet */
   g_lua.registerFunction<string(DNSNameSet::*)()>("toString", [](const DNSNameSet&dns ) { return dns.toString(); });
   g_lua.registerFunction<void(DNSNameSet::*)(DNSName&)>("add", [](DNSNameSet& dns, DNSName& dn) { dns.insert(dn); });
-  g_lua.registerFunction<bool(DNSNameSet::*)(DNSName&)>("contains", [](DNSNameSet& dns, DNSName& dn) { return dns.find(dn) != dns.end(); });
+  g_lua.registerFunction<bool(DNSNameSet::*)(DNSName&)>("check", [](DNSNameSet& dns, DNSName& dn) { return dns.find(dn) != dns.end(); });
   g_lua.registerFunction("delete",(size_t (DNSNameSet::*)(const DNSName&)) &DNSNameSet::erase);
   g_lua.registerFunction("size",(size_t (DNSNameSet::*)() const) &DNSNameSet::size);
   g_lua.registerFunction("clear",(void (DNSNameSet::*)()) &DNSNameSet::clear);

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -175,6 +175,16 @@ void setupLuaBindings(bool client)
   g_lua.registerFunction<string(DNSName::*)()>("toString", [](const DNSName&dn ) { return dn.toString(); });
   g_lua.writeFunction("newDNSName", [](const std::string& name) { return DNSName(name); });
   g_lua.writeFunction("newSuffixMatchNode", []() { return SuffixMatchNode(); });
+  g_lua.writeFunction("newDNSNameSet", []() { return DNSNameSet(); });
+
+  /* DNSNameSet */
+  g_lua.registerFunction<string(DNSNameSet::*)()>("toString", [](const DNSNameSet&dns ) { return dns.toString(); });
+  g_lua.registerFunction<void(DNSNameSet::*)(DNSName&)>("add", [](DNSNameSet& dns, DNSName& dn) { dns.insert(dn); });
+  g_lua.registerFunction<bool(DNSNameSet::*)(DNSName&)>("contains", [](DNSNameSet& dns, DNSName& dn) { return dns.find(dn) != dns.end(); });
+  g_lua.registerFunction("delete",(size_t (DNSNameSet::*)(const DNSName&)) &DNSNameSet::erase);
+  g_lua.registerFunction("size",(size_t (DNSNameSet::*)() const) &DNSNameSet::size);
+  g_lua.registerFunction("clear",(void (DNSNameSet::*)()) &DNSNameSet::clear);
+  g_lua.registerFunction("empty",(bool (DNSNameSet::*)()) &DNSNameSet::empty);
 
   /* SuffixMatchNode */
   g_lua.registerFunction("add",(void (SuffixMatchNode::*)(const DNSName&)) &SuffixMatchNode::add);

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -459,4 +459,8 @@ void setupLuaRules()
   g_lua.registerFunction<std::shared_ptr<DNSRule>(std::shared_ptr<TimedIPSetRule>::*)()>("slice", [](std::shared_ptr<TimedIPSetRule> tisr) {
       return std::dynamic_pointer_cast<DNSRule>(tisr);
     });
+
+  g_lua.writeFunction("QNameSetRule", [](const DNSNameSet& names) {
+      return std::shared_ptr<DNSRule>(new QNameSetRule(names));
+    });
 }

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -545,7 +545,7 @@ private:
 
 class QNameSetRule : public DNSRule {
 public:
-    QNameSetRule(const DNSNameSet names) : qname_idx(names) {}
+    QNameSetRule(const DNSNameSet& names) : qname_idx(names) {}
 
     bool matches(const DNSQuestion* dq) const override {
         return qname_idx.find(*dq->qname) != qname_idx.end();

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -530,6 +530,7 @@ public:
   QNameRule(const DNSName& qname) : d_qname(qname)
   {
   }
+
   bool matches(const DNSQuestion* dq) const override
   {
     return d_qname==*dq->qname;
@@ -542,6 +543,22 @@ private:
   DNSName d_qname;
 };
 
+class QNameSetRule : public DNSRule {
+public:
+    QNameSetRule(const DNSNameSet names) : qname_idx(names) {}
+
+    bool matches(const DNSQuestion* dq) const override {
+        return qname_idx.find(*dq->qname) != qname_idx.end();
+    }
+
+    string toString() const override {
+        std::stringstream ss;
+        ss << "qname in DNSNameSet(" << qname_idx.size() << " FQDNs)";
+        return ss.str();
+    }
+private:
+    DNSNameSet qname_idx;
+};
 
 class QTypeRule : public DNSRule
 {

--- a/pdns/dnsdistdist/docs/reference/dnsnameset.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsnameset.rst
@@ -1,0 +1,60 @@
+.. _DNSNameSet:
+
+DNSNameSet objects
+==================
+
+A :class:`DNSNameSet` object is a set of :class:`DNSName` objects. 
+Based on std::set (usually implemented as red-black trees).
+Creating a ``DNSName`` is done with the :func:`newDNSNameSet`::
+
+  myset = newDNSNameSet()
+
+The set can be filled by func:`DNSNameSet:add`::
+
+  myset.add(newDNSName("domain1.tld"))
+  myset.add(newDNSName("domain2.tld"))
+
+Functions and methods of a ``DNSNameSet``
+-----------------------------------------
+
+.. function:: newDNSNameSet(name) -> DNSNameSet
+
+  Returns the :class:`DNSNameSet`.
+
+.. class:: DNSNameSet
+
+  A ``DNSNameSet`` object is a set of :class:`DNSName` objects.
+
+  .. method:: DNSNameSet:add(name)
+
+    Adds the name to the set.
+
+    :param DNSName name The name to add.
+
+  .. method:: DNSNameSet:empty() -> bool
+
+    Returns true is the DNSNameSet is empty.
+
+  .. method:: DNSNameSet:clear()
+
+    Clean up the set.
+
+  .. method:: DNSNameSet:toString() -> string
+
+    Returns a human-readable form of the DNSName.
+
+  .. method:: DNSNameSet:size() -> int
+
+    Returns the number of names in the set.
+
+  .. method:: DNSNameSet:delete(name) -> int
+
+    Removes the name from the set. Returns the number of deleted elements.
+
+   :param DNSName name The name to remove.
+
+  .. method:: DNSNameSet:contains(name) -> bool
+
+    Returns true if the set contains the name.
+
+   :param DNSname name The name.

--- a/pdns/dnsdistdist/docs/reference/dnsnameset.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsnameset.rst
@@ -4,7 +4,7 @@ DNSNameSet objects
 ==================
 
 A :class:`DNSNameSet` object is a set of :class:`DNSName` objects. 
-Based on std::set (usually implemented as red-black trees).
+Based on std::unordered_set (hash table).
 Creating a ``DNSName`` is done with the :func:`newDNSNameSet`::
 
   myset = newDNSNameSet()

--- a/pdns/dnsdistdist/docs/reference/dnsnameset.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsnameset.rst
@@ -53,7 +53,7 @@ Functions and methods of a ``DNSNameSet``
 
    :param DNSName name The name to remove.
 
-  .. method:: DNSNameSet:contains(name) -> bool
+  .. method:: DNSNameSet:check(name) -> bool
 
     Returns true if the set contains the name.
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -610,6 +610,11 @@ These ``DNSRule``\ s be one of the following items:
 
    :param string qname: Qname to match
 
+.. function:: QNameSetRule(set)
+   Matches if the set contains qname.
+
+  :param DNSNameSet set: Set with qnames.
+
 .. function:: QNameLabelsCountRule(min, max)
 
   Matches if the qname has less than ``min`` or more than ``max`` labels.

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -611,9 +611,11 @@ These ``DNSRule``\ s be one of the following items:
    :param string qname: Qname to match
 
 .. function:: QNameSetRule(set)
-   Matches if the set contains qname.
+  Matches if the set contains excact qname.
 
-  :param DNSNameSet set: Set with qnames.
+   To match subdomain names, see :func:`SuffixMatchNodeRule`.
+
+   :param DNSNameSet set: Set with qnames.
 
 .. function:: QNameLabelsCountRule(min, max)
 
@@ -717,6 +719,8 @@ These ``DNSRule``\ s be one of the following items:
 
   Matches based on a group of domain suffixes for rapid testing of membership.
   Pass true as second parameter to prevent listing of all domains matched.
+
+  To match domain names exactly, see :func:`QNameSetRule`.
 
   :param SuffixMatchNode smb: The SuffixMatchNode to match on
   :param bool quiet: Do not return the list of matched domains. Default is false.

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -28,6 +28,7 @@
 #include <stdexcept>
 #include <sstream>
 #include <iterator>
+#include <unordered_set>
 
 #include <boost/version.hpp>
 
@@ -379,7 +380,7 @@ bool DNSName::operator==(const DNSName& rhs) const
 
 extern const DNSName g_rootdnsname, g_wildcarddnsname;
 
-struct DNSNameSet: public std::set<DNSName> {
+struct DNSNameSet: public std::unordered_set<DNSName> {
     std::string toString() const {
         std::ostringstream oss;
         std::copy(begin(), end(), std::ostream_iterator<DNSName>(oss, "\n"));

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -26,6 +26,8 @@
 #include <deque>
 #include <strings.h>
 #include <stdexcept>
+#include <sstream>
+#include <iterator>
 
 #include <boost/version.hpp>
 
@@ -376,3 +378,11 @@ bool DNSName::operator==(const DNSName& rhs) const
 }
 
 extern const DNSName g_rootdnsname, g_wildcarddnsname;
+
+struct DNSNameSet: public std::set<DNSName> {
+    std::string toString() const {
+        std::ostringstream oss;
+        std::copy(begin(), end(), std::ostream_iterator<DNSName>(oss, "\n"));
+        return oss.str();
+    }
+};


### PR DESCRIPTION
### Short description
Set of DNSName based on std::set.
Query rule for test if set contains qname.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
