### PR TITLE
auth web: make max request/response body size configurable

### DIFF
--- a/docs/http-api/index.rst
+++ b/docs/http-api/index.rst
@@ -19,6 +19,7 @@ The following webserver related configuration items are available:
 * :ref:`setting-webserver-password`: If set, viewers will have to enter this plaintext password in order to gain access to the statistics, in addition to entering the configured API key on the index page.
 * :ref:`setting-webserver-port`: Port to bind the webserver to.
 * :ref:`setting-webserver-allow-from`: Netmasks that are allowed to connect to the webserver
+* :ref:`setting-webserver-max-bodysize`: Maximum request/response body size in megabytes
 
 Enabling the API
 ----------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1665,6 +1665,17 @@ The value between the hooks is a UUID that is generated for each request. This c
 .. note::
   The webserver logs these line on the NOTICE level. The :ref:`setting-loglevel` seting must be 5 or higher for these lines to end up in the log.
 
+.. _setting-webserver-max-bodysize:
+
+``webserver-max-bodysize``
+--------------------------
+.. versionadded:: 4.2.0
+
+-  Integer
+-  Default: 2
+
+Maximum request/response body size in megabytes.
+
 .. _setting-webserver-password:
 
 ``webserver-password``

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -151,6 +151,7 @@ void declareArguments()
   ::arg().set("webserver-password","Password required for accessing the webserver")="";
   ::arg().set("webserver-allow-from","Webserver/API access is only allowed from these subnets")="127.0.0.1,::1";
   ::arg().set("webserver-loglevel", "Amount of logging in the webserver (none, normal, detailed)") = "normal";
+  ::arg().set("webserver-max-bodysize","Webserver/API maximum request/response body size in megabytes")="2";
 
   ::arg().setSwitch("do-ipv6-additional-processing", "Do AAAA additional processing")="yes";
   ::arg().setSwitch("query-logging","Hint backends that queries should be logged")="no";

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1725,17 +1725,6 @@ The value between the hooks is a UUID that is generated for each request. This c
 .. note::
   The webserver logs these line on the NOTICE level. The :ref:`settings-loglevel` seting must be 5 or higher for these lines to end up in the log.
 
-.. _setting-webserver-max-bodysize:
-
-``webserver-max-bodysize``
---------------------------
-.. versionadded:: 4.2.0
-
--  Integer
--  Default: 2
-
-Maximum request/response body size in megabytes.
-
 .. _setting-webserver-password:
 
 ``webserver-password``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1729,6 +1729,8 @@ The value between the hooks is a UUID that is generated for each request. This c
 
 ``webserver-max-bodysize``
 --------------------------
+.. versionadded:: 4.2.0
+
 -  Integer
 -  Default: 2
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1725,6 +1725,15 @@ The value between the hooks is a UUID that is generated for each request. This c
 .. note::
   The webserver logs these line on the NOTICE level. The :ref:`settings-loglevel` seting must be 5 or higher for these lines to end up in the log.
 
+.. _setting-webserver-max-bodysize:
+
+``webserver-max-bodysize``
+--------------------------
+-  Integer
+-  Default: 2
+
+Maximum request/response body size in megabytes.
+
 .. _setting-webserver-password:
 
 ``webserver-password``

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -358,7 +358,7 @@ void WebServer::serveConnection(std::shared_ptr<Socket> client) const {
     try {
       while(!req.complete) {
         int bytes;
-        char buf[1024];
+        char buf[16000];
         bytes = client->readWithTimeout(buf, sizeof(buf), timeout);
         if (bytes > 0) {
           string data = string(buf, bytes);

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -344,12 +344,14 @@ void WebServer::serveConnection(std::shared_ptr<Socket> client) const {
 
   HttpRequest req(logprefix);
   HttpResponse resp;
+  resp.max_response_size=d_maxbodysize;
   ComboAddress remote;
   string reply;
 
   try {
     YaHTTP::AsyncRequestLoader yarl;
     yarl.initialize(&req);
+    req.max_request_size=d_maxbodysize;
     int timeout = 5;
     client->setNonBlocking();
 
@@ -406,7 +408,8 @@ void WebServer::serveConnection(std::shared_ptr<Socket> client) const {
 WebServer::WebServer(const string &listenaddress, int port) :
   d_listenaddress(listenaddress),
   d_port(port),
-  d_server(nullptr)
+  d_server(nullptr),
+  d_maxbodysize(2*1024*1024)
 {
 }
 

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -171,6 +171,10 @@ public:
     d_webserverPassword = password;
   }
 
+  void setMaxBodySize(ssize_t s) { // in megabytes
+    d_maxbodysize = s * 1024 * 1024;
+  }
+
   void setACL(const NetmaskGroup &nmg) {
     d_acl = nmg;
   }
@@ -237,6 +241,8 @@ protected:
 
   std::string d_webserverPassword;
   bool d_registerWebHandlerCalled{false};
+
+  ssize_t d_maxbodysize; // in bytes
 
   NetmaskGroup d_acl;
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -78,6 +78,8 @@ AuthWebServer::AuthWebServer() :
     acl.toMasks(::arg()["webserver-allow-from"]);
     d_ws->setACL(acl);
 
+    d_ws->setMaxBodySize(::arg().asNum("webserver-max-bodysize"));
+
     d_ws->bind();
   }
 }


### PR DESCRIPTION
### Short description
Because some people have big zones.

Bumping the buffer size from 1024 to 16000 changes the read time for a 4 megabyte request from 2 minutes to around 10 seconds.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
