### PR TITLE
Utilize std::shuffle

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1300,6 +1300,7 @@ testrunner_SOURCES = \
 	rcpgenerator.cc \
 	responsestats.cc \
 	responsestats-auth.cc \
+	shuffle.cc shuffle.hh \
 	sillyrecords.cc \
 	statbag.cc \
 	test-arguments_cc.cc \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -213,6 +213,7 @@ pdns_server_SOURCES = \
 	secpoll-auth.cc secpoll-auth.hh \
 	serialtweaker.cc \
 	sha.hh \
+	shuffle.cc shuffle.hh \
 	signingpipe.cc signingpipe.hh \
 	sillyrecords.cc \
 	slavecommunicator.cc \
@@ -324,6 +325,7 @@ pdnsutil_SOURCES = \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
 	serialtweaker.cc \
+	shuffle.cc shuffle.hh \
 	signingpipe.cc \
 	sillyrecords.cc \
 	sstuff.hh \

--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -28,13 +28,10 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string>
-#include <random>
-
 #include "dns_random.hh"
 #include "arguments.hh"
 #include "logger.hh"
 #include "boost/lexical_cast.hpp"
-#include "dnsparser.hh"
 
 #if defined(HAVE_RANDOMBYTES_STIR)
 #include <sodium.h>
