### PR TITLE
OpenBSD only has protoc 3.x; tell python to install the proper runtime.

### DIFF
--- a/regression-tests.dnsdist/requirements.txt
+++ b/regression-tests.dnsdist/requirements.txt
@@ -2,7 +2,7 @@ dnspython>=1.11,<1.16.0
 nose>=1.3.7
 libnacl>=1.4.3
 requests>=2.1.0
-protobuf>=2.5,<3.0; sys_platform != 'darwin'
-protobuf>=3.0; sys_platform == 'darwin'
+protobuf>=2.5,<3.0; sys_platform != 'darwin' and sys_platform != 'openbsd6'
+protobuf>=3.0; sys_platform == 'darwin' or sys_platform == 'openbsd6'
 pysnmp>=4.3.4
 future>=0.17.1


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This fixes dnsdist regress test framework on OpenBSD.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
