### PR TITLE
dnsdist: Keep accepting fragmented UDP datagrams on DNSCrypt binds

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1844,14 +1844,15 @@ static void setUpLocalBind(std::unique_ptr<ClientState>& cs)
 #endif
   }
 
-  if (!cs->tcp) {
-    if (cs->local.isIPv4()) {
-      try {
-        setSocketIgnorePMTU(cs->udpFD);
-      }
-      catch(const std::exception& e) {
-        warnlog("Failed to set IP_MTU_DISCOVER on UDP server socket for local address '%s': %s", cs->local.toStringWithPort(), e.what());
-      }
+  /* Only set this on IPv4 UDP sockets.
+     Don't set it for DNSCrypt binds. DNSCrypt pads queries for privacy
+     purposes, so we do receive large, sometimes fragmented datagrams. */
+  if (!cs->tcp && cs->local.isIPv4() && !cs->dnscryptCtx) {
+    try {
+      setSocketIgnorePMTU(cs->udpFD);
+    }
+    catch(const std::exception& e) {
+      warnlog("Failed to set IP_MTU_DISCOVER on UDP server socket for local address '%s': %s", cs->local.toStringWithPort(), e.what());
     }
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`DNSCrypt` pads its queries for privacy purposes, and thus requires larger queries than plain DNS ones. Discarding fragmented datagrams doesn't make sense in that case, and actually leads to a very degraded service, as reported in https://github.com/PowerDNS/pdns/pull/7410#issuecomment-604318988.
At the moment I don't see any reason to accept fragmented datagrams for plain DNS queries, so this MR only applies to `DNSCrypt` binds for now.
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

