### PR TITLE
rec: backport 8694 to 4.3.x: Fix ./syncres.hh:228:20: warning: initialized lambda captures are a C++14 extension

### DIFF
--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -217,15 +217,16 @@ public:
     return i->value;
   }
 
-  counter_t incr(const ComboAddress& t, const struct timeval & now)
+  counter_t incr(const ComboAddress& address, const struct timeval& now)
   {
-    auto i = d_cont.insert(t).first;
+    auto i = d_cont.insert(address).first;
 
     if (i->value < std::numeric_limits<counter_t>::max()) {
       i->value++;
     }
     auto &ind = d_cont.get<ComboAddress>();
-    ind.modify(i, [t = now.tv_sec](value_t &val) { val.last = t;});
+    time_t tm = now.tv_sec;
+    ind.modify(i, [tm](value_t &val) { val.last = tm; });
     return i->value;
   }
 


### PR DESCRIPTION

(cherry picked from commit 7b07a07cce7b9476ef602b9e9b35d30a239bdc96)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
