### PR TITLE
auth: bindbackend: use metadata for also-notifies as well

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -444,6 +444,13 @@ void Bind2Backend::alsoNotifies(const DNSName& domain, set<string> *ips)
   for(set<string>::iterator i = this->alsoNotify.begin(); i != this->alsoNotify.end(); i++) {
     (*ips).insert(*i);
   }
+  // check metadata too if available
+  vector<string> meta;
+  if (getDomainMetadata(domain, "ALSO-NOTIFY", meta)) {
+    for(const auto& str: meta) {
+      (*ips).insert(str);
+    }
+  }
   ReadLock rl(&s_state_lock);  
   for(state_t::const_iterator i = s_state.begin(); i != s_state.end() ; ++i) {
     if(i->d_name == domain) {


### PR DESCRIPTION
### Short description
Makes bindbackend consult metadata, if available, for ALSO-NOTIFY entries. named.conf entries are  also still used too if set.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
