### PR TITLE
Rec: Purge map of failed auths periodically by keeping a last changed timestamp.

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2844,7 +2844,8 @@ static void doStats(void)
 
     g_log<<Logger::Notice<<"stats: throttle map: "
       << broadcastAccFunction<uint64_t>(pleaseGetThrottleSize) <<", ns speeds: "
-      << broadcastAccFunction<uint64_t>(pleaseGetNsSpeedsSize)<<endl;
+      << broadcastAccFunction<uint64_t>(pleaseGetNsSpeedsSize)<<", failed ns: "
+      << broadcastAccFunction<uint64_t>(pleaseGetFailedServersSize)<<endl;
     g_log<<Logger::Notice<<"stats: outpacket/query ratio "<<(int)(SyncRes::s_outqueries*100.0/SyncRes::s_queries)<<"%";
     g_log<<Logger::Notice<<", "<<(int)(SyncRes::s_throttledqueries*100.0/(SyncRes::s_outqueries+SyncRes::s_throttledqueries))<<"% throttled, "
      <<SyncRes::s_nodelegated<<" no-delegation drops"<<endl;
@@ -2908,6 +2909,8 @@ static void houseKeeping(void *)
       if(!((cleanCounter++)%40)) {  // this is a full scan!
 	time_t limit=now.tv_sec-300;
         SyncRes::pruneNSSpeeds(limit);
+        limit = now.tv_sec - SyncRes::s_serverdownthrottletime * 10;
+        SyncRes::pruneFailedServers(limit);
       }
       last_prune=time(0);
     }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2845,7 +2845,8 @@ static void doStats(void)
     g_log<<Logger::Notice<<"stats: throttle map: "
       << broadcastAccFunction<uint64_t>(pleaseGetThrottleSize) <<", ns speeds: "
       << broadcastAccFunction<uint64_t>(pleaseGetNsSpeedsSize)<<", failed ns: "
-      << broadcastAccFunction<uint64_t>(pleaseGetFailedServersSize)<<endl;
+      << broadcastAccFunction<uint64_t>(pleaseGetFailedServersSize)<<", ednsmap: "
+      <<broadcastAccFunction<uint64_t>(pleaseGetEDNSStatusesSize)<<endl;
     g_log<<Logger::Notice<<"stats: outpacket/query ratio "<<(int)(SyncRes::s_outqueries*100.0/SyncRes::s_queries)<<"%";
     g_log<<Logger::Notice<<", "<<(int)(SyncRes::s_throttledqueries*100.0/(SyncRes::s_outqueries+SyncRes::s_throttledqueries))<<"% throttled, "
      <<SyncRes::s_nodelegated<<" no-delegation drops"<<endl;
@@ -2911,6 +2912,8 @@ static void houseKeeping(void *)
         SyncRes::pruneNSSpeeds(limit);
         limit = now.tv_sec - SyncRes::s_serverdownthrottletime * 10;
         SyncRes::pruneFailedServers(limit);
+        limit = now.tv_sec - 2*3600;
+        SyncRes::pruneEDNSStatuses(limit);
       }
       last_prune=time(0);
     }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -917,6 +917,11 @@ uint64_t* pleaseGetFailedServersSize()
   return new uint64_t(SyncRes::getFailedServersSize());
 }
 
