### PR TITLE
Make ComboAddress::setPort() update the current object

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -306,11 +306,9 @@ union ComboAddress {
     return ntohs(sin4.sin_port);
   }
 
-  ComboAddress setPort(uint16_t port) const
+  void setPort(uint16_t port)
   {
-    ComboAddress ret(*this);
-    ret.sin4.sin_port=htons(port);
-    return ret;
+    sin4.sin_port = htons(port);
   }
 
   void reset()

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -784,10 +784,11 @@ int PacketHandler::trySuperMaster(const DNSPacket& p, const DNSName& tsigkeyname
 
 int PacketHandler::trySuperMasterSynchronous(const DNSPacket& p, const DNSName& tsigkeyname)
 {
-  ComboAddress remote = p.getRemote().setPort(53);
+  ComboAddress remote = p.getRemote();
   if(p.hasEDNSSubnet() && ::arg().contains("trusted-notification-proxy", remote.toString())) {
-    remote = p.getRealRemote().getNetwork().setPort(53);
+    remote = p.getRealRemote().getNetwork();
   }
+  remote.setPort(53);
 
   Resolver::res_t nsset;
   try {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -814,7 +814,7 @@ static void protobufLogQuery(uint8_t maskV4, uint8_t maskV6, const boost::uuids:
   }
 
   Netmask requestorNM(remote, remote.sin4.sin_family == AF_INET ? maskV4 : maskV6);
-  const ComboAddress requestor = requestorNM.getMaskedNetwork();
+  ComboAddress requestor = requestorNM.getMaskedNetwork();
   requestor.setPort(remote.getPort());
   RecProtoBufMessage message(DNSProtoBufMessage::Query, uniqueId, &requestor, &local, qname, qtype, qclass, id, tcp, len);
   message.setServerIdentity(SyncRes::s_serverID);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Make `ComboAddress::setPort()` update the current object instead of creating a new one.

This fixes the source port not being set in protobuf messages in the recursor, as introduced in #8702.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

