### PR TITLE
lua: better errors when a key/value table is expected

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2802,6 +2802,17 @@ struct LuaContext::Reader<std::unordered_map<TKey,TValue,THash,TKeyEqual>>
         if (!lua_istable(state, index))
             return boost::none;
 
+        size_t len;
+
+#if     LUA_VERSION_NUM >= 502
+        len = lua_rawlen(state, index);
+#else
+        len = lua_objlen(state, index);
+#endif
+
+        if (len != 0)
+            throw std::logic_error("Expected key/value table, got array");
+
         std::unordered_map<TKey,TValue,THash,TKeyEqual> result;
 
         // we traverse the table at the top of the stack

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2649,11 +2649,21 @@ struct LuaContext::Reader<std::string>
     static auto read(lua_State* state, int index)
         -> boost::optional<std::string>
     {
+        std::string result;
+
+        // lua_tolstring might convert the variable that would confuse lua_next, so we
+        //   make a copy of the variable.
+        lua_pushvalue(state, index);
+
         size_t len;
-        const auto val = lua_tolstring(state, index, &len);
-        if (val == 0)
-            return boost::none;
-        return std::string(val, len);
+        const auto val = lua_tolstring(state, -1, &len);
+
+        if (val != 0)
+          result.assign(val, len);
+
+        lua_pop(state, 1);
+
+        return val != 0 ? boost::optional<std::string>{ std::move(result) } : boost::none;
     }
 };
 

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2764,6 +2764,17 @@ struct LuaContext::Reader<std::map<TKey,TValue>>
         if (!lua_istable(state, index))
             return boost::none;
 
+        size_t len;
+
+#if     LUA_VERSION_NUM >= 502
+        len = lua_rawlen(state, index);
+#else
+        len = lua_objlen(state, index);
+#endif
+
+        if (len != 0)
+            throw std::logic_error("Expected key/value table, got array");
+
         std::map<TKey,TValue> result;
 
         // we traverse the table at the top of the stack

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -316,10 +316,7 @@ void doConsole()
       // tried to return something we don't understand
     }
     catch(const LuaContext::ExecutionErrorException& e) {
-      if(!strcmp(e.what(),"invalid key to 'next'"))
-        std::cerr<<"Error parsing parameters, did you forget parameter name?";
-      else
-        std::cerr << e.what(); 
+      std::cerr << e.what();
       try {
         std::rethrow_if_nested(e);
 
@@ -749,10 +746,7 @@ try
       // tried to return something we don't understand
     }
     catch(const LuaContext::ExecutionErrorException& e) {
-      if(!strcmp(e.what(),"invalid key to 'next'"))
-        response = "Error: Parsing function parameters, did you forget parameter name?";
-      else
-        response = "Error: " + string(e.what());
+      response = "Error: " + string(e.what());
       try {
         std::rethrow_if_nested(e);
       } catch(const std::exception& ne) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2030,7 +2030,7 @@ static void setupLuaConfig(bool client, bool configCheck)
         }
       });
 
