### PR TITLE
Add script to format code, 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,3 +14,7 @@ EXTRA_DIST = \
 ACLOCAL_AMFLAGS = -I m4
 
 dvi: # do nothing to build dvi
+
+format-code:
+	./build-scripts/format-code `find modules pdns -type f -name '*.[ch][ch]'`
+

--- a/build-scripts/format-code
+++ b/build-scripts/format-code
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+#
+# Reformat code, but do not touch if no changes.
+# Report if a files was changed.
+#
+
+if [ "$0" != "./build-scripts/format-code" ]; then
+    echo "Please run me from the root checkout dir"
+    exit 1
+fi
+
+if [ ! -e .clang-format ]; then
+    echo "No .clang-format file found in .";
+    exit 1
+fi
+
+for file in "${@}"; do
+    if ! clang-format -style=file "$file" > "$file.xxx"; then
+        rm "$file.xxx"
+    else
+        if ! cmp -s "$file" "$file.xxx"; then
+            echo "$file reformatted"
+            mv "$file.xxx" "$file"
+        else
+            rm "$file.xxx"
+        fi
+    fi
+done
+

--- a/build-scripts/format-code
+++ b/build-scripts/format-code
@@ -25,7 +25,7 @@ for file in "${@}"; do
         echo "$file: skipped, not a regular file or unreadable"
         continue
     fi
-    tmp=$(mktemp $file.XXXXXXXX)
+    tmp=$(mktemp "$file.XXXXXXXX")
     if ! clang-format -style=file "$file" > "$tmp"; then
         rm "$tmp"
     else

--- a/build-scripts/format-code
+++ b/build-scripts/format-code
@@ -2,28 +2,39 @@
 
 #
 # Reformat code, but do not touch if no changes.
-# Report if a files was changed.
 #
 
-if [ "$0" != "./build-scripts/format-code" ]; then
+if [ "$0" != "./build-scripts/format-code" -a "$0" != "build-scripts/format-code" ]; then
     echo "Please run me from the root checkout dir"
     exit 1
 fi
 
+if [ $# = 0 ]; then
+    echo usage: $0 file...
+    echo
+    echo format C++ files, does not touch non-regular files
+    exit 0
+fi
 if [ ! -e .clang-format ]; then
     echo "No .clang-format file found in .";
     exit 1
 fi
 
 for file in "${@}"; do
-    if ! clang-format -style=file "$file" > "$file.xxx"; then
-        rm "$file.xxx"
+    if [ -h "$file" -o ! -f "$file" ]; then
+        echo "$file: skipped, not a regular file or unreadable"
+        continue
+    fi
+    tmp=$(mktemp $file.XXXXXXXX)
+    if ! clang-format -style=file "$file" > "$tmp"; then
+        rm "$tmp"
     else
-        if ! cmp -s "$file" "$file.xxx"; then
-            echo "$file reformatted"
-            mv "$file.xxx" "$file"
+        if ! cmp -s "$file" "$tmp"; then
+            echo "$file: reformatted"
+            mv "$tmp" "$file"
         else
-            rm "$file.xxx"
+            echo "$file: already formatted to perfection"
+            rm "$tmp"
         fi
     fi
 done


### PR DESCRIPTION
Leaving the file untouched if not changed and report if it was changed.

Callable as separate script or with `make format-code` in toplevel
to reformat .cc and .hh files in the modules and pdns dirs.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
