### PR TITLE
Prevent unlimited memory usage by cache

### DIFF
--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -233,7 +233,7 @@ void AuthQueryCache::cleanupIfNeeded()
       uint64_t maxCached = (int)(2*d_maxEntries);
       uint64_t cacheSize = *d_statnumentries;
       
-      if (maxCached > cacheSize) {
+      if (cacheSize <= maxCached) {
         d_cleanskipped = true;
         d_nextclean += d_cleaninterval;
 

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -226,12 +226,21 @@ void AuthQueryCache::cleanupIfNeeded()
     DLOG(g_log<<"cleaninterval: "<<d_cleaninterval<<", timediff: "<<timediff<<endl);
 
     if (d_cleaninterval == s_maxcleaninterval && timediff < 30) {
-      d_cleanskipped = true;
-      d_nextclean += d_cleaninterval;
+      /* 
+      There might be very good reasons for the cache size to be limited, 
+      lets not skip cleanup if we notice the cache is already oversized
+      */
+      uint64_t maxCached = (int)(2*d_maxEntries);
+      uint64_t cacheSize = *d_statnumentries;
+      
+      if (maxCached > cacheSize) {
+        d_cleanskipped = true;
+        d_nextclean += d_cleaninterval;
 
-      DLOG(g_log<<"cleaning skipped, timediff: "<<timediff<<endl);
+        DLOG(g_log<<"cleaning skipped, timediff: "<<timediff<<endl);
 
-      return;
+        return;
+      }
     }
 
     if(!d_cleanskipped) {

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -230,7 +230,7 @@ void AuthQueryCache::cleanupIfNeeded()
       There might be very good reasons for the cache size to be limited, 
       lets not skip cleanup if we notice the cache is already oversized
       */
-      uint64_t maxCached = (int)(2*d_maxEntries);
+      uint64_t maxCached = 2*d_maxEntries;
       uint64_t cacheSize = *d_statnumentries;
       
       if (cacheSize <= maxCached) {


### PR DESCRIPTION
In my test-environment the cache would cause out of memory while max-cache-entries seemed to be ignored.
I first tried actually respecting max-cache-entries by not writing to the cache once it was more than full, but this seemed to cause a big penalty (in one test going from 17k QPS to about 11k QPS). 
The problem however seems to be reasonably under control with this change: if we don't skip cleanup if the cache is already too full. 

This change does still make things slower (now at around 14k QPS on my test-system when I try to trigger the out-of-memory), but the alternative was everything completely failing because of possible out of memory.
If s_maxcleaninterval is correctly chosen, then I expect the extra code to only be executed if we might be in the situation where the cache is being filled quicker than expected (and an out of memory is therefore a possibility).

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

