### PR TITLE
Better handling of reconnections in Remote Logger (dnsdist, rec)

### DIFF
--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -31,6 +31,7 @@
 
 #include "iputils.hh"
 #include "circular_buffer.hh"
+#include "sstuff.hh"
 
 /* Writes can be submitted and they are atomically accepted. Either the whole write
    ends up in the buffer or nothing ends up in the buffer.
@@ -45,14 +46,14 @@
 class CircularWriteBuffer
 {
 public:
-  explicit CircularWriteBuffer(int fd, size_t size) : d_fd(fd), d_buffer(size)
+  explicit CircularWriteBuffer(size_t size) : d_buffer(size)
   {
   }
 
-  void write(const std::string& str);
-  void flush();
+  bool hasRoomFor(const std::string& str) const;
+  bool write(const std::string& str);
+  bool flush(int fd);
 private:
-  int d_fd;
   boost::circular_buffer<char> d_buffer;
 };
 
@@ -100,12 +101,12 @@ private:
   bool reconnect();
   void maintenanceThread();
 
-  std::unique_ptr<CircularWriteBuffer> d_writer;
+  CircularWriteBuffer d_writer;
   ComboAddress d_remote;
   std::atomic<uint64_t> d_drops{0};
   std::atomic<uint64_t> d_queued{0};
   uint64_t d_maxQueuedBytes;
-  int d_socket{-1};
+  std::unique_ptr<Socket> d_socket{nullptr};
   uint16_t d_timeout;
   uint8_t d_reconnectWaitTime;
   std::atomic<bool> d_exiting{false};

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -105,7 +105,6 @@ private:
   ComboAddress d_remote;
   std::atomic<uint64_t> d_drops{0};
   std::atomic<uint64_t> d_queued{0};
-  uint64_t d_maxQueuedBytes;
   std::unique_ptr<Socket> d_socket{nullptr};
   uint16_t d_timeout;
   uint8_t d_reconnectWaitTime;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Do not lock while trying to reconnect ;
- Try to reconnect right away if the disconnection was detected in the maintenance thread ;
- Keep queueing messages when the connection has been lost, until the buffer gets full.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

