### PR TITLE
geoipbackend: propagate weighted rounding gap fix

### DIFF
--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -263,7 +263,7 @@ void GeoIPBackend::initialize() {
     for(auto &item: dom.records) {
       map<uint16_t, float> weights;
       map<uint16_t, float> sums;
-      map<uint16_t, GeoIPDNSResourceRecord> lasts;
+      map<uint16_t, GeoIPDNSResourceRecord*> lasts;
       bool has_weight=false;
       // first we look for used weight
       for(const auto &rr: item.second) {
@@ -277,13 +277,13 @@ void GeoIPBackend::initialize() {
           rr.weight=static_cast<int>((static_cast<float>(rr.weight) / weights[rr_type])*1000.0);
           sums[rr_type] += rr.weight;
           rr.has_weight = has_weight;
-          lasts[rr_type] = rr;
+          lasts[rr_type] = &rr;
         }
         // remove rounding gap
         for(auto &x: lasts) {
           float sum = sums[x.first];
           if (sum < 1000)
-            x.second.weight += (1000-sum);
+            x.second->weight += (1000-sum);
         }
       }
     }


### PR DESCRIPTION
### Short description

618824cb73db384d52cf379c7d49744dbb5b8f6d (PR #7219) fixed computation
of weighted round robin computation per Qtype.

That commit also introduced a bug on the removal of the rounding gap.

Because it works on a copy of a GeoIPDNSResourceRecord, the updated
weight of the last record is not propagated to the domain object.

The bug is as follow:
  1. The total weight is < 1000
  2. The random probabability gives 1000
  3. There is no resource to be given

This commit restores the original behavior of ensuring the gap is added
to the last resource so we always have 1000.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
