### PR TITLE
geoipbackend: accept custom lookup mapping

### DIFF
--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -145,6 +145,14 @@ that the ``‐`` before certain keys is part of the syntax.
         service.geo.example.com:
           default: [ '%co.%cn.service.geo.example.com', '%cn.service.geo.example.com' ]
           10.0.0.0/8: 'internal.service.geo.example.com'
+    mapping_lookup_formats: ['%cc-%re', '%cc']
+    custom_mapping:
+      fr: eu-central
+      be: eu-central
+      es: eu-south
+      pt: eu-south
+      us-tx: us-south
+      us-ca: us-south
 
 Keys explained
 ~~~~~~~~~~~~~~
@@ -165,6 +173,16 @@ Keys explained
 
   :services: Defines one or more services for querying.
              Each service name may have one or more placeholders.
+  :mapping_lookup_formats: Defines which format to interpolate when using the ``%mp`` placeholder. Each entry
+                           is looked up in the given order and stops at first match.
+                           This allows using a fine granularity, (e.g. per country), while limiting the number
+                           of records to create.
+                           You can use any placeholder, except ``%mp`` to avoid recursion, within the given
+                           format (e.g. %cc).
+  :custom_mapping: Defines the mapping between the lookup format and a custom value to replace ``%mp`` placeholder.
+
+:mapping_lookup_formats: Same as per domain, but used as default value if not defined at the domain level.
+:custom_mapping: Same as per domain, but used as default value if not defined at the domain level.
 
 .. note::
 
@@ -203,6 +221,16 @@ These placeholders disable caching for the record completely:
 :%ip: Client IP address
 :%ip4: Client IPv4 address
 :%ip6: Client IPv6 address
+
+Following placeholder allows custom mapping:
+
+:%mp: Use formats in ``mapping_lookup_formats`` and use user defined ``custom_mapping``
+
+.. versionadded:: 4.4.0
+
+  These placeholders have been added in version 4.4.0:
+
+  - %mp to expand user defined custom formats.
 
 .. versionadded:: 4.2.0
 

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -70,7 +70,7 @@ private:
   static ReadWriteLock s_state_lock;
 
   void initialize();
-  string format2str(string format, const Netmask &addr, GeoIPNetmask& gl);
+  string format2str(string format, const Netmask &addr, GeoIPNetmask& gl, const GeoIPDomain &dom);
   bool d_dnssec;
   bool hasDNSSECkey(const DNSName& name);
   bool lookup_static(const GeoIPDomain &dom, const DNSName &search, const QType &qtype, const DNSName& qdomain, const Netmask &addr, GeoIPNetmask& gl);

--- a/modules/geoipbackend/regression-tests/custom-mapping-txt-resolution/command
+++ b/modules/geoipbackend/regression-tests/custom-mapping-txt-resolution/command
@@ -1,0 +1,3 @@
+#!/bin/sh
+cleandig map.geo.example.com TXT ednssubnet $geoipregionip
+cleandig map.geo2.example.com TXT ednssubnet $geoipregionip

--- a/modules/geoipbackend/regression-tests/custom-mapping-txt-resolution/description
+++ b/modules/geoipbackend/regression-tests/custom-mapping-txt-resolution/description
@@ -1,0 +1,2 @@
+This test tries to resolve a straight TXT record that is available via
+custom mapping the database.

--- a/modules/geoipbackend/regression-tests/custom-mapping-txt-resolution/expected_result
+++ b/modules/geoipbackend/regression-tests/custom-mapping-txt-resolution/expected_result
@@ -1,0 +1,8 @@
+0	map.geo.example.com.	IN	TXT	30	"custom mapping"
+2	.	IN	OPT	0	AAgACAABIBgBAQEB
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='map.geo.example.com.', qtype=TXT
+0	map.geo2.example.com.	IN	TXT	30	"overridden moon mapping"
+2	.	IN	OPT	0	AAgACAABIBgBAQEB
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='map.geo2.example.com.', qtype=TXT

--- a/regression-tests/backends/geoip-master
+++ b/regression-tests/backends/geoip-master
@@ -51,11 +51,31 @@ domains:
       - a: $geoipregionip
     unknown.service.geo.example.com:
       - a: 127.0.0.1
+    earth.map.geo.example.com:
+      - txt: "custom mapping"
   services:
     geo.example.com: '%cn.service.geo.example.com'
     www.geo.example.com: '%cn.service.geo.example.com'
     indirect.geo.example.com: '%cn.elsewhere.example.com'
     city.geo.example.com: '%ci.%re.%cc.city.geo.example.com'
+    map.geo.example.com: '%mp.map.geo.example.com'
+- domain: geo2.example.com
+  ttl: 30
+  records:
+    geo2.example.com:
+      - soa: ns1.example.com hostmaster.example.com 2014090125 7200 3600 1209600 3600
+      - ns: ns1.example.com
+      - ns: ns2.example.com
+      - mx: 10 mx.example.com
+    moon.map.geo2.example.com:
+      - txt: "overridden moon mapping"
+  services:
+    map.geo2.example.com: '%mp.map.geo2.example.com'
+  custom_mapping:
+    $geoipregion: moon
+mapping_lookup_formats: ['%cn']
+custom_mapping:
+  $geoipregion: earth
 EOF
 		cat > $testsdir/region-a-resolution/expected_result <<EOF
 0	www.geo.example.com.	IN	A	30	$geoipregionip


### PR DESCRIPTION
If for example you want a per country granularity, but still want to
group by custom regions: uk, fr, be -> eu-central, pt, es -> eu-south;
you need to to use %cc and create identical country records. It means
you zones file can become huge and powerdns does not like it too much.

For a user to have a custom mapping without the need to rewrite the
GeoIP database, with this commit, he/she can specify a custom mapping,
so if we get from the GeoIP database fr, we will look in the custom
mapping and find eu-central. So we only need to create the eu-central
record and it will be used by for uk, fr and be as per our first
example.

Definition of mapping_lookup_formats or custom_mapping at the domain
level has priority, but if not defined the global config will be used
as default.

The custom lookup formats and mapping are specified in the zones file:

```
  ---
  mapping_lookup_formats: ['%cc-%re', '%cc']
  custom_mapping:
    'fr': 'eu-central'
    'be': 'eu-central'
    'es': 'eu-south'
    'pt': 'eu-south'
    'us-ca': 'us-west'
    'us-tx': 'us-south'
  domains:
  - domain: example.com
    services:
      www.example.com: [ '%mp.www.example.com' ]
    records:
      eu-central.www.example.com:
        - A: 1.1.1.1
      eu-south.www.example.com:
        - A: 1.1.1.2
      us-west.www.example.com:
        - A: 1.1.1.3
      us-south.www.example.com:
        - A: 1.1.1.4
  - domain: example2.com
    mapping_lookup_formats: ['%cc']
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)

