### PR TITLE
Don't create temporary strings to escape DNSName labels

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -177,7 +177,8 @@ std::string DNSName::toString(const std::string& separator, const bool trailing)
     const char* end = p + d_storage.size();
 
     while (p < end && *p) {
-      ret += escapeLabel(p + 1, static_cast<size_t>(*p)) + separator;
+      appendEscapedLabel(ret, p + 1, static_cast<size_t>(*p));
+      ret += separator;
       p += *p + 1;
     }
   }
@@ -430,29 +431,27 @@ size_t hash_value(DNSName const& d)
   return d.hash();
 }
 
-string DNSName::escapeLabel(const std::string& label)
+void DNSName::appendEscapedLabel(std::string& appendTo, const char* orig, size_t len)
 {
-  return escapeLabel(label.c_str(), label.size());
-}
-
-string DNSName::escapeLabel(const char* orig, size_t len)
-{
-  std::string ret;
   size_t pos = 0;
 
-  ret.reserve(len);
   while (pos < len) {
     auto p = static_cast<uint8_t>(orig[pos]);
     if(p=='.')
-      ret+="\\.";
+      appendTo+="\\.";
     else if(p=='\\')
-      ret+="\\\\";
+      appendTo+="\\\\";
     else if(p > 0x20 && p < 0x7f)
-      ret.append(1, (char)p);
+      appendTo.append(1, (char)p);
     else {
-      ret+="\\" + (boost::format("%03d") % (unsigned int)p).str();
+      char buf[] = "000";
+      auto got = snprintf(buf, sizeof(buf), "%03" PRIu8, p);
+      if (got < 0 || static_cast<size_t>(got) >= sizeof(buf)) {
+        throw std::runtime_error("Error, snprintf returned " + std::to_string(got) + " while escaping label " + std::string(orig, len));
+      }
+      appendTo.append(1, '\\');
+      appendTo += buf;
     }
     ++pos;
   }
-  return ret;
 }

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -150,8 +150,7 @@ private:
   string_t d_storage;
 
   void packetParser(const char* p, int len, int offset, bool uncompress, uint16_t* qtype, uint16_t* qclass, unsigned int* consumed, int depth, uint16_t minOffset);
-  static std::string escapeLabel(const std::string& orig);
-  static std::string escapeLabel(const char* orig, size_t len);
+  static void appendEscapedLabel(std::string& appendTo, const char* orig, size_t len);
   static std::string unescapeLabel(const std::string& orig);
 };
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Shaves a nice 20%+ off `DNSName::toString()` for regular names, and cut in half the CPU time when we encounter a 'special' character (not `.` or `\` and lesser or equal to `0x20` or greater or equal to `0x7f`).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
