### PR TITLE
rec: Small speed improvements in the SyncRes

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -278,8 +278,6 @@ void MOADNSParser::init(bool query, const std::string& packet)
         dr.d_content=DNSRecordContent::mastermake(dr, pr, d_header.opcode);
       }
 
-      d_answers.push_back(make_pair(dr, pr.getPosition() - sizeof(dnsheader)));
-
       /* XXX: XPF records should be allowed after TSIG as soon as the actual XPF option code has been assigned:
          if (dr.d_place == DNSResourceRecord::ADDITIONAL && seenTSIG && dr.d_type != QType::XPF)
       */
@@ -295,6 +293,8 @@ void MOADNSParser::init(bool query, const std::string& packet)
         seenTSIG = true;
         d_tsigPos = recordStartPos;
       }
+
+      d_answers.push_back(make_pair(std::move(dr), pr.getPosition() - sizeof(dnsheader)));
     }
 
 #if 0

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -922,7 +922,7 @@ struct PacketID
     if( tie(remote, ourSock, type) > tie(b.remote, bSock, b.type))
       return false;
 
-    return tie(domain, fd, id) < tie(b.domain, b.fd, b.id);
+    return tie(fd, id, domain) < tie(b.fd, b.id, b.domain);
   }
 };
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -67,7 +67,7 @@ extern GlobalStateHolder<NetmaskGroup> g_dontThrottleNetmasks;
 
 class RecursorLua4;
 
-typedef map<
+typedef std::unordered_map<
   DNSName,
   pair<
     vector<ComboAddress>,
@@ -337,7 +337,7 @@ public:
     ComboAddress d_best;
   };
 
-  typedef map<DNSName, DecayingEwmaCollection> nsspeeds_t;
+  typedef std::unordered_map<DNSName, DecayingEwmaCollection> nsspeeds_t;
   typedef map<ComboAddress, EDNSStatus> ednsstatus_t;
 
   vState getDSRecords(const DNSName& zone, dsmap_t& ds, bool onlyTA, unsigned int depth, bool bogusOnNXD=true, bool* foundCut=nullptr);
@@ -385,7 +385,7 @@ public:
     void addSOA(std::vector<DNSRecord>& records) const;
   };
 
-  typedef map<DNSName, AuthDomain> domainmap_t;
+  typedef std::unordered_map<DNSName, AuthDomain> domainmap_t;
   typedef Throttle<boost::tuple<ComboAddress,DNSName,uint16_t> > throttle_t;
   typedef Counters<ComboAddress> fails_t;
 
@@ -781,11 +781,11 @@ private:
   {
     DNSName qname;
     set<pair<DNSName,DNSName> > bestns;
-    uint8_t qtype; // only A and AAAA anyhow
+    uint8_t qtype;
     bool operator<(const GetBestNSAnswer &b) const
     {
-      return boost::tie(qname, qtype, bestns) <
-	boost::tie(b.qname, b.qtype, b.bestns);
+      return boost::tie(qtype, qname, bestns) <
+	boost::tie(b.qtype, b.qname, b.bestns);
     }
   };
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
No major improvement but a couple minor ones:
- Don't copy the `GetBestNSAnswer` object on insertion ;
- Skip the lookups (and `chopOff()`s) in `SyncRes::getBestAuthZone` if we don't have any internal auth zones ;
- Use unordered maps for `DNSName`s based maps (`NsSet` object, `nsSpeeds`, internal auth zones) ;
- Compare the `qtype` before the `DNSName` in `GetBestNSAnswer` comparisons since we have types than just `A` and `AAAA` ;
- Compare the socket descriptor and ID before the `qname` when comparing `PacketID`s ;
- Insert the new DNSRecord last in MOADNSParser so we can move it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
