### PR TITLE
Do coverity builds once a day via circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,8 +723,100 @@ jobs:
             PDNSRECURSOR="/opt/pdns-recursor/sbin/pdns_recursor" \
             ./runtests recursor
 
+  coverity-dnsdist:
+    docker:
+      - image: debian:buster
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt-get update && apt-get -qq --no-install-recommends install \
+            autoconf \
+            automake \
+            bison \
+            bzip2 \
+            ca-certificates \
+            curl \
+            flex \
+            g++ \
+            git \
+            libboost-all-dev \
+            libcap-dev \
+            libedit-dev \
+            libfstrm-dev \
+            libh2o-evloop-dev \
+            libluajit-5.1-dev \
+            libprotobuf-dev \
+            libre2-dev \
+            libsnmp-dev \
+            libsodium-dev \
+            libssl-dev \
+            libsystemd-dev \
+            libtool \
+            libwslay-dev \
+            make \
+            pkg-config \
+            protobuf-compiler \
+            ragel \
+            virtualenv
+      - run:
+          name: Install Coverity tools
+          command: curl -s https://scan.coverity.com/download/linux64 --data "token=${COVERITY_TOKEN}&project=dnsdist" |  gunzip | tar xvf /dev/stdin --strip-components=2 --no-same-owner -C /usr/local
+      - checkout-shallow
+      - run:
+          name: autoconf
+          command: BUILDER_VERSION=0.0.0-git1 autoreconf -vfi
+          working_directory: ~/project/pdns/dnsdistdist
+      - run:
+          name: configure
+          command: |
+            CFLAGS="-O1 -Werror=vla" \
+            CXXFLAGS="-O1 -Werror=vla" \
+            ./configure \
+            --disable-systemd \
+            --disable-unit-tests \
+            --enable-dnstap \
+            --enable-dnscrypt \
+            --enable-dns-over-tls \
+            --enable-dns-over-https \
+            --prefix=/opt/dnsdist \
+            --with-libsodium \
+            --with-lua=luajit \
+            --with-libcap \
+            --with-protobuf=yes \
+            --with-re2
+          working_directory: ~/project/pdns/dnsdistdist
+      - run:
+          name: build
+          command: /usr/local/bin/cov-build --dir cov-int make -j2 -k
+          working_directory: ~/project/pdns/dnsdistdist
+      - run:
+          name: Create Coverity tarball
+          command: tar caf dnsdist.tar.bz2 cov-int
+          working_directory: ~/project/pdns/dnsdistdist
+      - run:
+          name: Upload tarball to coverity
+          command: |
+            curl --form token=${COVERITY_TOKEN} \
+            --form email="${COVERITY_EMAIL}" \
+            --form file=@pdns/dnsdistdist/dnsdist.tar.bz2 \
+            --form version="$(./builder-support/gen-version)" \
+            --form description="master build" \
+            https://scan.coverity.com/builds?project=dnsdist
+
 workflows:
   version: 2
+  coverity:
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only: master
+    jobs:
+      - coverity-dnsdist:
+          context: dnsdist-coverity
+
   build-and-test-all:
     jobs:
       - build-auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -918,12 +918,12 @@ jobs:
 workflows:
   version: 2
   coverity:
-#    triggers:
-#      - schedule:
-#          cron: "0 0 * * *"
-#          filters:
-#            branches:
-#              only: master
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: master
     jobs:
       - coverity-auth:
           context: auth-coverity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -734,7 +734,7 @@ jobs:
 
   coverity-auth:
     docker:
-      - image: debian:buster
+      - image: debian:stretch
     steps:
       - install-auth-dev-deps
       - install-coverity-tools
@@ -772,7 +772,7 @@ jobs:
 
   coverity-dnsdist:
     docker:
-      - image: debian:buster
+      - image: debian:stretch
     steps:
       - run:
           name: Install dependencies
@@ -791,7 +791,6 @@ jobs:
             libcap-dev \
             libedit-dev \
             libfstrm-dev \
-            libh2o-evloop-dev \
             libluajit-5.1-dev \
             libprotobuf-dev \
             libre2-dev \
@@ -800,7 +799,6 @@ jobs:
             libssl-dev \
             libsystemd-dev \
             libtool \
-            libwslay-dev \
             make \
             pkg-config \
             protobuf-compiler \
@@ -823,7 +821,6 @@ jobs:
             --enable-dnstap \
             --enable-dnscrypt \
             --enable-dns-over-tls \
-            --enable-dns-over-https \
             --prefix=/opt/dnsdist \
             --with-libsodium \
             --with-lua=luajit \
@@ -851,7 +848,7 @@ jobs:
 
   coverity-recursor:
     docker:
-      - image: debian:buster
+      - image: debian:stretch
     steps:
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,13 @@ commands:
             fi
             git show -s
 
+  install-coverity-tools:
+    description: Install the coverity tools to /usr/local
+    steps:
+      - run:
+          name: Install Coverity tools
+          command: curl -s https://scan.coverity.com/download/linux64 --data "token=${COVERITY_TOKEN}&project=${COVERITY_PROJECT}" |  gunzip | tar xvf /dev/stdin --strip-components=2 --no-same-owner -C /usr/local
+
   auth-regress-setup:
     description: Prepare the environment for auth regression tests
     steps:
@@ -759,9 +766,7 @@ jobs:
             protobuf-compiler \
             ragel \
             virtualenv
