### PR TITLE
docs: Add missing words in pdns_control man page

### DIFF
--- a/docs/manpages/pdns_control.1.rst
+++ b/docs/manpages/pdns_control.1.rst
@@ -59,9 +59,9 @@ current-config
 ^^^^^^^^^^^^^^
 
 Show the currently running configuration. The output has the same
-format as ``pdns_server --config``. You'll notice that all the are
-uncommented. This is because PowerDNS simply has values, and the
-default isn't known at runtime.
+format as ``pdns_server --config``. You'll notice that all the
+configuration values are uncommented. This is because PowerDNS
+simply has values, and the default isn't known at runtime.
 
 cycle
 ^^^^^


### PR DESCRIPTION
### Short description
This patch adds some missing words for the "pdns_control
current-config" command in the pdns_control man page.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
