### PR TITLE
auth: Get rid of most remaining naked pointers

### DIFF
--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -249,7 +249,6 @@ private:
   void setupDNSSEC();
   void setupStatements();
   void freeStatements();
-  void release(SSqlStatement**);
   static bool safeGetBBDomainInfo(int id, BB2DomainInfo* bbd);
   static void safePutBBDomainInfo(const BB2DomainInfo& bbd);
   static bool safeGetBBDomainInfo(const DNSName& name, BB2DomainInfo* bbd);

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -125,11 +125,6 @@ void Bind2Backend::setupStatements()
   d_getTSIGKeysQuery_stmt = d_dnssecdb->prepare("select name,algorithm,secret from tsigkeys", 0);
 }
 
-void Bind2Backend::release(SSqlStatement** stmt) {
-  delete *stmt;
-  *stmt = NULL;
-}
-
 void Bind2Backend::freeStatements()
 {
   d_getAllDomainMetadataQuery_stmt.reset();

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -67,7 +67,7 @@ void gPgSQLBackend::reconnect()
 
 bool gPgSQLBackend::inTransaction()
 {
-  const auto* db = dynamic_cast<SPgSQL*>(d_db);
+  const auto* db = dynamic_cast<SPgSQL*>(d_db.get());
   if (db) {
     return db->in_trx();
   }

--- a/modules/pipebackend/pipebackend.hh
+++ b/modules/pipebackend/pipebackend.hh
@@ -41,7 +41,7 @@ public:
   void send(const string &line);
   void receive(string &line);
 private:
-  CoRemote* d_cp;
+  std::unique_ptr<CoRemote> d_cp;
   string d_command;
   void launch();
   int d_timeout;
@@ -62,10 +62,10 @@ public:
 private:
   void launch();
   void cleanup();
-  unique_ptr<CoWrapper> d_coproc;
+  std::unique_ptr<CoWrapper> d_coproc;
+  std::unique_ptr<Regex> d_regex;
   DNSName d_qname;
   QType d_qtype;
-  Regex* d_regex;
   string d_regexstr;
   bool d_disavow;
   int d_abiVersion;

--- a/pdns/auth-carbon.cc
+++ b/pdns/auth-carbon.cc
@@ -32,7 +32,7 @@
 
 #include "namespaces.hh"
 
-void* carbonDumpThread(void*)
+void carbonDumpThread()
 try
 {
   setThreadName("pdns/carbonDump");
@@ -85,20 +85,16 @@ try
     }
     sleep(arg().asNum("carbon-interval"));
   }
-  return 0;
 }
 catch(std::exception& e)
 {
   g_log<<Logger::Error<<"Carbon thread died: "<<e.what()<<endl;
-  return 0;
 }
 catch(PDNSException& e)
 {
   g_log<<Logger::Error<<"Carbon thread died, PDNSException: "<<e.reason<<endl;
-  return 0;
 }
 catch(...)
 {
   g_log<<Logger::Error<<"Carbon thread died"<<endl;
-  return 0;
 }

--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -52,9 +52,9 @@ public:
   AuthPacketCache(size_t mapsCount=1024);
   ~AuthPacketCache();
 
-  void insert(DNSPacket *q, DNSPacket *r, uint32_t maxTTL);  //!< We copy the contents of *p into our cache. Do not needlessly call this to insert questions already in the cache as it wastes resources
+  void insert(DNSPacket& q, DNSPacket& r, uint32_t maxTTL);  //!< We copy the contents of *p into our cache. Do not needlessly call this to insert questions already in the cache as it wastes resources
 
-  bool get(DNSPacket *p, DNSPacket *q); //!< We return a dynamically allocated copy out of our cache. You need to delete it. You also need to spoof in the right ID with the DNSPacket.spoofID() method.
+  bool get(DNSPacket& p, DNSPacket& q); //!< You need to spoof in the right ID with the DNSPacket.spoofID() method.
 
   void cleanup(); //!< force the cache to preen itself from expired packets
   uint64_t purge();

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -41,15 +41,13 @@ public:
   virtual ~GSQLBackend()
   {
     freeStatements();
-    if(d_db)
-      delete d_db;    
+    d_db.reset();
   }
   
   void setDB(SSql *db)
   {
     freeStatements();
-    delete d_db;
-    d_db=db;
+    d_db=std::unique_ptr<SSql>(db);
     if (d_db) {
       d_db->setLog(::arg().mustDo("query-logging"));
       allocateStatements();
@@ -399,7 +397,7 @@ private:
   unique_ptr<SSqlStatement> d_SearchCommentsQuery_stmt;
 
 protected:
-  SSql *d_db{nullptr};
+  std::unique_ptr<SSql> d_db{nullptr};
   bool d_dnssecQueries;
   bool d_inTransaction{false};
 };

--- a/pdns/common_startup.hh
+++ b/pdns/common_startup.hh
@@ -40,8 +40,8 @@ extern ArgvMap theArg;
 extern StatBag S;  //!< Statistics are gathered across PDNS via the StatBag class S
 extern AuthPacketCache PC; //!< This is the main PacketCache, shared across all threads
 extern AuthQueryCache QC;
-extern DNSProxy *DP;
-extern DynListener *dl;
+extern std::unique_ptr<DNSProxy> DP;
+extern std::unique_ptr<DynListener> dl;
 extern CommunicatorClass Communicator;
 extern std::shared_ptr<UDPNameserver> N;
 extern vector<std::shared_ptr<UDPNameserver> > g_udpReceivers;
@@ -52,7 +52,7 @@ extern void declareArguments();
 extern void declareStats();
 extern void mainthread();
 extern int isGuarded( char ** );
-void* carbonDumpThread(void*);
+void carbonDumpThread();
 extern bool g_anyToTcp;
 extern bool g_8bitDNS;
 #ifdef HAVE_LUA_RECORDS

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -31,7 +31,6 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
-#include <boost/scoped_ptr.hpp>
 using namespace boost::multi_index;
 
 #include <unistd.h>
@@ -169,7 +168,7 @@ public:
   bool justNotified(const DNSName &domain, const string &ip);
   void addSuckRequest(const DNSName &domain, const ComboAddress& master);
   void addSlaveCheckRequest(const DomainInfo& di, const ComboAddress& remote);
-  void addTrySuperMasterRequest(DNSPacket *p);
+  void addTrySuperMasterRequest(const DNSPacket& p);
   void notify(const DNSName &domain, const string &ip);
   void mainloop();
   void retrievalLoopThread();
@@ -194,7 +193,7 @@ private:
   map<pair<DNSName,string>,time_t>d_holes;
   pthread_mutex_t d_holelock;
   void suck(const DNSName &domain, const ComboAddress& remote);
-  void ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, boost::scoped_ptr<AuthLua4>& pdl,
+  void ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, std::unique_ptr<AuthLua4>& pdl,
                 ZoneStatus& zs, vector<DNSRecord>* axfr);
 
   void slaveRefresh(PacketHandler *P);

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -227,7 +227,7 @@ void DNSPacket::setCompress(bool compress)
   d_rrs.reserve(200);
 }
 
-bool DNSPacket::couldBeCached()
+bool DNSPacket::couldBeCached() const
 {
   return !d_wantsnsid && qclass==QClass::IN && !d_havetsig;
 }
@@ -396,10 +396,10 @@ void DNSPacket::setQuestion(int op, const DNSName &qd, int newqtype)
   qtype=newqtype;
 }
 
-/** convenience function for creating a reply packet from a question packet. Do not forget to delete it after use! */
-DNSPacket *DNSPacket::replyPacket() const
+/** convenience function for creating a reply packet from a question packet. */
+std::unique_ptr<DNSPacket> DNSPacket::replyPacket() const
 {
-  DNSPacket *r=new DNSPacket(false);
+  auto r=make_unique<DNSPacket>(false);
   r->setSocket(d_socket);
   r->d_anyLocal=d_anyLocal;
   r->setRemote(&d_remote);
@@ -436,7 +436,7 @@ DNSPacket *DNSPacket::replyPacket() const
   return r;
 }
 
-void DNSPacket::spoofQuestion(const DNSPacket *qd)
+void DNSPacket::spoofQuestion(const DNSPacket& qd)
 {
   d_wrapped=true; // if we do this, don't later on wrapup
   
@@ -444,10 +444,10 @@ void DNSPacket::spoofQuestion(const DNSPacket *qd)
   string::size_type i=sizeof(d);
 
   for(;;) {
-    labellen = qd->d_rawpacket[i];
+    labellen = qd.d_rawpacket[i];
     if(!labellen) break;
     i++;
-    d_rawpacket.replace(i, labellen, qd->d_rawpacket, i, labellen);
+    d_rawpacket.replace(i, labellen, qd.d_rawpacket, i, labellen);
     i = i + labellen;
   }
 }
