### PR TITLE
rec: backport 8684 to 4.2.x: parsing `dont-throttle-names` and `dont-throttle-netmasks` as comma separated lists

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3845,14 +3845,14 @@ static int serviceMain(int argc, char*argv[])
   {
     SuffixMatchNode dontThrottleNames;
     vector<string> parts;
-    stringtok(parts, ::arg()["dont-throttle-names"]);
+    stringtok(parts, ::arg()["dont-throttle-names"], " ,");
     for (const auto &p : parts) {
       dontThrottleNames.add(DNSName(p));
     }
     g_dontThrottleNames.setState(dontThrottleNames);
 
     NetmaskGroup dontThrottleNetmasks;
-    stringtok(parts, ::arg()["dont-throttle-netmasks"]);
+    stringtok(parts, ::arg()["dont-throttle-netmasks"], " ,");
     for (const auto &p : parts) {
       dontThrottleNetmasks.addMask(Netmask(p));
     }


### PR DESCRIPTION

(cherry picked from commit 5285831402f3f3a209c16cb3bd743eea640cf894)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
