### PR TITLE
Fix the rfc1982LessThan template, it only works properly if the cast …

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -112,6 +112,7 @@ stringtok (Container &container, string const &in,
 
 template<typename T> bool rfc1982LessThan(T a, T b)
 {
+  static_assert(std::is_unsigned<T>::value, "rfc1982LessThan only works for unsigned types");
   typedef typename std::make_signed<T>::type signed_t;
   return static_cast<signed_t>(a - b) < 0;
 }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -112,7 +112,8 @@ stringtok (Container &container, string const &in,
 
 template<typename T> bool rfc1982LessThan(T a, T b)
 {
-  return ((signed)(a - b)) < 0;
+  typedef typename std::make_signed<T>::type signed_t;
+  return static_cast<signed_t>(a - b) < 0;
 }
 
 // fills container with ranges, so {posbegin,posend}

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -176,5 +176,31 @@ BOOST_AUTO_TEST_CASE(test_SimpleMatch) {
   BOOST_CHECK_EQUAL(SimpleMatch("abc*").match(std::string("abc")), true);
 }
 
+template<typename T> bool rfc1982check(T x, T y) {
+  return rfc1982LessThan(x, y);
+}
+
+BOOST_AUTO_TEST_CASE(test_rfc1982LessThan) {
+  // The test cases from rfc1982 section 5.2
+  BOOST_CHECK(rfc1982check<uint8_t>(0, 1));
+  BOOST_CHECK(rfc1982check<uint8_t>(0, 44));
+  BOOST_CHECK(rfc1982check<uint8_t>(0, 100));
+  BOOST_CHECK(rfc1982check<uint8_t>(44, 100));
+  BOOST_CHECK(rfc1982check<uint8_t>(100, 200));
+  BOOST_CHECK(rfc1982check<uint8_t>(200, 255));
+  BOOST_CHECK(rfc1982check<uint8_t>(255, 0));
+  BOOST_CHECK(rfc1982check<uint8_t>(255, 100));
+  BOOST_CHECK(rfc1982check<uint8_t>(200, 0));
+  BOOST_CHECK(rfc1982check<uint8_t>(200, 44));
+
+  BOOST_CHECK(rfc1982check<uint32_t>(0, 1));
+  BOOST_CHECK(rfc1982check<uint32_t>(UINT32_MAX-10, 1));
+  BOOST_CHECK(rfc1982check<uint32_t>(UINT32_MAX/2, UINT32_MAX-10));
+
+  BOOST_CHECK(rfc1982check<uint64_t>(0, 1));
+  BOOST_CHECK(rfc1982check<uint64_t>(UINT64_MAX-10, 1));
+  BOOST_CHECK(rfc1982check<uint64_t>(UINT64_MAX/2, UINT64_MAX-10));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
…is done to a same-sized type.

If we use it for uint8_t or uint64_t it breaks currenty.  Add unit tests while there.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
