### PR TITLE
auth: add configurable timeout for inbound AXFR

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -160,6 +160,18 @@ Static pre-shared authentication key for access to the REST API.
 
 Disallow data modification through the REST API when set.
 
+.. _setting-axfr-fetch-timeout:
+
+``axfr-fetch-timeout``
+----------------------
+
+- Integer
+- Default: 10
+
+.. versionadded:: 4.3.0
+
+Maximum time in seconds for inbound AXFR to start or be idle after starting.
+
 .. _setting-axfr-lower-serial:
 
 ``axfr-lower-serial``

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -222,6 +222,7 @@ void declareArguments()
 
   ::arg().set("lua-axfr-script", "Script to be used to edit incoming AXFRs")="";
   ::arg().set("xfr-max-received-mbytes", "Maximum number of megabytes received from an incoming XFR")="100";
+  ::arg().set("axfr-fetch-timeout", "Maximum time in seconds for inbound AXFR to start or be idle after starting")="10";
 
   ::arg().set("tcp-fast-open", "Enable TCP Fast Open support on the listening sockets, using the supplied numerical value as the queue size")="0";
 

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -241,13 +241,14 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
 
 static vector<DNSResourceRecord> doAxfr(const ComboAddress& raddr, const DNSName& domain, const TSIGTriplet& tt, const ComboAddress& laddr,  scoped_ptr<AuthLua4>& pdl, ZoneStatus& zs)
 {
+  uint16_t axfr_timeout=::arg().asNum("axfr-fetch-timeout");
   vector<DNSResourceRecord> rrs;
-  AXFRRetriever retriever(raddr, domain, tt, (laddr.sin4.sin_family == 0) ? NULL : &laddr, ((size_t) ::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024);
+  AXFRRetriever retriever(raddr, domain, tt, (laddr.sin4.sin_family == 0) ? NULL : &laddr, ((size_t) ::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024, axfr_timeout);
   Resolver::res_t recs;
   bool first=true;
   bool firstNSEC3{true};
   bool soa_received {false};
-  while(retriever.getChunk(recs)) {
+  while(retriever.getChunk(recs, nullptr, axfr_timeout)) {
     if(first) {
       g_log<<Logger::Error<<"AXFR started for '"<<domain<<"'"<<endl;
       first=false;


### PR DESCRIPTION
### Short description
Adds a configurable timeout for inbound AXFR. Default is 10 seconds which it was previously hardcoded to.

Needed when transferring large zones from slow masters which take a while before sending anything. Same timeout setting is also applied for subsequent `getChunk` calls.

Fun fact: bind has a default timeout of 2 hours for the whole AXFR, and 1 hour for stalls during transfer.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

