### PR TITLE
YaHTTP: Support bracketed IPv6 addresses

### DIFF
--- a/ext/yahttp/yahttp/reqresp.hpp
+++ b/ext/yahttp/yahttp/reqresp.hpp
@@ -249,7 +249,7 @@ public:
     }
     void setup(const std::string& method_, const std::string& url_) {
       this->url.parse(url_);
-      this->headers["host"] = this->url.host;
+      this->headers["host"] = this->url.host.find(":") == std::string::npos ? this->url.host : "[" + this->url.host + "]";
       this->method = method_;
       std::transform(this->method.begin(), this->method.end(), this->method.begin(), ::toupper);
       this->headers["user-agent"] = "YaHTTP v1.0";

--- a/ext/yahttp/yahttp/url.hpp
+++ b/ext/yahttp/yahttp/url.hpp
@@ -38,7 +38,18 @@ namespace YaHTTP {
              host = url.substr(pos, pos1-pos);
              pos = pos1;
           }
-          if ( (pos1 = host.find_first_of(":")) != std::string::npos ) {
+          if (host.at(0) == '[') { // IPv6
+            if ((pos1 = host.find_first_of("]")) == std::string::npos) {
+              // incomplete address
+              return false;
+            }
+            size_t pos2;
+            if ((pos2 = host.find_first_of(":", pos1)) != std::string::npos) {
+              std::istringstream tmp(host.substr(pos2 + 1));
+              tmp >> port;
+            }
+            host = host.substr(1, pos1 - 1);
+          } else if ( (pos1 = host.find_first_of(":")) != std::string::npos ) {
              std::istringstream tmp(host.substr(pos1+1));
              tmp >> port;
              host = host.substr(0, pos1);


### PR DESCRIPTION
### Short description
This ensures that urls like `http://[2001::db8::fff:22]/` and `http://[2001::db8::fff:22]:2500/`. It also now sends a `Host` header with bracketed IPv6 addresses when needed.

cc: @cmouse 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)