### PR TITLE
RKEY is missing algorithm field

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -397,6 +397,7 @@ CDNSKEYRecordContent::CDNSKEYRecordContent() {}
 boilerplate_conv(RKEY, 57, 
                  conv.xfr16BitInt(d_flags); 
                  conv.xfr8BitInt(d_protocol); 
+                 conv.xfr8BitInt(d_algorithm); 
                  conv.xfrBlob(d_key);
                  )
 RKEYRecordContent::RKEYRecordContent() {}


### PR DESCRIPTION
This RR type is missing a data field.
draft-reid-dnsext-rkey-00 defines the data as flags (0) / protocol (1) / algorithm / key, and for these last two is refering to RFC4034

https://tools.ietf.org/html/draft-reid-dnsext-rkey-00
https://tools.ietf.org/html/rfc4034#section-2.1

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
