### PR TITLE
dnsdist: Move constants to proper namespace

### DIFF
--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -87,33 +87,54 @@ void setupLuaVars()
       {"KEYTAG",       EDNSOptionCode::KEYTAG }
     });
 
-  vector<pair<string, int> > rcodes = {{"NOERROR",  RCode::NoError  },
-                                       {"FORMERR",  RCode::FormErr  },
-                                       {"SERVFAIL", RCode::ServFail },
-                                       {"NXDOMAIN", RCode::NXDomain },
-                                       {"NOTIMP",   RCode::NotImp   },
-                                       {"REFUSED",  RCode::Refused  },
-                                       {"YXDOMAIN", RCode::YXDomain },
-                                       {"YXRRSET",  RCode::YXRRSet  },
-                                       {"NXRRSET",  RCode::NXRRSet  },
-                                       {"NOTAUTH",  RCode::NotAuth  },
-                                       {"NOTZONE",  RCode::NotZone  },
-                                       {"BADVERS",  ERCode::BADVERS },
-                                       {"BADSIG",   ERCode::BADSIG  },
-                                       {"BADKEY",   ERCode::BADKEY  },
-                                       {"BADTIME",  ERCode::BADTIME   },
-                                       {"BADMODE",  ERCode::BADMODE   },
-                                       {"BADNAME",  ERCode::BADNAME   },
-                                       {"BADALG",   ERCode::BADALG    },
-                                       {"BADTRUNC", ERCode::BADTRUNC  },
-                                       {"BADCOOKIE",ERCode::BADCOOKIE },
-  };
+  g_lua.writeVariable("DNSRCode", std::unordered_map<string, int>{
+      {"NOERROR",  RCode::NoError  },
+      {"FORMERR",  RCode::FormErr  },
+      {"SERVFAIL", RCode::ServFail },
+      {"NXDOMAIN", RCode::NXDomain },
+      {"NOTIMP",   RCode::NotImp   },
+      {"REFUSED",  RCode::Refused  },
+      {"YXDOMAIN", RCode::YXDomain },
+      {"YXRRSET",  RCode::YXRRSet  },
+      {"NXRRSET",  RCode::NXRRSet  },
+      {"NOTAUTH",  RCode::NotAuth  },
+      {"NOTZONE",  RCode::NotZone  },
+      {"BADVERS",  ERCode::BADVERS },
+      {"BADSIG",   ERCode::BADSIG  },
+      {"BADKEY",   ERCode::BADKEY  },
+      {"BADTIME",  ERCode::BADTIME   },
+      {"BADMODE",  ERCode::BADMODE   },
+      {"BADNAME",  ERCode::BADNAME   },
+      {"BADALG",   ERCode::BADALG    },
+      {"BADTRUNC", ERCode::BADTRUNC  },
+      {"BADCOOKIE",ERCode::BADCOOKIE }
+  });
+
   vector<pair<string, int> > dd;
   for(const auto& n : QType::names)
     dd.push_back({n.first, n.second});
