### PR TITLE
pycurl settings for darwin/brew

### DIFF
--- a/regression-tests.dnsdist/README
+++ b/regression-tests.dnsdist/README
@@ -9,10 +9,9 @@ DNSDISTBIN=../pdns/dnsdistdist/dnsdist ./runtests
 The tests are self-contained and require no further nameservers to be
 installed.
 
-However, do make sure to build a dnsdist with libsodium and dnscrypt support
-as otherwise some tests will fail.
+However, do make sure to build a dnsdist with libsodium, dnscrypt, DoT and DoH
+support as otherwise some tests will fail.
 
 To run a specific test, use something like:
 
 ./runtests test_Advanced.py:TestAdvancedSpoof.testSpoofActionMultiA
-

--- a/regression-tests.dnsdist/runtests
+++ b/regression-tests.dnsdist/runtests
@@ -16,7 +16,21 @@ if [ ! -d .venv ]; then
 fi
 . .venv/bin/activate
 python -V
+
+if [ `uname -s` == Darwin ]
+then
+  if [ ! -e /usr/local/opt/curl-openssl ]
+  then
+    echo Please run: brew install curl-openssl, and try again
+    exit 1
+  else
+    export PYCURL_CURL_CONFIG=/usr/local/opt/curl-openssl/bin/curl-config
+    export LDFLAGS=-L/usr/local/opt/openssl/lib
+    export CPPFLAGS=-I/usr/local/opt/openssl/include
+  fi
+fi
 pip install -r requirements.txt
+
 protoc -I=../pdns/ --python_out=. ../pdns/dnsmessage.proto
 protoc -I=../pdns/ --python_out=. ../pdns/dnstap.proto
 


### PR DESCRIPTION
### Short description
This makes `regression-tests.dnsdist/runtests` give forceful guidance about curl on macOS.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
