### PR TITLE
set --enable-option-checking=fatal on all package builds, enable SNMP in RPMs

### DIFF
--- a/builder-support/debian/dnsdist/debian-jessie/rules
+++ b/builder-support/debian/dnsdist/debian-jessie/rules
@@ -29,6 +29,7 @@ override_dh_auto_clean:
 
 override_dh_auto_configure:
 	./configure \
+	  --enable-option-checking=fatal \
 	  --host=$(DEB_HOST_GNU_TYPE) \
 	  --build=$(DEB_BUILD_GNU_TYPE) \
 	  --prefix=/usr \

--- a/builder-support/debian/dnsdist/debian-stretch/rules
+++ b/builder-support/debian/dnsdist/debian-stretch/rules
@@ -29,6 +29,7 @@ override_dh_auto_clean:
 
 override_dh_auto_configure:
 	./configure \
+	  --enable-option-checking=fatal \
 	  --host=$(DEB_HOST_GNU_TYPE) \
 	  --build=$(DEB_BUILD_GNU_TYPE) \
 	  --prefix=/usr \

--- a/builder-support/debian/dnsdist/ubuntu-trusty/rules
+++ b/builder-support/debian/dnsdist/ubuntu-trusty/rules
@@ -21,6 +21,7 @@ override_dh_auto_clean:
 
 override_dh_auto_configure:
 	./configure \
+	  --enable-option-checking=fatal \
 	  --host=$(DEB_HOST_GNU_TYPE) \
 	  --build=$(DEB_BUILD_GNU_TYPE) \
 	  --prefix=/usr \

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -73,6 +73,7 @@ sed -i '/^ExecStart/ s/dnsdist/dnsdist -u dnsdist -g dnsdist/' dnsdist.service.i
 
 %build
 %configure \
+  --enable-option-checking=fatal \
   --sysconfdir=/etc/dnsdist \
   --disable-static \
   --disable-dependency-tracking \

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -64,6 +64,7 @@ package if you need a dns cache for your network.
 
 %build
 %configure \
+    --enable-option-checking=fatal \
     --sysconfdir=%{_sysconfdir}/%{name} \
     --with-libsodium \
     --with-netsnmp \

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -67,7 +67,7 @@ package if you need a dns cache for your network.
     --enable-option-checking=fatal \
     --sysconfdir=%{_sysconfdir}/%{name} \
     --with-libsodium \
-    --with-netsnmp \
+    --with-net-snmp \
     --disable-silent-rules \
     --disable-static \
     --enable-unit-tests \

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -205,6 +205,7 @@ This package contains the ixfrdist program.
 export CPPFLAGS="-DLDAP_DEPRECATED"
 
 %configure \
+  --enable-option-checking=fatal \
   --sysconfdir=%{_sysconfdir}/%{name} \
   --disable-static \
   --disable-dependency-tracking \


### PR DESCRIPTION
### Short description
~WIP while this passes through the builder, so we can clean up the inevitable failures resulting from this.~ done

* [auth](https://builder.powerdns.com/#/buildrequests/114646?redirect_to_build=true)
* [dnsdist](https://builder.powerdns.com/#/buildrequests/114647?redirect_to_build=true)
* [rec](https://builder.powerdns.com/#/buildrequests/114648?redirect_to_build=true)

Rebased after #7671:
* [auth](https://builder.powerdns.com/#/buildrequests/115095?redirect_to_build=true) - succes
* [dnsdist](https://builder.powerdns.com/#/buildrequests/115096?redirect_to_build=true) - success
* [rec](https://builder.powerdns.com/#/buildrequests/115097?redirect_to_build=true) - el6, el7: `configure: error: unrecognized options: --with-netsnmp` (fix pushed, [rebuilding] (https://builder.powerdns.com/#/builders/97/builds/676)) - success

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
