### PR TITLE
Deb: Load DNSSEC Keys from disk by default

### DIFF
--- a/builder-support/debian/recursor/debian-buster/lua-config/rootkeys.lua
+++ b/builder-support/debian/recursor/debian-buster/lua-config/rootkeys.lua
@@ -1,0 +1,3 @@
+-- readTrustAnchorsFromFile reads the DNSSEC trust anchors from the provided file
+-- and reloads it every 24 hours.
+readTrustAnchorsFromFile("/usr/share/dns/root.key")

--- a/builder-support/debian/recursor/debian-buster/pdns-recursor.dirs
+++ b/builder-support/debian/recursor/debian-buster/pdns-recursor.dirs
@@ -1,0 +1,1 @@
+etc/powerdns/recursor.d

--- a/builder-support/debian/recursor/debian-buster/recursor.lua
+++ b/builder-support/debian/recursor/debian-buster/recursor.lua
@@ -1,0 +1,7 @@
+-- Debian default Lua configuration file for PowerDNS Recursor
+
+-- Load DNSSEC root keys from dns-root-data package.
+-- Note: If you provide your own Lua configuration file, consider
+-- running rootkeys.lua too.
+dofile("/usr/share/pdns-recursor/lua-config/rootkeys.lua")
+

--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -39,10 +39,15 @@ override_dh_auto_configure:
 
 override_dh_auto_install:
 	dh_auto_install
+	install -d debian/pdns-recursor/usr/share/pdns-recursor/lua-config
+	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
+	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist
 	./pdns_recursor --no-config --config | sed \
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
+		-e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \
+		-e 's!# lua-config-file=.*!lua-config-file=/etc/powerdns/recursor.lua!' \
 		-e 's!# quiet=.*!quiet=yes!' \
 		-e 's!# setgid=.*!setgid=pdns!' \
 		-e 's!# setuid=.*!setuid=pdns!' \
@@ -60,5 +65,5 @@ override_dh_gencontrol:
 
 override_dh_fixperms:
 	dh_fixperms
-        # these files often contain passwords. 640 as it is chowned to root:pdns
+# these files often contain passwords. 640 as it is chowned to root:pdns
 	chmod 0640 debian/pdns-recursor/etc/powerdns/recursor.conf

--- a/builder-support/debian/recursor/debian-jessie/lua-config/rootkeys.lua
+++ b/builder-support/debian/recursor/debian-jessie/lua-config/rootkeys.lua
@@ -1,0 +1,3 @@
+-- readTrustAnchorsFromFile reads the DNSSEC trust anchors from the provided file
+-- and reloads it every 24 hours.
+readTrustAnchorsFromFile("/usr/share/dns/root.key")

--- a/builder-support/debian/recursor/debian-jessie/pdns-recursor.dirs
+++ b/builder-support/debian/recursor/debian-jessie/pdns-recursor.dirs
@@ -1,0 +1,1 @@
+etc/powerdns/recursor.d

--- a/builder-support/debian/recursor/debian-jessie/recursor.lua
+++ b/builder-support/debian/recursor/debian-jessie/recursor.lua
@@ -1,0 +1,7 @@
+-- Debian default Lua configuration file for PowerDNS Recursor
+
+-- Load DNSSEC root keys from dns-root-data package.
+-- Note: If you provide your own Lua configuration file, consider
+-- running rootkeys.lua too.
+dofile("/usr/share/pdns-recursor/lua-config/rootkeys.lua")
+

--- a/builder-support/debian/recursor/debian-jessie/rules
+++ b/builder-support/debian/recursor/debian-jessie/rules
@@ -39,10 +39,15 @@ override_dh_auto_configure:
 
 override_dh_auto_install:
 	dh_auto_install -- STRIP_BINARIES=0
+	install -d debian/pdns-recursor/usr/share/pdns-recursor/lua-config
+	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
+	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	rm -f debian/tmp/etc/powerdns/recursor.conf-dist
 	./pdns_recursor --no-config --config | sed \
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
+		-e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \
+		-e 's!# lua-config-file=.*!lua-config-file=/etc/powerdns/recursor.lua!' \
 		-e 's!# quiet=.*!quiet=yes!' \
 		-e 's!# setgid=.*!setgid=pdns!' \
 		-e 's!# setuid=.*!setuid=pdns!' \
@@ -60,5 +65,5 @@ override_dh_gencontrol:
 
 override_dh_fixperms:
 	dh_fixperms
-        # these files often contain passwords. 640 as it is chowned to root:pdns
+# these files often contain passwords. 640 as it is chowned to root:pdns
 	chmod 0640 debian/tmp/etc/powerdns/recursor.conf

--- a/builder-support/debian/recursor/debian-stretch/lua-config/rootkeys.lua
+++ b/builder-support/debian/recursor/debian-stretch/lua-config/rootkeys.lua
@@ -1,0 +1,3 @@
+-- readTrustAnchorsFromFile reads the DNSSEC trust anchors from the provided file
+-- and reloads it every 24 hours.
+readTrustAnchorsFromFile("/usr/share/dns/root.key")

--- a/builder-support/debian/recursor/debian-stretch/pdns-recursor.dirs
+++ b/builder-support/debian/recursor/debian-stretch/pdns-recursor.dirs
@@ -1,0 +1,1 @@
+etc/powerdns/recursor.d

--- a/builder-support/debian/recursor/debian-stretch/recursor.lua
+++ b/builder-support/debian/recursor/debian-stretch/recursor.lua
@@ -1,0 +1,7 @@
+-- Debian default Lua configuration file for PowerDNS Recursor
+
+-- Load DNSSEC root keys from dns-root-data package.
+-- Note: If you provide your own Lua configuration file, consider
+-- running rootkeys.lua too.
+dofile("/usr/share/pdns-recursor/lua-config/rootkeys.lua")
+

--- a/builder-support/debian/recursor/debian-stretch/rules
+++ b/builder-support/debian/recursor/debian-stretch/rules
@@ -39,10 +39,15 @@ override_dh_auto_configure:
 
 override_dh_auto_install:
 	dh_auto_install
+	install -d debian/pdns-recursor/usr/share/pdns-recursor/lua-config
+	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
+	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist
 	./pdns_recursor --no-config --config | sed \
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
+		-e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \
+		-e 's!# lua-config-file=.*!lua-config-file=/etc/powerdns/recursor.lua!' \
 		-e 's!# quiet=.*!quiet=yes!' \
 		-e 's!# setgid=.*!setgid=pdns!' \
 		-e 's!# setuid=.*!setuid=pdns!' \
@@ -60,5 +65,5 @@ override_dh_gencontrol:
 
 override_dh_fixperms:
 	dh_fixperms
-        # these files often contain passwords. 640 as it is chowned to root:pdns
+# these files often contain passwords. 640 as it is chowned to root:pdns
 	chmod 0640 debian/pdns-recursor/etc/powerdns/recursor.conf


### PR DESCRIPTION
### Short description
This also automatically reloads them each 24 hours by default. A similar method was implemented by @zeha in Debian downstream for recursor 4.1.x.

@zeha you might want to port this to downstream (in 4.2.0+) as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)