### PR TITLE
pkgs: don't depend on dns-root-data on Trusty

### DIFF
--- a/builder-support/debian/recursor/ubuntu-trusty/control
+++ b/builder-support/debian/recursor/ubuntu-trusty/control
@@ -18,7 +18,6 @@ Homepage: https://www.powerdns.com/
 Package: pdns-recursor
 Architecture: any
 Depends: adduser,
-         dns-root-data,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: PowerDNS Recursor

--- a/builder-support/debian/recursor/ubuntu-trusty/rules
+++ b/builder-support/debian/recursor/ubuntu-trusty/rules
@@ -33,7 +33,6 @@ override_dh_auto_install:
 		-e 's!# quiet=.*!quiet=yes!' \
 		-e 's!# setgid=.*!setgid=pdns!' \
 		-e 's!# setuid=.*!setuid=pdns!' \
-		-e 's!# hint-file=.*!&\nhint-file=/usr/share/dns/root.hints!' \
 		> debian/tmp/etc/powerdns/recursor.conf
 
 override_dh_strip:


### PR DESCRIPTION
### Short description
That package does not exist on Trusty

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
