### PR TITLE
dnsdist: Add messages to debug TLS session resumption

### DIFF
--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -39,6 +39,7 @@ public:
   bool nameMatches(const unsigned char name[TLS_TICKETS_KEY_NAME_SIZE]) const;
   int encrypt(unsigned char keyName[TLS_TICKETS_KEY_NAME_SIZE], unsigned char *iv, EVP_CIPHER_CTX *ectx, HMAC_CTX *hctx) const;
   bool decrypt(const unsigned char* iv, EVP_CIPHER_CTX *ectx, HMAC_CTX *hctx) const;
+  std::string toString() const;
 
 private:
   unsigned char d_name[TLS_TICKETS_KEY_NAME_SIZE];

--- a/regression-tests.dnsdist/test_TLSSessionResumption.py
+++ b/regression-tests.dnsdist/test_TLSSessionResumption.py
@@ -31,7 +31,7 @@ class DNSDistTLSSessionResumptionTest(DNSDistTest):
         try:
             process = subprocess.Popen(testcmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
             # we need to wait just a bit so that the Post-Handshake New Session Ticket has the time to arrive..
-            time.sleep(0.1)
+            time.sleep(0.5)
             output = process.communicate(input=b'')
         except subprocess.CalledProcessError as exc:
             raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, process.output))


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR is only useful to investigate TLS session resumption failures inside Circle CI, do not merge it!!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
