### PR TITLE
Merge query-local-address6 into query-local-address

### DIFF
--- a/docs/appendices/FAQ.rst
+++ b/docs/appendices/FAQ.rst
@@ -59,7 +59,7 @@ Also, check that the configured backend is master or slave capable and you enter
 My masters won't allow PowerDNS to access zones as it is using the wrong local IP address
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 By default, PowerDNS lets the kernel pick the source address.
-To set an explicit source address, use the :ref:`setting-query-local-address` and :ref:`setting-query-local-address6` settings.
+To set an explicit source address, use the :ref:`setting-query-local-address` setting.
 
 PowerDNS does not answer queries on all my IP addresses (and I've ignored the warning I got about that at startup)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1270,21 +1270,33 @@ Seconds to store queries with an answer in the Query Cache. See :ref:`query-cach
 
 ``query-local-address``
 -----------------------
+.. versionchanged:: 4.4.0
+  Accepts both IPv4 and IPv6 addresses. Also accept more than one address per
+  address family.
 
--  IPv4 Address
--  Default: 0.0.0.0
+-  IP addresses, separated by spaces or commas
+-  Default: 0.0.0.0 ::
 
-The IP address to use as a source address for sending queries. Useful if
+The IP addresses to use as a source address for sending queries. Useful if
 you have multiple IPs and PowerDNS is not bound to the IP address your
 operating system uses by default for outgoing packets.
+
+PowerDNS will pick the correct address family based on the remote's address (v4
+for outgoing v4, v6 for outgoing v6). However, addresses are selected at random
+without taking into account ip subnet reachability. It is highly recommended to
+use the defaults in that case (the kernel will pick the right source address for
+the network).
 
 .. _setting-query-local-address6:
 
 ``query-local-address6``
 ------------------------
+.. deprecated:: 4.4.0
+  Use :ref:`setting-query-local-address`. The default has been changed
+  from '::' to unset.
 
 -  IPv6 Address
--  Default: '::'
+-  Default: unset
 
 Source IP address for sending IPv6 queries.
 

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -207,6 +207,7 @@ pdns_server_SOURCES = \
 	rcpgenerator.cc \
 	receiver.cc \
 	resolver.cc resolver.hh \
+	axfr-retriever.cc axfr-retriever.hh \
 	responsestats.cc responsestats.hh responsestats-auth.cc \
 	rfc2136handler.cc \
 	secpoll.cc secpoll.hh \
@@ -636,6 +637,7 @@ ixfrdist_SOURCES = \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
 	resolver.cc \
+	axfr-retriever.cc \
 	pollmplexer.cc \
 	sillyrecords.cc \
 	sstuff.hh \
@@ -690,6 +692,7 @@ ixplore_SOURCES = \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
 	resolver.cc \
+	axfr-retriever.cc \
 	ixfr.cc ixfr.hh \
 	ixfrutils.cc ixfrutils.hh \
 	ixplore.cc \
@@ -823,6 +826,7 @@ toysdig_LDADD += $(P11KIT1_LIBS)
 endif
 
 tsig_tests_SOURCES = \
+	axfr-retriever.cc \
 	arguments.cc \
 	base32.cc \
 	base64.cc base64.hh \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -204,6 +204,7 @@ pdns_server_SOURCES = \
 	packethandler.cc packethandler.hh \
 	pdnsexception.hh \
 	qtype.cc qtype.hh \
+	query-local-address.hh query-local-address.cc \
 	rcpgenerator.cc \
 	receiver.cc \
 	resolver.cc resolver.hh \
@@ -634,6 +635,7 @@ ixfrdist_SOURCES = \
 	misc.cc misc.hh \
 	mplexer.hh \
 	nsecrecords.cc \
+	query-local-address.hh query-local-address.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
 	resolver.cc \
@@ -689,6 +691,7 @@ ixplore_SOURCES = \
 	logger.cc \
 	misc.cc misc.hh \
 	nsecrecords.cc \
+	query-local-address.hh query-local-address.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
 	resolver.cc \
@@ -840,9 +843,11 @@ tsig_tests_SOURCES = \
 	dnssecinfra.cc \
 	dnswriter.cc dnswriter.hh \
 	gss_context.cc gss_context.hh \
+	iputils.cc \
 	logger.cc \
 	misc.cc misc.hh \
 	nsecrecords.cc \
+	query-local-address.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
 	resolver.cc \