-  for(const auto& n : rcodes)
-    dd.push_back({n.first, n.second});
-  g_lua.writeVariable("dnsdist", dd);
+  g_lua.writeVariable("DNSQType", dd);
+
+  g_lua.executeCode(R"LUA(
+    local tables = {
+      DNSQType = DNSQType,
+      DNSRCode = DNSRCode
+    }
+    local function index (table, key)
+      for tname,t in pairs(tables)
+      do
+        local val = t[key]
+        if val then
+          warnlog(string.format("access to dnsdist.%s is deprecated, please use %s.%s", key, tname, key))
+          return val
+        end
+      end
+    end
+
+    dnsdist = {}
+    setmetatable(dnsdist, { __index = index })
+    )LUA"
+  );
 
 #ifdef HAVE_DNSCRYPT
     g_lua.writeVariable("DNSCryptExchangeVersion", std::unordered_map<string,int>{

--- a/pdns/dnsdistdist/docs/advanced/axfr.rst
+++ b/pdns/dnsdistdist/docs/advanced/axfr.rst
@@ -13,12 +13,16 @@ AXFR or IXFR queries destined to this master. There are two issues that can aris
 The first issue can be solved by routing SOA, AXFR and IXFR requests explicitly to the master::
 
   newServer({address="192.168.1.2", name="master", pool={"master", "otherpool"}})
-  addAction(OrRule({QTypeRule(dnsdist.SOA), QTypeRule(dnsdist.AXFR), QTypeRule(dnsdist.IXFR)}), PoolAction("master"))
+  addAction(OrRule({QTypeRule(DNSQType.SOA), QTypeRule(DNSQType.AXFR), QTypeRule(DNSQType.IXFR)}), PoolAction("master"))
 
 The second one might require allowing AXFR/IXFR from the :program:`dnsdist` source address
 and moving the source address check to :program:`dnsdist`'s side::
 
-  addAction(AndRule({OrRule({QTypeRule(dnsdist.AXFR), QTypeRule(dnsdist.IXFR)}), NotRule(makeRule("192.168.1.0/24"))}), RCodeAction(dnsdist.REFUSED))
+  addAction(AndRule({OrRule({QTypeRule(DNSQType.AXFR), QTypeRule(DNSQTypeIXFR)}), NotRule(makeRule("192.168.1.0/24"))}), RCodeAction(DNSRCode.REFUSED))
+
+.. versionchanged:: 1.4.0
+  Before 1.4.0, the QTypes were in the ``dnsdist`` namespace. Use ``dnsdist.AXFR`` and ``dnsdist.IXFR`` in these versions.
+  Before 1.4.0, the RCodes were in the ``dnsdist`` namespace. Use ``dnsdist.REFUSED`` in these versions.
 
 When :program:`dnsdist` is deployed in front of slaves, however, an issue might arise with NOTIFY
 queries, because the slave will receive a notification coming from the :program:`dnsdist` address,
@@ -26,5 +30,7 @@ and not the master's one. One way to fix this issue is to allow NOTIFY from the 
 address on the slave side (for example with PowerDNS's `trusted-notification-proxy`) and move the address
 check to :program:`dnsdist`'s side::
 
-  addAction(AndRule({OpcodeRule(DNSOpcode.Notify), NotRule(makeRule("192.168.1.0/24"))}), RCodeAction(dnsdist.REFUSED))
+  addAction(AndRule({OpcodeRule(DNSOpcode.Notify), NotRule(makeRule("192.168.1.0/24"))}), RCodeAction(DNSRCode.REFUSED))
 
+.. versionchanged:: 1.4.0
+  Before 1.4.0, the RCodes were in the ``dnsdist`` namespace. Use ``dnsdist.REFUSED`` in these versions.

--- a/pdns/dnsdistdist/docs/guides/cache.rst
+++ b/pdns/dnsdistdist/docs/guides/cache.rst
@@ -49,7 +49,10 @@ For example, to remove all expired entries::
 
 Specific entries can also be removed using the :meth:`PacketCache:expungeByName` method::
 
-  getPool("poolname"):getCache():expungeByName(newDNSName("powerdns.com"), dnsdist.A)
+  getPool("poolname"):getCache():expungeByName(newDNSName("powerdns.com"), DNSQType.A)
+
+.. versionchanged:: 1.4.0
+  Before 1.4.0, the QTypes were in the ``dnsdist`` namespace. Use ``dnsdist.A`` in these versions.
 
 Finally, the :meth:`PacketCache:expunge` method will remove all entries until at most n entries remain in the cache::
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -614,7 +614,7 @@ See :doc:`../guides/cache` for a how to.
 
     :param int n: Number of entries to keep
 
-  .. method:: PacketCache:expungeByName(name [, qtype=dnsdist.ANY[, suffixMatch=false]])
+  .. method:: PacketCache:expungeByName(name [, qtype=DNSQType.ANY[, suffixMatch=false]])
 
     .. versionchanged:: 1.2.0
       ``suffixMatch`` parameter added.
@@ -622,7 +622,7 @@ See :doc:`../guides/cache` for a how to.
     Remove entries matching ``name`` and type from the cache.
 
     :param DNSName name: The name to expunge
-    :param int qtype: The type to expunge
+    :param int qtype: The type to expunge, can be a pre-defined :ref:`DNSQType`
     :param bool suffixMatch: When set to true, remove al entries under ``name``
 
   .. method:: PacketCache:getStats()

--- a/pdns/dnsdistdist/docs/reference/constants.rst
+++ b/pdns/dnsdistdist/docs/reference/constants.rst
@@ -8,6 +8,8 @@ There are many constants in :program:`dnsdist`.
 OPCode
 ------
 
+These constants represent the `OpCode <https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-5>`__ of a query.
+
 - ``DNSOpcode.Query``
 - ``DNSOpcode.IQuery``
 - ``DNSOpcode.Status``
@@ -21,6 +23,8 @@ Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#
 DNSClass
 ------
 
+These constants represent the `CLASS <https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-2>`__ of a DNS record.
+
 - ``DNSClass.IN``
 - ``DNSClass.CHAOS``
 - ``DNSClass.NONE``
@@ -33,31 +37,34 @@ Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#
 RCode
 -----
 
-- ``dnsdist.NOERROR``
-- ``dnsdist.FORMERR``
-- ``dnsdist.SERVFAIL``
-- ``dnsdist.NXDOMAIN``
-- ``dnsdist.NOTIMP``
-- ``dnsdist.REFUSED``
-- ``dnsdist.YXDOMAIN``
-- ``dnsdist.YXRRSET``
-- ``dnsdist.NXRRSET``
-- ``dnsdist.NOTAUTH``
-- ``dnsdist.NOTZONE``
-- ``dnsdist.BADVERS``
-- ``dnsdist.BADSIG``
-- ``dnsdist.BADKEY``
-- ``dnsdist.BADTIME``
-- ``dnsdist.BADMODE``
-- ``dnsdist.BADNAME``
-- ``dnsdist.BADALG``
-- ``dnsdist.BADTRUNC``
-- ``dnsdist.BADCOOKIE``
+These constants represent the different `RCODEs <https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6>`__ for DNS messages.
 
-RCodes below and including ``BADVERS`` are extended RCodes that can only be matched using :func:`ERCodeRule`.
+.. versionchanged:: 1.4.0
+  The prefix is changed from ``dnsdist`` to ``DNSRCode``.
 
-Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
+- ``DNSRCode.NOERROR``
+- ``DNSRCode.FORMERR``
+- ``DNSRCode.SERVFAIL``
+- ``DNSRCode.NXDOMAIN``
+- ``DNSRCode.NOTIMP``
+- ``DNSRCode.REFUSED``
+- ``DNSRCode.YXDOMAIN``
+- ``DNSRCode.YXRRSET``
+- ``DNSRCode.NXRRSET``
+- ``DNSRCode.NOTAUTH``
+- ``DNSRCode.NOTZONE``
 
+RCodes below are extended RCodes that can only be matched using :func:`ERCodeRule`.
+
+- ``DNSRCode.BADVERS``
+- ``DNSRCode.BADSIG``
+- ``DNSRCode.BADKEY``
+- ``DNSRCode.BADTIME``
+- ``DNSRCode.BADMODE``
+- ``DNSRCode.BADNAME``
+- ``DNSRCode.BADALG``
+- ``DNSRCode.BADTRUNC``
+- ``DNSRCode.BADCOOKIE``
 
 .. _EDNSOptionCode:
 
@@ -80,8 +87,10 @@ Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#
 
 .. _DNSSection:
 
-DNS Section
------------
+DNS Packet Sections
+-------------------
+
+These constants represent the section in the DNS Packet.
 
 - ``DNSSection.Question``
 - ``DNSSection.Answer``
@@ -109,6 +118,22 @@ These constants represent an Action that can be returned from :func:`LuaAction` 
  * ``DNSAction.Truncate``: truncate the response
  * ``DNSAction.NoRecurse``: set rd=0 on the query
 
+.. _DNSQType:
+
+DNSQType
+--------
+
+.. versionchanged:: 1.3.0
+  The prefix is changed from ``dnsdist.`` to ``DNSQType``.
+
+All named `QTypes <https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4>`__ are available as constants, prefixed with ``DNSQType.``, e.g.:
+
+ * ``DNSQType.AAAA``
+ * ``DNSQType.AXFR``
+ * ``DNSQType.A``
+ * ``DNSQType.NS``
+ * ``DNSQType.SOA``
+ * etc.
 
 .. _DNSResponseAction:
 

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -47,7 +47,7 @@ This state can be modified from the various hooks.
   .. attribute:: DNSQuestion.qtype
 
     QType (as an unsigned integer) of this question.
-    Can be compared against ``dnsdist.A``, ``dnsdist.AAAA`` etc.
+    Can be compared against the pre-defined :ref:`constants <DNSQType>` like ``DNSQType.A``, DNSQType.AAAA``.
 
   .. attribute:: DNSQuestion.remoteaddr
 
@@ -170,7 +170,7 @@ DNSResponse object
 
     - ``section`` is the section in the packet and can be compared to :ref:`DNSSection`
     - ``qclass`` is the QClass of the record. Can be compared to :ref:`DNSQClass`
-    - ``qtype`` is the QType of the record. Can be e.g. compared to ``dnsdist.A``, ``dnsdist.AAAA`` and the like.
+    - ``qtype`` is the QType of the record. Can be e.g. compared to ``DNSQType.A``, ``DNSQType.AAAA`` :ref:`constants <DNSQType>` and the like.
     - ``ttl`` is the current TTL
 
     This function must return an integer with the new TTL.

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -81,7 +81,10 @@ Rule Generators
   Set the TC-bit (truncate) on ANY queries received over UDP, forcing a retry over TCP.
   This function is deprecated as of 1.2.0 and will be removed in 1.3.0. This is equivalent to doing::
 
-    addAction(AndRule({QTypeRule(dnsdist.ANY), TCPRule(false)}), TCAction())
+   addAction(AndRule({QTypeRule(DNSQType.ANY), TCPRule(false)}), TCAction())
+
+  .. versionchanged:: 1.4.0
+    Before 1.4.0, the QTypes were in the ``dnsdist`` namespace. Use ``dnsdist.ANY`` in these versions.
 
 .. function:: addDelay(DNSrule, delay)
 
@@ -718,7 +721,7 @@ These ``DNSRule``\ s be one of the following items:
 
   Matches if there is at least ``minCount`` and at most ``maxCount`` records of type ``type`` in the section ``section``.
   ``section`` can be specified as an integer or as a ref:`DNSSection`.
-  ``qtype`` may be specified as an integer or as one of the built-in QTypes, for instance ``dnsdist.A`` or ``dnsdist.TXT``.
+  ``qtype`` may be specified as an integer or as one of the :ref:`built-in QTypes <DNSQType>`, for instance ``DNSQType.A`` or ``DNSQType.TXT``.
 
   :param int section: The section to match on
   :param int qtype: The QTYPE to match on

--- a/regression-tests.dnsdist/test-include-dir/test.conf
+++ b/regression-tests.dnsdist/test-include-dir/test.conf
@@ -1,1 +1,1 @@
-addAction(AllRule(), RCodeAction(dnsdist.REFUSED))
+addAction(AllRule(), RCodeAction(DNSRCode.REFUSED))

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -452,7 +452,7 @@ class TestAdvancedTruncateAnyAndTCP(DNSDistTest):
 class TestAdvancedAndNot(DNSDistTest):
 
     _config_template = """
-    addAction(AndRule({NotRule(QTypeRule("A")), TCPRule(false)}), RCodeAction(dnsdist.NOTIMP))
+    addAction(AndRule({NotRule(QTypeRule("A")), TCPRule(false)}), RCodeAction(DNSRCode.NOTIMP))
     newServer{address="127.0.0.1:%s"}
     """
     def testAOverUDPReturnsNotImplementedCanary(self):
@@ -519,7 +519,7 @@ class TestAdvancedAndNot(DNSDistTest):
 class TestAdvancedOr(DNSDistTest):
 
     _config_template = """
-    addAction(OrRule({QTypeRule("A"), TCPRule(false)}), RCodeAction(dnsdist.NOTIMP))
+    addAction(OrRule({QTypeRule("A"), TCPRule(false)}), RCodeAction(DNSRCode.NOTIMP))
     newServer{address="127.0.0.1:%s"}
     """
     def testAAAAOverUDPReturnsNotImplemented(self):
@@ -885,7 +885,7 @@ class TestAdvancedQPSNone(DNSDistTest):
 
     _config_template = """
     addAction("qpsnone.advanced.tests.powerdns.com", QPSAction(100))
-    addAction(AllRule(), RCodeAction(dnsdist.REFUSED))
+    addAction(AllRule(), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -912,7 +912,7 @@ class TestAdvancedNMGRule(DNSDistTest):
     _config_template = """
     allowed = newNMG()
     allowed:addMask("192.0.2.1/32")
-    addAction(NotRule(NetmaskGroupRule(allowed)), RCodeAction(dnsdist.REFUSED))
+    addAction(NotRule(NetmaskGroupRule(allowed)), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -937,7 +937,7 @@ class TestDSTPortRule(DNSDistTest):
 
     _config_params = ['_dnsDistPort', '_testServerPort']
     _config_template = """
-    addAction(DSTPortRule(%d), RCodeAction(dnsdist.REFUSED))
+    addAction(DSTPortRule(%d), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -962,7 +962,7 @@ class TestDSTPortRule(DNSDistTest):
 class TestAdvancedLabelsCountRule(DNSDistTest):
 
     _config_template = """
-    addAction(QNameLabelsCountRule(5,6), RCodeAction(dnsdist.REFUSED))
+    addAction(QNameLabelsCountRule(5,6), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -1015,7 +1015,7 @@ class TestAdvancedLabelsCountRule(DNSDistTest):
 class TestAdvancedWireLengthRule(DNSDistTest):
 
     _config_template = """
-    addAction(QNameWireLengthRule(54,56), RCodeAction(dnsdist.REFUSED))
+    addAction(QNameWireLengthRule(54,56), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -1351,7 +1351,7 @@ com.""")
 class TestAdvancedRD(DNSDistTest):
 
     _config_template = """
-    addAction(RDRule(), RCodeAction(dnsdist.REFUSED))
+    addAction(RDRule(), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -1654,7 +1654,7 @@ class TestAdvancedEDNSVersionRule(DNSDistTest):
 
     _config_template = """
     newServer{address="127.0.0.1:%s"}
-    addAction(EDNSVersionRule(0), ERCodeAction(dnsdist.BADVERS))
+    addAction(EDNSVersionRule(0), ERCodeAction(DNSRCode.BADVERS))
     """
 
     def testDropped(self):

--- a/regression-tests.dnsdist/test_Basics.py
+++ b/regression-tests.dnsdist/test_Basics.py
@@ -9,15 +9,15 @@ class TestBasics(DNSDistTest):
     _config_template = """
     newServer{address="127.0.0.1:%s"}
     truncateTC(true)
-    addAction(AndRule{QTypeRule(dnsdist.ANY), TCPRule(false)}, TCAction())
-    addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(dnsdist.REFUSED))
+    addAction(AndRule{QTypeRule(DNSQType.ANY), TCPRule(false)}, TCAction())
+    addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(DNSRCode.REFUSED))
     mySMN = newSuffixMatchNode()
     mySMN:add(newDNSName("nameAndQtype.tests.powerdns.com."))
-    addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(dnsdist.NOTIMP))
+    addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(DNSRCode.NOTIMP))
     addAction(makeRule("drop.test.powerdns.com."), DropAction())
