### PR TITLE
rec: Small speedups in the recursion 'slow' path

### DIFF
--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -169,7 +169,6 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
 
   srcmask = boost::none; // this is also our return value, even if EDNS0Level == 0
 
-  errno=0;
   if(!doTCP) {
     int queryfd;
     if(ip.sin4.sin_family==AF_INET6)

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -782,7 +782,7 @@ private:
   void getBestNSFromCache(const DNSName &qname, const QType &qtype, vector<DNSRecord>&bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere);
   DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere);
 
-  inline vector<DNSName> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);
+  inline vector<std::pair<DNSName, double>> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);
   inline vector<ComboAddress> shuffleForwardSpeed(const vector<ComboAddress> &rnameservers, const string &prefix, const bool wasRd);
   bool moreSpecificThan(const DNSName& a, const DNSName &b) const;
   vector<ComboAddress> getAddrs(const DNSName &qname, unsigned int depth, set<GetBestNSAnswer>& beenthere, bool cacheOnly);
@@ -791,7 +791,7 @@ private:
   bool nameserverIPBlockedByRPZ(const DNSFilterEngine& dfe, const ComboAddress&);
   bool throttledOrBlocked(const std::string& prefix, const ComboAddress& remoteIP, const DNSName& qname, const QType& qtype, bool pierceDontQuery);
 
-  vector<ComboAddress> retrieveAddressesForNS(const std::string& prefix, const DNSName& qname, vector<DNSName >::const_iterator& tns, const unsigned int depth, set<GetBestNSAnswer>& beenthere, const vector<DNSName >& rnameservers, NsSet& nameservers, bool& sendRDQuery, bool& pierceDontQuery, bool& flawedNSSet, bool cacheOnly);
+  vector<ComboAddress> retrieveAddressesForNS(const std::string& prefix, const DNSName& qname, vector<std::pair<DNSName, double>>::const_iterator& tns, const unsigned int depth, set<GetBestNSAnswer>& beenthere, const vector<std::pair<DNSName, double>>& rnameservers, NsSet& nameservers, bool& sendRDQuery, bool& pierceDontQuery, bool& flawedNSSet, bool cacheOnly);
 
   void sanitizeRecords(const std::string& prefix, LWResult& lwr, const DNSName& qname, const QType& qtype, const DNSName& auth, bool wasForwarded, bool rdQuery);
   RCode::rcodes_ updateCacheFromRecords(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, const DNSName& auth, bool wasForwarded, const boost::optional<Netmask>, vState& state, bool& needWildcardProof, bool& gatherWildcardProof, unsigned int& wildcardLabelsCount, bool sendRDQuery);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We are mostly focused on the performance of the 'fast' path, when the query can be served from the packet cache, and we had some low-hanging inefficiencies in the 'regular' path:
- `SyncRes::shuffleInSpeedOrder()` was very inefficient, doing several copies of `DNSName` objects including one in a map. The new version does only one copy, computes the needed speeds directly there and returns it ;
- We used `dns_random()` when shuffling `NS` records, and their corresponding `A` and `AAAA` entries. These operations really doesn't require a CSPRNG and `dns_random()` is much slower than the default randomness source used in C++11 ;
- The `UDPClientSocks` class was keeping every file descriptor it allocated in a set, checking that returned FDs belonged to that set before removing them from the FD multiplexer and closing them in any case. I couldn't find a case where we could return a socket that was not allocated by that class, and even if we did the FD multiplexer already does an internal accounting and would throw an exception, so I don't think it makes sense to do the work twice ;
- This one is just a nit but we used to set `errno` to 0 in `asyncresolve()`, and I couldn't find a reason why. `errno` is a special variable and setting it has a non-negligible cost so let's skip that. 

Without the first two items, `SyncRes::shuffleInSpeedOrder()` sometimes accounted for 10% of the total CPU cost in my flame graphs and is at a more reasonable level with this PR applied.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
