### PR TITLE
remotebackend: http connector - Properly escape parameters

### DIFF
--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -35,7 +35,22 @@
 #endif
 
 HTTPConnector::HTTPConnector(std::map<std::string,std::string> options): d_socket(nullptr) {
+
+    if (options.find("url") == options.end()) {
+      throw PDNSException("Cannot find 'url' option in the remote backend HTTP connector's parameters");
+    }
+
     this->d_url = options.find("url")->second;
+
+    try {
+      YaHTTP::URL url(d_url);
+      d_host = url.host;
+      d_port = url.port;
+    }
+    catch(const std::exception& e) {
+      throw PDNSException("Error parsing the 'url' option provided to the remote backend HTTP connector: " + std::string(e.what()));
+    }
+
     if (options.find("url-suffix") != options.end()) {
       this->d_url_suffix = options.find("url-suffix")->second;
     } else {
@@ -320,44 +335,39 @@ int HTTPConnector::send_message(const Json& input) {
 
     this->d_socket.reset();
 
-    if (req.url.protocol == "unix") {
-      // connect using unix socket
-    } else {
-      // connect using tcp
-      struct addrinfo *gAddr, *gAddrPtr, hints;
-      std::string sPort = std::to_string(req.url.port);
-      memset(&hints,0,sizeof hints);
-      hints.ai_family = AF_UNSPEC;
-      hints.ai_flags = AI_ADDRCONFIG; 
-      hints.ai_socktype = SOCK_STREAM;
-      hints.ai_protocol = 6; // tcp
-      if ((ec = getaddrinfo(req.url.host.c_str(), sPort.c_str(), &hints, &gAddr)) == 0) {
-        // try to connect to each address. 
-        gAddrPtr = gAddr;
-  
-        while(gAddrPtr) {
-          try {
-            d_socket = std::unique_ptr<Socket>(new Socket(gAddrPtr->ai_family, gAddrPtr->ai_socktype, gAddrPtr->ai_protocol));
-            d_addr.setSockaddr(gAddrPtr->ai_addr, gAddrPtr->ai_addrlen);
-            d_socket->connect(d_addr);
-            d_socket->setNonBlocking();
-            d_socket->writenWithTimeout(out.str().c_str(), out.str().size(), timeout);
-            rv = 1;
-          } catch (NetworkError& ne) {
-            g_log<<Logger::Error<<"While writing to HTTP endpoint "<<d_addr.toStringWithPort()<<": "<<ne.what()<<std::endl;
-          } catch (...) {
-            g_log<<Logger::Error<<"While writing to HTTP endpoint "<<d_addr.toStringWithPort()<<": exception caught"<<std::endl;
-          }
+    // connect using tcp
+    struct addrinfo *gAddr, *gAddrPtr, hints;
+    std::string sPort = std::to_string(d_port);
+    memset(&hints,0,sizeof hints);
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_flags = AI_ADDRCONFIG;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    if ((ec = getaddrinfo(d_host.c_str(), sPort.c_str(), &hints, &gAddr)) == 0) {
+      // try to connect to each address.
+      gAddrPtr = gAddr;
 
-          if (rv > -1) break;
-          d_socket.reset();
-          gAddrPtr = gAddrPtr->ai_next;
-          
+      while(gAddrPtr) {
+        try {
+          d_socket = std::unique_ptr<Socket>(new Socket(gAddrPtr->ai_family, gAddrPtr->ai_socktype, gAddrPtr->ai_protocol));
+          d_addr.setSockaddr(gAddrPtr->ai_addr, gAddrPtr->ai_addrlen);
+          d_socket->connect(d_addr);
+          d_socket->setNonBlocking();
+          d_socket->writenWithTimeout(out.str().c_str(), out.str().size(), timeout);
+          rv = 1;
+        } catch (NetworkError& ne) {
+          g_log<<Logger::Error<<"While writing to HTTP endpoint "<<d_addr.toStringWithPort()<<": "<<ne.what()<<std::endl;
+        } catch (...) {
+          g_log<<Logger::Error<<"While writing to HTTP endpoint "<<d_addr.toStringWithPort()<<": exception caught"<<std::endl;
         }
-        freeaddrinfo(gAddr);
-      } else {
-        g_log<<Logger::Error<<"Unable to resolve " << req.url.host << ": " << gai_strerror(ec) << std::endl;
+
+        if (rv > -1) break;
+        d_socket.reset();
+        gAddrPtr = gAddrPtr->ai_next;
       }
+      freeaddrinfo(gAddr);
+    } else {
+      g_log<<Logger::Error<<"Unable to resolve " << d_host << ": " << gai_strerror(ec) << std::endl;
     }
 
     return rv;

--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -71,7 +71,7 @@ HTTPConnector::~HTTPConnector() {
 void HTTPConnector::addUrlComponent(const Json &parameters, const string& element, std::stringstream& ss) {
     std::string sparam;
     if (parameters[element] != Json())
-       ss << "/" << asString(parameters[element]);
+       ss << "/" << YaHTTP::Utility::encodeURL(asString(parameters[element]), false);
 }
 
 std::string HTTPConnector::buildMemberListArgs(std::string prefix, const Json& args) {
@@ -81,9 +81,9 @@ std::string HTTPConnector::buildMemberListArgs(std::string prefix, const Json& a
         if (pair.second.is_bool()) {
           stream << (pair.second.bool_value()?"1":"0");
         } else if (pair.second.is_null()) {
-          stream << prefix << "[" << pair.first << "]=";
+          stream << prefix << "[" << YaHTTP::Utility::encodeURL(pair.first, false) << "]=";
         } else {
-          stream << prefix << "[" << pair.first << "]=" << this->asString(pair.second);
+          stream << prefix << "[" << YaHTTP::Utility::encodeURL(pair.first, false) << "]=" << YaHTTP::Utility::encodeURL(this->asString(pair.second), false);
         }
         stream << "&";
     }

--- a/modules/remotebackend/pipeconnector.cc
+++ b/modules/remotebackend/pipeconnector.cc
@@ -24,7 +24,7 @@
 #endif
 #include "remotebackend.hh"
 
-PipeConnector::PipeConnector(std::map<std::string,std::string> optionsMap) {
+PipeConnector::PipeConnector(std::map<std::string,std::string> optionsMap): d_pid(-1)  {
   if (optionsMap.count("command") == 0) {
     g_log<<Logger::Error<<"Cannot find 'command' option in connection string"<<endl;
     throw PDNSException();
@@ -37,8 +37,6 @@ PipeConnector::PipeConnector(std::map<std::string,std::string> optionsMap) {
      d_timeout = std::stoi(optionsMap.find("timeout")->second);
   }
 
-  d_pid = -1;
-  d_fp = NULL;
   d_fd1[0] = d_fd1[1] = -1;
   d_fd2[0] = d_fd2[1] = -1;
 }
@@ -53,8 +51,9 @@ PipeConnector::~PipeConnector(){
     waitpid(d_pid, &status, 0);
   }
 
-  close(d_fd1[1]);
-  if (d_fp != NULL) fclose(d_fp);
+  if (d_fd1[1]) {
+    close(d_fd1[1]);
+  }
 }
 
 void PipeConnector::launch() {
@@ -85,10 +84,10 @@ void PipeConnector::launch() {
     setCloseOnExec(d_fd1[1]);
     close(d_fd2[1]);
     setCloseOnExec(d_fd2[0]);
-    if(!(d_fp=fdopen(d_fd2[0],"r")))
+    if(!(d_fp=std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(d_fd2[0],"r"), fclose)))
       throw PDNSException("Unable to associate a file pointer with pipe: "+stringerror());
-    if (d_timeout) 
-      setbuf(d_fp,0); // no buffering please, confuses select
+    if (d_timeout)
+      setbuf(d_fp.get(),0); // no buffering please, confuses select
   }
   else if(!d_pid) { // child
     signal(SIGCHLD, SIG_DFL); // silence a warning from perl
@@ -163,15 +162,15 @@ int PipeConnector::recv_message(Json& output)
        tv.tv_usec = (d_timeout % 1000) * 1000;
        fd_set rds;
        FD_ZERO(&rds);
-       FD_SET(fileno(d_fp),&rds);
-       int ret=select(fileno(d_fp)+1,&rds,0,0,&tv);
+       FD_SET(fileno(d_fp.get()),&rds);
+       int ret=select(fileno(d_fp.get())+1,&rds,0,0,&tv);
        if(ret<0) 
          throw PDNSException("Error waiting on data from coprocess: "+stringerror());
        if(!ret)
          throw PDNSException("Timeout waiting for data from coprocess");
      }
 
-     if(!stringfgets(d_fp, receive))
+     if(!stringfgets(d_fp.get(), receive))
        throw PDNSException("Child closed pipe");
   
       s_output.append(receive);

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -71,11 +71,7 @@ RemoteBackend::RemoteBackend(const std::string &suffix)
       build();
 }
 
-RemoteBackend::~RemoteBackend() {
-    if (connector != NULL) {
- 	delete connector;
-     }
-}
+RemoteBackend::~RemoteBackend() { }
 
 bool RemoteBackend::send(Json& value) {
    try {
@@ -84,7 +80,7 @@ bool RemoteBackend::send(Json& value) {
      g_log<<Logger::Error<<"Exception caught when sending: "<<ex.reason<<std::endl;
    }
 
-   delete this->connector;
+   this->connector.reset();
    build();
    return false;
 }
@@ -98,7 +94,7 @@ bool RemoteBackend::recv(Json& value) {
      g_log<<Logger::Error<<"Exception caught when receiving"<<std::endl;;
    }
 
-   delete this->connector;
+   this->connector.reset();
    build();
    return false;
 }
@@ -147,17 +143,17 @@ int RemoteBackend::build() {
 
       // connectors know what they are doing
       if (type == "unix") {
-        this->connector = new UnixsocketConnector(options);
+        this->connector = std::unique_ptr<Connector>(new UnixsocketConnector(options));
       } else if (type == "http") {
-        this->connector = new HTTPConnector(options);
+        this->connector = std::unique_ptr<Connector>(new HTTPConnector(options));
       } else if (type == "zeromq") {
 #ifdef REMOTEBACKEND_ZEROMQ
-        this->connector = new ZeroMQConnector(options);
+        this->connector = std::unique_ptr<Connector>(new ZeroMQConnector(options));
 #else
         throw PDNSException("Invalid connection string: zeromq connector support not enabled. Recompile with --enable-remotebackend-zeromq");
 #endif
       } else if (type == "pipe") {
-        this->connector = new PipeConnector(options);
+        this->connector = std::unique_ptr<Connector>(new PipeConnector(options));
       } else {
         throw PDNSException("Invalid connection string: unknown connector");
       }

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -104,6 +104,8 @@ class HTTPConnector: public Connector {
     std::string buildMemberListArgs(std::string prefix, const Json& args);
     std::unique_ptr<Socket> d_socket;
     ComboAddress d_addr;
+    std::string d_host;
+    uint16_t d_port;
 };
 
 #ifdef REMOTEBACKEND_ZEROMQ

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -102,7 +102,7 @@ class HTTPConnector: public Connector {
     void post_requestbuilder(const Json &input, YaHTTP::Request& req);
     void addUrlComponent(const Json &parameters, const string& element, std::stringstream& ss);
     std::string buildMemberListArgs(std::string prefix, const Json& args);
-    Socket* d_socket;
+    std::unique_ptr<Socket> d_socket;
     ComboAddress d_addr;
 };
 
@@ -119,8 +119,8 @@ class ZeroMQConnector: public Connector {
     int d_timeout;
     int d_timespent;
     std::map<std::string,std::string> d_options;
-    void *d_ctx;
-    void *d_sock; 
+    std::unique_ptr<void, int(*)(void*)> d_ctx;
+    std::unique_ptr<void, int(*)(void*)> d_sock;
 };
 #endif
 
@@ -144,7 +144,7 @@ class PipeConnector: public Connector {
   int d_fd1[2], d_fd2[2];
   int d_pid;
   int d_timeout;
-  FILE *d_fp;
+  std::unique_ptr<FILE, int(*)(FILE*)> d_fp{nullptr, fclose};
 };
 
 class RemoteBackend : public DNSBackend
@@ -192,7 +192,7 @@ class RemoteBackend : public DNSBackend
 
   private:
     int build();
-    Connector *connector;
+    std::unique_ptr<Connector> connector;
     bool d_dnssec;
     Json d_result;
     int d_index;


### PR DESCRIPTION
### Short description
Fixes #7573 - caused by poorly escaped parameters.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
