### PR TITLE
Fix 7680: gmysql-thread-cleanup option documented incorrectly

### DIFF
--- a/docs/backends/generic-mysql.rst
+++ b/docs/backends/generic-mysql.rst
@@ -123,13 +123,13 @@ Use the InnoDB READ-COMMITTED transaction isolation level. Default: yes.
 The timeout in seconds for each attempt to read from, or write to the
 server. A value of 0 will disable the timeout. Default: 10
 
-.. _setting-gmysql-thread-closer:
+.. _setting-gmysql-thread-cleanup:
 
-``gmysql-thread-closer``
+``gmysql-thread-cleanup``
 ^^^^^^^^^^^^^^^^^^^^^^^^
 .. versionadded:: 4.1.8
 
-Older versions (such as those shipped on RHEL 7) of the MySQL/MariaDB client libraries leak memory unless applications explicitly report the end of each thread to the library. Enabling ``gmysql-thread-closer`` tells PowerDNS to call ``mysql_thread_end()`` whenever a thread ends.
+Older versions (such as those shipped on RHEL 7) of the MySQL/MariaDB client libraries leak memory unless applications explicitly report the end of each thread to the library. Enabling ``gmysql-thread-cleanup`` tells PowerDNS to call ``mysql_thread_end()`` whenever a thread ends.
 
 Only enable this if you are certain you need to. For more discussion, see https://github.com/PowerDNS/pdns/issues/6231.
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
https://github.com/PowerDNS/pdns/issues/7680

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
