### PR TITLE
cherry-pick-pr: fix branch name in merge command

### DIFF
--- a/build-scripts/cherry-pick-pr.py
+++ b/build-scripts/cherry-pick-pr.py
@@ -54,6 +54,6 @@ if args.merge_into:
     run_command(command)
 
     command = ['git', 'merge', '--no-ff',
-               'backport-{}'.format(args.pull_request), '-m',
+               'backport-{}-to-{}'.format(args.pull_request, args.merge_into[0].split('/')[-1]), '-m',
                'Backport #{}'.format(args.pull_request)]
     run_command(command)


### PR DESCRIPTION
### Short description
#7940 changed the default naming for creating backport branches; this PR also uses that default naming when merging backports into a branch.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
