### PR TITLE
Add a new endpoint to the api to find existing subzones for a zone

### DIFF
--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -159,7 +159,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=?");
     declare(suffix, "search-records-query", "", record_query+" name LIKE ? OR content LIKE ? LIMIT ?");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE ? OR comment LIKE ? LIMIT ?");
-    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE ?");
+    declare(suffix, "list-sub-domains-query", "", "SELECT id,name FROM domains WHERE name LIKE ?");
   }
 
   DNSBackend *make(const string &suffix="") override

--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -159,6 +159,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=?");
     declare(suffix, "search-records-query", "", record_query+" name LIKE ? OR content LIKE ? LIMIT ?");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE ? OR comment LIKE ? LIMIT ?");
+    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE ?");
   }
 
   DNSBackend *make(const string &suffix="") override

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -146,7 +146,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=?");
     declare(suffix, "search-records-query", "", record_query+" name LIKE ? OR content LIKE ? LIMIT ?");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE ? OR comment LIKE ? LIMIT ?");
-    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE ?");
+    declare(suffix, "list-sub-domains-query", "", "SELECT id,name FROM domains WHERE name LIKE ?");
   }
 
   //! Constructs a new gODBCBackend object.

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -146,6 +146,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=?");
     declare(suffix, "search-records-query", "", record_query+" name LIKE ? OR content LIKE ? LIMIT ?");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE ? OR comment LIKE ? LIMIT ?");
+    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE ?");
   }
 
   //! Constructs a new gODBCBackend object.

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -166,7 +166,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=$1");
     declare(suffix, "search-records-query", "", record_query+" name LIKE $1 OR content LIKE $2 LIMIT $3");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE $1 OR comment LIKE $2 LIMIT $3");
-    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE $1");
+    declare(suffix, "list-sub-domains-query", "", "SELECT id,name FROM domains WHERE name LIKE $1");
 
   }
 

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -166,6 +166,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=$1");
     declare(suffix, "search-records-query", "", record_query+" name LIKE $1 OR content LIKE $2 LIMIT $3");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE $1 OR comment LIKE $2 LIMIT $3");
+    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE $1");
 
   }
 

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -155,6 +155,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=:domain_id");
     declare(suffix, "search-records-query", "", record_query+" name LIKE :value OR content LIKE :value2 LIMIT :limit");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE :value OR comment LIKE :value2 LIMIT :limit");
+    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE :value");
   }
 
   //! Constructs a new gSQLite3Backend object.

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -155,7 +155,7 @@ public:
     declare(suffix, "delete-comments-query", "", "DELETE FROM comments WHERE domain_id=:domain_id");
     declare(suffix, "search-records-query", "", record_query+" name LIKE :value OR content LIKE :value2 LIMIT :limit");
     declare(suffix, "search-comments-query", "", "SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE :value OR comment LIKE :value2 LIMIT :limit");
-    declare(suffix, "get-sub-zones-query", "", "SELECT id,name FROM domains WHERE name LIKE :value");
+    declare(suffix, "list-sub-domains-query", "", "SELECT id,name FROM domains WHERE name LIKE :value");
   }
 
   //! Constructs a new gSQLite3Backend object.

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -933,12 +933,12 @@ bool RemoteBackend::searchComments(const string &pattern, int maxResults, vector
   return false;
 }
 
