### PR TITLE
Fix error in setQueryRate warning example

### DIFF
--- a/pdns/dnsdistdist/docs/guides/dynblocks.rst
+++ b/pdns/dnsdistdist/docs/guides/dynblocks.rst
@@ -82,5 +82,5 @@ action is applied.
 
   local dbr = dynBlockRulesGroup()
   -- generate a warning above 100 qps for 10s, and start dropping incoming queries above 300 qps for 10s
-  dbr:setQueryRate(300, 10, "Exceeded query rate", 60, 100)
+  dbr:setQueryRate(300, 10, "Exceeded query rate", 60, DNSAction.Drop, 100)
 


### PR DESCRIPTION
### Short description

The correct syntax for setQueryRate is:
```
:setQueryRate(rate, seconds, reason, blockingTime[, action[, warningRate]])
```

The guide forgot to include the "action" parameter in the warningRate example. Note that because the actions are integers, this was valid LUA. It even worked, but the rule wouldn't show up in showDynBlocks()

### Checklist
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

