### PR TITLE
Document the removal of api-readonly for the pdns-auth as well

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -154,6 +154,8 @@ Static pre-shared authentication key for access to the REST API.
 -  Default: no
 
 .. versionadded:: 4.0.0
+.. versionchanged:: 4.2.0
+This setting has been removed in 4.2.0.
 
 Disallow data modification through the REST API when set.
 


### PR DESCRIPTION
### Short description
#6845 removed support for api-readonly, but only documented that for the recursor


