### PR TITLE
Avoid having to use numbered indexes by given all indexes a tag

### DIFF
--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -207,7 +207,7 @@ uint64_t AuthPacketCache::purge()
 uint64_t AuthPacketCache::purgeExact(const DNSName& qname)
 {
   auto& mc = getMap(qname);
-  uint64_t delcount = purgeExactLockedCollection(mc, qname);
+  uint64_t delcount = purgeExactLockedCollection<NameTag>(mc, qname);
 
   *d_statnumentries -= delcount;
 
@@ -224,7 +224,7 @@ uint64_t AuthPacketCache::purge(const string &match)
   uint64_t delcount = 0;
 
   if(ends_with(match, "$")) {
-    delcount = purgeLockedCollectionsVector(d_maps, match);
+    delcount = purgeLockedCollectionsVector<NameTag>(d_maps, match);
     *d_statnumentries -= delcount;
   }
   else {
@@ -240,7 +240,7 @@ void AuthPacketCache::cleanup()
   uint64_t cacheSize = *d_statnumentries;
   uint64_t totErased = 0;
 
-  totErased = pruneLockedCollectionsVector(d_maps, maxCached, cacheSize);
+  totErased = pruneLockedCollectionsVector<SequencedTag>(d_maps, maxCached, cacheSize);
   *d_statnumentries -= totErased;
 
   DLOG(g_log<<"Done with cache clean, cacheSize: "<<(*d_statnumentries)<<", totErased"<<totErased<<endl);

--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -92,13 +92,13 @@ private:
 
   struct HashTag{};
   struct NameTag{};
-  struct SequenceTag{};
+  struct SequencedTag{};
   typedef multi_index_container<
     CacheEntry,
     indexed_by <
       hashed_non_unique<tag<HashTag>, member<CacheEntry,uint32_t,&CacheEntry::hash> >,
       ordered_non_unique<tag<NameTag>, member<CacheEntry,DNSName,&CacheEntry::qname>, CanonDNSNameCompare >,
-      sequenced<tag<SequenceTag>>
+      sequenced<tag<SequencedTag>>
       >
     > cmap_t;
 

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -173,7 +173,7 @@ uint64_t AuthQueryCache::purge()
 uint64_t AuthQueryCache::purgeExact(const DNSName& qname)
 {
   auto& mc = getMap(qname);
-  uint64_t delcount = purgeExactLockedCollection(mc, qname);
+  uint64_t delcount = purgeExactLockedCollection<NameTag>(mc, qname);
 
   *d_statnumentries -= delcount;
 
@@ -186,7 +186,7 @@ uint64_t AuthQueryCache::purge(const string &match)
   uint64_t delcount = 0;
 
   if(ends_with(match, "$")) {
-    delcount = purgeLockedCollectionsVector(d_maps, match);
+    delcount = purgeLockedCollectionsVector<NameTag>(d_maps, match);
     *d_statnumentries -= delcount;
   }
   else {
@@ -202,7 +202,7 @@ void AuthQueryCache::cleanup()
   uint64_t cacheSize = *d_statnumentries;
   uint64_t totErased = 0;
 
-  totErased = pruneLockedCollectionsVector(d_maps, maxCached, cacheSize);
+  totErased = pruneLockedCollectionsVector<SequencedTag>(d_maps, maxCached, cacheSize);
 
   *d_statnumentries -= totErased;
   DLOG(g_log<<"Done with cache clean, cacheSize: "<<*d_statnumentries<<", totErased"<<totErased<<endl);

--- a/pdns/auth-querycache.hh
+++ b/pdns/auth-querycache.hh
@@ -71,7 +71,7 @@ private:
 
   struct HashTag{};
   struct NameTag{};
-  struct SequenceTag{};
+  struct SequencedTag{};
   typedef multi_index_container<
     CacheEntry,
     indexed_by <
@@ -80,7 +80,7 @@ private:
                                                          member<CacheEntry,uint16_t,&CacheEntry::qtype>,
                                                          member<CacheEntry,int, &CacheEntry::zoneID> > > ,
       ordered_non_unique<tag<NameTag>, member<CacheEntry,DNSName,&CacheEntry::qname>, CanonDNSNameCompare >,
-      sequenced<tag<SequenceTag>>
+      sequenced<tag<SequencedTag>>
                            >
   > cmap_t;
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -224,7 +224,7 @@ void DNSSECKeeper::getFromMeta(const DNSName& zname, const std::string& key, std
     nce.d_value = value;
     {
       WriteLock l(&s_metacachelock);
-      lruReplacingInsert(s_metacache, nce);
+      lruReplacingInsert<SequencedTag>(s_metacache, nce);
     }
   }
 }
@@ -514,7 +514,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
     kce.d_ttd = now + ttl;
     {
       WriteLock l(&s_keycachelock);
-      lruReplacingInsert(s_keycache, kce);
+      lruReplacingInsert<SequencedTag>(s_keycache, kce);
     }
   }
 
@@ -832,11 +832,11 @@ void DNSSECKeeper::cleanup()
   if(now.tv_sec - s_last_prune > (time_t)(30)) {
     {
         WriteLock l(&s_metacachelock);
-        pruneCollection(*this, s_metacache, ::arg().asNum("max-cache-entries"));
+        pruneCollection<SequencedTag>(*this, s_metacache, ::arg().asNum("max-cache-entries"));
     }
     {
         WriteLock l(&s_keycachelock);
-        pruneCollection(*this, s_keycache, ::arg().asNum("max-cache-entries"));
+        pruneCollection<SequencedTag>(*this, s_keycache, ::arg().asNum("max-cache-entries"));
     }
     s_last_prune=time(0);
   }

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -103,7 +103,7 @@ public:
         iter = d_limits.insert(e).first;
       }
 
-      moveCacheItemToBack(d_limits, iter);
+      moveCacheItemToBack<SequencedTag>(d_limits, iter);
       return !iter->d_limiter.check(d_qps, d_burst);
     }
   }

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -256,24 +256,27 @@ private:
   
   };
   
