### PR TITLE
auth: fix referral response for DS queries

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1455,6 +1455,9 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
       bool doReferral = true;
       if(d_dk.doesDNSSEC()) {
         for(auto& loopRR: rrset) {
+          // In a dnssec capable backend auth=true means, there is no delagation at
+          // or above this qname in this zone (for DS queries). Without a delegation,
+          // at or above this level, it is pointless to search for refferals.
           if(loopRR.auth) {
             doReferral = false;
             break;
@@ -1462,6 +1465,8 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
         }
       } else {
         for(auto& loopRR: rrset) {
+          // In a non dnssec capable backend auth is always true, so our only option
+          // is, always look for referals. Unless there is a direct match for DS.
           if(loopRR.dr.d_type == QType::DS) {
             doReferral = false;
             break;

--- a/regression-tests.rootzone/tests/axfr/expected_result
+++ b/regression-tests.rootzone/tests/axfr/expected_result
@@ -5,6 +5,11 @@ a.gtld-servers.net.	172800	IN	A	192.5.6.30
 a.gtld-servers.net.	172800	IN	AAAA	2001:503:a83e::2:30
 a.root-servers.net.	518400	IN	A	198.41.0.4
 a.root-servers.net.	518400	IN	AAAA	2001:503:ba3e::2:30
+barney.advsys.co.uk.	172800	IN	A	217.23.160.50
 net.	172800	IN	NS	a.gtld-servers.net.
 net.	86400	IN	DS	35886 8 2 7862b27f5f516ebe19680444d4ce5e762981931842c465f00236401d8bd973ee
+nsa.nic.uk.	172800	IN	A	156.154.100.3
+nsa.nic.uk.	172800	IN	AAAA	2001:502:ad09::3
 org.	172800	IN	NS	a.gtld-servers.net.
+uk.	172800	IN	NS	nsa.nic.uk.
+uk.	86400	IN	DS	43876 8 2 a107ed2ac1bd14d924173bc7e827a1153582072394f9272ba37e2353bc659603

--- a/regression-tests.rootzone/tests/axfr/expected_result.dnssec
+++ b/regression-tests.rootzone/tests/axfr/expected_result.dnssec
@@ -11,11 +11,19 @@ a.gtld-servers.net.	172800	IN	A	192.5.6.30
 a.gtld-servers.net.	172800	IN	AAAA	2001:503:a83e::2:30
 a.root-servers.net.	518400	IN	A	198.41.0.4
 a.root-servers.net.	518400	IN	AAAA	2001:503:ba3e::2:30
+barney.advsys.co.uk.	172800	IN	A	217.23.160.50
 net.	172800	IN	NS	a.gtld-servers.net.
 net.	86400	IN	DS	35886 8 2 7862b27f5f516ebe19680444d4ce5e762981931842c465f00236401d8bd973ee
 net.	86400	IN	NSEC	org. NS DS RRSIG NSEC
 net.	86400	IN	RRSIG	DS 13 1 86400 [expiry] [inception] [keytag] . ...
 net.	86400	IN	RRSIG	NSEC 13 1 86400 [expiry] [inception] [keytag] . ...
+nsa.nic.uk.	172800	IN	A	156.154.100.3
+nsa.nic.uk.	172800	IN	AAAA	2001:502:ad09::3
 org.	172800	IN	NS	a.gtld-servers.net.
-org.	86400	IN	NSEC	. NS RRSIG NSEC
+org.	86400	IN	NSEC	uk. NS RRSIG NSEC
 org.	86400	IN	RRSIG	NSEC 13 1 86400 [expiry] [inception] [keytag] . ...
+uk.	172800	IN	NS	nsa.nic.uk.
+uk.	86400	IN	DS	43876 8 2 a107ed2ac1bd14d924173bc7e827a1153582072394f9272ba37e2353bc659603
+uk.	86400	IN	NSEC	. NS DS RRSIG NSEC
+uk.	86400	IN	RRSIG	DS 13 1 86400 [expiry] [inception] [keytag] . ...
+uk.	86400	IN	RRSIG	NSEC 13 1 86400 [expiry] [inception] [keytag] . ...

--- a/regression-tests.rootzone/tests/axfr/expected_result.nsec3
+++ b/regression-tests.rootzone/tests/axfr/expected_result.nsec3
@@ -13,11 +13,19 @@ a.gtld-servers.net.	172800	IN	A	192.5.6.30
 a.gtld-servers.net.	172800	IN	AAAA	2001:503:a83e::2:30
 a.root-servers.net.	518400	IN	A	198.41.0.4
 a.root-servers.net.	518400	IN	AAAA	2001:503:ba3e::2:30
+barney.advsys.co.uk.	172800	IN	A	217.23.160.50
 net.	172800	IN	NS	a.gtld-servers.net.
 net.	86400	IN	DS	35886 8 2 7862b27f5f516ebe19680444d4ce5e762981931842c465f00236401d8bd973ee
 net.	86400	IN	NSEC3	1 0 1 abcd [next owner] NS DS RRSIG
 net.	86400	IN	RRSIG	DS 13 1 86400 [expiry] [inception] [keytag] . ...
 net.	86400	IN	RRSIG	NSEC3 13 1 86400 [expiry] [inception] [keytag] . ...
+nsa.nic.uk.	172800	IN	A	156.154.100.3
+nsa.nic.uk.	172800	IN	AAAA	2001:502:ad09::3
 org.	172800	IN	NS	a.gtld-servers.net.
 org.	86400	IN	NSEC3	1 0 1 abcd [next owner] NS
 org.	86400	IN	RRSIG	NSEC3 13 1 86400 [expiry] [inception] [keytag] . ...
+uk.	172800	IN	NS	nsa.nic.uk.
+uk.	86400	IN	DS	43876 8 2 a107ed2ac1bd14d924173bc7e827a1153582072394f9272ba37e2353bc659603
+uk.	86400	IN	NSEC3	1 0 1 abcd [next owner] NS DS RRSIG
+uk.	86400	IN	RRSIG	DS 13 1 86400 [expiry] [inception] [keytag] . ...
+uk.	86400	IN	RRSIG	NSEC3 13 1 86400 [expiry] [inception] [keytag] . ...

--- a/regression-tests.rootzone/tests/axfr/expected_result.nsec3-optout
+++ b/regression-tests.rootzone/tests/axfr/expected_result.nsec3-optout
@@ -13,9 +13,17 @@ a.gtld-servers.net.	172800	IN	A	192.5.6.30
 a.gtld-servers.net.	172800	IN	AAAA	2001:503:a83e::2:30
 a.root-servers.net.	518400	IN	A	198.41.0.4
 a.root-servers.net.	518400	IN	AAAA	2001:503:ba3e::2:30
+barney.advsys.co.uk.	172800	IN	A	217.23.160.50
 net.	172800	IN	NS	a.gtld-servers.net.
 net.	86400	IN	DS	35886 8 2 7862b27f5f516ebe19680444d4ce5e762981931842c465f00236401d8bd973ee
 net.	86400	IN	NSEC3	1 1 1 abcd [next owner] NS DS RRSIG
 net.	86400	IN	RRSIG	DS 13 1 86400 [expiry] [inception] [keytag] . ...
 net.	86400	IN	RRSIG	NSEC3 13 1 86400 [expiry] [inception] [keytag] . ...
+nsa.nic.uk.	172800	IN	A	156.154.100.3
+nsa.nic.uk.	172800	IN	AAAA	2001:502:ad09::3
 org.	172800	IN	NS	a.gtld-servers.net.
+uk.	172800	IN	NS	nsa.nic.uk.
+uk.	86400	IN	DS	43876 8 2 a107ed2ac1bd14d924173bc7e827a1153582072394f9272ba37e2353bc659603
+uk.	86400	IN	NSEC3	1 1 1 abcd [next owner] NS DS RRSIG
+uk.	86400	IN	RRSIG	DS 13 1 86400 [expiry] [inception] [keytag] . ...
+uk.	86400	IN	RRSIG	NSEC3 13 1 86400 [expiry] [inception] [keytag] . ...

--- a/regression-tests.rootzone/tests/ds-at-ent-from-glue/command
+++ b/regression-tests.rootzone/tests/ds-at-ent-from-glue/command
@@ -1,0 +1,1 @@
+cleandig co.uk DS

--- a/regression-tests.rootzone/tests/ds-at-ent-from-glue/description
+++ b/regression-tests.rootzone/tests/ds-at-ent-from-glue/description
@@ -1,0 +1,2 @@
+A DS query at empty non-terminal (derived from glue) level.
+Should result in a referral response.

--- a/regression-tests.rootzone/tests/ds-at-ent-from-glue/expected_result
+++ b/regression-tests.rootzone/tests/ds-at-ent-from-glue/expected_result
@@ -1,0 +1,5 @@
+1	uk.	IN	NS	172800	nsa.nic.uk.
+2	nsa.nic.uk.	IN	A	172800	156.154.100.3
+2	nsa.nic.uk.	IN	AAAA	172800	2001:502:ad09::3
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 0, opcode: 0
+Reply to question for qname='co.uk.', qtype=DS

--- a/regression-tests.rootzone/tests/ds-at-ent-from-glue/expected_result.dnssec
+++ b/regression-tests.rootzone/tests/ds-at-ent-from-glue/expected_result.dnssec
@@ -1,0 +1,6 @@
+1	uk.	IN	DS	86400	43876 8 2 a107ed2ac1bd14d924173bc7e827a1153582072394f9272ba37e2353bc659603
+1	uk.	IN	NS	172800	nsa.nic.uk.
+2	nsa.nic.uk.	IN	A	172800	156.154.100.3
+2	nsa.nic.uk.	IN	AAAA	172800	2001:502:ad09::3
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 0, opcode: 0
+Reply to question for qname='co.uk.', qtype=DS

--- a/regression-tests.rootzone/tests/ds-at-ent/command
+++ b/regression-tests.rootzone/tests/ds-at-ent/command
@@ -1,0 +1,1 @@
+cleandig co.uk DS

--- a/regression-tests.rootzone/tests/ds-at-ent/description
+++ b/regression-tests.rootzone/tests/ds-at-ent/description
@@ -1,0 +1,1 @@
+A DS query at empty non-terminal level. Should result in a referral response.

--- a/regression-tests.rootzone/tests/ds-at-ent/expected_result
+++ b/regression-tests.rootzone/tests/ds-at-ent/expected_result
@@ -1,0 +1,5 @@
+1	uk.	IN	NS	172800	nsa.nic.uk.
+2	nsa.nic.uk.	IN	A	172800	156.154.100.3
+2	nsa.nic.uk.	IN	AAAA	172800	2001:502:ad09::3
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 0, opcode: 0
+Reply to question for qname='co.uk.', qtype=DS

--- a/regression-tests.rootzone/tests/ds-at-ent/expected_result.dnssec
+++ b/regression-tests.rootzone/tests/ds-at-ent/expected_result.dnssec
@@ -1,0 +1,6 @@
+1	uk.	IN	DS	86400	43876 8 2 a107ed2ac1bd14d924173bc7e827a1153582072394f9272ba37e2353bc659603
+1	uk.	IN	NS	172800	nsa.nic.uk.
+2	nsa.nic.uk.	IN	A	172800	156.154.100.3
+2	nsa.nic.uk.	IN	AAAA	172800	2001:502:ad09::3
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 0, opcode: 0
+Reply to question for qname='co.uk.', qtype=DS

--- a/regression-tests.rootzone/tests/ds-at-glue/command
+++ b/regression-tests.rootzone/tests/ds-at-glue/command
@@ -1,0 +1,1 @@
+cleandig barney.advsys.co.uk DS

--- a/regression-tests.rootzone/tests/ds-at-glue/description
+++ b/regression-tests.rootzone/tests/ds-at-glue/description
@@ -1,0 +1,1 @@
+A DS query at glue level. Should result in a referral response.

--- a/regression-tests.rootzone/tests/ds-at-glue/expected_result
+++ b/regression-tests.rootzone/tests/ds-at-glue/expected_result
@@ -1,0 +1,5 @@
+1	uk.	IN	NS	172800	nsa.nic.uk.
+2	nsa.nic.uk.	IN	A	172800	156.154.100.3
+2	nsa.nic.uk.	IN	AAAA	172800	2001:502:ad09::3
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 0, opcode: 0
+Reply to question for qname='barney.advsys.co.uk.', qtype=DS

--- a/regression-tests.rootzone/tests/ds-at-glue/expected_result.dnssec
+++ b/regression-tests.rootzone/tests/ds-at-glue/expected_result.dnssec
@@ -1,0 +1,6 @@
+1	uk.	IN	DS	86400	43876 8 2 a107ed2ac1bd14d924173bc7e827a1153582072394f9272ba37e2353bc659603
+1	uk.	IN	NS	172800	nsa.nic.uk.
+2	nsa.nic.uk.	IN	A	172800	156.154.100.3
+2	nsa.nic.uk.	IN	AAAA	172800	2001:502:ad09::3
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 0, opcode: 0
+Reply to question for qname='barney.advsys.co.uk.', qtype=DS

--- a/regression-tests.rootzone/zones/ROOT
+++ b/regression-tests.rootzone/zones/ROOT
@@ -11,3 +11,9 @@ org.			172800	IN	NS	a.gtld-servers.net.
 
 a.gtld-servers.net.	172800	IN	A	192.5.6.30
 a.gtld-servers.net.	172800	IN	AAAA	2001:503:a83e:0:0:0:2:30
+
+uk.			86400	IN	DS	43876 8 2 A107ED2AC1BD14D924173BC7E827A1153582072394F9272BA37E2353BC659603
+uk.			172800	IN	NS	nsa.nic.uk.
+nsa.nic.uk.		172800	IN	AAAA	2001:502:ad09::3
+nsa.nic.uk.		172800	IN	A	156.154.100.3
+barney.advsys.co.uk.	172800	IN	A	217.23.160.50


### PR DESCRIPTION
### Short description
Glue and ents derived from glue did confuse the DS referral logic.

Fixes: #7625

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
