### PR TITLE
move MIB from Lua docs to metrics docs

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/hooks.rst
+++ b/pdns/recursordist/docs/lua-scripting/hooks.rst
@@ -316,11 +316,6 @@ For example, to send a custom SNMP trap containing the qname from the
       return false
     end
 
-MIB
-^^^
-
-.. literalinclude:: ../../RECURSOR-MIB.txt
-
 .. _hooks-maintenance-callback:
 
 Maintenance callback

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -47,6 +47,11 @@ Sending metrics over SNMP
 
 The recursor can export statistics over SNMP and send traps from :doc:`Lua <lua-scripting/index>`, provided support is compiled into the Recursor and :ref:`setting-snmp-agent` set.
 
+MIB
+^^^
+
+.. literalinclude:: ../RECURSOR-MIB.txt
+
 Getting Metrics from the Recursor
 ---------------------------------
 


### PR DESCRIPTION
### Short description
I was confused to see the MIB in the Lua docs, where, at best, one needs to know the trap OID.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
