### PR TITLE
Ixfrdist: handle reading of empty files gracefully

### DIFF
--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -282,7 +282,7 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
     string dir = workdir + "/" + domain.toString();
     try {
       g_log<<Logger::Info<<"Trying to initially load domain "<<domain<<" from disk"<<endl;
-      auto serial = getSerialsFromDir(dir);
+      auto serial = getSerialFromDir(dir);
       shared_ptr<SOARecordContent> soa;
       uint32_t soaTTL;
       {

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -282,7 +282,6 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
     string dir = workdir + "/" + domain.toString();
     try {
       g_log<<Logger::Info<<"Trying to initially load domain "<<domain<<" from disk"<<endl;
-againserial:
       auto serial = getSerialFromDir(dir);
       shared_ptr<SOARecordContent> soa;
       uint32_t soaTTL;
@@ -293,7 +292,6 @@ againserial:
         if (soa == nullptr) {
           g_log<<Logger::Error<<"Could not load SOA from disk for zone "<<domain<<", removing file '"<<fname<<"'"<<endl;
           unlink(fname.c_str());
-          goto againserial;
         }
         loadZoneFromDisk(records, fname, domain);
         auto zoneInfo = std::make_shared<ixfrinfo_t>();

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -289,9 +289,11 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
         string fname = workdir + "/" + domain.toString() + "/" + std::to_string(serial);
         loadSOAFromDisk(domain, fname, soa, soaTTL);
         records_t records;
-        if (soa != nullptr) {
-          loadZoneFromDisk(records, fname, domain);
+        if (soa == nullptr) {
+          g_log<<Logger::Error<<"Could not load SOA from disk for zone "<<domain<<", ignoring file"<<endl;
+          continue;
         }
+        loadZoneFromDisk(records, fname, domain);
         auto zoneInfo = std::make_shared<ixfrinfo_t>();
         zoneInfo->latestAXFR = std::move(records);
         zoneInfo->soa = soa;

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -282,6 +282,7 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
     string dir = workdir + "/" + domain.toString();
     try {
       g_log<<Logger::Info<<"Trying to initially load domain "<<domain<<" from disk"<<endl;
+againserial:
       auto serial = getSerialFromDir(dir);
       shared_ptr<SOARecordContent> soa;
       uint32_t soaTTL;
@@ -290,8 +291,9 @@ void updateThread(const string& workdir, const uint16_t& keep, const uint16_t& a
         loadSOAFromDisk(domain, fname, soa, soaTTL);
         records_t records;
         if (soa == nullptr) {
-          g_log<<Logger::Error<<"Could not load SOA from disk for zone "<<domain<<", ignoring file"<<endl;
-          continue;
+          g_log<<Logger::Error<<"Could not load SOA from disk for zone "<<domain<<", removing file '"<<fname<<"'"<<endl;
+          unlink(fname.c_str());
+          goto againserial;
         }
         loadZoneFromDisk(records, fname, domain);
         auto zoneInfo = std::make_shared<ixfrinfo_t>();

--- a/pdns/ixfrutils.cc
+++ b/pdns/ixfrutils.cc
@@ -73,7 +73,7 @@ uint32_t getSerialFromMaster(const ComboAddress& master, const DNSName& zone, sh
   return 0;
 }
 
-uint32_t getSerialsFromDir(const std::string& dir)
+uint32_t getSerialFromDir(const std::string& dir)
 {
   uint32_t ret=0;
   DIR* dirhdl=opendir(dir.c_str());

--- a/pdns/ixfrutils.cc
+++ b/pdns/ixfrutils.cc
@@ -110,11 +110,13 @@ uint32_t getSerialFromRecords(const records_t& records, DNSRecord& soaret)
 static void writeRecords(FILE* fp, const records_t& records)
 {
   for(const auto& r: records) {
-    fprintf(fp, "%s\t%" PRIu32 "\tIN\t%s\t%s\n",
+    if(fprintf(fp, "%s\t%" PRIu32 "\tIN\t%s\t%s\n",
             r.d_name.isRoot() ? "@" :  r.d_name.toStringNoDot().c_str(),
             r.d_ttl,
             DNSRecordContent::NumberToType(r.d_type).c_str(),
-            r.d_content->getZoneRepresentation().c_str());
+            r.d_content->getZoneRepresentation().c_str()) < 0) {
+      throw runtime_error(stringerror());
+    }
   }
 }
 
@@ -129,13 +131,29 @@ void writeZoneToDisk(const records_t& records, const DNSName& zone, const std::s
 
   records_t soarecord;
   soarecord.insert(soa);
-  fprintf(fp, "$ORIGIN %s\n", zone.toString().c_str());
+  if(fprintf(fp, "$ORIGIN %s\n", zone.toString().c_str()) < 0) {
+    string error = "Error writing to zone file for " + zone.toLogString() + " in file " + fname + ".partial" + ": " + stringerror();
+    fclose(fp);
+    unlink((fname+".partial").c_str());
+    throw std::runtime_error(error);
+  }
 
-  writeRecords(fp, soarecord);
-  writeRecords(fp, records);
-  writeRecords(fp, soarecord);
+  try {
+    writeRecords(fp, soarecord);
+    writeRecords(fp, records);
+    writeRecords(fp, soarecord);
+  } catch (runtime_error &e) {
+    fclose(fp);
+    unlink((fname+".partial").c_str());
+    throw runtime_error("Error closing zone file for " + zone.toLogString() + " in file " + fname + ".partial" + ": " + e.what());
+  }
 
-  fclose(fp);
+  if(fclose(fp) != 0) {
+    string error = "Error closing zone file for " + zone.toLogString() + " in file " + fname + ".partial" + ": " + stringerror();
+    unlink((fname+".partial").c_str());
+    throw std::runtime_error(error);
+  }
+
   if (rename( (fname+".partial").c_str(), fname.c_str()) != 0) {
     throw std::runtime_error("Unable to move the zone file for " + zone.toLogString() + " from " + fname + ".partial to " + fname + ": " + stringerror());
   }

--- a/pdns/ixfrutils.hh
+++ b/pdns/ixfrutils.hh
@@ -50,7 +50,7 @@ typedef multi_index_container <
 > /* multi_index_container */ records_t;
 
 uint32_t getSerialFromMaster(const ComboAddress& master, const DNSName& zone, shared_ptr<SOARecordContent>& sr, const TSIGTriplet& tt = TSIGTriplet(), const uint16_t timeout = 2);
-uint32_t getSerialsFromDir(const std::string& dir);
+uint32_t getSerialFromDir(const std::string& dir);
 uint32_t getSerialFromRecords(const records_t& records, DNSRecord& soaret);
 void writeZoneToDisk(const records_t& records, const DNSName& zone, const std::string& directory);
 void loadZoneFromDisk(records_t& records, const string& fname, const DNSName& zone);

--- a/pdns/ixplore.cc
+++ b/pdns/ixplore.cc
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
     string directory(argv[5]);
     records_t records;
 
-    uint32_t ourSerial = getSerialsFromDir(directory);
+    uint32_t ourSerial = getSerialFromDir(directory);
 
     cout<<"Loading zone, our highest available serial is "<< ourSerial<<endl;
 


### PR DESCRIPTION
### Short description
We noticed `ixfrdist` crashing while trying to read empty zonefiles from its storage. This PR avoids that crash, and causes a fresh fetch from the master in such cases. 

~This PR does not prevent the writing of empty files.~ now it does

~Should this PR remove empty/unparseable files when spotted?~ now it does

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
