### PR TITLE
Add debug informations to the MPlexer unit tests, tracking a failure

### DIFF
--- a/pdns/test-mplexer.cc
+++ b/pdns/test-mplexer.cc
@@ -90,9 +90,9 @@ BOOST_AUTO_TEST_CASE(test_MPlexer) {
                         *calledPtr = true;
                 };
   mplexer->addReadFD(pipes[0],
-                      readCB,
-                      &readCBCalled,
-                      &ttd);
+                     readCB,
+                     &readCBCalled,
+                     &ttd);
 
   /* not ready for reading yet */
   readyFDs.clear();
@@ -124,6 +124,25 @@ BOOST_AUTO_TEST_CASE(test_MPlexer) {
   /* both should be available */
   readyFDs.clear();
   mplexer->getAvailableFDs(readyFDs, 0);
+  if (readyFDs.size() == 1) {
+    /* something is wrong, we need some debug infos */
+    cerr<<"FDMultiPlexer implementation is "<<mplexer->getName()<<endl;
+    cerr<<"Watching "<<mplexer->getWatchedFDCount(false)<<" FDs for read and "<<mplexer->getWatchedFDCount(true)<<" for write"<<endl;
+    cerr<<"pipes[0] is "<<pipes[0]<<endl;
+    cerr<<"pipes[1] is "<<pipes[1]<<endl;
+    cerr<<"The file descripttor returned as ready is "<<readyFDs.at(0)<<endl;
+    char buffer[2];
+    ssize_t res = read(pipes[0], &buffer[0], sizeof(buffer));
+    cerr<<"Reading from pipes[0] returns "<<res<<endl;
+    if (res == -1) {
+      cerr<<"errno is "<<errno<<endl;
+    }
+    res = write(pipes[1], "0", 1);
+    cerr<<"Writing to pipes[1] returns "<<res<<endl;
+    if (res == -1) {
+      cerr<<"errno is "<<errno<<endl;
+    }
+  }
   BOOST_REQUIRE_EQUAL(readyFDs.size(), 2);
 
   readCBCalled = false;

--- a/pdns/test-mplexer.cc
+++ b/pdns/test-mplexer.cc
@@ -133,14 +133,16 @@ BOOST_AUTO_TEST_CASE(test_MPlexer) {
     cerr<<"The file descripttor returned as ready is "<<readyFDs.at(0)<<endl;
     char buffer[2];
     ssize_t res = read(pipes[0], &buffer[0], sizeof(buffer));
+    int saved = errno;
     cerr<<"Reading from pipes[0] returns "<<res<<endl;
     if (res == -1) {
-      cerr<<"errno is "<<errno<<endl;
+      cerr<<"errno is "<<saved<<endl;
     }
     res = write(pipes[1], "0", 1);
+    saved = errno;
     cerr<<"Writing to pipes[1] returns "<<res<<endl;
     if (res == -1) {
-      cerr<<"errno is "<<errno<<endl;
+      cerr<<"errno is "<<saved<<endl;
     }
   }
   BOOST_REQUIRE_EQUAL(readyFDs.size(), 2);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
I can't reproduce the failure on Arch nor stretch, but I have now seen it occur two times on our CI tests, the most recent one in CircleCI, so I would like to understand what is happening.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
