### PR TITLE
dnsdist: Add Lua bindings, rules and action for DoH

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -197,6 +197,7 @@ try
               {"post-queries", doh->d_postqueries},
               {"bad-requests", doh->d_badrequests},
               {"error-responses", doh->d_errorresponses},
+              {"redirect-responses", doh->d_redirectresponses},
               {"valid-responses", doh->d_validresponses}
             };
 

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -410,6 +410,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "HTTPHeaderRule", true, "name, regex", "matches DoH queries with a HTTP header 'name' whose content matches the regular expression 'regex'"},
   { "HTTPPathRegexRule", true, "regex", "matches DoH queries whose HTTP path matches 'regex'"},
   { "HTTPPathRule", true, "path", "matches DoH queries whose HTTP path is an exact match to 'path'"},
+  { "HTTPStatusAction", true, "status, reason, body", "return an HTTP response"},
   { "inClientStartup", true, "", "returns true during console client parsing of configuration" },
   { "includeDirectory", true, "path", "nclude configuration files from `path`" },
   { "grepq", true, "Netmask|DNS Name|100ms|{\"::1\", \"powerdns.com\", \"100ms\"} [, n]", "shows the last n queries and responses matching the specified client address or range (Netmask), or the specified DNS Name, or slower than 100ms" },

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -408,6 +408,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "getTLSContext", true, "n", "returns the TLS context with index n" },
   { "getTLSFrontend", true, "n", "returns the TLS frontend with index n" },
   { "HTTPHeaderRule", true, "name, regex", "matches DoH queries with a HTTP header 'name' whose content matches the regular expression 'regex'"},
+  { "HTTPPathRegexRule", true, "regex", "matches DoH queries whose HTTP path matches 'regex'"},
   { "HTTPPathRule", true, "path", "matches DoH queries whose HTTP path is an exact match to 'path'"},
   { "inClientStartup", true, "", "returns true during console client parsing of configuration" },
   { "includeDirectory", true, "path", "nclude configuration files from `path`" },

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -1081,7 +1081,7 @@ private:
 class HTTPStatusAction: public DNSAction
 {
 public:
-  HTTPStatusAction(int code, const std::string& reason, const std::string& body): d_reason(reason), d_body(body), d_code(code)
+  HTTPStatusAction(int code, const std::string& body, const std::string& contentType): d_body(body), d_contentType(contentType), d_code(code)
   {
   }
 
@@ -1091,7 +1091,7 @@ public:
       return Action::None;
     }
 
-    dq->du->setHTTPResponse(d_code, d_reason, d_body);
+    dq->du->setHTTPResponse(d_code, d_body, d_contentType);
     dq->dh->qr = true; // for good measure
     return Action::HeaderModify;
   }
@@ -1101,8 +1101,8 @@ public:
     return "return an HTTP status of " + std::to_string(d_code);
   }
 private:
-  std::string d_reason;
   std::string d_body;
+  std::string d_contentType;
   int d_code;
 };
 #endif /* HAVE_DNS_OVER_HTTPS */
@@ -1412,8 +1412,8 @@ void setupLuaActions()
     });
 
 #ifdef HAVE_DNS_OVER_HTTPS
-  g_lua.writeFunction("HTTPStatusAction", [](uint16_t status, std::string reason, std::string body) {
-      return std::shared_ptr<DNSAction>(new HTTPStatusAction(status, reason, body));
+  g_lua.writeFunction("HTTPStatusAction", [](uint16_t status, std::string body, boost::optional<std::string> contentType) {
+      return std::shared_ptr<DNSAction>(new HTTPStatusAction(status, body, contentType ? *contentType : ""));
     });
 #endif /* HAVE_DNS_OVER_HTTPS */
 }

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -1091,7 +1091,7 @@ public:
       return Action::None;
     }
 
-    DOHSetHTTPResponse(*dq->du, d_code, d_reason, d_body);
+    dq->du->setHTTPResponse(d_code, d_reason, d_body);
     dq->dh->qr = true; // for good measure
     return Action::HeaderModify;
   }

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -213,7 +213,7 @@ void setupLuaBindingsDNSQuestion()
       return dq.du->getHTTPHeaders();
     });
 
