### PR TITLE
docs: suggest putting bind dnssec db in /var/lib/powerdns

### DIFF
--- a/docs/dnssec/modes-of-operation.rst
+++ b/docs/dnssec/modes-of-operation.rst
@@ -180,7 +180,7 @@ DNSSEC-related :doc:`domain metadata <../domainmetadata>` in an SQLite3
 database without launching a separate gsqlite3 backend.
 
 To use this mode, run
-``pdnsutil create-bind-db /var/db/bind-dnssec-db.sqlite3`` and set
+``pdnsutil create-bind-db /var/lib/powerdns/bind-dnssec-db.sqlite3`` and set
 :ref:`setting-bind-dnssec-db` in pdns.conf to the path of the created
 database. Then, restart PowerDNS.
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The example `pdnsutil` command in the DNSSEC Modes of Operation docs currently suggests putting the BIND DNSSEC database in `/var/db`.

Using a directory that pdns can't write to can be problematic, as discussed in #7888.

This PR changes it to `/var/lib/powerdns`, which the gsqlite3 backend `README.Debian` already suggests, and which is already owned by pdns as of #7889.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)