### PR TITLE
dnsdist: Add OCSP stapling (from files) for DoT and DoH

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -634,7 +634,7 @@ test_recursor() {
 
 test_dnsdist(){
   run "cd regression-tests.dnsdist"
-  run "DNSDISTBIN=$HOME/dnsdist/bin/dnsdist ./runtests -v --ignore-files='(?:^\.|^_,|^setup\.py$|^test_DOH\.py$)'"
+  run "DNSDISTBIN=$HOME/dnsdist/bin/dnsdist ./runtests -v --ignore-files='(?:^\.|^_,|^setup\.py$|^test_DOH\.py$|^test_OCSP\.py$)'"
   run "rm -f ./DNSCryptResolver.cert ./DNSCryptResolver.key"
   run "cd .."
 }

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -87,7 +87,7 @@ void resetLuaSideEffect()
   g_noLuaSideEffect = boost::logic::indeterminate;
 }
 
-typedef std::unordered_map<std::string, boost::variant<bool, int, std::string, std::vector<std::pair<int,int> >, std::map<std::string,std::string> > > localbind_t;
+typedef std::unordered_map<std::string, boost::variant<bool, int, std::string, std::vector<std::pair<int,int> >, std::map<std::string,std::string>, std::vector<std::pair<int, std::string> > > > localbind_t;
 
 static void parseLocalBindVars(boost::optional<localbind_t> vars, bool& reusePort, int& tcpFastOpenQueueSize, std::string& interface, std::set<int>& cpus)
 {
@@ -1732,6 +1732,12 @@ void setupLuaConfig(bool client)
           frontend->d_customResponseHeaders.push_back(headerResponse);
         }
       }
+      if (vars->count("ocspResponses")) {
+        auto files = boost::get<std::vector<std::pair<int, std::string>>>((*vars)["ocspResponses"]);
+        for (const auto& file : files) {
+          frontend->d_ocspFiles.push_back(file.second);
+        }
+      }
     }
     g_dohlocals.push_back(frontend);
     auto cs = std::unique_ptr<ClientState>(new ClientState(frontend->d_local, true, reusePort, tcpFastOpenQueueSize, interface, cpus));
@@ -1887,6 +1893,13 @@ void setupLuaConfig(bool client)
               return;
             }
             frontend->d_maxStoredSessions = value;
+          }
+
+          if (vars->count("ocspResponses")) {
+            auto files = boost::get<std::vector<std::pair<int, std::string>>>((*vars)["ocspResponses"]);
+            for (const auto& file : files) {
+              frontend->d_ocspFiles.push_back(file.second);
+            }
           }
         }
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -45,6 +45,10 @@
 #include "protobuf.hh"
 #include "sodcrypto.hh"
 
+#ifdef HAVE_LIBSSL
+#include "libssl.hh"
+#endif
+
 #include <boost/logic/tribool.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -2039,6 +2043,12 @@ void setupLuaConfig(bool client)
       });
 
     g_lua.writeFunction("setAllowEmptyResponse", [](bool allow) { g_allowEmptyResponse=allow; });
+
+#if defined(HAVE_LIBSSL) && defined(HAVE_OCSP_BASIC_SIGN)
+    g_lua.writeFunction("generateOCSPResponse", [](const std::string& certFile, const std::string& caCert, const std::string& caKey, const std::string& outFile, int ndays, int nmin) {
+      return libssl_generate_ocsp_response(certFile, caCert, caKey, outFile, ndays, nmin);
+    });
+#endif /* HAVE_LIBSSL && HAVE_OCSP_BASIC_SIGN*/
 }
 
 vector<std::function<void(void)>> setupLua(bool client, const std::string& config)

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -87,7 +87,7 @@ void resetLuaSideEffect()
   g_noLuaSideEffect = boost::logic::indeterminate;
 }
 
