### PR TITLE
docs: Add 4.2 SQL schema links

### DIFF
--- a/docs/backends/generic-mysql.rst
+++ b/docs/backends/generic-mysql.rst
@@ -153,6 +153,6 @@ Only enable this if you are certain you need to. For more discussion, see https:
 Default Schema
 --------------
 
-This is the 4.2 schema. Please find `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gmysqlbackend/schema.mysql.sql>`_.
+This is the 4.3 schema. Please find `the 4.2 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.2.x/modules/gmysqlbackend/schema.mysql.sql>`_ and `the 4.1 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gmysqlbackend/schema.mysql.sql>`_ on GitHub.
 
 .. literalinclude:: ../../modules/gmysqlbackend/schema.mysql.sql

--- a/docs/backends/generic-odbc.rst
+++ b/docs/backends/generic-odbc.rst
@@ -111,7 +111,7 @@ For convenience, a schema for MS SQL Server has been created: (Note:
 This schema can also be found in the PowerDNS source as
 ``modules/godbcbackend/schema.mssql.sql``).
 
-This is the schema for 4.2. For 4.1, please find `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/godbcbackend/schema.mssql.sql>`_.
+This is the schema for 4.3. Please find `the 4.2 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.2.x/modules/godbcbackend/schema.mssql.sql>`_ and `the 4.1 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/godbcbackend/schema.mssql.sql>`_ on GitHub.
 
 .. literalinclude:: ../../modules/godbcbackend/schema.mssql.sql
    :language: SQL

--- a/docs/backends/generic-postgresql.rst
+++ b/docs/backends/generic-postgresql.rst
@@ -94,7 +94,7 @@ Default: "".
 Default schema
 --------------
 
-This is the 4.2 schema. Please find `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gpgsqlbackend/schema.pgsql.sql>`_.
+This is the 4.3 schema. Please find `the 4.2 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.2.x/modules/gpgsqlbackend/schema.pgsql.sql>`_ and the `the 4.1 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gpgsqlbackend/schema.pgsql.sql>`_ on GitHub.
 
 .. literalinclude:: ../../modules/gpgsqlbackend/schema.pgsql.sql
    :language: SQL

--- a/docs/backends/generic-sqlite3.rst
+++ b/docs/backends/generic-sqlite3.rst
@@ -33,8 +33,8 @@ Setting up the database
 ------------------------
 
 Before you can use this backend you first have to set it up and fill it
-with data. The default setup conforms to the following schema in 4.2.
-If you have not upgraded to 4.2, please use `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gsqlite3backend/schema.sqlite3.sql>`_.
+with data. The default setup conforms to the following schema in 4.3.
+If you have not upgraded to 4.3, please use `the 4.2 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.2.x/modules/gsqlite3backend/schema.sqlite3.sql>`_ or `the 4.1 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gsqlite3backend/schema.sqlite3.sql>`_ on GitHub.
 
 .. literalinclude:: ../../modules/gsqlite3backend/schema.sqlite3.sql
 

--- a/docs/guides/basic-database.rst
+++ b/docs/guides/basic-database.rst
@@ -48,7 +48,7 @@ Example: configuring MySQL
 Connect to MySQL as a user with sufficient privileges and issue the
 following commands below if you are running the 4.2 or master version of PowerDNS:
 
-Please find `the 4.1 schema on GitHub <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gmysqlbackend/schema.mysql.sql>`_.
+Please find `the 4.2 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.2.x/modules/gmysqlbackend/schema.mysql.sql>`_ and `the 4.1 schema <https://github.com/PowerDNS/pdns/blob/rel/auth-4.1.x/modules/gmysqlbackend/schema.mysql.sql>`_ on GitHub.
 
 
 .. literalinclude:: ../../modules/gmysqlbackend/schema.mysql.sql


### PR DESCRIPTION
### Short description
The Auth SQL schema docs include links to the schemas for 4.1. This adds equivalent links for 4.2.

This is complementary to #8774. 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
