### PR TITLE
[backport to auth-4.1.x] gsqlbackend: Reset correct query in searchComments

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1726,7 +1726,7 @@ bool GSQLBackend::searchComments(const string &pattern, int maxResults, vector<C
       result.push_back(comment);
     }
 
-    d_SearchRecordsQuery_stmt->reset();
+    d_SearchCommentsQuery_stmt->reset();
 
     return true;
   }


### PR DESCRIPTION
Backport of #7546.

(cherry picked from commit b7309408d65edc2365392bb4c24f7a39696a880b)
