### PR TITLE
Allow unix domains sockets for dnstap destinations

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -983,7 +983,14 @@ static std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>> startFra
       options["outputQueueSize"] = config.outputQueueSize;
       options["queueNotifyThreshold"] = config.queueNotifyThreshold;
       options["reopenInterval"] = config.reopenInterval;
-      auto fsl = new FrameStreamLogger(server.sin4.sin_family, server.toStringWithPort(), true, options);
+      FrameStreamLogger *fsl = nullptr;
+      try {
+        ComboAddress address(server);
+        fsl = new FrameStreamLogger(address.sin4.sin_family, address.toStringWithPort(), true, options);
+      }
+      catch (const PDNSException& e) {
+        fsl = new FrameStreamLogger(AF_UNIX, server, true, options);
+      }
       fsl->setLogQueries(config.logQueries);
       fsl->setLogResponses(config.logResponses);
       result->emplace_back(fsl);

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -554,14 +554,14 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
             parseFrameStreamOptions(vars, lci.frameStreamExportConfig);
           }
           catch(std::exception& e) {
-            g_log<<Logger::Error<<"Error while starting dnstap framestream logger: "<<e.what()<<endl;
+            g_log<<Logger::Error<<"Error reading config for dnstap framestream logger: "<<e.what()<<endl;
           }
           catch(PDNSException& e) {
-            g_log<<Logger::Error<<"Error while starting dnstap framestream logger: "<<e.reason<<endl;
+            g_log<<Logger::Error<<"Error reading config for dnstap framestream logger: "<<e.reason<<endl;
           }
       }
       else {
-        g_log<<Logger::Error<<"Only one dnstapFrameStreamServer() directive can be configured, we already have "<<lci.frameStreamExportConfig.servers.at(0).toString()<<endl;
+        g_log<<Logger::Error<<"Only one dnstapFrameStreamServer() directive can be configured, we already have "<<lci.frameStreamExportConfig.servers.at(0)<<endl;
       }
     });
 #endif /* HAVE_FSTRM */

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -541,7 +541,9 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
           try {
             if (servers.type() == typeid(std::string)) {
               auto server = boost::get<const std::string>(servers);
-
+              if (!boost::starts_with(server, "/")) {
+                ComboAddress parsecheck(server);
+              }
               lci.frameStreamExportConfig.servers.emplace_back(server);
             }
             else {

--- a/pdns/rec-lua-conf.hh
+++ b/pdns/rec-lua-conf.hh
@@ -43,7 +43,7 @@ struct ProtobufExportConfig
 
 struct FrameStreamExportConfig
 {
-  std::vector<ComboAddress> servers;
+  std::vector<string> servers;
   bool enabled{false};
   bool logQueries{true};
   bool logResponses{true};

--- a/pdns/recursordist/docs/lua-config/protobuf.rst
+++ b/pdns/recursordist/docs/lua-config/protobuf.rst
@@ -103,11 +103,11 @@ The recursor must have been built with configure ``--enable-dnstap`` to make thi
 
 .. function:: dnstapFrameStreamServer(servers, [, options])
 
-  .. versionadded:: 4.X.0
+  .. versionadded:: 4.3.0
 
   Send dnstap formatted message to one or more framestream servers for outgoing queries and/or incoming responses.
 
-  :param servers: The IP and port to connect to, or a list of those. If more than one server is configured, all messages are sent to every server.
+  :param servers: Either a pathname of a unix domain socket starting with a slash or the IP:port to connect to, or a list of those. If more than one server is configured, all messages are sent to every server.
   :type servers: string or list of strings
   :param table options: A table with ``key=value`` pairs with options.
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Currently code forces a string that can be converted to a ComboAddress: a IPv4 or IPv6 address:port. But we want unix domain sockets (a path) in the typical case. The farsight "collector" expects that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
