### PR TITLE
changelog and secpoll for auth 4.2.0 rc2

### DIFF
--- a/docs/changelog/4.2.rst
+++ b/docs/changelog/4.2.rst
@@ -2,8 +2,238 @@ Changelogs for 4.2.x
 ====================
 
 .. changelog::
-  :version: 4.2.0
-  :released: *unreleased*
+  :version: 4.2.0-rc2
+  :released: 14th of June 2019
+
+  .. change::
+    :tags: Improvements, LMDB
+    :pullreq: 7807
+
+    Make explicit lmdbbackend synchronous option
+
+  .. change::
+    :tags: Improvements, LMDB
+    :pullreq: 7700
+
+    Reduce mmap size for lmdb on 32 bits plus restrict number of shards
+
+  .. change::
+    :tags: Bug Fixes, LMDB
+    :pullreq: 7784, 7697, 7643
+
+    LMDB improvements:
+
+    * lmdbbackend: auth was unset in get() (always true) (Kees Monshouwer)
+    * LMDB defaulted to port 0 for master addresses unless explicitly set
+    * fix ``getAllDomains()`` (Kees Monshouwer)
+
+  .. change::
+    :tags: Bug fixes, Backends
+    :pullreq: 7891
+
+    auth API, pdnsutil: improve backend transaction correctness
+
+  .. change::
+    :tags: Robustness, Backends
+    :pullreq: 7881
+
+    detect SOA cache pollution caused by broken backends (Kees Monshouwer)
+
+  .. change::
+    :tags: Improvements, Backends
+    :pullreq: 7852
+
+    sqlite3: make journal mode configurable; default to WAL
+
+  .. change::
+    :tags: Bug Fixes, Backends
+    :pullreq: 7854
+
+    auth gsql ``getAllDomains``: ignore stou errors
+
+  .. change::
+    :tags: Performance, Backends
+    :pullreq: 7460
+
+    speedup ``getUpdatedMasters()`` for the gsql backends (Kees Monshouwer)
+
+  .. change::
+    :tags: Bug Fixes, Backends
+    :pullreq: 7831, 7787
+
+    Rectify/ENT fixes:
+
+    * Allow updates to override existing ENT records
+    * Fix ENTs removal when "replacing" new records via the API
+
+  .. change::
+    :tags: Bug Fixes, Backends
+    :pullreq: 7363
+
+    Cleanup SOA editing (Kees Monshouwer)
+
+  .. change::
+    :tags: Backends
+    :pullreq: 7753
+
+    pdns_control reopens geoip databases on reload (jpmens)
+
+  .. change::
+    :tags: Backends
+    :pullreq: 7696
+
+    b2b-migrate did not open a transaction, breaking it for lmdb
+
+  .. change::
+    :tags: Backends
+    :pullreq: 7706
+
+    No longer filter DNSSEC metadata when DNSSEC is enabled in gsql
+
+  .. change::
+    :tags: Backends
+    :pullreq: 7580
+
+    Rectify for ent records in narrow zones was slightly wrong. (Kees Monshouwer)
+
+  .. change::
+    :tags: Backends
+    :pullreq: 7529
+
+    Clear caches (meta-data, keys) on domain deletion
+
+  .. change::
+    :tags: Performance, LUA
+    :pullreq: 7869, 7897
+
+    optionally reuse Lua state
+
+  .. change::
+    :tags: Improvements, Portability
+    :pullreq: 7862, 7861, 7818, 7668
+    
+    Portability/building improvements:
+
+    * Update boost.m4 to the latest version
+    * Check if ``-latomic`` is needed instead of hardcoding (neheb)
+    * Use ``net-snmp-config --netsnmp-agent-libs`` instead of ``--agent-libs``
+    * bump boost requirement to 1.42 unconditionally
+
+  .. change::
+    :tags: Improvements, Robustness
+    :pullreq: 7864, 7865, 7708
+
+    Robustness improvements:
+
+    * Fix warnings reported by Coverity
+    * Initialize cURL before starting any thread
+    * Don't do unaligned memory access
+
+  .. change::
+    :tags: Improvements, Compliance
+    :pullreq: 7873
+
+    Always truncate when the additional records do not fit in a response (Kees Monshouwer)
+
+  .. change::
+    :tags: Improvements, Compliance
+    :pullreq: 7859
+
+    Remove ``disable-tcp`` option
+
+  .. change::
+    :tags: Improvements, Compliance
+    :pullreq: 7615
+
+    RKEY is missing algorithm field (DNS-Leo)
+
+  .. change::
+    :tags: Bug Fixes, Compliance
+    :pullreq: 7789, 7772, 7410
+
+    DNSSEC fixes:
+
+    * Don't sign insecure records with keys from other zones (Kees Monshouwer)
+    * always add DS for secure zones, broken since #7523 (Kees Monshouwer)
+    * fix referral response for DS queries (Kees Monshouwer)
+
+  .. change::
+    :tags: Improvements, Compliance
+    :pullreq: 7410
+
+    Ignore Path MTU Discovery on UDP server socket
+
+  .. change::
+    :tags: Features, Tools
+    :pullreq: 7832
+
+    add DoH support to sdig
+
+  .. change::
+    :tags: Bug Fixes, Tools
+    :pullreq: 7801
+    :tickets: 7667
+
+    pdnsutil: show DS for second and further keys too
+
+  .. change::
+    :tags: Features, Tools
+    :pullreq: 7655
+
+    dumresp: add TCP support
+
+  .. change::
+    :tags: Deprecation, API
+    :pullreq: 7797
+
+    API: mark ``set-ptr`` as deprecated (zeha)
+
+  .. change::
+    :tags: Robustness
+    :pullreq: 7790, 7569, 7662, 7503, 7517, 7587
+
+    Various robustness improvements:
+
+    * Do not busy loop if we get lots of notifies.
+    * Improve error reporting with garbage in the 'master' field of the database
+    * Do not exit on exception resolving addresses to notify
+    * Auth ringbuffer simmaries were case sensitive & accounted delegations incorrectly
+    * plug mysql_thread_init memory leak
+    * Ensure we increase the number of queued queries before decreasing it
+
+  .. change::
+    :tags: Performance, DNSSEC
+    :pullreq: 7523
+
+    disable dnssec pre-processing for non dnssec zones and avoid a lot of ``isSecuredZone()`` calls (Kees Monshouwer)
+
+  .. change::
+    :tags: Bug fixes
+    :pullreq: 7723
+
+    rename 'supermaster' option to 'superslave'
+
+  .. change::
+    :tags: Improvements, Webserver
+    :pullreq: 5932
+
+    improve logging in the web server
+
+  .. change::
+    :tags: Features, Tools
+    :pullreq: 7481
+
+    pdnsutil, dnswasher: add support for encrypting IP addresses
+
+  .. change::
+    :tags: Improvements
+    :pullreq: 7584
+
+    GSQL: Log more data in error messages
+
+.. changelog::
+  :version: 4.2.0-rc1
+  :released: 19th of March 2019
 
   .. change::
     :tags: Bug Fixes

