### PR TITLE
auth: make configure call PDNS_CHECK_LIBCURL when needed 

### DIFF
--- a/m4/pdns_enable_tools.m4
+++ b/m4/pdns_enable_tools.m4
@@ -1,4 +1,5 @@
 AC_DEFUN([PDNS_ENABLE_TOOLS], [
+  AC_REQUIRE([PDNS_CHECK_LIBCURL]) dnl We only care about the #define HAVE_LIBCURL and can build tools without DOH support.
   AC_MSG_CHECKING([whether we will be building and installing the extra tools])
   AC_ARG_ENABLE([tools],
     [AS_HELP_STRING([--enable-tools], [if we should build and install the tools @<:@default=no@:>@])],
@@ -8,8 +9,4 @@ AC_DEFUN([PDNS_ENABLE_TOOLS], [
   AC_MSG_RESULT([$enable_tools])
 
   AM_CONDITIONAL([TOOLS], [test "x$enable_tools" != "xno"])
-
-  AS_IF([test "x$enable_tools" != "xno"], [
-    PDNS_CHECK_LIBCURL() dnl We only care about the #define HAVE_LIBCURL and can build tools without DOH support.
-  ])
 ])

--- a/m4/pdns_with_lua_records.m4
+++ b/m4/pdns_with_lua_records.m4
@@ -1,4 +1,5 @@
 AC_DEFUN([PDNS_WITH_LUA_RECORDS], [
+  AC_REQUIRE([PDNS_CHECK_LIBCURL])
   AC_MSG_CHECKING([whether we will enable LUA records])
 
   AC_ARG_ENABLE([lua-records],
@@ -12,7 +13,6 @@ AC_DEFUN([PDNS_WITH_LUA_RECORDS], [
     AS_IF([test "x$LUAPC" = "x"],
       AC_MSG_ERROR([LUA records need LUA. You can disable this feature with the --disable-lua-records switch or configure a proper LUA installation.])
     )
-    PDNS_CHECK_LIBCURL()
     AS_IF([test "$HAVE_LIBCURL" != "y"], [
       AC_MSG_ERROR([libcurl minimum version requirement not met. This is required for LUA records. You can disable it with the --disable-lua-records switch or use --with-libcurl to select another curl installation.])
     ])


### PR DESCRIPTION
### Short description
The autotools changes in #7832 broke `build.sh sdist`, because it puts an `AM_CONDITIONAL` inside an `AS_IF` conditional.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
