### PR TITLE
dnsdist: Implement dynamic blocking on ratio of rcode/total responses

### DIFF
--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -149,6 +149,67 @@ private:
     bool d_enabled{false};
   };
 
+  struct DynBlockRatioRule: DynBlockRule
+  {
+    DynBlockRatioRule(): DynBlockRule()
+    {
+    }
+
+    DynBlockRatioRule(const std::string& blockReason, unsigned int blockDuration, double ratio, double warningRatio, unsigned int seconds, DNSAction::Action action, size_t minimumNumberOfResponses): DynBlockRule(blockReason, blockDuration, 0, 0, seconds, action), d_minimumNumberOfResponses(minimumNumberOfResponses), d_ratio(ratio), d_warningRatio(warningRatio)
+    {
+    }
+
+    bool ratioExceeded(unsigned int total, unsigned int count) const
+    {
+      if (!d_enabled) {
+        return false;
+      }
+
+      if (total < d_minimumNumberOfResponses) {
+        return false;
+      }
+
+      double allowed = d_ratio * static_cast<double>(total);
+      return (count > allowed);
+    }
+
+    bool warningRatioExceeded(unsigned int total, unsigned int count) const
+    {
+      if (d_warningRate == 0) {
+        return false;
+      }
+
+      if (total < d_minimumNumberOfResponses) {
+        return false;
+      }
+
+      double allowed = d_warningRatio * static_cast<double>(total);
+      return (count > allowed);
+    }
+
+    std::string toString() const
+    {
+      if (!isEnabled()) {
+        return "";
+      }
+
+      std::stringstream result;
+      if (d_action != DNSAction::Action::None) {
+        result << DNSAction::typeToString(d_action) << " ";
+      }
+      else {
+        result << "Apply the global DynBlock action ";
+      }
+      result << "for " << std::to_string(d_blockDuration) << " seconds when over " << std::to_string(d_ratio) << " ratio during the last " << d_seconds << " seconds, reason: '" << d_blockReason << "'";
+
+      return result.str();
+    }
+
+    size_t d_minimumNumberOfResponses{0};
+    double d_ratio{0.0};
+    double d_warningRatio{0.0};
+  };
+
   typedef std::unordered_map<ComboAddress, Counts, ComboAddress::addressOnlyHash, ComboAddress::addressOnlyEqual> counts_t;
 
 public:
@@ -171,6 +232,12 @@ public:
   {
     auto& entry = d_rcodeRules[rcode];
     entry = DynBlockRule(reason, blockDuration, rate, warningRate, seconds, action);
+  }
+
+  void setRCodeRatio(uint8_t rcode, double ratio, double warningRatio, unsigned int seconds, std::string reason, unsigned int blockDuration, DNSAction::Action action, size_t minimumNumberOfResponses)
+  {
+    auto& entry = d_rcodeRatioRules[rcode];
+    entry = DynBlockRatioRule(reason, blockDuration, ratio, warningRatio, seconds, action, minimumNumberOfResponses);
   }
 
   void setQTypeRate(uint16_t qtype, unsigned int rate, unsigned int warningRate, unsigned int seconds, std::string reason, unsigned int blockDuration, DNSAction::Action action)
@@ -201,122 +268,7 @@ public:
     apply(now);
   }
 
