### PR TITLE
rec: Move replaced negcache entries to the back of the expunge queue

### DIFF
--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -201,3 +201,15 @@ template <typename T> uint64_t purgeExactLockedCollection(T& mc, const DNSName& 
 
   return delcount;
 }
+
+template<typename Index>
+std::pair<typename Index::iterator,bool>
+lruReplacingInsert(Index& i,const typename Index::value_type& x)
+{
+  std::pair<typename Index::iterator,bool> res = i.insert(x);
+  if (!res.second) {
+    moveCacheItemToBack(i, res.first);
+    res.second = i.replace(res.first, x);
+  }
+  return res;
+}

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -224,7 +224,7 @@ void DNSSECKeeper::getFromMeta(const DNSName& zname, const std::string& key, std
     nce.d_value = value;
     {
       WriteLock l(&s_metacachelock);
-      replacing_insert(s_metacache, nce);
+      lruReplacingInsert(s_metacache, nce);
     }
   }
 }
@@ -514,7 +514,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
     kce.d_ttd = now + ttl;
     {
       WriteLock l(&s_keycachelock);
-      replacing_insert(s_keycache, kce);
+      lruReplacingInsert(s_keycache, kce);
     }
   }
 

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -101,7 +101,7 @@ bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeva
  * \param ne The NegCacheEntry to add to the cache
  */
 void NegCache::add(const NegCacheEntry& ne) {
-  replacing_insert(d_negcache, ne);
+  lruReplacingInsert(d_negcache, ne);
 }
 
 /*!

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -264,6 +264,59 @@ BOOST_AUTO_TEST_CASE(test_prune) {
   BOOST_CHECK_EQUAL(cache.size(), 100);
 }
 
+BOOST_AUTO_TEST_CASE(test_prune_valid_entries) {
+  DNSName power1("powerdns.com.");
+  DNSName power2("powerdns-1.com.");
+  DNSName auth("com.");
+
+  struct timeval now;
+  Utility::gettimeofday(&now, 0);
+
+  NegCache cache;
+  NegCache::NegCacheEntry ne;
+
+  /* insert power1 then power2 */
+  ne = genNegCacheEntry(power1, auth, now);
+  cache.add(ne);
+  ne = genNegCacheEntry(power2, auth, now);
+  cache.add(ne);
+
+  BOOST_CHECK_EQUAL(cache.size(), 2);
+
+  /* power2 has been inserted more recently, so it should be
+     removed last */
+  cache.prune(1);
+  BOOST_CHECK_EQUAL(cache.size(), 1);
+
+  const NegCache::NegCacheEntry* got = nullptr;
+  bool ret = cache.get(power2, QType(1), now, &got);
+  BOOST_REQUIRE(ret);
+  BOOST_CHECK_EQUAL(got->d_name, power2);
+  BOOST_CHECK_EQUAL(got->d_auth, auth);
+
+  /* insert power1 back */
+  ne = genNegCacheEntry(power1, auth, now);
+  cache.add(ne);
+  BOOST_CHECK_EQUAL(cache.size(), 2);
+
+  /* replace the entry for power2 */
+  ne = genNegCacheEntry(power2, auth, now);
+  cache.add(ne);
+
+  BOOST_CHECK_EQUAL(cache.size(), 2);
+
+  /* power2 has been updated more recently, so it should be
+     removed last */
+  cache.prune(1);
+
+  BOOST_CHECK_EQUAL(cache.size(), 1);
+  got = nullptr;
+  ret = cache.get(power2, QType(1), now, &got);
+  BOOST_REQUIRE(ret);
+  BOOST_CHECK_EQUAL(got->d_name, power2);
+  BOOST_CHECK_EQUAL(got->d_auth, auth);
+}
+
 BOOST_AUTO_TEST_CASE(test_wipe_single) {
   string qname(".powerdns.com");
   DNSName auth("powerdns.com");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise they might get expunged very quickly while they just have been inserted.
Similar to https://github.com/PowerDNS/pdns/pull/3451, which fixed this issue for the positive caches.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
