### PR TITLE
auth statbag: move to std::mutex, avoid copies

### DIFF
--- a/pdns/statbag.cc
+++ b/pdns/statbag.cc
@@ -167,6 +167,16 @@ StatRing<T,Comp>::StatRing(unsigned int size)
 }
 
 template<typename T, typename Comp>
+StatRing<T,Comp>::StatRing(const StatRing<T,Comp> &arg)
+{
+  std::lock_guard<std::mutex> thislock(d_lock);
+  std::lock_guard<std::mutex> arglock(arg.d_lock);
+  
+  d_items = arg.d_items;
+  d_help = arg.d_help;
+}
+
+template<typename T, typename Comp>
 void StatRing<T,Comp>::account(const T& t)
 {
   std::lock_guard<std::mutex> l(d_lock);

--- a/pdns/statbag.cc
+++ b/pdns/statbag.cc
@@ -164,27 +164,26 @@ template<typename T, typename Comp>
 StatRing<T,Comp>::StatRing(unsigned int size)
 {
   d_items.set_capacity(size);
-  pthread_mutex_init(&d_lock, 0);
 }
 
 template<typename T, typename Comp>
 void StatRing<T,Comp>::account(const T& t)
 {
-  Lock l(&d_lock);
+  std::lock_guard<std::mutex> l(d_lock);
   d_items.push_back(t);
 }
 
 template<typename T, typename Comp>
 unsigned int StatRing<T,Comp>::getSize()
 {
-  Lock l(&d_lock);
+  std::lock_guard<std::mutex> l(d_lock);
   return d_items.capacity();
 }
 
 template<typename T, typename Comp>
 void StatRing<T,Comp>::resize(unsigned int newsize)
 {
-  Lock l(&d_lock);
+  std::lock_guard<std::mutex> l(d_lock);
   d_items.set_capacity(newsize);
 }
 
@@ -205,7 +204,7 @@ string StatRing<T,Comp>::getHelp()
 template<typename T, typename Comp>
 vector<pair<T, unsigned int> >StatRing<T,Comp>::get() const
 {
-  Lock l(&d_lock);
+  std::lock_guard<std::mutex> l(d_lock);
   map<T,unsigned int, Comp> res;
   for(typename boost::circular_buffer<T>::const_iterator i=d_items.begin();i!=d_items.end();++i) {
     res[*i]++;
@@ -222,19 +221,19 @@ vector<pair<T, unsigned int> >StatRing<T,Comp>::get() const
 
 void StatBag::declareRing(const string &name, const string &help, unsigned int size)
 {
-  d_rings[name]=StatRing<string, CIStringCompare>(size);
+  d_rings.emplace(name, size);
   d_rings[name].setHelp(help);
 }
 
 void StatBag::declareComboRing(const string &name, const string &help, unsigned int size)
 {
-  d_comborings[name]=StatRing<SComboAddress>(size);
+  d_comborings.emplace(name, size);
   d_comborings[name].setHelp(help);
 }
 
 void StatBag::declareDNSNameQTypeRing(const string &name, const string &help, unsigned int size)
 {
-  d_dnsnameqtyperings[name] = StatRing<std::tuple<DNSName, QType> >(size);
+  d_dnsnameqtyperings.emplace(name, size);
   d_dnsnameqtyperings[name].setHelp(help);
 }
 
@@ -264,7 +263,7 @@ vector<pair<string, unsigned int> > StatBag::getRing(const string &name)
 template<typename T, typename Comp>
 void StatRing<T,Comp>::reset()
 {
-  Lock l(&d_lock);
+  std::lock_guard<std::mutex> l(d_lock);
   d_items.clear();
 }
 

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -39,6 +39,9 @@ class StatRing
 {
 public:
   StatRing(unsigned int size=10000);
+  // Some older C++ libs have trouble emplacing without a copy-contructor, so provide one
+  StatRing(const StatRing &);
+  
   void account(const T &item);
 
   unsigned int getSize();

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -41,6 +41,7 @@ public:
   StatRing(unsigned int size=10000);
   // Some older C++ libs have trouble emplacing without a copy-contructor, so provide one
   StatRing(const StatRing &);
+  StatRing & operator=(const StatRing &) = delete;
   
   void account(const T &item);
 

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -23,6 +23,7 @@
 #define STATBAG_HH
 #include <pthread.h>
 #include <map>
+#include <mutex>
 #include <functional>
 #include <string>
 #include <vector>
@@ -54,7 +55,7 @@ private:
   }
 
   boost::circular_buffer<T> d_items;
-  mutable pthread_mutex_t d_lock;
+  mutable std::mutex d_lock;
   string d_help;
 };
 


### PR DESCRIPTION
### Short description
During the debugging of #8161, we discovered more moving around of mutexes. This fixes the other place we did that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
