### PR TITLE
Make explicit lmdbbackend synchronous option

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1591,7 +1591,7 @@ public:
   void declareArguments(const string &suffix="")
   {
     declare(suffix,"filename","Filename for lmdb","./pdns.lmdb");
-    declare(suffix,"sync-mode","Synchronisation mode: nosync, nometasync, mapasync","mapasync");
+    declare(suffix,"sync-mode","Synchronisation mode: nosync, nometasync, mapasync, sync","mapasync");
     // there just is no room for more on 32 bit
     declare(suffix,"shards","Records database will be split into this number of shards", (sizeof(long) == 4) ? "2" : "64"); 
   }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -58,7 +58,7 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     d_asyncFlag = MDB_NOMETASYNC;
   else if(syncMode == "mapasync")
     d_asyncFlag = MDB_MAPASYNC;
-  else if(syncMode.empty())
+  else if(syncMode.empty() || syncMode == "sync")
     d_asyncFlag = 0;
   else
     throw std::runtime_error("Unknown sync mode "+syncMode+" requested for LMDB backend");


### PR DESCRIPTION
### Short description
The LMDB backend has an option to pick the LMDB synchronisation mode. To pick lmdb synchronous mode (its default), you had to set `lmdb-syncmode=` which was weird. With this PR you can now do `lmdb-syncmode=sync` to achieve the same thing. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
