### PR TITLE
lua-recursor4: Add missing getregisteredname Lua function

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -544,6 +544,10 @@ RecursorLua4::RecursorLua4(const std::string& fname)
         g_snmpAgent->sendCustomTrap(str);
       }
     });
+
+  d_lw->writeFunction("getregisteredname", [](const DNSName &dname) {
+      return getRegisteredName(dname);
+    });
   
   ifstream ifs(fname);
   if(!ifs) {


### PR DESCRIPTION
It was drooped in 4b9a4e966257eb08d4803633f5726b5a144a8e99 and
forgotten in a3e7b73528a96a3642adb42dc1e729ea2e8765f4

(cherry picked from commit c2d0a26fecf13a40fa5a74a4cc13d9faef8b1669)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
