### PR TITLE
Use utf8mb4 instead of deprecated utf8

### DIFF
--- a/modules/gmysqlbackend/schema.mysql.sql
+++ b/modules/gmysqlbackend/schema.mysql.sql
@@ -5,7 +5,7 @@ CREATE TABLE domains (
   last_check            INT DEFAULT NULL,
   type                  VARCHAR(6) NOT NULL,
   notified_serial       INT UNSIGNED DEFAULT NULL,
-  account               VARCHAR(40) CHARACTER SET 'utf8' DEFAULT NULL,
+  account               VARCHAR(40) CHARACTER SET 'utf8mb4' DEFAULT NULL,
   PRIMARY KEY (id)
 ) Engine=InnoDB CHARACTER SET 'latin1';
 
@@ -34,7 +34,7 @@ CREATE INDEX ordername ON records (ordername);
 CREATE TABLE supermasters (
   ip                    VARCHAR(64) NOT NULL,
   nameserver            VARCHAR(255) NOT NULL,
-  account               VARCHAR(40) CHARACTER SET 'utf8' NOT NULL,
+  account               VARCHAR(40) CHARACTER SET 'utf8mb4' NOT NULL,
   PRIMARY KEY (ip, nameserver)
 ) Engine=InnoDB CHARACTER SET 'latin1';
 
@@ -45,8 +45,8 @@ CREATE TABLE comments (
   name                  VARCHAR(255) NOT NULL,
   type                  VARCHAR(10) NOT NULL,
   modified_at           INT NOT NULL,
-  account               VARCHAR(40) CHARACTER SET 'utf8' DEFAULT NULL,
-  comment               TEXT CHARACTER SET 'utf8' NOT NULL,
+  account               VARCHAR(40) CHARACTER SET 'utf8mb4' DEFAULT NULL,
+  comment               TEXT CHARACTER SET 'utf8mb4' NOT NULL,
   PRIMARY KEY (id)
 ) Engine=InnoDB CHARACTER SET 'latin1';
 


### PR DESCRIPTION
### Short description
utf8 is an alias for utf8mb3 that is deprecated since MySQL 8.0, released 2018.
utf8mb4 is supported since MySQL 5.5.3, released 2010.

Deprecation info:
https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8.html

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)