### PR TITLE
rec: Implement EDNS0 padding (rfc7830) for outgoing responses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1269,6 +1269,7 @@ jobs:
         environment:
           UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1'
           ASAN_OPTIONS: detect_leaks=0
+          SKIP_IPV6_TESTS: y
     steps:
       - add-auth-repo
       - run: apt-get --no-install-recommends install -qq -y pdns-server pdns-backend-bind pdns-tools daemontools authbind jq libfaketime lua-posix lua-socket moreutils bc python3-venv protobuf-compiler

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -451,7 +451,7 @@ template <typename Container> void GenericDNSPacketWriter<Container>::getRecordP
   records.assign(d_content.begin() + d_sor, d_content.end());
 }
 
-template <typename Container> uint32_t GenericDNSPacketWriter<Container>::size()
+template <typename Container> uint32_t GenericDNSPacketWriter<Container>::size() const
 {
   return d_content.size();
 }
@@ -495,8 +495,18 @@ template <typename Container> void GenericDNSPacketWriter<Container>::commit()
 
 }
 
+template <typename Container> size_t GenericDNSPacketWriter<Container>::getSizeWithOpts(const optvect_t& options) const
+{
+  size_t result = size() + /* root */ 1 + DNS_TYPE_SIZE + DNS_CLASS_SIZE + DNS_TTL_SIZE + DNS_RDLENGTH_SIZE;
+
+  for(auto const &option : options) {
+    result += 4;
+    result += option.second.size();
+  }
+
+  return result;
+}
+
 template class GenericDNSPacketWriter<std::vector<uint8_t>>;
 #include "noinitvector.hh"
 template class GenericDNSPacketWriter<PacketBuffer>;
-
-

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -77,7 +77,7 @@ public:
    */
   void commit();
 
-  uint32_t size(); // needs to be 32 bit because otherwise we don't see the wrap coming when it happened!
+  uint32_t size() const; // needs to be 32 bit because otherwise we don't see the wrap coming when it happened!
 
   /** Should the packet have grown too big for the writer's liking, rollback removes the record currently being written */
   void rollback();
@@ -155,6 +155,9 @@ public:
   const string getRemaining() const {
     return "";
   }
+
+  size_t getSizeWithOpts(const optvect_t& options) const;
+
 private:
   uint16_t lookupName(const DNSName& name, uint16_t* matchlen);
   vector<uint16_t> d_namepositions;

--- a/pdns/ednspadding.cc
+++ b/pdns/ednspadding.cc
@@ -1,0 +1,31 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "ednspadding.hh"
+
+std::string makeEDNSPaddingOptString(size_t bytes)
+{
+  std::string ret;
+  ret.resize(bytes, '0');
+  return ret;
+}
+

--- a/pdns/ednspadding.cc
+++ b/pdns/ednspadding.cc
@@ -25,7 +25,7 @@
 std::string makeEDNSPaddingOptString(size_t bytes)
 {
   std::string ret;
-  ret.resize(bytes, '0');
+  ret.resize(bytes, 0);
   return ret;
 }
 

--- a/pdns/ednspadding.hh
+++ b/pdns/ednspadding.hh
@@ -1,0 +1,26 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <string>
+
+std::string makeEDNSPaddingOptString(size_t bytes);

--- a/pdns/lua-recursor4-ffi.hh
+++ b/pdns/lua-recursor4-ffi.hh
@@ -82,4 +82,6 @@ extern "C" {
   /* returns true if the record was correctly added, false if something went wrong.
      Passing a NULL pointer to 'name' will result in the qname being used for the record owner name. */
   bool pdns_ffi_param_add_record(pdns_ffi_param_t *ref, const char* name, uint16_t type, uint32_t ttl, const char* content, size_t contentSize, pdns_record_place_t place) __attribute__ ((visibility ("default")));
+
+  void pdns_ffi_param_set_padding_disabled(pdns_ffi_param_t* ref, bool disabled)  __attribute__ ((visibility ("default")));
 }

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -164,6 +164,7 @@ void RecursorLua4::postPrepareContext()
   d_lw->registerMember<bool (DNSQuestion::*)>("variable", [](const DNSQuestion& dq) -> bool { return dq.variable; }, [](DNSQuestion& dq, bool newVariable) { dq.variable = newVariable; });
   d_lw->registerMember<bool (DNSQuestion::*)>("wantsRPZ", [](const DNSQuestion& dq) -> bool { return dq.wantsRPZ; }, [](DNSQuestion& dq, bool newWantsRPZ) { dq.wantsRPZ = newWantsRPZ; });
   d_lw->registerMember<bool (DNSQuestion::*)>("logResponse", [](const DNSQuestion& dq) -> bool { return dq.logResponse; }, [](DNSQuestion& dq, bool newLogResponse) { dq.logResponse = newLogResponse; });
