### PR TITLE
dnsdist: Prevent entries from expiring if the unit tests are slow

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -335,7 +335,7 @@ size_t DNSDistPacketCache::purgeExpired(size_t upTo)
    entries in the cache */
 size_t DNSDistPacketCache::expunge(size_t upTo)
 {
-  bool removed = 0;
+  size_t removed = 0;
   const uint64_t size = getSize();
 
   if (upTo >= size) {

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -37,9 +37,9 @@ public:
 
   void insert(uint32_t key, const boost::optional<Netmask>& subnet, uint16_t queryFlags, bool dnssecOK, const DNSName& qname, uint16_t qtype, uint16_t qclass, const char* response, uint16_t responseLen, bool tcp, uint8_t rcode, boost::optional<uint32_t> tempFailureTTL);
   bool get(const DNSQuestion& dq, uint16_t consumed, uint16_t queryId, char* response, uint16_t* responseLen, uint32_t* keyOut, boost::optional<Netmask>& subnetOut, bool dnssecOK, uint32_t allowExpired=0, bool skipAging=false);
-  void purgeExpired(size_t upTo=0);
-  void expunge(size_t upTo=0);
-  void expungeByName(const DNSName& name, uint16_t qtype=QType::ANY, bool suffixMatch=false);
+  size_t purgeExpired(size_t upTo=0);
+  size_t expunge(size_t upTo=0);
+  size_t expungeByName(const DNSName& name, uint16_t qtype=QType::ANY, bool suffixMatch=false);
   bool isFull();
   string toString();
   uint64_t getSize();

--- a/pdns/dnsdistdist/test-dnsdistrules_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrules_cc.cc
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(test_MaxQPSIPRule) {
   BOOST_CHECK_EQUAL(rule.matches(&dq), true);
   BOOST_CHECK_EQUAL(rule.getEntriesCount(), 1);
 
-  /* remove all entries that have not been since 'now' + 1,
+  /* remove all entries that have not been updated since 'now' + 1,
      so all of them */
   expiredTime.tv_sec += 1;
   rule.cleanup(expiredTime);

--- a/pdns/dnsdistdist/test-dnsdistrules_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrules_cc.cc
@@ -45,12 +45,16 @@ BOOST_AUTO_TEST_CASE(test_MaxQPSIPRule) {
   BOOST_CHECK_EQUAL(rule.matches(&dq), true);
   BOOST_CHECK_EQUAL(rule.getEntriesCount(), 1);
 
+  /* remove all entries that have not been since 'now' + 1,
+     so all of them */
   expiredTime.tv_sec += 1;
   rule.cleanup(expiredTime);
 
   /* we should have been cleaned up */
   BOOST_CHECK_EQUAL(rule.getEntriesCount(), 0);
 
+  struct timespec beginInsertionTime;
+  gettime(&beginInsertionTime);
   /* we should not be blocked anymore */
   BOOST_CHECK_EQUAL(rule.matches(&dq), false);
   /* and we be back */
@@ -58,21 +62,21 @@ BOOST_AUTO_TEST_CASE(test_MaxQPSIPRule) {
 
 
   /* Let's insert a lot of different sources now */
-  struct timespec insertionTime;
-  gettime(&insertionTime);
   for (size_t idxByte3 = 0; idxByte3 < 256; idxByte3++) {
     for (size_t idxByte4 = 0; idxByte4 < 256; idxByte4++) {
       rem = ComboAddress("10.0." + std::to_string(idxByte3) + "." + std::to_string(idxByte4));
       BOOST_CHECK_EQUAL(rule.matches(&dq), false);
     }
   }
+  struct timespec endInsertionTime;
+  gettime(&endInsertionTime);
 
   /* don't forget the existing entry */
   size_t total = 1 + 256 * 256;
   BOOST_CHECK_EQUAL(rule.getEntriesCount(), total);
 
   /* make sure all entries are still valid */
-  struct timespec notExpiredTime = insertionTime;
+  struct timespec notExpiredTime = beginInsertionTime;
   notExpiredTime.tv_sec -= 1;
 
   size_t scanned = 0;
@@ -83,7 +87,7 @@ BOOST_AUTO_TEST_CASE(test_MaxQPSIPRule) {
   BOOST_CHECK_EQUAL(rule.getEntriesCount(), total);
 
   /* make sure all entries are _not_ valid anymore */
-  expiredTime = insertionTime;
+  expiredTime = endInsertionTime;
   expiredTime.tv_sec += 1;
 
   removed = rule.cleanup(expiredTime, &scanned);

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
       }
     }
 
-    /* in the unlikely event that the test took so long that entries did expire.. */
+    /* in the unlikely event that the test took so long that the entries did expire.. */
     auto expired = PC.purgeExpired();
     BOOST_CHECK_EQUAL(matches + expired, expected);
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If the host running the unit tests is very, very slow, some entries could previously have expired before the end of the tests and were not accounted for.
This PR tries to make sure that the entries last long enough, or at least account for expired entries if they don't.
Hopefully fixes #7590.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
