### PR TITLE
rec: backport 8648 to rec 4.3.x: fix wrong zoneCuts caused by cache only lookup

### DIFF
--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -141,6 +141,7 @@ void initSR(bool debug)
   SyncRes::clearDelegationOnly();
   SyncRes::clearDontQuery();
   SyncRes::setECSScopeZeroAddress(Netmask("127.0.0.1/32"));
+  SyncRes::s_qnameminimization = false;
 
   SyncRes::clearNSSpeeds();
   BOOST_CHECK_EQUAL(SyncRes::getNSSpeedsSize(), 0U);
@@ -170,7 +171,6 @@ void initSR(bool debug)
   ::arg().set("version-string", "string reported on version.pdns or version.bind") = "PowerDNS Unit Tests";
   ::arg().set("rng") = "auto";
   ::arg().set("entropy-source") = "/dev/urandom";
-  ::arg().setSwitch("qname-minimization", "Use Query Name Minimization") = "yes";
 }
 
 void initSR(std::unique_ptr<SyncRes>& sr, bool dnssec, bool debug, time_t fakeNow)

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2134,12 +2134,15 @@ void SyncRes::computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned
     return;
   }
 
+  const bool oldCacheOnly = setCacheOnly(false);
+
   dsmap_t ds;
   vState cutState = getDSRecords(end, ds, false, depth);
   LOG(d_prefix<<": setting cut state for "<<end<<" to "<<vStates[cutState]<<endl);
   d_cutStates[end] = cutState;
 
   if (!shouldValidate()) {
+    setCacheOnly(oldCacheOnly);
     return;
   }
 
@@ -2212,6 +2215,7 @@ void SyncRes::computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned
       LOG(" - "<<cut.first<<": "<<vStates[cut.second]<<endl);
     }
   }
+  setCacheOnly(oldCacheOnly);
 }
 
 vState SyncRes::validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Including unit test (which is PR #8667)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
