### PR TITLE
rfc2136, pdnsutil: somewhat improve duplicate record handling

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -392,7 +392,9 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
     content.str("");
     content<<rr.qname<<" "<<rr.qtype.getName()<<" "<<rr.content;
     string contentstr = content.str();
-    if (rr.qtype.getCode() != QType::TXT) contentstr=toLower(contentstr);
+    if (rr.qtype.getCode() != QType::TXT) {
+      contentstr=toLower(contentstr);
+    }
     if (recordcontents.count(contentstr)) {
       cout<<"[Error] Duplicate record found in rrset: '"<<rr.qname<<" IN "<<rr.qtype.getName()<<" "<<rr.content<<"'"<<endl;
       numerrors++;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -391,12 +391,14 @@ int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, const vect
 
     content.str("");
     content<<rr.qname<<" "<<rr.qtype.getName()<<" "<<rr.content;
-    if (recordcontents.count(toLower(content.str()))) {
+    string contentstr = content.str();
+    if (rr.qtype.getCode() != QType::TXT) contentstr=toLower(contentstr);
+    if (recordcontents.count(contentstr)) {
       cout<<"[Error] Duplicate record found in rrset: '"<<rr.qname<<" IN "<<rr.qtype.getName()<<" "<<rr.content<<"'"<<endl;
       numerrors++;
       continue;
     } else
-      recordcontents.insert(toLower(content.str()));
+      recordcontents.insert(contentstr);
 
     content.str("");
     content<<rr.qname<<" "<<rr.qtype.getName();

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -216,9 +216,18 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
       } else {
         int updateTTL=0;
         foundRecord = false;
+        bool lowerCase = false;
+        if (rrType.getCode() == QType::PTR ||
+            rrType.getCode() == QType::MX ||
+            rrType.getCode() == QType::SRV) {
+          lowerCase = true;
+        }
+        string content = rr->d_content->getZoneRepresentation();
+        if (lowerCase) content = toLower(content);
         for (auto& i : rrset) {
-          string content = rr->d_content->getZoneRepresentation();
-          if (rrType == i.qtype.getCode() && i.getZoneRepresentation() == content) {
+          string icontent = i.getZoneRepresentation();
+          if (lowerCase) icontent = toLower(icontent);
+          if (rrType == i.qtype.getCode() && icontent == content) {
             foundRecord=true;
             if (i.ttl != rr->d_ttl)  {
               i.ttl = rr->d_ttl;

--- a/regression-tests/tests/1dyndns-content-casemix/command
+++ b/regression-tests/tests/1dyndns-content-casemix/command
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo == Verify RRset absence
-cleandig ptr1.test.dyndns PTR
+cleandig ptr1.test.dyndns PTR | grep -v SOA
 
 echo
 echo == Add PTR
@@ -14,7 +14,7 @@ answer
 
 echo
 echo == Verify PTR presence
-cleandig ptr1.test.dyndns PTR
+cleandig ptr1.test.dyndns PTR | grep -v SOA
 
 echo
 echo == Add the PTR again
@@ -42,4 +42,4 @@ answer
 
 echo
 echo == Verify RRset absence
-cleandig ptr1.test.dyndns PTR
+cleandig ptr1.test.dyndns PTR | grep -v SOA

--- a/regression-tests/tests/1dyndns-content-casemix/command
+++ b/regression-tests/tests/1dyndns-content-casemix/command
@@ -1,0 +1,45 @@
+#!/bin/sh
+echo == Verify RRset absence
+cleandig ptr1.test.dyndns PTR
+
+echo
+echo == Add PTR
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update add ptr1.test.dyndns. 3600 PTR host-2.test.dyndns.
+send
+answer
+!
+
+echo
+echo == Verify PTR presence
+cleandig ptr1.test.dyndns PTR
+
+echo
+echo == Add the PTR again
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update add ptr1.test.dyndns. 3600 PTR HOST-2.test.dyndns.
+send
+answer
+!
+
+echo
+echo == Verify that we have one PTR
+cleandig ptr1.test.dyndns PTR
+
+echo
+echo == Clean up
+cleannsupdate <<!
+server $nameserver $port
+zone test.dyndns
+update delete ptr1.test.dyndns. PTR
+send
+answer
+!
+
+echo
+echo == Verify RRset absence
+cleandig ptr1.test.dyndns PTR

--- a/regression-tests/tests/1dyndns-content-casemix/description
+++ b/regression-tests/tests/1dyndns-content-casemix/description
@@ -1,0 +1,1 @@
+Make sure duplicate content is disallowed when case is mixed.

--- a/regression-tests/tests/1dyndns-content-casemix/expected_result
+++ b/regression-tests/tests/1dyndns-content-casemix/expected_result
@@ -1,5 +1,4 @@
 == Verify RRset absence
-1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2019082709 28800 7200 604800 86400
 Rcode: 3 (Non-Existent domain), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='ptr1.test.dyndns.', qtype=PTR
 
@@ -38,6 +37,5 @@ Answer:
 
 
 == Verify RRset absence
-1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2019082711 28800 7200 604800 86400
 Rcode: 3 (Non-Existent domain), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='ptr1.test.dyndns.', qtype=PTR

--- a/regression-tests/tests/1dyndns-content-casemix/expected_result
+++ b/regression-tests/tests/1dyndns-content-casemix/expected_result
@@ -1,0 +1,43 @@
+== Verify RRset absence
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2019082709 28800 7200 604800 86400
+Rcode: 3 (Non-Existent domain), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='ptr1.test.dyndns.', qtype=PTR
+
+== Add PTR
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+
+== Verify PTR presence
+0	ptr1.test.dyndns.	IN	PTR	3600	host-2.test.dyndns.
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='ptr1.test.dyndns.', qtype=PTR
+
+== Add the PTR again
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+
+== Verify that we have one PTR
+0	ptr1.test.dyndns.	IN	PTR	3600	host-2.test.dyndns.
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='ptr1.test.dyndns.', qtype=PTR
+
+== Clean up
+Answer:
+;; ->>HEADER<<- opcode: UPDATE, status: NOERROR, id: [id]
+;; flags: qr aa; ZONE: 1, PREREQ: 0, UPDATE: 0, ADDITIONAL: 0
+;; ZONE SECTION:
+;test.dyndns.			IN	SOA
+
+
+== Verify RRset absence
+1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. 2019082711 28800 7200 604800 86400
+Rcode: 3 (Non-Existent domain), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='ptr1.test.dyndns.', qtype=PTR

--- a/regression-tests/tests/1dyndns-content-casemix/skip.nodyndns
+++ b/regression-tests/tests/1dyndns-content-casemix/skip.nodyndns
@@ -1,0 +1,1 @@
+Skip this test if the backend does not support dyndns/rfc2136


### PR DESCRIPTION
### Short description
Improves #8217.

* pdnsutil: compare TXT records case sensitively when checking for duplicates
* rfc2136: compare PTR/MX/SRV case INsensitively when checking for duplicates

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
