### PR TITLE
Change all occurrences of string to std::string

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -35,11 +35,11 @@
 class DropAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     return Action::Drop;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "drop";
   }
@@ -48,11 +48,11 @@ public:
 class AllowAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     return Action::Allow;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "allow";
   }
@@ -61,11 +61,11 @@ public:
 class NoneAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "no op";
   }
@@ -76,14 +76,14 @@ class QPSAction : public DNSAction
 public:
   QPSAction(int limit) : d_qps(limit, limit)
   {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if(d_qps.check())
       return Action::None;
     else
       return Action::Drop;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "qps limit to "+std::to_string(d_qps.getRate());
   }
@@ -96,12 +96,12 @@ class DelayAction : public DNSAction
 public:
   DelayAction(int msec) : d_msec(msec)
   {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     *ruleresult=std::to_string(d_msec);
     return Action::Delay;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "delay by "+std::to_string(d_msec)+ " msec";
   }
@@ -115,9 +115,9 @@ class TeeAction : public DNSAction
 public:
   TeeAction(const ComboAddress& ca, bool addECS=false);
   ~TeeAction() override;
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override;
-  string toString() const override;
-  std::map<string, double> getStats() const override;
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override;
+  std::string toString() const override;
+  std::map<std::string, double> getStats() const override;
 
 private:
   ComboAddress d_remote;
@@ -156,7 +156,7 @@ TeeAction::~TeeAction()
   d_worker.join();
 }
 
-DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) const
+DNSAction::Action TeeAction::operator()(DNSQuestion* dq, std::string* ruleresult) const
 {
   if(dq->tcp) {
     d_tcpdrops++;
@@ -173,7 +173,7 @@ DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) con
       query.reserve(dq->size);
       query.assign((char*) dq->dh, len);
 
-      string newECSOption;
+      std::string newECSOption;
       generateECSOption(dq->ecsSet ? dq->ecs.getNetwork() : *dq->remote, newECSOption, dq->ecsSet ? dq->ecs.getBits() :  dq->ecsPrefixLength);
 
       if (!handleEDNSClientSubnet(const_cast<char*>(query.c_str()), query.capacity(), dq->qname->wirelength(), &len, &ednsAdded, &ecsAdded, dq->ecsOverride, newECSOption, g_preserveTrailingData)) {
@@ -192,12 +192,12 @@ DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) con
   return DNSAction::Action::None;
 }
 
-string TeeAction::toString() const
+std::string TeeAction::toString() const
 {
   return "tee to "+d_remote.toStringWithPort();
 }
 
