### PR TITLE
dnsdist: improve Lua error reporting during config load

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1967,13 +1967,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   setupLuaRules();
   setupLuaVars();
 
-  std::ifstream ifs(config);
-  if(!ifs)
-    warnlog("Unable to read configuration from '%s'", config);
-  else
-    vinfolog("Read configuration from '%s'", config);
-
-  g_lua.executeCode(ifs);
+  g_lua.executeCode("dofile('"+config+"')");
 
   auto ret = *g_launchWork;
   delete g_launchWork;


### PR DESCRIPTION
### Short description
This replaces the useless `[string "chunk"]` with the file name. It preserves the showing of the actual error:
```
$ ./dnsdist -C ./dnsdist.conf
Fatal Lua error: ./dnsdist.conf:3: unfinished string near ''dnsdist2.lua)()'
$ ./dnsdist -C ./dnsdist2.conf
Fatal Lua error: cannot open ./dnsdist2.conf: No such file or directory
$ ./dnsdist -C /dev/mem
Fatal Lua error: cannot open /dev/mem: Permission denied
```

TODO: also fix this in `includeDirectory`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
