### PR TITLE
rec: Reuse the outgoing query protobuf for the incoming response

### DIFF
--- a/pdns/protobuf.cc
+++ b/pdns/protobuf.cc
@@ -300,12 +300,16 @@ void DNSProtoBufMessage::setInitialRequestID(const boost::uuids::uuid& uuid)
   std::copy(uuid.begin(), uuid.end(), messageId->begin());
 }
 
-void DNSProtoBufMessage::update(const boost::uuids::uuid& uuid, const ComboAddress* requestor, const ComboAddress* responder, bool isTCP, uint16_t id)
+void DNSProtoBufMessage::updateTime()
 {
   struct timespec ts;
   gettime(&ts, true);
   setTime(ts.tv_sec, ts.tv_nsec / 1000);
+}
 
+void DNSProtoBufMessage::update(const boost::uuids::uuid& uuid, const ComboAddress* requestor, const ComboAddress* responder, bool isTCP, uint16_t id)
+{
+  updateTime();
   setUUID(uuid);
   d_message.set_id(ntohs(id));
 

--- a/pdns/protobuf.hh
+++ b/pdns/protobuf.hh
@@ -59,6 +59,7 @@ public:
   void setEDNSSubnet(const Netmask& subnet, uint8_t mask=128);
   void setBytes(size_t bytes);
   void setTime(time_t sec, uint32_t usec);
+  void updateTime();
   void setQueryTime(time_t sec, uint32_t usec);
   void setResponseCode(uint8_t rcode);
   void addRRsFromPacket(const char* packet, const size_t len, bool includeCNAME=false);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Allocating memory for the ProtoBuf objects an their fields is costly, as is converting the qname and potential UUID to strings, for example.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
