### PR TITLE
pthread_rwlock_init() should be matched by pthread_rwlock_destroy()

### DIFF
--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -33,9 +33,6 @@ const unsigned int AuthPacketCache::s_mincleaninterval, AuthPacketCache::s_maxcl
 AuthPacketCache::AuthPacketCache(size_t mapsCount): d_lastclean(time(nullptr))
 {
   d_maps.resize(mapsCount);
-  for(auto& mc : d_maps) {
-    pthread_rwlock_init(&mc.d_mut, 0);
-  }
 
   S.declare("packetcache-hit", "Number of hits on the packet cache");
   S.declare("packetcache-miss", "Number of misses on the packet cache");

--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -104,7 +104,13 @@ private:
 
   struct MapCombo
   {
-    pthread_rwlock_t d_mut;    
+    MapCombo() {
+      pthread_rwlock_init(&d_mut, nullptr);
+    }
+    ~MapCombo() {
+      pthread_rwlock_destroy(&d_mut);
+    }
+    pthread_rwlock_t d_mut;
     cmap_t d_map;
   };
 

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -34,9 +34,6 @@ const unsigned int AuthQueryCache::s_mincleaninterval, AuthQueryCache::s_maxclea
 AuthQueryCache::AuthQueryCache(size_t mapsCount): d_lastclean(time(nullptr))
 {
   d_maps.resize(mapsCount);
-  for(auto& mc : d_maps) {
-    pthread_rwlock_init(&mc.d_mut, 0);
-  }
 
   S.declare("query-cache-hit","Number of hits on the query cache");
   S.declare("query-cache-miss","Number of misses on the query cache");

--- a/pdns/auth-querycache.hh
+++ b/pdns/auth-querycache.hh
@@ -87,7 +87,13 @@ private:
 
   struct MapCombo
   {
-    pthread_rwlock_t d_mut;    
+    MapCombo() {
+      pthread_rwlock_init(&d_mut, nullptr);
+    }
+    ~MapCombo() {
+      pthread_rwlock_destroy(&d_mut);
+    }
+    pthread_rwlock_t d_mut;
     cmap_t d_map;
   };
 

--- a/pdns/dnscrypt.cc
+++ b/pdns/dnscrypt.cc
@@ -123,6 +123,11 @@ DNSCryptQuery::~DNSCryptQuery()
 }
 #endif /* HAVE_CRYPTO_BOX_EASY_AFTERNM */
 
+
+DNSCryptContext::~DNSCryptContext() {
+  pthread_rwlock_destroy(&d_lock);
+}
+
 DNSCryptContext::DNSCryptContext(const std::string& pName, const std::vector<CertKeyPaths>& certKeys): d_certKeyPaths(certKeys), providerName(pName)
 {
   pthread_rwlock_init(&d_lock, 0);

--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -262,7 +262,8 @@ public:
 
   DNSCryptContext(const std::string& pName, const std::vector<CertKeyPaths>& certKeys);
   DNSCryptContext(const std::string& pName, const DNSCryptCert& certificate, const DNSCryptPrivateKey& pKey);
-
+  ~DNSCryptContext();
+  
   void reloadCertificates();
   void loadNewCertificate(const std::string& certFile, const std::string& keyFile, bool active=true, bool reload=false);
   void addNewCertificate(const DNSCryptCert& newCert, const DNSCryptPrivateKey& newKey, bool active=true, bool reload=false);

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -92,13 +92,15 @@ private:
   public:
     CacheShard(): d_entriesCount(0)
     {
-      pthread_rwlock_init(&d_lock, 0);
+      pthread_rwlock_init(&d_lock, nullptr);
     }
     CacheShard(const CacheShard& old): d_entriesCount(0)
     {
-      pthread_rwlock_init(&d_lock, 0);
+      pthread_rwlock_init(&d_lock, nullptr);
     }
-
+    ~CacheShard() {
+      pthread_rwlock_destroy(&d_lock);
+    }
     void setSize(size_t maxSize)
     {
       d_map.reserve(maxSize);

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -655,6 +655,10 @@ struct QueryCount {
   {
     pthread_rwlock_init(&queryLock, nullptr);
   }
+  ~QueryCount()
+  {
+    pthread_rwlock_destroy(&queryLock);
+  }
   QueryCountRecords records;
   QueryCountFilter filter;
   pthread_rwlock_t queryLock;
@@ -845,6 +849,7 @@ struct DownstreamState
         fd = -1;
       }
     }
+    pthread_rwlock_destroy(&d_lock);
   }
   boost::uuids::uuid id;
   std::set<unsigned int> hashes;
@@ -999,6 +1004,10 @@ struct ServerPool
   ServerPool()
   {
     pthread_rwlock_init(&d_lock, nullptr);
+  }
+  ~ServerPool()
+  {
+    pthread_rwlock_destroy(&d_lock);
   }
 
   const std::shared_ptr<DNSDistPacketCache> getCache() const { return packetCache; };

--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -128,6 +128,10 @@ CDBKVStore::CDBKVStore(const std::string& fname, time_t refreshDelay): d_fname(f
   refreshDBIfNeeded(now);
 }
 
+CDBKVStore::~CDBKVStore() {
+  pthread_rwlock_destroy(&d_lock);
+}
+
 bool CDBKVStore::reload(const struct stat& st)
 {
   auto newCDB = std::unique_ptr<CDB>(new CDB(d_fname));

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -181,6 +181,7 @@ class CDBKVStore: public KeyValueStore
 {
 public:
   CDBKVStore(const std::string& fname, time_t refreshDelay);
+  ~CDBKVStore();
 
   bool keyExists(const std::string& key) override;
   bool getValue(const std::string& key, std::string& value) override;

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -235,6 +235,11 @@ public:
     pthread_rwlock_init(&d_lock4, 0);
     pthread_rwlock_init(&d_lock6, 0);
   }
+  ~TimedIPSetRule()
+  {
+    pthread_rwlock_destroy(&d_lock4);
+    pthread_rwlock_destroy(&d_lock6);
+  }
   bool matches(const DNSQuestion* dq) const override
   {
     if(dq->remote->sin4.sin_family == AF_INET) {

--- a/pdns/test-lock_hh.cc
+++ b/pdns/test-lock_hh.cc
@@ -57,7 +57,9 @@ BOOST_AUTO_TEST_CASE(test_pdns_lock)
   TryReadLock trl2(&*g_locks[0]);
   BOOST_CHECK(trl2.gotIt());
   
-  
+  for(auto& pp : g_locks) {
+    pthread_rwlock_destroy(pp.get());
+  }  
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
On some platforms, pthread_rwlock_init() not only inits mem, but also
acquires resources.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
