### PR TITLE
dnsdist: More prometheus fixes

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -91,6 +91,7 @@ try
           boost::replace_all(serverName, ".", "_");
           const string base = namespace_name + "." + hostname + "." + instance_name + ".servers." + serverName + ".";
           str<<base<<"queries" << ' ' << state->queries.load() << " " << now << "\r\n";
+          str<<base<<"responses" << ' ' << state->responses.load() << " " << now << "\r\n";
           str<<base<<"drops" << ' ' << state->reuseds.load() << " " << now << "\r\n";
           str<<base<<"latency" << ' ' << (state->availability != DownstreamState::Availability::Down ? state->latencyUsec/1000.0 : 0) << " " << now << "\r\n";
           str<<base<<"senderrors" << ' ' << state->sendErrors.load() << " " << now << "\r\n";
@@ -120,6 +121,7 @@ try
 
           const string base = namespace_name + "." + hostname + "." + instance_name + ".frontends." + frontName + ".";
           str<<base<<"queries" << ' ' << front->queries.load() << " " << now << "\r\n";
+          str<<base<<"responses" << ' ' << front->responses.load() << " " << now << "\r\n";
           str<<base<<"tcpdiedreadingquery" << ' '<< front->tcpDiedReadingQuery.load() << " " << now << "\r\n";
           str<<base<<"tcpdiedsendingresponse" << ' '<< front->tcpDiedSendingResponse.load() << " " << now << "\r\n";
           str<<base<<"tcpgaveup" << ' '<< front->tcpGaveUp.load() << " " << now << "\r\n";

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -763,9 +763,16 @@ static void handleResponse(std::shared_ptr<IncomingTCPConnectionState>& state, s
   if (state->d_isXFR && !state->d_xfrStarted) {
     /* don't bother parsing the content of the response for now */
     state->d_xfrStarted = true;
+    ++g_stats.responses;
+    ++state->d_ci.cs->responses;
+    ++state->d_ds->responses;
   }
 
-  ++g_stats.responses;
+  if (!state->d_isXFR) {
+    ++g_stats.responses;
+    ++state->d_ci.cs->responses;
+    ++state->d_ds->responses;
+  }
 
   sendResponse(state, now);
 }

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -652,6 +652,10 @@ static void connectionThread(int sock, ComboAddress remote)
 
         auto localPools = g_pools.getLocal();
         const string cachebase = "dnsdist_pool_";
