### PR TITLE
dnsdist: Check that tickets have really been written in the tests, really disable tickets when asked

### DIFF
--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -930,7 +930,13 @@ static std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> getTLSContext(DOHFrontend& df
     SSL_OP_SINGLE_ECDH_USE;
 
   if (!df.d_enableTickets || df.d_numberOfTicketsKeys == 0) {
+    /* for TLS 1.3 this means no stateless tickets, but stateful tickets might still be issued,
+       which is something we don't want. */
     sslOptions |= SSL_OP_NO_TICKET;
+    /* really disable all tickets */
+#ifdef HAVE_SSL_CTX_SET_NUM_TICKETS
+    SSL_CTX_set_num_tickets(ctx.get(), 0);
+#endif /* HAVE_SSL_CTX_SET_NUM_TICKETS */
   }
   else {
     df.d_ticketKeys = std::unique_ptr<OpenSSLTLSTicketKeysRing>(new OpenSSLTLSTicketKeysRing(df.d_numberOfTicketsKeys));

--- a/pdns/dnsdistdist/m4/dnsdist_with_libssl.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([DNSDIST_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -243,7 +243,13 @@ public:
     }
 
     if (!fe.d_enableTickets || fe.d_numberOfTicketsKeys == 0) {
+      /* for TLS 1.3 this means no stateless tickets, but stateful tickets might still be issued,
+         which is something we don't want. */
       sslOptions |= SSL_OP_NO_TICKET;
+      /* really disable all tickets */
+#ifdef HAVE_SSL_CTX_SET_NUM_TICKETS
+      SSL_CTX_set_num_tickets(d_tlsCtx.get(), 0);
+#endif /* HAVE_SSL_CTX_SET_NUM_TICKETS */
     }
     else {
       /* use our own ticket keys handler so we can rotate them */

--- a/regression-tests.dnsdist/test_TLSSessionResumption.py
+++ b/regression-tests.dnsdist/test_TLSSessionResumption.py
@@ -2,7 +2,9 @@
 import base64
 import dns
 import os
+import shutil
 import subprocess
+import tempfile
 import time
 from dnsdisttests import DNSDistTest
 try:
@@ -16,10 +18,12 @@ class DNSDistTLSSessionResumptionTest(DNSDistTest):
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
 
     @classmethod
-    def checkSessionResumed(cls, addr, port, serverName, caFile, ticketFileOut, ticketFileIn):
+    def checkSessionResumed(cls, addr, port, serverName, caFile, ticketFileOut, ticketFileIn, allowNoTicket=False):
+        outFile = tempfile.NamedTemporaryFile()
+
         # we force TLS 1.3 because the session file gets updated when an existing ticket encrypted with an older key gets re-encrypted with the active key
         # whereas in TLS 1.2 the existing ticket is written instead..
-        testcmd = ['openssl', 's_client', '-tls1_3', '-CAfile', caFile, '-connect', '%s:%d' % (addr, port), '-servername', serverName, '-sess_out', ticketFileOut]
+        testcmd = ['openssl', 's_client', '-tls1_3', '-CAfile', caFile, '-connect', '%s:%d' % (addr, port), '-servername', serverName, '-sess_out', outFile.name]
         if ticketFileIn and os.path.exists(ticketFileIn):
             testcmd = testcmd + ['-sess_in', ticketFileIn]
 
@@ -30,7 +34,17 @@ class DNSDistTLSSessionResumptionTest(DNSDistTest):
             time.sleep(0.1)
             output = process.communicate(input=b'')
         except subprocess.CalledProcessError as exc:
-            raise AssertionError('dnsdist --check-config failed (%d): %s' % (exc.returncode, exc.output))
+            raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, process.output))
+
+        if process.returncode != 0:
+          raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, output))
+
+        if os.stat(outFile.name).st_size == 0:
+          # if tickets have been disabled, or if the session ticket encryption key is exactly the same, we might not get a new ticket
+          if not allowNoTicket:
+            raise AssertionError('%s failed (%d) to write a session to the output file: %s' % (testcmd, process.returncode, output))
+        else:
+          shutil.copyfile(outFile.name, ticketFileOut)
 
         for line in output[0].decode().splitlines():
             if line.startswith('Reused, TLSv1.'):
