### PR TITLE
Action for extended error codes

### DIFF
--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -69,6 +69,69 @@ std::string ERCode::to_s(uint8_t rcode) {
   return RCode::rcodes_s[rcode];
 }
 
+
+static std::vector<std::string> noerror_info_codes = boost::assign::list_of
+  ("")
+  ("Unsupported DNSKEY Algorithm")
+  ("Unsupported DS Algorithm")
+  ("Stale Answer")
+  ("Forged answer")
+  ("DNSSEC Indeterminate")
+;
+
+static std::vector<std::string> formerr_info_codes = boost::assign::list_of
+  ("")
+;
+
+static std::vector<std::string> servfail_info_codes = boost::assign::list_of
+  ("")
+  ("DNSSEC Bogus")
+  ("Signature Expired")
+  ("Signature Not Yet Valid")
+  ("DNSKEY missing")
+  ("RRSIGs missing")
+  ("No Zone Key Bit Set")
+  ("No Reachable Authority")
+  ("NSEC Missing")
+  ("Cached Error")
+  ("Not Ready")
+;
+
+static std::vector<std::string> nxdomain_info_codes = boost::assign::list_of
+  ("")
+  ("Blocked")
+  ("Censored")
+  ("Stale Answer")
+;
+
+static std::vector<std::string> notimp_info_codes = boost::assign::list_of
+  ("")
+  ("Deprecated")
+;
+
+static std::vector<std::string> refused_info_codes = boost::assign::list_of
+  ("")
+  ("Lame")
+  ("Prohibited")
+;
+
+std::vector< std::vector<std::string> > ExErrInfoCode::exerrinfocodes_s = boost::assign::list_of
+  (noerror_info_codes)
+  (formerr_info_codes)
+  (servfail_info_codes)
+  (nxdomain_info_codes)
+  (notimp_info_codes)
+  (refused_info_codes)
+;
+
+// The meaning of info_code depends on which rcode it is for.
+std::string ExErrInfoCode::to_s(uint8_t rcode, uint16_t info_code) {
+  if ((rcode >= ExErrInfoCode::exerrinfocodes_s.size()) || (info_code >= ExErrInfoCode::exerrinfocodes_s[rcode].size())) {
+    return std::string("ExErrInfoCode#")+std::to_string(rcode)+std::string(".")+std::to_string(info_code);
+  }
+  return ExErrInfoCode::exerrinfocodes_s[rcode][info_code];
+}
+
 class BoundsCheckingPointer
 {
 public:

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -67,6 +67,16 @@ public:
   static std::string to_s(uint8_t rcode);
 };
 
