### PR TITLE
Use move semantics when updating the content of the StateHolder

### DIFF
--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -282,7 +282,7 @@ public:
     }
 
     if (updated && blocks) {
-      g_dynblockNMG.setState(*blocks);
+      g_dynblockNMG.setState(std::move(*blocks));
     }
 
     if (!statNodeRoot.empty()) {
@@ -312,7 +312,7 @@ public:
           addOrRefreshBlockSMT(smtBlocks, now, name, d_suffixMatchRule, updated);
         }
         if (updated) {
-          g_dynblockSMT.setState(smtBlocks);
+          g_dynblockSMT.setState(std::move(smtBlocks));
         }
       }
     }

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -1173,7 +1173,7 @@ private:
 };
 
 template<typename T, typename ActionT>
-static void addAction(GlobalStateHolder<vector<T> > *someRulActions, luadnsrule_t& var, std::shared_ptr<ActionT>& action, boost::optional<luaruleparams_t>& params) {
+static void addAction(GlobalStateHolder<vector<T> > *someRulActions, const luadnsrule_t& var, const std::shared_ptr<ActionT>& action, boost::optional<luaruleparams_t>& params) {
   setLuaSideEffect();
 
   boost::uuids::uuid uuid;

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -1173,7 +1173,7 @@ private:
 };
 
 template<typename T, typename ActionT>
-static void addAction(GlobalStateHolder<vector<T> > *someRulActions, luadnsrule_t var, std::shared_ptr<ActionT> action, boost::optional<luaruleparams_t> params) {
+static void addAction(GlobalStateHolder<vector<T> > *someRulActions, luadnsrule_t& var, std::shared_ptr<ActionT>& action, boost::optional<luaruleparams_t>& params) {
   setLuaSideEffect();
 
   boost::uuids::uuid uuid;
@@ -1181,8 +1181,8 @@ static void addAction(GlobalStateHolder<vector<T> > *someRulActions, luadnsrule_
   parseRuleParams(params, uuid, creationOrder);
 
   auto rule=makeRule(var);
-  someRulActions->modify([rule, action, uuid, creationOrder](vector<T>& rulactions){
-      rulactions.push_back({rule, action, uuid, creationOrder});
+  someRulActions->modify([&rule, &action, &uuid, creationOrder](vector<T>& rulactions){
+      rulactions.push_back({std::move(rule), std::move(action), std::move(uuid), creationOrder});
     });
 }
 
@@ -1194,7 +1194,7 @@ void setupLuaActions()
       parseRuleParams(params, uuid, creationOrder);
 
       auto rule=makeRule(dnsrule);
-      DNSDistRuleAction ra({rule, action, uuid, creationOrder});
+      DNSDistRuleAction ra({std::move(rule), action, uuid, creationOrder});
       return std::make_shared<DNSDistRuleAction>(ra);
     });
 

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -143,7 +143,7 @@ static void rmRule(GlobalStateHolder<vector<T> > *someRulActions, boost::variant
     }
     rules.erase(rules.begin()+*pos);
   }
-  someRulActions->setState(rules);
+  someRulActions->setState(std::move(rules));
 }
 
 template<typename T>
@@ -155,7 +155,7 @@ static void topRule(GlobalStateHolder<vector<T> > *someRulActions) {
   auto subject = *rules.rbegin();
   rules.erase(std::prev(rules.end()));
   rules.insert(rules.begin(), subject);
-  someRulActions->setState(rules);
+  someRulActions->setState(std::move(rules));
 }
 
 template<typename T>
@@ -175,7 +175,7 @@ static void mvRule(GlobalStateHolder<vector<T> > *someRespRulActions, unsigned i
       --to;
     rules.insert(rules.begin()+to, subject);
   }
-  someRespRulActions->setState(rules);
+  someRespRulActions->setState(std::move(rules));
 }
 
 void setupLuaRules()
