### PR TITLE
Remove a std::move() preventing Return-Value Optimization in lmdb-safe.cc

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -338,7 +338,7 @@ MDBRWTransaction MDBRWTransactionImpl::getRWTransaction()
 
 MDBROTransaction MDBRWTransactionImpl::getROTransaction()
 {
-  return std::move(getRWTransaction());
+  return getRWTransaction();
 }
 
 MDBROTransaction MDBEnv::getROTransaction()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported by `clang++`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

