### PR TITLE
ixfrdist: test in CircleCI; remove useless error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,18 @@ commands:
               protobuf-compiler \
               virtualenv
 
+  install-ixfrdist-deps:
+    description: "Install all libraries needed for testing ixfrdist"
+    steps:
+      - run: apt-get update
+      - run:
+          command: |
+            apt-get install -qq -y \
+              libboost-all-dev \
+              libsystemd0 \
+              libyaml-cpp0.5v5 \
+              virtualenv
+
   install-auth-dev-deps:
     description: Install all packages needed to build the auth
     steps:
@@ -220,6 +232,7 @@ commands:
               libsqlite3-dev \
               libssl-dev \
               libtool \
+              libyaml-cpp-dev \
               make \
               pkg-config \
               ragel \
@@ -462,7 +475,8 @@ jobs:
               --enable-tools \
               --with-lmdb=/usr \
               --with-libsodium \
-              --prefix=/opt/pdns-auth
+              --prefix=/opt/pdns-auth \
+              --enable-ixfrdist
       - run:
           name: build
           command: make -j3 -k
@@ -1235,6 +1249,23 @@ jobs:
             DNSDISTBIN="/opt/dnsdist/bin/dnsdist" \
             ./runtests
 
+  test-ixfrdist-regression:
+    docker:
+      - image: debian:stretch
+        environment:
+          UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1'
+    steps:
+      - install-ixfrdist-deps
+      - checkout-shallow
+      - attach_workspace:
+          at: /opt
+      - run:
+          name: Run ixfrdist tests
+          workdir: ~/project/regression-tests.ixfrdist
+          command: |
+            IXFRDISTBIN="/opt/pdns-auth/bin/ixfrdist" \
+            ./runtests
+
 workflows:
   version: 2
   coverity:
@@ -1305,6 +1336,9 @@ workflows:
       - test-dnsdist-regression:
           requires:
             - build-dnsdist
+      - test-ixfrdist-regression:
+          requires:
+            - build-auth
 
   build-docs:
     jobs:

--- a/regression-tests.ixfrdist/test_Stats.py
+++ b/regression-tests.ixfrdist/test_Stats.py
@@ -1,20 +1,8 @@
 from ixfrdisttests import IXFRDistTest
-from xfrserver.xfrserver import AXFRServer
 import time
 import requests
 
-zones = {
-    1: """
-$ORIGIN example.
-@        86400   SOA    foo bar 1 2 3 4 5
-@        4242    NS     ns1.example.
-@        4242    NS     ns2.example.
-ns1.example.    4242    A       192.0.2.1
-ns2.example.    4242    A       192.0.2.2
-"""}
-
 xfrServerPort = 4244
-xfrServer = AXFRServer(xfrServerPort, zones)
 
 class IXFRDistStatsTest(IXFRDistTest):
     """


### PR DESCRIPTION
### Short description
The error was caused by both `test_*.py` starting an `xfrserver` on the same port.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
