### PR TITLE
fix formatting for thread distribution stats message

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2642,7 +2642,7 @@ static void doStats(void)
     size_t idx = 0;
     for (const auto& threadInfo : s_threadInfos) {
       if(threadInfo.isWorker) {
-        g_log<<Logger::Notice<<"Thread "<<idx<<" has been distributed "<<threadInfo.numberOfDistributedQueries<<" queries"<<endl;
+        g_log<<Logger::Notice<<"stats: thread "<<idx<<" has been distributed "<<threadInfo.numberOfDistributedQueries<<" queries"<<endl;
         ++idx;
       }
     }


### PR DESCRIPTION
### Short description
Before:
```
Apr 16 08:59:51 stats: 19 questions, 294 cache entries, 8 negative entries, 52% cache hits
Apr 16 08:59:51 stats: throttle map: 2, ns speeds: 111
Apr 16 08:59:51 stats: outpacket/query ratio 375%, 0% throttled, 0 no-delegation drops
Apr 16 08:59:51 stats: 2 outgoing tcp connections, 0 queries running, 2 outgoing timeouts
Apr 16 08:59:51 stats: 19 packet cache entries, 0% packet cache hits
Apr 16 08:59:51 Thread 0 has been distributed 7 queries
Apr 16 08:59:51 Thread 1 has been distributed 12 queries
Apr 16 08:59:51 stats: 0 qps (average over 12316 seconds)
```

After:
```
Apr 16 09:47:57 stats: 203 questions, 193 cache entries, 1 negative entries, 99% cache hits
Apr 16 09:47:57 stats: throttle map: 0, ns speeds: 86
Apr 16 09:47:57 stats: outpacket/query ratio 19%, 0% throttled, 0 no-delegation drops
Apr 16 09:47:57 stats: 0 outgoing tcp connections, 0 queries running, 0 outgoing timeouts
Apr 16 09:47:57 stats: 203 packet cache entries, 0% packet cache hits
Apr 16 09:47:57 stats: thread 0 has been distributed 101 queries
Apr 16 09:47:57 stats: thread 1 has been distributed 102 queries
Apr 16 09:47:57 stats: 0 qps (average over 7 seconds)
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
