### PR TITLE
auth: Add more SQL schema files to packages and tarballs

### DIFF
--- a/builder-support/debian/authoritative/debian-buster/pdns-backend-bind.docs
+++ b/builder-support/debian/authoritative/debian-buster/pdns-backend-bind.docs
@@ -1,0 +1,2 @@
+pdns/bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql
+pdns/bind-dnssec.schema.sqlite3.sql

--- a/builder-support/debian/authoritative/debian-buster/pdns-backend-mysql.docs
+++ b/builder-support/debian/authoritative/debian-buster/pdns-backend-mysql.docs
@@ -1,3 +1,6 @@
+modules/gmysqlbackend/3.4.0_to_4.1.0_schema.mysql.sql
+modules/gmysqlbackend/4.1.0_to_4.2.0_schema.mysql.sql
+modules/gmysqlbackend/4.2.0_to_4.3.0_schema.mysql.sql
 modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
 modules/gmysqlbackend/enable-foreign-keys.mysql.sql
 modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql

--- a/builder-support/debian/authoritative/debian-buster/pdns-backend-mysql.docs
+++ b/builder-support/debian/authoritative/debian-buster/pdns-backend-mysql.docs
@@ -1,3 +1,4 @@
 modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
+modules/gmysqlbackend/enable-foreign-keys.mysql.sql
 modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql
 modules/gmysqlbackend/schema.mysql.sql

--- a/builder-support/debian/authoritative/debian-buster/pdns-backend-odbc.docs
+++ b/builder-support/debian/authoritative/debian-buster/pdns-backend-odbc.docs
@@ -1,1 +1,3 @@
+modules/godbcbackend/4.0.0_to_4.2.0_schema.mssql.sql
+modules/godbcbackend/4.2.0_to_4.3.0_schema.mssql.sql
 modules/godbcbackend/schema.mssql.sql

--- a/builder-support/debian/authoritative/debian-buster/pdns-backend-pgsql.docs
+++ b/builder-support/debian/authoritative/debian-buster/pdns-backend-pgsql.docs
@@ -1,3 +1,6 @@
+modules/gpgsqlbackend/3.4.0_to_4.1.0_schema.pgsql.sql
+modules/gpgsqlbackend/4.1.0_to_4.2.0_schema.pgsql.sql
+modules/gpgsqlbackend/4.2.0_to_4.3.0_schema.pgsql.sql
 modules/gpgsqlbackend/dnssec-3.x_to_3.4.0_schema.pgsql.sql
 modules/gpgsqlbackend/nodnssec-3.x_to_3.4.0_schema.pgsql.sql
 modules/gpgsqlbackend/schema.pgsql.sql

--- a/builder-support/debian/authoritative/debian-buster/pdns-backend-sqlite3.docs
+++ b/builder-support/debian/authoritative/debian-buster/pdns-backend-sqlite3.docs
@@ -1,3 +1,6 @@
+modules/gsqlite3backend/3.4.0_to_4.0.0_schema.sqlite3.sql
+modules/gsqlite3backend/4.0.0_to_4.2.0_schema.sqlite3.sql
+modules/gsqlite3backend/4.2.0_to_4.3.0_schema.sqlite3.sql
 modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/schema.sqlite3.sql

--- a/builder-support/debian/authoritative/debian-jessie/pdns-backend-bind.docs
+++ b/builder-support/debian/authoritative/debian-jessie/pdns-backend-bind.docs
@@ -1,0 +1,2 @@
+pdns/bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql
+pdns/bind-dnssec.schema.sqlite3.sql

--- a/builder-support/debian/authoritative/debian-jessie/pdns-backend-mysql.docs
+++ b/builder-support/debian/authoritative/debian-jessie/pdns-backend-mysql.docs
@@ -1,3 +1,6 @@
+modules/gmysqlbackend/3.4.0_to_4.1.0_schema.mysql.sql
+modules/gmysqlbackend/4.1.0_to_4.2.0_schema.mysql.sql
+modules/gmysqlbackend/4.2.0_to_4.3.0_schema.mysql.sql
 modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
 modules/gmysqlbackend/enable-foreign-keys.mysql.sql
 modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql

