### PR TITLE
forward-port #7964: catch name & IP parse errors during outgoing notify preparations

### DIFF
--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -251,7 +251,7 @@ private:
 class FindNS
 {
 public:
-  vector<string> lookup(const DNSName &name, UeberBackend *b, const DNSName& zone)
+  vector<string> lookup(const DNSName &name, UeberBackend *b)
   {
     vector<string> addresses;
 
@@ -269,11 +269,11 @@ public:
         }
         // After an exception, b can be inconsistent so break
         catch (PDNSException &ae) {
-          g_log << Logger::Error << "Could not lookup address for nameserver " << name << " in zone " << zone << ", cannot notify: " << ae.reason << endl;
+          g_log << Logger::Error << "Skipping record(s): " << ae.reason << endl;
           break;
         }
         catch (std::exception &e) {
-          g_log << Logger::Error << "Could not lookup address for nameserver " << name << " in zone " << zone << ", cannot notify: " << e.what() << endl;
+          g_log << Logger::Error << "Skipping record(s): " << e.what() << endl;
           break;
         }
       }

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -258,25 +258,26 @@ public:
     this->resolve_name(&addresses, name);
     
     if(b) {
-      b->lookup(QType(QType::ANY),name);
-      while (true) {
-        try {
+        b->lookup(QType(QType::ANY),name);
+        bool ok;
+        do {
           DNSZoneRecord rr;
-          if (!b->get(rr))
-            break;
-          if (rr.dr.d_type == QType::A || rr.dr.d_type == QType::AAAA)
-            addresses.push_back(rr.dr.d_content->getZoneRepresentation());   // SOL if you have a CNAME for an NS
-        }
-        // After an exception, b can be inconsistent so break
-        catch (PDNSException &ae) {
-          g_log << Logger::Error << "Skipping record(s): " << ae.reason << endl;
-          break;
-        }
-        catch (std::exception &e) {
-          g_log << Logger::Error << "Skipping record(s): " << e.what() << endl;
-          break;
-        }
-      }
+          try {
+            ok = b->get(rr);
+          }
+          catch (PDNSException &ae) {
+            g_log << Logger::Error << "Skipping record: " << ae.reason << endl;
+            continue;
+          }
+          catch (std::exception &e) {
+            g_log << Logger::Error << "Skipping record: " << e.what() << endl;
+            continue;
+          }
+          if (ok) {
+            if (rr.dr.d_type == QType::A || rr.dr.d_type == QType::AAAA)
+              addresses.push_back(rr.dr.d_content->getZoneRepresentation());   // SOL if you have a CNAME for an NS
+          }
+        } while (ok);
     }
     return addresses;
   }

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -259,25 +259,10 @@ public:
     
     if(b) {
         b->lookup(QType(QType::ANY),name);
-        bool ok;
-        do {
-          DNSZoneRecord rr;
-          try {
-            ok = b->get(rr);
-          }
-          catch (PDNSException &ae) {
-            g_log << Logger::Error << "Skipping record: " << ae.reason << endl;
-            continue;
-          }
-          catch (std::exception &e) {
-            g_log << Logger::Error << "Skipping record: " << e.what() << endl;
-            continue;
-          }
-          if (ok) {
-            if (rr.dr.d_type == QType::A || rr.dr.d_type == QType::AAAA)
-              addresses.push_back(rr.dr.d_content->getZoneRepresentation());   // SOL if you have a CNAME for an NS
-          }
-        } while (ok);
+        DNSZoneRecord rr;
+        while(b->get(rr))
+          if(rr.dr.d_type == QType::A || rr.dr.d_type==QType::AAAA)
+            addresses.push_back(rr.dr.d_content->getZoneRepresentation());   // SOL if you have a CNAME for an NS
     }
     return addresses;
   }

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -50,6 +50,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
   FindNS fns;
 
 
+  try {
   if (d_onlyNotify.size()) {
     B->lookup(QType(QType::NS), di.zone);
     while(B->get(rr))
@@ -77,6 +78,16 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
       hasQueuedItem=true;
     }
   }
+  }
+  catch (PDNSException &ae) {
+    g_log << Logger::Error << "Error looking up name servers for " << di.zone << ", cannot notify: " << ae.reason << endl;
+    return;
+  }
+  catch (std::exception &e) {
+    g_log << Logger::Error << "Error looking up name servers for " << di.zone << ", cannot notify: " << e.what() << endl;
+    return;
+  }
+
 
   set<string> alsoNotify(d_alsoNotify);
   B->alsoNotifies(di.zone, &alsoNotify);

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -56,7 +56,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
       nsset.insert(getRR<NSRecordContent>(rr.dr)->getNS().toString());
 
     for(set<string>::const_iterator j=nsset.begin();j!=nsset.end();++j) {
-      vector<string> nsips=fns.lookup(DNSName(*j), B, di.zone);
+      vector<string> nsips=fns.lookup(DNSName(*j), B);
       if(nsips.empty())
         g_log<<Logger::Warning<<"Unable to queue notification of domain '"<<di.zone<<"': nameservers do not resolve!"<<endl;
       else

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -494,7 +494,7 @@ bool TCPNameserver::canDoAXFR(shared_ptr<DNSPacket> q)
         while(B->get(rr)) 
           nsset.insert(DNSName(rr.content));
         for(const auto & j: nsset) {
-          vector<string> nsips=fns.lookup(j, s_P->getBackend(),q->qdomain);
+          vector<string> nsips=fns.lookup(j, s_P->getBackend());
           for(vector<string>::const_iterator k=nsips.begin();k!=nsips.end();++k) {
             // cerr<<"got "<<*k<<" from AUTO-NS"<<endl;
             if(*k == q->getRemote().toString())


### PR DESCRIPTION
### Short description
This brings master in line with  https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-04.html

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
