### PR TITLE
dnsdist: Set the DoH ticket rotation delay before loading tickets

### DIFF
--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1098,6 +1098,7 @@ static void setupTLSContext(DOHAcceptContext& acceptCtx,
 
   h2o_ssl_register_alpn_protocols(ctx.get(), h2o_http2_alpn_protocols);
 
+  acceptCtx.d_ticketsKeyRotationDelay = tlsConfig.d_ticketsKeyRotationDelay;
   if (tlsConfig.d_ticketKeyFile.empty()) {
     acceptCtx.handleTicketsKeyRotation();
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Before that change, we could have loaded DoH STEK from a file without properly setting the next rotation, causing a ticket rotation to happen during the first TLS session establishment.
This can be prevented by setting `ticketsKeysRotationDelay=0`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

