### PR TITLE
packethandler: Compare TSIG key name using DNSName

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -873,8 +873,9 @@ int PacketHandler::processNotify(DNSPacket *p)
     }
     vector<string> meta;
     if (B.getDomainMetadata(p->qdomain,"AXFR-MASTER-TSIG",meta) && meta.size() > 0) {
-      if (!pdns_iequals(meta[0], p->getTSIGKeyname().toStringNoDot())) {
-        g_log<<Logger::Warning<<"Received secure NOTIFY for "<<p->qdomain<<" from "<<p->getRemote()<<": expected TSIG key '"<<meta[0]<<", got '"<<p->getTSIGKeyname()<<"' (Refused)"<<endl;
+      DNSName expected{meta[0]};
+      if (p->getTSIGKeyname() != expected) {
+        g_log<<Logger::Warning<<"Received secure NOTIFY for "<<p->qdomain<<" from "<<p->getRemote()<<": expected TSIG key '"<<expected<<"', got '"<<p->getTSIGKeyname()<<"' (Refused)"<<endl;
         return RCode::Refused;
       }
     }


### PR DESCRIPTION
### Short description
When verifying NOTIFY, compare TSIG key name using DNSName to validate it correctly. Fixes #8070 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
