### PR TITLE
dnsdist: Add more options to LogAction (non-verbose mode, timestamps)

### DIFF
--- a/contrib/DNSDistLogActionReader.py
+++ b/contrib/DNSDistLogActionReader.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import socket
+import struct
+import sys
+
+def readRecord(fp, withTimestamp):
+
+    if withTimestamp:
+        data = fp.read(12)
+        if not data:
+            return False
+        tv_sec, tv_nsec = struct.unpack("QI", data)
+
+    data = fp.read(2)
+    if not data:
+        return False
+
+    queryID = struct.unpack("!H", data)[0]
+    qname = ''
+    while True:
+        labelLen = struct.unpack("B", fp.read(1))[0]
+        if labelLen == 0:
+            break
+        label = fp.read(labelLen)
+        if qname != '':
+            qname = qname + '.'
+        qname = qname + label.decode()
+
+    qtype = struct.unpack("H", fp.read(2))[0]
+    addrType = struct.unpack("H", fp.read(2))[0]
+    addr = None
+    if addrType == socket.AF_INET:
+        addr = socket.inet_ntop(socket.AF_INET, fp.read(4))
+    elif addrType == socket.AF_INET6:
+        addr = socket.inet_ntop(socket.AF_INET6, fp.read(16))
+    else:
+        print('Unsupported address type %d, skipping this record' % (int(addrType)))
+        return False
+    port = struct.unpack("!H", fp.read(2))[0]
+
+    if withTimestamp:
+        print('[%u.%u] Packet from %s:%d for %s %s with id %d' % (tv_sec, tv_nsec, addr, port, qname, qtype, queryID))
+    else:
+        print('Packet from %s:%d for %s %s with id %d' % (addr, port, qname, qtype, queryID))
+
+    return True
+
+def readLogFile(filename, withTimestamps):
+    with open(filename, mode='rb') as fp:
+        while True:
+            if not readRecord(fp, withTimestamps):
+                break
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 and (len(sys.argv) != 3 or sys.argv[2] != 'with-timestamps'):
+        sys.exit('Usage: %s <path to log file> [with-timestamps]' % (sys.argv[0]))
+
+    readLogFile(sys.argv[1], len(sys.argv) == 3)
+
+    sys.exit(0)

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -988,18 +988,28 @@ The following actions exist.
   :param KeyValueLookupKey lookupKey: The key to use for the lookup
   :param string destinationTag: The name of the tag to store the result into
 
-.. function:: LogAction(filename[, binary[, append[, buffered]]])
+.. function:: LogAction([filename[, binary[, append[, buffered[, verboseOnly[, includeTimestamp]]]]]])
+
+  .. versionchanged:: 1.4.0
+    Added the optional parameters ``verboseOnly`` and ``includeTimestamp``, made ``filename`` optional.
 
   Log a line for each query, to the specified ``file`` if any, to the console (require verbose) if the empty string is given as filename.
-  When logging to a file, the ``binary`` optional parameter specifies whether we log in binary form (default) or in textual form.
+
+  If an empty string is supplied in the file name, the logging is done to stdout, and only in verbose mode by default. This can be changed by setting ``verboseOnly`` to true.
+
+  When logging to a file, the ``binary`` optional parameter specifies whether we log in binary form (default) or in textual form. Before 1.4.0 the binary log format only included the qname and qtype. Since 1.4.0 it includes an optional timestamp, the query ID, qname, qtype, remote address and port.
+
   The ``append`` optional parameter specifies whether we open the file for appending or truncate each time (default).
   The ``buffered`` optional parameter specifies whether writes to the file are buffered (default) or not.
+
   Subsequent rules are processed after this action.
 
   :param string filename: File to log to. Set to an empty string to log to the normal stdout log, this only works when ``-v`` is set on the command line.
   :param bool binary: Do binary logging. Default true
   :param bool append: Append to the log. Default false
-  :param bool buffered: Use buffered I/O. default true
+  :param bool buffered: Use buffered I/O. Default true
+  :param bool verboseOnly: Whether to log only in verbose mode when logging to stdout. Default is true
+  :param bool includeTimestamp: Whether to include a timestamp for every entry. Default is false
 
 .. function:: LuaAction(function)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
* Adds an option to include timestamps ;
* and a second one to log to stdout in non-verbose mode ;
* and the binary format now includes an optional timestamp, the query ID, the qname, the qtype, the source address and port.

This PR also adds a small python snippet to the contrib/ directory to be able to read the binary logs.

Closes #8390.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