-    addAction(AndRule({QTypeRule(dnsdist.A),QNameRule("ds9a.nl")}), SpoofAction("1.2.3.4"))
-    addAction(newDNSName("dnsname.addaction.powerdns.com."), RCodeAction(dnsdist.REFUSED))
-    addAction({newDNSName("dnsname-table1.addaction.powerdns.com."), newDNSName("dnsname-table2.addaction.powerdns.com.")}, RCodeAction(dnsdist.REFUSED))
+    addAction(AndRule({QTypeRule(DNSQType.A),QNameRule("ds9a.nl")}), SpoofAction("1.2.3.4"))
+    addAction(newDNSName("dnsname.addaction.powerdns.com."), RCodeAction(DNSRCode.REFUSED))
+    addAction({newDNSName("dnsname-table1.addaction.powerdns.com."), newDNSName("dnsname-table2.addaction.powerdns.com.")}, RCodeAction(DNSRCode.REFUSED))
     """
 
     def testDropped(self):

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -1038,7 +1038,7 @@ class TestCacheManagement(DNSDistTest):
         self.assertEquals(receivedResponse, response2)
 
         # remove cached entries from name A
-        self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"" + name + "\"), dnsdist.A)")
+        self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"" + name + "\"), DNSQType.A)")
 
         # Miss for name A
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
@@ -1119,7 +1119,7 @@ class TestCacheManagement(DNSDistTest):
         self.assertEquals(receivedResponse, response2)
 
         # remove cached entries from name
-        self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"suffix.cache.tests.powerdns.com.\"), dnsdist.ANY, true)")
+        self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"suffix.cache.tests.powerdns.com.\"), DNSQType.ANY, true)")
 
         # Miss for name
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
@@ -1200,7 +1200,7 @@ class TestCacheManagement(DNSDistTest):
         self.assertEquals(receivedResponse, response2)
 
         # remove cached entries from name A
-        self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"suffixtype.cache.tests.powerdns.com.\"), dnsdist.A, true)")
+        self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"suffixtype.cache.tests.powerdns.com.\"), DNSQType.A, true)")
 
         # Miss for name A
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)

--- a/regression-tests.dnsdist/test_CheckConfig.py
+++ b/regression-tests.dnsdist/test_CheckConfig.py
@@ -33,11 +33,11 @@ class TestCheckConfig(unittest.TestCase):
         configTemplate = """
             newServer{address="127.0.0.1:53"}
             truncateTC(true)
