### PR TITLE
Use the correct property names for the tsig values in a zone object

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -946,14 +946,14 @@ definitions:
         items:
           type: string
         description: 'MAY be sent in client bodies during creation, and MUST NOT be sent by the server. Simple list of strings of nameserver names, including the trailing dot. Not required for slave zones.'
-      tsig_master_key_ids:
+      master_tsig_key_ids:
         type: array
         items:
           type: string
         description: 'The id of the TSIG keys used for master operation in this zone'
         externalDocs:
           url: 'https://doc.powerdns.com/authoritative/tsig.html#provisioning-outbound-axfr-access'
-      tsig_slave_key_ids:
+      slave_tsig_key_ids:
         type: array
         items:
           type: string


### PR DESCRIPTION
### Short description
Fix a small discrepancy between the swagger spec and the actual code concerning the tsig zone properties

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