-      - run:
-          name: Install Coverity tools
-          command: curl -s https://scan.coverity.com/download/linux64 --data "token=${COVERITY_TOKEN}&project=dnsdist" |  gunzip | tar xvf /dev/stdin --strip-components=2 --no-same-owner -C /usr/local
+      - install-coverity-tools
       - checkout-shallow
       - run:
           name: autoconf
@@ -802,7 +807,76 @@ jobs:
             --form file=@pdns/dnsdistdist/dnsdist.tar.bz2 \
             --form version="$(./builder-support/gen-version)" \
             --form description="master build" \
-            https://scan.coverity.com/builds?project=dnsdist
+            https://scan.coverity.com/builds?project=${COVERITY_PROJECT}
+
+  coverity-recursor:
+    docker:
+      - image: debian:buster
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt-get update && apt-get -qq --no-install-recommends install \
+            autoconf \
+            automake \
+            ca-certificates \
+            curl \
+            bison \
+            bzip2 \
+            flex \
+            g++ \
+            git \
+            libboost-all-dev \
+            libcap-dev \
+            libluajit-5.1-dev \
+            libprotobuf-dev \
+            libsodium-dev \
+            libssl-dev \
+            libsystemd-dev \
+            libtool \
+            make \
+            pkg-config \
+            protobuf-compiler \
+            ragel \
+            virtualenv
+      - install-coverity-tools
+      - checkout-shallow
+      - run:
+          name: autoconf
+          command: BUILDER_VERSION=0.0.0-git1 autoreconf -vfi
+          working_directory: ~/project/pdns/recursordist
+      - run:
+          name: configure
+          command: |
+            CFLAGS="-O1 -Werror=vla" \
+            CXXFLAGS="-O1 -Werror=vla" \
+            ./configure \
+            --disable-systemd \
+            --disable-unit-tests \
+            --prefix=/opt/pdns-recursor \
+            --with-libsodium \
+            --with-lua=luajit \
+            --with-libcap \
+            --with-protobuf=yes \
+            --without-net-snmp
+          working_directory: ~/project/pdns/recursordist
+      - run:
+          name: build
+          command: /usr/local/bin/cov-build --dir cov-int make -j2 -k
+          working_directory: ~/project/pdns/recursordist
+      - run:
+          name: Create Coverity tarball
+          command: tar caf recursor.tar.bz2 cov-int
+          working_directory: ~/project/pdns/recursordist
+      - run:
+          name: Upload tarball to coverity
+          command: |
+            curl --form token=${COVERITY_TOKEN} \
+            --form email="${COVERITY_EMAIL}" \
+            --form file=@pdns/recursordist/recursor.tar.bz2 \
+            --form version="$(./builder-support/gen-version)" \
+            --form description="master build" \
+            https://scan.coverity.com/builds?project=${COVERITY_PROJECT}
 
 workflows:
   version: 2
@@ -816,6 +890,9 @@ workflows:
     jobs:
       - coverity-dnsdist:
           context: dnsdist-coverity
+      - coverity-recursor:
+          context: recursor-coverity
+
 
   build-and-test-all:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,8 @@ commands:
               autoconf \
               automake \
               bison \
+              bzip2 \
+              curl \
               default-libmysqlclient-dev \
               flex \
               g++ \
@@ -730,6 +732,44 @@ jobs:
             PDNSRECURSOR="/opt/pdns-recursor/sbin/pdns_recursor" \
             ./runtests recursor
 
+  coverity-auth:
+    docker:
+      - image: debian:buster
+    steps:
+      - install-auth-dev-deps
+      - install-coverity-tools
+      - checkout-shallow
+      - run:
+          name: autoconf
+          command: BUILDER_VERSION=0.0.0-git1 autoreconf -vfi
+      - run:
+          name: configure
+          command: |
+            CFLAGS="-O1 -Werror=vla" \
+            CXXFLAGS="-O1 -Werror=vla" \
+            ./configure \
+              --disable-lua-records \
+              --with-modules='bind lmdb ldap gmysql gsqlite3 gpgsql godbc mydns random tinydns' \
+              --enable-tools \
+              --with-lmdb=/usr \
+              --with-libsodium \
+              --prefix=/opt/pdns-auth
+      - run:
+          name: build
+          command: /usr/local/bin/cov-build --dir cov-int make -j2 -k
+      - run:
+          name: Create Coverity tarball
+          command: tar caf auth.tar.bz2 cov-int
+      - run:
+          name: Upload tarball to coverity
+          command: |
+            curl --form token=${COVERITY_TOKEN} \
+            --form email="${COVERITY_EMAIL}" \
+            --form file=@auth.tar.bz2 \
+            --form version="$(./builder-support/gen-version)" \
+            --form description="master build" \
+            https://scan.coverity.com/builds?project=${COVERITY_PROJECT}
+
   coverity-dnsdist:
     docker:
       - image: debian:buster
@@ -888,11 +928,12 @@ workflows:
 #            branches:
 #              only: master
     jobs:
+      - coverity-auth:
+          context: auth-coverity
       - coverity-dnsdist:
           context: dnsdist-coverity
       - coverity-recursor:
           context: recursor-coverity
-
 
   build-and-test-all:
     jobs:


### PR DESCRIPTION
### Short description
We have not been running coverity for some time due to changes in the build infrastructure. This PR re-enables coverity by running it in circleci once per day, on the master branch.

Note that the PowerDNS organization in circleci needs to create 3 environments (dnsdist-coverity, auth-coverity and recursor-coverity) with 3 environment variables:

* `COVERITY_EMAIL`: the email address for build submission
* `COVERITY_TOKEN`: the token for the project
* `COVERITY_PROJECT`: The exact name of the project in coverity

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)