### PR TITLE
dnsdist: Add a 'preferServerCiphers' option for DoH and DoT

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1772,6 +1772,10 @@ void setupLuaConfig(bool client)
         frontend->d_enableTickets = boost::get<bool>((*vars)["sessionTickets"]);
       }
 
+      if (vars->count("preferServerCiphers")) {
+        frontend->d_preferServerCiphers = boost::get<bool>((*vars)["preferServerCiphers"]);
+      }
+
       if (vars->count("numberOfStoredSessions")) {
         auto value = boost::get<int>((*vars)["numberOfStoredSessions"]);
         if (value < 0) {
@@ -1967,6 +1971,10 @@ void setupLuaConfig(bool client)
 
           if (vars->count("sessionTickets")) {
             frontend->d_enableTickets = boost::get<bool>((*vars)["sessionTickets"]);
+          }
+
+          if (vars->count("preferServerCiphers")) {
+            frontend->d_preferServerCiphers = boost::get<bool>((*vars)["preferServerCiphers"]);
           }
 
           if (vars->count("numberOfStoredSessions")) {

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -135,6 +135,7 @@ Listen Sockets
   * ``ticketsKeysRotationDelay``: int - Set the delay before the TLS tickets key is rotated, in seconds. Default is 43200 (12h).
   * ``sessionTickets``: bool - Whether session resumption via session tickets is enabled. Default is true, meaning tickets are enabled.
   * ``numberOfStoredSessions``: int - The maximum number of sessions kept in memory at the same time. Default is 20480. Setting this value to 0 disables stored session entirely.
+  * ``preferServerCiphers``: bool - Whether to prefer the order of ciphers set by the server instead of the one set by the client. Default is false, meaning that the order of the client is used.
 
 .. function:: addTLSLocal(address, certFile(s), keyFile(s) [, options])
 
@@ -145,7 +146,7 @@ Listen Sockets
   .. versionchanged:: 1.3.3
     ``numberOfStoredSessions`` option added.
   .. versionchanged:: 1.4.0
-    ``ciphersTLS13``, ``minTLSVersion`` and ``ocspResponses`` options added.
+    ``ciphersTLS13``, ``minTLSVersion``, ``ocspResponses`` and ``preferServerCiphers`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
@@ -171,6 +172,7 @@ Listen Sockets
   * ``numberOfStoredSessions``: int - The maximum number of sessions kept in memory at the same time. At this time this is only supported by the OpenSSL provider, as stored sessions are not supported with the GnuTLS one. Default is 20480. Setting this value to 0 disables stored session entirely.
   * ``ocspResponses``: list - List of files containing OCSP responses, in the same order than the certificates and keys, that will be used to provide OCSP stapling responses.
   * ``minTLSVersion``: str - Minimum version of the TLS protocol to support. Possible values are 'tls1.0', 'tls1.1', 'tls1.2' and 'tls1.3'. Default is to require at least TLS 1.0. Note that this value is ignored when the GnuTLS provider is in use, and the ``ciphers`` option should be set accordingly instead. For example, 'NORMAL:!VERS-TLS1.0:!VERS-TLS1.1' will disable TLS 1.0 and 1.1.
+  * ``preferServerCiphers``: bool - Whether to prefer the order of ciphers set by the server instead of the one set by the client. Default is false, meaning that the order of the client is used.
 
 .. function:: setLocal(address[, options])
 

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -927,8 +927,7 @@ static std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> getTLSContext(DOHFrontend& df
     SSL_OP_NO_COMPRESSION |
     SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION |
     SSL_OP_SINGLE_DH_USE |
-    SSL_OP_SINGLE_ECDH_USE |
-    SSL_OP_CIPHER_SERVER_PREFERENCE;
+    SSL_OP_SINGLE_ECDH_USE;
 
   if (!df.d_enableTickets || df.d_numberOfTicketsKeys == 0) {
     sslOptions |= SSL_OP_NO_TICKET;
@@ -937,6 +936,10 @@ static std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> getTLSContext(DOHFrontend& df
     df.d_ticketKeys = std::unique_ptr<OpenSSLTLSTicketKeysRing>(new OpenSSLTLSTicketKeysRing(df.d_numberOfTicketsKeys));
     SSL_CTX_set_tlsext_ticket_key_cb(ctx.get(), &ticket_key_callback);
     libssl_set_ticket_key_callback_data(ctx.get(), &df);
+  }
+
+  if (df.d_preferServerCiphers) {
+    sslOptions |= SSL_OP_CIPHER_SERVER_PREFERENCE;
   }
 
   SSL_CTX_set_options(ctx.get(), sslOptions);

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -232,8 +232,7 @@ public:
       SSL_OP_NO_COMPRESSION |
       SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION |
       SSL_OP_SINGLE_DH_USE |
-      SSL_OP_SINGLE_ECDH_USE |
-      SSL_OP_CIPHER_SERVER_PREFERENCE;
+      SSL_OP_SINGLE_ECDH_USE;
 
     registerOpenSSLUser();
 
@@ -250,6 +249,10 @@ public:
       /* use our own ticket keys handler so we can rotate them */
       SSL_CTX_set_tlsext_ticket_key_cb(d_tlsCtx.get(), &OpenSSLTLSIOCtx::ticketKeyCb);
       libssl_set_ticket_key_callback_data(d_tlsCtx.get(), this);
+    }
+
+    if (fe.d_preferServerCiphers) {
+      sslOptions |= SSL_OP_CIPHER_SERVER_PREFERENCE;
     }
 
     SSL_CTX_set_options(d_tlsCtx.get(), sslOptions);

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -64,6 +64,7 @@ struct DOHFrontend
   size_t d_maxStoredSessions{20480};
   uint8_t d_numberOfTicketsKeys{5};
   bool d_enableTickets{true};
+  bool d_preferServerCiphers{false};
 
   std::atomic<uint64_t> d_httpconnects;   // number of TCP/IP connections established
   std::atomic<uint64_t> d_tls10queries;   // valid DNS queries received via TLSv1.0

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -154,6 +154,7 @@ public:
   LibsslTLSVersion d_minTLSVersion{LibsslTLSVersion::TLS10};
 
   bool d_enableTickets{true};
+  bool d_preferServerCiphers{false};
 
 private:
   std::shared_ptr<TLSCtx> d_ctx{nullptr};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It used to be that the servers had a much better configuration than the clients, but nowadays we better rely on the clients, as they know whether they have hardware support for a specific algorithm
which might save battery life or improve latency by a large margin.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

