### PR TITLE
rec: set the query-zone field in the dnstap messages. 

### DIFF
--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -70,14 +70,15 @@ static bool isEnabledForQueries(const std::shared_ptr<std::vector<std::unique_pt
   return false;
 }
 
-static void logFstreamQuery(const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstreamLoggers, const struct timeval &queryTime, const ComboAddress& ip, bool doTCP, const vector<uint8_t>& packet)
+static void logFstreamQuery(const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstreamLoggers, const struct timeval &queryTime, const ComboAddress& ip, bool doTCP,
+  boost::optional<const DNSName&> auth, const vector<uint8_t>& packet)
 {
   if (fstreamLoggers == nullptr)
     return;
 
   struct timespec ts;
   TIMEVAL_TO_TIMESPEC(&queryTime, &ts);
-  RecDnstapMessage message(SyncRes::s_serverID, nullptr, &ip, doTCP, reinterpret_cast<const char*>(&*packet.begin()), packet.size(), &ts, nullptr);
+  RecDnstapMessage message(SyncRes::s_serverID, nullptr, &ip, doTCP, auth, reinterpret_cast<const char*>(&*packet.begin()), packet.size(), &ts, nullptr);
   std::string str;
   message.serialize(str);
 
@@ -99,7 +100,8 @@ static bool isEnabledForResponses(const std::shared_ptr<std::vector<std::unique_
   return false;
 }
 
-static void logFstreamResponse(const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstreamLoggers, const ComboAddress& ip, bool doTCP, const std::string& packet, const struct timeval& queryTime, const struct timeval& replyTime)
+static void logFstreamResponse(const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstreamLoggers, const ComboAddress& ip, bool doTCP,
+  boost::optional<const DNSName&> auth, const std::string& packet, const struct timeval& queryTime, const struct timeval& replyTime)
 {
   if (fstreamLoggers == nullptr)
     return;
@@ -107,7 +109,7 @@ static void logFstreamResponse(const std::shared_ptr<std::vector<std::unique_ptr
   struct timespec ts1, ts2;
   TIMEVAL_TO_TIMESPEC(&queryTime, &ts1);
   TIMEVAL_TO_TIMESPEC(&replyTime, &ts2);
-  RecDnstapMessage message(SyncRes::s_serverID, nullptr, &ip, doTCP, static_cast<const char*>(&*packet.begin()), packet.size(), &ts1, &ts2);
+  RecDnstapMessage message(SyncRes::s_serverID, nullptr, &ip, doTCP, auth, static_cast<const char*>(&*packet.begin()), packet.size(), &ts1, &ts2);
   std::string str;
   message.serialize(str);
 
@@ -234,7 +236,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
 #endif /* HAVE_PROTOBUF */
 #ifdef HAVE_FSTRM
   if (isEnabledForQueries(fstrmLoggers)) {
-    logFstreamQuery(fstrmLoggers, queryTime, ip, doTCP, vpacket);
+    logFstreamQuery(fstrmLoggers, queryTime, ip, doTCP, context ? context->d_auth : boost::none, vpacket);
   }
 #endif /* HAVE_FSTRM */
 
@@ -312,7 +314,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
 
 #ifdef HAVE_FSTRM
   if (isEnabledForResponses(fstrmLoggers)) {
-    logFstreamResponse(fstrmLoggers, ip, doTCP, buf, queryTime, *now);
+    logFstreamResponse(fstrmLoggers, ip, doTCP, context ? context->d_auth : boost::none, buf, queryTime, *now);
   }
 #endif /* HAVE_FSTRM */
 

--- a/pdns/rec-dnstap.hh
+++ b/pdns/rec-dnstap.hh
@@ -28,10 +28,13 @@
 class RecDnstapMessage : public DnstapMessage
 {
 public:
-  RecDnstapMessage(const std::string& identity, const ComboAddress* requestor, const ComboAddress* responder, bool isTCP, const char* packet, const size_t len, const struct timespec* queryTime, const struct timespec* responseTime)
+  RecDnstapMessage(const std::string& identity, const ComboAddress* requestor, const ComboAddress* responder, bool isTCP, boost::optional<const DNSName&> auth, const char* packet, const size_t len, const struct timespec* queryTime, const struct timespec* responseTime)
       : DnstapMessage(identity, requestor, responder, isTCP, packet, len, queryTime, responseTime) {
     const struct dnsheader* dh = reinterpret_cast<const struct dnsheader*>(packet);
     dnstap::Message* message = proto_message.mutable_message();
     message->set_type(!dh->qr ? dnstap::Message_Type_RESOLVER_QUERY : dnstap::Message_Type_RESOLVER_RESPONSE);
+    if (auth) {
+      message->set_query_zone(auth->toDNSString());
+    }
   }
 };

--- a/pdns/resolve-context.hh
+++ b/pdns/resolve-context.hh
@@ -15,8 +15,14 @@ struct ResolveContext {
 #ifdef HAVE_PROTOBUF
     this->d_initialRequestId = ctx.d_initialRequestId;
 #endif
+#ifdef HAVE_FSTRM
+    this->d_auth = ctx.d_auth;
+#endif
   }
 #ifdef HAVE_PROTOBUF
   boost::optional<const boost::uuids::uuid&> d_initialRequestId;
+#endif
+#ifdef HAVE_FSTRM
+  boost::optional<const DNSName&> d_auth;
 #endif
 };

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -809,7 +809,7 @@ private:
 
   bool doSpecialNamesResolve(const DNSName &qname, const QType &qtype, const uint16_t qclass, vector<DNSRecord> &ret);
 
-  int asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res, bool* chained) const;
+  int asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, const DNSName& auth, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res, bool* chained) const;
 
   boost::optional<Netmask> getEDNSSubnetMask(const DNSName&dn, const ComboAddress& rem);
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This requires passing the auth zone name to asyncresolve(). I chose to do this via the context so that we do not have to add an extra parameter to a function already having too many of them.

This is not strictly needed (query-zone is an optional field in dnstap), but it can be handy for diagnosis and other purposes. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
