### PR TITLE
dnsdist: Fix signedness issue in isEDNSOptionInOpt()

### DIFF
--- a/pdns/dnsdist-ecs.cc
+++ b/pdns/dnsdist-ecs.cc
@@ -492,7 +492,7 @@ bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const s
     return false;
   }
   size_t p = optStart + 9;
-  uint16_t rdLen = (0x100*packet.at(p) + packet.at(p+1));
+  uint16_t rdLen = (0x100*static_cast<unsigned char>(packet.at(p)) + static_cast<unsigned char>(packet.at(p+1)));
   p += sizeof(rdLen);
   if (rdLen > (optLen - optRecordMinimumSize)) {
     return false;
@@ -500,9 +500,9 @@ bool isEDNSOptionInOpt(const std::string& packet, const size_t optStart, const s
 
   size_t rdEnd = p + rdLen;
   while ((p + 4) <= rdEnd) {
-    const uint16_t optionCode = 0x100*packet.at(p) + packet.at(p+1);
+    const uint16_t optionCode = 0x100*static_cast<unsigned char>(packet.at(p)) + static_cast<unsigned char>(packet.at(p+1));
     p += sizeof(optionCode);
-    const uint16_t optionLen = 0x100*packet.at(p) + packet.at(p+1);
+    const uint16_t optionLen = 0x100*static_cast<unsigned char>(packet.at(p)) + static_cast<unsigned char>(packet.at(p+1));
     p += sizeof(optionLen);
 
     if ((p + optionLen) > rdEnd) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Interpreting the value as signed could result in a large value being considered negative. After the addition it would be stored into an unsigned value and thus become positive again, but the result of the addition would be wrong.
This means that we could fail to locate some EDNS options whose codes are too large and, while it's extremely unlikely to happen, we could get only a partial content for some very large options.

Reported by Brian Sullivan on the mailing-list [1].

[1]: https://mailman.powerdns.com/pipermail/dnsdist/2019-July/000596.html

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)

