### PR TITLE
TSIG Keys are also used for DNSUPDATE, so update API docs

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -1033,7 +1033,7 @@ definitions:
 
   TSIGKey:
     title: TSIGKey
-    description: A TSIG key that can be used to authenticate NOTIFYs and AXFRs
+    description: A TSIG key that can be used to authenticate NOTIFY, AXFR, and DNSUPDATE queries.
     properties:
       name:
         type: string


### PR DESCRIPTION
Signed-off-by: Kevin P. Fleming <kevin@km6g.us>