### PR TITLE
dnsdist: Don't let 'self' dangling while parsing the request's qname

### DIFF
--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -279,16 +279,17 @@ static void on_generator_dispose(void *_self)
 static void doh_dispatch_query(DOHServerConfig* dsc, h2o_handler_t* self, h2o_req_t* req, std::string&& query, const ComboAddress& local, const ComboAddress& remote)
 {
   try {
-    auto du = std::unique_ptr<DOHUnit>(new DOHUnit);
-    du->self = reinterpret_cast<DOHUnit**>(h2o_mem_alloc_shared(&req->pool, sizeof(*self), on_generator_dispose));
     uint16_t qtype;
     DNSName qname(query.c_str(), query.size(), sizeof(dnsheader), false, &qtype);
+
+    auto du = std::unique_ptr<DOHUnit>(new DOHUnit);
     du->req = req;
-    du->query = std::move(query);
     du->dest = local;
     du->remote = remote;
     du->rsock = dsc->dohresponsepair[0];
+    du->query = std::move(query);
     du->qtype = qtype;
+    du->self = reinterpret_cast<DOHUnit**>(h2o_mem_alloc_shared(&req->pool, sizeof(*self), on_generator_dispose));
     auto ptr = du.release();
     *(ptr->self) = ptr;
     try  {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise we might try to read an uninitialized value in the destructor if the parsing fails.
Hopefully fixes #7810.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