-typedef std::unordered_map<std::string, boost::variant<bool, int, std::string, std::vector<std::pair<int,int> >, std::map<std::string,std::string>, std::vector<std::pair<int, std::string> > > > localbind_t;
+typedef std::unordered_map<std::string, boost::variant<bool, int, std::string, std::vector<std::pair<int,int> >, std::vector<std::pair<int, std::string> >, std::map<std::string,std::string>  > > localbind_t;
 
 static void parseLocalBindVars(boost::optional<localbind_t> vars, bool& reusePort, int& tcpFastOpenQueueSize, std::string& interface, std::set<int>& cpus)
 {

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -127,6 +127,7 @@ Listen Sockets
   * ``ciphersTLS13``: str - The TLS ciphers to use for TLS 1.3, in OpenSSL format.
   * ``serverTokens``: str - The content of the Server: HTTP header returned by dnsdist. The default is "h2o/dnsdist".
   * ``customResponseHeaders={}``: table - Set custom HTTP header(s) returned by dnsdist.
+  * ``ocspResponses``: list - List of files containing OCSP responses, in the same order than the certificates and keys, that will be used to provide OCSP stapling responses.
 
 .. function:: addTLSLocal(address, certFile(s), keyFile(s) [, options])
 
@@ -137,7 +138,7 @@ Listen Sockets
   .. versionchanged:: 1.3.3
     ``numberOfStoredSessions`` option added.
   .. versionchanged:: 1.4.0
-    ``ciphersTLS13`` option added.
+    ``ciphersTLS13`` and ``ocspResponses`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
@@ -161,6 +162,7 @@ Listen Sockets
   * ``ticketsKeysRotationDelay``: int - Set the delay before the TLS tickets key is rotated, in seconds. Default is 43200 (12h).
   * ``sessionTickets``: bool - Whether session resumption via session tickets is enabled. Default is true, meaning tickets are enabled.
   * ``numberOfStoredSessions``: int - The maximum number of sessions kept in memory at the same time. At this time this is only supported by the OpenSSL provider, as stored sessions are not supported with the GnuTLS one. Default is 20480. Setting this value to 0 disables stored session entirely.
+  * ``ocspResponses``: list - List of files containing OCSP responses, in the same order than the certificates and keys, that will be used to provide OCSP stapling responses.
 
 .. function:: setLocal(address[, options])
 

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -773,7 +773,11 @@ static std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> getTLSContext(const std::vect
       throw std::runtime_error("Failed to setup SSL/TLS for DoH listener, the key from '" + pair.second + "' does not match the certificate from '" + pair.first + "'");
     }
     /* store the type of the new key, we might need it later to select the right OCSP stapling response */
-    keyTypes.push_back(libssl_get_last_key_type(ctx));
+    auto keyType = libssl_get_last_key_type(ctx);
+    if (keyType < 0) {
+      throw std::runtime_error("Failed to setup SSL/TLS for DoH listener, the key from '" + pair.second + "' has an unknown type");
+    }
+    keyTypes.push_back(keyType);
   }
 
   if (!ocspFiles.empty()) {

--- a/pdns/dnsdistdist/libssl.cc
+++ b/pdns/dnsdistdist/libssl.cc
@@ -5,9 +5,13 @@
 #ifdef HAVE_LIBSSL
 
 #include <atomic>
+#include <fstream>
+#include <cstring>
 #include <pthread.h>
+
 #include <openssl/conf.h>
 #include <openssl/err.h>
+#include <openssl/ocsp.h>
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 
@@ -84,6 +88,133 @@ void unregisterOpenSSLUser()
     openssl_thread_cleanup();
   }
 #endif
+}
+
+int libssl_ocsp_stapling_callback(SSL* ssl, const std::map<int, std::string>& ocspMap)
+{
+  auto pkey = SSL_get_privatekey(ssl);
+  if (pkey == nullptr) {
+    return SSL_TLSEXT_ERR_NOACK;
+  }
+
+  /* look for an OCSP response for the corresponding private key type (RSA, ECDSA..) */
+  const auto& data = ocspMap.find(EVP_PKEY_base_id(pkey));
+  if (data == ocspMap.end()) {
+    return SSL_TLSEXT_ERR_NOACK;
+  }
+
+  /* we need to allocate a copy because OpenSSL will free the pointer passed to SSL_set_tlsext_status_ocsp_resp() */
+  void* copy = OPENSSL_malloc(data->second.size());
+  if (copy == nullptr) {
+    return SSL_TLSEXT_ERR_NOACK;
+  }
+
+  memcpy(copy, data->second.data(), data->second.size());
+  SSL_set_tlsext_status_ocsp_resp(ssl, copy, data->second.size());
+  return SSL_TLSEXT_ERR_OK;
+}
+
+static bool libssl_validate_ocsp_response(const std::string& response)
+{
+  auto responsePtr = reinterpret_cast<const unsigned char *>(response.data());
+  std::unique_ptr<OCSP_RESPONSE, void(*)(OCSP_RESPONSE*)> resp(d2i_OCSP_RESPONSE(nullptr, &responsePtr, response.size()), OCSP_RESPONSE_free);
+  if (resp == nullptr) {
+    throw std::runtime_error("Unable to parse OCSP response");
+  }
+
+  int status = OCSP_response_status(resp.get());
+  if (status != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
+    throw std::runtime_error("OCSP response status is not successful: " + std::to_string(status));
+  }
+
+  std::unique_ptr<OCSP_BASICRESP, void(*)(OCSP_BASICRESP*)> basic(OCSP_response_get1_basic(resp.get()), OCSP_BASICRESP_free);
+  if (basic == nullptr) {
+    throw std::runtime_error("Error getting a basic OCSP response");
+  }
+
+  if (OCSP_resp_count(basic.get()) != 1) {
+    throw std::runtime_error("More than one single response in an OCSP basic response");
+  }
+
+  auto singleResponse = OCSP_resp_get0(basic.get(), 0);
+  if (singleResponse == nullptr) {
+    throw std::runtime_error("Error getting a single response from the basic OCSP response");
+  }
+
+  int reason;
+  ASN1_GENERALIZEDTIME* revTime = nullptr;
+  ASN1_GENERALIZEDTIME* thisUpdate = nullptr;
+  ASN1_GENERALIZEDTIME* nextUpdate = nullptr;
+
+  auto singleResponseStatus = OCSP_single_get0_status(singleResponse, &reason, &revTime, &thisUpdate, &nextUpdate);
+  if (singleResponseStatus != V_OCSP_CERTSTATUS_GOOD) {
+    throw std::runtime_error("Invalid status for OCSP single response (" + std::to_string(singleResponseStatus) + ")");
+  }
+  if (thisUpdate == nullptr || nextUpdate == nullptr) {
+    throw std::runtime_error("Error getting validity of OCSP single response");
+  }
+
+  auto validityResult = OCSP_check_validity(thisUpdate, nextUpdate, /* 5 minutes of leeway */ 5 * 60, -1);
+  if (validityResult == 0) {
+    throw std::runtime_error("OCSP single response is not yet, or no longer, valid");
+  }
+
+  return true;
+}
+
+std::map<int, std::string> libssl_load_ocsp_responses(const std::vector<std::string>& ocspFiles, std::vector<int> keyTypes)
+{
+  std::map<int, std::string> ocspResponses;
+
+  if (ocspFiles.size() > keyTypes.size()) {
+    throw std::runtime_error("More OCSP files than certificates and keys loaded!");
+  }
+
+  size_t count = 0;
+  for (const auto& filename : ocspFiles) {
+    std::ifstream file(filename, std::ios::binary);
+    std::string content;
+    while(file) {
+      char buffer[4096];
+      file.read(buffer, sizeof(buffer));
+      if (file.bad()) {
+        file.close();
+        throw std::runtime_error("Unable to load OCSP response from '" + filename + "'");
+      }
+      content.append(buffer, file.gcount());
+    }
+    file.close();
+
+    try {
+      libssl_validate_ocsp_response(content);
+      ocspResponses.insert({keyTypes.at(count), std::move(content)});
+    }
+    catch (const std::exception& e) {
+      throw std::runtime_error("Error checking the validity of OCSP response from '" + filename + "': " + e.what());
+    }
+    ++count;
+  }
+
+  return ocspResponses;
+}
+
+int libssl_get_last_key_type(std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)>& ctx)
+{
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined LIBRESSL_VERSION_NUMBER)
+  auto pkey = SSL_CTX_get0_privatekey(ctx.get());
+#else
+  auto temp = std::unique_ptr<SSL, void(*)(SSL*)>(SSL_new(ctx.get()), SSL_free);
+  if (!temp) {
+    return -1;
+  }
+  auto pkey = SSL_get_privatekey(temp.get());
+#endif
+
+  if (!pkey) {
+    return -1;
+  }
+
+  return EVP_PKEY_base_id(pkey);
 }
 
 #endif /* HAVE_LIBSSL */

--- a/pdns/dnsdistdist/libssl.hh
+++ b/pdns/dnsdistdist/libssl.hh
@@ -18,4 +18,8 @@ int libssl_ocsp_stapling_callback(SSL* ssl, const std::map<int, std::string>& oc
 std::map<int, std::string> libssl_load_ocsp_responses(const std::vector<std::string>& ocspFiles, std::vector<int> keyTypes);
 int libssl_get_last_key_type(std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)>& ctx);
 
+#ifdef HAVE_OCSP_BASIC_SIGN
+bool libssl_generate_ocsp_response(const std::string& certFile, const std::string& caCert, const std::string& caKey, const std::string& outFile, int ndays, int nmin);
+#endif
+
 #endif /* HAVE_LIBSSL */

--- a/pdns/dnsdistdist/libssl.hh
+++ b/pdns/dnsdistdist/libssl.hh
@@ -1,4 +1,21 @@
 #pragma once
 
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "config.h"
+
+#ifdef HAVE_LIBSSL
+#include <openssl/ssl.h>
+
 void registerOpenSSLUser();
 void unregisterOpenSSLUser();
+
+int libssl_ocsp_stapling_callback(SSL* ssl, const std::map<int, std::string>& ocspMap);
+
+std::map<int, std::string> libssl_load_ocsp_responses(const std::vector<std::string>& ocspFiles, std::vector<int> keyTypes);
+int libssl_get_last_key_type(std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)>& ctx);
+
+#endif /* HAVE_LIBSSL */

--- a/pdns/dnsdistdist/m4/dnsdist_with_libssl.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_with_libssl.m4
@@ -16,8 +16,8 @@ AC_DEFUN([DNSDIST_WITH_LIBSSL], [
         save_CFLAGS=$CFLAGS
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
-        LIBS="$LIBSSL_LIBS $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites])
+        LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -438,7 +438,11 @@ public:
       }
 
       /* store the type of the new key, we might need it later to select the right OCSP stapling response */
-      keyTypes.push_back(libssl_get_last_key_type(d_tlsCtx));
+      auto keyType = libssl_get_last_key_type(d_tlsCtx);
+      if (keyType < 0) {
+        throw std::runtime_error("Key from '" + pair.second + "' has an unknown type");
+      }
+      keyTypes.push_back(keyType);
     }
 
     if (!fe.d_ocspFiles.empty()) {

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -7,6 +7,7 @@ struct DOHFrontend
 {
   std::shared_ptr<DOHServerConfig> d_dsc{nullptr};
   std::vector<std::pair<std::string, std::string>> d_certKeyPairs;
+  std::vector<std::string> d_ocspFiles;
   std::string d_ciphers;
   std::string d_ciphers13;
   std::string d_serverTokens{"h2o/dnsdist"};

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -139,6 +139,7 @@ public:
   }
 
   std::vector<std::pair<std::string, std::string>> d_certKeyPairs;
+  std::vector<std::string> d_ocspFiles;
   ComboAddress d_addr;
   std::string d_ciphers;
   std::string d_ciphers13;

--- a/regression-tests.dnsdist/.gitignore
+++ b/regression-tests.dnsdist/.gitignore
@@ -14,4 +14,5 @@
 /server.csr
 /server.key
 /server.pem
+/server.ocsp
 /configs

--- a/regression-tests.dnsdist/runtests
+++ b/regression-tests.dnsdist/runtests
@@ -46,7 +46,7 @@ if [ "${PDNS_DEBUG}" = "YES" ]; then
   set -x
 fi
 
-rm -f ca.key ca.pem ca.srl server.csr server.key server.pem server.chain
+rm -f ca.key ca.pem ca.srl server.csr server.key server.pem server.chain server.ocsp
 rm -rf configs/*
 
 # Generate a new CA
@@ -66,4 +66,4 @@ if ! nosetests --with-xunit $@; then
     false
 fi
 
-rm ca.key ca.pem ca.srl server.csr server.key server.pem server.chain
+rm -f ca.key ca.pem ca.srl server.csr server.key server.pem server.chain server.ocsp

--- a/regression-tests.dnsdist/test_OCSP.py
+++ b/regression-tests.dnsdist/test_OCSP.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+import dns
+import subprocess
+from dnsdisttests import DNSDistTest
+
+class DNSDistOCSPStaplingTest(DNSDistTest):
+
+    @classmethod
+    def checkOCSPStaplingStatus(cls, addr, port, serverName, caFile):
+        testcmd = ['openssl', 's_client', '-CAfile', caFile, '-connect', '%s:%d' % (addr, port), '-status', '-servername', serverName ]
+        output = None
+        try:
+            process = subprocess.Popen(testcmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
+            output = process.communicate(input='')
+        except subprocess.CalledProcessError as exc:
+            raise AssertionError('dnsdist --check-config failed (%d): %s' % (exc.returncode, exc.output))
+
+        return output[0].decode()
+
+class TestOCSPStaplingDOH(DNSDistOCSPStaplingTest):
+
+    _serverKey = 'server.key'
+    _serverCert = 'server.chain'
+    _serverName = 'tls.tests.dnsdist.org'
+    _ocspFile = 'server.ocsp'
+    _caCert = 'ca.pem'
+    _caKey = 'ca.key'
+    _dohServerPort = 8443
+    _config_template = """
+    newServer{address="127.0.0.1:%s"}
+
+    -- generate an OCSP response file for our certificate, valid one day
+    generateOCSPResponse('%s', '%s', '%s', '%s', 1, 0)
+    addDOHLocal("127.0.0.1:%s", "%s", "%s", { "/" }, { ocspResponses={"%s"}})
+    """
+    _config_params = ['_testServerPort', '_serverCert', '_caCert', '_caKey', '_ocspFile', '_dohServerPort', '_serverCert', '_serverKey', '_ocspFile']
+
+    def testOCSPStapling(self):
+        """
+        OCSP Stapling: DOH
+        """
+        output = self.checkOCSPStaplingStatus('127.0.0.1', self._dohServerPort, self._serverName, self._caCert)
+        self.assertIn('OCSP Response Status: successful (0x0)', output)
+
+class TestOCSPStaplingTLSGnuTLS(DNSDistOCSPStaplingTest):
+
+    _serverKey = 'server.key'
+    _serverCert = 'server.chain'
+    _serverName = 'tls.tests.dnsdist.org'
+    _ocspFile = 'server.ocsp'
+    _caCert = 'ca.pem'
+    _caKey = 'ca.key'
+    _tlsServerPort = 8443
+    _config_template = """
+    newServer{address="127.0.0.1:%s"}
+
+    -- generate an OCSP response file for our certificate, valid one day
+    generateOCSPResponse('%s', '%s', '%s', '%s', 1, 0)
+    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="gnutls", ocspResponses={"%s"}})
+    """
+    _config_params = ['_testServerPort', '_serverCert', '_caCert', '_caKey', '_ocspFile', '_tlsServerPort', '_serverCert', '_serverKey', '_ocspFile']
+
+    def testOCSPStapling(self):
+        """
+        OCSP Stapling: TLS (GnuTLS)
+        """
+        output = self.checkOCSPStaplingStatus('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert)
+        self.assertIn('OCSP Response Status: successful (0x0)', output)
+
+class TestOCSPStaplingTLSOpenSSL(DNSDistOCSPStaplingTest):
+
+    _serverKey = 'server.key'
+    _serverCert = 'server.chain'
+    _serverName = 'tls.tests.dnsdist.org'
+    _ocspFile = 'server.ocsp'
+    _caCert = 'ca.pem'
+    _caKey = 'ca.key'
+    _tlsServerPort = 8443
+    _config_template = """
+    newServer{address="127.0.0.1:%s"}
+
+    -- generate an OCSP response file for our certificate, valid one day
+    generateOCSPResponse('%s', '%s', '%s', '%s', 1, 0)
+    addTLSLocal("127.0.0.1:%s", "%s", "%s", { provider="openssl", ocspResponses={"%s"}})
+    """
+    _config_params = ['_testServerPort', '_serverCert', '_caCert', '_caKey', '_ocspFile', '_tlsServerPort', '_serverCert', '_serverKey', '_ocspFile']
+
+    def testOCSPStapling(self):
+        """
+        OCSP Stapling: TLS (OpenSSL)
+        """
+        output = self.checkOCSPStaplingStatus('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert)
+        self.assertIn('OCSP Response Status: successful (0x0)', output)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The OCSP responses are loaded from files on startup, and reloaded when the `reloadAllCertificates()` command is issued.

Fixes #7812.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
