### PR TITLE
dns64: stop hiding PTR indirection

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -111,13 +111,14 @@ static int getFakePTRRecords(const DNSName& qname, const std::string& prefix, ve
   newquery += "in-addr.arpa.";
 
 
+  DNSRecord rr;
+  rr.d_name = qname;
+  rr.d_type = QType::CNAME;
+  rr.d_content = std::make_shared<CNAMERecordContent>(newquery);
+  ret.push_back(rr);
+
   int rcode = directResolve(DNSName(newquery), QType(QType::PTR), 1, ret);
-  for(DNSRecord& rr :  ret)
-  {
-    if(rr.d_type == QType::PTR && rr.d_place==DNSResourceRecord::ANSWER) {
-      rr.d_name = qname;
-    }
-  }
+
   return rcode;
 
 }


### PR DESCRIPTION
### Short description
Before:
```
;; QUESTION SECTION:
;4.2.a.7.6.5.3.6.f.f.7.7.b.1.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa. IN PTR

;; ANSWER SECTION:
4.2.a.7.6.5.3.6.f.f.7.7.b.1.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa. 82726	IN PTR server-99-86-122-36.dub2.r.cloudfront.net.
```

After:
```
;; QUESTION SECTION:
;4.2.a.7.6.5.3.6.f.f.7.7.b.1.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa. IN PTR

;; ANSWER SECTION:
4.2.a.7.6.5.3.6.f.f.7.7.b.1.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa. 0 IN CNAME 36.122.86.99.in-addr.arpa.
36.122.86.99.in-addr.arpa. 81396 IN	PTR	server-99-86-122-36.dub2.r.cloudfront.net.
```

requested by @tuxis-ie

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
