### PR TITLE
dnsdist: clarify in the examples that DelayAction is UDP-only

### DIFF
--- a/pdns/dnsdistdist/docs/advanced/qpslimits.rst
+++ b/pdns/dnsdistdist/docs/advanced/qpslimits.rst
@@ -7,7 +7,7 @@ Traffic that exceeds a QPS limit, in total or per IP (subnet) can be matched by 
 
   addAction(MaxQPSIPRule(5, 32, 48), DelayAction(100))
 
-This measures traffic per IPv4 address and per /48 of IPv6, and if traffic for such an address (range) exceeds 5 :term:`qps`, it gets delayed by 100ms.
+This measures traffic per IPv4 address and per /48 of IPv6, and if UDP traffic for such an address (range) exceeds 5 :term:`qps`, it gets delayed by 100ms.
 
 As another example:
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -32,7 +32,7 @@ For example::
 
   addAction(MaxQPSIPRule(5, 32, 48), DelayAction(100))
 
-This measures traffic per IPv4 address and per /48 of IPv6, and if traffic for such an address (range) exceeds 5 qps, it gets delayed by 100ms.
+This measures traffic per IPv4 address and per /48 of IPv6, and if traffic for such an address (range) exceeds 5 qps, it gets delayed by 100ms. (Please note: :func:`DelayAction` can only delay UDP traffic). 
 
 As another example::
 


### PR DESCRIPTION
### Short description
DelayAction() is only capable of delaying UDP queries. While it is noted in the reference for that command, DelayAction is used as an example in multiple places. Clarify in those examples that this will only delay UDP traffic.

### Checklist
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
