### PR TITLE
rec: fix wrong zoneCuts caused by cache only lookup

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2134,12 +2134,15 @@ void SyncRes::computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned
     return;
   }
 
+  const bool oldCacheOnly = setCacheOnly(false);
+
   dsmap_t ds;
   vState cutState = getDSRecords(end, ds, false, depth);
   LOG(d_prefix<<": setting cut state for "<<end<<" to "<<vStates[cutState]<<endl);
   d_cutStates[end] = cutState;
 
   if (!shouldValidate()) {
+    setCacheOnly(oldCacheOnly);
     return;
   }
 
@@ -2212,6 +2215,7 @@ void SyncRes::computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned
       LOG(" - "<<cut.first<<": "<<vStates[cut.second]<<endl);
     }
   }
+  setCacheOnly(oldCacheOnly);
 }
 
 vState SyncRes::validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth)


### PR DESCRIPTION
QName Minimization consults the cache first to see work needs tobe done. Via doCacheCheck() this can lead to a call to computeZoneCuts()
which might/does not work properly on only cached records, so always
make sure it can go out if needed. Should fix #8642.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