@@ -62,8 +76,8 @@ class TestNoTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
         """
         Session Resumption: DoH (disabled)
         """
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.out', None))
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.out', '/tmp/session.out'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/no-session.out.doh', None, allowNoTicket=True))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/no-session.out.doh', '/tmp/no-session.out.doh', allowNoTicket=True))
 
 class TestTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
 
@@ -86,28 +100,28 @@ class TestTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
         """
         Session Resumption: DoH
         """
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', None))
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', None))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
         # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
         for _ in range(self._numberOfKeys - 1):
             self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
 
         # the session should be resumed and a new ticket, encrypted with the newly active key, should be stored
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
         # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
         for _ in range(self._numberOfKeys - 1):
             self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
 
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
         # rotate the TLS session ticket keys several times, not keeping any key around this time!
         for _ in range(self._numberOfKeys):
             self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
 
         # we should not be able to resume
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
         # generate a file containing _numberOfKeys ticket keys
         self.generateTicketKeysFile(self._numberOfKeys, '/tmp/ticketKeys.1')
@@ -116,48 +130,48 @@ class TestTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
         self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.1')")
 
         # create a new session, resume it
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', None))
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', None))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
         # reload the same keys
         self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.1')")
 
         # should still be able to resume
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
         # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
         for _ in range(self._numberOfKeys - 1):
             self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
         # should still be able to resume
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
         # reload the same keys
         self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.1')")
         # since the last key was only present in memory, we should not be able to resume
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh'))
 
         # but now we can
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
         # generate a file with only _numberOfKeys - 1 keys, so the last active one should still be around after loading that one
         self.generateTicketKeysFile(self._numberOfKeys - 1, '/tmp/ticketKeys.2')
         self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.2')")
         # we should be able to resume, and the ticket should be re-encrypted with the new key (NOTE THAT we store into a new file!!)
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.2', '/tmp/session'))
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.2', '/tmp/session.2'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh.2', '/tmp/session.doh'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh.2', '/tmp/session.doh.2', allowNoTicket=True))
 
         # rotate all keys, we should not be able to resume
         for _ in range(self._numberOfKeys):
             self.sendConsoleCommand("getDOHFrontend(0):rotateTicketsKey()")
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.3', '/tmp/session.2'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh.3', '/tmp/session.doh.2'))
 
         # reload from file 1, the old session should resume
         self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.1')")
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh', '/tmp/session.doh', allowNoTicket=True))
 
         # reload from file 2, the latest session should resume
         self.sendConsoleCommand("getDOHFrontend(0):loadTicketsKeys('/tmp/ticketKeys.2')")
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.2', '/tmp/session.2'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/session.doh.2', '/tmp/session.doh.2', allowNoTicket=True))
 
 class TestNoTLSSessionResumptionDOT(DNSDistTLSSessionResumptionTest):
 
@@ -178,8 +192,8 @@ class TestNoTLSSessionResumptionDOT(DNSDistTLSSessionResumptionTest):
         """
         Session Resumption: DoT (disabled)
         """
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.out', None))
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.out', '/tmp/session.out'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/no-session.out.dot', None, allowNoTicket=True))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/no-session.out.dot', '/tmp/no-session.out.dot', allowNoTicket=True))
 
 class TestTLSSessionResumptionDOT(DNSDistTLSSessionResumptionTest):
 
