### PR TITLE
dnsdist: Fix KVS compilation on Boost < 1.56

### DIFF
--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -72,13 +72,13 @@ std::vector<std::string> KeyValueLookupKeySuffix::getKeys(const DNSName& qname)
 
 bool LMDBKVStore::getValue(const std::string& key, std::string& value)
 {
-  string_view result;
   try {
     auto transaction = d_env.getROTransaction();
     auto dbi = transaction.openDB(d_dbName, 0);
+    MDBOutVal result;
     int rc = transaction.get(dbi, MDBInVal(key), result);
     if (rc == 0) {
-      value = result.to_string();
+      value = result.get<std::string>();
       return true;
     }
     else if (rc == MDB_NOTFOUND) {
@@ -93,10 +93,10 @@ bool LMDBKVStore::getValue(const std::string& key, std::string& value)
 
 bool LMDBKVStore::keyExists(const std::string& key)
 {
-  string_view result;
   try {
     auto transaction = d_env.getROTransaction();
     auto dbi = transaction.openDB(d_dbName, 0);
+    MDBOutVal result;
     int rc = transaction.get(dbi, MDBInVal(key), result);
     if (rc == 0) {
       return true;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When neither the C++ 17 nor Boost >= 1.61 `string_view` are available, we fall back to `boost::string_ref`. Unfortunately it didn't have the `to_string()` method before 1.56.
Since we end up converting it to a string anyway, let's just skip the `string_view`/`string_ref` part.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

