### PR TITLE
auth: auto-generate lua.hpp

### DIFF
--- a/modules/lua2backend/Makefile.am
+++ b/modules/lua2backend/Makefile.am
@@ -9,5 +9,15 @@ liblua2backend_la_SOURCES = \
 	lua2backend.cc lua2backend.hh \
 	lua2api2.hh lua2api2.cc
 
+if !HAVE_LUA_HPP
+BUILT_SOURCES = lua.hpp
+nodist_liblua2backend_la_SOURCES = lua.hpp
+CLEANFILES = lua.hpp
+endif
+
 liblua2backend_la_LDFLAGS = -module -avoid-version
 liblua2backend_la_LIBADD = $(LUA_LIBS)
+
+if !HAVE_LUA_HPP
+include ../../pdns/lua_hpp.mk
+endif

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -48,6 +48,7 @@ EXTRA_DIST = \
 	mtasker.cc \
 	inflighter.cc \
 	bindparser.h \
+	lua_hpp.mk \
 	named.conf.parsertest \
 	pdns.service.in \
 	ixfrdist.service.in \
@@ -115,6 +116,13 @@ bin_PROGRAMS += \
 sysconf_DATA += \
 	ixfrdist.example.yml
 endif
+
+if !HAVE_LUA_HPP
+BUILT_SOURCES += lua.hpp
+nodist_pdns_server_SOURCES = lua.hpp
+CLEANFILES += lua.hpp
+endif
+
 
 EXTRA_PROGRAMS = \
 	calidns \
@@ -1645,3 +1653,7 @@ CLEANFILES += \
 	ixfrdist@.service
 
 endif # HAVE_SYSTEMD
+
+if !HAVE_LUA_HPP
+include lua_hpp.mk
+endif


### PR DESCRIPTION
### Short description
On systems without an available lua.hpp, the builds for the lua backends and pdns-server
will fail. To fix this, we can auto-generate the file at build time. This fixes #4959

Only issue I can see with this is including the same code in multiple places. I will also test including this in the root Makefile and simply employing symlinks instead and see how that works.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code