### PR TITLE
Clarify XPF support in Auth changelog

### DIFF
--- a/docs/changelog/4.2.rst
+++ b/docs/changelog/4.2.rst
@@ -1236,7 +1236,7 @@ Changelogs for 4.2.x
     :pullreq: 6220
     :tickets: 5079, 5594, 5654
 
-    Add XPF support.
+    Add XPF support to sdig, PowerDNS Recursor and dnsdist.
 
   .. change::
     :tags: Improvements, Internals


### PR DESCRIPTION
### Short description
#6220's title was "Add XPF support", but the only actual changes to Auth were to `sdig` and the test suite, and the changelog entry was misleading.

Reported by @spheron1.

This should be backported to 4.2.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)