### PR TITLE
auth [WIP] An attempt at zero-copying of packet data in auth

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -415,8 +415,12 @@ try
     NS = N;
   }
 
+  unique_ptr<DNSPacket> question;
   for(;;) {
-    unique_ptr<DNSPacket> question = make_unique<DNSPacket>(true);
+    // On first iteration and whenever the object was moved to the distributor, reallocate
+    if (!question) {
+      question = make_unique<DNSPacket>(true);
+    }
     if(!NS->receive(*question, buffer)) { // receive a packet         inline
       continue;                    // packet was broken, try again
     }

--- a/pdns/test-distributor_hh.cc
+++ b/pdns/test-distributor_hh.cc
@@ -49,9 +49,9 @@ BOOST_AUTO_TEST_CASE(test_distributor_basic) {
 
   int n;
   for(n=0; n < 100; ++n)  {
-    Question q;
-    q.d_dt.set(); 
-    d->question(q, report);
+    auto q = make_unique<Question>();
+    q->d_dt.set(); 
+    d->question(std::move(q), report);
   }
   sleep(1);
   BOOST_CHECK_EQUAL(n, g_receivedAnswers);
@@ -85,9 +85,9 @@ BOOST_AUTO_TEST_CASE(test_distributor_queue) {
     int n;
     // bound should be higher than max-queue-length
     for(n=0; n < 2000; ++n)  {
-      Question q;
-      q.d_dt.set(); 
-      d->question(q, report1);
+      auto q = make_unique<Question>();
+      q->d_dt.set(); 
+      d->question(std::move(q), report1);
     }
     }, DistributorFatal, [](DistributorFatal) { return true; });
 };
@@ -136,11 +136,11 @@ BOOST_AUTO_TEST_CASE(test_distributor_dies) {
 
   try {
     for(int n=0; n < 100; ++n)  {
-      Question q;
-      q.d_dt.set(); 
-      q.qdomain=DNSName(std::to_string(n));
-      q.qtype = QType(QType::A);
-      d->question(q, report2);
+      auto q = make_unique<Question>();
+      q->d_dt.set(); 
+      q->qdomain=DNSName(std::to_string(n));
+      q->qtype = QType(QType::A);
+      d->question(std::move(q), report2);
     }
 
     sleep(1);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This moves the 
```
allocate p
loop {
  receive p
  new q
  copy p into q
  process q
  delete q
}
```
into:
```
loop {
  new p
  receive p
  process p
  delete p
}
```
So far this is only an experiment, although unit tests and regression tests succeed.

After feedback, the loop is now:

``` 
p = nullptr
loop {
  new p if it is null or moved to distributor
  receive p
  process p: move to distributor only if needed
}
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)