### PR TITLE
DNSSEC docs: Improve wording in "BIND-mode operation"

### DIFF
--- a/docs/dnssec/modes-of-operation.rst
+++ b/docs/dnssec/modes-of-operation.rst
@@ -162,13 +162,14 @@ Signatures and Hashing is similar as described in :ref:`dnssec-online-signing`.
 BIND-mode operation
 -------------------
 
-The :doc:`bindbackend <../backends/bind>` can manage keys in an
-SQLite3 database without launching a separate gsqlite3 backend.
+The :doc:`bindbackend <../backends/bind>` can manage keys and other
+DNSSEC-related :doc:`domain metadata <../domainmetadata>` in an SQLite3
+database without launching a separate gsqlite3 backend.
 
-To use this mode, add
-``bind-dnssec-db=/var/db/bind-dnssec-db.sqlite3`` to pdns.conf, and run
-``pdnsutil create-bind-db /var/db/bind-dnssec-db.sqlite3``. Then,
-restart PowerDNS.
+To use this mode, run
+``pdnsutil create-bind-db /var/db/bind-dnssec-db.sqlite3`` and set
+:ref:`setting-bind-dnssec-db` in pdns.conf to the path of the created
+database. Then, restart PowerDNS.
 
 .. note::
   This sqlite database is different from the database used for the regular :doc:`SQLite 3 backend <../backends/generic-sqlite3>`.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Documentation only - slightly improved the text as the title says.

Also:
* Mention that not just keys are part of this database.
* Link to the pdns.conf setting, that includes a warning with #7640.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
  (yes built the docs, did not introduce new Sphinx warnings)
- [x] tested this code
  (the link works)
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
  n/a
- [x] added or modified regression test(s)
  n/a
- [x] added or modified unit test(s)
  n/a