@@ -639,7 +639,7 @@ bool DNSPacket::hasEDNSSubnet() const
   return d_haveednssubnet;
 }
 
-bool DNSPacket::hasEDNS() 
+bool DNSPacket::hasEDNS() const
 {
   return d_haveednssection;
 }

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -105,7 +105,7 @@ public:
 
   DTime d_dt; //!< the time this packet was created. replyPacket() copies this in for you, so d_dt becomes the time spent processing the question+answer
   void wrapup();  // writes out queued rrs, and generates the binary packet. also shuffles. also rectifies dnsheader 'd', and copies it to the stringbuffer
-  void spoofQuestion(const DNSPacket *qd); //!< paste in the exact right case of the question. Useful for PacketCache
+  void spoofQuestion(const DNSPacket& qd); //!< paste in the exact right case of the question. Useful for PacketCache
   unsigned int getMinTTL(); //!< returns lowest TTL of any record in the packet
   bool isEmpty(); //!< returns true if there are no rrs in the packet
 
@@ -113,15 +113,15 @@ public:
   vector<DNSZoneRecord*> getAnswerRecords(); //!< get a vector with DNSZoneRecords that are answers
   void setCompress(bool compress);
 
-  DNSPacket *replyPacket() const; //!< convenience function that creates a virgin answer packet to this question
+  std::unique_ptr<DNSPacket> replyPacket() const; //!< convenience function that creates a virgin answer packet to this question
 
   void commitD(); //!< copies 'd' into the stringbuffer
   unsigned int getMaxReplyLen(); //!< retrieve the maximum length of the packet we should send in response
   void setMaxReplyLen(int bytes); //!< set the max reply len (used when retrieving from the packet cache, and this changed)
 
-  bool couldBeCached(); //!< returns 0 if this query should bypass the packet cache
+  bool couldBeCached() const; //!< returns 0 if this query should bypass the packet cache
   bool hasEDNSSubnet() const;
-  bool hasEDNS();
+  bool hasEDNS() const;
   uint8_t getEDNSVersion() const { return d_ednsversion; };
   void setEDNSRcode(uint16_t extRCode)
   {

--- a/pdns/dnsproxy.hh
+++ b/pdns/dnsproxy.hh
@@ -54,7 +54,7 @@ public:
   DNSProxy(const string &ip); //!< creates socket
   ~DNSProxy(); //<! dtor for DNSProxy
   void go(); //!< launches the actual thread
-  bool completePacket(DNSPacket *r, const DNSName& target,const DNSName& aname, const uint8_t scopeMask);
+  bool completePacket(std::unique_ptr<DNSPacket>& r, const DNSName& target,const DNSName& aname, const uint8_t scopeMask);
 
   void mainloop();                  //!< this is the main loop that receives reply packets and sends them out again
   static void *launchhelper(void *p)
@@ -69,7 +69,7 @@ private:
     time_t created;
     boost::optional<ComboAddress> anyLocal;
     DNSName qname;
-    DNSPacket* complete;
+    std::unique_ptr<DNSPacket> complete;
     DNSName aname;
     uint8_t anameScopeMask;
     ComboAddress remote;

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -404,7 +404,7 @@ void measureResultAndClean(qids_t::const_iterator iter)
 }
 
 
-Socket *s_socket;
+std::unique_ptr<Socket> s_socket = nullptr;
 
 void receiveFromReference()
 try
@@ -772,7 +772,7 @@ try
   g_timeoutMsec=g_vm["timeout-msec"].as<uint32_t>();
 
   PcapPacketReader pr(g_vm["pcap-source"].as<string>());
-  s_socket= new Socket(AF_INET, SOCK_DGRAM);
+  s_socket= make_unique<Socket>(AF_INET, SOCK_DGRAM);
 
   s_socket->setNonBlocking();
 

--- a/pdns/dnsscope.cc
+++ b/pdns/dnsscope.cc
@@ -222,9 +222,9 @@ try
 
   for(unsigned int fno=0; fno < files.size(); ++fno) {
     PcapPacketReader pr(files[fno]);
-    PcapPacketWriter* pw=0;
+    std::unique_ptr<PcapPacketWriter> pw=nullptr;
     if(!g_vm["write-failures"].as<string>().empty())
-      pw=new PcapPacketWriter(g_vm["write-failures"].as<string>(), pr);
+      pw=std::unique_ptr<PcapPacketWriter>(new PcapPacketWriter(g_vm["write-failures"].as<string>(), pr));
  
     EDNSOpts edo;
     while(pr.getUDPPacket()) {

--- a/pdns/dnstcpbench.cc
+++ b/pdns/dnstcpbench.cc
@@ -132,18 +132,17 @@ try
     throw PDNSException("tcp read failed");
   
   len=ntohs(len);
-  char *creply = new char[len];
+  std::unique_ptr<char[]> creply(new char[len]);
   int n=0;
   int numread;
   while(n<len) {
-    numread=sock.read(creply+n, len-n);
+    numread=sock.read(creply.get()+n, len-n);
     if(numread<0)
       throw PDNSException("tcp read failed");
     n+=numread;
   }
   
-  reply=string(creply, len);
-  delete[] creply;
+  reply=string(creply.get(), len);
   
   gettimeofday(&now, 0);
   q->tcpUsec = makeUsec(now - tv);

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -20,10 +20,10 @@ AuthLua4::AuthLua4() { prepareContext(); }
 
 #if !defined(HAVE_LUA)
 
-bool AuthLua4::updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, DNSPacket *packet) { return false; }
+bool AuthLua4::updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, const DNSPacket& packet) { return false; }
 bool AuthLua4::axfrfilter(const ComboAddress& remote, const DNSName& zone, const DNSResourceRecord& in, vector<DNSResourceRecord>& out) { return false; }
-LuaContext* AuthLua4::getLua() { return 0; }
-DNSPacket *AuthLua4::prequery(DNSPacket *q) { return NULL; }
+LuaContext* AuthLua4::getLua() { return nullptr; }
+std::unique_ptr<DNSPacket> AuthLua4::prequery(const DNSPacket& q) { return nullptr; }
 
 AuthLua4::~AuthLua4() { }
 
@@ -56,8 +56,8 @@ void AuthLua4::postPrepareContext() {
   });
 
 /* DNSPacket */
-  d_lw->writeFunction("newDNSPacket", [](bool isQuery) { return new DNSPacket(isQuery); });
-  d_lw->writeFunction("dupDNSPacket", [](const DNSPacket &orig) { return new DNSPacket(orig); });
+  d_lw->writeFunction("newDNSPacket", [](bool isQuery) { return make_unique<DNSPacket>(isQuery); });
+  d_lw->writeFunction("dupDNSPacket", [](const std::unique_ptr<DNSPacket> &orig) { return make_unique<DNSPacket>(*orig); });
   d_lw->registerFunction<DNSPacket, int(const char *, size_t)>("noparse", [](DNSPacket &p, const char *mesg, size_t len){ return p.noparse(mesg, len); });
   d_lw->registerFunction<DNSPacket, int(const char *, size_t)>("parse", [](DNSPacket &p, const char *mesg, size_t len){ return p.parse(mesg, len); });
   d_lw->registerFunction<DNSPacket, const std::string()>("getString", [](DNSPacket &p) { return p.getString(); });
