### PR TITLE
auth: make sure we look at 10% of all cached items during cleanup

### DIFF
--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -248,11 +248,7 @@ uint64_t AuthPacketCache::purge(const string &match)
 			   
 void AuthPacketCache::cleanup()
 {
-  uint64_t maxCached = d_maxEntries;
-  uint64_t cacheSize = *d_statnumentries;
-  uint64_t totErased = 0;
-
-  totErased = pruneLockedCollectionsVector<SequencedTag>(d_maps, maxCached, cacheSize);
+  uint64_t totErased = pruneLockedCollectionsVector<SequencedTag>(d_maps);
   *d_statnumentries -= totErased;
 
   DLOG(g_log<<"Done with cache clean, cacheSize: "<<(*d_statnumentries)<<", totErased"<<totErased<<endl);

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -209,13 +209,9 @@ uint64_t AuthQueryCache::purge(const string &match)
 
 void AuthQueryCache::cleanup()
 {
-  uint64_t maxCached = d_maxEntries;
-  uint64_t cacheSize = *d_statnumentries;
-  uint64_t totErased = 0;
-
-  totErased = pruneLockedCollectionsVector<SequencedTag>(d_maps, maxCached, cacheSize);
-
+  uint64_t totErased = pruneLockedCollectionsVector<SequencedTag>(d_maps);
   *d_statnumentries -= totErased;
+
   DLOG(g_log<<"Done with cache clean, cacheSize: "<<*d_statnumentries<<", totErased"<<totErased<<endl);
 }
 

--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -111,39 +111,25 @@ template <typename S, typename T> void moveCacheItemToBack(T& collection, typena
   moveCacheItemToFrontOrBack<S>(collection, iter, false);
 }
 
-template <typename S, typename T> uint64_t pruneLockedCollectionsVector(vector<T>& maps, uint64_t maxCached, uint64_t cacheSize)
+template <typename S, typename T> uint64_t pruneLockedCollectionsVector(vector<T>& maps)
 {
-  time_t now = time(nullptr);
   uint64_t totErased = 0;
-  uint64_t toTrim = 0;
-  uint64_t lookAt = 0;
-
-  // two modes - if toTrim is 0, just look through 10%  of the cache and nuke everything that is expired
-  // otherwise, scan first 5*toTrim records, and stop once we've nuked enough
-  if (maxCached && cacheSize > maxCached) {
-    toTrim = cacheSize - maxCached;
-    lookAt = 5 * toTrim;
-  } else {
-    lookAt = cacheSize / 10;
-  }
+  time_t now = time(nullptr);
 
   for(auto& mc : maps) {
     WriteLock wl(&mc.d_mut);
+
+    uint64_t lookAt = (mc.d_map.size() + 9) / 10; // Look at 10% of this shard
+    uint64_t erased = 0;
+
     auto& sidx = boost::multi_index::get<S>(mc.d_map);
-    uint64_t erased = 0, lookedAt = 0;
-    for(auto i = sidx.begin(); i != sidx.end(); lookedAt++) {
+    for(auto i = sidx.begin(); i != sidx.end() && lookAt > 0; lookAt--) {
       if(i->ttd < now) {
         i = sidx.erase(i);
         erased++;
       } else {
         ++i;
       }
-
-      if(toTrim && erased > toTrim / maps.size())
-        break;
-
-      if(lookedAt > lookAt / maps.size())
-        break;
     }
     totErased += erased;
   }


### PR DESCRIPTION
### Short description
Purging was very inefficient for large shards when the cached items are not equally distributed over all shards. We now look at 10% of the cached items in every shard. This was 10% of all items divided over all shards.

In some setups this will result in a dramatic decrease of cached items (up to 100x) with an identical cache hit rate.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
