### PR TITLE
Reduce mmap size for lmdb on 32 bits plus restrict number of shards

### DIFF
--- a/modules/lmdbbackend/lmdb-safe.cc
+++ b/modules/lmdbbackend/lmdb-safe.cc
@@ -26,8 +26,10 @@ MDBDbi::MDBDbi(MDB_env* env, MDB_txn* txn, const string_view dbname, int flags)
 
 MDBEnv::MDBEnv(const char* fname, int flags, int mode)
 {
-  mdb_env_create(&d_env);   
-  if(mdb_env_set_mapsize(d_env, 16ULL*4096*244140ULL)) // 4GB
+  mdb_env_create(&d_env);
+  uint64_t mapsizeMB = (sizeof(long)==4) ? 100 : 16000;
+  // on 32 bit platforms, there is just no room for more
+  if(mdb_env_set_mapsize(d_env, mapsizeMB * 1048576))
     throw std::runtime_error("setting map size");
     /*
 Various other options may also need to be set before opening the handle, e.g. mdb_env_set_mapsize(), mdb_env_set_maxreaders(), mdb_env_set_maxdbs(),

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1592,7 +1592,8 @@ public:
   {
     declare(suffix,"filename","Filename for lmdb","./pdns.lmdb");
     declare(suffix,"sync-mode","Synchronisation mode: nosync, nometasync, mapasync","mapasync");
-    declare(suffix,"shards","Records database will be split into this number of shards","64");
+    // there just is no room for more on 32 bit
+    declare(suffix,"shards","Records database will be split into this number of shards", (sizeof(long) == 4) ? "2" : "64"); 
   }
   DNSBackend *make(const string &suffix="")
   {


### PR DESCRIPTION
### Short description
On 32 bit systems, there is almost no room for large mmaps. This PR changes the default for 32 bit systems. The lmdb map size should be configurable but it is very late in the 4.2 release time to do a good job there as we'd need to thread that all through lmdb-safe etc. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
