### PR TITLE
Add SLAVE-RENOTIFY zone metadata support

### DIFF
--- a/docs/domainmetadata.rst
+++ b/docs/domainmetadata.rst
@@ -172,6 +172,16 @@ This metadata can also be set using the
 and ``set-publish-cds``. For an example for an :rfc:`7344` key rollover,
 see the :doc:`guides/kskrollcdnskey`.
 
+.. _metadata-slave-renotify:
+
+SLAVE-RENOTIFY
+--------------
+.. versionadded:: 4.3.0
+
+If set to 1, will make PowerDNS renotify the slaves after an AXFR is received from a master.
+Any other value means that no renotifies are done. If not set at all, action will depend on
+the :ref:`setting-slave-renotify` setting.
+
 .. _metadata-soa-edit:
 
 SOA-EDIT

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1404,6 +1404,8 @@ This setting will make PowerDNS renotify the slaves after an AXFR is
 *received* from a master. This is useful when using when running a
 signing-slave.
 
+See :ref:`metadata-slave-renotify` to set this per-zone.
+
 .. _setting-soa-expire-default:
 
 ``soa-expire-default``

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -599,7 +599,19 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote)
 
 
     g_log<<Logger::Error<<"AXFR done for '"<<domain<<"', zone committed with serial number "<<zs.soa_serial<<endl;
+
+    bool renotify = false;
     if(::arg().mustDo("slave-renotify"))
+      renotify = true;
+    vector<string> meta;
+    if (B.getDomainMetadata(domain, "SLAVE-RENOTIFY", meta) && meta.size() > 0) {
+      if (meta[0] == "1") {
+        renotify = true;
+      } else {
+        renotify = false;
+      }
+    }
+    if(renotify)
       notifyDomain(domain);
   }
   catch(DBException &re) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -823,6 +823,7 @@ static bool isValidMetadataKind(const string& kind, bool readonly) {
     "PRESIGNED",
     "PUBLISH-CDNSKEY",
     "PUBLISH-CDS",
+    "SLAVE-RENOTIFY",
     "SOA-EDIT",
     "TSIG-ALLOW-AXFR",
     "TSIG-ALLOW-DNSUPDATE"


### PR DESCRIPTION
### Short description
Adds support for new per-zone metadata SLAVE-RENOTIFY, which does the same thing as the global slave-renotify setting, but per-zone.

Needed for example when pdns is acting as a slave for a hidden master, but still needs to notify upstream slaves for specific zones.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
