### PR TITLE
allow local-ipv6 until 4.4.0

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -751,7 +751,7 @@ available in non-static distributions.
   Before 4.3.0, this setting only supported IPv4.
 
 -  IPv4 Addresses, separated by commas or whitespace
--  Default: 0.0.0.0, ``::``
+-  Default: ``0.0.0.0, ::``
 
 Local IP addresses to which we bind. It is highly advised to bind to
 specific interfaces and not use the default 'bind to any'. This causes
@@ -774,14 +774,14 @@ Fail to start if one or more of the
 
 ``local-ipv6``
 --------------
-.. versionchanged:: 4.3.0
+.. versionchanged:: 4.4.0
   removed, use :ref:`setting-local-address`
 
 .. deprecated:: 4.3.0
-  This setting has been removed, use :ref:`setting-localaddress`
+  This setting has been deprecated, use :ref:`setting-local-address`
 
 -  IPv6 Addresses, separated by commas or whitespace
--  Default: '::'
+-  Default: ``::``
 
 Local IPv6 address to which we bind. It is highly advised to bind to
 specific interfaces and not use the default 'bind to any'. This causes
@@ -792,7 +792,7 @@ big problems if you have multiple IP addresses.
 ``local-ipv6-nonexist-fail``
 ----------------------------
 
-.. deprecated:: 4.3.0
+.. versionchanged:: 4.3.0
   This setting has been removed, use :ref:`setting-localaddress-nonexist-fail`
 
 -  Boolean

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -50,7 +50,7 @@ New settings
 Removed settings
 ^^^^^^^^^^^^^^^^
 
-- :ref:`setting-local-ipv6` has been removed. IPv4 and IPv6 listen addresses can now be set with :ref:`setting-local-address`. The default for the latter has been changed to ``0.0.0.0, ::``.
+- :ref:`setting-local-ipv6` has been deprecated, and will be removed in 4.4.0. IPv4 and IPv6 listen addresses can now be set with :ref:`setting-local-address`. The default for the latter has been changed to ``0.0.0.0, ::``.
 
 
 4.1.X to 4.2.0

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -87,6 +87,7 @@ void declareArguments()
   ::arg().setSwitch("log-dns-details","If PDNS should log DNS non-erroneous details")="no";
   ::arg().setSwitch("log-dns-queries","If PDNS should log all incoming DNS queries")="no";
   ::arg().set("local-address","Local IP addresses to which we bind")="0.0.0.0, ::";
+  ::arg().set("local-ipv6","DEPRECATED, will be removed, move your IPs to local-address")="";
   ::arg().setSwitch("local-address-nonexist-fail","Fail to start if one or more of the local-address's do not exist on this server")="yes";
   ::arg().setSwitch("non-local-bind", "Enable binding to non-local addresses by using FREEBIND / BINDANY socket options")="no";
   ::arg().setSwitch("reuseport","Enable higher performance on compliant kernels by using SO_REUSEPORT allowing each receiver thread to open its own socket")="no";

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -89,7 +89,12 @@ vector<ComboAddress> g_localaddresses; // not static, our unit tests need to pok
 void UDPNameserver::bindAddresses()
 {
   vector<string>locals;
+  stringtok(locals,::arg()["local-ipv6"]," ,");
+  if (!locals.empty()) {
+    g_log<<Logger::Error<<"NOTE: Deprecated local-ipv6 setting used. Please move those addresses to the local-address setting."<<endl;
+  }
   stringtok(locals,::arg()["local-address"]," ,");
+
   int one = 1;
 
   if(locals.empty())

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1202,6 +1202,7 @@ TCPNameserver::TCPNameserver()
   d_tid=0;
 
   vector<string>locals;
+  stringtok(locals,::arg()["local-ipv6"]," ,");
   stringtok(locals,::arg()["local-address"]," ,");
   if(locals.empty())
     throw PDNSException("No local addresses specified");


### PR DESCRIPTION
### Short description
Dropping options makes upgrades hard. Fixes #8624. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