-  void apply(const struct timespec& now)
-  {
-    counts_t counts;
-    StatNode statNodeRoot;
-
-    size_t entriesCount = 0;
-    if (hasQueryRules()) {
-      entriesCount += g_rings.getNumberOfQueryEntries();
-    }
-    if (hasResponseRules()) {
-      entriesCount += g_rings.getNumberOfResponseEntries();
-    }
-    counts.reserve(entriesCount);
-
-    processQueryRules(counts, now);
-    processResponseRules(counts, statNodeRoot, now);
-
-    if (counts.empty() && statNodeRoot.empty()) {
-      return;
-    }
-
-    boost::optional<NetmaskTree<DynBlock> > blocks;
-    bool updated = false;
-
-    for (const auto& entry : counts) {
-      const auto& requestor = entry.first;
-      const auto& counters = entry.second;
-
-      if (d_queryRateRule.warningRateExceeded(counters.queries, now)) {
-        handleWarning(blocks, now, requestor, d_queryRateRule, updated);
-      }
-
-      if (d_queryRateRule.rateExceeded(counters.queries, now)) {
-        addBlock(blocks, now, requestor, d_queryRateRule, updated);
-        continue;
-      }
-
-      if (d_respRateRule.warningRateExceeded(counters.respBytes, now)) {
-        handleWarning(blocks, now, requestor, d_respRateRule, updated);
-      }
-
-      if (d_respRateRule.rateExceeded(counters.respBytes, now)) {
-        addBlock(blocks, now, requestor, d_respRateRule, updated);
-        continue;
-      }
-
-      for (const auto& pair : d_qtypeRules) {
-        const auto qtype = pair.first;
-
-        const auto& typeIt = counters.d_qtypeCounts.find(qtype);
-        if (typeIt != counters.d_qtypeCounts.cend()) {
-
-          if (pair.second.warningRateExceeded(typeIt->second, now)) {
-            handleWarning(blocks, now, requestor, pair.second, updated);
-          }
-
-          if (pair.second.rateExceeded(typeIt->second, now)) {
-            addBlock(blocks, now, requestor, pair.second, updated);
-            break;
-          }
-        }
-      }
-
-      for (const auto& pair : d_rcodeRules) {
-        const auto rcode = pair.first;
-
-        const auto& rcodeIt = counters.d_rcodeCounts.find(rcode);
-        if (rcodeIt != counters.d_rcodeCounts.cend()) {
-          if (pair.second.warningRateExceeded(rcodeIt->second, now)) {
-            handleWarning(blocks, now, requestor, pair.second, updated);
-          }
-
-          if (pair.second.rateExceeded(rcodeIt->second, now)) {
-            addBlock(blocks, now, requestor, pair.second, updated);
-            break;
-          }
-        }
-      }
-    }
-
-    if (updated && blocks) {
-      g_dynblockNMG.setState(std::move(*blocks));
-    }
-
-    if (!statNodeRoot.empty()) {
-      StatNode::Stat node;
-      std::unordered_set<DNSName> namesToBlock;
-      statNodeRoot.visit([this,&namesToBlock](const StatNode* node_, const StatNode::Stat& self, const StatNode::Stat& children) {
-                           bool block = false;
-
-                           if (d_smtVisitorFFI) {
-                             dnsdist_ffi_stat_node_t tmp(*node_, self, children);
-                             block = d_smtVisitorFFI(&tmp);
-                           }
-                           else {
-                             block = d_smtVisitor(*node_, self, children);
-                           }
-
-                           if (block) {
-                             namesToBlock.insert(DNSName(node_->fullname));
-                           }
-                         },
-        node);
-
-      if (!namesToBlock.empty()) {
-        updated = false;
-        SuffixMatchTree<DynBlock> smtBlocks = g_dynblockSMT.getCopy();
-        for (const auto& name : namesToBlock) {
-          addOrRefreshBlockSMT(smtBlocks, now, name, d_suffixMatchRule, updated);
-        }
-        if (updated) {
-          g_dynblockSMT.setState(std::move(smtBlocks));
-        }
-      }
-    }
-  }
+  void apply(const struct timespec& now);
 
   void excludeRange(const Netmask& range)
   {
@@ -344,6 +296,9 @@ public:
     for (const auto& rule : d_rcodeRules) {
       result << "- " << RCode::to_s(rule.first) << ": " << rule.second.toString() << std::endl;
     }
+    for (const auto& rule : d_rcodeRatioRules) {
+      result << "- " << RCode::to_s(rule.first) << ": " << rule.second.toString() << std::endl;
+    }
     result << "QType rules: " << std::endl;
     for (const auto& rule : d_qtypeRules) {
       result << "- " << QType(rule.first).getName() << ": " << rule.second.toString() << std::endl;
@@ -360,116 +315,11 @@ public:
   }
 
 private:
-  bool checkIfQueryTypeMatches(const Rings::Query& query)
-  {
-    auto rule = d_qtypeRules.find(query.qtype);
-    if (rule == d_qtypeRules.end()) {
-      return false;
-    }
 
-    return rule->second.matches(query.when);
-  }
-
-  bool checkIfResponseCodeMatches(const Rings::Response& response)
-  {
-    auto rule = d_rcodeRules.find(response.dh.rcode);
-    if (rule == d_rcodeRules.end()) {
-      return false;
-    }
-
-    return rule->second.matches(response.when);
-  }
-
-  void addOrRefreshBlock(boost::optional<NetmaskTree<DynBlock> >& blocks, const struct timespec& now, const ComboAddress& requestor, const DynBlockRule& rule, bool& updated, bool warning)
-  {
-    if (d_excludedSubnets.match(requestor)) {
-      /* do not add a block for excluded subnets */
-      return;
-    }
-
-    if (!blocks) {
-      blocks = g_dynblockNMG.getCopy();
-    }
-    struct timespec until = now;
-    until.tv_sec += rule.d_blockDuration;
-    unsigned int count = 0;
-    const auto& got = blocks->lookup(Netmask(requestor));
-    bool expired = false;
-    bool wasWarning = false;
-
-    if (got) {
-      if (warning && !got->second.warning) {
-        /* we have an existing entry which is not a warning,
-           don't override it */
-        return;
-      }
-      else if (!warning && got->second.warning) {
-        wasWarning = true;
-      }
-      else {
-        if (until < got->second.until) {
-          // had a longer policy
-          return;
-        }
-      }
-
-      if (now < got->second.until) {
-        // only inherit count on fresh query we are extending
-        count = got->second.blocks;
-      }
-      else {
-        expired = true;
-      }
-    }
-
-    DynBlock db{rule.d_blockReason, until, DNSName(), warning ? DNSAction::Action::NoOp : rule.d_action};
-    db.blocks = count;
-    db.warning = warning;
-    if (!d_beQuiet && (!got || expired || wasWarning)) {
-      warnlog("Inserting %sdynamic block for %s for %d seconds: %s", warning ? "(warning) " :"", requestor.toString(), rule.d_blockDuration, rule.d_blockReason);
-    }
-    blocks->insert(Netmask(requestor)).second = db;
-    updated = true;
-  }
-
-  void addOrRefreshBlockSMT(SuffixMatchTree<DynBlock>& blocks, const struct timespec& now, const DNSName& name, const DynBlockRule& rule, bool& updated)
-  {
-    if (d_excludedDomains.check(name)) {
-      /* do not add a block for excluded domains */
-      return;
-    }
-
-    struct timespec until = now;
-    until.tv_sec += rule.d_blockDuration;
-    unsigned int count = 0;
-    const auto& got = blocks.lookup(name);
-    bool expired = false;
-    DNSName domain(name.makeLowerCase());
-
-    if (got) {
-      if (until < got->until) {
-        // had a longer policy
-        return;
-      }
-
-      if (now < got->until) {
-        // only inherit count on fresh query we are extending
-        count = got->blocks;
-      }
-      else {
-        expired = true;
-      }
-    }
-
-    DynBlock db{rule.d_blockReason, until, domain, rule.d_action};
-    db.blocks = count;
-
-    if (!d_beQuiet && (!got || expired)) {
-      warnlog("Inserting dynamic block for %s for %d seconds: %s", domain, rule.d_blockDuration, rule.d_blockReason);
-    }
-    blocks.add(domain, db);
-    updated = true;
-  }
+  bool checkIfQueryTypeMatches(const Rings::Query& query);
+  bool checkIfResponseCodeMatches(const Rings::Response& response);
+  void addOrRefreshBlock(boost::optional<NetmaskTree<DynBlock> >& blocks, const struct timespec& now, const ComboAddress& requestor, const DynBlockRule& rule, bool& updated, bool warning);
+  void addOrRefreshBlockSMT(SuffixMatchTree<DynBlock>& blocks, const struct timespec& now, const DNSName& name, const DynBlockRule& rule, bool& updated);
 
   void addBlock(boost::optional<NetmaskTree<DynBlock> >& blocks, const struct timespec& now, const ComboAddress& requestor, const DynBlockRule& rule, bool& updated)
   {
@@ -488,7 +338,7 @@ private:
 
   bool hasResponseRules() const
   {
-    return d_respRateRule.isEnabled() || !d_rcodeRules.empty();
+    return d_respRateRule.isEnabled() || !d_rcodeRules.empty() || !d_rcodeRatioRules.empty();
   }
 
   bool hasSuffixMatchRules() const
@@ -501,89 +351,11 @@ private:
     return hasQueryRules() || hasResponseRules();
   }
 
-  void processQueryRules(counts_t& counts, const struct timespec& now)
-  {
-    if (!hasQueryRules()) {
-      return;
-    }
-
-    d_queryRateRule.d_cutOff = d_queryRateRule.d_minTime = now;
-    d_queryRateRule.d_cutOff.tv_sec -= d_queryRateRule.d_seconds;
-
-    for (auto& rule : d_qtypeRules) {
-      rule.second.d_cutOff = rule.second.d_minTime = now;
-      rule.second.d_cutOff.tv_sec -= rule.second.d_seconds;
-    }
-
-    for (const auto& shard : g_rings.d_shards) {
-      std::lock_guard<std::mutex> rl(shard->queryLock);
-      for(const auto& c : shard->queryRing) {
-        if (now < c.when) {
-          continue;
-        }
-
-        bool qRateMatches = d_queryRateRule.matches(c.when);
-        bool typeRuleMatches = checkIfQueryTypeMatches(c);
-
-        if (qRateMatches || typeRuleMatches) {
-          auto& entry = counts[c.requestor];
-          if (qRateMatches) {
-            entry.queries++;
-          }
-          if (typeRuleMatches) {
-            entry.d_qtypeCounts[c.qtype]++;
-          }
-        }
-      }
-    }
-  }
-
-  void processResponseRules(counts_t& counts, StatNode& root, const struct timespec& now)
-  {
-    if (!hasResponseRules() && !hasSuffixMatchRules()) {
-      return;
-    }
-
-    d_respRateRule.d_cutOff = d_respRateRule.d_minTime = now;
-    d_respRateRule.d_cutOff.tv_sec -= d_respRateRule.d_seconds;
-
-    d_suffixMatchRule.d_cutOff = d_suffixMatchRule.d_minTime = now;
-    d_suffixMatchRule.d_cutOff.tv_sec -= d_suffixMatchRule.d_seconds;
-
-    for (auto& rule : d_rcodeRules) {
-      rule.second.d_cutOff = rule.second.d_minTime = now;
-      rule.second.d_cutOff.tv_sec -= rule.second.d_seconds;
-    }
-
-    for (const auto& shard : g_rings.d_shards) {
-      std::lock_guard<std::mutex> rl(shard->respLock);
-      for(const auto& c : shard->respRing) {
-        if (now < c.when) {
-          continue;
-        }
-
-        bool respRateMatches = d_respRateRule.matches(c.when);
-        bool suffixMatchRuleMatches = d_suffixMatchRule.matches(c.when);
-        bool rcodeRuleMatches = checkIfResponseCodeMatches(c);
-
-        if (respRateMatches || rcodeRuleMatches) {
-          auto& entry = counts[c.requestor];
-          if (respRateMatches) {
-            entry.respBytes += c.size;
-          }
-          if (rcodeRuleMatches) {
-            entry.d_rcodeCounts[c.dh.rcode]++;
-          }
-        }
-
-        if (suffixMatchRuleMatches) {
-          root.submit(c.name, ((c.dh.rcode == 0 && c.usec == std::numeric_limits<unsigned int>::max()) ? -1 : c.dh.rcode), c.size, boost::none);
-        }
-      }
-    }
-  }
+  void processQueryRules(counts_t& counts, const struct timespec& now);
+  void processResponseRules(counts_t& counts, StatNode& root, const struct timespec& now);
 
   std::map<uint8_t, DynBlockRule> d_rcodeRules;
+  std::map<uint8_t, DynBlockRatioRule> d_rcodeRatioRules;
   std::map<uint16_t, DynBlockRule> d_qtypeRules;
   DynBlockRule d_queryRateRule;
   DynBlockRule d_respRateRule;

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -741,6 +741,11 @@ void setupLuaInspection()
         group->setRCodeRate(rcode, rate, warningRate ? *warningRate : 0, seconds, reason, blockDuration, action ? *action : DNSAction::Action::None);
       }
     });
