### PR TITLE
dnsdist: Add missing overrides for ::getServerNameIndication()

### DIFF
--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -360,7 +360,7 @@ public:
     }
   }
 
-  std::string getServerNameIndication()
+  std::string getServerNameIndication() override
   {
     if (d_conn) {
       const char* value = SSL_get_servername(d_conn.get(), TLSEXT_NAMETYPE_host_name);
@@ -872,7 +872,7 @@ public:
     return got;
   }
 
-  std::string getServerNameIndication()
+  std::string getServerNameIndication() override
   {
     if (d_conn) {
       unsigned int type;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported by clang.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
