### PR TITLE
Secpoll code: fixes and clean-ups

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -207,6 +207,7 @@ pdns_server_SOURCES = \
 	resolver.cc resolver.hh \
 	responsestats.cc responsestats.hh responsestats-auth.cc \
 	rfc2136handler.cc \
+	secpoll.cc secpoll.hh \
 	secpoll-auth.cc secpoll-auth.hh \
 	serialtweaker.cc \
 	sha.hh \

--- a/pdns/dnsdistdist/dnsdist-secpoll.cc
+++ b/pdns/dnsdistdist/dnsdist-secpoll.cc
@@ -192,7 +192,7 @@ void doSecPoll(const std::string& suffix)
   }
 
   const std::string pkgv(PACKAGEVERSION);
-  bool releaseVersion = pkgv.find("0.0.") != 0;
+  bool releaseVersion = std::count(pkgv.begin(), pkgv.end(), '.') == 2;
   const std::string version = "dnsdist-" + pkgv;
   std::string queriedName = version.substr(0, 63) + ".security-status." + suffix;
 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -161,8 +161,8 @@ pdns_recursor_SOURCES = \
 	root-addresses.hh \
 	root-dnssec.hh \
 	rpzloader.cc rpzloader.hh \
-	secpoll-recursor.cc \
-	secpoll-recursor.hh \
+	secpoll-recursor.cc secpoll-recursor.hh \
+	secpoll.cc secpoll.hh \
 	sholder.hh \
 	sillyrecords.cc \
 	snmp-agent.hh snmp-agent.cc \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -252,6 +252,7 @@ testrunner_SOURCES = \
 	recursor_cache.cc recursor_cache.hh \
 	responsestats.cc \
 	root-dnssec.hh \
+	secpoll.cc \
 	sillyrecords.cc \
 	sholder.hh \
 	sstuff.hh \
@@ -278,6 +279,7 @@ testrunner_SOURCES = \
 	test-rcpgenerator_cc.cc \
 	test-recpacketcache_cc.cc \
 	test-recursorcache_cc.cc \
+	test-secpoll_cc.cc \
 	test-signers.cc \
 	test-syncres_cc.hh \
 	test-syncres_cc.cc \

--- a/pdns/recursordist/secpoll.cc
+++ b/pdns/recursordist/secpoll.cc
@@ -1,0 +1,1 @@
+../secpoll.cc

--- a/pdns/recursordist/secpoll.hh
+++ b/pdns/recursordist/secpoll.hh
@@ -1,0 +1,1 @@
+../secpoll.hh

--- a/pdns/recursordist/test-secpoll_cc.cc
+++ b/pdns/recursordist/test-secpoll_cc.cc
@@ -28,12 +28,12 @@ bool checkBasicMessage3(const PDNSException &ex) {
 }
 
 bool checkBasicMessage4(const PDNSException &ex) {
-  BOOST_CHECK_EQUAL(ex.reason, "Could not parse status number: stoi: no conversion");
+  BOOST_CHECK(ex.reason.find("Could not parse status number: stoi") == 0);
   return true;
 }
 
 bool checkBasicMessage5(const PDNSException &ex) {
-  BOOST_CHECK_EQUAL(ex.reason, "Could not parse status number: stoi: no conversion");
+  BOOST_CHECK(ex.reason.find("Could not parse status number: stoi") == 0);
   return true;
 }
 

