### PR TITLE
dnsdist: test on circleci; support py3 in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1131,6 +1131,8 @@ jobs:
   build-dnsdist:
     docker:
       - image: debian:buster
+        environment:
+          UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1'
     steps:
       - restore-cache-ccache:
           product: dnsdist
@@ -1207,6 +1209,8 @@ jobs:
   test-dnsdist-regression:
     docker:
       - image: debian:buster
+        environment:
+          UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1'
     steps:
       - install-dnsdist-deps
       - checkout-shallow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,27 @@ commands:
             default-libmysqlclient-dev \
             unixodbc
 
+  install-dnsdist-deps:
+    description: "Install all libraries needed for testing dnsdist"
+    steps:
+      - run: apt-get update
+      - run:
+          command: |
+            apt-get install -qq -y \
+              libluajit-5.1 \
+              libboost-all-dev \
+              libcap2 \
+              libcurl4-openssl-dev \
+              libfstrm0 \
+              libh2o-evloop0.13 \
+              libre2-5 \
+              libssl-dev \
+              libsystemd0 \
+              libsodium23 \
+              libprotobuf17 \
+              protobuf-compiler \
+              virtualenv
+
   install-auth-dev-deps:
     description: Install all packages needed to build the auth
     steps:
@@ -1107,6 +1128,103 @@ jobs:
             --form description="master build" \
             https://scan.coverity.com/builds?project=${COVERITY_PROJECT}
 
+  build-dnsdist:
+    docker:
+      - image: debian:buster
+    steps:
+      - restore-cache-ccache:
+          product: dnsdist
+      - run:
+          name: Install dependencies
+          command: |
+            apt-get update && apt-get -qq --no-install-recommends install \
+            autoconf \
+            automake \
+            g++ \
+            git \
+            libboost-all-dev \
+            libcap-dev \
+            libedit-dev \
+            libfstrm-dev \
+            libh2o-evloop-dev \
+            libluajit-5.1-dev \
+            libprotobuf-dev \
+            libre2-dev \
+            libsnmp-dev \
+            libsodium-dev \
+            libssl-dev \
+            libsystemd-dev \
+            libtool \
+            make \
+            pkg-config \
+            protobuf-compiler \
+            ragel \
+            virtualenv
+      - checkout-shallow
+      - run:
+          name: autoconf
+          command: BUILDER_VERSION=0.0.0-git1 autoreconf -vfi
+          working_directory: ~/project/pdns/dnsdistdist
+      - run:
+          name: configure
+          command: |
+            CFLAGS="-O1 -Werror=vla" \
+            CXXFLAGS="-O1 -Werror=vla" \
+            ./configure \
+            --enable-unit-tests \
+            --enable-dnstap \
+            --enable-dnscrypt \
+            --enable-dns-over-tls \
+            --enable-dns-over-https \
+            --prefix=/opt/dnsdist \
+            --with-libsodium \
+            --with-lua=luajit \
+            --with-libcap \
+            --with-protobuf=yes \
+            --with-re2 \
+            --enable-asan \
+            --enable-ubsan
+          working_directory: ~/project/pdns/dnsdistdist
+      - run:
+          name: build
+          command: make -j1 -k
+          working_directory: ~/project/pdns/dnsdistdist
+      - save-ccache-cache:
+          product: dnsdist
+      - run:
+          name: Run unit tests
+          command: make check || (cat test-suite.log; false)
+          working_directory: ~/project/pdns/dnsdistdist
+      - run:
+          name: Install resulting binaries
+          command: make install
+          working_directory: ~/project/pdns/dnsdistdist
+      - persist_to_workspace:
+          root: /opt
+          paths:
+            - dnsdist
+
+  test-dnsdist-regression:
+    docker:
+      - image: debian:buster
+    steps:
+      - install-dnsdist-deps
+      - checkout-shallow
+      - run:
+          name: setup snmp
+          command: |
+            apt-get -qq --no-install-recommends install snmpd
+            sed "s/agentxperms 0700 0755 dnsdist/agentxperms 0700 0755/g" regression-tests.dnsdist/snmpd.conf > /etc/snmp/snmpd.conf
+            /etc/init.d/snmpd start
+      - attach_workspace:
+          at: /opt
+      - run:
+          name: Run dnsdist tests
+          workdir: ~/project/regression-tests.dnsdist
+          command: |
+            DNSDISTBIN="/opt/dnsdist/bin/dnsdist" \
+            ./runtests
+
 workflows:
   version: 2
   coverity:
