### PR TITLE
Revert "rec: backport 8236: Add missing inc in rpz findClientPolicy loop."

### DIFF
--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -151,7 +151,6 @@ DNSFilterEngine::Policy DNSFilterEngine::getQueryPolicy(const DNSName& qname, co
       //	cerr<<"Had a hit on the IP address ("<<ca.toString()<<") of the client"<<endl;
       return pol;
     }
-    ++count;
   }
 
   return pol;


### PR DESCRIPTION
Reverts PowerDNS/pdns#8238