-            addAction(AndRule{QTypeRule(dnsdist.ANY), TCPRule(false)}, TCAction())
-            addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(dnsdist.REFUSED))
+            addAction(AndRule{QTypeRule(DNSQType.ANY), TCPRule(false)}, TCAction())
+            addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(DNSRCode.REFUSED))
             mySMN = newSuffixMatchNode()
             mySMN:add(newDNSName("nameAndQtype.tests.powerdns.com."))
-            addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(dnsdist.NOTIMP))
+            addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(DNSRCode.NOTIMP))
             addAction(makeRule("drop.test.powerdns.com."), DropAction())
         """
 

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -102,7 +102,7 @@ class TestDnstapOverRemoteLogger(DNSDistTest):
 
     function luaFunc(dq)
       dq.dh:setQR(true)
-      dq.dh:setRCode(dnsdist.NXDOMAIN)
+      dq.dh:setRCode(DNSRCode.NXDOMAIN)
       return DNSAction.None, ""
     end
 

--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -803,7 +803,7 @@ class TestDynBlockGroupServFails(DynBlocksTest):
     _config_params = ['_dynBlockQPS', '_dynBlockPeriod', '_dynBlockDuration', '_testServerPort']
     _config_template = """
     local dbr = dynBlockRulesGroup()
