### PR TITLE
rec backport to 4.2.x: Clear CMSG_SPACE(sizeof(data)) in cmsghdr to appease valgrind.

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -900,7 +900,8 @@ void addCMsgSrcAddr(struct msghdr* msgh, void* cmsgbuf, const ComboAddress* sour
     cmsg->cmsg_len = CMSG_LEN(sizeof(*pkt));
 
     pkt = (struct in6_pktinfo *) CMSG_DATA(cmsg);
-    memset(pkt, 0, sizeof(*pkt));
+    // Include the padding to stop valgrind complaining about passing uninitialized data
+    memset(pkt, 0, CMSG_SPACE(sizeof(*pkt)));
     pkt->ipi6_addr = source->sin6.sin6_addr;
     pkt->ipi6_ifindex = itfIndex;
   }
@@ -917,7 +918,8 @@ void addCMsgSrcAddr(struct msghdr* msgh, void* cmsgbuf, const ComboAddress* sour
     cmsg->cmsg_len = CMSG_LEN(sizeof(*pkt));
 
     pkt = (struct in_pktinfo *) CMSG_DATA(cmsg);
-    memset(pkt, 0, sizeof(*pkt));
+    // Include the padding to stop valgrind complaining about passing uninitialized data
+    memset(pkt, 0, CMSG_SPACE(sizeof(*pkt)));
     pkt->ipi_spec_dst = source->sin4.sin_addr;
     pkt->ipi_ifindex = itfIndex;
 #elif defined(IP_SENDSRCADDR)
@@ -931,7 +933,9 @@ void addCMsgSrcAddr(struct msghdr* msgh, void* cmsgbuf, const ComboAddress* sour
     cmsg->cmsg_type = IP_SENDSRCADDR;
     cmsg->cmsg_len = CMSG_LEN(sizeof(*in));
 
+    // Include the padding to stop valgrind complaining about passing uninitialized data
     in = (struct in_addr *) CMSG_DATA(cmsg);
+    memset(in, 0, CMSG_SPACE(sizeof(*in)));
     *in = source->sin4.sin_addr;
 #endif
   }


### PR DESCRIPTION
(cherry picked from commit 20b22895546a3e7fb7760940599dfb1e29a00777)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
