### PR TITLE
rec backport to 4.2.x: Fix the export of only outgoing queries or incoming responses

### DIFF
--- a/pdns/fstrm_logger.hh
+++ b/pdns/fstrm_logger.hh
@@ -42,6 +42,7 @@ public:
   {
     return "FrameStreamLogger to " + d_address;
   }
+
 private:
   const int d_family;
   const std::string d_address;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -888,7 +888,10 @@ static std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>> startProtobuf
 
   for (const auto& server : config.servers) {
     try {
-      result->emplace_back(new RemoteLogger(server, config.timeout, 100*config.maxQueuedEntries, config.reconnectWaitTime, config.asyncConnect));
+      auto logger = make_unique<RemoteLogger>(server, config.timeout, 100*config.maxQueuedEntries, config.reconnectWaitTime, config.asyncConnect);
+      logger->setLogQueries(config.logQueries);
+      logger->setLogResponses(config.logResponses);
+      result->emplace_back(std::move(logger));
     }
     catch(const std::exception& e) {
       g_log<<Logger::Error<<"Error while starting protobuf logger to '"<<server<<": "<<e.what()<<endl;

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -62,6 +62,15 @@ public:
   virtual ~RemoteLoggerInterface() {};
   virtual void queueData(const std::string& data) = 0;
   virtual std::string toString() const = 0;
+
+  bool logQueries(void) const { return d_logQueries; }
+  bool logResponses(void) const { return d_logResponses; }
+  void setLogQueries(bool flag) { d_logQueries = flag; }
+  void setLogResponses(bool flag) { d_logResponses = flag; }
+
+private:
+  bool d_logQueries{true};
+  bool d_logResponses{true};
 };
 
 /* Thread safe. Will connect asynchronously on request.
@@ -87,6 +96,7 @@ public:
     d_exiting = true;
   }
   std::atomic<uint32_t> d_drops{0};
+
 private:
   bool reconnect();
   void maintenanceThread();
@@ -98,8 +108,8 @@ private:
   uint16_t d_timeout;
   uint8_t d_reconnectWaitTime;
   std::atomic<bool> d_exiting{false};
-
   bool d_asyncConnect{false};
-  std::thread d_thread;
+
   std::mutex d_mutex;
+  std::thread d_thread;
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Master re-uses the message but 4.2.x not. So this has to be reviewed with extra care,  it is not a straight merge.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
