### PR TITLE
Add the source and destination ports to the protobuf msg

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -138,6 +138,8 @@ class PDNSPBConnHandler(object):
             datestr = datestr + '.' + str(msg.timeUsec)
         ipfromstr = 'N/A'
         iptostr = 'N/A'
+        toportstr = ''
+        fromportstr = ''
         fromvalue = getattr(msg, 'from')
         if msg.socketFamily == dnsmessage_pb2.PBDNSMessage.INET:
             if msg.HasField('from'):
@@ -146,14 +148,20 @@ class PDNSPBConnHandler(object):
                 iptostr = socket.inet_ntop(socket.AF_INET, msg.to)
         else:
             if msg.HasField('from'):
-                ipfromstr = socket.inet_ntop(socket.AF_INET6, fromvalue)
+                ipfromstr = '[' + socket.inet_ntop(socket.AF_INET6, fromvalue) + ']'
             if msg.HasField('to'):
-                iptostr = socket.inet_ntop(socket.AF_INET6, msg.to)
+                iptostr = '[' + socket.inet_ntop(socket.AF_INET6, msg.to) + ']'
 
         if msg.socketProtocol == dnsmessage_pb2.PBDNSMessage.UDP:
             protostr = 'UDP'
         else:
             protostr = 'TCP'
+
+        if msg.HasField('fromPort'):
+            fromportstr = ':' + str(msg.fromPort) + ' '
+
+        if msg.HasField('toPort'):
+            toportstr = ':' + str(msg.toPort) + ' '
 
         messageidstr = binascii.hexlify(bytearray(msg.messageId))
 
@@ -176,13 +184,15 @@ class PDNSPBConnHandler(object):
         if (msg.HasField('newlyObservedDomain')):
             nod = msg.newlyObservedDomain
 
