### PR TITLE
Revert "enable a bunch of extra features during LGTM builds"

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -14,16 +14,15 @@ extraction:
       command:
       - "pushd pdns/dnsdistdist"
       - "sed -i '/^dist_man_MANS/d' Makefile.am"
-      - "autoreconf -vi && ./configure --enable-option-checking=fatal --enable-unit-tests --enable-dnscrypt --enable-dns-over-tls --enable-dns-over-https LIBS=-lwslay"
+      - "autoreconf -vi && ./configure"
       - "popd"
       - "pushd pdns/recursordist/"
       - "sed -i '/^dist_man_MANS/d' Makefile.am"
-      - "autoreconf -vi && ./configure --enable-option-checking=fatal --enable-unit-tests --enable-nod --enable-dnstap"
+      - "autoreconf -vi && ./configure"
       - "popd"
       - "sed -i 's/codedocs docs//' Makefile.am"
       - "autoreconf -vi"
-      - "./configure --enable-option-checking=fatal --with-modules='bind geoip gmysql godbc gpgsql gsqlite3 ldap lmdb lua lua2 mydns opendbx pipe random remote tinydns
-' --enable-fuzz-targets --enable-experimental-pkcs11 --enable-experimental-gss-tsig --enable-remotebackend-zeromq --enable-tools --enable-ixfrdist"
+      - "./configure --with-modules='bind gsqlite3 gmysql gpgsql ldap'"
     index:
       build_command:
       - "pushd pdns/dnsdistdist"


### PR DESCRIPTION
This reverts commit 8763cf1ca8ba2c7266521272fedc2b130af71f75.

### Short description
LGTM keeps spending hours of CPU on our PRs to then eventually time out for some reason. I have the impression this started after #8077, so here we revert that to see if it helps.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
