### PR TITLE
rec: fix two coverity issues

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -342,7 +342,7 @@ struct DNSComboWriter {
   bool d_ecsParsed{false};
   bool d_followCNAMERecords{false};
   bool d_logResponse{false};
-  bool d_tcp;
+  bool d_tcp{false};
 };
 
 MT_t* getMT()


### PR DESCRIPTION
1. Uninitialized field in DNSComboWriter.
2. TOCTOU wrt stat() and then opendir(). opendir() already tells us if the path
is not a dir or not accesible, so no need to do a TOCTOU sensitive pre-check.
Use uniform error messages in log and exceptions while here.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

** CID 1404735:  Uninitialized members  (UNINIT_CTOR)
** CID 1401970:  Security best practices violations  (TOCTOU)

With some whitespace fixes, since the indentation was completely wrong

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
