### PR TITLE
pdns/devpollmplexer: remove unused syncres.hh include

### DIFF
--- a/pdns/devpollmplexer.cc
+++ b/pdns/devpollmplexer.cc
@@ -33,7 +33,6 @@
 #include <iostream>
 #include <unistd.h>
 #include "misc.hh"
-#include "syncres.hh"
 
 #include "namespaces.hh"
 


### PR DESCRIPTION
### Short description
remove unused import to enable compile on illumos.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