+        output << "# HELP dnsdist_pool_servers " << "Number of servers in that pool" << "\n";
+        output << "# TYPE dnsdist_pool_servers " << "gauge" << "\n";
+        output << "# HELP dnsdist_pool_active_servers " << "Number of available servers in that pool" << "\n";
+        output << "# TYPE dnsdist_pool_active_servers " << "gauge" << "\n";
 
         for (const auto& entry : *localPools) {
           string poolName = entry.first;

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -611,8 +611,15 @@ static void connectionThread(int sock, ComboAddress remote)
         output << "# TYPE " << frontsbase << "doh_version_status_responses " << "counter" << "\n";
 
 #ifdef HAVE_DNS_OVER_HTTPS
+        std::map<std::string,uint64_t> dohFrontendDuplicates;
         for(const auto& doh : g_dohlocals) {
-          const std::string addrlabel = boost::str(boost::format("address=\"%1%\" ") % doh->d_local.toStringWithPort());
+          string frontName = doh->d_local.toStringWithPort();
+          auto dupPair = frontendDuplicates.insert({frontName, 1});
+          if (!dupPair.second) {
+            frontName = frontName + "_" + std::to_string(dupPair.first->second);
+            ++(dupPair.first->second);
+          }
+          const std::string addrlabel = boost::str(boost::format("address=\"%1%\"") % frontName);
           const std::string label = "{" + addrlabel + "} ";
 
           output << frontsbase << "http_connects" << label << doh->d_httpconnects << "\n";

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -464,6 +464,8 @@ static void connectionThread(int sock, ComboAddress remote)
 
         output << "# HELP " << statesbase << "queries "                << "Amount of queries relayed to server"                               << "\n";
         output << "# TYPE " << statesbase << "queries "                << "counter"                                                           << "\n";
+        output << "# HELP " << statesbase << "responses "              << "Amount of responses received from this server"                     << "\n";
+        output << "# TYPE " << statesbase << "responses "              << "counter"                                                           << "\n";
         output << "# HELP " << statesbase << "drops "                  << "Amount of queries not answered by server"                          << "\n";
         output << "# TYPE " << statesbase << "drops "                  << "counter"                                                           << "\n";
         output << "# HELP " << statesbase << "latency "                << "Server's latency when answering questions in milliseconds"         << "\n";
@@ -507,6 +509,7 @@ static void connectionThread(int sock, ComboAddress remote)
             % serverName % state->remote.toStringWithPort());
 
           output << statesbase << "queries"                << label << " " << state->queries.load()             << "\n";
+          output << statesbase << "responses"              << label << " " << state->responses.load()           << "\n";
           output << statesbase << "drops"                  << label << " " << state->reuseds.load()             << "\n";
           output << statesbase << "latency"                << label << " " << state->latencyUsec/1000.0         << "\n";
           output << statesbase << "senderrors"             << label << " " << state->sendErrors.load()          << "\n";
@@ -526,6 +529,8 @@ static void connectionThread(int sock, ComboAddress remote)
         const string frontsbase = "dnsdist_frontend_";
         output << "# HELP " << frontsbase << "queries " << "Amount of queries received by this frontend" << "\n";
         output << "# TYPE " << frontsbase << "queries " << "counter" << "\n";
+        output << "# HELP " << frontsbase << "responses " << "Amount of responses sent by this frontend" << "\n";
+        output << "# TYPE " << frontsbase << "responses " << "counter" << "\n";
         output << "# HELP " << frontsbase << "tcpdiedreadingquery " << "Amount of TCP connections terminated while reading the query from the client" << "\n";
         output << "# TYPE " << frontsbase << "tcpdiedreadingquery " << "counter" << "\n";
         output << "# HELP " << frontsbase << "tcpdiedsendingresponse " << "Amount of TCP connections terminated while sending a response to the client" << "\n";
@@ -564,6 +569,7 @@ static void connectionThread(int sock, ComboAddress remote)
             % frontName % proto);
 
           output << frontsbase << "queries" << label << front->queries.load() << "\n";
