### PR TITLE
ws-auth: Allow DNAME in apex with SOA and NS records

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -59,7 +59,7 @@ static void makePtr(const DNSResourceRecord& rr, DNSResourceRecord* ptr);
 // QTypes that MUST NOT have multiple records of the same type in a given RRset.
 static const std::set<uint16_t> onlyOneEntryTypes = { QType::CNAME, QType::DNAME, QType::SOA };
 // QTypes that MUST NOT be used with any other QType on the same name.
-static const std::set<uint16_t> exclusiveEntryTypes = { QType::CNAME, QType::DNAME };
+static const std::set<uint16_t> exclusiveEntryTypes = { QType::CNAME };
 
 AuthWebServer::AuthWebServer() :
   d_tid(0),
@@ -2029,6 +2029,8 @@ static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp) {
 
         if (replace_records) {
           bool ent_present = false;
+          bool dname_seen = false, ns_seen = false;
+
           di.backend->lookup(QType(QType::ANY), qname, di.id);
           DNSResourceRecord rr;
           while (di.backend->get(rr)) {
@@ -2037,6 +2039,10 @@ static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp) {
               /* that's fine, we will override it */
               continue;
             }
+            if (qtype == QType::DNAME || rr.qtype == QType::DNAME)
+              dname_seen = true;
+            if (qtype == QType::NS || rr.qtype == QType::NS)
+              ns_seen = true;
             if (qtype.getCode() != rr.qtype.getCode()
               && (exclusiveEntryTypes.count(qtype.getCode()) != 0
                 || exclusiveEntryTypes.count(rr.qtype.getCode()) != 0)) {
@@ -2049,6 +2055,9 @@ static void patchZone(UeberBackend& B, HttpRequest* req, HttpResponse* resp) {
             }
           }
 
+          if (dname_seen && ns_seen && qname != zonename) {
+            throw ApiException("RRset "+qname.toString()+" IN "+qtype.getName()+": Cannot have both NS and DNAME except in zone apex");
+          }
           if (!new_records.empty() && ent_present) {
             QType qt_ent{0};
             if (!di.backend->replaceRRSet(di.id, qname, qt_ent, new_records)) {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1443,7 +1443,7 @@ $ORIGIN %NAME%
             'ttl': 3600,
             'records': [
                 {
-                    "content": "example.org.",
+                    "content": "example.com.",
                     "disabled": False
                 }
             ]
@@ -1453,6 +1453,43 @@ $ORIGIN %NAME%
                                headers={'content-type': 'application/json'})
         self.assertEquals(r.status_code, 422)
         self.assertIn('Cannot have both NS and DNAME except in zone apex', r.json()['error'])
+
+## FIXME: Enable this when it's time for it
+#    def test_rrset_dname_nothing_under(self):
+#        name, payload, zone = self.create_zone()
+#        rrset = {
+#            'changetype': 'replace',
+#            'name': 'delegation.'+name,
+#            'type': 'DNAME',
+#            'ttl': 3600,
+#            'records': [
+#                {
+#                    "content": "example.com.",
+#                    "disabled": False
+#                }
+#            ]
+#        }
+#        payload = {'rrsets': [rrset]}
+#        r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
+#                               headers={'content-type': 'application/json'})
+#        self.assert_success(r)
+#        rrset = {
+#            'changetype': 'replace',
+#            'name': 'sub.delegation.'+name,
+#            'type': 'A',
+#            'ttl': 3600,
+#            'records': [
+#                {
+#                    "content": "1.2.3.4",
+#                    "disabled": False
+#                }
+#            ]
+#        }
+#        payload = {'rrsets': [rrset]}
+#        r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
+#                               headers={'content-type': 'application/json'})
+#        self.assertEquals(r.status_code, 422)
+#        self.assertIn('You cannot have record(s) under CNAME/DNAME', r.json()['error'])
 
     def test_create_zone_with_leading_space(self):
         # Actual regression.


### PR DESCRIPTION
### Short description
Permits DNAME with SOA and NS in zone apex. Closes #8641.

<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)