### PR TITLE
Rec: more bulk test variations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -937,7 +937,7 @@ jobs:
             ./build-scripts/test-recursor
 
   test-recursor-bulk:
-    resource_class: small
+    resource_class: medium
 
     docker:
       - image: debian:buster
@@ -954,14 +954,76 @@ jobs:
             curl -LO http://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip && \
             unzip top-1m.csv.zip -d .
       - run:
-          name: Run bulktests
+          name: Run bulktest A
           command: |
             DNSBULKTEST=/usr/bin/dnsbulktest \
             RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
             THRESHOLD=95 \
             TRACE=no \
-            ./timestamp ./recursor-test 5300 50000 || \
-            (cat recursor.log; false)
+            ./timestamp ./recursor-test 5300 50000 2
+          workdir: ~/project/regression-tests
+      - run:
+          name: Run bulktest B
+          command: |
+            DNSBULKTEST=/usr/bin/dnsbulktest \
+            RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            THRESHOLD=95 \
+            TRACE=no \
+            ./timestamp ./recursor-test 5300 50000 4
+          workdir: ~/project/regression-tests
+      - run:
+          name: Run bulktest C
+          command: |
+            DNSBULKTEST=/usr/bin/dnsbulktest \
+            RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            THRESHOLD=95 \
+            TRACE=no \
+            ./timestamp ./recursor-test 5300 50000 8
+          workdir: ~/project/regression-tests
+      - run:
+          name: Run bulktest D
+          command: |
+            DNSBULKTEST=/usr/bin/dnsbulktest \
+            RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            THRESHOLD=95 \
+            TRACE=no \
+            ./timestamp ./recursor-test 5300 50000 16
+          workdir: ~/project/regression-tests
+      - run:
+          name: Run bulktest E
+          command: |
+            DNSBULKTEST=/usr/bin/dnsbulktest \
+            RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            THRESHOLD=95 \
+            TRACE=no \
+            ./timestamp ./recursor-test 5300 50000 2 4096
+          workdir: ~/project/regression-tests
+      - run:
+          name: Run bulktest F
+          command: |
+            DNSBULKTEST=/usr/bin/dnsbulktest \
+            RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            THRESHOLD=95 \
+            TRACE=no \
+            ./timestamp ./recursor-test 5300 50000 4 4096
+          workdir: ~/project/regression-tests
+      - run:
+          name: Run bulktest G
+          command: |
+            DNSBULKTEST=/usr/bin/dnsbulktest \
+            RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            THRESHOLD=95 \
+            TRACE=no \
+            ./timestamp ./recursor-test 5300 50000 8 4096
+          workdir: ~/project/regression-tests
+      - run:
+          name: Run bulktest H
+          command: |
+            DNSBULKTEST=/usr/bin/dnsbulktest \
+            RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            THRESHOLD=95 \
+            TRACE=no \
+            ./timestamp ./recursor-test 5300 50000 16 4096
           workdir: ~/project/regression-tests
 
   test-recursor-api:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -958,6 +958,7 @@ jobs:
           command: |
             DNSBULKTEST=/usr/bin/dnsbulktest \
             RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            RECCONTROL=/opt/pdns-recursor/bin/rec_control \
             THRESHOLD=95 \
             TRACE=no \
             ./timestamp ./recursor-test 5300 50000 2
@@ -967,6 +968,7 @@ jobs:
           command: |
             DNSBULKTEST=/usr/bin/dnsbulktest \
             RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            RECCONTROL=/opt/pdns-recursor/bin/rec_control \
             THRESHOLD=95 \
             TRACE=no \
             ./timestamp ./recursor-test 5300 50000 4
@@ -976,6 +978,7 @@ jobs:
           command: |
             DNSBULKTEST=/usr/bin/dnsbulktest \
             RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            RECCONTROL=/opt/pdns-recursor/bin/rec_control \
             THRESHOLD=95 \
             TRACE=no \
             ./timestamp ./recursor-test 5300 50000 8
@@ -985,6 +988,7 @@ jobs:
           command: |
             DNSBULKTEST=/usr/bin/dnsbulktest \
             RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            RECCONTROL=/opt/pdns-recursor/bin/rec_control \
             THRESHOLD=95 \
             TRACE=no \
             ./timestamp ./recursor-test 5300 50000 16
@@ -994,6 +998,7 @@ jobs:
           command: |
             DNSBULKTEST=/usr/bin/dnsbulktest \
             RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            RECCONTROL=/opt/pdns-recursor/bin/rec_control \
             THRESHOLD=95 \
             TRACE=no \
             ./timestamp ./recursor-test 5300 50000 2 4096