+// In principle we can use a "struct" instead of a "class" here, since
+// in C++ a struct is just a class where all members default to
+// public. But since the other definitions use class, we will too.
+class ExErrInfoCode
+{
+public:
+  static std::string to_s(uint8_t rcode, uint16_t info_code);
+  static std::vector<std::vector<std::string>> exerrinfocodes_s;
+};
+
 class Opcode
 {
 public:

--- a/pdns/dnsdist-extended-error.cc
+++ b/pdns/dnsdist-extended-error.cc
@@ -1,0 +1,103 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "dnsdist.hh"
+#include "dnsdist-ecs.hh"
+#include "dnsdist-extended-error.hh"
+#include "ednsoptions.hh"
+
+std::string generateExtendedError(const DNSQuestion& dq)
+{
+  std::string errbuf;
+  const EDNSExtendedError& exerr = *(dq.ednsExtendedError);
+
+  errbuf.reserve(4 + exerr.extra_text.length());
+  if (exerr.retry) {
+    errbuf.append("\x80\x00", 2);
+  } else {
+    errbuf.append("\x00\x00", 2);
+  }
+  char code[2] = { char((dq.dh->rcode << 4) | ((exerr.info_code >> 8) & 0xf)),
+                   char(exerr.info_code & 0xFF) };
+  errbuf.append(code, 2);
+  errbuf.append(exerr.extra_text);
+
+  return errbuf;
+}
+
+bool handleEDNSExtendedError(DNSQuestion& dq)
+{
+  char* packet = reinterpret_cast<char*>(dq.dh);
+
+  uint16_t optRDPosition;
+  size_t remaining;
+  int res = getEDNSOptionsStart(packet, dq.consumed, dq.len, &optRDPosition, &remaining);
+
+  // If we don't have an OPT RR, then we won't add extended error information.
+  //
+  // We also have the same restrictions as ECS (where the function is defined),
+  // which means it returns the OPT record for questions without any RR
+  // except for the OPT records.
+  if (res != 0) {
+    return true;
+  }
+
+  std::string errbuf = generateExtendedError(dq);
+
+  // Make sure that we have enough room in our buffer for our extended error information.
+  if (dq.size < (dq.len + 4 + errbuf.length())) {
+    return false;
+  }
+
+  // Make sure we actually have length in our OPT record.
+  if (remaining < 2) {
+    return false;
+  }
+
+  // Get our OPT record and its length.
+  char *opt = packet + optRDPosition;
+  unsigned int optLen = (opt[0] << 8) + opt[1];
+
+  // Figure out the new length of the OPT record.
+  unsigned int newOptLen = optLen + 4 + errbuf.length();
+  if (newOptLen > 65535) {
+    return false;
+  }
+
+  // Update our OPT length.
+  opt[0] = (newOptLen >> 8) & 0xFF;
+  opt[1] = newOptLen & 0xFF;
+
+  // Add our new OPT RR.
+  opt[optLen] = (EDNSOptionCode::EXTENDED_ERROR >> 8) & 0xFF;
+  opt[optLen+1] = EDNSOptionCode::EXTENDED_ERROR & 0xFF;
+  opt[optLen+2] = (errbuf.length() >> 8) & 0xFF;
+  opt[optLen+3] = errbuf.length() & 0xFF;
+  memcpy(opt + optLen + 4, errbuf.c_str(), errbuf.length());
+
+  // Update the length of our packet.
+  dq.len += 4 + errbuf.length();
+
+  // And it worked!
+  return true;
+}
+

--- a/pdns/dnsdist-extended-error.cc
+++ b/pdns/dnsdist-extended-error.cc
@@ -25,7 +25,7 @@
 #include "dnsdist-extended-error.hh"
 #include "ednsoptions.hh"
 
-std::string generateExtendedError(const DNSQuestion& dq)
+static std::string generateExtendedError(const DNSQuestion& dq)
 {
   std::string errbuf;
   const EDNSExtendedError& exerr = *(dq.ednsExtendedError);
@@ -44,7 +44,7 @@ std::string generateExtendedError(const DNSQuestion& dq)
   return errbuf;
 }
 
-bool handleEDNSExtendedError(DNSQuestion& dq)
+bool addEDNSExtendedError(DNSQuestion& dq)
 {
   char* packet = reinterpret_cast<char*>(dq.dh);
 

--- a/pdns/dnsdist-extended-error.hh
+++ b/pdns/dnsdist-extended-error.hh
@@ -23,4 +23,4 @@
 
 #include "dnsdist.hh"
 
-bool addExtendedError(DNSQuestion& dq, const EDNSExtendedError& exerr);
+bool addEDNSExtendedError(DNSQuestion& dq);

--- a/pdns/dnsdist-extended-error.hh
+++ b/pdns/dnsdist-extended-error.hh
@@ -1,0 +1,26 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "dnsdist.hh"
+
+bool addExtendedError(DNSQuestion& dq, const EDNSExtendedError& exerr);

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -341,6 +341,8 @@ public:
       dq->ednsExtendedError->retry = d_retry;
       dq->ednsExtendedError->info_code = d_info_code;
       dq->ednsExtendedError->extra_text = d_extra_text;
+    } else {
+      dq->ednsExtendedError = nullptr;
     }
     return Action::HeaderModify;
   }
