### PR TITLE
Recursor 4.2: Backport #8008 #8047 test improvements

### DIFF
--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -419,7 +419,7 @@ void generateKeyMaterial(const DNSName& name, unsigned int algo, uint8_t digest,
   dsAnchors[name].insert(keys[name].second);
 }
 
-int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth, int type, const testkeysset_t& keys, bool proveCut)
+int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth, int type, const testkeysset_t& keys, bool proveCut, boost::optional<time_t> now)
 {
   if (type == QType::DS) {
     auth.chopOff();
@@ -427,7 +427,7 @@ int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth
     setLWResult(res, 0, true, false, true);
 
     if (addDS(domain, 300, res->d_records, keys, DNSResourceRecord::ANSWER)) {
-      addRRSIG(keys, res->d_records, auth, 300);
+      addRRSIG(keys, res->d_records, auth, 300, false, boost::none, boost::none, now);
     }
     else {
       addRecordToLW(res, auth, QType::SOA, "foo. bar. 2017032800 1800 900 604800 86400", DNSResourceRecord::AUTHORITY, 86400);
@@ -436,7 +436,7 @@ int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth
       const auto it = keys.find(auth);
       if (it != keys.cend()) {
         /* sign the SOA */
-        addRRSIG(keys, res->d_records, auth, 300);
+        addRRSIG(keys, res->d_records, auth, 300, false, boost::none, boost::none, now);
         /* add a NSEC denying the DS */
         std::set<uint16_t> types = { QType::NSEC };
         if (proveCut) {
@@ -444,7 +444,7 @@ int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth
         }
 
         addNSECRecordToLW(domain, DNSName("z") + domain, types, 600, res->d_records);
-        addRRSIG(keys, res->d_records, auth, 300);
+        addRRSIG(keys, res->d_records, auth, 300, false, boost::none, boost::none, now);
       }
     }
 

--- a/pdns/recursordist/test-syncres_cc.hh
+++ b/pdns/recursordist/test-syncres_cc.hh
@@ -75,7 +75,7 @@ void generateKeyMaterial(const DNSName& name, unsigned int algo, uint8_t digest,
 
 void generateKeyMaterial(const DNSName& name, unsigned int algo, uint8_t digest, testkeysset_t& keys, map<DNSName,dsmap_t>& dsAnchors);
 
-int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth, int type, const testkeysset_t& keys, bool proveCut=true);
+int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth, int type, const testkeysset_t& keys, bool proveCut=true, boost::optional<time_t> now=boost::none);
 
 int basicRecordsForQnameMinimisation(LWResult* res, const DNSName& domain, int type);
 


### PR DESCRIPTION
### Short description
In Debian I had to apply #8008 and #8047 on top of the Recursor 4.2.0 release to make `make check` pass on mipsel (which is super slow).

Please consider applying these to the release branch.

Disclaimer: While I've tested these in Debian, I have not tested this exact git hash.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
