### PR TITLE
Allow forced retrieval

### DIFF
--- a/docs/manpages/pdns_control.1.rst
+++ b/docs/manpages/pdns_control.1.rst
@@ -147,10 +147,12 @@ respsizes
 
 Get a histogram of the response sizes.
 
-retrieve *DOMAIN*
+retrieve *DOMAIN* [IP]
 ^^^^^^^^^^^^^^^^^
 
 Retrieve slave *DOMAIN* from its master. Done nearly immediately.
+If IP is specified, then retrieval is forced from the specified IP.
+Port may be specified in AFI specific manner.
 
 set *VARIABLE* *VALUE*
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -54,7 +54,7 @@ void CommunicatorClass::retrievalLoopThread(void)
       sr=d_suckdomains.front();
       d_suckdomains.pop_front();
     }
-    suck(sr.domain, sr.master);
+    suck(sr.domain, sr.master, sr.force);
   }
 }
 

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -45,6 +45,7 @@ struct SuckRequest
 {
   DNSName domain;
   ComboAddress master;
+  bool force;
   bool operator<(const SuckRequest& b) const
   {
     return tie(domain, master) < tie(b.domain, b.master);
@@ -161,7 +162,7 @@ public:
   
   void drillHole(const DNSName &domain, const string &ip);
   bool justNotified(const DNSName &domain, const string &ip);
-  void addSuckRequest(const DNSName &domain, const ComboAddress& master);
+  void addSuckRequest(const DNSName &domain, const ComboAddress& master, bool force=false);
   void addSlaveCheckRequest(const DomainInfo& di, const ComboAddress& remote);
   void addTrySuperMasterRequest(const DNSPacket& p);
   void notify(const DNSName &domain, const string &ip);
@@ -176,7 +177,7 @@ private:
   int d_nsock4, d_nsock6;
   map<pair<DNSName,string>,time_t>d_holes;
   std::mutex d_holelock;
-  void suck(const DNSName &domain, const ComboAddress& remote);
+  void suck(const DNSName &domain, const ComboAddress& remote, bool force=false);
   void ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, std::unique_ptr<AuthLua4>& pdl,
                 ZoneStatus& zs, vector<DNSRecord>* axfr);
 

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -275,7 +275,7 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
     return "Domain '"+domain.toString()+"' is not a slave domain (or has no master defined)";
 
   shuffle(di.masters.begin(), di.masters.end(), pdns::dns_random_engine());
-  auto master = di.masters.front();
+  const auto& master = di.masters.front();
   Communicator.addSuckRequest(domain, master, override_master);
   g_log<<Logger::Warning<<"Retrieval request for domain '"<<domain<<"' from master '"<<master<<"' received from operator"<<endl;
   return "Added retrieval request for '"+domain.toLogString()+"' from master "+master.toLogString();

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -239,8 +239,8 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
 {
   extern CommunicatorClass Communicator;
   ostringstream os;
-  if(parts.size()!=2)
-    return "syntax: retrieve domain";
+  if(parts.size()!=2 && parts.size()!=3)
+    return "syntax: retrieve domain [ip]";
 
   DNSName domain;
   try {
@@ -249,17 +249,34 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
     return "Failed to parse domain as valid DNS name";
   }
 
+  ComboAddress master_ip;
+  bool override_master = false;
+  if (parts.size() == 3) {
+    try {
+      master_ip = ComboAddress{parts[2], 53};
+    } catch (...) {
+      return "Invalid master address";
+    }
+    override_master = true;
+  }
+
   DomainInfo di;
   UeberBackend B;
-  if(!B.getDomainInfo(domain, di))
-    return "Domain '"+domain.toString()+"' unknown";
-  
-  if(di.kind != DomainInfo::Slave || di.masters.empty())
+  if(!B.getDomainInfo(domain, di)) {
+    return " Domain '"+domain.toString()+"' unknown";
+  }
+
+  if (override_master) {
+    di.masters.clear();
+    di.masters.push_back(master_ip);
+  }
+
+  if(!override_master && (di.kind != DomainInfo::Slave || di.masters.empty()))
     return "Domain '"+domain.toString()+"' is not a slave domain (or has no master defined)";
 
   shuffle(di.masters.begin(), di.masters.end(), pdns::dns_random_engine());
   auto master = di.masters.front();
-  Communicator.addSuckRequest(domain, master);
+  Communicator.addSuckRequest(domain, master, override_master);
   g_log<<Logger::Warning<<"Retrieval request for domain '"<<domain<<"' from master '"<<master<<"' received from operator"<<endl;
   return "Added retrieval request for '"+domain.toLogString()+"' from master "+master.toLogString();
 }

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -586,7 +586,7 @@ int main(int argc, char **argv)
     DynListener::registerFunc("RESPSIZES", &DLRSizesHandler, "get histogram of response sizes");
     DynListener::registerFunc("REMOTES", &DLRemotesHandler, "get top remotes");
     DynListener::registerFunc("SET",&DLSettingsHandler, "set config variables", "<var> <value>");
-    DynListener::registerFunc("RETRIEVE",&DLNotifyRetrieveHandler, "retrieve slave domain", "<domain>");
+    DynListener::registerFunc("RETRIEVE",&DLNotifyRetrieveHandler, "retrieve slave domain", "<domain> [<ip>]");
     DynListener::registerFunc("CURRENT-CONFIG",&DLCurrentConfigHandler, "retrieve the current configuration", "[diff]");
     DynListener::registerFunc("LIST-ZONES",&DLListZones, "show list of zones", "[master|slave|native]");
     DynListener::registerFunc("TOKEN-LOGIN", &DLTokenLogin, "Login to a PKCS#11 token", "<module> <slot> <pin>");


### PR DESCRIPTION
### Short description
This patch allows using `pdns_control retrieve domain ip` to force retrieve the domain. This overrides all slave checks.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)