### PR TITLE
bind backend: pthread_mutex_t should be inited and destroyed and not be copied

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -80,6 +80,9 @@ pthread_mutex_t Bind2Backend::s_supermaster_config_lock=PTHREAD_MUTEX_INITIALIZE
 pthread_mutex_t Bind2Backend::s_startup_lock=PTHREAD_MUTEX_INITIALIZER;
 string Bind2Backend::s_binddirectory;  
 
+template <typename T>
+std::mutex LookButDontTouch<T>::s_lock;
+
 BB2DomainInfo::BB2DomainInfo()
 {
   d_loaded=false;

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -29,6 +29,7 @@
 #include <pthread.h>
 #include <time.h>
 #include <fstream>
+#include <mutex>
 #include <boost/utility.hpp>
 
 #include <boost/tuple/tuple.hpp>
@@ -103,22 +104,18 @@ template <typename T>
 class LookButDontTouch //  : public boost::noncopyable
 {
 public:
-  LookButDontTouch() 
+  LookButDontTouch()
   {
-    pthread_mutex_init(&d_lock, 0);
-    pthread_mutex_init(&d_swaplock, 0);
   }
   LookButDontTouch(shared_ptr<T> records) : d_records(records)
   {
-    pthread_mutex_init(&d_lock, 0);
-    pthread_mutex_init(&d_swaplock, 0);
   }
 
   shared_ptr<const T> get()
   {
     shared_ptr<const T> ret;
     {
-      Lock l(&d_lock);
+      std::lock_guard<std::mutex> lock(s_lock);
       ret = d_records;
     }
     return ret;
@@ -128,22 +125,14 @@ public:
   {
     shared_ptr<T> ret;
     {
-      Lock l(&d_lock);
+      std::lock_guard<std::mutex> lock(s_lock);
       ret = d_records;
     }
     return ret;
   }
 
-
-  void swap(shared_ptr<T> records)
-  {
-    Lock l(&d_lock);
-    Lock l2(&d_swaplock);
-    d_records.swap(records);
-  }
-  pthread_mutex_t d_lock;
-  pthread_mutex_t d_swaplock;
 private:
+  static std::mutex s_lock;
   shared_ptr<T> d_records;
 };
 


### PR DESCRIPTION

To make our live easier, use a native C++ mutex.
Fixes #8161

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
