### PR TITLE
auth: deprecate SOA autocomplete in pdnsutil check-zone

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -391,6 +391,9 @@ Overrides :ref:`setting-default-soa-edit`
 
 -  String
 
+.. deprecated:: 4.2.0
+  This setting has been deprecated and will be removed in 4.3.0
+
 Mail address to insert in the SOA record if none set in the backend.
 
 .. _setting-default-soa-name:
@@ -400,6 +403,9 @@ Mail address to insert in the SOA record if none set in the backend.
 
 -  String
 -  Default: a.misconfigured.powerdns.server
+
+.. deprecated:: 4.2.0
+  This setting has been deprecated and will be removed in 4.3.0
 
 Name to insert in the SOA record if none set in the backend.
 
@@ -1412,6 +1418,9 @@ signing-slave.
 -  Integer
 -  Default: 604800
 
+.. deprecated:: 4.2.0
+  This setting has been deprecated and will be removed in 4.3.0
+
 Default :ref:`types-soa` expire.
 
 .. _setting-soa-minimum-ttl:
@@ -1421,6 +1430,9 @@ Default :ref:`types-soa` expire.
 
 -  Integer
 -  Default: 3600
+
+.. deprecated:: 4.2.0
+  This setting has been deprecated and will be removed in 4.3.0
 
 Default :ref:`types-soa` minimum ttl.
 
@@ -1432,6 +1444,9 @@ Default :ref:`types-soa` minimum ttl.
 -  Integer
 -  Default: 10800
 
+.. deprecated:: 4.2.0
+  This setting has been deprecated and will be removed in 4.3.0
+
 Default :ref:`types-soa` refresh.
 
 .. _setting-soa-retry-default:
@@ -1441,6 +1456,9 @@ Default :ref:`types-soa` refresh.
 
 -  Integer
 -  Default: 3600
+
+.. deprecated:: 4.2.0
+  This setting has been deprecated and will be removed in 4.3.0
 
 Default :ref:`types-soa` retry.
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -347,6 +347,10 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
       vector<string>parts;
       stringtok(parts, rr.content);
 
+      if(parts.size() < 7) {
+        cout<<"[Warning] SOA autocomplete is deprecated, missing field(s) in SOA content: "<<rr.qname<<" IN " <<rr.qtype.getName()<< " '" << rr.content<<"'"<<endl;
+      }
+
       ostringstream o;
       o<<rr.content;
       for(int pleft=parts.size(); pleft < 7; ++pleft) {


### PR DESCRIPTION
### Short description

- default-soa-mail
- default-soa-name
- soa-refresh-default
- soa-retry-default
- soa-expire-default
- soa-minimum-ttl

Have reached their expiration date. They are incompatible with the API and the new lmdb backend.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
