### PR TITLE
dnsdist: Move PoolAvailableRule to rules section

### DIFF
--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -521,16 +521,6 @@ Functions for manipulating Self-Answered Response Rules:
 
   Move the last self answered response rule to the first position.
 
-Function for pool related rules
-
-.. function:: PoolAvailableRule(poolname)
-
-  .. versionadded:: 1.3.3
-
-  Check whether a pool has any servers available to handle queries
-
-  :param string poolname: Pool to check
-
 .. _RulesIntro:
 
 Matching Packets (Selectors)
@@ -795,6 +785,21 @@ These ``DNSRule``\ s be one of the following items:
 .. function:: TrailingDataRule()
 
   Matches if the query has trailing data.
+
+.. function:: PoolAvailableRule(poolname)
+
+  .. versionadded:: 1.3.3
+
+  Check whether a pool has any servers available to handle queries
+
+  .. code-block:: Lua
+
+    --- Send queries to default pool when servers are available
+    addAction(PoolAvailableRule(""), PoolAction(""))
+    --- Send queries to fallback pool if not
+    addAction(AllRule(), PoolAction("fallback"))
+
+  :param string poolname: Pool to check
 
 Combining Rules
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
### Short description
I wasn't sure whether or not `PoolAvailableRule` was a rule or not and if it was how to use it. I've moved the rule to the rules section and added a example use case.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