+  d_lw->registerMember<bool (DNSQuestion::*)>("addPaddingToResponse", [](const DNSQuestion& dq) -> bool { return dq.addPaddingToResponse; }, [](DNSQuestion& dq, bool add) { dq.addPaddingToResponse = add; });
 
   d_lw->registerMember("rcode", &DNSQuestion::rcode);
   d_lw->registerMember("tag", &DNSQuestion::tag);
@@ -525,7 +526,8 @@ bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& reque
   bool variableAnswer = false;
   bool wantsRPZ = false;
   bool logQuery = false;
-  RecursorLua4::DNSQuestion dq(ns, requestor, query, qtype.getCode(), isTcp, variableAnswer, wantsRPZ, logQuery);
+  bool addPaddingToResponse = false;
+  RecursorLua4::DNSQuestion dq(ns, requestor, query, qtype.getCode(), isTcp, variableAnswer, wantsRPZ, logQuery, addPaddingToResponse);
   dq.currentRecords = &res;
 
   return genhook(d_preoutquery, dq, ret);
@@ -967,4 +969,9 @@ bool pdns_ffi_param_add_record(pdns_ffi_param_t *ref, const char* name, uint16_t
     g_log<<Logger::Error<<"Error attempting to add a record from Lua via pdns_ffi_param_add_record(): "<<e.what()<<endl;
     return false;
   }
+}
+
+void pdns_ffi_param_set_padding_disabled(pdns_ffi_param_t* ref, bool disabled)
+{
+  ref->params.disablePadding = disabled;
 }

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -62,7 +62,7 @@ public:
 
   struct DNSQuestion
   {
-    DNSQuestion(const ComboAddress& rem, const ComboAddress& loc, const DNSName& query, uint16_t type, bool tcp, bool& variable_, bool& wantsRPZ_, bool& logResponse_): qname(query), qtype(type), local(loc), remote(rem), isTcp(tcp), variable(variable_), wantsRPZ(wantsRPZ_), logResponse(logResponse_)
+    DNSQuestion(const ComboAddress& rem, const ComboAddress& loc, const DNSName& query, uint16_t type, bool tcp, bool& variable_, bool& wantsRPZ_, bool& logResponse_, bool& addPaddingToResponse_): qname(query), qtype(type), local(loc), remote(rem), isTcp(tcp), variable(variable_), wantsRPZ(wantsRPZ_), logResponse(logResponse_), addPaddingToResponse(addPaddingToResponse_)
     {
     }
     const DNSName& qname;
@@ -87,6 +87,7 @@ public:
     bool& variable;
     bool& wantsRPZ;
     bool& logResponse;
+    bool& addPaddingToResponse;
     unsigned int tag{0};
 
     void addAnswer(uint16_t type, const std::string& content, boost::optional<int> ttl, boost::optional<string> name);
@@ -134,7 +135,7 @@ public:
   struct FFIParams
   {
   public:
-    FFIParams(const DNSName& qname_, uint16_t qtype_, const ComboAddress& local_, const ComboAddress& remote_, const Netmask& ednssubnet_, LuaContext::LuaObject& data_, std::unordered_set<std::string>& policyTags_, std::vector<DNSRecord>& records_, const EDNSOptionViewMap& ednsOptions_, const std::vector<ProxyProtocolValue>& proxyProtocolValues_, std::string& requestorId_, std::string& deviceId_, std::string& deviceName_, std::string& routingTag_, boost::optional<int>& rcode_, uint32_t& ttlCap_, bool& variable_, bool tcp_, bool& logQuery_, bool& logResponse_, bool& followCNAMERecords_, boost::optional<uint16_t>& extendedErrorCode_, std::string& extendedErrorExtra_): data(data_), qname(qname_), local(local_), remote(remote_), ednssubnet(ednssubnet_), policyTags(policyTags_), records(records_), ednsOptions(ednsOptions_), proxyProtocolValues(proxyProtocolValues_), requestorId(requestorId_), deviceId(deviceId_), deviceName(deviceName_), routingTag(routingTag_), extendedErrorExtra(extendedErrorExtra_), rcode(rcode_), extendedErrorCode(extendedErrorCode_), ttlCap(ttlCap_), variable(variable_), logQuery(logQuery_), logResponse(logResponse_), followCNAMERecords(followCNAMERecords_), qtype(qtype_), tcp(tcp_)
+    FFIParams(const DNSName& qname_, uint16_t qtype_, const ComboAddress& local_, const ComboAddress& remote_, const Netmask& ednssubnet_, LuaContext::LuaObject& data_, std::unordered_set<std::string>& policyTags_, std::vector<DNSRecord>& records_, const EDNSOptionViewMap& ednsOptions_, const std::vector<ProxyProtocolValue>& proxyProtocolValues_, std::string& requestorId_, std::string& deviceId_, std::string& deviceName_, std::string& routingTag_, boost::optional<int>& rcode_, uint32_t& ttlCap_, bool& variable_, bool tcp_, bool& logQuery_, bool& logResponse_, bool& followCNAMERecords_, boost::optional<uint16_t>& extendedErrorCode_, std::string& extendedErrorExtra_, bool& disablePadding_): data(data_), qname(qname_), local(local_), remote(remote_), ednssubnet(ednssubnet_), policyTags(policyTags_), records(records_), ednsOptions(ednsOptions_), proxyProtocolValues(proxyProtocolValues_), requestorId(requestorId_), deviceId(deviceId_), deviceName(deviceName_), routingTag(routingTag_), extendedErrorExtra(extendedErrorExtra_), rcode(rcode_), extendedErrorCode(extendedErrorCode_), ttlCap(ttlCap_), variable(variable_), logQuery(logQuery_), logResponse(logResponse_), followCNAMERecords(followCNAMERecords_), disablePadding(disablePadding_), qtype(qtype_), tcp(tcp_)
     {
     }
 
@@ -159,6 +160,7 @@ public:
     bool& logQuery;
     bool& logResponse;
     bool& followCNAMERecords;
+    bool& disablePadding;
 
     unsigned int tag{0};
     uint16_t qtype;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5602,7 +5602,7 @@ int main(int argc, char **argv)
 
     ::arg().setSwitch("aggressive-nsec-cache-size", "The number of records to cache in the aggressive cache. If set to a value greater than 0, and DNSSEC validation is enabled, the recursor will cache NSEC and NSEC3 records to generate negative answers, as defined in rfc8198")="100000";
 
-    ::arg().set("edns-padding-from", "List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses, provided that 'edns-padding-mode' is set")="";
+    ::arg().set("edns-padding-from", "List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses, provided that 'edns-padding-mode' applies")="";
     ::arg().set("edns-padding-mode", "Whether to add EDNS padding to all responses ('always') or only to responses for queries containing the EDNS padding option ('padded-queries-only', the default). In both modes, padding will only be added to responses for queries coming from `edns-padding-from`_ sources")="padded-queries-only";
     ::arg().set("edns-padding-tag", "Packetcache tag associated to responses sent with EDNS padding, to prevent sending these to non-whitelisted clients.")="7830";
 
@@ -5719,4 +5719,3 @@ int main(int argc, char **argv)
 
   return ret;
 }
-

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2003,7 +2003,7 @@ static void startDoResolve(void *p)
            RFC 7830) and SHOULD pad the corresponding response to a
            multiple of 468 octets (see below).
         */