-    g_lua.registerFunction<void(DNSQuestion::*)(uint16_t statusCode, std::string body, std::string contentType)>("setHTTPResponse", [](DNSQuestion& dq, uint16_t statusCode, std::string body, boost::optional<std::string> contentType) {
+    g_lua.registerFunction<void(DNSQuestion::*)(uint16_t statusCode, const std::string& body, const boost::optional<std::string> contentType)>("setHTTPResponse", [](DNSQuestion& dq, uint16_t statusCode, const std::string& body, const boost::optional<std::string> contentType) {
       if (dq.du == nullptr) {
         return;
       }

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -176,4 +176,48 @@ void setupLuaBindingsDNSQuestion()
       }
 #endif /* HAVE_NET_SNMP */
     });
+
+#ifdef HAVE_DNS_OVER_HTTPS
+    g_lua.registerFunction<std::string(DNSQuestion::*)(void)>("getHTTPPath", [](const DNSQuestion& dq) {
+      if (dq.du == nullptr) {
+        return std::string();
+      }
+      return dq.du->getHTTPPath();
+    });
+
+    g_lua.registerFunction<std::string(DNSQuestion::*)(void)>("getHTTPQueryString", [](const DNSQuestion& dq) {
+      if (dq.du == nullptr) {
+        return std::string();
+      }
+      return dq.du->getHTTPQueryString();
+    });
+
+    g_lua.registerFunction<std::string(DNSQuestion::*)(void)>("getHTTPHost", [](const DNSQuestion& dq) {
+      if (dq.du == nullptr) {
+        return std::string();
+      }
+      return dq.du->getHTTPHost();
+    });
+
+    g_lua.registerFunction<std::string(DNSQuestion::*)(void)>("getHTTPScheme", [](const DNSQuestion& dq) {
+      if (dq.du == nullptr) {
+        return std::string();
+      }
+      return dq.du->getHTTPScheme();
+    });
+
+    g_lua.registerFunction<std::unordered_map<std::string, std::string>(DNSQuestion::*)(void)>("getHTTPHeaders", [](const DNSQuestion& dq) {
+      if (dq.du == nullptr) {
+        return std::unordered_map<std::string, std::string>();
+      }
+      return dq.du->getHTTPHeaders();
+    });
+
+    g_lua.registerFunction<void(DNSQuestion::*)(uint16_t statusCode, std::string reason, std::string body)>("setHTTPResponse", [](DNSQuestion& dq, uint16_t statusCode, std::string reason, std::string body) {
+      if (dq.du == nullptr) {
+        return;
+      }
+      dq.du->setHTTPResponse(statusCode, reason, body);
+    });
+#endif /* HAVE_DNS_OVER_HTTPS */
 }

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -213,11 +213,11 @@ void setupLuaBindingsDNSQuestion()
       return dq.du->getHTTPHeaders();
     });
 
