### PR TITLE
auth: Prepare the caches' buckets in advance

### DIFF
--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -58,6 +58,14 @@ AuthPacketCache::~AuthPacketCache()
   }
 }
 
+void AuthPacketCache::MapCombo::reserve(size_t numberOfEntries)
+{
+#if BOOST_VERSION >= 105600
+  WriteLock wl(&d_mut);
+  d_map.get<HashTag>().reserve(numberOfEntries);
+#endif /* BOOST_VERSION >= 105600 */
+}
+
 bool AuthPacketCache::get(DNSPacket& p, DNSPacket& cached)
 {
   if(!d_ttl) {

--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -66,6 +66,9 @@ public:
   void setMaxEntries(uint64_t maxEntries) 
   {
     d_maxEntries = maxEntries;
+    for (auto& shard : d_maps) {
+      shard.reserve(maxEntries / d_maps.size());
+    }
   }
   void setTTL(uint32_t ttl)
   {
@@ -114,6 +117,8 @@ private:
     }
     MapCombo(const MapCombo&) = delete; 
     MapCombo& operator=(const MapCombo&) = delete;
+
+    void reserve(size_t numberOfEntries);
 
     pthread_rwlock_t d_mut;
     cmap_t d_map;

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -59,6 +59,14 @@ AuthQueryCache::~AuthQueryCache()
   }
 }
 
+void AuthQueryCache::MapCombo::reserve(size_t numberOfEntries)
+{
+#if BOOST_VERSION >= 105600
+  WriteLock wl(&d_mut);
+  d_map.get<HashTag>().reserve(numberOfEntries);
+#endif /* BOOST_VERSION >= 105600 */
+}
+
 // called from ueberbackend
 bool AuthQueryCache::getEntry(const DNSName &qname, const QType& qtype, vector<DNSZoneRecord>& value, int zoneID)
 {

--- a/pdns/auth-querycache.hh
+++ b/pdns/auth-querycache.hh
@@ -56,6 +56,9 @@ public:
   void setMaxEntries(uint64_t maxEntries)
   {
     d_maxEntries = maxEntries;
+    for (auto& shard : d_maps) {
+      shard.reserve(maxEntries / d_maps.size());
+    }
   }
 private:
 
@@ -97,6 +100,8 @@ private:
     }
     MapCombo(const MapCombo &) = delete; 
     MapCombo & operator=(const MapCombo &) = delete;
+
+    void reserve(size_t numberOfEntries);
 
     pthread_rwlock_t d_mut;
     cmap_t d_map;

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -540,6 +540,7 @@ void mainthread()
    PC.setTTL(::arg().asNum("cache-ttl"));
    PC.setMaxEntries(::arg().asNum("max-packet-cache-entries"));
    QC.setMaxEntries(::arg().asNum("max-cache-entries"));
+   DNSSECKeeper::setMaxEntries(::arg().asNum("max-cache-entries"));
 
    if (!PC.enabled() && ::arg().mustDo("log-dns-queries")) {
      g_log<<Logger::Warning<<"Packet cache disabled, logging queries without HIT/MISS"<<endl;

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -235,6 +235,9 @@ public:
   void getSoaEdit(const DNSName& zname, std::string& value);
   bool unSecureZone(const DNSName& zone, std::string& error, std::string& info);
   bool rectifyZone(const DNSName& zone, std::string& error, std::string& info, bool doTransaction);
+
+  static void setMaxEntries(size_t maxEntries);
+
 private:
 
 
@@ -277,6 +280,7 @@ private:
       sequenced<tag<SequencedTag>>
     >
   > keycache_t;
+
   typedef multi_index_container<
     METACacheEntry,
     indexed_by<
@@ -298,6 +302,7 @@ private:
   static pthread_rwlock_t s_keycachelock;
   static AtomicCounter s_ops;
   static time_t s_last_prune;
+  static size_t s_maxEntries;
 
 public:
   void preRemoval(const KeyCacheEntry&)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR allocates the buckets for hashed indexes in advance to prevent having to re-allocate and re-hash later when the caches grow.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