-bool RemoteBackend::getSubZones(const string &pattern, vector<std::tuple<string, string>>& result)
+bool RemoteBackend::getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result)
 {
     Json query = Json::object{
     { "method", "getSubZones" },
     { "parameters", Json::object{
-      { "pattern", pattern }
+      { "zoneName", zoneName }
     }}
   };
 

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -933,12 +933,12 @@ bool RemoteBackend::searchComments(const string &pattern, int maxResults, vector
   return false;
 }
 
-bool RemoteBackend::getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result)
+bool RemoteBackend::listSubDomains(const DNSName &parent_zone, vector<std::tuple<uint32_t, string>>& result)
 {
     Json query = Json::object{
     { "method", "getSubZones" },
     { "parameters", Json::object{
-      { "zoneName", zoneName }
+      { "parent_zone", parent_zone.toStringNoDot() }
     }}
   };
 
@@ -950,7 +950,7 @@ bool RemoteBackend::getSubZones(const string &zoneName, vector<std::tuple<string
     return false;
   
   for(const auto& row: answer["result"].array_items()) {
-    result.push_back(std::tuple<string, string>{stringFromJson(row, "zone_id"), stringFromJson(row, "name")});
+    result.push_back(std::tuple<uint32_t, string>{intFromJson(row, "zone_id"), stringFromJson(row, "name")});
   }
   return true;
 }

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -933,6 +933,28 @@ bool RemoteBackend::searchComments(const string &pattern, int maxResults, vector
   return false;
 }
 
+bool RemoteBackend::getSubZones(const string &pattern, vector<std::tuple<string, string>>& result)
+{
+    Json query = Json::object{
+    { "method", "getSubZones" },
+    { "parameters", Json::object{
+      { "pattern", pattern }
+    }}
+  };
+
+  Json answer;
+  if (this->send(query) == false || this->recv(answer) == false)
+    return false;
+
+  if (answer["result"].is_array() == false)
+    return false;
+  
+  for(const auto& row: answer["result"].array_items()) {
+    result.push_back(std::tuple<string, string>{stringFromJson(row, "zone_id"), stringFromJson(row, "name")});
+  }
+  return true;
+}
+
 void RemoteBackend::getAllDomains(vector<DomainInfo> *domains, bool include_disabled)
 {
   Json query = Json::object{

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -188,7 +188,7 @@ class RemoteBackend : public DNSBackend
   string directBackendCmd(const string& querystr) override;
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
-  bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result) override;
+  bool getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;
   void getUpdatedMasters(vector<DomainInfo>* domains) override;
   void alsoNotifies(const DNSName &domain, set<string> *ips) override;

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -188,7 +188,7 @@ class RemoteBackend : public DNSBackend
   string directBackendCmd(const string& querystr) override;
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
-  bool getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result) override;
+  bool listSubDomains(const DNSName &parent_zone, vector<std::tuple<uint32_t, string>>& result) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;
   void getUpdatedMasters(vector<DomainInfo>* domains) override;
   void alsoNotifies(const DNSName &domain, set<string> *ips) override;

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -188,6 +188,7 @@ class RemoteBackend : public DNSBackend
   string directBackendCmd(const string& querystr) override;
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
+  bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result) override;
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;
   void getUpdatedMasters(vector<DomainInfo>* domains) override;
   void alsoNotifies(const DNSName &domain, set<string> *ips) override;

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1832,10 +1832,10 @@ bool GSQLBackend::searchComments(const string &pattern, int maxResults, vector<C
   return false;
 }
 