-        static const size_t blockSize = 468;
+        const size_t blockSize = 468;
         size_t modulo = (currentSize + 4) % blockSize;
         size_t padSize = 0;
         if (modulo > 0) {
@@ -5594,8 +5594,8 @@ int main(int argc, char **argv)
 
     ::arg().setSwitch("aggressive-nsec-cache-size", "The number of records to cache in the aggressive cache. If set to a value greater than 0, and DNSSEC validation is enabled, the recursor will cache NSEC and NSEC3 records to generate negative answers, as defined in rfc8198")="100000";
 
-    ::arg().set("edns-padding-from", "Sources (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses")="";
-    ::arg().set("edns-padding-mode", "Whether to add EDNS padding to all responses ('always') or only to the ones to padded queries ('padded-queries-only')")="padded-queries-only";
+    ::arg().set("edns-padding-from", "List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses to queries containing the EDNS padding option, provided that 'edns-padding-mode' is set")="";
+    ::arg().set("edns-padding-mode", "Whether to add EDNS padding to all responses ('always') or only to responses for queries containing the EDNS padding option and coming from 'edns-padding-from' sources ('padded-queries-only', the default)")="padded-queries-only";
     ::arg().set("edns-padding-tag", "Packetcache tag associated to responses sent with EDNS padding, to prevent sending these to non-whitelisted clients.")="7830";
 
     ::arg().setCmd("help","Provide a helpful message");

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5602,8 +5602,8 @@ int main(int argc, char **argv)
 
     ::arg().setSwitch("aggressive-nsec-cache-size", "The number of records to cache in the aggressive cache. If set to a value greater than 0, and DNSSEC validation is enabled, the recursor will cache NSEC and NSEC3 records to generate negative answers, as defined in rfc8198")="100000";
 
-    ::arg().set("edns-padding-from", "List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses to queries containing the EDNS padding option, provided that 'edns-padding-mode' is set")="";
-    ::arg().set("edns-padding-mode", "Whether to add EDNS padding to all responses ('always') or only to responses for queries containing the EDNS padding option and coming from 'edns-padding-from' sources ('padded-queries-only', the default)")="padded-queries-only";
+    ::arg().set("edns-padding-from", "List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses, provided that 'edns-padding-mode' is set")="";
+    ::arg().set("edns-padding-mode", "Whether to add EDNS padding to all responses ('always') or only to responses for queries containing the EDNS padding option ('padded-queries-only', the default). In both modes, padding will only be added to responses for queries coming from `edns-padding-from`_ sources")="padded-queries-only";
     ::arg().set("edns-padding-tag", "Packetcache tag associated to responses sent with EDNS padding, to prevent sending these to non-whitelisted clients.")="7830";
 
     ::arg().setCmd("help","Provide a helpful message");

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -117,6 +117,7 @@ pdns_recursor_SOURCES = \
 	dnswriter.cc dnswriter.hh \
 	ednsextendederror.cc ednsextendederror.hh \
 	ednsoptions.cc ednsoptions.hh \
+	ednspadding.cc ednspadding.hh \
 	ednssubnet.cc ednssubnet.hh \
 	filterpo.cc filterpo.hh \
 	fstrm_logger.cc fstrm_logger.hh \
@@ -246,6 +247,7 @@ testrunner_SOURCES = \
 	ednscookies.cc ednscookies.hh \
 	ednsextendederror.cc ednsextendederror.hh \
 	ednsoptions.cc ednsoptions.hh \
+	ednspadding.cc ednspadding.hh \
 	ednssubnet.cc ednssubnet.hh \
 	filterpo.cc filterpo.hh \
 	gettime.cc gettime.hh \

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -11,6 +11,12 @@ The DNSQuestion object contains at least the following fields:
   An object that contains everything about the current query.
   This object has the following attributes:
 
+  .. attribute:: DNSQuestion.addPaddingToResponse
+
+      .. versionadded:: 4.5.0
+
+      Whether the response will get EDNS Padding. See :ref:`setting-edns-padding-from` and :ref:`setting-edns-padding-mode`.
+
   .. attribute:: DNSQuestion.extendedErrorCode
 
       .. versionadded:: 4.5.0

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -632,7 +632,7 @@ List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP 
 
 Whether to add EDNS padding to all responses (``always``) or only to the ones for padded queries (``padded-queries-only``, the default) coming from `edns-padding-from`_ sources.
 
-.. _setting-edns-padding-mode:
+.. _setting-edns-padding-tag:
 
 ``edns-padding-tag``
 --------------------

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -619,7 +619,7 @@ Lower this if you experience timeouts.
 -  Comma separated list of netmasks
 -  Default: (none)
 
-List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses. See also `edns-padding-mode`_.
+List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses to queries containing the EDNS padding option, provided that `edns-padding-mode`_ is set.
 
 .. _setting-edns-padding-mode:
 
@@ -630,7 +630,7 @@ List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP 
 -  One of ``always``, ``padded-queries-only``, String
 -  Default: ``padded-queries-only``
 
-Whether to add EDNS padding to all responses (``always``) or only to the ones for padded queries (``padded-queries-only``, the default) coming from `edns-padding-from`_ sources.
+Whether to add EDNS padding to all responses (``always``) or only to responses for queries containing the EDNS padding option and coming from `edns-padding-from`_ sources (``padded-queries-only``, the default).
 
 .. _setting-edns-padding-tag:
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -619,7 +619,7 @@ Lower this if you experience timeouts.
 -  Comma separated list of netmasks
 -  Default: (none)
 
-List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses, provided that `edns-padding-mode`_ is set.
+List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses, provided that `edns-padding-mode`_ applies.
 
 .. _setting-edns-padding-mode:
 
@@ -2177,4 +2177,3 @@ List of names whose DNSSEC validation metrics will be counted in a separate set 
 with ``x-dnssec-result-``.
 The names are suffix-matched.
 This can be used to not count known failing (test) name validations in the ordinary DNSSEC metrics.
-

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -610,6 +610,40 @@ found, the recursor fallbacks to sending 127.0.0.1.
 This is the value set for the EDNS0 buffer size in outgoing packets.
 Lower this if you experience timeouts.
 
+.. _setting-edns-padding-from:
+
+``edns-padding-from``
+---------------------
+.. versionadded:: 4.4.0
+
+-  Comma separated list of netmasks
+-  Default: (none)
+
+List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses. See also `edns-padding-mode`_.
+
+.. _setting-edns-padding-mode:
+
+``edns-padding-mode``
+---------------------
+.. versionadded:: 4.4.0
+
+-  One of ``always``, ``padded-queries-only``, String
+-  Default: ``padded-queries-only``
+
+Whether to add EDNS padding to all responses (``always``) or only to the ones for padded queries (``padded-queries-only``, the default) coming from `edns-padding-from`_ sources.
+
+.. _setting-edns-padding-mode:
+
+``edns-padding-tag``
+--------------------
+.. versionadded:: 4.4.0
+
+-  Integer
+-  Default: 7830
+
+The packetcache tag to use for padded responses, to prevent a client not allowed by the `edns-padding-from`_ list to be served a cached answer generated for an allowed one. This
+effectively divides the packet cache in two when `edns-padding-from`_ is used. Note that this will not override a tag set from one of the ``Lua`` hooks.
+
 .. _setting-edns-subnet-whitelist:
 
 ``edns-subnet-whitelist``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -614,7 +614,7 @@ Lower this if you experience timeouts.
 
 ``edns-padding-from``
 ---------------------
-.. versionadded:: 4.4.0
+.. versionadded:: 4.5.0
 
 -  Comma separated list of netmasks
 -  Default: (none)
@@ -625,7 +625,7 @@ List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP 
 
 ``edns-padding-mode``
 ---------------------
-.. versionadded:: 4.4.0
+.. versionadded:: 4.5.0
 
 -  One of ``always``, ``padded-queries-only``, String
 -  Default: ``padded-queries-only``
@@ -636,7 +636,7 @@ Whether to add EDNS padding to all responses (``always``) or only to responses f
 
 ``edns-padding-tag``
 --------------------
-.. versionadded:: 4.4.0
+.. versionadded:: 4.5.0
 
 -  Integer
 -  Default: 7830

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -619,7 +619,7 @@ Lower this if you experience timeouts.
 -  Comma separated list of netmasks
 -  Default: (none)
 
-List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses to queries containing the EDNS padding option, provided that `edns-padding-mode`_ is set.
+List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP otherwise) for which EDNS padding will be enabled in responses, provided that `edns-padding-mode`_ is set.
 
 .. _setting-edns-padding-mode:
 
