### PR TITLE
sdig: add DoH GET support

### DIFF
--- a/pdns/minicurl.cc
+++ b/pdns/minicurl.cc
@@ -117,9 +117,10 @@ void MiniCurl::setupURL(const std::string& str, const ComboAddress* rem, const C
   d_data.clear();
 }
 
-std::string MiniCurl::getURL(const std::string& str, const ComboAddress* rem, const ComboAddress* src)
+std::string MiniCurl::getURL(const std::string& str, MiniCurlHeaders& headers, const ComboAddress* rem, const ComboAddress* src)
 {
   setupURL(str, rem, src);
+  setHeaders(headers);
   auto res = curl_easy_perform(d_curl);
   long http_code = 0;
   curl_easy_getinfo(d_curl, CURLINFO_RESPONSE_CODE, &http_code);

--- a/pdns/minicurl.hh
+++ b/pdns/minicurl.hh
@@ -38,7 +38,7 @@ public:
   MiniCurl(const string& useragent="MiniCurl/0.0");
   ~MiniCurl();
   MiniCurl& operator=(const MiniCurl&) = delete;
-  std::string getURL(const std::string& str, const ComboAddress* rem=0, const ComboAddress* src=0);
+  std::string getURL(const std::string& str, MiniCurlHeaders& headers, const ComboAddress* rem=0, const ComboAddress* src=0);
   std::string postURL(const std::string& str, const std::string& postdata, MiniCurlHeaders& headers);
 private:
   CURL *d_curl;

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -168,16 +168,13 @@ try
   if(doh) {
 #ifdef HAVE_LIBCURL
     string method = argv[2];
+    MiniCurl mc;
+    MiniCurl::MiniCurlHeaders mch;
+    mch.insert(std::make_pair("Accept", "application/dns-message"));
     if (method == "POST") {
-      MiniCurl mc;
-      MiniCurl::MiniCurlHeaders mch;
       mch.insert(std::make_pair("Content-Type", "application/dns-message"));
-      mch.insert(std::make_pair("Accept", "application/dns-message"));
       reply = mc.postURL(argv[1], question, mch);
     } else if (method == "GET") {
-      MiniCurl mc;
-      MiniCurl::MiniCurlHeaders mch;
-      mch.insert(std::make_pair("Accept", "application/dns-message"));
       string url = argv[1];
       string b64question = Base64Encode(question);
       boost::replace_all(b64question, "+", "-");


### PR DESCRIPTION
### Short description
Draft because the minicurl interface changes I did break LUA. Need to figure out how to do this cleanly.

Needs docs.

This does not strip `==` padding from the base64 string, while 8484 requires that we do so.

Usage:
* `./sdig https://doh.powerdns.org/ GET nu.nl A recurse`
* `./sdig https://doh.powerdns.org/ POST nu.nl A recurse`

While we're thinking about the minicurl API, I'd also like a way to tell it to CURLOPT_VERBOSE so that sdig can enable that if the user wants it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
