### PR TITLE
Rework NetmaskTree for better CPU and memory efficiency.

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1087,8 +1087,8 @@ void setupLuaConfig(bool client, bool configCheck)
       boost::format fmt("%-24s %8d %8d %-10s %-20s %s\n");
       g_outputBuffer = (fmt % "What" % "Seconds" % "Blocks" % "Warning" % "Action" % "Reason").str();
       for(const auto& e: slow) {
-	if(now < e->second.until)
-	  g_outputBuffer+= (fmt % e->first.toString() % (e->second.until.tv_sec - now.tv_sec) % e->second.blocks % (e->second.warning ? "true" : "false") % DNSAction::typeToString(e->second.action != DNSAction::Action::None ? e->second.action : g_dynBlockAction) % e->second.reason).str();
+	if(now < e.second.until)
+	  g_outputBuffer+= (fmt % e.first.toString() % (e.second.until.tv_sec - now.tv_sec) % e.second.blocks % (e.second.warning ? "true" : "false") % DNSAction::typeToString(e.second.action != DNSAction::Action::None ? e.second.action : g_dynBlockAction) % e.second.reason).str();
       }
       auto slow2 = g_dynblockSMT.getCopy();
       slow2.visit([&now, &fmt](const SuffixMatchTree<DynBlock>& node) {

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -395,15 +395,15 @@ static void connectionThread(int sock, ComboAddress remote)
         struct timespec now;
         gettime(&now);
         for(const auto& e: *nmg) {
-          if(now < e->second.until ) {
+          if(now < e.second.until ) {
             Json::object thing{
-              {"reason", e->second.reason},
-              {"seconds", (double)(e->second.until.tv_sec - now.tv_sec)},
-              {"blocks", (double)e->second.blocks},
-              {"action", DNSAction::typeToString(e->second.action != DNSAction::Action::None ? e->second.action : g_dynBlockAction) },
-              {"warning", e->second.warning }
+              {"reason", e.second.reason},
+              {"seconds", (double)(e.second.until.tv_sec - now.tv_sec)},
+              {"blocks", (double)e.second.blocks},
+              {"action", DNSAction::typeToString(e.second.action != DNSAction::Action::None ? e.second.action : g_dynBlockAction) },
+              {"warning", e.second.warning }
             };
-            obj.insert({e->first.toString(), thing});
+            obj.insert({e.first.toString(), thing});
           }
         }
 

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -619,14 +619,14 @@ void DNSFilterEngine::Zone::dump(FILE* fp) const
   }
 
   for (const auto pair : d_qpolAddr) {
-    dumpAddrPolicy(fp, pair->first, DNSName("rpz-client-ip.") + d_domain, pair->second);
+    dumpAddrPolicy(fp, pair.first, DNSName("rpz-client-ip.") + d_domain, pair.second);
   }
 
   for (const auto pair : d_propolNSAddr) {
-    dumpAddrPolicy(fp, pair->first, DNSName("rpz-nsip.") + d_domain, pair->second);
+    dumpAddrPolicy(fp, pair.first, DNSName("rpz-nsip.") + d_domain, pair.second);
   }
 
   for (const auto pair : d_postpolAddr) {
-    dumpAddrPolicy(fp, pair->first, DNSName("rpz-ip.") + d_domain, pair->second);
+    dumpAddrPolicy(fp, pair.first, DNSName("rpz-ip.") + d_domain, pair.second);
   }
 }

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -596,6 +596,28 @@ public:
   {
     return d_network.getBits();
   }
+
+  /** Get the value of the bit at the provided bit index. When the index >= 0,
+      the index is relative to the LSB starting at index zero. When the index < 0,
+      the index is relative to the MSB starting at index -1 and counting down.
+      When the index points outside the network bits, it always yields zero.
+   */
+  bool getBit(int bit) const
+  {
+    if (bit < -d_bits)
+      return false;
+    if (bit >= 0) {
+      if(isIPv4()) {
+        if (bit >= 32 || bit < (32 - d_bits))
+          return false;
+      }
+      if(isIPv6()) {
+        if (bit >= 128 || bit < (128 - d_bits))
+          return false;
+      }
+    }
+    return d_network.getBit(bit);
+  }
 private:
   ComboAddress d_network;
   uint32_t d_mask;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -790,13 +790,10 @@ private:
   }
 
 public:
-  NetmaskTree() noexcept : NetmaskTree(false) {
+  NetmaskTree() noexcept : d_root(new TreeNode()) {
   }
 
-  NetmaskTree(bool cleanup) noexcept : d_root(new TreeNode()), d_cleanup_tree(cleanup) {
-  }
-
-  NetmaskTree(const NetmaskTree& rhs): d_root(new TreeNode()), d_cleanup_tree(rhs.d_cleanup_tree) {
+  NetmaskTree(const NetmaskTree& rhs): d_root(new TreeNode()) {
     // it is easier to copy the nodes than tree.
     // also acts as handy compactor
     for(auto const& node: rhs._nodes)
@@ -808,7 +805,6 @@ public:
     // see above.
     for(auto const& node: rhs._nodes)
       insert(node->first).second = node->second;
-    d_cleanup_tree = rhs.d_cleanup_tree;
     return *this;
   }
 
@@ -1031,9 +1027,7 @@ public:
       _nodes.erase(node->node.get());
       node->assigned = false;
       node->node->second = value_type();
-
-      if (d_cleanup_tree)
-        cleanup_tree(node);
+      cleanup_tree(node);
     }
   }
 
@@ -1075,7 +1069,6 @@ public:
 private:
   unique_ptr<TreeNode> d_root; //<! Root of our tree
   std::set<node_type*> _nodes; //<! Container for actual values