--- a/pdns/axfr-retriever.cc
+++ b/pdns/axfr-retriever.cc
@@ -1,0 +1,248 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "axfr-retriever.hh"
+#include "arguments.hh"
+#include "dns_random.hh"
+#include "utility.hh"
+#include "resolver.hh"
+
+using pdns::resolver::parseResult;
+
+AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
+                             const DNSName& domain,
+                             const TSIGTriplet& tt, 
+                             const ComboAddress* laddr,
+                             size_t maxReceivedBytes,
+                             uint16_t timeout)
+  : d_tsigVerifier(tt, remote, d_trc), d_receivedBytes(0), d_maxReceivedBytes(maxReceivedBytes)
+{
+  ComboAddress local;
+  if (laddr != nullptr) {
+    local = ComboAddress(*laddr);
+  } else {
+    string qlas = remote.sin4.sin_family == AF_INET ? "query-local-address" : "query-local-address6";
+    if (::arg()[qlas].empty()) {
+      throw ResolverException("Unable to determine source address for AXFR request to " + remote.toStringWithPort() + " for " + domain.toLogString() + ". " + qlas + " is unset");
+    }
+    local=ComboAddress(::arg()[qlas]);
+  }
+  d_sock = -1;
+  try {
+    d_sock = makeQuerySocket(local, false); // make a TCP socket
+    if (d_sock < 0)
+      throw ResolverException("Error creating socket for AXFR request to "+d_remote.toStringWithPort());
+    d_buf = shared_array<char>(new char[65536]);
+    d_remote = remote; // mostly for error reporting
+    this->connect(timeout);
+    d_soacount = 0;
+  
+    vector<uint8_t> packet;
+    DNSPacketWriter pw(packet, domain, QType::AXFR);
+    pw.getHeader()->id = dns_random_uint16();
+  
+    if(!tt.name.empty()) {
+      if (tt.algo == DNSName("hmac-md5"))
+        d_trc.d_algoName = tt.algo + DNSName("sig-alg.reg.int");
+      else
+        d_trc.d_algoName = tt.algo;
+      d_trc.d_time = time(0);
+      d_trc.d_fudge = 300;
+      d_trc.d_origID=ntohs(pw.getHeader()->id);
+      d_trc.d_eRcode=0;
+      addTSIG(pw, d_trc, tt.name, tt.secret, "", false);
+    }
+  
+    uint16_t replen=htons(packet.size());
+    Utility::iovec iov[2];
+    iov[0].iov_base=reinterpret_cast<char*>(&replen);
+    iov[0].iov_len=2;
+    iov[1].iov_base=packet.data();
+    iov[1].iov_len=packet.size();
+  
+    int ret=Utility::writev(d_sock, iov, 2);
+    if(ret < 0)
+      throw ResolverException("Error sending question to "+d_remote.toStringWithPort()+": "+stringerror());
+    if(ret != (int)(2+packet.size())) {
+      throw ResolverException("Partial write on AXFR request to "+d_remote.toStringWithPort());
+    }
+  
+    int res = waitForData(d_sock, timeout, 0);
+    
+    if(!res)
+      throw ResolverException("Timeout waiting for answer from "+d_remote.toStringWithPort()+" during AXFR");
+    if(res<0)
+      throw ResolverException("Error waiting for answer from "+d_remote.toStringWithPort()+": "+stringerror());
+  }
+  catch(...) {
+    if(d_sock >= 0)
+      close(d_sock);
+    d_sock = -1;
+    throw;
+  }
+}
+
+AXFRRetriever::~AXFRRetriever()
+{
+  close(d_sock);
+}
+
+
+
+int AXFRRetriever::getChunk(Resolver::res_t &res, vector<DNSRecord>* records, uint16_t timeout) // Implementation is making sure RFC2845 4.4 is followed.
+{
+  if(d_soacount > 1)
+    return false;
+
+  // d_sock is connected and is about to spit out a packet
+  int len=getLength(timeout);
+  if(len<0)
+    throw ResolverException("EOF trying to read axfr chunk from remote TCP client");
+
+  if (d_maxReceivedBytes > 0 && (d_maxReceivedBytes - d_receivedBytes) < (size_t) len)
+    throw ResolverException("Reached the maximum number of received bytes during AXFR");
+
+  timeoutReadn(len, timeout);
+
+  d_receivedBytes += (uint16_t) len;
+
+  MOADNSParser mdp(false, d_buf.get(), len);
+
+  int err = mdp.d_header.rcode;
+
+  if(err) {
+    throw ResolverException("AXFR chunk error: " + RCode::to_s(err));
+  }
+
+  try {
+    d_tsigVerifier.check(std::string(d_buf.get(), len), mdp);
+  }
+  catch(const std::runtime_error& re) {
+    throw ResolverException(re.what());
+  }
+
+  if(!records) {
+    err = parseResult(mdp, DNSName(), 0, 0, &res);
+
+    if (!err) {
+      for(const auto& answer :  mdp.d_answers)
+        if (answer.first.d_type == QType::SOA)
+          d_soacount++;
+    }
+  }
+  else {
+    records->clear();
+    records->reserve(mdp.d_answers.size());
+
+    for(auto& r: mdp.d_answers) {
+      if (r.first.d_type == QType::SOA) {
+        d_soacount++;
+      }
+
+      records->push_back(std::move(r.first));
+    }
+  }
+
+  return true;
+}
+
+void AXFRRetriever::timeoutReadn(uint16_t bytes, uint16_t timeoutsec)
+{
+  time_t start=time(nullptr);
+  int n=0;
+  int numread;
+  while(n<bytes) {
+    int res=waitForData(d_sock, timeoutsec-(time(nullptr)-start));
+    if(res<0)
+      throw ResolverException("Reading data from remote nameserver over TCP: "+stringerror());
+    if(!res)
+      throw ResolverException("Timeout while reading data from remote nameserver over TCP");
+
+    numread=recv(d_sock, d_buf.get()+n, bytes-n, 0);
+    if(numread<0)
+      throw ResolverException("Reading data from remote nameserver over TCP: "+stringerror());
+    if(numread==0)
+      throw ResolverException("Remote nameserver closed TCP connection");
+    n+=numread;
+  }
+}
+
+void AXFRRetriever::connect(uint16_t timeout)
+{
+  setNonBlocking( d_sock );
+
+  int err;
+
+  if((err=::connect(d_sock,(struct sockaddr*)&d_remote, d_remote.getSocklen()))<0 && errno!=EINPROGRESS) {
+    try {
+      closesocket(d_sock);
+    }
+    catch(const PDNSException& e) {
+      d_sock=-1;
+      throw ResolverException("Error closing AXFR socket after connect() failed: "+e.reason);
+    }
+
+    throw ResolverException("connect: "+stringerror());
+  }
+
+  if(!err)
+    goto done;
+
+  err=waitForRWData(d_sock, false, timeout, 0); // wait for writeability
+  
+  if(!err) {
+    try {
+      closesocket(d_sock); // timeout
+    }
+    catch(const PDNSException& e) {
+      d_sock=-1;
+      throw ResolverException("Error closing AXFR socket after timeout: "+e.reason);
+    }
+
+    d_sock=-1;
+    errno=ETIMEDOUT;
+    
+    throw ResolverException("Timeout connecting to server");
+  }
+  else if(err < 0) {
+    throw ResolverException("Error connecting: "+stringerror());
+  }
+  else {
+    Utility::socklen_t len=sizeof(err);
+    if(getsockopt(d_sock, SOL_SOCKET,SO_ERROR,(char *)&err,&len)<0)
+      throw ResolverException("Error connecting: "+stringerror()); // Solaris
+
+    if(err)
+      throw ResolverException("Error connecting: "+string(strerror(err)));
+  }
+  
+ done:
+  setBlocking( d_sock );
+  // d_sock now connected
+}
+
+int AXFRRetriever::getLength(uint16_t timeout)
+{
+  timeoutReadn(2, timeout);
+  return (unsigned char)d_buf[0]*256+(unsigned char)d_buf[1];
+}
+

