### PR TITLE
[backport to auth-4.1.x] Rectify for ent records in narrow zones was slightly wrong

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -691,7 +691,7 @@ bool DNSSECKeeper::rectifyZone(const DNSName& zone, string& error, string& info,
   }
 
   set<DNSName> nsec3set;
-  if (haveNSEC3 && !narrow) {
+  if (haveNSEC3) {
     for (auto &loopRR: rrs) {
       bool skip=false;
       DNSName shorter = loopRR.qname;
@@ -742,12 +742,12 @@ bool DNSSECKeeper::rectifyZone(const DNSName& zone, string& error, string& info,
 
     if(haveNSEC3) // NSEC3
     {
-      if(!narrow && nsec3set.count(qname)) {
-        ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname)));
-        if(!realrr)
+      if(nsec3set.count(qname)) {
+        if(!narrow)
+          ordername=DNSName(toBase32Hex(hashQNameWithSalt(ns3pr, qname)));
+        if(!realrr && !isOptOut)
           auth=true;
-      } else if(!realrr)
-        auth=false;
+      }
     }
     else if (realrr) // NSEC
       ordername=qname.makeRelative(zone);

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -691,7 +691,7 @@ bool DNSSECKeeper::rectifyZone(const DNSName& zone, string& error, string& info,
   }
 
   set<DNSName> nsec3set;
-  if (haveNSEC3) {
+  if (haveNSEC3 && (!narrow || !isOptOut)) {
     for (auto &loopRR: rrs) {
       bool skip=false;
       DNSName shorter = loopRR.qname;


### PR DESCRIPTION
Backport of #7580.

(Cherrypicked from:
    - 666c721173d00d55953b86941099874867bae2c3
    - 2885750af64e945ba475fd02f7f3cd5194052202 )