-bool GSQLBackend::getSubZones(const string &pattern, vector<std::tuple<string, string>>& result)
+bool GSQLBackend::getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result)
 {
   d_qname.clear();
-  string escaped_pattern = "%." +pattern2SQLPattern(pattern);
+  string escaped_pattern = "%." +pattern2SQLPattern(zoneName);
   try {
     reconnectIfNeeded();
 
@@ -1858,7 +1858,7 @@ bool GSQLBackend::getSubZones(const string &pattern, vector<std::tuple<string, s
     return true;
   }
   catch (SSqlException &e) {
-    throw PDNSException("GSQLBackend unable to search for subzones with pattern '" + pattern + "' (escaped pattern '" + escaped_pattern + "'): "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to search for subzones for zone '" + zoneName + "' (escaped pattern '" + escaped_pattern + "'): "+e.txtReason());
   }
 
   return false;

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -123,6 +123,7 @@ GSQLBackend::GSQLBackend(const string &mode, const string &suffix)
 
   d_SearchRecordsQuery = getArg("search-records-query");
   d_SearchCommentsQuery = getArg("search-comments-query");
+  d_GetSubZonesQuery = getArg("get-sub-zones-query");
 
   d_query_stmt = NULL;
   d_NoIdQuery_stmt = NULL;
@@ -184,6 +185,7 @@ GSQLBackend::GSQLBackend(const string &mode, const string &suffix)
   d_DeleteCommentsQuery_stmt = NULL;
   d_SearchRecordsQuery_stmt = NULL;
   d_SearchCommentsQuery_stmt = NULL;
+  d_GetSubZonesQuery_stmt = NULL;
 }
 
 void GSQLBackend::setNotified(uint32_t domain_id, uint32_t serial)
@@ -1830,6 +1832,38 @@ bool GSQLBackend::searchComments(const string &pattern, int maxResults, vector<C
   return false;
 }
 
+bool GSQLBackend::getSubZones(const string &pattern, vector<std::tuple<string, string>>& result)
+{
+  d_qname.clear();
+  string escaped_pattern = "%." +pattern2SQLPattern(pattern);
+  try {
+    reconnectIfNeeded();
+
+    d_GetSubZonesQuery_stmt->
+      bind("value", escaped_pattern)->
+      execute();
+
+    while(d_GetSubZonesQuery_stmt->hasNextRow())
+    {
+      SSqlStatement::row_t row;
+      std::tuple<string, string> z;
+      d_GetSubZonesQuery_stmt->nextRow(row);
+      ASSERT_ROW_COLUMNS("get-sub-zones-query", row, 2);
+      extractZoneReference(row, z);
+      result.push_back(z);
+    }
+
+    d_GetSubZonesQuery_stmt->reset();
+
+    return true;
+  }
+  catch (SSqlException &e) {
+    throw PDNSException("GSQLBackend unable to search for subzones with pattern '" + pattern + "' (escaped pattern '" + escaped_pattern + "'): "+e.txtReason());
+  }
+
+  return false;
+}
+
 void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)
 {
   static const int defaultTTL = ::arg().asNum( "default-ttl" );
@@ -1874,6 +1908,11 @@ void GSQLBackend::extractComment(SSqlStatement::row_t& row, Comment& comment)
   comment.modified_at = pdns_stou(row[3]);
   comment.account = std::move(row[4]);
   comment.content = std::move(row[5]);
+}
+
+void GSQLBackend::extractZoneReference(const SSqlStatement::row_t& row, std::tuple<string, string>& reference)
+{
+  reference = std::tuple<string, string>{row[0], row[1]};
 }
 
 SSqlStatement::~SSqlStatement() { 

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -228,7 +228,7 @@ public:
   bool deactivateDomainKey(const DNSName& name, unsigned int id) override;
   bool publishDomainKey(const DNSName& name, unsigned int id) override;
   bool unpublishDomainKey(const DNSName& name, unsigned int id) override;
-  
+
   bool getTSIGKey(const DNSName& name, DNSName* algorithm, string* content) override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
   bool deleteTSIGKey(const DNSName& name) override;
@@ -241,7 +241,7 @@ public:
   string directBackendCmd(const string &query) override;
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
-  bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result) override;
+  bool getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result) override;
 
 protected:
   string pattern2SQLPattern(const string& pattern);

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -115,6 +115,7 @@ protected:
       d_DeleteCommentsQuery_stmt = d_db->prepare(d_DeleteCommentsQuery, 1);
       d_SearchRecordsQuery_stmt = d_db->prepare(d_SearchRecordsQuery, 3);
       d_SearchCommentsQuery_stmt = d_db->prepare(d_SearchCommentsQuery, 3);
+      d_GetSubZonesQuery_stmt = d_db->prepare(d_GetSubZonesQuery, 1);
     }
   }
 
@@ -179,6 +180,7 @@ protected:
     d_DeleteCommentsQuery_stmt.reset();
     d_SearchRecordsQuery_stmt.reset();
     d_SearchCommentsQuery_stmt.reset();
+    d_GetSubZonesQuery_stmt.reset();
   }
 
 public:
@@ -239,11 +241,13 @@ public:
   string directBackendCmd(const string &query) override;
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
+  bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result) override;
 
 protected:
   string pattern2SQLPattern(const string& pattern);
   void extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& rr);
   void extractComment(SSqlStatement::row_t& row, Comment& c);
