### PR TITLE
docs/dnsupdate.rst: Fix typo in getZoneName()

### DIFF
--- a/docs/dnsupdate.rst
+++ b/docs/dnsupdate.rst
@@ -455,7 +455,7 @@ each record at a time and you can approve or reject any or all.
 The object has following methods available:
 
 - ``DNSName getQName()`` - name to update
-- ``DNSName getZonename()`` - zone name
+- ``DNSName getZoneName()`` - zone name
 - ``int getQType()`` - record type, it can be 255(ANY) for delete.
 - ``ComboAddress getLocal()`` - local socket address
 - ``ComboAddress getRemote()`` - remote socket address


### PR DESCRIPTION
The function name getZoneName() was misspelled in the reference.
If the wrong name is used as it was documented, that lead to nasty,
silent failure of the script as lua assumed default behavior of
non-existing functions and doesn't abort.

### Short description
docs/dnsupdate.rst: Fix typo in getZoneName()

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
