### PR TITLE
auth: Do an ANY lookup for all types then filter

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -116,6 +116,22 @@ When notifying a domain, also notify these nameservers. Example:
 ``also-notify`` always receive a notification. Even if they do not match
 the list in :ref:`setting-only-notify`.
 
+.. _setting-any-lookups-only:
+
+``any-lookups-only``
+--------------------
+
+-  Boolean
+-  Default: yes
+
+.. versionadded:: 4.4.0
+
+Whether PowerDNS will only send ANY lookups to its backends, instead of sometimes requesting the exact needed type.
+This reduces the load on backends by retrieving all the types for a given name at once, adding all of them to the cache.
+It improves performance significantly for latency-sensitive backends, like SQL ones, where a round-trip takes serious time.
+This behaviour is enabled by default but can be disabled by setting this option to "no" for the few multi-backends setups
+that do not support it.
+
 .. _setting-any-to-tcp:
 
 ``any-to-tcp``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -116,22 +116,6 @@ When notifying a domain, also notify these nameservers. Example:
 ``also-notify`` always receive a notification. Even if they do not match
 the list in :ref:`setting-only-notify`.
 
-.. _setting-any-lookups-only:
-
-``any-lookups-only``
---------------------
-
--  Boolean
--  Default: yes
-
-.. versionadded:: 4.4.0
-
-Whether PowerDNS will only send ANY lookups to its backends, instead of sometimes requesting the exact needed type.
-This reduces the load on backends by retrieving all the types for a given name at once, adding all of them to the cache.
-It improves performance significantly for latency-sensitive backends, like SQL ones, where a round-trip takes serious time.
-This behaviour is enabled by default but can be disabled by setting this option to "no" for the few multi-backends setups
-that do not support it.
-
 .. _setting-any-to-tcp:
 
 ``any-to-tcp``
@@ -322,6 +306,22 @@ compile-time.
 
 Name of this virtual configuration - will rename the binary image. See
 :doc:`guides/virtual-instances`.
+
+.. _setting-consistent-backends:
+
+``consistent-backends``
+--------------------
+
+-  Boolean
+-  Default: no
+
+.. versionadded:: 4.4.0
+
+When this is set, PowerDNS assumes that any single domain lives in only one backend.
+This allows PowerDNS to send ANY lookups to its backends, instead of sometimes requesting the exact needed type.
+This reduces the load on backends by retrieving all the types for a given name at once, adding all of them to the cache.
+It improves performance significantly for latency-sensitive backends, like SQL ones, where a round-trip takes serious time.
+This behaviour will be enabled by default in a future release.
 
 .. _setting-control-console:
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -245,7 +245,7 @@ void declareArguments()
 
   ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
 