-    g_lua.registerFunction<void(DNSQuestion::*)(uint16_t statusCode, std::string reason, std::string body)>("setHTTPResponse", [](DNSQuestion& dq, uint16_t statusCode, std::string reason, std::string body) {
+    g_lua.registerFunction<void(DNSQuestion::*)(uint16_t statusCode, std::string body, std::string contentType)>("setHTTPResponse", [](DNSQuestion& dq, uint16_t statusCode, std::string body, boost::optional<std::string> contentType) {
       if (dq.du == nullptr) {
         return;
       }
-      dq.du->setHTTPResponse(statusCode, reason, body);
+      dq.du->setHTTPResponse(statusCode, body, contentType ? *contentType : "");
     });
 #endif /* HAVE_DNS_OVER_HTTPS */
 }

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -287,6 +287,9 @@ void setupLuaRules()
   g_lua.writeFunction("HTTPPathRule", [](const std::string& path) {
       return std::shared_ptr<DNSRule>(new HTTPPathRule(path));
     });
+  g_lua.writeFunction("HTTPPathRegexRule", [](const std::string& regex) {
+      return std::shared_ptr<DNSRule>(new HTTPPathRegexRule(regex));
+    });
 #endif
 
 #ifdef HAVE_RE2

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1747,11 +1747,11 @@ void setupLuaConfig(bool client)
         setLuaNoSideEffect();
         try {
           ostringstream ret;
-          boost::format fmt("%-3d %-20.20s %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d");
-          ret << (fmt % "#" % "Address" % "HTTP" % "HTTP/1" % "HTTP/2" % "TLS 1.0" % "TLS 1.1" % "TLS 1.2" % "TLS 1.3" % "TLS other" % "GET" % "POST" % "Bad" % "Errors" % "Valid") << endl;
+          boost::format fmt("%-3d %-20.20s %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d %-15d");
+          ret << (fmt % "#" % "Address" % "HTTP" % "HTTP/1" % "HTTP/2" % "TLS 1.0" % "TLS 1.1" % "TLS 1.2" % "TLS 1.3" % "TLS other" % "GET" % "POST" % "Bad" % "Errors" % "Redirects" % "Valid") << endl;
           size_t counter = 0;
           for (const auto& ctx : g_dohlocals) {
-            ret << (fmt % counter % ctx->d_local.toStringWithPort() % ctx->d_httpconnects % ctx->d_http1Stats.d_nbQueries % ctx->d_http1Stats.d_nbQueries % ctx->d_tls10queries % ctx->d_tls11queries % ctx->d_tls12queries % ctx->d_tls13queries % ctx->d_tlsUnknownqueries % ctx->d_getqueries % ctx->d_postqueries % ctx->d_badrequests % ctx->d_errorresponses % ctx->d_validresponses) << endl;
+            ret << (fmt % counter % ctx->d_local.toStringWithPort() % ctx->d_httpconnects % ctx->d_http1Stats.d_nbQueries % ctx->d_http1Stats.d_nbQueries % ctx->d_tls10queries % ctx->d_tls11queries % ctx->d_tls12queries % ctx->d_tls13queries % ctx->d_tlsUnknownqueries % ctx->d_getqueries % ctx->d_postqueries % ctx->d_badrequests % ctx->d_errorresponses % ctx->d_redirectresponses %ctx->d_validresponses) << endl;
             counter++;
           }
           g_outputBuffer = ret.str();

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -591,6 +591,8 @@ static void connectionThread(int sock, ComboAddress remote)
         output << "# TYPE " << dohfrontsbase << "bad_requests " << "counter" << "\n";
         output << "# HELP " << dohfrontsbase << "error_responses " << "Number of responses sent by dnsdist indicating an error" << "\n";
         output << "# TYPE " << dohfrontsbase << "error_responses " << "counter" << "\n";
+        output << "# HELP " << dohfrontsbase << "redirect_responses " << "Number of responses sent by dnsdist indicating a redirect" << "\n";
+        output << "# TYPE " << dohfrontsbase << "redirect_responses " << "counter" << "\n";
         output << "# HELP " << dohfrontsbase << "valid_responses " << "Number of valid responses sent by dnsdist" << "\n";
         output << "# TYPE " << dohfrontsbase << "valid_responses " << "counter" << "\n";
         output << "# HELP " << dohfrontsbase << "http1_queries " << "Number of queries received over HTTP/1.x" << "\n";
@@ -636,6 +638,7 @@ static void connectionThread(int sock, ComboAddress remote)
           output << dohfrontsbase << "post_queries" << label << doh->d_postqueries << "\n";
           output << dohfrontsbase << "bad_requests" << label << doh->d_badrequests << "\n";
           output << dohfrontsbase << "error_responses" << label << doh->d_errorresponses << "\n";
+          output << dohfrontsbase << "redirect_responses" << label << doh->d_redirectresponses << "\n";
           output << dohfrontsbase << "valid_responses" << label << doh->d_validresponses << "\n";
 
           output << dohfrontsbase << "http1_queries" << label << doh->d_http1Stats.d_nbQueries << "\n";
@@ -798,6 +801,7 @@ static void connectionThread(int sock, ComboAddress remote)
             { "post-queries", (double) doh->d_postqueries },
             { "bad-requests", (double) doh->d_badrequests },
             { "error-responses", (double) doh->d_errorresponses },
+            { "redirect-responses", (double) doh->d_redirectresponses },
             { "valid-responses", (double) doh->d_validresponses }
           };
           dohs.push_back(obj);

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -529,6 +529,17 @@ public:
 private:
   string d_path;
 };
