### PR TITLE
Add latomic to ARC platform

### DIFF
--- a/m4/pdns_check_os.m4
+++ b/m4/pdns_check_os.m4
@@ -36,7 +36,7 @@ AC_DEFUN([PDNS_CHECK_OS],[
   AM_CONDITIONAL([HAVE_SOLARIS], [test "x$have_solaris" = "xyes"])
 
   case "$host" in
-  mips* | powerpc-* )
+  arc-* | mips* | powerpc-* )
     AC_MSG_CHECKING([whether the linker accepts -latomic])
     LDFLAGS="-latomic $LDFLAGS"
     AC_LINK_IFELSE([m4_default([],[AC_LANG_PROGRAM()])],


### PR DESCRIPTION
Will fail otherwise with linking errors.

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/dnsdist/compile.txt

Assuming it disappears:

```
  CXXLD    dnsdist
libtool: warning: library '/var/lib/buildbot/slaves/weimar/arc_arc700/build/sdk/staging_dir/toolchain-arc_arc700_gcc-8.3.0_uClibc/lib/libstdc++.la' was moved.
libtool: warning: library '/var/lib/buildbot/slaves/weimar/arc_arc700/build/sdk/staging_dir/toolchain-arc_arc700_gcc-8.3.0_uClibc/lib/libstdc++.la' was moved.
/var/lib/buildbot/slaves/weimar/arc_arc700/build/sdk/staging_dir/toolchain-arc_arc700_gcc-8.3.0_uClibc/bin/../lib/gcc/arc-openwrt-linux-uclibc/8.3.0/../../../../arc-openwrt-linux-uclibc/bin/ld: dnsdist.o: undefined reference to symbol '__atomic_fetch_sub_8@@LIBATOMIC_1.0'
/var/lib/buildbot/slaves/weimar/arc_arc700/build/sdk/staging_dir/toolchain-arc_arc700_gcc-8.3.0_uClibc/bin/../lib/gcc/arc-openwrt-linux-uclibc/8.3.0/../../../../arc-openwrt-linux-uclibc/bin/ld: /var/lib/buildbot/slaves/weimar/arc_arc700/build/sdk/staging_dir/toolchain-arc_arc700_gcc-8.3.0_uClibc/arc-openwrt-linux-uclibc/bin/../../../toolchain-arc_arc700_gcc-8.3.0_uClibc/lib/libatomic.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:1048: recipe for target 'dnsdist' failed
```