### PR TITLE
auth-4.2.x: m4/systemd.m4: Fail when systemctl is not available

### DIFF
--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -130,48 +130,52 @@ AC_DEFUN([AX_AVAILABLE_SYSTEMD], [
 ])
 
 AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
-        if test x"$systemd" = "xy"; then
-            _systemd_version=`systemctl --version|head -1 |cut -d" " -f 2`
-            if test $_systemd_version -ge 183; then
-               systemd_private_tmp=y
-            fi
-            if test $_systemd_version -ge 209; then
-               systemd_system_call_architectures=y
-               systemd_private_devices=y
-            fi
-            if test $_systemd_version -ge 211; then
-               systemd_restrict_address_families=y
-            fi
-            if test $_systemd_version -ge 214; then
-               systemd_protect_system=y
-               systemd_protect_home=y
-            fi
-            if test $_systemd_version -ge 231; then
-               systemd_restrict_realtime=y
-               systemd_memory_deny_write_execute=y
-            fi
-            if test $_systemd_version -ge 232; then
-               systemd_protect_control_groups=y
-               systemd_protect_kernel_modules=y
-               systemd_protect_kernel_tunables=y
-               systemd_remove_ipc=y
-               systemd_dynamic_user=y
-               systemd_private_users=y
-               systemd_protect_system_strict=y
-            fi
-            if test $_systemd_version -ge 233; then
-               systemd_restrict_namespaces=y
-            fi
-            if test $_systemd_version -ge 235; then
-               systemd_lock_personality=y
-               # while SystemCallFilter is technically available starting with 187,
-               # we use the pre-defined call filter sets that have been introduced later.
-               # Initial support for these landed in 231
-               # @filesystem @reboot @swap in 233
-               # @aio, @sync, @chown, @setuid, @memlock, @signal and @timer in 235
-               systemd_system_call_filter=y
-            fi
-        fi
+        AS_IF([test x"$systemd" = "xy"], [
+          AC_PATH_PROG([SYSTEMCTL], [systemctl], [no])
+          AS_IF([test "$SYSTEMCTL" = "no"],
+            [AC_MSG_ERROR([systemctl not found])], [
+              _systemd_version=`${SYSTEMCTL} --version|head -1 |cut -d" " -f 2`
+              if test $_systemd_version -ge 183; then
+                 systemd_private_tmp=y
+              fi
+              if test $_systemd_version -ge 209; then
+                 systemd_system_call_architectures=y
+                 systemd_private_devices=y
+              fi
+              if test $_systemd_version -ge 211; then
+                 systemd_restrict_address_families=y
+              fi
+              if test $_systemd_version -ge 214; then
+                 systemd_protect_system=y
+                 systemd_protect_home=y
+              fi
+              if test $_systemd_version -ge 231; then
+                 systemd_restrict_realtime=y
+                 systemd_memory_deny_write_execute=y
+              fi
+              if test $_systemd_version -ge 232; then
+                 systemd_protect_control_groups=y
+                 systemd_protect_kernel_modules=y
+                 systemd_protect_kernel_tunables=y
+                 systemd_remove_ipc=y
+                 systemd_dynamic_user=y
+                 systemd_private_users=y
+                 systemd_protect_system_strict=y
+              fi
+              if test $_systemd_version -ge 233; then
+                 systemd_restrict_namespaces=y
+              fi
+              if test $_systemd_version -ge 235; then
+                 systemd_lock_personality=y
+                 # while SystemCallFilter is technically available starting with 187,
+                 # we use the pre-defined call filter sets that have been introduced later.
+                 # Initial support for these landed in 231
+                 # @filesystem @reboot @swap in 233
+                 # @aio, @sync, @chown, @setuid, @memlock, @signal and @timer in 235
+                 systemd_system_call_filter=y
+              fi
+          ])
+        ])
         AM_CONDITIONAL([HAVE_SYSTEMD_DYNAMIC_USER], [ test x"$systemd_dynamic_user" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_LOCK_PERSONALITY], [ test x"$systemd_lock_personality" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE], [ test x"$systemd_memory_deny_write_execute" = "xy" ])


### PR DESCRIPTION
We use systemctl to determine the version as to find out what features
to enable in the unit file.

(cherry picked from commit 1f988403108ef7454006fcd995574d89f83aef7f)

### Short description
Backport of #8081 (without the coverity bits).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