--- a/pdns/axfr-retriever.hh
+++ b/pdns/axfr-retriever.hh
@@ -1,0 +1,56 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+#include <boost/utility.hpp>
+
+#include "iputils.hh"
+#include "dnsname.hh"
+#include "resolver.hh"
+
+class AXFRRetriever : public boost::noncopyable
+{
+  public:
+    AXFRRetriever(const ComboAddress& remote,
+                  const DNSName& zone,
+                  const TSIGTriplet& tt = TSIGTriplet(),
+                  const ComboAddress* laddr = NULL,
+                  size_t maxReceivedBytes=0,
+                  uint16_t timeout=10);
+    ~AXFRRetriever();
+    int getChunk(Resolver::res_t &res, vector<DNSRecord>* records=0, uint16_t timeout=10);
+
+  private:
+    void connect(uint16_t timeout);
+    int getLength(uint16_t timeout);
+    void timeoutReadn(uint16_t bytes, uint16_t timeoutsec=10);
+
+    shared_array<char> d_buf;
+    string d_domain;
+    int d_sock;
+    int d_soacount;
+    ComboAddress d_remote;
+    TSIGTCPVerifier d_tsigVerifier;
+
+    size_t d_receivedBytes;
+    size_t d_maxReceivedBytes;
+    TSIGRecordContent d_trc;
+};

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -92,8 +92,8 @@ void declareArguments()
   ::arg().setSwitch("local-address-nonexist-fail","Fail to start if one or more of the local-address's do not exist on this server")="yes";
   ::arg().setSwitch("non-local-bind", "Enable binding to non-local addresses by using FREEBIND / BINDANY socket options")="no";
   ::arg().setSwitch("reuseport","Enable higher performance on compliant kernels by using SO_REUSEPORT allowing each receiver thread to open its own socket")="no";
-  ::arg().set("query-local-address","Source IP address for sending queries")="0.0.0.0";
-  ::arg().set("query-local-address6","Source IPv6 address for sending queries")="::";
+  ::arg().set("query-local-address","Source IP address for sending queries")="0.0.0.0 ::";
+  ::arg().set("query-local-address6","DEPRECATED: Use query-local-address. Source IPv6 address for sending queries")="";
   ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";
 
@@ -630,7 +630,10 @@ void mainthread()
   }
 
   pdns::parseQueryLocalAddress(::arg()["query-local-address"]);
-  pdns::parseQueryLocalAddress(::arg()["query-local-address6"]);
+  if (!::arg()["query-local-address6"].empty()) {
+    g_log<<Logger::Warning<<"query-local-address6 is deprecated and will be removed in a future version. Please use query-local-address for IPv6 addresses as well"<<endl;
+    pdns::parseQueryLocalAddress(::arg()["query-local-address6"]);
+  }
 
   // NOW SAFE TO CREATE THREADS!
   dl->go();

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -31,6 +31,7 @@
 #include "dnsseckeeper.hh"
 #include "threadname.hh"
 #include "misc.hh"
+#include "query-local-address.hh"
 
 #include <thread>
 
@@ -627,6 +628,9 @@ void mainthread()
       exit(1);
     }
   }
