### PR TITLE
Minor fixes to dnsdist docs

### DIFF
--- a/pdns/dnsdistdist/docs/advanced/axfr.rst
+++ b/pdns/dnsdistdist/docs/advanced/axfr.rst
@@ -18,7 +18,7 @@ The first issue can be solved by routing SOA, AXFR and IXFR requests explicitly 
 The second one might require allowing AXFR/IXFR from the :program:`dnsdist` source address
 and moving the source address check to :program:`dnsdist`'s side::
 
-  addAction(AndRule({OrRule({QTypeRule(DNSQType.AXFR), QTypeRule(DNSQTypeIXFR)}), NotRule(makeRule("192.168.1.0/24"))}), RCodeAction(DNSRCode.REFUSED))
+  addAction(AndRule({OrRule({QTypeRule(DNSQType.AXFR), QTypeRule(DNSQType.IXFR)}), NotRule(makeRule("192.168.1.0/24"))}), RCodeAction(DNSRCode.REFUSED))
 
 .. versionchanged:: 1.4.0
   Before 1.4.0, the QTypes were in the ``dnsdist`` namespace. Use ``dnsdist.AXFR`` and ``dnsdist.IXFR`` in these versions.

--- a/pdns/dnsdistdist/docs/reference/constants.rst
+++ b/pdns/dnsdistdist/docs/reference/constants.rst
@@ -123,7 +123,7 @@ These constants represent an Action that can be returned from :func:`LuaAction` 
 DNSQType
 --------
 
-.. versionchanged:: 1.3.0
+.. versionchanged:: 1.4.0
   The prefix is changed from ``dnsdist.`` to ``DNSQType``.
 
 All named `QTypes <https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4>`__ are available as constants, prefixed with ``DNSQType.``, e.g.:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This fixes some minor issues in the dnsdist docs:

DNSQType was introduced in 1.4.0, not 1.3.0
Typo in AXFR example (DNSQTypeIXFR)


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
