### PR TITLE
 SuffixMatchTree: Fix root removal, partial match of non-leaf nodes

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -336,11 +336,7 @@ struct SuffixMatchTree
       return nullptr;
     }
 
-    auto result = lookup(name.getRawLabels());
-    if (result) {
-      return result;
-    }
-    return endNode ? &d_value : nullptr;
+    return lookup(name.getRawLabels());
   }
 
   T* lookup(std::vector<std::string> labels) const

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -333,9 +333,14 @@ struct SuffixMatchTree
     if(children.empty()) { // speed up empty set
       if(endNode)
         return &d_value;
-      return 0;
+      return nullptr;
     }
-    return lookup(name.getRawLabels());
+
+    auto result = lookup(name.getRawLabels());
+    if (result) {
+      return result;
+    }
+    return endNode ? &d_value : nullptr;
   }
 
   T* lookup(std::vector<std::string> labels) const
@@ -343,7 +348,7 @@ struct SuffixMatchTree
     if(labels.empty()) { // optimization
       if(endNode)
         return &d_value;
-      return 0;
+      return nullptr;
     }
 
     SuffixMatchTree smn(*labels.rbegin());
@@ -351,10 +356,14 @@ struct SuffixMatchTree
     if(child == children.end()) {
       if(endNode)
         return &d_value;
-      return 0;
+      return nullptr;
     }
     labels.pop_back();
-    return child->lookup(labels);
+    auto result = child->lookup(labels);
+    if (result) {
+      return result;
+    }
+    return endNode ? &d_value : nullptr;
   }
 
   // Returns all end-nodes, fully qualified (not as separate labels)

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -299,6 +299,11 @@ struct SuffixMatchTree
    */
   void remove(std::vector<std::string> labels) const
   {
+    if (labels.empty()) { // this allows removal of the root
+      endNode = false;
+      return;
+    }
+
     SuffixMatchTree smt(*labels.rbegin());
     auto child = children.find(smt);
     if (child == children.end()) {

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -508,10 +508,16 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch) {
   BOOST_CHECK(smn.check(examplenet));
   BOOST_CHECK(smn.check(net));
 
-  // Remove .net and check that example.net still exists
+  // Remove .net and the root, and check that example.net still exists
+  smn.remove(g_rootdnsname);
   smn.remove(net);
   BOOST_CHECK_EQUAL(smn.check(net), false);
   BOOST_CHECK(smn.check(examplenet));
+
+  smn.add(DNSName("fr."));
+  smn.add(DNSName("www.sub.domain.fr."));
+  // should not match www.sub.domain.fr. but should still match fr.
+  BOOST_CHECK(smn.check(DNSName("sub.domain.fr.")));
 }
 
 BOOST_AUTO_TEST_CASE(test_suffixmatch_tree) {
@@ -564,7 +570,8 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch_tree) {
   BOOST_REQUIRE(smt.lookup(net));
   BOOST_CHECK_EQUAL(*smt.lookup(net), net);
 
-  // Remove .net, and check that example.net remains
+  // Remove .net and the root, and check that example.net remains
+  smt.remove(g_rootdnsname);
   smt.remove(net);
   BOOST_CHECK(smt.lookup(net) == nullptr);
   BOOST_CHECK_EQUAL(*smt.lookup(examplenet), examplenet);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If we insert fr and www.domain.fr, domain.fr should not match www.domain.fr, the leaf node, and it should not match the intermediary domain.fr node, but it should match the fr end-node.
It should also be possible to remove the root from the tree.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
