### PR TITLE
sdig: decode DNS packets from stdin; exit non-zero on failure

### DIFF
--- a/docs/manpages/sdig.1.rst
+++ b/docs/manpages/sdig.1.rst
@@ -13,7 +13,7 @@ Description
 the answer in a formatted way.
 If the address starts with an ``h``, it is assumed to be a DoH endpoint, and *PORT* is ignored.
 If qname and qtype are both `-` and tcp is used, multiple lines are read
-form stdin, where each line contains a qname and a type.
+from stdin, where each line contains a qname and a type.
 
 Options
 -------

--- a/docs/manpages/sdig.1.rst
+++ b/docs/manpages/sdig.1.rst
@@ -9,11 +9,9 @@ Synopsis
 Description
 -----------
 
-:program:`sdig` sends a DNS query to *IP-ADDRESS-OR-DOH-URL* on port *PORT* and displays
-the answer in a formatted way.
+:program:`sdig` sends a DNS query to *IP-ADDRESS-OR-DOH-URL* on port *PORT* and displays the answer in a formatted way.
 If the address starts with an ``h``, it is assumed to be a DoH endpoint, and *PORT* is ignored.
-If qname and qtype are both `-` and tcp is used, multiple lines are read
-from stdin, where each line contains a qname and a type.
+If qname and qtype are both `-` and tcp is used, multiple lines are read from stdin, where each line contains a qname and a type.
 
 Options
 -------
@@ -25,8 +23,7 @@ class *CLASSNUM*
 dnssec
     Set the DO bit to request DNSSEC information.
 ednssubnet *SUBNET*
-    Send *SUBNET* in the edns-client-subnet option. If this option is
-    not set, no edns-client-subnet option is set in the query.
+    Send *SUBNET* in the edns-client-subnet option. If this option is not set, no edns-client-subnet option is set in the query.
 hidesoadetails
     Don't show the SOA serial in the response.
 hidettl

--- a/docs/manpages/sdig.1.rst
+++ b/docs/manpages/sdig.1.rst
@@ -12,6 +12,7 @@ Description
 :program:`sdig` sends a DNS query to *IP-ADDRESS-OR-DOH-URL* on port *PORT* and displays the answer in a formatted way.
 If the address starts with an ``h``, it is assumed to be a DoH endpoint, and *PORT* is ignored.
 If qname and qtype are both `-` and tcp is used, multiple lines are read from stdin, where each line contains a qname and a type.
+If the address is ``stdin``, a DNS packet is read from stdin instead of from the network, and *PORT* is ignored.
 
 Options
 -------

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -190,6 +190,7 @@ try {
   bool showflags = false;
   bool hidesoadetails = false;
   bool doh = false;
+  bool stdin = false;
   boost::optional<Netmask> ednsnm;
   uint16_t xpfcode = 0, xpfversion = 0, xpfproto = 0;
   char *xpfsrc = NULL, *xpfdst = NULL;
@@ -260,6 +261,8 @@ try {
   ComboAddress dest;
   if (*argv[1] == 'h') {
     doh = true;
+  } else if(strcmp(argv[1], "stdin") == 0) {
+    stdin = true;
   } else {
     dest = ComboAddress(argv[1] + (*argv[1] == '@'), atoi(argv[2]));
   }
@@ -297,6 +300,10 @@ try {
 #else
     throw PDNSException("please link sdig against libcurl for DoH support");
 #endif
+  } else if (stdin) {
+    std::istreambuf_iterator<char> begin(std::cin), end;
+    reply = string(begin, end);
+    printReply(reply, showflags, hidesoadetails);
   } else if (tcp) {
     Socket sock(dest.sin4.sin_family, SOCK_STREAM);
     sock.connect(dest);


### PR DESCRIPTION
### Short description
~The stdin feature needs docs~. Manpage updated.

~The non-zero exit feature may need regression test adjustments.~ Tests pass!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
