### PR TITLE
Make pdnsutil set-publish-cds default to SHA-256 only

### DIFF
--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -109,7 +109,7 @@ unset-nsec3 *ZONE*
 set-publish-cds *ZONE* [*DIGESTALGOS*]
     Set *ZONE* to respond to queries for its CDS records. the optional
     argument *DIGESTALGOS* should be a comma-separated list of DS
-    algorithms to use. By default, this is 1,2 (SHA1 and SHA2-256).
+    algorithms to use. By default, this is 2 (SHA-256).
 set-publish-cdnskey *ZONE*
     Set *ZONE* to publish CDNSKEY records.
 unset-publish-cds *ZONE*

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2013,7 +2013,7 @@ try
     cout<<"set-presigned ZONE                 Use presigned RRSIGs from storage"<<endl;
     cout<<"set-publish-cdnskey ZONE           Enable sending CDNSKEY responses for ZONE"<<endl;
     cout<<"set-publish-cds ZONE [DIGESTALGOS] Enable sending CDS responses for ZONE, using DIGESTALGOS as signature algorithms"<<endl;
-    cout<<"                                   DIGESTALGOS should be a comma separated list of numbers, it is '1,2' by default"<<endl;
+    cout<<"                                   DIGESTALGOS should be a comma separated list of numbers, it is '2' by default"<<endl;
     cout<<"add-meta ZONE KIND VALUE           Add zone metadata, this adds to the existing KIND"<<endl;
     cout<<"                   [VALUE ...]"<<endl;
     cout<<"set-meta ZONE KIND [VALUE] [VALUE] Set zone metadata, optionally providing a value. *No* value clears meta"<<endl;
@@ -2571,7 +2571,7 @@ try
 
     // If DIGESTALGOS is unset
     if(cmds.size() == 2)
-      cmds.push_back("1,2");
+      cmds.push_back("2");
 
     if (! dk.setPublishCDS(DNSName(cmds[1]), cmds[2])) {
       cerr << "Could not set publishing for CDS records for "<< cmds[1]<<endl;

--- a/regression-tests/tests/publishing-cds-cdnskey/expected_result
+++ b/regression-tests/tests/publishing-cds-cdnskey/expected_result
@@ -1,4 +1,3 @@
-0	secure-delegated.dnssec-parent.com.	IN	CDS	86400	54319 8 1 a28ebe791e9cc7f4c2821131be367326ddd7434c
 0	secure-delegated.dnssec-parent.com.	IN	CDS	86400	54319 8 2 a0b9c38cd324182af0ef66830d0a0e85a1d58979c9834e18c871779e040857b7
 0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDS 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...
 0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDS 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...
@@ -12,13 +11,11 @@ Reply to question for qname='secure-delegated.dnssec-parent.com.', qtype=CDS
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='secure-delegated.dnssec-parent.com.', qtype=CDNSKEY
 0	secure-delegated.dnssec-parent.com.	IN	CDNSKEY	86400	257 3 8 AwEAAZd9R7SWWGqA12oG7Ls+h3b0/IAyMj/Pqn/ZuKWM/OdpxT/cn2xwLDhkdmqP/pUqAzvyFPyd4kTqrmLfbohBwA7+07pBVa4qf/jxlHivdMNUD72H+dUYqBlmhCC6l3eG+8FZi2tkdwn8kUoa9kyLMtrEaFnOd/oUQbmNvIDp+8VWv1cSnRJ8UXKdXLl0smpvC7h1K2AUiC5oGIYQTCYWwYRM1wCbb+q1fbFCdkbI7OQW/h7Pj30eLpIuz0bJj4vdKXXZHK8clSdTMAFm6rQsNDI0w7QdCgaDmTn3b6TF2UJi4eDnh7uDbSpUd1mI5XWNw4C6WrUmebFLfiry6vqdiIc=
-0	secure-delegated.dnssec-parent.com.	IN	CDS	86400	54319 8 1 a28ebe791e9cc7f4c2821131be367326ddd7434c
 0	secure-delegated.dnssec-parent.com.	IN	CDS	86400	54319 8 2 a0b9c38cd324182af0ef66830d0a0e85a1d58979c9834e18c871779e040857b7
 0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDNSKEY 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...
 0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDNSKEY 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...
 0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDS 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...
 0	secure-delegated.dnssec-parent.com.	IN	RRSIG	86400	CDS 8 3 86400 [expiry] [inception] [keytag] secure-delegated.dnssec-parent.com. ...
-0	cdnskey-cds-test.com.	IN	CDS	86400
 0	cdnskey-cds-test.com.	IN	CDS	86400
 0	cdnskey-cds-test.com.	IN	RRSIG	86400
 2	.	IN	OPT	32768	
@@ -30,7 +27,6 @@ Reply to question for qname='cdnskey-cds-test.com.', qtype=CDS
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='cdnskey-cds-test.com.', qtype=CDNSKEY
 0	cdnskey-cds-test.com.	IN	CDNSKEY	86400
-0	cdnskey-cds-test.com.	IN	CDS	86400
 0	cdnskey-cds-test.com.	IN	CDS	86400
 0	cdnskey-cds-test.com.	IN	RRSIG	86400
 0	cdnskey-cds-test.com.	IN	RRSIG	86400


### PR DESCRIPTION
### Short description
`pdnsutil set-publish-cds` defaults to enabling both SHA-1 and SHA-256. This changes it to use SHa-256 only.

(It's just a default, anyone can still enable SHA-1 if they want to.)

Reasons:

* ~~Burning hatred for all things SHA-1.~~
* Popular TLDs including .com use only SHA-256, so a resolver that only supports SHA-1 is terribly old and not very useful.
* `secure-zone` uses ECDSA by default. Are there even any resolvers that support ECDSA but don't support SHA-256?
* [BIND 9.15.0 did it.](https://ftp.isc.org/isc/bind9/9.15.0/RELEASE-NOTES-bind-9.15.0.html)

I've run part of the test suite, but not actually tried it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)