### PR TITLE
lua: add backtraces to errors

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -1417,9 +1417,9 @@ private:
     }
     
     static int gettraceback(lua_State* L) {
-        lua_getglobal(L, "debug"); // stack: error, "debug"
-        lua_getfield(L, -1, "traceback"); // stack: error, "debug", debug.traceback
-        lua_remove(L, -2); // stack: error, debug.traceback
+        lua_getglobal(L, "debug"); // stack: error, debug library
+        lua_getfield(L, -1, "traceback"); // stack: error, debug library, debug.traceback function
+        lua_remove(L, -2); // stack: error, debug.traceback function
         lua_pushstring(L, ""); // stack: error, debug.traceback, ""
         lua_pushinteger(L, 2); // stack: error, debug.traceback, "", 2
         lua_call(L, 2, 1); // stack: error, traceback


### PR DESCRIPTION
### Short description

via https://github.com/ahupowerdns/luawrapper/pull/33

```
> pc = newPacketCache(5000000, {86400, 0, 60, 60, false, 40} )
[string "pc = newPacketCache(5000000, {86400, 0, 60, 6..."]:1: Caught exception: Expected key/value table, got array
stack traceback:
	[C]: in function 'newPacketCache'
	[string "pc = newPacketCache(5000000, {86400, 0, 60, 6..."]:1: in main chunk
```

(it's even more useful with files, of course)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master