### PR TITLE
rec: Backport 8826 to rec 4.3.x: Refuse NSEC records with a bitmap length > 32

### DIFF
--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -110,15 +110,19 @@ void NSECBitmap::fromPacket(PacketReader& pr)
   }
   
   for(unsigned int n = 0; n+1 < bitmap.size();) {
-    unsigned int window=static_cast<unsigned char>(bitmap[n++]);
-    unsigned int blen=static_cast<unsigned char>(bitmap[n++]);
+    uint8_t window=static_cast<uint8_t>(bitmap[n++]);
+    uint8_t blen=static_cast<uint8_t>(bitmap[n++]);
 
     // end if zero padding and ensure packet length
-    if(window == 0 && blen == 0) {
+    if (window == 0 && blen == 0) {
       break;
     }
 
-    if(n + blen > bitmap.size()) {
+    if (blen > 32) {
+      throw MOADNSException("NSEC record with invalid bitmap length");
+    }
+
+    if (n + blen > bitmap.size()) {
       throw MOADNSException("NSEC record with bitmap length > packet length");
     }
 

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -488,6 +488,27 @@ BOOST_AUTO_TEST_CASE(test_nsec_records_types) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_nsec_invalid_bitmap_len) {
+  auto validNSEC = DNSRecordContent::mastermake(QType::NSEC, QClass::IN, "host.example.com. A MX RRSIG NSEC AAAA NSEC3 TYPE1234 TYPE65535");
+  const DNSName powerdnsName("powerdns.com.");
+
+  vector<uint8_t> packet;
+  DNSPacketWriter writer(packet, powerdnsName, QType::NSEC, QClass::IN, 0);
+  writer.getHeader()->qr = 1;
+  writer.startRecord(powerdnsName, QType::NSEC, 100, QClass::IN, DNSResourceRecord::ANSWER, false);
+  validNSEC->toPacket(writer);
+  writer.commit();
+
+  size_t nsecDataPos = sizeof(dnsheader) + powerdnsName.wirelength() + sizeof(uint16_t) + sizeof (uint16_t) + powerdnsName.wirelength() + sizeof(uint16_t) + sizeof (uint16_t) + sizeof(uint32_t) + sizeof(uint16_t);
+  size_t typeBitMapsFieldPos = nsecDataPos + DNSName("host.example.com.").wirelength();
+  auto invalidPacket = packet;
+  /* set the bitmap length value to 33, while the maximum possible value is 32 */
+  invalidPacket.at(typeBitMapsFieldPos + 1) = 33;
+
+  MOADNSParser parser(false, reinterpret_cast<const char*>(packet.data()), packet.size());
+  BOOST_CHECK_THROW(MOADNSParser failParser(false, reinterpret_cast<const char*>(invalidPacket.data()), invalidPacket.size()), MOADNSException);
+}
+
 BOOST_AUTO_TEST_CASE(test_nsec3_records_types) {
 
   {


### PR DESCRIPTION
(cherry picked from commit 3d51568b456205c9bd60ceeedb4b43af4a33f019)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
