### PR TITLE
webserver: handle exceptions instead of SIGABRTing the world

### DIFF
--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -202,7 +202,18 @@ void WebServer::registerWebHandler(const string& url, HandlerFunction handler) {
 
 static void *WebServerConnectionThreadStart(const WebServer* webServer, std::shared_ptr<Socket> client) {
   setThreadName("pdns-r/webhndlr");
-  webServer->serveConnection(client);
+  try {
+    webServer->serveConnection(client);
+  }
+  catch(PDNSException &e) {
+    g_log<<Logger::Error<<"PDNSException while serving a connection in main webserver thread: "<<e.reason<<endl;
+  }
+  catch(std::exception &e) {
+    g_log<<Logger::Error<<"STL Exception while serving a connection in main webserver thread: "<<e.what()<<endl;
+  }
+  catch(...) {
+    g_log<<Logger::Error<<"Unknown exception while serving a connection in main webserver thread"<<endl;
+  }
   return nullptr;
 }
 


### PR DESCRIPTION
### Short description
Without this, any exception that manages to bubble out of `serveConnection` will take down the whole pdns_server (or ixfrdist or recursor or ...) process with SIGABRT. Except on 'Linux', the user would also be left none the wiser as to the reason of the crash.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
