### PR TITLE
dnsdist: Add a Lua binding for `DynBlockRulesGroup:setQuiet(quiet)`

### DIFF
--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -745,5 +745,6 @@ void setupLuaInspection()
   g_lua.registerFunction<void(std::shared_ptr<DynBlockRulesGroup>::*)()>("apply", [](std::shared_ptr<DynBlockRulesGroup>& group) {
     group->apply();
   });
+  g_lua.registerFunction("setQuiet", &DynBlockRulesGroup::setQuiet);
   g_lua.registerFunction("toString", &DynBlockRulesGroup::toString);
 }

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1043,6 +1043,14 @@ faster than the existing rules.
 
     Walk the in-memory query and response ring buffers and apply the configured rate-limiting rules, adding dynamic blocks when the limits have been exceeded.
 
+  .. method:: DynBlockRulesGroup:setQuiet(quiet)
+
+    .. versionadded:: 1.4.0
+
+    Set whether newly blocked clients or domains should be logged.
+
+    :param bool quiet: True means that insertions will not be logged, false that they will. Default is false.
+
   .. method:: DynBlockRulesGroup:excludeRange(netmasks)
 
     .. versionadded:: 1.3.1


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Allowing to prevent the insertion of new dynamic block to be logged.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