@@ -79,7 +79,7 @@ void AuthLua4::postPrepareContext() {
   d_lw->registerFunction<DNSPacket, void(const vector<pair<unsigned int, DNSRecord> >&)>("addRecords", [](DNSPacket &p, const vector<pair<unsigned int, DNSRecord> >& records){ for(const auto &dr: records){ DNSZoneRecord dzr; dzr.dr = std::get<1>(dr); dzr.auth = true; p.addRecord(dzr); }});
   d_lw->registerFunction<DNSPacket, void(unsigned int, const DNSName&, const std::string&)>("setQuestion", [](DNSPacket &p, unsigned int opcode, const DNSName &name, const string &type){ QType qtype; qtype = type; p.setQuestion(static_cast<int>(opcode), name, static_cast<int>(qtype.getCode())); });
   d_lw->registerFunction<DNSPacket, bool()>("isEmpty", [](DNSPacket &p){return p.isEmpty();});
-  d_lw->registerFunction<DNSPacket, DNSPacket*()>("replyPacket",[](DNSPacket& p){ return p.replyPacket();});
+  d_lw->registerFunction<DNSPacket, std::unique_ptr<DNSPacket>()>("replyPacket",[](DNSPacket& p){ return p.replyPacket();});
   d_lw->registerFunction<DNSPacket, bool()>("hasEDNSSubnet", [](DNSPacket &p){return p.hasEDNSSubnet();});
   d_lw->registerFunction<DNSPacket, bool()>("hasEDNS",[](DNSPacket &p){return p.hasEDNS();});
   d_lw->registerFunction<DNSPacket, unsigned int()>("getEDNSVersion",[](DNSPacket &p){return p.getEDNSVersion();});
@@ -159,31 +159,31 @@ bool AuthLua4::axfrfilter(const ComboAddress& remote, const DNSName& zone, const
 }
 
 
-bool AuthLua4::updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, DNSPacket *packet) {
+bool AuthLua4::updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, const DNSPacket& packet) {
   // default decision is all goes
-  if (d_update_policy == NULL) return true;
+  if (d_update_policy == nullptr) return true;
 
   UpdatePolicyQuery upq;
   upq.qname = qname;
   upq.qtype = qtype.getCode();
   upq.zonename = zonename;
-  upq.local = packet->getLocal();
-  upq.remote = packet->getRemote();
-  upq.realRemote = packet->getRealRemote();
-  upq.tsigName = packet->getTSIGKeyname();
-  upq.peerPrincipal = packet->d_peer_principal;
+  upq.local = packet.getLocal();
+  upq.remote = packet.getRemote();
+  upq.realRemote = packet.getRealRemote();
+  upq.tsigName = packet.getTSIGKeyname();
+  upq.peerPrincipal = packet.d_peer_principal;
 
   return d_update_policy(upq);
 }
 
-DNSPacket *AuthLua4::prequery(DNSPacket *q) {
-  if (d_prequery == NULL) return NULL;
+std::unique_ptr<DNSPacket> AuthLua4::prequery(const DNSPacket& q) {
+  if (d_prequery == nullptr) return nullptr;
 
-  DNSPacket *r = q->replyPacket();
-  if (d_prequery(r))
+  auto r = q.replyPacket();
+  if (d_prequery(r.get()))
     return r;
-  delete r;
-  return NULL;
+
+  return nullptr;
 }
 
 AuthLua4::~AuthLua4() { }

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -56,8 +56,8 @@ void AuthLua4::postPrepareContext() {
   });
 
 /* DNSPacket */
-  d_lw->writeFunction("newDNSPacket", [](bool isQuery) { return make_unique<DNSPacket>(isQuery); });
-  d_lw->writeFunction("dupDNSPacket", [](const std::unique_ptr<DNSPacket> &orig) { return make_unique<DNSPacket>(*orig); });
+  d_lw->writeFunction("newDNSPacket", [](bool isQuery) { return std::make_shared<DNSPacket>(isQuery); });
+  d_lw->writeFunction("dupDNSPacket", [](const std::shared_ptr<DNSPacket> &orig) { return std::make_shared<DNSPacket>(*orig); });
   d_lw->registerFunction<DNSPacket, int(const char *, size_t)>("noparse", [](DNSPacket &p, const char *mesg, size_t len){ return p.noparse(mesg, len); });
   d_lw->registerFunction<DNSPacket, int(const char *, size_t)>("parse", [](DNSPacket &p, const char *mesg, size_t len){ return p.parse(mesg, len); });
   d_lw->registerFunction<DNSPacket, const std::string()>("getString", [](DNSPacket &p) { return p.getString(); });
@@ -79,7 +79,7 @@ void AuthLua4::postPrepareContext() {
   d_lw->registerFunction<DNSPacket, void(const vector<pair<unsigned int, DNSRecord> >&)>("addRecords", [](DNSPacket &p, const vector<pair<unsigned int, DNSRecord> >& records){ for(const auto &dr: records){ DNSZoneRecord dzr; dzr.dr = std::get<1>(dr); dzr.auth = true; p.addRecord(dzr); }});
   d_lw->registerFunction<DNSPacket, void(unsigned int, const DNSName&, const std::string&)>("setQuestion", [](DNSPacket &p, unsigned int opcode, const DNSName &name, const string &type){ QType qtype; qtype = type; p.setQuestion(static_cast<int>(opcode), name, static_cast<int>(qtype.getCode())); });
   d_lw->registerFunction<DNSPacket, bool()>("isEmpty", [](DNSPacket &p){return p.isEmpty();});
-  d_lw->registerFunction<DNSPacket, std::unique_ptr<DNSPacket>()>("replyPacket",[](DNSPacket& p){ return p.replyPacket();});
+  d_lw->registerFunction<DNSPacket, std::shared_ptr<DNSPacket>()>("replyPacket",[](DNSPacket& p){ return p.replyPacket();});
   d_lw->registerFunction<DNSPacket, bool()>("hasEDNSSubnet", [](DNSPacket &p){return p.hasEDNSSubnet();});
   d_lw->registerFunction<DNSPacket, bool()>("hasEDNS",[](DNSPacket &p){return p.hasEDNS();});
   d_lw->registerFunction<DNSPacket, unsigned int()>("getEDNSVersion",[](DNSPacket &p){return p.getEDNSVersion();});

--- a/pdns/lua-auth4.hh
+++ b/pdns/lua-auth4.hh
@@ -13,11 +13,11 @@ class AuthLua4 : public BaseLua4
 {
 public:
   AuthLua4();
-  bool updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, DNSPacket *packet);
+  bool updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, const DNSPacket& packet);
   bool axfrfilter(const ComboAddress&, const DNSName&, const DNSResourceRecord&, std::vector<DNSResourceRecord>&);
   LuaContext* getLua();
 
-  DNSPacket *prequery(DNSPacket *p);
+  std::unique_ptr<DNSPacket> prequery(const DNSPacket& p);
 
   ~AuthLua4(); // this is so unique_ptr works with an incomplete type
 protected:

