### PR TITLE
Clarify the "easy setup guide": schema listed is for 4.2/master only

### DIFF
--- a/docs/guides/basic-database.rst
+++ b/docs/guides/basic-database.rst
@@ -46,9 +46,23 @@ Example: configuring MySQL
 --------------------------
 
 Connect to MySQL as a user with sufficient privileges and issue the
-following commands:
+following commands below if you are running the 4.2 or master version of PowerDNS:
+
+Please find `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gmysqlbackend/schema.mysql.sql>`_.
+
 
 .. literalinclude:: ../../modules/gmysqlbackend/schema.mysql.sql
+
+We recommend you add the following MySQL statements as well. These will add
+foreign key constraints to the tables in order to automate deletion of records, key
+material, and other information upon deletion of a domain from the
+domains table. These will only work on the InnoDB storage engine, but if you
+followed our guide so far, that's exactly the engine we are using.
+
+The following SQL does the job:
+
+.. literalinclude:: ../../modules/gmysqlbackend/enable-foreign-keys.mysql.sql
+
 
 Now we have a database and an empty table. PowerDNS should now be able
 to launch in monitor mode and display no errors:

--- a/modules/gmysqlbackend/enable-foreign-keys.mysql.sql
+++ b/modules/gmysqlbackend/enable-foreign-keys.mysql.sql
@@ -3,7 +3,7 @@ Using this SQL causes Mysql to create foreign keys on your database. This will
 make sure that no records, comments or keys exists for domains that you already
 removed. This is not enabled by default, because we're not sure what the
 consequences are from a performance point of view. If you do have feedback,
-please let us know how this effects your setup.
+please let us know how this affects your setup.
 
 Please note that it's not possible to apply this, before you cleaned up your
 database, as the foreign keys do not exist.


### PR DESCRIPTION
### Short description
The "easy install" guide includes the SQL schema for a MySQL backend, but fails to point out that that schema is for the 4.2/master releases. As the latest "stable" is 4.1.x, this confuses users.

I've also included the SQL for the constraints, as those are important enough to have new people load as a default. As they are following the getting-started guide, they are using InnoDB, and start with an empty DB, so there shouldn't be any problems adding the constraints.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