-        print('[%s] %s of size %d: %s%s -> %s (%s), id: %d, uuid: %s%s '
+        print('[%s] %s of size %d: %s%s%s -> %s%s (%s), id: %d, uuid: %s%s '
                   'requestorid: %s deviceid: %s serverid: %s nod: %d' % (datestr,
                                                     typestr,
                                                     msg.inBytes,
                                                     ipfromstr,
+                                                    fromportstr,
                                                     requestorstr,
                                                     iptostr,
+                                                    toportstr,
                                                     protostr,
                                                     msg.id,
                                                     messageidstr,

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -72,17 +72,29 @@ void setupLuaBindingsProtoBuf(bool client)
   g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(time_t, uint32_t)>("setQueryTime", [](DNSDistProtoBufMessage& message, time_t sec, uint32_t usec) { message.setQueryTime(sec, usec); });
   g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(uint8_t)>("setResponseCode", [](DNSDistProtoBufMessage& message, uint8_t rcode) { message.setResponseCode(rcode); });
   g_lua.registerFunction<std::string(DNSDistProtoBufMessage::*)()>("toDebugString", [](const DNSDistProtoBufMessage& message) { return message.toDebugString(); });
-  g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(const ComboAddress&)>("setRequestor", [](DNSDistProtoBufMessage& message, const ComboAddress& addr) {
+  g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(const ComboAddress&, boost::optional<uint16_t>)>("setRequestor", [](DNSDistProtoBufMessage& message, const ComboAddress& addr, boost::optional<uint16_t> port) {
       message.setRequestor(addr);
+      if (port) {
+        message.setRequestorPort(*port);
+      }
     });
-  g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(const std::string&)>("setRequestorFromString", [](DNSDistProtoBufMessage& message, const std::string& str) {
+  g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(const std::string&, boost::optional<uint16_t>)>("setRequestorFromString", [](DNSDistProtoBufMessage& message, const std::string& str, boost::optional<uint16_t> port) {
       message.setRequestor(str);
+      if (port) {
+        message.setRequestorPort(*port);
+      }
     });
-  g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(const ComboAddress&)>("setResponder", [](DNSDistProtoBufMessage& message, const ComboAddress& addr) {
+  g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(const ComboAddress&, boost::optional<uint16_t>)>("setResponder", [](DNSDistProtoBufMessage& message, const ComboAddress& addr, boost::optional<uint16_t> port) {
       message.setResponder(addr);
+      if (port) {
+        message.setResponderPort(*port);
+      }
     });
-  g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(const std::string&)>("setResponderFromString", [](DNSDistProtoBufMessage& message, const std::string& str) {
+  g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(const std::string&, boost::optional<uint16_t>)>("setResponderFromString", [](DNSDistProtoBufMessage& message, const std::string& str, boost::optional<uint16_t> port) {
       message.setResponder(str);
+      if (port) {
+        message.setResponderPort(*port);
+      }
     });
   g_lua.registerFunction<void(DNSDistProtoBufMessage::*)(const std::string&)>("setServerIdentity", [](DNSDistProtoBufMessage& message, const std::string& str) {
       message.setServerIdentity(str);

--- a/pdns/dnsdistdist/docs/reference/protobuf.rst
+++ b/pdns/dnsdistdist/docs/reference/protobuf.rst
@@ -62,29 +62,45 @@ Protobuf Logging Reference
     :param int sec: Optional query time in seconds.
     :param int usec: Optional query time in additional micro-seconds.
 
-  .. method:: DNSDistProtoBufMessage:setRequestor(address)
+  .. method:: DNSDistProtoBufMessage:setRequestor(address [, port])
+
+    .. versionchanged:: 1.5.0
+      ``port`` optional parameter added.
 
     Set the requestor's address.
 
     :param ComboAddress address: The address to set to
+    :param int port: The requestor source port
 
-  .. method:: DNSDistProtoBufMessage:setRequestorFromString(address)
+  .. method:: DNSDistProtoBufMessage:setRequestorFromString(address [, port])
+
+    .. versionchanged:: 1.5.0
+      ``port`` optional parameter added.
 
     Set the requestor's address from a string.
 
     :param string address: The address to set to
+    :param int port: The requestor source port
 
-  .. method:: DNSDistProtoBufMessage:setResponder(address)
+  .. method:: DNSDistProtoBufMessage:setResponder(address [, port])
+
+    .. versionchanged:: 1.5.0
+      ``port`` optional parameter added.
 
     Set the responder's address.
 
     :param ComboAddress address: The address to set to
+    :param int port: The responder port
 
-  .. method:: DNSDistProtoBufMessage:setResponderFromString(address)
+  .. method:: DNSDistProtoBufMessage:setResponderFromString(address [, port])
+
+    .. versionchanged:: 1.5.0
+      ``port`` optional parameter added.
 
     Set the responder's address.
 
     :param string address: The address to set to
+    :param int port: The responder port
 
   .. method:: DNSDistProtoBufMessage:setResponseCode(rcode)
 

--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -88,4 +88,6 @@ message PBDNSMessage {
   optional bytes deviceId = 17;     		// Device ID of the requestor (could be mac address IP address or e.g. IMEI)
   optional bool  newlyObservedDomain = 18;      // True if the domain has not been seen before
   optional string deviceName = 19;              // Device name of the requestor
+  optional uint32 fromPort = 20;                // Source port of the DNS query (client)
+  optional uint32 toPort = 21;                  // Destination port of the DNS query (server)
 }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -814,7 +814,8 @@ static void protobufLogQuery(uint8_t maskV4, uint8_t maskV6, const boost::uuids:
   }
 
   Netmask requestorNM(remote, remote.sin4.sin_family == AF_INET ? maskV4 : maskV6);
-  const ComboAddress& requestor = requestorNM.getMaskedNetwork();
+  const ComboAddress requestor = requestorNM.getMaskedNetwork();
+  requestor.setPort(remote.getPort());
   RecProtoBufMessage message(DNSProtoBufMessage::Query, uniqueId, &requestor, &local, qname, qtype, qclass, id, tcp, len);
   message.setServerIdentity(SyncRes::s_serverID);
   message.setEDNSSubnet(ednssubnet, ednssubnet.isIPv4() ? maskV4 : maskV6);
@@ -1184,7 +1185,8 @@ static void startDoResolve(void *p)
 #ifdef HAVE_PROTOBUF
     if (checkProtobufExport(luaconfsLocal)) {
       Netmask requestorNM(dc->d_source, dc->d_source.sin4.sin_family == AF_INET ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
-      const ComboAddress& requestor = requestorNM.getMaskedNetwork();
+      ComboAddress requestor = requestorNM.getMaskedNetwork();
+      requestor.setPort(dc->d_source.getPort());
       pbMessage = RecProtoBufMessage(RecProtoBufMessage::Response, dc->d_uuid, &requestor, &dc->d_destination, dc->d_mdp.d_qname, dc->d_mdp.d_qtype, dc->d_mdp.d_qclass, dc->d_mdp.d_header.id, dc->d_tcp, 0);
       pbMessage->setServerIdentity(SyncRes::s_serverID);
       pbMessage->setEDNSSubnet(dc->d_ednssubnet.source, dc->d_ednssubnet.source.isIPv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
@@ -2381,7 +2383,8 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
 #ifdef HAVE_PROTOBUF
       if(t_protobufServers && logResponse && !(luaconfsLocal->protobufExportConfig.taggedOnly && pbMessage->getAppliedPolicy().empty() && pbMessage->getPolicyTags().empty())) {
         Netmask requestorNM(source, source.sin4.sin_family == AF_INET ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
-        const ComboAddress& requestor = requestorNM.getMaskedNetwork();
+        ComboAddress requestor = requestorNM.getMaskedNetwork();
+        requestor.setPort(source.getPort());
         pbMessage->update(uniqueId, &requestor, &destination, false, dh->id);
         pbMessage->setEDNSSubnet(ednssubnet.source, ednssubnet.source.isIPv4() ? luaconfsLocal->protobufMaskV4 : luaconfsLocal->protobufMaskV6);
         if (g_useKernelTimestamp && tv.tv_sec) {

--- a/pdns/protobuf.cc
+++ b/pdns/protobuf.cc
@@ -239,6 +239,13 @@ void DNSProtoBufMessage::setRequestor(const ComboAddress& requestor)
 #endif /* HAVE_PROTOBUF */
 }
 
+void DNSProtoBufMessage::setRequestorPort(uint16_t port)
+{
+#ifdef HAVE_PROTOBUF
+  d_message.set_fromport(port);
+#endif /* HAVE_PROTOBUF */
+}
+
 void DNSProtoBufMessage::setRequestorId(const std::string& requestorId)
 {
 #ifdef HAVE_PROTOBUF
@@ -283,6 +290,13 @@ void DNSProtoBufMessage::setResponder(const ComboAddress& responder)
   else if (responder.sin4.sin_family == AF_INET6) {
     d_message.set_to(&responder.sin6.sin6_addr.s6_addr, sizeof(responder.sin6.sin6_addr.s6_addr));
   }
+#endif /* HAVE_PROTOBUF */
+}
+
+void DNSProtoBufMessage::setResponderPort(uint16_t port)
+{
+#ifdef HAVE_PROTOBUF
+  d_message.set_toport(port);
 #endif /* HAVE_PROTOBUF */
 }
 
@@ -342,9 +356,11 @@ void DNSProtoBufMessage::update(const boost::uuids::uuid& uuid, const ComboAddre
 
   if (responder) {
     setResponder(*responder);
+    setResponderPort(responder->getPort());
   }
   if (requestor) {
     setRequestor(*requestor);
+    setRequestorPort(requestor->getPort());
   }
 }
 

--- a/pdns/protobuf.hh
+++ b/pdns/protobuf.hh
@@ -67,8 +67,10 @@ public:
   void serialize(std::string& data) const;
   void setRequestor(const std::string& requestor);
   void setRequestor(const ComboAddress& requestor);
+  void setRequestorPort(uint16_t port);
   void setResponder(const std::string& responder);
   void setResponder(const ComboAddress& responder);
+  void setResponderPort(uint16_t port);
   void setRequestorId(const std::string& requestorId);
   void setDeviceId(const std::string& deviceId);
   void setDeviceName(const std::string& deviceName);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- for all protobuf messages in dnsdist ;
- for incoming queries / outgoing responses in the recursor.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