@@ -630,7 +630,8 @@ List of netmasks (proxy IP in case of XPF or proxy-protocol presence, client IP 
 -  One of ``always``, ``padded-queries-only``, String
 -  Default: ``padded-queries-only``
 
-Whether to add EDNS padding to all responses (``always``) or only to responses for queries containing the EDNS padding option and coming from `edns-padding-from`_ sources (``padded-queries-only``, the default).
+Whether to add EDNS padding to all responses (``always``) or only to responses for queries containing the EDNS padding option (``padded-queries-only``, the default).
+In both modes, padding will only be added to responses for queries coming from `edns-padding-from`_ sources.
 
 .. _setting-edns-padding-tag:
 

--- a/pdns/recursordist/ednspadding.cc
+++ b/pdns/recursordist/ednspadding.cc
@@ -1,0 +1,1 @@
+../ednspadding.cc

--- a/pdns/recursordist/ednspadding.hh
+++ b/pdns/recursordist/ednspadding.hh
@@ -1,0 +1,1 @@
+../ednspadding.hh

--- a/regression-tests.recursor-dnssec/paddingoption.py
+++ b/regression-tests.recursor-dnssec/paddingoption.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import dns
+import dns.edns
+import dns.flags
+import dns.message
+import dns.query
+
+class PaddingOption(dns.edns.Option):
+    """Implementation of rfc7830.
+    """
+
+    def __init__(self, numberOfBytes):
+        super(PaddingOption, self).__init__(12)
+        self.numberOfBytes = numberOfBytes
+
+    def to_wire(self, file):
+        """Create EDNS packet as defined in rfc7830."""
+
+        file.write(bytes(self.numberOfBytes))
+
+    def from_wire(cls, otype, wire, current, olen):
+        """Read EDNS packet as defined in rfc7830.
+
+        Returns:
+            An instance of PaddingOption based on the EDNS packet
+        """
+
+        numberOfBytes = olen
+
+        return cls(numberOfBytes)
+
+    from_wire = classmethod(from_wire)
+
+    def __repr__(self):
+        return '%s(%d)' % (
+            self.__class__.__name__,
+            self.numberOfBytes
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, PaddingOption):
+            return False
+        return self.numberOfBytes == numberOfBytes
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+dns.edns._type_to_class[0x000C] = PaddingOption

--- a/regression-tests.recursor-dnssec/paddingoption.py
+++ b/regression-tests.recursor-dnssec/paddingoption.py
@@ -14,10 +14,13 @@ class PaddingOption(dns.edns.Option):
         super(PaddingOption, self).__init__(12)
         self.numberOfBytes = numberOfBytes
 
-    def to_wire(self, file):
+    def to_wire(self, file=None):
         """Create EDNS packet as defined in rfc7830."""
 
-        file.write(bytes(self.numberOfBytes))
+        if file:
+            file.write(bytes(self.numberOfBytes))
+        else:
+            return bytes(self.numberOfBytes)
 
     def from_wire(cls, otype, wire, current, olen):
         """Read EDNS packet as defined in rfc7830.
@@ -31,6 +34,12 @@ class PaddingOption(dns.edns.Option):
         return cls(numberOfBytes)
 
     from_wire = classmethod(from_wire)
+
+    # needed in 2.0.0
+    @classmethod
+    def from_wire_parser(cls, otype, parser):
+        data = parser.get_remaining()
+        return cls(len(data))
 
     def __repr__(self):
         return '%s(%d)' % (

--- a/regression-tests.recursor-dnssec/test_EDNSPadding.py
+++ b/regression-tests.recursor-dnssec/test_EDNSPadding.py
@@ -256,6 +256,13 @@ local-address=127.0.0.1, ::1
 packetcache-ttl=60
     """
 
+    @classmethod
+    def setUpClass(cls):
+        if 'SKIP_IPV6_TESTS' in os.environ:
+            raise unittest.SkipTest('IPv6 tests are disabled')
+
+        super(PaddingAllowedAlwaysSameTagTest, cls).setUpClass()
+
     def testQueryWithPadding(self):
         name = 'secure.example.'
         expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')

--- a/regression-tests.recursor-dnssec/test_EDNSPadding.py
+++ b/regression-tests.recursor-dnssec/test_EDNSPadding.py
@@ -1,0 +1,181 @@
+import dns
+import os
+import socket
+
+import paddingoption
+
+from recursortests import RecursorTest
+
+class TestRecursorEDNSPadding(RecursorTest):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setUpSockets()
+
+        cls.startResponders()
+
+        confdir = os.path.join('configs', cls._confdir)
+        cls.createConfigDir(confdir)
+        cls.generateAllAuthConfig(confdir)
+
+        # we only need these auths and this cuts the needed time in half
+        if cls._auth_zones:
+            for auth_suffix in ['8', '9', '10']:
+                authconfdir = os.path.join(confdir, 'auth-%s' % auth_suffix)
+                ipaddress = cls._PREFIX + '.' + auth_suffix
+                cls.startAuth(authconfdir, ipaddress)
+
+        cls.generateRecursorConfig(confdir)
+        cls.startRecursor(confdir, cls._recursorPort)
+
+        print("Launching tests..")
+
+    def checkPadding(self, message, numberOfBytes=None):
+      self.assertEqual(message.edns, 0)
+      self.assertEquals(len(message.options), 1)
+      for option in message.options:
+          self.assertEquals(option.otype, 12)
+          if numberOfBytes:
+              self.assertEquals(option.olen, numberOfBytes)
+
+    def checkNoPadding(self, message):
+      self.assertEqual(message.edns, 0)
+      self.assertEquals(len(message.options), 0)
+
+    def sendUDPQueryOverIPv6(self, query, timeout=2.0):
+      sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+      sock.settimeout(2.0)
+      sock.connect(("127.0.0.1", self._recursorPort))
+
+      if timeout:
+        sock.settimeout(timeout)
+
+      try:
+        sock.send(query.to_wire())
+        data = sock.recv(4096)
+      except socket.timeout:
+        data = None
+      finally:
+        if timeout:
+          sock.settimeout(None)
+
+      message = None
+      if data:
+        message = dns.message.from_wire(data)
+      return message
+
+class PaddingDefaultTest(TestRecursorEDNSPadding):
+
+    _confdir = 'PaddingDefault'
+
+    def testQueryWithPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, 'A', want_dnssec=True, options=[po])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkNoPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+    def testqueryWithoutPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        query = dns.message.make_query(name, 'A', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkNoPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+class PaddingAllowedAlwaysTest(TestRecursorEDNSPadding):
+
+    _confdir = 'PaddingAlways'
+    _config_template = """edns-padding-from=127.0.0.1
+edns-padding-mode=always
+edns-padding-tag=7830
+    """
+
+    def testQueryWithPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, 'A', want_dnssec=True, options=[po])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+    def testqueryWithoutPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        query = dns.message.make_query(name, 'A', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+class PaddingAllowedWhenPaddedTest(TestRecursorEDNSPadding):
+
+    _confdir = 'PaddingWhenPadded'
+    _config_template = """edns-padding-from=127.0.0.1
+edns-padding-mode=padded-queries-only
+edns-padding-tag=7830
+    """
+
+    def testQueryWithPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, 'A', want_dnssec=True, options=[po])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+    def testqueryWithoutPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        query = dns.message.make_query(name, 'A', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkNoPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+class PaddingAllowedAlwaysSameTagTest(TestRecursorEDNSPadding):
+
+    # we use the default tag (0) for padded responses, which will cause
+    # the same packet cache entry (with padding ) to be returned to a client
+    # not allowed by the edns-padding-from list
+    _confdir = 'PaddingAlwaysSameTag'
+    _config_template = """edns-padding-from=127.0.0.1
+edns-padding-mode=always
+edns-padding-tag=0
+local-address=127.0.0.1, ::1
+    """
+
+    def testQueryWithPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, 'A', want_dnssec=True, options=[po])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+        res = self.sendUDPQueryOverIPv6(query)
+        self.checkPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+    def testqueryWithoutPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        query = dns.message.make_query(name, 'A', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+        res = self.sendUDPQueryOverIPv6(query)
+        self.checkPadding(res)
+        self.assertRRsetInAnswer(res, expected)

--- a/regression-tests.recursor-dnssec/test_EDNSPadding.py
+++ b/regression-tests.recursor-dnssec/test_EDNSPadding.py
@@ -1,6 +1,7 @@
 import dns
 import os
 import socket
+import unittest
 
 import paddingoption
 
@@ -31,41 +32,43 @@ class RecursorEDNSPaddingTest(RecursorTest):
         print("Launching tests..")
 
     def checkPadding(self, message, numberOfBytes=None):
-      self.assertEqual(message.edns, 0)
-      self.assertEquals(len(message.options), 1)
-      for option in message.options:
-          self.assertEquals(option.otype, 12)
-          if numberOfBytes:
-              self.assertEquals(option.olen, numberOfBytes)
+        self.assertEqual(message.edns, 0)
+        self.assertEquals(len(message.options), 1)
+        for option in message.options:
+            self.assertEquals(option.otype, 12)
+            if numberOfBytes:
+                self.assertEquals(option.olen, numberOfBytes)
 
     def checkNoPadding(self, message):
-      self.assertEqual(message.edns, 0)
-      self.assertEquals(len(message.options), 0)
+        self.assertEqual(message.edns, 0)
+        self.assertEquals(len(message.options), 0)
 
     def checkNoEDNS(self, message):
-      self.assertEqual(message.edns, -1)
+        self.assertEqual(message.edns, -1)
 
-    def sendUDPQueryOverIPv6(self, query, timeout=2.0):
-      sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-      sock.settimeout(2.0)
-      sock.connect(("127.0.0.1", self._recursorPort))
+    def sendUDPQueryTo(self, query, toAddr, v6=True, timeout=2.0):
+        if v6:
+            sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        else:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-      if timeout:
-        sock.settimeout(timeout)
+        sock.settimeout(2.0)
+        sock.connect((toAddr, self._recursorPort))
 
-      try:
-        sock.send(query.to_wire())
-        data = sock.recv(4096)
-      except socket.timeout:
-        data = None
-      finally:
         if timeout:
-          sock.settimeout(None)
+            sock.settimeout(timeout)
 
-      message = None
-      if data:
-        message = dns.message.from_wire(data)
-      return message
+        try:
+            sock.send(query.to_wire())
+            data = sock.recv(4096)
+        except socket.timeout:
+            data = None
+
+        sock.close()
+        message = None
+        if data:
+            message = dns.message.from_wire(data)
+        return message
 
     def testQueryWithoutEDNS(self):
         name = 'secure.example.'
@@ -99,12 +102,39 @@ class PaddingDefaultTest(RecursorEDNSPaddingTest):
         self.checkNoPadding(res)
         self.assertRRsetInAnswer(res, expected)
 
-class PaddingAllowedAlwaysTest(RecursorEDNSPaddingTest):
+class PaddingDefaultNotAllowedTest(RecursorEDNSPaddingTest):
+
+    _confdir = 'PaddingDefaultNotAllowed'
+    _config_template = """edns-padding-from=127.0.0.2
+packetcache-ttl=60
+    """
+
+    def testQueryWithPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, 'A', want_dnssec=True, options=[po])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkNoPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+    def testQueryWithoutPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        query = dns.message.make_query(name, 'A', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkNoPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+class PaddingAlwaysTest(RecursorEDNSPaddingTest):
 
     _confdir = 'PaddingAlways'
     _config_template = """edns-padding-from=127.0.0.1
 edns-padding-mode=always
 edns-padding-tag=7830
+packetcache-ttl=60
     """
 
     def testQueryWithPadding(self):
@@ -126,12 +156,42 @@ edns-padding-tag=7830
         self.checkPadding(res)
         self.assertRRsetInAnswer(res, expected)
 
-class PaddingAllowedWhenPaddedTest(RecursorEDNSPaddingTest):
+class PaddingNotAllowedAlwaysTest(RecursorEDNSPaddingTest):
+
+    _confdir = 'PaddingAlwaysNotAllowed'
+    _config_template = """edns-padding-from=127.0.0.2
+edns-padding-mode=always
+edns-padding-tag=7830
+packetcache-ttl=60
+    """
+
+    def testQueryWithPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, 'A', want_dnssec=True, options=[po])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkNoPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+    def testQueryWithoutPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        query = dns.message.make_query(name, 'A', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkNoPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+class PaddingWhenPaddedTest(RecursorEDNSPaddingTest):
 
     _confdir = 'PaddingWhenPadded'
     _config_template = """edns-padding-from=127.0.0.1
 edns-padding-mode=padded-queries-only
 edns-padding-tag=7830
+local-address=127.0.0.1
+packetcache-ttl=60
     """
 
     def testQueryWithPadding(self):
@@ -153,6 +213,36 @@ edns-padding-tag=7830
         self.checkNoPadding(res)
         self.assertRRsetInAnswer(res, expected)
 
+class PaddingWhenPaddedNotAllowedTest(RecursorEDNSPaddingTest):
+
+    _confdir = 'PaddingWhenPaddedNotAllowed'
+    _config_template = """edns-padding-from=127.0.0.2
+edns-padding-mode=padded-queries-only
+edns-padding-tag=7830
+local-address=127.0.0.1
+packetcache-ttl=60
+    """
+
+    def testQueryWithPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, 'A', want_dnssec=True, options=[po])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkNoPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+    def testQueryWithoutPadding(self):
+        name = 'secure.example.'
+        expected = dns.rrset.from_text(name, 0, dns.rdataclass.IN, 'A', '192.0.2.17')
+        query = dns.message.make_query(name, 'A', want_dnssec=True)
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkNoPadding(res)
+        self.assertRRsetInAnswer(res, expected)
+
+@unittest.skipIf('SKIP_IPV6_TESTS' in os.environ, 'IPv6 tests are disabled')
 class PaddingAllowedAlwaysSameTagTest(RecursorEDNSPaddingTest):
 
     # we use the default tag (0) for padded responses, which will cause