-  ::arg().set("any-lookups-only", "Send only ANY lookup operations to the backend to reduce the number of lookups")="yes";
+  ::arg().set("consistent-backends", "Assume individual domains are not divided over backends. Send only ANY lookup operations to the backend to reduce the number of lookups")="yes";
 
   ::arg().set("rng", "Specify the random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
   ::arg().setDefaults();

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -245,7 +245,7 @@ void declareArguments()
 
   ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
 
-  ::arg().set("any-lookups-only", "Send only ANY lookup operations to the backend to reduce the number of lookups.")="yes";
+  ::arg().set("any-lookups-only", "Send only ANY lookup operations to the backend to reduce the number of lookups")="yes";
 
   ::arg().set("rng", "Specify the random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
   ::arg().setDefaults();

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -245,6 +245,8 @@ void declareArguments()
 
   ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
 
+  ::arg().set("any-lookups-only", "Send only ANY lookup operations to the backend to reduce the number of lookups.")="yes";
+
   ::arg().set("rng", "Specify the random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
   ::arg().setDefaults();
 }

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -32,6 +32,9 @@
 #include "pdns/packetcache.hh"
 #include "dnspacket.hh"
 #include "dns.hh"
+#include "statbag.hh"
+
+extern StatBag S;
 
 // this has to be somewhere central, and not in a file that requires Lua
 // this is so the geoipbackend can set this pointer if loaded for lua-record.cc
@@ -241,6 +244,7 @@ vector<DNSBackend *> BackendMakerClass::all(bool metadataOnly)
 bool DNSBackend::getSOA(const DNSName &domain, SOAData &sd)
 {
   this->lookup(QType(QType::SOA),domain,-1);
+  S.inc("backend-queries");
 
   DNSResourceRecord rr;
   rr.auth = true;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -135,6 +135,7 @@ static void loadMainConfig(const std::string& configdir)
   ::arg().set("chroot","Switch to this chroot jail")="";
   ::arg().set("dnssec-key-cache-ttl","Seconds to cache DNSSEC keys from the database")="30";
   ::arg().set("domain-metadata-cache-ttl","Seconds to cache domain metadata from the database")="60";
+  ::arg().set("any-lookups-only","Send only ANY lookup operations to the backend to reduce the number of lookups")="yes";
 
   // Keep this line below all ::arg().set() statements
   if (! ::arg().laxFile(configname.c_str()))

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -135,7 +135,7 @@ static void loadMainConfig(const std::string& configdir)
   ::arg().set("chroot","Switch to this chroot jail")="";
   ::arg().set("dnssec-key-cache-ttl","Seconds to cache DNSSEC keys from the database")="30";
   ::arg().set("domain-metadata-cache-ttl","Seconds to cache domain metadata from the database")="60";
-  ::arg().set("any-lookups-only","Send only ANY lookup operations to the backend to reduce the number of lookups")="yes";
+  ::arg().set("consistent-backends", "Assume individual domains are not divided over backends. Send only ANY lookup operations to the backend to reduce the number of lookups")="yes";
 
   // Keep this line below all ::arg().set() statements
   if (! ::arg().laxFile(configname.c_str()))

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -335,6 +335,7 @@ struct UeberBackendSetupArgFixture {
     extern AuthQueryCache QC;
     ::arg().set("query-cache-ttl")="0";
     ::arg().set("negquery-cache-ttl")="0";
+    ::arg().set("consistent-backends")="no";
     QC.cleanup();
     BackendMakers().clear();
     SimpleBackend::s_zones.clear();

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -319,11 +319,12 @@ bool UeberBackend::getAuth(const DNSName &target, const QType& qtype, SOAData* s
   vector<pair<size_t, SOAData> > bestmatch (backends.size(), make_pair(target.wirelength()+1, SOAData()));
   do {
 
+    d_question.qtype = QType::SOA;
+    d_question.qname = shorter;
+    d_question.zoneId = -1;
+
     // Check cache
     if(cachedOk && (d_cache_ttl || d_negcache_ttl)) {
-      d_question.qtype = QType::SOA;
-      d_question.qname = shorter;
-      d_question.zoneId = -1;
 
       cstat = cacheHas(d_question,d_answers);
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -99,7 +99,7 @@ void UeberBackend::go(void)
   S.declare("backend-queries", "Number of queries sent to the backend(s)");
   s_backendQueries = S.getPointer("backend-queries");
 
-  if (::arg().mustDo("any-lookups-only")) {
+  if (::arg().mustDo("consistent-backends")) {
     s_doANYLookupsOnly = true;
   }
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -714,12 +714,12 @@ bool UeberBackend::get(DNSZoneRecord &rr)
 
   if (!gotRecord) {
     // cout<<"end of ueberbackend get, seeing if we should cache"<<endl;
-    if (s_doANYLookupsOnly && d_anyCount == 0 && d_handle.qname.countLabels()) {
+    if (s_doANYLookupsOnly && d_anyCount == 0 && !d_handle.qname.empty()) {
       /* we can negcache the whole name */
       // cerr<<"we can negcache the whole name"<<endl;
       addNegCache(d_question, QType::ANY);
     }
-    else if (d_ancount == 0 && d_handle.qname.countLabels()) {
+    else if (d_ancount == 0 && !d_handle.qname.empty()) {
       /* we can negcache that specific type */
       // cerr<<"we can negcache the exact type of type "<<d_question.qtype.getName()<<endl;
       addNegCache(d_question, d_question.qtype);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -76,16 +76,16 @@ public:
     ~handle();
 
     //! The UeberBackend class where this handle belongs to
-    UeberBackend *parent;
+    UeberBackend *parent{nullptr};
     //! The current real backend, which is answering questions
-    DNSBackend *d_hinterBackend;
+    DNSBackend *d_hinterBackend{nullptr};
 
     //! DNSPacket who asked this question
-    DNSPacket* pkt_p;
+    DNSPacket* pkt_p{nullptr};
     DNSName qname;
 
     //! Index of the current backend within the backends vector
-    unsigned int i;
+    unsigned int i{0};
     QType qtype;
 
   private:
@@ -144,19 +144,20 @@ private:
     DNSName qname;
     int zoneId;
     QType qtype;
-  }d_question;
+  } d_question;
 
   unsigned int d_cache_ttl, d_negcache_ttl;
-  int d_domain_id;
-  int d_ancount;
+  unsigned int d_ancount{0};
+  unsigned int d_anyCount{0};
+  int d_domain_id{-1};
 
-  bool d_negcached;
-  bool d_cached;
+  bool d_negcached{false};
+  bool d_cached{false};
+  bool d_stale{false};
+
   static bool d_go;
-  bool d_stale;
 
   int cacheHas(const Question &q, vector<DNSZoneRecord> &rrs);
-  void addNegCache(const Question &q);
-  void addCache(const Question &q, vector<DNSZoneRecord>&& rrs);
-  
+  void addNegCache(const Question &q, const QType& qtype);
+  void addCache(const Question &q, const QType& qtype, vector<DNSZoneRecord>&& rrs);
 };

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -155,6 +155,7 @@ private:
   bool d_cached{false};
   bool d_stale{false};
 
+  static AtomicCounter* s_backendQueries;
   static bool d_go;
 
   int cacheHas(const Question &q, vector<DNSZoneRecord> &rrs);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -157,6 +157,7 @@ private:
 
   static AtomicCounter* s_backendQueries;
   static bool d_go;
+  static bool s_doANYLookupsOnly;
 
   int cacheHas(const Question &q, vector<DNSZoneRecord> &rrs);
   void addNegCache(const Question &q, const QType& qtype);

--- a/regression-tests.nobackend/counters/command
+++ b/regression-tests.nobackend/counters/command
@@ -27,7 +27,7 @@ $SDIG ::1 $port example.com SOA >&2 >/dev/null
 $SDIG ::1 $port example.com SOA tcp >&2 >/dev/null
 
 $PDNSCONTROL --config-name= --no-config --socket-dir=./ 'show *' | \
-  tr ',' '\n'| grep -v -E '(user-msec|sys-msec|cpu-iowait|cpu-steal|uptime|udp-noport-errors|udp-in-errors|real-memory-usage|special-memory-usage|udp-recvbuf-errors|udp-sndbuf-errors|-hit|-miss|fd-usage|latency)' | LC_ALL=C sort
+  tr ',' '\n'| grep -v -E '(user-msec|sys-msec|cpu-iowait|cpu-steal|uptime|udp-noport-errors|udp-in-errors|real-memory-usage|special-memory-usage|udp-recvbuf-errors|udp-sndbuf-errors|-hit|-miss|fd-usage|latency|backend-queries)' | LC_ALL=C sort
 
 kill $(cat pdns*.pid)
 rm pdns*.pid


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Most of our backends have a very high latency, meaning that it takes a long time to send a query and get the answer, regardless of whether we are asking for one type or several. Our code base often asks for a specific type, and our current code stores separately the answers for ANY queries and the ones for a specific type. This seems wasteful since the answer to an ANY query already contains the records for a more specific one, and our in-memory records cache is must faster than going to the backend. We could save a round-trip by looking for ANY answers when we don't find a specific one in the record cache, but our first query is often for the specific NS type because we are looking for a referral.
This PR converts all lookups to an ANY lookup instead, making sure that we fill the cache as fast as possible to save round-trips to the backend later.

My tests showed roughly one third less queries to the backend in simple cases, and probably more in DNSSEC cases, while achieving higher QPS boundaries (~ +30%). CPU usage is also significantly reduced while replying a real-world PCAP.
The number of entries in the records cache is also significantly lower since we don't need to store a record twice, for ANY and for the exact type itself.

We could easily enable that change for specific backends only if we believe it might have a negative effect on some of them, although testing with the bind backend showed a slight improvement there as well, even though lookups in the bind backend are already quite fast.
I have not tested LMDB.

We could reduce the number of round-trips to the backend even more by getting rid of the 'SOA' special case, since I'm not aware of any backend currently implementing it in a special way.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

