### PR TITLE
ship SRPM files as well

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -60,3 +60,4 @@ RUN if $(grep -q 'release 6' /etc/redhat-release); then \
 # See: https://github.com/moby/moby/issues/33733
 #RUN mv /root/rpmbuild/RPMS/* /dist/
 RUN cp -R /root/rpmbuild/RPMS/* /dist/
+RUN cp -R /root/rpmbuild/SRPMS/* /dist/


### PR DESCRIPTION
### Short description
This change makes us ship *.src.rpm files as well. This will allow anyone to rebuild easily on RPM-based systems. A src RPM contains the exact specfile and tarball used to build the RPM packages.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
