### PR TITLE
auth: use BIGINT for notified_serial in pg schema

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -13,6 +13,8 @@ upgrade notes if your version is older than 3.4.2.
 
 - Superslave operation is no longer enabled by default, use :ref:`setting-superslave` to enable. This setting was called ``supermaster`` in some 4.2.0 prereleases.
 - The gsqlite3 backend, and the DNSSEC database for the BIND backend, have a new journal-mode setting. This setting defaults to `WAL <https://www.sqlite.org/wal.html>`_; older versions of PowerDNS did not set the journal mode, which means they used the SQLite default of DELETE.
+- Autoserial support has been removed. The ``change_date`` column has been removed from the ``domains`` table in all gsql backends, but leaving it in is harmless.
+- The :doc:`Generic PostgreSQL backend <backends/generic-postgresql>` schema has changed: the ``notified_serial`` column type in the ``domains`` table has been changed from ``INT DEFAULT NULL`` to ``BIGINT DEFAULT NULL``: ``ALTER TABLE domains ALTER notified_serial TYPE bigint USING CASE WHEN notified_serial >= 0 THEN notified_serial::bigint END;``
 
 4.1.0 to 4.1.1
 --------------

--- a/modules/gpgsqlbackend/4.1.0_to_4.2.0_schema.pgsql.sql
+++ b/modules/gpgsqlbackend/4.1.0_to_4.2.0_schema.pgsql.sql
@@ -1,1 +1,2 @@
 ALTER TABLE records DROP COLUMN change_date;
+ALTER TABLE domains ALTER notified_serial TYPE bigint USING CASE WHEN notified_serial >= 0 THEN notified_serial::bigint END;

--- a/modules/gpgsqlbackend/schema.pgsql.sql
+++ b/modules/gpgsqlbackend/schema.pgsql.sql
@@ -4,7 +4,7 @@ CREATE TABLE domains (
   master                VARCHAR(128) DEFAULT NULL,
   last_check            INT DEFAULT NULL,
   type                  VARCHAR(6) NOT NULL,
-  notified_serial       INT DEFAULT NULL,
+  notified_serial       BIGINT DEFAULT NULL,
   account               VARCHAR(40) DEFAULT NULL,
   CONSTRAINT c_lowercase_name CHECK (((name)::TEXT = LOWER((name)::TEXT)))
 );

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1868,6 +1868,20 @@ void testSchema(DNSSECKeeper& dk, const DNSName& zone)
     return;
   }
   cout<<"[+] ordername sorting is correct for names starting with _"<<endl;
+  cout<<"Setting low notified serial"<<endl;
+  db->setNotified(di.id, 500);
+  db->getDomainInfo(zone, di);
+  if(di.notified_serial != 500) {
+    cout<<"[-] Set serial 500, got back "<<di.notified_serial<<endl;
+  }
+  cout<<"Setting serial that needs 32 bits"<<endl;
+  db->setNotified(di.id, 2147484148);
+  db->getDomainInfo(zone, di);
+  if(di.notified_serial != 2147484148) {
+    cout<<"[-] Set serial 2147484148, got back "<<di.notified_serial<<endl;
+  } else {
+    cout<<"[+] Big serials work correctly"<<endl;
+  }
   cout<<endl;
   cout<<"End of tests, please remove "<<zone<<" from domains+records"<<endl;
 }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1776,6 +1776,7 @@ void testSchema(DNSSECKeeper& dk, const DNSName& zone)
   cout<<"Note: test-schema will try to create the zone, but it will not remove it."<<endl;
   cout<<"Please clean up after this."<<endl;
   cout<<endl;
+  cout<<"If this test reports an error and aborts, please check your database schema."<<endl;
   cout<<"Constructing UeberBackend"<<endl;
   UeberBackend B("default");
   cout<<"Picking first backend - if this is not what you want, edit launch line!"<<endl;
@@ -1817,13 +1818,13 @@ void testSchema(DNSSECKeeper& dk, const DNSName& zone)
     if(db->get(rrthrowaway)) // should not touch rr but don't assume anything
     {
       cout<<"Expected one record, got multiple, aborting"<<endl;
-      return;
+      exit(EXIT_FAILURE);
     }
     int size=rrget.content.size();
     if(size != 302)
     {
       cout<<"Expected 302 bytes, got "<<size<<", aborting"<<endl;
-      return;
+      exit(EXIT_FAILURE);
     }
   }
   cout<<"[+] content field is over 255 bytes"<<endl;
@@ -1860,25 +1861,33 @@ void testSchema(DNSSECKeeper& dk, const DNSName& zone)
   if(before != DNSName("_underscore")+zone)
   {
     cout<<"before is wrong, got '"<<before.toString()<<"', expected '_underscore."<<zone.toString()<<"', aborting"<<endl;
-    return;
+    exit(EXIT_FAILURE);
   }
   if(after != zone)
   {
     cout<<"after is wrong, got '"<<after.toString()<<"', expected '"<<zone.toString()<<"', aborting"<<endl;
-    return;
+    exit(EXIT_FAILURE);
   }
   cout<<"[+] ordername sorting is correct for names starting with _"<<endl;
   cout<<"Setting low notified serial"<<endl;
   db->setNotified(di.id, 500);
   db->getDomainInfo(zone, di);
   if(di.notified_serial != 500) {
-    cout<<"[-] Set serial 500, got back "<<di.notified_serial<<endl;
+    cout<<"[-] Set serial 500, got back "<<di.notified_serial<<", aborting"<<endl;
+    exit(EXIT_FAILURE);
   }
   cout<<"Setting serial that needs 32 bits"<<endl;
-  db->setNotified(di.id, 2147484148);
+  try {
+    db->setNotified(di.id, 2147484148);
+  } catch(const PDNSException &pe) {
+    cout<<"While setting serial, got error: "<<pe.reason<<endl;
+    cout<<"aborting"<<endl;
+    exit(EXIT_FAILURE);
+  }
   db->getDomainInfo(zone, di);
   if(di.notified_serial != 2147484148) {
-    cout<<"[-] Set serial 2147484148, got back "<<di.notified_serial<<endl;
+    cout<<"[-] Set serial 2147484148, got back "<<di.notified_serial<<", aborting"<<endl;
+    exit(EXIT_FAILURE);
   } else {
     cout<<"[+] Big serials work correctly"<<endl;
   }


### PR DESCRIPTION
### Short description
Fixes #6815.

Also adds the `change_date` and autoserial removal to the auth 4.2 upgrade docs.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
