### PR TITLE
Fix a delete call on abstract class without virtual dt clang warning.

### DIFF
--- a/pdns/dnswasher.cc
+++ b/pdns/dnswasher.cc
@@ -54,6 +54,9 @@ po::variables_map g_vm;
 class IPObfuscator
 {
 public:
+  virtual ~IPObfuscator()
+  {
+  }
   virtual uint32_t obf4(uint32_t orig)=0;
   virtual struct in6_addr obf6(const struct in6_addr& orig)=0;
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixes this clang warning:
```
/usr/include/c++/v1/memory:2321:5: warning: delete called on 'IPObfuscator' that is abstract but has non-virtual destructor [-Wdelete-non-virtual-dtor]
    delete __ptr;
    ^
/usr/include/c++/v1/memory:2634:7: note: in instantiation of member function 'std::__1::default_delete<IPObfuscator>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
/usr/include/c++/v1/memory:2588:19: note: in instantiation of member function 'std::__1::unique_ptr<IPObfuscator, std::__1::default_delete<IPObfuscator> >::reset' requested here
  ~unique_ptr() { reset(); }
                  ^
dnswasher.cc:74:12: note: in instantiation of member function 'std::__1::unique_ptr<IPObfuscator, std::__1::default_delete<IPObfuscator> >::~unique_ptr' requested here
    return std::unique_ptr<IPObfuscator>(new IPSeqObfuscator());
           ^
```
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
