### PR TITLE
dnsdist: Send better HTTP status codes, handle ACL drops earlier

### DIFF
--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -61,6 +61,14 @@ struct DOHUnit
   DOHUnit** self{nullptr};
   int rsock;
   uint16_t qtype;
+  /* the error and status_code are set from
+     processDOHQuery() (which is executed in
+     the DOH client thread) so that the correct
+     response can be sent in on_dnsdist(),
+     after the DOHUnit has been passed back to
+     the main DoH thread.
+  */
+  uint16_t status_code{0};
   bool error{false};
   bool ednsAdded{false};
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to send a 500 status code when a query was dropped, regardless of the reason. This PR tries to return a more appropriate status code instead.
It also moves the ACL check right after the connection has been accepted, before the HTTP/2 and DNS parsing, to avoid wasting cycles on queries that we will end up dropping anyway. It's a bit more mean to HTTP clients that will get their TCP connection closed right away instead of a 403 status code, but I think it's worth it. Comments welcome :) 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