-std::map<string,double> TeeAction::getStats() const
+std::map<std::string,double> TeeAction::getStats() const
 {
   return {{"queries", d_queries},
           {"responses", d_responses},
@@ -253,18 +253,18 @@ class PoolAction : public DNSAction
 {
 public:
   PoolAction(const std::string& pool) : d_pool(pool) {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     *ruleresult=d_pool;
     return Action::Pool;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "to pool "+d_pool;
   }
 
 private:
-  string d_pool;
+  std::string d_pool;
 };
 
 
@@ -272,7 +272,7 @@ class QPSPoolAction : public DNSAction
 {
 public:
   QPSPoolAction(unsigned int limit, const std::string& pool) : d_qps(limit, limit), d_pool(pool) {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if(d_qps.check()) {
       *ruleresult=d_pool;
@@ -281,27 +281,27 @@ public:
     else
       return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "max " +std::to_string(d_qps.getRate())+" to pool "+d_pool;
   }
 
 private:
   QPSLimiter d_qps;
-  string d_pool;
+  std::string d_pool;
 };
 
 class RCodeAction : public DNSAction
 {
 public:
   RCodeAction(uint8_t rcode) : d_rcode(rcode) {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->dh->rcode = d_rcode;
     dq->dh->qr = true; // for good measure
     return Action::HeaderModify;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set rcode "+std::to_string(d_rcode);
   }
@@ -314,14 +314,14 @@ class ERCodeAction : public DNSAction
 {
 public:
   ERCodeAction(uint8_t rcode) : d_rcode(rcode) {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->dh->rcode = (d_rcode & 0xF);
     dq->ednsRCode = ((d_rcode & 0xFFF0) >> 4);
     dq->dh->qr = true; // for good measure
     return Action::HeaderModify;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set ercode "+ERCode::to_s(d_rcode);
   }
@@ -333,23 +333,23 @@ private:
 class TCAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     return Action::Truncate;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "tc=1 answer";
   }
 };
 
-DNSAction::Action LuaAction::operator()(DNSQuestion* dq, string* ruleresult) const
+DNSAction::Action LuaAction::operator()(DNSQuestion* dq, std::string* ruleresult) const
 {
   std::lock_guard<std::mutex> lock(g_luamutex);
   try {
     auto ret = d_func(dq);
     if (ruleresult) {
-      if (boost::optional<string> rule = std::get<1>(ret)) {
+      if (boost::optional<std::string> rule = std::get<1>(ret)) {
         *ruleresult = *rule;
       }
       else {
@@ -366,13 +366,13 @@ DNSAction::Action LuaAction::operator()(DNSQuestion* dq, string* ruleresult) con
   return DNSAction::Action::ServFail;
 }
 
-DNSResponseAction::Action LuaResponseAction::operator()(DNSResponse* dr, string* ruleresult) const
+DNSResponseAction::Action LuaResponseAction::operator()(DNSResponse* dr, std::string* ruleresult) const
 {
   std::lock_guard<std::mutex> lock(g_luamutex);
   try {
     auto ret = d_func(dr);
     if(ruleresult) {
-      if (boost::optional<string> rule = std::get<1>(ret)) {
+      if (boost::optional<std::string> rule = std::get<1>(ret)) {
         *ruleresult = *rule;
       }
       else {
@@ -389,7 +389,7 @@ DNSResponseAction::Action LuaResponseAction::operator()(DNSResponse* dr, string*
   return DNSResponseAction::Action::ServFail;
 }
 
-DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, string* ruleresult) const
+DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, std::string* ruleresult) const
 {
   uint16_t qtype = dq->qtype;
   // do we even have a response?
@@ -443,7 +443,7 @@ DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, string* ruleresult) c
   dq->dh->arcount = 0; // for now, forget about your EDNS, we're marching over it
 
   if(qtype == QType::CNAME) {
-    string wireData = d_cname.toDNSString(); // Note! This doesn't do compression!
+    std::string wireData = d_cname.toDNSString(); // Note! This doesn't do compression!
     const unsigned char recordstart[]={0xc0, 0x0c,    // compressed name
                                        0, (unsigned char) qtype,
                                        0, QClass::IN, // IN
@@ -493,19 +493,19 @@ class MacAddrAction : public DNSAction
 public:
   MacAddrAction(uint16_t code) : d_code(code)
   {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if(dq->dh->arcount)
       return Action::None;
 
-    string mac = getMACAddress(*dq->remote);
+    std::string mac = getMACAddress(*dq->remote);
     if(mac.empty())
       return Action::None;
 
-    string optRData;
+    std::string optRData;
     generateEDNSOption(d_code, mac, optRData);
 
-    string res;
+    std::string res;
     generateOptRR(optRData, res, g_EdnsUDPPayloadSize, 0, false);
 
     if ((dq->size - dq->len) < res.length())
@@ -518,7 +518,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "add EDNS MAC (code="+std::to_string(d_code)+")";
   }
@@ -529,12 +529,12 @@ private:
 class NoRecurseAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->dh->rd = false;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set rd=0";
   }
@@ -555,7 +555,7 @@ public:
     else
       d_fp = fopen(str.c_str(), "w");
     if(!d_fp)
-      throw std::runtime_error("Unable to open file '"+str+"' for logging: "+string(strerror(errno)));
+      throw std::runtime_error("Unable to open file '"+str+"' for logging: "+std::string(strerror(errno)));
     if(!buffered)
       setbuf(d_fp, 0);
   }
@@ -564,14 +564,14 @@ public:
     if(d_fp)
       fclose(d_fp);
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if(!d_fp) {
       vinfolog("Packet from %s for %s %s with id %d", dq->remote->toStringWithPort(), dq->qname->toString(), QType(dq->qtype).getName(), dq->dh->id);
     }
     else {
       if(d_binary) {
-        string out = dq->qname->toDNSString();
+        std::string out = dq->qname->toDNSString();
         fwrite(out.c_str(), 1, out.size(), d_fp);
         fwrite((void*)&dq->qtype, 1, 2, d_fp);
       }
@@ -581,7 +581,7 @@ public:
     }
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     if (!d_fname.empty()) {
       return "log to " + d_fname;
@@ -589,7 +589,7 @@ public:
     return "log";
   }
 private:
-  string d_fname;
+  std::string d_fname;
   FILE* d_fp{0};
   bool d_binary{true};
 };
@@ -598,12 +598,12 @@ private:
 class DisableValidationAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->dh->cd = true;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set cd=1";
   }
@@ -612,12 +612,12 @@ public:
 class SkipCacheAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->skipCache = true;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "skip cache";
   }
@@ -628,12 +628,12 @@ class TempFailureCacheTTLAction : public DNSAction
 public:
   TempFailureCacheTTLAction(uint32_t ttl) : d_ttl(ttl)
   {}
-  TempFailureCacheTTLAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  TempFailureCacheTTLAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->tempFailureTTL = d_ttl;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set tempfailure cache ttl to "+std::to_string(d_ttl);
   }
@@ -647,12 +647,12 @@ public:
   ECSPrefixLengthAction(uint16_t v4Length, uint16_t v6Length) : d_v4PrefixLength(v4Length), d_v6PrefixLength(v6Length)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->ecsPrefixLength = dq->remote->sin4.sin_family == AF_INET ? d_v4PrefixLength : d_v6PrefixLength;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set ECS prefix length to " + std::to_string(d_v4PrefixLength) + "/" + std::to_string(d_v6PrefixLength);
   }
@@ -667,12 +667,12 @@ public:
   ECSOverrideAction(bool ecsOverride) : d_ecsOverride(ecsOverride)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->ecsOverride = d_ecsOverride;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set ECS override to " + std::to_string(d_ecsOverride);
   }
@@ -684,12 +684,12 @@ private:
 class DisableECSAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->useECS = false;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "disable ECS";
   }
@@ -706,7 +706,7 @@ public:
   {
   }
 
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->ecsSet = true;
 
@@ -720,9 +720,9 @@ public:
     return Action::None;
   }
 
-  string toString() const override
+  std::string toString() const override
   {
-    string result = "set ECS to " + d_v4.toString();
+    std::string result = "set ECS to " + d_v4.toString();
     if (d_hasV6) {
       result += " / " + d_v6.toString();
     }
@@ -742,7 +742,7 @@ public:
   DnstapLogAction(const std::string& identity, std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSQuestion&, DnstapMessage*)> > alterFunc): d_identity(identity), d_logger(logger), d_alterFunc(alterFunc)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
 #ifdef HAVE_PROTOBUF
     DnstapMessage message(d_identity, dq->remote, dq->local, dq->tcp, reinterpret_cast<const char*>(dq->dh), dq->len, dq->queryTime, nullptr);
@@ -758,7 +758,7 @@ public:
 #endif /* HAVE_PROTOBUF */
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "remote log as dnstap to " + (d_logger ? d_logger->toString() : "");
   }
@@ -774,7 +774,7 @@ public:
   RemoteLogAction(std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSQuestion&, DNSDistProtoBufMessage*)> > alterFunc, const std::string& serverID): d_logger(logger), d_alterFunc(alterFunc), d_serverID(serverID)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
 #ifdef HAVE_PROTOBUF
     if (!dq->uniqueId) {
@@ -797,7 +797,7 @@ public:
 #endif /* HAVE_PROTOBUF */
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "remote log to " + (d_logger ? d_logger->toString() : "");
   }