+  void extractZoneReference(SSqlStatement::row_t& row, std::tuple<string, string>& reference);
   bool isConnectionUsable() {
     if (d_db) {
       return d_db->isConnectionUsable();
@@ -344,6 +348,7 @@ private:
 
   string d_SearchRecordsQuery;
   string d_SearchCommentsQuery;
+  string d_GetSubZonesQuery;
 
 
   unique_ptr<SSqlStatement> d_NoIdQuery_stmt;
@@ -406,6 +411,7 @@ private:
   unique_ptr<SSqlStatement> d_DeleteCommentsQuery_stmt;
   unique_ptr<SSqlStatement> d_SearchRecordsQuery_stmt;
   unique_ptr<SSqlStatement> d_SearchCommentsQuery_stmt;
+  unique_ptr<SSqlStatement> d_GetSubZonesQuery_stmt;
 
 protected:
   std::unique_ptr<SSql> d_db{nullptr};

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -60,7 +60,7 @@ protected:
       d_ANYNoIdQuery_stmt = d_db->prepare(d_ANYNoIdQuery, 1);
       d_ANYIdQuery_stmt = d_db->prepare(d_ANYIdQuery, 2);
       d_listQuery_stmt = d_db->prepare(d_listQuery, 2);
-      d_listSubZoneQuery_stmt = d_db->prepare(d_listSubZoneQuery, 3);
+      d_ListSubDomainQuery_stmt = d_db->prepare(d_ListSubDomainQuery, 3);
       d_MasterOfDomainsZoneQuery_stmt = d_db->prepare(d_MasterOfDomainsZoneQuery, 1);
       d_InfoOfDomainsZoneQuery_stmt = d_db->prepare(d_InfoOfDomainsZoneQuery, 1);
       d_InfoOfAllSlaveDomainsQuery_stmt = d_db->prepare(d_InfoOfAllSlaveDomainsQuery, 0);
@@ -115,7 +115,7 @@ protected:
       d_DeleteCommentsQuery_stmt = d_db->prepare(d_DeleteCommentsQuery, 1);
       d_SearchRecordsQuery_stmt = d_db->prepare(d_SearchRecordsQuery, 3);
       d_SearchCommentsQuery_stmt = d_db->prepare(d_SearchCommentsQuery, 3);
-      d_GetSubZonesQuery_stmt = d_db->prepare(d_GetSubZonesQuery, 1);
+      d_ListSubDomainsQuery_stmt = d_db->prepare(d_ListSubDomainsQuery, 1);
     }
   }
 
@@ -125,7 +125,7 @@ protected:
     d_ANYNoIdQuery_stmt.reset();
     d_ANYIdQuery_stmt.reset();
     d_listQuery_stmt.reset();
-    d_listSubZoneQuery_stmt.reset();
+    d_ListSubDomainQuery_stmt.reset();
     d_MasterOfDomainsZoneQuery_stmt.reset();
     d_InfoOfDomainsZoneQuery_stmt.reset();
     d_InfoOfAllSlaveDomainsQuery_stmt.reset();
@@ -180,7 +180,7 @@ protected:
     d_DeleteCommentsQuery_stmt.reset();
     d_SearchRecordsQuery_stmt.reset();
     d_SearchCommentsQuery_stmt.reset();
-    d_GetSubZonesQuery_stmt.reset();
+    d_ListSubDomainsQuery_stmt.reset();
   }
 
 public:
@@ -241,13 +241,12 @@ public:
   string directBackendCmd(const string &query) override;
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result) override;
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result) override;
-  bool getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result) override;
+  bool listSubDomains(const DNSName &parent_zone, vector<std::tuple<uint32_t, string>>& result) override;
 
 protected:
   string pattern2SQLPattern(const string& pattern);
   void extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& rr);
   void extractComment(SSqlStatement::row_t& row, Comment& c);