--- a/pdns/nameserver.hh
+++ b/pdns/nameserver.hh
@@ -81,8 +81,8 @@ class UDPNameserver
 {
 public:
   UDPNameserver( bool additional_socket = false );  //!< Opens the socket
-  DNSPacket *receive(DNSPacket *prefilled, std::string& buffer); //!< call this in a while or for(;;) loop to get packets
-  void send(DNSPacket *); //!< send a DNSPacket. Will call DNSPacket::truncate() if over 512 bytes
+  bool receive(DNSPacket& packet, std::string& buffer); //!< call this in a while or for(;;) loop to get packets
+  void send(DNSPacket&); //!< send a DNSPacket. Will call DNSPacket::truncate() if over 512 bytes
   inline bool canReusePort() {
 #ifdef SO_REUSEPORT
     return d_can_reuseport;

--- a/pdns/nsec3dig.cc
+++ b/pdns/nsec3dig.cc
@@ -142,18 +142,17 @@ try
     throw PDNSException("tcp read failed");
 
   len=ntohs(len);
-  char *creply = new char[len];
+  std::unique_ptr<char[]> creply(new char[len]);
   int n=0;
   int numread;
   while(n<len) {
-    numread=sock.read(creply+n, len-n);
+    numread=sock.read(creply.get()+n, len-n);
     if(numread<0)
       throw PDNSException("tcp read failed");
     n+=numread;
   }
 
-  string reply(creply, len);
-  delete[] creply;
+  string reply(creply.get(), len);
 
   MOADNSParser mdp(false, reply);
   cout<<"Reply to question for qname='"<<mdp.d_qname<<"', qtype="<<DNSRecordContent::NumberToType(mdp.d_qtype)<<endl;

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -55,53 +55,53 @@ class NSEC3PARAMRecordContent;
 class PacketHandler
 {
 public:
-  DNSPacket *doQuestion(DNSPacket *); //!< hand us a DNS packet with a question, we give you an answer
-  DNSPacket *question(DNSPacket *); //!< hand us a DNS packet with a question, we give you an answer
+  std::unique_ptr<DNSPacket> doQuestion(DNSPacket&); //!< hand us a DNS packet with a question, we give you an answer
+  std::unique_ptr<DNSPacket> question(DNSPacket&); //!< hand us a DNS packet with a question, we give you an answer
   PacketHandler(); 
   ~PacketHandler(); // defined in packethandler.cc, and does --count
   static int numRunning(){return s_count;}; //!< Returns the number of running PacketHandlers. Called by Distributor
  
   UeberBackend *getBackend();
 
-  int trySuperMasterSynchronous(const DNSPacket *p, const DNSName& tsigkeyname);
+  int trySuperMasterSynchronous(const DNSPacket& p, const DNSName& tsigkeyname);
   static NetmaskGroup s_allowNotifyFrom;
   static set<string> s_forwardNotify;
 
 private:
-  int trySuperMaster(DNSPacket *p, const DNSName& tsigkeyname);
-  int processNotify(DNSPacket *);
-  void addRootReferral(DNSPacket *r);
-  int doChaosRequest(DNSPacket *p, DNSPacket *r, DNSName &target);
-  bool addDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd);
-  bool addCDNSKEY(DNSPacket *p, DNSPacket *r, const SOAData& sd);
-  bool addCDS(DNSPacket *p, DNSPacket *r, const SOAData& sd);
-  bool addNSEC3PARAM(DNSPacket *p, DNSPacket *r, const SOAData& sd);
-  int doAdditionalProcessingAndDropAA(DNSPacket *p, DNSPacket *r, const SOAData& sd, bool retargeted);
-  void addNSECX(DNSPacket *p, DNSPacket* r, const DNSName &target, const DNSName &wildcard, const DNSName &auth, int mode);
-  void addNSEC(DNSPacket *p, DNSPacket* r, const DNSName &target, const DNSName &wildcard, const DNSName& auth, int mode);
-  void addNSEC3(DNSPacket *p, DNSPacket* r, const DNSName &target, const DNSName &wildcard, const DNSName& auth, const NSEC3PARAMRecordContent& nsec3param, bool narrow, int mode);
-  void emitNSEC(DNSPacket *r, const SOAData& sd, const DNSName& name, const DNSName& next, int mode);
-  void emitNSEC3(DNSPacket *r, const SOAData& sd, const NSEC3PARAMRecordContent &ns3rc, const DNSName& unhashed, const string& begin, const string& end, int mode);
-  int processUpdate(DNSPacket *p);
-  int forwardPacket(const string &msgPrefix, DNSPacket *p, DomainInfo *di);
+  int trySuperMaster(const DNSPacket& p, const DNSName& tsigkeyname);
+  int processNotify(const DNSPacket& );
+  void addRootReferral(DNSPacket& r);
+  int doChaosRequest(const DNSPacket& p, std::unique_ptr<DNSPacket>& r, DNSName &target) const;
+  bool addDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd);
+  bool addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd);
+  bool addCDS(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd);
+  bool addNSEC3PARAM(const DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd);
+  int doAdditionalProcessingAndDropAA(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd, bool retargeted);
+  void addNSECX(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName &target, const DNSName &wildcard, const DNSName &auth, int mode);
+  void addNSEC(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName &target, const DNSName &wildcard, const DNSName& auth, int mode);
+  void addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName &target, const DNSName &wildcard, const DNSName& auth, const NSEC3PARAMRecordContent& nsec3param, bool narrow, int mode);
+  void emitNSEC(std::unique_ptr<DNSPacket>& r, const SOAData& sd, const DNSName& name, const DNSName& next, int mode);
+  void emitNSEC3(std::unique_ptr<DNSPacket>& r, const SOAData& sd, const NSEC3PARAMRecordContent &ns3rc, const DNSName& unhashed, const string& begin, const string& end, int mode);
+  int processUpdate(DNSPacket& p);
+  int forwardPacket(const string &msgPrefix, const DNSPacket& p, const DomainInfo& di);
   uint performUpdate(const string &msgPrefix, const DNSRecord *rr, DomainInfo *di, bool isPresigned, bool* narrow, bool* haveNSEC3, NSEC3PARAMRecordContent *ns3pr, bool *updatedSerial);
   int checkUpdatePrescan(const DNSRecord *rr);
   int checkUpdatePrerequisites(const DNSRecord *rr, DomainInfo *di);
   void increaseSerial(const string &msgPrefix, const DomainInfo *di, bool haveNSEC3, bool narrow, const NSEC3PARAMRecordContent *ns3pr);
 
-  void makeNXDomain(DNSPacket* p, DNSPacket* r, const DNSName& target, const DNSName& wildcard, const SOAData& sd);
-  void makeNOError(DNSPacket* p, DNSPacket* r, const DNSName& target, const DNSName& wildcard, const SOAData& sd, int mode);
-  vector<DNSZoneRecord> getBestReferralNS(DNSPacket *p, SOAData& sd, const DNSName &target);
-  vector<DNSZoneRecord> getBestDNAMESynth(DNSPacket *p, SOAData& sd, DNSName &target);
-  bool tryDNAME(DNSPacket *p, DNSPacket*r, SOAData& sd, DNSName &target);
-  bool tryReferral(DNSPacket *p, DNSPacket*r, SOAData& sd, const DNSName &target, bool retargeted);
+  void makeNXDomain(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName& target, const DNSName& wildcard, const SOAData& sd);
+  void makeNOError(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName& target, const DNSName& wildcard, const SOAData& sd, int mode);
+  vector<DNSZoneRecord> getBestReferralNS(DNSPacket& p, const SOAData& sd, const DNSName &target);
+  vector<DNSZoneRecord> getBestDNAMESynth(DNSPacket& p, const SOAData& sd, DNSName &target);
+  bool tryDNAME(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd, DNSName &target);
+  bool tryReferral(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd, const DNSName &target, bool retargeted);
 
-  bool getBestWildcard(DNSPacket *p, SOAData& sd, const DNSName &target, DNSName &wildcard, vector<DNSZoneRecord>* ret);
-  bool tryWildcard(DNSPacket *p, DNSPacket*r, SOAData& sd, DNSName &target, DNSName &wildcard, bool& retargeted, bool& nodata);
-  bool addDSforNS(DNSPacket* p, DNSPacket* r, SOAData& sd, const DNSName& dsname);
-  void completeANYRecords(DNSPacket *p, DNSPacket*r, SOAData& sd, const DNSName &target);
+  bool getBestWildcard(DNSPacket& p, const SOAData& sd, const DNSName &target, DNSName &wildcard, vector<DNSZoneRecord>* ret);
+  bool tryWildcard(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd, DNSName &target, DNSName &wildcard, bool& retargeted, bool& nodata);
+  bool addDSforNS(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd, const DNSName& dsname);
+  void completeANYRecords(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd, const DNSName &target);
 
-  void tkeyHandler(DNSPacket *p, DNSPacket *r); //<! process TKEY record, and adds TKEY record to (r)eply, or error code.
+  void tkeyHandler(const DNSPacket& p, std::unique_ptr<DNSPacket>& r); //<! process TKEY record, and adds TKEY record to (r)eply, or error code.
 
   static AtomicCounter s_count;
   static pthread_mutex_t s_rfc2136lock;
@@ -116,6 +116,6 @@ private:
   UeberBackend B; // every thread an own instance
   DNSSECKeeper d_dk; // B is shared with DNSSECKeeper
 };
-bool getNSEC3Hashes(bool narrow, DNSBackend* db, int id, const std::string& hashed, bool decrement, DNSName& unhashed, string& before, string& after, int mode=0);
+
 std::shared_ptr<DNSRecordContent> makeSOAContent(const SOAData& sd);
 #endif /* PACKETHANDLER */

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -541,15 +541,15 @@ int main(int argc, char **argv)
 
     if(isGuarded(argv)) {
       g_log<<Logger::Warning<<"This is a guarded instance of pdns"<<endl;
-      dl=new DynListener; // listens on stdin 
+      dl=make_unique<DynListener>(); // listens on stdin 
     }
     else {
       g_log<<Logger::Warning<<"This is a standalone pdns"<<endl; 
       
       if(::arg().mustDo("control-console"))
-        dl=new DynListener();
+        dl=make_unique<DynListener>();
       else
-        dl=new DynListener(s_programname);
+        dl=std::unique_ptr<DynListener>(new DynListener(s_programname));
       
       writePid();
     }

--- a/pdns/saxfr.cc
+++ b/pdns/saxfr.cc
@@ -128,17 +128,17 @@ try
         throw PDNSException("tcp read failed");
 
       len=ntohs(len);
-      char *creply = new char[len];
+      std::unique_ptr<char[]> creply(new char[len]);
       int n=0;
       int numread;
       while(n<len) {
-        numread=sock.read(creply+n, len-n);
+        numread=sock.read(creply.get()+n, len-n);
         if(numread<0)
           throw PDNSException("tcp read failed");
         n+=numread;
       }
 
-      MOADNSParser mdp(false, string(creply, len));
+      MOADNSParser mdp(false, string(creply.get(), len));
        if (mdp.d_header.rcode != 0) {
          throw PDNSException(string("Remote server refused: ") + std::to_string(mdp.d_header.rcode));
        }
