### PR TITLE
limit compression pointers to 14 bits

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1316,6 +1316,7 @@ testrunner_SOURCES = \
 	test-dnsparser_cc.cc \
 	test-dnsparser_hh.cc \
 	test-dnsrecords_cc.cc \
+	test-dnswriter_cc.cc \
 	test-ipcrypt_cc.cc \
 	test-iputils_hh.cc \
 	test-ixfr_cc.cc \

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -76,6 +76,7 @@ dnsheader* DNSPacketWriter::getHeader()
 
 void DNSPacketWriter::startRecord(const DNSName& name, uint16_t qtype, uint32_t ttl, uint16_t qclass, DNSResourceRecord::Place place, bool compress)
 {
+  d_compress = compress;
   commit();
   d_rollbackmarker=d_content.size();
 
@@ -327,7 +328,7 @@ void DNSPacketWriter::xfrName(const DNSName& name, bool compress, bool)
 
   uint16_t li=0;
   uint16_t matchlen=0;
-  if(compress && (li=lookupName(name, &matchlen)) && li < 16384) {
+  if(d_compress && compress && (li=lookupName(name, &matchlen)) && li < 16384) {
     const auto& dns=name.getStorage(); 
     if(l_verbose)
       cout<<"Found a substring of "<<matchlen<<" bytes from the back, offset: "<<li<<", dnslen: "<<dns.size()<<endl;

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -167,7 +167,7 @@ private:
 
   uint16_t d_truncatemarker; // end of header, for truncate
   DNSResourceRecord::Place d_recordplace;
-  bool d_canonic, d_lowerCase;
+  bool d_canonic, d_lowerCase, d_compress{false};
 };
 
 typedef vector<pair<string::size_type, string::size_type> > labelparts_t;

--- a/pdns/test-dnswriter_cc.cc
+++ b/pdns/test-dnswriter_cc.cc
@@ -1,0 +1,51 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <boost/test/unit_test.hpp>
+#include <fstream>
+
+#include "dnswriter.hh"
+#include "dnsparser.hh"
+
+BOOST_AUTO_TEST_SUITE(test_dnswriter_cc)
+
+BOOST_AUTO_TEST_CASE(test_compressionBoundary) {
+  DNSName name("powerdns.com.");
+
+  vector<uint8_t> packet;
+  DNSPacketWriter pwR(packet, name, QType::A, QClass::IN, 0);
+  pwR.getHeader()->qr = 1;
+
+  /* record we want to see altered */
+  pwR.startRecord(name, QType::TXT, 3600, QClass::IN, DNSResourceRecord::ANSWER);
+  auto txt = string("\"")+string(16262, 'A')+string("\"");
+  pwR.xfrText(txt);
+  pwR.commit();
+  BOOST_CHECK_EQUAL(pwR.size(), 16368);
+
+  pwR.startRecord(DNSName("mediumsizedlabel.example.net"), QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER);
+  pwR.xfrIP('P'<<24 |
+            'Q'<<16 |
+            'R'<<8  |
+            'S');
+  pwR.commit();
+  BOOST_CHECK_EQUAL(pwR.size(), 16412); // 16412 (0x401c) puts '7example3net' at 0x4001
+
+  pwR.startRecord(DNSName("adifferentlabel.example.net"), QType::A, 3600, QClass::IN, DNSResourceRecord::ANSWER);
+  pwR.xfrIP('D'<<24 |
+            'E'<<16 |
+            'F'<<8  |
+            'G');
+  pwR.commit();
+  BOOST_CHECK_EQUAL(pwR.size(), 16455);
+
+  string spacket(packet.begin(), packet.end());
+
+  BOOST_CHECK_NO_THROW(MOADNSParser mdp(false, spacket));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
In a very specific edge case, we would get compression pointers above the 0-0x3fff range, and truncate those to a very low number, causing clients to throw parse errors.

I have added a fix from @pieterlexis where DNSPacketWriter did not honour `compress=false` for the content of any type (like NS) that is permitted to compress by RFC.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