+
+  pdns::parseQueryLocalAddress(::arg()["query-local-address"]);
+  pdns::parseQueryLocalAddress(::arg()["query-local-address6"]);
 
   // NOW SAFE TO CREATE THREADS!
   dl->go();

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -92,7 +92,7 @@ void declareArguments()
   ::arg().setSwitch("local-address-nonexist-fail","Fail to start if one or more of the local-address's do not exist on this server")="yes";
   ::arg().setSwitch("non-local-bind", "Enable binding to non-local addresses by using FREEBIND / BINDANY socket options")="no";
   ::arg().setSwitch("reuseport","Enable higher performance on compliant kernels by using SO_REUSEPORT allowing each receiver thread to open its own socket")="no";
-  ::arg().set("query-local-address","Source IP address for sending queries")="0.0.0.0 ::";
+  ::arg().set("query-local-address","Source IP addresses for sending queries")="0.0.0.0 ::";
   ::arg().set("query-local-address6","DEPRECATED: Use query-local-address. Source IPv6 address for sending queries")="";
   ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -30,7 +30,6 @@
 #include "dnsbackend.hh"
 #include "ueberbackend.hh"
 #include "packethandler.hh"
-#include "resolver.hh"
 #include "logger.hh"
 #include "dns.hh"
 #include "arguments.hh"

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -36,7 +36,7 @@
 #include <condition_variable>
 #include "ixfr.hh"
 #include "ixfrutils.hh"
-#include "resolver.hh"
+#include "axfr-retriever.hh"
 #include "dns_random.hh"
 #include "sstuff.hh"
 #include "mplexer.hh"

--- a/pdns/ixplore.cc
+++ b/pdns/ixplore.cc
@@ -34,7 +34,7 @@
 #include "dns_random.hh"
 #include "gss_context.hh"
 #include <boost/multi_index_container.hpp>
-#include "resolver.hh"
+#include "axfr-retriever.hh"
 #include <fstream>
 #include "ixfr.hh"
 #include "ixfrutils.hh"

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -47,6 +47,7 @@
 #include <boost/algorithm/string.hpp>
 #include "validate-recursor.hh"
 #include "ednssubnet.hh"
+#include "query-local-address.hh"
 
 #ifdef HAVE_PROTOBUF
 
@@ -55,6 +56,8 @@
 #ifdef HAVE_FSTRM
 #include "rec-dnstap.hh"
 #include "fstrm_logger.hh"
+
+
 bool g_syslog;
 
 static bool isEnabledForQueries(const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstreamLoggers)
@@ -315,7 +318,7 @@ int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool d
       Socket s(ip.sin4.sin_family, SOCK_STREAM);
 
       s.setNonBlocking();
-      ComboAddress local = getQueryLocalAddress(ip.sin4.sin_family, 0);
+      ComboAddress local = pdns::getQueryLocalAddress(ip.sin4.sin_family, 0);
 
       s.bind(local);
         

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -215,7 +215,7 @@ time_t CommunicatorClass::doNotifications(PacketHandler *P)
         ComboAddress remote(ip, 53); // default to 53
         if((d_nsock6 < 0 && remote.sin4.sin_family == AF_INET6) ||
            (d_nsock4 < 0 && remote.sin4.sin_family == AF_INET)) {
-             g_log<<Logger::Warning<<"Unable to notify "<<remote.toStringWithPort()<<" for domain '"<<domain<<"', address family is disabled. Is query-local-address"<<(remote.sin4.sin_family == AF_INET ? "" : "6")<<" unset?"<<endl;
+             g_log<<Logger::Warning<<"Unable to notify "<<remote.toStringWithPort()<<" for domain '"<<domain<<"', address family is disabled. Is an IPv"<<(remote.sin4.sin_family == AF_INET ? "4" : "6")<<" address set in query-local-address?"<<endl;
              d_nq.removeIf(remote.toStringWithPort(), id, domain); // Remove, we'll never be able to notify
              continue; // don't try to notify what we can't!
         }

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -40,6 +40,7 @@
 #include "packetcache.hh"
 #include "base64.hh"
 #include "namespaces.hh"
+#include "query-local-address.hh"
 
 
 void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
@@ -299,13 +300,13 @@ bool CommunicatorClass::justNotified(const DNSName &domain, const string &ip)
 
 void CommunicatorClass::makeNotifySockets()
 {
-  if(!::arg()["query-local-address"].empty()) {
-    d_nsock4 = makeQuerySocket(ComboAddress(::arg()["query-local-address"]), true, ::arg().mustDo("non-local-bind"));
+  if(pdns::isQueryLocalAddressFamilyEnabled(AF_INET)) {
+    d_nsock4 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET, 0), true, ::arg().mustDo("non-local-bind"));
   } else {
     d_nsock4 = -1;
   }
