### PR TITLE
auth: Switch pdns:root to root:pdns in postinst files

### DIFF
--- a/builder-support/debian/authoritative/debian-buster/pdns-server.postinst
+++ b/builder-support/debian/authoritative/debian-buster/pdns-server.postinst
@@ -20,7 +20,7 @@ case "$1" in
       echo -n "Creating user and group pdns..."
       adduser --quiet --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
       echo "done"
-      chown pdns:root /etc/powerdns/pdns.conf
+      chown root:pdns /etc/powerdns/pdns.conf
     fi
     chown pdns:pdns /var/lib/powerdns || :
   ;;

--- a/builder-support/debian/authoritative/debian-buster/rules
+++ b/builder-support/debian/authoritative/debian-buster/rules
@@ -76,8 +76,8 @@ endif
 
 override_dh_fixperms:
 	dh_fixperms
-	# these files often contain passwords. 660 as it is chowned to root:pdns
-	chmod 0660 debian/pdns-server/etc/powerdns/pdns.conf
+	# these files often contain passwords. 640 as it is chowned to root:pdns
+	chmod 0640 debian/pdns-server/etc/powerdns/pdns.conf
 
 # restore moved files
 override_dh_clean:

--- a/builder-support/debian/authoritative/debian-jessie/pdns-server.postinst
+++ b/builder-support/debian/authoritative/debian-jessie/pdns-server.postinst
@@ -20,7 +20,7 @@ case "$1" in
       echo -n "Creating user and group pdns..."
       adduser --quiet --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
       echo "done"
-      chown pdns:root /etc/powerdns/pdns.conf
+      chown root:pdns /etc/powerdns/pdns.conf
     fi
     chown pdns:pdns /var/lib/powerdns || :
   ;;

--- a/builder-support/debian/authoritative/debian-jessie/rules
+++ b/builder-support/debian/authoritative/debian-jessie/rules
@@ -75,8 +75,8 @@ override_dh_auto_build-arch:
 
 override_dh_fixperms:
 	dh_fixperms
-	# these files often contain passwords. 660 as it is chowned to root:pdns
-	chmod 0660 debian/pdns-server/etc/powerdns/pdns.conf
+	# these files often contain passwords. 640 as it is chowned to root:pdns
+	chmod 0640 debian/pdns-server/etc/powerdns/pdns.conf
 
 # restore moved files
 override_dh_clean:

--- a/builder-support/debian/authoritative/debian-stretch/pdns-server.postinst
+++ b/builder-support/debian/authoritative/debian-stretch/pdns-server.postinst
@@ -20,7 +20,7 @@ case "$1" in
       echo -n "Creating user and group pdns..."
       adduser --quiet --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
       echo "done"
-      chown pdns:root /etc/powerdns/pdns.conf
+      chown root:pdns /etc/powerdns/pdns.conf
     fi
     chown pdns:pdns /var/lib/powerdns || :
   ;;

--- a/builder-support/debian/authoritative/debian-stretch/rules
+++ b/builder-support/debian/authoritative/debian-stretch/rules
@@ -70,8 +70,8 @@ override_dh_auto_test:
 
 override_dh_fixperms:
 	dh_fixperms
-	# these files often contain passwords. 660 as it is chowned to root:pdns
-	chmod 0660 debian/pdns-server/etc/powerdns/pdns.conf
+	# these files often contain passwords. 640 as it is chowned to root:pdns
+	chmod 0640 debian/pdns-server/etc/powerdns/pdns.conf
 
 # restore moved files
 override_dh_clean:


### PR DESCRIPTION
### Short description
The `rules` file comments say `pdns.conf` is owned by `root:pdns`, but the actual ownership is `pdns:root`.

This PR switches the `chown` command to use `root:pdns` instead.

Depending on which one was actually intended, one of #8329 and #8330 should be merged and the other should be closed.

See e.g.:

https://github.com/PowerDNS/pdns/blob/9de6bc5acffd1ddf9de686f86c9ebcd36b35cf6e/builder-support/debian/authoritative/debian-buster/pdns-server.postinst#L23
https://github.com/PowerDNS/pdns/blob/9de6bc5acffd1ddf9de686f86c9ebcd36b35cf6e/builder-support/debian/authoritative/debian-buster/rules#L79

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)