### PR TITLE
auth: remove redundant --no-config in makefile

### DIFF
--- a/builder-support/debian/authoritative/debian-buster/rules
+++ b/builder-support/debian/authoritative/debian-buster/rules
@@ -55,7 +55,7 @@ override_dh_installinit:
 
 override_dh_install:
 	dh_install
-	./pdns/pdns_server --no-config --config=default | sed \
+	./pdns/pdns_server --config=default | sed \
 	  -e 's!# module-dir=.*!!' \
 	  -e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/pdns.d!' \
 	  -e 's!# launch=.*!&\nlaunch=!' \

--- a/builder-support/debian/authoritative/debian-jessie/rules
+++ b/builder-support/debian/authoritative/debian-jessie/rules
@@ -52,7 +52,7 @@ override_dh_installinit:
 
 override_dh_install:
 	dh_install
-	./pdns/pdns_server --no-config --config=default | sed \
+	./pdns/pdns_server --config=default | sed \
 	  -e 's!# module-dir=.*!!' \
 	  -e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/pdns.d!' \
 	  -e 's!# launch=.*!&\nlaunch=!' \

--- a/builder-support/debian/authoritative/debian-stretch/rules
+++ b/builder-support/debian/authoritative/debian-stretch/rules
@@ -51,7 +51,7 @@ override_dh_installinit:
 
 override_dh_install:
 	dh_install
-	./pdns/pdns_server --no-config --config=default | sed \
+	./pdns/pdns_server --config=default | sed \
 	  -e 's!# module-dir=.*!!' \
 	  -e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/pdns.d!' \
 	  -e 's!# launch=.*!&\nlaunch=!' \

--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -44,7 +44,7 @@ override_dh_auto_install:
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
 	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist
-	./pdns_recursor --no-config --config=default | sed \
+	./pdns_recursor --config=default | sed \
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
 		-e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \

--- a/builder-support/debian/recursor/debian-jessie/rules
+++ b/builder-support/debian/recursor/debian-jessie/rules
@@ -43,7 +43,7 @@ override_dh_auto_install:
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
 	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	rm -f debian/tmp/etc/powerdns/recursor.conf-dist
-	./pdns_recursor --no-config --config=default | sed \
+	./pdns_recursor --config=default | sed \
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
 		-e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \

--- a/builder-support/debian/recursor/debian-stretch/rules
+++ b/builder-support/debian/recursor/debian-stretch/rules
@@ -44,7 +44,7 @@ override_dh_auto_install:
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
 	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist
-	./pdns_recursor --no-config --config=default | sed \
+	./pdns_recursor --config=default | sed \
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
 		-e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -238,7 +238,7 @@ make install DESTDIR=%{buildroot}
 %{__install} -D -p %{SOURCE1} %{buildroot}%{_initrddir}/pdns
 %endif
 
-%{buildroot}/usr/sbin/pdns_server --no-config --config=default | sed \
+%{buildroot}/usr/sbin/pdns_server --config=default | sed \
   -e 's!# daemon=.*!daemon=no!' \
   -e 's!# guardian=.*!guardian=no!' \
   -e 's!# launch=.*!&\\nlaunch=!' \

--- a/docs/backends/generic-sql.rst
+++ b/docs/backends/generic-sql.rst
@@ -190,7 +190,7 @@ the C function 'snprintf' which implies that substitutions are performed
 on the basis of %-placeholders.
 
 To see the default queries for a backend, run
-``pdns_server --no-config --launch=BACKEND --config``.
+``pdns_server --launch=BACKEND --config=default``.
 
 Regular Queries
 ^^^^^^^^^^^^^^^

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1264,7 +1264,7 @@ endif
 endif
 
 pdns.conf-dist: pdns_server
-	$(AM_V_GEN)./pdns_server --no-config --config=default 2>/dev/null > $@
+	$(AM_V_GEN)./pdns_server --config=default 2>/dev/null > $@
 
 testrunner_SOURCES = \
 	arguments.cc \

--- a/pdns/recursordist/docs/getting-started.rst
+++ b/pdns/recursordist/docs/getting-started.rst
@@ -34,7 +34,7 @@ Configuring the Recursor
 The configuration file is called ``recursor.conf`` and is located in the ``SYSCONFDIR`` defined at compile-time.
 This is usually ``/etc/powerdns``, ``/etc/pdns``, ``/etc/pdns-recursor``, ``/usr/local/etc`` or similar.
 
-Run ``pdns_recursor --no-config --config | grep config-dir`` to find this location on you installation.
+Run ``pdns_recursor --config=default | grep config-dir`` to find this location on you installation.
 
 The PowerDNS Recursor listens on the local loopback interface by default, this can be changed with the :ref:`setting-local-address` setting.
 


### PR DESCRIPTION
### Short description
During the configuration generation step in the build process for auth, the flag --no-config in 'pdns_server --no-config --config' is redundant as the --config flag already prevents auth from loading configurations as per https://github.com/PowerDNS/pdns/blob/master/pdns/receiver.cc#L418-L419

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
