### PR TITLE
Improve error reporting with garbage in the 'master' field of the database

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -339,12 +339,16 @@ void GSQLBackend::getUnfreshSlaveInfos(vector<DomainInfo> *unfreshDomains)
 
   vector<DomainInfo> allSlaves;
 
+  bool loggedAssertRowColumns = false;
   for(const auto& row : d_result) { // id,name,master,last_check
     DomainInfo sd;
     try {
       ASSERT_ROW_COLUMNS("info-all-slaves-query", row, 4);
     } catch(const PDNSException &e) {
-      g_log<<Logger::Warning<<e.reason<<endl;
+      if (!loggedAssertRowColumns) {
+        g_log<<Logger::Warning<<e.reason<<endl;
+      }
+      loggedAssertRowColumns = true;
       continue;
     }
 

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1304,8 +1304,13 @@ void GSQLBackend::getAllDomains(vector<DomainInfo> *domains, bool include_disabl
       if (!row[4].empty()) {
         vector<string> masters;
         stringtok(masters, row[4], " ,\t");
-        for(const auto& m : masters)
-          di.masters.emplace_back(m, 53);
+        for(const auto& m : masters) {
+          try {
+            di.masters.emplace_back(m, 53);
+          } catch(const PDNSException &e) {
+            throw PDNSException("Could not parse master address (" + m + ") for zone '" + di.zone.toLogString() + "': " + e.reason);
+          }
+        }
       }
 
       SOAData sd;

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1312,7 +1312,7 @@ void GSQLBackend::getAllDomains(vector<DomainInfo> *domains, bool include_disabl
           try {
             di.masters.emplace_back(m, 53);
           } catch(const PDNSException &e) {
-            throw PDNSException("Could not parse master address (" + m + ") for zone '" + di.zone.toLogString() + "': " + e.reason);
+            g_log<<Logger::Warning<<"Could not parse master address ("<<m<<") for zone '"<<di.zone<<"': "<<e.reason;
           }
         }
       }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1679,7 +1679,11 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       domains.push_back(di);
     }
   } else {
-    B.getAllDomains(&domains, true); // incl. disabled
+    try {
+      B.getAllDomains(&domains, true); // incl. disabled
+    } catch(const PDNSException &e) {
+      throw HttpInternalServerErrorException("Could not retrieve all domain information: " + e.reason);
+    }
   }
 
   Json::array doc;


### PR DESCRIPTION
### Short description
This improves the error reporting when running in `slave` mode, as well as via `pdnsutil` and the API.

Before, we should silently ignore slave zones with broken IPs in 'master'. Now we report on this:

```
Mar 12 16:25:55 Could not parse master address (foo) for zone 'example.com': Unable to convert presentation address 'foo'
Mar 12 16:25:55 No masters for slave zone 'example.com' found in the database
Mar 12 16:25:55 No new unfresh slave domains, 0 queued for AXFR already, 0 in progress
```

```
$ pdnsutil check-zone example.com
[Error] non-IP address for masters: Unable to convert presentation address 'foo'
[Error] No SOA record present, or active, in zone 'example.com'
Checked 0 records of 'example.com', 2 errors, 0 warnings.
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)