+uint64_t* pleaseGetEDNSStatusesSize()
+{
+  return new uint64_t(SyncRes::getEDNSStatusesSize());
+}
+
 uint64_t* pleaseGetConcurrentQueries()
 {
   return new uint64_t(getMT() ? getMT()->numProcesses() : 0);

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -146,7 +146,21 @@ dump-throttlemap *FILENAME*
       :program:`pdns_recursor` often runs in a chroot. You can
       retrieve the file using::
 
-        rec_control dump-rpz ZONE_NAME /tmp/file
+        rec_control dump-throttlemap /tmp/file
+        mv /proc/$(pidof pdns_recursor)/root/tmp/file /tmp/filename
+
+dump-failedservers *FILENAME*
+    Dump the contents of the failed server map to the *FILENAME* mentioned.
+    This file should not exist already, PowerDNS will refuse to
+    overwrite it otherwise. While dumping, the recursor will not answer
+    questions.
+
+    .. note::
+
+      :program:`pdns_recursor` often runs in a chroot. You can
+      retrieve the file using::
+
+        rec_control dump-failedservers /tmp/file
         mv /proc/$(pidof pdns_recursor)/root/tmp/file /tmp/filename
 
 get *STATISTIC* [*STATISTIC*]...

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -536,16 +536,15 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
      If '3', send bare queries
   */
 
-  SyncRes::EDNSStatus* ednsstatus;
-  ednsstatus = &t_sstorage.ednsstatus[ip]; // does this include port? YES
+  SyncRes::EDNSStatus* ednsstatus = &t_sstorage.ednsstatus[ip]; // does this include port? YES
 
-  if(ednsstatus->modeSetAt && ednsstatus->modeSetAt + 3600 < d_now.tv_sec) {
-    *ednsstatus=SyncRes::EDNSStatus();
+  if (ednsstatus->modeSetAt && ednsstatus->modeSetAt + 3600 < d_now.tv_sec) {
+    *ednsstatus = SyncRes::EDNSStatus();
     //    cerr<<"Resetting EDNS Status for "<<ip.toString()<<endl);
   }
 
-  SyncRes::EDNSStatus::EDNSMode& mode=ednsstatus->mode;
-  SyncRes::EDNSStatus::EDNSMode oldmode = mode;
+  SyncRes::EDNSStatus::EDNSMode *mode = &ednsstatus->mode;
+  SyncRes::EDNSStatus::EDNSMode oldmode = *mode;
   int EDNSLevel = 0;
   auto luaconfsLocal = g_luaconfs.getLocal();
   ResolveContext ctx;
@@ -560,11 +559,11 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
   for(int tries = 0; tries < 3; ++tries) {
     //    cerr<<"Remote '"<<ip.toString()<<"' currently in mode "<<mode<<endl;
     
-    if(mode==EDNSStatus::NOEDNS) {
+    if (*mode == EDNSStatus::NOEDNS) {
       g_stats.noEdnsOutQueries++;
       EDNSLevel = 0; // level != mode
     }
-    else if(ednsMANDATORY || mode==EDNSStatus::UNKNOWN || mode==EDNSStatus::EDNSOK || mode==EDNSStatus::EDNSIGNORANT)
+    else if (ednsMANDATORY || *mode == EDNSStatus::UNKNOWN || *mode == EDNSStatus::EDNSOK || *mode == EDNSStatus::EDNSIGNORANT)
       EDNSLevel = 1;
 
     DNSName sendQname(domain);
@@ -577,6 +576,9 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
     else {
       ret=asyncresolve(ip, sendQname, type, doTCP, sendRDQuery, EDNSLevel, now, srcmask, ctx, d_outgoingProtobufServers, d_frameStreamServers, luaconfsLocal->outgoingProtobufExportConfig.exportTypes, res, chained);
     }
+    // ednsstatus might be cleared, so do a new lookup
+    ednsstatus = &t_sstorage.ednsstatus[ip]; // does this include port? YES
+    mode = &ednsstatus->mode;
     if(ret < 0) {
       return ret; // transport error, nothing to learn here
     }
@@ -584,25 +586,25 @@ int SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, con
     if(ret == 0) { // timeout, not doing anything with it now
       return ret;
     }
-    else if(mode==EDNSStatus::UNKNOWN || mode==EDNSStatus::EDNSOK || mode == EDNSStatus::EDNSIGNORANT ) {
+    else if (*mode == EDNSStatus::UNKNOWN || *mode == EDNSStatus::EDNSOK || *mode == EDNSStatus::EDNSIGNORANT ) {
       if(res->d_validpacket && !res->d_haveEDNS && res->d_rcode == RCode::FormErr)  {
 	//	cerr<<"Downgrading to NOEDNS because of "<<RCode::to_s(res->d_rcode)<<" for query to "<<ip.toString()<<" for '"<<domain<<"'"<<endl;
-        mode = EDNSStatus::NOEDNS;
+        *mode = EDNSStatus::NOEDNS;
         continue;
       }
       else if(!res->d_haveEDNS) {
-        if(mode != EDNSStatus::EDNSIGNORANT) {
-          mode = EDNSStatus::EDNSIGNORANT;
+        if (*mode != EDNSStatus::EDNSIGNORANT) {
+          *mode = EDNSStatus::EDNSIGNORANT;
 	  //	  cerr<<"We find that "<<ip.toString()<<" is an EDNS-ignorer for '"<<domain<<"', moving to mode 2"<<endl;
 	}
       }
       else {
-	mode = EDNSStatus::EDNSOK;
+	*mode = EDNSStatus::EDNSOK;
 	//	cerr<<"We find that "<<ip.toString()<<" is EDNS OK!"<<endl;
       }
       
     }
-    if(oldmode != mode || !ednsstatus->modeSetAt)
+    if (oldmode != *mode || !ednsstatus->modeSetAt)
       ednsstatus->modeSetAt=d_now.tv_sec;
     //    cerr<<"Result: ret="<<ret<<", EDNS-level: "<<EDNSLevel<<", haveEDNS: "<<res->d_haveEDNS<<", new mode: "<<mode<<endl;  
     return ret;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -239,8 +239,9 @@ public:
     typename cont_t::iterator i = d_cont.find(t);
 
     if (i == d_cont.end()) {
-      d_cont[t].value = 1;
-      d_cont[t].last = now.tv_sec;
+      auto &r = d_cont[t];
+      r.value = 1;
+      r.last = now.tv_sec;
       return 1;
     }
     else {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -294,9 +294,8 @@ public:
 
   struct EDNSStatus
   {
-    EDNSStatus() : mode(UNKNOWN), modeSetAt(0) {}
-    enum EDNSMode { UNKNOWN=0, EDNSOK=1, EDNSIGNORANT=2, NOEDNS=3 } mode;
-    time_t modeSetAt;
+    time_t modeSetAt{0};
+    enum EDNSMode { UNKNOWN=0, EDNSOK=1, EDNSIGNORANT=2, NOEDNS=3 } mode{UNKNOWN};
   };
 
   enum class HardenNXD { No, DNSSEC, Yes };

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -513,6 +513,16 @@ public:
   {
     t_sstorage.ednsstatus.clear();
   }
+  static void pruneEDNSStatuses(time_t cutoff)
+  {
+    for (auto it = t_sstorage.ednsstatus.begin(); it != t_sstorage.ednsstatus.end(); ) {
+      if (it->second.modeSetAt && it->second.modeSetAt <= cutoff) {
+        it = t_sstorage.ednsstatus.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
   static uint64_t getThrottledServersSize()
   {
     return t_sstorage.throttle.size();
@@ -1083,6 +1093,7 @@ template<class T> T broadcastAccFunction(const boost::function<T*()>& func);
 std::shared_ptr<SyncRes::domainmap_t> parseAuthAndForwards();
 uint64_t* pleaseGetNsSpeedsSize();
 uint64_t* pleaseGetFailedServersSize();
+uint64_t* pleaseGetEDNSStatusesSize();
 uint64_t* pleaseGetCacheSize();
 uint64_t* pleaseGetNegCacheSize();
 uint64_t* pleaseGetCacheHits();

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -214,60 +214,74 @@ private:
 template<class Thing> class Counters : public boost::noncopyable
 {
 public:
-  Counters()
-  {
-  }
-  unsigned long value(const Thing& t) const
-  {
-    typename cont_t::const_iterator i=d_cont.find(t);
+  typedef unsigned long counter_t;
+  struct value_t {
+    counter_t value;
+    time_t last;
+  };
+  typedef std::map<Thing, value_t> cont_t;
 
-    if(i==d_cont.end()) {
+  cont_t getMap() const {
+    return d_cont;
+  }
+  counter_t value(const Thing& t) const
+  {
+    typename cont_t::const_iterator i = d_cont.find(t);
+
+    if (i == d_cont.end()) {
       return 0;
     }
-    return (unsigned long)i->second;
+    return i->second.value;
   }
-  unsigned long incr(const Thing& t)
-  {
-    typename cont_t::iterator i=d_cont.find(t);
 
-    if(i==d_cont.end()) {
-      d_cont[t]=1;
+  counter_t incr(const Thing& t, const struct timeval & now)
+  {
+    typename cont_t::iterator i = d_cont.find(t);
+
+    if (i == d_cont.end()) {
+      d_cont[t].value = 1;
+      d_cont[t].last = now.tv_sec;
       return 1;
     }
     else {
-      if (i->second < std::numeric_limits<unsigned long>::max())
-        i->second++;
-      return (unsigned long)i->second;
-   }
+      if (i->second.value < std::numeric_limits<counter_t>::max()) {
+        i->second.value++;
+      }
+      i->second.last = now.tv_sec;
+      return i->second.value;
+    }
   }
-  unsigned long decr(const Thing& t)
-  {
-    typename cont_t::iterator i=d_cont.find(t);
 
-    if(i!=d_cont.end() && --i->second == 0) {
-      d_cont.erase(i);
-      return 0;
-    } else
-      return (unsigned long)i->second;
-  }
   void clear(const Thing& t)
   {
-    typename cont_t::iterator i=d_cont.find(t);
+    typename cont_t::iterator i = d_cont.find(t);
 
-    if(i!=d_cont.end()) {
+    if (i != d_cont.end()) {
       d_cont.erase(i);
     }
   }
+
   void clear()
   {
     d_cont.clear();
   }
+
   size_t size() const
   {
     return d_cont.size();
   }
+
+  void prune(time_t cutoff) {
+    for (auto it = d_cont.begin(); it != d_cont.end(); ) {
+      if (it->second.last <= cutoff) {
+        it = d_cont.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
 private:
-  typedef map<Thing,unsigned long> cont_t;
   cont_t d_cont;
 };
 
@@ -406,6 +420,7 @@ public:
   static uint64_t doEDNSDump(int fd);
   static uint64_t doDumpNSSpeeds(int fd);
   static uint64_t doDumpThrottleMap(int fd);
+  static uint64_t doDumpFailedServers(int fd);
   static int getRootNS(struct timeval now, asyncresolve_t asyncCallback);
   static void clearDelegationOnly()
   {
@@ -525,6 +540,10 @@ public:
   static void clearFailedServers()
   {
     t_sstorage.fails.clear();
+  }
+  static void pruneFailedServers(time_t cutoff)
+  {
+    t_sstorage.fails.prune(cutoff);
   }
   static unsigned long getServerFailsCount(const ComboAddress& server)
   {
@@ -1063,6 +1082,7 @@ template<class T> T broadcastAccFunction(const boost::function<T*()>& func);
 
 std::shared_ptr<SyncRes::domainmap_t> parseAuthAndForwards();
 uint64_t* pleaseGetNsSpeedsSize();
+uint64_t* pleaseGetFailedServersSize();
 uint64_t* pleaseGetCacheSize();
 uint64_t* pleaseGetNegCacheSize();
 uint64_t* pleaseGetCacheHits();

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -516,7 +516,7 @@ public:
   static void pruneEDNSStatuses(time_t cutoff)
   {
     for (auto it = t_sstorage.ednsstatus.begin(); it != t_sstorage.ednsstatus.end(); ) {
-      if (it->second.modeSetAt && it->second.modeSetAt <= cutoff) {
+      if (it->second.modeSetAt <= cutoff) {
         it = t_sstorage.ednsstatus.erase(it);
       } else {
         ++it;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
SyncRes thread local storage includes a map of failed auths which was
only cleaned if a specific IP was contacted again and that contact
succeeded. Persistent failing auths or auths that are never tried
again remained in the map.

While here add code to dump the failed servers map. Might (partially?)
solve #7771.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
