### PR TITLE
rec: Update CentOS 6 init script

### DIFF
--- a/builder-support/specs/pdns-recursor.init
+++ b/builder-support/specs/pdns-recursor.init
@@ -9,7 +9,7 @@
 # description:  PowerDNS Recursor is a non authoritative/recursing DNS server
 # processname:  pdns-recursor
 # config: /etc/pdns-recursor/recursor.conf
-# pidfile: /var/run/pdns_recursor.pid
+# pidfile: /var/run/pdns-recursor/pdns_recursor.pid
 #
 
 # . function library
@@ -18,7 +18,7 @@
 RETVAL=0
 
 PIDDIR=$(awk -F= '/^socket-dir=/ {print $2}' /etc/pdns-recursor/recursor.conf)
-if [ -z "$PIDDIR" ]; then PIDDIR=/var/run; mkdir -p $PIDDIR; fi
+if [ -z "$PIDDIR" ]; then PIDDIR=/var/run/pdns-recursor; mkdir -p $PIDDIR; fi
 
 start() {
 	echo -n $"Starting pdns-recursor: "


### PR DESCRIPTION
### Short description
Looks like everything was updated except this, and now the 4.3.0 master packages (pdns-recursor-4.3.0-0.alpha1.master.382.g479525a52.1pdns.el6.x86_64) don't run without making the directory first.

I have *not* checked what 4.2.0 is using. 

@pieterlexis  can you review?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
