### PR TITLE
dns_random: verify upper bound; fix boundary condition for QID generation

### DIFF
--- a/docs/lua-records/reference/misc.rst
+++ b/docs/lua-records/reference/misc.rst
@@ -21,8 +21,8 @@ Other functions
   - `pdns.loglevels.Warning`
   - `pdns.loglevels.Error`
 
-.. function:: pdnsrandom([maximum])
+.. function:: pdnsrandom([upper_bound])
 
   Get a random number.
 
-  :param int maximum: The largest number to return. This is 2^32-1 by default.
+  :param int upper_bound: The upper bound. You will get a random number below this upper bound.

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -394,7 +394,7 @@ try
 
     DNSPacketWriter pw(packet, DNSName(qname), DNSRecordContent::TypeToNumber(qtype));
     pw.getHeader()->rd=wantRecursion;
-    pw.getHeader()->id=dns_random(UINT16_MAX);
+    pw.getHeader()->id=dns_random_uint16();
 
     if(!subnet.empty() || !ecsRange.empty()) {
       EDNSSubnetOpts opt;

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -76,7 +76,7 @@ public:
     nr.domain   = domain;
     nr.ip       = caIp.toStringWithPort();
     nr.attempts = 0;
-    nr.id       = dns_random(0xffff);
+    nr.id       = dns_random_uint16();
     nr.next     = time(0);
 
     d_nqueue.push_back(nr);

--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -320,3 +320,8 @@ uint32_t dns_random(uint32_t upper_bound) {
     throw std::runtime_error("Unreachable at " __FILE__ ":" + boost::lexical_cast<std::string>(__LINE__)); // cannot be reached
   };
 }
+
+uint16_t dns_random_uint16()
+{
+  return dns_random(0x10000);
+}

--- a/pdns/dns_random.hh
+++ b/pdns/dns_random.hh
@@ -25,5 +25,6 @@
 
 void dns_random_init(const std::string& data = "", bool force_reinit = false);
 uint32_t dns_random(uint32_t n);
+uint16_t dns_random_uint16();
 
 #endif

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -387,7 +387,7 @@ void DNSPacket::wrapup()
 void DNSPacket::setQuestion(int op, const DNSName &qd, int newqtype)
 {
   memset(&d,0,sizeof(d));
-  d.id=dns_random(0xffff);
+  d.id=dns_random_uint16();
   d.rd=d.tc=d.aa=false;
   d.qr=false;
   d.qdcount=1; // is htons'ed later on

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -78,7 +78,7 @@ DNSProxy::DNSProxy(const string &remote)
     throw PDNSException("Unable to UDP connect to remote nameserver "+d_remote.toStringWithPort()+": "+stringerror());
   }
 
-  d_xor=dns_random(0xffff);
+  d_xor=dns_random_uint16();
   g_log<<Logger::Error<<"DNS Proxy launched, local port "<<ntohs(local.sin4.sin_port)<<", remote "<<d_remote.toStringWithPort()<<endl;
 } 
 

--- a/pdns/ixfr.cc
+++ b/pdns/ixfr.cc
@@ -131,7 +131,7 @@ vector<pair<vector<DNSRecord>, vector<DNSRecord> > > getIXFRDeltas(const ComboAd
   DNSPacketWriter pw(packet, zone, QType::IXFR);
   pw.getHeader()->qr=0;
   pw.getHeader()->rd=0;
-  pw.getHeader()->id=dns_random(0xffff);
+  pw.getHeader()->id=dns_random_uint16();
   pw.startRecord(zone, QType::SOA, 0, QClass::IN, DNSResourceRecord::AUTHORITY);
   oursr.d_content->toPacket(pw);
 

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -229,7 +229,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
   buf.resize(bufsize);
   vector<uint8_t> vpacket;
   //  string mapped0x20=dns0x20(domain);
-  uint16_t qid = dns_random(0xffff);
+  uint16_t qid = dns_random_uint16();
   DNSPacketWriter pw(vpacket, domain, type);
 
   pw.getHeader()->rd=sendRDQuery;

--- a/pdns/notify.cc
+++ b/pdns/notify.cc
@@ -115,7 +115,7 @@ try
     }
     vector<uint8_t> outpacket;
     DNSPacketWriter pw(outpacket, DNSName(argv[2]), QType::SOA, 1, Opcode::Notify);
