### PR TITLE
bindbackend docs: Add warning on empty bind-dnssec-db for slave operation

### DIFF
--- a/docs/backends/bind.rst
+++ b/docs/backends/bind.rst
@@ -64,6 +64,11 @@ slave DNSSEC-enabled domains (where the RRSIGS are in the AXFR), a
 :ref:`metadata-presigned` domain metadata is set
 during the zonetransfer.
 
+.. warning::
+   If this is left empty on slaves and a presigned zone is transferred,
+   it will (silently) serve it without DNSSEC. This in turn results in
+   serving the domain as bogus.
+
 .. _setting-bind-hybrid:
 
 ``bind-hybrid``


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
I fell right into the pitfall of configuring a slave with the Bind backend, serving presigned records, assuming it will serve the RRSIGs just fine, but no, my domain went bogus. This was documented, but
not as clearly as I hoped for, this PR improves the documentation regarding that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
  (sorry for the slightly longer first line in commit message)
- [x] compiled this code
  (yes built the docs, did not introduce new Sphinx warnings)
- [x] tested this code
  (the admonition looks fine to me)
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
  n/a
- [x] added or modified regression test(s)
  n/a
- [x] added or modified unit test(s)
  n/a