### PR TITLE
dnsdist: Make FrameStream IO parameters configurable

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -452,8 +452,8 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "newDNSName", true, "name", "make a DNSName based on this .-terminated name" },
   { "newDNSNameSet", true, "", "returns a new DNSNameSet" },
   { "newDynBPFFilter", true, "bpf", "Return a new dynamic eBPF filter associated to a given BPF Filter" },
-  { "newFrameStreamTcpLogger", true, "addr", "create a FrameStream logger object writing to a TCP address (addr should be ip:port), to use with `DnstapLogAction()` and `DnstapLogResponseAction()`" },
-  { "newFrameStreamUnixLogger", true, "socket", "create a FrameStream logger object writing to a local unix socket, to use with `DnstapLogAction()` and `DnstapLogResponseAction()`" },
+  { "newFrameStreamTcpLogger", true, "addr [, options]", "create a FrameStream logger object writing to a TCP address (addr should be ip:port), to use with `DnstapLogAction()` and `DnstapLogResponseAction()`" },
+  { "newFrameStreamUnixLogger", true, "socket [, options]", "create a FrameStream logger object writing to a local unix socket, to use with `DnstapLogAction()` and `DnstapLogResponseAction()`" },
 #ifdef HAVE_LMDB
   { "newLMDBKVStore", true, "fname, dbName", "Return a new KeyValueStore object associated to the corresponding LMDB database" },
 #endif

--- a/pdns/dnsdistdist/docs/reference/dnstap.rst
+++ b/pdns/dnsdistdist/docs/reference/dnstap.rst
@@ -11,20 +11,50 @@ As an extension, :program:`dnsdist` can send raw dnstap protobuf messages over a
 
 To use FrameStream transport, :program:`dnsdist` must have been built with `libfstrm`.
 
-.. function:: newFrameStreamUnixLogger(path)
+.. function:: newFrameStreamUnixLogger(path [, options])
+
+  .. versionchanged:: 1.5.0
+    Added the optional parameter ``options``.
 
   Create a Frame Stream Logger object, to use with :func:`DnstapLogAction` and :func:`DnstapLogResponseAction`.
   This version will log to a local AF_UNIX socket.
 
   :param string path: A local AF_UNIX socket path. Note that most platforms have a rather short limit on the length.
+  :param table options: A table with key: value pairs with options.
 
-.. function:: newFrameStreamTcpLogger(address)
+  The following options apply to the settings of the framestream library. Refer to the documentation of that
+  library for the default and allowed values for these options, as well as their exact descriptions.
+  For all these options, absence or a zero value has the effect of using the library-provided default value.
+
+  * ``bufferHint=0``: unsigned
+  * ``flushTimeout=0``: unsigned
+  * ``inputQueueSize=0``: unsigned
+  * ``outputQueueSize=0``: unsigned
+  * ``queueNotifyThreshold=0``: unsigned
+  * ``reopenInterval=0``: unsigned
+
+.. function:: newFrameStreamTcpLogger(address [, options])
+
+  .. versionchanged:: 1.5.0
+    Added the optional parameter ``options``.
 
   Create a Frame Stream Logger object, to use with :func:`DnstapLogAction` and :func:`DnstapLogResponseAction`.
   This version will log to a possibly remote TCP socket.
   Needs tcp_writer support in libfstrm.
 
   :param string address: An IP:PORT combination where the logger will connect to.
+  :param table options: A table with key: value pairs with options.
+
+  The following options apply to the settings of the framestream library. Refer to the documentation of that
+  library for the default and allowed values for these options, as well as their exact descriptions.
+  For all these options, absence or a zero value has the effect of using the library-provided default value.
+
+  * ``bufferHint=0``: unsigned
+  * ``flushTimeout=0``: unsigned
+  * ``inputQueueSize=0``: unsigned
+  * ``outputQueueSize=0``: unsigned
+  * ``queueNotifyThreshold=0``: unsigned
+  * ``reopenInterval=0``: unsigned
 
 .. class:: DnstapMessage
 

--- a/pdns/recursordist/docs/lua-config/protobuf.rst
+++ b/pdns/recursordist/docs/lua-config/protobuf.rst
@@ -113,10 +113,10 @@ The recursor must have been built with configure ``--enable-dnstap`` to make thi
 
   Options:
 
-  * ``logQueries=true``: bool - log oputgoing queries
+  * ``logQueries=true``: bool - log outgoing queries
   * ``logResponses=true``: bool - log incoming responses
  
-  The follwing options apply to the settings of the framestream library. Refer to the documentation of that
+  The following options apply to the settings of the framestream library. Refer to the documentation of that
   library for the default values, exact description and allowable values for these options.
   For all these options, absence or a zero value has the effect of using the library-provided default value.
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR makes it possible to tune the Frame Stream library IO parameters in dnsdist.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
