### PR TITLE
[backport to auth-4.1.x] fix dot stripping in setContent()

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -38,7 +38,7 @@ void DNSResourceRecord::setContent(const string &cont) {
     case QType::DNAME:
     case QType::NS:
     case QType::PTR:
-      if(!content.empty())
+      if (content.size() >= 2 && *(content.rbegin()) == '.')
         boost::erase_tail(content, 1);
   }
 }


### PR DESCRIPTION
Backport of #7459.

(cherry picked from commit 0583946ff70d73b5da579db1d81c9c374adf2cc3)