### PR TITLE
Respect max-packet-cache-entries and max-cache-entries

### DIFF
--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -147,7 +147,27 @@ template <typename T> uint64_t pruneLockedCollectionsVector(vector<T>& maps, uin
     }
     totErased += erased;
   }
+  
+  toTrim = toTrim - totErased;
 
+  if (toTrim > 0) {
+    //Just trowing away the old stuff wasn't sufficient, start from the top
+    
+    for(auto& mc : maps) {
+      WriteLock wl(&mc.d_mut);
+      auto& sidx = boost::multi_index::get<2>(mc.d_map);
+      uint64_t erased = 0, lookedAt = 0;
+      for(auto i = sidx.begin(); i != sidx.end(); lookedAt++) {
+        i = sidx.erase(i);
+        erased++;
+
+        if(erased > toTrim / maps.size())
+          break;
+      }
+      totErased += erased;
+    }
+  }
+  
   return totErased;
 }
 

--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -159,12 +159,13 @@ template <typename T> uint64_t pruneLockedCollectionsVector(vector<T>& maps, uin
       
       //Is it possible for toThrowAway to be larger than sidx.size()? Better safe than sorry
       uint64_t toThrowAway = std::min(toTrim / maps.size(), sidx.size());
+      if (toThrowAway > 0) {
+        auto eraseIter = sidx.begin();
+        std::advance(eraseIter, toThrowAway);
+        sidx.erase(sidx.begin(),eraseIter);
 
-      auto eraseIter = sidx.begin();
-      std::advance(eraseIter, toThrowAway);
-      sidx.erase(sidx.begin(),eraseIter);
-
-      totErased += toThrowAway;
+        totErased += toThrowAway;
+      }
     }
   }
   

--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -151,7 +151,7 @@ template <typename T> uint64_t pruneLockedCollectionsVector(vector<T>& maps, uin
   toTrim = toTrim - totErased;
 
   if (toTrim > 0) {
-    //Just trowing away the old stuff wasn't sufficient, start from the top
+    //Just throwing away the old stuff wasn't sufficient, start from the top
     
     for(auto& mc : maps) {
       WriteLock wl(&mc.d_mut);

--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -156,8 +156,8 @@ template <typename T> uint64_t pruneLockedCollectionsVector(vector<T>& maps, uin
     for(auto& mc : maps) {
       WriteLock wl(&mc.d_mut);
       auto& sidx = boost::multi_index::get<2>(mc.d_map);
-      uint64_t erased = 0, lookedAt = 0;
-      for(auto i = sidx.begin(); i != sidx.end(); lookedAt++) {
+      uint64_t erased = 0;
+      for(auto i = sidx.begin(); i != sidx.end();) {
         i = sidx.erase(i);
         erased++;
 

--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -156,15 +156,15 @@ template <typename T> uint64_t pruneLockedCollectionsVector(vector<T>& maps, uin
     for(auto& mc : maps) {
       WriteLock wl(&mc.d_mut);
       auto& sidx = boost::multi_index::get<2>(mc.d_map);
-      uint64_t erased = 0;
-      for(auto i = sidx.begin(); i != sidx.end();) {
-        i = sidx.erase(i);
-        erased++;
+      
+      //Is it possible for toThrowAway to be larger than sidx.size()? Better safe than sorry
+      uint64_t toThrowAway = std::min(toTrim / maps.size(), sidx.size());
 
-        if(erased > toTrim / maps.size())
-          break;
-      }
-      totErased += erased;
+      auto eraseIter = sidx.begin();
+      std::advance(eraseIter, toThrowAway);
+      sidx.erase(sidx.begin(),eraseIter);
+
+      totErased += toThrowAway;
     }
   }
   


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixed proposed for #7458
This might replace or be combined with #7793 
This solution however seems to carry a smaller speed penalty and is less likely to be triggered when it's not actually needed.

If the initial attempt to clean the cache by only throwing away the old stuff wasn't sufficient to get below maxCached, then we will start throwing away from the top until we are at or close to the maximum. This way users are able to prevent out of memory by settings max-packet-cache-entries and max-cache-entries to appropriate values.

Code will execute only when max-cache has actually been exceeded. Overhead should be limited to when it's actually needed. 

I used dnsperf to test the speed and to stress-test on a 1G machine with LMDB backend and using fully random subdomains. Without this patch (and without #7793), PDNS would run out of memory after about 60 seconds. With the patch and with max-packet-cache-entries and max-cache-entries set to the default of 1000000 it would remain well within the memory limits.

My stress-tests triggered the code execution and even then speed penalty seems limited:
Two 60 second runs prior to the patch (runs cancelled just before it would otherwise go out of memory): 16981QPS and 17133QPS reported by dnsperf
Two 60 second runs with the patch: 16340QPS and 16988QPS


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ X ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ X ] compiled this code
- [ X ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
