### PR TITLE
always link in uuid-utils because webserver logging needs it now

### DIFF
--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -168,6 +168,7 @@ pdns_recursor_SOURCES = \
 	ueberbackend.hh \
 	unix_utility.cc \
 	utility.hh \
+	uuid-utils.hh uuid-utils.cc \
 	validate.cc validate.hh validate-recursor.cc validate-recursor.hh \
 	version.cc version.hh \
 	webserver.cc webserver.hh \
@@ -362,10 +363,6 @@ testrunner_LDADD += $(PROTOBUF_LIBS)
 testrunner$(OBJEXT): dnsmessage.pb.cc
 
 endif
-
-pdns_recursor_SOURCES += \
-	uuid-utils.hh uuid-utils.cc
-
 endif
 
 rec_control_SOURCES = \


### PR DESCRIPTION
### Short description
uuid-utils was conditional on protobuf use, but we now use it for webserver logging, which means all builds need it.

This fixes our el6 build, which does not have protobuf.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
