### PR TITLE
rec: Remove duplicate *PolicyTags docs

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -168,9 +168,19 @@ The DNSQuestion object contains at least the following fields:
 
   .. method:: DNSQuestion:addPolicyTag(tag)
 
-     Add a policy tag.
+     Add policyTag ``tag`` to the list of policyTags.
 
      :param str tag: The tag to add
+
+  .. method:: DNSQuestion:getPolicyTags() -> {str}
+
+      Get the current policy tags as a table of strings.
+
+  .. method:: DNSQuestion:setPolicyTags(tags)
+
+      Set the policy tags to ``tags``, overwriting any existing policy tags.
+
+      :param {str} tags: The policy tags
 
   .. method:: DNSQuestion:discardPolicy(policyname)
 
@@ -183,19 +193,9 @@ The DNSQuestion object contains at least the following fields:
 
       Returns the :class:`DNSHeader` of the query or nil.
 
-  .. method:: DNSQuestion:getPolicyTags() -> {str}
-
-      Get the current policy tags as a table of strings.
-
   .. method:: DNSQuestion:getRecords() -> {DNSRecord}
 
       Get a table of DNS Records in this DNS Question (or answer by now).
-
-  .. method:: DNSQuestion:setPolicyTags(tags)
-
-      Set the policy tags to ``tags``, overwriting any existing policy tags.
-
-      :param {str} tags: The policy tags
 
   .. method:: DNSQuestion:setRecords(records)
 
@@ -224,16 +224,6 @@ The DNSQuestion object contains at least the following fields:
   .. method:: DNSQuestion:getEDNSSubnet() -> Netmask
 
       Returns the :class:`Netmask` specified in the EDNSSubnet option, or empty if there was none.
-
-  .. method:: DNSQuestion:addPolicyTag(tag)
-
-      Add policyTag ``tag`` to the list of policyTags
-
-      :param str tag: The tag to add
-
-  .. method:: DNSQuestion:getPolicyTags() -> {str}
-
-      Get a list the policyTags for this message.
 
 DNSHeader Object
 ================


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Two lua functions have double docs. Also group them a bit more naturally.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
