### PR TITLE
rec: debian postinst / do not fail on user creation if it already exists

### DIFF
--- a/builder-support/debian/recursor/debian-buster/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-buster/pdns-recursor.postinst
@@ -3,8 +3,12 @@ set -e
 
 case "$1" in
   configure)
-    addgroup --system pdns
-    adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ -z "`getent group pdns`" ]; then
+      addgroup --system pdns
+    fi
+    if [ -z "`getent passwd pdns`" ]; then
+      adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    fi
     if [ "`stat -c '%U:%G' /etc/powerdns/recursor.conf`" = "root:root" ]; then
       chown root:pdns /etc/powerdns/recursor.conf
       # Make sure that pdns can read it; the default used to be 0600

--- a/builder-support/debian/recursor/debian-jessie/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-jessie/pdns-recursor.postinst
@@ -3,8 +3,12 @@ set -e
 
 case "$1" in
   configure)
-    addgroup --system pdns
-    adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ -z "`getent group pdns`" ]; then
+      addgroup --system pdns
+    fi
+    if [ -z "`getent passwd pdns`" ]; then
+      adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    fi
     if [ "`stat -c '%U:%G' /etc/powerdns/recursor.conf`" = "root:root" ]; then
       chown root:pdns /etc/powerdns/recursor.conf
       # Make sure that pdns can read it; the default used to be 0600

--- a/builder-support/debian/recursor/debian-stretch/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-stretch/pdns-recursor.postinst
@@ -3,8 +3,12 @@ set -e
 
 case "$1" in
   configure)
-    addgroup --system pdns
-    adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ -z "`getent group pdns`" ]; then
+      addgroup --system pdns
+    fi
+    if [ -z "`getent passwd pdns`" ]; then
+      adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    fi
     if [ "`stat -c '%U:%G' /etc/powerdns/recursor.conf`" = "root:root" ]; then
       chown root:pdns /etc/powerdns/recursor.conf
       # Make sure that pdns can read it; the default used to be 0600


### PR DESCRIPTION
### Short description

We manage the `pdns` user on our Debian systems manually, and we are having issues with the pdns-recursor postinst script failing because we use a non-system uid for it.

I simply copied the if statements [from the pdns-server postinst script](https://github.com/PowerDNS/pdns/blob/e963f425a360f6348102208308ffdcd24e8d5e09/builder-support/debian/authoritative/debian-buster/pdns-server.postinst) to the pdns-recursor ones so that the script doesn't try to create the user if it already exists.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
