### PR TITLE
Ensure a valid range to string() in PacketReader::getUnquotedText()

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -484,6 +484,11 @@ string PacketReader::getUnquotedText(bool lenField)
   else
     stop_at = d_recordlen;
 
+  /* think unsigned overflow */
+  if (stop_at < d_pos) {
+    throw std::out_of_range("getUnquotedText out of record range");
+  }
+
   if(stop_at == d_pos)
     return "";
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR is quite similar to #7272.

In some cases we might have called:
```
string::string(InputIt first, InputIt last)
```
with last < first, which is invalid.

`libstdc++` handles that gracefully by throwing an out-of-range exception but `libc++` tries to allocate a negative value of bytes, which in turns triggers a request for a very large memory allocation, which fails.

This issue was triggered on `OSS-fuzz`.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