-  if(!::arg()["query-local-address6"].empty()) {
-    d_nsock6 = makeQuerySocket(ComboAddress(::arg()["query-local-address6"]), true, ::arg().mustDo("non-local-bind"));
+  if(pdns::isQueryLocalAddressFamilyEnabled(AF_INET6)) {
+    d_nsock6 = makeQuerySocket(pdns::getQueryLocalAddress(AF_INET6, 0), true, ::arg().mustDo("non-local-bind"));
   } else {
     d_nsock6 = -1;
   }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3991,7 +3991,11 @@ static int serviceMain(int argc, char*argv[])
   checkLinuxIPv6Limits();
   try {
     pdns::parseQueryLocalAddress(::arg()["query-local-address"]);
-    pdns::parseQueryLocalAddress(::arg()["query-local-address6"]);
+    if (!::arg()["query-local-address6"].empty()) {
+      // TODO remove in 4.5.0
+      g_log<<Logger::Warning<<"query-local-address6 is deprecated and will be removed in a future version. Please use query-local-address for IPv6 addresses as well"<<endl;
+      pdns::parseQueryLocalAddress(::arg()["query-local-address6"]);
+    }
   }
   catch(std::exception& e) {
     g_log<<Logger::Error<<"Assigning local query addresses: "<<e.what();
@@ -4003,7 +4007,7 @@ static int serviceMain(int argc, char*argv[])
     g_log<<Logger::Warning<<"Enabling IPv6 transport for outgoing queries"<<endl;
   }
   else {
-    g_log<<Logger::Warning<<"NOT using IPv6 for outgoing queries - set 'query-local-address6=::' to enable"<<endl;
+    g_log<<Logger::Warning<<"NOT using IPv6 for outgoing queries - add an IPv6 address (like '::') to query-local-address to enable"<<endl;
   }
 
   // keep this ABOVE loadRecursorLuaConfig!
@@ -4797,7 +4801,7 @@ int main(int argc, char **argv)
     ::arg().set("socket-dir",string("Where the controlsocket will live, ")+LOCALSTATEDIR+"/pdns-recursor when unset and not chrooted" )="";
     ::arg().set("delegation-only","Which domains we only accept delegations from")="";
     ::arg().set("query-local-address","Source IP address for sending queries")="0.0.0.0";
-    ::arg().set("query-local-address6","Source IPv6 address for sending queries. IF UNSET, IPv6 WILL NOT BE USED FOR OUTGOING QUERIES")="";
+    ::arg().set("query-local-address6","DEPRECATED: Use query-local-address for IPv6 as well. Source IPv6 address for sending queries. IF UNSET, IPv6 WILL NOT BE USED FOR OUTGOING QUERIES")="";
     ::arg().set("client-tcp-timeout","Timeout in seconds when talking to TCP clients")="2";
     ::arg().set("max-mthreads", "Maximum number of simultaneous Mtasker threads")="2048";
     ::arg().set("max-tcp-clients","Maximum number of simultaneous TCP clients")="128";

--- a/pdns/query-local-address.cc
+++ b/pdns/query-local-address.cc
@@ -1,0 +1,100 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "query-local-address.hh"
+#include "iputils.hh"
+#include "dns_random.hh"
+
+namespace pdns {
+  static const ComboAddress local4("0.0.0.0");
+  static const ComboAddress local6("::");
+
+  static vector<ComboAddress> g_localQueryAddresses4;
+  static vector<ComboAddress> g_localQueryAddresses6;
+
+  ComboAddress getQueryLocalAddress(const sa_family_t family, const in_port_t port) {
+    ComboAddress ret;
+    if (family==AF_INET) {
+      if (g_localQueryAddresses4.empty()) {
+        ret = local4;
+      } else if (g_localQueryAddresses4.size() == 1) {
+        ret = g_localQueryAddresses4.at(0);
+      } else {
+        ret = g_localQueryAddresses4[dns_random(g_localQueryAddresses4.size())];
+      }
+      ret.sin4.sin_port = htons(port);
+    }
+    else {
+      if (g_localQueryAddresses6.empty()) {
+        ret = local6;
+      } else if (g_localQueryAddresses6.size() == 1) {
+        ret = g_localQueryAddresses6.at(0);
+      } else {
+        ret = g_localQueryAddresses6[dns_random(g_localQueryAddresses6.size())];
+      }
+      ret.sin6.sin6_port = htons(port);
+    }
+    return ret;
+  }
+
+  ComboAddress getNonAnyQueryLocalAddress(const sa_family_t family) {
+    if (family == AF_INET) {
+      for (const auto& addr : pdns::g_localQueryAddresses4) {
+        if (!IsAnyAddress(addr)) {
+          return addr;
+        }
+      }
+    }
+    if (family == AF_INET6) {
+      for (const auto& addr : pdns::g_localQueryAddresses6) {
+        if (!IsAnyAddress(addr)) {
+          return addr;
+        }
+      }
+    }
+    ComboAddress ret("0.0.0.0");
+    ret.reset(); // Ensure all is zero, even the addr family
+    return ret;
+  }
+
+  void parseQueryLocalAddress(const std::string &qla) {
+    vector<string> addrs;
+    stringtok(addrs, qla, ", ;");
+    for(const string& addr : addrs) {
+      ComboAddress tmp(addr);
+      if (tmp.isIPv4()) {
+        g_localQueryAddresses4.push_back(tmp);
+        continue;
+      }
+      g_localQueryAddresses6.push_back(tmp);
+    }
+  }
+
+  bool isQueryLocalAddressFamilyEnabled(const sa_family_t family) {
+    if (family == AF_INET) {
+      return !g_localQueryAddresses4.empty();
+    }
+    if (family == AF_INET6) {
+      return !g_localQueryAddresses6.empty();
+    }
+    return false;
+  }
+} // namespace pdns

--- a/pdns/query-local-address.hh
+++ b/pdns/query-local-address.hh
@@ -1,0 +1,59 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "iputils.hh"
+
+namespace pdns {
+  /*! pick a random query local address for family
+   *
+   * Will always return a ComboAddress.
+   *
+   * @param family Address Family, only AF_INET and AF_INET6 are supported
+   * @param port   Port to set in the returned ComboAddress
+   */
+  ComboAddress getQueryLocalAddress(const sa_family_t family, const in_port_t port);
+
+  /*! Returns a non-Any address QLA, or an empty QLA when the QLA is any
+   *
+   * @param family  Address Family
+   */
+  ComboAddress getNonAnyQueryLocalAddress(const sa_family_t family);
+
+  /*! Populate the query local address vectors
+   *
+   * Will throw when an address can't be parsed
+   *
+   * @param qla  A string of one or more ip addresses, separated by
+   *             spaces, semi-colons or commas
+   */
+  void parseQueryLocalAddress(const std::string &qla);
+
+  /*! Is the address family explicitly enabled
+   *
+   * i.e. was there an address parsed by parseQueryLocalAddress belonging
+   * to this family
+   *
+   * @param family  Address Family, only AF_INET and AF_INET6 are supported
+   */
+  bool isQueryLocalAddressFamilyEnabled(const sa_family_t family);
+} // namespace pdns

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -160,6 +160,7 @@ pdns_recursor_SOURCES = \
 	reczones.cc \
 	remote_logger.cc remote_logger.hh \
 	resolver.hh resolver.cc \
+	axfr-retriever.hh axfr-retriever.cc \
 	resolve-context.hh \
 	responsestats.hh responsestats.cc \
 	root-addresses.hh \
@@ -259,6 +260,7 @@ testrunner_SOURCES = \
 	responsestats.cc \
 	rpzloader.cc rpzloader.hh \
 	resolver.hh resolver.cc \
+	axfr-retriever.hh axfr-retriever.cc \
 	root-dnssec.hh \
 	secpoll.cc \
 	sillyrecords.cc \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -148,6 +148,7 @@ pdns_recursor_SOURCES = \
 	pubsuffix.hh pubsuffix.cc \
 	pubsuffixloader.cc \
 	qtype.hh qtype.cc \
+	query-local-address.hh query-local-address.cc \
 	rcpgenerator.cc rcpgenerator.hh \
 	rec-carbon.cc \
 	rec-lua-conf.hh rec-lua-conf.cc \
@@ -253,6 +254,7 @@ testrunner_SOURCES = \
 	pollmplexer.cc \
 	protobuf.cc protobuf.hh \
 	qtype.cc qtype.hh \
+	query-local-address.hh query-local-address.cc \
 	rcpgenerator.cc \
 	rec-protobuf.cc rec-protobuf.hh \
 	recpacketcache.cc recpacketcache.hh \

--- a/pdns/recursordist/axfr-retriever.cc
+++ b/pdns/recursordist/axfr-retriever.cc
@@ -1,0 +1,1 @@
+../axfr-retriever.cc

--- a/pdns/recursordist/axfr-retriever.hh
+++ b/pdns/recursordist/axfr-retriever.hh
@@ -1,0 +1,1 @@
+../axfr-retriever.hh

--- a/pdns/recursordist/docs/lua-config/rpz.rst
+++ b/pdns/recursordist/docs/lua-config/rpz.rst
@@ -146,7 +146,7 @@ The default value of 0 means no restriction.
 localAddress
 ^^^^^^^^^^^^
 The source IP address to use when transferring the RPZ.
-When unset, :ref:`setting-query-local-address` and :ref:`setting-query-local-address6` are used.
+When unset, :ref:`setting-query-local-address` is used.
 
 axfrTimeout
 ^^^^^^^^^^^

--- a/pdns/recursordist/docs/manpages/pdns_recursor.1.rst
+++ b/pdns/recursordist/docs/manpages/pdns_recursor.1.rst
@@ -88,12 +88,8 @@ at `<https://doc.powerdns.com/>`
     Maximum number of simultaneous TCP clients.
 --max-tcp-per-client=<num>
     If set, maximum number of TCP sessions per client (IP address).
---query-local-address=<address>
+--query-local-address=<address>[,address...]
     Use *address* as Source IP address when sending queries.
---query-local-address6=<address>
-    Send out local IPv6 queries from *address*. Disabled by default,
-    which also disables outgoing IPv6 support. A useful setting is
-    '::0'.
 --quiet
     Suppress logging of questions and answers.
 --server-id=<text>

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -529,7 +529,7 @@ The IP address sent via EDNS Client Subnet to authoritative servers listed in
 `edns-subnet-whitelist`_ when `use-incoming-edns-subnet`_ is set and the query has
 an ECS source prefix-length set to 0.
 The default is to look for the first usable (not an ``any`` one) address in
-`query-local-address`_ then `query-local-address6`_. If no suitable address is
+`query-local-address`_ (starting with IPv4). If no suitable address is
 found, the recursor fallbacks to sending 127.0.0.1.
 
 .. _setting-edns-outgoing-bufsize:
@@ -1280,15 +1280,24 @@ described in :rfc:`7816`.
 
 ``query-local-address``
 -----------------------
--  IPv4 Address, comma separated
+.. versionchanged:: 4.4.0
+  IPv6 addresses can be set with this option as well.
+
+-  IP addresses, comma separated
 -  Default: 0.0.0.0
 
-Send out local queries from this address, or addresses, by adding multiple addresses, increased spoofing resilience is achieved.
+Send out local queries from this address, or addresses. By adding multiple
+addresses, increased spoofing resilience is achieved. When no address of a certain
+address family is configured, there are *no* queries sent with that address family.
+In the default configuration this means that IPv6 is not used for outgoing queries.
 
 .. _setting-query-local-address6:
 
 ``query-local-address6``
 ------------------------
+.. deprecated:: 4.4.0
+  Use :ref:`setting-query-local-address` for IPv4 and IPv6.
+
 -  IPv6 addresses, comma separated
 -  Default: unset
 

--- a/pdns/recursordist/query-local-address.cc
+++ b/pdns/recursordist/query-local-address.cc
@@ -1,0 +1,1 @@
+../query-local-address.cc

--- a/pdns/recursordist/query-local-address.hh
+++ b/pdns/recursordist/query-local-address.hh
@@ -1,0 +1,1 @@
+../query-local-address.hh

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -160,11 +160,9 @@ uint16_t Resolver::sendResolve(const ComboAddress& remote, const ComboAddress& l
   // choose socket based on local
   if (local.sin4.sin_family == 0) {
     // up to us.
-    if (remote.sin4.sin_family == AF_INET && !pdns::isQueryLocalAddressFamilyEnabled(AF_INET)) {
-      throw ResolverException("No IPv4 socket available, is query-local-address set?");
-    }
-    if (remote.sin4.sin_family == AF_INET6 && !pdns::isQueryLocalAddressFamilyEnabled(AF_INET6)) {
-      throw ResolverException("No IPv6 socket available, is query-local-address6 set?");
+    if (!pdns::isQueryLocalAddressFamilyEnabled(remote.sin4.sin_family)) {
+      string ipv = remote.sin4.sin_family == AF_INET ? "4" : "6";
+      throw ResolverException("No IPv" + ipv + " socket available, is such an address configured in query-local-address?");
     }
     sock = remote.sin4.sin_family == AF_INET ? locals["default4"] : locals["default6"];
   } else {

--- a/pdns/resolver.hh
+++ b/pdns/resolver.hh
@@ -76,31 +76,8 @@ private:
   std::map<std::string, int> locals;
 };
 
-class AXFRRetriever : public boost::noncopyable
-{
-  public:
-    AXFRRetriever(const ComboAddress& remote,
-                  const DNSName& zone,
-                  const TSIGTriplet& tt = TSIGTriplet(),
-                  const ComboAddress* laddr = NULL,
-                  size_t maxReceivedBytes=0,
-                  uint16_t timeout=10);
-    ~AXFRRetriever();
-    int getChunk(Resolver::res_t &res, vector<DNSRecord>* records=0, uint16_t timeout=10);
-  
-  private:
-    void connect(uint16_t timeout);
-    int getLength(uint16_t timeout);
-    void timeoutReadn(uint16_t bytes, uint16_t timeoutsec=10);
-
-    shared_array<char> d_buf;
-    string d_domain;
-    int d_sock;
-    int d_soacount;
-    ComboAddress d_remote;
-    TSIGTCPVerifier d_tsigVerifier;
-
-    size_t d_receivedBytes;
-    size_t d_maxReceivedBytes;
-    TSIGRecordContent d_trc;
-};
+namespace pdns {
+  namespace resolver {
+    int parseResult(MOADNSParser& mdp, const DNSName& origQname, uint16_t origQtype, uint16_t id, Resolver::res_t* result);
+  } // namespace resolver
+} // namespace pdns

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -3,7 +3,7 @@
 #include "dnsrecords.hh"
 #include "ixfr.hh"
 #include "syncres.hh"
-#include "resolver.hh"
+#include "axfr-retriever.hh"
 #include "logger.hh"
 #include "rec-lua-conf.hh"
 #include "rpzloader.hh"

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -9,6 +9,7 @@
 #include "rpzloader.hh"
 #include "zoneparser-tng.hh"
 #include "threadname.hh"
+#include "query-local-address.hh"
 
 Netmask makeNetmaskFromRPZ(const DNSName& name)
 {
@@ -193,7 +194,7 @@ static shared_ptr<SOARecordContent> loadRPZFromServer(const ComboAddress& master
 
   ComboAddress local(localAddress);
   if (local == ComboAddress())
-    local = getQueryLocalAddress(master.sin4.sin_family, 0);
+    local = pdns::getQueryLocalAddress(master.sin4.sin_family, 0);
 
   AXFRRetriever axfr(master, zoneName, tt, &local, maxReceivedBytes, axfrTimeout);
   unsigned int nrecords=0;
@@ -433,7 +434,7 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& masters, boost::optional<DN
 
       ComboAddress local(localAddress);
       if (local == ComboAddress()) {
-        local = getQueryLocalAddress(master.sin4.sin_family, 0);
+        local = pdns::getQueryLocalAddress(master.sin4.sin_family, 0);
       }
 
       try {

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -377,7 +377,7 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote)
       if (!pdns::isQueryLocalAddressFamilyEnabled(remote.sin4.sin_family)) {
         bool isV6 = remote.sin4.sin_family == AF_INET6;
         g_log<<Logger::Error<<"Unable to AXFR, destination address is "<<remote<<" (IPv"<< (isV6 ? "6" : "4") <<
-          ", but that address family is not enabled for outgoing traffic (query-local-address"<<(isV6 ? "6" : "")<<")"<<endl;
+          ", but that address family is not enabled for outgoing traffic (query-local-address)"<<endl;
         return;
       }
       laddr = pdns::getQueryLocalAddress(remote.sin4.sin_family, 0);

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -34,7 +34,7 @@
 #include "dnsbackend.hh"
 #include "ueberbackend.hh"
 #include "packethandler.hh"
-#include "resolver.hh"
+#include "axfr-retriever.hh"
 #include "logger.hh"
 #include "dns.hh"
 #include "arguments.hh"

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1085,7 +1085,6 @@ extern bool g_lowercaseOutgoing;
 
 std::string reloadAuthAndForwards();
 ComboAddress parseIPAndPort(const std::string& input, uint16_t port);
-ComboAddress getQueryLocalAddress(int family, uint16_t port);
 typedef boost::function<void*(void)> pipefunc_t;
 void broadcastFunction(const pipefunc_t& func);
 void distributeAsyncFunction(const std::string& question, const pipefunc_t& func);

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -53,7 +53,6 @@
 #include "common_startup.hh"
 #include "packethandler.hh"
 #include "statbag.hh"
-#include "resolver.hh"
 #include "communicator.hh"
 #include "namespaces.hh"
 #include "signingpipe.hh"

--- a/pdns/tsig-tests.cc
+++ b/pdns/tsig-tests.cc
@@ -14,6 +14,7 @@
 #include "axfr-retriever.hh"
 #include "arguments.hh"
 #include "dns_random.hh"
+#include "query-local-address.hh"
 
 StatBag S;
 
@@ -26,8 +27,7 @@ ArgvMap& arg()
 int main(int argc, char** argv)
 try
 {
-  ::arg().set("query-local-address","Source IP address for sending queries")="0.0.0.0";
-  ::arg().set("query-local-address6","Source IPv6 address for sending queries")="::";
+  pdns::parseQueryLocalAddress(":: 0.0.0.0");
 
   reportAllTypes();
 

--- a/pdns/tsig-tests.cc
+++ b/pdns/tsig-tests.cc
@@ -11,7 +11,7 @@
 #include "digests.hh"
 #include "base64.hh"
 #include "dnssecinfra.hh"
-#include "resolver.hh"
+#include "axfr-retriever.hh"
 #include "arguments.hh"
 #include "dns_random.hh"
 

--- a/regression-tests.recursor-dnssec/test_ECS.py
+++ b/regression-tests.recursor-dnssec/test_ECS.py
@@ -350,7 +350,7 @@ ecs-ipv6-bits=128
 ecs-ipv4-cache-bits=32
 ecs-ipv6-cache-bits=128
 forward-zones=ecs-echo.example=%s.21
-query-local-address6=::1
+query-local-address=::1
     """ % (os.environ['PREFIX'])
 
     def testSendECS(self):
@@ -367,8 +367,7 @@ query-local-address6=::1
         self.sendECSQuery(query, expected, ttlECS)
 
     def testRequireNoECS(self):
-        # we should get ::1/128 because neither ecs-scope-zero-addr nor query-local-address are set,
-        # but query-local-address6 is set to ::1
+        # we should get ::1/128 because ecs-scope-zero-addr is unset and query-local-address is set to ::1
         expected = dns.rrset.from_text(nameECS, ttlECS, dns.rdataclass.IN, 'TXT', "::1/128")
 
         ecso = clientsubnetoption.ClientSubnetOption('0.0.0.0', 0)

--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -19,7 +19,7 @@ shards=$5
 
 if [ $IPv6 = 1 ]
 then
-	QLA6="::"
+	QLA6=" ::"
 else
 	QLA6=""
 fi
@@ -31,7 +31,7 @@ rm -f recursor.pid pdns_recursor.pid
 <measurement><name>system CPU seconds</name><value>%S</value></measurement>
 <measurement><name>wallclock seconds</name><value>%e</value></measurement>
 <measurement><name>%% CPU used</name><value>%P</value></measurement>
-'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address6="${QLA6}" --threads=$threads --cache-shards=$shards --disable-packetcache > recursor.log 2>&1 &
+'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address="0.0.0.0${QLA6}" --threads=$threads --cache-shards=$shards --disable-packetcache > recursor.log 2>&1 &
 sleep 3
 
 # warm up the cache

--- a/regression-tests/recursor-test-freebsd
+++ b/regression-tests/recursor-test-freebsd
@@ -12,13 +12,13 @@ limit=$2
 
 if [ $IPv6 = 1 ]
 then
-	QLA6="::"
+	QLA6=" ::"
 else
 	QLA6=""
 fi
 
 rm -f recursor.pid pdns_recursor.pid
-${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --local-address=0.0.0.0 --allow-from=0.0.0.0/0 --query-local-address6="${QLA6}" > recursor.log 2>&1 &
+${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --local-address=0.0.0.0 --allow-from=0.0.0.0/0 --query-local-address="0.0.0.0${QLA6}" > recursor.log 2>&1 &
 sleep 3
 ./dnsbulktest -qe 37.252.127.190 $port $limit < ${CSV} > bulktest.results
 kill $(cat pdns_recursor.pid)


### PR DESCRIPTION
### Short description
This also splits the AXFRRetriever into its own files, centralizes the handling of query local addresses for both the auth and the recursor and deprecates the use of query-local-address6 without removing the option just yet.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)