### PR TITLE
auth: Fix a memory leak when sqlite3_exec() fails

### DIFF
--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -235,10 +235,15 @@ void SSQLite3::execute(const string& query) {
   int rc;
   if (sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg) == SQLITE_BUSY) {
     if (m_in_transaction) {
-        throw("Failed to execute query: " + string(errmsg));
+      std::string errstr(errmsg);
+      sqlite3_free(errmsg);
+      throw("Failed to execute query: " + errstr);
     } else {
-      if ((rc = sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg) != SQLITE_OK) && rc != SQLITE_DONE && rc != SQLITE_ROW)
-        throw("Failed to execute query: " + string(errmsg));
+      if ((rc = sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg) != SQLITE_OK) && rc != SQLITE_DONE && rc != SQLITE_ROW) {
+        std::string errstr(errmsg);
+        sqlite3_free(errmsg);
+        throw("Failed to execute query: " + errstr);
+      }
     }
   }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If an statement is passed, or there is something wrong with the database, we might have leaked the memory allocated by `sqlite3_exec`'s error message.
This doesn't really matter today because these conditions will abort the server, but it's cleaner that way. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