--- a/pdns/recursordist/test-secpoll_cc.cc
+++ b/pdns/recursordist/test-secpoll_cc.cc
@@ -1,0 +1,85 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <boost/test/unit_test.hpp>
+
+#include "test-common.hh"
+#include "secpoll.hh"
+
+BOOST_AUTO_TEST_SUITE(test_secpoll_cc)
+
+bool checkBasicMessage1(const PDNSException &ex) {
+  BOOST_CHECK_EQUAL(ex.reason, "Had empty answer on NOERROR RCODE");
+  return true;
+}
+
+bool checkBasicMessage2(const PDNSException &ex) {
+  BOOST_CHECK_EQUAL(ex.reason, "RCODE was not NOERROR but " + RCode::to_s(1));
+  return true;
+}
+
+bool checkBasicMessage3(const PDNSException &ex) {
+  BOOST_CHECK_EQUAL(ex.reason, "No TXT record found in response");
+  return true;
+}
+
+bool checkBasicMessage4(const PDNSException &ex) {
+  BOOST_CHECK_EQUAL(ex.reason, "Could not parse status number: stoi: no conversion");
+  return true;
+}
+
+bool checkBasicMessage5(const PDNSException &ex) {
+  BOOST_CHECK_EQUAL(ex.reason, "Could not parse status number: stoi: no conversion");
+  return true;
+}
+
+BOOST_AUTO_TEST_CASE(test_secpoll_basic) {
+
+  BOOST_CHECK(!isReleaseVersion(""));
+  BOOST_CHECK(isReleaseVersion(".."));
+  BOOST_CHECK(!isReleaseVersion("..."));
+
+
+  int status = 0;
+  std::string message;
+
+  BOOST_CHECK_EXCEPTION(processSecPoll(0, std::vector<DNSRecord>(), status, message), PDNSException, checkBasicMessage1);
+  BOOST_CHECK_EXCEPTION(processSecPoll(1, std::vector<DNSRecord>(), status, message), PDNSException, checkBasicMessage2);
+
+  std::vector<DNSRecord> v;
+
+  addRecordToList(v, DNSName("aname"), QType::A, "1.2.3.4");
+  BOOST_CHECK_EXCEPTION(processSecPoll(0, v, status, message), PDNSException, checkBasicMessage3);
+
+  v.clear();
+  addRecordToList(v, DNSName("aname"), QType::TXT, "");
+  BOOST_CHECK_EXCEPTION(processSecPoll(0, v, status, message), PDNSException, checkBasicMessage4);
+
+  v.clear();
+  addRecordToList(v, DNSName("aname"), QType::TXT, "1NOQUOTES");
+  processSecPoll(0, v, status, message);
+  BOOST_CHECK_EQUAL(status, 1);
+  BOOST_CHECK_EQUAL(message, "");
+
+  v.clear();
+  addRecordToList(v, DNSName("aname"), QType::TXT, "\"1OK\"");
+  processSecPoll(0, v, status, message);
+  BOOST_CHECK_EQUAL(status, 1);
+  BOOST_CHECK_EQUAL(message, "");
+
+  v.clear();
+  addRecordToList(v, DNSName("aname"), QType::TXT, "\"1 OK\"");
+  processSecPoll(0, v, status, message);
+  BOOST_CHECK_EQUAL(status, 1);
+  BOOST_CHECK_EQUAL(message, "OK");
+
+  v.clear();
+  addRecordToList(v, DNSName("aname"), QType::TXT, "\"X OK\"");
+  BOOST_CHECK_EXCEPTION(processSecPoll(0, v, status, message), PDNSException, checkBasicMessage5);
+
+}
+BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/secpoll-auth.cc
+++ b/pdns/secpoll-auth.cc
@@ -62,10 +62,10 @@ void doSecPoll(bool first)
   }
   else {
     string pkgv(PACKAGEVERSION);
-    if(pkgv.find("0.0.") != 0)
-      g_log<<Logger::Warning<<"Could not retrieve security status update for '" + pkgv + "' on '"+query+"', RCODE = "<< RCode::to_s(res)<<endl;
-    else
+    if (std::count(pkgv.begin(), pkgv.end(), '.') > 2)
       g_log<<Logger::Warning<<"Not validating response for security status update, this is a non-release version."<<endl;
+    else
+      g_log<<Logger::Warning<<"Could not retrieve security status update for '" + pkgv + "' on '"+query+"', RCODE = "<< RCode::to_s(res)<<endl;
   }
 
   if(security_status == 1 && first) {

--- a/pdns/secpoll-recursor.cc
+++ b/pdns/secpoll-recursor.cc
@@ -78,10 +78,10 @@ void doSecPoll(time_t* last_secpoll)
     g_security_message = split.second;
   }
   else {
-    if(pkgv.find("0.0.") != 0)
-      g_log<<Logger::Warning<<"Could not retrieve security status update for '" +pkgv+ "' on '"<<query<<"', RCODE = "<< RCode::to_s(res)<<endl;
-    else
+    if (std::count(pkgv.begin(), pkgv.end(), '.') > 2)
       g_log<<Logger::Warning<<"Ignoring response for security status update, this is a non-release version."<<endl;
+    else
+      g_log<<Logger::Warning<<"Could not retrieve security status update for '" +pkgv+ "' on '"<<query<<"', RCODE = "<< RCode::to_s(res)<<endl;
 
     if(g_security_status == 1) // it was ok, now it is unknown
       g_security_status = 0;

--- a/pdns/secpoll-recursor.cc
+++ b/pdns/secpoll-recursor.cc
@@ -7,6 +7,7 @@
 #include "arguments.hh"
 #include "version.hh"
 #include "validate-recursor.hh"
+#include "secpoll.hh"
 
 #include <stdint.h>
 #ifndef PACKAGEVERSION 
@@ -36,7 +37,7 @@ void doSecPoll(time_t* last_secpoll)
   }
 
   vector<DNSRecord> ret;
