### PR TITLE
rec: Bump max-qperq default to 100 

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3970,7 +3970,7 @@ static int serviceMain(int argc, char*argv[])
   if (SyncRes::s_qnameminimization) {
     // With an empty cache, a rev ipv6 query with dnssec enabled takes
     // almost 100 queries. Default maxqperq is 60.
-    SyncRes::s_maxqperq = SyncRes::s_maxqperq * 5 / 3;
+    SyncRes::s_maxqperq = std::max(SyncRes::s_maxqperq, 100);
   }
 
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3970,7 +3970,7 @@ static int serviceMain(int argc, char*argv[])
   if (SyncRes::s_qnameminimization) {
     // With an empty cache, a rev ipv6 query with dnssec enabled takes
     // almost 100 queries. Default maxqperq is 60.
-    SyncRes::s_maxqperq = std::max(SyncRes::s_maxqperq, 100);
+    SyncRes::s_maxqperq = std::max(SyncRes::s_maxqperq, static_cast<unsigned int>(100));
   }
 
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4695,7 +4695,7 @@ int main(int argc, char **argv)
     ::arg().set("udp-truncation-threshold", "Maximum UDP response size before we truncate")="1232";
     ::arg().set("edns-outgoing-bufsize", "Outgoing EDNS buffer size")="1232";
     ::arg().set("minimum-ttl-override", "Set under adverse conditions, a minimum TTL")="0";
-    ::arg().set("max-qperq", "Maximum outgoing queries per query")="50";
+    ::arg().set("max-qperq", "Maximum outgoing queries per query")="100";
     ::arg().set("max-total-msec", "Maximum total wall-clock time per query in milliseconds, 0 for unlimited")="7000";
     ::arg().set("max-recursion-depth", "Maximum number of internal recursion calls per query, 0 for unlimited")="40";
     ::arg().set("max-udp-queries-per-round", "Maximum number of UDP queries processed per recvmsg() round, before returning back to normal processing")="10000";

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3967,6 +3967,12 @@ static int serviceMain(int argc, char*argv[])
 
   SyncRes::s_qnameminimization = ::arg().mustDo("qname-minimization");
 
+  if (SyncRes::s_qnameminimization) {
+    // With an empty cache, a rev ipv6 query with dnssec enabled takes
+    // almost 100 queries. Default maxqperq is 60.
+    SyncRes::s_maxqperq = SyncRes::s_maxqperq * 5 / 3;
+  }
+
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;
   string value = ::arg()["nothing-below-nxdomain"];
   if (value == "yes") {
@@ -4695,7 +4701,7 @@ int main(int argc, char **argv)
     ::arg().set("udp-truncation-threshold", "Maximum UDP response size before we truncate")="1232";
     ::arg().set("edns-outgoing-bufsize", "Outgoing EDNS buffer size")="1232";
     ::arg().set("minimum-ttl-override", "Set under adverse conditions, a minimum TTL")="0";
-    ::arg().set("max-qperq", "Maximum outgoing queries per query")="100";
+    ::arg().set("max-qperq", "Maximum outgoing queries per query")="60";
     ::arg().set("max-total-msec", "Maximum total wall-clock time per query in milliseconds, 0 for unlimited")="7000";
     ::arg().set("max-recursion-depth", "Maximum number of internal recursion calls per query, 0 for unlimited")="40";
     ::arg().set("max-udp-queries-per-round", "Maximum number of UDP queries processed per recvmsg() round, before returning back to normal processing")="10000";

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -914,10 +914,12 @@ Maximum number of Packet Cache entries.
 ``max-qperq``
 -------------
 -  Integer
--  Default: 100
+-  Default: 60
 
 The maximum number of outgoing queries that will be sent out during the resolution of a single client query.
 This is used to limit endlessly chasing CNAME redirections.
+If qname-minimization is enabled, the number will be increased to
+allow for the extra queries qname-minimization generates when the cache is empty.
 
 .. _setting-max-negative-ttl:
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -914,7 +914,7 @@ Maximum number of Packet Cache entries.
 ``max-qperq``
 -------------
 -  Integer
--  Default: 50
+-  Default: 100
 
 The maximum number of outgoing queries that will be sent out during the resolution of a single client query.
 This is used to limit endlessly chasing CNAME redirections.

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -918,8 +918,8 @@ Maximum number of Packet Cache entries.
 
 The maximum number of outgoing queries that will be sent out during the resolution of a single client query.
 This is used to limit endlessly chasing CNAME redirections.
-If qname-minimization is enabled, the number will be increased to
-allow for the extra queries qname-minimization generates when the cache is empty.
+If qname-minimization is enabled, the number will be forced to be 100
+at a minimum to allow for the extra queries qname-minimization generates when the cache is empty.
 
 .. _setting-max-negative-ttl:
 


### PR DESCRIPTION
This is enough for rev v6 queries with cold cache with validations and qname minimization enabled.  Fixes #8646.

These cases (with cold cache) might still take more than 5s though, so timeouts can still happen.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
