### PR TITLE
[backport to auth-4.1.x] prevent leak of file descriptor if running out of ports for incoming AXFR

### DIFF
--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -86,10 +86,11 @@ int makeQuerySocket(const ComboAddress& local, bool udpOrTCP, bool nonLocalBind)
   }
   else {
     // tcp, let the kernel figure out the port
-    // cerr<<"letting kernel pick TCP port"<<endl;
     ourLocal.sin4.sin_port = 0;
-    if(::bind(sock, (struct sockaddr *)&ourLocal, ourLocal.getSocklen()) < 0)
+    if(::bind(sock, (struct sockaddr *)&ourLocal, ourLocal.getSocklen()) < 0) {
+      closesocket(sock);
       throw PDNSException("Resolver binding to local TCP socket on "+ourLocal.toString()+": "+stringerror());
+    }
   }
   return sock;
 }


### PR DESCRIPTION
Backport of #7294.

(cherry picked from commit f852aff670c19b7dac9a0cef2c3912ebd8946201)
