### PR TITLE
auth: correct syntax for GLIBC detection

### DIFF
--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -354,7 +354,7 @@ static int guardian(int argc, char **argv)
   }
 }
 
-#ifdef __GLIBC__ && !defined(__UCLIBC__)
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
 #include <execinfo.h>
 static void tbhandler(int num)
 {
@@ -386,7 +386,7 @@ int main(int argc, char **argv)
   s_programname="pdns";
   s_starttime=time(0);
 
-#ifdef __GLIBC__ && !defined(__UCLIBC__)
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
   signal(SIGSEGV,tbhandler);
   signal(SIGFPE,tbhandler);
   signal(SIGABRT,tbhandler);
@@ -450,7 +450,7 @@ int main(int argc, char **argv)
     
     // we really need to do work - either standalone or as an instance
 
-#ifdef __GLIBC__ && !defined(__UCLIBC__)
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
     if(!::arg().mustDo("traceback-handler")) {
       g_log<<Logger::Warning<<"Disabling traceback handler"<<endl;
       signal(SIGSEGV,SIG_DFL);


### PR DESCRIPTION
### Short description
This commit fixes invalid syntax introduced in #7980 which caused build failures on some platforms

Failure from OpenWRT: (gcc-8.3.0 on arc uclibc)
```
receiver.cc:394:18: warning: extra tokens at end of #ifdef directive
 #ifdef __GLIBC__ && !defined(__UCLIBC__)
                  ^~
receiver.cc:395:10: fatal error: execinfo.h: No such file or directory
 #include <execinfo.h>
          ^~~~~~~~~~~~
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
