### PR TITLE
properly capitalise reusePort

### DIFF
--- a/pdns/dnsdistdist/docs/advanced/tuning.rst
+++ b/pdns/dnsdistdist/docs/advanced/tuning.rst
@@ -37,12 +37,12 @@ When Lua inspection is needed, the best course of action is to restrict the quer
 
 :program:`dnsdist` design choices mean that the processing of UDP queries is done by only one thread per local bind.
 This is great to keep lock contention to a low level, but might not be optimal for setups using a lot of processing power, caused for example by a large number of complicated rules.
-To be able to use more CPU cores for UDP queries processing, it is possible to use the ``reuseport`` parameter of the :func:`addLocal` and :func:`setLocal` directives to be able to add several identical local binds to dnsdist::
+To be able to use more CPU cores for UDP queries processing, it is possible to use the ``reusePort`` parameter of the :func:`addLocal` and :func:`setLocal` directives to be able to add several identical local binds to dnsdist::
 
-  addLocal("192.0.2.1:53", {reuseport=true})
-  addLocal("192.0.2.1:53", {reuseport=true})
-  addLocal("192.0.2.1:53", {reuseport=true})
-  addLocal("192.0.2.1:53", {reuseport=true})
+  addLocal("192.0.2.1:53", {reusePort=true})
+  addLocal("192.0.2.1:53", {reusePort=true})
+  addLocal("192.0.2.1:53", {reusePort=true})
+  addLocal("192.0.2.1:53", {reusePort=true})
 
 :program:`dnsdist` will then add four identical local binds as if they were different IPs or ports, start four threads to handle incoming queries and let the kernel load balance those randomly to the threads, thus using four CPU cores for rules processing.
 Note that this require ``SO_REUSEPORT`` support in the underlying operating system (added for example in Linux 3.9).


### PR DESCRIPTION
### Short description
It was correct in the config reference, but not in the tuning guide. The lowercase version just gets ignored by dnsdist, possibly leading the admin to believe that reuseport does not work on their system.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
