### PR TITLE
dnsdist: remove maxEntries from newPacketCache opts

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -275,10 +275,6 @@ void setupLuaBindings(bool client)
           keepStaleData = boost::get<bool>((*vars)["keepStaleData"]);
         }
 
-        if (vars->count("maxEntries")) {
-          maxEntries = boost::get<size_t>((*vars)["maxEntries"]);
-        }
-
         if (vars->count("maxNegativeTTL")) {
           maxNegativeTTL = boost::get<size_t>((*vars)["maxNegativeTTL"]);
         }

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -614,7 +614,6 @@ See :doc:`../guides/cache` for a how to.
   * ``deferrableInsertLock=true``: bool - Whether the cache should give up insertion if the lock is held by another thread, or simply wait to get the lock.
   * ``dontAge=false``: bool - Don't reduce TTLs when serving from the cache. Use this when :program:`dnsdist` fronts a cluster of authoritative servers.
   * ``keepStaleData=false``: bool - Whether to suspend the removal of expired entries from the cache when there is no backend available in at least one of the pools using this cache.
-  * ``maxEntries``: int - The maximum number of entries in this cache.
   * ``maxNegativeTTL=3600``: int - Cache a NXDomain or NoData answer from the backend for at most this amount of seconds, even if the TTL of the SOA record is higher.
   * ``maxTTL=86400``: int - Cap the TTL for records to his number.
   * ``minTTL=0``: int - Don't cache entries with a TTL lower than this.


### PR DESCRIPTION
### Short description
maxEntries is already a mandatory parameter for `newPacketCache`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)