### PR TITLE
Backport fix out-of-bound access for zero length "serialized" string.

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -114,7 +114,10 @@ shared_ptr<DNSRecordContent> DNSRecordContent::unserialize(const DNSName& qname,
   drh.d_clen=htons(serialized.size());
 
   memcpy(&packet[pos], &drh, sizeof(drh)); pos+=sizeof(drh);
-  memcpy(&packet[pos], serialized.c_str(), serialized.size()); pos+=(uint16_t)serialized.size();
+  if (serialized.size() > 0) {
+    memcpy(&packet[pos], serialized.c_str(), serialized.size());
+    pos += (uint16_t) serialized.size();
+  }
 
   MOADNSParser mdp(false, (char*)&*packet.begin(), (unsigned int)packet.size());
   shared_ptr<DNSRecordContent> ret= mdp.d_answers.begin()->first.d_content;


### PR DESCRIPTION
### Not so short description
PowerDNS with lmdb, compiled by mock, is crashing regularly.

```
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 Got a signal 6, attempting to print trace:
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(+0x2d470a) [0x55c94ea2070a]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /lib64/libc.so.6(+0x379c0) [0x7fc0bf8b79c0]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /lib64/libc.so.6(gsignal+0x10f) [0x7fc0bf8b793f]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /lib64/libc.so.6(abort+0x127) [0x7fc0bf8a1c95]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(+0x1591f8) [0x55c94e8a51f8]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(_ZN16DNSRecordContent11unserializeERK7DNSNametRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x40f) [0x55c94e8fbb5f]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/lib64/pdns/liblmdbbackend.so(_Z20unserializeContentZRtRK7DNSNameRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x3d) [0x7fc0bdb41c9d]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/lib64/pdns/liblmdbbackend.so(_ZN11LMDBBackend10get_lookupER13DNSZoneRecord+0x231) [0x7fc0bdb42ae1]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(_ZN12UeberBackend6handle3getER13DNSZoneRecord+0x76) [0x55c94ea71ed6]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(_ZN12UeberBackend3getER13DNSZoneRecord+0x271) [0x55c94ea727b1]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(_ZN13PacketHandler15getBestWildcardEP9DNSPacketR7SOADataRK7DNSNameRS4_PSt6vectorI13DNSZoneRecordSaIS9_EE+0x4d3) [0x55c94ea0d853]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(_ZN13PacketHandler11tryWildcardEP9DNSPacketS1_R7SOADataR7DNSNameS5_RbS6_+0xae) [0x55c94ea10fde]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(_ZN13PacketHandler10doQuestionEP9DNSPacket+0x1098) [0x55c94ea14e08]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(_ZN13PacketHandler8questionEP9DNSPacket+0xe8) [0x55c94ea15ff8]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /usr/sbin/pdns_server(_ZN22MultiThreadDistributorI9DNSPacketS0_13PacketHandlerE10makeThreadEPv+0x179) [0x55c94e8be899]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /lib64/libpthread.so.0(+0x82de) [0x7fc0bfc4c2de]
Dec  6 12:36:05 ns pdns_server[21249]: Dec 06 12:36:05 /lib64/libc.so.6(clone+0x43) [0x7fc0bf97ca63]
Dec  6 12:36:05 ns systemd[1]: pdns.service: Main process exited, code=killed, status=6/ABRT
Dec  6 12:36:05 ns systemd[1]: pdns.service: Failed with result 'signal'.
```

Steps to reproduce:

Build with the default mock compiler flags and config options

```
CFLAGS='-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection'
export CFLAGS
CXXFLAGS='-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection'
export CXXFLAGS
FFLAGS='-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -I/usr/lib64/gfortran/modules'
export FFLAGS
FCFLAGS='-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -I/usr/lib64/gfortran/modules'
export FCFLAGS
LDFLAGS='-Wl,-z,relro  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld'
export LDFLAGS

./configure --build=x86_64-redhat-linux-gnu --host=x86_64-redhat-linux-gnu --program-prefix= --disable-dependency-tracking --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --datadir=/usr/share --includedir=/usr/include --libdir=/usr/lib64 --libexecdir=/usr/libexec --localstatedir=/var --sharedstatedir=/var/lib --mandir=/usr/share/man --infodir=/usr/share/info --sysconfdir=/etc/pdns --with-sqlite3 --with-lua=lua --with-protobuf --with-modules= '--with-dynmodules=bind gmysql gpgsql gsqlite3 ldap lua lua2 mydns pipe remote lmdb' --disable-lua-records --disable-static --enable-tools
```

With this commit added to 4.2.1 pdns (lmdb) is running stable on el8

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