+  struct KeyCacheTag{};
+  struct CompositeTag{};
+  struct SequencedTag{};
   
   typedef multi_index_container<
     KeyCacheEntry,
     indexed_by<
-      ordered_unique<member<KeyCacheEntry, DNSName, &KeyCacheEntry::d_domain> >,
-      sequenced<>
+    ordered_unique<tag<KeyCacheTag>,member<KeyCacheEntry, DNSName, &KeyCacheEntry::d_domain> >,
+    sequenced<tag<SequencedTag>>
     >
   > keycache_t;
   typedef multi_index_container<
     METACacheEntry,
     indexed_by<
-      ordered_unique<
+      ordered_unique<tag<CompositeTag>,
         composite_key< 
           METACacheEntry, 
           member<METACacheEntry, DNSName, &METACacheEntry::d_domain> ,
           member<METACacheEntry, std::string, &METACacheEntry::d_key>
         >, composite_key_compare<std::less<DNSName>, CIStringCompare> >,
-      sequenced<>
+      sequenced<tag<SequencedTag>>
     >
   > metacache_t;
 

--- a/pdns/recpacketcache.cc
+++ b/pdns/recpacketcache.cc
@@ -73,7 +73,7 @@ bool RecursorPacketCache::checkResponseMatches(std::pair<packetCache_t::index<Ha
       }
 
       d_hits++;
-      moveCacheItemToBack(d_packetCache, iter);
+      moveCacheItemToBack<SequencedTag>(d_packetCache, iter);
 #ifdef HAVE_PROTOBUF
       if (protobufMessage) {
         if (iter->d_protobufMessage) {
@@ -88,7 +88,7 @@ bool RecursorPacketCache::checkResponseMatches(std::pair<packetCache_t::index<Ha
       return true;
     }
     else {
-      moveCacheItemToFront(d_packetCache, iter); 
+      moveCacheItemToFront<SequencedTag>(d_packetCache, iter); 
       d_misses++;
       break;
     }
@@ -161,7 +161,7 @@ void RecursorPacketCache::insertResponsePacket(unsigned int tag, uint32_t qhash,
       continue;
     }
 
-    moveCacheItemToBack(d_packetCache, iter);
+    moveCacheItemToBack<SequencedTag>(d_packetCache, iter);
     iter->d_packet = std::move(responsePacket);
     iter->d_query = std::move(query);
     iter->d_ecsBegin = ecsBegin;
@@ -214,7 +214,7 @@ uint64_t RecursorPacketCache::bytes()
 
 void RecursorPacketCache::doPruneTo(unsigned int maxCached)
 {
-  pruneCollection(*this, d_packetCache, maxCached);
+  pruneCollection<SequencedTag>(*this, d_packetCache, maxCached);
 }
 
 uint64_t RecursorPacketCache::doDump(int fd)

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -98,11 +98,12 @@ private:
     }
   };
 
+  struct SequencedTag{};
   typedef multi_index_container<
     Entry,
     indexed_by  <
       hashed_non_unique<tag<HashTag>, composite_key<Entry, member<Entry,uint32_t,&Entry::d_tag>, member<Entry,uint32_t,&Entry::d_qhash> > >,
-      sequenced<> ,
+      sequenced<tag<SequencedTag>> ,
       ordered_non_unique<tag<NameTag>, member<Entry,DNSName,&Entry::d_name>, CanonDNSNameCompare >
       >
   > packetCache_t;

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -78,7 +78,7 @@ int32_t MemRecursorCache::handleHit(MemRecursorCache::OrderedTagIterator_t& entr
     *wasAuth = entry->d_auth;
   }
 
-  moveCacheItemToBack(d_cache, entry);
+  moveCacheItemToBack<SequencedTag>(d_cache, entry);
 
   return ttd;
 }