-    pw.getHeader()->id = dns_random(UINT16_MAX);
+    pw.getHeader()->id = dns_random_uint16();
 
     if(send(sock, &outpacket[0], outpacket.size(), 0) < 0) {
       cerr<<"Unable to send notify to "<<addr.toStringWithPort()<<": "+stringerror()<<endl;

--- a/pdns/recursordist/docs/lua-scripting/functions.rst
+++ b/pdns/recursordist/docs/lua-scripting/functions.rst
@@ -16,8 +16,8 @@ These are some functions that don't really have a place in one of the other cate
 
   returns an unsigned integer identifying the thread handling the current request.
 
-.. function:: pdnsrandom([maximum])
+.. function:: pdnsrandom([upper_bound])
 
   Get a random number.
 
-  :param int maximum: The largest number to return. This is 2^32 by default.
+  :param int upper_bound: The upper bound. You will get a random number below this upper bound.

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -130,7 +130,7 @@ uint16_t Resolver::sendResolve(const ComboAddress& remote, const ComboAddress& l
   uint16_t randomid;
   vector<uint8_t> packet;
   DNSPacketWriter pw(packet, domain, type);
-  pw.getHeader()->id = randomid = dns_random(0xffff);
+  pw.getHeader()->id = randomid = dns_random_uint16();
 
   if(dnssecOK) {
     pw.addOpt(2800, 0, EDNSOpts::DNSSECOK);
@@ -392,7 +392,7 @@ AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
   
     vector<uint8_t> packet;
     DNSPacketWriter pw(packet, domain, QType::AXFR);
-    pw.getHeader()->id = dns_random(0xffff);
+    pw.getHeader()->id = dns_random_uint16();
   
     if(!tt.name.empty()) {
       if (tt.algo == DNSName("hmac-md5"))

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -614,7 +614,7 @@ int PacketHandler::forwardPacket(const string &msgPrefix, DNSPacket *p, DomainIn
     }
 
     DNSPacket forwardPacket(*p);
-    forwardPacket.setID(dns_random(0xffff));
+    forwardPacket.setID(dns_random_uint16());
     forwardPacket.setRemote(&remote);
     uint16_t len=htons(forwardPacket.getString().length());
     string buffer((const char*)&len, 2);

--- a/pdns/saxfr.cc
+++ b/pdns/saxfr.cc
@@ -112,7 +112,7 @@ try
       tkrc.d_keysize = output.size();
       tkrc.d_key = output;
       tkrc.d_othersize = 0;
-      pwtkey.getHeader()->id = dns_random(0xffff);
+      pwtkey.getHeader()->id = dns_random_uint16();
       pwtkey.startRecord(gssctx.getLabel(), QType::TKEY, 3600, QClass::ANY, DNSResourceRecord::ADDITIONAL, false);
       tkrc.toPacket(pwtkey);
       pwtkey.commit();
@@ -161,7 +161,7 @@ try
 
   DNSPacketWriter pw(packet, DNSName(argv[3]), 252);
 
-  pw.getHeader()->id = dns_random(0xffff);
+  pw.getHeader()->id = dns_random_uint16();
 
   if (tsig) {
     TSIGRecordContent trc;

--- a/pdns/stubresolver.cc
+++ b/pdns/stubresolver.cc
@@ -121,7 +121,7 @@ int stubDoResolve(const DNSName& qname, uint16_t qtype, vector<DNSZoneRecord>& r
   vector<uint8_t> packet;
 
   DNSPacketWriter pw(packet, qname, qtype);
-  pw.getHeader()->id=dns_random(0xffff);
+  pw.getHeader()->id=dns_random_uint16();
   pw.getHeader()->rd=1;
 
   string msg ="Doing stub resolving, using resolvers: ";

--- a/pdns/test-dns_random_hh.cc
+++ b/pdns/test-dns_random_hh.cc
@@ -78,6 +78,30 @@ BOOST_AUTO_TEST_CASE(test_dns_random_garbage) {
   BOOST_CHECK_THROW(dns_random_init("", true), std::runtime_error);
 }
 
+BOOST_AUTO_TEST_CASE(test_dns_random_upper_bound) {
+  ::arg().set("rng")="auto";
+  ::arg().set("entropy-source")="/dev/urandom";
+
+  dns_random_init("", true);
+
+  map<int, bool> seen;
+  for(unsigned int n=0; n < 100000; ++n) {
+    seen[dns_random(10)] = true;
+  }
+
+  BOOST_CHECK_EQUAL(seen[0], true);
+  BOOST_CHECK_EQUAL(seen[1], true);
+  BOOST_CHECK_EQUAL(seen[2], true);
+  BOOST_CHECK_EQUAL(seen[3], true);
+  BOOST_CHECK_EQUAL(seen[4], true);
+  BOOST_CHECK_EQUAL(seen[5], true);
+  BOOST_CHECK_EQUAL(seen[6], true);
+  BOOST_CHECK_EQUAL(seen[7], true);
+  BOOST_CHECK_EQUAL(seen[8], true);
+  BOOST_CHECK_EQUAL(seen[9], true);
+  BOOST_CHECK_EQUAL(seen[10], false);
+}
+
 #if defined(HAVE_GETRANDOM)
 BOOST_AUTO_TEST_CASE(test_dns_random_getrandom_average) {
 

--- a/pdns/test-recpacketcache_cc.cc
+++ b/pdns/test-recpacketcache_cc.cc
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimple) {
   DNSPacketWriter pw(packet, qname, QType::A);
   pw.getHeader()->rd=true;
   pw.getHeader()->qr=false;
-  pw.getHeader()->id=dns_random(UINT16_MAX);
+  pw.getHeader()->id=dns_random_uint16();
   string qpacket((const char*)&packet[0], packet.size());
   pw.startRecord(qname, QType::A, ttd);
 
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCacheSimple) {
 
   pw2.getHeader()->rd=true;
   pw2.getHeader()->qr=false;
-  pw2.getHeader()->id=dns_random(UINT16_MAX);
+  pw2.getHeader()->id=dns_random_uint16();
   qpacket.assign((const char*)&packet[0], packet.size());
 
   found = rpc.getResponsePacket(tag, qpacket, time(nullptr), &fpacket, &age, &qhash);
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(test_recPacketCache_Tags) {
   DNSPacketWriter pw(packet, qname, QType::A);
   pw.getHeader()->rd=true;
   pw.getHeader()->qr=false;
-  pw.getHeader()->id=dns_random(UINT16_MAX);
+  pw.getHeader()->id=dns_random_uint16();
   string qpacket(reinterpret_cast<const char*>(&packet[0]), packet.size());
   pw.startRecord(qname, QType::A, ttd);
 


### PR DESCRIPTION
### Short description
Some of our `dns_random` usage looked like it expected the parameter to be an inclusive upper bound. This PR adds a test that ensures the upper bound is exclusive. The common `dns_random(0xffff)` pattern, which was off by one, is replaced by a single function with a clear name.

Reported by Matt Nordhoff, thanks!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
