### PR TITLE
auth: completely disable the packet when cache-ttl=0

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -180,8 +180,7 @@ Also AXFR a zone from a master with a lower serial.
 -  Integer
 -  Default: 20
 
-Seconds to store packets in the :ref:`packet-cache`. A value of 0 will disable
-the cache.
+Seconds to store packets in the :ref:`packet-cache`. A value of 0 will disable the cache.
 
 .. _setting-carbon-instance:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -180,7 +180,8 @@ Also AXFR a zone from a master with a lower serial.
 -  Integer
 -  Default: 20
 
-Seconds to store packets in the :ref:`packet-cache`.
+Seconds to store packets in the :ref:`packet-cache`. A value of 0 will disable
+the cache.
 
 .. _setting-carbon-instance:
 

--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -65,12 +65,11 @@ AuthPacketCache::~AuthPacketCache()
 
 bool AuthPacketCache::get(DNSPacket *p, DNSPacket *cached)
 {
-  cleanupIfNeeded();
-
   if(!d_ttl) {
-    (*d_statnummiss)++;
     return false;
   }
+
+  cleanupIfNeeded();
 
   uint32_t hash = canHashPacket(p->getString());
   p->setHash(hash);
@@ -113,6 +112,10 @@ bool AuthPacketCache::entryMatches(cmap_t::index<HashTag>::type::iterator& iter,
 
 void AuthPacketCache::insert(DNSPacket *q, DNSPacket *r, unsigned int maxTTL)
 {
+  if(!d_ttl) {
+    return;
+  }
+
   cleanupIfNeeded();
 
   if (ntohs(q->d.qdcount) != 1) {
@@ -192,6 +195,10 @@ bool AuthPacketCache::getEntryLocked(cmap_t& map, const std::string& query, uint
 /* clears the entire cache. */
 uint64_t AuthPacketCache::purge()
 {
+  if(!d_ttl) {
+    return 0;
+  }
+
   d_statnumentries->store(0);
 
   return purgeLockedCollectionsVector(d_maps);
@@ -210,6 +217,10 @@ uint64_t AuthPacketCache::purgeExact(const DNSName& qname)
 /* purges entries from the packetcache. If match ends on a $, it is treated as a suffix */
 uint64_t AuthPacketCache::purge(const string &match)
 {
+  if(!d_ttl) {
+    return 0;
+  }
+
   uint64_t delcount = 0;
 
   if(ends_with(match, "$")) {

--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -70,7 +70,11 @@ public:
   void setTTL(uint32_t ttl)
   {
     d_ttl = ttl;
-  }  
+  }
+  bool enabled()
+  {
+    return (d_ttl > 0);
+  }
 private:
 
   struct CacheEntry

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -437,7 +437,7 @@ try
       g_log<<": ";
     }
 
-    if((P->d.opcode != Opcode::Notify && P->d.opcode != Opcode::Update) && P->couldBeCached()) {
+    if(PC.enabled() && (P->d.opcode != Opcode::Notify && P->d.opcode != Opcode::Update) && P->couldBeCached()) {
       bool haveSomething=PC.get(P, &cached); // does the PacketCache recognize this question?
       if (haveSomething) {
         if(logDNSQueries)
@@ -463,7 +463,7 @@ try
       continue;
     }
         
-    if(logDNSQueries) 
+    if(PC.enabled() && logDNSQueries)
       g_log<<"packetcache MISS"<<endl;
 
     try {

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1546,8 +1546,7 @@ DNSPacket *PacketHandler::doQuestion(DNSPacket *p)
     if(doSigs)
       addRRSigs(d_dk, B, authSet, r->getRRS());
       
-    r->wrapup(); // needed for inserting in cache
-    if(!noCache && p->couldBeCached())
+    if(PC.enabled() && !noCache && p->couldBeCached())
       PC.insert(p, r, r->getMinTTL()); // in the packet cache
   }
   catch(DBException &e) {


### PR DESCRIPTION
This was inspired by #7802 but is more in line with the current query cache behaviour

closes #7802

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