+
+class HTTPPathRegexRule : public DNSRule
+{
+public:
+  HTTPPathRegexRule(const std::string& regex);
+  bool matches(const DNSQuestion* dq) const override;
+  string toString() const override;
+private:
+  Regex d_regex;
+  std::string d_visual;
+};
 #endif
 
 class SNIRule : public DNSRule

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -181,6 +181,7 @@ This state can be modified from the various hooks.
     Set the HTTP status code and content to immediately send back to the client.
     For HTTP redirects (3xx), the string supplied in ''body'' should be the URL to redirect to.
     For 200 responses, the value of the content type header can be specified via the ''contentType'' parameter.
+    In order for the response to be sent, the QR bit should be set before returning and the function should return Action.HeaderModify.
 
     :param int status: The HTTP status code to return
     :param string body: The body of the HTTP response, or a URL if the status code is a redirect (3xx)

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -92,6 +92,46 @@ This state can be modified from the various hooks.
 
     :returns: A table of EDNSOptionView objects, indexed on the ECS Option code
 
+  .. method:: DNSQuestion:getHTTPHeaders() -> table
+
+    .. versionadded:: 1.4.0
+
+    Return the HTTP headers for a DoH query, as a table whose keys are the header names and values the header values.
+
+    :returns: A table of HTTP headers
+
+  .. method:: DNSQuestion:getHTTPHost() -> string
+
+    .. versionadded:: 1.4.0
+
+    Return the HTTP Host for a DoH query, which may or may not contain the port.
+
+    :returns: The host of the DoH query
+
+  .. method:: DNSQuestion:getHTTPPath() -> string
+
+    .. versionadded:: 1.4.0
+
+    Return the HTTP path for a DoH query.
+
+    :returns: The path part of the DoH query URI
+
+  .. method:: DNSQuestion:getHTTPQueryString() -> string
+
+    .. versionadded:: 1.4.0
+
+    Return the HTTP query string for a DoH query.
+
+    :returns: The query string part of the DoH query URI
+
+  .. method:: DNSQuestion:getHTTPScheme() -> string
+
+    .. versionadded:: 1.4.0
+
+    Return the HTTP scheme for a DoH query.
+
+    :returns: The scheme of the DoH query, for example ''http'' or ''https''
+
   .. method:: DNSQuestion:getServerNameIndication() -> string
 
     .. versionadded:: 1.4.0
@@ -133,6 +173,18 @@ This state can be modified from the various hooks.
     Send an SNMP trap.
 
     :param string reason: An optional string describing the reason why this trap was sent
+
+  .. method:: DNSQuestion:setHTTPResponse(status, body, contentType="")
+
+    .. versionadded:: 1.4.0
+
+    Set the HTTP status code and content to immediately send back to the client.
+    For HTTP redirects (3xx), the string supplied in ''body'' should be the URL to redirect to.
+    For 200 responses, the value of the content type header can be specified via the ''contentType'' parameter.
+
+    :param int status: The HTTP status code to return
+    :param string body: The body of the HTTP response, or a URL if the status code is a redirect (3xx)
+    :param string contentType: The HTTP Content-Type header to return for a 200 response, ignored otherwise. Default is ''application/dns-message''.
 
   .. method:: DNSQuestion:setTag(key, value)
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -948,14 +948,14 @@ The following actions exist.
 
   :param int rcode: The extended RCODE to respond with.
 
-.. function:: HTTPStatusAction(status, reason, body)
+.. function:: HTTPStatusAction(status, body, contentType="")
   .. versionadded:: 1.4.0
 
-  Return an HTTP response with a status code of ''status'' and a reason of ''reason''. For HTTP redirects, ''body'' should be the redirect URL.
+  Return an HTTP response with a status code of ''status''. For HTTP redirects, ''body'' should be the redirect URL.
 
   :param int status: The HTTP status code to return.
-  :param str reason: The HTTP reason.
-  :param str body: the body of the HTTP response, or an URL if the status code is a redirect (3xx).
+  :param string body: The body of the HTTP response, or a URL if the status code is a redirect (3xx).
+  :param string contentType: The HTTP Content-Type header to return for a 200 response, ignored otherwise. Default is ''application/dns-message''.
 
 .. function:: LogAction([filename[, binary[, append[, buffered]]]])
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -583,6 +583,13 @@ These ``DNSRule``\ s be one of the following items:
   :param str name: The case-insensitive name of the HTTP header to match on
   :param str regex: A regular expression to match the content of the specified header
 
