### PR TITLE
gpgsqlbackend: Avoid actually prepared statements

### DIFF
--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -35,7 +35,7 @@
 class SPgSQLStatement: public SSqlStatement
 {
 public:
-  SPgSQLStatement(const string& query, bool dolog, int nparams, SPgSQL* db, unsigned int nstatement) {
+  SPgSQLStatement(const string& query, bool dolog, int nparams, SPgSQL* db) {
     d_query = query;
     d_dolog = dolog;
     d_parent = db;
@@ -45,7 +45,6 @@ public:
     d_res_set = NULL;
     paramValues = NULL;
     paramLengths = NULL;
-    d_nstatement = nstatement;
     d_paridx = 0;
     d_residx = 0;
     d_resnum = 0;
@@ -243,7 +242,6 @@ private:
   int d_resnum;
   int d_fnum;
   int d_cur_set;
-  unsigned int d_nstatement;
 };
 
 bool SPgSQL::s_dolog;
@@ -254,7 +252,6 @@ SPgSQL::SPgSQL(const string &database, const string &host, const string& port, c
   d_db=0;
   d_in_trx = false;
   d_connectstr="";
-  d_nstatement = 0;
 
   if (!database.empty())
     d_connectstr+="dbname="+database;
@@ -321,8 +318,7 @@ void SPgSQL::execute(const string& query)
 
 std::unique_ptr<SSqlStatement> SPgSQL::prepare(const string& query, int nparams)
 {
-  d_nstatement++;
-  return std::unique_ptr<SSqlStatement>(new SPgSQLStatement(query, s_dolog, nparams, this, d_nstatement));
+  return std::unique_ptr<SSqlStatement>(new SPgSQLStatement(query, s_dolog, nparams, this));
 }
 
 void SPgSQL::startTransaction() {

--- a/modules/gpgsqlbackend/spgsql.hh
+++ b/modules/gpgsqlbackend/spgsql.hh
@@ -55,7 +55,6 @@ private:
   string d_connectlogstr;
   static bool s_dolog;
   bool d_in_trx;
-  unsigned int d_nstatement;
 };
 
 #endif /* SPGSQL_HH */


### PR DESCRIPTION
### Short description

Remove real prepared statements from the generic PostgreSQL backend. Instead use the parameterised libpq API, which was (as far as I remember) the original intent.

This should help users with transaction level pooling servers (like pgbouncer) where relying on cross-transaction session state is not possible (and prepared statement are such state).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
