### PR TITLE
Update docker repo script for auth-4.2.1.

### DIFF
--- a/build-scripts/docker/generate-repo-files.sh
+++ b/build-scripts/docker/generate-repo-files.sh
@@ -21,7 +21,14 @@ write_centos()
     cat <<EOF > Dockerfile.$RELEASE.$OS-$VERSION
 FROM $OS:$VERSION
 
-RUN yum install -y epel-release yum-plugin-priorities
+RUN yum install -y epel-release bind-utils
+EOF
+    if [ "$VERSION" = "6" -o "$VERSION" = "7" ]; then
+        cat <<EOF >> Dockerfile.$RELEASE.$OS-$VERSION
+RUN yum install -y yum-plugin-priorities
+EOF
+    fi
+    cat <<EOF >> Dockerfile.$RELEASE.$OS-$VERSION
 RUN curl -o /etc/yum.repos.d/powerdns-$RELEASE.repo https://repo.powerdns.com/repo-files/$OS-$RELEASE.repo
 RUN yum install -y $PKG
 
@@ -48,7 +55,7 @@ EOF
 FROM $OS:$VERSION
 
 RUN apt-get update
-RUN apt-get install -y curl gnupg
+RUN apt-get install -y curl gnupg dnsutils
 
 COPY pdns.debian-and-ubuntu /etc/apt/preferences.d/pdns
 COPY pdns.list.$RELEASE.$OS-$VERSION /etc/apt/sources.list.d/pdns.list

--- a/build-scripts/docker/generate-repo-files.sh
+++ b/build-scripts/docker/generate-repo-files.sh
@@ -114,13 +114,11 @@ elif [ "$RELEASE" = "rec-41" ]; then
 elif [ "$RELEASE" = "rec-42" ]; then
     write_centos 6 pdns-recursor pdns_recursor
     write_centos 7 pdns-recursor pdns_recursor
-    write_debian jessie pdns-recursor pdns_recursor
+    write_centos 8 pdns-recursor pdns_recursor
     write_debian stretch pdns-recursor pdns_recursor
     write_debian buster pdns-recursor pdns_recursor
-    write_ubuntu trusty pdns-recursor pdns_recursor
     write_ubuntu xenial pdns-recursor pdns_recursor
     write_ubuntu bionic pdns-recursor pdns_recursor
-    write_ubuntu cosmic pdns-recursor pdns_recursor
 else
     echo "Invalid release: $RELEASE"
     exit 1

--- a/build-scripts/docker/generate-repo-files.sh
+++ b/build-scripts/docker/generate-repo-files.sh
@@ -91,12 +91,11 @@ elif [ "$RELEASE" = "auth-41" ]; then
 elif [ "$RELEASE" = "auth-42" ]; then
     write_centos 6 pdns pdns_server
     write_centos 7 pdns pdns_server
-    write_debian jessie pdns-server pdns_server
+    write_centos 8 pdns pdns_server
     write_debian stretch pdns-server pdns_server
-    write_ubuntu trusty pdns-server pdns_server
+    write_debian buster pdns-server pdns_server
     write_ubuntu xenial pdns-server pdns_server
     write_ubuntu bionic pdns-server pdns_server
-    write_ubuntu cosmic pdns-server pdns_server
 elif [ "$RELEASE" = "rec-40" ]; then
     write_centos 6 pdns-recursor pdns_recursor
     write_centos 7 pdns-recursor pdns_recursor


### PR DESCRIPTION
Updated for the distros and versions that are generated for the auth-4.2.1+ packages.

Files for Centos 8 do not seem to be correct since they give this error:

```
$ docker build --no-cache --pull --file Dockerfile.auth-42.centos-8 .
Sending build context to Docker daemon  23.55kB
Step 1/5 : FROM centos:8
8: Pulling from library/centos
Digest: sha256:f94c1d992c193b3dc09e297ffd54d8a4f1dc946c37cbeceb26d35ce1647f88d9
Status: Image is up to date for centos:8
 ---> 0f3e07c0138f
Step 2/5 : RUN yum install -y epel-release yum-plugin-priorities
 ---> Running in 791b4b6b270f
CentOS-8 - AppStream                            3.2 MB/s | 6.3 MB     00:01    
CentOS-8 - Base                                 7.4 MB/s | 7.9 MB     00:01    
CentOS-8 - Extras                               7.3 kB/s | 2.1 kB     00:00    
No match for argument: yum-plugin-priorities
Error: Unable to find a match
The command '/bin/sh -c yum install -y epel-release yum-plugin-priorities' returned a non-zero code: 1
```

This has not been further investigated yet.