### PR TITLE
auth: on presigned zones, skip addDNSKEY&friends for presigned zones

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -107,6 +107,8 @@ PacketHandler::~PacketHandler()
 **/
 bool PacketHandler::addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd)
 {
+  if (d_dk.isPresigned(p.qdomain)) return false;
+
   string publishCDNSKEY;
   d_dk.getFromMeta(p.qdomain, "PUBLISH-CDNSKEY", publishCDNSKEY);
   if (publishCDNSKEY != "1")
@@ -148,6 +150,8 @@ bool PacketHandler::addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, cons
 **/
 bool PacketHandler::addDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd)
 {
+  if (d_dk.isPresigned(p.qdomain)) return false;
+
   DNSZoneRecord rr;
   bool haveOne=false;
 
@@ -186,6 +190,8 @@ bool PacketHandler::addDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const
 **/
 bool PacketHandler::addCDS(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd)
 {
+  if (d_dk.isPresigned(p.qdomain)) return false;
+
   string publishCDS;
   d_dk.getFromMeta(p.qdomain, "PUBLISH-CDS", publishCDS);
   if (publishCDS.empty())


### PR DESCRIPTION

### Short description
this avoids duplicate work, and stops us from messing up the TTL on those records

Reported by @mdavids

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
