### PR TITLE
remote: Support ::alsoNotifies

### DIFF
--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -144,6 +144,11 @@ in this array will be logged in PowerDNS at loglevel ``info`` (6).
 Methods
 ^^^^^^^
 
+Methods required for different features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:Always required: ``initialize``, ``lookup``
+:Master operation: ``list``, ``getUpdatedMasters``, ``setNotified``
+
 ``initialize``
 ~~~~~~~~~~~~~~
 
@@ -958,12 +963,13 @@ Alternative response
 
 ``createSlaveDomain``
 ~~~~~~~~~~~~~~~~~~~~~
-
 Creates new domain. This method is called when NOTIFY is received and
 you are superslaving.
 
-Mandatory: No Parameters: ip, domain Optional parameters: nameserver,
-account Reply: true for success, false for failure
+ - Mandatory: No
+ - Parameters: ip, domain
+ - Optional parameters: nameserver, account
+ - Reply: true for success, false for failure
 
 Example JSON/RPC
 ''''''''''''''''
@@ -1516,7 +1522,7 @@ Used to find out any updates to master domains. This is used to trigger notifica
 
 -  Mandatory: no
 -  Parameters: none
--  Reply: array of DomainInfo
+-  Reply: array of DomainInfo or at least the ``id``, ``zone``, ``serial`` and ``notified_serial`` fields
 
 Example JSON/RPC
 ''''''''''''''''

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -904,6 +904,13 @@ void RemoteBackend::getAllDomains(vector<DomainInfo> *domains, bool include_disa
   }
 }
 
+void RemoteBackend::alsoNotifies(const DNSName &domain, set<string> *ips)
+{
+  std::vector<std::string> meta;
+  getDomainMetadata(domain, "ALSO-NOTIFY", meta);
+  ips->insert(meta.begin(), meta.end());
+}
+
 void RemoteBackend::getUpdatedMasters(vector<DomainInfo>* domains)
 {
   Json query = Json::object{

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -189,6 +189,7 @@ class RemoteBackend : public DNSBackend
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;
   void getUpdatedMasters(vector<DomainInfo>* domains) override;
+  void alsoNotifies(const DNSName &domain, set<string> *ips) override;
 
   static DNSBackend *maker();
 

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -89,6 +89,17 @@ BOOST_AUTO_TEST_CASE(test_method_setDomainMetadata) {
    BOOST_CHECK(be->setDomainMetadata(DNSName("unit.test."),"TEST", meta));
 }
 
+BOOST_AUTO_TEST_CASE(test_method_alsoNotifies) {
+   BOOST_CHECK(be->setDomainMetadata(DNSName("unit.test."),"ALSO-NOTIFY", {"192.0.2.1"}));
+   std::set<std::string> alsoNotifies;
+   BOOST_TEST_MESSAGE("Testing alsoNotifies method");
+   be->alsoNotifies(DNSName("unit.test."), &alsoNotifies);
+   BOOST_CHECK_EQUAL(alsoNotifies.size(), 1);
+   if (alsoNotifies.size() > 0)
+      BOOST_CHECK_EQUAL(alsoNotifies.count("192.0.2.1"), 1);
+   BOOST_CHECK(be->setDomainMetadata(DNSName("unit.test."),"ALSO-NOTIFY", std::vector<std::string>()));
+}
+
 BOOST_AUTO_TEST_CASE(test_method_getDomainMetadata) {
    std::vector<std::string> meta;
    BOOST_TEST_MESSAGE("Testing getDomainMetadata method");


### PR DESCRIPTION
### Short description
The remote backend did not support 'also-notifies'. This PR implements this as a call to `getDomainMetadata` for `ALSO-NOTIFY`.

cc: @cmouse 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)