### PR TITLE
Fixes #8422 abort transaction and return refused to client when update policy returns false

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -938,7 +938,8 @@ int PacketHandler::processUpdate(DNSPacket& p) {
         if (this->d_update_policy_lua != NULL) {
           if (this->d_update_policy_lua->updatePolicy(rr->d_name, QType(rr->d_type), di.zone, p) == false) {
             g_log<<Logger::Warning<<msgPrefix<<"Refusing update for " << rr->d_name << "/" << QType(rr->d_type).getName() << ": Not permitted by policy"<<endl;
-            continue;
+            di.backend->abortTransaction();
+            return RCode::Refused;
           } else {
             g_log<<Logger::Debug<<msgPrefix<<"Accepting update for " << rr->d_name << "/" << QType(rr->d_type).getName() << ": Permitted by policy"<<endl;
           }


### PR DESCRIPTION
### Short description
Fixes #8422 abort transaction and return refused to client when update policy returns false
### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

