### PR TITLE
Boost string_view only appeared in Boost 1.61, not 1.54 as we were assuming

### DIFF
--- a/modules/lmdbbackend/lmdb-safe.hh
+++ b/modules/lmdbbackend/lmdb-safe.hh
@@ -13,7 +13,7 @@
 // apple compiler somehow has string_view even in c++11!
 #if __cplusplus < 201703L && !defined(__APPLE__)
 #include <boost/version.hpp>
-#if BOOST_VERSION > 105400
+#if BOOST_VERSION >= 106100
 #include <boost/utility/string_view.hpp>
 using boost::string_view;
 #else

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -224,10 +224,10 @@ std::shared_ptr<DNSRecordContent> unserializeContentZR(uint16_t qtype, const DNS
    Note - domain_id, name and type are ONLY present on the index!
 */
 
-#if BOOST_VERSION <= 105400
-#define StringView string
-#else
+#if BOOST_VERSION >= 106100
 #define StringView string_view
+#else
+#define StringView string
 #endif
 
 void LMDBBackend::deleteDomainRecords(RecordsRWTransaction& txn, uint32_t domain_id, uint16_t qtype)


### PR DESCRIPTION
### Short description
Use boost::string_view only from Boost 1.61 and later, fall back to string_ref otherwise. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
