### PR TITLE
Update changelog and secpoll for auth-4.1.8

### DIFF
--- a/docs/changelog/4.1.rst
+++ b/docs/changelog/4.1.rst
@@ -27,11 +27,11 @@ Changelogs for 4.1.x
     Fix rectify for ENT records in narrow zones.
 
   .. change::
-    :tags: Bug Fixes, LMDB
+    :tags: Bug Fixes
     :pullreq: 7607
     :tickets: 7472
 
-    Do not compress the root since LMDB backend cannot set a root zone with a compressible SOA record.
+    Do not compress the root.
 
   .. change::
     :tags: Bug Fixes

--- a/docs/changelog/4.1.rst
+++ b/docs/changelog/4.1.rst
@@ -2,6 +2,79 @@ Changelogs for 4.1.x
 ====================
 
 .. changelog::
+  :version: 4.1.8
+  :released: March 22nd 2019
+
+  .. change::
+    :tags: Bug Fixes
+    :pullreq: 7604
+    :tickets: 7494
+
+    Correctly interpret an empty AXFR response to an IXFR query.
+
+  .. change::
+    :tags: Bug Fixes
+    :pullreq: 7610
+    :tickets: 7341
+
+    Fix replying from ANY address for non-standard port.
+
+  .. change::
+    :tags: Bug Fixes, Internals
+    :pullreq: 7609
+    :tickets: 7580
+
+    Fix rectify for ENT records in narrow zones.
+
+  .. change::
+    :tags: Bug Fixes, LMDB
+    :pullreq: 7607
+    :tickets: 7472
+
+    Do not compress the root since LMDB backend cannot set a root zone with a compressible SOA record.
+
+  .. change::
+    :tags: Bug Fixes
+    :pullreq: 7608
+    :tickets: 7459
+
+    Fix dot stripping in ``setcontent()``.
+
+  .. change::
+    :tags: Bug Fixes, MySQL
+    :pullreq: 7605
+    :tickets: 7496
+
+    Fix invalid SOA record in MySQL which prevented the authoritative server from starting.
+
+  .. change::
+    :tags: Bug Fixes, Internals
+    :pullreq: 7603
+    :tickets: 7294
+
+    Prevent leak of file descriptor if running out of ports for incoming AXFR.
+
+  .. change::
+    :tags: Bug Fixes, API
+    :pullreq: 7602
+    :tickets: 7546
+
+    Fix API search failed with "Commands out of sync; you can't run this command now".
+
+  .. change::
+    :tags: Bug Fixes, MySQL
+    :pullreq: 7509
+    :tickets: 7517
+
+    Plug ``mysql_thread_init`` memory leak.
+
+  .. change::
+    :tags: Bug Fixes, Internals
+    :pullreq: 7567
+
+    EL6: fix ``CXXFLAGS`` to build with compiler optimizations.
+
+.. changelog::
   :version: 4.1.7
   :released: March 18th 2019
 

--- a/docs/secpoll.zone
+++ b/docs/secpoll.zone
@@ -1,4 +1,4 @@
-@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2019031901 10800 3600 604800 10800
+@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2019032201 10800 3600 604800 10800
 @       3600    IN  NS  pdns-public-ns1.powerdns.com.
 @       3600    IN  NS  pdns-public-ns2.powerdns.com.
 ; Auth
@@ -44,6 +44,7 @@ auth-4.1.4.security-status                              60 IN TXT "3 Upgrade now
 auth-4.1.5.security-status                              60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-03.html"
 auth-4.1.6.security-status                              60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-03.html"
 auth-4.1.7.security-status                              60 IN TXT "1 OK"
+auth-4.1.8.security-status                              60 IN TXT "1 OK"
 auth-4.2.0-alpha1.security-status                       60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-03.html"
 auth-4.2.0-beta1.security-status                        60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-03.html"
 auth-4.2.0-rc1.security-status                          60 IN TXT "1 OK"


### PR DESCRIPTION
Most of these also appear in the 4.2.x changelogs.

I guess #7567 doesn't necessarily need to be in here, but it's a fun entry.