### PR TITLE
auth: Emulate a buffered read in the pipe backend, ~3x faster

### DIFF
--- a/modules/pipebackend/coprocess.hh
+++ b/modules/pipebackend/coprocess.hh
@@ -43,18 +43,20 @@ class CoProcess : public CoRemote
 public:
   CoProcess(const string &command,int timeout=0, int infd=0, int outfd=1);
   ~CoProcess();
-  void sendReceive(const string &send, string &receive);
-  void receive(string &rcv);
-  void send(const string &send);
+  void sendReceive(const string &send, string &receive) override;
+  void receive(string &rcv) override;
+  void send(const string &send) override;
+  void launch();
 private:
-  void launch(const char **argv, int timeout=0, int infd=0, int outfd=1);
   void checkStatus();
+  std::vector<std::string> d_params;
+  std::vector<const char *> d_argv;
+  std::string d_remaining;
   int d_fd1[2], d_fd2[2];
   int d_pid;
   int d_infd;
   int d_outfd;
   int d_timeout;
-  FILE *d_fp;
 };
 
 class UnixRemote : public CoRemote
@@ -62,9 +64,9 @@ class UnixRemote : public CoRemote
 public:
   UnixRemote(const string &path, int timeout=0);
   ~UnixRemote();
-  void sendReceive(const string &send, string &receive);
-  void receive(string &rcv);
-  void send(const string &send);
+  void sendReceive(const string &send, string &receive) override;
+  void receive(string &rcv) override;
+  void send(const string &send) override;
 private:
   int d_fd;
   FILE *d_fp;

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -69,10 +69,14 @@ void CoWrapper::launch()
    if(d_command.empty())
      throw ArgException("pipe-command is not specified");
 
-   if(isUnixSocket(d_command))
+   if(isUnixSocket(d_command)) {
      d_cp = new UnixRemote(d_command, d_timeout);
-   else
-     d_cp = new CoProcess(d_command, d_timeout);
+   }
+   else {
+     auto coprocess = new CoProcess(d_command, d_timeout);
+     coprocess->launch();
+     d_cp = coprocess;
+   }
 
    d_cp->send("HELO\t"+std::to_string(d_abiVersion));
    string banner;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
By default the pipe backend enforces a timeout on the external process response time, via `poll()`. Since a buffered read would result in `poll()` considering that there is no unread data available even if there still is some in the buffer, the existing code disables any buffering on the pipe when the timeout is not disabled.
Unfortunately a non-buffered read is quite slower than a buffered one, so this PR implements an internal buffer in the pipe backend itself to speed things up, resulting in roughly 3 times more QPS with a very simple pipe backend script.    

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

