### PR TITLE
pipebackend coprocess: initialise d_pid

### DIFF
--- a/modules/pipebackend/coprocess.cc
+++ b/modules/pipebackend/coprocess.cc
@@ -50,6 +50,7 @@ CoProcess::CoProcess(const string &command,int timeout, int infd, int outfd): d_
   for (size_t n = 0; n < d_params.size(); n++) {
     d_argv[n]=d_params[n].c_str();
   }
+  d_pid = 0;
 }
 
 void CoProcess::launch()
@@ -103,9 +104,11 @@ void CoProcess::launch()
 CoProcess::~CoProcess()
 {
   int status;
-  if(!waitpid(d_pid, &status, WNOHANG)) {
-    kill(d_pid, 9);
-    waitpid(d_pid, &status, 0);
+  if(d_pid){
+    if(!waitpid(d_pid, &status, WNOHANG)) {
+      kill(d_pid, 9);
+      waitpid(d_pid, &status, 0);
+    }
   }
   
   close(d_fd1[1]);


### PR DESCRIPTION
### Short description
This closes a Coverity report 'Non-static class member "d_pid" is not initialized in this constructor nor in any functions that it calls.' and would also avoid us killing the wrong thing when we happen to `exit()` between instantiation and launch of a CoProcess.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
