### PR TITLE
dnsdist: don't start as root within a systemd environment

### DIFF
--- a/builder-support/debian/dnsdist/debian-buster/dnsdist.postinst
+++ b/builder-support/debian/dnsdist/debian-buster/dnsdist.postinst
@@ -18,6 +18,12 @@ case "$1" in
 
     adduser --force-badname --system --home /nonexistent --group \
         --no-create-home --quiet _dnsdist || true
+
+    if [ "`stat -c '%U:%G' /etc/powerdns/dnsdist.conf`" = "root:root" ]; then
+      chown root:_dnsdist /etc/powerdns/dnsdist.conf
+      # Make sure that dnsdist can read it; the default used to be 0600
+      chmod g+r /etc/powerdns/dnsdist.conf
+    fi
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/builder-support/debian/dnsdist/debian-buster/rules
+++ b/builder-support/debian/dnsdist/debian-buster/rules
@@ -51,6 +51,8 @@ override_dh_auto_configure:
 	  --with-ebpf \
 	  --with-lua=luajit \
 	  --with-protobuf \
+	  --with-service-user='_dnsdist' \
+	  --with-service-group='_dnsdist' \
 	  $(CONFIGURE_ARGS)
 
 override_dh_auto_build-arch:
@@ -58,8 +60,6 @@ override_dh_auto_build-arch:
 
 override_dh_install:
 	dh_auto_install
