### PR TITLE
dnsdist: Add bindings for the noerrors and drops members of StatNode

### DIFF
--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -576,7 +576,7 @@ private:
         }
 
         if (suffixMatchRuleMatches) {
-          root.submit(c.name, c.dh.rcode, boost::none);
+          root.submit(c.name, ((c.dh.rcode == 0 && c.usec == std::numeric_limits<unsigned int>::max()) ? -1 : c.dh.rcode), boost::none);
         }
       }
     }

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -117,7 +117,7 @@ static void statNodeRespRing(statvisitor_t visitor, unsigned int seconds)
       if (seconds && c.when < cutoff)
         continue;
 
-      root.submit(c.name, c.dh.rcode, boost::none);
+      root.submit(c.name, ((c.dh.rcode == 0 && c.usec == std::numeric_limits<unsigned int>::max()) ? -1 : c.dh.rcode), boost::none);
     }
   }
 

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -706,6 +706,8 @@ void setupLuaInspection()
   g_lua.registerMember("servfails", &StatNode::Stat::servfails);
   g_lua.registerMember("nxdomains", &StatNode::Stat::nxdomains);
   g_lua.registerMember("queries", &StatNode::Stat::queries);
+  g_lua.registerMember("noerrors", &StatNode::Stat::noerrors);
+  g_lua.registerMember("drops", &StatNode::Stat::drops);
 
   g_lua.writeFunction("statNodeRespRing", [](statvisitor_t visitor, boost::optional<unsigned int> seconds) {
       statNodeRespRing(visitor, seconds ? *seconds : 0);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds bindings to access the `noerrors` and `drops` members of the `StatNode` object from `Lua`. It also fixes the accounting of actively discovered timeouts in that same object.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