@@ -813,7 +813,7 @@ public:
   SNMPTrapAction(const std::string& reason): d_reason(reason)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if (g_snmpAgent && g_snmpTrapsEnabled) {
       g_snmpAgent->sendDNSTrap(*dq, d_reason);
@@ -821,7 +821,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "send SNMP trap";
   }
@@ -835,7 +835,7 @@ public:
   TagAction(const std::string& tag, const std::string& value): d_tag(tag), d_value(value)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if (!dq->qTag) {
       dq->qTag = std::make_shared<QTag>();
@@ -845,7 +845,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set tag '" + d_tag + "' to value '" + d_value + "'";
   }
@@ -860,7 +860,7 @@ public:
   DnstapLogResponseAction(const std::string& identity, std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSResponse&, DnstapMessage*)> > alterFunc): d_identity(identity), d_logger(logger), d_alterFunc(alterFunc)
   {
   }
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
 #ifdef HAVE_PROTOBUF
     struct timespec now;
@@ -878,7 +878,7 @@ public:
 #endif /* HAVE_PROTOBUF */
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "log response as dnstap to " + (d_logger ? d_logger->toString() : "");
   }
@@ -894,7 +894,7 @@ public:
   RemoteLogResponseAction(std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSResponse&, DNSDistProtoBufMessage*)> > alterFunc, const std::string& serverID, bool includeCNAME): d_logger(logger), d_alterFunc(alterFunc), d_serverID(serverID), d_includeCNAME(includeCNAME)
   {
   }
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
 #ifdef HAVE_PROTOBUF
     if (!dr->uniqueId) {
@@ -917,7 +917,7 @@ public:
 #endif /* HAVE_PROTOBUF */
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "remote log response to " + (d_logger ? d_logger->toString() : "");
   }
