### PR TITLE
dnsdist: Make KVS lookup text read better

### DIFF
--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -99,7 +99,7 @@ public:
   std::string toString() const override
   {
     if (d_minLabels > 0) {
-      return "suffix " + std::string(d_wireFormat ? "in wire format " : "") + "at least " + std::to_string(d_minLabels) + " labels)";
+      return "suffix " + std::string(d_wireFormat ? "in wire format " : "") + "with at least " + std::to_string(d_minLabels) + " label(s)";
     }
     return "suffix" + std::string(d_wireFormat ? " in wire format" : "");
   }


### PR DESCRIPTION
### Short description

Fixes a funny looking message:
```
lookup key-value store based on 'suffix at least 2 labels)' and set the result in tag [...]
```

to:

```
lookup key-value store based on 'suffix with at least 2 label(s)' and set the result in tag [...]
```


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