--- a/builder-support/debian/authoritative/debian-jessie/pdns-backend-mysql.docs
+++ b/builder-support/debian/authoritative/debian-jessie/pdns-backend-mysql.docs
@@ -1,3 +1,4 @@
 modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
+modules/gmysqlbackend/enable-foreign-keys.mysql.sql
 modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql
 modules/gmysqlbackend/schema.mysql.sql

--- a/builder-support/debian/authoritative/debian-jessie/pdns-backend-odbc.docs
+++ b/builder-support/debian/authoritative/debian-jessie/pdns-backend-odbc.docs
@@ -1,1 +1,3 @@
+modules/godbcbackend/4.0.0_to_4.2.0_schema.mssql.sql
+modules/godbcbackend/4.2.0_to_4.3.0_schema.mssql.sql
 modules/godbcbackend/schema.mssql.sql

--- a/builder-support/debian/authoritative/debian-jessie/pdns-backend-pgsql.docs
+++ b/builder-support/debian/authoritative/debian-jessie/pdns-backend-pgsql.docs
@@ -1,3 +1,6 @@
+modules/gpgsqlbackend/3.4.0_to_4.1.0_schema.pgsql.sql
+modules/gpgsqlbackend/4.1.0_to_4.2.0_schema.pgsql.sql
+modules/gpgsqlbackend/4.2.0_to_4.3.0_schema.pgsql.sql
 modules/gpgsqlbackend/dnssec-3.x_to_3.4.0_schema.pgsql.sql
 modules/gpgsqlbackend/nodnssec-3.x_to_3.4.0_schema.pgsql.sql
 modules/gpgsqlbackend/schema.pgsql.sql

--- a/builder-support/debian/authoritative/debian-jessie/pdns-backend-sqlite3.docs
+++ b/builder-support/debian/authoritative/debian-jessie/pdns-backend-sqlite3.docs
@@ -1,3 +1,6 @@
+modules/gsqlite3backend/3.4.0_to_4.0.0_schema.sqlite3.sql
+modules/gsqlite3backend/4.0.0_to_4.2.0_schema.sqlite3.sql
+modules/gsqlite3backend/4.2.0_to_4.3.0_schema.sqlite3.sql
 modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/schema.sqlite3.sql

--- a/builder-support/debian/authoritative/debian-stretch/pdns-backend-bind.docs
+++ b/builder-support/debian/authoritative/debian-stretch/pdns-backend-bind.docs
@@ -1,0 +1,2 @@
+pdns/bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql
+pdns/bind-dnssec.schema.sqlite3.sql

--- a/builder-support/debian/authoritative/debian-stretch/pdns-backend-mysql.docs
+++ b/builder-support/debian/authoritative/debian-stretch/pdns-backend-mysql.docs
@@ -1,3 +1,6 @@
+modules/gmysqlbackend/3.4.0_to_4.1.0_schema.mysql.sql
+modules/gmysqlbackend/4.1.0_to_4.2.0_schema.mysql.sql
+modules/gmysqlbackend/4.2.0_to_4.3.0_schema.mysql.sql
 modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
 modules/gmysqlbackend/enable-foreign-keys.mysql.sql
 modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql

--- a/builder-support/debian/authoritative/debian-stretch/pdns-backend-mysql.docs
+++ b/builder-support/debian/authoritative/debian-stretch/pdns-backend-mysql.docs
@@ -1,3 +1,4 @@
 modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
+modules/gmysqlbackend/enable-foreign-keys.mysql.sql
 modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql
 modules/gmysqlbackend/schema.mysql.sql

--- a/builder-support/debian/authoritative/debian-stretch/pdns-backend-odbc.docs
+++ b/builder-support/debian/authoritative/debian-stretch/pdns-backend-odbc.docs
@@ -1,1 +1,3 @@
+modules/godbcbackend/4.0.0_to_4.2.0_schema.mssql.sql
+modules/godbcbackend/4.2.0_to_4.3.0_schema.mssql.sql
 modules/godbcbackend/schema.mssql.sql