-	echo Patching uid and git into debian/dnsdist/lib/systemd/system/*.service
-	perl -pi -e 's/(^ExecStart=.*)/$$1 -u _dnsdist -g _dnsdist/' debian/dnsdist/lib/systemd/system/*.service
 ifeq ($(DEB_HOST_ARCH_BITS),32)
 	echo RestrictAddressFamilies is broken on 32bit, removing it from service file
 	perl -ni -e 'print unless /RestrictAddressFamilies/' debian/dnsdist/lib/systemd/system/*.service

--- a/builder-support/debian/dnsdist/debian-buster/rules
+++ b/builder-support/debian/dnsdist/debian-buster/rules
@@ -75,3 +75,7 @@ override_dh_installexamples:
 override_dh_installinit:
 	# do nothing here. avoids referencing a non-existant init script.
 
+override_dh_fixperms:
+	dh_fixperms
+        # these files often contain passwords. 640 as it is chowned to root:_dnsdist
+	chmod 0640 debian/pdns-server/etc/powerdns/dnsdist.conf

--- a/builder-support/debian/dnsdist/debian-buster/rules
+++ b/builder-support/debian/dnsdist/debian-buster/rules
@@ -78,4 +78,4 @@ override_dh_installinit:
 override_dh_fixperms:
 	dh_fixperms
         # these files often contain passwords. 640 as it is chowned to root:_dnsdist
-	chmod 0640 debian/pdns-server/etc/powerdns/dnsdist.conf
+	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.conf

--- a/builder-support/debian/dnsdist/debian-jessie/dnsdist.postinst
+++ b/builder-support/debian/dnsdist/debian-jessie/dnsdist.postinst
@@ -18,6 +18,12 @@ case "$1" in
 
     adduser --force-badname --system --home /nonexistent --group \
         --no-create-home --quiet _dnsdist || true
+
+    if [ "`stat -c '%U:%G' /etc/powerdns/dnsdist.conf`" = "root:root" ]; then
+      chown root:_dnsdist /etc/powerdns/dnsdist.conf
+      # Make sure that dnsdist can read it; the default used to be 0600
+      chmod g+r /etc/powerdns/dnsdist.conf
+    fi
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/builder-support/debian/dnsdist/debian-jessie/rules
+++ b/builder-support/debian/dnsdist/debian-jessie/rules
@@ -47,6 +47,8 @@ override_dh_auto_configure:
 	  --with-ebpf \
 	  --with-lua=luajit \
 	  --with-protobuf \
+	  --with-service-user='_dnsdist' \
+	  --with-service-group='_dnsdist' \
 	  $(CONFIGURE_ARGS)
 
 override_dh_auto_build-arch:
@@ -54,8 +56,6 @@ override_dh_auto_build-arch:
 
 override_dh_install:
 	dh_install
-	echo Patching uid and git into debian/dnsdist/lib/systemd/system/*.service
-	perl -pi -e 's/(^ExecStart=.*)/$$1 -u _dnsdist -g _dnsdist/' debian/dnsdist/lib/systemd/system/*.service
 ifeq ($(DEB_HOST_ARCH_BITS),32)
 	echo RestrictAddressFamilies is broken on 32bit, removing it from service file
 	perl -ni -e 'print unless /RestrictAddressFamilies/' debian/dnsdist/lib/systemd/system/*.service

--- a/builder-support/debian/dnsdist/debian-jessie/rules
+++ b/builder-support/debian/dnsdist/debian-jessie/rules
@@ -74,3 +74,8 @@ override_dh_strip:
 override_dh_installinit:
 	dh_installinit
 	dh_systemd_start -pdnsdist --restart-after-upgrade dnsdist.service
+
+override_dh_fixperms:
+	dh_fixperms
+        # these files often contain passwords. 640 as it is chowned to root:_dnsdist
+	chmod 0640 debian/pdns-server/etc/powerdns/dnsdist.conf

--- a/builder-support/debian/dnsdist/debian-jessie/rules
+++ b/builder-support/debian/dnsdist/debian-jessie/rules
@@ -78,4 +78,4 @@ override_dh_installinit:
 override_dh_fixperms:
 	dh_fixperms
         # these files often contain passwords. 640 as it is chowned to root:_dnsdist
-	chmod 0640 debian/pdns-server/etc/powerdns/dnsdist.conf
+	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.conf

--- a/builder-support/debian/dnsdist/debian-stretch/dnsdist.postinst
+++ b/builder-support/debian/dnsdist/debian-stretch/dnsdist.postinst
@@ -18,6 +18,12 @@ case "$1" in
 
     adduser --force-badname --system --home /nonexistent --group \
         --no-create-home --quiet _dnsdist || true
+
+    if [ "`stat -c '%U:%G' /etc/powerdns/dnsdist.conf`" = "root:root" ]; then
+      chown root:_dnsdist /etc/powerdns/dnsdist.conf
+      # Make sure that dnsdist can read it; the default used to be 0600
+      chmod g+r /etc/powerdns/dnsdist.conf
+    fi
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/builder-support/debian/dnsdist/debian-stretch/rules
+++ b/builder-support/debian/dnsdist/debian-stretch/rules
@@ -74,3 +74,7 @@ override_dh_installexamples:
 override_dh_installinit:
 	# do nothing here. avoids referencing a non-existant init script.
 
+override_dh_fixperms:
+	dh_fixperms
+        # these files often contain passwords. 640 as it is chowned to root:_dnsdist
+	chmod 0640 debian/pdns-server/etc/powerdns/dnsdist.conf

--- a/builder-support/debian/dnsdist/debian-stretch/rules
+++ b/builder-support/debian/dnsdist/debian-stretch/rules
@@ -77,4 +77,4 @@ override_dh_installinit:
 override_dh_fixperms:
 	dh_fixperms
         # these files often contain passwords. 640 as it is chowned to root:_dnsdist
-	chmod 0640 debian/pdns-server/etc/powerdns/dnsdist.conf
+	chmod 0640 debian/dnsdist/etc/dnsdist/dnsdist.conf

--- a/builder-support/debian/dnsdist/debian-stretch/rules
+++ b/builder-support/debian/dnsdist/debian-stretch/rules
@@ -50,6 +50,8 @@ override_dh_auto_configure:
 	  --with-ebpf \
 	  --with-lua=luajit \
 	  --with-protobuf \
+	  --with-service-user='_dnsdist' \
+	  --with-service-group='_dnsdist' \
 	  $(CONFIGURE_ARGS)
 
 override_dh_auto_build-arch:
@@ -57,8 +59,6 @@ override_dh_auto_build-arch:
 
 override_dh_install:
 	dh_auto_install
-	echo Patching uid and git into debian/dnsdist/lib/systemd/system/*.service
-	perl -pi -e 's/(^ExecStart=.*)/$$1 -u _dnsdist -g _dnsdist/' debian/dnsdist/lib/systemd/system/*.service
 ifeq ($(DEB_HOST_ARCH_BITS),32)
 	echo RestrictAddressFamilies is broken on 32bit, removing it from service file
 	perl -ni -e 'print unless /RestrictAddressFamilies/' debian/dnsdist/lib/systemd/system/*.service

--- a/m4/pdns_with_service_user.m4
+++ b/m4/pdns_with_service_user.m4
@@ -1,0 +1,17 @@
+AC_DEFUN([PDNS_WITH_SERVICE_USER], [
+  AC_MSG_CHECKING([What user and group will be used by service])
+  AC_ARG_WITH([service-user],
+    AS_HELP_STRING([--with-service-user], [User to use by service when running the service @<:@default=$1@:>@. Only the setuid setting and User in the systemd unit file are affected, the user is not created.]),
+    [AC_SUBST([service_user], [$withval])],
+    [AC_SUBST([service_user], [$1])]
+  )
+
+  AC_ARG_WITH([service-group],
+    AS_HELP_STRING([--with-service-group], [Group to use by service when running the service @<:@default=$1@:>@. Only the setgid setting and Group in the systemd unit file are affected, the group is not created.]),
+    [AC_SUBST([service_group], [$withval])],
+    [AC_SUBST([service_group], [$1])]
+  )
+
+  AS_IF([test -z "$service_user"], [AC_MSG_ERROR([No service user has been defined!])], [ : ])
+  AC_MSG_RESULT([$service_user])
+])

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2650,8 +2650,8 @@ try
   }
 #endif
 
-  uid_t newgid=0;
-  gid_t newuid=0;
+  uid_t newgid=getegid();
+  gid_t newuid=geteuid();
 
   if(!g_cmdLine.gid.empty())
     newgid = strToGID(g_cmdLine.gid.c_str());
@@ -2659,8 +2659,11 @@ try
   if(!g_cmdLine.uid.empty())
     newuid = strToUID(g_cmdLine.uid.c_str());
 
-  dropGroupPrivs(newgid);
-  dropUserPrivs(newuid);
+  if (getegid() != newgid)
+    dropGroupPrivs(newgid);
+  if (geteuid() != newuid)
+    dropUserPrivs(newuid);
+
   try {
     /* we might still have capabilities remaining,
        for example if we have been started as root

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -127,6 +127,7 @@ dnsdist_SOURCES = \
 	dnsdist-rules.hh \
 	dnsdist-secpoll.cc dnsdist-secpoll.hh \
 	dnsdist-snmp.cc dnsdist-snmp.hh \
+	dnsdist-systemd.cc dnsdist-systemd.hh \
 	dnsdist-tcp.cc \
 	dnsdist-web.cc \
 	dnsdist-xpf.cc dnsdist-xpf.hh \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -364,7 +364,7 @@ endif
 
 if HAVE_SYSTEMD
 dnsdist.service: dnsdist.service.in
-	$(AM_V_GEN)sed -e 's![@]bindir[@]!$(bindir)!' < $< > $@
+	$(AM_V_GEN)sed -e 's![@]bindir[@]!$(bindir)!' -e 's![@]service_user[@]!$(service_user)!' -e 's![@]service_group[@]!$(service_group)!' < $< > $@
 if !HAVE_SYSTEMD_LOCK_PERSONALITY
 	$(AM_V_GEN)perl -ni -e 'print unless /^LockPersonality/' $@
 endif

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -47,6 +47,7 @@ PDNS_WITH_LIBCAP
 AX_AVAILABLE_SYSTEMD
 AX_CHECK_SYSTEMD_FEATURES
 AM_CONDITIONAL([HAVE_SYSTEMD], [ test x"$systemd" = "xy" ])
+PDNS_WITH_SERVICE_USER([dnsdist])
 
 AC_SUBST([YAHTTP_CFLAGS], ['-I$(top_srcdir)/ext/yahttp'])
 AC_SUBST([YAHTTP_LIBS], ['$(top_builddir)/ext/yahttp/yahttp/libyahttp.la'])

--- a/pdns/dnsdistdist/dnsdist-systemd.cc
+++ b/pdns/dnsdistdist/dnsdist-systemd.cc
@@ -1,0 +1,35 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "config.h"
+#include "dnsdist-systemd.hh"
+#include <cstdlib>
+
+bool running_in_service_mgr() {
+#ifdef HAVE_SYSTEMD
+  char *c;
+  c = getenv("NOTIFY_SOCKET"); // XXX Ideally we'd check for INVOCATION_ID (systemd.exec(5)), but that was introduced in systemd 232, and Debian Jessie has 215
+  if (c != nullptr) {
+    return true;
+  }
+#endif
+  return false;
+}

--- a/pdns/dnsdistdist/dnsdist-systemd.hh
+++ b/pdns/dnsdistdist/dnsdist-systemd.hh
@@ -1,0 +1,24 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+bool running_in_service_mgr();

--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -9,6 +9,8 @@ After=network-online.target
 ExecStartPre=@bindir@/dnsdist --check-config
 # Note: when editing the ExecStart command, keep --supervised and --disable-syslog
 ExecStart=@bindir@/dnsdist --supervised --disable-syslog
+User=@service_user@
+Group=@service_group@
 Type=notify
 Restart=on-failure
 RestartSec=2
@@ -20,7 +22,8 @@ LimitNOFILE=16384
 TasksMax=8192
 
 # Sandboxing
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 LockPersonality=true
 NoNewPrivileges=true
 PrivateDevices=true

--- a/pdns/dnsdistdist/m4/pdns_with_service_user.m4
+++ b/pdns/dnsdistdist/m4/pdns_with_service_user.m4
@@ -1,0 +1,1 @@
+../../../m4/pdns_with_service_user.m4


### PR DESCRIPTION
### Short description
With this PR, dnsdist is never started as root on Linux systems with systemd. This PR adds a `configure` option to set the username and group in the service file. It also removes the capabilities for dnsdist to do setuid and setgid.

Discussion:

* Should dnsdist log a warning when run inside systemd (`NOTIFY_SOCKET` defined) and `-u` or `-g` is set on the command line?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
