### PR TITLE
LGTM/coverity spotted issues: copy constructors and = operators

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -242,6 +242,17 @@ struct SuffixMatchTree
       d_value = rhs.d_value;
     }
   }
+  SuffixMatchTree & operator=(const SuffixMatchTree &rhs)
+  {
+    d_name = rhs.d_name;
+    children = rhs.children;
+    endNode = rhs.endNode;
+    if (endNode) {
+      d_value = rhs.d_value;
+    }
+    return *this;
+  }
+  
   std::string d_name;
   mutable std::set<SuffixMatchTree> children;
   mutable bool endNode;

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -77,49 +77,6 @@ uint16_t DNSPacket::getRemotePort() const
   return d_remote.sin4.sin_port;
 }
 
-DNSPacket::DNSPacket(const DNSPacket &orig) :
-  d_anyLocal(orig.d_anyLocal),
-  d_dt(orig.d_dt),
-  qdomain(orig.qdomain),
-  qdomainwild(orig.qdomainwild),
-  qdomainzone(orig.qdomainzone),
-
-  d(orig.d),
-  d_trc(orig.d_trc),
-  d_remote(orig.d_remote),
-  d_tsig_algo(orig.d_tsig_algo),
-
-  d_ednsRawPacketSizeLimit(orig.d_ednsRawPacketSizeLimit),
-  qclass(orig.qclass),
-  qtype(orig.qtype),
-  d_tcp(orig.d_tcp),
-  d_dnssecOk(orig.d_dnssecOk),
-  d_havetsig(orig.d_havetsig),
-
-  d_tsigsecret(orig.d_tsigsecret),
-  d_tsigkeyname(orig.d_tsigkeyname),
-  d_tsigprevious(orig.d_tsigprevious),
-  d_rrs(orig.d_rrs),
-  d_rawpacket(orig.d_rawpacket),
-  d_eso(orig.d_eso),
-  d_maxreplylen(orig.d_maxreplylen),
-  d_socket(orig.d_socket),
-  d_hash(orig.d_hash),
-  d_ednsrcode(orig.d_ednsrcode),
-  d_ednsversion(orig.d_ednsversion),
-
-  d_wrapped(orig.d_wrapped),
-  d_compress(orig.d_compress),
-  d_tsigtimersonly(orig.d_tsigtimersonly),
-  d_wantsnsid(orig.d_wantsnsid),
-  d_haveednssubnet(orig.d_haveednssubnet),
-  d_haveednssection(orig.d_haveednssection),
-
-  d_isQuery(orig.d_isQuery)
-{
-  DLOG(g_log<<"DNSPacket copy constructor called!"<<endl);
-}
-
 void DNSPacket::setRcode(int v)
 {
   d.rcode=v;

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -56,7 +56,8 @@ class DNSPacket
 {
 public:
   DNSPacket(bool isQuery);
-  DNSPacket(const DNSPacket &orig);
+  DNSPacket(const DNSPacket &orig) = default;
+  DNSPacket & operator=(const DNSPacket &) = default;
 
   int noparse(const char *mesg, size_t len); //!< just suck the data inward
   int parse(const char *mesg, size_t len); //!< parse a raw UDP or TCP packet and suck the data inward

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -447,10 +447,6 @@ DTime::DTime()
   d_set.tv_sec=d_set.tv_usec=0;
 }
 
-DTime::DTime(const DTime &dt) : d_set(dt.d_set)
-{
-}
-
 time_t DTime::time()
 {
   return d_set.tv_sec;

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -191,7 +191,8 @@ class DTime
 {
 public:
   DTime(); //!< Does not set the timer for you! Saves lots of gettimeofday() calls
-  DTime(const DTime &dt);
+  DTime(const DTime &dt) = default;
+  DTime & operator=(const DTime &dt) = default;
   time_t time();
   inline void set();  //!< Reset the timer
   inline int udiff(); //!< Return the number of microseconds since the timer was last set.

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -331,7 +331,7 @@ struct DNSComboWriter {
   EDNSSubnetOpts d_ednssubnet;
   shared_ptr<TCPConnection> d_tcpConnection;
   boost::optional<int> d_rcode{boost::none};
-  int d_socket;
+  int d_socket{-1};
   unsigned int d_tag{0};
   uint32_t d_qhash{0};
   uint32_t d_ttlCap{std::numeric_limits<uint32_t>::max()};

--- a/pdns/resolve-context.hh
+++ b/pdns/resolve-context.hh
@@ -10,15 +10,10 @@ struct ResolveContext {
   ResolveContext()
   {
   }
-  ResolveContext(const ResolveContext& ctx)
-  {
-#ifdef HAVE_PROTOBUF
-    this->d_initialRequestId = ctx.d_initialRequestId;
-#endif
-#ifdef HAVE_FSTRM
-    this->d_auth = ctx.d_auth;
-#endif
-  }
+
+  ResolveContext(const ResolveContext& ctx) = delete;
+  ResolveContext & operator=(const ResolveContext&) = delete;
+  
 #ifdef HAVE_PROTOBUF
   boost::optional<const boost::uuids::uuid&> d_initialRequestId;
 #endif

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -163,10 +163,9 @@ public:
     d_lastget=d_last;
   }
 
-  DecayingEwma(const DecayingEwma& orig) : d_last(orig.d_last),  d_lastget(orig.d_lastget), d_val(orig.d_val), d_needinit(orig.d_needinit)
-  {
-  }
-
+  DecayingEwma(const DecayingEwma& orig) = delete;
+  DecayingEwma & operator=(const DecayingEwma& orig) = delete;
+  
   void submit(int val, const struct timeval* tv)
   {
     struct timeval now=*tv;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

A few issues spotted by lgtm and one by coverity (uninitialized field).
The lgtms ones are "rule-of-two" ones. Either define both a copy constructor and an assignment operator, or none.

I  have been explicit by choosing `= delete` or `= default` and in once case (SuffixMatchTree) adding a non-default assignment operator. I wonder though if the non-default copy ct and assignment operator are needed in tis case

I use ` = delete` if the methods are not used atm, and potentially wrong if used.
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