-    g_lua.registerFunction<void(std::shared_ptr<DOHFrontend>::*)(const std::map<int, std::shared_ptr<DOHResponseMapEntry>>&)>("setResponsesMap", [](std::shared_ptr<DOHFrontend> frontend, const std::map<int, std::shared_ptr<DOHResponseMapEntry>>& map) {
+    g_lua.registerFunction<void(std::shared_ptr<DOHFrontend>::*)(const std::vector<std::pair<int, std::shared_ptr<DOHResponseMapEntry>>>&)>("setResponsesMap", [](std::shared_ptr<DOHFrontend> frontend, const std::vector<std::pair<int, std::shared_ptr<DOHResponseMapEntry>>>& map) {
         if (frontend != nullptr) {
           std::vector<std::shared_ptr<DOHResponseMapEntry>> newMap;
           newMap.reserve(map.size());

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
@@ -50,13 +50,13 @@ void setupLuaBindingsDNSCrypt()
 
       ctx->addNewCertificate(newCert, newKey, active ? *active : true);
     });
-    g_lua.registerFunction<std::map<int, std::shared_ptr<DNSCryptCertificatePair>>(std::shared_ptr<DNSCryptContext>::*)()>("getCertificatePairs", [](std::shared_ptr<DNSCryptContext> ctx) {
-      std::map<int, std::shared_ptr<DNSCryptCertificatePair>> result;
+    g_lua.registerFunction<std::vector<std::pair<int, std::shared_ptr<DNSCryptCertificatePair>>>(std::shared_ptr<DNSCryptContext>::*)()>("getCertificatePairs", [](std::shared_ptr<DNSCryptContext> ctx) {
+      std::vector<std::pair<int, std::shared_ptr<DNSCryptCertificatePair>>> result;
 
       if (ctx != nullptr) {
         size_t idx = 1;
         for (auto pair : ctx->getCertificates()) {
-          result[idx++] = pair;
+          result.push_back(make_pair(idx++, pair));
         }
       }
 

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -24,12 +24,12 @@ LuaContext* AuthLua4::getLua()
 void AuthLua4::postPrepareContext() {
   d_lw->writeFunction("resolve", [](const std::string& qname, uint16_t qtype) {
       std::vector<DNSZoneRecord> ret;
-      std::unordered_map<int, DNSResourceRecord> luaResult;
+      std::vector<std::pair<int, DNSResourceRecord> > luaResult;
       stubDoResolve(DNSName(qname), qtype, ret);
       int i = 0;
       for(const auto &row: ret) {
-        luaResult[++i] = DNSResourceRecord::fromWire(row.dr);
-        luaResult[i].auth = row.auth;
+        luaResult.push_back(make_pair(++i, DNSResourceRecord::fromWire(row.dr)));
+        luaResult[i].second.auth = row.auth;
       }
       return luaResult;
   });

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -137,7 +137,7 @@ public:
             d_postresolve);
   }
 
-  typedef std::function<std::tuple<unsigned int,boost::optional<std::unordered_map<int,string> >,boost::optional<LuaContext::LuaObject>,boost::optional<std::string>,boost::optional<std::string>,boost::optional<std::string> >(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const EDNSOptionViewMap&, bool, const std::vector<std::pair<int, const ProxyProtocolValue*>>&)> gettag_t;
+  typedef std::function<std::tuple<unsigned int,boost::optional<std::vector<std::pair<int,string> > >,boost::optional<LuaContext::LuaObject>,boost::optional<std::string>,boost::optional<std::string>,boost::optional<std::string> >(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const EDNSOptionViewMap&, bool, const std::vector<std::pair<int, const ProxyProtocolValue*>>&)> gettag_t;
   gettag_t d_gettag; // public so you can query if we have this hooked
   typedef std::function<boost::optional<LuaContext::LuaObject>(pdns_ffi_param_t*)> gettag_ffi_t;
   gettag_ffi_t d_gettag_ffi;

--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -479,7 +479,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
       lci.protobufMaskV6 = maskV6;
     });
 
-  Lua.writeFunction("protobufServer", [&lci](boost::variant<const std::string, const std::unordered_map<int, std::string>> servers, boost::optional<protobufOptions_t> vars) {
+  Lua.writeFunction("protobufServer", [&lci](boost::variant<const std::string, const std::vector<std::pair<int, std::string> > > servers, boost::optional<protobufOptions_t> vars) {
         if (!lci.protobufExportConfig.enabled) {
 
           lci.protobufExportConfig.enabled = true;
@@ -491,7 +491,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
               lci.protobufExportConfig.servers.emplace_back(server);
             }
             else {
-              auto serversMap = boost::get<const std::unordered_map<int,std::string>>(servers);
+              auto serversMap = boost::get<const std::vector<std::pair<int, std::string> >>(servers);
               for (const auto& serverPair : serversMap) {
                 lci.protobufExportConfig.servers.emplace_back(serverPair.second);
               }
@@ -511,7 +511,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
         }
     });
 
-  Lua.writeFunction("outgoingProtobufServer", [&lci](boost::variant<const std::string, const std::unordered_map<int, std::string>> servers, boost::optional<protobufOptions_t> vars) {
+  Lua.writeFunction("outgoingProtobufServer", [&lci](boost::variant<const std::string, const std::vector<std::pair<int, std::string>>> servers, boost::optional<protobufOptions_t> vars) {
       if (!lci.outgoingProtobufExportConfig.enabled) {
 
         lci.outgoingProtobufExportConfig.enabled = true;
@@ -523,7 +523,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
               lci.outgoingProtobufExportConfig.servers.emplace_back(server);
             }
             else {
-              auto serversMap = boost::get<const std::unordered_map<int,std::string>>(servers);
+              auto serversMap = boost::get<const std::vector<std::pair<int, std::string>>>(servers);
               for (const auto& serverPair : serversMap) {
                 lci.outgoingProtobufExportConfig.servers.emplace_back(serverPair.second);
               }
@@ -545,7 +545,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
 #endif
 
 #ifdef HAVE_FSTRM
-  Lua.writeFunction("dnstapFrameStreamServer", [&lci](boost::variant<const std::string, const std::unordered_map<int, std::string>> servers, boost::optional<frameStreamOptions_t> vars) {
+  Lua.writeFunction("dnstapFrameStreamServer", [&lci](boost::variant<const std::string, const std::vector<std::pair<int, std::string>>> servers, boost::optional<frameStreamOptions_t> vars) {
       if (!lci.frameStreamExportConfig.enabled) {
 
         lci.frameStreamExportConfig.enabled = true;
@@ -559,7 +559,7 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
               lci.frameStreamExportConfig.servers.emplace_back(server);
             }
             else {
-              auto serversMap = boost::get<const std::unordered_map<int,std::string>>(servers);
+              auto serversMap = boost::get<const std::vector<std::pair<int,std::string>>>(servers);
               for (const auto& serverPair : serversMap) {
                 lci.frameStreamExportConfig.servers.emplace_back(serverPair.second);
               }

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -91,13 +91,13 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         try:
             output = subprocess.check_output(testcmd, stderr=subprocess.STDOUT, close_fds=True)
         except subprocess.CalledProcessError as exc:
-            raise AssertionError('dnsdist --check-config failed (%d): %s' % (exc.returncode, exc.output))
+            raise AssertionError('dnsdist --check-config (-C %s) failed (%d): %s' % (confFile, exc.returncode, exc.output))
         if cls._checkConfigExpectedOutput is not None:
           expectedOutput = cls._checkConfigExpectedOutput
         else:
           expectedOutput = ('Configuration \'%s\' OK!\n' % (confFile)).encode()
         if output != expectedOutput:
-            raise AssertionError('dnsdist --check-config failed: %s' % output)
+            raise AssertionError('dnsdist --check-config (-C %s) failed: %s' % (confFile, output))
 
         logFile = os.path.join('configs', 'dnsdist_%s.log' % (cls.__name__))
         with open(logFile, 'w') as fdLog:


### PR DESCRIPTION
### Short description

```
> pc = newPacketCache(5000000, {86400, 0, 60, 60, false, 40} )
```

Before: `Error parsing parameters, did you forget parameter name?` (lua 5.3) or `Unknown Lua error` (luajit), without a line number.

Now: `[string "pc = newPacketCache(5000000, {86400, 0, 60, 6..."]:1: Caught exception: Expected key/value table, got array`

The enforcement on unordered map to not have a length is pretty brutal. I wonder if CI will pick anything up, I only tested dnsdist.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master