### PR TITLE
auth LUA records: make sure weights are positive non-zero numbers

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -40,6 +40,15 @@ using wiplist_t = std::unordered_map<int, string>;
 using ipunitlist_t = vector<pair<int, iplist_t> >;
 using opts_t = std::unordered_map<string,string>;
 
+unsigned int pdns_stou_nonzero(const std::string& str, size_t * idx = 0, int base = 10)
+{
+  unsigned long result = pdns_stou(str, idx, base);
+  if (result == 0) {
+    throw std::out_of_range("number cannot be zero");
+  }
+  return result;
+}
+
 class IsUpOracle
 {
 private:
@@ -508,7 +517,7 @@ static vector<pair<int, ComboAddress> > convWIplist(std::unordered_map<int, wipl
   vector<pair<int,ComboAddress> > ret;
 
   for(const auto& i : src) {
-    ret.emplace_back(atoi(i.second.at(1).c_str()), ComboAddress(i.second.at(2)));
+    ret.emplace_back(pdns_stou_nonzero(i.second.at(1).c_str()), ComboAddress(i.second.at(2)));
   }
 
   return ret;
@@ -806,7 +815,7 @@ void setupLuaRecords()
       vector<pair<int,ComboAddress> > conv;
 
       for(auto& i : ips)
-        conv.emplace_back(atoi(i.second[1].c_str()), ComboAddress(i.second[2]));
+        conv.emplace_back(pdns_stou_nonzero(i.second[1].c_str()), ComboAddress(i.second[2]));
 
       return pickwhashed(s_lua_record_ctx->bestwho, conv).toString();
     });

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -55,6 +55,7 @@ none.ifportup                3600 IN LUA  A     "ifportup(8080, {{'192.168.42.21
 all.noneup.ifportup          3600 IN LUA  A     "ifportup(8080, {{'192.168.42.21', '192.168.21.42'}}, {{ backupSelector='all' }})"
 
 whashed.example.org.         3600 IN LUA  A     "pickwhashed({{ {{15, '1.2.3.4'}}, {{42, '4.3.2.1'}} }})"
+whashedzero.example.org.     3600 IN LUA  A     "pickwhashed({{ {{15, '1.2.3.4'}}, {{0, '4.3.2.1'}} }})"
 rand.example.org.            3600 IN LUA  A     "pickrandom({{'{prefix}.101', '{prefix}.102'}})"
 v6-bogus.rand.example.org.   3600 IN LUA  AAAA  "pickrandom({{'{prefix}.101', '{prefix}.102'}})"
 v6.rand.example.org.         3600 IN LUA  AAAA  "pickrandom({{'2001:db8:a0b:12f0::1', 'fe80::2a1:9bff:fe9b:f268'}})"
@@ -548,6 +549,16 @@ any              IN           TXT "hello there"
             res = self.sendUDPQuery(query)
             self.assertRcodeEqual(res, dns.rcode.NOERROR)
             self.assertRRsetInAnswer(res, first.answer[0])
+
+    def testWHashedZero(self):
+        """
+        Test that pickwhashed() does not accept zero weights
+        """
+
+        query = dns.message.make_query('whashedzero.example.org', 'A')
+
+        response = self.sendUDPQuery(query)
+        self.assertRcodeEqual(response, dns.rcode.SERVFAIL)
 
     def testTimeout(self):
         """


### PR DESCRIPTION
### Short description
Coverity reported that we let zero/negative numbers through. This PR prevents that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master