@@ -1215,7 +1217,7 @@ void setupLuaActions()
     });
 
   g_lua.writeFunction("ERCodeAction", [](uint8_t rcode, boost::optional<int> info_code, boost::optional<std::string> extra_text, boost::optional<bool> retry) {
-      return std::shared_ptr<DNSAction>(new ERCodeAction(rcode, info_code ? *info_code : -1, extra_text ? *extra_text : "", retry ? *retry : false));
+      return std::shared_ptr<DNSAction>(new ERCodeAction(rcode, info_code ? *info_code : 0, extra_text ? *extra_text : "", retry ? *retry : false));
     });
 
   g_lua.writeFunction("SkipCacheAction", []() {

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -35,11 +35,11 @@
 class DropAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     return Action::Drop;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "drop";
   }
@@ -48,11 +48,11 @@ public:
 class AllowAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     return Action::Allow;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "allow";
   }
@@ -61,11 +61,11 @@ public:
 class NoneAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "no op";
   }
@@ -76,14 +76,14 @@ class QPSAction : public DNSAction
 public:
   QPSAction(int limit) : d_qps(limit, limit)
   {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if(d_qps.check())
       return Action::None;
     else
       return Action::Drop;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "qps limit to "+std::to_string(d_qps.getRate());
   }
@@ -96,12 +96,12 @@ class DelayAction : public DNSAction
 public:
   DelayAction(int msec) : d_msec(msec)
   {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     *ruleresult=std::to_string(d_msec);
     return Action::Delay;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "delay by "+std::to_string(d_msec)+ " msec";
   }
@@ -115,9 +115,9 @@ class TeeAction : public DNSAction
 public:
   TeeAction(const ComboAddress& ca, bool addECS=false);
   ~TeeAction() override;
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override;
-  string toString() const override;
-  std::map<string, double> getStats() const override;
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override;
+  std::string toString() const override;
+  std::map<std::string, double> getStats() const override;
 
 private:
   ComboAddress d_remote;
@@ -156,7 +156,7 @@ TeeAction::~TeeAction()
   d_worker.join();
 }
 
-DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) const
+DNSAction::Action TeeAction::operator()(DNSQuestion* dq, std::string* ruleresult) const
 {
   if(dq->tcp) {
     d_tcpdrops++;
@@ -173,7 +173,7 @@ DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) con
       query.reserve(dq->size);
       query.assign((char*) dq->dh, len);
 
-      string newECSOption;
+      std::string newECSOption;
       generateECSOption(dq->ecsSet ? dq->ecs.getNetwork() : *dq->remote, newECSOption, dq->ecsSet ? dq->ecs.getBits() :  dq->ecsPrefixLength);
 
       if (!handleEDNSClientSubnet(const_cast<char*>(query.c_str()), query.capacity(), dq->qname->wirelength(), &len, &ednsAdded, &ecsAdded, dq->ecsOverride, newECSOption, g_preserveTrailingData)) {
@@ -192,12 +192,12 @@ DNSAction::Action TeeAction::operator()(DNSQuestion* dq, string* ruleresult) con
   return DNSAction::Action::None;
 }
 
-string TeeAction::toString() const
+std::string TeeAction::toString() const
 {
   return "tee to "+d_remote.toStringWithPort();
 }
 
-std::map<string,double> TeeAction::getStats() const
+std::map<std::string,double> TeeAction::getStats() const
 {
   return {{"queries", d_queries},
           {"responses", d_responses},
@@ -253,18 +253,18 @@ class PoolAction : public DNSAction
 {
 public:
   PoolAction(const std::string& pool) : d_pool(pool) {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     *ruleresult=d_pool;
     return Action::Pool;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "to pool "+d_pool;
   }
 
 private:
-  string d_pool;
+  std::string d_pool;
 };
 
 
@@ -272,7 +272,7 @@ class QPSPoolAction : public DNSAction
 {
 public:
   QPSPoolAction(unsigned int limit, const std::string& pool) : d_qps(limit, limit), d_pool(pool) {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if(d_qps.check()) {
       *ruleresult=d_pool;
@@ -281,27 +281,27 @@ public:
     else
       return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "max " +std::to_string(d_qps.getRate())+" to pool "+d_pool;
   }
 
 private:
   QPSLimiter d_qps;
-  string d_pool;
+  std::string d_pool;
 };
 
 class RCodeAction : public DNSAction
 {
 public:
   RCodeAction(uint8_t rcode) : d_rcode(rcode) {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->dh->rcode = d_rcode;
     dq->dh->qr = true; // for good measure
     return Action::HeaderModify;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set rcode "+std::to_string(d_rcode);
   }
@@ -314,14 +314,14 @@ class ERCodeAction : public DNSAction
 {
 public:
   ERCodeAction(uint8_t rcode) : d_rcode(rcode) {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->dh->rcode = (d_rcode & 0xF);
     dq->ednsRCode = ((d_rcode & 0xFFF0) >> 4);
     dq->dh->qr = true; // for good measure
     return Action::HeaderModify;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set ercode "+ERCode::to_s(d_rcode);
   }
@@ -333,23 +333,23 @@ private:
 class TCAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     return Action::Truncate;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "tc=1 answer";
   }
 };
 
-DNSAction::Action LuaAction::operator()(DNSQuestion* dq, string* ruleresult) const
+DNSAction::Action LuaAction::operator()(DNSQuestion* dq, std::string* ruleresult) const
 {
   std::lock_guard<std::mutex> lock(g_luamutex);
   try {
     auto ret = d_func(dq);
     if (ruleresult) {
-      if (boost::optional<string> rule = std::get<1>(ret)) {
+      if (boost::optional<std::string> rule = std::get<1>(ret)) {
         *ruleresult = *rule;
       }
       else {
@@ -366,13 +366,13 @@ DNSAction::Action LuaAction::operator()(DNSQuestion* dq, string* ruleresult) con
   return DNSAction::Action::ServFail;
 }
 
-DNSResponseAction::Action LuaResponseAction::operator()(DNSResponse* dr, string* ruleresult) const
+DNSResponseAction::Action LuaResponseAction::operator()(DNSResponse* dr, std::string* ruleresult) const
 {
   std::lock_guard<std::mutex> lock(g_luamutex);
   try {
     auto ret = d_func(dr);
     if(ruleresult) {
-      if (boost::optional<string> rule = std::get<1>(ret)) {
+      if (boost::optional<std::string> rule = std::get<1>(ret)) {
         *ruleresult = *rule;
       }
       else {
@@ -389,7 +389,7 @@ DNSResponseAction::Action LuaResponseAction::operator()(DNSResponse* dr, string*
   return DNSResponseAction::Action::ServFail;
 }
 
-DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, string* ruleresult) const
+DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, std::string* ruleresult) const
 {
   uint16_t qtype = dq->qtype;
   // do we even have a response?
@@ -443,7 +443,7 @@ DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, string* ruleresult) c
   dq->dh->arcount = 0; // for now, forget about your EDNS, we're marching over it
 
   if(qtype == QType::CNAME) {
-    string wireData = d_cname.toDNSString(); // Note! This doesn't do compression!
+    std::string wireData = d_cname.toDNSString(); // Note! This doesn't do compression!
     const unsigned char recordstart[]={0xc0, 0x0c,    // compressed name
                                        0, (unsigned char) qtype,
                                        0, QClass::IN, // IN
@@ -493,19 +493,19 @@ class MacAddrAction : public DNSAction
 public:
   MacAddrAction(uint16_t code) : d_code(code)
   {}
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if(dq->dh->arcount)
       return Action::None;
 
-    string mac = getMACAddress(*dq->remote);
+    std::string mac = getMACAddress(*dq->remote);
     if(mac.empty())
       return Action::None;
 
-    string optRData;
+    std::string optRData;
     generateEDNSOption(d_code, mac, optRData);
 
-    string res;
+    std::string res;
     generateOptRR(optRData, res, g_EdnsUDPPayloadSize, 0, false);
 
     if ((dq->size - dq->len) < res.length())
@@ -518,7 +518,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "add EDNS MAC (code="+std::to_string(d_code)+")";
   }
@@ -529,12 +529,12 @@ private:
 class NoRecurseAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->dh->rd = false;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set rd=0";
   }
@@ -555,7 +555,7 @@ public:
     else
       d_fp = fopen(str.c_str(), "w");
     if(!d_fp)
-      throw std::runtime_error("Unable to open file '"+str+"' for logging: "+string(strerror(errno)));
+      throw std::runtime_error("Unable to open file '"+str+"' for logging: "+std::string(strerror(errno)));
     if(!buffered)
       setbuf(d_fp, 0);
   }
@@ -564,14 +564,14 @@ public:
     if(d_fp)
       fclose(d_fp);
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if(!d_fp) {
       vinfolog("Packet from %s for %s %s with id %d", dq->remote->toStringWithPort(), dq->qname->toString(), QType(dq->qtype).getName(), dq->dh->id);
     }
     else {
       if(d_binary) {
-        string out = dq->qname->toDNSString();
+        std::string out = dq->qname->toDNSString();
         fwrite(out.c_str(), 1, out.size(), d_fp);
         fwrite((void*)&dq->qtype, 1, 2, d_fp);
       }
@@ -581,7 +581,7 @@ public:
     }
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     if (!d_fname.empty()) {
       return "log to " + d_fname;
@@ -589,7 +589,7 @@ public:
     return "log";
   }
 private:
-  string d_fname;
+  std::string d_fname;
   FILE* d_fp{0};
   bool d_binary{true};
 };
@@ -598,12 +598,12 @@ private:
 class DisableValidationAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->dh->cd = true;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set cd=1";
   }
@@ -612,12 +612,12 @@ public:
 class SkipCacheAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->skipCache = true;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "skip cache";
   }
@@ -628,12 +628,12 @@ class TempFailureCacheTTLAction : public DNSAction
 public:
   TempFailureCacheTTLAction(uint32_t ttl) : d_ttl(ttl)
   {}
-  TempFailureCacheTTLAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  TempFailureCacheTTLAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->tempFailureTTL = d_ttl;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set tempfailure cache ttl to "+std::to_string(d_ttl);
   }
@@ -647,12 +647,12 @@ public:
   ECSPrefixLengthAction(uint16_t v4Length, uint16_t v6Length) : d_v4PrefixLength(v4Length), d_v6PrefixLength(v6Length)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->ecsPrefixLength = dq->remote->sin4.sin_family == AF_INET ? d_v4PrefixLength : d_v6PrefixLength;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set ECS prefix length to " + std::to_string(d_v4PrefixLength) + "/" + std::to_string(d_v6PrefixLength);
   }
@@ -667,12 +667,12 @@ public:
   ECSOverrideAction(bool ecsOverride) : d_ecsOverride(ecsOverride)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->ecsOverride = d_ecsOverride;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set ECS override to " + std::to_string(d_ecsOverride);
   }
@@ -684,12 +684,12 @@ private:
 class DisableECSAction : public DNSAction
 {
 public:
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->useECS = false;
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "disable ECS";
   }
@@ -706,7 +706,7 @@ public:
   {
   }
 
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     dq->ecsSet = true;
 
@@ -720,9 +720,9 @@ public:
     return Action::None;
   }
 
-  string toString() const override
+  std::string toString() const override
   {
-    string result = "set ECS to " + d_v4.toString();
+    std::string result = "set ECS to " + d_v4.toString();
     if (d_hasV6) {
       result += " / " + d_v6.toString();
     }
@@ -742,7 +742,7 @@ public:
   DnstapLogAction(const std::string& identity, std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSQuestion&, DnstapMessage*)> > alterFunc): d_identity(identity), d_logger(logger), d_alterFunc(alterFunc)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
 #ifdef HAVE_PROTOBUF
     DnstapMessage message(d_identity, dq->remote, dq->local, dq->tcp, reinterpret_cast<const char*>(dq->dh), dq->len, dq->queryTime, nullptr);
@@ -758,7 +758,7 @@ public:
 #endif /* HAVE_PROTOBUF */
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "remote log as dnstap to " + (d_logger ? d_logger->toString() : "");
   }
@@ -774,7 +774,7 @@ public:
   RemoteLogAction(std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSQuestion&, DNSDistProtoBufMessage*)> > alterFunc, const std::string& serverID): d_logger(logger), d_alterFunc(alterFunc), d_serverID(serverID)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
 #ifdef HAVE_PROTOBUF
     if (!dq->uniqueId) {
@@ -797,7 +797,7 @@ public:
 #endif /* HAVE_PROTOBUF */
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "remote log to " + (d_logger ? d_logger->toString() : "");
   }
@@ -813,7 +813,7 @@ public:
   SNMPTrapAction(const std::string& reason): d_reason(reason)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if (g_snmpAgent && g_snmpTrapsEnabled) {
       g_snmpAgent->sendDNSTrap(*dq, d_reason);
@@ -821,7 +821,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "send SNMP trap";
   }
@@ -835,7 +835,7 @@ public:
   TagAction(const std::string& tag, const std::string& value): d_tag(tag), d_value(value)
   {
   }
-  DNSAction::Action operator()(DNSQuestion* dq, string* ruleresult) const override
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
   {
     if (!dq->qTag) {
       dq->qTag = std::make_shared<QTag>();
@@ -845,7 +845,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set tag '" + d_tag + "' to value '" + d_value + "'";
   }
@@ -860,7 +860,7 @@ public:
   DnstapLogResponseAction(const std::string& identity, std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSResponse&, DnstapMessage*)> > alterFunc): d_identity(identity), d_logger(logger), d_alterFunc(alterFunc)
   {
   }
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
 #ifdef HAVE_PROTOBUF
     struct timespec now;
@@ -878,7 +878,7 @@ public:
 #endif /* HAVE_PROTOBUF */
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "log response as dnstap to " + (d_logger ? d_logger->toString() : "");
   }
