### PR TITLE
dnsdist: Deduplicate frontends entries with carbon and prometheus

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -104,12 +104,20 @@ try
           str<<base<<"tcpavgqueriesperconnection" << ' '<< state->tcpAvgQueriesPerConnection.load() << " " << now << "\r\n";
           str<<base<<"tcpavgconnectionduration" << ' '<< state->tcpAvgConnectionDuration.load() << " " << now << "\r\n";
         }
+
+        std::map<std::string,uint64_t> frontendDuplicates;
         for(const auto& front : g_frontends) {
           if (front->udpFD == -1 && front->tcpFD == -1)
             continue;
 
           string frontName = front->local.toString() + ":" + std::to_string(front->local.getPort()) +  (front->udpFD >= 0 ? "_udp" : "_tcp");
           boost::replace_all(frontName, ".", "_");
+          auto dupPair = frontendDuplicates.insert({frontName, 1});
+          if (dupPair.second == false) {
+            frontName = frontName + "_" + std::to_string(dupPair.first->second);
+            ++dupPair.first->second;
+          }
+
           const string base = namespace_name + "." + hostname + "." + instance_name + ".frontends." + frontName + ".";
           str<<base<<"queries" << ' ' << front->queries.load() << " " << now << "\r\n";
           str<<base<<"tcpdiedreadingquery" << ' '<< front->tcpDiedReadingQuery.load() << " " << now << "\r\n";
@@ -121,6 +129,7 @@ try
           str<<base<<"tcpavgqueriesperconnection" << ' '<< front->tcpAvgQueriesPerConnection.load() << " " << now << "\r\n";
           str<<base<<"tcpavgconnectionduration" << ' '<< front->tcpAvgConnectionDuration.load() << " " << now << "\r\n";
         }
+
         auto localPools = g_pools.getLocal();
         for (const auto& entry : *localPools) {
           string poolName = entry.first;
@@ -148,6 +157,7 @@ try
 
 #ifdef HAVE_DNS_OVER_HTTPS
         {
+          std::map<std::string,uint64_t> dohFrontendDuplicates;
           const string base = "dnsdist." + hostname + ".main.doh.";
           for(const auto& doh : g_dohlocals) {
             string name = doh->d_local.toStringWithPort();
@@ -155,6 +165,12 @@ try
             boost::replace_all(name, ":", "_");
             boost::replace_all(name, "[", "_");
             boost::replace_all(name, "]", "_");
+
+            auto dupPair = dohFrontendDuplicates.insert({name, 1});
+            if (dupPair.second == false) {
+              name = name + "_" + std::to_string(dupPair.first->second);
+              ++dupPair.first->second;
+            }
 
             vector<pair<const char*, const std::atomic<uint64_t>&>> v{
               {"http-connects", doh->d_httpconnects},


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is a work-around, and not a very pretty one, to avoid messing up our carbon/prometheus metrics when we add the same frontends several times with `addLocal()`, `addTLSLocal()` or `addDOHLocal()` and `reuseport`.
The proper fix would be to be able to provide the number of threads directly as a parameter to the `add*Local()` and provide aggregated metrics (but also per-thread metrics, at least for the number of queries, so we can check that the distribution done by the kernel is working correctly), but this would require an important refactoring and we are too late in the 1.4.0 release process for that IMHO.

We will to implement the deduplication for the DoH metrics in prometheus as well, either in this PR if https://github.com/PowerDNS/pdns/pull/7933 is merged first, or in #7933 otherwise.

Fixes https://github.com/PowerDNS/pdns/issues/7358.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