@@ -1003,6 +1008,7 @@ jobs:
           command: |
             DNSBULKTEST=/usr/bin/dnsbulktest \
             RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            RECCONTROL=/opt/pdns-recursor/bin/rec_control \
             THRESHOLD=95 \
             TRACE=no \
             ./timestamp ./recursor-test 5300 50000 4 4096
@@ -1012,6 +1018,7 @@ jobs:
           command: |
             DNSBULKTEST=/usr/bin/dnsbulktest \
             RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            RECCONTROL=/opt/pdns-recursor/bin/rec_control \
             THRESHOLD=95 \
             TRACE=no \
             ./timestamp ./recursor-test 5300 50000 8 4096
@@ -1021,6 +1028,7 @@ jobs:
           command: |
             DNSBULKTEST=/usr/bin/dnsbulktest \
             RECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
+            RECCONTROL=/opt/pdns-recursor/bin/rec_control \
             THRESHOLD=95 \
             TRACE=no \
             ./timestamp ./recursor-test 5300 50000 16 4096

--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -1,8 +1,12 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 port=$1
 [ -z "$port" ] && port=5300
 limit=$2
 [ -z "$limit" ] && limit=100000
+threads=$3
+[ -z "$threads" ] && threads=2
+mthreads=$4
+[ -z "$mthreads" ] && mthreads=100
 
 : ${RECURSOR:="../pdns/recursordist/pdns_recursor"}
 : ${CSV:="top-1m.csv"}
@@ -24,9 +28,23 @@ rm -f recursor.pid pdns_recursor.pid
 <measurement><name>system CPU seconds</name><value>%S</value></measurement>
 <measurement><name>wallclock seconds</name><value>%e</value></measurement>
 <measurement><name>%% CPU used</name><value>%P</value></measurement>
-'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=100 --query-local-address6="${QLA6}" > recursor.log 2>&1 &
+'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address6="${QLA6}" --threads=$threads --disable-packetcache > recursor.log 2>&1 &
 sleep 3
+
+# warm up the cache
+echo
+echo === First run with limit=$limit threads=$threads mthreads=$mthreads ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
+# rerun wit hot cache
+echo
+echo === Second run with limit=$limit threads=$threads mthreads=$mthreads ===
+${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
+
+echo
+echo "=== RECURSOR LOG ==="
+cat recursor.log
+echo "=== END RECURSOR LOG ==="
+
 kill $(cat pdns_recursor.pid)
 sleep 5
 

--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -39,6 +39,10 @@ ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.result
 echo
 echo === Second run with limit=$limit threads=$threads mthreads=$mthreads ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
+# rerun 2 wit hot cache
+echo
+echo === Third run with limit=$limit threads=$threads mthreads=$mthreads ===
+${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
 
 echo
 echo "=== RECURSOR LOG ==="

--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -9,6 +9,7 @@ mthreads=$4
 [ -z "$mthreads" ] && mthreads=100
 
 : ${RECURSOR:="../pdns/recursordist/pdns_recursor"}
+: ${RECCONTROL:="../pdns/recursordist/rec_control"}
 : ${CSV:="top-1m.csv"}
 : ${IPv6:="0"}
 : ${TRACE:="fail"}
@@ -35,15 +36,22 @@ sleep 3
 echo
 echo === First run with limit=$limit threads=$threads mthreads=$mthreads ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
-# rerun wit hot cache
+kill -USR1 $(cat pdns_recursor.pid)
+${RECCONTROL} --socket-dir=. --config-dir=. get-all
+# rerun 1 with hot cache
 echo
 echo === Second run with limit=$limit threads=$threads mthreads=$mthreads ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
-# rerun 2 wit hot cache
+kill -USR1 $(cat pdns_recursor.pid)
+${RECCONTROL} --socket-dir=. --config-dir=. get-all
+# rerun 2 with hot cache
 echo
 echo === Third run with limit=$limit threads=$threads mthreads=$mthreads ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
+kill -USR1 $(cat pdns_recursor.pid)
+${RECCONTROL} --socket-dir=. --config-dir=. get-all
 
+sleep 1
 echo
 echo "=== RECURSOR LOG ==="
 cat recursor.log


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This runs more variations of the bulk tests on circleci with different thread/mthread settings.
Also, the test itself is repeated: once to fill the record cache and then twice to use the record cache. I do two runs with the hot cache to see timing variations.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
