### PR TITLE
Make Lua mandatory for Auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,9 +178,11 @@ commands:
           apt-get install -qq -y --no-install-recommends \
             libboost-all-dev \
             libcdb1 \
+            libcurl4 \
             libkrb5-3 \
             libldap-2.4-2 \
             liblmdb0 \
+            libluajit-5.1-2 \
             libpq5 \
             libssl1.1 \
             libsodium23 \
@@ -242,9 +244,11 @@ commands:
               git \
               libboost-all-dev \
               libcdb-dev \
+              libcurl4-openssl-dev \
               libkrb5-dev \
               libldap2-dev \
               liblmdb-dev \
+              libluajit-5.1-dev \
               libpq-dev \
               libsodium-dev \
               libsqlite3-dev \
@@ -522,8 +526,7 @@ jobs:
             CFLAGS="-O1 -Werror=vla -Werror=shadow -Wformat=2 -Werror=format-security" \
             CXXFLAGS="-O1 -Werror=vla -Werror=shadow -Wformat=2 -Werror=format-security -Wp,-D_GLIBCXX_ASSERTIONS" \
             ./configure \
-              --disable-lua-records \
-              --with-modules='bind lmdb ldap gmysql gsqlite3 gpgsql godbc random tinydns' \
+              --with-modules='bind lmdb ldap gmysql gsqlite3 gpgsql godbc random tinydns lua2' \
               --enable-systemd \
               --enable-tools \
               --with-lmdb=/usr \

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ compiler with C++-2011 support.
 On Debian 9, the following is useful:
 
 ```sh
-apt install g++ libboost-all-dev libtool make pkg-config default-libmysqlclient-dev libssl-dev virtualenv
+apt install g++ libboost-all-dev libtool make pkg-config default-libmysqlclient-dev libssl-dev virtualenv libluajit-5.1-dev
 ```
 
 When building from git, the following packages are also required:
@@ -82,7 +82,7 @@ autoreconf -vi
 To compile a very clean version, use:
 
 ```sh
-./configure --with-modules="" --without-lua --disable-lua-records
+./configure --with-modules="" --disable-lua-records
 make
 # make install
 ```
@@ -219,7 +219,7 @@ Homebrew. You need to tell configure where to find OpenSSL, too.
 
 ```sh
 brew install boost lua pkg-config ragel openssl
-./configure --with-modules="" --with-lua PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
+./configure --with-modules="" PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
 make -j4
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ m4_pattern_forbid([^_?PKG_[A-Z_]+$], [*** pkg.m4 missing, please install pkg-con
 PDNS_CHECK_OS
 PTHREAD_SET_NAME
 
-PDNS_WITH_LUA
+PDNS_WITH_LUA([mandatory])
 PDNS_CHECK_LUA_HPP
 
 AX_CXX_COMPILE_STDCXX_11
@@ -205,12 +205,7 @@ for a in $modules $dynmodules; do
       PDNS_CHECK_GEOIP
       ;;
     lua*)
-      AS_IF([test "x$with_lua" = "xno"],
-        [AC_MSG_ERROR([${a} backend needs lua, run ./configure --with-lua])]
-      )
-      AS_IF([test "x$LUAPC" = "x"],
-        [AC_MSG_ERROR([${a} backend needs lua but we cannot find it])]
-      )
+      dnl Lua has been checked above
       ;;
     lmdb)
       needlmdb=yes

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -1,7 +1,5 @@
 #include "config.h"
-#if defined(HAVE_LUA)
 #include "ext/luawrapper/include/LuaContext.hpp"
-#endif
 #include "lua-auth4.hh"
 #include "stubresolver.hh"
 #include <fstream>
@@ -17,25 +15,6 @@
 #include "ueberbackend.hh"
 
 AuthLua4::AuthLua4() { prepareContext(); }
-
-#if !defined(HAVE_LUA)
-
-bool AuthLua4::updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, const DNSPacket& packet) { return false; }
-bool AuthLua4::axfrfilter(const ComboAddress& remote, const DNSName& zone, const DNSResourceRecord& in, vector<DNSResourceRecord>& out) { return false; }
-LuaContext* AuthLua4::getLua() { return nullptr; }
-std::unique_ptr<DNSPacket> AuthLua4::prequery(const DNSPacket& q) { return nullptr; }
-
-AuthLua4::~AuthLua4() { }
-
-void AuthLua4::postPrepareContext()
-{
-}
-
-void AuthLua4::postLoad()
-{
-}
-
-#else
 
 LuaContext* AuthLua4::getLua()
 {
@@ -187,6 +166,3 @@ std::unique_ptr<DNSPacket> AuthLua4::prequery(const DNSPacket& q) {
 }
 
 AuthLua4::~AuthLua4() { }
-
-
-#endif

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -10,6 +10,7 @@
 #include "namespaces.hh"
 #include "ednssubnet.hh"
 #include "lua-base4.hh"
+#include "ext/luawrapper/include/LuaContext.hpp"
 #include "dns_random.hh"
 
 BaseLua4::BaseLua4() {
@@ -31,16 +32,6 @@ void BaseLua4::loadString(const std::string &script) {
 
 //  By default no features
 void BaseLua4::getFeatures(Features &) { }
-
-#if !defined(HAVE_LUA)
-
-void BaseLua4::prepareContext() { return; }
-void BaseLua4::loadStream(std::istream &is) { return; }
-BaseLua4::~BaseLua4() { }
-
-#else
-
-#include "ext/luawrapper/include/LuaContext.hpp"
 
 void BaseLua4::prepareContext() {
   d_lw = std::unique_ptr<LuaContext>(new LuaContext);
@@ -260,5 +251,3 @@ void BaseLua4::loadStream(std::istream &is) {
 }
 
 BaseLua4::~BaseLua4() { }
-
-#endif

--- a/pdns/lua-base4.hh
+++ b/pdns/lua-base4.hh
@@ -4,19 +4,12 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-
-class LuaContext;
-
-#if defined(HAVE_LUA)
 #include "ext/luawrapper/include/LuaContext.hpp"
-#endif
 
 class BaseLua4 : public boost::noncopyable
 {
 protected:
-#ifdef HAVE_LUA
   std::unique_ptr<LuaContext> d_lw; // this is way on top because it must get destroyed _last_
-#endif
 
 public:
   BaseLua4();


### PR DESCRIPTION
### Short description
Recursor and dnsdist already treat Lua as mandatory; with the growing Lua-based feature set in the Auth, it would make sense to also treat Lua as mandatory. At times in the past we've discovered that nobody really tests building without Lua anymore.

Also see #8706.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
