### PR TITLE
[backport to auth-4.1.x] Do not compress the root

### DIFF
--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -79,7 +79,7 @@ void DNSPacketWriter::startRecord(const DNSName& name, uint16_t qtype, uint32_t 
   commit();
   d_rollbackmarker=d_content.size();
 
-  if(compress && !name.empty() && d_qname==name) {  // don't do the whole label compression thing if we *know* we can get away with "see question" - except when compressing the root
+  if(compress && !name.isRoot() && d_qname==name) {  // don't do the whole label compression thing if we *know* we can get away with "see question" - except when compressing the root
     static unsigned char marker[2]={0xc0, 0x0c};
     d_content.insert(d_content.end(), (const char *) &marker[0], (const char *) &marker[2]);
   }


### PR DESCRIPTION
Backport of #7472.

(cherry picked from commit 2d6c4fcb18ec7ae1ef689656ce6d52b399cc26a9)
