### PR TITLE
auth packetcache: sync init order with member order

### DIFF
--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -30,7 +30,7 @@ extern StatBag S;
 
 const unsigned int AuthPacketCache::s_mincleaninterval, AuthPacketCache::s_maxcleaninterval;
 
-AuthPacketCache::AuthPacketCache(size_t mapsCount): d_lastclean(time(nullptr)), d_maps(mapsCount)
+AuthPacketCache::AuthPacketCache(size_t mapsCount): d_maps(mapsCount), d_lastclean(time(nullptr))
 {
   S.declare("packetcache-hit", "Number of hits on the packet cache");
   S.declare("packetcache-miss", "Number of misses on the packet cache");


### PR DESCRIPTION
### Short description
This avoids:
```
In file included from auth-packetcache.cc:25:
auth-packetcache.hh: In constructor ‘AuthPacketCache::AuthPacketCache(size_t)’:
auth-packetcache.hh:136:10: warning: ‘AuthPacketCache::d_lastclean’ will be initialized after [-Wreorder]
   time_t d_lastclean; // doesn't need to be atomic
          ^~~~~~~~~~~
auth-packetcache.hh:120:20: warning:   ‘std::vector<AuthPacketCache::MapCombo> AuthPacketCache::d_maps’ [-Wreorder]
   vector<MapCombo> d_maps;
                    ^~~~~~
auth-packetcache.cc:33:1: warning:   when initialized here [-Wreorder]
 AuthPacketCache::AuthPacketCache(size_t mapsCount): d_lastclean(time(nullptr)), d_maps(mapsCount)
 ^~~~~~~~~~~~~~~
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
