### PR TITLE
auth: Initialize cURL before starting any thread

### DIFF
--- a/pdns/minicurl.hh
+++ b/pdns/minicurl.hh
@@ -31,6 +31,8 @@
 class MiniCurl
 {
 public:
+  static void init();
+
   MiniCurl(const string& useragent="MiniCurl/0.0");
   ~MiniCurl();
   MiniCurl& operator=(const MiniCurl&) = delete;

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -72,6 +72,10 @@
 #include "dnsrecords.hh"
 #include "version.hh"
 
+#ifdef HAVE_LUA_RECORDS
+#include "minicurl.hh"
+#endif /* HAVE_LUA_RECORDS */
+
 time_t s_starttime;
 
 string s_programname="pdns"; // used in packethandler.cc
@@ -467,6 +471,10 @@ int main(int argc, char **argv)
     openssl_seed();
     /* setup rng */
     dns_random_init();
+
+#ifdef HAVE_LUA_RECORDS
+    MiniCurl::init();
+#endif /* HAVE_LUA_RECORDS */
 
     if(!::arg()["load-modules"].empty()) {
       vector<string> modules;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If `curl_global_init()` was not called prior to any call to `curl_easy_init()`, it will be automatically called.
The documentation states that:

> This may be lethal in multi-threaded cases, since
> curl_global_init is not thread-safe, and it may result in
> resource problems because there is no corresponding cleanup.

I have witnessed several crashes related to `libcurl` on Travis and I believe this might be the root cause of these failures.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
