### PR TITLE
rec: cachonly vs forwarding

### DIFF
--- a/pdns/recursordist/test-syncres_cc3.cc
+++ b/pdns/recursordist/test-syncres_cc3.cc
@@ -677,12 +677,10 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_nord) {
         addRecordToLW(res, domain, QType::A, "192.0.2.42");
         return 1;
       }
-
+      // Not reached
+      BOOST_CHECK(false);
       return 0;
   });
-
-  /* simulate a no-RD query */
-  sr->setCacheOnly();
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
@@ -718,6 +716,8 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_rd) {
         addRecordToLW(res, domain, QType::A, "192.0.2.42");
         return 1;
       }
+      // Should not be reached
+      BOOST_CHECK(false);
 
       return 0;
   });
@@ -751,7 +751,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord) {
   const ComboAddress forwardedNS("192.0.2.42:53");
 
   SyncRes::AuthDomain ad;
-  ad.d_rdForward = true;
+  ad.d_rdForward = false;
   ad.d_servers.push_back(forwardedNS);
   (*SyncRes::t_sstorage.domainmap)[target] = ad;
 
@@ -764,12 +764,11 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord) {
         addRecordToLW(res, domain, QType::A, "192.0.2.42");
         return 1;
       }
+      // Should not be reached
+      BOOST_CHECK(false);
 
       return 0;
   });
-
-  /* simulate a no-RD query */
-  sr->setCacheOnly();
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
@@ -801,6 +800,8 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd) {
         addRecordToLW(res, domain, QType::A, "192.0.2.42");
         return 1;
       }
+      // Should not be reached
+      BOOST_CHECK(false);
 
       return 0;
   });

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -363,9 +363,6 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_cache_only) {
       return 1;
   });
 
-  /* simulate a no-RD query */
-  sr->setCacheOnly();
-
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -747,19 +747,21 @@ int SyncRes::doResolveNoQNameMinimization(const DNSName &qname, const QType &qty
 
           d_totUsec += lwr.d_usec;
           accountAuthLatency(lwr.d_usec, remoteIP.sin4.sin_family);
-          if (fromCache)
-            *fromCache = true;
           
           // filter out the good stuff from lwr.result()
-          if (res == 1) {
-            for(const auto& rec : lwr.d_records) {
-              if(rec.d_place == DNSResourceRecord::ANSWER)
-                ret.push_back(rec);
+          if (lwr.d_aabit) {
+            if (fromCache)
+              *fromCache = true;
+            if (res == 1) {
+              for(const auto& rec : lwr.d_records) {
+                if(rec.d_place == DNSResourceRecord::ANSWER)
+                  ret.push_back(rec);
+              }
+              return 0;
             }
-            return 0;
-          }
-          else {
-            return RCode::ServFail;
+            else {
+              return RCode::ServFail;
+            }
           }
         }
       }


### PR DESCRIPTION
The cacheonly vs forwarding logic is twisted. If we get an non-aa answer from the forward, continue consulting the cache in a regular way.

#8106 

But not confident yet this is the real fix. Hence the draft status.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

