### PR TITLE
Refactor auth-py tests so config templates can be used

### DIFF
--- a/regression-tests.auth-py/authtests.py
+++ b/regression-tests.auth-py/authtests.py
@@ -23,6 +23,25 @@ class AuthTest(unittest.TestCase):
     _confdir = 'auth'
     _authPort = 5300
 
+    _config_params = []
+
+    _config_template_default = """
+module-dir=../regression-tests/modules
+daemon=no
+local-ipv6=
+bind-config={confdir}/named.conf
+bind-dnssec-db={bind_dnssec_db}
+socket-dir={confdir}
+cache-ttl=0
+negquery-cache-ttl=0
+query-cache-ttl=0
+log-dns-queries=yes
+log-dns-details=yes
+loglevel=9
+distributor-threads=1"""
+
+    _config_template = ""
+
     _root_DS = "63149 13 1 a59da3f5c1b97fcd5fa2b3b2b0ac91d38a60d33a"
 
     # The default SOA for zones in the authoritative servers
@@ -92,28 +111,13 @@ options {
     def generateAuthConfig(cls, confdir):
         bind_dnssec_db = os.path.join(confdir, 'bind-dnssec.sqlite3')
 
+        params = tuple([getattr(cls, param) for param in cls._config_params])
+
         with open(os.path.join(confdir, 'pdns.conf'), 'w') as pdnsconf:
-            pdnsconf.write("""
-module-dir=../regression-tests/modules
-launch=bind geoip
-daemon=no
-local-ipv6=
-bind-config={confdir}/named.conf
-bind-dnssec-db={bind_dnssec_db}
-socket-dir={confdir}
-cache-ttl=0
-negquery-cache-ttl=0
-query-cache-ttl=0
-log-dns-queries=yes
-log-dns-details=yes
-loglevel=9
-geoip-database-files=../modules/geoipbackend/regression-tests/GeoLiteCity.mmdb
-edns-subnet-processing=yes
-expand-alias=yes
-resolver={prefix}.1:5301
-any-to-tcp=no
-distributor-threads=1""".format(confdir=confdir, prefix=cls._PREFIX,
-                                bind_dnssec_db=bind_dnssec_db))
+            pdnsconf.write(cls._config_template_default.format(
+                confdir=confdir, prefix=cls._PREFIX,
+                bind_dnssec_db=bind_dnssec_db))
+            pdnsconf.write(cls._config_template % params)
 
         pdnsutilCmd = [os.environ['PDNSUTIL'],
                        '--config-dir=%s' % confdir,

--- a/regression-tests.auth-py/test_ALIAS.py
+++ b/regression-tests.auth-py/test_ALIAS.py
@@ -15,6 +15,15 @@ aliasUDPReactorRunning = False
 
 
 class TestALIAS(AuthTest):
+    _config_template = """
+expand-alias=yes
+resolver=%s.1:5301
+any-to-tcp=no
+launch=bind
+"""
+
+    _config_params = ['_PREFIX']
+
     _zones = {
         'example.org': """
 example.org.                 3600 IN SOA  {soa}

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -30,6 +30,13 @@ class FakeHTTPServer(BaseHTTPRequestHandler):
         self._set_headers()
 
 class TestLuaRecords(AuthTest):
+    _config_template = """
+geoip-database-files=../modules/geoipbackend/regression-tests/GeoLiteCity.mmdb
+edns-subnet-processing=yes
+launch=bind geoip
+any-to-tcp=no
+"""
+
     _zones = {
         'example.org': """
 example.org.                 3600 IN SOA  {soa}


### PR DESCRIPTION
### Short description
This will make it easier in the future to write tests needing different configurations.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)