### PR TITLE
Use latest tag for version numbers for master builds

### DIFF
--- a/builder-support/gen-version
+++ b/builder-support/gen-version
@@ -10,7 +10,7 @@ DIRTY=""
 git status | grep -q clean || DIRTY='.dirty'
 
 # Special environment variable to signal that we are building a release, as this
-# has condequenses for the version number.
+# has consequenses for the version number.
 if [ "${IS_RELEASE}" = "YES" ]; then
   TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
   if [ -n "${TAG}" ]; then
@@ -27,17 +27,26 @@ fi
 # Generate the version number based on the branch
 #
 if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
-  GIT_VERSION=""
-  if $(git rev-parse --abbrev-ref HEAD | grep -q 'rel/'); then
-    REL_TYPE="$(git rev-parse --abbrev-ref HEAD | cut -d/ -f 2 | cut -d- -f 1)"
-    GIT_VERSION="$(git describe --match=${REL_TYPE}-* --tags | cut -d- -f2-)"
+  if [ -n "${BUILDER_MODULES}" ]; then
+    match=${BUILDER_MODULES}
+    [ $match = "authoritative" ] && match='auth'
+    [ $match = "recursor" ] && match='rec'
+    GIT_VERSION="$(git describe --match=${match}-* --tags | cut -d- -f2-)"
+    if [ $(echo ${GIT_VERSION} | awk -F"-" '{print NF-1}') = '3' ]; then
+      # A prerelease happened before
+      LAST_TAG="$(echo ${GIT_VERSION} | cut -d- -f1-2)"
+      COMMITS_SINCE_TAG="$(echo ${GIT_VERSION} | cut -d- -f3)"
+      GIT_HASH="$(echo ${GIT_VERSION} | cut -d- -f4)"
+    else
+      LAST_TAG="$(echo ${GIT_VERSION} | cut -d- -f1)"
+      COMMITS_SINCE_TAG="$(echo ${GIT_VERSION} | cut -d- -f2)"
+      GIT_HASH="$(echo ${GIT_VERSION} | cut -d- -f3)"
+    fi
   fi
 
-  LAST_TAG="$(echo ${GIT_VERSION} | cut -d- -f1)"
-  COMMITS_SINCE_TAG="$(echo ${GIT_VERSION} | cut -d- -f2)"
-  GIT_HASH="$(echo ${GIT_VERSION} | cut -d- -f3)"
-
   if [ -z "${GIT_VERSION}" ]; then
+    # BUILDER_SUPPORT has more than one product listed, fall back to the 0.0.0 logic
+
     # We used 0.0.XXXXgHASH for master in the previous incarnation of our build pipeline.
     # This now becomes 0.0.XXXX.0.gHASH, as 0.0.0.XXXX.gHASH (which is more correct)
     # would break upgrades for those running master
@@ -45,11 +54,10 @@ if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
     LAST_TAG=0.0
     COMMITS_SINCE_TAG="$(git rev-list --count 12c868770afc20b6cc0da439d881105151d557dd..HEAD 2> /dev/null).0"
     [ "${COMMITS_SINCE_TAG}" = ".0" ] && COMMITS_SINCE_TAG=0.0
-    GIT_HASH="$(git rev-parse HEAD | cut -c1-10 2> /dev/null)"
+    GIT_HASH="g$(git rev-parse HEAD | cut -c1-10 2> /dev/null)"
   fi
 
   BRANCH=".$(git rev-parse --abbrev-ref HEAD | perl -p -e 's/[^[:alnum:]]//g;')"
-  [ "${BRANCH}" = ".master" ] && BRANCH=''
 
   TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
   if [ -n "${TAG}" ]; then # We're exactly on a tag
@@ -60,7 +68,7 @@ if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
     fi
   fi
 
-  VERSION="${LAST_TAG}.${COMMITS_SINCE_TAG}${BRANCH}.g${GIT_HASH}${DIRTY}"
+  VERSION="${LAST_TAG}.${COMMITS_SINCE_TAG}${BRANCH}.${GIT_HASH}${DIRTY}"
 fi
 
 printf $VERSION


### PR DESCRIPTION
### Short description
As Debian broke our 0.0.0 with a 'Breaks' in libstdc++, we now use the
last released version number (when building a single product) so users
can keep installing packages built from master on Debian.

Closes #7781

Note that the build-infra might need some work too.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)