+.. function:: HTTPPathRegexRule(regex)
+  .. versionadded:: 1.4.0
+
+  Matches DNS over HTTPS queries with a HTTP path matching the regular expression supplied in ``regex``. For example, if the query has been sent to the https://192.0.2.1:443/PowerDNS?dns=... URL, the path would be '/PowerDNS'.
+
+  :param str regex: The regex to match on
+
 .. function:: HTTPPathRule(path)
   .. versionadded:: 1.4.0
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -948,6 +948,15 @@ The following actions exist.
 
   :param int rcode: The extended RCODE to respond with.
 
+.. function:: HTTPStatusAction(status, reason, body)
+  .. versionadded:: 1.4.0
+
+  Return an HTTP response with a status code of ''status'' and a reason of ''reason''. For HTTP redirects, ''body'' should be the redirect URL.
+
+  :param int status: The HTTP status code to return.
+  :param str reason: The HTTP reason.
+  :param str body: the body of the HTTP response, or an URL if the status code is a redirect (3xx).
+
 .. function:: LogAction([filename[, binary[, append[, buffered]]]])
 
   Log a line for each query, to the specified ``file`` if any, to the console (require verbose) otherwise.

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -810,21 +810,26 @@ static void on_dnsdist(h2o_socket_t *listener, const char *err)
     ++dsc->df->d_redirectresponses;
   }
   else {
-    switch(du->status_code) {
-    case 400:
-      h2o_send_error_400(du->req, getReasonFromStatusCode(du->status_code).c_str(), du->response.empty() ? "invalid DNS query" : du->response.c_str(), 0);
-      break;
-    case 403:
-      h2o_send_error_403(du->req, getReasonFromStatusCode(du->status_code).c_str(), du->response.empty() ? "dns query not allowed" : du->response.c_str(), 0);
-      break;
-    case 502:
-      h2o_send_error_502(du->req, getReasonFromStatusCode(du->status_code).c_str(), du->response.empty() ? "no downstream server available" : du->response.c_str(), 0);
-      break;
-    case 500:
-      /* fall-through */
-    default:
-      h2o_send_error_500(du->req, getReasonFromStatusCode(du->status_code).c_str(), du->response.empty() ? "Internal Server Error" : du->response.c_str(), 0);
-      break;
+    if (!du->response.empty()) {
+      h2o_send_error_generic(du->req, du->status_code, getReasonFromStatusCode(du->status_code).c_str(), du->response.c_str(), 0);
+    }
+    else {
+      switch(du->status_code) {
+      case 400:
+        h2o_send_error_400(du->req, getReasonFromStatusCode(du->status_code).c_str(), "invalid DNS query" , 0);
+        break;
+      case 403:
+        h2o_send_error_403(du->req, getReasonFromStatusCode(du->status_code).c_str(), "dns query not allowed", 0);
+        break;
+      case 502:
+        h2o_send_error_502(du->req, getReasonFromStatusCode(du->status_code).c_str(), "no downstream server available", 0);
+        break;
+      case 500:
+        /* fall-through */
+      default:
+        h2o_send_error_500(du->req, getReasonFromStatusCode(du->status_code).c_str(), "Internal Server Error", 0);
+        break;
+      }
     }
 
     ++dsc->df->d_errorresponses;

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -542,6 +542,7 @@ HTTPHeaderRule::HTTPHeaderRule(const std::string& header, const std::string& reg
   d_visual = "http[" + header+ "] ~ " + regex;
 
 }
+
 bool HTTPHeaderRule::matches(const DNSQuestion* dq) const
 {
   if(!dq->du) {
@@ -585,6 +586,30 @@ bool HTTPPathRule::matches(const DNSQuestion* dq) const
 string HTTPPathRule::toString() const
 {
   return "url path == " + d_path;
+}
+
+HTTPPathRegexRule::HTTPPathRegexRule(const std::string& regex): d_regex(regex), d_visual("http path ~ " + regex)
+{
+}
+
+bool HTTPPathRegexRule::matches(const DNSQuestion* dq) const
+{
+  if(!dq->du) {
+    return false;
+  }
+
+  if(dq->du->req->query_at == SIZE_MAX) {
+    return d_regex.match(std::string(dq->du->req->path.base, dq->du->req->path.len));
+  }
+  else {
+    cerr<<std::string(dq->du->req->path.base, dq->du->req->path.len - dq->du->req->query_at)<<endl;
+    return d_regex.match(std::string(dq->du->req->path.base, dq->du->req->path.len - dq->du->req->query_at));
+  }
+}
+
+string HTTPPathRegexRule::toString() const
+{
+  return d_visual;
 }
 
 void dnsdistclient(int qsock, int rsock)

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -64,6 +64,8 @@ struct DOHUnit
 };
 
 #else /* HAVE_DNS_OVER_HTTPS */
+#include <unordered_map>
+
 struct st_h2o_req_t;
 
 struct DOHUnit
@@ -75,7 +77,6 @@ struct DOHUnit
   st_h2o_req_t* req{nullptr};
   DOHUnit** self{nullptr};
   std::string reason;
-  std::string body;
   int rsock;
   uint16_t qtype;
   /* the status_code is set from
@@ -87,9 +88,14 @@ struct DOHUnit
   */
   uint16_t status_code{200};
   bool ednsAdded{false};
-};
 
-void DOHSetHTTPResponse(DOHUnit& du, uint16_t statusCode, const std::string& reason, const std::string& body);
+  std::string getHTTPPath() const;
+  std::string getHTTPHost() const;
+  std::string getHTTPScheme() const;
+  std::string getHTTPQueryString() const;
+  std::unordered_map<std::string, std::string> getHTTPHeaders() const;
+  void setHTTPResponse(uint16_t statusCode, const std::string& reason, const std::string& body);
+};
 
 #endif /* HAVE_DNS_OVER_HTTPS  */
 

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -27,6 +27,7 @@ struct DOHFrontend
   std::atomic<uint64_t> d_postqueries;    // valid DNS queries received via POST
   std::atomic<uint64_t> d_badrequests;     // request could not be converted to dns query
   std::atomic<uint64_t> d_errorresponses; // dnsdist set 'error' on response
+    std::atomic<uint64_t> d_redirectresponses; // dnsdist set 'redirect' on response
   std::atomic<uint64_t> d_validresponses; // valid responses sent out
 
   struct HTTPVersionStats
@@ -73,19 +74,22 @@ struct DOHUnit
   ComboAddress dest;
   st_h2o_req_t* req{nullptr};
   DOHUnit** self{nullptr};
+  std::string reason;
+  std::string body;
   int rsock;
   uint16_t qtype;
-  /* the error and status_code are set from
+  /* the status_code is set from
      processDOHQuery() (which is executed in
      the DOH client thread) so that the correct
      response can be sent in on_dnsdist(),
      after the DOHUnit has been passed back to
      the main DoH thread.
   */
-  uint16_t status_code{0};
-  bool error{false};
+  uint16_t status_code{200};
   bool ednsAdded{false};
 };
