### PR TITLE
global: Normalize isIpv4/6 to isIPv4/6

### DIFF
--- a/docs/backends/pipe.rst
+++ b/docs/backends/pipe.rst
@@ -20,7 +20,7 @@ read a question on standard input and answer on standard output.
 The number of distributor (backend) threads (``distributor-threads``) to start
 per receiver thread is low by default. This can impact the performance if
 you have latency-bound application as backend. You should increase the
-number of ``distributor-threads`` in such cases. See :doc:`performance`.
+number of ``distributor-threads`` in such cases. See :doc:`../performance`.
 
 The PipeBackend is primarily meant for allowing rapid development of new
 backends without tight integration with PowerDNS. It allows end-users to

--- a/docs/lua-records/reference/netmask.rst
+++ b/docs/lua-records/reference/netmask.rst
@@ -43,9 +43,25 @@ The :class:`Netmask` class represents an IP netmask.
 
   .. method:: Netmask:isIpv4() -> bool
 
+  .. deprecated:: v4.3.0
+
+      True if the netmask is an IPv4 netmask.
+
+  .. method:: Netmask:isIPv4() -> bool
+
+  .. versionadded:: v4.3.0
+
       True if the netmask is an IPv4 netmask.
 
   .. method:: Netmask:isIpv6() -> bool
+
+  .. deprecated:: v4.3.0
+
+      True if the netmask is an IPv6 netmask.
+
+  .. method:: Netmask:isIPv6() -> bool
+
+  .. deprecated:: v4.3.0
 
       True if the netmask is an IPv6 netmask.
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -8,6 +8,11 @@ Please upgrade to the PowerDNS Authoritative Server 4.0.0 from 3.4.2+.
 See the `3.X <https://doc.powerdns.com/3/authoritative/upgrading/>`__
 upgrade notes if your version is older than 3.4.2.
 
+4.2.x to 4.3.0
+--------------
+
+- Netmask class methods ``isIpv4`` and ``isIpv6`` have been deprecated in Lua, use :func:`Netmask.isIPv4` and :func:`Netmask.isIPv6` instead. In C++ API these methods have been removed.
+
 4.1.X to 4.2.0
 --------------
 

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -193,9 +193,9 @@ void GeoIPBackend::initialize() {
           } else {
             Netmask nm{net->first.as<string>()};
             nmt.insert(nm).second.swap(value);
-            if (nm.isIpv6() == true && netmask6 < nm.getBits())
+            if (nm.isIPv6() == true && netmask6 < nm.getBits())
               netmask6 = nm.getBits();
-            if (nm.isIpv6() == false && netmask4 < nm.getBits())
+            if (nm.isIPv6() == false && netmask4 < nm.getBits())
               netmask4 = nm.getBits();
           }
         }
