### PR TITLE
auth: Add an extended status report in the bind backend

### DIFF
--- a/docs/backends/bind.rst
+++ b/docs/backends/bind.rst
@@ -144,7 +144,16 @@ will be loaded at first request.
 .. note::
   This does not add the zone to the :ref:`setting-bind-config` file.
 
-``bind-domain-status <domain> [domain]``
+``bind-domain-extended-status [domain ...]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.3.0
+
+Output an extended status of a domain or domains, containing much more information than
+the simple domain status, like the number of records currently loaded, whether pdns
+is master or slave for the domain, the list of masters, various timers, etc
+
+``bind-domain-status [domain ...]``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Output status of domain or domains. Can be one of:

--- a/docs/manpages/pdns_control.1.rst
+++ b/docs/manpages/pdns_control.1.rst
@@ -34,6 +34,14 @@ When using the BIND backend, add a zone. This zone is added in-memory
 and served immediately. Note that this does not add the zone to the
 bind-config file. *FILENAME* must be an absolute path.
 
+bind-domain-extended-status [*DOMAIN*...]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Output an extended status of all domains, containing much more information than
+the simple domain status, like the number of records currently loaded, whether pdns
+is master or slave for the domain, the list of masters, various timers, etc
+Optionally, append *DOMAIN*\ s to get the status of specific zones.
+
 bind-domain-status [*DOMAIN*...]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -121,6 +121,12 @@ public:
     return ret;
   }
 
+  size_t getEntriesCount() const
+  {
+    std::lock_guard<std::mutex> lock(s_lock);
+    return d_records->size();
+  }
+
 private:
   static std::mutex s_lock;
   shared_ptr<T> d_records;
@@ -136,6 +142,10 @@ public:
   bool current();
   //! configure how often this domain should be checked for changes (on disk)
   void setCheckInterval(time_t seconds);
+  time_t getCheckInterval() const
+  {
+    return d_checkinterval;
+  }
 
   DNSName d_name;   //!< actual name of the domain
   DomainInfo::DomainKind d_kind; //!< the kind of domain
@@ -299,6 +309,7 @@ private:
   static void insertRecord(std::shared_ptr<recordstorage_t>& records, const DNSName& zoneName, const DNSName &qname, const QType &qtype, const string &content, int ttl, const std::string& hashed=string(), bool *auth=nullptr);
   void reload() override;
   static string DLDomStatusHandler(const vector<string>&parts, Utility::pid_t ppid);
+  static string DLDomExtendedStatusHandler(const vector<string>&parts, Utility::pid_t ppid);
   static string DLListRejectsHandler(const vector<string>&parts, Utility::pid_t ppid);
   static string DLReloadNowHandler(const vector<string>&parts, Utility::pid_t ppid);
   static string DLAddDomainHandler(const vector<string>&parts, Utility::pid_t ppid);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
I find very useful to be able to get much more information about the current status of the domain.

Sample output:
```
$ pdns_control BIND-DOMAIN-EXTENDED-STATUS
example.zone: 
         Status: parsed into memory at 2020-01-08 17:38:12 +0100
         Internal ID: 1
         On-disk file: /etc/powerdns/example.zone (1578495472)
         Kind: Slave
         Masters: 
                 - 192.0.2.1:53
         Also Notify: 
         Number of records: 42
         Loaded: 1
         Check now: 0
         Check interval: 0
         Last check: 1578501492
         Last notified: 0
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

