### PR TITLE
dnsdist: Add support for early DoH HTTP responses

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -369,7 +369,14 @@ void setupLuaBindings(bool client)
     return values;
   });
 
-  g_lua.writeFunction("newDOHResponseMapEntry", [](const std::string& regex, uint16_t status, const std::string& content) {
-    return std::make_shared<DOHResponseMapEntry>(regex, status, content);
+  g_lua.writeFunction("newDOHResponseMapEntry", [](const std::string& regex, uint16_t status, const std::string& content, boost::optional<std::map<std::string, std::string>> customHeaders) {
+    boost::optional<std::vector<std::pair<std::string, std::string>>> headers{boost::none};
+    if (customHeaders) {
+      headers = std::vector<std::pair<std::string, std::string>>();
+      for (const auto& header : *customHeaders) {
+        headers->push_back({ header.first, header.second });
+      }
+    }
+    return std::make_shared<DOHResponseMapEntry>(regex, status, content, headers);
   });
 }

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -369,4 +369,7 @@ void setupLuaBindings(bool client)
     return values;
   });
 
+  g_lua.writeFunction("newDOHResponseMapEntry", [](const std::string& regex, uint16_t status, const std::string& content) {
+    return std::make_shared<DOHResponseMapEntry>(regex, status, content);
+  });
 }

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1812,8 +1812,11 @@ void setupLuaConfig(bool client)
 #endif
       });
 