+
+void DOHSetHTTPResponse(DOHUnit& du, uint16_t statusCode, const std::string& reason, const std::string& body);
 
 #endif /* HAVE_DNS_OVER_HTTPS  */
 

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -76,7 +76,7 @@ struct DOHUnit
   ComboAddress dest;
   st_h2o_req_t* req{nullptr};
   DOHUnit** self{nullptr};
-  std::string reason;
+  std::string contentType;
   int rsock;
   uint16_t qtype;
   /* the status_code is set from
@@ -94,7 +94,7 @@ struct DOHUnit
   std::string getHTTPScheme() const;
   std::string getHTTPQueryString() const;
   std::unordered_map<std::string, std::string> getHTTPHeaders() const;
-  void setHTTPResponse(uint16_t statusCode, const std::string& reason, const std::string& body);
+  void setHTTPResponse(uint16_t statusCode, const std::string& body, const std::string& contentType="");
 };
 
 #endif /* HAVE_DNS_OVER_HTTPS  */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds:
- `HTTPPathRegexRule` to be able to match the path of a DoH query with a regular expression ;
- `HTTPStatusAction` to be able to return a specific HTTP response to a DoH query ;
- Lua bindings (`DNQuestion:getHTTPHeaders()`, `DNSQuestion:getHTTPHost()`, `DNSQuestion:getHTTPPath()`, `DNSQuestion:getHTTPQueryString() and `DNSQuestion:getHTTPScheme()` to be able to inspect a DoH query from Lua ;
- `DNSQuestion:setHTTPResponse()` to be able to return a specific HTTP response from Lua as well.

Fixes #8133.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

