### PR TITLE
auth: Avoid contention issues in the packet cache's unit tests

### DIFF
--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -156,9 +156,11 @@ try
     DNSPacket r(false);
     r.parse((char*)&pak[0], pak.size());
 
-    /* this step is necessary to get a valid hash */
-    DNSPacket cached(false);
-    g_PC->get(&q, &cached);
+    /* this step is necessary to get a valid hash
+       we directly compute the hash instead of querying the
+       cache because 1/ it's faster 2/ no deferred-lookup issues
+    */
+    q.setHash(g_PC->canHashPacket(q.getString()));
 
     const unsigned int maxTTL = 3600;
     g_PC->insert(&q, &r, maxTTL);
@@ -212,6 +214,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheThreaded) {
       pthread_join(tid[i], &res);
 
     BOOST_CHECK_EQUAL(PC.size() + S.read("deferred-packetcache-inserts"), 400000);
+    BOOST_CHECK_EQUAL(S.read("deferred-packetcache-lookup"), 0);
     BOOST_CHECK_SMALL(1.0*S.read("deferred-packetcache-inserts"), 10000.0);
 
     for(int i=0; i < 4; ++i)
@@ -224,9 +227,12 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheThreaded) {
     cerr<<"Hits: "<<S.read("packetcache-hit")<<endl;
     cerr<<"Deferred inserts: "<<S.read("deferred-packetcache-inserts")<<endl;
     cerr<<"Deferred lookups: "<<S.read("deferred-packetcache-lookup")<<endl;
+    cerr<<g_PCmissing<<endl;
+    cerr<<PC.size()<<endl;
 */
+
     BOOST_CHECK_EQUAL(g_PCmissing + S.read("packetcache-hit"), 400000);
-    BOOST_CHECK_GT(S.read("deferred-packetcache-inserts") + S.read("deferred-packetcache-lookup"), g_PCmissing);
+    BOOST_CHECK_EQUAL(S.read("deferred-packetcache-inserts") + S.read("deferred-packetcache-lookup"), g_PCmissing);
   }
   catch(PDNSException& e) {
     cerr<<"Had error: "<<e.reason<<endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to do a retrieval from the cache to compute the hash, but that could have failed due to another thread already having the relevant lock ("deferred-lookup"), resulting the hash value not being updated.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
