### PR TITLE
builder: touch /var/lib/rpm/* in every docker layer that uses rpmdb

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -1,5 +1,6 @@
 FROM dist-base as package-builder
-RUN yum install -y rpm-build rpmdevtools /usr/bin/python3 && \
+RUN touch /var/lib/rpm/* && \
+    yum install -y rpm-build rpmdevtools /usr/bin/python3 && \
     yum groupinstall -y "Development Tools" && \
     rpmdev-setuptree
 
@@ -42,7 +43,7 @@ RUN if $(grep -q 'release 6' /etc/redhat-release); then \
       true ; \
     else \
       mkdir /libh2o && cd /libh2o && \
-      yum install -y curl openssl-devel cmake && \
+      touch /var/lib/rpm/* && yum install -y curl openssl-devel cmake && \
       curl -L https://github.com/h2o/h2o/archive/v2.2.6.tar.gz | tar xz && \
       CFLAGS='-fPIC' cmake -DWITH_PICOTLS=off -DWITH_BUNDLED_SSL=off -DWITH_MRUBY=off -DCMAKE_INSTALL_PREFIX=/opt ./h2o-2.2.6 && \
       make install && \

--- a/builder-support/dockerfiles/Dockerfile.target.amazon-2
+++ b/builder-support/dockerfiles/Dockerfile.target.amazon-2
@@ -5,7 +5,7 @@
 # Put only the bare minimum of common commands here, without dev tools
 FROM amazonlinux:2 as dist-base
 ARG BUILDER_CACHE_BUSTER=
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN touch /var/lib/rpm/* && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 # Do the actual rpm build
 @INCLUDE Dockerfile.rpmbuild

--- a/builder-support/dockerfiles/Dockerfile.target.centos-6
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-6
@@ -6,8 +6,8 @@
 FROM centos:6 as dist-base
 ARG BUILDER_CACHE_BUSTER=
 RUN which yum
-RUN yum clean all
-RUN yum install -y --verbose epel-release centos-release-scl-rh && \
+RUN touch /var/lib/rpm/* && yum clean all
+RUN touch /var/lib/rpm/* && yum install -y --verbose epel-release centos-release-scl-rh && \
     yum install -y --nogpgcheck devtoolset-7-gcc-c++
 
 # Do the actual rpm build

--- a/builder-support/dockerfiles/Dockerfile.target.centos-7
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-7
@@ -5,7 +5,7 @@
 # Put only the bare minimum of common commands here, without dev tools
 FROM centos:7 as dist-base
 ARG BUILDER_CACHE_BUSTER=
-RUN yum install -y epel-release
+RUN touch /var/lib/rpm/* && yum install -y epel-release
 
 # Do the actual rpm build
 @INCLUDE Dockerfile.rpmbuild

--- a/builder-support/dockerfiles/Dockerfile.target.centos-8
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-8
@@ -5,7 +5,7 @@
 # Put only the bare minimum of common commands here, without dev tools
 FROM centos:8 as dist-base
 ARG BUILDER_CACHE_BUSTER=
-RUN yum install -y epel-release && \
+RUN touch /var/lib/rpm/* && yum install -y epel-release && \
     dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled PowerTools
 


### PR DESCRIPTION
references:
https://github.com/pombredanne/dnf-plugin-ovl
https://bugzilla.redhat.com/show_bug.cgi?id=1213602

### Short description
This hopefully avoids the occasional RPMDB corruption we see in our builds.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
