### PR TITLE
dnsdist: TLS 1.3 requires OpenSSL 1.1.1.

### DIFF
--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -897,7 +897,9 @@ static std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> getTLSContext(const std::vect
     SSL_OP_SINGLE_ECDH_USE;
 
   SSL_CTX_set_options(ctx.get(), sslOptions);
-  libssl_set_min_tls_version(ctx, minTLSVersion);
+  if (!libssl_set_min_tls_version(ctx, minTLSVersion)) {
+    throw std::runtime_error("Failed to set the minimum version to '" + libssl_tls_version_to_string(minTLSVersion) + "' for DoH listener");
+  }
 
 #ifdef SSL_CTX_set_ecdh_auto
   SSL_CTX_set_ecdh_auto(ctx.get(), 1);

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -409,7 +409,10 @@ public:
     SSL_CTX_set_tlsext_ticket_key_cb(d_tlsCtx.get(), &OpenSSLTLSIOCtx::ticketKeyCb);
     SSL_CTX_set_ex_data(d_tlsCtx.get(), s_ticketsKeyIndex, this);
     SSL_CTX_set_options(d_tlsCtx.get(), sslOptions);
-    libssl_set_min_tls_version(d_tlsCtx, fe.d_minTLSVersion);
+    if (!libssl_set_min_tls_version(d_tlsCtx, fe.d_minTLSVersion)) {
+      throw std::runtime_error("Failed to set the minimum version to '" + libssl_tls_version_to_string(fe.d_minTLSVersion) + "' for ths TLS context on " + fe.d_addr.toStringWithPort());
+    }
+
 #if defined(SSL_CTX_set_ecdh_auto)
     SSL_CTX_set_ecdh_auto(d_tlsCtx.get(), 1);
 #endif

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -25,6 +25,7 @@ bool libssl_generate_ocsp_response(const std::string& certFile, const std::strin
 #endif
 
 LibsslTLSVersion libssl_tls_version_from_string(const std::string& str);
+const std::string& libssl_tls_version_to_string(LibsslTLSVersion version);
 bool libssl_set_min_tls_version(std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)>& ctx, LibsslTLSVersion version);
 
 #endif /* HAVE_LIBSSL */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Make sure that the version of OpenSSL supports TLS 1.3. Fix a silent failure when setting the minimum TLS version.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

