### PR TITLE
[backport to auth-4.1.x] Fix replying from ANY address for non-standard port

### DIFF
--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -112,10 +112,12 @@ void UDPNameserver::bindIPv4()
     if(!setNonBlocking(s))
       throw PDNSException("Unable to set UDP socket to non-blocking: "+stringerror());
 
-    locala.reset();
-    locala.sin4.sin_family=AF_INET;
+    locala=ComboAddress(localname, ::arg().asNum("local-port"));
 
-    if(localname=="0.0.0.0")
+    if(locala.sin4.sin_family != AF_INET)
+      throw PDNSException("Attempting to bind IPv4 socket to IPv6 address");
+
+    if(IsAnyAddress(locala))
       setsockopt(s, IPPROTO_IP, GEN_IP_PKTINFO, &one, sizeof(one));
 
     if (!setSocketTimestamps(s))
@@ -130,9 +132,6 @@ void UDPNameserver::bindIPv4()
     if( ::arg().mustDo("non-local-bind") )
 	Utility::setBindAny(AF_INET, s);
 
-    locala=ComboAddress(localname, ::arg().asNum("local-port"));
-    if(locala.sin4.sin_family != AF_INET) 
-      throw PDNSException("Attempting to bind IPv4 socket to IPv6 address");
 
     if( !d_additional_socket )
         g_localaddresses.push_back(locala);


### PR DESCRIPTION
Previously, we would not recognize 0.0.0.0:5300 or even 0.0.0.0:53 as the 'any' address, leading us to answer from the wrong address.

Backport of #7341.

(cherry picked from commit 36025a51ed16e31e5d186b2c126ef1178a39a569)
