### PR TITLE
auth: make sure get() is always returning the default value for d_place

### DIFF
--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -633,6 +633,9 @@ bool UeberBackend::get(DNSZoneRecord &rr)
     d_answers.clear();
     return false;
   }
+
+  rr.dr.d_place=DNSResourceRecord::ANSWER;
+
   d_ancount++;
   d_answers.push_back(rr);
   return true;


### PR DESCRIPTION
### Short description
Make sure get() is always returning the default value for d_place and not some, random, previously set value.

Fixes #8626

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
