### PR TITLE
[DOC dnsdist] Extend guide for DoH over HTTP

### DIFF
--- a/pdns/dnsdistdist/docs/guides/dns-over-https.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-https.rst
@@ -23,11 +23,11 @@ DoH. If you want your DoH server to handle
 the call to :func:`addDOHLocal`. It is optional and defaults to ``/``, the root of your HTTP site.
 
 The fifth parameter, if present, indicates various options. For
-instance, you use it to indicate custom HTTP headers. An example is:
+instance, you use it to indicate custom HTTP headers. An example is::
 
   addDOHLocal('2001:db8:1:f00::1', '/etc/ssl/certs/example.com.pem', '/etc/ssl/private/example.com.key', "/dns", {customResponseHeaders={["x-foo"]="bar"}}
 
-A more complicated (and more realistic) example is when you want to indicate metainformation about the server, such as the stated policy (privacy statement and so on). We use the link types of RFC 8631:
+A more complicated (and more realistic) example is when you want to indicate metainformation about the server, such as the stated policy (privacy statement and so on). We use the link types of RFC 8631::
 
   addDOHLocal('2001:db8:1:f00::1', '/etc/ssl/certs/example.com.pem', '/etc/ssl/private/example.com.key', "/", {customResponseHeaders={["link"]="<https://example.com/policy.html> rel=\\"service-meta\\"; type=\\"text/html\\""}})
 

--- a/pdns/dnsdistdist/docs/guides/dns-over-https.rst
+++ b/pdns/dnsdistdist/docs/guides/dns-over-https.rst
@@ -31,3 +31,8 @@ A more complicated (and more realistic) example is when you want to indicate met
 
   addDOHLocal('2001:db8:1:f00::1', '/etc/ssl/certs/example.com.pem', '/etc/ssl/private/example.com.key', "/", {customResponseHeaders={["link"]="<https://example.com/policy.html> rel=\\"service-meta\\"; type=\\"text/html\\""}})
 
+In case you want to run DNS-over-HTTPS behind a reverse proxy you probably don't want to encrypt your traffic between reverse proxy and dnsdist.
+To let dnsdist listen for DoH queries over HTTP on localhost at port 8053 add one of the following to your config::
+
+  addDOHLocal("127.0.0.1:8053")
+  addDOHLocal("127.0.0.1:8053", nil, nil, "/", { reusePort=true })


### PR DESCRIPTION
In #8263 DoH over unencrypted HTTP got implemented.
In #8540 the general usage got explained but this feature did not get mentioned.
I think it might be common that people will want to use a reverse proxy in front of dnsdist.

We use dnsdist in this form with the following config:
```
addDOHLocal("127.0.0.1:8053", nil, nil, "/", { reusePort=true })
```

I extended the guide accordingly.

PS: The formatting in the pdf looks weird atm. The only difference to the "correctly formatted" version seems to be the "::" at the end of the line ahead of the code block.
I added that as well.