### PR TITLE
dnsdist: Load an openssl configuration file, if any, during startup

### DIFF
--- a/pdns/dnsdistdist/libssl.cc
+++ b/pdns/dnsdistdist/libssl.cc
@@ -72,7 +72,11 @@ static int s_keyLogIndex{-1};
 void registerOpenSSLUser()
 {
   if (s_users.fetch_add(1) == 0) {
-#if (OPENSSL_VERSION_NUMBER < 0x1010000fL || defined LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined LIBRESSL_VERSION_NUMBER)
+    /* load the default configuration file (or one specified via OPENSSL_CONF),
+       which can then be used to load engines */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, nullptr);
+#else /* (OPENSSL_VERSION_NUMBER < 0x1010000fL || defined LIBRESSL_VERSION_NUMBER) */
     SSL_load_error_strings();
     OpenSSL_add_ssl_algorithms();
     openssl_thread_setup();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This way dnsdist will load the default OpenSSL configuration, or a custom one specified via the `OPENSSL_CONF` environment variable.
It allows loading an engine or configuration various options supported by OpenSSL.
This requires OpenSSL >= 1.1.0.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

