### PR TITLE
dnsdist docs: fix versionadded formatting

### DIFF
--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -576,6 +576,7 @@ These ``DNSRule``\ s be one of the following items:
   :param int rcode: The RCODE to match on
 
 .. function:: HTTPHeaderRule(name, regex)
+
   .. versionadded:: 1.4.0
 
   Matches DNS over HTTPS queries with a HTTP header ``name`` whose content matches the regular expression ``regex``.
@@ -584,6 +585,7 @@ These ``DNSRule``\ s be one of the following items:
   :param str regex: A regular expression to match the content of the specified header
 
 .. function:: HTTPPathRegexRule(regex)
+
   .. versionadded:: 1.4.0
 
   Matches DNS over HTTPS queries with a HTTP path matching the regular expression supplied in ``regex``. For example, if the query has been sent to the https://192.0.2.1:443/PowerDNS?dns=... URL, the path would be '/PowerDNS'.
@@ -592,6 +594,7 @@ These ``DNSRule``\ s be one of the following items:
   :param str regex: The regex to match on
 
 .. function:: HTTPPathRule(path)
+
   .. versionadded:: 1.4.0
 
   Matches DNS over HTTPS queries with a HTTP path of ``path``. For example, if the query has been sent to the https://192.0.2.1:443/PowerDNS?dns=... URL, the path would be '/PowerDNS'.
@@ -600,6 +603,7 @@ These ``DNSRule``\ s be one of the following items:
   :param str path: The exact HTTP path to match on
 
 .. function:: KeyValueStoreLookupRule(kvs, lookupKey)
+
   .. versionadded:: 1.4.0
 
   As of 1.4.0, this code is considered experimental.
@@ -773,6 +777,7 @@ These ``DNSRule``\ s be one of the following items:
   :param str regex: The regular expression to match the QNAME.
 
 .. function:: SNIRule(name)
+
   .. versionadded:: 1.4.0
 
   Matches against the TLS Server Name Indication value sent by the client, if any. Only makes
@@ -964,6 +969,7 @@ The following actions exist.
   :param int rcode: The extended RCODE to respond with.
 
 .. function:: HTTPStatusAction(status, body, contentType="")
+
   .. versionadded:: 1.4.0
 
   Return an HTTP response with a status code of ''status''. For HTTP redirects, ''body'' should be the redirect URL.


### PR DESCRIPTION
### Short description
This fixes the `versionadded` currently visible at https://dnsdist.org/rules-actions.html#HTTPStatusAction

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
