### PR TITLE
not finding a boost lib should not be fatal. Fixes #6942

### DIFF
--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -336,9 +336,6 @@ case $Boost_lib in #(
     AC_SUBST([BOOST_LDPATH], [$Boost_lib_LDPATH])dnl
     AC_SUBST(AS_TR_CPP([BOOST_$1_LIBS]), [$Boost_lib_LIBS])dnl
     ;;
-  (no) _AC_MSG_LOG_CONFTEST
-    AC_MSG_ERROR([cannot find flags to link with the Boost $1 library (libboost-$1)])
-    ;;
 esac
 CPPFLAGS=$boost_save_CPPFLAGS
 AS_VAR_POPDEF([Boost_lib])dnl


### PR DESCRIPTION
### Short description
The error exit was accidentally introduced in #6905, after a botched merge on upstream boost.m4

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
