### PR TITLE
remotebackend: fix SOA in unittests

### DIFF
--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(test_method_lookup) {
    // then we check rr contains what we expect
    BOOST_CHECK_EQUAL(rr.qname.toString(), "unit.test.");
    BOOST_CHECK_MESSAGE(rr.qtype == QType::SOA, "returned qtype was not SOA");
-   BOOST_CHECK_EQUAL(rr.content, "ns.unit.test. hostmaster.unit.test. 1 2 3 4 5 6");
+   BOOST_CHECK_EQUAL(rr.content, "ns.unit.test. hostmaster.unit.test. 1 2 3 4 5");
    BOOST_CHECK_EQUAL(rr.ttl, 300);
 }
 

--- a/modules/remotebackend/unittest.rb
+++ b/modules/remotebackend/unittest.rb
@@ -9,7 +9,7 @@ $notified_serial = 1
 
 $domain = {
   "unit.test." => { 
-      "SOA" => ["ns.unit.test. hostmaster.unit.test. 1 2 3 4 5 6"],
+      "SOA" => ["ns.unit.test. hostmaster.unit.test. 1 2 3 4 5"],
       "NS" => ["ns1.unit.test.", "ns2.unit.test."],
   },
   "ns1.unit.test." => {


### PR DESCRIPTION
Otherwise check-zone and NS-queries fail.

Noticed while verifying a remotebackend patch in Debian against 4.1.5. Not tested on master.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
