### PR TITLE
rec: Fix the export of only outgoing queries or incoming responses

### DIFF
--- a/pdns/fstrm_logger.hh
+++ b/pdns/fstrm_logger.hh
@@ -43,10 +43,6 @@ public:
   {
     return "FrameStreamLogger to " + d_address;
   }
-  bool logQueries(void) const { return d_logQueries; }
-  bool logResponses(void) const { return d_logResponses; }
-  void setLogQueries(bool flag) { d_logQueries = flag; }
-  void setLogResponses(bool flag) { d_logResponses = flag; }
 
 private:
 
@@ -63,9 +59,6 @@ private:
   struct fstrm_iothr *d_iothr{nullptr};
 
   void cleanup();
-
-  bool d_logQueries{true};
-  bool d_logResponses{true};
 };
 
 #else

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -122,8 +122,21 @@ static void logFstreamResponse(const std::shared_ptr<std::vector<std::unique_ptr
 
 static void logOutgoingQuery(const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, boost::optional<RecProtoBufMessage>& message, boost::optional<const boost::uuids::uuid&> initialRequestId, const boost::uuids::uuid& uuid, const ComboAddress& ip, const DNSName& domain, int type, uint16_t qid, bool doTCP, size_t bytes, boost::optional<Netmask>& srcmask)
 {
-  if(!outgoingLoggers)
+  if (!outgoingLoggers) {
     return;
+  }
+
+  bool log = false;
+  for (auto& logger : *outgoingLoggers) {
+    if (logger->logQueries()) {
+      log = true;
+      break;
+    }
+  }
+
+  if (!log) {
+    return;
+  }
 
   message = RecProtoBufMessage(DNSProtoBufMessage::OutgoingQuery, uuid, nullptr, &ip, domain, type, QClass::IN, qid, doTCP, bytes);
   message->setServerIdentity(SyncRes::s_serverID);
@@ -141,18 +154,48 @@ static void logOutgoingQuery(const std::shared_ptr<std::vector<std::unique_ptr<R
   message->serialize(str);
 
   for (auto& logger : *outgoingLoggers) {
-    logger->queueData(str);
+    if (logger->logQueries()) {
+      logger->queueData(str);
+    }
   }
 }
 
-static void logIncomingResponse(const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, boost::optional<RecProtoBufMessage>& message, size_t bytes, int rcode, const std::vector<DNSRecord>& records, const struct timeval& queryTime, const std::set<uint16_t>& exportTypes)
+static void logIncomingResponse(const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, boost::optional<RecProtoBufMessage>& message, boost::optional<const boost::uuids::uuid&> initialRequestId, const boost::uuids::uuid& uuid, const ComboAddress& ip, const DNSName& domain, int type, uint16_t qid, bool doTCP, boost::optional<Netmask>& srcmask, size_t bytes, int rcode, const std::vector<DNSRecord>& records, const struct timeval& queryTime, const std::set<uint16_t>& exportTypes)
 {
-  if(!outgoingLoggers || !message)
+  if (!outgoingLoggers) {
     return;
+  }
 
-  message->updateTime();
-  message->setType(DNSProtoBufMessage::IncomingResponse);
-  message->setBytes(bytes);
+  bool log = false;
+  for (auto& logger : *outgoingLoggers) {
+    if (logger->logResponses()) {
+      log = true;
+      break;
+    }
+  }
+
+  if (!log) {
+    return;
+  }
+
+  if (!message) {
+    message = RecProtoBufMessage(DNSProtoBufMessage::IncomingResponse, uuid, nullptr, &ip, domain, type, QClass::IN, qid, doTCP, bytes);
+    message->setServerIdentity(SyncRes::s_serverID);
+
+    if (initialRequestId) {
+      message->setInitialRequestID(*initialRequestId);
+    }
+
+    if (srcmask) {
+      message->setEDNSSubnet(*srcmask);
+    }
+  }
+  else {
+    message->updateTime();
+    message->setType(DNSProtoBufMessage::IncomingResponse);
+    message->setBytes(bytes);
+  }
+
   message->setQueryTime(queryTime.tv_sec, queryTime.tv_usec);
   message->setResponseCode(rcode);
   message->addRRs(records, exportTypes);
@@ -162,7 +205,9 @@ static void logIncomingResponse(const std::shared_ptr<std::vector<std::unique_pt
   message->serialize(str);
 
   for (auto& logger : *outgoingLoggers) {
-    logger->queueData(str);
+    if (logger->logResponses()) {
+      logger->queueData(str);
+    }
   }
 }
 #endif /* HAVE_PROTOBUF */
@@ -328,7 +373,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
     if(mdp.d_header.rcode == RCode::FormErr && mdp.d_qname.empty() && mdp.d_qtype == 0 && mdp.d_qclass == 0) {
 #ifdef HAVE_PROTOBUF
       if(outgoingLoggers) {
-        logIncomingResponse(outgoingLoggers, pbMessage, len, lwr->d_rcode, lwr->d_records, queryTime, exportTypes);
+        logIncomingResponse(outgoingLoggers, pbMessage, context ? context->d_initialRequestId : boost::none, uuid, ip, domain, type, qid, doTCP, srcmask, len, lwr->d_rcode, lwr->d_records, queryTime, exportTypes);
       }
 #endif
       lwr->d_validpacket=true;
@@ -374,7 +419,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
         
 #ifdef HAVE_PROTOBUF
     if(outgoingLoggers) {
-      logIncomingResponse(outgoingLoggers, pbMessage, len, lwr->d_rcode, lwr->d_records, queryTime, exportTypes);
+      logIncomingResponse(outgoingLoggers, pbMessage, context ? context->d_initialRequestId : boost::none, uuid, ip, domain, type, qid, doTCP, srcmask, len, lwr->d_rcode, lwr->d_records, queryTime, exportTypes);
     }
 #endif
     lwr->d_validpacket=true;
@@ -387,7 +432,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
     g_stats.serverParseError++;
 #ifdef HAVE_PROTOBUF
     if(outgoingLoggers) {
-      logIncomingResponse(outgoingLoggers, pbMessage, len, lwr->d_rcode, lwr->d_records, queryTime, exportTypes);
+      logIncomingResponse(outgoingLoggers, pbMessage, context ? context->d_initialRequestId : boost::none, uuid, ip, domain, type, qid, doTCP, srcmask, len, lwr->d_rcode, lwr->d_records, queryTime, exportTypes);
     }
 #endif
     lwr->d_validpacket=false;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -891,7 +891,10 @@ static std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>> startProtobuf
 
   for (const auto& server : config.servers) {
     try {
-      result->emplace_back(new RemoteLogger(server, config.timeout, 100*config.maxQueuedEntries, config.reconnectWaitTime, config.asyncConnect));
+      auto logger = make_unique<RemoteLogger>(server, config.timeout, 100*config.maxQueuedEntries, config.reconnectWaitTime, config.asyncConnect);
+      logger->setLogQueries(config.logQueries);
+      logger->setLogResponses(config.logResponses);
+      result->emplace_back(std::move(logger));
     }
     catch(const std::exception& e) {
       g_log<<Logger::Error<<"Error while starting protobuf logger to '"<<server<<": "<<e.what()<<endl;

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -62,6 +62,15 @@ public:
   virtual ~RemoteLoggerInterface() {};
   virtual void queueData(const std::string& data) = 0;
   virtual std::string toString() const = 0;
+
+  bool logQueries(void) const { return d_logQueries; }
+  bool logResponses(void) const { return d_logResponses; }
+  void setLogQueries(bool flag) { d_logQueries = flag; }
+  void setLogResponses(bool flag) { d_logResponses = flag; }
+
+private:
+  bool d_logQueries{true};
+  bool d_logResponses{true};
 };
 
 /* Thread safe. Will connect asynchronously on request.
@@ -87,6 +96,7 @@ public:
     d_exiting = true;
   }
   std::atomic<uint32_t> d_drops{0};
+
 private:
   bool reconnect();
   void maintenanceThread();
@@ -98,8 +108,8 @@ private:
   uint16_t d_timeout;
   uint8_t d_reconnectWaitTime;
   std::atomic<bool> d_exiting{false};
-
   bool d_asyncConnect{false};
-  std::thread d_thread;
+
   std::mutex d_mutex;
+  std::thread d_thread;
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The documentation states that you can log only outgoing queries or incoming responses, but this was not actually supported.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
