### PR TITLE
rec: Make threads run until asked to stop.

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4319,6 +4319,10 @@ static int serviceMain(int argc, char*argv[])
       ti.thread.join();
     }
   }
+
+#ifdef HAVE_PROTOBUF
+  google::protobuf::ShutdownProtobufLibrary();
+#endif /* HAVE_PROTOBUF */
   return 0;
 }
 
@@ -4403,11 +4407,13 @@ try
 
   t_fdm=getMultiplexer();
 
+  RecursorWebServer *rws = nullptr;
+  
   if(threadInfo.isHandler) {
     if(::arg().mustDo("webserver")) {
       g_log<<Logger::Warning << "Enabling web server" << endl;
       try {
-        new RecursorWebServer(t_fdm);
+        rws = new RecursorWebServer(t_fdm);
       }
       catch(PDNSException &e) {
         g_log<<Logger::Error<<"Exception: "<<e.reason<<endl;
@@ -4521,6 +4527,8 @@ try
       }
     }
   }
+  delete rws;
+  delete t_fdm;
   return 0;
 }
 catch(PDNSException &ae) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4279,6 +4279,8 @@ static int serviceMain(int argc, char*argv[])
     infos.isListener = true;
     infos.isWorker = true;
     recursorThread(currentThreadId++, "worker");
+    
+    handlerInfos.thread.join();
   }
   else {
 
@@ -4313,7 +4315,9 @@ static int serviceMain(int argc, char*argv[])
     infos.isHandler = true;
     infos.thread = std::thread(recursorThread, 0, "web+stat");
 
-    s_threadInfos.at(0).thread.join();
+    for (auto & ti : s_threadInfos) {
+      ti.thread.join();
+    }
   }
   return 0;
 }
@@ -4448,7 +4452,8 @@ try
   time_t carbonInterval=::arg().asNum("carbon-interval");
   time_t luaMaintenanceInterval=::arg().asNum("lua-maintenance-interval");
   counter.store(0); // used to periodically execute certain tasks
-  for(;;) {
+
+  while (!RecursorControlChannel::stop) {
     while(MT->schedule(&g_now)); // MTasker letting the mthreads do their thing
 
     if(!(counter%500)) {
@@ -4516,6 +4521,7 @@ try
       }
     }
   }
+  return 0;
 }
 catch(PDNSException &ae) {
   g_log<<Logger::Error<<"Exception: "<<ae.reason<<endl;

--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -17,6 +17,8 @@
 
 #include "namespaces.hh"
 
+volatile sig_atomic_t RecursorControlChannel::stop;
+
 RecursorControlChannel::RecursorControlChannel()
 {
   d_fd=-1;

--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -17,7 +17,7 @@
 
 #include "namespaces.hh"
 
-volatile sig_atomic_t RecursorControlChannel::stop;
+volatile sig_atomic_t RecursorControlChannel::stop = 0;
 
 RecursorControlChannel::RecursorControlChannel()
 {

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -27,6 +27,7 @@
 #include <vector>
 #include <inttypes.h>
 #include <sys/un.h>
+#include <signal.h>
 #include <pthread.h>
 #include "iputils.hh"
 #include "dnsname.hh"
@@ -53,6 +54,7 @@ public:
   std::string recv(std::string* remote=0, unsigned int timeout=5);
 
   int d_fd;
+  static volatile sig_atomic_t stop;
 private:
   struct sockaddr_un d_local;
 };

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1165,15 +1165,16 @@ void doExitGeneric(bool nicely)
 {
   g_log<<Logger::Error<<"Exiting on user request"<<endl;
   extern RecursorControlChannel s_rcc;
-  s_rcc.~RecursorControlChannel(); 
+  s_rcc.~RecursorControlChannel();
 
   extern string s_pidfname;
-  if(!s_pidfname.empty()) 
+  if(!s_pidfname.empty())
     unlink(s_pidfname.c_str()); // we can at least try..
-  if(nicely)
-    exit(1);
-  else
+  if(nicely) {
+    RecursorControlChannel::stop = 1;
+  } else {
     _exit(1);
+  }
 }
 
 void doExit()


### PR DESCRIPTION
This is safer since the atexit handler is not ran while threads are
still active. Also, when using valgrind we get more clean leak reports.

Retry of the accidentally merged #8518 that was reverted.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