@@ -321,7 +321,7 @@ bool GeoIPBackend::lookup_static(const GeoIPDomain &dom, const DNSName &search, 
       if (qtype != QType::ANY && rr.qtype != qtype) continue;
 
       if (rr.has_weight) {
-        gl.netmask = (addr.isIpv6()?128:32);
+        gl.netmask = (addr.isIPv6()?128:32);
         int comp = cumul_probabilities[rr.qtype.getCode()];
         cumul_probabilities[rr.qtype.getCode()] += rr.weight;
         if (rr.weight == 0 || probability_rnd < comp || probability_rnd > (comp + rr.weight))
@@ -389,13 +389,13 @@ void GeoIPBackend::lookup(const QType &qtype, const DNSName& qdomain, int zoneId
     tmp_gl.netmask = 0;
     // get netmask from geoip backend
     if (queryGeoIP(addr, GeoIPInterface::Name, tmp_gl) == "unknown") {
-      if (addr.isIpv6())
+      if (addr.isIPv6())
         gl.netmask = target->second.netmask6;
       else
         gl.netmask = target->second.netmask4;
     }
   } else {
-    if (addr.isIpv6())
+    if (addr.isIPv6())
       gl.netmask = target->second.netmask6;
     else
       gl.netmask = target->second.netmask4;
@@ -452,37 +452,37 @@ static string queryGeoIP(const Netmask& addr, GeoIPInterface::GeoIPQueryAttribut
 
     switch(attribute) {
     case GeoIPInterface::ASn:
-      if (addr.isIpv6()) found = gi->queryASnumV6(val, gl, ip);
+      if (addr.isIPv6()) found = gi->queryASnumV6(val, gl, ip);
       else found =gi->queryASnum(val, gl, ip);
       break;
     case GeoIPInterface::Name:
-      if (addr.isIpv6()) found = gi->queryNameV6(val, gl, ip);
+      if (addr.isIPv6()) found = gi->queryNameV6(val, gl, ip);
       else found = gi->queryName(val, gl, ip);
       break;
     case GeoIPInterface::Continent:
-      if (addr.isIpv6()) found = gi->queryContinentV6(val, gl, ip);
+      if (addr.isIPv6()) found = gi->queryContinentV6(val, gl, ip);
       else found = gi->queryContinent(val, gl, ip);
       break;
     case GeoIPInterface::Region:
-      if (addr.isIpv6()) found = gi->queryRegionV6(val, gl, ip);
+      if (addr.isIPv6()) found = gi->queryRegionV6(val, gl, ip);
       else found = gi->queryRegion(val, gl, ip);
       break;
     case GeoIPInterface::Country:
-      if (addr.isIpv6()) found = gi->queryCountryV6(val, gl, ip);
+      if (addr.isIPv6()) found = gi->queryCountryV6(val, gl, ip);
       else found = gi->queryCountry(val, gl, ip);
       break;
     case GeoIPInterface::Country2:
-      if (addr.isIpv6()) found = gi->queryCountry2V6(val, gl, ip);
+      if (addr.isIPv6()) found = gi->queryCountry2V6(val, gl, ip);
       else found = gi->queryCountry2(val, gl, ip);
       break;
     case GeoIPInterface::City:
-      if (addr.isIpv6()) found = gi->queryCityV6(val, gl, ip);
+      if (addr.isIPv6()) found = gi->queryCityV6(val, gl, ip);
       else found = gi->queryCity(val, gl, ip);
       break;
     case GeoIPInterface::Location:
       double lat=0, lon=0;
       boost::optional<int> alt, prec;
-      if (addr.isIpv6()) found = gi->queryLocationV6(gl, ip, lat, lon, alt, prec);
+      if (addr.isIPv6()) found = gi->queryLocationV6(gl, ip, lat, lon, alt, prec);
       else found = gi->queryLocation(gl, ip, lat, lon, alt, prec);
       val = std::to_string(lat)+" "+std::to_string(lon);
       break;
@@ -494,7 +494,7 @@ static string queryGeoIP(const Netmask& addr, GeoIPInterface::GeoIPQueryAttribut
     break;
   }
 
-  if (ret == "unknown") gl.netmask = (addr.isIpv6()?128:32); // prevent caching
+  if (ret == "unknown") gl.netmask = (addr.isIPv6()?128:32); // prevent caching
   return ret;
 }
 
@@ -524,7 +524,7 @@ bool queryGeoLocation(const Netmask& addr, GeoIPNetmask& gl, double& lat, double
 {
   for(auto const& gi: s_geoip_files) {
     string val;
-    if (addr.isIpv6()) {
+    if (addr.isIPv6()) {
       if (gi->queryLocationV6(gl, addr.toStringNoMask(), lat, lon, alt, prec))
         return true;
      } else if (gi->queryLocation(gl, addr.toStringNoMask(), lat, lon, alt, prec))
@@ -554,7 +554,7 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
     } else if (!sformat.compare(cur,3,"%cc")) {
       rep = queryGeoIP(addr, GeoIPInterface::Country2, tmp_gl);
     } else if (!sformat.compare(cur,3,"%af")) {
-      rep = (addr.isIpv6()?"v6":"v4");
+      rep = (addr.isIPv6()?"v6":"v4");
     } else if (!sformat.compare(cur,3,"%as")) {
       rep = queryGeoIP(addr, GeoIPInterface::ASn, tmp_gl);
     } else if (!sformat.compare(cur,3,"%re")) {
@@ -607,44 +607,44 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
       nrep = 4;
     } else if (!sformat.compare(cur,3,"%hh")) {
       rep = boost::str(boost::format("%02d") % gtm.tm_hour);
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,3,"%yy")) {
       rep = boost::str(boost::format("%02d") % (gtm.tm_year + 1900));
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,3,"%dd")) {
       rep = boost::str(boost::format("%02d") % (gtm.tm_yday + 1));
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,4,"%wds")) {
       nrep=4;
       rep = GeoIP_WEEKDAYS[gtm.tm_wday];
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,4,"%mos")) {
       nrep=4;
       rep = GeoIP_MONTHS[gtm.tm_mon];
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,3,"%wd")) {
       rep = boost::str(boost::format("%02d") % (gtm.tm_wday + 1));
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,3,"%mo")) {
       rep = boost::str(boost::format("%02d") % (gtm.tm_mon + 1));
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,4,"%ip6")) {
       nrep = 4;
-      if (addr.isIpv6())
+      if (addr.isIPv6())
         rep = addr.toStringNoMask();
       else
         rep = "";
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,4,"%ip4")) {
       nrep = 4;
-      if (!addr.isIpv6())
+      if (!addr.isIPv6())
         rep = addr.toStringNoMask();
       else
         rep = "";
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,3,"%ip")) {
       rep = addr.toStringNoMask();
-      tmp_gl.netmask = (addr.isIpv6()?128:32);
+      tmp_gl.netmask = (addr.isIPv6()?128:32);
     } else if (!sformat.compare(cur,2,"%%")) {
       last = cur + 2; continue;
     } else {

--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -335,7 +335,7 @@ try
       ecsRange = Netmask(g_vm["ecs"].as<string>());
       if (!ecsRange.empty()) {
 
-        if (!ecsRange.isIpv4()) {
+        if (!ecsRange.isIPv4()) {
           cerr<<"Only IPv4 ranges are supported for ECS at the moment!"<<endl;
           return EXIT_FAILURE;
         }

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -273,7 +273,7 @@ void DNSPacket::wrapup()
   {
     // this is an upper bound
     optsize += EDNS_OPTION_CODE_SIZE + EDNS_OPTION_LENGTH_SIZE + 2 + 1 + 1; // code+len+family+src len+scope len
-    optsize += d_eso.source.isIpv4() ? 4 : 16;
+    optsize += d_eso.source.isIPv4() ? 4 : 16;
   }
 
   if (d_trc.d_algoName.countLabels())

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -478,7 +478,7 @@ public:
     if(isIpv4()) {
       result.sin4.sin_addr.s_addr = htonl(ntohl(result.sin4.sin_addr.s_addr) & d_mask);
     }
-    else if(isIpv6()) {
+    else if(isIPv6()) {
       size_t idx;
       uint8_t bytes=d_bits/8;
       uint8_t *us=(uint8_t*) &result.sin6.sin6_addr.s6_addr;
@@ -499,7 +499,7 @@ public:
   {
     return d_bits;
   }
-  bool isIpv6() const 
+  bool isIPv6() const
   {
     return d_network.sin6.sin6_family == AF_INET6;
   }

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -475,7 +475,7 @@ public:
   const ComboAddress getMaskedNetwork() const
   {
     ComboAddress result(d_network);
-    if(isIpv4()) {
+    if(isIPv4()) {
       result.sin4.sin_addr.s_addr = htonl(ntohl(result.sin4.sin_addr.s_addr) & d_mask);
     }
     else if(isIPv6()) {
@@ -503,7 +503,7 @@ public:
   {
     return d_network.sin6.sin6_family == AF_INET6;
   }
-  bool isIpv4() const
+  bool isIPv4() const
   {
     return d_network.sin4.sin_family == AF_INET;
   }

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -165,7 +165,8 @@ void BaseLua4::prepareContext() {
   d_lw->writeFunction("newNetmask", [](const string& s) { return Netmask(s); });
   d_lw->registerFunction<ComboAddress(Netmask::*)()>("getNetwork", [](const Netmask& nm) { return nm.getNetwork(); } ); // const reference makes this necessary
   d_lw->registerFunction<ComboAddress(Netmask::*)()>("getMaskedNetwork", [](const Netmask& nm) { return nm.getMaskedNetwork(); } );
-  d_lw->registerFunction("isIpv4", &Netmask::isIpv4);
+  d_lw->registerFunction("isIpv4", &Netmask::isIPv4);
+  d_lw->registerFunction("isIPv4", &Netmask::isIPv4);
   d_lw->registerFunction("isIpv6", &Netmask::isIPv6);
   d_lw->registerFunction("isIPv6", &Netmask::isIPv6);
   d_lw->registerFunction("getBits", &Netmask::getBits);

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -166,7 +166,8 @@ void BaseLua4::prepareContext() {
   d_lw->registerFunction<ComboAddress(Netmask::*)()>("getNetwork", [](const Netmask& nm) { return nm.getNetwork(); } ); // const reference makes this necessary
   d_lw->registerFunction<ComboAddress(Netmask::*)()>("getMaskedNetwork", [](const Netmask& nm) { return nm.getMaskedNetwork(); } );
   d_lw->registerFunction("isIpv4", &Netmask::isIpv4);
-  d_lw->registerFunction("isIpv6", &Netmask::isIpv6);
+  d_lw->registerFunction("isIpv6", &Netmask::isIPv6);
+  d_lw->registerFunction("isIPv6", &Netmask::isIPv6);
   d_lw->registerFunction("getBits", &Netmask::getBits);
   d_lw->registerFunction("toString", &Netmask::toString);
   d_lw->registerFunction("empty", &Netmask::empty);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -817,7 +817,7 @@ static void protobufLogQuery(uint8_t maskV4, uint8_t maskV6, const boost::uuids:
   const ComboAddress& requestor = requestorNM.getMaskedNetwork();
   RecProtoBufMessage message(DNSProtoBufMessage::Query, uniqueId, &requestor, &local, qname, qtype, qclass, id, tcp, len);
   message.setServerIdentity(SyncRes::s_serverID);
-  message.setEDNSSubnet(ednssubnet, ednssubnet.isIpv4() ? maskV4 : maskV6);
+  message.setEDNSSubnet(ednssubnet, ednssubnet.isIPv4() ? maskV4 : maskV6);
   message.setRequestorId(requestorId);
   message.setDeviceId(deviceId);
   message.setDeviceName(deviceName);
@@ -1187,7 +1187,7 @@ static void startDoResolve(void *p)
       const ComboAddress& requestor = requestorNM.getMaskedNetwork();
       pbMessage = RecProtoBufMessage(RecProtoBufMessage::Response, dc->d_uuid, &requestor, &dc->d_destination, dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_mdp.d_qclass, dc->d_mdp.d_header.id, dc->d_tcp, 0);
       pbMessage->setServerIdentity(SyncRes::s_serverID);
-      pbMessage->setEDNSSubnet(dc->d_ednssubnet.source, dc->d_ednssubnet.source.isIpv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
+      pbMessage->setEDNSSubnet(dc->d_ednssubnet.source, dc->d_ednssubnet.source.isIPv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
     }
 #endif /* HAVE_PROTOBUF */
 
@@ -2383,7 +2383,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
         Netmask requestorNM(source, source.sin4.sin_family == AF_INET ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
         const ComboAddress& requestor = requestorNM.getMaskedNetwork();
         pbMessage->update(uniqueId, &requestor, &destination, false, dh->id);
-        pbMessage->setEDNSSubnet(ednssubnet.source, ednssubnet.source.isIpv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
+        pbMessage->setEDNSSubnet(ednssubnet.source, ednssubnet.source.isIPv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
         if (g_useKernelTimestamp && tv.tv_sec) {
           pbMessage->setQueryTime(tv.tv_sec, tv.tv_usec);
         }

--- a/pdns/recursordist/docs/lua-scripting/netmask.rst
+++ b/pdns/recursordist/docs/lua-scripting/netmask.rst
@@ -43,9 +43,25 @@ The :class:`Netmask` class represents an IP netmask.
 
   .. method:: Netmask:isIpv4() -> bool
 
+  .. deprecated:: v4.3.0
+
+      True if the netmask is an IPv4 netmask.
+
+  .. method:: Netmask:isIPv4() -> bool
+
+  .. versionadded:: v4.3.0
+
       True if the netmask is an IPv4 netmask.
 
   .. method:: Netmask:isIpv6() -> bool
+
+  .. deprecated:: v4.3.0
+
+      True if the netmask is an IPv6 netmask.
+
+  .. method:: Netmask:isIPv6() -> bool
+
+  .. deprecated:: v4.3.0
 
       True if the netmask is an IPv6 netmask.
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -4,8 +4,13 @@ Upgrade Guide
 Before upgrading, it is advised to read the :doc:`changelog/index`.
 When upgrading several versions, please read **all** notes applying to the upgrade.
 
-4.1.x to 4.2.0 or master
+4.2.x to 4.3.0 or master
 ------------------------
+
+- Netmask class methods ``isIpv4`` and ``isIpv6`` have been deprecated in Lua, use :func:`Netmask.isIPv4` and :func:`Netmask.isIPv6` instead. In C++ API these methods have been removed.
+
+4.1.x to 4.2.0
+--------------
 
 Two new settings have been added:
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2785,7 +2785,7 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr
         // If ednsmask is relevant, we do not want to cache if the scope prefix length is large and TTL is small
         if (SyncRes::s_ecscachelimitttl > 0) {
           bool manyMaskBits = (ednsmask->isIpv4() && ednsmask->getBits() > SyncRes::s_ecsipv4cachelimit) ||
-            (ednsmask->isIpv6() && ednsmask->getBits() > SyncRes::s_ecsipv6cachelimit);
+            (ednsmask->isIPv6() && ednsmask->getBits() > SyncRes::s_ecsipv6cachelimit);
 
           if (manyMaskBits) {
             uint32_t minttl = UINT32_MAX;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2784,7 +2784,7 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr
       if (i->first.place == DNSResourceRecord::ANSWER && ednsmask) {
         // If ednsmask is relevant, we do not want to cache if the scope prefix length is large and TTL is small
         if (SyncRes::s_ecscachelimitttl > 0) {
-          bool manyMaskBits = (ednsmask->isIpv4() && ednsmask->getBits() > SyncRes::s_ecsipv4cachelimit) ||
+          bool manyMaskBits = (ednsmask->isIPv4() && ednsmask->getBits() > SyncRes::s_ecsipv4cachelimit) ||
             (ednsmask->isIPv6() && ednsmask->getBits() > SyncRes::s_ecsipv6cachelimit);
 
           if (manyMaskBits) {
@@ -3141,7 +3141,7 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
       s_ecsresponses++;
       LOG(prefix<<qname<<": Received EDNS Client Subnet Mask "<<ednsmask->toString()<<" on response"<<endl);
       if (ednsmask->getBits() > 0) {
-        if (ednsmask->isIpv4()) {
+        if (ednsmask->isIPv4()) {
           ++SyncRes::s_ecsResponsesBySubnetSize4.at(ednsmask->getBits()-1);
         }
         else {
@@ -3556,7 +3556,7 @@ void SyncRes::setQuerySource(const ComboAddress& requestor, boost::optional<cons
 
   if (incomingECS && incomingECS->source.getBits() > 0) {
     d_cacheRemote = incomingECS->source.getMaskedNetwork();
-    uint8_t bits = std::min(incomingECS->source.getBits(), (incomingECS->source.isIpv4() ? s_ecsipv4limit : s_ecsipv6limit));
+    uint8_t bits = std::min(incomingECS->source.getBits(), (incomingECS->source.isIPv4() ? s_ecsipv4limit : s_ecsipv6limit));
     ComboAddress trunc = incomingECS->source.getNetwork();
     trunc.truncate(bits);
     d_outgoingECSNetwork = boost::optional<Netmask>(Netmask(trunc, bits));

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -177,14 +177,14 @@ BOOST_AUTO_TEST_CASE(test_Netmask) {
   BOOST_CHECK(nm.getBits() == 24);
   BOOST_CHECK(nm.match(local));
   BOOST_CHECK(!nm.match(remote));
-  BOOST_CHECK(nm.isIpv4());
+  BOOST_CHECK(nm.isIPv4());
   BOOST_CHECK(!nm.isIPv6());
 
   Netmask nm6("fe80::92fb:a6ff:fe4a:51da/64");
   BOOST_CHECK(nm6.getBits() == 64);
   BOOST_CHECK(nm6.match("fe80::92fb:a6ff:fe4a:51db"));
   BOOST_CHECK(!nm6.match("fe81::92fb:a6ff:fe4a:51db"));
-  BOOST_CHECK(!nm6.isIpv4());
+  BOOST_CHECK(!nm6.isIPv4());
   BOOST_CHECK(nm6.isIPv6());
 
   Netmask nmp("130.161.252.29/32");

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -178,14 +178,14 @@ BOOST_AUTO_TEST_CASE(test_Netmask) {
   BOOST_CHECK(nm.match(local));
   BOOST_CHECK(!nm.match(remote));
   BOOST_CHECK(nm.isIpv4());
-  BOOST_CHECK(!nm.isIpv6());
+  BOOST_CHECK(!nm.isIPv6());
 
   Netmask nm6("fe80::92fb:a6ff:fe4a:51da/64");
   BOOST_CHECK(nm6.getBits() == 64);
   BOOST_CHECK(nm6.match("fe80::92fb:a6ff:fe4a:51db"));
   BOOST_CHECK(!nm6.match("fe81::92fb:a6ff:fe4a:51db"));
   BOOST_CHECK(!nm6.isIpv4());
-  BOOST_CHECK(nm6.isIpv6());
+  BOOST_CHECK(nm6.isIPv6());
 
   Netmask nmp("130.161.252.29/32");
   BOOST_CHECK(nmp.match(remote));


### PR DESCRIPTION
### Short description
This changes the Netmask class to use isIPv6 instead of isIpv6.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