--- a/builder-support/debian/authoritative/debian-stretch/pdns-backend-pgsql.docs
+++ b/builder-support/debian/authoritative/debian-stretch/pdns-backend-pgsql.docs
@@ -1,3 +1,6 @@
+modules/gpgsqlbackend/3.4.0_to_4.1.0_schema.pgsql.sql
+modules/gpgsqlbackend/4.1.0_to_4.2.0_schema.pgsql.sql
+modules/gpgsqlbackend/4.2.0_to_4.3.0_schema.pgsql.sql
 modules/gpgsqlbackend/dnssec-3.x_to_3.4.0_schema.pgsql.sql
 modules/gpgsqlbackend/nodnssec-3.x_to_3.4.0_schema.pgsql.sql
 modules/gpgsqlbackend/schema.pgsql.sql

--- a/builder-support/debian/authoritative/debian-stretch/pdns-backend-sqlite3.docs
+++ b/builder-support/debian/authoritative/debian-stretch/pdns-backend-sqlite3.docs
@@ -1,3 +1,6 @@
+modules/gsqlite3backend/3.4.0_to_4.0.0_schema.sqlite3.sql
+modules/gsqlite3backend/4.0.0_to_4.2.0_schema.sqlite3.sql
+modules/gsqlite3backend/4.2.0_to_4.3.0_schema.sqlite3.sql
 modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/schema.sqlite3.sql

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -298,7 +298,10 @@ fi
 %endif
 
 %files
-%doc COPYING README
+%doc COPYING
+%doc README
+%doc pdns/bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql
+%doc pdns/bind-dnssec.schema.sqlite3.sql
 %{_bindir}/pdns_control
 %{_bindir}/pdnsutil
 %{_bindir}/zone2sql

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -367,6 +367,7 @@ fi
 %doc modules/gmysqlbackend/schema.mysql.sql
 %doc modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
 %doc modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql
+%doc modules/gmysqlbackend/enable-foreign-keys.mysql.sql
 %{_libdir}/%{name}/libgmysqlbackend.so
 
 %files backend-postgresql

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -367,6 +367,9 @@ fi
 %doc modules/gmysqlbackend/schema.mysql.sql
 %doc modules/gmysqlbackend/dnssec-3.x_to_3.4.0_schema.mysql.sql
 %doc modules/gmysqlbackend/nodnssec-3.x_to_3.4.0_schema.mysql.sql
+%doc modules/gmysqlbackend/3.4.0_to_4.1.0_schema.mysql.sql
+%doc modules/gmysqlbackend/4.1.0_to_4.2.0_schema.mysql.sql
+%doc modules/gmysqlbackend/4.2.0_to_4.3.0_schema.mysql.sql
 %doc modules/gmysqlbackend/enable-foreign-keys.mysql.sql
 %{_libdir}/%{name}/libgmysqlbackend.so
 
@@ -374,6 +377,9 @@ fi
 %doc modules/gpgsqlbackend/schema.pgsql.sql
 %doc modules/gpgsqlbackend/dnssec-3.x_to_3.4.0_schema.pgsql.sql
 %doc modules/gpgsqlbackend/nodnssec-3.x_to_3.4.0_schema.pgsql.sql
+%doc modules/gpgsqlbackend/3.4.0_to_4.1.0_schema.pgsql.sql
+%doc modules/gpgsqlbackend/4.1.0_to_4.2.0_schema.pgsql.sql
+%doc modules/gpgsqlbackend/4.2.0_to_4.3.0_schema.pgsql.sql
 %{_libdir}/%{name}/libgpgsqlbackend.so
 
 %files backend-pipe
@@ -395,11 +401,16 @@ fi
 %doc modules/gsqlite3backend/schema.sqlite3.sql
 %doc modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
 %doc modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
