### PR TITLE
better assertEqual for dnspython

### DIFF
--- a/contrib/assert-equal-DNSMessage/eqdnsmessage.py
+++ b/contrib/assert-equal-DNSMessage/eqdnsmessage.py
@@ -1,0 +1,30 @@
+import difflib
+import dns
+import unittest
+
+class AssertEqualDNSMessageMixin(unittest.TestCase):
+    def assertEqualDNSMessage(self, first, second, msg=None):
+        if not first == second:
+            a = str(first).split('\n')
+            b = str(second).split('\n')
+
+            diff = '\n'.join(
+                difflib.unified_diff(
+                    a,
+                    b,
+                    fromfile='first',
+                    tofile='second',
+                    n=max(len(a), len(b)),
+                    lineterm=""
+                )
+            )
+
+            standardMsg = "%s != %s:\n%s" % (repr(first), repr(second), diff)
+            msg = self._formatMessage(msg, standardMsg)
+
+            raise self.failureException(msg)
+
+    def setUp(self):
+        self.addTypeEqualityFunc(dns.message.Message, self.assertEqualDNSMessage)
+
+        super(AssertEqualDNSMessageMixin, self).setUp()

--- a/regression-tests.auth-py/authtests.py
+++ b/regression-tests.auth-py/authtests.py
@@ -14,8 +14,9 @@ import dns
 import dns.message
 
 from pprint import pprint
+from eqdnsmessage import AssertEqualDNSMessageMixin
 
-class AuthTest(unittest.TestCase):
+class AuthTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     """
     Setup auth required for the tests
     """
@@ -341,7 +342,7 @@ options {
 
     def setUp(self):
         # This function is called before every tests
-        return
+        super(AuthTest, self).setUp()
 
     ## Functions for comparisons
     def assertMessageHasFlags(self, msg, flags, ednsflags=[]):

--- a/regression-tests.auth-py/eqdnsmessage.py
+++ b/regression-tests.auth-py/eqdnsmessage.py
@@ -1,0 +1,1 @@
+../contrib/assert-equal-DNSMessage/eqdnsmessage.py

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -440,6 +440,8 @@ class DNSDistTest(unittest.TestCase):
     def setUp(self):
         # This function is called before every tests
 
+        self.addTypeEqualityFunc(dns.message.Message, self.assertEqualDNSMessage)
+
         # Clear the responses counters
         for key in self._responsesCounter:
             self._responsesCounter[key] = 0
@@ -577,3 +579,26 @@ class DNSDistTest(unittest.TestCase):
 
     def checkResponseNoEDNS(self, expected, received):
         self.checkMessageNoEDNS(expected, received)
+
+    def assertEqualDNSMessage(self, first, second, msg=None):
+        if not first == second:
+            a = str(first).split('\n')
+            b = str(second).split('\n')
+
+            import difflib
+
+            diff = '\n'.join(
+                difflib.unified_diff(
+                    a,
+                    b,
+                    fromfile='first',
+                    tofile='second',
+                    n=max(len(a), len(b)),
+                    lineterm=""
+                )
+            )
+
+            standardMsg = "%s != %s:\n%s" % (repr(first), repr(second), diff)
+            msg = self._formatMessage(msg, standardMsg)
+
+            raise self.failureException(msg)

--- a/regression-tests.dnsdist/eqdnsmessage.py
+++ b/regression-tests.dnsdist/eqdnsmessage.py
@@ -1,0 +1,1 @@
+../contrib/assert-equal-DNSMessage/eqdnsmessage.py

--- a/regression-tests.ixfrdist/eqdnsmessage.py
+++ b/regression-tests.ixfrdist/eqdnsmessage.py
@@ -1,0 +1,1 @@
+../contrib/assert-equal-DNSMessage/eqdnsmessage.py

--- a/regression-tests.ixfrdist/ixfrdisttests.py
+++ b/regression-tests.ixfrdist/ixfrdisttests.py
@@ -12,7 +12,9 @@ import unittest
 import dns
 import dns.message
 
-class IXFRDistTest(unittest.TestCase):
+from eqdnsmessage import AssertEqualDNSMessageMixin
+
+class IXFRDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
     _ixfrDistStartupDelay = 2.0
     _ixfrDistPort = 5342
@@ -196,5 +198,5 @@ failed-soa-retry: 3
 
     def setUp(self):
         # This function is called before every tests
-        return
+        super(IXFRDistTest, self).setUp()
 

--- a/regression-tests.recursor-dnssec/eqdnsmessage.py
+++ b/regression-tests.recursor-dnssec/eqdnsmessage.py
@@ -1,0 +1,1 @@
+../contrib/assert-equal-DNSMessage/eqdnsmessage.py

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -13,7 +13,9 @@ import unittest
 import dns
 import dns.message
 
-class RecursorTest(unittest.TestCase):
+from eqdnsmessage import AssertEqualDNSMessageMixin
+
+class RecursorTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     """
     Setup all recursors and auths required for the tests
     """
@@ -659,7 +661,7 @@ distributor-threads=1""".format(confdir=confdir,
 
     def setUp(self):
         # This function is called before every tests
-        return
+        super(RecursorTest, self).setUp()
 
     ## Functions for comparisons
     def assertMessageHasFlags(self, msg, flags, ednsflags=[]):


### PR DESCRIPTION
before:
```
AssertionError: <DNS message, ID 38993> != <DNS message, ID 38993>
```

after:
```
AssertionError: <DNS message, ID 46818> != <DNS message, ID 46818>:
--- first
+++ second
@@ -1,10 +1,10 @@
 id 46818
-opcode 6
-rcode NOTAUTH
-flags AD CD
+opcode QUERY
+rcode NOERROR
+flags RD
 ;QUESTION
 xpf.tests.powerdns.com. IN A
 ;ANSWER
 ;AUTHORITY
 ;ADDITIONAL
-. 0 IN TYPE65422 \# 14 04117f0000017f000001f8bc14dc
+xpf.tests.powerdns.com. 60 IN TYPE65422 \# 14 04117f0000017f00000100000000
```

(I'm pretty sure the two different names and TTLs on the TYPE65422 line are some dnspython bug.)

### Short description
Improve `assertEqual` output for differing DNS messages.

Draft until we are happy with the format; then I'll add the same support to our other dnspython-based test suites.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
