### PR TITLE
Add signal handling for SIGTERM and SIGINT in pdns_recursor, if we are PID1

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2786,6 +2786,11 @@ static void daemonize(void)
   }
 }
 
+static void termIntHandler(int)
+{
+  doExitNicely();
+}
+
 static void usr1Handler(int)
 {
   statsWanted=true;
@@ -4075,6 +4080,8 @@ static int serviceMain(int argc, char*argv[])
     g_log.toConsole(Logger::Critical);
     daemonize();
   }
+  signal(SIGTERM,termIntHandler);
+  signal(SIGINT,termIntHandler);
   signal(SIGUSR1,usr1Handler);
   signal(SIGUSR2,usr2Handler);
   signal(SIGPIPE,SIG_IGN);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4081,7 +4081,19 @@ static int serviceMain(int argc, char*argv[])
     daemonize();
   }
   if(Utility::getpid() == 1) {
-    /* We are running as pid 1, register sigterm and sigint handler */
+    /* We are running as pid 1, register sigterm and sigint handler
+     
+      The Linux kernel will handle SIGTERM and SIGINT for all processes, except PID 1.
+      It assumes that the processes running as pid 1 is an "init" like system.
+      For years, this was a safe assumption, but containers change that: in
+      most (all?) container implementations, the application itself is running
+      as pid 1. This means that sending signals to those applications, will not
+      be handled by default. Results might be "you container not responsing
+      when asking it to stop", or "ctrl-c" not working even when the app is
+      running in the foreground inside a container.
+
+      So TL;DR: If we're running pid 1 (container), we should handle SIGTERM and SIGINT ourselves */
+
     signal(SIGTERM,termIntHandler);
     signal(SIGINT,termIntHandler);
   } 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2788,7 +2788,7 @@ static void daemonize(void)
 
 static void termIntHandler(int)
 {
-  doExitNicely();
+  doExit();
 }
 
 static void usr1Handler(int)
@@ -4080,8 +4080,12 @@ static int serviceMain(int argc, char*argv[])
     g_log.toConsole(Logger::Critical);
     daemonize();
   }
-  signal(SIGTERM,termIntHandler);
-  signal(SIGINT,termIntHandler);
+  if(Utility::getpid() == 1) {
+    /* We are running as pid 1, register sigterm and sigint handler */
+    signal(SIGTERM,termIntHandler);
+    signal(SIGINT,termIntHandler);
+  } 
+
   signal(SIGUSR1,usr1Handler);
   signal(SIGUSR2,usr2Handler);
   signal(SIGPIPE,SIG_IGN);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4088,9 +4088,9 @@ static int serviceMain(int argc, char*argv[])
       For years, this was a safe assumption, but containers change that: in
       most (all?) container implementations, the application itself is running
       as pid 1. This means that sending signals to those applications, will not
-      be handled by default. Results might be "you container not responsing
-      when asking it to stop", or "ctrl-c" not working even when the app is
-      running in the foreground inside a container.
+      be handled by default. Results might be "your container not responsing
+      when asking it to stop", or "ctrl-c not working even when the app is
+      running in the foreground inside a container".
 
       So TL;DR: If we're running pid 1 (container), we should handle SIGTERM and SIGINT ourselves */
 

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -89,3 +89,6 @@ void blacklistStats(StatComponent component, const string& stats);
 
 void registerAllStats();
 
+void doExitGeneric(bool nicely);
+void doExit();
+void doExitNicely();

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1161,7 +1161,7 @@ void registerAllStats()
   }
 }
 
-static void doExitGeneric(bool nicely)
+void doExitGeneric(bool nicely)
 {
   g_log<<Logger::Error<<"Exiting on user request"<<endl;
   extern RecursorControlChannel s_rcc;
@@ -1176,12 +1176,12 @@ static void doExitGeneric(bool nicely)
     _exit(1);
 }
 
-static void doExit()
+void doExit()
 {
   doExitGeneric(false);
 }
 
-static void doExitNicely()
+void doExitNicely()
 {
   doExitGeneric(true);
 }


### PR DESCRIPTION
### Short description
The Linux kernel handles signals for PID 1 processes differently. It
doesn't implement a default handler for some signals such as
SIGTERM/SIGINT.

When running pdns_recursor as a container, this causes a few annoyances.
You can work around those by running your containers with --init or by
installing `tini` inside the container. Or you can handle the signals in
the application itself.

This commit adds signal() handlers for SIGTERM and SIGINT for
pdns_recursor, if we are running as PID 1.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
