### PR TITLE
auth smysql: mimic error message format from mysql tooling

### DIFF
--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -515,7 +515,7 @@ SMySQL::~SMySQL()
 
 SSqlException SMySQL::sPerrorException(const string &reason)
 {
-  return SSqlException(reason+string(": ")+mysql_error(&d_db));
+  return SSqlException(reason+string(": ERROR ")+std::to_string(mysql_errno(&d_db))+" ("+string(mysql_sqlstate(&d_db))+"): "+mysql_error(&d_db));
 }
 
 std::unique_ptr<SSqlStatement> SMySQL::prepare(const string& query, int nparams)


### PR DESCRIPTION
### Short description
Before: `Can't connect to MySQL server on 'mariadb.mydomain.local' (101)`

Now: `ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)`

Sadly, the errno is still not expanded to a useful string, like `perror` could do if the `101` or `2` was offered by libmysqlclient as an integer, instead of something hidden in a string.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master