### PR TITLE
Add CentOS 8 as builder target

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.centos-8
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-8
@@ -1,0 +1,17 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+# This defines the dstribution base layer
+# Put only the bare minimum of common commands here, without dev tools
+FROM centos:8 as dist-base
+ARG BUILDER_CACHE_BUSTER=
+RUN yum install -y epel-release && \
+    dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled PowerTools
+
+# Do the actual rpm build
+@INCLUDE Dockerfile.rpmbuild
+
+# Do a test install and verify
+# Can be skipped with skiptests=1 in the environment
+# @EXEC [ "$skiptests" = "" ] && include Dockerfile.rpmtest

--- a/builder-support/specs/dnsdist.spec
+++ b/builder-support/specs/dnsdist.spec
@@ -56,7 +56,10 @@ Requires(pre): shadow
 %endif
 %if 0%{?rhel} >= 7
 Requires(pre): shadow-utils
+%if 0%{?rhel} == 7
+# No fstrm in EPEL 8 (yet) https://bugzilla.redhat.com/show_bug.cgi?id=1760298
 BuildRequires: fstrm-devel
+%endif
 %systemd_requires
 %endif
 
@@ -98,8 +101,10 @@ sed -i '/^ExecStart/ s/dnsdist/dnsdist -u dnsdist -g dnsdist/' dnsdist.service.i
   --without-protobuf \
   --without-net-snmp
 %endif
-%if 0%{?rhel} >= 7
+%if 0%{?rhel} == 7
   --enable-dnstap \
+%endif
+%if 0%{?rhel} >= 7
   --with-gnutls \
   --with-protobuf \
   --with-lua=%{lua_implementation} \

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -35,7 +35,11 @@ BuildRequires: libatomic
 %if 0%{?rhel} >= 7
 BuildRequires: protobuf-compiler
 BuildRequires: protobuf-devel
+
+%if 0%{?rhel} == 7
+# No fstrm in EPEL 8 yet
 BuildRequires: fstrm-devel
+%endif
 %endif
 
 BuildRequires: openssl-devel

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -166,7 +166,9 @@ Summary: Geo backend for %{name}
 Group: System Environment/Daemons
 Requires: %{name}%{?_isa} = %{version}-%{release}
 BuildRequires: yaml-cpp-devel
+%if 0%{?rhel} <= 7
 BuildRequires: geoip-devel
+%endif
 BuildRequires: libmaxminddb-devel
 %global backends %{backends} geoip
 


### PR DESCRIPTION
### Short description
This produces packages for EL8 for all products.

```
builder/tmp/4.3.0-alpha1.288.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-recursor-4.3.0-0.alpha1.centos8pkgs.288.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.3.0-alpha1.288.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-recursor-debuginfo-4.3.0-0.alpha1.centos8pkgs.288.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.3.0-alpha1.288.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-recursor-debugsource-4.3.0-0.alpha1.centos8pkgs.288.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.3.0-alpha1.288.centos8pkgs.g0c8b25175.dirty/centos-8/dist/pdns-recursor-4.3.0-0.alpha1.centos8pkgs.288.g0c8b25175.dirty.1pdns.el8.src.rpm

builder/tmp/1.4.0-rc3.68.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/dnsdist-debugsource-1.4.0-0.rc3.centos8pkgs.68.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/1.4.0-rc3.68.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/dnsdist-debuginfo-1.4.0-0.rc3.centos8pkgs.68.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/1.4.0-rc3.68.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/dnsdist-1.4.0-0.rc3.centos8pkgs.68.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/1.4.0-rc3.68.centos8pkgs.g0c8b25175.dirty/centos-8/dist/dnsdist-1.4.0-0.rc3.centos8pkgs.68.g0c8b25175.dirty.1pdns.el8.src.rpm

builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/pdns-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.src.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-mysql-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-tools-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-tinydns-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-ixfrdist-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-lmdb-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-lmdb-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-mysql-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-postgresql-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-mydns-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-lua-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-remote-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-tools-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-geoip-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-lua-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-odbc-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-lua2-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-sqlite-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-tinydns-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-lua2-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-ldap-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-ixfrdist-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-odbc-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-remote-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-sqlite-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-ldap-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-pipe-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-mydns-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-postgresql-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-geoip-debuginfo-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-backend-pipe-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
builder/tmp/4.2.0-rc2.813.centos8pkgs.g0c8b25175.dirty/centos-8/dist/x86_64/pdns-debugsource-4.2.0-0.rc2.centos8pkgs.813.g0c8b25175.dirty.1pdns.el8.x86_64.rpm
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)