### PR TITLE
Printing a pthread_t on platforms having a non-int pthread_id requires a cast to uintptr_t.

### DIFF
--- a/modules/luabackend/reload.cc
+++ b/modules/luabackend/reload.cc
@@ -56,7 +56,7 @@ void LUABackend::reload() {
     
     backend_name.clear();
 
-    backend_name = "[LUABackend: " + uitoa(backend_pid) + " (" + uitoa(backend_count) +")] ";
+    backend_name = "[LUABackend: " + uitoa((uintptr_t)backend_pid) + " (" + uitoa(backend_count) +")] ";
     
     if (lua)
 	lua_close(lua);


### PR DESCRIPTION

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Allows building of lua backend on OpenBSD.
Or do we prefet a C++  style cast?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