@@ -193,17 +193,17 @@ try
       throw PDNSException("tcp read failed");
 
     len=ntohs(len);
-    char *creply = new char[len];
+    std::unique_ptr<char[]> creply(new char[len]);
     int n=0;
     int numread;
     while(n<len) {
-      numread=sock.read(creply+n, len-n);
+      numread=sock.read(creply.get()+n, len-n);
       if(numread<0)
         throw PDNSException("tcp read failed");
       n+=numread;
     }
 
-    MOADNSParser mdp(false, string(creply, len));
+    MOADNSParser mdp(false, string(creply.get(), len));
     if (mdp.d_header.rcode != 0) {
       throw PDNSException(string("Remote server refused: ") + std::to_string(mdp.d_header.rcode));
     }
@@ -274,8 +274,6 @@ try
       }while(shorter.chopOff());
 
     }
-
-    delete[] creply;
   }
 
   if (isNSEC3 && unhash)

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -189,18 +189,17 @@ try
       throw PDNSException("tcp read failed");
 
     len=ntohs(len);
-    char *creply = new char[len];
+    std::unique_ptr<char[]> creply(new char[len]);
     int n=0;
     int numread;
     while(n<len) {
-      numread=sock.read(creply+n, len-n);
+      numread=sock.read(creply.get()+n, len-n);
       if(numread<0)
         throw PDNSException("tcp read failed");
       n+=numread;
     }
 
-    reply=string(creply, len);
-    delete[] creply;
+    reply=string(creply.get(), len);
   }
   else //udp
   {

--- a/pdns/signingpipe.hh
+++ b/pdns/signingpipe.hh
@@ -57,7 +57,7 @@ private:
   void flushToSign();	
   void dedupRRSet();
   void sendRRSetToWorker(); // dispatch RRSET to worker
-  void addSignedToChunks(chunk_t* signedChunk);
+  void addSignedToChunks(std::unique_ptr<chunk_t>& signedChunk);
   pair<vector<int>, vector<int> > waitForRW(bool rd, bool wr, int seconds);
 
   static void* helperWorker(ChunkedSigningPipe* csp, int fd);
@@ -66,7 +66,7 @@ private:
   unsigned int d_numworkers;
   unsigned int d_submitted;
 
-  rrset_t* d_rrsetToSign;
+  std::unique_ptr<rrset_t> d_rrsetToSign;
   std::deque< std::vector<DNSZoneRecord> > d_chunks;
   DNSName d_signer;
   

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -46,8 +46,6 @@
 #include "common_startup.hh"
 
 #include "ixfr.hh"
-using boost::scoped_ptr;
-
 
 void CommunicatorClass::addSuckRequest(const DNSName &domain, const ComboAddress& master)
 {
@@ -80,7 +78,7 @@ struct ZoneStatus
 };
 
 
-void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, scoped_ptr<AuthLua4>& pdl,
+void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, unique_ptr<AuthLua4>& pdl,
                                  ZoneStatus& zs, vector<DNSRecord>* axfr)
 {
   UeberBackend B; // fresh UeberBackend
@@ -239,7 +237,7 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
    5) It updates the Empty Non Terminals
 */
 
-static vector<DNSResourceRecord> doAxfr(const ComboAddress& raddr, const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr,  scoped_ptr<AuthLua4>& pdl, ZoneStatus& zs)
+static vector<DNSResourceRecord> doAxfr(const ComboAddress& raddr, const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr,  unique_ptr<AuthLua4>& pdl, ZoneStatus& zs)
 {
   uint16_t axfr_timeout=::arg().asNum("axfr-fetch-timeout");
   vector<DNSResourceRecord> rrs;
@@ -340,7 +338,7 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote)
     }
 
 
