### PR TITLE
Fix the detection of snmp_select_info2()

### DIFF
--- a/m4/pdns_with_net_snmp.m4
+++ b/m4/pdns_with_net_snmp.m4
@@ -11,7 +11,10 @@ AC_DEFUN([PDNS_WITH_NET_SNMP], [
     AS_IF([test "x$with_net_snmp" = "xyes" -o "x$with_net_snmp" = "xauto"], [
       AC_CHECK_PROG([NET_SNMP_CFLAGS], [net-snmp-config], [`net-snmp-config --cflags`])
       AC_CHECK_PROG([NET_SNMP_LIBS], [net-snmp-config], [`net-snmp-config --netsnmp-agent-libs`])
-      AC_CHECK_DECLS([snmp_select_info2], [ : ], [ : ],
+      AC_CHECK_DECLS([snmp_select_info2], [
+          AC_DEFINE([HAVE_SNMP_SELECT_INFO2], [1], [define to 1 if snmp_select_info2 is available.])
+        ],
+        [ : ],
         [AC_INCLUDES_DEFAULT
           #include <net-snmp/net-snmp-config.h>
           #include <net-snmp/definitions.h>


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We did not properly check whether `snmp_select_info2()` was available, resulting in this function not being used even when supported.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
