### PR TITLE
Add 'queue full' metrics for our remote logger, log at debug only

### DIFF
--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -33,7 +33,6 @@
 
 #include <boost/variant.hpp>
 
-#include "bpf-filter.hh"
 #include "capabilities.hh"
 #include "circular_buffer.hh"
 #include "dnscrypt.hh"

--- a/pdns/fstrm_logger.cc
+++ b/pdns/fstrm_logger.cc
@@ -195,13 +195,15 @@ void FrameStreamLogger::queueData(const std::string& data)
 
   if (res == fstrm_res_success) {
     // Frame successfully queued.
+    ++d_framesSent;
   } else if (res == fstrm_res_again) {
     free(frame);
 #ifdef RECURSOR
-    g_log<<Logger::Warning<<"FrameStreamLogger: queue full, dropping."<<std::endl;
+    g_log<<Logger::Debug<<"FrameStreamLogger: queue full, dropping."<<std::endl;
 #else
-    warnlog("FrameStreamLogger: queue full, dropping.");
+    vinfolog("FrameStreamLogger: queue full, dropping.");
 #endif
+    ++d_queueFullDrops;
  } else {
     // Permanent failure.
     free(frame);
@@ -210,6 +212,7 @@ void FrameStreamLogger::queueData(const std::string& data)
 #else
     warnlog("FrameStreamLogger: submitting to queue failed.");
 #endif
+    ++d_permanentFailures;
   }
 }
 

--- a/pdns/fstrm_logger.hh
+++ b/pdns/fstrm_logger.hh
@@ -37,11 +37,11 @@ class FrameStreamLogger : public RemoteLoggerInterface, boost::noncopyable
 {
 public:
   FrameStreamLogger(int family, const std::string& address, bool connect, const std::unordered_map<string,unsigned>& options = std::unordered_map<string,unsigned>());
-  virtual ~FrameStreamLogger();
-  virtual void queueData(const std::string& data) override;
-  virtual std::string toString() const override
+  ~FrameStreamLogger();
+  void queueData(const std::string& data) override;
+  std::string toString() const override
   {
-    return "FrameStreamLogger to " + d_address;
+    return "FrameStreamLogger to " + d_address + " (" + std::to_string(d_framesSent) + " frames sent, " + std::to_string(d_queueFullDrops) + " dropped, " + std::to_string(d_permanentFailures) + " permanent failures)";
   }
 
 private:
@@ -57,6 +57,9 @@ private:
   struct fstrm_writer *d_writer{nullptr};
   struct fstrm_iothr_options *d_iothropt{nullptr};
   struct fstrm_iothr *d_iothr{nullptr};
+  std::atomic<uint64_t> d_framesSent{0};
+  std::atomic<uint64_t> d_queueFullDrops{0};
+  std::atomic<uint64_t> d_permanentFailures{0};
 
   void cleanup();
 };

--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -54,11 +54,13 @@ void CircularWriteBuffer::flush()
     throw std::runtime_error("EOF");
   }
   //  cout<<"Flushed "<<res<<" bytes out of " << total <<endl;
-  if((size_t)res == d_buffer.size())
+  if (static_cast<size_t>(res) == d_buffer.size()) {
     d_buffer.clear();
+  }
   else {
-    while(res--)
+    while(res--) {
       d_buffer.pop_front();
+    }
   }
 }
 
@@ -96,17 +98,18 @@ bool RemoteLogger::reconnect()
 void RemoteLogger::queueData(const std::string& data)
 {
   if(!d_writer) {
-    d_drops++;
+    ++d_drops;
     return;
   }
   std::unique_lock<std::mutex> lock(d_mutex);
   if(d_writer) {
     try {
       d_writer->write(data);
+      ++d_queued;
     }
-    catch(std::exception& e) {
+    catch(const std::exception& e) {
       //      cout << "Got exception writing: "<<e.what()<<endl;
-      d_drops++;
+      ++d_drops;
       d_writer.reset();
       close(d_socket);
       d_socket = -1;
@@ -151,7 +154,7 @@ try
     sleep(d_reconnectWaitTime);
   }
 }
-catch(std::exception& e)
+catch(const std::exception& e)
 {
   cerr<<"Thead died on: "<<e.what()<<endl;
 }

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -89,22 +89,23 @@ public:
   void queueData(const std::string& data) override;
   std::string toString() const override
   {
-    return d_remote.toStringWithPort();
+    return d_remote.toStringWithPort() + " (" + std::to_string(d_queued) + " queued, " + std::to_string(d_drops) + " dropped)";
   }
   void stop()
   {
     d_exiting = true;
   }
-  std::atomic<uint32_t> d_drops{0};
 
 private:
   bool reconnect();
   void maintenanceThread();
 
+  std::unique_ptr<CircularWriteBuffer> d_writer;
   ComboAddress d_remote;
+  std::atomic<uint64_t> d_drops{0};
+  std::atomic<uint64_t> d_queued{0};
   uint64_t d_maxQueuedBytes;
   int d_socket{-1};
-  std::unique_ptr<CircularWriteBuffer> d_writer;
   uint16_t d_timeout;
   uint8_t d_reconnectWaitTime;
   std::atomic<bool> d_exiting{false};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fixes #8629. 
Note that the metrics are accessible from the RemoteLogger object in dnsdist but not in the recursor. It's still an improvement to stop flooding the logs!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

