### PR TITLE
rec: Fix OOO tests on CircleCI and enable DNSSEC for them as well.

### DIFF
--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -70,14 +70,14 @@ example.                 3600 IN NS   ns2.example.
 example.                 3600 IN DS   53174 13 1 50c9e913818767c236c06c2d8272723cb78cbf26
 
 ns1.example.             3600 IN A    {prefix}.10
-ns2.example.             3600 IN A    {prefix}.11
+ns2.example.             3600 IN A    {prefix}.18
         """,
         'example': """
 example.                 3600 IN SOA  {soa}
 example.                 3600 IN NS   ns1.example.
 example.                 3600 IN NS   ns2.example.
 ns1.example.             3600 IN A    {prefix}.10
-ns2.example.             3600 IN A    {prefix}.11
+ns2.example.             3600 IN A    {prefix}.18
 
 secure.example.          3600 IN NS   ns.secure.example.
 secure.example.          3600 IN DS   64723 13 1 53eb985040d3a89bacf29dbddb55a65834706f33
@@ -119,8 +119,11 @@ sort.example.                      3600 IN MX    25 mx
 
 delay1.example.                     3600 IN NS   ns1.delay1.example.
 ns1.delay1.example.                 3600 IN A    {prefix}.16
+delay1.example.                     3600 IN DS 42043 13 2 7319fa605cf117f36e3de070157577ebb9a05a1d1f963d80eda55b5d6e793eb2
+
 delay2.example.                     3600 IN NS   ns1.delay2.example.
 ns1.delay2.example.                 3600 IN A    {prefix}.17
+delay2.example.                     3600 IN DS 42043 13 2 60a047b87740c8564c21d5fd34626c10a77a6c41e3b34564230119c2f13937b8
         """,
         'secure.example': """
 secure.example.          3600 IN SOA  {soa}
@@ -310,6 +313,18 @@ PrivateKey: kvoV/g4IO/tefSro+FLJ5UC7H3BUf0IUtZQSUOfQGyA=
 Private-key-format: v1.2
 Algorithm: 13 (ECDSAP256SHA256)
 PrivateKey: Ep9uo6+wwjb4MaOmqq7LHav2FLrjotVOeZg8JT1Qk04=
+""",
+
+        'delay1.example': """
+Private-key-format: v1.2
+Algorithm: 13 (ECDSAP256SHA256)
+PrivateKey: Ep9uo6+wwjb4MaOmqq7LHav2FLrjotVOeZg8JT1Qk04=
+""",
+
+        'delay2.example': """
+Private-key-format: v1.2
+Algorithm: 13 (ECDSAP256SHA256)
+PrivateKey: Ep9uo6+wwjb4MaOmqq7LHav2FLrjotVOeZg8JT1Qk04=
 """
     }
 
@@ -323,8 +338,9 @@ PrivateKey: Ep9uo6+wwjb4MaOmqq7LHav2FLrjotVOeZg8JT1Qk04=
               'zones': ['secure.example', 'islandofsecurity.example']},
         '10': {'threads': 1,
                'zones': ['example']},
-        '11': {'threads': 1,
-               'zones': ['example']},
+
+        # 11 is used by CircleCI provided resolver
+
         '12': {'threads': 1,
                'zones': ['bogus.example', 'undelegated.secure.example', 'undelegated.insecure.example']},
         '13': {'threads': 1,
@@ -336,7 +352,9 @@ PrivateKey: Ep9uo6+wwjb4MaOmqq7LHav2FLrjotVOeZg8JT1Qk04=
         '16': {'threads': 2,
                'zones': ['delay1.example']},
         '17': {'threads': 2,
-               'zones': ['delay2.example']}
+               'zones': ['delay2.example']},
+        '18': {'threads': 1,
+               'zones': ['example']}
     }
 
     _auth_cmd = ['authbind',

--- a/regression-tests.recursor-dnssec/test_OOOTCP.py
+++ b/regression-tests.recursor-dnssec/test_OOOTCP.py
@@ -6,19 +6,19 @@ from recursortests import RecursorTest
 class testOOOTCP(RecursorTest):
     _confdir = 'OOOTCP'
 
-    _config_template = """dnssec=off
+    _config_template = """dnssec=validate
 """
 
     @classmethod
     def generateRecursorConfig(cls, confdir):
         super(testOOOTCP, cls).generateRecursorConfig(confdir)
 
-    def XXXOOOVeryBasic(self):
+    def testOOOVeryBasic(self):
         expected = {}
         queries = []
         for zone in ['5.delay1.example.', '0.delay2.example.']:
             expected[zone] = dns.rrset.from_text(zone, 0, dns.rdataclass.IN, 'TXT', 'a')
-            query = dns.message.make_query(zone, 'TXT', want_dnssec=False)
+            query = dns.message.make_query(zone, 'TXT', want_dnssec=True)
             query.flags |= dns.flags.AD
             queries.append(query)
 
@@ -32,16 +32,16 @@ class testOOOTCP(RecursorTest):
             print(ress[i].answer[0].to_text())
             print('exp')
             print(exp.to_text())
-            #self.assertMessageIsAuthenticated(ress[i])
+            self.assertMessageIsAuthenticated(ress[i])
             self.assertRRsetInAnswer(ress[i], exp)
-            #self.assertMatchingRRSIGInAnswer(ress[i], exp)
+            self.assertMatchingRRSIGInAnswer(ress[i], exp)
             i = i + 1
 
-    def XXXOOOTimeout(self):
+    def testOOOTimeout(self):
         expected = {}
         queries = []
         for zone in ['25.delay1.example.', '1.delay2.example.']:
-            query = dns.message.make_query(zone, 'TXT', want_dnssec=False)
+            query = dns.message.make_query(zone, 'TXT', want_dnssec=True)
             query.flags |= dns.flags.AD
             queries.append(query)
 
@@ -50,8 +50,10 @@ class testOOOTCP(RecursorTest):
         self.assertEqual(len(ress), 2)
         exp = dns.rrset.from_text('1.delay2.example.', 0, dns.rdataclass.IN, 'TXT', 'a')
         self.assertRRsetInAnswer(ress[0], exp)
+        self.assertMatchingRRSIGInAnswer(ress[0], exp)
         self.assertRcodeEqual(ress[1], dns.rcode.SERVFAIL)
 
         # Let the auth timeout happen to not disturb other tests
+        # this can happen if the auth is single-threaded
         time.sleep(1)
 


### PR DESCRIPTION
CircleCI is running a recursor on 127.0.0.11 and redirects packets to it,
eating the packets that were targeted for the test auth on 127.0.0.11.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
