### PR TITLE
circleci coverity target: fix cwd for dnsdist and rec when uploading tarballs 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1122,6 +1122,7 @@ jobs:
           working_directory: /opt/project/pdns/dnsdistdist
       - run:
           name: Upload tarball to coverity
+          working_directory: /opt/project/
           command: |
             curl --form token=${COVERITY_TOKEN} \
             --form email="${COVERITY_EMAIL}" \
@@ -1192,6 +1193,7 @@ jobs:
           working_directory: /opt/project/pdns/recursordist
       - run:
           name: Upload tarball to coverity
+          working_directory: /opt/project/
           command: |
             curl --form token=${COVERITY_TOKEN} \
             --form email="${COVERITY_EMAIL}" \


### PR DESCRIPTION
so ./builder-support is accessible.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Currently dnsdist and rec coverity targets fails because of wrong working dir.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
