### PR TITLE
lmdb: fill di.serial (code stolen straight from gsqlbackend)

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1860,7 +1860,7 @@ static bool secureZone(DNSSECKeeper& dk, const DNSName& zone)
 
   DomainInfo di;
   UeberBackend B("default");
-  if(!B.getDomainInfo(zone, di) || !di.backend) { // di.backend and B are mostly identical
+  if(!B.getDomainInfo(zone, di, false) || !di.backend) { // di.backend and B are mostly identical
     cerr<<"Can't find a zone called '"<<zone<<"'"<<endl;
     return false;
   }


### PR DESCRIPTION
### Short description
This changes the serial from `0` to the correct value in a domain-specific API call such as `/api/v1/servers/localhost/zones/example.com.`.

`/api/v1/servers/localhost/zones` yields the right serial without this patch, and I see that `void LMDBBackend::getAllDomains(vector<DomainInfo> *domains, bool include_disabled)` uses more 'direct' code to get the serial. PRing this as draft until I figure out which code is right.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
