### PR TITLE
SNMP: Use net-snmp-config --netsnmp-agent-libs instead of --agent-libs

### DIFF
--- a/m4/pdns_with_net_snmp.m4
+++ b/m4/pdns_with_net_snmp.m4
@@ -10,7 +10,7 @@ AC_DEFUN([PDNS_WITH_NET_SNMP], [
   AS_IF([test "x$with_net_snmp" != "xno"], [
     AS_IF([test "x$with_net_snmp" = "xyes" -o "x$with_net_snmp" = "xauto"], [
       AC_CHECK_PROG([NET_SNMP_CFLAGS], [net-snmp-config], [`net-snmp-config --cflags`])
-      AC_CHECK_PROG([NET_SNMP_LIBS], [net-snmp-config], [`net-snmp-config --agent-libs`])
+      AC_CHECK_PROG([NET_SNMP_LIBS], [net-snmp-config], [`net-snmp-config --netsnmp-agent-libs`])
       AC_CHECK_DECLS([snmp_select_info2], [ : ], [ : ],
         [AC_INCLUDES_DEFAULT
           #include <net-snmp/net-snmp-config.h>


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
As discussed in https://github.com/PowerDNS/pdns/issues/7762, this seems to keep the environment cleaner.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
