### PR TITLE
Set type of Cryptokey ID to integer

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -1237,7 +1237,7 @@ definitions:
         type: string
         description: 'set to "Cryptokey"'
       id:
-        type: string
+        type: integer
         description: 'The internal identifier, read only'
       keytype:
         type: string


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
While implementing the Cryptokey JSON API, I was wondering why the API always returns a number instead of a string. If I understood correctly, according to [this](https://github.com/PowerDNS/pdns/blob/master/pdns/dbdnsseckeeper.cc#L134), this is valid behaviour.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)