### PR TITLE
backport: No longer filter DNSSEC metadata when DNSSEC is enabled in gsql

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -958,7 +958,7 @@ bool GSQLBackend::getAllDomainMetadata(const DNSName& name, std::map<std::string
       d_GetAllDomainMetadataQuery_stmt->nextRow(row);
       ASSERT_ROW_COLUMNS("get-all-domain-metadata-query", row, 2);
 
-      if (!isDnssecDomainMetadata(row[0]))
+      if (d_dnssecQueries || !isDnssecDomainMetadata(row[0]))
         meta[row[0]].push_back(row[1]);
     }
 


### PR DESCRIPTION
### Short description
As noted in #7705, gsql getAllDomainMetadata() did not return all domain
metadata.  This function would always filter DNSSEC related metadata, even
if a backend was configured to support DNSSEC.

Backport of #7706 

(cherry picked from commit d97e1ae1430a1e66893e8156bdf1c7232d3d0331)


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
