### PR TITLE
auth: Remove disable-tcp option

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -508,6 +508,9 @@ inside a supervisor that handles logging (like systemd).
 -  Boolean
 -  Default: no
 
+.. versionchanged:: 4.2.0
+  This setting has been removed
+
 Do not listen to TCP queries. Breaks RFC compliance.
 
 .. _setting-distributor-threads:

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -117,7 +117,6 @@ void declareArguments()
   ::arg().set("queue-limit","Maximum number of milliseconds to queue a query")="1500"; 
   ::arg().set("resolver","Use this resolver for ALIAS and the internal stub resolver")="no";
   ::arg().set("udp-truncation-threshold", "Maximum UDP response size before we truncate")="1232";
-  ::arg().set("disable-tcp","Do not listen to TCP queries")="no";
   
   ::arg().set("config-name","Name of this virtual configuration - will rename the binary image")="";
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -52,7 +52,7 @@ DynListener *dl;
 CommunicatorClass Communicator;
 shared_ptr<UDPNameserver> N;
 int avg_latency;
-TCPNameserver *TN;
+unique_ptr<TCPNameserver> TN;
 static vector<DNSDistributor*> g_distributors;
 vector<std::shared_ptr<UDPNameserver> > g_udpReceivers;
 
@@ -606,8 +606,7 @@ void mainthread()
   if(::arg().mustDo("slave") || ::arg().mustDo("master") || !::arg()["forward-notify"].empty())
     Communicator.go(); 
 
-  if(TN)
-    TN->go(); // tcp nameserver launch
+  TN->go(); // tcp nameserver launch
 
   //  fork(); (this worked :-))
   unsigned int max_rthreads= ::arg().asNum("receiver-threads", 1);

--- a/pdns/common_startup.hh
+++ b/pdns/common_startup.hh
@@ -46,7 +46,7 @@ extern CommunicatorClass Communicator;
 extern std::shared_ptr<UDPNameserver> N;
 extern vector<std::shared_ptr<UDPNameserver> > g_udpReceivers;
 extern int avg_latency;
-extern TCPNameserver *TN;
+extern std::unique_ptr<TCPNameserver> TN;
 extern ArgvMap & arg( void );
 extern void declareArguments();
 extern void declareStats();

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -590,8 +590,7 @@ int main(int argc, char **argv)
       }
     }
 
-    if(!::arg().mustDo("disable-tcp"))
-      TN=new TCPNameserver; 
+    TN = new TCPNameserver;
   }
   catch(const ArgException &A) {
     g_log<<Logger::Error<<"Fatal error: "<<A.reason<<endl;

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -590,7 +590,7 @@ int main(int argc, char **argv)
       }
     }
 
-    TN = new TCPNameserver;
+    TN = make_unique<TCPNameserver>();
   }
   catch(const ArgException &A) {
     g_log<<Logger::Error<<"Fatal error: "<<A.reason<<endl;


### PR DESCRIPTION
### Short description
Also turns the TCPNameserver into a shared_ptr instead of a naked pointer.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)