+%doc modules/gsqlite3backend/3.4.0_to_4.0.0_schema.sqlite3.sql
+%doc modules/gsqlite3backend/4.0.0_to_4.2.0_schema.sqlite3.sql
+%doc modules/gsqlite3backend/4.2.0_to_4.3.0_schema.sqlite3.sql
 %{_libdir}/%{name}/libgsqlite3backend.so
 
 %if 0%{?rhel} >= 7
 %files backend-odbc
 %doc modules/godbcbackend/schema.mssql.sql
+%doc modules/godbcbackend/4.0.0_to_4.2.0_schema.mssql.sql
+%doc modules/godbcbackend/4.2.0_to_4.3.0_schema.mssql.sql
 %{_libdir}/%{name}/libgodbcbackend.so
 
 %files backend-geoip

--- a/modules/gmysqlbackend/Makefile.am
+++ b/modules/gmysqlbackend/Makefile.am
@@ -6,11 +6,13 @@ EXTRA_DIST = \
 	OBJECTFILES \
 	OBJECTLIBS \
 	dnssec-3.x_to_3.4.0_schema.mysql.sql \
+	enable-foreign-keys.mysql.sql \
 	nodnssec-3.x_to_3.4.0_schema.mysql.sql \
 	schema.mysql.sql
 
 dist_doc_DATA = \
 	dnssec-3.x_to_3.4.0_schema.mysql.sql \
+	enable-foreign-keys.mysql.sql \
 	nodnssec-3.x_to_3.4.0_schema.mysql.sql \
 	3.4.0_to_4.1.0_schema.mysql.sql \
 	4.1.0_to_4.2.0_schema.mysql.sql \

--- a/modules/gmysqlbackend/Makefile.am
+++ b/modules/gmysqlbackend/Makefile.am
@@ -14,6 +14,7 @@ dist_doc_DATA = \
 	nodnssec-3.x_to_3.4.0_schema.mysql.sql \
 	3.4.0_to_4.1.0_schema.mysql.sql \
 	4.1.0_to_4.2.0_schema.mysql.sql \
+	4.2.0_to_4.3.0_schema.mysql.sql \
 	schema.mysql.sql
 
 libgmysqlbackend_la_SOURCES = \

--- a/modules/gmysqlbackend/Makefile.am
+++ b/modules/gmysqlbackend/Makefile.am
@@ -8,6 +8,9 @@ EXTRA_DIST = \
 	dnssec-3.x_to_3.4.0_schema.mysql.sql \
 	enable-foreign-keys.mysql.sql \
 	nodnssec-3.x_to_3.4.0_schema.mysql.sql \
+	3.4.0_to_4.1.0_schema.mysql.sql \
+	4.1.0_to_4.2.0_schema.mysql.sql \
+	4.2.0_to_4.3.0_schema.mysql.sql \
 	schema.mysql.sql
 
 dist_doc_DATA = \

--- a/modules/gmysqlbackend/Makefile.am
+++ b/modules/gmysqlbackend/Makefile.am
@@ -4,14 +4,7 @@ pkglib_LTLIBRARIES = libgmysqlbackend.la
 
 EXTRA_DIST = \
 	OBJECTFILES \
-	OBJECTLIBS \
-	dnssec-3.x_to_3.4.0_schema.mysql.sql \
-	enable-foreign-keys.mysql.sql \
-	nodnssec-3.x_to_3.4.0_schema.mysql.sql \
-	3.4.0_to_4.1.0_schema.mysql.sql \
-	4.1.0_to_4.2.0_schema.mysql.sql \
-	4.2.0_to_4.3.0_schema.mysql.sql \
-	schema.mysql.sql
+	OBJECTLIBS
 
 dist_doc_DATA = \
 	dnssec-3.x_to_3.4.0_schema.mysql.sql \

--- a/modules/godbcbackend/Makefile.am
+++ b/modules/godbcbackend/Makefile.am
@@ -1,14 +1,21 @@
 AM_CPPFLAGS += $(UNIXODBC_CFLAGS)
 pkglib_LTLIBRARIES = libgodbcbackend.la
 
-EXTRA_DIST=OBJECTFILES OBJECTLIBS
-
-dist_doc_DATA=schema.mssql.sql \
+EXTRA_DIST = \
+	OBJECTFILES \
+	OBJECTLIBS \
+	schema.mssql.sql \
 	4.0.0_to_4.2.0_schema.mssql.sql \
 	4.2.0_to_4.3.0_schema.mssql.sql
 
