### PR TITLE
rec: backport to 4.3.x: dnsdist: Require Python libnacl < 1.7

### DIFF
--- a/regression-tests.dnsdist/requirements.txt
+++ b/regression-tests.dnsdist/requirements.txt
@@ -1,6 +1,6 @@
 dnspython>=1.11,<1.16.0
 nose>=1.3.7
-libnacl>=1.4.3
+libnacl>=1.4.3,<1.7
 requests>=2.1.0
 protobuf>=3.0
 pysnmp>=4.3.4


### PR DESCRIPTION
Otherwise we need libsodium >= 1.0.12 (required by this change:
https://github.com/saltstack/libnacl/commit/8c8b2f8bc05a5b67f39acf9a6bc0bef6fa839166
) and we don't have it in Trusty, which we still use in Travis.

(cherry picked from commit 1f474f69cc45af37646513618badd7bfa06741fd)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
