### PR TITLE
dnsdist-console: flush cout after printing g_outputBuffer

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -299,7 +299,7 @@ void doConsole()
           }
         }
         else 
-          cout << g_outputBuffer;
+          cout << g_outputBuffer << std::flush;
         if(!getLuaNoSideEffect())
           feedConfigDelta(line);
       }


### PR DESCRIPTION
### Short description

cout may not be a tty, in which case it is block buffered by stdlib, so flush it after printing g_outputBuffer.

Fixes #8130

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)