@@ -931,11 +931,11 @@ private:
 class DropResponseAction : public DNSResponseAction
 {
 public:
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     return Action::Drop;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "drop";
   }
@@ -944,11 +944,11 @@ public:
 class AllowResponseAction : public DNSResponseAction
 {
 public:
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     return Action::Allow;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "allow";
   }
@@ -959,12 +959,12 @@ class DelayResponseAction : public DNSResponseAction
 public:
   DelayResponseAction(int msec) : d_msec(msec)
   {}
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     *ruleresult=std::to_string(d_msec);
     return Action::Delay;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "delay by "+std::to_string(d_msec)+ " msec";
   }
@@ -978,7 +978,7 @@ public:
   SNMPTrapResponseAction(const std::string& reason): d_reason(reason)
   {
   }
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     if (g_snmpAgent && g_snmpTrapsEnabled) {
       g_snmpAgent->sendDNSTrap(*dr, d_reason);
@@ -986,7 +986,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "send SNMP trap";
   }
@@ -1000,7 +1000,7 @@ public:
   TagResponseAction(const std::string& tag, const std::string& value): d_tag(tag), d_value(value)
   {
   }
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     if (!dr->qTag) {
       dr->qTag = std::make_shared<QTag>();
@@ -1010,7 +1010,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set tag '" + d_tag + "' to value '" + d_value + "'";
   }
@@ -1121,7 +1121,7 @@ void setupLuaActions()
       return std::shared_ptr<DNSAction>(new MacAddrAction(code));
     });
 
-  g_lua.writeFunction("PoolAction", [](const string& a) {
+  g_lua.writeFunction("PoolAction", [](const std::string& a) {
       return std::shared_ptr<DNSAction>(new PoolAction(a));
     });
 
@@ -1129,16 +1129,16 @@ void setupLuaActions()
       return std::shared_ptr<DNSAction>(new QPSAction(limit));
     });
 
-  g_lua.writeFunction("QPSPoolAction", [](int limit, const string& a) {
+  g_lua.writeFunction("QPSPoolAction", [](int limit, const std::string& a) {
       return std::shared_ptr<DNSAction>(new QPSPoolAction(limit, a));
     });
 
-  g_lua.writeFunction("SpoofAction", [](boost::variant<string,vector<pair<int, string>>> inp, boost::optional<string> b ) {
+  g_lua.writeFunction("SpoofAction", [](boost::variant<std::string,vector<pair<int, std::string>>> inp, boost::optional<std::string> b ) {
       vector<ComboAddress> addrs;
-      if(auto s = boost::get<string>(&inp))
+      if(auto s = boost::get<std::string>(&inp))
         addrs.push_back(ComboAddress(*s));
       else {
-        const auto& v = boost::get<vector<pair<int,string>>>(inp);
+        const auto& v = boost::get<vector<pair<int,std::string>>>(inp);
         for(const auto& a: v)
           addrs.push_back(ComboAddress(a.second));
       }
@@ -1147,7 +1147,7 @@ void setupLuaActions()
       return std::shared_ptr<DNSAction>(new SpoofAction(addrs));
     });
 
-  g_lua.writeFunction("SpoofCNAMEAction", [](const string& a) {
+  g_lua.writeFunction("SpoofCNAMEAction", [](const std::string& a) {
       return std::shared_ptr<DNSAction>(new SpoofAction(a));
     });
 


### PR DESCRIPTION
I noticed that there were both `string` and `std::string` in the file that I am working on. This converts them all to `std::string`.

### Short description
No issues, just some code hygiene improvement by making the style consistent. 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)