@@ -894,7 +894,7 @@ public:
   RemoteLogResponseAction(std::shared_ptr<RemoteLoggerInterface>& logger, boost::optional<std::function<void(const DNSResponse&, DNSDistProtoBufMessage*)> > alterFunc, const std::string& serverID, bool includeCNAME): d_logger(logger), d_alterFunc(alterFunc), d_serverID(serverID), d_includeCNAME(includeCNAME)
   {
   }
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
 #ifdef HAVE_PROTOBUF
     if (!dr->uniqueId) {
@@ -917,7 +917,7 @@ public:
 #endif /* HAVE_PROTOBUF */
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "remote log response to " + (d_logger ? d_logger->toString() : "");
   }
@@ -931,11 +931,11 @@ private:
 class DropResponseAction : public DNSResponseAction
 {
 public:
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     return Action::Drop;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "drop";
   }
@@ -944,11 +944,11 @@ public:
 class AllowResponseAction : public DNSResponseAction
 {
 public:
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     return Action::Allow;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "allow";
   }
@@ -959,12 +959,12 @@ class DelayResponseAction : public DNSResponseAction
 public:
   DelayResponseAction(int msec) : d_msec(msec)
   {}
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     *ruleresult=std::to_string(d_msec);
     return Action::Delay;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "delay by "+std::to_string(d_msec)+ " msec";
   }