-libgodbcbackend_la_SOURCES=godbcbackend.cc godbcbackend.hh \
-                sodbc.hh sodbc.cc
+dist_doc_DATA = \
+	schema.mssql.sql \
+	4.0.0_to_4.2.0_schema.mssql.sql \
+	4.2.0_to_4.3.0_schema.mssql.sql
 
-libgodbcbackend_la_LDFLAGS=-module -avoid-version
-libgodbcbackend_la_LIBADD=$(UNIXODBC_LIBS)
+libgodbcbackend_la_SOURCES = \
+	godbcbackend.cc godbcbackend.hh \
+	sodbc.cc sodbc.hh
+
+libgodbcbackend_la_LDFLAGS = -module -avoid-version
+libgodbcbackend_la_LIBADD = $(UNIXODBC_LIBS)

--- a/modules/godbcbackend/Makefile.am
+++ b/modules/godbcbackend/Makefile.am
@@ -4,7 +4,8 @@ pkglib_LTLIBRARIES = libgodbcbackend.la
 EXTRA_DIST=OBJECTFILES OBJECTLIBS
 
 dist_doc_DATA=schema.mssql.sql \
-	4.0.0_to_4.2.0_schema.mssql.sql
+	4.0.0_to_4.2.0_schema.mssql.sql \
+	4.2.0_to_4.3.0_schema.mssql.sql
 
 libgodbcbackend_la_SOURCES=godbcbackend.cc godbcbackend.hh \
                 sodbc.hh sodbc.cc

--- a/modules/godbcbackend/Makefile.am
+++ b/modules/godbcbackend/Makefile.am
@@ -3,10 +3,7 @@ pkglib_LTLIBRARIES = libgodbcbackend.la
 
 EXTRA_DIST = \
 	OBJECTFILES \
-	OBJECTLIBS \
-	schema.mssql.sql \
-	4.0.0_to_4.2.0_schema.mssql.sql \
-	4.2.0_to_4.3.0_schema.mssql.sql
+	OBJECTLIBS
 
 dist_doc_DATA = \
 	schema.mssql.sql \

--- a/modules/gpgsqlbackend/Makefile.am
+++ b/modules/gpgsqlbackend/Makefile.am
@@ -13,7 +13,8 @@ dist_doc_DATA = \
 	nodnssec-3.x_to_3.4.0_schema.pgsql.sql \
 	dnssec-3.x_to_3.4.0_schema.pgsql.sql \
 	3.4.0_to_4.1.0_schema.pgsql.sql \
-	4.1.0_to_4.2.0_schema.pgsql.sql
+	4.1.0_to_4.2.0_schema.pgsql.sql \
+	4.2.0_to_4.3.0_schema.pgsql.sql
 
 libgpgsqlbackend_la_SOURCES = \
 	gpgsqlbackend.cc gpgsqlbackend.hh \

--- a/modules/gpgsqlbackend/Makefile.am
+++ b/modules/gpgsqlbackend/Makefile.am
@@ -3,13 +3,7 @@ pkglib_LTLIBRARIES = libgpgsqlbackend.la
 
 EXTRA_DIST = \
 	OBJECTFILES \
-	OBJECTLIBS \
-	3.4.0_to_4.1.0_schema.pgsql.sql \
-	4.1.0_to_4.2.0_schema.pgsql.sql \
-	4.2.0_to_4.3.0_schema.pgsql.sql \
-	dnssec-3.x_to_3.4.0_schema.pgsql.sql \
-	nodnssec-3.x_to_3.4.0_schema.pgsql.sql \
-	schema.pgsql.sql
+	OBJECTLIBS
 
 dist_doc_DATA = \
 	schema.pgsql.sql \

--- a/modules/gpgsqlbackend/Makefile.am
+++ b/modules/gpgsqlbackend/Makefile.am
@@ -4,6 +4,9 @@ pkglib_LTLIBRARIES = libgpgsqlbackend.la
 EXTRA_DIST = \
 	OBJECTFILES \
 	OBJECTLIBS \