-  
+
   string version = "recursor-" +pkgv;
   string qstring(version.substr(0, 63)+ ".security-status."+::arg()["security-poll-suffix"]);
 
@@ -48,7 +49,7 @@ void doSecPoll(time_t* last_secpoll)
 
   vState state = Indeterminate;
   DNSName query(qstring);
-  int res=sr.beginResolve(query, QType(QType::TXT), 1, ret);
+  int res = sr.beginResolve(query, QType(QType::TXT), 1, ret);
 
   if (g_dnssecmode != DNSSECMode::Off && res) {
     state = sr.getValidationState();
@@ -61,44 +62,33 @@ void doSecPoll(time_t* last_secpoll)
     return;
   }
 
-  if (res != 0) { // Not NOERROR
-    if(g_security_status == 1) // it was ok, now it is unknown
-      g_security_status = 0;
-
-    if (std::count(pkgv.begin(), pkgv.end(), '.') > 2) {
-      g_log<<Logger::Warning<<"Ignoring response for security status update, this is a non-release version."<<endl;
-      return;
-    }
-    g_log<<Logger::Warning<<"Could not retrieve security status update for '" +pkgv+ "' on '"<<query<<"', RCODE = "<< RCode::to_s(res)<<endl;
+  if (res == RCode::NXDomain && !isReleaseVersion(pkgv)) {
+    g_log<<Logger::Warning<<"Not validating response for security status update, this is a non-release version"<<endl;
     return;
   }
 
-  if (ret.empty()) { // Empty NOERROR
-    if(g_security_status == 1) // it was ok, now it is unknown
-      g_security_status = 0;
-    g_log<<Logger::Warning<<"Could not retrieve security status update for '" +pkgv+ "' on '"<<query<<"', had empty answer, RCODE = "<< RCode::to_s(res)<<endl;
+  string security_message;
+  int security_status = g_security_status;
+
+  try {
+    processSecPoll(res, ret, security_status, security_message);
+  } catch(const PDNSException &pe) {
+    g_security_status = security_status;
+    g_log<<Logger::Warning<<"Could not retrieve security status update for '" << pkgv << "' on '"<< query << "': "<<pe.reason<<endl;
     return;
   }
 
-  string content;
-  for(const auto&r : ret) {
-    if(r.d_type == QType::TXT)
-      content = r.d_content->getZoneRepresentation();
+  g_security_message = security_message;
+
+  if(g_security_status != 1 && security_status == 1) {
+    g_log<<Logger::Warning << "Polled security status of version "<<pkgv<<", no known issues reported: " <<g_security_message<<endl;
   }
-
-  if(!content.empty() && content[0]=='"' && content[content.size()-1]=='"') {
-    content=content.substr(1, content.length()-2);
-  }
-
-  pair<string, string> split = splitField(content, ' ');
-
-  g_security_status = std::stoi(split.first);
-  g_security_message = split.second;
-
-  if(g_security_status == 2) {
+  if(security_status == 2) {
     g_log<<Logger::Error<<"PowerDNS Security Update Recommended: "<<g_security_message<<endl;
   }
-  else if(g_security_status == 3) {
+  if(security_status == 3) {
     g_log<<Logger::Error<<"PowerDNS Security Update Mandatory: "<<g_security_message<<endl;
   }
+
+  g_security_status = security_status;
 }

--- a/pdns/secpoll.cc
+++ b/pdns/secpoll.cc
@@ -1,0 +1,73 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string>
+#include <vector>
+#include "dnsrecords.hh"
+#include "pdnsexception.hh"
+#include "misc.hh"
+
+bool isReleaseVersion(const std::string &version) {
+  return std::count(version.begin(), version.end(), '.') == 2;
+}
+
+void processSecPoll(const int res, const std::vector<DNSRecord> &ret, int &secPollStatus, std::string &secPollMessage) {
+  secPollMessage.clear();
+  if (res != 0) { // not NOERROR
+    if(secPollStatus == 1) // it was ok, now it is unknown
+      secPollStatus = 0;
+    throw PDNSException("RCODE was not NOERROR but " + RCode::to_s(res));
+  }
+
+  if (ret.empty()) { // empty NOERROR... wat?
+    if(secPollStatus == 1) // it was ok, now it is unknown
+      secPollStatus = 0;
+    throw PDNSException("Had empty answer on NOERROR RCODE");
+  }
+
+  DNSRecord record;
+  for (auto const &r: ret) {
+    if (r.d_type == QType::TXT && r.d_place == DNSResourceRecord::Place::ANSWER) {
+      record = r;
+      break;
+    }
+  }
+
+  if (record.d_name.empty()) {
+    throw PDNSException("No TXT record found in response");
+  }
+
+  auto recordContent = getRR<TXTRecordContent>(record);
+  if (recordContent == nullptr) {
+    throw PDNSException("Could not parse TXT record content");
+  }
+  string content = recordContent->d_text;
+
+  pair<string, string> split = splitField(unquotify(content), ' ');
+
+  try {
+    secPollStatus = std::stoi(split.first);
+  } catch (const std::exception &e) {
+    throw PDNSException(std::string("Could not parse status number: ") + e.what());
+  }
+  secPollMessage = split.second;
+}

--- a/pdns/secpoll.hh
+++ b/pdns/secpoll.hh
@@ -20,10 +20,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include "namespaces.hh"
-#include "dnsparser.hh"
+#include <string>
+#include <vector>
+#include "dnsrecords.hh"
 
-void stubParseResolveConf();
-bool resolversDefined();
-int stubDoResolve(const DNSName& qname, uint16_t qtype, vector<DNSZoneRecord>& ret);
-int stubDoResolve(const DNSName& qname, uint16_t qtype, vector<DNSRecord>& ret);
+/* Parses the result of a security poll, will throw a PDNSException when it could not be parsed, secPollStatus is
+ * set correctly regardless whether or not an exception was thrown.
+ *
+ * res: DNS Rcode result from the secpoll
+ * ret: Records returned during secpoll
+ * secPollStatus: The actual secpoll status, pass the current status in here and it is changed to the new status
+ * secPollMessage: Will be cleared and filled with the message from the secpoll message
+ */
+void processSecPoll(const int res, const std::vector<DNSRecord> &ret, int &secPollStatus, std::string &secPollMessage);
+bool isReleaseVersion(const std::string &version);

--- a/pdns/stubresolver.cc
+++ b/pdns/stubresolver.cc
@@ -169,3 +169,12 @@ int stubDoResolve(const DNSName& qname, uint16_t qtype, vector<DNSZoneRecord>& r
   }
   return RCode::ServFail;
 }
+
+int stubDoResolve(const DNSName& qname, uint16_t qtype, vector<DNSRecord>& ret) {
+  vector<DNSZoneRecord> ret2;
+  int res = stubDoResolve(qname, qtype, ret2);
+  for (const auto &r : ret2) {
+    ret.push_back(r.dr);
+  }
+  return res;
+}


### PR DESCRIPTION
### Short description

* Fix log messages for non-releases (see #7895)
* Refactor auth and rec secpoll code to return early and catch an additional condition
* Set the security state to unknown in the auth on error (when state is OK)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)