--- a/docs/secpoll.zone
+++ b/docs/secpoll.zone
@@ -1,4 +1,4 @@
-@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2019060601 10800 3600 604800 10800
+@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2019061101 10800 3600 604800 10800
 @       3600    IN  NS  pdns-public-ns1.powerdns.com.
 @       3600    IN  NS  pdns-public-ns2.powerdns.com.
 ; Auth
@@ -48,6 +48,7 @@ auth-4.1.8.security-status                              60 IN TXT "1 OK"
 auth-4.2.0-alpha1.security-status                       60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-03.html"
 auth-4.2.0-beta1.security-status                        60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-03.html"
 auth-4.2.0-rc1.security-status                          60 IN TXT "1 OK"
+auth-4.2.0-rc2.security-status                          60 IN TXT "1 OK"
 
 ; Auth Debian
 auth-3.4.1-2.debian.security-status                     60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/3/security/powerdns-advisory-2015-01/ and https://doc.powerdns.com/3/security/powerdns-advisory-2015-02/ and https://doc.powerdns.com/3/security/powerdns-advisory-2016-02/ and https://doc.powerdns.com/3/security/powerdns-advisory-2016-03/ and https://doc.powerdns.com/3/security/powerdns-advisory-2016-04/ and https://doc.powerdns.com/3/security/powerdns-advisory-2016-05/"


### PR DESCRIPTION
### Short description
We are pleased to announce the second Release Candidate for Authoritative Server version 4.2.0. Many of our users have given RC1 a spin, and we very much appreciate their feedback.

RC2 contains a host of minor robustness improvements, some performance increases, and other improvements. We'll name a few here; for the rest, please see the changelog

* improved logging in gsqlbackend, and in the web server
* no more path discovery on UDP; no more disabling of TCP
* when truncating a response might strip out relevant glue, we instead truncate the whole packet now
* the `sdig` tool can query DoH servers now
* backend transactions (from either the API or pdnsutil) now use transactions correctly for most situations. This avoids funky 'my record disappeared for 1 millisecond and now everybody has that cached' situations.
* LUA records can now be configured to reuse their Lua state between invocations, giving a 7x speedup!

Please try this version, especially if you had any problems with RC1. With some luck, RC2 can become 4.2.0 with no changes in just a week or two!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
