### PR TITLE
fix typo in DNSName reference documentation

### DIFF
--- a/pdns/dnsdistdist/docs/reference/dnsname.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsname.rst
@@ -35,7 +35,7 @@ Functions and methods of a ``DNSName``
   A ``DNSName`` object represents a name in the DNS.
   It is returned by several functions and has several functions to programmatically interact with it.
 
-  .. method:: DNSName:chopoff() -> bool
+  .. method:: DNSName:chopOff() -> bool
 
     .. versionadded:: 1.2.0
 


### PR DESCRIPTION
### Short description
This PR fixes a small typo in the reference documentation of dnsdist DNSName class.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
