### PR TITLE
auth: export TAs and forward zones for rec testing with auth zones

### DIFF
--- a/regression-tests/.gitignore
+++ b/regression-tests/.gitignore
@@ -32,3 +32,5 @@
 /remotebackend-access.log
 /pdns.lmdb*
 /pdns2.lmdb*
+/recursor.forward-zones-file
+/recursor.trustedkeys.lua

--- a/regression-tests/tests/00dnssec-grabkeys/command
+++ b/regression-tests/tests/00dnssec-grabkeys/command
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 rm -f trustedkeys
 rm -f unbound-host.conf
+rm -f recursor.trustedkeys.lua
+rm -f recursor.forward-zones-file
 
 for zone in $(grep 'zone ' named.conf  | cut -f2 -d\") addzone.com
 do
@@ -12,6 +14,8 @@ do
 	echo "  name: $zone" >> unbound-host.conf
 	echo "  stub-addr: $nameserver@$port" >> unbound-host.conf
 	echo "" >> unbound-host.conf
+
+	echo "$zone=$nameserver:$port" >> recursor.forward-zones-file
 done
 
 echo "server:" >> unbound-host.conf
@@ -22,3 +26,5 @@ if [ -e trustedkeys ]
 then
   cat trustedkeys | grep -c '.' # because wc -l is not portable enough!
 fi
+
+ldns-key2ds -n trustedkeys | awk -F '\t' '{print "addTA(\""$1"\", \""$5"\")"}' > recursor.trustedkeys.lua


### PR DESCRIPTION
### Short description
This generates two files that can then be used like `-lua-config-file=../../regression-tests/recursor.trustedkeys.lua --forward-zones-file=../../regression-tests/recursor.forward-zones-file` on the Recursor.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
