### PR TITLE
Ensure Debian SysV users get set{g,u}id

### DIFF
--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -44,6 +44,8 @@ override_dh_auto_install:
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \
 		-e 's!# quiet=.*!quiet=yes!' \
+		-e 's!# setgid=.*!setgid=pdns!' \
+		-e 's!# setuid=.*!setuid=pdns!' \
 		-e 's!# hint-file=.*!&\nhint-file=/usr/share/dns/root.hints!' \
 		> debian/pdns-recursor/etc/powerdns/recursor.conf
 

--- a/builder-support/debian/recursor/debian-jessie/rules
+++ b/builder-support/debian/recursor/debian-jessie/rules
@@ -44,6 +44,8 @@ override_dh_auto_install:
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \
 		-e 's!# quiet=.*!quiet=yes!' \
+		-e 's!# setgid=.*!setgid=pdns!' \
+		-e 's!# setuid=.*!setuid=pdns!' \
 		-e 's!# hint-file=.*!&\nhint-file=/usr/share/dns/root.hints!' \
 		> debian/tmp/etc/powerdns/recursor.conf
 

--- a/builder-support/debian/recursor/debian-stretch/rules
+++ b/builder-support/debian/recursor/debian-stretch/rules
@@ -44,6 +44,8 @@ override_dh_auto_install:
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \
 		-e 's!# quiet=.*!quiet=yes!' \
+		-e 's!# setgid=.*!setgid=pdns!' \
+		-e 's!# setuid=.*!setuid=pdns!' \
 		-e 's!# hint-file=.*!&\nhint-file=/usr/share/dns/root.hints!' \
 		> debian/pdns-recursor/etc/powerdns/recursor.conf
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4424,8 +4424,17 @@ int main(int argc, char **argv)
     ::arg().set("log-timestamp","Print timestamps in log lines, useful to disable when running with a tool that timestamps stdout already")="yes";
     ::arg().set("log-common-errors","If we should log rather common errors")="no";
     ::arg().set("chroot","switch to chroot jail")="";
-    ::arg().set("setgid","If set, change group id to this gid for more security")="";
-    ::arg().set("setuid","If set, change user id to this uid for more security")="";
+    ::arg().set("setgid","If set, change group id to this gid for more security"
+#ifdef HAVE_SYSTEMD
+#define SYSTEMD_SETID_MSG ". When running inside systemd, use the User and Group settings in the unit-file!"
+        SYSTEMD_SETID_MSG
+#endif
+        )="";
+    ::arg().set("setuid","If set, change user id to this uid for more security"
+#ifdef HAVE_SYSTEMD
+        SYSTEMD_SETID_MSG
+#endif
+        )="";
     ::arg().set("network-timeout", "Wait this number of milliseconds for network i/o")="1500";
     ::arg().set("threads", "Launch this number of threads")="2";
     ::arg().set("distributor-threads", "Launch this number of distributor threads, distributing queries to other threads")="0";


### PR DESCRIPTION
### Short description
As we'd now run as root in those instances. We also add a warning in the config-file about this. See https://github.com/PowerDNS/pdns/pull/7879#issuecomment-509033651 for the discussion

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)