### PR TITLE
Allow disabling packet cache with max-packet-cache-entries=0

### DIFF
--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -65,6 +65,9 @@ AuthPacketCache::~AuthPacketCache()
 
 bool AuthPacketCache::get(DNSPacket *p, DNSPacket *cached)
 {
+  if (d_maxEntries == 0)
+    return false; // packetCache is disabled
+  
   cleanupIfNeeded();
 
   if(!d_ttl) {
@@ -113,6 +116,9 @@ bool AuthPacketCache::entryMatches(cmap_t::index<HashTag>::type::iterator& iter,
 
 void AuthPacketCache::insert(DNSPacket *q, DNSPacket *r, unsigned int maxTTL)
 {
+  if (d_maxEntries == 0)
+    return; // packetCache is disabled  
+
   cleanupIfNeeded();
 
   if (ntohs(q->d.qdcount) != 1) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In some configurations (dnsdist in front of pdns?) a packet cache might hurt performance. I didn't find an option to actually disable this. Setting max-packet-cache-entries=0 will now disable writing to it or reading from it.

Performance gain of well over 10% in usage case where packet cache wasn't being hit.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