@@ -332,83 +329,4 @@ uint32_t dns_random(uint32_t upper_bound) {
 uint16_t dns_random_uint16()
 {
   return dns_random(0x10000);
-}
-
-// shuffle, maintaining some semblance of order
-void shuffle(vector<DNSZoneRecord>& rrs)
-{
-  vector<DNSZoneRecord>::iterator first, second;
-  for(first=rrs.begin();first!=rrs.end();++first)
-    if(first->dr.d_place==DNSResourceRecord::ANSWER && first->dr.d_type != QType::CNAME) // CNAME must come first
-      break;
-  for(second=first;second!=rrs.end();++second)
-    if(second->dr.d_place!=DNSResourceRecord::ANSWER)
-      break;
-
-  dns_random_engine r;
-  if(second-first > 1)
-    shuffle(first, second, r);
-
-  // now shuffle the additional records
-  for(first=second;first!=rrs.end();++first)
-    if(first->dr.d_place==DNSResourceRecord::ADDITIONAL && first->dr.d_type != QType::CNAME) // CNAME must come first
-      break;
-  for(second=first;second!=rrs.end();++second)
-    if(second->dr.d_place!=DNSResourceRecord::ADDITIONAL)
-      break;
-
-  if(second-first>1)
-    shuffle(first, second, r);
-
-  // we don't shuffle the rest
-}
-
-
-// shuffle, maintaining some semblance of order
-void shuffle(vector<DNSRecord>& rrs)
-{
-  vector<DNSRecord>::iterator first, second;
-  for(first=rrs.begin();first!=rrs.end();++first)
-    if(first->d_place==DNSResourceRecord::ANSWER && first->d_type != QType::CNAME) // CNAME must come first
-      break;
-  for(second=first;second!=rrs.end();++second)
-    if(second->d_place!=DNSResourceRecord::ANSWER || second->d_type == QType::RRSIG) // leave RRSIGs at the end
-      break;
-
-  dns_random_engine r;
-  if(second-first>1)
-    shuffle(first, second, r);
-
-  // now shuffle the additional records
-  for(first=second;first!=rrs.end();++first)
-    if(first->d_place==DNSResourceRecord::ADDITIONAL && first->d_type != QType::CNAME) // CNAME must come first
-      break;
-  for(second=first; second!=rrs.end(); ++second)
-    if(second->d_place!=DNSResourceRecord::ADDITIONAL)
-      break;
-
-  if(second-first>1)
-    shuffle(first, second, r);
-
-  // we don't shuffle the rest
-}
-
-static uint16_t mapTypesToOrder(uint16_t type)
-{
-  if (type == QType::CNAME)
-    return 0;
-  if (type == QType::RRSIG)
-    return 65535;
-  else
-    return 1;
-}
-
-// make sure rrs is sorted in d_place order to avoid surprises later
-// then shuffle the parts that desire shuffling
-void orderAndShuffle(vector<DNSRecord>& rrs)
-{
-  std::stable_sort(rrs.begin(), rrs.end(), [](const DNSRecord&a, const DNSRecord& b) { 
-      return std::make_tuple(a.d_place, mapTypesToOrder(a.d_type)) < std::make_tuple(b.d_place, mapTypesToOrder(b.d_type));
-    });
-  shuffle(rrs);
 }

--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -28,10 +28,13 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string>
+#include <random>
+
 #include "dns_random.hh"
 #include "arguments.hh"
 #include "logger.hh"
 #include "boost/lexical_cast.hpp"
+#include "dnsparser.hh"
 
 #if defined(HAVE_RANDOMBYTES_STIR)
 #include <sodium.h>
@@ -329,4 +332,83 @@ uint32_t dns_random(uint32_t upper_bound) {
 uint16_t dns_random_uint16()
 {
   return dns_random(0x10000);
+}
+
+// shuffle, maintaining some semblance of order
+void shuffle(vector<DNSZoneRecord>& rrs)
+{
+  vector<DNSZoneRecord>::iterator first, second;
+  for(first=rrs.begin();first!=rrs.end();++first)
+    if(first->dr.d_place==DNSResourceRecord::ANSWER && first->dr.d_type != QType::CNAME) // CNAME must come first
+      break;
+  for(second=first;second!=rrs.end();++second)
+    if(second->dr.d_place!=DNSResourceRecord::ANSWER)
+      break;
+
+  dns_random_engine r;
+  if(second-first > 1)
+    shuffle(first, second, r);
+
+  // now shuffle the additional records
+  for(first=second;first!=rrs.end();++first)
+    if(first->dr.d_place==DNSResourceRecord::ADDITIONAL && first->dr.d_type != QType::CNAME) // CNAME must come first
+      break;
+  for(second=first;second!=rrs.end();++second)
+    if(second->dr.d_place!=DNSResourceRecord::ADDITIONAL)
+      break;
+
+  if(second-first>1)
+    shuffle(first, second, r);
+
+  // we don't shuffle the rest
+}
+
+
+// shuffle, maintaining some semblance of order
+void shuffle(vector<DNSRecord>& rrs)
+{
+  vector<DNSRecord>::iterator first, second;
+  for(first=rrs.begin();first!=rrs.end();++first)
+    if(first->d_place==DNSResourceRecord::ANSWER && first->d_type != QType::CNAME) // CNAME must come first
+      break;
+  for(second=first;second!=rrs.end();++second)
+    if(second->d_place!=DNSResourceRecord::ANSWER || second->d_type == QType::RRSIG) // leave RRSIGs at the end
+      break;
+
+  dns_random_engine r;
+  if(second-first>1)
+    shuffle(first, second, r);
+
+  // now shuffle the additional records
+  for(first=second;first!=rrs.end();++first)
+    if(first->d_place==DNSResourceRecord::ADDITIONAL && first->d_type != QType::CNAME) // CNAME must come first
+      break;
+  for(second=first; second!=rrs.end(); ++second)
+    if(second->d_place!=DNSResourceRecord::ADDITIONAL)
+      break;
+
+  if(second-first>1)
+    shuffle(first, second, r);
+
+  // we don't shuffle the rest
+}
+
+static uint16_t mapTypesToOrder(uint16_t type)
+{
+  if (type == QType::CNAME)
+    return 0;
+  if (type == QType::RRSIG)
+    return 65535;
+  else
+    return 1;
+}
+
+// make sure rrs is sorted in d_place order to avoid surprises later
+// then shuffle the parts that desire shuffling
+void orderAndShuffle(vector<DNSRecord>& rrs)
+{
+  std::stable_sort(rrs.begin(), rrs.end(), [](const DNSRecord&a, const DNSRecord& b) { 
+      return std::make_tuple(a.d_place, mapTypesToOrder(a.d_type)) < std::make_tuple(b.d_place, mapTypesToOrder(b.d_type));
+    });
+  shuffle(rrs);
 }

--- a/pdns/dns_random.hh
+++ b/pdns/dns_random.hh
@@ -21,7 +21,37 @@
  */
 #pragma once
 #include <cstdint>
+#include <limits>
+#include <vector>
 
 void dns_random_init(const std::string& data = "", bool force_reinit = false);
 uint32_t dns_random(uint32_t n);
 uint16_t dns_random_uint16();
+
+
+struct dns_random_engine {
+
+  typedef uint32_t result_type;
+
+  static constexpr result_type min()
+  {
+    return 0;
+  }
+
+  static constexpr result_type max()
+  {
+    return std::numeric_limits<result_type>::max() - 1;
+  }
+
+  result_type operator()()
+  {
+    return dns_random(std::numeric_limits<result_type>::max());
+  }
+};
+
+struct DNSRecord;
+struct DNSZoneRecord;
+void shuffle(std::vector<DNSRecord>& rrs);
+void shuffle(std::vector<DNSZoneRecord>& rrs);
+void orderAndShuffle(std::vector<DNSRecord>& rrs);
+

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -50,6 +50,7 @@
 #include "ednssubnet.hh"
 #include "gss_context.hh"
 #include "dns_random.hh"
+#include "shuffle.hh"
 
 bool DNSPacket::s_doEDNSSubnetProcessing;
 uint16_t DNSPacket::s_udpTruncationThreshold;
@@ -226,7 +227,7 @@ void DNSPacket::wrapup()
   static bool mustNotShuffle = ::arg().mustDo("no-shuffle");
 
   if(!d_tcp && !mustNotShuffle) {
-    shuffle(d_rrs);
+    pdns::shuffle(d_rrs);
   }
   d_wrapped=true;
 

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -288,8 +288,6 @@ inline void unixDie(const string &why)
 
 string makeHexDump(const string& str);
 
-void orderAndShuffle(vector<DNSRecord>& rrs);
-
 void normalizeTV(struct timeval& tv);
 const struct timeval operator+(const struct timeval& lhs, const struct timeval& rhs);
 const struct timeval operator-(const struct timeval& lhs, const struct timeval& rhs);

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -287,10 +287,6 @@ inline void unixDie(const string &why)
 }
 
 string makeHexDump(const string& str);
-struct DNSRecord;
-struct DNSZoneRecord;
-void shuffle(vector<DNSRecord>& rrs);
-void shuffle(vector<DNSZoneRecord>& rrs);
 
 void orderAndShuffle(vector<DNSRecord>& rrs);
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -90,6 +90,7 @@
 #include "gettime.hh"
 #include "proxy-protocol.hh"
 #include "pubsuffix.hh"
+#include "shuffle.hh"
 #ifdef NOD_ENABLED
 #include "nod.hh"
 #endif /* NOD_ENABLED */
@@ -1557,7 +1558,7 @@ static void startDoResolve(void *p)
       }
 
       if(ret.size()) {
-        orderAndShuffle(ret);
+        pdns::orderAndShuffle(ret);
 	if(auto sl = luaconfsLocal->sortlist.getOrderCmp(dc->d_source)) {
 	  stable_sort(ret.begin(), ret.end(), *sl);
 	  variableAnswer=true;

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -168,6 +168,7 @@ pdns_recursor_SOURCES = \
 	secpoll-recursor.cc secpoll-recursor.hh \
 	secpoll.cc secpoll.hh \
 	sholder.hh \
+	shuffle.cc shuffle.hh \
 	sillyrecords.cc \
 	snmp-agent.hh snmp-agent.cc \
 	sortlist.cc sortlist.hh \

--- a/pdns/recursordist/shuffle.cc
+++ b/pdns/recursordist/shuffle.cc
@@ -1,0 +1,1 @@
+../shuffle.cc

--- a/pdns/recursordist/shuffle.hh
+++ b/pdns/recursordist/shuffle.hh
@@ -1,0 +1,1 @@
+../shuffle.hh

--- a/pdns/shuffle.cc
+++ b/pdns/shuffle.cc
@@ -1,0 +1,109 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string>
+
+#include "shuffle.hh"
+#include "dns_random.hh"
+#include "dnsparser.hh"
+
+// shuffle, maintaining some semblance of order
+void pdns::shuffle(std::vector<DNSZoneRecord>& rrs)
+{
+  std::vector<DNSZoneRecord>::iterator first, second;
+  for(first=rrs.begin();first!=rrs.end();++first)
+    if(first->dr.d_place==DNSResourceRecord::ANSWER && first->dr.d_type != QType::CNAME) // CNAME must come first
+      break;
+  for(second=first;second!=rrs.end();++second)
+    if(second->dr.d_place!=DNSResourceRecord::ANSWER)
+      break;
+
+  dns_random_engine r;
+  if(second-first > 1)
+    shuffle(first, second, r);
+
+  // now shuffle the additional records
+  for(first=second;first!=rrs.end();++first)
+    if(first->dr.d_place==DNSResourceRecord::ADDITIONAL && first->dr.d_type != QType::CNAME) // CNAME must come first
+      break;
+  for(second=first;second!=rrs.end();++second)
+    if(second->dr.d_place!=DNSResourceRecord::ADDITIONAL)
+      break;
+
+  if(second-first>1)
+    shuffle(first, second, r);
+
+  // we don't shuffle the rest
+}
+
+
+// shuffle, maintaining some semblance of order
+void pdns::shuffle(std::vector<DNSRecord>& rrs)
+{
+  std::vector<DNSRecord>::iterator first, second;
+  for(first=rrs.begin();first!=rrs.end();++first)
+    if(first->d_place==DNSResourceRecord::ANSWER && first->d_type != QType::CNAME) // CNAME must come first
+      break;
+  for(second=first;second!=rrs.end();++second)
+    if(second->d_place!=DNSResourceRecord::ANSWER || second->d_type == QType::RRSIG) // leave RRSIGs at the end
+      break;
+
+  dns_random_engine r;
+  if(second-first>1)
+    shuffle(first, second, r);
+
+  // now shuffle the additional records
+  for(first=second;first!=rrs.end();++first)
+    if(first->d_place==DNSResourceRecord::ADDITIONAL && first->d_type != QType::CNAME) // CNAME must come first
+      break;
+  for(second=first; second!=rrs.end(); ++second)
+    if(second->d_place!=DNSResourceRecord::ADDITIONAL)
+      break;
+
+  if(second-first>1)
+    shuffle(first, second, r);
+
+  // we don't shuffle the rest
+}
+
+static uint16_t mapTypesToOrder(uint16_t type)
+{
+  if (type == QType::CNAME)
+    return 0;
+  if (type == QType::RRSIG)
+    return 65535;
+  else
+    return 1;
+}
+
+// make sure rrs is sorted in d_place order to avoid surprises later
+// then shuffle the parts that desire shuffling
+void pdns::orderAndShuffle(vector<DNSRecord>& rrs)
+{
+  std::stable_sort(rrs.begin(), rrs.end(), [](const DNSRecord&a, const DNSRecord& b) { 
+      return std::make_tuple(a.d_place, mapTypesToOrder(a.d_type)) < std::make_tuple(b.d_place, mapTypesToOrder(b.d_type));
+    });
+  shuffle(rrs);
+}

--- a/pdns/shuffle.hh
+++ b/pdns/shuffle.hh
@@ -20,32 +20,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include <cstdint>
-#include <limits>
+#include <vector>
 
-void dns_random_init(const std::string& data = "", bool force_reinit = false);
-uint32_t dns_random(uint32_t n);
-uint16_t dns_random_uint16();
+struct DNSRecord;
+struct DNSZoneRecord;
 
 namespace pdns {
-  struct dns_random_engine {
-
-    typedef uint32_t result_type;
-
-    static constexpr result_type min()
-    {
-      return 0;
-    }
-
-    static constexpr result_type max()
-    {
-      return std::numeric_limits<result_type>::max() - 1;
-    }
-
-    result_type operator()()
-    {
-      return dns_random(std::numeric_limits<result_type>::max());
-    }
-  };
+  void shuffle(std::vector<DNSRecord>& rrs);
+  void shuffle(std::vector<DNSZoneRecord>& rrs);
+  void orderAndShuffle(std::vector<DNSRecord>& rrs);
 }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -992,7 +992,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   t_sstorage.nsSpeeds[qname].purge(speeds);
 
   if(ret.size() > 1) {
-    random_shuffle(ret.begin(), ret.end());
+    shuffle(ret.begin(), ret.end(), pdns::dns_random_engine());
     speedOrderCA so(speeds);
     stable_sort(ret.begin(), ret.end(), so);
 
@@ -1657,7 +1657,7 @@ inline std::vector<std::pair<DNSName, float>> SyncRes::shuffleInSpeedOrder(NsSet
       return rnameservers;
   }
 
-  random_shuffle(rnameservers.begin(),rnameservers.end());
+  shuffle(rnameservers.begin(), rnameservers.end(), pdns::dns_random_engine());
   speedOrder so;
   stable_sort(rnameservers.begin(),rnameservers.end(), so);
 
@@ -1688,7 +1688,7 @@ inline vector<ComboAddress> SyncRes::shuffleForwardSpeed(const vector<ComboAddre
     speed=t_sstorage.nsSpeeds[nsName].get(d_now);
     speeds[val]=speed;
   }
-  random_shuffle(nameservers.begin(),nameservers.end());
+  shuffle(nameservers.begin(),nameservers.end(), pdns::dns_random_engine());
   speedOrderCA so(speeds);
   stable_sort(nameservers.begin(),nameservers.end(), so);
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1657,7 +1657,9 @@ inline std::vector<std::pair<DNSName, float>> SyncRes::shuffleInSpeedOrder(NsSet
       return rnameservers;
   }
 
-  shuffle(rnameservers.begin(), rnameservers.end(), pdns::dns_random_engine());
+  // Using  shuffle(rnameservers.begin(), rnameservers.end(), pdsn:dns_ramndom_engine()) causes a boost assert,
+  // to be investigated
+  random_shuffle(rnameservers.begin(),rnameservers.end());
   speedOrder so;
   stable_sort(rnameservers.begin(),rnameservers.end(), so);
 


### PR DESCRIPTION
std::random_shuffle is deprecated and removed starting from C++17, so we
might better use std::shuffle which uses URBG:
https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator
under the hood for a better randoms generation.

### Short description
utilize std::shuffle
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
