### PR TITLE
dnsdist: add frontend response statistics

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -467,6 +467,17 @@ void tcpClientThread(int pipefd)
 #endif
               handler.writeSizeAndMsg(cachedResponse, cachedResponseSize, g_tcpSendTimeout);
               g_stats.cacheHits++;
+              switch (dr.dh->rcode) {
+              case RCode::NXDomain:
+                ++g_stats.frontendNXDomain;
+                break;
+              case RCode::ServFail:
+                ++g_stats.frontendServFail;
+                break;
+              case RCode::NoError:
+                ++g_stats.frontendNoError;
+                break;
+              }
               continue;
             }
 
@@ -501,6 +512,17 @@ void tcpClientThread(int pipefd)
 #endif
             handler.writeSizeAndMsg(cachedResponse, cachedResponseSize, g_tcpSendTimeout);
             ++g_stats.cacheHits;
+            switch (dr.dh->rcode) {
+            case RCode::NXDomain:
+              ++g_stats.frontendNXDomain;
+              break;
+            case RCode::ServFail:
+              ++g_stats.frontendServFail;
+              break;
+            case RCode::NoError:
+              ++g_stats.frontendNoError;
+              break;
+            }
             continue;
           }
           ++g_stats.cacheMisses;
@@ -711,6 +733,17 @@ void tcpClientThread(int pipefd)
         }
 
         ++g_stats.responses;
+        switch (dr.dh->rcode) {
+        case RCode::NXDomain:
+           ++g_stats.frontendNXDomain;
+           break;
+        case RCode::ServFail:
+          ++g_stats.frontendServFail;
+          break;
+        case RCode::NoError:
+          ++g_stats.frontendNoError;
+          break;
+        }
         struct timespec answertime;
         gettime(&answertime);
         unsigned int udiff = 1000000.0*DiffTime(now,answertime);

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -208,6 +208,9 @@ struct DNSDistStats
   stat_t responses{0};
   stat_t servfailResponses{0};
   stat_t queries{0};
+  stat_t frontendNXDomain{0};
+  stat_t frontendServFail{0};
+  stat_t frontendNoError{0};
   stat_t nonCompliantQueries{0};
   stat_t nonCompliantResponses{0};
   stat_t rdQueries{0};
@@ -235,6 +238,9 @@ struct DNSDistStats
     {"responses", &responses},
     {"servfail-responses", &servfailResponses},
     {"queries", &queries},
+    {"frontend-nxdomain", &frontendNXDomain},
+    {"frontend-servfail", &frontendServFail},
+    {"frontend-noerror", &frontendNoError},
     {"acl-drops", &aclDrops},
     {"rule-drop", &ruleDrop},
     {"rule-nxdomain", &ruleNXDomain},
@@ -324,6 +330,9 @@ struct MetricDefinitionStorage {
     { "responses",              MetricDefinition(PrometheusMetricType::counter, "Number of responses received from backends") },
     { "servfail-responses",     MetricDefinition(PrometheusMetricType::counter, "Number of SERVFAIL answers received from backends") },
     { "queries",                MetricDefinition(PrometheusMetricType::counter, "Number of received queries")},
+    { "frontend-nxdomain",      MetricDefinition(PrometheusMetricType::counter, "Number of NXDomain answers sent to clients")},
+    { "frontend-servfail",      MetricDefinition(PrometheusMetricType::counter, "Number of SERVFAIL answers sent to clients")},
+    { "frontend-noerror",       MetricDefinition(PrometheusMetricType::counter, "Number of NoError answers sent to clients")},
     { "acl-drops",              MetricDefinition(PrometheusMetricType::counter, "Number of packets dropped because of the ACL")},
     { "rule-drop",              MetricDefinition(PrometheusMetricType::counter, "Number of queries dropped because of a rule")},
     { "rule-nxdomain",          MetricDefinition(PrometheusMetricType::counter, "Number of NXDomain answers returned because of a rule")},

--- a/pdns/dnsdistdist/docs/statistics.rst
+++ b/pdns/dnsdistdist/docs/statistics.rst
@@ -67,6 +67,18 @@ fd-usage
 --------
 Number of currently used file descriptors.
 
+frontend-noerror
+----------------
+Number of NoError answers sent to clients.
+
+frontend-nxdomain
+-----------------
+Number of NXDomain answers sent to clients.
+
+frontend-servfail
+-----------------
+Number of ServFail answers sent to clients.
+
 latency-avg100
 --------------
 Average response latency in microseconds of the last 100 packets

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -226,6 +226,7 @@ class TestAPIBasics(DNSDistTest):
             values[entry['name']] = entry['value']
 
         expected = ['responses', 'servfail-responses', 'queries', 'acl-drops',
+                    'frontend-noerror', 'frontend-nxdomain', 'frontend-servfail',
                     'rule-drop', 'rule-nxdomain', 'rule-refused', 'self-answered', 'downstream-timeouts',
                     'downstream-send-errors', 'trunc-failures', 'no-policy', 'latency0-1',
                     'latency1-10', 'latency10-50', 'latency50-100', 'latency100-1000',
@@ -255,6 +256,7 @@ class TestAPIBasics(DNSDistTest):
         content = r.json()
 
         expected = ['responses', 'servfail-responses', 'queries', 'acl-drops',
+                    'frontend-noerror', 'frontend-nxdomain', 'frontend-servfail',
                     'rule-drop', 'rule-nxdomain', 'rule-refused', 'self-answered', 'downstream-timeouts',
                     'downstream-send-errors', 'trunc-failures', 'no-policy', 'latency0-1',
                     'latency1-10', 'latency10-50', 'latency50-100', 'latency100-1000',


### PR DESCRIPTION
### Short description
Adds new global "frontend" stats for noerror, nxdomain and servfail answers sent to clients (like in the recursor).

If using cache in dnsdist you otherwise lose visibility of the types of answers sent from there.

Stat names are up for discussion, the term frontend seems to be used elsewhere as well. Perhaps servfail-responses and responses should be renamed to backend-* ?

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
