### PR TITLE
Fix typo in setQueryRate docs

### DIFF
--- a/pdns/dnsdistdist/docs/guides/dynblocks.rst
+++ b/pdns/dnsdistdist/docs/guides/dynblocks.rst
@@ -81,6 +81,6 @@ action is applied.
 .. code-block:: lua
 
   local dbr = dynBlockRulesGroup()
-  -- generate a warning above 100 qps for 10s, and start dropping incoming queries above 300 qps for 10s
+  -- generate a warning above 100 qps for 10s, and start dropping incoming queries above 300 qps for 60s
   dbr:setQueryRate(300, 10, "Exceeded query rate", 60, DNSAction.Drop, 100)
 

--- a/pdns/dnsdistdist/docs/guides/dynblocks.rst
+++ b/pdns/dnsdistdist/docs/guides/dynblocks.rst
@@ -81,6 +81,7 @@ action is applied.
 .. code-block:: lua
 
   local dbr = dynBlockRulesGroup()
-  -- generate a warning above 100 qps for 10s, and start dropping incoming queries above 300 qps for 60s
+  -- Generate a warning if we detect a query rate above 100 qps for at least 10s.
+  -- If the query rate raises above 300 qps for 10 seconds, we'll block the client for 60s.
   dbr:setQueryRate(300, 10, "Exceeded query rate", 60, DNSAction.Drop, 100)
 


### PR DESCRIPTION
### Short description
Fix small typo in the dnsdist DynBlocks guide

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
