### PR TITLE
SuffixMatchNode:add: Accept more types

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -205,7 +205,32 @@ void setupLuaBindings(bool client)
   g_lua.registerFunction("empty",(bool (DNSNameSet::*)()) &DNSNameSet::empty);
 
   /* SuffixMatchNode */
-  g_lua.registerFunction("add",(void (SuffixMatchNode::*)(const DNSName&)) &SuffixMatchNode::add);
+  g_lua.registerFunction<void (SuffixMatchNode::*)(const boost::variant<DNSName, string, vector<pair<int, DNSName>>, vector<pair<int, string>>> &name)>("add", [](SuffixMatchNode &smn, const boost::variant<DNSName, string, vector<pair<int, DNSName>>, vector<pair<int, string>>> &name) {
+      if (name.type() == typeid(DNSName)) {
+          auto n = boost::get<DNSName>(name);
+          smn.add(n);
+          return;
+      }
+      if (name.type() == typeid(string)) {
+          auto n = boost::get<string>(name);
+          smn.add(n);
+          return;
+      }
+      if (name.type() == typeid(vector<pair<int, DNSName>>)) {
+          auto names = boost::get<vector<pair<int, DNSName>>>(name);
+          for (auto const n : names) {
+            smn.add(n.second);
+          }
+          return;
+      }
+      if (name.type() == typeid(vector<pair<int, string>>)) {
+          auto names = boost::get<vector<pair<int, string>>>(name);
+          for (auto const n : names) {
+            smn.add(n.second);
+          }
+          return;
+      }
+  });
   g_lua.registerFunction("check",(bool (SuffixMatchNode::*)(const DNSName&) const) &SuffixMatchNode::check);
 
   /* NetmaskGroup */

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1072,10 +1072,14 @@ If you are looking for exact name matching, your might want to consider using a 
   Represent a set of DNS suffixes for quick matching.
 
   .. method:: SuffixMatchNode:add(name)
+    .. versionchanged:: 1.4.0
+      This method now accepts strings, lists of DNSNames and lists of strings.
 
     Add a suffix to the current set.
 
     :param DNSName name: The suffix to add to the set.
+    :param string name: The suffix to add to the set.
+    :param table name: The suffixes to add to the set. Elements of the table should be of the same type, either DNSName or string.
 
   .. method:: SuffixMatchNode:check(name) -> bool
 

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -394,6 +394,11 @@ struct SuffixMatchNode
       d_nodes.insert(dnsname);
     }
 
+    void add(const std::string& name)
+    {
+      add(DNSName(name));
+    }
+
     void add(std::vector<std::string> labels)
     {
       d_tree.add(labels, true);

--- a/regression-tests.dnsdist/test_CheckConfig.py
+++ b/regression-tests.dnsdist/test_CheckConfig.py
@@ -37,6 +37,10 @@ class TestCheckConfig(unittest.TestCase):
             addAction(RegexRule("evil[0-9]{4,}\\\\.regex\\\\.tests\\\\.powerdns\\\\.com$"), RCodeAction(DNSRCode.REFUSED))
             mySMN = newSuffixMatchNode()
             mySMN:add(newDNSName("nameAndQtype.tests.powerdns.com."))
+            mySMN:add("string.smn.tests.powerdns.com.")
+            mySMN:add("string-no-dot.smn.tests.powerdns.com")
+            mySMN:add({"string-one.smn.tests.powerdns.com", "string-two.smn.tests.powerdns.com"})
+            mySMN:add({newDNSName("dnsname-one.smn.tests.powerdns.com"), newDNSName("dnsname-two.smn.tests.powerdns.com")})
             addAction(AndRule{SuffixMatchNodeRule(mySMN), QTypeRule("TXT")}, RCodeAction(DNSRCode.NOTIMP))
             addAction(makeRule("drop.test.powerdns.com."), DropAction())
         """


### PR DESCRIPTION
### Short description
The SuffixMatchNode now also accepts a table of DNSNames, a table of
string, and singular strings.

Closes https://github.com/PowerDNS/pdns/issues/7390.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)