@@ -163,6 +253,7 @@ class PaddingAllowedAlwaysSameTagTest(RecursorEDNSPaddingTest):
 edns-padding-mode=always
 edns-padding-tag=0
 local-address=127.0.0.1, ::1
+packetcache-ttl=60
     """
 
     def testQueryWithPadding(self):
@@ -175,7 +266,7 @@ local-address=127.0.0.1, ::1
         self.checkPadding(res)
         self.assertRRsetInAnswer(res, expected)
 
-        res = self.sendUDPQueryOverIPv6(query)
+        res = self.sendUDPQueryTo(query, '::1')
         self.checkPadding(res)
         self.assertRRsetInAnswer(res, expected)
 
@@ -188,6 +279,6 @@ local-address=127.0.0.1, ::1
         self.checkPadding(res)
         self.assertRRsetInAnswer(res, expected)
 
-        res = self.sendUDPQueryOverIPv6(query)
+        res = self.sendUDPQueryTo(query, '::1')
         self.checkPadding(res)
         self.assertRRsetInAnswer(res, expected)

--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -60,7 +60,6 @@ log-common-errors=yes
         local extra = 'Extra text from Lua FFI!'
         ffi.C.pdns_ffi_param_set_extended_error_extra(obj, #extra, extra)
       end
-      return {}
     end
     """ % ('A'*427)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The initial idea is to be able to add EDNS padding when answering to queries received over DoT or DoH. This PR allows adding this option based on the source (so you could use a different source when forwarding a query from dnsdist to the recursor, based on whether it was received over DoH or DoT), and optionally on whether the initial query had padding.

One of the challenge is that this duplicates the content of the packet cache to avoid mixing padded and non-padded responses.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

