### PR TITLE
Avoid copying of pthread_rwlock_t

### DIFF
--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -30,10 +30,8 @@ extern StatBag S;
 
 const unsigned int AuthPacketCache::s_mincleaninterval, AuthPacketCache::s_maxcleaninterval;
 
-AuthPacketCache::AuthPacketCache(size_t mapsCount): d_lastclean(time(nullptr))
+AuthPacketCache::AuthPacketCache(size_t mapsCount): d_lastclean(time(nullptr)), d_maps(mapsCount)
 {
-  d_maps.resize(mapsCount);
-
   S.declare("packetcache-hit", "Number of hits on the packet cache");
   S.declare("packetcache-miss", "Number of misses on the packet cache");
   S.declare("packetcache-size", "Number of entries in the packet cache");

--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -110,6 +110,9 @@ private:
     ~MapCombo() {
       pthread_rwlock_destroy(&d_mut);
     }
+    MapCombo(const MapCombo&) = delete; 
+    MapCombo& operator=(const MapCombo&) = delete;
+
     pthread_rwlock_t d_mut;
     cmap_t d_map;
   };

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -31,10 +31,8 @@ extern StatBag S;
 
 const unsigned int AuthQueryCache::s_mincleaninterval, AuthQueryCache::s_maxcleaninterval;
 
-AuthQueryCache::AuthQueryCache(size_t mapsCount): d_lastclean(time(nullptr))
+AuthQueryCache::AuthQueryCache(size_t mapsCount): d_maps(mapsCount), d_lastclean(time(nullptr))
 {
-  d_maps.resize(mapsCount);
-
   S.declare("query-cache-hit","Number of hits on the query cache");
   S.declare("query-cache-miss","Number of misses on the query cache");
   S.declare("query-cache-size", "Number of entries in the query cache");

--- a/pdns/auth-querycache.hh
+++ b/pdns/auth-querycache.hh
@@ -93,6 +93,9 @@ private:
     ~MapCombo() {
       pthread_rwlock_destroy(&d_mut);
     }
+    MapCombo(const MapCombo &) = delete; 
+    MapCombo & operator=(const MapCombo &) = delete;
+
     pthread_rwlock_t d_mut;
     cmap_t d_map;
   };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Alternatively, we could introduce a copy constructor like dnsdist does; but we do not have dynamic resize in auth. So setup the cache size on construct.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
