### PR TITLE
make separate bug/report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,17 +4,11 @@
 
 <!-- Tell us what is issue is about -->
  - Program: Authoritative, Recursor, dnsdist <!-- delete the ones that do not apply -->
- - Issue type: Bug report/Feature request <!-- delete the one that does not apply -->
+ - Issue type: Bug report
 
 ### Short description
 <!-- Explain in a few sentences what the issue/request is -->
 
-
-
-
-<!--
-If this is a bug report, use the following part of the the template and delete the part at the bottom
--->
 ### Environment
 <!-- Tell us about the environment -->
  - Operating system: 
@@ -35,15 +29,3 @@ If this is a bug report, use the following part of the the template and delete t
 
 ### Other information
 <!-- if you already did more digging into the issue, please provide all the information you gathered -->
-
-
-
-
-<!--
-Use the part below to file a feature request and delete the bug report part above.
--->
-### Usecase
-<!-- Tell what you're trying to achieve, without describing _what_ the requested feature should do -->
-
-### Description
-<!-- Describe as extensively as possible what you want the software to do -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+<!-- Hi! Thanks for filing an issue. It will be read with care by human beings. Can we ask you to please fill out this template and not simply demand new features or send in complaints? Thanks! -->
+<!-- Also please search the existing issues (both open and closed) to see if your report might be duplicate -->
+<!-- Please don't file an issue when you have a support question, send support questions to the mailinglist or ask them on IRC (https://www.powerdns.com/opensource.html) -->
+
+<!-- Tell us what is issue is about -->
+ - Program: Authoritative, Recursor, dnsdist <!-- delete the ones that do not apply -->
+ - Issue type: Feature request
+
+### Short description
+<!-- Explain in a few sentences what the issue/request is -->
+
+### Usecase
+<!-- Tell what you're trying to achieve, without describing _what_ the requested feature should do -->
+
+### Description
+<!-- Describe as extensively as possible what you want the software to do -->


### PR DESCRIPTION
### Short description
This should give users a nice chooser page instead of requiring them to extensively strip the template.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
