### PR TITLE
rec: backport 8864 to rec 4.1.x: Only log qname parsing errors when 'log-common-errors' is set

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1820,7 +1820,8 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
     }
   }
   catch(std::exception& e) {
-    L<<Logger::Error<<"Error processing or aging answer packet: "<<e.what()<<endl;
+    if(g_logCommonErrors)
+      L<<Logger::Error<<"Error processing or aging answer packet: "<<e.what()<<endl;
     return 0;
   }
 


### PR DESCRIPTION
(cherry picked from commit 4b4566e8d28ff3b18152213e8c8666aa643f8eb9)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
