### PR TITLE
ixfrdist: limit XFR chunk size to 16k

### DIFF
--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -573,7 +573,7 @@ static bool addRecordToWriter(DNSPacketWriter& pw, const DNSName& zoneName, cons
 {
   pw.startRecord(record.d_name + zoneName, record.d_type, record.d_ttl, QClass::IN, DNSResourceRecord::ANSWER, compress);
   record.d_content->toPacket(pw);
-  if (pw.size() > 65535) {
+  if (pw.size() > 16384) {
     pw.rollback();
     return false;
   }


### PR DESCRIPTION
### Short description
When compressing, bigger chunks limit our compression ratio. When not compressing, smaller chunks don't make a huge difference in performance.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
