### PR TITLE
lua-recursor4: Add missing getregisteredname Lua function

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -463,6 +463,10 @@ void RecursorLua4::postPrepareContext()
         g_snmpAgent->sendCustomTrap(str);
       }
     });
+
+  d_lw->writeFunction("getregisteredname", [](const DNSName &dname) {
+      return getRegisteredName(dname);
+  });
 }
 
 void RecursorLua4::postLoad() {


### PR DESCRIPTION

### Short description
`getregisteredname` function was accidentically dropped in 4b9a4e966257eb08d4803633f5726b5a144a8e99 without adding it in a3e7b73528a96a3642adb42dc1e729ea2e8765f4
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)