### PR TITLE
auth: add edited_serial to Zone object

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -919,6 +919,9 @@ definitions:
       notified_serial:
         type: integer
         description: 'The SOA serial notifications have been sent out for'
+      edited_serial:
+        type: integer
+        description: 'The SOA serial as seen in query responses. Calculated using the SOA-EDIT metadata, default-soa-edit and default-soa-edit-signed settings'
       masters:
         type: array
         items:

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -336,6 +336,7 @@ static Json::object getZoneInfo(const DomainInfo& di, DNSSECKeeper *dk) {
     { "account", di.account },
     { "masters", masters },
     { "serial", (double)di.serial },
+    { "edited_serial", (double)calculateEditSOA(di.serial, *dk, di.zone) },
     { "notified_serial", (double)di.notified_serial },
     { "last_check", (double)di.last_check }
   };

--- a/regression-tests.api/runtests.py
+++ b/regression-tests.api/runtests.py
@@ -38,6 +38,7 @@ gsqlite3-dnssec=on
 gsqlite3-database="""+SQLITE_DB+"""
 module-dir=../regression-tests/modules
 bind-config=bindbackend.conf
+default-soa-edit=INCEPTION-INCREMENT
 """
 
 BINDBACKEND_CONF_TPL = """

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -59,7 +59,7 @@ class Zones(ApiTestCase):
         print(example_com)
         required_fields = ['id', 'url', 'name', 'kind']
         if is_auth():
-            required_fields = required_fields + ['masters', 'last_check', 'notified_serial', 'serial', 'account']
+            required_fields = required_fields + ['masters', 'last_check', 'notified_serial', 'edited_serial', 'serial', 'account']
             self.assertNotEquals(example_com['serial'], 0)
         elif is_recursor():
             required_fields = required_fields + ['recursion_desired', 'servers']
@@ -99,7 +99,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
     def test_create_zone(self):
         # soa_edit_api has a default, override with empty for this test
         name, payload, data = self.create_zone(serial=22, soa_edit_api='')
-        for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'soa_edit_api', 'soa_edit', 'account'):
+        for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'edited_serial', 'soa_edit_api', 'soa_edit', 'account'):
             self.assertIn(k, data)
             if k in payload:
                 self.assertEquals(data[k], payload[k])
@@ -113,6 +113,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         # Because we had confusion about dots, check that the DB is without dots.
         dbrecs = get_db_records(name, 'SOA')
         self.assertEqual(dbrecs[0]['content'], expected_soa.replace('. ', ' '))
+        self.assertNotEquals(data['serial'], data['edited_serial'])
 
     def test_create_zone_with_soa_edit_api(self):
         # soa_edit_api wins over serial


### PR DESCRIPTION
### Short description
This gives API consumers the ability to see the edited SOA serial. The
API code used the same functions as the DNSSECKeeper, so this serial
will match the one send to clients in response to queries.

Closes #7961

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)