### PR TITLE
Correct dnsdist & recursor information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ If you run into C++11-related symbol trouble, please try passing `CPPFLAGS=-D_GL
 
 Compiling the Recursor
 ----------------------
-See the README in pdns/recursordist.
+See [README.md](pdns/recursordist/README.md) in `pdns/recursordist/`.
 
 Compiling dnsdist
 -----------------
-See the README in pdns/dnsdistdist.
+See [README-dnsdist.md](pdns/README-dnsdist.md) in `pdns/`.
 
 Building the HTML documentation
 -------------------------------


### PR DESCRIPTION
### Short description
The information about the dnsdist README location was wrong. This fixes that, and also makes the information about that and the PowerDNS Recursor Markdown relative links, so they are nice and pretty when viewed on GitHub.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
