### PR TITLE
Adapt calidns for openbsd and other systems without rcvmmsg(2)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,9 +130,11 @@ PDNS_CHECK_VIRTUALENV
 PDNS_FROM_GIT
 
 dnl Checks for library functions.
-AC_CHECK_FUNCS_ONCE([strcasestr localtime_r recvmmsg getrandom arc4random])
+AC_CHECK_FUNCS_ONCE([strcasestr localtime_r recvmmsg sched_setscheduler getrandom arc4random])
 
 AM_CONDITIONAL([HAVE_RECVMMSG], [test "x$ac_cv_func_recvmmsg" = "xyes"])
+
+AM_CONDITIONAL([HAVE_SCHED_SETSCHEDULER], [test "x$ac_cv_func_sched_setscheduler" = "xyes"])
 
 AS_IF([test "x$lt_cv_dlopen" = "xno"],
   [AC_MSG_ERROR([Your system does not support dlopen])]

--- a/configure.ac
+++ b/configure.ac
@@ -134,8 +134,6 @@ AC_CHECK_FUNCS_ONCE([strcasestr localtime_r recvmmsg sched_setscheduler getrando
 
 AM_CONDITIONAL([HAVE_RECVMMSG], [test "x$ac_cv_func_recvmmsg" = "xyes"])
 
-AM_CONDITIONAL([HAVE_SCHED_SETSCHEDULER], [test "x$ac_cv_func_sched_setscheduler" = "xyes"])
-
 AS_IF([test "x$lt_cv_dlopen" = "xno"],
   [AC_MSG_ERROR([Your system does not support dlopen])]
 )

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -99,9 +99,7 @@ bin_PROGRAMS += \
 	ixplore \
 	sdig
 
-if HAVE_RECVMMSG
 bin_PROGRAMS += calidns
-endif
 
 if HAVE_BOOST_GE_148
 bin_PROGRAMS += \

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -68,37 +68,52 @@ static void* recvThread(const vector<Socket*>* sockets)
 
   int err;
 
+#if HAVE_RECVMMSG
   vector<struct mmsghdr> buf(100);
   for(auto& m : buf) {
     fillMSGHdr(&m.msg_hdr, new struct iovec, new char[512], 512, new char[1500], 1500, new ComboAddress("127.0.0.1"));
   }
+#else
+  struct msghdr buf;
+  fillMSGHdr(&buf, new struct iovec, new char[512], 512, new char[1500], 1500, new ComboAddress("127.0.0.1"));
+#endif
 
   while(!g_done) {
     fds=rfds;
 
     err = poll(&fds[0], fds.size(), -1);
-    if(err < 0) {
-      if(errno==EINTR)
-	continue;
+    if (err < 0) {
+      if (errno == EINTR)
+        continue;
       unixDie("Unable to poll for new UDP events");
-    }    
-    
+    }
+
     for(auto &pfd : fds) {
-      if(pfd.revents & POLLIN) {
-	
-	if((err=recvmmsg(pfd.fd, &buf[0], buf.size(), MSG_WAITFORONE, 0)) < 0 ) {
-	  if(errno != EAGAIN)
-	    cerr<<"recvfrom gave error, ignoring: "<<strerror(errno)<<endl;
-	  unixDie("recvmmsg");
-	  continue;
-	}
-	g_recvcounter+=err;
-	for(int n=0; n < err; ++n)
-	  g_recvbytes += buf[n].msg_len;
+      if (pfd.revents & POLLIN) {
+#if HAVE_RECVMMSG
+        if ((err=recvmmsg(pfd.fd, &buf[0], buf.size(), MSG_WAITFORONE, 0)) < 0 ) {
+          if(errno != EAGAIN)
+            cerr<<"recvmmsg gave error, ignoring: "<<strerror(errno)<<endl;
+          unixDie("recvmmsg");
+          continue;
+        }
+        g_recvcounter+=err;
+        for(int n=0; n < err; ++n)
+        g_recvbytes += buf[n].msg_len;
+#else
+        if ((err = recvmsg(pfd.fd, &buf, 0)) < 0) {
+          if (errno != EAGAIN)
+            cerr << "recvmsg gave error, ignoring: " << strerror(errno) << endl;
+          unixDie("recvmsg");
+          continue;
+        }
+        g_recvcounter++;
+        for (int i = 0; i < buf.msg_iovlen; i++)
+          g_recvbytes += buf.msg_iov[i].iov_len;
+#endif
       }
     }
   }
-
   return 0;
 }
 
@@ -184,11 +199,11 @@ static void sendPackets(const vector<Socket*>* sockets, const vector<vector<uint
       replaceEDNSClientSubnet(p, ecsRange);
     }
 
-    fillMSGHdr(&u.msgh, &u.iov, u.cbuf, 0, (char*)&(*p)[0], p->size(), &dest);
+    fillMSGHdr(&u.msgh, &u.iov, nullptr, 0, (char*)&(*p)[0], p->size(), &dest);
     if((ret=sendmsg((*sockets)[count % sockets->size()]->getHandle(), 
 		    &u.msgh, 0)))
       if(ret < 0)
-	unixDie("sendmmsg");
+	      unixDie("sendmsg");
     
     
     if(!(count%burst)) {
@@ -339,11 +354,13 @@ try
   struct sched_param param;
   param.sched_priority=99;
 
+#if HAVE_SCHED_SETSCHEDULER
   if(sched_setscheduler(0, SCHED_FIFO, &param) < 0) {
     if (!g_quiet) {
       cerr<<"Unable to set SCHED_FIFO: "<<strerror(errno)<<endl;
     }
   }
+#endif
 
   ifstream ifs(g_vm["query-file"].as<string>());
   string line;

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -93,18 +93,16 @@ static void* recvThread(const vector<Socket*>* sockets)
 #if HAVE_RECVMMSG
         if ((err=recvmmsg(pfd.fd, &buf[0], buf.size(), MSG_WAITFORONE, 0)) < 0 ) {
           if(errno != EAGAIN)
-            cerr<<"recvmmsg gave error, ignoring: "<<strerror(errno)<<endl;
-          unixDie("recvmmsg");
+            unixDie("recvmmsg");
           continue;
         }
         g_recvcounter+=err;
         for(int n=0; n < err; ++n)
-        g_recvbytes += buf[n].msg_len;
+          g_recvbytes += buf[n].msg_len;
 #else
         if ((err = recvmsg(pfd.fd, &buf, 0)) < 0) {
           if (errno != EAGAIN)
-            cerr << "recvmsg gave error, ignoring: " << strerror(errno) << endl;
-          unixDie("recvmsg");
+            unixDie("recvmsg");
           continue;
         }
         g_recvcounter++;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Implement receiving using `recvmsg(2)` and guard `sched_setscheduler(2)`.
Also, a non-null control msg of length 0 is illegal on OpenBSD.

I tried tried to avoid reformatting too much, formatting is a broken in a lot of places.

The error handling in the `poll` loop was broken afaiks, so I fixed that as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
