### PR TITLE
Fix trusted-notification-proxy port

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -786,7 +786,7 @@ int PacketHandler::trySuperMasterSynchronous(const DNSPacket& p, const DNSName& 
 {
   ComboAddress remote = p.getRemote().setPort(53);
   if(p.hasEDNSSubnet() && ::arg().contains("trusted-notification-proxy", remote.toString())) {
-    remote = p.getRealRemote().getNetwork();
+    remote = p.getRealRemote().getNetwork().setPort(53);
   }
 
   Resolver::res_t nsset;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Explicitly set the port for outgoing queries to the SuperMaster when using trusted-notification-proxy and EDNS Client Subnet

Closes #8584

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)