### PR TITLE
DNSName: Don't call strlen() when the length is already known

### DIFF
--- a/pdns/dnslabeltext.rl
+++ b/pdns/dnslabeltext.rl
@@ -83,7 +83,7 @@ vector<string> segmentDNSText(const string& input )
 };
 
 
-DNSName::string_t segmentDNSNameRaw(const char* realinput)
+DNSName::string_t segmentDNSNameRaw(const char* realinput, size_t inputlen)
 {
 %%{
         machine dnsnameraw;
@@ -100,7 +100,6 @@ DNSName::string_t segmentDNSNameRaw(const char* realinput)
           return ret;
         }
 
-        unsigned int inputlen=strlen(realinput);
         ret.reserve(inputlen+1);
 
         const char *p = realinput, *pe = realinput + inputlen;

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -41,7 +41,7 @@ std::ostream & operator<<(std::ostream &os, const DNSName& d)
   return os <<d.toLogString();
 }
 
-DNSName::DNSName(const char* p)
+DNSName::DNSName(const char* p, size_t length)
 {
   if(p[0]==0 || (p[0]=='.' && p[1]==0)) {
     d_storage.assign(1, (char)0);
@@ -49,7 +49,7 @@ DNSName::DNSName(const char* p)
     if(!strchr(p, '\\')) {
       unsigned char lenpos=0;
       unsigned char labellen=0;
-      size_t plen=strlen(p);
+      size_t plen=length;
       const char* const pbegin=p, *pend=p+plen;
       d_storage.reserve(plen+1);
       for(auto iter = pbegin; iter != pend; ) {
@@ -76,7 +76,7 @@ DNSName::DNSName(const char* p)
       d_storage.append(1, (char)0);
     }
     else {
-      d_storage=segmentDNSNameRaw(p); 
+      d_storage=segmentDNSNameRaw(p, length);
       if(d_storage.size() > 255) {
         throw std::range_error("name too long");
       }

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -62,8 +62,9 @@ class DNSName
 {
 public:
   DNSName()  {}          //!< Constructs an *empty* DNSName, NOT the root!
-  explicit DNSName(const char* p);      //!< Constructs from a human formatted, escaped presentation
-  explicit DNSName(const std::string& str) : DNSName(str.c_str()) {}; //!< Constructs from a human formatted, escaped presentation
+  explicit DNSName(const char* p): DNSName(p, strlen(p)) {} //!< Constructs from a human formatted, escaped presentation
+  explicit DNSName(const char* p, size_t len);      //!< Constructs from a human formatted, escaped presentation
+  explicit DNSName(const std::string& str) : DNSName(str.c_str(), str.length()) {}; //!< Constructs from a human formatted, escaped presentation
   DNSName(const char* p, int len, int offset, bool uncompress, uint16_t* qtype=nullptr, uint16_t* qclass=nullptr, unsigned int* consumed=nullptr, uint16_t minOffset=0); //!< Construct from a DNS Packet, taking the first question if offset=12. If supplied, consumed is set to the number of bytes consumed from the packet, which will not be equal to the wire length of the resulting name in case of compression.
   
   bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name?
@@ -468,7 +469,7 @@ namespace std {
     };
 }
 
-DNSName::string_t segmentDNSNameRaw(const char* input); // from ragel
+DNSName::string_t segmentDNSNameRaw(const char* input, size_t inputlen); // from ragel
 bool DNSName::operator==(const DNSName& rhs) const
 {
   if(rhs.empty() != empty() || rhs.d_storage.size() != d_storage.size())

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -173,5 +173,4 @@ private:
 typedef vector<pair<string::size_type, string::size_type> > labelparts_t;
 // bool labeltokUnescape(labelparts_t& parts, const DNSName& label);
 std::vector<string> segmentDNSText(const string& text); // from dnslabeltext.rl
-std::deque<string> segmentDNSName(const string& input ); // from dnslabeltext.rl
 #endif


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Saving a call to `strlen()` when we already know the size, i.e. when the `DNSName` is constructed from a string. This is often the case when we retrieved the name from a `SQL` backend, for example.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

