### PR TITLE
pdns_control reopens geoip databases on reload

### DIFF
--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -94,7 +94,7 @@ caching options described
 ``geoip-zones-file``
 ~~~~~~~~~~~~~~~~~~~~
 
-Specifies the full path of the zone configuration file to use.
+Specifies the full path of the zone configuration file to use. The file is re-opened with a ``pdns_control reload''.
 
 .. _setting-geoip-dnssec-keydir:
 


### PR DESCRIPTION
closes https://github.com/PowerDNS/pdns/issues/7752

### Short description
document pdns_control re-opens databases on reload

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