@@ -202,28 +216,28 @@ class TestTLSSessionResumptionDOT(DNSDistTLSSessionResumptionTest):
         """
         Session Resumption: DoT
         """
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', None))
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', None))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot', allowNoTicket=True))
 
         # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
         for _ in range(self._numberOfKeys - 1):
             self.sendConsoleCommand("getTLSContext(0):rotateTicketsKey()")
 
         # the session should be resumed and a new ticket, encrypted with the newly active key, should be stored
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot'))
 
         # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
         for _ in range(self._numberOfKeys - 1):
             self.sendConsoleCommand("getTLSContext(0):rotateTicketsKey()")
 
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot'))
 
         # rotate the TLS session ticket keys several times, not keeping any key around this time!
         for _ in range(self._numberOfKeys):
             self.sendConsoleCommand("getTLSContext(0):rotateTicketsKey()")
 
         # we should not be able to resume
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot'))
 
         # generate a file containing _numberOfKeys ticket keys
         self.generateTicketKeysFile(self._numberOfKeys, '/tmp/ticketKeys.1')
@@ -232,45 +246,45 @@ class TestTLSSessionResumptionDOT(DNSDistTLSSessionResumptionTest):
         self.sendConsoleCommand("getTLSContext(0):loadTicketsKeys('/tmp/ticketKeys.1')")
 
         # create a new session, resume it
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', None))
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', None))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot', allowNoTicket=True))
 
         # reload the same keys
         self.sendConsoleCommand("getTLSContext(0):loadTicketsKeys('/tmp/ticketKeys.1')")
 
         # should still be able to resume
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot', allowNoTicket=True))
 
         # rotate the TLS session ticket keys several times, but keep the previously active one around so we can resume
         for _ in range(self._numberOfKeys - 1):
             self.sendConsoleCommand("getTLSContext(0):rotateTicketsKey()")
         # should still be able to resume
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot'))
 
         # reload the same keys
         self.sendConsoleCommand("getTLSContext(0):loadTicketsKeys('/tmp/ticketKeys.1')")
         # since the last key was only present in memory, we should not be able to resume
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot'))
 
         # but now we can
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot', allowNoTicket=True))
 
         # generate a file with only _numberOfKeys - 1 keys, so the last active one should still be around after loading that one
         self.generateTicketKeysFile(self._numberOfKeys - 1, '/tmp/ticketKeys.2')
         self.sendConsoleCommand("getTLSContext(0):loadTicketsKeys('/tmp/ticketKeys.2')")
         # we should be able to resume, and the ticket should be re-encrypted with the new key (NOTE THAT we store into a new file!!)
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.2', '/tmp/session'))
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.2', '/tmp/session.2'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot.2', '/tmp/session.dot'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot.2', '/tmp/session.dot.2', allowNoTicket=True))
 
         # rotate all keys, we should not be able to resume
         for _ in range(self._numberOfKeys):
             self.sendConsoleCommand("getTLSContext(0):rotateTicketsKey()")
-        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.3', '/tmp/session.2'))
+        self.assertFalse(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot.3', '/tmp/session.dot.2'))
 
         # reload from file 1, the old session should resume
         self.sendConsoleCommand("getTLSContext(0):loadTicketsKeys('/tmp/ticketKeys.1')")
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session', '/tmp/session'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot', '/tmp/session.dot', allowNoTicket=True))
 
         # reload from file 2, the latest session should resume
         self.sendConsoleCommand("getTLSContext(0):loadTicketsKeys('/tmp/ticketKeys.2')")
-        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.2', '/tmp/session.2'))
+        self.assertTrue(self.checkSessionResumed('127.0.0.1', self._tlsServerPort, self._serverName, self._caCert, '/tmp/session.dot.2', '/tmp/session.dot.2', allowNoTicket=True))


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR has all the non-debug parts of #8389: 
- really disable TLS tickets when asked, since OpenSSL either ignores the `SSL_OP_NO_TICKET` for TLS 1.3 or only disables stateless tickets but implements stateful ones (don't ask) ;
- In the regression tests, make sure that the `openssl s_client` command really wrote a new ticket to the output file when we expect one, and fail otherwise. Also rename the output file so that we can't try to reuse the session file left over by a previous test by mistake. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

