### PR TITLE
Use a smaller test size to not fill the pipe buffer on systems with small buffer

### DIFF
--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -68,11 +68,17 @@ struct BackendSlow
 
 
 BOOST_AUTO_TEST_CASE(test_distributor_queue) {
+  ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
+  ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="1000";
+  ::arg().set("queue-limit","Maximum number of milliseconds to queue a query")="1500";
+  S.declare("servfail-packets","Number of times a server-failed packet was sent out");
+  S.declare("timedout-packets", "timedout-packets");
+
   auto d=Distributor<DNSPacket, Question, BackendSlow>::Create(2);
 
   BOOST_CHECK_EXCEPTION( {
     int n;
-    for(n=0; n < 6000; ++n)  {
+    for(n=0; n < 2000; ++n)  {
       auto q = new Question();
       q->d_dt.set(); 
       d->question(q, report);
@@ -115,6 +121,12 @@ static void report2(DNSPacket* A)
 
 
 BOOST_AUTO_TEST_CASE(test_distributor_dies) {
+  ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
+  ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";
+  ::arg().set("queue-limit","Maximum number of milliseconds to queue a query")="1500";
+  S.declare("servfail-packets","Number of times a server-failed packet was sent out");
+  S.declare("timedout-packets", "timedout-packets");
+
   auto d=Distributor<DNSPacket, Question, BackendDies>::Create(10);
   sleep(1);
   g_receivedAnswers=0;

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -78,6 +78,7 @@ BOOST_AUTO_TEST_CASE(test_distributor_queue) {
 
   BOOST_CHECK_EXCEPTION( {
     int n;
+    // bound should be higher than max-queue-length
     for(n=0; n < 2000; ++n)  {
       auto q = new Question();
       q->d_dt.set(); 


### PR DESCRIPTION
Also, explictly set arguments to avoid order dependencies and make it possible
to run single tests.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
