### PR TITLE
add key make time to pdnsutil test-all-algorithms, cleanup return type

### DIFF
--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -82,7 +82,7 @@ class DNSCryptoKeyEngine
     typedef shared_ptr<DNSCryptoKeyEngine> maker_t(unsigned int algorithm);
     
     static void report(unsigned int algorithm, maker_t* maker, bool fallback=false);
-    static std::pair<unsigned int, unsigned int> testMakers(unsigned int algorithm, maker_t* creator, maker_t* signer, maker_t* verifier);
+    static void testMakers(unsigned int algorithm, maker_t* creator, maker_t* signer, maker_t* verifier);
     static vector<pair<uint8_t, string>> listAllAlgosWithBackend();
     static bool testAll();
     static bool testOne(int algo);


### PR DESCRIPTION
### Short description
`Testing algorithm 8: 'OpenSSL RSA' ->'OpenSSL RSA' -> 'OpenSSL RSA' Signature & verify ok, create 173usec, signature 75usec, verify 14usec` - the `create` part is new.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
