### PR TITLE
Note that Lua is now required for the recursor

### DIFF
--- a/pdns/recursordist/README.md
+++ b/pdns/recursordist/README.md
@@ -14,8 +14,8 @@ Starting with version 4.0.0, the PowerDNS recursor uses autotools and compiling
 make
 ```
 
-As for dependencies, Boost (http://boost.org/) and OpenSSL (https://openssl.org/)
-are required.
+As for dependencies, Boost (http://boost.org/), OpenSSL (https://openssl.org/),
+and Lua (https://www.lua.org/) are required.
 
 On most modern UNIX distributions, you can simply install 'boost' or
 'boost-dev' or 'boost-devel'. Otherwise, just download boost, and point the


### PR DESCRIPTION
### Short description
Update PowerDNS Recursor `README.md` to note that Lua is required.

Trying to run `./configure` for the PowerDNS Recursor fails with a message saying that this is not possible. 

Indeed it is:
https://github.com/PowerDNS/pdns/blob/master/pdns/recursordist/configure.ac#L104

This updates the documentation to reflect this sad reality. 😉

### Checklist
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
