### PR TITLE
Improved version of #8031 and some other fixes and optimizations.

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1053,7 +1053,7 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qn
   }
 }
 
-void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *pkt_p, int zoneId )
+void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, int zoneId, DNSPacket *pkt_p )
 {
   d_handle.reset();
   DNSName domain(qname);

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1066,7 +1066,7 @@ void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *p
 
   do {
     found = safeGetBBDomainInfo(domain, &bbd);
-  } while ((!found || (zoneId != (int)bbd.d_id && zoneId != -1)) && domain.chopOff());
+  } while ((!found || (zoneId != (int)bbd.d_id && zoneId != -1)) && qtype != QType::SOA && domain.chopOff());
 
   if(!found) {
     if(mustlog)

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1056,17 +1056,26 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qn
 void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, int zoneId, DNSPacket *pkt_p )
 {
   d_handle.reset();
-  DNSName domain(qname);
 
   static bool mustlog=::arg().mustDo("query-logging");
-  if(mustlog) 
-    g_log<<Logger::Warning<<"Lookup for '"<<qtype.getName()<<"' of '"<<domain<<"' within zoneID "<<zoneId<<endl;
-  bool found=false;
+
+  bool found;
+  DNSName domain;
   BB2DomainInfo bbd;
 
-  do {
-    found = safeGetBBDomainInfo(domain, &bbd);
-  } while ((!found || (zoneId != (int)bbd.d_id && zoneId != -1)) && qtype != QType::SOA && domain.chopOff());
+  if(mustlog)
+    g_log<<Logger::Warning<<"Lookup for '"<<qtype.getName()<<"' of '"<<qname<<"' within zoneID "<<zoneId<<endl;
+
+  if (zoneId >= 0) {
+    if ((found = safeGetBBDomainInfo(zoneId, &bbd))) {
+      domain = bbd.d_name;
+    }
+  } else {
+    domain = qname;
+    do {
+      found = safeGetBBDomainInfo(domain, &bbd);
+    } while (!found && qtype != QType::SOA && domain.chopOff());
+  }
 
   if(!found) {
     if(mustlog)
@@ -1077,12 +1086,9 @@ void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, int zoneId, 
 
   if(mustlog)
     g_log<<Logger::Warning<<"Found a zone '"<<domain<<"' (with id " << bbd.d_id<<") that might contain data "<<endl;
-    
+
   d_handle.id=bbd.d_id;
-  
-  DLOG(g_log<<"Bind2Backend constructing handle for search for "<<qtype.getName()<<" for "<<
-       qname<<endl);
-  
+
   if(domain.empty())
     d_handle.qname=qname;
   else if(qname.isPartOf(domain))

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1067,7 +1067,7 @@ void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, int zoneId, 
     g_log<<Logger::Warning<<"Lookup for '"<<qtype.getName()<<"' of '"<<qname<<"' within zoneID "<<zoneId<<endl;
 
   if (zoneId >= 0) {
-    if ((found = safeGetBBDomainInfo(zoneId, &bbd))) {
+    if ((found = (safeGetBBDomainInfo(zoneId, &bbd) && qname.isPartOf(bbd.d_name)))) {
       domain = bbd.d_name;
     }
   } else {
@@ -1079,7 +1079,7 @@ void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, int zoneId, 
 
   if(!found) {
     if(mustlog)
-      g_log<<Logger::Warning<<"Found no authoritative zone for "<<qname<<endl;
+      g_log<<Logger::Warning<<"Found no authoritative zone for '"<<qname<<"' and/or id "<<bbd.d_id<<endl;
     d_handle.d_list=false;
     return;
   }
@@ -1088,12 +1088,7 @@ void Bind2Backend::lookup(const QType &qtype, const DNSName &qname, int zoneId, 
     g_log<<Logger::Warning<<"Found a zone '"<<domain<<"' (with id " << bbd.d_id<<") that might contain data "<<endl;
 
   d_handle.id=bbd.d_id;
-
-  if(domain.empty())
-    d_handle.qname=qname;
-  else if(qname.isPartOf(domain))
-    d_handle.qname=qname.makeRelative(domain); // strip domain name
-
+  d_handle.qname=qname.makeRelative(domain); // strip domain name
   d_handle.qtype=qtype;
   d_handle.domain=domain;
 

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -195,7 +195,7 @@ public:
   time_t getCtime(const string &fname);
    // DNSSEC
   bool getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after) override;
-  void lookup(const QType &, const DNSName &qdomain, DNSPacket *p=0, int zoneId=-1) override;
+  void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *p=nullptr) override;
   bool list(const DNSName &target, int id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -343,7 +343,7 @@ bool GeoIPBackend::lookup_static(const GeoIPDomain &dom, const DNSName &search, 
   return false;
 };
 
-void GeoIPBackend::lookup(const QType &qtype, const DNSName& qdomain, DNSPacket *pkt_p, int zoneId) {
+void GeoIPBackend::lookup(const QType &qtype, const DNSName& qdomain, int zoneId, DNSPacket *pkt_p) {
   ReadLock rl(&s_state_lock);
   const GeoIPDomain* dom;
   GeoIPNetmask gl;

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -49,7 +49,7 @@ public:
   GeoIPBackend(const std::string& suffix="");
   ~GeoIPBackend();
 
-  void lookup(const QType &qtype, const DNSName &qdomain, DNSPacket *pkt_p=0, int zoneId=-1) override;
+  void lookup(const QType &qtype, const DNSName &qdomain, int zoneId, DNSPacket *pkt_p=nullptr) override;
   bool list(const DNSName &target, int domain_id, bool include_disabled=false) override { return false; } // not supported
   bool get(DNSResourceRecord &r) override;
   void reload() override;

--- a/modules/ldapbackend/ldapbackend.hh
+++ b/modules/ldapbackend/ldapbackend.hh
@@ -174,7 +174,7 @@ class LdapBackend : public DNSBackend
 
     // Native backend
     bool list( const DNSName& target, int domain_id, bool include_disabled=false ) override;
-    void lookup( const QType& qtype, const DNSName& qdomain, DNSPacket* p = 0, int zoneid = -1 ) override;
+    void lookup( const QType& qtype, const DNSName& qdomain, int zoneid, DNSPacket* p = nullptr ) override;
     bool get( DNSResourceRecord& rr ) override;
 
     bool getDomainInfo( const DNSName& domain, DomainInfo& di, bool getSerial=true ) override;

--- a/modules/ldapbackend/native.cc
+++ b/modules/ldapbackend/native.cc
@@ -117,7 +117,7 @@ bool LdapBackend::list_strict( const DNSName& target, int domain_id )
 
 
 
-void LdapBackend::lookup( const QType &qtype, const DNSName &qname, DNSPacket *dnspkt, int zoneid )
+void LdapBackend::lookup( const QType &qtype, const DNSName &qname, int zoneid, DNSPacket *dnspkt )
 {
   try
   {
@@ -138,7 +138,7 @@ void LdapBackend::lookup( const QType &qtype, const DNSName &qname, DNSPacket *d
   {
     g_log << Logger::Warning << d_myname << " Connection to LDAP lost, trying to reconnect" << endl;
     if ( reconnect() )
-      this->lookup( qtype, qname, dnspkt, zoneid );
+      this->lookup( qtype, qname, zoneid, dnspkt );
     else
       throw PDNSException( "Failed to reconnect to LDAP server" );
   }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -540,7 +540,7 @@ bool LMDBBackend::list(const DNSName &target, int id, bool include_disabled)
   return true;
 }
 
-void LMDBBackend::lookup(const QType &type, const DNSName &qdomain, DNSPacket *p, int zoneId)
+void LMDBBackend::lookup(const QType &type, const DNSName &qdomain, int zoneId, DNSPacket *p)
 {
   if(d_dolog) {
     g_log << Logger::Warning << "Got lookup for "<<qdomain<<"|"<<type.getName()<<" in zone "<< zoneId<<endl;
@@ -635,7 +635,7 @@ bool LMDBBackend::get(DNSResourceRecord& rr)
 bool LMDBBackend::getSOA(const DNSName &domain, SOAData &sd)
 {
   //  cout <<"Native getSOA called"<<endl;
-  lookup(QType(QType::SOA), domain, 0, -1);
+  lookup(QType(QType::SOA), domain, -1);
   DNSZoneRecord dzr;
   bool found=false;
   while(get(dzr)) {

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -51,7 +51,7 @@ public:
   bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
 
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;
-  void lookup(const QType &type, const DNSName &qdomain, DNSPacket *p, int zoneId) override;
+  void lookup(const QType &type, const DNSName &qdomain, int zoneId, DNSPacket *p=nullptr) override;
   bool get(DNSResourceRecord &rr) override;
   bool get(DNSZoneRecord& dzr) override;
 

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -180,7 +180,7 @@ public:
     return true;
   }
 
-  void lookup(const QType &qtype, const DNSName &qname, DNSPacket *p, int domain_id) override {
+  void lookup(const QType &qtype, const DNSName &qname, int domain_id, DNSPacket *p=nullptr) override {
     if (d_result.size() != 0)
       throw PDNSException("lookup attempted while another was running");
 

--- a/modules/luabackend/luabackend.hh
+++ b/modules/luabackend/luabackend.hh
@@ -47,7 +47,7 @@ public:
     LUABackend(const string &suffix="");
     ~LUABackend();
     bool list(const DNSName &target, int domain_id, bool include_disabled=false) override;
-    void lookup(const QType &qtype, const DNSName &qname, DNSPacket *p, int domain_id) override;
+    void lookup(const QType &qtype, const DNSName &qname, int domain_id, DNSPacket *p=nullptr) override;
     bool get(DNSResourceRecord &rr) override;
     //! fills the soadata struct with the SOA details. Returns false if there is no SOA.
     bool getSOA(const DNSName &name, SOAData &soadata) override;

--- a/modules/luabackend/minimal.cc
+++ b/modules/luabackend/minimal.cc
@@ -97,7 +97,7 @@ bool LUABackend::list(const DNSName &target, int domain_id, bool include_disable
     return ok;
 }
 
-void LUABackend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *p, int domain_id) {
+void LUABackend::lookup(const QType &qtype, const DNSName &qname, int domain_id, DNSPacket *p) {
     if (logging)
 	g_log << Logger::Info << backend_name << "(lookup) BEGIN" << endl;
 

--- a/modules/mydnsbackend/mydnsbackend.cc
+++ b/modules/mydnsbackend/mydnsbackend.cc
@@ -242,7 +242,7 @@ bool MyDNSBackend::getSOA(const DNSName& name, SOAData& soadata) {
   return true;
 }
 
-void MyDNSBackend::lookup(const QType &qtype, const DNSName &qname, DNSPacket *p, int zoneId) {
+void MyDNSBackend::lookup(const QType &qtype, const DNSName &qname, int zoneId, DNSPacket *p) {
   SSqlStatement::row_t rrow;
   bool found = false;
 

--- a/modules/mydnsbackend/mydnsbackend.hh
+++ b/modules/mydnsbackend/mydnsbackend.hh
@@ -36,7 +36,7 @@ public:
   MyDNSBackend(const string &suffix);
   ~MyDNSBackend();
   
-  void lookup(const QType &, const DNSName &qdomain, DNSPacket *p=0, int zoneId=-1) override;
+  void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *p=nullptr) override;
   bool list(const DNSName &target, int domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
   bool getSOA(const DNSName& name, SOAData& soadata) override;

--- a/modules/opendbxbackend/odbxbackend.cc
+++ b/modules/opendbxbackend/odbxbackend.cc
@@ -289,7 +289,7 @@ bool OdbxBackend::list( const DNSName& target, int zoneid, bool include_disabled
 
 
 
-void OdbxBackend::lookup( const QType& qtype, const DNSName& qname, DNSPacket* dnspkt, int zoneid )
+void OdbxBackend::lookup( const QType& qtype, const DNSName& qname, int zoneid, DNSPacket* dnspkt )
 {
         try
         {

--- a/modules/opendbxbackend/odbxbackend.hh
+++ b/modules/opendbxbackend/odbxbackend.hh
@@ -76,7 +76,7 @@ public:
         OdbxBackend( const string& suffix="" );
         ~OdbxBackend();
 
-        void lookup( const QType& qtype, const DNSName& qdomain, DNSPacket* p = 0, int zoneid = -1 ) override;
+        void lookup( const QType& qtype, const DNSName& qdomain, int zoneid, DNSPacket* p = nullptr ) override;
         bool getSOA( const DNSName& domain, SOAData& sd ) override;
         bool list( const DNSName& target, int domain_id, bool include_disabled=false ) override;
         bool get( DNSResourceRecord& rr ) override;

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -159,7 +159,7 @@ void PipeBackend::cleanup()
   d_abiVersion = 0;
 }
 
-void PipeBackend::lookup(const QType& qtype,const DNSName& qname, DNSPacket *pkt_p,  int zoneId)
+void PipeBackend::lookup(const QType& qtype,const DNSName& qname, int zoneId, DNSPacket *pkt_p)
 {
   try {
     launch();

--- a/modules/pipebackend/pipebackend.hh
+++ b/modules/pipebackend/pipebackend.hh
@@ -53,7 +53,7 @@ class PipeBackend : public DNSBackend
 public:
   PipeBackend(const string &suffix="");
   ~PipeBackend();
-  void lookup(const QType&, const DNSName& qdomain, DNSPacket *p=0, int zoneId=-1) override;
+  void lookup(const QType&, const DNSName& qdomain, int zoneId, DNSPacket *p=nullptr) override;
   bool list(const DNSName& target, int domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
   string directBackendCmd(const string &query) override;

--- a/modules/randombackend/randombackend.cc
+++ b/modules/randombackend/randombackend.cc
@@ -48,7 +48,7 @@ public:
     return false; // we don't support AXFR
   }
 
-  void lookup(const QType &type, const DNSName &qdomain, DNSPacket *p, int zoneId) override
+  void lookup(const QType &type, const DNSName &qdomain, int zoneId, DNSPacket *p) override
   {
     if(qdomain == d_ourdomain){
       if(type.getCode() == QType::SOA || type.getCode() == QType::ANY) {

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -165,7 +165,7 @@ int RemoteBackend::build() {
  * The functions here are just remote json stubs that send and receive the method call
  * data is mainly left alone, some defaults are assumed.
  */
-void RemoteBackend::lookup(const QType &qtype, const DNSName& qdomain, DNSPacket *pkt_p, int zoneId) {
+void RemoteBackend::lookup(const QType &qtype, const DNSName& qdomain, int zoneId, DNSPacket *pkt_p) {
    if (d_index != -1)
       throw PDNSException("Attempt to lookup while one running");
 

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -155,7 +155,7 @@ class RemoteBackend : public DNSBackend
   RemoteBackend(const std::string &suffix="");
   ~RemoteBackend();
 
-  void lookup(const QType &qtype, const DNSName& qdomain, DNSPacket *pkt_p=0, int zoneId=-1) override;
+  void lookup(const QType &qtype, const DNSName& qdomain, int zoneId=-1, DNSPacket *pkt_p=nullptr) override;
   bool get(DNSResourceRecord &rr) override;
   bool list(const DNSName& target, int domain_id, bool include_disabled=false) override;
 

--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -196,7 +196,7 @@ bool TinyDNSBackend::list(const DNSName &target, int domain_id, bool include_dis
   return d_cdbReader->searchSuffix(key);
 }
 
-void TinyDNSBackend::lookup(const QType &qtype, const DNSName &qdomain, DNSPacket *pkt_p, int zoneId) {
+void TinyDNSBackend::lookup(const QType &qtype, const DNSName &qdomain, int zoneId, DNSPacket *pkt_p) {
   d_isAxfr = false;
   string queryDomain = toLowerCanonic(qdomain.toString());
 

--- a/modules/tinydnsbackend/tinydnsbackend.hh
+++ b/modules/tinydnsbackend/tinydnsbackend.hh
@@ -67,7 +67,7 @@ class TinyDNSBackend : public DNSBackend
 public:
   // Methods for simple operation
   TinyDNSBackend(const string &suffix);
-  void lookup(const QType &qtype, const DNSName &qdomain, DNSPacket *pkt_p=0, int zoneId=-1) override;
+  void lookup(const QType &qtype, const DNSName &qdomain, int zoneId, DNSPacket *pkt_p=nullptr) override;
   bool list(const DNSName &target, int domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &rr) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1038,7 +1038,7 @@ bool GSQLBackend::setDomainMetadata(const DNSName& name, const std::string& kind
   return true;
 }
 
-void GSQLBackend::lookup(const QType &qtype,const DNSName &qname, DNSPacket *pkt_p, int domain_id)
+void GSQLBackend::lookup(const QType &qtype,const DNSName &qname, int domain_id, DNSPacket *pkt_p)
 {
   try {
     reconnectIfNeeded();

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -179,7 +179,7 @@ public:
     d_SearchCommentsQuery_stmt.reset();
   }
 
-  void lookup(const QType &, const DNSName &qdomain, DNSPacket *p=0, int zoneId=-1) override;
+  void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *p=nullptr) override;
   bool list(const DNSName &target, int domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -118,7 +118,7 @@ void CommunicatorClass::mainloop(void)
     for(;;) {
       slaveRefresh(&P);
       masterUpdateCheck(&P);
-      tick=doNotifications(); // this processes any notification acknowledgements and actually send out our own notifications
+      tick=doNotifications(&P); // this processes any notification acknowledgements and actually send out our own notifications
       
       tick = min (tick, d_tickinterval); 
       
@@ -145,7 +145,7 @@ void CommunicatorClass::mainloop(void)
           break; // something happened
         }
         // this gets executed at least once every second
-        doNotifications();
+        doNotifications(&P);
       }
     }
   }

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -161,7 +161,7 @@ public:
     d_nsock6 = -1;
     d_preventSelfNotification = false;
   }
-  time_t doNotifications();    
+  time_t doNotifications(PacketHandler *P);
   void go();
   
   
@@ -173,7 +173,7 @@ public:
   void notify(const DNSName &domain, const string &ip);
   void mainloop();
   void retrievalLoopThread();
-  void sendNotification(int sock, const DNSName &domain, const ComboAddress& remote, uint16_t id);
+  void sendNotification(int sock, const DNSName &domain, const ComboAddress& remote, uint16_t id, UeberBackend* B);
 
   static void *launchhelper(void *p)
   {
@@ -185,7 +185,7 @@ public:
     static_cast<CommunicatorClass *>(p)->retrievalLoopThread();
     return 0;
   }
-  bool notifyDomain(const DNSName &domain);
+  bool notifyDomain(const DNSName &domain, UeberBackend* B);
 private:
   void loadArgsIntoSet(const char *listname, set<string> &listset);
   void makeNotifySockets();

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -258,7 +258,7 @@ public:
     this->resolve_name(&addresses, name);
     
     if(b) {
-        b->lookup(QType(QType::ANY),name);
+        b->lookup(QType(QType::ANY),name,-1);
         DNSZoneRecord rr;
         while(b->get(rr))
           if(rr.dr.d_type == QType::A || rr.dr.d_type==QType::AAAA)

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -546,7 +546,7 @@ bool DNSSECKeeper::getPreRRSIGs(UeberBackend& db, const DNSName& signer, const D
                 DLOG(g_log<<"Could not get SOA for domain"<<endl);
                 return false;
         }
-        db.lookup(QType(QType::RRSIG), wildcardname.countLabels() ? wildcardname : qname, NULL, sd.domain_id);
+        db.lookup(QType(QType::RRSIG), wildcardname.countLabels() ? wildcardname : qname, sd.domain_id);
         DNSZoneRecord rr;
         while(db.get(rr)) {
           auto rrsig = getRR<RRSIGRecordContent>(rr.dr);

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -221,7 +221,7 @@ vector<DNSBackend *>BackendMakerClass::all(bool metadataOnly)
 */
 bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd)
 {
-  this->lookup(QType(QType::SOA),domain);
+  this->lookup(QType(QType::SOA),domain,-1);
 
   DNSResourceRecord rr;
   rr.auth = true;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -121,7 +121,7 @@ class DNSBackend
 {
 public:
   //! lookup() initiates a lookup. A lookup without results should not throw!
-  virtual void lookup(const QType &qtype, const DNSName &qdomain, DNSPacket *pkt_p=0, int zoneId=-1)=0; 
+  virtual void lookup(const QType &qtype, const DNSName &qdomain, int zoneId=-1, DNSPacket *pkt_p=nullptr)=0;
   virtual bool get(DNSResourceRecord &)=0; //!< retrieves one DNSResource record, returns false if no more were available
   virtual bool get(DNSZoneRecord &r);
 

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -301,7 +301,7 @@ string DLNotifyHandler(const vector<string>&parts, Utility::pid_t ppid)
     for (const auto& di : domains) {
       if (di.kind == DomainInfo::Master || di.kind == DomainInfo::Slave) { // MASTER and Slave if slave-renotify is enabled
         total++;
-        if(Communicator.notifyDomain(di.zone))
+        if(Communicator.notifyDomain(di.zone, &B))
           notified++;
       }
     }
@@ -316,7 +316,7 @@ string DLNotifyHandler(const vector<string>&parts, Utility::pid_t ppid)
     } catch (...) {
       return "Failed to parse domain as valid DNS name";
     }
-    if(!Communicator.notifyDomain(DNSName(parts[1])))
+    if(!Communicator.notifyDomain(DNSName(parts[1]), &B))
       return "Failed to add to the queue - see log";
     return "Added to queue";
   }

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -393,7 +393,7 @@ static std::vector<DNSZoneRecord> lookup(const DNSName& name, uint16_t qtype, in
   static UeberBackend ub;
   static std::mutex mut;
   std::lock_guard<std::mutex> lock(mut);
-  ub.lookup(QType(qtype), name, nullptr, zoneid);
+  ub.lookup(QType(qtype), name, zoneid);
   DNSZoneRecord dr;
   vector<DNSZoneRecord> ret;
   while(ub.get(dr)) {

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -52,7 +52,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
 
   try {
   if (d_onlyNotify.size()) {
-    B->lookup(QType(QType::NS), di.zone, -1);
+    B->lookup(QType(QType::NS), di.zone, di.id);
     while(B->get(rr))
       nsset.insert(getRR<NSRecordContent>(rr.dr)->getNS().toString());
 

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -112,15 +112,14 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
 }
 
 
-bool CommunicatorClass::notifyDomain(const DNSName &domain)
+bool CommunicatorClass::notifyDomain(const DNSName &domain, UeberBackend* B)
 {
   DomainInfo di;
-  UeberBackend B;
-  if(!B.getDomainInfo(domain, di)) {
+  if(!B->getDomainInfo(domain, di)) {
     g_log<<Logger::Error<<"No such domain '"<<domain<<"' in our database"<<endl;
     return false;
   }
-  queueNotifyDomain(di, &B);
+  queueNotifyDomain(di, B);
   // call backend and tell them we sent out the notification - even though that is premature    
   di.backend->setNotified(di.id, di.serial);
 
@@ -166,8 +165,9 @@ void CommunicatorClass::masterUpdateCheck(PacketHandler *P)
   }
 }
 
-time_t CommunicatorClass::doNotifications()
+time_t CommunicatorClass::doNotifications(PacketHandler *P)
 {
+  UeberBackend *B=P->getBackend();
   ComboAddress from;
   Utility::socklen_t fromlen;
   char buffer[1500];
@@ -220,7 +220,7 @@ time_t CommunicatorClass::doNotifications()
         if(d_preventSelfNotification && AddressIsUs(remote))
           continue;
 
-        sendNotification(remote.sin4.sin_family == AF_INET ? d_nsock4 : d_nsock6, domain, remote, id);
+        sendNotification(remote.sin4.sin_family == AF_INET ? d_nsock4 : d_nsock6, domain, remote, id, B);
         drillHole(domain, ip);
       }
       catch(ResolverException &re) {
@@ -234,16 +234,15 @@ time_t CommunicatorClass::doNotifications()
   return d_nq.earliest();
 }
 
-void CommunicatorClass::sendNotification(int sock, const DNSName& domain, const ComboAddress& remote, uint16_t id)
+void CommunicatorClass::sendNotification(int sock, const DNSName& domain, const ComboAddress& remote, uint16_t id, UeberBackend *B)
 {
-  UeberBackend B;
   vector<string> meta;
   DNSName tsigkeyname;
   DNSName tsigalgorithm;
   string tsigsecret64;
   string tsigsecret;
 
-  if (::arg().mustDo("send-signed-notify") && B.getDomainMetadata(domain, "TSIG-ALLOW-AXFR", meta) && meta.size() > 0) {
+  if (::arg().mustDo("send-signed-notify") && B->getDomainMetadata(domain, "TSIG-ALLOW-AXFR", meta) && meta.size() > 0) {
     tsigkeyname = DNSName(meta[0]);
   }
 
@@ -253,7 +252,7 @@ void CommunicatorClass::sendNotification(int sock, const DNSName& domain, const 
   pw.getHeader()->aa = true; 
 
   if (tsigkeyname.empty() == false) {
-    if (!B.getTSIGKey(tsigkeyname, &tsigalgorithm, &tsigsecret64)) {
+    if (!B->getTSIGKey(tsigkeyname, &tsigalgorithm, &tsigsecret64)) {
       g_log<<Logger::Error<<"TSIG key '"<<tsigkeyname<<"' for domain '"<<domain<<"' not found"<<endl;
       return;
     }

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -204,7 +204,7 @@ time_t CommunicatorClass::doNotifications(PacketHandler *P)
   // send out possible new notifications
   DNSName domain;
   string ip;
-  uint16_t id;
+  uint16_t id=0;
 
   bool purged;
   while(d_nq.getOne(domain, ip, &id, purged)) {

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -52,7 +52,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
 
   try {
   if (d_onlyNotify.size()) {
-    B->lookup(QType(QType::NS), di.zone);
+    B->lookup(QType(QType::NS), di.zone, -1);
     while(B->get(rr))
       nsset.insert(getRR<NSRecordContent>(rr.dr)->getNS().toString());
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1611,9 +1611,8 @@ bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = false)
     vector<DNSKEYRecordContent> keys;
     DNSZoneRecord zr;
 
-    B.lookup(QType(QType::DNSKEY), zone, -1 );
-    while(B.get(zr)) {
-      if (zr.dr.d_type != QType::DNSKEY) continue;
+    di.backend->lookup(QType(QType::DNSKEY), zone, di.id );
+    while(di.backend->get(zr)) {
       keys.push_back(*getRR<DNSKEYRecordContent>(zr.dr));
     }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -193,11 +193,11 @@ void dbBench(const std::string& fname)
   unsigned int hits=0, misses=0;
   for(; n < 10000; ++n) {
     DNSName domain(domains[dns_random(domains.size())]);
-    B.lookup(QType(QType::NS), domain);
+    B.lookup(QType(QType::NS), domain, -1);
     while(B.get(rr)) {
       hits++;
     }
-    B.lookup(QType(QType::A), DNSName(std::to_string(random()))+domain);
+    B.lookup(QType(QType::A), DNSName(std::to_string(random()))+domain, -1);
     while(B.get(rr)) {
     }
     misses++;
@@ -299,7 +299,7 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
     if(B.getSOAUncached(parent, sd_p)) {
       bool ns=false;
       DNSZoneRecord zr;
-      B.lookup(QType(QType::ANY), zone, NULL, sd_p.domain_id);
+      B.lookup(QType(QType::ANY), zone, sd_p.domain_id);
       while(B.get(zr))
         ns |= (zr.dr.d_type == QType::NS);
       if (!ns) {
@@ -1232,7 +1232,7 @@ int addOrReplaceRecord(bool addOrReplace, const vector<string>& cmds) {
   di.backend->startTransaction(zone, -1);
 
   if(addOrReplace) { // the 'add' case
-    di.backend->lookup(rr.qtype, rr.qname, 0, di.id);
+    di.backend->lookup(rr.qtype, rr.qname, di.id);
 
     while(di.backend->get(oldrr))
       newrrs.push_back(oldrr);
@@ -1249,7 +1249,7 @@ int addOrReplaceRecord(bool addOrReplace, const vector<string>& cmds) {
     }
   }
 
-  di.backend->lookup(QType(QType::ANY), rr.qname, 0, di.id);
+  di.backend->lookup(QType(QType::ANY), rr.qname, di.id);
   bool found=false;
   if(rr.qtype.getCode() == QType::CNAME) { // this will save us SO many questions
 
@@ -1285,7 +1285,7 @@ int addOrReplaceRecord(bool addOrReplace, const vector<string>& cmds) {
 
   di.backend->replaceRRSet(di.id, name, rr.qtype, newrrs);
   // need to be explicit to bypass the ueberbackend cache!
-  di.backend->lookup(rr.qtype, name, 0, di.id);
+  di.backend->lookup(rr.qtype, name, di.id);
   di.backend->commitTransaction();
   cout<<"New rrset:"<<endl;
   while(di.backend->get(rr)) {
@@ -1611,7 +1611,7 @@ bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = false)
     vector<DNSKEYRecordContent> keys;
     DNSZoneRecord zr;
 
-    B.lookup(QType(QType::DNSKEY), zone);
+    B.lookup(QType(QType::DNSKEY), zone, -1 );
     while(B.get(zr)) {
       if (zr.dr.d_type != QType::DNSKEY) continue;
       keys.push_back(*getRR<DNSKEYRecordContent>(zr.dr));
@@ -1851,7 +1851,7 @@ void testSchema(DNSSECKeeper& dk, const DNSName& zone)
   cout<<"Committing"<<endl;
   db->commitTransaction();
   cout<<"Querying TXT"<<endl;
-  db->lookup(QType(QType::TXT), zone, NULL, di.id);
+  db->lookup(QType(QType::TXT), zone, di.id);
   if(db->get(rrget))
   {
     DNSResourceRecord rrthrowaway;

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -33,7 +33,7 @@ int PacketHandler::checkUpdatePrerequisites(const DNSRecord *rr, DomainInfo *di)
 
   bool foundRecord=false;
   DNSResourceRecord rec;
-  di->backend->lookup(QType(QType::ANY), rr->d_name, nullptr, di->id);
+  di->backend->lookup(QType(QType::ANY), rr->d_name, di->id);
   while(di->backend->get(rec)) {
     if (!rec.qtype.getCode())
       continue;
@@ -171,7 +171,7 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
 
 
     bool foundRecord = false;
-    di->backend->lookup(rrType, rr->d_name, nullptr, di->id);
+    di->backend->lookup(rrType, rr->d_name, di->id);
     while (di->backend->get(rec)) {
       rrset.push_back(rec);
       foundRecord = true;
@@ -289,7 +289,7 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
             break;
 
           bool foundShorter = false;
-          di->backend->lookup(QType(QType::ANY), shorter, nullptr, di->id);
+          di->backend->lookup(QType(QType::ANY), shorter, di->id);
           while (di->backend->get(rec)) {
             if (rec.qname == rr->d_name && rec.qtype == QType::DS)
               fixDS = true;
@@ -444,7 +444,7 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
     } // end of NSEC3PARAM delete block
 
 
-    di->backend->lookup(rrType, rr->d_name, nullptr, di->id);
+    di->backend->lookup(rrType, rr->d_name, di->id);
     while(di->backend->get(rec)) {
       if (rr->d_class == QClass::ANY) { // 3.4.2.3
         if (rec.qname == di->zone && (rec.qtype == QType::NS || rec.qtype == QType::SOA)) // Never delete all SOA and NS's
@@ -861,7 +861,7 @@ int PacketHandler::processUpdate(DNSPacket *p) {
       rrVector_t *vec = &preRRSet->second;
 
       DNSResourceRecord rec;
-      di.backend->lookup(QType(QType::ANY), rrSet.first, nullptr, di.id);
+      di.backend->lookup(QType(QType::ANY), rrSet.first, di.id);
       uint16_t foundRR=0, matchRR=0;
       while (di.backend->get(rec)) {
         if (rec.qtype == rrSet.second) {
@@ -959,7 +959,7 @@ int PacketHandler::processUpdate(DNSPacket *p) {
     }
     for (const auto &rr : cnamesToAdd) {
       DNSResourceRecord rec;
-      di.backend->lookup(QType(QType::ANY), rr->d_name, nullptr, di.id);
+      di.backend->lookup(QType(QType::ANY), rr->d_name, di.id);
       while (di.backend->get(rec)) {
         if (rec.qtype != QType::CNAME && rec.qtype != QType::ENT && rec.qtype != QType::RRSIG) {
           // leave database handle in a consistent state
@@ -974,7 +974,7 @@ int PacketHandler::processUpdate(DNSPacket *p) {
     }
     for (const auto &rr : nonCnamesToAdd) {
       DNSResourceRecord rec;
-      di.backend->lookup(QType(QType::CNAME), rr->d_name, nullptr, di.id);
+      di.backend->lookup(QType(QType::CNAME), rr->d_name, di.id);
       while (di.backend->get(rec)) {
         if (rec.qtype == QType::CNAME && rr->d_type != QType::RRSIG) {
           // leave database handle in a consistent state
@@ -990,7 +990,7 @@ int PacketHandler::processUpdate(DNSPacket *p) {
     if (nsRRtoDelete.size()) {
       vector<DNSResourceRecord> nsRRInZone;
       DNSResourceRecord rec;
-      di.backend->lookup(QType(QType::NS), di.zone, nullptr, di.id);
+      di.backend->lookup(QType(QType::NS), di.zone, di.id);
       while (di.backend->get(rec)) {
         nsRRInZone.push_back(rec);
       }

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -1028,7 +1028,7 @@ int PacketHandler::processUpdate(DNSPacket *p) {
         vector<string> notify;
         B.getDomainMetadata(p->qdomain, "NOTIFY-DNSUPDATE", notify);
         if (!notify.empty() && notify.front() == "1") {
-          Communicator.notifyDomain(di.zone);
+          Communicator.notifyDomain(di.zone, &B);
         }
       }
 

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -613,7 +613,7 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote)
       }
     }
     if(renotify)
-      notifyDomain(domain);
+      notifyDomain(domain, &B);
   }
   catch(DBException &re) {
     g_log<<Logger::Error<<"Unable to feed record during incoming AXFR of '" << domain<<"': "<<re.reason<<endl;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -960,7 +960,7 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
     else if(hasSOA && theirserial == ourserial) {
       uint32_t maxExpire=0, maxInception=0;
       if(dk.isPresigned(di.zone)) {
-        B->lookup(QType(QType::RRSIG), di.zone, -1); // can't use DK before we are done with this lookup!
+        B->lookup(QType(QType::RRSIG), di.zone, di.id); // can't use DK before we are done with this lookup!
         DNSZoneRecord zr;
         while(B->get(zr)) {
           auto rrsig = getRR<RRSIGRecordContent>(zr.dr);

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -141,7 +141,7 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
         vector<DNSRecord> rrset;
         {
           DNSZoneRecord zrr;
-          B.lookup(QType(g.first.second), g.first.first+domain, 0, di.id);
+          B.lookup(QType(g.first.second), g.first.first+domain, di.id);
           while(B.get(zrr)) {
             zrr.dr.d_name.makeUsRelative(domain);
             rrset.push_back(zrr.dr);
@@ -960,7 +960,7 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
     else if(hasSOA && theirserial == ourserial) {
       uint32_t maxExpire=0, maxInception=0;
       if(dk.isPresigned(di.zone)) {
-        B->lookup(QType(QType::RRSIG), di.zone); // can't use DK before we are done with this lookup!
+        B->lookup(QType(QType::RRSIG), di.zone, -1); // can't use DK before we are done with this lookup!
         DNSZoneRecord zr;
         while(B->get(zr)) {
           auto rrsig = getRR<RRSIGRecordContent>(zr.dr);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -491,7 +491,7 @@ bool TCPNameserver::canDoAXFR(shared_ptr<DNSPacket> q)
         DNSResourceRecord rr;
         set<DNSName> nsset;
 
-        B->lookup(QType(QType::NS),q->qdomain);
+        B->lookup(QType(QType::NS),q->qdomain,sd.domain_id);
         while(B->get(rr)) 
           nsset.insert(DNSName(rr.content));
         for(const auto & j: nsset) {
@@ -715,7 +715,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   }
   
   if(::arg().mustDo("direct-dnskey")) {
-    sd.db->lookup(QType(QType::DNSKEY), target, NULL, sd.domain_id);
+    sd.db->lookup(QType(QType::DNSKEY), target, sd.domain_id);
     while(sd.db->get(zrr)) {
       zrr.dr.d_ttl = sd.default_ttl;
       csp.submit(zrr);

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -540,7 +540,7 @@ UeberBackend::~UeberBackend()
 }
 
 // this handle is more magic than most
-void UeberBackend::lookup(const QType &qtype,const DNSName &qname, DNSPacket *pkt_p, int zoneId)
+void UeberBackend::lookup(const QType &qtype,const DNSName &qname, int zoneId, DNSPacket *pkt_p)
 {
   if(d_stale) {
     g_log<<Logger::Error<<"Stale ueberbackend received question, signalling that we want to be recycled"<<endl;
@@ -580,7 +580,7 @@ void UeberBackend::lookup(const QType &qtype,const DNSName &qname, DNSPacket *pk
       //      cout<<"UeberBackend::lookup("<<qname<<"|"<<DNSRecordContent::NumberToType(qtype.getCode())<<"): uncached"<<endl;
       d_negcached=d_cached=false;
       d_answers.clear(); 
-      (d_handle.d_hinterBackend=backends[d_handle.i++])->lookup(qtype, qname,pkt_p,zoneId);
+      (d_handle.d_hinterBackend=backends[d_handle.i++])->lookup(qtype, qname,zoneId,pkt_p);
     } 
     else if(cstat==0) {
       //      cout<<"UeberBackend::lookup("<<qname<<"|"<<DNSRecordContent::NumberToType(qtype.getCode())<<"): NEGcached"<<endl;
@@ -681,7 +681,7 @@ bool UeberBackend::handle::get(DNSZoneRecord &r)
            <<" out of answers, taking next"<<endl);
       
       d_hinterBackend=parent->backends[i++];
-      d_hinterBackend->lookup(qtype,qname,pkt_p,parent->d_domain_id);
+      d_hinterBackend->lookup(qtype,qname,parent->d_domain_id,pkt_p);
     }
     else 
       break;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -97,7 +97,7 @@ public:
     static AtomicCounter instances;
   };
 
-  void lookup(const QType &, const DNSName &qdomain, DNSPacket *pkt_p=0,  int zoneId=-1);
+  void lookup(const QType &, const DNSName &qdomain, int zoneId, DNSPacket *pkt_p=nullptr);
 
   /** Determines if we are authoritative for a zone, and at what level */
   bool getAuth(const DNSName &target, const QType &qtype, SOAData* sd, bool cachedOk=true);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1820,7 +1820,7 @@ static void apiServerZoneNotify(HttpRequest* req, HttpResponse* resp) {
     throw HttpNotFoundException();
   }
 
-  if(!Communicator.notifyDomain(zonename))
+  if(!Communicator.notifyDomain(zonename, &B))
     throw ApiException("Failed to add to the queue - see server log");
 
   resp->setSuccessResult("Notification queued");

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2013,7 +2013,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
 
         if (replace_records) {
           bool ent_present = false;
-          di.backend->lookup(QType(QType::ANY), qname);
+          di.backend->lookup(QType(QType::ANY), qname, -1);
           DNSResourceRecord rr;
           while (di.backend->get(rr)) {
             if (rr.qtype.getCode() == QType::ENT) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2013,7 +2013,7 @@ static void patchZone(HttpRequest* req, HttpResponse* resp) {
 
         if (replace_records) {
           bool ent_present = false;
-          di.backend->lookup(QType(QType::ANY), qname, -1);
+          di.backend->lookup(QType(QType::ANY), qname, di.id);
           DNSResourceRecord rr;
           while (di.backend->get(rr)) {
             if (rr.qtype.getCode() == QType::ENT) {


### PR DESCRIPTION
### Short description
The first commit is an improved version of #8031, since this optimization is only possible for SOA queries. The second commit is a cleanup to make it more easy to spot incorrect use of lookup() without a zone_id. The other commits are 'collateral damage' found while testing the first two commits.

Closes #8031

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
