### PR TITLE
dnsdist: Add `quiet` parameter to NetmaskGroupRule

### DIFF
--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -303,8 +303,8 @@ void setupLuaRules()
       return std::shared_ptr<DNSRule>(new SuffixMatchNodeRule(smn, quiet ? *quiet : false));
     });
 
-  g_lua.writeFunction("NetmaskGroupRule", [](const NetmaskGroup& nmg, boost::optional<bool> src) {
-      return std::shared_ptr<DNSRule>(new NetmaskGroupRule(nmg, src ? *src : true));
+  g_lua.writeFunction("NetmaskGroupRule", [](const NetmaskGroup& nmg, boost::optional<bool> src, boost::optional<bool> quiet) {
+      return std::shared_ptr<DNSRule>(new NetmaskGroupRule(nmg, src ? *src : true, quiet ? *quiet : false));
     });
 
   g_lua.writeFunction("benchRule", [](std::shared_ptr<DNSRule> rule, boost::optional<int> times_, boost::optional<string> suffix_)  {

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -183,9 +183,10 @@ protected:
 class NetmaskGroupRule : public NMGRule
 {
 public:
-  NetmaskGroupRule(const NetmaskGroup& nmg, bool src) : NMGRule(nmg)
+  NetmaskGroupRule(const NetmaskGroup& nmg, bool src, bool quiet = false) : NMGRule(nmg)
   {
       d_src = src;
+      d_quiet = quiet;
   }
   bool matches(const DNSQuestion* dq) const override
   {
@@ -197,13 +198,18 @@ public:
 
   string toString() const override
   {
+    string ret = "Src: ";
     if(!d_src) {
-        return "Dst: "+d_nmg.toString();
+        ret = "Dst: ";
     }
-    return "Src: "+d_nmg.toString();
+    if (d_quiet) {
+      return ret + "in-group";
+    }
+    return ret + d_nmg.toString();
   }
 private:
   bool d_src;
+  bool d_quiet;
 };
 
 class TimedIPSetRule : public DNSRule, boost::noncopyable

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -625,7 +625,7 @@ These ``DNSRule``\ s be one of the following items:
 
   :param NetMaskGroup nmg: The NetMaskGroup to match on
   :param bool src: Whether to match source or destination address of the packet. Defaults to true (matches source)
-  :param bool quiet: Do not return the list of matched netmasks. Default is false.
+  :param bool quiet: Do not display the list of matched netmasks in Rules. Default is false.
 
 .. function:: OpcodeRule(code)
 
@@ -769,7 +769,7 @@ These ``DNSRule``\ s be one of the following items:
   To match domain names exactly, see :func:`QNameSetRule`.
 
   :param SuffixMatchNode smb: The SuffixMatchNode to match on
-  :param bool quiet: Do not return the list of matched domains. Default is false.
+  :param bool quiet: Do not display the list of matched domains in Rules. Default is false.
 
 .. function:: TagRule(name [, value])
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -613,7 +613,10 @@ These ``DNSRule``\ s be one of the following items:
 
   :param int qps: The number of queries per second allowed, above this number the traffic is **not** matched anymore
 
-.. function:: NetmaskGroupRule(nmg[, src])
+.. function:: NetmaskGroupRule(nmg[, src[, quiet]])
+
+  .. versionchanged:: 1.4.0
+    ``quiet`` parameter added
 
   Matches traffic from/to the network range specified in ``nmg``.
 
@@ -622,6 +625,7 @@ These ``DNSRule``\ s be one of the following items:
 
   :param NetMaskGroup nmg: The NetMaskGroup to match on
   :param bool src: Whether to match source or destination address of the packet. Defaults to true (matches source)
+  :param bool quiet: Do not return the list of matched netmasks. Default is false.
 
 .. function:: OpcodeRule(code)
 


### PR DESCRIPTION
### Short description
This allows the user to hide the list of matched IPs in `showRules()`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)