### PR TITLE
Correct typo in Swagger specification

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -1234,7 +1234,7 @@ definitions:
         description: 'Whether or not the key is in active use'
       published:
         type: boolean
-        descriptioon: 'Whether or not the DNSKEY record is published in the zone'
+        description: 'Whether or not the DNSKEY record is published in the zone'
       dnskey:
         type: string
         description: 'The DNSKEY record for this key'


### PR DESCRIPTION
Found when loading the spec into a validating parser :-)
