### PR TITLE
rec: backport 8559 to rec 4.2.x: Avoid startup race by setting the state of a tread before starting it.

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4065,13 +4065,24 @@ static int serviceMain(int argc, char*argv[])
   }
   else {
 
+    
+    if (g_weDistributeQueries) {
+      for(unsigned int n=0; n < g_numDistributorThreads; ++n) {
+        auto& infos = s_threadInfos.at(currentThreadId + n);
+        infos.isListener = true;
+      }
+    }
+    for(unsigned int n=0; n < g_numWorkerThreads; ++n) {
+      auto& infos = s_threadInfos.at(currentThreadId + (g_weDistributeQueries ? g_numDistributorThreads : 0) + n);
+      infos.isListener = !g_weDistributeQueries;
+      infos.isWorker = true;
+    }
+
     if (g_weDistributeQueries) {
       g_log<<Logger::Warning<<"Launching "<< g_numDistributorThreads <<" distributor threads"<<endl;
       for(unsigned int n=0; n < g_numDistributorThreads; ++n) {
         auto& infos = s_threadInfos.at(currentThreadId);
-        infos.isListener = true;
         infos.thread = std::thread(recursorThread, currentThreadId++, "distr");
-
         setCPUMap(cpusMap, currentThreadId, infos.thread.native_handle());
       }
     }
@@ -4080,10 +4091,7 @@ static int serviceMain(int argc, char*argv[])
 
     for(unsigned int n=0; n < g_numWorkerThreads; ++n) {
       auto& infos = s_threadInfos.at(currentThreadId);
-      infos.isListener = g_weDistributeQueries ? false : true;
-      infos.isWorker = true;
       infos.thread = std::thread(recursorThread, currentThreadId++, "worker");
-
       setCPUMap(cpusMap, currentThreadId, infos.thread.native_handle());
     }
 


### PR DESCRIPTION
(cherry picked from commit ef31b0902fa09fd9a03276b56a51d88d63e68c6f)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
