### PR TITLE
auth: Clear the TSIG algo between iterations in the API

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -778,10 +778,10 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
 
   if (!document["master_tsig_key_ids"].is_null()) {
     vector<string> metadata;
-    DNSName keyAlgo;
-    string keyContent;
     for(auto value : document["master_tsig_key_ids"].array_items()) {
       auto keyname(apiZoneIdToName(value.string_value()));
+      DNSName keyAlgo;
+      string keyContent;
       B.getTSIGKey(keyname, &keyAlgo, &keyContent);
       if (keyAlgo.empty() || keyContent.empty()) {
         throw ApiException("A TSIG key with the name '"+keyname.toLogString()+"' does not exist");
@@ -794,10 +794,10 @@ static void updateDomainSettingsFromDocument(UeberBackend& B, const DomainInfo& 
   }
   if (!document["slave_tsig_key_ids"].is_null()) {
     vector<string> metadata;
-    DNSName keyAlgo;
-    string keyContent;
     for(auto value : document["slave_tsig_key_ids"].array_items()) {
       auto keyname(apiZoneIdToName(value.string_value()));
+      DNSName keyAlgo;
+      string keyContent;
       B.getTSIGKey(keyname, &keyAlgo, &keyContent);
       if (keyAlgo.empty() || keyContent.empty()) {
         throw ApiException("A TSIG key with the name '"+keyname.toLogString()+"' does not exist");


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise `GSQLBackend::getTSIGKey()` will try to match the algorithm in `keyAlgo` if it's set, which will prevent retrieving a key with a different algorithm that the previous one.

Untested, but will hopefully fix #8645.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

