### PR TITLE
 dnsdist: Display TCP/DoT queries and responses in verbose mode, opcode in grepq

### DIFF
--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -70,7 +70,7 @@ std::string ERCode::to_s(uint8_t rcode) {
 }
 
 std::string Opcode::to_s(uint8_t opcode) {
-  static std::vector<std::string> s_opcodes = { "Query", "IQuery", "Status", "3", "Notify", "Update" };
+  static const std::vector<std::string> s_opcodes = { "Query", "IQuery", "Status", "3", "Notify", "Update" };
 
   if (opcode >= s_opcodes.size()) {
     return std::to_string(opcode);

--- a/pdns/dns.cc
+++ b/pdns/dns.cc
@@ -69,6 +69,16 @@ std::string ERCode::to_s(uint8_t rcode) {
   return RCode::rcodes_s[rcode];
 }
 
+std::string Opcode::to_s(uint8_t opcode) {
+  static std::vector<std::string> s_opcodes = { "Query", "IQuery", "Status", "3", "Notify", "Update" };
+
+  if (opcode >= s_opcodes.size()) {
+    return std::to_string(opcode);
+  }
+
+  return s_opcodes.at(opcode);
+}
+
 class BoundsCheckingPointer
 {
 public:

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -71,6 +71,7 @@ class Opcode
 {
 public:
   enum { Query=0, IQuery=1, Status=2, Notify=4, Update=5 };
+  static std::string to_s(uint8_t opcode);
 };
 
 // enum for policy decisions, used by both auth and recursor. Not all values supported everywhere.

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -439,7 +439,7 @@ void setupLuaInspection()
 
       std::multimap<struct timespec, string> out;
 
-      boost::format      fmt("%-7.1f %-47s %-12s %-5d %-25s %-5s %-6.1f %-2s %-2s %-2s %s\n");
+      boost::format      fmt("%-7.1f %-47s %-12s %-5d %-25s %-5s %-6.1f %-2s %-2s %-2s %-s\n");
       g_outputBuffer+= (fmt % "Time" % "Client" % "Server" % "ID" % "Name" % "Type" % "Lat." % "TC" % "RD" % "AA" % "Rcode").str();
 
       if(msec==-1) {
@@ -451,7 +451,11 @@ void setupLuaInspection()
             dnmatch = c.name.isPartOf(*dn);
           if(nmmatch && dnmatch) {
             QType qt(c.qtype);
-            out.insert(make_pair(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % "" % htons(c.dh.id) % c.name.toString() % qt.getName()  % "" % (c.dh.tc ? "TC" : "") % (c.dh.rd? "RD" : "") % (c.dh.aa? "AA" : "") %  "Question").str() )) ;
+            std::string extra;
+            if (c.dh.opcode != 0) {
+              extra = " (" + Opcode::to_s(c.dh.opcode) + ")";
+            }
+            out.insert(make_pair(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % "" % htons(c.dh.id) % c.name.toString() % qt.getName()  % "" % (c.dh.tc ? "TC" : "") % (c.dh.rd? "RD" : "") % (c.dh.aa? "AA" : "") % ("Question" + extra)).str() )) ;
 
             if(limit && *limit==++num)
               break;

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -659,6 +659,7 @@ static void handleResponseSent(std::shared_ptr<IncomingTCPConnectionState>& stat
     gettime(&answertime);
     double udiff = state->d_ids.sentTime.udiff();
     g_rings.insertResponse(answertime, state->d_ci.remote, state->d_ids.qname, state->d_ids.qtype, static_cast<unsigned int>(udiff), static_cast<unsigned int>(state->d_responseBuffer.size()), state->d_cleartextDH, state->d_ds->remote);
+    vinfolog("Got answer from %s, relayed to %s (%s), took %f usec", state->d_ds->remote.toStringWithPort(), state->d_ids.origRemote.toStringWithPort(), (state->d_ci.cs->tlsFrontend ? "DoT" : "TCP"), udiff);
   }
 
   if (g_maxTCPQueriesPerConn && state->d_queriesCount > g_maxTCPQueriesPerConn) {
@@ -772,6 +773,8 @@ static void sendQueryToBackend(std::shared_ptr<IncomingTCPConnectionState>& stat
     vinfolog("Downstream connection to %s failed %d times in a row, giving up.", ds->getName(), state->d_downstreamFailures);
     return;
   }
+
+  vinfolog("Got query for %s|%s from %s (%s), relayed to %s", state->d_ids.qname.toString(), QType(state->d_ids.qtype).getName(), state->d_ci.remote.toStringWithPort(), (state->d_ci.cs->tlsFrontend ? "DoT" : "TCP"), ds->getName());
 
   handleDownstreamIO(state, now);
   return;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- We display the queries and responses received over UDP and DoH in verbose mode, but we were not displaying the ones received over TCP or DoT ;
- Display any non-zero opcode in `grepq()`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
