### PR TITLE
Fix some conditionally added source files missing from extra dist

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -81,6 +81,7 @@ EXTRA_DIST=COPYING \
 	   epollmplexer.cc \
 	   kqueuemplexer.cc \
 	   portsmplexer.cc \
+	   ipcipher.cc ipcipher.hh \
 	   builder-support/gen-version
 
 bin_PROGRAMS = dnsdist

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -63,6 +63,8 @@ EXTRA_DIST = \
 	mtasker_fcontext.cc mtasker_ucontext.cc \
 	NOTICE \
 	opensslsigners.hh opensslsigners.cc \
+	sodiumsigners.cc \
+	decafsigners.cc \
 	portsmplexer.cc \
 	dnstap.proto dnstap.cc dnstap.hh fstrm_logger.cc fstrm_logger.hh rec-dnstap.hh \
 	rrd/* \
@@ -70,6 +72,7 @@ EXTRA_DIST = \
 	test_libcrypto \
 	pdns-recursor.service.in \
 	RECURSOR-MIB.txt \
+	nod.hh nod.cc \
 	builder-support/gen-version
 
 dist-hook:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
They are conditionally added to `dnsdist_SOURCES` or `pdns_recursor_SOURCES` so we need to add them to `EXTRA_DIST` in order for them to be included in the dist even if the relevant dependencies are not available at `make dist` time.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