+	3.4.0_to_4.1.0_schema.pgsql.sql \
+	4.1.0_to_4.2.0_schema.pgsql.sql \
+	4.2.0_to_4.3.0_schema.pgsql.sql \
 	dnssec-3.x_to_3.4.0_schema.pgsql.sql \
 	nodnssec-3.x_to_3.4.0_schema.pgsql.sql \
 	schema.pgsql.sql

--- a/modules/gsqlite3backend/Makefile.am
+++ b/modules/gsqlite3backend/Makefile.am
@@ -12,6 +12,7 @@ dist_doc_DATA = \
 	nodnssec-3.x_to_3.4.0_schema.sqlite3.sql \
 	3.4.0_to_4.0.0_schema.sqlite3.sql \
 	4.0.0_to_4.2.0_schema.sqlite3.sql \
+	4.2.0_to_4.3.0_schema.sqlite3.sql \
 	schema.sqlite3.sql
 
 libgsqlite3backend_la_SOURCES = gsqlite3backend.cc gsqlite3backend.hh

--- a/modules/gsqlite3backend/Makefile.am
+++ b/modules/gsqlite3backend/Makefile.am
@@ -2,13 +2,7 @@ pkglib_LTLIBRARIES = libgsqlite3backend.la
 
 EXTRA_DIST = \
 	OBJECTFILES \
-	OBJECTLIBS \
-	dnssec-3.x_to_3.4.0_schema.sqlite3.sql \
-	nodnssec-3.x_to_3.4.0_schema.sqlite3.sql \
-	3.4.0_to_4.0.0_schema.sqlite3.sql \
-	4.0.0_to_4.2.0_schema.sqlite3.sql \
-	4.2.0_to_4.3.0_schema.sqlite3.sql \
-	schema.sqlite3.sql
+	OBJECTLIBS
 
 dist_doc_DATA = \
 	dnssec-3.x_to_3.4.0_schema.sqlite3.sql \

--- a/modules/gsqlite3backend/Makefile.am
+++ b/modules/gsqlite3backend/Makefile.am
@@ -5,6 +5,9 @@ EXTRA_DIST = \
 	OBJECTLIBS \
 	dnssec-3.x_to_3.4.0_schema.sqlite3.sql \
 	nodnssec-3.x_to_3.4.0_schema.sqlite3.sql \
+	3.4.0_to_4.0.0_schema.sqlite3.sql \
+	4.0.0_to_4.2.0_schema.sqlite3.sql \
+	4.2.0_to_4.3.0_schema.sqlite3.sql \
 	schema.sqlite3.sql
 
 dist_doc_DATA = \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -47,6 +47,7 @@ EXTRA_DIST = \
 	effective_tld_names.dat \
 	mtasker.cc \
 	inflighter.cc \
+	bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql \
 	bind-dnssec.schema.sqlite3.sql \
 	bindparser.h \
 	named.conf.parsertest \


### PR DESCRIPTION
### Short description
* Add the 4.3.0 SQL schema upgrade files to tarballs. (I think.)
* Add the 3.4.0 through 4.3.0 files to the packages!
* Add the `bind` files to the `pdns` (rpm) and `pdns-backend-bind` (deb) packages.
* Add `enable-foreign-keys.mysql.sql` to the package and tarballs. (Don't know if it's useful, but it's not not useful.)
* Also reformat `godbc`'s `Makefile.am` similar to how the other backends were done. (And switch the order of a `.cc` file and a `.hh` file; I think it's an unordered list?)

The tarball issue was reported by HellSpawn the other day.

I've tested building CentOS 8, Debian Buster and Ubuntu Bionic with pdns-builder, and listed the contents of the debs and rpms and tarballs produced, but I haven't done any further testing (like actually installing things).

I duplicated SQL files between `EXTRA_DIST` and `dist_doc_DATA`, which was probably unnecessary.

I don't know if there are additional steps beyond "create `pdns-backend-bind.docs`", but that's what I did and it worked...

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
