### PR TITLE
Add LMDB backend to centos-7

### DIFF
--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -175,6 +175,16 @@ This package contains the geoip backend for %{name}
 It allows different answers to DNS queries coming from different
 IP address ranges or based on the geoipgraphic location
 
+%package backend-lmdb
+Summary: LMDB backend for %{name}
+Group: System Environment/Daemons
+Requires: %{name}%{?_isa} = %{version}-%{release}
+BuildRequires: lmdb-devel
+%global backends %{backends} lmdb
+
+%description backend-lmdb
+This package contains the lmdb backend for %{name}
+
 %package backend-tinydns
 Summary: TinyDNS backend for %{name}
 Group: System Environment/Daemons
@@ -407,6 +417,9 @@ fi
 
 %files backend-geoip
 %{_libdir}/%{name}/libgeoipbackend.so
+
+%files backend-lmdb
+%{_libdir}/%{name}/liblmdbbackend.so
 
 %files backend-tinydns
 %{_libdir}/%{name}/libtinydnsbackend.so


### PR DESCRIPTION
### Short description
This creates the pdns-backend-lmdb package for CentOS 7 builds

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)