### PR TITLE
Fix typo in SQL query name in documentation

### DIFF
--- a/docs/backends/generic-sql.rst
+++ b/docs/backends/generic-sql.rst
@@ -239,7 +239,7 @@ These queries are used by e.g. ``pdnsutil rectify-zone``. Make sure to
 read :ref:`rules-for-filling-out-dnssec-fields`
 if you wish to calculate ordername and auth without using pdns-rectify.
 
--  ``insert-empty-non-terminal-order--query``: Insert empty non-terminal
+-  ``insert-empty-non-terminal-order-query``: Insert empty non-terminal
    in zone.
 -  ``delete-empty-non-terminal-query``: Delete an empty non-terminal in
    a zone.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Just fixing this incorrect query name in the docs.

`insert-empty-non-terminal-order-query` (`-query` instead of `--query`) is the correct name of the query, see:
https://github.com/PowerDNS/pdns/blob/rec-4.2.0/pdns/backends/gsql/gsqlbackend.cc#L82
and
https://github.com/PowerDNS/pdns/search?q=insert-empty-non-terminal-order-query&type=Code

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
