### PR TITLE
auth: Fix comment about user & group in Debian rules files

### DIFF
--- a/builder-support/debian/authoritative/debian-buster/rules
+++ b/builder-support/debian/authoritative/debian-buster/rules
@@ -76,7 +76,7 @@ endif
 
 override_dh_fixperms:
 	dh_fixperms
-	# these files often contain passwords. 660 as it is chowned to root:pdns
+	# these files often contain passwords. 660 as it is chowned to pdns:root
 	chmod 0660 debian/pdns-server/etc/powerdns/pdns.conf
 
 # restore moved files

--- a/builder-support/debian/authoritative/debian-jessie/rules
+++ b/builder-support/debian/authoritative/debian-jessie/rules
@@ -75,7 +75,7 @@ override_dh_auto_build-arch:
 
 override_dh_fixperms:
 	dh_fixperms
-	# these files often contain passwords. 660 as it is chowned to root:pdns
+	# these files often contain passwords. 660 as it is chowned to pdns:root
 	chmod 0660 debian/pdns-server/etc/powerdns/pdns.conf
 
 # restore moved files

--- a/builder-support/debian/authoritative/debian-stretch/rules
+++ b/builder-support/debian/authoritative/debian-stretch/rules
@@ -70,7 +70,7 @@ override_dh_auto_test:
 
 override_dh_fixperms:
 	dh_fixperms
-	# these files often contain passwords. 660 as it is chowned to root:pdns
+	# these files often contain passwords. 660 as it is chowned to pdns:root
 	chmod 0660 debian/pdns-server/etc/powerdns/pdns.conf
 
 # restore moved files


### PR DESCRIPTION
### Short description
`pdns.conf` is owned by `pdns:root`, but the comments says it's `root:pdns`.

This PR changes the comment to be consistent with the actual ownership.

Depending on which one was actually intended, one of #8329 and #8330 should be merged and the other should be closed.

See e.g.:

https://github.com/PowerDNS/pdns/blob/9de6bc5acffd1ddf9de686f86c9ebcd36b35cf6e/builder-support/debian/authoritative/debian-buster/pdns-server.postinst#L23
https://github.com/PowerDNS/pdns/blob/9de6bc5acffd1ddf9de686f86c9ebcd36b35cf6e/builder-support/debian/authoritative/debian-buster/rules#L79

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)