### PR TITLE
recursor: log UDP TC bits during trace

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2985,6 +2985,7 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
       }
       return false;
     }
+    LOG(prefix<<qname<<": truncated bit set, over UDP"<<endl);
 
     return true;
   }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2977,10 +2977,12 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
   if(lwr.d_tcbit) {
     *truncated = true;
 
-    if (doTCP && !dontThrottle) {
+    if (doTCP) {
       LOG(prefix<<qname<<": truncated bit set, over TCP?"<<endl);
-      /* let's treat that as a ServFail answer from this server */
-      t_sstorage.throttle.throttle(d_now.tv_sec, boost::make_tuple(remoteIP, qname, qtype.getCode()), 60, 3);
+      if (!dontThrottle) {
+        /* let's treat that as a ServFail answer from this server */
+        t_sstorage.throttle.throttle(d_now.tv_sec, boost::make_tuple(remoteIP, qname, qtype.getCode()), 60, 3);
+      }
       return false;
     }
 


### PR DESCRIPTION
### Short description
Before:
```
May 22 15:48:06 [1] tipsport.cz: Trying IP 90.183.101.40:53, asking 'tipsport.cz|NS'
May 22 15:48:06 [1] tipsport.cz: using TCP with 90.183.101.40:53
```

leading to the question 'why is it using TCP?'

After:
```
May 22 15:48:06 [1] tipsport.cz: Trying IP 90.183.101.40:53, asking 'tipsport.cz|NS'
May 22 15:48:06 [1] tipsport.cz: truncated bit set, over UDP
May 22 15:48:06 [1] tipsport.cz: using TCP with 90.183.101.40:53
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
