### PR TITLE
Some unneeded float<->double conversions.

### DIFF
--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -181,21 +181,21 @@ public:
       float diff= makeFloat(d_last - now);
 
       d_last=now;
-      double factor=exp(diff)/2.0; // might be '0.5', or 0.0001
-      d_val=(float)((1-factor)*val+ (float)factor*d_val);
+      float factor=expf(diff)/2.0f; // might be '0.5', or 0.0001
+      d_val=(1-factor)*val + factor*d_val;
     }
   }
 
-  double get(const struct timeval* tv)
+  float get(const struct timeval* tv)
   {
     struct timeval now=*tv;
     float diff=makeFloat(d_lastget-now);
     d_lastget=now;
-    float factor=exp(diff/60.0f); // is 1.0 or less
+    float factor=expf(diff/60.0f); // is 1.0 or less
     return d_val*=factor;
   }
 
-  double peek(void) const
+  float peek(void) const
   {
     return d_val;
   }


### PR DESCRIPTION
Note that float saves mem, but on some machines it might even be
slower than double, since most FPUs are optimized for double.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Code does not seem to be able to make up its mind whether to use float or double ;-)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
