### PR TITLE
rec: prime NS records of root-servers.net parent (.net)

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2914,8 +2914,10 @@ static void houseKeeping(void *)
 
     if(now.tv_sec - last_rootupdate > 7200) {
       int res = SyncRes::getRootNS(g_now, nullptr);
-      if (!res)
+      if (!res) {
         last_rootupdate=now.tv_sec;
+        primeRootNSZones(g_dnssecmode != DNSSECMode::Off);
+      }
     }
 
     if(isHandlerThread()) {

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -27,6 +27,10 @@ int getMTaskerTID()
   return 0;
 }
 
+void primeRootNSZones(bool)
+{
+}
+
 bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret) const
 {
   return false;

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -97,11 +97,17 @@ void primeHints(void)
   }
   t_RC->doWipeCache(g_rootdnsname, false, QType::NS);
   t_RC->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, boost::none, validationState); // and stuff in the cache
-
-  
-
 }
 
+
+// Do not only put the root hints into the cache, but also make sure
+// the NS records of the top level domains of the names of the root
+// servers are in the cache. We need these to correctly determine the
+// security status of that specific domain (normally
+// root-servers.net). This is caused by the accident that the root
+// servers are authoritative for root-servers.net, and some
+// implementations reply not with a delegation on a root-servers.net
+// DS query, but with a NODATA response (the domain is unsigned).
 void primeRootNSZones(bool dnssecmode)
 {
   struct timeval now;

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -119,6 +119,7 @@ void primeRootNSZones(bool dnssecmode)
     sr.setDNSSECValidationRequested(true);
   }
   for (const auto & qname: t_rootNSZones) {
+    t_RC->doWipeCache(qname, false, QType::NS);
     vector<DNSRecord> ret;
     sr.beginResolve(qname, QType(QType::NS), QClass::IN, ret);
   }

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -32,11 +32,14 @@
 extern int g_argc;
 extern char** g_argv;
 
+static thread_local set<DNSName> t_rootNSZones;
+
 void primeHints(void)
 {
   // prime root cache
   const vState validationState = Insecure;
   vector<DNSRecord> nsset;
+  t_rootNSZones.clear();
   if(!t_RC)
     t_RC = std::unique_ptr<MemRecursorCache>(new MemRecursorCache());
 
@@ -54,6 +57,7 @@ void primeHints(void)
       templ[sizeof(templ)-1] = '\0';
       *templ=c;
       aaaarr.d_name=arr.d_name=DNSName(templ);
+      t_rootNSZones.insert(arr.d_name.getLastLabel());
       nsrr.d_content=std::make_shared<NSRecordContent>(DNSName(templ));
       arr.d_content=std::make_shared<ARecordContent>(ComboAddress(rootIps4[c-'a']));
       vector<DNSRecord> aset;
@@ -88,10 +92,30 @@ void primeHints(void)
         rr.content=toLower(rr.content);
         nsset.push_back(DNSRecord(rr));
       }
+      t_rootNSZones.insert(rr.qname.getLastLabel());
     }
   }
   t_RC->doWipeCache(g_rootdnsname, false, QType::NS);
   t_RC->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, boost::none, validationState); // and stuff in the cache
+
+  
+
+}
+
+void primeRootNSZones(bool dnssecmode)
+{
+  struct timeval now;
+  gettimeofday(&now, 0);
+  SyncRes sr(now);
+
+  if (dnssecmode) {
+    sr.setDoDNSSEC(true);
+    sr.setDNSSECValidationRequested(true);
+  }
+  for (const auto & qname: t_rootNSZones) {
+    vector<DNSRecord> ret;
+    sr.beginResolve(qname, QType(QType::NS), QClass::IN, ret);
+  }
 }
 
 static void makeNameToIPZone(std::shared_ptr<SyncRes::domainmap_t> newMap, const DNSName& hostname, const string& ip)
@@ -479,4 +503,3 @@ std::shared_ptr<SyncRes::domainmap_t> parseAuthAndForwards()
   }
   return newMap;
 }
-

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1025,6 +1025,7 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vecto
     if(subdomain.isRoot() && !brokeloop) {
       // We lost the root NS records
       primeHints();
+      primeRootNSZones(g_dnssecmode != DNSSECMode::Off);
       LOG(prefix<<qname<<": reprimed the root"<<endl);
       /* let's prevent an infinite loop */
       if (!d_updatingRootNS) {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1073,6 +1073,7 @@ uint64_t* pleaseWipePacketCache(const DNSName& canon, bool subtree);
 uint64_t* pleaseWipeAndCountNegCache(const DNSName& canon, bool subtree=false);
 void doCarbonDump(void*);
 void primeHints(void);
+void primeRootNSZones(bool);
 
 extern __thread struct timeval g_now;
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Do not only put the root hints into the cache, but also make sure the NS records of the top level domains of the *names* of the root servers are in the cache. We need these to correctly determine the security status of that specific domain (normally `root-servers.net`). This is caused by the accident that the root servers are authoritative for `root-servers.net`, and some implementations reply not with a delegation on a `root-servers.net` `DS` query, but with a `NODATA` response (the domain is unsigned).

Discussed with @Habbie and @pieterlexis 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
