### PR TITLE
rec: check return value of dup() and avoid fd leak if if fdopen() fails

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -413,8 +413,13 @@ bool SyncRes::isForwardOrAuth(const DNSName &qname) const {
 
 uint64_t SyncRes::doEDNSDump(int fd)
 {
-  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(dup(fd), "w"), fclose);
+  int newfd = dup(fd);
+  if (newfd == -1) {
+    return 0;
+  }
+  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(newfd, "w"), fclose);
   if (!fp) {
+    close(newfd);
     return 0;
   }
   uint64_t count = 0;
@@ -430,9 +435,15 @@ uint64_t SyncRes::doEDNSDump(int fd)
 
 uint64_t SyncRes::doDumpNSSpeeds(int fd)
 {
-  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(dup(fd), "w"), fclose);
-  if(!fp)
+  int newfd = dup(fd);
+  if (newfd == -1) {
     return 0;
+  }
+  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  if (!fp) {
+    close(newfd);
+    return 0;
+  }
   fprintf(fp.get(), "; nsspeed dump from thread follows\n;\n");
   uint64_t count=0;
 
@@ -454,9 +465,15 @@ uint64_t SyncRes::doDumpNSSpeeds(int fd)
 
 uint64_t SyncRes::doDumpThrottleMap(int fd)
 {
-  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(dup(fd), "w"), fclose);
-  if(!fp)
+  int newfd = dup(fd);
+  if (newfd == -1) {
     return 0;
+  }
+  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  if (!fp) {
+    close(newfd);
+    return 0;
+  }
   fprintf(fp.get(), "; throttle map dump follows\n");
   fprintf(fp.get(), "; remote IP\tqname\tqtype\tcount\tttd\n");
   uint64_t count=0;
@@ -475,9 +492,15 @@ uint64_t SyncRes::doDumpThrottleMap(int fd)
 
 uint64_t SyncRes::doDumpFailedServers(int fd)
 {
-  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(dup(fd), "w"), fclose);
-  if(!fp)
+  int newfd = dup(fd);
+  if (newfd == -1) {
     return 0;
+  }
+  auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fdopen(newfd, "w"), fclose);
+  if (!fp) {
+    close(newfd);
+    return 0;
+  }
   fprintf(fp.get(), "; failed servers dump follows\n");
   fprintf(fp.get(), "; remote IP\tcount\ttimestamp\n");
   uint64_t count=0;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Coverity noted the missing error check, but we also do not want to leak an fd if `fdopen` fails.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