+          output << frontsbase << "responses" << label << front->responses.load() << "\n";
           if (front->isTCP()) {
             output << frontsbase << "tcpdiedreadingquery" << label << front->tcpDiedReadingQuery.load() << "\n";
             output << frontsbase << "tcpdiedsendingresponse" << label << front->tcpDiedSendingResponse.load() << "\n";
@@ -706,6 +712,7 @@ static void connectionThread(int sock, ComboAddress remote)
           {"pools", pools},
           {"latency", (double)(a->latencyUsec/1000.0)},
           {"queries", (double)a->queries},
+          {"responses", (double)a->responses},
           {"sendErrors", (double)a->sendErrors},
           {"tcpDiedSendingQuery", (double)a->tcpDiedSendingQuery},
           {"tcpDiedReadingResponse", (double)a->tcpDiedReadingResponse},
@@ -738,6 +745,7 @@ static void connectionThread(int sock, ComboAddress remote)
           { "tcp", front->tcpFD >= 0 },
           { "type", front->getType() },
           { "queries", (double) front->queries.load() },
+          { "responses", (double) front->responses.load() },
           { "tcpDiedReadingQuery", (double) front->tcpDiedReadingQuery.load() },
           { "tcpDiedSendingResponse", (double) front->tcpDiedSendingResponse.load() },
           { "tcpGaveUp", (double) front->tcpGaveUp.load() },

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -544,8 +544,8 @@ static void connectionThread(int sock, ComboAddress remote)
         output << "# TYPE " << frontsbase << "tcpgaveup " << "counter" << "\n";
         output << "# HELP " << frontsbase << "tcpclientimeouts " << "Amount of TCP connections terminated by a timeout while reading from the client" << "\n";
         output << "# TYPE " << frontsbase << "tcpclientimeouts " << "counter" << "\n";
-        output << "# HELP " << frontsbase << "tcpdownstreamimeouts " << "Amount of TCP connections terminated by a timeout while reading from the backend" << "\n";
-        output << "# TYPE " << frontsbase << "tcpdownstreamimeouts " << "counter" << "\n";
+        output << "# HELP " << frontsbase << "tcpdownstreamtimeouts " << "Amount of TCP connections terminated by a timeout while reading from the backend" << "\n";
+        output << "# TYPE " << frontsbase << "tcpdownstreamtimeouts " << "counter" << "\n";
         output << "# HELP " << frontsbase << "tcpcurrentconnections " << "Amount of current incoming TCP connections from clients" << "\n";
         output << "# TYPE " << frontsbase << "tcpcurrentconnections " << "gauge" << "\n";
         output << "# HELP " << frontsbase << "tcpavgqueriesperconnection " << "The average number of queries per TCP connection" << "\n";

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -630,6 +630,8 @@ try {
         }
 
         ++g_stats.responses;
+        ++ids->cs->responses;
+        ++dss->responses;
 
         double udiff = ids->sentTime.udiff();
         vinfolog("Got answer from %s, relayed to %s%s, took %f usec", dss->remote.toStringWithPort(), ids->origRemote.toStringWithPort(),
@@ -1442,6 +1444,7 @@ ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& 
       }
 
       ++g_stats.selfAnswered;
+      ++cs.responses;
       return ProcessQueryResult::SendAnswer;
     }
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -679,6 +679,7 @@ struct ClientState
   std::shared_ptr<DOHFrontend> dohFrontend{nullptr};
   std::string interface;
   std::atomic<uint64_t> queries{0};
+  mutable std::atomic<uint64_t> responses{0};
   std::atomic<uint64_t> tcpDiedReadingQuery{0};
   std::atomic<uint64_t> tcpDiedSendingResponse{0};
   std::atomic<uint64_t> tcpGaveUp{0};
@@ -858,6 +859,7 @@ struct DownstreamState
   std::atomic<uint64_t> outstanding{0};
   std::atomic<uint64_t> reuseds{0};
   std::atomic<uint64_t> queries{0};
+  std::atomic<uint64_t> responses{0};
   struct {
     std::atomic<uint64_t> sendErrors{0};
     std::atomic<uint64_t> reuseds{0};

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -396,9 +396,6 @@ struct MetricDefinitionStorage {
     { "dyn-blocked",            MetricDefinition(PrometheusMetricType::counter, "Number of queries dropped because of a dynamic block")},
     { "dyn-block-nmg-size",     MetricDefinition(PrometheusMetricType::gauge,   "Number of dynamic blocks entries") },
     { "security-status",        MetricDefinition(PrometheusMetricType::gauge,   "Security status of this software. 0=unknown, 1=OK, 2=upgrade recommended, 3=upgrade mandatory") },
-    // Latency histogram
-    { "latency-sum",            MetricDefinition(PrometheusMetricType::counter, "Total response time in milliseconds")},
-    { "latency-count",          MetricDefinition(PrometheusMetricType::counter, "Number of queries contributing to response time histogram")},
   };
 };
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Add per-frontend and per-server response counters
- Fix handling of latency-sum and latency-count in prometheus (found via `promtool check metrics`)
- Fix a typo in 'tcpdownstreamtimeouts' prometheus description (found via `promtool check metrics`)
- Add missing prometheus descriptions for  dnsdist_pool_servers and dnsdist_pool_active_servers (found via `promtool check metrics`)
- Deduplicate DoH frontend names in prometheus

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

