### PR TITLE
backport to rec -4.2.x: Remove version number in man page footer

### DIFF
--- a/pdns/recursordist/docs/conf.py
+++ b/pdns/recursordist/docs/conf.py
@@ -59,7 +59,7 @@ author = 'PowerDNS.COM BV'
 # built documents.
 #
 # The short X.Y version.
-version = '4.1'
+#version = '4.1'
 # The full version, including alpha/beta/rc tags.
 #release = '4.1.0-alpha1'
 


### PR DESCRIPTION
(cherry picked from commit 760d679c2a3566dac8001115db95762344cdcbd5)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Man pages/docs now contain 4.1.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
