### PR TITLE
dnsdist: Exit when requested DoT/DoH support is not compiled in

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -541,7 +541,8 @@ void setupLuaConfig(bool client)
         }
       }
       catch(std::exception& e) {
-	g_outputBuffer="Error: "+string(e.what())+"\n";
+        g_outputBuffer="Error: "+string(e.what())+"\n";
+        errlog("Error while trying to listen on %s: %s\n", addr, string(e.what()));
       }
     });
 
@@ -1649,10 +1650,10 @@ void setupLuaConfig(bool client)
   });
 
   g_lua.writeFunction("addDOHLocal", [client](const std::string& addr, boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles, boost::optional<boost::variant<std::string, vector<pair<int, std::string> > > > urls, boost::optional<localbind_t> vars) {
+#ifdef HAVE_DNS_OVER_HTTPS
     if (client) {
       return;
     }
-#ifdef HAVE_DNS_OVER_HTTPS
     setLuaSideEffect();
     if (g_configurationDone) {
       g_outputBuffer="addDOHLocal cannot be used at runtime!\n";
@@ -1708,7 +1709,7 @@ void setupLuaConfig(bool client)
     cs->dohFrontend = frontend;
     g_frontends.push_back(std::move(cs));
 #else
-    g_outputBuffer="DNS over HTTPS support is not present!\n";
+    throw std::runtime_error("addDOHLocal() called but DNS over HTTPS support is not present!");
 #endif
   });
 
@@ -1750,7 +1751,7 @@ void setupLuaConfig(bool client)
         }
         catch(const std::exception& e) {
           g_outputBuffer="Error while trying to get DOH frontend with index " + std::to_string(index) + ": "+string(e.what())+"\n";
-          errlog("Error while trying to get get DOH frontend with index %zu: %s\n", index, string(e.what()));
+          errlog("Error while trying to get DOH frontend with index %zu: %s\n", index, string(e.what()));
         }
 #else
         g_outputBuffer="DNS over HTTPS support is not present!\n";
@@ -1765,9 +1766,9 @@ void setupLuaConfig(bool client)
       });
 
   g_lua.writeFunction("addTLSLocal", [client](const std::string& addr, boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles, boost::optional<localbind_t> vars) {
+#ifdef HAVE_DNS_OVER_TLS
         if (client)
           return;
-#ifdef HAVE_DNS_OVER_TLS
         setLuaSideEffect();
         if (g_configurationDone) {
           g_outputBuffer="addTLSLocal cannot be used at runtime!\n";
@@ -1841,7 +1842,7 @@ void setupLuaConfig(bool client)
           g_outputBuffer="Error: "+string(e.what())+"\n";
         }
 #else
-        g_outputBuffer="DNS over TLS support is not present!\n";
+        throw std::runtime_error("addTLSLocal() called but DNS over TLS support is not present!");
 #endif
       });
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to log to the console but happily start, and running `--check` would report no error (because it simulates `client` mode, see https://github.com/PowerDNS/pdns/pull/7181).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
