### PR TITLE
Explicitly align the buffer used for cmsgs

### DIFF
--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -71,11 +71,13 @@ static void* recvThread(const vector<Socket*>* sockets)
 #if HAVE_RECVMMSG
   vector<struct mmsghdr> buf(100);
   for(auto& m : buf) {
-    fillMSGHdr(&m.msg_hdr, new struct iovec, new char[512], 512, new char[1500], 1500, new ComboAddress("127.0.0.1"));
+    cmsgbuf_aligned *cbuf = new cmsgbuf_aligned;
+    fillMSGHdr(&m.msg_hdr, new struct iovec, cbuf, sizeof(*cbuf), new char[1500], 1500, new ComboAddress("127.0.0.1"));
   }
 #else
   struct msghdr buf;
-  fillMSGHdr(&buf, new struct iovec, new char[512], 512, new char[1500], 1500, new ComboAddress("127.0.0.1"));
+  cmsgbuf_aligned *cbuf = new cmsgbuf_aligned;
+  fillMSGHdr(&buf, new struct iovec, cbuf, sizeof(*cbuf), new char[1500], 1500, new ComboAddress("127.0.0.1"));
 #endif
 
   while(!g_done) {
@@ -183,7 +185,7 @@ static void sendPackets(const vector<Socket*>* sockets, const vector<vector<uint
   struct Unit {
     struct msghdr msgh;
     struct iovec iov;
-    char cbuf[256];
+    cmsgbuf_aligned cbuf;
   };
   vector<unique_ptr<Unit> > units;
   int ret;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1618,11 +1618,11 @@ static void MultipleMessagesUDPClientThread(ClientState* cs, LocalHolders& holde
   struct MMReceiver
   {
     char packet[4096];
-    /* used by HarvestDestinationAddress */
-    cmsgbuf_aligned cbuf;
     ComboAddress remote;
     ComboAddress dest;
     struct iovec iov;
+    /* used by HarvestDestinationAddress */
+    cmsgbuf_aligned cbuf;
   };
   const size_t vectSize = g_udpVectorSize;
   /* the actual buffer is larger because:

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -191,7 +191,7 @@ void DNSProxy::mainloop(void)
 
     struct msghdr msgh;
     struct iovec iov;
-    char cbuf[256];
+    cmsgbuf_aligned cbuf;
     ComboAddress fromaddr;
 
     for(;;) {
@@ -284,7 +284,7 @@ void DNSProxy::mainloop(void)
         msgh.msg_control=NULL;
 
         if(i->second.anyLocal) {
-          addCMsgSrcAddr(&msgh, cbuf, i->second.anyLocal.get_ptr(), 0);
+          addCMsgSrcAddr(&msgh, &cbuf, i->second.anyLocal.get_ptr(), 0);
         }
         if(sendmsg(i->second.outsock, &msgh, 0) < 0)
           g_log<<Logger::Warning<<"dnsproxy.cc: Error sending reply with sendmsg (socket="<<i->second.outsock<<"): "<<strerror(errno)<<endl;

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -221,7 +221,7 @@ ssize_t sendfromto(int sock, const char* data, size_t len, int flags, const Comb
 {
   struct msghdr msgh;
   struct iovec iov;
-  char cbuf[256];
+  cmsgbuf_aligned cbuf;
 
   /* Set up iov and msgh structures. */
   memset(&msgh, 0, sizeof(struct msghdr));
@@ -233,7 +233,7 @@ ssize_t sendfromto(int sock, const char* data, size_t len, int flags, const Comb
   msgh.msg_namelen = to.getSocklen();
 
   if(from.sin4.sin_family) {
-    addCMsgSrcAddr(&msgh, cbuf, &from, 0);
+    addCMsgSrcAddr(&msgh, &cbuf, &from, 0);
   }
   else {
     msgh.msg_control=NULL;
@@ -244,7 +244,7 @@ ssize_t sendfromto(int sock, const char* data, size_t len, int flags, const Comb
 // be careful: when using this for receive purposes, make sure addr->sin4.sin_family is set appropriately so getSocklen works!
 // be careful: when using this function for *send* purposes, be sure to set cbufsize to 0!
 // be careful: if you don't call addCMsgSrcAddr after fillMSGHdr, make sure to set msg_control to NULL
-void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, char* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr)
+void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, cmsgbuf_aligned* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr)
 {
   iov->iov_base = data;
   iov->iov_len  = datalen;
@@ -294,7 +294,7 @@ size_t sendMsgWithOptions(int fd, const char* buffer, size_t len, const ComboAdd
 {
   struct msghdr msgh;
   struct iovec iov;
-  char cbuf[256];
+  cmsgbuf_aligned cbuf;
 
   /* Set up iov and msgh structures. */
   memset(&msgh, 0, sizeof(struct msghdr));
@@ -312,7 +312,7 @@ size_t sendMsgWithOptions(int fd, const char* buffer, size_t len, const ComboAdd
   msgh.msg_flags = 0;
 
   if (localItf != 0 && local) {
-    addCMsgSrcAddr(&msgh, cbuf, local, localItf);
+    addCMsgSrcAddr(&msgh, &cbuf, local, localItf);
   }
 
   iov.iov_base = reinterpret_cast<void*>(const_cast<char*>(buffer));

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1057,7 +1057,7 @@ void setSocketIgnorePMTU(int sockfd);
 bool IsAnyAddress(const ComboAddress& addr);
 bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destination);
 bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv);
-void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, char* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr);
+void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, cmsgbuf_aligned* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr);
 ssize_t sendfromto(int sock, const char* data, size_t len, int flags, const ComboAddress& from, const ComboAddress& to);
 size_t sendMsgWithOptions(int fd, const char* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags);
 

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -885,8 +885,6 @@ Regex::Regex(const string &expr)
 // with msgh->msg_controllen, please refer to https://github.com/PowerDNS/pdns/pull/3962
 // first.
 // Note that cmsgbuf should be aligned the same as a struct cmsghdr
-// This can be achieved by declaring it as
-//    union { struct cmsghdr hdr; char buf[CMSG_SPACE(spaceneeded)]; } cmsgbuf;
 void addCMsgSrcAddr(struct msghdr* msgh, cmsgbuf_aligned* cmsgbuf, const ComboAddress* source, int itfIndex)
 {
   struct cmsghdr *cmsg = NULL;

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -884,7 +884,10 @@ Regex::Regex(const string &expr)
 // if you end up here because valgrind told you were are doing something wrong
 // with msgh->msg_controllen, please refer to https://github.com/PowerDNS/pdns/pull/3962
 // first.
-void addCMsgSrcAddr(struct msghdr* msgh, void* cmsgbuf, const ComboAddress* source, int itfIndex)
+// Note that cmsgbuf should be aligned the same as a struct cmsghdr
+// This can be achieved by declaring it as
+//    union { struct cmsghdr hdr; char buf[CMSG_SPACE(spaceneeded)]; } cmsgbuf;
+void addCMsgSrcAddr(struct msghdr* msgh, cmsgbuf_aligned* cmsgbuf, const ComboAddress* source, int itfIndex)
 {
   struct cmsghdr *cmsg = NULL;
 

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -515,8 +515,11 @@ private:
 };
 
 union ComboAddress;
+
+typedef union { struct cmsghdr hdr; char buf[256]; } cmsgbuf_aligned;
+
 /* itfIndex is an interface index, as returned by if_nametoindex(). 0 means default. */
-void addCMsgSrcAddr(struct msghdr* msgh, void* cmsgbuf, const ComboAddress* source, int itfIndex);
+void addCMsgSrcAddr(struct msghdr* msgh, cmsgbuf_aligned* cbuf, const ComboAddress* source, int itfIndex);
 
 unsigned int getFilenumLimit(bool hardOrSoft=0);
 void setFilenumLimit(unsigned int lim);

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -516,6 +516,7 @@ private:
 
 union ComboAddress;
 
+// An aligned type to hold cmsgbufs. See https://man.openbsd.org/CMSG_DATA
 typedef union { struct cmsghdr hdr; char buf[256]; } cmsgbuf_aligned;
 
 /* itfIndex is an interface index, as returned by if_nametoindex(). 0 means default. */

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -295,13 +295,13 @@ void UDPNameserver::send(DNSPacket *p)
 
   struct msghdr msgh;
   struct iovec iov;
-  char cbuf[256];
+  cmsgbuf_aligned cbuf;
 
-  fillMSGHdr(&msgh, &iov, cbuf, 0, (char*)buffer.c_str(), buffer.length(), &p->d_remote);
+  fillMSGHdr(&msgh, &iov, &cbuf, 0, (char*)buffer.c_str(), buffer.length(), &p->d_remote);
 
   msgh.msg_control=NULL;
   if(p->d_anyLocal) {
-    addCMsgSrcAddr(&msgh, cbuf, p->d_anyLocal.get_ptr(), 0);
+    addCMsgSrcAddr(&msgh, &cbuf, p->d_anyLocal.get_ptr(), 0);
   }
   DLOG(g_log<<Logger::Notice<<"Sending a packet to "<< p->getRemote() <<" ("<< buffer.length()<<" octets)"<<endl);
   if(buffer.length() > p->getMaxReplyLen()) {
@@ -320,10 +320,10 @@ DNSPacket *UDPNameserver::receive(DNSPacket *prefilled, std::string& buffer)
 
   struct msghdr msgh;
   struct iovec iov;
-  char cbuf[256];
+  cmsgbuf_aligned cbuf;
 
   remote.sin6.sin6_family=AF_INET6; // make sure it is big enough
-  fillMSGHdr(&msgh, &iov, cbuf, sizeof(cbuf), &buffer.at(0), buffer.size(), &remote);
+  fillMSGHdr(&msgh, &iov, &cbuf, sizeof(cbuf), &buffer.at(0), buffer.size(), &remote);
   
   int err;
   vector<struct pollfd> rfds= d_rfds;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1659,7 +1659,7 @@ static void startDoResolve(void *p)
       msgh.msg_control=NULL;
 
       if(g_fromtosockets.count(dc->d_socket)) {
-	      addCMsgSrcAddr(&msgh, &cbuf, &dc->d_local, 0);
+        addCMsgSrcAddr(&msgh, &cbuf, &dc->d_local, 0);
       }
       if(sendmsg(dc->d_socket, &msgh, 0) < 0 && g_logCommonErrors) 
         g_log<<Logger::Warning<<"Sending UDP reply to client "<<dc->getRemote()<<" failed with: "<<strerror(errno)<<endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
OpenBSDs man page http://man.openbsd.org/CMSG_DATA recommend explicit alignment of the buffer to hold cmsg data. 
This probably does not matter on non-strict alignment architectures, but is good practise.
(Disclaimer: I was one of the devs involved in this change to the man page, see http://cvsweb.openbsd.org/src/share/man/man3/CMSG_DATA.3).

Noticed while studying #7981

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
