### PR TITLE
Remove the empty user-defined destructor of DNSResourceRecord

### DIFF
--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -82,7 +82,6 @@ class DNSResourceRecord
 {
 public:
   DNSResourceRecord() : last_modified(0), ttl(0), signttl(0), domain_id(-1), qclass(1), scopeMask(0), auth(1), disabled(0) {};
-  ~DNSResourceRecord(){};
   static DNSResourceRecord fromWire(const DNSRecord& d);
 
   enum Place : uint8_t {QUESTION=0, ANSWER=1, AUTHORITY=2, ADDITIONAL=3}; //!< Type describing the positioning within, say, a DNSPacket


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Having a user-defined destructor prevents the compiler from generating implicit definition of the move constructor and the move assignment operator, which might have a serious performance impact.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

