### PR TITLE
bind-load-threads config improves (re)load

### DIFF
--- a/docs/backends/bind.rst
+++ b/docs/backends/bind.rst
@@ -64,6 +64,15 @@ Interval in seconds to check for zone file changes. Default is 0 (disabled).
 
 See :ref:`bind-operation` section for more information.
 
+.. _setting-bind-load-threads:
+
+``bind-load-threads``
+~~~~~~~~~~~~~~~
+
+The number of threads to use when loading zone files. The default is 1 thread
+but if you have a lot of files you can significantly improve (re)load
+performance by increasing this to roughly the number of cores on your server.
+
 .. _setting-bind-dnssec-db:
 
 ``bind-dnssec-db``

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -184,8 +184,11 @@ class NSEC3PARAMRecordContent;
 struct NameTag
 {};
 
+class BindParallelParser;
+
 class Bind2Backend : public DNSBackend
 {
+  friend class BindParallelParser;
 public:
   Bind2Backend(const string &suffix="", bool loadZones=true); 
   ~Bind2Backend();


### PR DESCRIPTION
### Short description

Changed the bindbackend config loader to be multi-threaded when loading individual zones. Added a new bind-load-threads to configure how many this should be (default 1). I see linear improvement in load speed from 22sec at 140k zones to 6 sec with 4 threads on my laptop, I believe this probably scales linearly to roughly 16 cores before the master thread controlling access to the main data structure gets overworked.

I have not fully tested this code in all exception cases yet although I don't think there should be many surprises. I am requesting a code review to ensure you are happy with the idea behind this and the code done so far before I continue.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
