### PR TITLE
rec: qname-minimization metrics 

### DIFF
--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -115,6 +115,7 @@ static const oid dnssecCheckDisabledQueriesOID[] = { RECURSOR_STATS_OID, 96 };
 static const oid variableResponsesOID[] = { RECURSOR_STATS_OID, 97 };
 static const oid specialMemoryUsageOID[] = { RECURSOR_STATS_OID, 98 };
 static const oid rebalancedQueriesOID[] = { RECURSOR_STATS_OID, 99 };
+static const oid qnameMinFallbackSuccessOID[] = { RECURSOR_STATS_OID, 100 };
 
 static std::unordered_map<oid, std::string> s_statsMap;
 
@@ -288,6 +289,7 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   registerCounter64Stat("ipv6-outqueries", ipv6OutqueriesOID, OID_LENGTH(ipv6OutqueriesOID));
   registerCounter64Stat("throttled-outqueries", throttledOutqueriesOID, OID_LENGTH(throttledOutqueriesOID));
   registerCounter64Stat("dont-outqueries", dontOutqueriesOID, OID_LENGTH(dontOutqueriesOID));
+  registerCounter64Stat("qname-min-fallback-success", qnameMinFallbackSuccessOID, OID_LENGTH(qnameMinFallbackSuccessOID));
   registerCounter64Stat("unreachables", unreachablesOID, OID_LENGTH(unreachablesOID));
   registerCounter64Stat("chain-resends", chainResendsOID, OID_LENGTH(chainResendsOID));
   registerCounter64Stat("tcp-clients", tcpClientsOID, OID_LENGTH(tcpClientsOID));

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1089,6 +1089,7 @@ void registerAllStats()
   addGetStat("ipv6-outqueries", &g_stats.ipv6queries);
   addGetStat("throttled-outqueries", &SyncRes::s_throttledqueries);
   addGetStat("dont-outqueries", &SyncRes::s_dontqueries);
+  addGetStat("qname-min-fallback-success", &SyncRes::s_qnameminfallbacksuccess);
   addGetStat("throttled-out", &SyncRes::s_throttledqueries);
   addGetStat("unreachables", &SyncRes::s_unreachables);
   addGetStat("ecs-queries", &SyncRes::s_ecsqueries);

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -15,7 +15,7 @@ IMPORTS
         FROM SNMPv2-CONF;
 
 rec MODULE-IDENTITY
-    LAST-UPDATED "201812240000Z"
+    LAST-UPDATED "201911140000Z"
     ORGANIZATION "PowerDNS BV"
     CONTACT-INFO "support@powerdns.com"
     DESCRIPTION
@@ -26,6 +26,9 @@ rec MODULE-IDENTITY
 
     REVISION "201812240000Z"
     DESCRIPTION "Added the dnssecAuthenticDataQueries and dnssecCheckDisabledQueries stats."
+
+    REVISION "201911140000Z"
+    DESCRIPTION "Added qnameMinFallbackSuccess stats."
 
     ::= { powerdns 2 }
 
@@ -825,6 +828,14 @@ rebalancedQueries OBJECT-TYPE
         "Number of queries re-distributed because the first selected worker thread was above the target load"
     ::= { stats 99 }
 
+qnameMinFallbackSuccess OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of successful queries due to fallback mechanism within 'qname-minimisation' setting"
+    ::= { stats 100 }
+
 ---
 --- Traps / Notifications
 ---
@@ -967,7 +978,8 @@ recGroup OBJECT-GROUP
         variableResponses,
         specialMemoryUsage,
         rebalancedQueries,
-        trapReason
+        trapReason,
+        qnameMinFallbackSuccess
     }
     STATUS current
     DESCRIPTION "Objects conformance group for PowerDNS Recursor"

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -833,7 +833,7 @@ qnameMinFallbackSuccess OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-        "Number of successful queries due to fallback mechanism within 'qname-minimisation' setting"
+        "Number of successful queries due to fallback mechanism within 'qname-minimization' setting"
     ::= { stats 100 }
 
 ---

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -237,6 +237,11 @@ dont-outqueries
 ^^^^^^^^^^^^^^^
 number of outgoing queries dropped because of   :ref:`setting-dont-query` setting (since 3.3)
 