-    scoped_ptr<AuthLua4> pdl;
+    unique_ptr<AuthLua4> pdl{nullptr};
     vector<string> scripts;
     string script=::arg()["lua-axfr-script"];
     if(B.getDomainMetadata(domain, "LUA-AXFR-SCRIPT", scripts) && !scripts.empty()) {
@@ -352,7 +350,7 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote)
     }
     if(!script.empty()){
       try {
-        pdl.reset(new AuthLua4());
+        pdl = make_unique<AuthLua4>();
         pdl->loadFile(script);
         g_log<<Logger::Info<<"Loaded Lua script '"<<script<<"' to edit the incoming AXFR of '"<<domain<<"'"<<endl;
       }
@@ -750,10 +748,10 @@ void CommunicatorClass::addSlaveCheckRequest(const DomainInfo& di, const ComboAd
   d_any_sem.post(); // kick the loop!
 }
 
-void CommunicatorClass::addTrySuperMasterRequest(DNSPacket *p)
+void CommunicatorClass::addTrySuperMasterRequest(const DNSPacket& p)
 {
   Lock l(&d_lock);
-  DNSPacket ours = *p;
+  DNSPacket ours = p;
   if(d_potentialsupermasters.insert(ours).second)
     d_any_sem.post(); // kick the loop!
 }
@@ -799,7 +797,7 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
     TSIGRecordContent trc;
     DNSName tsigkeyname;
     dp.getTSIGDetails(&trc, &tsigkeyname);
-    P->trySuperMasterSynchronous(&dp, tsigkeyname); // FIXME could use some error loging
+    P->trySuperMasterSynchronous(dp, tsigkeyname); // FIXME could use some error loging
   }
   if(rdomains.empty()) { // if we have priority domains, check them first
     B->getUnfreshSlaveInfos(&rdomains);

--- a/pdns/statbag.cc
+++ b/pdns/statbag.cc
@@ -99,8 +99,8 @@ string StatBag::getDescrip(const string &item)
 
 void StatBag::declare(const string &key, const string &descrip)
 {
-  AtomicCounter *i=new AtomicCounter(0);
-  d_stats[key]=i;
+  auto i=make_unique<AtomicCounter>(0);
+  d_stats[key]=std::move(i);
   d_keyDescrips[key]=descrip;
 }
 
@@ -153,15 +153,11 @@ string StatBag::getValueStrZero(const string &key)
 AtomicCounter *StatBag::getPointer(const string &key)
 {
   exists(key);
-  return d_stats[key];
+  return d_stats[key].get();
 }
 
 StatBag::~StatBag()
 {
-  for(const auto& i: d_stats) {
-    delete i.second;
-  }
-  
 }
 
 template<typename T, typename Comp>

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -62,7 +62,7 @@ private:
 //! use this to gather and query statistics
 class StatBag
 {
-  map<string, AtomicCounter *> d_stats;
+  map<string, std::unique_ptr<AtomicCounter>> d_stats;
   map<string, string> d_keyDescrips;
   map<string,StatRing<string, CIStringCompare> >d_rings;
   map<string,StatRing<SComboAddress> >d_comborings;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -67,9 +67,9 @@ extern StatBag S;
 */
 
 pthread_mutex_t TCPNameserver::s_plock = PTHREAD_MUTEX_INITIALIZER;
-Semaphore *TCPNameserver::d_connectionroom_sem;
+std::unique_ptr<Semaphore> TCPNameserver::d_connectionroom_sem{nullptr};
+std::unique_ptr<PacketHandler> TCPNameserver::s_P{nullptr};
 unsigned int TCPNameserver::d_maxTCPConnections = 0;
-PacketHandler *TCPNameserver::s_P; 
 NetmaskGroup TCPNameserver::d_ng;
 size_t TCPNameserver::d_maxTransactionsPerConn;
 size_t TCPNameserver::d_maxConnectionsPerClient;
@@ -81,9 +81,9 @@ std::map<ComboAddress,size_t,ComboAddress::addressOnlyLessThan> TCPNameserver::s
 void TCPNameserver::go()
 {
   g_log<<Logger::Error<<"Creating backend connection for TCP"<<endl;
-  s_P=0;
+  s_P.reset();
   try {
-    s_P=new PacketHandler;
+    s_P=make_unique<PacketHandler>();
   }
   catch(PDNSException &ae) {
     g_log<<Logger::Error<<"TCP server is unable to launch backends - will try again when questions come in: "<<ae.reason<<endl;
@@ -200,7 +200,7 @@ void connectWithTimeout(int fd, struct sockaddr* remote, size_t socklen)
   ;
 }
 
-void TCPNameserver::sendPacket(shared_ptr<DNSPacket> p, int outsock)
+void TCPNameserver::sendPacket(std::unique_ptr<DNSPacket>& p, int outsock)
 {
   g_rs.submitResponse(*p, false);
 
@@ -255,7 +255,7 @@ void TCPNameserver::decrementClientCount(const ComboAddress& remote)
 void *TCPNameserver::doConnection(void *data)
 {
   setThreadName("pdns/tcpConnect");
-  shared_ptr<DNSPacket> packet;
+  std::unique_ptr<DNSPacket> packet;
   // Fix gcc-4.0 error (on AMD64)
   int fd=(int)(long)data; // gotta love C (generates a harmless warning on opteron)
   ComboAddress remote;
@@ -328,7 +328,7 @@ void *TCPNameserver::doConnection(void *data)
       else
         S.inc("tcp4-queries");
 
-      packet=shared_ptr<DNSPacket>(new DNSPacket(true));
+      packet=make_unique<DNSPacket>(true);
       packet->setRemote(&remote);
       packet->d_tcp=true;
       packet->setSocket(fd);
@@ -347,8 +347,8 @@ void *TCPNameserver::doConnection(void *data)
         continue;
       }
 
-      shared_ptr<DNSPacket> reply; 
-      shared_ptr<DNSPacket> cached= shared_ptr<DNSPacket>(new DNSPacket(false));
+      std::unique_ptr<DNSPacket> reply; 
+      auto cached = make_unique<DNSPacket>(false);
       if(logDNSQueries)  {
         string remote_text;
         if(packet->hasEDNSSubnet())
@@ -360,7 +360,7 @@ void *TCPNameserver::doConnection(void *data)
       }
 
       if(PC.enabled()) {
-        if(packet->couldBeCached() && PC.get(packet.get(), cached.get())) { // short circuit - does the PacketCache recognize this question?
+        if(packet->couldBeCached() && PC.get(*packet, *cached)) { // short circuit - does the PacketCache recognize this question?
           if(logDNSQueries)
             g_log<<"packetcache HIT"<<endl;
           cached->setRemote(&packet->d_remote);
@@ -378,10 +378,10 @@ void *TCPNameserver::doConnection(void *data)
         Lock l(&s_plock);
         if(!s_P) {
           g_log<<Logger::Error<<"TCP server is without backend connections, launching"<<endl;
-          s_P=new PacketHandler;
+          s_P=make_unique<PacketHandler>();
         }
 
-        reply=shared_ptr<DNSPacket>(s_P->doQuestion(packet.get())); // we really need to ask the backend :-)
+        reply= s_P->doQuestion(*packet); // we really need to ask the backend :-)
       }
 
       if(!reply)  // unable to write an answer?
@@ -392,8 +392,7 @@ void *TCPNameserver::doConnection(void *data)
   }
   catch(PDNSException &ae) {
     Lock l(&s_plock);
-    delete s_P;
-    s_P = 0; // on next call, backend will be recycled
+    s_P.reset(); // on next call, backend will be recycled
     g_log<<Logger::Error<<"TCP nameserver had error, cycling backend: "<<ae.reason<<endl;
   }
   catch(NetworkError &e) {
@@ -422,7 +421,7 @@ void *TCPNameserver::doConnection(void *data)
 
 
 // call this method with s_plock held!
-bool TCPNameserver::canDoAXFR(shared_ptr<DNSPacket> q)
+bool TCPNameserver::canDoAXFR(std::unique_ptr<DNSPacket>& q)
 {
   if(::arg().mustDo("disable-axfr"))
     return false;
@@ -539,9 +538,9 @@ namespace {
     bool d_auth;
   };
 
-  shared_ptr<DNSPacket> getFreshAXFRPacket(shared_ptr<DNSPacket> q)
+  std::unique_ptr<DNSPacket> getFreshAXFRPacket(std::unique_ptr<DNSPacket>& q)
   {
-    shared_ptr<DNSPacket> ret = shared_ptr<DNSPacket>(q->replyPacket());
+    std::unique_ptr<DNSPacket> ret = std::unique_ptr<DNSPacket>(q->replyPacket());
     ret->setCompress(false);
     ret->d_dnssecOk=false; // RFC 5936, 2.2.5
     ret->d_tcp = true;
@@ -551,9 +550,9 @@ namespace {
 
 
 /** do the actual zone transfer. Return 0 in case of error, 1 in case of success */
-int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int outsock)
+int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, int outsock)
 {
-  shared_ptr<DNSPacket> outpacket= getFreshAXFRPacket(q);
+  std::unique_ptr<DNSPacket> outpacket= getFreshAXFRPacket(q);
   if(q->d_dnssecOk)
     outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
 
@@ -566,7 +565,7 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
     DLOG(g_log<<"Looking for SOA"<<endl);    // find domain_id via SOA and list complete domain. No SOA, no AXFR
     if(!s_P) {
       g_log<<Logger::Error<<"TCP server is without backend connections in doAXFR, launching"<<endl;
-      s_P=new PacketHandler;
+      s_P=make_unique<PacketHandler>();
     }
 
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
@@ -1049,9 +1048,9 @@ int TCPNameserver::doAXFR(const DNSName &target, shared_ptr<DNSPacket> q, int ou
   return 1;
 }
 
-int TCPNameserver::doIXFR(shared_ptr<DNSPacket> q, int outsock)
+int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock)
 {
-  shared_ptr<DNSPacket> outpacket=getFreshAXFRPacket(q);
+  std::unique_ptr<DNSPacket> outpacket=getFreshAXFRPacket(q);
   if(q->d_dnssecOk)
     outpacket->d_dnssecOk=true; // RFC 5936, 2.2.5 'SHOULD'
 
@@ -1095,7 +1094,7 @@ int TCPNameserver::doIXFR(shared_ptr<DNSPacket> q, int outsock)
     DLOG(g_log<<"Looking for SOA"<<endl); // find domain_id via SOA and list complete domain. No SOA, no IXFR
     if(!s_P) {
       g_log<<Logger::Error<<"TCP server is without backend connections in doIXFR, launching"<<endl;
-      s_P=new PacketHandler;
+      s_P=make_unique<PacketHandler>();
     }
 
     // canDoAXFR does all the ACL checks, and has the if(disable-axfr) shortcut, call it first.
@@ -1184,7 +1183,6 @@ int TCPNameserver::doIXFR(shared_ptr<DNSPacket> q, int outsock)
 
 TCPNameserver::~TCPNameserver()
 {
-  delete d_connectionroom_sem;
 }
 
 TCPNameserver::TCPNameserver()
@@ -1195,7 +1193,7 @@ TCPNameserver::TCPNameserver()
   d_maxConnectionsPerClient = ::arg().asNum("max-tcp-connections-per-client");
 
 //  sem_init(&d_connectionroom_sem,0,::arg().asNum("max-tcp-connections"));
-  d_connectionroom_sem = new Semaphore( ::arg().asNum( "max-tcp-connections" ));
+  d_connectionroom_sem = make_unique<Semaphore>( ::arg().asNum( "max-tcp-connections" ));
   d_maxTCPConnections = ::arg().asNum( "max-tcp-connections" );
   d_tid=0;
   vector<string>locals;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -538,7 +538,7 @@ namespace {
     bool d_auth;
   };
 
-  std::unique_ptr<DNSPacket> getFreshAXFRPacket(std::unique_ptr<DNSPacket>& q)
+  static std::unique_ptr<DNSPacket> getFreshAXFRPacket(std::unique_ptr<DNSPacket>& q)
   {
     std::unique_ptr<DNSPacket> ret = std::unique_ptr<DNSPacket>(q->replyPacket());
     ret->setCompress(false);

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -50,12 +50,12 @@ public:
   unsigned int numTCPConnections();
 private:
 
-  static void sendPacket(std::shared_ptr<DNSPacket> p, int outsock);
+  static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock);
   static int readLength(int fd, ComboAddress *remote);
   static void getQuestion(int fd, char *mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);
-  static int doAXFR(const DNSName &target, std::shared_ptr<DNSPacket> q, int outsock);
-  static int doIXFR(std::shared_ptr<DNSPacket> q, int outsock);
-  static bool canDoAXFR(std::shared_ptr<DNSPacket> q);
+  static int doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, int outsock);
+  static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock);
+  static bool canDoAXFR(std::unique_ptr<DNSPacket>& q);
   static void *doConnection(void *data);
   static void *launcher(void *data);
   static void decrementClientCount(const ComboAddress& remote);
@@ -63,9 +63,9 @@ private:
   static pthread_mutex_t s_plock;
   static std::mutex s_clientsCountMutex;
   static std::map<ComboAddress,size_t,ComboAddress::addressOnlyLessThan> s_clientsCount;
-  static PacketHandler *s_P;
+  static std::unique_ptr<PacketHandler> s_P;
   pthread_t d_tid;
-  static Semaphore *d_connectionroom_sem;
+  static std::unique_ptr<Semaphore> d_connectionroom_sem;
   static unsigned int d_maxTCPConnections;
   static NetmaskGroup d_ng;
   static size_t d_maxTransactionsPerConn;

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -18,24 +18,23 @@ struct Question
   DTime d_dt;
   DNSName qdomain;
   QType qtype;
-  DNSPacket* replyPacket()
+  std::unique_ptr<DNSPacket> replyPacket()
   {
-    return new DNSPacket(false);
+    return make_unique<DNSPacket>(false);
   }
 };
 
 struct Backend
 {
-  DNSPacket* question(Question*)
+  std::unique_ptr<DNSPacket> question(Question&)
   {
-    return new DNSPacket(true);
+    return make_unique<DNSPacket>(true);
   }
 };
 
 static std::atomic<int> g_receivedAnswers;
-static void report(DNSPacket* A)
+static void report(std::unique_ptr<DNSPacket>& A)
 {
-  delete A;
   g_receivedAnswers++;
 }
 
@@ -50,8 +49,8 @@ BOOST_AUTO_TEST_CASE(test_distributor_basic) {
 
   int n;
   for(n=0; n < 100; ++n)  {
-    auto q = new Question();
-    q->d_dt.set(); 
+    Question q;
+    q.d_dt.set(); 
     d->question(q, report);
   }
   sleep(1);
@@ -60,17 +59,16 @@ BOOST_AUTO_TEST_CASE(test_distributor_basic) {
 
 struct BackendSlow
 {
-  DNSPacket* question(Question*)
+  std::unique_ptr<DNSPacket> question(Question&)
   {
     sleep(1);
-    return new DNSPacket(true);
+    return make_unique<DNSPacket>(true);
   }
 };
 
 static std::atomic<int> g_receivedAnswers1;
-static void report1(DNSPacket* A)
+static void report1(std::unique_ptr<DNSPacket>& A)
 {
-  delete A;
   g_receivedAnswers1++;
 }
 
@@ -87,8 +85,8 @@ BOOST_AUTO_TEST_CASE(test_distributor_queue) {
     int n;
     // bound should be higher than max-queue-length
     for(n=0; n < 2000; ++n)  {
-      auto q = new Question();
-      q->d_dt.set(); 
+      Question q;
+      q.d_dt.set(); 
       d->question(q, report1);
     }
     }, DistributorFatal, [](DistributorFatal) { return true; });
@@ -103,14 +101,14 @@ struct BackendDies
   ~BackendDies()
   {
   }
-  DNSPacket* question(Question* q)
+  std::unique_ptr<DNSPacket> question(Question& q)
   {
     //  cout<<"Q: "<<q->qdomain<<endl;
     if(!d_ourcount && ++d_count == 10) {
       // cerr<<"Going.. down!"<<endl;
       throw runtime_error("kill");
     }
-    return new DNSPacket(true);
+    return make_unique<DNSPacket>(true);
   }
   static std::atomic<int> s_count;
   int d_count{0};
@@ -121,9 +119,8 @@ std::atomic<int> BackendDies::s_count;
 
 std::atomic<int> g_receivedAnswers2;
 
-static void report2(DNSPacket* A)
+static void report2(std::unique_ptr<DNSPacket>& A)
 {
-  delete A;
   g_receivedAnswers2++;
 }
 
@@ -139,10 +136,10 @@ BOOST_AUTO_TEST_CASE(test_distributor_dies) {
 
   try {
     for(int n=0; n < 100; ++n)  {
-      auto q = new Question();
-      q->d_dt.set(); 
-      q->qdomain=DNSName(std::to_string(n));
-      q->qtype = QType(QType::A);
+      Question q;
+      q.d_dt.set(); 
+      q.qdomain=DNSName(std::to_string(n));
+      q.qtype = QType(QType::A);
       d->question(q, report2);
     }
 

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -7,7 +7,6 @@
 #include <boost/assign/list_of.hpp>
 
 #include <boost/tuple/tuple.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include "base32.hh"
 #include "dnsrecords.hh"

--- a/pdns/test-lock_hh.cc
+++ b/pdns/test-lock_hh.cc
@@ -24,9 +24,9 @@ static void lthread()
 BOOST_AUTO_TEST_CASE(test_pdns_lock)
 {
   for(unsigned int n=0; n < 1000; ++n) {
-    auto p = new pthread_rwlock_t;
-    pthread_rwlock_init(p, 0);
-    g_locks.emplace_back(p);
+    auto p = make_unique<pthread_rwlock_t>();
+    pthread_rwlock_init(p.get(), 0);
+    g_locks.emplace_back(std::move(p));
   }
 
   std::vector<ReadLock> rlocks;

--- a/pdns/test-lua_auth4_cc.cc
+++ b/pdns/test-lua_auth4_cc.cc
@@ -27,12 +27,13 @@ BOOST_AUTO_TEST_CASE(test_prequery) {
 "  return false\n"
 "end";
   AuthLua4 lua;
-  DNSPacket *p = new DNSPacket(true);
-  p->qdomain = DNSName("mod.unit.test.");
+  DNSPacket p(true);
+  p.qdomain = DNSName("mod.unit.test.");
   lua.loadString(script);
-  DNSPacket *r = nullptr;
+  std::unique_ptr<DNSPacket> r{nullptr};
   try {
     r = lua.prequery(p);
+    BOOST_REQUIRE(r != nullptr);
     BOOST_CHECK_EQUAL(r->qdomain.toString(), "mod.unit.test.");
   } catch (const LuaContext::ExecutionErrorException& e) {
     try {
@@ -41,8 +42,6 @@ BOOST_AUTO_TEST_CASE(test_prequery) {
      g_log<<"Extra info: "<<exp.what();
     }
   }
-  delete r;
-  delete p;
 }
 
 BOOST_AUTO_TEST_CASE(test_updatePolicy) {
@@ -56,18 +55,17 @@ BOOST_AUTO_TEST_CASE(test_updatePolicy) {
 "  return false\n"
 "end";
   AuthLua4 lua;
-  DNSPacket *p = new DNSPacket(true);
+  DNSPacket p(true);
   ComboAddress ca(std::string("192.168.1.1"));
   lua.loadString(script);
-  p->setRemote(&ca);
-  p->d_peer_principal = "admin@DOMAIN";
+  p.setRemote(&ca);
+  p.d_peer_principal = "admin@DOMAIN";
   BOOST_CHECK_EQUAL(lua.updatePolicy(DNSName("mod.example.com."), QType(QType::A), DNSName("example.com."), p), true);
-  p->d_peer_principal = "";
+  p.d_peer_principal = "";
   BOOST_CHECK_EQUAL(lua.updatePolicy(DNSName("mod.example.com."), QType(QType::A), DNSName("example.com."), p), true);
   ca = ComboAddress(std::string("192.168.1.2"));
-  p->setRemote(&ca);
+  p.setRemote(&ca);
   BOOST_CHECK_EQUAL(lua.updatePolicy(DNSName("mod.example.com."), QType(QType::A), DNSName("example.com."), p), false);
-  delete p;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-packetcache_cc.cc
+++ b/pdns/test-packetcache_cc.cc
@@ -164,7 +164,7 @@ try
     q.setHash(g_PC->canHashPacket(q.getString()));
 
     const unsigned int maxTTL = 3600;
-    g_PC->insert(&q, &r, maxTTL);
+    g_PC->insert(q, r, maxTTL);
   }
 
   return 0;
@@ -188,7 +188,7 @@ try
     q.parse((char*)&pak[0], pak.size());
     DNSPacket r(false);
 
-    if(!g_PC->get(&q, &r)) {
+    if(!g_PC->get(q, r)) {
       g_PCmissing++;
     }
   }
@@ -378,85 +378,85 @@ BOOST_AUTO_TEST_CASE(test_AuthPacketCache) {
     }
 
     /* this call is required so the correct hash is set into q->d_hash */
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), false);
 
-    PC.insert(&q, &r, 3600);
+    PC.insert(q, r, 3600);
     BOOST_CHECK_EQUAL(PC.size(), 1);
 
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), true);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), true);
     BOOST_CHECK_EQUAL(r2.qdomain, r.qdomain);
 
     /* different QID, still should match */
-    BOOST_CHECK_EQUAL(PC.get(&differentIDQ, &r2), true);
+    BOOST_CHECK_EQUAL(PC.get(differentIDQ, r2), true);
     BOOST_CHECK_EQUAL(r2.qdomain, r.qdomain);
 
     /* with EDNS, should not match */
-    BOOST_CHECK_EQUAL(PC.get(&ednsQ, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(ednsQ, r2), false);
     /* inserting the EDNS-enabled one too */
-    PC.insert(&ednsQ, &r, 3600);
+    PC.insert(ednsQ, r, 3600);
     BOOST_CHECK_EQUAL(PC.size(), 2);
 
     /* different EDNS versions, should not match */
-    BOOST_CHECK_EQUAL(PC.get(&ednsVersion42, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(ednsVersion42, r2), false);
 
     /* EDNS DO set, should not match */
-    BOOST_CHECK_EQUAL(PC.get(&ednsDO, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(ednsDO, r2), false);
 
     /* EDNS Client Subnet set, should not match
        since not only we don't skip the actual option, but the
        total EDNS opt RR is still different. */
-    BOOST_CHECK_EQUAL(PC.get(&ecs1, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(ecs1, r2), false);
 
     /* inserting the version with ECS Client Subnet set,
      it should NOT replace the existing EDNS one. */
-    PC.insert(&ecs1, &r, 3600);
+    PC.insert(ecs1, r, 3600);
     BOOST_CHECK_EQUAL(PC.size(), 3);
 
     /* different subnet of same size, should NOT match
      since we don't skip the option */
-    BOOST_CHECK_EQUAL(PC.get(&ecs2, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(ecs2, r2), false);
     BOOST_CHECK_EQUAL(r2.qdomain, r.qdomain);
 
     /* different subnet of different size, should NOT match. */
-    BOOST_CHECK_EQUAL(PC.get(&ecs3, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(ecs3, r2), false);
 
     BOOST_CHECK_EQUAL(PC.purge("www.powerdns.com"), 3);
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), false);
     BOOST_CHECK_EQUAL(PC.size(), 0);
 
-    PC.insert(&q, &r, 3600);
+    PC.insert(q, r, 3600);
     BOOST_CHECK_EQUAL(PC.size(), 1);
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), true);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), true);
     BOOST_CHECK_EQUAL(r2.qdomain, r.qdomain);
     BOOST_CHECK_EQUAL(PC.purge("com$"), 1);
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), false);
     BOOST_CHECK_EQUAL(PC.size(), 0);
 
-    PC.insert(&q, &r, 3600);
+    PC.insert(q, r, 3600);
     BOOST_CHECK_EQUAL(PC.size(), 1);
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), true);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), true);
     BOOST_CHECK_EQUAL(r2.qdomain, r.qdomain);
     BOOST_CHECK_EQUAL(PC.purge("powerdns.com$"), 1);
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), false);
     BOOST_CHECK_EQUAL(PC.size(), 0);
 