-  bool d_cleanup_tree; //<! Whether or not to cleanup the tree on erase
 };
 
 /** This class represents a group of supplemental Netmask classes. An IP address matchs
@@ -1084,12 +1077,7 @@ private:
 class NetmaskGroup
 {
 public:
-  //! By default, initialise the tree to cleanup
-  NetmaskGroup() noexcept : NetmaskGroup(true) {
-  }
-
-  //! This allows control over whether to cleanup or not
-  NetmaskGroup(bool cleanup) noexcept : tree(cleanup) {
+  NetmaskGroup() noexcept {
   }
 
   //! If this IP address is matched by any of the classes within

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -650,7 +650,7 @@ public:
 
   typedef Netmask key_type;
   typedef T value_type;
-  typedef std::pair<key_type,value_type> node_type;
+  typedef std::pair<const key_type,value_type> node_type;
   typedef size_t size_type;
   typedef class Iterator iterator;
 

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -111,12 +111,12 @@ union ComboAddress {
   {
     if(sin4.sin_family == 0) {
       return false;
-    } 
+    }
     if(boost::tie(sin4.sin_family, sin4.sin_port) < boost::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
       return true;
     if(boost::tie(sin4.sin_family, sin4.sin_port) > boost::tie(rhs.sin4.sin_family, rhs.sin4.sin_port))
       return false;
-    
+
     if(sin4.sin_family == AF_INET)
       return sin4.sin_addr.s_addr < rhs.sin4.sin_addr.s_addr;
     else
@@ -130,8 +130,8 @@ union ComboAddress {
 
   struct addressOnlyHash
   {
-    uint32_t operator()(const ComboAddress& ca) const 
-    { 
+    uint32_t operator()(const ComboAddress& ca) const
+    {
       const unsigned char* start;
       int len;
       if(ca.sin4.sin_family == AF_INET) {
@@ -182,8 +182,8 @@ union ComboAddress {
     else
       return sizeof(sin6);
   }
-  
-  ComboAddress() 
+
+  ComboAddress()
   {
     sin4.sin_family=AF_INET;
     sin4.sin_addr.s_addr=0;
@@ -218,8 +218,8 @@ union ComboAddress {
     if(makeIPv4sockaddr(str, &sin4)) {
       sin6.sin6_family = AF_INET6;
       if(makeIPv6sockaddr(str, &sin6) < 0)
-        throw PDNSException("Unable to convert presentation address '"+ str +"'"); 
-      
+        throw PDNSException("Unable to convert presentation address '"+ str +"'");
+
     }
     if(!sin4.sin_port) // 'str' overrides port!
       sin4.sin_port=htons(port);
@@ -238,20 +238,20 @@ union ComboAddress {
   {
     if(sin4.sin_family!=AF_INET6)
       return false;
-    
+
     int n=0;
     const unsigned char*ptr = (unsigned char*) &sin6.sin6_addr.s6_addr;
     for(n=0; n < 10; ++n)
       if(ptr[n])
         return false;
-    
+
     for(; n < 12; ++n)
       if(ptr[n]!=0xff)
         return false;
-    
+
     return true;
   }
-  
+
   ComboAddress mapToIPv4() const
   {
     if(!isMappedIPv4())
@@ -259,7 +259,7 @@ union ComboAddress {
     ComboAddress ret;
     ret.sin4.sin_family=AF_INET;
     ret.sin4.sin_port=sin4.sin_port;
-    
+
     const unsigned char*ptr = (unsigned char*) &sin6.sin6_addr.s6_addr;
     ptr+=(sizeof(sin6.sin6_addr.s6_addr) - sizeof(ret.sin4.sin_addr.s_addr));
     memcpy(&ret.sin4.sin_addr.s_addr, ptr, sizeof(ret.sin4.sin_addr.s_addr));
@@ -320,7 +320,7 @@ union ComboAddress {
 };
 
 /** This exception is thrown by the Netmask class and by extension by the NetmaskGroup class */
-class NetmaskException: public PDNSException 
+class NetmaskException: public PDNSException
 {
 public:
   NetmaskException(const string &a) : PDNSException(a) {}
@@ -333,7 +333,7 @@ inline ComboAddress makeComboAddress(const string& str)
   if(inet_pton(AF_INET, str.c_str(), &address.sin4.sin_addr) <= 0) {
     address.sin4.sin_family=AF_INET6;
     if(makeIPv6sockaddr(str, &address.sin6) < 0)
-      throw NetmaskException("Unable to convert '"+str+"' to a netmask");        
+      throw NetmaskException("Unable to convert '"+str+"' to a netmask");
   }
   return address;
 }
@@ -369,31 +369,31 @@ class Netmask
 public:
   Netmask()
   {
-	d_network.sin4.sin_family=0; // disable this doing anything useful
-	d_network.sin4.sin_port = 0; // this guarantees d_network compares identical
-	d_mask=0;
-	d_bits=0;
+    d_network.sin4.sin_family=0; // disable this doing anything useful
+    d_network.sin4.sin_port = 0; // this guarantees d_network compares identical
+    d_mask=0;
+    d_bits=0;
   }
-  
+
   Netmask(const ComboAddress& network, uint8_t bits=0xff): d_network(network)
   {
     d_network.sin4.sin_port=0;
     if(bits > 128)
       bits = (network.sin4.sin_family == AF_INET) ? 32 : 128;
-    
+
     d_bits = bits;
     if(d_bits<32)
       d_mask=~(0xFFFFFFFF>>d_bits);
     else
       d_mask=0xFFFFFFFF; // not actually used for IPv6
   }
-  
-  //! Constructor supplies the mask, which cannot be changed 
-  Netmask(const string &mask) 
+
+  //! Constructor supplies the mask, which cannot be changed
+  Netmask(const string &mask)
   {
     pair<string,string> split=splitField(mask,'/');
     d_network=makeComboAddress(split.first);
-    
+
     if(!split.second.empty()) {
       d_bits = (uint8_t)pdns_stou(split.second);
       if(d_bits<32)
@@ -429,7 +429,7 @@ public:
       uint8_t bytes=d_bits/8, n;
       const uint8_t *us=(const uint8_t*) &d_network.sin6.sin6_addr.s6_addr;
       const uint8_t *them=(const uint8_t*) &ip->sin6.sin6_addr.s6_addr;
-      
+
       for(n=0; n < bytes; ++n) {
         if(us[n]!=them[n]) {
           return false;
@@ -506,7 +506,7 @@ public:
     return d_network.sin4.sin_family == AF_INET;
   }
 
-  bool operator<(const Netmask& rhs) const 
+  bool operator<(const Netmask& rhs) const
   {
     if (empty() && !rhs.empty())
       return false;
@@ -527,12 +527,12 @@ public:
     return rhs.operator<(*this);
   }
 
-  bool operator==(const Netmask& rhs) const 
+  bool operator==(const Netmask& rhs) const
   {
     return tie(d_network, d_bits) == tie(rhs.d_network, rhs.d_bits);
   }
 
-  bool empty() const 
+  bool empty() const
   {
     return d_network.sin4.sin_family==0;
   }
@@ -576,35 +576,35 @@ private:
     */
   class TreeNode : boost::noncopyable {
   public:
-     explicit TreeNode(int bits) noexcept : parent(NULL),d_bits(bits) {
-     }
+    explicit TreeNode(int bits) noexcept : parent(NULL),d_bits(bits) {
+    }
 
-     //<! Makes a left node with one more bit than parent
-     TreeNode* make_left() {
-       if (!left) {
-         left = unique_ptr<TreeNode>(new TreeNode(d_bits+1));
-         left->parent = this;
-       }
-       return left.get();
-     }
+    //<! Makes a left node with one more bit than parent
+    TreeNode* make_left() {
+      if (!left) {
+        left = unique_ptr<TreeNode>(new TreeNode(d_bits+1));
+        left->parent = this;
+      }
+      return left.get();
+    }
 
-     //<! Makes a right node with one more bit than parent
-     TreeNode* make_right() {
-       if (!right) {
-         right = unique_ptr<TreeNode>(new TreeNode(d_bits+1));
-         right->parent = this;
-       }
-       return right.get();
-     }
+    //<! Makes a right node with one more bit than parent
+    TreeNode* make_right() {
+      if (!right) {
+        right = unique_ptr<TreeNode>(new TreeNode(d_bits+1));
+        right->parent = this;
+      }
+      return right.get();
+    }
 
-     unique_ptr<TreeNode> left;
-     unique_ptr<TreeNode> right;
-     TreeNode* parent;
+    unique_ptr<TreeNode> left;
+    unique_ptr<TreeNode> right;
+    TreeNode* parent;
 
-     unique_ptr<node_type> node4; //<! IPv4 value-pair
-     unique_ptr<node_type> node6; //<! IPv6 value-pair
+    unique_ptr<node_type> node4; //<! IPv4 value-pair
+    unique_ptr<node_type> node6; //<! IPv6 value-pair
 
-     int d_bits; //<! How many bits have been used so far
+    int d_bits; //<! How many bits have been used so far
   };
 
 public:
@@ -783,12 +783,12 @@ public:
       TreeNode* pparent = node->parent;
       // delete this node
       if (pparent) {
-	if (pparent->left.get() == node)
-	  pparent->left.reset();
-	else
-	  pparent->right.reset();
-	// now recurse up to the parent
-	cleanup_tree(pparent);
+        if (pparent->left.get() == node)
+          pparent->left.reset();
+        else
+          pparent->right.reset();
+        // now recurse up to the parent
+        cleanup_tree(pparent);
       }
     }
   }
@@ -1009,7 +1009,6 @@ private:
   NetmaskTree<bool> tree;
 };
 
