### PR TITLE
dnsdist: Wait longer for the TLS ticket to arrive in our tests

### DIFF
--- a/regression-tests.dnsdist/test_TLSSessionResumption.py
+++ b/regression-tests.dnsdist/test_TLSSessionResumption.py
@@ -32,7 +32,7 @@ class DNSDistTLSSessionResumptionTest(DNSDistTest):
         try:
             process = subprocess.Popen(testcmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
             # we need to wait just a bit so that the Post-Handshake New Session Ticket has the time to arrive..
-            time.sleep(0.1)
+            time.sleep(0.5)
             output = process.communicate(input=b'')
         except subprocess.CalledProcessError as exc:
             raise AssertionError('%s failed (%d): %s' % (testcmd, process.returncode, process.output))


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In TLS 1.3 the server sends the TLS ticket after the handshake has been completed, but not necessarily right after that. Ideally we would like to wait for up to several seconds, but stop waiting as soon as we receive a ticket. Unfortunately we can't ask that from `openssl s_client`, and we are currently not always waiting long enough to get a ticket, leading to spurious failures.
Let's try waiting a bit longer to see if that helps.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
