### PR TITLE
dnsdist: Handle ENOTCONN on read() over TCP

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -361,7 +361,7 @@ IOState tryRead(int fd, std::vector<uint8_t>& buffer, size_t& pos, size_t toRead
       throw runtime_error("EOF while reading message");
     }
     if (res < 0) {
-      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOTCONN) {
         return IOState::NeedRead;
       }
       else {

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -214,7 +214,7 @@ public:
         throw runtime_error("EOF while reading message");
       }
       if (res < 0) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOTCONN) {
           return IOState::NeedRead;
         }
         else {
@@ -250,7 +250,7 @@ public:
         throw runtime_error("EOF while sending message");
       }
       if (res < 0) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOTCONN) {
           return IOState::NeedWrite;
         }
         else {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When a non-blocking connect() has returned `EINPROGRESS`, it looks like BSD can return `ENOTCONN` on `read()` even after a `write()` succeeded.
We did not get a trace confirming that `read()` can indeed return `ENOTCONN` in that case yet, though.

Fixes #8021.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
