### PR TITLE
rec backport to 4.1.x: Add counters for incoming AD and CD queries

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -826,6 +826,21 @@ static void startDoResolve(void *p)
         DNSSECOK=true;
         g_stats.dnssecQueries++;
       }
+      if (dc->d_mdp.d_header.cd) {
+        /* Per rfc6840 section 5.9, "When processing a request with
+           the Checking Disabled (CD) bit set, a resolver SHOULD attempt
+           to return all response data, even data that has failed DNSSEC
+           validation. */
+        ++g_stats.dnssecCheckDisabledQueries;
+      }
+      if (dc->d_mdp.d_header.ad) {
+        /* Per rfc6840 section 5.7, "the AD bit in a query as a signal
+           indicating that the requester understands and is interested in the
+           value of the AD bit in the response.  This allows a requester to
+           indicate that it understands the AD bit without also requesting
+           DNSSEC data via the DO bit. */
+        ++g_stats.dnssecAuthenticDataQueries;
+      }
     } else {
       // Ignore the client-set CD flag
       pw.getHeader()->cd=0;

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -108,6 +108,8 @@ static const oid policyResultNodataOID[] = { RECURSOR_STATS_OID, 89 };
 static const oid policyResultTruncateOID[] = { RECURSOR_STATS_OID, 90 };
 static const oid policyResultCustomOID[] = { RECURSOR_STATS_OID, 91 };
 static const oid queryPipeFullDropsOID[] = { RECURSOR_STATS_OID, 92 };
+static const oid dnssecAuthenticDataQueriesOID[] = { RECURSOR_STATS_OID, 95 };
+static const oid dnssecCheckDisabledQueriesOID[] = { RECURSOR_STATS_OID, 96 };
 
 static std::unordered_map<oid, std::string> s_statsMap;
 
@@ -273,6 +275,8 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   registerCounter64Stat("edns-ping-matches", ednsPingMatchesOID, OID_LENGTH(ednsPingMatchesOID));
   registerCounter64Stat("edns-ping-mismatches", ednsPingMismatchesOID, OID_LENGTH(ednsPingMismatchesOID));
   registerCounter64Stat("dnssec-queries", dnssecQueriesOID, OID_LENGTH(dnssecQueriesOID));
+  registerCounter64Stat("dnssec-authentic-data-queries", dnssecAuthenticDataQueriesOID, OID_LENGTH(dnssecAuthenticDataQueriesOID));
+  registerCounter64Stat("dnssec-check-disabled-queries", dnssecCheckDisabledQueriesOID, OID_LENGTH(dnssecCheckDisabledQueriesOID));
   registerCounter64Stat("noping-outqueries", nopingOutqueriesOID, OID_LENGTH(nopingOutqueriesOID));
   registerCounter64Stat("noedns-outqueries", noednsOutqueriesOID, OID_LENGTH(noednsOutqueriesOID));
   registerCounter64Stat("uptime", uptimeOID, OID_LENGTH(uptimeOID));

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1004,6 +1004,8 @@ void registerAllStats()
   addGetStat("edns-ping-matches", &g_stats.ednsPingMatches);
   addGetStat("edns-ping-mismatches", &g_stats.ednsPingMismatches);
   addGetStat("dnssec-queries", &g_stats.dnssecQueries);
+  addGetStat("dnssec-authentic-data-queries", &g_stats.dnssecAuthenticDataQueries);
+  addGetStat("dnssec-check-disabled-queries", &g_stats.dnssecCheckDisabledQueries);
 
   addGetStat("noping-outqueries", &g_stats.noPingOutQueries);
   addGetStat("noedns-outqueries", &g_stats.noEdnsOutQueries);

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -15,7 +15,7 @@ IMPORTS
         FROM SNMPv2-CONF;
 
 rec MODULE-IDENTITY
-    LAST-UPDATED "201611290000Z"
+    LAST-UPDATED "201812240000Z"
     ORGANIZATION "PowerDNS BV"
     CONTACT-INFO "support@powerdns.com"
     DESCRIPTION
@@ -23,6 +23,9 @@ rec MODULE-IDENTITY
 
     REVISION "201611290000Z"
     DESCRIPTION "Initial revision."
+
+    REVISION "201812240000Z"
+    DESCRIPTION "Added the dnssecAuthenticDataQueries and dnssecCheckDisabledQueries stats."
 
     ::= { powerdns 2 }
 
@@ -766,6 +769,22 @@ queryPipeFullDrops OBJECT-TYPE
         "Number of queries dropped because the query distribution pipe was full"
     ::= { stats 92 }
 
+dnssecAuthenticDataQueries OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of queries received with the AD bit set"
+    ::= { stats 95 }
+
+dnssecCheckDisabledQueries OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of queries received with the CD bit set"
+    ::= { stats 96 }
+
 ---
 --- Traps / Notifications
 ---
@@ -900,6 +919,8 @@ recGroup OBJECT-GROUP
         policyResultTruncate,
         policyResultCustom,
         queryPipeFullDrops,
+        dnssecAuthenticDataQueries,
+        dnssecCheckDisabledQueries,
         trapReason
     }
     STATUS current

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -188,6 +188,18 @@ dlg-only-drops
 ^^^^^^^^^^^^^^
 number of records dropped because of :ref:`setting-delegation-only` setting
 
+dnssec-authentic-data-queries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.2
+
+number of queries received with the AD bit set
+
+dnssec-check-disabled-queries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.2
+
+number of queries received with the CD bit set
+
 dnssec-queries
 ^^^^^^^^^^^^^^
 number of queries received with the DO bit set

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -190,13 +190,13 @@ number of records dropped because of :ref:`setting-delegation-only` setting
 
 dnssec-authentic-data-queries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. versionadded:: 4.2
+.. versionadded:: 4.1.14
 
 number of queries received with the AD bit set
 
 dnssec-check-disabled-queries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. versionadded:: 4.2
+.. versionadded:: 4.1.14
 
 number of queries received with the CD bit set
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -916,6 +916,8 @@ struct RecursorStats
   std::atomic<uint64_t> ignoredCount;
   time_t startupTime;
   std::atomic<uint64_t> dnssecQueries;
+  std::atomic<uint64_t> dnssecAuthenticDataQueries;
+  std::atomic<uint64_t> dnssecCheckDisabledQueries;
   unsigned int maxMThreadStackUsage;
   std::atomic<uint64_t> dnssecValidations; // should be the sum of all dnssecResult* stats
   std::map<vState, std::atomic<uint64_t> > dnssecResults;


### PR DESCRIPTION
(cherry picked from commit 88c33dca92f68d3c4a0a9dc8cb3c9838f034b94b)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Would it be an issue that the snmp objects IDs are no longer contiguous?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X <!-- remove this line if your PR is against master --> checked that this code was merged to master
