### PR TITLE
Set IP(V6)_RECVERR socket option to get notified of more than just port unreachable errors on Linux.

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1101,6 +1101,22 @@ bool isNonBlocking(int sock)
   return flags & O_NONBLOCK;
 }
 
+bool setReceiveSocketErrors(int sock, int af)
+{
+#ifdef __linux__
+  int tmp = 1, ret;
+  if (af == AF_INET) {
+    ret = setsockopt(sock, IPPROTO_IP, IP_RECVERR, &tmp, sizeof(tmp));
+  } else {
+    ret = setsockopt(sock, IPPROTO_IPV6, IPV6_RECVERR, &tmp, sizeof(tmp));
+  }
+  if (ret < 0) {
+    throw PDNSException(string("Setsockopt failed: ") + strerror(errno));
+  }
+#endif
+  return true;
+}
+
 // Closes a socket.
 int closesocket( int socket )
 {

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -534,6 +534,7 @@ bool setNonBlocking( int sock );
 bool setTCPNoDelay(int sock);
 bool setReuseAddr(int sock);
 bool isNonBlocking(int sock);
+bool setReceiveSocketErrors(int sock, int af);
 int closesocket(int fd);
 bool setCloseOnExec(int sock);
 uint64_t udpErrorStats(const std::string& str);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -623,6 +623,7 @@ public:
     if(!tries)
       throw PDNSException("Resolver binding to local query client socket on "+sin.toString()+": "+stringerror());
 
+    setReceiveSocketErrors(ret, family);
     setNonBlocking(ret);
     return ret;
   }


### PR DESCRIPTION
See https://sourceware.org/bugzilla/show_bug.cgi?id=24047

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
On Linux, by default only some icmp errors received are propagated upward.
By setting the right socket option, more icmp errors are reported as failed recv calls with the proper errno set. Specifcally host unreachable and net unreachable are interesting.

This has the effect that in the cases where such an icmp message is received, we actively abort the receive and continue with alternatives, instead of needing to wait for a timeout.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
