### PR TITLE
Make sure we always compile with BOOST_CB_ENABLE_DEBUG set to 0

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -160,6 +160,7 @@ pdns_server_SOURCES = \
 	bindlexer.l \
 	bindparser.cc \
 	cachecleaner.hh \
+	circular_buffer.hh \
 	comment.hh \
 	common_startup.cc common_startup.hh \
 	communicator.cc communicator.hh \
@@ -296,6 +297,7 @@ pdnsutil_SOURCES = \
 	bindlexer.l \
 	bindparser.yy \
 	cachecleaner.hh \
+	circular_buffer.hh \
 	dbdnsseckeeper.cc \
 	dnsbackend.cc \
 	dns.cc \

--- a/pdns/circular_buffer.hh
+++ b/pdns/circular_buffer.hh
@@ -21,6 +21,10 @@
  */
 #pragma once
 
+// Disable the non-threadsafe debug code in boost::circular_buffer before 1.62
+#define BOOST_CB_DISABLE_DEBUG 1
+
+// Make sure it is also disabled when >= 1.62
 #ifndef BOOST_CB_ENABLE_DEBUG
 #define BOOST_CB_ENABLE_DEBUG 0
 #endif
@@ -28,7 +32,7 @@
 #if BOOST_CB_ENABLE_DEBUG
 // https://github.com/boostorg/circular_buffer/pull/9
 // https://svn.boost.org/trac10/ticket/6277
-#error Building with BOOST_CB_ENABLE_DEBUG prevents accessing a boost::circular_buffer from two threads at once
+#error Building with BOOST_CB_ENABLE_DEBUG prevents accessing a boost::circular_buffer from more than one thread at once
 #endif /* BOOST_CB_ENABLE_DEBUG */
 
 #include <boost/circular_buffer.hpp>

--- a/pdns/circular_buffer.hh
+++ b/pdns/circular_buffer.hh
@@ -1,0 +1,34 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#ifndef BOOST_CB_ENABLE_DEBUG
+#define BOOST_CB_ENABLE_DEBUG 0
+#endif
+
+#if BOOST_CB_ENABLE_DEBUG
+// https://github.com/boostorg/circular_buffer/pull/9
+// https://svn.boost.org/trac10/ticket/6277
+#error Building with BOOST_CB_ENABLE_DEBUG prevents accessing a boost::circular_buffer from two threads at once
+#endif /* BOOST_CB_ENABLE_DEBUG */
+
+#include <boost/circular_buffer.hpp>

--- a/pdns/dnsdist-rings.hh
+++ b/pdns/dnsdist-rings.hh
@@ -25,9 +25,9 @@
 #include <time.h>
 #include <unordered_map>
 
-#include <boost/circular_buffer.hpp>
 #include <boost/variant.hpp>
 
+#include "circular_buffer.hh"
 #include "dnsname.hh"
 #include "iputils.hh"
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -31,11 +31,11 @@
 #include <unistd.h>
 #include <unordered_map>
 
-#include <boost/circular_buffer.hpp>
 #include <boost/variant.hpp>
 
 #include "bpf-filter.hh"
 #include "capabilities.hh"
+#include "circular_buffer.hh"
 #include "dnscrypt.hh"
 #include "dnsdist-cache.hh"
 #include "dnsdist-dynbpf.hh"

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -103,6 +103,7 @@ dnsdist_SOURCES = \
 	bpf-filter.cc bpf-filter.hh \
 	cachecleaner.hh \
 	capabilities.cc capabilities.hh \
+	circular_buffer.hh \
 	dns.cc dns.hh \
 	dnscrypt.cc dnscrypt.hh \
 	dnsdist.cc dnsdist.hh \
@@ -253,9 +254,11 @@ testrunner_SOURCES = \
 	test-iputils_hh.cc \
 	test-mplexer.cc \
 	cachecleaner.hh \
+	circular_buffer.hh \
 	dnsdist.hh \
 	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
+	dnsdist-rings.hh \
 	dnsdist-xpf.cc dnsdist-xpf.hh \
 	dnscrypt.cc dnscrypt.hh \
 	dnslabeltext.cc \

--- a/pdns/dnsdistdist/circular_buffer.hh
+++ b/pdns/dnsdistdist/circular_buffer.hh
@@ -1,0 +1,1 @@
+../circular_buffer.hh

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -1,6 +1,7 @@
 #include <fstream>
 
 #include "config.h"
+#include "circular_buffer.hh"
 #include "dolog.hh"
 #include "iputils.hh"
 #include "lock.hh"
@@ -16,8 +17,6 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
-
-#include <boost/circular_buffer.hpp>
 
 #include "libssl.hh"
 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -100,6 +100,7 @@ pdns_recursor_SOURCES = \
 	base64.cc base64.hh \
 	cachecleaner.hh \
 	capabilities.cc capabilities.hh \
+	circular_buffer.hh \
 	comment.hh \
 	dns.hh dns.cc \
 	dns_random.hh dns_random.cc \
@@ -218,6 +219,7 @@ testrunner_SOURCES = \
 	arguments.cc \
 	base32.cc \
 	base64.cc base64.hh \
+	circular_buffer.hh \
 	dns.cc dns.hh \
 	dns_random.cc dns_random.hh \
 	dnslabeltext.cc \

--- a/pdns/recursordist/circular_buffer.hh
+++ b/pdns/recursordist/circular_buffer.hh
@@ -1,0 +1,1 @@
+../circular_buffer.hh

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -30,7 +30,7 @@
 #include <thread>
 
 #include "iputils.hh"
-#include <boost/circular_buffer.hpp>
+#include "circular_buffer.hh"
 
 /* Writes can be submitted and they are atomically accepted. Either the whole write
    ends up in the buffer or nothing ends up in the buffer.

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -29,7 +29,7 @@
 #include "lock.hh"
 #include "namespaces.hh"
 #include "iputils.hh"
-#include <boost/circular_buffer.hpp>
+#include "circular_buffer.hh"
 
 
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -35,8 +35,8 @@
 #include "misc.hh"
 #include "lwres.hh"
 #include <boost/optional.hpp>
-#include <boost/circular_buffer.hpp>
 #include <boost/utility.hpp>
+#include "circular_buffer.hh"
 #include "sstuff.hh"
 #include "recursor_cache.hh"
 #include "recpacketcache.hh"

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -24,7 +24,6 @@
 #endif
 
 #include <boost/tokenizer.hpp>
-#include <boost/circular_buffer.hpp>
 #include "namespaces.hh"
 #include "ws-api.hh"
 #include "json.hh"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Even though the documentation states that:

> simultaneous read accesses to a shared circular_buffer are safe

`boost::circular_buffer` < 1.62 was built with a debugging facility *by default* that made it unsafe to access the same circular buffer from more than one thread at once, in addition to making iterator operations slower. 

- https://svn.boost.org/trac10/ticket/6277
- https://github.com/boostorg/circular_buffer/pull/9

It's only a real issue in dnsdist since our DNS over TLS code is the only place where we read from a circular buffer from several threads at once, but this change might provide a small performance boost in the auth and rec as well on platforms where boost is older than 1.62.

Note that I have compiled and tested this code only on Arch, we need to test it on other distributions before merging this PR, especially ones with a boost version lesser than 1.62. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