-
 struct SComboAddress
 {
   SComboAddress(const ComboAddress& orig) : ca(orig) {}
@@ -1049,7 +1048,7 @@ void setSocketIgnorePMTU(int sockfd);
 #if defined(IP_PKTINFO)
   #define GEN_IP_PKTINFO IP_PKTINFO
 #elif defined(IP_RECVDSTADDR)
-  #define GEN_IP_PKTINFO IP_RECVDSTADDR 
+  #define GEN_IP_PKTINFO IP_RECVDSTADDR
 #endif
 
 bool IsAnyAddress(const ComboAddress& addr);

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -738,8 +738,8 @@ public:
   //<! Creates new value-pair in tree and returns it.
   node_type& insert(const key_type& key) {
     // lazily initialize tree on first insert.
-    if (!root) root = unique_ptr<TreeNode>(new TreeNode(0));
-    TreeNode* node = root.get();
+    if (!d_root) d_root = unique_ptr<TreeNode>(new TreeNode(0));
+    TreeNode* node = d_root.get();
     node_type* value = nullptr;
 
     if (key.getNetwork().sin4.sin_family == AF_INET) {
@@ -804,9 +804,9 @@ public:
 
   //<! Perform best match lookup for value, using at most max_bits
   const node_type* lookup(const ComboAddress& value, int max_bits = 128) const {
-    if (!root) return nullptr;
+    if (!d_root) return nullptr;
 
-    TreeNode *node = root.get();
+    TreeNode *node = d_root.get();
     node_type *ret = nullptr;
 
     // exact same thing as above, except
@@ -853,7 +853,7 @@ public:
 
   //<! Removes key from TreeMap.
   void erase(const key_type& key) {
-    TreeNode *node = root.get();
+    TreeNode *node = d_root.get();
 
     // no tree, no value
     if ( node == nullptr ) return;
@@ -924,17 +924,17 @@ public:
   //<! Clean out the tree
   void clear() {
     _nodes.clear();
-    root.reset(nullptr);
+    d_root.reset(nullptr);
   }
 
   //<! swaps the contents with another NetmaskTree
   void swap(NetmaskTree& rhs) {
-    root.swap(rhs.root);
+    std::swap(d_root, rhs.d_root);
     _nodes.swap(rhs._nodes);
   }
 
 private:
-  unique_ptr<TreeNode> root; //<! Root of our tree
+  unique_ptr<TreeNode> d_root; //<! Root of our tree
   std::set<node_type*> _nodes; //<! Container for actual values
   bool d_cleanup_tree; //<! Whether or not to cleanup the tree on erase
 };

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -751,15 +751,14 @@ public:
     } else
       throw NetmaskException("invalid address family");
 
-    int bits = 0;
     // we turn left on 0 and right on 1
-    while(bits < key.getBits()) {
+    int bits = 0;
+    for(; bits < key.getBits(); bits++) {
       bool val = key.getBit(-1-bits);
       if (val)
         node = node->make_right();
       else
         node = node->make_left();
-      bits++;
     }
 
     // only create node if not yet assigned
@@ -809,7 +808,7 @@ public:
     node_type *ret = nullptr;
 
     int bits = 0;
-    while(bits < max_bits) {
+    for(; bits < max_bits; bits++) {
       // ...we keep track of last non-empty node
       if (node->node) ret = node->node.get();
       bool val = value.getBit(-1-bits);
@@ -822,7 +821,6 @@ public:
         if (node->left) node = node->left.get();
         else break;
       }
-      bits++;
     }
     // needed if we did not find one in loop
     if (node->node) ret = node->node.get();
@@ -845,14 +843,13 @@ public:
     if (node == nullptr) return;
 
     int bits = 0;
-    while(node && bits < key.getBits()) {
+    for(; node && bits < key.getBits(); bits++) {
       bool val = key.getBit(-1-bits);
       if (val) {
         node = node->right.get();
       } else {
         node = node->left.get();
       }
-      bits++;
     }
     if (node) {
       _nodes.erase(node->node.get());

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -590,6 +590,12 @@ public:
   Netmask getSuper(uint8_t bits) const {
     return Netmask(d_network, std::min(d_bits, bits));
   }
+
+  //! Get the total number of address bits for this netmask (either 32 or 128 depending on IP version)
+  uint8_t getAddressBits() const
+  {
+    return d_network.getBits();
+  }
 private:
   ComboAddress d_network;
   uint32_t d_mask;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -761,6 +761,51 @@ private:
       return new_node;
     }
 
+    //<! Traverse left branch depth-first
+    TreeNode *traverse_l()
+    {
+      TreeNode *tnode = this;
+
+      while (tnode->left)
+        tnode = tnode->left.get();
+      return tnode;
+    }
+
+    //<! Traverse tree depth-first and in-order (L-N-R)
+    TreeNode *traverse_lnr()
+    {
+      TreeNode *tnode = this;
+
+      // precondition: descended left as deep as possible
+      if (tnode->right) {
+        // descend right
+        tnode = tnode->right.get();
+        // descend left as deep as possible and return next node
+        return tnode->traverse_l();
+      }
+
+      // ascend to parent
+      while (tnode->parent != nullptr) {
+        TreeNode *prev_child = tnode;
+        tnode = tnode->parent;
+
+        // return this node, but only when we come from the left child branch
+        if (tnode->left && tnode->left.get() == prev_child)
+          return tnode;
+      }
+      return nullptr;
+    }
+
+    //<! Traverse only assigned nodes
+    TreeNode *traverse_lnr_assigned()
+    {
+      TreeNode *tnode = traverse_lnr();
+
+      while (tnode != nullptr && !tnode->assigned)
+        tnode = tnode->traverse_lnr();
+      return tnode;
+    }
+
     unique_ptr<TreeNode> left;
     unique_ptr<TreeNode> right;
     TreeNode* parent;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -326,6 +326,42 @@ union ComboAddress {
       return 128;
     return 0;
   }
+  /** Get the value of the bit at the provided bit index. When the index >= 0,
+      the index is relative to the LSB starting at index zero. When the index < 0,
+      the index is relative to the MSB starting at index -1 and counting down.
+   */
+  bool getBit(int index) const
+  {
+    if(isIPv4()) {
+      if (index >= 32)
+        return false;
+      if (index < 0) {
+        if (index < -32)
+          return false;
+        index = 32 + index;
+      }
+
+      uint32_t s_addr = ntohl(sin4.sin_addr.s_addr);
+
+      return ((s_addr & (1<<index)) != 0x00000000);
+    }
+    if(isIPv6()) {
+      if (index >= 128)
+        return false;
+      if (index < 0) {
+        if (index < -128)
+          return false;
+        index = 128 + index;
+      }
+
+      uint8_t *s_addr = (uint8_t*)sin6.sin6_addr.s6_addr;
+      uint8_t byte_idx = index / 8;
+      uint8_t bit_idx = index % 8;
+
+      return ((s_addr[15-byte_idx] & (1 << bit_idx)) != 0x00);
+    }
+    return false;
+  }
 };
 
 /** This exception is thrown by the Netmask class and by extension by the NetmaskGroup class */

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -834,22 +834,31 @@ private:
     }
   }
 
+  void copyTree(const NetmaskTree& rhs)
+  {
+    TreeNode *node;
+
+    node = rhs.d_root.get();
+    if (node != nullptr)
+      node = node->traverse_l();
+    while (node != nullptr) {
+      if (node->assigned)
+        insert(node->node->first).second = node->node->second;
+      node = node->traverse_lnr();
+    }
+  }
+
 public:
   NetmaskTree() noexcept : d_root(new TreeNode()) {
   }
 
   NetmaskTree(const NetmaskTree& rhs): d_root(new TreeNode()) {
-    // it is easier to copy the nodes than tree.
-    // also acts as handy compactor
-    for(auto const& node: rhs._nodes)
-      insert(node->first).second = node->second;
+    copyTree(rhs);
   }
 
   NetmaskTree& operator=(const NetmaskTree& rhs) {
     clear();
-    // see above.
-    for(auto const& node: rhs._nodes)
-      insert(node->first).second = node->second;
+    copyTree(rhs);
     return *this;
   }
 

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -743,11 +743,10 @@ public:
     node_type* value = nullptr;
 
     if (key.getNetwork().sin4.sin_family == AF_INET) {
-      std::bitset<32> addr(be32toh(key.getNetwork().sin4.sin_addr.s_addr));
       int bits = 0;
       // we turn left on 0 and right on 1
       while(bits < key.getBits()) {
-        uint8_t val = addr[31-bits];
+        bool val = key.getBit(-1-bits);
         if (val)
           node = node->make_right();
         else
@@ -761,18 +760,9 @@ public:
       }
       value = node->node4.get();
     } else {
-      uint64_t addr[2];
-      memcpy(addr, key.getNetwork().sin6.sin6_addr.s6_addr, sizeof(addr));
-      std::bitset<64> addr_low(be64toh(addr[1]));
-      std::bitset<64> addr_high(be64toh(addr[0]));
       int bits = 0;
       while(bits < key.getBits()) {
-        uint8_t val;
-        // we use high address until we are
-        if (bits < 64) val = addr_high[63-bits];
-        // past 64 bits, and start using low address
-        else val = addr_low[127-bits];
-
+        bool val = key.getBit(-1-bits);
         // we turn left on 0 and right on 1
         if (val)
           node = node->make_right();
@@ -821,14 +811,11 @@ public:
 
     // exact same thing as above, except
     if (value.sin4.sin_family == AF_INET) {
-      max_bits = std::max(0,std::min(max_bits,32));
-      std::bitset<32> addr(be32toh(value.sin4.sin_addr.s_addr));
       int bits = 0;
-
       while(bits < max_bits) {
         // ...we keep track of last non-empty node
         if (node->node4) ret = node->node4.get();
-        uint8_t val = addr[31-bits];
+        bool val = value.getBit(-1-bits);
         // ...and we don't create left/right hand
         if (val) {
           if (node->right) node = node->right.get();
@@ -843,17 +830,11 @@ public:
       // needed if we did not find one in loop
       if (node->node4) ret = node->node4.get();
     } else {
-      uint64_t addr[2];
-      memcpy(addr, value.sin6.sin6_addr.s6_addr, sizeof(addr));
       max_bits = std::max(0,std::min(max_bits,128));
-      std::bitset<64> addr_low(be64toh(addr[1]));
-      std::bitset<64> addr_high(be64toh(addr[0]));
       int bits = 0;
       while(bits < max_bits) {
         if (node->node6) ret = node->node6.get();
-        uint8_t val;
-        if (bits < 64) val = addr_high[63-bits];
-        else val = addr_low[127-bits];
+        bool val = value.getBit(-1-bits);
         if (val) {
           if (node->right) node = node->right.get();
           else break;
@@ -879,10 +860,9 @@ public:
 
     // exact same thing as above, except
     if (key.getNetwork().sin4.sin_family == AF_INET) {
-      std::bitset<32> addr(be32toh(key.getNetwork().sin4.sin_addr.s_addr));
       int bits = 0;
       while(node && bits < key.getBits()) {
-        uint8_t val = addr[31-bits];
+        bool val = key.getBit(-1-bits);
         if (val) {
           node = node->right.get();
         } else {
@@ -898,15 +878,9 @@ public:
           cleanup_tree(node);
       }
     } else {
-      uint64_t addr[2];
-      memcpy(addr, key.getNetwork().sin6.sin6_addr.s6_addr, sizeof(addr));
-      std::bitset<64> addr_low(be64toh(addr[1]));
-      std::bitset<64> addr_high(be64toh(addr[0]));
       int bits = 0;
       while(node && bits < key.getBits()) {
-        uint8_t val;
-        if (bits < 64) val = addr_high[63-bits];
-        else val = addr_low[127-bits];
+        bool val = key.getBit(-1-bits);
         if (val) {
           node = node->right.get();
         } else {

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -632,6 +632,9 @@ private:
  * to a *LIST* of *PREFIXES*. Not the other way round.
  *
  * You can store IPv4 and IPv6 addresses to same tree, separate payload storage is kept per AFI.
+ * Network prefixes (Netmasks) are always recorded in normalized fashion, meaning that only
+ * the network bits are set. This is what is returned in the insert() and lookup() return
+ * values.
  *
  * Use swap if you need to move the tree to another NetmaskTree instance, it is WAY faster
  * than using copy ctor or assignment operator, since it moves the nodes and tree root to
@@ -657,7 +660,7 @@ private:
       parent(nullptr), node(new node_type()), assigned(false), d_bits(0) {
     }
     explicit TreeNode(const key_type& key) noexcept :
-      parent(nullptr), node(new node_type({key, value_type()})),
+      parent(nullptr), node(new node_type({key.getNormalized(), value_type()})),
       assigned(false), d_bits(key.getAddressBits()) {
     }
 
@@ -906,8 +909,6 @@ public:
       node->assigned = true;
     }
 
-    // assign key
-    value->first = key;
     return *value;
   }
 

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -541,6 +541,10 @@ public:
   Netmask getNormalized() const {
     return Netmask(getMaskedNetwork(), d_bits);
   }
+  //! Get Netmask for super network of this one (i.e. with fewer network bits)
+  Netmask getSuper(uint8_t bits) const {
+    return Netmask(d_network, std::min(d_bits, bits));
+  }
 private:
   ComboAddress d_network;
   uint32_t d_mask;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -574,7 +574,7 @@ private:
     */
   class TreeNode : boost::noncopyable {
   public:
-    explicit TreeNode(int bits) noexcept : parent(NULL),d_bits(bits) {
+    explicit TreeNode(int bits) noexcept : parent(nullptr),d_bits(bits) {
     }
 
     //<! Makes a left node with one more bit than parent

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -423,10 +423,8 @@ public:
   Netmask(const ComboAddress& network, uint8_t bits=0xff): d_network(network)
   {
     d_network.sin4.sin_port=0;
-    if(bits > 128)
-      bits = (network.sin4.sin_family == AF_INET) ? 32 : 128;
+    d_bits = (network.isIPv4() ? std::min(bits, (uint8_t)32) : std::min(bits, (uint8_t)128));
 
-    d_bits = bits;
     if(d_bits<32)
       d_mask=~(0xFFFFFFFF>>d_bits);
     else

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -854,9 +854,9 @@ private:
 public:
   class Iterator {
   public:
-    typedef node_type* value_type;
-    typedef node_type* reference;
-    typedef void pointer;
+    typedef node_type value_type;
+    typedef node_type& reference;
+    typedef node_type* pointer;
     typedef std::forward_iterator_tag iterator_category;
     typedef size_type difference_type;
 
@@ -893,6 +893,15 @@ public:
       if (d_node == nullptr) {
         throw std::logic_error(
           "NetmaskTree::Iterator::operator*: iterator is invalid");
+      }
+      return d_node->node;
+    }
+
+    pointer operator->()
+    {
+      if (d_node == nullptr) {
+        throw std::logic_error(
+          "NetmaskTree::Iterator::operator->: iterator is invalid");
       }
       return &d_node->node;
     }
@@ -1315,9 +1324,9 @@ public:
     for(auto iter = tree.begin(); iter != tree.end(); ++iter) {
       if(iter != tree.begin())
         str <<", ";
-      if(!((*iter)->second))
+      if(!(iter->second))
         str<<"!";
-      str<<(*iter)->first.toString();
+      str<<iter->first.toString();
     }
     return str.str();
   }
@@ -1325,7 +1334,7 @@ public:
   void toStringVector(vector<string>* vec) const
   {
     for(auto iter = tree.begin(); iter != tree.end(); ++iter) {
-      vec->push_back(((*iter)->second ? "" : "!") + (*iter)->first.toString());
+      vec->push_back((iter->second ? "" : "!") + iter->first.toString());
     }
   }
 

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -554,8 +554,6 @@ private:
  *
  * You can store IPv4 and IPv6 addresses to same tree, separate payload storage is kept per AFI.
  *
- * To erase something copy values to new tree sans the value you want to erase.
- *
  * Use swap if you need to move the tree to another NetmaskTree instance, it is WAY faster
  * than using copy ctor or assignment operator, since it moves the nodes and tree root to
  * new home instead of actually recreating the tree.
@@ -793,7 +791,7 @@ public:
     }
   }
 
-  //<! Removes key from TreeMap. This does not clean up the tree.
+  //<! Removes key from TreeMap.
   void erase(const key_type& key) {
     TreeNode *node = root.get();
 
@@ -876,7 +874,7 @@ public:
     root.reset(nullptr);
   }
 
-  //<! swaps the contents, rhs is left with nullptr.
+  //<! swaps the contents with another NetmaskTree
   void swap(NetmaskTree& rhs) {
     root.swap(rhs.root);
     _nodes.swap(rhs._nodes);

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -317,6 +317,15 @@ union ComboAddress {
     memset(&sin6, 0, sizeof(sin6));
   }
 
+  //! Get the total number of address bits (either 32 or 128 depending on IP version)
+  uint8_t getBits() const
+  {
+    if (isIPv4())
+      return 32;
+    if (isIPv6())
+      return 128;
+    return 0;
+  }
 };
 
 /** This exception is thrown by the Netmask class and by extension by the NetmaskGroup class */

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -684,6 +684,24 @@ private:
     int d_bits; //<! How many bits have been used so far
   };
 
+  void cleanup_tree(TreeNode* node)
+  {
+    // only cleanup this node if it has no children and node4 and node6 are both empty
+    if (!(node->left || node->right || node->node6 || node->node4)) {
+      // get parent node ptr
+      TreeNode* pparent = node->parent;
+      // delete this node
+      if (pparent) {
+        if (pparent->left.get() == node)
+          pparent->left.reset();
+        else
+          pparent->right.reset();
+        // now recurse up to the parent
+        cleanup_tree(pparent);
+      }
+    }
+  }
+
 public:
   NetmaskTree() noexcept : NetmaskTree(false) {
   }
@@ -850,24 +868,6 @@ public:
 
     // this can be nullptr.
     return ret;
-  }
-
-  void cleanup_tree(TreeNode* node)
-  {
-    // only cleanup this node if it has no children and node4 and node6 are both empty
-    if (!(node->left || node->right || node->node6 || node->node4)) {
-      // get parent node ptr
-      TreeNode* pparent = node->parent;
-      // delete this node
-      if (pparent) {
-        if (pparent->left.get() == node)
-          pparent->left.reset();
-        else
-          pparent->right.reset();
-        // now recurse up to the parent
-        cleanup_tree(pparent);
-      }
-    }
   }
 
   //<! Removes key from TreeMap.

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -537,6 +537,10 @@ public:
     return d_network.sin4.sin_family==0;
   }
 
+  //! Get normalized version of the netmask. This means that all address bits below the network bits are zero.
+  Netmask getNormalized() const {
+    return Netmask(getMaskedNetwork(), d_bits);
+  }
 private:
   ComboAddress d_network;
   uint32_t d_mask;

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -240,6 +240,9 @@ void MemRecursorCache::replace(time_t now, const DNSName &qname, const QType& qt
 {
   d_cachecachevalid = false;
   //  cerr<<"Replacing "<<qname<<" for "<< (ednsmask ? ednsmask->toString() : "everyone") << endl;
+  if (ednsmask) {
+    ednsmask = ednsmask->getNormalized();
+  }
   auto key = boost::make_tuple(qname, qt.getCode(), ednsmask ? *ednsmask : Netmask());
   bool isNew = false;
   cache_t::iterator stored = d_cache.find(key);

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -73,7 +73,7 @@ private:
   struct CacheEntry
   {
     CacheEntry(const boost::tuple<DNSName, uint16_t, Netmask>& key, bool auth):
-      d_qname(key.get<0>()), d_netmask(key.get<2>()), d_state(Indeterminate), d_ttd(0), d_qtype(key.get<1>()), d_auth(auth)
+      d_qname(key.get<0>()), d_netmask(key.get<2>().getNormalized()), d_state(Indeterminate), d_ttd(0), d_qtype(key.get<1>()), d_auth(auth)
     {
     }
 

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -107,7 +107,7 @@ private:
   class ECSIndexEntry
   {
   public:
-    ECSIndexEntry(const DNSName& qname, uint16_t qtype): d_nmt(true), d_qname(qname), d_qtype(qtype)
+    ECSIndexEntry(const DNSName& qname, uint16_t qtype): d_nmt(), d_qname(qname), d_qtype(qtype)
     {
     }
 

--- a/pdns/sortlist.cc
+++ b/pdns/sortlist.cc
@@ -13,7 +13,7 @@ int SortList::getMaxOrder(const Netmask& formask) const
   auto place = d_sortlist.lookup(formask);
   if(place && place->first == formask) {
     for(const auto& o : place->second.d_orders) 
-      order = std::max(order, o->second); // aki, shouldn't this be o.second?
+      order = std::max(order, o.second);
   }
   
   return order;

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -478,7 +478,7 @@ BOOST_AUTO_TEST_CASE(test_scale) {
 
 BOOST_AUTO_TEST_CASE(test_removal) {
   std::string prefix = "192.";
-  NetmaskTree<int> nmt(true);
+  NetmaskTree<int> nmt;
   BOOST_CHECK(nmt.empty());
   BOOST_CHECK_EQUAL(nmt.size(), 0);
 

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -162,7 +162,6 @@ BOOST_AUTO_TEST_CASE(test_ComboAddressTruncate) {
   }
 }
 
-
 BOOST_AUTO_TEST_CASE(test_Mapping)
 {
   ComboAddress lh("::1");
@@ -339,7 +338,6 @@ BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
     BOOST_CHECK_EQUAL(NMGOutputToSorted(ng.toString()), NMGOutputToSorted("10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16, 172.16.0.0/16, !172.16.4.0/24, !fe80::/24"));
   }
 }
-
 
 BOOST_AUTO_TEST_CASE(test_NetmaskTree) {
   NetmaskTree<int> nmt;

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -391,6 +391,16 @@ BOOST_AUTO_TEST_CASE(test_NetmaskTree) {
   BOOST_CHECK(found);
   BOOST_CHECK_EQUAL(found->second, 2);
 
+  nmt.insert(Netmask("0.0.0.0/0")).second=3;
+  BOOST_CHECK_EQUAL(nmt.size(), 4);
+  nmt.insert(Netmask("0.0.0.0/7")).second=4;
+  BOOST_CHECK_EQUAL(nmt.size(), 5);
+  nmt.insert(Netmask("0.0.0.0/15")).second=5;
+  BOOST_CHECK_EQUAL(nmt.size(), 6);
+  BOOST_CHECK_EQUAL(nmt.lookup(Netmask("0.0.0.0/0"))->second, 3);
+  BOOST_CHECK_EQUAL(nmt.lookup(Netmask("0.0.0.0/7"))->second, 4);
+  BOOST_CHECK_EQUAL(nmt.lookup(Netmask("0.0.0.0/15"))->second, 5);
+
   nmt.clear();
   BOOST_CHECK_EQUAL(nmt.empty(), true);
   BOOST_CHECK_EQUAL(nmt.size(), 0);

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -258,9 +258,14 @@ BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
 
   {
     NetmaskGroup ng;
+    BOOST_CHECK_EQUAL(ng.empty(), true);
+    BOOST_CHECK_EQUAL(ng.size(), 0);
     ng.addMask("10.0.1.0");
+    BOOST_CHECK_EQUAL(ng.empty(), false);
+    BOOST_CHECK_EQUAL(ng.size(), 1);
     BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
     ng.toMasks("127.0.0.0/8, 10.0.0.0/24");
+    BOOST_CHECK_EQUAL(ng.size(), 3);
     BOOST_CHECK(ng.match(ComboAddress("127.0.0.1")));
     BOOST_CHECK(ng.match(ComboAddress("10.0.0.3")));
     BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
@@ -268,21 +273,26 @@ BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
     BOOST_CHECK(!ng.match(ComboAddress("10.0.1.1")));
     BOOST_CHECK(!ng.match(ComboAddress("::1")));
     ng.addMask("::1");
+    BOOST_CHECK_EQUAL(ng.size(), 4);
     BOOST_CHECK(ng.match(ComboAddress("::1")));
     BOOST_CHECK(!ng.match(ComboAddress("::2")));
     ng.addMask("fe80::/16");
+    BOOST_CHECK_EQUAL(ng.size(), 5);
     BOOST_CHECK(ng.match(ComboAddress("fe80::1")));
     BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
     BOOST_CHECK_EQUAL(NMGOutputToSorted(ng.toString()), NMGOutputToSorted("10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16"));
 
     /* negative entries using the explicit flag */
     ng.addMask("172.16.0.0/16", true);
+    BOOST_CHECK_EQUAL(ng.size(), 6);
     BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
     BOOST_CHECK(ng.match(ComboAddress("172.16.4.50")));
     ng.addMask("172.16.4.0/24", false);
+    BOOST_CHECK_EQUAL(ng.size(), 7);
     BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
     BOOST_CHECK(!ng.match(ComboAddress("172.16.4.50")));
     ng.addMask("fe80::/24", false);
+    BOOST_CHECK_EQUAL(ng.size(), 8);
     BOOST_CHECK(!ng.match(ComboAddress("fe80::1")));
     BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
     /* not in fe80::/24 but in fe80::/16, should match */
@@ -291,9 +301,12 @@ BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
     /* negative entries using '!' */
     BOOST_CHECK(ng.match(ComboAddress("172.16.10.80")));
     ng.addMask("!172.16.10.0/24");
+    BOOST_CHECK_EQUAL(ng.size(), 9);
     BOOST_CHECK(!ng.match(ComboAddress("172.16.10.80")));
     ng.addMask("2001:db8::/32");
+    BOOST_CHECK_EQUAL(ng.size(), 10);
     ng.addMask("!2001:db8::/64");
+    BOOST_CHECK_EQUAL(ng.size(), 11);
     BOOST_CHECK(!ng.match(ComboAddress("2001:db8::1")));
     /* not in 2001:db8::/64 but in 2001:db8::/32, should match */
     BOOST_CHECK(ng.match(ComboAddress("2001:db8:1::1")));
@@ -304,10 +317,16 @@ BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
   {
     /* this time using Netmask objects instead of strings */
     NetmaskGroup ng;
+    BOOST_CHECK_EQUAL(ng.empty(), true);
+    BOOST_CHECK_EQUAL(ng.size(), 0);
     ng.addMask(Netmask("10.0.1.0"));
+    BOOST_CHECK_EQUAL(ng.empty(), false);
+    BOOST_CHECK_EQUAL(ng.size(), 1);
     BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
     ng.addMask(Netmask("127.0.0.0/8"));
+    BOOST_CHECK_EQUAL(ng.size(), 2);
     ng.addMask(Netmask("10.0.0.0/24"));
+    BOOST_CHECK_EQUAL(ng.size(), 3);
     BOOST_CHECK(ng.match(ComboAddress("127.0.0.1")));
     BOOST_CHECK(ng.match(ComboAddress("10.0.0.3")));
     BOOST_CHECK(ng.match(ComboAddress("10.0.1.0")));
@@ -315,21 +334,26 @@ BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
     BOOST_CHECK(!ng.match(ComboAddress("10.0.1.1")));
     BOOST_CHECK(!ng.match(ComboAddress("::1")));
     ng.addMask(Netmask("::1"));
+    BOOST_CHECK_EQUAL(ng.size(), 4);
     BOOST_CHECK(ng.match(ComboAddress("::1")));
     BOOST_CHECK(!ng.match(ComboAddress("::2")));
     ng.addMask(Netmask("fe80::/16"));
+    BOOST_CHECK_EQUAL(ng.size(), 5);
     BOOST_CHECK(ng.match(ComboAddress("fe80::1")));
     BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
     BOOST_CHECK_EQUAL(NMGOutputToSorted(ng.toString()), NMGOutputToSorted("10.0.1.0/32, 127.0.0.0/8, 10.0.0.0/24, ::1/128, fe80::/16"));
 
     /* negative entries using the explicit flag */
     ng.addMask(Netmask("172.16.0.0/16"), true);
+    BOOST_CHECK_EQUAL(ng.size(), 6);
     BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
     BOOST_CHECK(ng.match(ComboAddress("172.16.4.50")));
     ng.addMask(Netmask("172.16.4.0/24"), false);
+    BOOST_CHECK_EQUAL(ng.size(), 7);
     BOOST_CHECK(ng.match(ComboAddress("172.16.1.1")));
     BOOST_CHECK(!ng.match(ComboAddress("172.16.4.50")));
     ng.addMask("fe80::/24", false);
+    BOOST_CHECK_EQUAL(ng.size(), 8);
     BOOST_CHECK(!ng.match(ComboAddress("fe80::1")));
     BOOST_CHECK(!ng.match(ComboAddress("fe81::1")));
     /* not in fe80::/24 but in fe80::/16, should match */
@@ -341,9 +365,15 @@ BOOST_AUTO_TEST_CASE(test_NetmaskGroup) {
 
 BOOST_AUTO_TEST_CASE(test_NetmaskTree) {
   NetmaskTree<int> nmt;
+  BOOST_CHECK_EQUAL(nmt.empty(), true);
+  BOOST_CHECK_EQUAL(nmt.size(), 0);
   nmt.insert(Netmask("130.161.252.0/24")).second=0;
+  BOOST_CHECK_EQUAL(nmt.empty(), false);
+  BOOST_CHECK_EQUAL(nmt.size(), 1);
   nmt.insert(Netmask("130.161.0.0/16")).second=1;
+  BOOST_CHECK_EQUAL(nmt.size(), 2);
   nmt.insert(Netmask("130.0.0.0/8")).second=2;
+  BOOST_CHECK_EQUAL(nmt.size(), 3);
 
   BOOST_CHECK_EQUAL(nmt.lookup(ComboAddress("213.244.168.210")), (void*)0);
   auto found=nmt.lookup(ComboAddress("130.161.252.29"));
@@ -362,11 +392,17 @@ BOOST_AUTO_TEST_CASE(test_NetmaskTree) {
   BOOST_CHECK_EQUAL(found->second, 2);
 
   nmt.clear();
+  BOOST_CHECK_EQUAL(nmt.empty(), true);
+  BOOST_CHECK_EQUAL(nmt.size(), 0);
   BOOST_CHECK(!nmt.lookup(ComboAddress("130.161.180.1")));
 
   nmt.insert(Netmask("::1")).second=1;
+  BOOST_CHECK_EQUAL(nmt.empty(), false);
+  BOOST_CHECK_EQUAL(nmt.size(), 1);
   nmt.insert(Netmask("::/0")).second=0;
+  BOOST_CHECK_EQUAL(nmt.size(), 2);
   nmt.insert(Netmask("fe80::/16")).second=2;
+  BOOST_CHECK_EQUAL(nmt.size(), 3);
   BOOST_CHECK_EQUAL(nmt.lookup(ComboAddress("130.161.253.255")), (void*)0);
   BOOST_CHECK_EQUAL(nmt.lookup(ComboAddress("::2"))->second, 0);
   BOOST_CHECK_EQUAL(nmt.lookup(ComboAddress("::ffff"))->second, 0);
@@ -376,16 +412,22 @@ BOOST_AUTO_TEST_CASE(test_NetmaskTree) {
 
 BOOST_AUTO_TEST_CASE(test_single) {
   NetmaskTree<bool> nmt;
+  BOOST_CHECK_EQUAL(nmt.empty(), true);
+  BOOST_CHECK_EQUAL(nmt.size(), 0);
   nmt.insert(Netmask("127.0.0.0/8")).second=1;
+  BOOST_CHECK_EQUAL(nmt.empty(), false);
+  BOOST_CHECK_EQUAL(nmt.size(), 1);
   BOOST_CHECK_EQUAL(nmt.lookup(ComboAddress("127.0.0.1"))->second, 1);
 }
 
 BOOST_AUTO_TEST_CASE(test_scale) {
   string start="192.168.";
   NetmaskTree<int> works;
+  BOOST_CHECK_EQUAL(works.size(), 0);
   for(int i=0; i < 256; ++i) {
     for(int j=0; j < 256; ++j) {
       works.insert(Netmask(start+std::to_string(i)+"."+std::to_string(j))).second=i*j;
+      BOOST_CHECK_EQUAL(works.size(), i*256 + j + 1);
     }
   }
 
@@ -406,6 +448,7 @@ BOOST_AUTO_TEST_CASE(test_scale) {
   for(int i=0; i < 256; ++i) {
     for(int j=0; j < 256; ++j) {
       works.insert(Netmask(start+std::to_string(i)+":"+std::to_string(j)+"::/64")).second=i*j;
+      BOOST_CHECK_EQUAL(works.size(), (256*256) + i*256 + j + 1);
     }
   }
 
@@ -426,16 +469,17 @@ BOOST_AUTO_TEST_CASE(test_scale) {
 BOOST_AUTO_TEST_CASE(test_removal) {
   std::string prefix = "192.";
   NetmaskTree<int> nmt(true);
+  BOOST_CHECK(nmt.empty());
+  BOOST_CHECK_EQUAL(nmt.size(), 0);
 
   size_t count = 0;
   for(unsigned int i = 0; i < 256; ++i) {
     for(unsigned int j = 16; j <= 32; ++j) {
       nmt.insert(Netmask(prefix + std::to_string(i) +".127.255/"+std::to_string(j))).second = j;
       count++;
+      BOOST_CHECK_EQUAL(nmt.size(), count);
     }
   }
-
-  BOOST_CHECK_EQUAL(nmt.size(), count);
 
   for(unsigned int i = 0; i < 256; ++i) {
     ComboAddress key(prefix + std::to_string(i) + ".127.255");
@@ -449,6 +493,8 @@ BOOST_AUTO_TEST_CASE(test_removal) {
     for(int j = 32; j >= 16; --j) {
       ComboAddress key(prefix + std::to_string(i) + ".127.255");
       nmt.erase(Netmask(key, j));
+      count--;
+      BOOST_CHECK_EQUAL(nmt.size(), count);
       const auto result = nmt.lookup(key);
 
       if (j > 16) {

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -623,7 +623,7 @@ BOOST_AUTO_TEST_CASE(test_iterator) {
   BOOST_CHECK_EQUAL(std::distance(masks_set1.begin(), masks_set1.end()),
                     std::distance(masks_set2.begin(), masks_set2.end()));
   for (auto entry: masks_set1) {
-    Netmask mask = entry->first.getNormalized();
+    Netmask mask = entry.first.getNormalized();
 
     BOOST_CHECK(masks_set2.find(mask) != masks_set2.end());
   }
@@ -643,7 +643,7 @@ BOOST_AUTO_TEST_CASE(test_iterator) {
   BOOST_CHECK_EQUAL(std::distance(masks_set1_cp1.begin(), masks_set1_cp1.end()),
                     std::distance(masks_set2.begin(), masks_set2.end()));
   for (auto entry: masks_set1_cp1) {
-    Netmask mask = entry->first.getNormalized();
+    Netmask mask = entry.first.getNormalized();
 
     BOOST_CHECK(masks_set2.find(mask) != masks_set2.end());
   }
@@ -663,7 +663,7 @@ BOOST_AUTO_TEST_CASE(test_iterator) {
   BOOST_CHECK_EQUAL(std::distance(masks_set1_cp2.begin(), masks_set1_cp2.end()),
                     std::distance(masks_set2.begin(), masks_set2.end()));
   for (auto entry: masks_set1_cp2) {
-    Netmask mask = entry->first.getNormalized();
+    Netmask mask = entry.first.getNormalized();
 
     BOOST_CHECK(masks_set2.find(mask) != masks_set2.end());
   }
@@ -684,7 +684,7 @@ BOOST_AUTO_TEST_CASE(test_iterator) {
   BOOST_CHECK_EQUAL(std::distance(masks_set1_cp3.begin(), masks_set1_cp3.end()),
                     std::distance(masks_set2.begin(), masks_set2.end()));
   for (auto entry: masks_set1_cp3) {
-    Netmask mask = entry->first.getNormalized();
+    Netmask mask = entry.first.getNormalized();
 
     BOOST_CHECK(masks_set2.find(mask) != masks_set2.end());
   }
@@ -693,12 +693,12 @@ BOOST_AUTO_TEST_CASE(test_iterator) {
   }
 
   // copy contents to an std::set
-  std::set<NetmaskTree<int>::node_type *> masks_set1_cp4(masks_set1_cp3.begin(), masks_set1_cp3.end());
+  std::set<NetmaskTree<int>::node_type> masks_set1_cp4(masks_set1_cp3.begin(), masks_set1_cp3.end());
 
   // check set equality
   BOOST_CHECK_EQUAL(masks_set1_cp4.size(), masks_set2.size());
   for (auto entry: masks_set1_cp4) {
-    Netmask mask = entry->first.getNormalized();
+    Netmask mask = entry.first.getNormalized();
 
     BOOST_CHECK(masks_set2.find(mask) != masks_set2.end());
   }
@@ -706,7 +706,7 @@ BOOST_AUTO_TEST_CASE(test_iterator) {
     Netmask maskl = mask.getNormalized();
     bool found = false;
     for (auto entry: masks_set1_cp4) {
-      Netmask maskr = entry->first.getNormalized();
+      Netmask maskr = entry.first.getNormalized();
 
       if (maskl == maskr)
         found = true;
@@ -779,7 +779,7 @@ BOOST_AUTO_TEST_CASE(test_iterator) {
   BOOST_CHECK_EQUAL(std::distance(masks_set1_cp5.begin(), masks_set1_cp5.end()),
                     std::distance(masks_set2.begin(), masks_set2.end()));
   for (auto entry: masks_set1_cp5) {
-    Netmask mask = entry->first.getNormalized();
+    Netmask mask = entry.first.getNormalized();
 
     BOOST_CHECK(masks_set2.find(mask) != masks_set2.end());
   }


### PR DESCRIPTION
### Short description
The existing implementation of class NetmaskTree was inefficient because:
- it created a new tree node for each bit in the Netmask
- used a redundant std::set to provide iterator support.

These changes mend both these problems, yielding an overall decrease in CPU usage and memory requirements.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
