### PR TITLE
dnsdist: Fix handling of backend connection failing over TCP

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -71,8 +71,8 @@ static std::unique_ptr<Socket> setupTCPDownstream(shared_ptr<DownstreamState>& d
 
   do {
     vinfolog("TCP connecting to downstream %s (%d)", ds->remote.toStringWithPort(), downstreamFailures);
-    result = std::unique_ptr<Socket>(new Socket(ds->remote.sin4.sin_family, SOCK_STREAM, 0));
     try {
+      result = std::unique_ptr<Socket>(new Socket(ds->remote.sin4.sin_family, SOCK_STREAM, 0));
       if (!IsAnyAddress(ds->sourceAddr)) {
         SSetsockopt(result->getHandle(), SOL_SOCKET, SO_REUSEADDR, 1);
 #ifdef IP_BIND_ADDRESS_NO_PORT
@@ -750,24 +750,24 @@ static void sendQueryToBackend(std::shared_ptr<IncomingTCPConnectionState>& stat
     return;
   }
 
-  while (state->d_downstreamFailures < state->d_ds->retries)
-  {
-    state->d_downstreamConnection = getConnectionToDownstream(ds, state->d_downstreamFailures, now);
-
-    if (!state->d_downstreamConnection) {
-      ++ds->tcpGaveUp;
-      ++state->d_ci.cs->tcpGaveUp;
-      vinfolog("Downstream connection to %s failed %d times in a row, giving up.", ds->getName(), state->d_downstreamFailures);
-      return;
+  if (state->d_downstreamFailures < state->d_ds->retries) {
+    try {
+      state->d_downstreamConnection = getConnectionToDownstream(ds, state->d_downstreamFailures, now);
     }
+    catch (const std::runtime_error& e) {
+      state->d_downstreamConnection.reset();
+    }
+  }
 
-    handleDownstreamIO(state, now);
+  if (!state->d_downstreamConnection) {
+    ++ds->tcpGaveUp;
+    ++state->d_ci.cs->tcpGaveUp;
+    vinfolog("Downstream connection to %s failed %d times in a row, giving up.", ds->getName(), state->d_downstreamFailures);
     return;
   }
 
-  ++ds->tcpGaveUp;
-  ++state->d_ci.cs->tcpGaveUp;
-  vinfolog("Downstream connection to %s failed %u times in a row, giving up.", ds->getName(), state->d_downstreamFailures);
+  handleDownstreamIO(state, now);
+  return;
 }
 
 static void handleQuery(std::shared_ptr<IncomingTCPConnectionState>& state, struct timeval& now)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- The creation of the `Socket` object can throw if we run out of file descriptors ;
- Catch exceptions thrown from `setupTCPDownstream()` earlier, we don't care why it failed later, only that it did.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
