### PR TITLE
Add a parameter to limit the number of '$GENERATE' steps

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -927,6 +927,21 @@ will generally suffice for most installations.
 Maximum number of empty non-terminals to add to a zone. This is a
 protection measure to avoid database explosion due to long names.
 
+.. _setting-max-generate-steps:
+
+``max-generate-steps``
+----------------------
+
+.. versionadded:: 4.3.0
+
+-  Integer
+-  Default: 0
+
+Maximum number of steps for a '$GENERATE' directive when parsing a
+zone file. This is a protection measure to prevent consuming a lot of
+CPU and memory when untrusted zones are loaded. Default to 0 which
+means unlimited.
+
 .. _setting-max-nsec3-iterations:
 
 ``max-nsec3-iterations``

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -481,11 +481,11 @@ void Bind2Backend::parseZoneFile(BB2DomainInfo *bbd)
     nsec3zone=getNSEC3PARAM(bbd->d_name, &ns3pr);
 
   bbd->d_records = shared_ptr<recordstorage_t>(new recordstorage_t());
-        
   ZoneParserTNG zpt(bbd->d_filename, bbd->d_name, s_binddirectory);
+  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
   DNSResourceRecord rr;
   string hashed;
-  while(zpt.get(rr)) { 
+  while(zpt.get(rr)) {
     if(rr.qtype.getCode() == QType::NSEC || rr.qtype.getCode() == QType::NSEC3 || rr.qtype.getCode() == QType::NSEC3PARAM)
       continue; // we synthesise NSECs on demand
 

--- a/pdns/comfun.cc
+++ b/pdns/comfun.cc
@@ -420,7 +420,7 @@ try
   }
   else if(mode=="scan-ns") {
     ifstream ns(string(argv[2])+".nameservers");
-    g_powerdns = make_unique<ofstream>(string(argv[2])+".powerdns");
+    g_powerdns = std::unique_ptr<ofstream>(new ofstream(string(argv[2])+".powerdns"));
     string line;
     int count=0;
     vector<string> parts;

--- a/pdns/comfun.cc
+++ b/pdns/comfun.cc
@@ -311,6 +311,7 @@ void printStats()
 int parseZone(const std::string& str, unsigned int limit)
 {
   ZoneParserTNG zpt(str);
+  zpt.disableGenerate();
   DNSResourceRecord rr;
 
   std::thread stats(printStats);
@@ -517,6 +518,7 @@ try
     }
     cerr<<"Have "<<powerdns.size()<<" known NS names that are PowerDNS"<<endl;
     ZoneParserTNG zpt(argv[2]);
+    zpt.disableGenerate();
     DNSResourceRecord rr;
     
     set<DNSName> seen, pdnsdomains;

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -228,6 +228,8 @@ void declareArguments()
 
   ::arg().set("tcp-fast-open", "Enable TCP Fast Open support on the listening sockets, using the supplied numerical value as the queue size")="0";
 
+  ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
+
   ::arg().set("rng", "Specify the random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
 }
 

--- a/pdns/fuzz_zoneparsertng.cc
+++ b/pdns/fuzz_zoneparsertng.cc
@@ -47,6 +47,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     boost::split(lines, tmp, boost::is_any_of("\n"));
 
     ZoneParserTNG zpt(lines, g_rootdnsname);
+    /* limit the number of steps for '$GENERATE' entries */
+    zpt.setMaxGenerateSteps(10000);
     DNSResourceRecord drr;
     while (zpt.get(drr)) {
     }

--- a/pdns/ixfrutils.cc
+++ b/pdns/ixfrutils.cc
@@ -163,6 +163,7 @@ void loadZoneFromDisk(records_t& records, const string& fname, const DNSName& zo
 {
   ZoneParserTNG zpt(fname, zone);
 
+  zpt.disableGenerate();
   DNSResourceRecord rr;
   bool seenSOA=false;
   while(zpt.get(rr)) {
@@ -189,6 +190,7 @@ void loadZoneFromDisk(records_t& records, const string& fname, const DNSName& zo
 void loadSOAFromDisk(const DNSName& zone, const string& fname, shared_ptr<SOARecordContent>& soa, uint32_t& soaTTL)
 {
   ZoneParserTNG zpt(fname, zone);
+  zpt.disableGenerate();
   DNSResourceRecord rr;
 
   while(zpt.get(rr)) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4698,6 +4698,7 @@ int main(int argc, char **argv)
     ::arg().set("distribution-load-factor", "The load factor used when PowerDNS is distributing queries to worker threads")="0.0";
     ::arg().setSwitch("qname-minimization", "Use Query Name Minimization")="no";
     ::arg().setSwitch("nothing-below-nxdomain", "When an NXDOMAIN exists in cache for a name with fewer labels than the qname, send NXDOMAIN without doing a lookup (see RFC 8020)")="yes";
+    ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
 #ifdef NOD_ENABLED
     ::arg().set("new-domain-tracking", "Track newly observed domains (i.e. never seen before).")="no";
     ::arg().set("new-domain-log", "Log newly observed domains.")="yes";

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -90,6 +90,7 @@ void loadMainConfig(const std::string& configdir)
   ::arg().set("max-nsec3-iterations","Limit the number of NSEC3 hash iterations")="500"; // RFC5155 10.3
   ::arg().set("max-signature-cache-entries", "Maximum number of signatures cache entries")="";
   ::arg().set("rng", "Specify random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
+  ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
   ::arg().laxFile(configname.c_str());
 
   if(!::arg()["load-modules"].empty()) {
@@ -917,6 +918,7 @@ int editZone(const DNSName &zone) {
   }
   cmdline.clear();
   ZoneParserTNG zpt(tmpnam, g_rootdnsname);
+  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
   DNSResourceRecord zrr;
   map<pair<DNSName,uint16_t>, vector<DNSRecord> > grouped;
   try {
@@ -1088,6 +1090,7 @@ int loadZone(DNSName zone, const string& fname) {
   }
   DNSBackend* db = di.backend;
   ZoneParserTNG zpt(fname, zone);
+  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
 
   DNSResourceRecord rr;
   if(!db->startTransaction(zone, di.id)) {
@@ -1416,6 +1419,7 @@ void testSpeed(DNSSECKeeper& dk, const DNSName& zone, const string& remote, int 
 void verifyCrypto(const string& zone)
 {
   ZoneParserTNG zpt(zone);
+  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
   DNSResourceRecord rr;
   DNSKEYRecordContent drc;
   RRSIGRecordContent rrc;

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -872,6 +872,20 @@ Maximum number of incoming requests handled concurrently per tcp
 connection. This number must be larger than 0 and smaller than 65536
 and also smaller than `max-mthreads`.
 
+.. _setting-max-generate-steps:
+
+``max-generate-steps``
+----------------------
+
+.. versionadded:: 4.3.0
+
+-  Integer
+-  Default: 0
+
+Maximum number of steps for a '$GENERATE' directive when parsing a
+zone file. This is a protection measure to prevent consuming a lot of
+CPU and memory when untrusted zones are loaded. Default to 0 which
+means unlimited.
 
 .. _setting-max-mthreads:
 

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -84,6 +84,7 @@ void primeHints(void)
   }
   else {
     ZoneParserTNG zpt(::arg()["hint-file"]);
+    zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
     DNSResourceRecord rr;
 
     while(zpt.get(rr)) {
@@ -381,6 +382,7 @@ std::shared_ptr<SyncRes::domainmap_t> parseAuthAndForwards()
         ad.d_rdForward = false;
         g_log<<Logger::Error<<"Parsing authoritative data for zone '"<<headers.first<<"' from file '"<<headers.second<<"'"<<endl;
         ZoneParserTNG zpt(headers.second, DNSName(headers.first));
+        zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
         DNSResourceRecord rr;
 	DNSRecord dr;
         while(zpt.get(rr)) {

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -1,3 +1,4 @@
+#include "arguments.hh"
 #include "dnsparser.hh"
 #include "dnsrecords.hh"
 #include "ixfr.hh"
@@ -235,6 +236,7 @@ std::shared_ptr<SOARecordContent> loadRPZFromFile(const std::string& fname, std:
 {
   shared_ptr<SOARecordContent> sr = nullptr;
   ZoneParserTNG zpt(fname);
+  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
   DNSResourceRecord drr;
   DNSName domain;
   while(zpt.get(drr)) {

--- a/pdns/validate-recursor.cc
+++ b/pdns/validate-recursor.cc
@@ -34,6 +34,7 @@ bool updateTrustAnchorsFromFile(const std::string &fname, map<DNSName, dsmap_t> 
   map<DNSName,dsmap_t> newDSAnchors;
   try {
     auto zp = ZoneParserTNG(fname);
+    zp.disableGenerate();
     DNSResourceRecord rr;
     DNSRecord dr;
     while(zp.get(rr)) {

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1304,6 +1304,7 @@ static void gatherRecordsFromZone(const std::string& zonestring, vector<DNSResou
   stringtok(zonedata, zonestring, "\r\n");
 
   ZoneParserTNG zpt(zonedata, zonename);
+  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
 
   bool seenSOA=false;
 

--- a/pdns/zone2json.cc
+++ b/pdns/zone2json.cc
@@ -108,6 +108,7 @@ try
     ::arg().set("soa-refresh-default","Do not change")="0";
     ::arg().set("soa-retry-default","Do not change")="0";
     ::arg().set("soa-expire-default","Do not change")="0";
+    ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print the version");
@@ -174,6 +175,7 @@ try
             Json::object obj;
             Json::array recs;
             ZoneParserTNG zpt(i->filename, i->name, BP.getDirectory());
+            zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
             DNSResourceRecord rr;
             obj["name"] = i->name.toString();
 
@@ -205,6 +207,7 @@ try
     }
     else {
       ZoneParserTNG zpt(zonefile, DNSName(::arg()["zone-name"]));
+      zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
       DNSResourceRecord rr;
       string zname;
       Json::object obj;

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -248,6 +248,7 @@ int main( int argc, char* argv[] )
                 args.set( "layout", "How to arrange entries in the directory (simple or as tree)" ) = "simple";
                 args.set( "domainid", "Domain ID of the first domain found (incremented afterwards)" ) = "1";
                 args.set( "metadata-dn", "DN under which to store the domain metadata" ) = "";
+                args.set( "max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
 
                 args.parse( argc, argv );
 
@@ -316,6 +317,7 @@ int main( int argc, char* argv[] )
                                                 cerr << "Parsing file: " << i.filename << ", domain: " << i.name << endl;
                                                 g_zonename = i.name;
                                                 ZoneParserTNG zpt(i.filename, i.name, BP.getDirectory());
+                                                zpt.setMaxGenerateSteps(args.asNum("max-generate-steps"));
                                                 DNSResourceRecord rr;
                                                 while(zpt.get(rr)) {
                                                         callback(g_domainid, rr.qname, rr.qtype.getName(), encode_non_ascii(rr.content), rr.ttl);
@@ -344,6 +346,7 @@ int main( int argc, char* argv[] )
 
                         g_zonename = DNSName(args["zone-name"]);
                         ZoneParserTNG zpt(args["zone-file"], g_zonename);
+                        zpt.setMaxGenerateSteps(args.asNum("max-generate-steps"));
                         DNSResourceRecord rr;
                         while(zpt.get(rr)) {
                                 callback(g_domainid, rr.qname, rr.qtype.getName(), encode_non_ascii(rr.content), rr.ttl);

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -236,6 +236,7 @@ try
     ::arg().set("soa-refresh-default","Do not change")="0";
     ::arg().set("soa-retry-default","Do not change")="0";
     ::arg().set("soa-expire-default","Do not change")="0";
+    ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print the version");
@@ -319,6 +320,7 @@ try
             emitDomain(i->name, &(i->masters));
             
             ZoneParserTNG zpt(i->filename, i->name, BP.getDirectory());
+            zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
             DNSResourceRecord rr;
             bool seenSOA=false;
             string comment;
@@ -357,6 +359,7 @@ try
         zonename = DNSName(::arg()["zone-name"]);
 
       ZoneParserTNG zpt(zonefile, zonename);
+      zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
       DNSResourceRecord rr;
       startNewTransaction();
       string comment;

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -328,6 +328,12 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
           d_templatestop < d_templatecounter) {
         throw exception("Invalid $GENERATE parameters");
       }
+      if (d_maxGenerateSteps != 0) {
+        size_t numberOfSteps = (d_templatestop - d_templatecounter) / d_templatestep;
+        if (numberOfSteps > d_maxGenerateSteps) {
+          throw exception("The number of $GENERATE steps (" + std::to_string(numberOfSteps) + ") is too high, the maximum is set to " + std::to_string(d_maxGenerateSteps));
+        }
+      }
       d_templateline=d_line;
       parts.pop_front();
       parts.pop_front();

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -319,6 +319,9 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
       d_zonename = DNSName(makeString(d_line, parts[1]));
     }
     else if(pdns_iequals(command, "$GENERATE") && parts.size() > 2) {
+      if (!d_generateEnabled) {
+        throw exception("$GENERATE is not allowed in this zone");
+      }
       // $GENERATE 1-127 $ CNAME $.0
       string range=makeString(d_line, parts[1]);
       d_templatestep=1;

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -41,6 +41,10 @@ public:
   DNSName getZoneName();
   string getLineOfFile(); // for error reporting purposes
   pair<string,int> getLineNumAndFile(); // idem
+  void disableGenerate()
+  {
+    d_generateEnabled = false;
+  }
   void setMaxGenerateSteps(size_t max)
   {
     d_maxGenerateSteps = max;
@@ -72,6 +76,7 @@ private:
   uint32_t d_templatecounter, d_templatestop, d_templatestep;
   bool d_havedollarttl;
   bool d_fromfile;
+  bool d_generateEnabled{true};
 };
 
 #endif

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -41,6 +41,10 @@ public:
   DNSName getZoneName();
   string getLineOfFile(); // for error reporting purposes
   pair<string,int> getLineNumAndFile(); // idem
+  void setMaxGenerateSteps(size_t max)
+  {
+    d_maxGenerateSteps = max;
+  }
 private:
   bool getLine();
   bool getTemplateLine();
@@ -63,6 +67,7 @@ private:
   vector<string>::iterator d_zonedataline;
   std::stack<filestate> d_filestates;
   parts_t d_templateparts;
+  size_t d_maxGenerateSteps{0};
   int d_defaultttl;
   uint32_t d_templatecounter, d_templatestop, d_templatestep;
   bool d_havedollarttl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
A very large number of steps in one bind-style zone could trigger a lot of CPU and memory usage. This is not really a problem in most of the deployment scenarios but OSS-Fuzz has recently figured out how to trigger it.  

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
