### PR TITLE
auth LUA: optionally reuse Lua state

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -511,6 +511,7 @@ void mainthread()
    g_8bitDNS = ::arg().mustDo("8bit-dns");
 #ifdef HAVE_LUA_RECORDS
    g_doLuaRecord = ::arg().mustDo("enable-lua-records");
+   g_LuaRecordSharedState = (::arg()["enable-lua-records"] == "shared");
    g_luaRecordExecLimit = ::arg().asNum("lua-records-exec-limit");
 #endif
 

--- a/pdns/common_startup.hh
+++ b/pdns/common_startup.hh
@@ -57,6 +57,7 @@ extern bool g_anyToTcp;
 extern bool g_8bitDNS;
 #ifdef HAVE_LUA_RECORDS
 extern bool g_doLuaRecord;
+extern bool g_LuaRecordSharedState;
 #endif // HAVE_LUA_RECORDS
 
 #endif // COMMON_STARTUP_HH

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -465,13 +465,19 @@ static vector<pair<int, ComboAddress> > convWIplist(std::unordered_map<int, wipl
   return ret;
 }
 
+thread_local unique_ptr<AuthLua4> alua;
+
 std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& query, const DNSName& zone, int zoneid, const DNSPacket& dnsp, uint16_t qtype)
 {
-  AuthLua4 alua;
+  if(!alua) {
+    cerr<<"initializing AuthLua4"<<endl;
+
+    alua = make_unique<AuthLua4>();
+  }
 
   std::vector<shared_ptr<DNSRecordContent>> ret;
 
-  LuaContext& lua = *alua.getLua();
+  LuaContext& lua = *alua->getLua();
   lua.writeVariable("qname", query);
   lua.writeVariable("who", dnsp.getRemote());
   lua.writeVariable("dh", (dnsheader*)&dnsp.d);


### PR DESCRIPTION
### Short description
Nonscientific measurements:
* 60kqps from a plain A records
* 5kqps from `LUA A "'192.0.2.1'"`
* 35kqps from that same LUA with this patch and `enable-lua-records=shared`

Needs docs, maybe a test?

We could (presumably) win even more if we avoided doing 22 `writeFunction` calls for each LUA query still, but because of the captured variables, fixing that is not trivial. ~(After I just talked to @ahupowerdns  I'd like to try anyway)~ we'll try that for 4.3

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
