### PR TITLE
Lua QClass global does not exist

### DIFF
--- a/pdns/dnsdistdist/docs/reference/constants.rst
+++ b/pdns/dnsdistdist/docs/reference/constants.rst
@@ -16,15 +16,15 @@ OPCode
 
 Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-5
 
-.. _DNSQClass:
+.. _DNSClass:
 
-QClass
+DNSClass
 ------
 
-- ``QClass.IN``
-- ``QClass.CHAOS``
-- ``QClass.NONE``
-- ``QClass.ANY``
+- ``DNSClass.IN``
+- ``DNSClass.CHAOS``
+- ``DNSClass.NONE``
+- ``DNSClass.ANY``
 
 Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-2
 


### PR DESCRIPTION
The C code uses `QClass`, but the Lua variable was added as `DNSClass` for whatever reason.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Documentation should use the Lua name, not the C name.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
