### PR TITLE
Fix unittest order deps

### DIFF
--- a/pdns/dnsdistdist/test-delaypipe_hh.cc
+++ b/pdns/dnsdistdist/test-delaypipe_hh.cc
@@ -26,7 +26,8 @@ BOOST_AUTO_TEST_CASE(test_object_pipe) {
 };
 
 int done=0;
-BOOST_AUTO_TEST_CASE(test_delay_pipe_small) {  
+BOOST_AUTO_TEST_CASE(test_delay_pipe_small) {
+  done=0;
   struct Work
   {
     int i;

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -113,8 +113,6 @@ static void init(bool debug=false)
     g_log.toConsole(Logger::Error);
   }
 
-  reportAllTypes();
-
   t_RC = std::unique_ptr<MemRecursorCache>(new MemRecursorCache());
 
   SyncRes::s_maxqperq = 50;

--- a/pdns/recursordist/testrunner.cc
+++ b/pdns/recursordist/testrunner.cc
@@ -30,7 +30,6 @@
 #include <dnsrecords.hh>
 
 bool init_unit_test() {
-  std::cerr << "Initing..." << std::endl;
   reportAllTypes();
   return true;
 }

--- a/pdns/recursordist/testrunner.cc
+++ b/pdns/recursordist/testrunner.cc
@@ -20,12 +20,23 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MAIN
-#define BOOST_TEST_MODULE unit
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 #include <boost/test/unit_test.hpp>
 
+#include <iostream>
+#include <dnsrecords.hh>
 
+bool init_unit_test() {
+  std::cerr << "Initing..." << std::endl;
+  reportAllTypes();
+  return true;
+}
+
+// entry point:
+int main(int argc, char* argv[])
+{
+  return boost::unit_test::unit_test_main( &init_unit_test, argc, argv );
+}

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -66,6 +66,12 @@ struct BackendSlow
   }
 };
 
+static std::atomic<int> g_receivedAnswers1;
+static void report1(DNSPacket* A)
+{
+  delete A;
+  g_receivedAnswers1++;
+}
 
 BOOST_AUTO_TEST_CASE(test_distributor_queue) {
   ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
@@ -82,7 +88,7 @@ BOOST_AUTO_TEST_CASE(test_distributor_queue) {
     for(n=0; n < 2000; ++n)  {
       auto q = new Question();
       q->d_dt.set(); 
-      d->question(q, report);
+      d->question(q, report1);
     }
     }, DistributorFatal, [](DistributorFatal) { return true; });
 };
@@ -129,8 +135,6 @@ BOOST_AUTO_TEST_CASE(test_distributor_dies) {
   S.declare("timedout-packets", "timedout-packets");
 
   auto d=Distributor<DNSPacket, Question, BackendDies>::Create(10);
-  sleep(1);
-  g_receivedAnswers=0;
 
   try {
     for(int n=0; n < 100; ++n)  {

--- a/pdns/test-dnsrecordcontent.cc
+++ b/pdns/test-dnsrecordcontent.cc
@@ -10,7 +10,6 @@
 BOOST_AUTO_TEST_SUITE(test_dnsrecordcontent)
 
 BOOST_AUTO_TEST_CASE(test_equality) {
-  reportAllTypes();
   ComboAddress ip("1.2.3.4"), ip2("10.0.0.1"), ip6("::1");
   ARecordContent a1(ip), a2(ip), a3(ip2);
   AAAARecordContent aaaa(ip6), aaaa1(ip6);

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -44,7 +44,6 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
   // tuple contains <type, user value, zone representation, line value, broken>
   typedef boost::tuple<QType::typeenum, std::string, std::string, std::string, broken_marker> case_t;
   typedef std::list<case_t> cases_t;
-  reportAllTypes();
   MRRecordContent::report();
   IPSECKEYRecordContent::report();
   KXRecordContent::report();

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheThreaded) {
     PC.setTTL(3600);
 
     g_PC=&PC;
-    g_QCmissing = 0;
+    g_PCmissing = 0;
     pthread_t tid[4];
     for(int i=0; i < 4; ++i)
       pthread_create(&tid[i], 0, threadPCMangler, (void*)(i*1000000UL));

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -104,6 +104,7 @@ catch(PDNSException& e) {
 
 BOOST_AUTO_TEST_CASE(test_QueryCacheThreaded) {
   try {
+    g_QCmissing = 0;
     AuthQueryCache QC;
     QC.setMaxEntries(1000000);
     g_QC=&QC;
@@ -206,6 +207,7 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheThreaded) {
     PC.setTTL(3600);
 
     g_PC=&PC;
+    g_QCmissing = 0;
     pthread_t tid[4];
     for(int i=0; i < 4; ++i)
       pthread_create(&tid[i], 0, threadPCMangler, (void*)(i*1000000UL));

--- a/pdns/testrunner.cc
+++ b/pdns/testrunner.cc
@@ -20,7 +20,6 @@ ArgvMap &arg()
 
 
 bool init_unit_test() {
-  cerr << "Initing..." << endl;
   reportAllTypes();
   return true;
 }

--- a/pdns/testrunner.cc
+++ b/pdns/testrunner.cc
@@ -1,6 +1,4 @@
 #define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MAIN
-#define BOOST_TEST_MODULE unit
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -18,4 +16,17 @@ ArgvMap &arg()
 {
   static ArgvMap theArg;
   return theArg;
+}
+
+
+bool init_unit_test() {
+  cerr << "Initing..." << endl;
+  reportAllTypes();
+  return true;
+}
+
+// entry point:
+int main(int argc, char* argv[])
+{
+  return boost::unit_test::unit_test_main( &init_unit_test, argc, argv );
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

To make it possible to run individual unit test they should not depend on each other.
This makes sure all tests setup globals properly. Additionally, the testrunners of auth and rec call `reportAllTypes()` in init code since a lot of tests need that and a large set did not call it but depended silently on other tests to do it for them.

`./testrunner --random` now works all the time for all subprojects as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