-    PC.insert(&q, &r, 3600);
+    PC.insert(q, r, 3600);
     BOOST_CHECK_EQUAL(PC.size(), 1);
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), true);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), true);
     BOOST_CHECK_EQUAL(r2.qdomain, r.qdomain);
     BOOST_CHECK_EQUAL(PC.purge("www.powerdns.com$"), 1);
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), false);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), false);
     BOOST_CHECK_EQUAL(PC.size(), 0);
 
-    PC.insert(&q, &r, 3600);
+    PC.insert(q, r, 3600);
     BOOST_CHECK_EQUAL(PC.size(), 1);
     BOOST_CHECK_EQUAL(PC.purge("www.powerdns.net"), 0);
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), true);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), true);
     BOOST_CHECK_EQUAL(r2.qdomain, r.qdomain);
     BOOST_CHECK_EQUAL(PC.size(), 1);
 
     BOOST_CHECK_EQUAL(PC.purge("net$"), 0);
-    BOOST_CHECK_EQUAL(PC.get(&q, &r2), true);
+    BOOST_CHECK_EQUAL(PC.get(q, r2), true);
     BOOST_CHECK_EQUAL(r2.qdomain, r.qdomain);
     BOOST_CHECK_EQUAL(PC.size(), 1);
 

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -7,7 +7,6 @@
 #include <boost/assign/list_of.hpp>
 
 #include <boost/tuple/tuple.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include "base64.hh"
 #include "dnsseckeeper.hh"