-  void extractZoneReference(SSqlStatement::row_t& row, std::tuple<string, string>& reference);
   bool isConnectionUsable() {
     if (d_db) {
       return d_db->isConnectionUsable();
@@ -280,7 +279,7 @@ private:
   string d_ANYIdQuery;
 
   string d_listQuery;
-  string d_listSubZoneQuery;
+  string d_ListSubDomainQuery;
   string d_logprefix;
 
   string d_MasterOfDomainsZoneQuery;
@@ -348,7 +347,7 @@ private:
 
   string d_SearchRecordsQuery;
   string d_SearchCommentsQuery;
-  string d_GetSubZonesQuery;
+  string d_ListSubDomainsQuery;
 
 
   unique_ptr<SSqlStatement> d_NoIdQuery_stmt;
@@ -356,7 +355,7 @@ private:
   unique_ptr<SSqlStatement> d_ANYNoIdQuery_stmt;
   unique_ptr<SSqlStatement> d_ANYIdQuery_stmt;
   unique_ptr<SSqlStatement> d_listQuery_stmt;
-  unique_ptr<SSqlStatement> d_listSubZoneQuery_stmt;
+  unique_ptr<SSqlStatement> d_ListSubDomainQuery_stmt;
   unique_ptr<SSqlStatement> d_MasterOfDomainsZoneQuery_stmt;
   unique_ptr<SSqlStatement> d_InfoOfDomainsZoneQuery_stmt;
   unique_ptr<SSqlStatement> d_InfoOfAllSlaveDomainsQuery_stmt;
@@ -411,7 +410,7 @@ private:
   unique_ptr<SSqlStatement> d_DeleteCommentsQuery_stmt;
   unique_ptr<SSqlStatement> d_SearchRecordsQuery_stmt;
   unique_ptr<SSqlStatement> d_SearchCommentsQuery_stmt;
-  unique_ptr<SSqlStatement> d_GetSubZonesQuery_stmt;
+  unique_ptr<SSqlStatement> d_ListSubDomainsQuery_stmt;
 
 protected:
   std::unique_ptr<SSql> d_db{nullptr};

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -384,7 +384,7 @@ public:
   }
 
   //! Return subzones for a zone, returns true if search was done successfully.
-  virtual bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result)
+  virtual bool getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result)
   {
     return false;
   }

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -383,6 +383,12 @@ public:
     return false;
   }
 
+  //! Return subzones for a zone, returns true if search was done successfully.
+  virtual bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result)
+  {
+    return false;
+  }
+
   const string& getPrefix() { return d_prefix; };
 protected:
   bool mustDo(const string &key);

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -384,7 +384,7 @@ public:
   }
 
   //! Return subzones for a zone, returns true if search was done successfully.
-  virtual bool getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result)
+  virtual bool listSubDomains(const DNSName &parent_zone, vector<std::tuple<uint32_t, string>>& result)
   {
     return false;
   }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -681,11 +681,11 @@ bool UeberBackend::searchComments(const string& pattern, int maxResults, vector<
   return rc;
 }
 
-bool UeberBackend::getSubZones(const string& zoneName, vector<std::tuple<string, string>>& result)
+bool UeberBackend::listSubDomains(const DNSName &parent_zone,  vector<std::tuple<uint32_t, string>>& result)
 {
   bool rc = false;
   for ( vector< DNSBackend * >::iterator i = backends.begin(); i != backends.end(); ++i )
-    if ((*i)->getSubZones(zoneName, result)) rc = true;
+    if ((*i)->listSubDomains(parent_zone, result)) rc = true;
   return rc;
 }
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -681,6 +681,14 @@ bool UeberBackend::searchComments(const string& pattern, int maxResults, vector<
   return rc;
 }
 
+bool UeberBackend::getSubZones(const string& pattern, vector<std::tuple<string, string>>& result)
+{
+  bool rc = false;
+  for ( vector< DNSBackend * >::iterator i = backends.begin(); i != backends.end(); ++i )
+    if ((*i)->getSubZones(pattern, result)) rc = true;
+  return rc;
+}
+
 AtomicCounter UeberBackend::handle::instances(0);
 
 UeberBackend::handle::handle()

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -681,11 +681,11 @@ bool UeberBackend::searchComments(const string& pattern, int maxResults, vector<
   return rc;
 }
 
