### PR TITLE
rec backport to 4.2.x: Check if -latomic is needed instead of hardcoding

### DIFF
--- a/m4/pdns_check_os.m4
+++ b/m4/pdns_check_os.m4
@@ -35,16 +35,21 @@ AC_DEFUN([PDNS_CHECK_OS],[
   AM_CONDITIONAL([HAVE_LINUX], [test "x$have_linux" = "xyes"])
   AM_CONDITIONAL([HAVE_SOLARIS], [test "x$have_solaris" = "xyes"])
 
-  case "$host" in
-  mips* | powerpc-* )
-    AC_MSG_CHECKING([whether the linker accepts -latomic])
-    LDFLAGS="-latomic $LDFLAGS"
-    AC_LINK_IFELSE([m4_default([],[AC_LANG_PROGRAM()])],
-      [AC_MSG_RESULT([yes])],
-      [AC_MSG_ERROR([Unable to link against libatomic, cannot continue])]
-    )
-    ;;
-  esac
+  AC_MSG_CHECKING([whether -latomic is needed for __atomic builtins])
+  AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM([[#include <stdint.h>]],
+       [[uint64_t val = 0; __atomic_add_fetch(&val, 1, __ATOMIC_RELAXED);]]
+    )],
+    [AC_MSG_RESULT([no])],
+    [LIBS="$LIBS -latomic"
+     AC_LINK_IFELSE(
+       [AC_LANG_PROGRAM([[#include <stdint.h>]],
+               [[uint64_t val = 0; __atomic_add_fetch(&val, 1, __ATOMIC_RELAXED);]]
+       )],
+       [AC_MSG_RESULT([yes])],
+       [AC_MSG_FAILURE([libatomic needed, but linking with -latomic failed, cannot continue])]
+    )]
+  )
 
   AC_SUBST(THREADFLAGS)
   AC_SUBST([DYNLINKFLAGS], [-export-dynamic])


### PR DESCRIPTION
This avoids having a huge list of platforms which can change over time.

(cherry picked from commit 1735eb98cd295c0aec2c2cd4cff436a786dbc70f)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