-    dbr:setRCodeRate(dnsdist.SERVFAIL, %d, %d, "Exceeded query rate", %d)
+    dbr:setRCodeRate(DNSRCode.SERVFAIL, %d, %d, "Exceeded query rate", %d)
 
     function maintenance()
 	    dbr:apply()

--- a/regression-tests.dnsdist/test_EDNSSelfGenerated.py
+++ b/regression-tests.dnsdist/test_EDNSSelfGenerated.py
@@ -11,7 +11,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
     """
 
     _config_template = """
-    addAction("rcode.edns-self.tests.powerdns.com.", RCodeAction(dnsdist.REFUSED))
+    addAction("rcode.edns-self.tests.powerdns.com.", RCodeAction(DNSRCode.REFUSED))
     addAction("tc.edns-self.tests.powerdns.com.", TCAction())
 
     function luarule(dq)
@@ -262,7 +262,7 @@ class TestEDNSSelfGeneratedDisabled(DNSDistTest):
     _config_template = """
     setAddEDNSToSelfGeneratedResponses(false)
 
-    addAction("rcode.edns-self-disabled.tests.powerdns.com.", RCodeAction(dnsdist.REFUSED))
+    addAction("rcode.edns-self-disabled.tests.powerdns.com.", RCodeAction(DNSRCode.REFUSED))
     addAction("tc.edns-self-disabled.tests.powerdns.com.", TCAction())
 
     function luarule(dq)

--- a/regression-tests.dnsdist/test_HealthChecks.py
+++ b/regression-tests.dnsdist/test_HealthChecks.py
@@ -163,7 +163,7 @@ class TestHealthCheckCustomFunction(HealthCheckTest):
     function myHealthCheckFunction(qname, qtype, qclass, dh)
       dh:setCD(true)
 
-      return newDNSName('powerdns.com.'), dnsdist.AAAA, qclass
+      return newDNSName('powerdns.com.'), DNSQType.AAAA, qclass
     end
 
     srv = newServer{address="127.0.0.1:%d", checkName='powerdns.org.', checkFunction=myHealthCheckFunction}

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -198,7 +198,7 @@ class TestProtobuf(DNSDistProtobufTest):
         protobuf:setTagArray(tablePB)				-- store table in protobuf
         protobuf:setTag("Query,123")				-- add another tag entry in protobuf
 
-        protobuf:setResponseCode(dnsdist.NXDOMAIN)        	-- set protobuf response code to be NXDOMAIN
+        protobuf:setResponseCode(DNSRCode.NXDOMAIN)        	-- set protobuf response code to be NXDOMAIN
 
         local strReqName = dq.qname:toString()		  	-- get request dns name
 

--- a/regression-tests.dnsdist/test_RecordsCount.py
+++ b/regression-tests.dnsdist/test_RecordsCount.py
@@ -7,7 +7,7 @@ from dnsdisttests import DNSDistTest
 class TestRecordsCountOnlyOneAR(DNSDistTest):
 
     _config_template = """
