### PR TITLE
dnsdist: DownstreamState::getName() should return a ref, not a temp

### DIFF
--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -111,8 +111,8 @@ void setupLuaBindings(bool client)
       }
       s.setAuto();
     });
-  g_lua.registerFunction("getName", &DownstreamState::getName);
-  g_lua.registerFunction("getNameWithAddr", &DownstreamState::getNameWithAddr);
+  g_lua.registerFunction<std::string(DownstreamState::*)()>("getName", [](const DownstreamState& s) { return s.getName(); });
+  g_lua.registerFunction<std::string(DownstreamState::*)()>("getNameWithAddr", [](const DownstreamState& s) { return s.getNameWithAddr(); });
   g_lua.registerMember("upStatus", &DownstreamState::upStatus);
   g_lua.registerMember<int (DownstreamState::*)>("weight",
     [](const DownstreamState& s) -> int {return s.weight;},

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -851,10 +851,10 @@ struct DownstreamState
   void setUp() { availability = Availability::Up; }
   void setDown() { availability = Availability::Down; }
   void setAuto() { availability = Availability::Auto; }
-  string getName() const {
+  const string& getName() const {
     return name;
   }
-  string getNameWithAddr() const {
+  const string& getNameWithAddr() const {
     return nameWithAddr;
   }
   void setName(const std::string& newName)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is required by the new FFI interface. 
Reported by Coverity.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
