### PR TITLE
pdnsutil: remove unused humanTime function

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -51,15 +51,6 @@ ArgvMap &arg()
   return arg;
 }
 
-string humanTime(time_t t)
-{
-  char ret[256];
-  struct tm tm;
-  localtime_r(&t, &tm);
-  strftime(ret, sizeof(ret)-1, "%c", &tm);   // %h:%M %Y-%m-%d
-  return ret;
-}
-
 void loadMainConfig(const std::string& configdir)
 {
   ::arg().set("config-dir","Location of configuration directory (pdns.conf)")=configdir;


### PR DESCRIPTION
### Short description
Discovered due to this new (to us) compiler warning:
```
pdnsutil.cc:59:32: warning: '%c' yields only last 2 digits of year in some locales [-Wformat-y2k]
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
