### PR TITLE
bind getAllDomains: ignore per-zone exceptions

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -373,7 +373,11 @@ void Bind2Backend::getAllDomains(vector<DomainInfo> *domains, bool include_disab
     // do not corrupt di if domain supplied by another backend.
     if (di.backend != this)
       continue;
-    this->getSOA(di.zone, soadata);
+    try {
+      this->getSOA(di.zone, soadata);
+    } catch(...) {
+      continue;
+    }
     di.serial=soadata.serial;
   }
 }


### PR DESCRIPTION
### Short description
This fixes #7994. it also fixes `pdns_control list-zones` under the same error condition.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
