### PR TITLE
dnsdist: Fix key logging for DNS over TLS

### DIFF
--- a/pdns/dnsdistdist/libssl.cc
+++ b/pdns/dnsdistdist/libssl.cc
@@ -744,6 +744,7 @@ static void libssl_key_log_file_callback(const SSL* ssl, const char* line)
   }
 
   fprintf(fp, "%s\n", line);
+  fflush(fp);
 }
 #endif /* HAVE_SSL_CTX_SET_KEYLOG_CALLBACK */
 

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -42,6 +42,7 @@ public:
   OpenSSLTLSTicketKeysRing d_ticketKeys;
   std::map<int, std::string> d_ocspResponses;
   std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> d_tlsCtx{nullptr, SSL_CTX_free};
+  std::unique_ptr<FILE, int(*)(FILE*)> d_keyLogFile{nullptr, fclose};
 };
 
 class OpenSSLTLSConnection: public TLSConnection
@@ -302,6 +303,10 @@ public:
     }
 
     libssl_set_error_counters_callback(d_feContext->d_tlsCtx, &fe.d_tlsCounters);
+
+    if (!fe.d_tlsConfig.d_keyLogFile.empty()) {
+      d_feContext->d_keyLogFile = libssl_set_key_log_file(d_feContext->d_tlsCtx, fe.d_tlsConfig.d_keyLogFile);
+    }
 
     try {
       if (fe.d_tlsConfig.d_ticketKeyFile.empty()) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It turns out that the `keyLogFile` directive was ignored for DNS over TLS, while correctly working with DNS over HTTPS. I know I tested both when writing the code for #8442 but I guess the DoT part was lost in a refactoring at some point before opening the PR :-/
This PR also makes the feature more usable by flushing the key material to the file right away, so we don't have to wait for the buffer to get flushed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

