### PR TITLE
auth: lmdbbackend: auth was unset in get() (always true)

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -618,6 +618,7 @@ bool LMDBBackend::get(DNSResourceRecord& rr)
   rr.qtype =dzr.dr.d_type;
   rr.content = dzr.dr.d_content->getZoneRepresentation();
   rr.domain_id = dzr.domain_id;
+  rr.auth = dzr.auth;
   //  cout<<"old school called for "<<rr.qname<<", "<<rr.qtype.getName()<<endl;
   return true;
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -616,7 +616,7 @@ bool LMDBBackend::get(DNSResourceRecord& rr)
   rr.qname = dzr.dr.d_name;
   rr.ttl = dzr.dr.d_ttl;
   rr.qtype =dzr.dr.d_type;
-  rr.content = dzr.dr.d_content->getZoneRepresentation();
+  rr.content = dzr.dr.d_content->getZoneRepresentation(true);
   rr.domain_id = dzr.domain_id;
   rr.auth = dzr.auth;
   //  cout<<"old school called for "<<rr.qname<<", "<<rr.qtype.getName()<<endl;


### PR DESCRIPTION
### Short description
Fix auth=1 bug and avoid the "Parsed and original record content are not equal:" warnings in pdnsutil check-zone

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
