### PR TITLE
remove second, incomplete copy of Lua EDNSOptionCode table

### DIFF
--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -142,17 +142,4 @@ void setupLuaVars()
         { "VERSION2", DNSCryptExchangeVersion::VERSION2 },
     });
 #endif
-
-  g_lua.writeVariable("EDNSOptionCode", std::unordered_map<string, uint8_t>{
-      { "NSID", EDNSOptionCode::NSID },
-      { "DAU", EDNSOptionCode::DAU },
-      { "DHU", EDNSOptionCode::DHU },
-      { "N3U", EDNSOptionCode::N3U },
-      { "ECS", EDNSOptionCode::ECS },
-      { "EXPIRE", EDNSOptionCode::EXPIRE },
-      { "COOKIE", EDNSOptionCode::COOKIE },
-      { "TCPKEEPALIVE", EDNSOptionCode::TCPKEEPALIVE },
-      { "PADDING", EDNSOptionCode::PADDING },
-      { "CHAIN", EDNSOptionCode::CHAIN }
-    });
 }


### PR DESCRIPTION
### Short description
The second incomplete copy was the one being used in practice, making `EDNSOptionCode.KEYTAG` invisible because it only existed in the first copy of the table.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
