### PR TITLE
auth 4.2: Fix SERVFAIL when backend returns empty DNSName

### DIFF
--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -330,7 +330,7 @@ bool UeberBackend::getAuth(const DNSName &target, const QType& qtype, SOAData* s
           DLOG(g_log<<Logger::Error<<"lookup: "<<shorter<<endl);
           if((*i)->getAuth(shorter, sd)) {
             DLOG(g_log<<Logger::Error<<"got: "<<sd->qname<<endl);
-            if(!shorter.isPartOf(sd->qname) && !sd->qname.empty()) {
+            if(!sd->qname.empty() && !shorter.isPartOf(sd->qname)) {
               throw PDNSException("getAuth() returned an SOA for the wrong zone. Zone '"+sd->qname.toLogString()+"' is not part of '"+shorter.toLogString()+"'");
             }
             j->first = sd->qname.wirelength();


### PR DESCRIPTION
According to the documentation on UeberBackend::getAuth(), a backend
returning an empty DNSName should signal that no matching parent zone
exists in this backend. However commit ae14c1f36a raises an exception if
isPartOf() is called on an empty DNSName so we need to switch the order
of the logic to prevent a SERVFAIL as a result.

(cherry picked from commit 41147d678b30612d2431b59a898879368f1c4b06)

### Short description
Backport of #8054 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
