### PR TITLE
YAHTTP: Accept headers without spaces

### DIFF
--- a/ext/yahttp/yahttp/reqresp.cpp
+++ b/ext/yahttp/yahttp/reqresp.cpp
@@ -101,10 +101,11 @@ namespace YaHTTP {
           break;
         }
         // split headers
-        if ((pos1 = line.find(": ")) == std::string::npos)
+        if ((pos1 = line.find(":")) == std::string::npos) {
           throw ParseError("Malformed header line");
+        }
         key = line.substr(0, pos1);
-        value = line.substr(pos1+2);
+        value = line.substr(pos1 + 1);
         for(std::string::iterator it=key.begin(); it != key.end(); it++)
           if (YaHTTP::isspace(*it))
             throw ParseError("Header key contains whitespace which is not allowed by RFC");


### PR DESCRIPTION
### Short description
cc @cmouse 

YaHTTP did not accept a header like

```
Accept:application/json
```

Which should be allowed according to RFC 7230:

>    Each header field consists of a case-insensitive field name followed by a colon (":"), optional leading whitespace, the field value, and optional trailing whitespace.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)