-    addAction(NotRule(RecordsCountRule(DNSSection.Additional, 1, 1)), RCodeAction(dnsdist.REFUSED))
+    addAction(NotRule(RecordsCountRule(DNSSection.Additional, 1, 1)), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -79,7 +79,7 @@ class TestRecordsCountMoreThanOneLessThanFour(DNSDistTest):
 
     _config_template = """
     addAction(RecordsCountRule(DNSSection.Answer, 2, 3), AllowAction())
-    addAction(AllRule(), RCodeAction(dnsdist.REFUSED))
+    addAction(AllRule(), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -156,7 +156,7 @@ class TestRecordsCountNothingInNS(DNSDistTest):
 
     _config_template = """
     addAction(RecordsCountRule(DNSSection.Authority, 0, 0), AllowAction())
-    addAction(AllRule(), RCodeAction(dnsdist.REFUSED))
+    addAction(AllRule(), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 
@@ -213,7 +213,7 @@ class TestRecordsCountNothingInNS(DNSDistTest):
 class TestRecordsCountNoOPTInAR(DNSDistTest):
 
     _config_template = """
-    addAction(NotRule(RecordsTypeCountRule(DNSSection.Additional, dnsdist.OPT, 0, 0)), RCodeAction(dnsdist.REFUSED))
+    addAction(NotRule(RecordsTypeCountRule(DNSSection.Additional, DNSQType.OPT, 0, 0)), RCodeAction(DNSRCode.REFUSED))
     newServer{address="127.0.0.1:%s"}
     """
 

--- a/regression-tests.dnsdist/test_Responses.py
+++ b/regression-tests.dnsdist/test_Responses.py
@@ -8,7 +8,7 @@ class TestResponseRuleNXDelayed(DNSDistTest):
 
     _config_template = """
     newServer{address="127.0.0.1:%s"}
-    addResponseAction(RCodeRule(dnsdist.NXDOMAIN), DelayResponseAction(1000))
+    addResponseAction(RCodeRule(DNSRCode.NXDOMAIN), DelayResponseAction(1000))
     """
 
     def testNXDelayed(self):
@@ -57,7 +57,7 @@ class TestResponseRuleERCode(DNSDistTest):
 
     _config_template = """
     newServer{address="127.0.0.1:%s"}
-    addResponseAction(ERCodeRule(dnsdist.BADVERS), DelayResponseAction(1000))
+    addResponseAction(ERCodeRule(DNSRCode.BADVERS), DelayResponseAction(1000))
     """
 
     def testBADVERSDelayed(self):
@@ -244,7 +244,7 @@ class TestResponseLuaActionReturnSyntax(DNSDistTest):
       return DNSResponseAction.Drop
     end
     addResponseAction("drop.responses.tests.powerdns.com.", LuaResponseAction(customDrop))
-    addResponseAction(RCodeRule(dnsdist.NXDOMAIN), LuaResponseAction(customDelay))
+    addResponseAction(RCodeRule(DNSRCode.NXDOMAIN), LuaResponseAction(customDelay))
     """
 
     def testResponseActionDelayed(self):

--- a/regression-tests.dnsdist/test_TCPKeepAlive.py
+++ b/regression-tests.dnsdist/test_TCPKeepAlive.py
@@ -29,7 +29,7 @@ class TestTCPKeepAlive(DNSDistTest):
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
     getPool(""):setCache(pc)
     addAction("largernumberofconnections.tcpka.tests.powerdns.com.", SkipCacheAction())
-    addAction("refused.tcpka.tests.powerdns.com.", RCodeAction(dnsdist.REFUSED))
+    addAction("refused.tcpka.tests.powerdns.com.", RCodeAction(DNSRCode.REFUSED))
     addAction("dropped.tcpka.tests.powerdns.com.", DropAction())
     addResponseAction("dropped-response.tcpka.tests.powerdns.com.", DropResponseAction())
     -- create the pool named "nosuchpool"

--- a/regression-tests.dnsdist/test_TeeAction.py
+++ b/regression-tests.dnsdist/test_TeeAction.py
@@ -16,8 +16,8 @@ class TestTeeAction(DNSDistTest):
     setKey("%s")
     controlSocket("127.0.0.1:%s")
     newServer{address="127.0.0.1:%d"}
-    addAction(QTypeRule(dnsdist.A), TeeAction("127.0.0.1:%d", true))
-    addAction(QTypeRule(dnsdist.AAAA), TeeAction("127.0.0.1:%d", false))
+    addAction(QTypeRule(DNSQType.A), TeeAction("127.0.0.1:%d", true))
+    addAction(QTypeRule(DNSQType.AAAA), TeeAction("127.0.0.1:%d", false))
     """
     _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_teeServerPort', '_teeServerPort']
     @classmethod


### PR DESCRIPTION
### Short description
Redo of #5669. Separate PR because the rebase involved some manual work (some code got removed, moved around, etc. since), and this way we can compare the two PRs to make sure I did not miss anything.

~TODO: add the deprecation warnings as discussed in #5669.~ Pushed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
