### PR TITLE
 dnsdist: Implement SNIRule for DoT and DoH

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -546,6 +546,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "showVersion", true, "", "show the current version" },
   { "shutdown", true, "", "shut down `dnsdist`" },
   { "SkipCacheAction", true, "", "Don’t lookup the cache for this query, don’t store the answer" },
+  { "SNIRule", true, "name", "Create a rule which matches on the incoming TLS SNI value, if any (DoT or DoH)" },
   { "snmpAgent", true, "enableTraps [, masterSocket]", "enable `SNMP` support. `enableTraps` is a boolean indicating whether traps should be sent and `masterSocket` an optional string specifying how to connect to the master agent"},
   { "SNMPTrapAction", true, "[reason]", "send an SNMP trap, adding the optional `reason` string as the query description"},
   { "SNMPTrapResponseAction", true, "[reason]", "send an SNMP trap, adding the optional `reason` string as the response description"},

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -85,6 +85,10 @@ void setupLuaBindingsDNSQuestion()
       return true;
     });
 
+  g_lua.registerFunction<std::string(DNSQuestion::*)()>("getServerNameIndication", [](const DNSQuestion& dq) {
+      return dq.sni;
+    });
+
   g_lua.registerFunction<void(DNSQuestion::*)(std::string)>("sendTrap", [](const DNSQuestion& dq, boost::optional<std::string> reason) {
 #ifdef HAVE_NET_SNMP
       if (g_snmpAgent && g_snmpTrapsEnabled) {

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -295,6 +295,10 @@ void setupLuaRules()
     });
 #endif
 
+  g_lua.writeFunction("SNIRule", [](const std::string& name) {
+      return std::shared_ptr<DNSRule>(new SNIRule(name));
+  });
+
   g_lua.writeFunction("SuffixMatchNodeRule", [](const SuffixMatchNode& smn, boost::optional<bool> quiet) {
       return std::shared_ptr<DNSRule>(new SuffixMatchNodeRule(smn, quiet ? *quiet : false));
     });

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -808,6 +808,7 @@ static void handleQuery(std::shared_ptr<IncomingTCPConnectionState>& state, stru
   DNSName qname(query, state->d_querySize, sizeof(dnsheader), false, &qtype, &qclass, &consumed);
   DNSQuestion dq(&qname, qtype, qclass, consumed, &state->d_ids.origDest, &state->d_ci.remote, reinterpret_cast<dnsheader*>(query), state->d_buffer.size(), state->d_querySize, true, &queryRealTime);
   dq.dnsCryptQuery = std::move(dnsCryptQuery);
+  dq.sni = state->d_handler.getServerNameIndication();
 
   state->d_isXFR = (dq.qtype == QType::AXFR || dq.qtype == QType::IXFR);
   if (state->d_isXFR) {

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -75,6 +75,7 @@ struct DNSQuestion
 #endif
   Netmask ecs;
   boost::optional<Netmask> subnet;
+  std::string sni; /* Server Name Indication, if any (DoT or DoH) */
   const DNSName* qname{nullptr};
   const ComboAddress* local{nullptr};
   const ComboAddress* remote{nullptr};

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -525,6 +525,24 @@ private:
 };
 #endif
 
+class SNIRule : public DNSRule
+{
+public:
+  SNIRule(const std::string& name) : d_sni(name)
+  {
+  }
+  bool matches(const DNSQuestion* dq) const override
+  {
+    return dq->sni == d_sni;
+  }
+  string toString() const override
+  {
+    return "SNI == " + d_sni;
+  }
+private:
+  std::string d_sni;
+};
+
 class SuffixMatchNodeRule : public DNSRule
 {
 public:

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -92,6 +92,14 @@ This state can be modified from the various hooks.
 
     :returns: A table of EDNSOptionView objects, indexed on the ECS Option code
 
+  .. method:: DNSQuestion:getServerNameIndication() -> string
+
+    .. versionadded:: 1.4.0
+
+    Return the TLS Server Name Indication (SNI) value sent by the client over DoT or DoH, if any
+
+    :returns: A string containing the TLS SNI value, if any
+
   .. method:: DNSQuestion:getTag(key) -> string
 
     .. versionadded:: 1.2.0

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -96,7 +96,8 @@ This state can be modified from the various hooks.
 
     .. versionadded:: 1.4.0
 
-    Return the TLS Server Name Indication (SNI) value sent by the client over DoT or DoH, if any
+    Return the TLS Server Name Indication (SNI) value sent by the client over DoT or DoH, if any. See :func:`SNIRule`
+    for more information, especially about the availability of SNI over DoH.
 
     :returns: A string containing the TLS SNI value, if any
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -756,6 +756,15 @@ These ``DNSRule``\ s be one of the following items:
 
   :param str regex: The regular expression to match the QNAME.
 
+.. function:: SNIRule(name)
+  .. versionadded:: 1.4.0
+
+  Matches against the TLS Server Name Indication value sent by the client, if any. Only makes
+  sense for DoT or DoH, and for that last one matching on the HTTP Host header might provide
+  more consistent results.
+
+  :param str name: The exact SNI name to match.
+
 .. function:: SuffixMatchNodeRule(smn[, quiet])
 
   Matches based on a group of domain suffixes for rapid testing of membership.

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -760,8 +760,10 @@ These ``DNSRule``\ s be one of the following items:
   .. versionadded:: 1.4.0
 
   Matches against the TLS Server Name Indication value sent by the client, if any. Only makes
-  sense for DoT or DoH, and for that last one matching on the HTTP Host header might provide
-  more consistent results.
+  sense for DoT or DoH, and for that last one matching on the HTTP Host header using :func:`HTTPHeaderRule`
+  might provide more consistent results.
+  As of the version 2.3.0-beta of h2o, it is unfortunately not possible to extract the SNI value from DoH
+  connections, and it is therefore necessary to use the HTTP Host header until version 2.3.0 is released.
 
   :param str name: The exact SNI name to match.
 

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -185,6 +185,13 @@ static int processDOHQuery(DOHUnit* du)
     dq.ednsAdded = du->ednsAdded;
     dq.du = du;
     queryId = ntohs(dh->id);
+#ifdef HAVE_H2O_SOCKET_GET_SSL_SERVER_NAME
+    h2o_socket_t* sock = du->req->conn->callbacks->get_socket(du->req->conn);
+    const char * sni = h2o_socket_get_ssl_server_name(sock);
+    if (sni != nullptr) {
+      dq.sni = sni;
+    }
+#endif /* HAVE_H2O_SOCKET_BET_SSL_SERVER_NAME */
 
     std::shared_ptr<DownstreamState> ss{nullptr};
     auto result = processQuery(dq, cs, holders, ss);

--- a/pdns/dnsdistdist/m4/pdns_check_libh2o_evloop.m4
+++ b/pdns/dnsdistdist/m4/pdns_check_libh2o_evloop.m4
@@ -3,6 +3,19 @@ AC_DEFUN([PDNS_CHECK_LIBH2OEVLOOP], [
   PKG_CHECK_MODULES([LIBH2OEVLOOP], [libh2o-evloop], [
     [HAVE_LIBH2OEVLOOP=1]
     AC_DEFINE([HAVE_LIBH2OEVLOOP], [1], [Define to 1 if you have libh2o-evloop])
+    save_CFLAGS=$CFLAGS
+    save_LIBS=$LIBS
+    CFLAGS="$LIBH2OEVLOOP_CFLAGS $CFLAGS"
+    LIBS="$LIBH2OEVLOOP_LIBS $LIBS"
+    AC_CHECK_DECLS([h2o_socket_get_ssl_server_name], [
+          AC_DEFINE([HAVE_H2O_SOCKET_GET_SSL_SERVER_NAME], [1], [define to 1 if h2o_socket_get_ssl_server_name is available.])
+        ],
+        [ : ],
+        [AC_INCLUDES_DEFAULT
+          #include <h2o/socket.h>
+      ])
+    CFLAGS=$save_CFLAGS
+    LIBS=$save_LIBS
   ], [ : ])
   AM_CONDITIONAL([HAVE_LIBH2OEVLOOP], [test "x$LIBH2OEVLOOP_LIBS" != "x"])
 ])

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -352,11 +352,23 @@ public:
 
     return got;
   }
+
   void close() override
   {
     if (d_conn) {
       SSL_shutdown(d_conn.get());
     }
+  }
+
+  std::string getServerNameIndication()
+  {
+    if (d_conn) {
+      const char* value = SSL_get_servername(d_conn.get(), TLSEXT_NAMETYPE_host_name);
+      if (value) {
+        return std::string(value);
+      }
+    }
+    return std::string();
   }
 
 private:
@@ -858,6 +870,23 @@ public:
     while (got < bufferSize);
 
     return got;
+  }
+
+  std::string getServerNameIndication()
+  {
+    if (d_conn) {
+      unsigned int type;
+      size_t name_len = 256;
+      std::string sni;
+      sni.resize(name_len);
+
+      int res = gnutls_server_name_get(d_conn.get(), const_cast<char*>(sni.c_str()), &name_len, &type, 0);
+      if (res == GNUTLS_E_SUCCESS) {
+        sni.resize(name_len);
+        return sni;
+      }
+    }
+    return std::string();
   }
 
   void close() override

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -16,6 +16,7 @@ public:
   virtual size_t write(const void* buffer, size_t bufferSize, unsigned int writeTimeout) = 0;
   virtual IOState tryWrite(std::vector<uint8_t>& buffer, size_t& pos, size_t toWrite) = 0;
   virtual IOState tryRead(std::vector<uint8_t>& buffer, size_t& pos, size_t toRead) = 0;
+  virtual std::string getServerNameIndication() = 0;
   virtual void close() = 0;
 
 protected:
@@ -273,6 +274,14 @@ public:
     else {
       return writen2WithTimeout(d_socket, buffer, bufferSize, writeTimeout);
     }
+  }
+
+  std::string getServerNameIndication()
+  {
+    if (d_conn) {
+      return d_conn->getServerNameIndication();
+    }
+    return std::string();
   }
 
 private:

