### PR TITLE
auth: Fix the accounting of servfail-queries in the distributor

### DIFF
--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -222,7 +222,7 @@ retry:
 
           a->setRcode(RCode::ServFail);
           S.inc("servfail-packets");
-          S.ringAccount("servfail-queries",QD->Q->qdomain.toLogString());
+          S.ringAccount("servfail-queries", QD->Q->qdomain, QD->Q->qtype);
 
           delete QD->Q;
         } else {
@@ -239,7 +239,7 @@ retry:
 
           a->setRcode(RCode::ServFail);
           S.inc("servfail-packets");
-          S.ringAccount("servfail-queries",QD->Q->qdomain.toLogString());
+          S.ringAccount("servfail-queries", QD->Q->qdomain, QD->Q->qtype);
 
           delete QD->Q;
         } else {
@@ -286,7 +286,7 @@ retry:
 
       a->setRcode(RCode::ServFail);
       S.inc("servfail-packets");
-      S.ringAccount("servfail-queries",q->qdomain.toLogString());
+      S.ringAccount("servfail-queries", q->qdomain, q->qtype);
     } else {
       g_log<<Logger::Notice<<"Backend error (retry once): "<<e.reason<<endl;
       goto retry;
@@ -301,7 +301,7 @@ retry:
 
       a->setRcode(RCode::ServFail);
       S.inc("servfail-packets");
-      S.ringAccount("servfail-queries",q->qdomain.toLogString());
+      S.ringAccount("servfail-queries", q->qdomain, q->qtype);
     } else {
       g_log<<Logger::Warning<<"Caught unknown exception in Distributor thread "<<(unsigned long)pthread_self()<<" (retry once)"<<endl;
       goto retry;

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -17,6 +17,7 @@ struct Question
   int q;
   DTime d_dt;
   DNSName qdomain;
+  QType qtype;
   DNSPacket* replyPacket()
   {
     return new DNSPacket(false);
@@ -141,6 +142,7 @@ BOOST_AUTO_TEST_CASE(test_distributor_dies) {
       auto q = new Question();
       q->d_dt.set(); 
       q->qdomain=DNSName(std::to_string(n));
+      q->qtype = QType(QType::A);
       d->question(q, report2);
     }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This was broken since eb029b8efe0217b39c5cf34235b565b4c8d6e95e which introduced a specific type of DNSName,qtype ring.
It compiles but then fails on insertion with:
```
 terminate called after throwing an instance of 'std::runtime_error'
  what():  Attempting to account to non-existent ring 'servfail-queries'
Jun 28 14:24:19 Got a signal 6, attempting to print trace: 
Jun 28 14:24:19 pdns/pdns_server(+0x2f2486) [0x56222f0ea486]
Jun 28 14:24:19 /usr/lib/libc.so.6(+0x3a7e0) [0x7f3c2327a7e0]
Jun 28 14:24:19 /usr/lib/libc.so.6(gsignal+0x145) [0x7f3c2327a755]
Jun 28 14:24:19 /usr/lib/libc.so.6(abort+0x125) [0x7f3c23265851]
Jun 28 14:24:19 /usr/lib/libstdc++.so.6(+0x9581f) [0x7f3c2361981f]
Jun 28 14:24:19 /usr/lib/libstdc++.so.6(+0xa230a) [0x7f3c2362630a]
Jun 28 14:24:19 /usr/lib/libstdc++.so.6(+0xa2367) [0x7f3c23626367]
Jun 28 14:24:19 /usr/lib/libstdc++.so.6(+0xa25bd) [0x7f3c236265bd]
Jun 28 14:24:19 pdns/pdns_server(_ZN7StatBag11ringAccountEPKcRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x3d1) [0x56222ef96411]
Jun 28 14:24:19 pdns/pdns_server(_ZN23SingleThreadDistributorI9DNSPacketS0_13PacketHandlerE8questionEPS0_St8functionIFvS3_EE+0x1cb) [0x56222ef9937b]
Jun 28 14:24:19 pdns/pdns_server(_Z7qthreadPv+0x4b9) [0x56222ef90869]
Jun 28 14:24:19 /usr/lib/libpthread.so.0(+0x957f) [0x7f3c2340c57f]
Jun 28 14:24:19 /usr/lib/libc.so.6(clone+0x43) [0x7f3c2333c0e3]
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