@@ -1173,6 +1291,10 @@ workflows:
       - test-recursor-api:
           requires:
             - build-recursor
+      - build-dnsdist
+      - test-dnsdist-regression:
+          requires:
+            - build-dnsdist
 
   build-docs:
     jobs:

--- a/regression-tests.dnsdist/requirements.txt
+++ b/regression-tests.dnsdist/requirements.txt
@@ -2,8 +2,7 @@ dnspython>=1.11,<1.16.0
 nose>=1.3.7
 libnacl>=1.4.3
 requests>=2.1.0
-protobuf>=2.5,<3.0; sys_platform != 'darwin' and sys_platform != 'openbsd6'
-protobuf>=3.0; sys_platform == 'darwin' or sys_platform == 'openbsd6'
+protobuf>=3.0
 pysnmp>=4.3.4
 future>=0.17.1
 pycurl>=7.43.0

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -409,7 +409,7 @@ class TestProtobufIPCipher(DNSDistProtobufTest):
         """
         name = 'query.protobuf-ipcipher.tests.powerdns.com.'
 
-        target = b'target.protobuf-ipcipher.tests.powerdns.com.'
+        target = 'target.protobuf-ipcipher.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
         response = dns.message.make_response(query)
 
@@ -450,7 +450,7 @@ class TestProtobufIPCipher(DNSDistProtobufTest):
         self.assertEquals(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.CNAME, name, 3600)
-        self.assertEquals(rr.rdata, target)
+        self.assertEquals(rr.rdata.decode('ascii'), target)
         rr = msg.response.rrs[1]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, target, 3600)
         self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
@@ -476,7 +476,7 @@ class TestProtobufIPCipher(DNSDistProtobufTest):
         self.assertEquals(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.CNAME, name, 3600)
-        self.assertEquals(rr.rdata, target)
+        self.assertEquals(rr.rdata.decode('ascii'), target)
         rr = msg.response.rrs[1]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, target, 3600)
         self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')

--- a/regression-tests.dnsdist/test_SNMP.py
+++ b/regression-tests.dnsdist/test_SNMP.py
@@ -58,7 +58,7 @@ class TestSNMP(DNSDistTest):
             self.assertTrue(isinstance(results[oid], OctetString))
 
         ## name
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.2.0'], "servername")
+        self.assertEquals(str(results['1.3.6.1.4.1.43315.3.2.1.2.0']), "servername")
         ## weight
         self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.4.0'], 1)
         ## outstanding
@@ -68,11 +68,11 @@ class TestSNMP(DNSDistTest):
         ## reused
         self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.7.0'], 0)
         ## state
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.8.0'], "up")
+        self.assertEquals(str(results['1.3.6.1.4.1.43315.3.2.1.8.0']), "up")
         ## address
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.9.0'], ("127.0.0.1:%s" % (self._testServerPort)))
+        self.assertEquals(str(results['1.3.6.1.4.1.43315.3.2.1.9.0']), ("127.0.0.1:%s" % (self._testServerPort)))
         ## pools
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.10.0'], "")
+        self.assertEquals(str(results['1.3.6.1.4.1.43315.3.2.1.10.0']), "")
         ## queries
         self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.12.0'], queriesCountersValue)
         ## order


### PR DESCRIPTION
### Short description
This adds circleci testing for dnsdist, running on debian buster, because it's easier than stretch-backports (for libh2o-evloop) and buster will be out soon anyway.

This fixes running dnsdist tests on python3 on my local systems (debian buster); it also does not appear to break testing on Travis, somehow. Specifically this removes the 2.x/3.x split in the python protobuf dependency.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