@@ -259,7 +259,7 @@ void setupLuaRules()
             const auto& newruleaction = pair.second;
             if (newruleaction->d_action) {
               auto rule=makeRule(newruleaction->d_rule);
-              gruleactions.push_back({rule, newruleaction->d_action, newruleaction->d_id, newruleaction->d_creationOrder});
+              gruleactions.push_back({std::move(rule), newruleaction->d_action, newruleaction->d_id, newruleaction->d_creationOrder});
             }
           }
         });

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4047,14 +4047,14 @@ static int serviceMain(int argc, char*argv[])
     for (const auto &p : parts) {
       dontThrottleNames.add(DNSName(p));
     }
-    g_dontThrottleNames.setState(dontThrottleNames);
+    g_dontThrottleNames.setState(std::move(dontThrottleNames));
 
     NetmaskGroup dontThrottleNetmasks;
     stringtok(parts, ::arg()["dont-throttle-netmasks"]);
     for (const auto &p : parts) {
       dontThrottleNetmasks.addMask(Netmask(p));
     }
-    g_dontThrottleNetmasks.setState(dontThrottleNetmasks);
+    g_dontThrottleNetmasks.setState(std::move(dontThrottleNetmasks));
   }
 
   s_balancingFactor = ::arg().asDouble("distribution-load-factor");

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -570,7 +570,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
 
   try {
     Lua.executeCode(ifs);
-    g_luaconfs.setState(lci);
+    g_luaconfs.setState(std::move(lci));
   }
   catch(const LuaContext::ExecutionErrorException& e) {
     g_log<<Logger::Error<<"Unable to load Lua script from '"+fname+"': ";

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1438,7 +1438,7 @@ static string addDontThrottleNames(T begin, T end) {
     dnt.add(d);
   }
 
-  g_dontThrottleNames.setState(dnt);
+  g_dontThrottleNames.setState(std::move(dnt));
 
   ret += " to the list of nameservers that may not be throttled";
   g_log<<Logger::Info<<ret<<", requested via control channel"<<endl;
@@ -1477,7 +1477,7 @@ static string addDontThrottleNetmasks(T begin, T end) {
     dnt.addMask(t);
   }
 
-  g_dontThrottleNetmasks.setState(dnt);
+  g_dontThrottleNetmasks.setState(std::move(dnt));
 
   ret += " to the list of nameserver netmasks that may not be throttled";
   g_log<<Logger::Info<<ret<<", requested via control channel"<<endl;
@@ -1491,7 +1491,7 @@ static string clearDontThrottleNames(T begin, T end) {
 
   if (begin + 1 == end && *begin == "*"){
     SuffixMatchNode smn;
-    g_dontThrottleNames.setState(smn);
+    g_dontThrottleNames.setState(std::move(smn));
     string ret = "Cleared list of nameserver names that may not be throttled";
     g_log<<Logger::Warning<<ret<<", requested via control channel"<<endl;
     return ret + "\n";
@@ -1523,7 +1523,7 @@ static string clearDontThrottleNames(T begin, T end) {
     dnt.remove(name);
   }
 
-  g_dontThrottleNames.setState(dnt);
+  g_dontThrottleNames.setState(std::move(dnt));
 
   ret += " from the list of nameservers that may not be throttled";
   g_log<<Logger::Info<<ret<<", requested via control channel"<<endl;
@@ -1538,7 +1538,7 @@ static string clearDontThrottleNetmasks(T begin, T end) {
   if (begin + 1 == end && *begin == "*"){
     auto nmg = g_dontThrottleNetmasks.getCopy();
     nmg.clear();
-    g_dontThrottleNetmasks.setState(nmg);
+    g_dontThrottleNetmasks.setState(std::move(nmg));
 
     string ret = "Cleared list of nameserver addresses that may not be throttled";
     g_log<<Logger::Warning<<ret<<", requested via control channel"<<endl;
@@ -1575,7 +1575,7 @@ static string clearDontThrottleNetmasks(T begin, T end) {
     dnt.deleteMask(mask);
   }
 
-  g_dontThrottleNetmasks.setState(dnt);
+  g_dontThrottleNetmasks.setState(std::move(dnt));
 
   ret += " from the list of nameservers that may not be throttled";
   g_log<<Logger::Info<<ret<<", requested via control channel"<<endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR prevents unnecessary copies when adding/updating rules in dnsdist, and possibly for some configuration updates of the recursor as well. I only measured the dnsdist case, to be clear.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
