### PR TITLE
dnsdist: Add bounded loads to the consistent hashing policy

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -496,6 +496,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "setAPIWritable", true, "bool, dir", "allow modifications via the API. if `dir` is set, it must be a valid directory where the configuration files will be written by the API" },
   { "setCacheCleaningDelay", true, "num", "Set the interval in seconds between two runs of the cache cleaning algorithm, removing expired entries" },
   { "setCacheCleaningPercentage", true, "num", "Set the percentage of the cache that the cache cleaning algorithm will try to free by removing expired entries. By default (100), all expired entries are remove" },
+  { "setConsistentHashingBalancingFactor", true, "factor", "Set the balancing factor for bounded-load consistent hashing" },
   { "setConsoleACL", true, "{netmask, netmask}", "replace the console ACL set with these netmasks" },
   { "setConsoleConnectionsLogging", true, "enabled", "whether to log the opening and closing of console connections" },
   { "setConsoleOutputMaxMsgSize", true, "messageSize", "set console message maximum size in bytes, default is 10 MB" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1593,7 +1593,14 @@ void setupLuaConfig(bool client)
 
   g_lua.writeFunction("setConsistentHashingBalancingFactor", [](double factor) {
       setLuaSideEffect();
-      g_consistentHashBalancingFactor = factor;
+      if (factor >= 0) {
+        g_consistentHashBalancingFactor = factor;
+      }
+      else {
+        errlog("Invalid value passed to setConsistentHashingBalancingFactor()!");
+        g_outputBuffer="Invalid value passed to setConsistentHashingBalancingFactor()!\n";
+        return;
+      }
     });
 
   g_lua.writeFunction("setRingBuffersSize", [](size_t capacity, boost::optional<size_t> numberOfShards) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1591,6 +1591,11 @@ void setupLuaConfig(bool client)
       g_roundrobinFailOnNoServer = fail;
     });
 
+  g_lua.writeFunction("setConsistentHashingBalancingFactor", [](double factor) {
+      setLuaSideEffect();
+      g_consistentHashBalancingFactor = factor;
+    });
+
   g_lua.writeFunction("setRingBuffersSize", [](size_t capacity, boost::optional<size_t> numberOfShards) {
       setLuaSideEffect();
       if (g_configurationDone) {

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -896,7 +896,7 @@ shared_ptr<DownstreamState> chashed(const NumberedServerVector& servers, const D
   shared_ptr<DownstreamState> ret = nullptr, first = nullptr;
 
   double targetLoad = std::numeric_limits<double>::max();
-  if (g_consistentHashBalancingFactor != 0) {
+  if (g_consistentHashBalancingFactor > 0) {
     /* we start with one, representing the query we are currently handling */
     double currentLoad = 1;
     for (const auto& pair : servers) {

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1161,6 +1161,7 @@ extern size_t g_udpVectorSize;
 extern bool g_preserveTrailingData;
 extern bool g_allowEmptyResponse;
 extern bool g_roundrobinFailOnNoServer;
+extern double g_consistentHashBalancingFactor;
 
 #ifdef HAVE_EBPF
 extern shared_ptr<BPFFilter> g_defaultBPFFilter;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds support for a bounded-load version of the consistent hashing policy, preventing one server from receiving much more queries than the others, even if the distribution of queries is not perfect.
This "consistent hashing with bounded loads" algorithm is enabled by setting `setConsistentHashingBalancingFactor()` to a value other than 0, which is the default. This value is the maximum number of outstanding queries that a given server can have at a given time, as a ratio of the average number of outstanding queries for all the active servers in the pool.
For example, setting `setConsistentHashingBalancingFactor(1.5)` means that no server will be allowed to have more outstanding queries than 1.5 times the average of all outstanding queries in the pool. The algorithm will try to select a server based on the hash of the qname, as is done when no bounded-load is set, but will disqualify all servers that have more outstanding queries than the average times the factor, until a suitable server is found. The higher the factor, the more imbalance between the servers is allowed.

Implements the `chashed` part of #7387, not the `whashed` one.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