--- a/regression-tests.dnsdist/configCA.conf
+++ b/regression-tests.dnsdist/configCA.conf
@@ -18,3 +18,6 @@ countryName = NL
 [custom_extensions]
 basicConstraints = CA:true
 keyUsage = cRLSign, keyCertSign
+
+[CA_default]
+copy_extensions = copy

--- a/regression-tests.dnsdist/configServer.conf
+++ b/regression-tests.dnsdist/configServer.conf
@@ -3,9 +3,18 @@ default_bits = 2048
 encrypt_key = no
 prompt = no
 distinguished_name = server_distinguished_name
+req_extensions = v3_req
 
 [server_distinguished_name]
 CN = tls.tests.dnsdist.org
 OU = PowerDNS.com BV
 countryName = NL
 
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = tls.tests.dnsdist.org
+DNS.2 = powerdns.com

--- a/regression-tests.dnsdist/runtests
+++ b/regression-tests.dnsdist/runtests
@@ -54,7 +54,7 @@ openssl req -new -x509 -days 1 -extensions v3_ca -keyout ca.key -out ca.pem -nod
 # Generate a new server certificate request
 openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr -config configServer.conf
 # Sign the server cert
-openssl x509 -req -days 1 -CA ca.pem -CAkey ca.key -CAcreateserial -in server.csr -out server.pem
+openssl x509 -req -days 1 -CA ca.pem -CAkey ca.key -CAcreateserial -in server.csr -out server.pem -extfile configServer.conf -extensions v3_req
 # Generate a chain
 cat server.pem ca.pem > server.chain
 

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -12,6 +12,7 @@ class TestTLS(DNSDistTest):
     _config_template = """
     newServer{address="127.0.0.1:%s"}
     addTLSLocal("127.0.0.1:%s", "%s", "%s")
+    addAction(SNIRule("powerdns.com"), SpoofAction("1.2.3.4"))
     """
     _config_params = ['_testServerPort', '_tlsServerPort', '_serverCert', '_serverKey']
 
