### PR TITLE
avoid 'git show -s' from starting a pager in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
               git clone --depth 1 --branch $CIRCLE_BRANCH $CIRCLE_REPOSITORY_URL /opt/project
             fi
             cd /opt/project
-            git show -s
+            git --no-pager show -s
 
   get-workspace:
     description: "Attach workspace to /opt and symlink checkout into home"


### PR DESCRIPTION
    this
    is
    a
    very
    long
    commit
    message
    to
    trigger
    the
    problem
    where
    our
    circleci
    setup
    tries
    to
    use
    the
    pager
    to
    show
    long
    commit
    messages
    just
    like
    this
    one
    although
    there
    are
    others
    quite
    like
    it
    but
    those
    tend
    to
    be
    way
    easier
    to
    read

### Short description
Long commit messages hang our Circle build. This PR fixes that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
