### PR TITLE
dnsdist: Rule stats for Prometheus

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -260,7 +260,6 @@ static string someResponseRulesToPrometheus(const string basename, GlobalStateHo
   return output.str();
 }
 
-
 static void connectionThread(int sock, ComboAddress remote)
 {
   setThreadName("dnsdist/webConn");
@@ -548,18 +547,26 @@ static void connectionThread(int sock, ComboAddress remote)
         }
 
         const string rule_action = "dnsdist_rule_action";
+        output << "# HELP " << rule_action << " Number of queries matching the specified action rule" << "\n";
+        output << "# TYPE " << rule_action << " counter" << "\n";
         auto actionRules = someResponseRulesToPrometheus(rule_action, &g_rulactions);
         output << actionRules;
 
         const string rule_response = "dnsdist_rule_response";
+        output << "# HELP " << rule_response << " Number of queries matching the specified response rule" << "\n";
+        output << "# TYPE " << rule_response << " counter" << "\n";
         auto responseRules = someResponseRulesToPrometheus(rule_response, &g_resprulactions);
         output << responseRules;
 
-        const string rule_cacheHit = "dnsdist_rule_cacheHit";
+        const string rule_cacheHit = "dnsdist_rule_cachehit";
+        output << "# HELP " << rule_cacheHit << " Number of queries matching the specified cache hit rule" << "\n";
+        output << "# TYPE " << rule_cacheHit << " counter" << "\n";
         auto cacheHitResponseRules = someResponseRulesToPrometheus(rule_cacheHit, &g_cachehitresprulactions);
         output << cacheHitResponseRules;
 
-        const string rule_selfAnsweredResponse = "dnsdist_rule_selfAnsweredResponse";
+        const string rule_selfAnsweredResponse = "dnsdist_rule_selfansweredresponse";
+        output << "# HELP " << rule_selfAnsweredResponse << " Number of queries matching the specified self answered response rule" << "\n";
+        output << "# TYPE " << rule_selfAnsweredResponse << " counter" << "\n";
         auto selfAnsweredResponseRules = someResponseRulesToPrometheus(rule_selfAnsweredResponse, &g_selfansweredresprulactions);
         output << selfAnsweredResponseRules;
 


### PR DESCRIPTION
### Short description
We have a desire to capture rule matches and aggregate them in Prometheus.  This does create some nasty long attributes in some cases, but putting this out there to see how offensive this really is. 

Produces output like:

```
dnsdist_rule_action{id="0",creationOrder="0",uuid="4bc426c5-b41e-4661-b559-ede4ee56472f",rule="All",action="delay by 40 msec"} 0
dnsdist_rule_response{id="0",creationOrder="1",uuid="86d7b044-677d-4b3e-94fc-10e9f9f43056",rule="All",action="delay by 50 msec"} 0
dnsdist_rule_cacheHit{id="0",creationOrder="2",uuid="94470e79-0c4b-48dc-be4d-d327bee56783",rule="All",action="delay by 60 msec"} 0
dnsdist_rule_selfAnsweredResponse{id="0",creationOrder="3",uuid="194b8181-3b34-4a16-9ac9-a3e8c2d3efa7",rule="All",action="delay by 70 msec"} 0
```

TODO: HELP/TYPE stuff.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