@@ -90,3 +91,44 @@ class TestTLS(DNSDistTest):
             receivedQuery.id = query.id
             self.assertEquals(query, receivedQuery)
             self.assertEquals(response, receivedResponse)
+
+    def testTLSSNIRouting(self):
+        """
+        TLS: SNI Routing
+        """
+        name = 'sni.tls.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN', use_edns=False)
+        query.flags &= ~dns.flags.RD
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '127.0.0.1')
+        response.answer.append(rrset)
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    3600,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '1.2.3.4')
+        expectedResponse.answer.append(rrset)
+
+        # this SNI should match so we should get a spoofed answer
+        conn = self.openTLSConnection(self._tlsServerPort, 'powerdns.com', self._caCert)
+
+        self.sendTCPQueryOverConnection(conn, query, response=None)
+        receivedResponse = self.recvTCPResponseOverConnection(conn, useQueue=False)
+        self.assertTrue(receivedResponse)
+        self.assertEquals(expectedResponse, receivedResponse)
+
+        # this one should not
+        conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
+
+        self.sendTCPQueryOverConnection(conn, query, response=response)
+        (receivedQuery, receivedResponse) = self.recvTCPResponseOverConnection(conn, useQueue=True)
+        self.assertTrue(receivedQuery)
+        self.assertTrue(receivedResponse)
+        receivedQuery.id = query.id
+        self.assertEquals(query, receivedQuery)
+        self.assertEquals(response, receivedResponse)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Support for DoT should work with any version of OpenSSL or GnuTLS but for DoH it requires the addition of `h2o_socket_get_ssl_server_name()` in `libh2o` (PR in preparation). It's already possible to do HTTP Host header matching for DoH, though.

Closes #7210.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
