### PR TITLE
builder: demand user chooses a module except when building docs

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.debbuild
+++ b/builder-support/dockerfiles/Dockerfile.debbuild
@@ -1,4 +1,4 @@
-@IF [ ! -z "$M_authoritative$M_all" ]
+@IF [ ! -z "$M_authoritative" ]
 RUN if $(echo ${BUILDER_VERSION} | grep -q -E '^0\.0\.'); then \
   # make sure we don't break dependencies for master releases \
   sed -i '/pdns-server (<< .*/d' pdns-${BUILDER_VERSION}/debian/control; \
@@ -9,13 +9,13 @@ RUN PDNS_TEST_NO_IPV6=1 builder/helpers/build-debs.sh pdns-${BUILDER_VERSION}
 RUN mv pdns*.deb /dist; mv pdns*.ddeb /dist || true
 @ENDIF
 
-@IF [ ! -z "$M_recursor$M_all" ]
+@IF [ ! -z "$M_recursor" ]
 RUN builder/helpers/build-debs.sh pdns-recursor-${BUILDER_VERSION}
 
 RUN mv pdns-recursor*.deb /dist; mv pdns-recursor*.ddeb /dist || true
 @ENDIF
 
-@IF [ ! -z "$M_dnsdist$M_all" ]
+@IF [ ! -z "$M_dnsdist" ]
 RUN builder/helpers/build-debs.sh dnsdist-${BUILDER_VERSION}
 
 RUN mv dnsdist*.deb /dist; mv dnsdist*.ddeb /dist || true

--- a/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -21,7 +21,7 @@ RUN for file in /sdist/* ; do ln -s $file /root/rpmbuild/SOURCES/ ; done && ls /
 ADD builder-support/specs/ /pdns/builder-support/specs
 RUN find /pdns/builder-support/specs/ -not -name '*.spec' -exec ln -s {} /root/rpmbuild/SOURCES/ \;
 
-@IF [ ! -z "$M_authoritative$M_all" ]
+@IF [ ! -z "$M_authoritative" ]
 RUN if $(grep -q 'release 6' /etc/redhat-release); then \
       scl enable devtoolset-7 -- builder/helpers/build-specs.sh builder-support/specs/pdns.spec; \
     else \
@@ -29,7 +29,7 @@ RUN if $(grep -q 'release 6' /etc/redhat-release); then \
     fi
 @ENDIF
 
-@IF [ ! -z "$M_recursor$M_all" ]
+@IF [ ! -z "$M_recursor" ]
 RUN if $(grep -q 'release 6' /etc/redhat-release); then \
       scl enable devtoolset-7 -- builder/helpers/build-specs.sh builder-support/specs/pdns-recursor.spec; \
     else \
@@ -37,7 +37,7 @@ RUN if $(grep -q 'release 6' /etc/redhat-release); then \
     fi
 @ENDIF
 
-@IF [ ! -z "$M_dnsdist$M_all" ]
+@IF [ ! -z "$M_dnsdist" ]
 RUN if $(grep -q 'release 6' /etc/redhat-release); then \
       true ; \
     else \

--- a/builder-support/dockerfiles/Dockerfile.target.sdist
+++ b/builder-support/dockerfiles/Dockerfile.target.sdist
@@ -1,20 +1,20 @@
-@IF [ ! -z "$M_authoritative$M_all" ]
+@IF [ ! -z "$M_authoritative" ]
 @INCLUDE Dockerfile.authoritative
 @ENDIF
 
-@IF [ ! -z "$M_recursor$M_all" ]
+@IF [ ! -z "$M_recursor" ]
 @INCLUDE Dockerfile.recursor
 @ENDIF
 
-@IF [ ! -z "$M_dnsdist$M_all" ]
+@IF [ ! -z "$M_dnsdist" ]
 @INCLUDE Dockerfile.dnsdist
 @ENDIF
 
 FROM alpine:3.10 as sdist
 ARG BUILDER_CACHE_BUSTER=
 
-@IF [ -z "$M_all$M_authoritative$M_recursor$M_dnsdist"]
-RUN echo "no valid modules specified!" ; exit 1
+@IF [ -z "$M_authoritative$M_recursor$M_dnsdist"]
+RUN echo "no valid module specified! - please pick just one using -m {authoritative|recursor|dnsdist}" ; exit 1
 @ENDIF
 
 @IF [ ! -z "$M_authoritative$M_all" ]


### PR DESCRIPTION
### Short description
Without this, running something like `builder/build.sh centos-7` (without any `-m`) will spend a lot of time, and then fail confusingly.

Only lightly tested. PRed because @pieterlexis and I half-solved this problem 3 times before but it never landed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
