### PR TITLE
auth 4.2.x: API: do not return dnssec info in domain list

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -101,6 +101,12 @@ paths:
             When set to the name of a zone, only this zone is returned.
             If no zone with that name exists, the response is an empty array.
             This can e.g. be used to check if a zone exists in the database without having to guess/encode the zone's id or to check if a zone exists.
+        - name: dnssec
+          in: query
+          required: false
+          type: boolean
+          default: true
+          description: '“true” (default) or “false”, whether to include the “dnssec” and ”edited_serial” fields in the Zone objects. Setting this to ”false” will make the query a lot faster.'
       responses:
         '200':
           description: An array of Zones

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -49,8 +49,11 @@ def eq_zone_rrsets(rrsets, expected):
 
 class Zones(ApiTestCase):
 
-    def test_list_zones(self):
-        r = self.session.get(self.url("/api/v1/servers/localhost/zones"))
+    def _test_list_zones(self, dnssec=True):
+        path = "/api/v1/servers/localhost/zones"
+        if not dnssec:
+            path = path + "?dnssec=false"
+        r = self.session.get(self.url(path))
         self.assert_success_json(r)
         domains = r.json()
         example_com = [domain for domain in domains if domain['name'] in ('example.com', 'example.com.')]
@@ -59,13 +62,22 @@ class Zones(ApiTestCase):
         print(example_com)
         required_fields = ['id', 'url', 'name', 'kind']
         if is_auth():
-            required_fields = required_fields + ['masters', 'last_check', 'notified_serial', 'edited_serial', 'serial', 'account']
+            required_fields = required_fields + ['masters', 'last_check', 'notified_serial', 'serial', 'account']
+            if dnssec:
+                required_fields = required_fields = ['dnssec', 'edited_serial']
             self.assertNotEquals(example_com['serial'], 0)
         elif is_recursor():
             required_fields = required_fields + ['recursion_desired', 'servers']
         for field in required_fields:
             self.assertIn(field, example_com)
+        if not dnssec:
+            self.assertNotIn('dnssec', example_com)
 
+    def test_list_zones_with_dnssec(self):
+        self._test_list_zones(True)
+
+    def test_list_zones_without_dnssec(self):
+        self._test_list_zones(False)
 
 class AuthZonesHelperMixin(object):
     def create_zone(self, name=None, **kwargs):

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -66,15 +66,16 @@ class Zones(ApiTestCase):
             if dnssec:
                 required_fields = required_fields = ['dnssec', 'edited_serial']
             self.assertNotEquals(example_com['serial'], 0)
+            if not dnssec:
+                self.assertNotIn('dnssec', example_com)
         elif is_recursor():
             required_fields = required_fields + ['recursion_desired', 'servers']
         for field in required_fields:
             self.assertIn(field, example_com)
-        if not dnssec:
-            self.assertNotIn('dnssec', example_com)
 
     def test_list_zones_with_dnssec(self):
-        self._test_list_zones(True)
+        if is_auth():
+            self._test_list_zones(True)
 
     def test_list_zones_without_dnssec(self):
         self._test_list_zones(False)


### PR DESCRIPTION
### Short description
Backport of #4628.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
