### PR TITLE
Improve commandline error reporting for non-opts

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4646,7 +4646,20 @@ int main(int argc, char **argv)
     cleanSlashes(configname);
 
     if(!::arg().getCommands().empty()) {
-      cerr<<"Fatal: non-option on the command line, perhaps a '--setting=123' statement missed the '='?"<<endl;
+      cerr<<"Fatal: non-option";
+      if (::arg().getCommands().size() > 1) {
+        cerr<<"s";
+      }
+      cerr<<" (";
+      bool first = true;
+      for (auto const c : ::arg().getCommands()) {
+        if (!first) {
+          cerr<<", ";
+        }
+        first = false;
+        cerr<<c;
+      }
+      cerr<<") on the command line, perhaps a '--setting=123' statement missed the '='?"<<endl;
       exit(99);
     }
 

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -488,7 +488,20 @@ int main(int argc, char **argv)
     BackendMakers().launch(::arg()["launch"]); // vrooooom!
 
     if(!::arg().getCommands().empty()) {
-      cerr<<"Fatal: non-option on the command line, perhaps a '--setting=123' statement missed the '='?"<<endl;
+      cerr<<"Fatal: non-option";
+      if (::arg().getCommands().size() > 1) {
+        cerr<<"s";
+      }
+      cerr<<" (";
+      bool first = true;
+      for (auto const c : ::arg().getCommands()) {
+        if (!first) {
+          cerr<<", ";
+        }
+        first = false;
+        cerr<<c;
+      }
+      cerr<<") on the command line, perhaps a '--setting=123' statement missed the '='?"<<endl;
       exit(99);
     }
     


### PR DESCRIPTION
### Short description
Before:

```
pdns_server --launch=random --socket-dir=. foo
Fatal: non-option on the command line, perhaps a '--setting=123' statement missed the '='?
```

After:
```
pdns_server --launch=random --socket-dir=. bar
Sep 10 17:24:25 Unable to open /usr/local/etc/pdns.conf
Fatal: non-options (bar) on the command line, perhaps a '--setting=123' statement missed the '='?

pdns_server --launch=random --socket-dir=. bar foo
Sep 10 17:24:25 Unable to open /usr/local/etc/pdns.conf
Fatal: non-options (bar, foo) on the command line, perhaps a '--setting=123' statement missed the '='?
```

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)