--- a/pdns/toysdig.cc
+++ b/pdns/toysdig.cc
@@ -56,20 +56,18 @@ public:
       throw PDNSException("EOF on TCP read");
 
     len=ntohs(len);
-    char *creply = new char[len];
+    std::unique_ptr<char[]> creply(new char[len]);
     int n=0;
     int numread;
     while(n<len) {
-      numread=d_rsock.read(creply+n, len-n);
+      numread=d_rsock.read(creply.get()+n, len-n);
       if(numread<0) {
-        delete[] creply;
         throw PDNSException("tcp read failed: "+stringerror());
       }
       n+=numread;
     }
 
-    string reply(creply, len);
-    delete[] creply;
+    string reply(creply.get(), len);
 
     return reply;
   }

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -85,7 +85,7 @@ public:
     DNSBackend *d_hinterBackend;
 
     //! DNSPacket who asked this question
-    DNSPacket *pkt_p;
+    DNSPacket* pkt_p;
     DNSName qname;
 
     //! Index of the current backend within the backends vector

--- a/pdns/unix_semaphore.cc
+++ b/pdns/unix_semaphore.cc
@@ -148,8 +148,8 @@ Semaphore::~Semaphore()
 
 Semaphore::Semaphore(unsigned int value)
 {
-  m_pSemaphore=new sem_t;
-  if (sem_init(m_pSemaphore, 0, value) == -1) {
+  m_pSemaphore=make_unique<sem_t>();
+  if (sem_init(m_pSemaphore.get(), 0, value) == -1) {
     g_log << Logger::Error << "Cannot create semaphore: " << stringerror() << endl;
     exit(1);
   }
@@ -157,30 +157,29 @@ Semaphore::Semaphore(unsigned int value)
 
 int Semaphore::post()
 {
-  return sem_post(m_pSemaphore);
+  return sem_post(m_pSemaphore.get());
 }
 
 int Semaphore::wait()
 {
   int ret;
   do
-    ret = sem_wait(m_pSemaphore);
+    ret = sem_wait(m_pSemaphore.get());
   while (ret == -1 && errno == EINTR);
   return ret;
 }
 int Semaphore::tryWait()
 {
-  return sem_trywait(m_pSemaphore);
+  return sem_trywait(m_pSemaphore.get());
 }
 
 int Semaphore::getValue(Semaphore::sem_value_t *sval)
 {
-  return sem_getvalue(m_pSemaphore, sval);
+  return sem_getvalue(m_pSemaphore.get(), sval);
 }
 
 Semaphore::~Semaphore()
 {
-  delete m_pSemaphore;
 }
 
 #endif

--- a/pdns/utility.hh
+++ b/pdns/utility.hh
@@ -59,7 +59,7 @@ private:
   sem_value_t     m_count;
   uint32_t       m_nwaiters;
 #else
-  sem_t *m_pSemaphore;
+  std::unique_ptr<sem_t> m_pSemaphore;
 #endif
 
 protected:

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -30,8 +30,6 @@
 #include "namespaces.hh"
 #include "sstuff.hh"
 
-class WebServer;
-
 class HttpRequest : public YaHTTP::Request {
 public:
   HttpRequest(const string& logprefix="") : YaHTTP::Request(), accept_json(false), accept_html(false), complete(false), logprefix(logprefix) { };

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -500,7 +500,7 @@ RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
 {
   registerAllStats();
 
-  d_ws = new AsyncWebServer(fdm, arg()["webserver-address"], arg().asNum("webserver-port"));
+  d_ws = std::unique_ptr<AsyncWebServer>(new AsyncWebServer(fdm, arg()["webserver-address"], arg().asNum("webserver-port")));
   d_ws->setApiKey(arg()["api-key"]);
   d_ws->setPassword(arg()["webserver-password"]);
   d_ws->setLogLevel(arg()["webserver-loglevel"]);

--- a/pdns/ws-recursor.hh
+++ b/pdns/ws-recursor.hh
@@ -69,7 +69,7 @@ public:
   void jsonstat(HttpRequest* req, HttpResponse *resp);
 
 private:
-  AsyncWebServer* d_ws;
+  std::unique_ptr<AsyncWebServer> d_ws{nullptr};
 };
 
 #endif /* PDNS_WSRECURSOR_HH */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR attempts to remove almost all the remaining naked pointers in the auth, moving to smart pointers instead.
It's a bit bigger that it could be because I also used the opportunity to replace the use of a `DNSPacket*` by a `DNSPacket&` whenever it was easily doable, to make it clearer that the callee is not responsible for deleting the packet. We could get rid of that part if that is an issue.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

