### PR TITLE
s/ZSK/CSK

### DIFF
--- a/docs/dnssec/pdnsutil.rst
+++ b/docs/dnssec/pdnsutil.rst
@@ -16,7 +16,7 @@ DNSSEC Defaults
 
 Since version 4.0, when securing a zone using ``pdnsutil secure-zone``,
 a single ECDSA (algorithm 13, ECDSAP256SHA256) key is generated that is
-used as ZSK. Before 4.0, 3 RSA (algorithm 8) keys were generated, one as
+used as CSK. Before 4.0, 3 RSA (algorithm 8) keys were generated, one as
 the KSK and two ZSKs. As all keys are online in the database, it made no
 sense to have this split-key setup.
 


### PR DESCRIPTION
### Short description
documentation erroneously specifies ZSK instead of CSK

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