+qname-min-fallback-success
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.3.0
+number of successful queries due to fallback mechanism within :ref:`setting-dont-query` setting (since 4.3)
+
 ecs-queries
 ^^^^^^^^^^^
 number of outgoing queries adorned with an EDNS Client Subnet option (since 4.1)

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -240,7 +240,7 @@ number of outgoing queries dropped because of   :ref:`setting-dont-query` settin
 qname-min-fallback-success
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. versionadded:: 4.3.0
-number of successful queries due to fallback mechanism within :ref:`setting-dont-query` setting (since 4.3)
+number of successful queries due to fallback mechanism within :ref:`qname-minimization` setting.
 
 ecs-queries
 ^^^^^^^^^^^

--- a/pdns/recursordist/rec_metrics.hh
+++ b/pdns/recursordist/rec_metrics.hh
@@ -127,6 +127,7 @@ private:
 
             { "dnssec-validations",              MetricDefinition(PrometheusMetricType::counter, "Number of DNSSEC validations performed") },
             { "dont-outqueries",              MetricDefinition(PrometheusMetricType::counter, "Number of outgoing queries dropped because of `setting-dont-query` setting") },
+            { "qname-min-fallback-success",   MetricDefinition(PrometheusMetricType::counter, "Number of successful queries due to fallback mechanism within 'qname-minimisation' setting") },
             { "ecs-queries",              MetricDefinition(PrometheusMetricType::counter, "Number of outgoing queries adorned with an EDNS Client Subnet option") },
             { "ecs-responses",              MetricDefinition(PrometheusMetricType::counter, "Number of responses received from authoritative servers with an EDNS Client Subnet option we used") },
             { "edns-ping-matches",              MetricDefinition(PrometheusMetricType::counter, "Number of servers that sent a valid EDNS PING response") },

--- a/pdns/recursordist/rec_metrics.hh
+++ b/pdns/recursordist/rec_metrics.hh
@@ -127,7 +127,7 @@ private:
 
             { "dnssec-validations",              MetricDefinition(PrometheusMetricType::counter, "Number of DNSSEC validations performed") },
             { "dont-outqueries",              MetricDefinition(PrometheusMetricType::counter, "Number of outgoing queries dropped because of `setting-dont-query` setting") },
-            { "qname-min-fallback-success",   MetricDefinition(PrometheusMetricType::counter, "Number of successful queries due to fallback mechanism within 'qname-minimisation' setting") },
+            { "qname-min-fallback-success",   MetricDefinition(PrometheusMetricType::counter, "Number of successful queries due to fallback mechanism within 'qname-minimization' setting") },
             { "ecs-queries",              MetricDefinition(PrometheusMetricType::counter, "Number of outgoing queries adorned with an EDNS Client Subnet option") },
             { "ecs-responses",              MetricDefinition(PrometheusMetricType::counter, "Number of responses received from authoritative servers with an EDNS Client Subnet option we used") },
             { "edns-ping-matches",              MetricDefinition(PrometheusMetricType::counter, "Number of servers that sent a valid EDNS PING response") },

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -71,6 +71,7 @@ std::atomic<uint64_t> SyncRes::s_outqueries;
 std::atomic<uint64_t> SyncRes::s_tcpoutqueries;
 std::atomic<uint64_t> SyncRes::s_throttledqueries;
 std::atomic<uint64_t> SyncRes::s_dontqueries;
+std::atomic<uint64_t> SyncRes::s_qnameminfallbacksuccess;
 std::atomic<uint64_t> SyncRes::s_nodelegated;
 std::atomic<uint64_t> SyncRes::s_unreachables;
 std::atomic<uint64_t> SyncRes::s_ecsqueries;
@@ -691,6 +692,11 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
         QLOG("Step5: other rcode, last effort final resolve");
         setQNameMinimization(false);
         res = doResolveNoQNameMinimization(qname, qtype, ret, depth + 1, beenthere, state);
+
+        if(res == RCode::NoError) {
+          s_qnameminfallbacksuccess++;
+        }
+
         QLOG("Step5 End resolve: " << RCode::to_s(res) << "/" << ret.size());
         return res;
       }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -720,6 +720,7 @@ public:
   static std::atomic<uint64_t> s_outgoing6timeouts;
   static std::atomic<uint64_t> s_throttledqueries;
   static std::atomic<uint64_t> s_dontqueries;
+  static std::atomic<uint64_t> s_qnameminfallbacksuccess;
   static std::atomic<uint64_t> s_authzonequeries;
   static std::atomic<uint64_t> s_outqueries;
   static std::atomic<uint64_t> s_tcpoutqueries;


### PR DESCRIPTION
### Short description
Keep a counter of the number of outqueries that resort to 'use the full qname'

I have only tested rec_control gets for this so far.

Thoughts?

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)