### PR TITLE
Clearified hot to automatically load a non *.conf

### DIFF
--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -41,6 +41,12 @@ Global configuration
   Include configuration files from ``path``.
 
   :param str path: The directory to load configuration files from. Each file must end in ``.conf``.
+  
+To automical load ``downstream_servers.lua`` configuration file, you have to load it from your dnsdist.conf with
+
+.. code-block:: lua
+
+  dofile('/etc/dnsdist/conf/downstream_servers.lua')
 
 Listen Sockets
 ~~~~~~~~~~~~~~
@@ -284,15 +290,13 @@ Ringbuffers
 ~~~~~~~~~~~
 
 .. function:: setRingBuffersLockRetries(num)
-
   .. versionadded:: 1.3.0
 
   Set the number of shards to attempt to lock without blocking before giving up and simply blocking while waiting for the next shard to be available
 
-  :param int num: The maximum number of attempts. Defaults to 5 if there is more than one shard, 0 otherwise.
+  :param int num: The maximum number of attempts. Defaults to 5 if there are more than one shard, 0 otherwise.
 
 .. function:: setRingBuffersSize(num [, numberOfShards])
-
   .. versionchanged:: 1.3.0
     ``numberOfShards`` optional parameter added.
 
@@ -308,10 +312,13 @@ Servers
               newServer(server_table)
 
   .. versionchanged:: 1.3.0
-    Added ``checkClass``, ``sockets`` and ``checkFunction`` to server_table.
+    - Added ``checkClass`` to server_table.
+    - Added ``sockets`` to server_table
+    - Added ``checkFunction`` to server_table
 
   .. versionchanged:: 1.3.4
-    Added ``checkTimeout`` and ``rise`` to server_table.
+    - Added ``checkTimeout`` to server_table
+    - Added ``rise`` to server_table.
 
   Add a new backend server. Call this function with either a string::
 


### PR DESCRIPTION
For newbies there are no other information about how to load the lua configuration files under dnsdist, this is intended to give a view of this

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
