### PR TITLE
catch name & IP parse errors during outgoing notify preparations 

### DIFF
--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -244,32 +244,18 @@ private:
 class FindNS
 {
 public:
-  vector<string> lookup(const DNSName &name, UeberBackend *b, const DNSName& zone)
+  vector<string> lookup(const DNSName &name, UeberBackend *b)
   {
     vector<string> addresses;
 
     this->resolve_name(&addresses, name);
     
     if(b) {
-      b->lookup(QType(QType::ANY),name);
-      while (true) {
-        try {
-          DNSZoneRecord rr;
-          if (!b->get(rr))
-            break;
-          if (rr.dr.d_type == QType::A || rr.dr.d_type == QType::AAAA)
+        b->lookup(QType(QType::ANY),name);
+        DNSZoneRecord rr;
+        while(b->get(rr))
+          if(rr.dr.d_type == QType::A || rr.dr.d_type==QType::AAAA)
             addresses.push_back(rr.dr.d_content->getZoneRepresentation());   // SOL if you have a CNAME for an NS
-        }
-        // After an exception, b can be inconsistent so break
-        catch (PDNSException &ae) {
-          L << Logger::Error << "Could not lookup address for nameserver " << name << " in zone " << zone << ", cannot notify: " << ae.reason << endl;
-          break;
-        }
-        catch (std::exception &e) {
-          L << Logger::Error << "Could not lookup address for nameserver " << name << " in zone " << zone << ", cannot notify: " << e.what() << endl;
-          break;
-        }
-      }
     }
     return addresses;
   }

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -56,7 +56,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
       nsset.insert(getRR<NSRecordContent>(rr.dr)->getNS().toString());
 
     for(set<string>::const_iterator j=nsset.begin();j!=nsset.end();++j) {
-      vector<string> nsips=fns.lookup(DNSName(*j), B, di.zone);
+      vector<string> nsips=fns.lookup(DNSName(*j), B);
       if(nsips.empty())
         L<<Logger::Warning<<"Unable to queue notification of domain '"<<di.zone<<"': nameservers do not resolve!"<<endl;
       else

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -50,6 +50,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
   FindNS fns;
 
 
+  try {
   if (d_onlyNotify.size()) {
     B->lookup(QType(QType::NS), di.zone);
     while(B->get(rr))
@@ -77,6 +78,16 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
       hasQueuedItem=true;
     }
   }
+  }
+  catch (PDNSException &ae) {
+    L << Logger::Error << "Error looking up name servers for " << di.zone << ", cannot notify: " << ae.reason << endl;
+    return;
+  }
+  catch (std::exception &e) {
+    L << Logger::Error << "Error looking up name servers for " << di.zone << ", cannot notify: " << e.what() << endl;
+    return;
+  }
+
 
   set<string> alsoNotify(d_alsoNotify);
   B->alsoNotifies(di.zone, &alsoNotify);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -491,7 +491,7 @@ bool TCPNameserver::canDoAXFR(shared_ptr<DNSPacket> q)
         while(B->get(rr)) 
           nsset.insert(DNSName(rr.content));
         for(const auto & j: nsset) {
-          vector<string> nsips=fns.lookup(j, s_P->getBackend(),q->qdomain);
+          vector<string> nsips=fns.lookup(j, s_P->getBackend());
           for(vector<string>::const_iterator k=nsips.begin();k!=nsips.end();++k) {
             // cerr<<"got "<<*k<<" from AUTO-NS"<<endl;
             if(*k == q->getRemote().toString())


### PR DESCRIPTION
### Short description
#7663 (backport of #7662) did not catch name parse errors. This PR moves the exception `catch` up so that we catch both name and IP parse errors. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
