### PR TITLE
rec: Export a protobuf incoming response message for timeouts

### DIFF
--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -72,7 +72,7 @@ message PBDNSMessage {
       optional bytes rdata = 5;
       optional bool  udr = 6;                   // True if this is the first time this RR has been seen for this question
     }
-    optional uint32 rcode = 1;
+    optional uint32 rcode = 1;                  // DNS Response code, or 65536 for a network error including a timeout
     repeated DNSRR rrs = 2;
     optional string appliedPolicy = 3;          // Filtering policy (RPZ or Lua) applied
     repeated string tags = 4;                   // Additional tags

--- a/pdns/protobuf.cc
+++ b/pdns/protobuf.cc
@@ -62,6 +62,17 @@ void DNSProtoBufMessage::setResponseCode(uint8_t rcode)
 #endif /* HAVE_PROTOBUF */
 }
 
+void DNSProtoBufMessage::setNetworkErrorResponseCode()
+{
+#ifdef HAVE_PROTOBUF
+  PBDNSMessage_DNSResponse* response = d_message.mutable_response();
+  if (response) {
+    /* special code meaning 'network error', like a timeout */
+    response->set_rcode(65536);
+  }
+#endif /* HAVE_PROTOBUF */
+}
+
 void DNSProtoBufMessage::setTime(time_t sec, uint32_t usec)
 {
 #ifdef HAVE_PROTOBUF

--- a/pdns/protobuf.hh
+++ b/pdns/protobuf.hh
@@ -62,6 +62,7 @@ public:
   void updateTime();
   void setQueryTime(time_t sec, uint32_t usec);
   void setResponseCode(uint8_t rcode);
+  void setNetworkErrorResponseCode();
   void addRRsFromPacket(const char* packet, const size_t len, bool includeCNAME=false);
   void serialize(std::string& data) const;
   void setRequestor(const std::string& requestor);

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -143,7 +143,7 @@ class TestRecursorProtobuf(RecursorTest):
             self.assertEquals(len(msg.originalRequestorSubnet), 4)
             self.assertEquals(socket.inet_ntop(socket.AF_INET, msg.originalRequestorSubnet), '127.0.0.1')
 
-    def checkOutgoingProtobufBase(self, msg, protocol, query, initiator):
+    def checkOutgoingProtobufBase(self, msg, protocol, query, initiator, length=None):
         self.assertTrue(msg)
         self.assertTrue(msg.HasField('timeSec'))
         self.assertTrue(msg.HasField('socketFamily'))
@@ -155,8 +155,11 @@ class TestRecursorProtobuf(RecursorTest):
         self.assertTrue(msg.HasField('id'))
         self.assertNotEquals(msg.id, query.id)
         self.assertTrue(msg.HasField('inBytes'))
-        # compare inBytes with length of query/response
-        self.assertEquals(msg.inBytes, len(query.to_wire()))
+        if length is not None:
+          self.assertEquals(msg.inBytes, length)
+        else:
+          # compare inBytes with length of query/response
+          self.assertEquals(msg.inBytes, len(query.to_wire()))
 
     def checkProtobufQuery(self, msg, protocol, query, qclass, qtype, qname, initiator='127.0.0.1'):
         self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSQueryType)
@@ -203,9 +206,9 @@ class TestRecursorProtobuf(RecursorTest):
         for tag in msg.response.tags:
             self.assertTrue(tag in tags)
 
-    def checkProtobufOutgoingQuery(self, msg, protocol, query, qclass, qtype, qname, initiator='127.0.0.1'):
+    def checkProtobufOutgoingQuery(self, msg, protocol, query, qclass, qtype, qname, initiator='127.0.0.1', length=None):
         self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSOutgoingQueryType)
-        self.checkOutgoingProtobufBase(msg, protocol, query, initiator)
+        self.checkOutgoingProtobufBase(msg, protocol, query, initiator, length=length)
         self.assertTrue(msg.HasField('to'))
         self.assertTrue(msg.HasField('question'))
         self.assertTrue(msg.question.HasField('qClass'))
@@ -215,11 +218,16 @@ class TestRecursorProtobuf(RecursorTest):
         self.assertTrue(msg.question.HasField('qName'))
         self.assertEquals(msg.question.qName, qname)
 
-    def checkProtobufIncomingResponse(self, msg, protocol, response, initiator='127.0.0.1'):
+    def checkProtobufIncomingResponse(self, msg, protocol, response, initiator='127.0.0.1', length=None):
         self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSIncomingResponseType)
-        self.checkOutgoingProtobufBase(msg, protocol, response, initiator)
+        self.checkOutgoingProtobufBase(msg, protocol, response, initiator, length=length)
         self.assertTrue(msg.HasField('response'))
+        self.assertTrue(msg.response.HasField('rcode'))
         self.assertTrue(msg.response.HasField('queryTimeSec'))
+
+    def checkProtobufIncomingNetworkErrorResponse(self, msg, protocol, response, initiator='127.0.0.1'):
+        self.checkProtobufIncomingResponse(msg, protocol, response, initiator, length=0)
+        self.assertEquals(msg.response.rcode, 65536)
 
     @classmethod
     def setUpClass(cls):
@@ -350,9 +358,9 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # check the protobuf messages corresponding to the UDP query and answer
         msg = self.getFirstProtobufMessage()
         self.checkProtobufOutgoingQuery(msg, dnsmessage_pb2.PBDNSMessage.UDP, query, dns.rdataclass.IN, dns.rdatatype.A, name)
-#        # then the response
-#        msg = self.getFirstProtobufMessage()
-#        self.checkProtobufIncomingResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
+        # then the response
+        msg = self.getFirstProtobufMessage()
+        self.checkProtobufIncomingNetworkErrorResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
         self.checkNoRemainingMessage()
 
 class OutgoingProtobufNoQueriesTest(TestRecursorProtobuf):
@@ -376,11 +384,9 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         query.flags |= dns.flags.RD
         res = self.sendUDPQuery(query)
 
-#        # check the response
-#        msg = self.getFirstProtobufMessage()
-#        self.checkProtobufIncomingResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
-        # let's wait a bit for a potential message to arrive
-        time.sleep(2)
+        # check the response
+        msg = self.getFirstProtobufMessage()
+        self.checkProtobufIncomingNetworkErrorResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
         self.checkNoRemainingMessage()
 
 class ProtobufMasksTest(TestRecursorProtobuf):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The protobuf messages we send when we receive an incoming DNS response from an authoritative server have all the information found in the protobuf message for the corresponding outgoing DNS query, except that we don't generate a message for a timeout or a network error, so it still requires sending and keeping track of the outgoing query messages to detect these.
This PR amends the existing code to generate a special protobuf message for timeout or network errors, with a rcode set to the special `65536` value and a size of `0` bytes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
