### PR TITLE
Remove not implemented zone check API from spec

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -301,29 +301,6 @@ paths:
           schema:
             type: string
 
-  '/servers/{server_id}/zones/{zone_id}/check':
-    get:
-      summary: 'Verify zone contents/configuration.'
-      operationId: checkZone
-      tags:
-        - zones
-      parameters:
-        - name: server_id
-          in: path
-          required: true
-          description: The id of the server to retrieve
-          type: string
-        - name: zone_id
-          type: string
-          in: path
-          required: true
-          description: The id of the zone to retrieve
-      responses:
-        '200':
-          description: OK
-          schema:
-            type: string
-
   '/servers/{server_id}/zones/{zone_id}/rectify':
     put:
       summary: 'Rectify the zone data.'

--- a/docs/http-api/zone.rst
+++ b/docs/http-api/zone.rst
@@ -7,7 +7,7 @@ Zone Endpoints
 --------------
 
 .. openapi:: swagger/authoritative-api-swagger.yaml
-  :paths: /servers/{server_id}/zones /servers/{server_id}/zones/{zone_id} /servers/{server_id}/zones/{zone_id}/axfr-retrieve /servers/{server_id}/zones/{zone_id}/notify /servers/{server_id}/zones/{zone_id}/export /servers/{server_id}/zones/{zone_id}/check /servers/{server_id}/zones/{zone_id}/rectify
+  :paths: /servers/{server_id}/zones /servers/{server_id}/zones/{zone_id} /servers/{server_id}/zones/{zone_id}/axfr-retrieve /servers/{server_id}/zones/{zone_id}/notify /servers/{server_id}/zones/{zone_id}/export /servers/{server_id}/zones/{zone_id}/rectify
 
 Objects
 -------


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

I've never implemented the '/servers/{server_id}/zones/{zone_id}/check' endpoint, and won't find time in the short term future.

Lets remove it to avoid potential confusion.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