@@ -116,7 +116,7 @@ MemRecursorCache::cache_t::const_iterator MemRecursorCache::getEntryUsingECSInde
       }
       else {
         /* this netmask-specific entry has expired */
-        moveCacheItemToFront(d_cache, entry);
+        moveCacheItemToFront<SequencedTag>(d_cache, entry);
         ecsIndex->removeNetmask(best);
         if (ecsIndex->isEmpty()) {
           d_ecsIndex.erase(ecsIndex);
@@ -136,7 +136,7 @@ MemRecursorCache::cache_t::const_iterator MemRecursorCache::getEntryUsingECSInde
       }
     }
     else {
-      moveCacheItemToFront(d_cache, entry);
+      moveCacheItemToFront<SequencedTag>(d_cache, entry);
     }
   }
 
@@ -217,7 +217,7 @@ int32_t MemRecursorCache::get(time_t now, const DNSName &qname, const QType& qt,
 
       auto firstIndexIterator = d_cache.project<OrderedTag>(i);
       if (i->d_ttd <= now) {
-        moveCacheItemToFront(d_cache, firstIndexIterator);
+        moveCacheItemToFront<SequencedTag>(d_cache, firstIndexIterator);
         continue;
       }
 
@@ -311,7 +311,7 @@ void MemRecursorCache::replace(time_t now, const DNSName &qname, const QType& qt
   }
 
   if (!isNew) {
-    moveCacheItemToBack(d_cache, stored);
+    moveCacheItemToBack<SequencedTag>(d_cache, stored);
   }
   d_cache.replace(stored, ce);
 }
@@ -480,6 +480,6 @@ void MemRecursorCache::doPrune(unsigned int keep)
 {
   d_cachecachevalid=false;
 
-  pruneCollection(*this, d_cache, keep);
+  pruneCollection<SequencedTag>(*this, d_cache, keep);
 }
 

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -50,10 +50,10 @@ bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, c
     // We have something
     if ((uint32_t)now.tv_sec < ni->d_ttd) {
       *ne = &(*ni);
-      moveCacheItemToBack(d_negcache, ni);
+      moveCacheItemToBack<SequenceTag>(d_negcache, ni);
       return true;
     }
-    moveCacheItemToFront(d_negcache, ni);
+    moveCacheItemToFront<SequenceTag>(d_negcache, ni);
     ++ni;
   }
   return false;
@@ -83,11 +83,11 @@ bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeva
       if ((uint32_t)now.tv_sec < ni->d_ttd) {
         // Not expired
         *ne = &(*ni);
-        moveCacheItemToBack(d_negcache, firstIndexIterator);
+        moveCacheItemToBack<SequenceTag>(d_negcache, firstIndexIterator);
         return true;
       }
       // expired
-      moveCacheItemToFront(d_negcache, firstIndexIterator);
+      moveCacheItemToFront<SequenceTag>(d_negcache, firstIndexIterator);
     }
     ++ni;
   }
@@ -101,7 +101,7 @@ bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeva
  */
 void NegCache::add(const NegCacheEntry& ne)
 {
-  lruReplacingInsert(d_negcache, ne);
+  lruReplacingInsert<SequenceTag>(d_negcache, ne);
 }
 
 /*!
@@ -185,7 +185,7 @@ void NegCache::clear()
  */
 void NegCache::prune(unsigned int maxEntries)
 {
-  pruneCollection(*this, d_negcache, maxEntries, 200);
+  pruneCollection<SequenceTag>(*this, d_negcache, maxEntries, 200);
 }
 
 /*!
@@ -199,7 +199,7 @@ uint64_t NegCache::dumpToFile(FILE* fp)
   struct timeval now;
   Utility::gettimeofday(&now, nullptr);
 
-  negcache_sequence_t& sidx = d_negcache.get<1>();
+  negcache_sequence_t& sidx = d_negcache.get<SequenceTag>();
   for (const NegCacheEntry& ne : sidx) {
     ret++;
     fprintf(fp, "%s %" PRId64 " IN %s VIA %s ; (%s)\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), ne.d_qtype.getName().c_str(), ne.d_auth.toString().c_str(), vStates[ne.d_validationState]);

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -83,18 +83,24 @@ public:
   }
 
 private:
+  struct CompositeKey
+  {
+  };
+  struct SequenceTag
+  {
+  };
   typedef boost::multi_index_container<
     NegCacheEntry,
     indexed_by<
-      ordered_unique<
+      ordered_unique<tag<CompositeKey>,
         composite_key<
           NegCacheEntry,
           member<NegCacheEntry, DNSName, &NegCacheEntry::d_name>,
           member<NegCacheEntry, QType, &NegCacheEntry::d_qtype>>,
         composite_key_compare<
           CanonDNSNameCompare, std::less<QType>>>,
-      sequenced<>,
-      hashed_non_unique<
+      sequenced<tag<SequenceTag>>,
+      hashed_non_unique<tag<NegCacheEntry>,
         member<NegCacheEntry, DNSName, &NegCacheEntry::d_name>>>>
     negcache_t;
 


### PR DESCRIPTION

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Numbered indexes are hard to read and error prone. Specifying the tag in the call isn't a big burden and tells the reader which index is used. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