-    g_lua.writeFunction("getDOHFrontend", [](size_t index) {
+    g_lua.writeFunction("getDOHFrontend", [client](size_t index) {
         std::shared_ptr<DOHFrontend> result = nullptr;
+        if (client) {
+          return result;
+        }
 #ifdef HAVE_DNS_OVER_HTTPS
         setLuaNoSideEffect();
         try {
@@ -1838,6 +1841,19 @@ void setupLuaConfig(bool client)
     g_lua.registerFunction<void(std::shared_ptr<DOHFrontend>::*)()>("reloadCertificates", [](std::shared_ptr<DOHFrontend> frontend) {
         if (frontend != nullptr) {
           frontend->reloadCertificates();
+        }
+      });
+
+    g_lua.registerFunction<void(std::shared_ptr<DOHFrontend>::*)(const std::map<int, std::shared_ptr<DOHResponseMapEntry>>&)>("setResponsesMap", [](std::shared_ptr<DOHFrontend> frontend, const std::map<int, std::shared_ptr<DOHResponseMapEntry>>& map) {
+        if (frontend != nullptr) {
+          std::vector<std::shared_ptr<DOHResponseMapEntry>> newMap;
+          newMap.reserve(map.size());
+
+          for (const auto& entry : map) {
+            newMap.push_back(entry.second);
+          }
+
+          frontend->d_responsesMap = std::move(newMap);
         }
       });
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1152,7 +1152,7 @@ DOHFrontend
      :param list of DOHResponseMapEntry objects rules: A list of DOHResponseMapEntry objects, obtained with :func:`newDOHResponseMapEntry`.
 
 
-.. function:: newDOHResponseMapEntry(regex, status, content) -> DOHResponseMapEntry
+.. function:: newDOHResponseMapEntry(regex, status, content [, headers]) -> DOHResponseMapEntry
 
   .. versionadded:: 1.4.0
 
@@ -1162,6 +1162,7 @@ DOHFrontend
   :param str regex: A regular expression to match the path against.
   :param int status: The HTTP code to answer with.
   :param str content: The content of the HTTP response, or a URL if the status is a redirection (3xx).
+  :param table of headers: The custom headers to set for the HTTP response, if any. The default is to use the value of the ``customResponseHeaders`` parameter passed to :func:`addDOHLocal`.
 
 TLSContext
 ~~~~~~~~~~

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1145,6 +1145,24 @@ DOHFrontend
 
      Reload the current TLS certificate and key pairs.
 
+  .. method:: DOHFrontend:setResponsesMap(rules)
+
+     Set a list of HTTP response rules allowing to intercept HTTP queries very early, before the DNS payload has been processed, and send custom responses including error pages, redirects and static content.
+
+     :param list of DOHResponseMapEntry objects rules: A list of DOHResponseMapEntry objects, obtained with :func:`newDOHResponseMapEntry`.
+
+
+.. function:: newDOHResponseMapEntry(regex, status, content) -> DOHResponseMapEntry
+
+  .. versionadded:: 1.4.0
+
+  Return a DOHResponseMapEntry that can be used with :meth:`DOHFrontend.setResponsesMap`. Every query whose path matches the regular expression supplied in ``regex`` will be immediately answered with a HTTP response.
+  The status of the HTTP response will be the one supplied by ``status``, and the content set to the one supplied by ``content``, except if the status is a redirection (3xx) in which case the content is expected to be the URL to redirect to.
+
+  :param str regex: A regular expression to match the path against.
+  :param int status: The HTTP code to answer with.
+  :param str content: The content of the HTTP response, or a URL if the status is a redirection (3xx).
+
 TLSContext
 ~~~~~~~~~~
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -587,6 +587,7 @@ These ``DNSRule``\ s be one of the following items:
   .. versionadded:: 1.4.0
 
   Matches DNS over HTTPS queries with a HTTP path matching the regular expression supplied in ``regex``. For example, if the query has been sent to the https://192.0.2.1:443/PowerDNS?dns=... URL, the path would be '/PowerDNS'.
+  Only valid DNS over HTTPS queries are matched. If you want to match all HTTP queries, see :meth:`DOHFrontend.setResponsesMap` instead.
 
   :param str regex: The regex to match on
 
@@ -594,6 +595,7 @@ These ``DNSRule``\ s be one of the following items:
   .. versionadded:: 1.4.0
 
   Matches DNS over HTTPS queries with a HTTP path of ``path``. For example, if the query has been sent to the https://192.0.2.1:443/PowerDNS?dns=... URL, the path would be '/PowerDNS'.
+  Only valid DNS over HTTPS queries are matched. If you want to match all HTTP queries, see :meth:`DOHFrontend.setResponsesMap` instead.
 
   :param str path: The exact HTTP path to match on
 

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -4,11 +4,40 @@
 
 struct DOHServerConfig;
 
+class DOHResponseMapEntry
+{
+public:
+  DOHResponseMapEntry(const std::string& regex, uint16_t status, const std::string& content): d_regex(regex), d_content(content), d_status(status)
+  {
+  }
+
+  bool matches(const std::string& path) const
+  {
+    return d_regex.match(path);
+  }
+
+  uint16_t getStatusCode() const
+  {
+    return d_status;
+  }
+
+  const std::string& getContent() const
+  {
+    return d_content;
+  }
+
+private:
+  Regex d_regex;
+  std::string d_content;
+  uint16_t d_status;
+};
+
 struct DOHFrontend
 {
   std::shared_ptr<DOHServerConfig> d_dsc{nullptr};
   std::vector<std::pair<std::string, std::string>> d_certKeyPairs;
   std::vector<std::string> d_ocspFiles;
+  std::vector<std::shared_ptr<DOHResponseMapEntry>> d_responsesMap;
   std::string d_ciphers;
   std::string d_ciphers13;
   std::string d_serverTokens{"h2o/dnsdist"};
@@ -30,7 +59,7 @@ struct DOHFrontend
   std::atomic<uint64_t> d_postqueries;    // valid DNS queries received via POST
   std::atomic<uint64_t> d_badrequests;     // request could not be converted to dns query
   std::atomic<uint64_t> d_errorresponses; // dnsdist set 'error' on response
-    std::atomic<uint64_t> d_redirectresponses; // dnsdist set 'redirect' on response
+  std::atomic<uint64_t> d_redirectresponses; // dnsdist set 'redirect' on response
   std::atomic<uint64_t> d_validresponses; // valid responses sent out
 
   struct HTTPVersionStats

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -7,7 +7,7 @@ struct DOHServerConfig;
 class DOHResponseMapEntry
 {
 public:
-  DOHResponseMapEntry(const std::string& regex, uint16_t status, const std::string& content): d_regex(regex), d_content(content), d_status(status)
+  DOHResponseMapEntry(const std::string& regex, uint16_t status, const std::string& content, const boost::optional<std::vector<std::pair<std::string, std::string>>>& headers): d_regex(regex), d_customHeaders(headers), d_content(content), d_status(status)
   {
   }
 
@@ -26,8 +26,14 @@ public:
     return d_content;
   }
 
+  const boost::optional<std::vector<std::pair<std::string, std::string>>>& getHeaders() const
+  {
+    return d_customHeaders;
+  }
+
 private:
   Regex d_regex;
+  boost::optional<std::vector<std::pair<std::string, std::string>>> d_customHeaders;
   std::string d_content;
   uint16_t d_status;
 };

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -579,7 +579,7 @@ class TestDOH(DNSDistDOHTest):
         conn.setopt(pycurl.HEADERFUNCTION, response_headers.write)
         data = conn.perform_rb()
         rcode = conn.getinfo(pycurl.RESPONSE_CODE)
-        headers = response_headers.getvalue()
+        headers = response_headers.getvalue().decode()
 
         self.assertEquals(rcode, 418)
         self.assertEquals(data, b'C0FFEE')
@@ -600,7 +600,7 @@ class TestDOH(DNSDistDOHTest):
 
         data = conn.perform_rb()
         rcode = conn.getinfo(pycurl.RESPONSE_CODE)
-        headers = response_headers.getvalue()
+        headers = response_headers.getvalue().decode()
         self.assertEquals(rcode, 418)
         self.assertEquals(data, b'C0FFEE')
         self.assertIn('foo: bar', headers)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The `HTTPPathRule` and `HTTPPathRegexRule`, and the `Lua` bindings to access the HTTP informations are only invoked for valid DNS over HTTP queries. This PR adds support for responding to HTTP queries _before_ the DNS payload has been parsed, thus allowing to respond to all HTTP queries.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
