### PR TITLE
auth: add new metadata ALLOW-AXFR-ONLY-FROM

### DIFF
--- a/docs/domainmetadata.rst
+++ b/docs/domainmetadata.rst
@@ -46,6 +46,18 @@ Each ACL has its own row in the database:
 To disallow all IP's, except those explicitly allowed by domainmetadata
 records, add ``allow-axfr-ips=`` to ``pdns.conf``.
 
+.. _metadata-allow-axfr-only-from:
+
+ALLOW-AXFR-ONLY-FROM
+--------------------
+.. versionadded:: 4.3.0
+
+Same as ``ALLOW-AXFR-FROM``, but allows only the specified subnets.
+Global ``allow-axfr-ips=`` setting and any possible ``ALLOW-AXFR-FROM`` entries
+are ignored. Empty value "" will deny transfers from all addresses.
+
+GSS/TSIG authenticated AXFRs will still work regardless of this setting.
+
 .. _metadata-api-rectify:
 
 API-RECTIFY

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3007,9 +3007,9 @@ try
     }
     DNSName zone(cmds[1]);
     string kind = cmds[2];
-    static vector<string> multiMetaWhitelist = {"ALLOW-AXFR-FROM", "ALLOW-DNSUPDATE-FROM",
-      "ALSO-NOTIFY", "TSIG-ALLOW-AXFR", "TSIG-ALLOW-DNSUPDATE", "GSS-ALLOW-AXFR-PRINCIPAL",
-      "PUBLISH-CDS"};
+    static vector<string> multiMetaWhitelist = {"ALLOW-AXFR-FROM", "ALLOW-AXFR-ONLY-FROM",
+      "ALLOW-DNSUPDATE-FROM", "ALSO-NOTIFY", "TSIG-ALLOW-AXFR", "TSIG-ALLOW-DNSUPDATE",
+      "GSS-ALLOW-AXFR-PRINCIPAL", "PUBLISH-CDS"};
     bool clobber = true;
     if (cmds[0] == "add-meta") {
       clobber = false;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -808,6 +808,7 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
 static bool isValidMetadataKind(const string& kind, bool readonly) {
   static vector<string> builtinOptions {
     "ALLOW-AXFR-FROM",
+    "ALLOW-AXFR-ONLY-FROM",
     "AXFR-SOURCE",
     "ALLOW-DNSUPDATE-FROM",
     "TSIG-ALLOW-DNSUPDATE",


### PR DESCRIPTION
### Short description
Same as ALLOW-AXFR-FROM, but allows only the specified subnets.
Global allow-axfr-ips= setting and any possible ALLOW-AXFR-FROM entries are ignored. Empty value "" will deny transfers from all addresses.

GSS/TSIG authenticated AXFRs will still work regardless of this setting.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
