### PR TITLE
Bail out when no Context library is available

### DIFF
--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -51,11 +51,15 @@ BOOST_FIND_HEADER([boost/container/flat_set.hpp], [AC_MSG_NOTICE([boost::contain
 
 # Boost Context was introduced in 1.51 (Aug 2012), but there was an immediate
 # API break in 1.52 (Nov 2012), so we only support that, and later.
-pdns_context_library="System V ucontexts"
+pdns_context_library=""
 AS_IF([test $boost_major_version -ge 152], [BOOST_CONTEXT([], [no])])
+AS_IF([test x"$boost_cv_lib_context" = "xyes"], [
+  pdns_context_library="Boost Context"
+], [
+  AC_CHECK_FUNCS([getcontext makecontext swapcontext], [pdns_context_library="System V ucontexts"])
+])
 AC_MSG_CHECKING([what context library to use for MTasker])
-AS_IF([test x"$boost_cv_lib_context" = "xyes"], [pdns_context_library="Boost Context"])
-AC_MSG_RESULT([$pdns_context_library])
+AS_IF([test -n "$pdns_context_library"], [AC_MSG_RESULT([$pdns_context_library])], [AC_MSG_ERROR([neither boost::context nor System V ucontexts available])])
 
 PDNS_ENABLE_UNIT_TESTS
 PDNS_ENABLE_REPRODUCIBLE


### PR DESCRIPTION
### Short description
On MIPS, there is no Boost Context. On OpenWRT, this is combined with a lack of `getcontext` in musl. This means we can never compile there. This PR makes configure do this, instead of waiting for the linker to error after compilation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)