### PR TITLE
rec: backport 8639 to 4.2.x: debian postinst / do not fail on user creation if it already exists

### DIFF
--- a/builder-support/debian/recursor/debian-buster/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-buster/pdns-recursor.postinst
@@ -3,8 +3,12 @@ set -e
 
 case "$1" in
   configure)
-    addgroup --system pdns
-    adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ -z "`getent group pdns`" ]; then
+      addgroup --system pdns
+    fi
+    if [ -z "`getent passwd pdns`" ]; then
+      adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    fi
   ;;
 
   *)

--- a/builder-support/debian/recursor/debian-jessie/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-jessie/pdns-recursor.postinst
@@ -3,8 +3,12 @@ set -e
 
 case "$1" in
   configure)
-    addgroup --system pdns
-    adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ -z "`getent group pdns`" ]; then
+      addgroup --system pdns
+    fi
+    if [ -z "`getent passwd pdns`" ]; then
+      adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    fi
   ;;
 
   *)

--- a/builder-support/debian/recursor/debian-stretch/pdns-recursor.postinst
+++ b/builder-support/debian/recursor/debian-stretch/pdns-recursor.postinst
@@ -3,8 +3,12 @@ set -e
 
 case "$1" in
   configure)
-    addgroup --system pdns
-    adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    if [ -z "`getent group pdns`" ]; then
+      addgroup --system pdns
+    fi
+    if [ -z "`getent passwd pdns`" ]; then
+      adduser --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    fi
   ;;
 
   *)


### PR DESCRIPTION
(cherry picked from commit fddad2718fb994d4fd016c03e1e05ef6c67aae14)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
