### PR TITLE
Auth API: be a bit more lenient

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1535,8 +1535,8 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp) {
       throw ApiException("You cannot give rrsets AND zone data as text");
 
     auto nameservers = document["nameservers"];
-    if (!nameservers.is_array() && zonekind != DomainInfo::Slave)
-      throw ApiException("Nameservers list must be given (but can be empty if NS records are supplied)");
+    if (!nameservers.is_null() && !nameservers.is_array() && zonekind != DomainInfo::Slave)
+      throw ApiException("Nameservers is not a list");
 
     string soa_edit_api_kind;
     if (document["soa_edit_api"].is_string()) {


### PR DESCRIPTION
### Short description
While working with openapi-codegen generated code, it seems that the auth API might be a bit too strict when it comes to the createZone call.

This PR addresses 2 of these issues.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)