### PR TITLE
dnsdist: Use env toggles to disable some regression tests in Travis

### DIFF
--- a/build-scripts/travis.sh
+++ b/build-scripts/travis.sh
@@ -632,7 +632,9 @@ test_recursor() {
 
 test_dnsdist(){
   run "cd regression-tests.dnsdist"
-  run "DNSDISTBIN=$HOME/dnsdist/bin/dnsdist ./runtests -v --ignore-files='(?:^\.|^_,|^setup\.py$|^test_DOH\.py$|^test_OCSP\.py$|^test_Prometheus\.py$|^test_TLSSessionResumption\.py$)'"
+  export SKIP_DOH_TESTS=1
+  export SKIP_PROMETHEUS_TESTS=1
+  run "DNSDISTBIN=$HOME/dnsdist/bin/dnsdist ./runtests -v --ignore-files='(?:^\.|^_,|^setup\.py$|^test_TLSSessionResumption\.py$)'"
   run "rm -f ./DNSCryptResolver.cert ./DNSCryptResolver.key"
   run "cd .."
 }

--- a/regression-tests.dnsdist/test_Basics.py
+++ b/regression-tests.dnsdist/test_Basics.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import unittest
 import dns
 import clientsubnetoption
 from dnsdisttests import DNSDistTest

--- a/regression-tests.dnsdist/test_CDB.py
+++ b/regression-tests.dnsdist/test_CDB.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 import unittest
 import dns
+import os
 import shutil
 import socket
 import time
 from dnsdisttests import DNSDistTest
 
+@unittest.skipIf('SKIP_CDB_TESTS' in os.environ, 'CDB tests are disabled')
 class CDBTest(DNSDistTest):
 
     _cdbFileName = '/tmp/test-cdb-db'

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import base64
 import dns
+import os
+import unittest
 import clientsubnetoption
 from dnsdisttests import DNSDistTest
 
@@ -9,6 +11,7 @@ from io import BytesIO
 #from hyper import HTTP20Connection
 #from hyper.ssl_compat import SSLContext, PROTOCOL_TLSv1_2
 
+@unittest.skipIf('SKIP_DOH_TESTS' in os.environ, 'DNS over HTTPS tests are disabled')
 class DNSDistDOHTest(DNSDistTest):
 
     @classmethod
@@ -106,6 +109,19 @@ class DNSDistDOHTest(DNSDistTest):
 
         cls._response_headers = response_headers.getvalue()
         return (receivedQuery, message)
+
+    @classmethod
+    def setUpClass(cls):
+
+        # for some reason, @unittest.skipIf() is not applied to derived classes with some versions of Python
+        if 'SKIP_DOH_TESTS' in os.environ:
+            raise unittest.SkipTest('DNS over HTTPS tests are disabled')
+
+        cls.startResponders()
+        cls.startDNSDist()
+        cls.setUpSockets()
+
+        print("Launching tests..")
 
 #     @classmethod
 #     def openDOHConnection(cls, port, caFile, timeout=2.0):

--- a/regression-tests.dnsdist/test_LMDB.py
+++ b/regression-tests.dnsdist/test_LMDB.py
@@ -2,9 +2,11 @@
 import unittest
 import dns
 import lmdb
+import os
 import socket
 from dnsdisttests import DNSDistTest
 
+@unittest.skipIf('SKIP_LMDB_TESTS' in os.environ, 'LMDB tests are disabled')
 class TestLMDB(DNSDistTest):
 
     _lmdbFileName = '/tmp/test-lmdb-db'

--- a/regression-tests.dnsdist/test_Prometheus.py
+++ b/regression-tests.dnsdist/test_Prometheus.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+import os
 import requests
 import subprocess
+import unittest
 from dnsdisttests import DNSDistTest
 
+@unittest.skipIf('SKIP_PROMETHEUS_TESTS' in os.environ, 'Prometheus tests are disabled')
 class TestPrometheus(DNSDistTest):
 
     _webTimeout = 2.0

--- a/regression-tests.dnsdist/test_TLSSessionResumption.py
+++ b/regression-tests.dnsdist/test_TLSSessionResumption.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+import unittest
 from dnsdisttests import DNSDistTest
 try:
   range = xrange
@@ -57,6 +58,7 @@ class DNSDistTLSSessionResumptionTest(DNSDistTest):
         with open(outputFile, 'wb') as fp:
             fp.write(os.urandom(numberOfTickets * 80))
 
+@unittest.skipIf('SKIP_DOH_TESTS' in os.environ, 'DNS over HTTPS tests are disabled')
 class TestNoTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
 
     _serverKey = 'server.key'
@@ -79,6 +81,7 @@ class TestNoTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
         self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/no-session.out.doh', None, allowNoTicket=True))
         self.assertFalse(self.checkSessionResumed('127.0.0.1', self._dohServerPort, self._serverName, self._caCert, '/tmp/no-session.out.doh', '/tmp/no-session.out.doh', allowNoTicket=True))
 
+@unittest.skipIf('SKIP_DOH_TESTS' in os.environ, 'DNS over HTTPS tests are disabled')
 class TestTLSSessionResumptionDOH(DNSDistTLSSessionResumptionTest):
 
     _serverKey = 'server.key'

--- a/regression-tests.dnsdist/test_Tags.py
+++ b/regression-tests.dnsdist/test_Tags.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import unittest
 import dns
 import clientsubnetoption
 from dnsdisttests import DNSDistTest


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It provides a better granularity, allowing the OCSP tests to be run for DoT even in the absence of DoH support.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

