### PR TITLE
builder: error out when no valid modules are specified

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.sdist
+++ b/builder-support/dockerfiles/Dockerfile.target.sdist
@@ -13,6 +13,10 @@
 FROM alpine:3.6 as sdist
 ARG BUILDER_CACHE_BUSTER=
 
+@IF [ -z "$M_all$M_authoritative$M_recursor$M_dnsdist"]
+RUN echo "no valid modules specified!" ; exit 1
+@ENDIF
+
 @IF [ ! -z "$M_authoritative$M_all" ]
 COPY --from=pdns-authoritative /sdist/ /sdist/
 @ENDIF


### PR DESCRIPTION
### Short description
Otherwise, passing something like `-m auth` will cause very confusing errors.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