@@ -978,7 +978,7 @@ public:
   SNMPTrapResponseAction(const std::string& reason): d_reason(reason)
   {
   }
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     if (g_snmpAgent && g_snmpTrapsEnabled) {
       g_snmpAgent->sendDNSTrap(*dr, d_reason);
@@ -986,7 +986,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "send SNMP trap";
   }
@@ -1000,7 +1000,7 @@ public:
   TagResponseAction(const std::string& tag, const std::string& value): d_tag(tag), d_value(value)
   {
   }
-  DNSResponseAction::Action operator()(DNSResponse* dr, string* ruleresult) const override
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
   {
     if (!dr->qTag) {
       dr->qTag = std::make_shared<QTag>();
@@ -1010,7 +1010,7 @@ public:
 
     return Action::None;
   }
-  string toString() const override
+  std::string toString() const override
   {
     return "set tag '" + d_tag + "' to value '" + d_value + "'";
   }
@@ -1121,7 +1121,7 @@ void setupLuaActions()
       return std::shared_ptr<DNSAction>(new MacAddrAction(code));
     });
 
-  g_lua.writeFunction("PoolAction", [](const string& a) {
+  g_lua.writeFunction("PoolAction", [](const std::string& a) {
       return std::shared_ptr<DNSAction>(new PoolAction(a));
     });
 
@@ -1129,16 +1129,16 @@ void setupLuaActions()
       return std::shared_ptr<DNSAction>(new QPSAction(limit));
     });
 
