### PR TITLE
rec: chmod/own recursor.conf for the systemd case

### DIFF
--- a/builder-support/debian/recursor/debian-buster/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-buster/pdns-recursor.postinst
@@ -5,6 +5,11 @@ case "$1" in
   configure)
     addgroup --system pdns
     adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ "`stat -c '%U:%G' /etc/powerdns/recursor.conf`" = "root:root" ]; then
+      chown root:pdns /etc/powerdns/recursor.conf
+      # Make sure that pdns can read it; the default used to be 0600
+      chmod g+r /etc/powerdns/recursor.conf
+    fi
   ;;
 
   *)

--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -57,3 +57,8 @@ override_dh_installinit:
 
 override_dh_gencontrol:
 	dh_gencontrol -- $(SUBSTVARS)
+
+override_dh_fixperms:
+	dh_fixperms
+        # these files often contain passwords. 640 as it is chowned to root:pdns
+	chmod 0640 debian/pdns-server/etc/powerdns/recursor.conf

--- a/builder-support/debian/recursor/debian-jessie/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-jessie/pdns-recursor.postinst
@@ -5,6 +5,11 @@ case "$1" in
   configure)
     addgroup --system pdns
     adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ "`stat -c '%U:%G' /etc/powerdns/recursor.conf`" = "root:root" ]; then
+      chown root:pdns /etc/powerdns/recursor.conf
+      # Make sure that pdns can read it; the default used to be 0600
+      chmod g+r /etc/powerdns/recursor.conf
+    fi
   ;;
 
   *)

--- a/builder-support/debian/recursor/debian-jessie/rules
+++ b/builder-support/debian/recursor/debian-jessie/rules
@@ -57,3 +57,8 @@ override_dh_installinit:
 
 override_dh_gencontrol:
 	dh_gencontrol -- $(SUBSTVARS)
+
+override_dh_fixperms:
+	dh_fixperms
+        # these files often contain passwords. 640 as it is chowned to root:pdns
+	chmod 0640 debian/pdns-server/etc/powerdns/recursor.conf

--- a/builder-support/debian/recursor/debian-stretch/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-stretch/pdns-recursor.postinst
@@ -5,6 +5,11 @@ case "$1" in
   configure)
     addgroup --system pdns
     adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ "`stat -c '%U:%G' /etc/powerdns/recursor.conf`" = "root:root" ]; then
+      chown root:pdns /etc/powerdns/recursor.conf
+      # Make sure that pdns can read it; the default used to be 0600
+      chmod g+r /etc/powerdns/recursor.conf
+    fi
   ;;
 
   *)

--- a/builder-support/debian/recursor/debian-stretch/rules
+++ b/builder-support/debian/recursor/debian-stretch/rules
@@ -57,3 +57,8 @@ override_dh_installinit:
 
 override_dh_gencontrol:
 	dh_gencontrol -- $(SUBSTVARS)
+
+override_dh_fixperms:
+	dh_fixperms
+        # these files often contain passwords. 640 as it is chowned to root:pdns
+	chmod 0640 debian/pdns-server/etc/powerdns/recursor.conf


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

When run as non-root. we need to make sure rec can read it's config file.

Same as #8352, but  for rec

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
