### PR TITLE
dnsdist: Fix a UnicodeDecodeError with py2 in the regression tests

### DIFF
--- a/regression-tests.dnsdist/test_BrokenAnswer.py
+++ b/regression-tests.dnsdist/test_BrokenAnswer.py
@@ -25,7 +25,7 @@ def responseCallback(request):
     raw = response.to_wire()
     # first label length of this rrset is at 12 (dnsheader) + length(qname) + 2 (leading label length + trailing 0) + 2 (qtype) + 2 (qclass)
     offset = 12 + len(str(request.question[0].name)) + 2 + 2 + 2
-    altered = raw[:offset] + chr(255).encode() + raw[offset+1:]
+    altered = raw[:offset] + b'\xff' + raw[offset+1:]
     return altered
 
 class TestBrokenAnswerECS(DNSDistTest):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The regression test added in #8078 introduced an issue when executed with Python 2:
```
Exception in thread TCP Responder:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "regression-tests.dnsdist/dnsdisttests.py", line 256, in TCPResponder
    wire = callback(request)
  File "regression-tests.dnsdist/test_BrokenAnswer.py", line 28, in responseCallback
    altered = raw[:offset] + chr(255).encode('utf-8') + raw[offset+1:]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xff in position 0: ordinal not in range(128)
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