-bool UeberBackend::getSubZones(const string& pattern, vector<std::tuple<string, string>>& result)
+bool UeberBackend::getSubZones(const string& zoneName, vector<std::tuple<string, string>>& result)
 {
   bool rc = false;
   for ( vector< DNSBackend * >::iterator i = backends.begin(); i != backends.end(); ++i )
-    if ((*i)->getSubZones(pattern, result)) rc = true;
+    if ((*i)->getSubZones(zoneName, result)) rc = true;
   return rc;
 }
 

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -131,6 +131,7 @@ public:
   void reload();
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result);
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result);
+  bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result);
 private:
   handle d_handle;
   vector<DNSZoneRecord> d_answers;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -131,7 +131,7 @@ public:
   void reload();
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result);
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result);
-  bool getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result);
+  bool listSubDomains(const DNSName &parent_zone, vector<std::tuple<uint32_t, string>>& result);
 private:
   handle d_handle;
   vector<DNSZoneRecord> d_answers;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -131,7 +131,7 @@ public:
   void reload();
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result);
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result);
-  bool getSubZones(const string &pattern, vector<std::tuple<string, string>>& result);
+  bool getSubZones(const string &zoneName, vector<std::tuple<string, string>>& result);
 private:
   handle d_handle;
   vector<DNSZoneRecord> d_answers;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2291,16 +2291,16 @@ static void apiServerSubZones(HttpRequest* req, HttpResponse* resp) {
   if(req->method != "GET")
     throw HttpMethodNotAllowedException();
 
-  DNSName zoneName = apiZoneIdToName(req->parameters["id"]);
+  DNSName parent_zone = apiZoneIdToName(req->parameters["id"]);
   Json::array doc;
-  vector<std::tuple<string, string>> subZoneResult;
+  vector<std::tuple<uint32_t, string>> subZoneResult;
   UeberBackend B;
-  B.getSubZones(zoneName.toStringNoDot(), subZoneResult);
-  for(const std::tuple<string, string> &z: subZoneResult)
+  B.listSubDomains(parent_zone, subZoneResult);
+  for(const std::tuple<uint32_t, string> &z: subZoneResult)
   {
     auto object = Json::object {
         { "object_type", "subzone" },
-        { "zone_id", std::get<0>(z) },
+        { "zone_id",  std::to_string(std::get<0>(z)) },
         { "name", std::get<1>(z) }
       };
     doc.push_back(object);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2291,11 +2291,11 @@ static void apiServerSubZones(HttpRequest* req, HttpResponse* resp) {
   if(req->method != "GET")
     throw HttpMethodNotAllowedException();
 
-  DNSName zonename = apiZoneIdToName(req->parameters["id"]);
+  DNSName zoneName = apiZoneIdToName(req->parameters["id"]);
   Json::array doc;
   vector<std::tuple<string, string>> subZoneResult;
   UeberBackend B;
-  B.getSubZones(zonename.toStringNoDot(), subZoneResult);
+  B.getSubZones(zoneName.toStringNoDot(), subZoneResult);
   for(const std::tuple<string, string> &z: subZoneResult)
   {
     auto object = Json::object {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -2081,6 +2081,20 @@ $ORIGIN %NAME%
         self.assertEquals(r.status_code, 422)
         self.assertIn('A TSIG key with the name', r.json()['error'])
 
+    def test_get_subzones(self):
+        name = unique_zone_name()
+        self.create_zone(name=name)
+        self.create_zone(name='subdomain.'+name)
+        self.create_zone(name='subdomain2.'+name)
+        other_zone_name = unique_zone_name()
+        self.create_zone(name=other_zone_name)
+        r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name + "/sub-zones"))
+        self.assert_success_json(r)
+        self.assertEquals(len(r.json()), 2)
+        self.assertIn('subdomain', str(r.json()))
+        self.assertIn('subdomain2', str(r.json()))
+        self.assertNotIn(other_zone_name, str(r.json()))
+
 
 @unittest.skipIf(not is_auth(), "Not applicable")
 class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):


### PR DESCRIPTION
### Short description
This PR adds a new endpoint /zones/<id>/sub-zones, which provides a fast search for the names and zone ids for all existing subdomain zones for a selected zone.
This should resolve issue PowerDNS#8841

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)