-  g_lua.writeFunction("QPSPoolAction", [](int limit, const string& a) {
+  g_lua.writeFunction("QPSPoolAction", [](int limit, const std::string& a) {
       return std::shared_ptr<DNSAction>(new QPSPoolAction(limit, a));
     });
 
-  g_lua.writeFunction("SpoofAction", [](boost::variant<string,vector<pair<int, string>>> inp, boost::optional<string> b ) {
+  g_lua.writeFunction("SpoofAction", [](boost::variant<std::string,vector<pair<int, std::string>>> inp, boost::optional<std::string> b ) {
       vector<ComboAddress> addrs;
-      if(auto s = boost::get<string>(&inp))
+      if(auto s = boost::get<std::string>(&inp))
         addrs.push_back(ComboAddress(*s));
       else {
-        const auto& v = boost::get<vector<pair<int,string>>>(inp);
+        const auto& v = boost::get<vector<pair<int,std::string>>>(inp);
         for(const auto& a: v)
           addrs.push_back(ComboAddress(a.second));
       }
@@ -1147,7 +1147,7 @@ void setupLuaActions()
       return std::shared_ptr<DNSAction>(new SpoofAction(addrs));
     });
 
-  g_lua.writeFunction("SpoofCNAMEAction", [](const string& a) {
+  g_lua.writeFunction("SpoofCNAMEAction", [](const std::string& a) {
       return std::shared_ptr<DNSAction>(new SpoofAction(a));
     });
 

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -324,10 +324,10 @@ public:
     }
 
     // It would be nice if we could check the EXTRA-TEXT to ensure
-    // that it is not too big. However, the field has no limit beyond
-    // the size limit of any OPT RR (65535). There can only be a
-    // single OPT record in a DNS message, which is also limited to
-    // 65535 bytes - shared by all OPT RR in the message.
+    // that it is not too big. However, in theory the field has no
+    // limit beyond the size limit of any OPT RR (65535). There can
+    // only be a single OPT record in a DNS message, which is also
+    // limited to 65535 bytes - shared by all OPT RR in the message.
     //
     // Presumably the OPT record is checked to make sure that the
     // combined OPT RR sizes are not too big at some point when we

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -264,12 +264,12 @@ void restoreFlags(struct dnsheader* dh, uint16_t origFlags)
   *flags |= origFlags;
 }
 
-bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags)
+void fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags)
 {
   restoreFlags(dq.dh, origFlags);
 
+  addEDNSToQueryTurnedResponse(dq);
   addEDNSExtendedError(dq);
-  return addEDNSToQueryTurnedResponse(dq);
 }
 
 bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope)

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -45,6 +45,7 @@
 #include "dnsdist-cache.hh"
 #include "dnsdist-console.hh"
 #include "dnsdist-ecs.hh"
+#include "dnsdist-extended-error.hh"
 #include "dnsdist-lua.hh"
 #include "dnsdist-rings.hh"
 #include "dnsdist-secpoll.hh"
@@ -267,6 +268,7 @@ bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags)
 {
   restoreFlags(dq.dh, origFlags);
 
+  addEDNSExtendedError(dq);
   return addEDNSToQueryTurnedResponse(dq);
 }
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -80,6 +80,7 @@ struct DNSQuestion
   uint16_t len;
   uint16_t ecsPrefixLength;
   uint8_t ednsRCode{0};
+  std::shared_ptr<EDNSExtendedError> ednsExtendedError{nullptr};
   boost::optional<uint32_t> tempFailureTTL;
   const bool tcp;
   const struct timespec* queryTime;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1026,7 +1026,7 @@ void resetLuaSideEffect(); // reset to indeterminate state
 bool responseContentMatches(const char* response, const uint16_t responseLen, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote, unsigned int& consumed);
 bool processQuery(LocalHolders& holders, DNSQuestion& dq, string& poolname, int* delayMsec, const struct timespec& now);
 bool processResponse(LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, int* delayMsec);
-bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags);
+void fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags);
 bool fixUpResponse(char** response, uint16_t* responseLen, size_t* responseSize, const DNSName& qname, uint16_t origFlags, bool ednsAdded, bool ecsAdded, std::vector<uint8_t>& rewrittenResponse, uint16_t addRoom, bool* zeroScope);
 void restoreFlags(struct dnsheader* dh, uint16_t origFlags);
 bool checkQueryHeaders(const struct dnsheader* dh);

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -98,6 +98,7 @@ dnsdist_SOURCES = \
 	dnsdist-dnscrypt.cc \
 	dnsdist-dynblocks.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
+	dnsdist-extended-error.cc dns-extended-error.hh \
 	dnsdist-lua.hh dnsdist-lua.cc \
 	dnsdist-lua-actions.cc \
 	dnsdist-lua-bindings.cc \

--- a/pdns/ednsoptions.hh
+++ b/pdns/ednsoptions.hh
@@ -26,7 +26,7 @@
 
 struct EDNSOptionCode
 {
-  enum EDNSOptionCodeEnum {NSID=3, DAU=5, DHU=6, N3U=7, ECS=8, EXPIRE=9, COOKIE=10, TCPKEEPALIVE=11, PADDING=12, CHAIN=13, KEYTAG=14};
+  enum EDNSOptionCodeEnum {NSID=3, DAU=5, DHU=6, N3U=7, ECS=8, EXPIRE=9, COOKIE=10, TCPKEEPALIVE=11, PADDING=12, CHAIN=13, KEYTAG=14, EXTENDED_ERROR=65500};
 };
 
 /* extract a specific EDNS0 option from a pointer on the beginning rdLen of the OPT RR */
@@ -44,6 +44,16 @@ struct EDNSOptionView
 };
 
 typedef std::map<uint16_t, EDNSOptionView> EDNSOptionViewMap;
+
+// Extended errors are currently defined in this draft:
+//  https://tools.ietf.org/html/draft-ietf-dnsop-extended-error-05
+struct EDNSExtendedError
+{
+  bool retry;
+  uint16_t info_code;
+  std::string extra_text;
+};
+
 
 /* extract all EDNS0 options from a pointer on the beginning rdLen of the OPT RR */
 int getEDNSOptions(const char* optRR, size_t len, EDNSOptionViewMap& options);


### PR DESCRIPTION
### Short description
This PR implements the Extended DNS Errors draft:

https://tools.ietf.org/html/draft-ietf-dnsop-extended-error-05

It was started at the IETF 104 hackathon and finished up in the week of the IETF.

I looked through the documented error codes in the draft and think that only three really apply to proxies:

REFUSED Extended DNS Error Code 2 - Prohibited
NXDOMAIN Extended DNS Error Code 1 - Blocked
NXDOMAIN Extended DNS Error Code 2 - Censored

Since adding an ACL to `dnsdist` causes it to drop packets on the floor, none of these make sense to happen "automagically" somehow.

Instead, this PR takes the approach of enhancing the existing `ERCodeAction` to provide optional additional parameters which can be used to deliver extended error code information, for example:
```
setLocal("[::1]:5321")
newServer("9.9.9.9")
addAction(RegexRule("."), ERCodeAction(3, 1, "DENIED ✋"))
```
This will return `NXDomain` with the extended code 1 (blocked), while providing a helpful error message.

I used a few C-isms while poking around the packet bytes. There are probably more verbose C++ ways to do this which - while not actually being any safer or faster - are at least really long and hard to read, therefore preferred by C++ developers. 😉

I also note that there did not seem to be straightforward ways to manipulate packet contents (for example, adding OPT RR and so on). I tried to mimic the approach taken in the ECS stuff, although that has a lot more work involved than the extended error codes. Probably a refactoring to handle OPT record processing in a more elegant way would be worth it, but outside of the scope of the hackathon. 

The  `dnsdist-lua-actions.cc` file has a lot of changes because of the `string` to `std::string` conversion. I can clean these up if desired, but my guess is that this PR will probably need other changes anyway so I've left them in. 

While the existing tests work, I did not bother to add any new ones. I guess there would be something like 10 additional cases to cover all the combinations of ways to do things correctly and broken with such an option.

Finally, it might be also be useful to provide a way to read the extended error code provided by the backends, and allow a rule (or Lua) to act on them. If the extended error code draft is still a work in progress by the next IETF hackathon, maybe I'll give that a shot then.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
