### PR TITLE
dnsdist: Add more leeway in the health checks tests

### DIFF
--- a/regression-tests.dnsdist/test_HealthChecks.py
+++ b/regression-tests.dnsdist/test_HealthChecks.py
@@ -27,7 +27,7 @@ class TestDefaultHealthCheck(HealthCheckTest):
         HealthChecks: Default
         """
         before = TestDefaultHealthCheck._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertGreater(TestDefaultHealthCheck._healthCheckCounter, before)
         self.assertEquals(self.getBackendStatus(), 'up')
 
@@ -35,14 +35,14 @@ class TestDefaultHealthCheck(HealthCheckTest):
         self.assertEquals(self.getBackendStatus(), 'up')
 
         before = TestDefaultHealthCheck._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertEquals(TestDefaultHealthCheck._healthCheckCounter, before)
 
         self.sendConsoleCommand("getServer(0):setDown()")
         self.assertEquals(self.getBackendStatus(), 'down')
 
         before = TestDefaultHealthCheck._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertEquals(TestDefaultHealthCheck._healthCheckCounter, before)
 
         self.sendConsoleCommand("getServer(0):setAuto()")
@@ -50,7 +50,7 @@ class TestDefaultHealthCheck(HealthCheckTest):
         self.assertEquals(self.getBackendStatus(), 'up')
 
         before = TestDefaultHealthCheck._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertGreater(TestDefaultHealthCheck._healthCheckCounter, before)
         self.assertEquals(self.getBackendStatus(), 'up')
 
@@ -59,7 +59,7 @@ class TestDefaultHealthCheck(HealthCheckTest):
         self.sendConsoleCommand("getServer(0):setAuto(false)")
 
         before = TestDefaultHealthCheck._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertGreater(TestDefaultHealthCheck._healthCheckCounter, before)
         self.assertEquals(self.getBackendStatus(), 'up')
 
@@ -80,7 +80,7 @@ class TestHealthCheckForcedUP(HealthCheckTest):
         HealthChecks: Forced UP
         """
         before = TestHealthCheckForcedUP._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertEquals(TestHealthCheckForcedUP._healthCheckCounter, before)
         self.assertEquals(self.getBackendStatus(), 'up')
 
@@ -101,7 +101,7 @@ class TestHealthCheckForcedDown(HealthCheckTest):
         HealthChecks: Forced Down
         """
         before = TestHealthCheckForcedDown._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertEquals(TestHealthCheckForcedDown._healthCheckCounter, before)
 
 class TestHealthCheckCustomName(HealthCheckTest):
@@ -122,7 +122,7 @@ class TestHealthCheckCustomName(HealthCheckTest):
         HealthChecks: Custom name
         """
         before = TestHealthCheckCustomName._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertGreater(TestHealthCheckCustomName._healthCheckCounter, before)
         self.assertEquals(self.getBackendStatus(), 'up')
 
@@ -143,7 +143,7 @@ class TestHealthCheckCustomNameNoAnswer(HealthCheckTest):
         HealthChecks: Custom name not expected by the responder
         """
         before = TestHealthCheckCustomNameNoAnswer._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertEquals(TestHealthCheckCustomNameNoAnswer._healthCheckCounter, before)
         self.assertEquals(self.getBackendStatus(), 'down')
 
@@ -172,6 +172,6 @@ class TestHealthCheckCustomFunction(HealthCheckTest):
         HealthChecks: Custom function
         """
         before = TestHealthCheckCustomFunction._healthCheckCounter
-        time.sleep(1)
+        time.sleep(1.5)
         self.assertGreater(TestHealthCheckCustomFunction._healthCheckCounter, before)
         self.assertEquals(self.getBackendStatus(), 'up')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We have recurrent failures in CircleCI, likely caused by the fact that the next health check test has not completed yet, so be a bit more permissive about that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