+  g_lua.registerFunction<void(std::shared_ptr<DynBlockRulesGroup>::*)(uint8_t, double, unsigned int, const std::string&, unsigned int, size_t, boost::optional<DNSAction::Action>, boost::optional<double>)>("setRCodeRatio", [](std::shared_ptr<DynBlockRulesGroup>& group, uint8_t rcode, double ratio, unsigned int seconds, const std::string& reason, unsigned int blockDuration, size_t minimumNumberOfResponses, boost::optional<DNSAction::Action> action, boost::optional<double> warningRatio) {
+      if (group) {
+        group->setRCodeRatio(rcode, ratio, warningRatio ? *warningRatio : 0.0, seconds, reason, blockDuration, action ? *action : DNSAction::Action::None, minimumNumberOfResponses);
+      }
+    });
   g_lua.registerFunction<void(std::shared_ptr<DynBlockRulesGroup>::*)(uint16_t, unsigned int, unsigned int, const std::string&, unsigned int, boost::optional<DNSAction::Action>, boost::optional<unsigned int>)>("setQTypeRate", [](std::shared_ptr<DynBlockRulesGroup>& group, uint16_t qtype, unsigned int rate, unsigned int seconds, const std::string& reason, unsigned int blockDuration, boost::optional<DNSAction::Action> action, boost::optional<unsigned int> warningRate) {
       if (group) {
         group->setQTypeRate(qtype, rate, warningRate ? *warningRate : 0, seconds, reason, blockDuration, action ? *action : DNSAction::Action::None);

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -122,7 +122,7 @@ dnsdist_SOURCES = \
 	dnsdist-carbon.cc \
 	dnsdist-console.cc dnsdist-console.hh \
 	dnsdist-dnscrypt.cc \
-	dnsdist-dynblocks.hh \
+	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
 	dnsdist-idstate.cc \
 	dnsdist-kvs.hh dnsdist-kvs.cc \
@@ -204,6 +204,7 @@ testrunner_SOURCES = \
 	circular_buffer.hh \
 	dnsdist.hh \
 	dnsdist-cache.cc dnsdist-cache.hh \
+	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
 	dnsdist-kvs.cc dnsdist-kvs.hh \
 	dnsdist-rings.hh \

--- a/pdns/dnsdistdist/dnsdist-dynblocks.cc
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.cc
@@ -1,0 +1,340 @@
+
+#include "dnsdist.hh"
+#include "dnsdist-dynblocks.hh"
+
+void DynBlockRulesGroup::apply(const struct timespec& now)
+{
+  counts_t counts;
+  StatNode statNodeRoot;
+
+  size_t entriesCount = 0;
+  if (hasQueryRules()) {
+    entriesCount += g_rings.getNumberOfQueryEntries();
+  }
+  if (hasResponseRules()) {
+    entriesCount += g_rings.getNumberOfResponseEntries();
+  }
+  counts.reserve(entriesCount);
+
+  processQueryRules(counts, now);
+  processResponseRules(counts, statNodeRoot, now);
+
+  if (counts.empty() && statNodeRoot.empty()) {
+    return;
+  }
+
+  boost::optional<NetmaskTree<DynBlock> > blocks;
+  bool updated = false;
+
+  for (const auto& entry : counts) {
+    const auto& requestor = entry.first;
+    const auto& counters = entry.second;
+
+    if (d_queryRateRule.warningRateExceeded(counters.queries, now)) {
+      handleWarning(blocks, now, requestor, d_queryRateRule, updated);
+    }
+
+    if (d_queryRateRule.rateExceeded(counters.queries, now)) {
+      addBlock(blocks, now, requestor, d_queryRateRule, updated);
+      continue;
+    }
+
+    if (d_respRateRule.warningRateExceeded(counters.respBytes, now)) {
+      handleWarning(blocks, now, requestor, d_respRateRule, updated);
+    }
+
+    if (d_respRateRule.rateExceeded(counters.respBytes, now)) {
+      addBlock(blocks, now, requestor, d_respRateRule, updated);
+      continue;
+    }
+
+    for (const auto& pair : d_qtypeRules) {
+      const auto qtype = pair.first;
+
+      const auto& typeIt = counters.d_qtypeCounts.find(qtype);
+      if (typeIt != counters.d_qtypeCounts.cend()) {
+
+        if (pair.second.warningRateExceeded(typeIt->second, now)) {
+          handleWarning(blocks, now, requestor, pair.second, updated);
+        }
+
+        if (pair.second.rateExceeded(typeIt->second, now)) {
+          addBlock(blocks, now, requestor, pair.second, updated);
+          break;
+        }
+      }
+    }
+
+    for (const auto& pair : d_rcodeRules) {
+      const auto rcode = pair.first;
+
+      const auto& rcodeIt = counters.d_rcodeCounts.find(rcode);
+      if (rcodeIt != counters.d_rcodeCounts.cend()) {
+        if (pair.second.warningRateExceeded(rcodeIt->second, now)) {
+          handleWarning(blocks, now, requestor, pair.second, updated);
+        }
+
+        if (pair.second.rateExceeded(rcodeIt->second, now)) {
+          addBlock(blocks, now, requestor, pair.second, updated);
+          break;
+        }
+      }
+    }
+
+    for (const auto& pair : d_rcodeRatioRules) {
+      const auto rcode = pair.first;
+
+      const auto& rcodeIt = counters.d_rcodeCounts.find(rcode);
+      if (rcodeIt != counters.d_rcodeCounts.cend()) {
+        if (pair.second.warningRatioExceeded(counters.queries, rcodeIt->second)) {
+          handleWarning(blocks, now, requestor, pair.second, updated);
+        }
+
+        if (pair.second.ratioExceeded(counters.queries, rcodeIt->second)) {
+          addBlock(blocks, now, requestor, pair.second, updated);
+          break;
+        }
+      }
+    }
+  }
+
+  if (updated && blocks) {
+    g_dynblockNMG.setState(std::move(*blocks));
+  }
+
+  if (!statNodeRoot.empty()) {
+    StatNode::Stat node;
+    std::unordered_set<DNSName> namesToBlock;
+    statNodeRoot.visit([this,&namesToBlock](const StatNode* node_, const StatNode::Stat& self, const StatNode::Stat& children) {
+                         bool block = false;
+
+                         if (d_smtVisitorFFI) {
+                           dnsdist_ffi_stat_node_t tmp(*node_, self, children);
+                           block = d_smtVisitorFFI(&tmp);
+                         }
+                         else {
+                           block = d_smtVisitor(*node_, self, children);
+                         }
+
+                         if (block) {
+                           namesToBlock.insert(DNSName(node_->fullname));
+                         }
+                       },
+      node);
+
+    if (!namesToBlock.empty()) {
+      updated = false;
+      SuffixMatchTree<DynBlock> smtBlocks = g_dynblockSMT.getCopy();
+      for (const auto& name : namesToBlock) {
+        addOrRefreshBlockSMT(smtBlocks, now, name, d_suffixMatchRule, updated);
+      }
+      if (updated) {
+        g_dynblockSMT.setState(std::move(smtBlocks));
+      }
+    }
+  }
+}
+
+bool DynBlockRulesGroup::checkIfQueryTypeMatches(const Rings::Query& query)
+{
+  auto rule = d_qtypeRules.find(query.qtype);
+  if (rule == d_qtypeRules.end()) {
+    return false;
+  }
+
+  return rule->second.matches(query.when);
+}
+
+bool DynBlockRulesGroup::checkIfResponseCodeMatches(const Rings::Response& response)
+{
+  auto rule = d_rcodeRules.find(response.dh.rcode);
+  if (rule != d_rcodeRules.end() && rule->second.matches(response.when)) {
+    return true;
+  }
+
+  auto ratio = d_rcodeRatioRules.find(response.dh.rcode);
+  if (ratio != d_rcodeRatioRules.end() && ratio->second.matches(response.when)) {
+    return true;
+  }
+
+  return false;
+}
+
+void DynBlockRulesGroup::addOrRefreshBlock(boost::optional<NetmaskTree<DynBlock> >& blocks, const struct timespec& now, const ComboAddress& requestor, const DynBlockRule& rule, bool& updated, bool warning)
+{
+  if (d_excludedSubnets.match(requestor)) {
+    /* do not add a block for excluded subnets */
+    return;
+  }
+
+  if (!blocks) {
+    blocks = g_dynblockNMG.getCopy();
+  }
+  struct timespec until = now;
+  until.tv_sec += rule.d_blockDuration;
+  unsigned int count = 0;
+  const auto& got = blocks->lookup(Netmask(requestor));
+  bool expired = false;
+  bool wasWarning = false;
+
+  if (got) {
+    if (warning && !got->second.warning) {
+      /* we have an existing entry which is not a warning,
+         don't override it */
+      return;
+    }
+    else if (!warning && got->second.warning) {
+      wasWarning = true;
+    }
+    else {
+      if (until < got->second.until) {
+        // had a longer policy
+        return;
+      }
+    }
+
+    if (now < got->second.until) {
+      // only inherit count on fresh query we are extending
+      count = got->second.blocks;
+    }
+    else {
+      expired = true;
+    }
+  }
+
+  DynBlock db{rule.d_blockReason, until, DNSName(), warning ? DNSAction::Action::NoOp : rule.d_action};
+  db.blocks = count;
+  db.warning = warning;
+  if (!d_beQuiet && (!got || expired || wasWarning)) {
+    warnlog("Inserting %sdynamic block for %s for %d seconds: %s", warning ? "(warning) " :"", requestor.toString(), rule.d_blockDuration, rule.d_blockReason);
+  }
+  blocks->insert(Netmask(requestor)).second = db;
+  updated = true;
+}
+
+void DynBlockRulesGroup::addOrRefreshBlockSMT(SuffixMatchTree<DynBlock>& blocks, const struct timespec& now, const DNSName& name, const DynBlockRule& rule, bool& updated)
+{
+  if (d_excludedDomains.check(name)) {
+    /* do not add a block for excluded domains */
+    return;
+  }
+
+  struct timespec until = now;
+  until.tv_sec += rule.d_blockDuration;
+  unsigned int count = 0;
+  const auto& got = blocks.lookup(name);
+  bool expired = false;
+  DNSName domain(name.makeLowerCase());
+
+  if (got) {
+    if (until < got->until) {
+      // had a longer policy
+      return;
+    }
+
+    if (now < got->until) {
+      // only inherit count on fresh query we are extending
+      count = got->blocks;
+    }
+    else {
+      expired = true;
+    }
+  }
+
+  DynBlock db{rule.d_blockReason, until, domain, rule.d_action};
+  db.blocks = count;
+
+  if (!d_beQuiet && (!got || expired)) {
+    warnlog("Inserting dynamic block for %s for %d seconds: %s", domain, rule.d_blockDuration, rule.d_blockReason);
+  }
+  blocks.add(domain, db);
+  updated = true;
+}
+
+void DynBlockRulesGroup::processQueryRules(counts_t& counts, const struct timespec& now)
+{
+  if (!hasQueryRules()) {
+    return;
+  }
+
+  d_queryRateRule.d_cutOff = d_queryRateRule.d_minTime = now;
+  d_queryRateRule.d_cutOff.tv_sec -= d_queryRateRule.d_seconds;
+
+  for (auto& rule : d_qtypeRules) {
+    rule.second.d_cutOff = rule.second.d_minTime = now;
+    rule.second.d_cutOff.tv_sec -= rule.second.d_seconds;
+  }
+
+  for (const auto& shard : g_rings.d_shards) {
+    std::lock_guard<std::mutex> rl(shard->queryLock);
+    for(const auto& c : shard->queryRing) {
+      if (now < c.when) {
+        continue;
+      }
+
+      bool qRateMatches = d_queryRateRule.matches(c.when);
+      bool typeRuleMatches = checkIfQueryTypeMatches(c);
+
+      if (qRateMatches || typeRuleMatches) {
+        auto& entry = counts[c.requestor];
+        if (qRateMatches) {
+          ++entry.queries;
+        }
+        if (typeRuleMatches) {
+          ++entry.d_qtypeCounts[c.qtype];
+        }
+      }
+    }
+  }
+}
+
+void DynBlockRulesGroup::processResponseRules(counts_t& counts, StatNode& root, const struct timespec& now)
+{
+  if (!hasResponseRules() && !hasSuffixMatchRules()) {
+    return;
+  }
+
+  d_respRateRule.d_cutOff = d_respRateRule.d_minTime = now;
+  d_respRateRule.d_cutOff.tv_sec -= d_respRateRule.d_seconds;
+
+  d_suffixMatchRule.d_cutOff = d_suffixMatchRule.d_minTime = now;
+  d_suffixMatchRule.d_cutOff.tv_sec -= d_suffixMatchRule.d_seconds;
+
+  for (auto& rule : d_rcodeRules) {
+    rule.second.d_cutOff = rule.second.d_minTime = now;
+    rule.second.d_cutOff.tv_sec -= rule.second.d_seconds;
+  }
+
+  for (auto& rule : d_rcodeRatioRules) {
+    rule.second.d_cutOff = rule.second.d_minTime = now;
+    rule.second.d_cutOff.tv_sec -= rule.second.d_seconds;
+  }
+
+  for (const auto& shard : g_rings.d_shards) {
+    std::lock_guard<std::mutex> rl(shard->respLock);
+    for(const auto& c : shard->respRing) {
+      if (now < c.when) {
+        continue;
+      }
+
+      auto& entry = counts[c.requestor];
+      ++entry.queries;
+      bool respRateMatches = d_respRateRule.matches(c.when);
+      bool suffixMatchRuleMatches = d_suffixMatchRule.matches(c.when);
+      bool rcodeRuleMatches = checkIfResponseCodeMatches(c);
+
+      if (respRateMatches || rcodeRuleMatches) {
+        if (respRateMatches) {
+          entry.respBytes += c.size;
+        }
+        if (rcodeRuleMatches) {
+          ++entry.d_rcodeCounts[c.dh.rcode];
+        }
+      }
+
+      if (suffixMatchRuleMatches) {
+        root.submit(c.name, ((c.dh.rcode == 0 && c.usec == std::numeric_limits<unsigned int>::max()) ? -1 : c.dh.rcode), c.size, boost::none);
+      }
+    }
+  }
+}

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1020,6 +1020,21 @@ faster than the existing rules.
     :param int action: The action to take when the dynamic block matches, see :ref:`here <DNSAction>`. (default to the one set with :func:`setDynBlocksAction`)
     :param int warningRate: If set to a non-zero value, the rate above which a warning message will be issued and a no-op block inserted
 
+  .. method:: DynBlockRulesGroup:setRCodeRatio(rcode, ratio, seconds, reason, blockingTime, minimumNumberOfResponses [, action [, warningRate]])
+
+    .. versionadded:: 1.5.0
+
+    Adds a rate-limiting rule for the ratio of responses of code ``rcode`` over the total number of responses for a given client.
+
+    :param int rcode: The response code
+    :param int ratio: Ratio of responses per second of the given rcode over the total number of responses for this client to exceed
+    :param int seconds: Number of seconds the ratio has been exceeded
+    :param string reason: The message to show next to the blocks
+    :param int blockingTime: The number of seconds this block to expire
+    :param int minimumNumberOfResponses: How many total responses is required for this rule to apply
+    :param int action: The action to take when the dynamic block matches, see :ref:`here <DNSAction>`. (default to the one set with :func:`setDynBlocksAction`)
+    :param int warningRatio: If set to a non-zero value, the ratio above which a warning message will be issued and a no-op block inserted
+
   .. method:: DynBlockRulesGroup:setQTypeRate(qtype, rate, seconds, reason, blockingTime [, action [, warningRate]])
 
     .. versionchanged:: 1.3.3


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Implements a dynamic blocking mechanism based on the ratio of a given rcode over all responses, as suggested in https://github.com/PowerDNS/pdns/issues/8045.
Could use a good review.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)

