### PR TITLE
Fix #8338: Issue with "zz" abbreviation for IPv6 RPZ triggers

### DIFF
--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -253,6 +253,8 @@ testrunner_SOURCES = \
 	recpacketcache.cc recpacketcache.hh \
 	recursor_cache.cc recursor_cache.hh \
 	responsestats.cc \
+	rpzloader.cc rpzloader.hh \
+	resolver.hh resolver.cc \
 	root-dnssec.hh \
 	secpoll.cc \
 	sillyrecords.cc \
@@ -281,6 +283,7 @@ testrunner_SOURCES = \
 	test-rcpgenerator_cc.cc \
 	test-recpacketcache_cc.cc \
 	test-recursorcache_cc.cc \
+	test-rpzloader_cc.cc \
 	test-secpoll_cc.cc \
 	test-signers.cc \
 	test-syncres_cc.hh \

--- a/pdns/recursordist/test-rpzloader_cc.cc
+++ b/pdns/recursordist/test-rpzloader_cc.cc
@@ -1,0 +1,42 @@
+#define BOOST_TEST_RPZ_LOADER
+#define BOOST_TEST_RPZ_LOADER
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "rpzloader.hh"
+#include <boost/test/unit_test.hpp>
+
+// Provide stubs for some symbols
+bool g_logRPZChanges{false};
+ComboAddress getQueryLocalAddress(int family, uint16_t port) {
+  cerr << "getQueryLocalAddress() STUBBED IN TEST!" << endl;
+  BOOST_ASSERT(false);
+  return ComboAddress();
+}
+
+BOOST_AUTO_TEST_SUITE(rpzloader_cc)
+
+BOOST_AUTO_TEST_CASE(test_rpz_loader) {
+
+  string tests[][2] = {
+      {"32.3.2.168.192", "192.168.2.3/32"},
+      {"27.73.2.168.192", "192.168.2.73/27"},
+      {"24.0.2.168.192", "192.168.2.0/24"},
+      {"128.57.zz.1.0.db8.2001", "2001:db8:0:1::57/128"},
+      {"48.zz.1.0.db8.2001", "2001:db8:0:1::/48"},
+      {"128.5.C0A8.FFFF.0.1.0.db8.2001", "2001:db8:0:1:0:ffff:c0a8:5/128"},
+
+      {"21.0.248.44.5", "5.44.248.0/21"},
+      {"64.0.0.0.0.0.1.0.0.", "0:0:1::/64"},
+      {"64.zz.2.0.0", "0:0:2::/64"},
+      {"80.0.0.0.1.0.0.0.0", "::1:0:0:0/80"},
+      {"80.0.0.0.1.zz", "::1:0:0:0/80"}};
+
+  for (auto &test : tests) {
+    Netmask n = makeNetmaskFromRPZ(DNSName(test[0]));
+    BOOST_CHECK_EQUAL(n.toString(), test[1]);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -9,7 +9,7 @@
 #include "zoneparser-tng.hh"
 #include "threadname.hh"
 
-static Netmask makeNetmaskFromRPZ(const DNSName& name)
+Netmask makeNetmaskFromRPZ(const DNSName& name)
 {
   auto parts = name.getRawLabels();
   /*
@@ -46,14 +46,14 @@ static Netmask makeNetmaskFromRPZ(const DNSName& name)
 
   string v6;
 
+  if (parts[parts.size()-1] == "") {
+    v6 += ":";
+  }
   for (uint8_t i = parts.size()-1 ; i > 0; i--) {
     v6 += parts[i];
-    if (parts[i] == "" && i == 1 && i == parts.size()-1)
-        v6+= "::";
-    if (parts[i] == "" && i != parts.size()-1)
-        v6+= ":";
-    if (parts[i] != "" && i != 1)
+    if (i > 1 || (i == 1 && parts[i] == "")) {
       v6 += ":";
+    }
   }
   v6 += "/" + parts[0];
 

--- a/pdns/rpzloader.hh
+++ b/pdns/rpzloader.hh
@@ -39,4 +39,5 @@ struct rpzStats
   std::atomic<uint32_t> d_serial;
 };
 
+Netmask makeNetmaskFromRPZ(const DNSName& name);
 shared_ptr<rpzStats> getRPZZoneStats(const std::string& zone);


### PR DESCRIPTION
While there, add unittest for translating rpz names into netmasks

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixes issue #8338 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
