### PR TITLE
auth api: add includerings option to statistics endpoint

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -412,7 +412,12 @@ paths:
           description: |
             When set to the name of a specific statistic, only this value is returned.
             If no statistic with that name exists, the response has a 422 status and an error message.
-
+        - name: includerings
+          in: query
+          required: false
+          type: boolean
+          default: true
+          description: '“true” (default) or “false”, whether to include the Ring items, which can contain thousands of log messages or queried domains. Setting this to ”false” may make the response a lot smaller.'
       responses:
         '200':
           description: List of Statistic Items

--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -248,25 +248,28 @@ void apiServerStatistics(HttpRequest* req, HttpResponse* resp) {
   }
 
 #ifndef RECURSOR
-  for(const auto& ringName : S.listRings()) {
-    Json::array values;
-    const auto& ring = S.getRing(ringName);
-    for(const auto& item : ring) {
-      if (item.second == 0)
-        continue;
+  if (!req->getvars.count("includerings") ||
+       req->getvars["includerings"] != "false") {
+    for(const auto& ringName : S.listRings()) {
+      Json::array values;
+      const auto& ring = S.getRing(ringName);
+      for(const auto& item : ring) {
+        if (item.second == 0)
+          continue;
 
-      values.push_back(Json::object {
-        { "name", item.first },
-        { "value", std::to_string(item.second) },
+        values.push_back(Json::object {
+          { "name", item.first },
+          { "value", std::to_string(item.second) },
+        });
+      }
+
+      doc.push_back(Json::object {
+        { "type", "RingStatisticItem" },
+        { "name", ringName },
+        { "size", std::to_string(S.getRingSize(ringName)) },
+        { "value", values },
       });
     }
-
-    doc.push_back(Json::object {
-      { "type", "RingStatisticItem" },
-      { "name", ringName },
-      { "size", std::to_string(S.getRingSize(ringName)) },
-      { "value", values },
-    });
   }
 #endif
 


### PR DESCRIPTION
### Short description
The rings can easily grow to megabytes, and many statistics consumers are entirely uninterested in them.

~This uses `skiprings=true` (defaulting to false), as opposed to `dnssec=false` (defaulting to false) on the Zones endpoint. Should probably flip that around to work the same way (`includerings=false` with true as default)?~ Did this.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
