### PR TITLE
Add support for dnsdist-15 to repo script.

### DIFF
--- a/build-scripts/docker/generate-repo-files.sh
+++ b/build-scripts/docker/generate-repo-files.sh
@@ -9,7 +9,8 @@ if [ "$1" = "" -o "$1" = "-?" -o "$1" = "-h" -o "$1" = "--help" ]; then
     echo "Usage: generate-repo-files.sh RELEASE"
     echo
     echo "  • RELEASE: [ auth-40 | auth-41 | auth-42 | auth-43 |"
-    echo "               rec-40 | rec-41 | rec-42 | rec-43 ]"
+    echo "               rec-40 | rec-41 | rec-42 | rec-43 |"
+    echo "               dnsdist-15 ]"
     exit 1
 fi
 
@@ -63,6 +64,16 @@ write_debian_or_ubuntu()
 deb [arch=amd64] http://repo.powerdns.com/$OS $VERSION-$RELEASE main
 EOF
 
+    # For the following two maybe only create depending on package, but
+    # it's not really a big deal.
+
+    # if not exists
+    cat <<EOF > dnsdist.debian-and-ubuntu
+Package: dnsdist*
+Pin: origin repo.powerdns.com
+Pin-Priority: 600
+EOF
+
     # if not exists
     cat <<EOF > pdns.debian-and-ubuntu
 Package: pdns-*
@@ -76,6 +87,7 @@ FROM $OS:$VERSION
 RUN apt-get update
 RUN apt-get install -y curl gnupg dnsutils
 
+COPY dnsdist.debian-and-ubuntu /etc/apt/preferences.d/dnsdist
 COPY pdns.debian-and-ubuntu /etc/apt/preferences.d/pdns
 COPY pdns.list.$RELEASE.$OS-$VERSION /etc/apt/sources.list.d/pdns.list
 
@@ -158,6 +170,14 @@ elif [ "$RELEASE" = "rec-42" -o "$RELEASE" = "rec-43" ]; then
     write_debian buster pdns-recursor pdns_recursor
     write_ubuntu xenial pdns-recursor pdns_recursor
     write_ubuntu bionic pdns-recursor pdns_recursor
+elif [ "$RELEASE" = "dnsdist-15" ]; then
+    write_centos 6 dnsdist dnsdist
+    write_centos 7 dnsdist dnsdist
+    write_centos 8 dnsdist dnsdist
+    write_debian stretch dnsdist dnsdist
+    write_debian buster dnsdist dnsdist
+    write_ubuntu xenial dnsdist dnsdist
+    write_ubuntu bionic dnsdist dnsdist
 else
     echo "Invalid release: $RELEASE"
     exit 1

--- a/build-scripts/docker/generate-repo-files.sh
+++ b/build-scripts/docker/generate-repo-files.sh
@@ -3,7 +3,9 @@
 # - `docker build --no-cache --pull --file Dockerfile.auth-41.ubuntu-bionic --tag auth-41.ubuntu-bionic .`
 # - `docker run -it auth-41.ubuntu-bionic`
 # - `docker run -it auth-41.ubuntu-bionic /bin/bash`
+#     - `dnsdist --verbose 9.9.9.9`
 #     - `pdns_recursor`
+#     - `pdns_server`
 
 if [ "$1" = "" -o "$1" = "-?" -o "$1" = "-h" -o "$1" = "--help" ]; then
     echo "Usage: generate-repo-files.sh RELEASE"
@@ -31,6 +33,11 @@ EOF
     if [ "$VERSION" = "6" -o "$VERSION" = "7" ]; then
         cat <<EOF >> Dockerfile.$RELEASE.$OS-$VERSION
 RUN yum install -y yum-plugin-priorities
+EOF
+    elif [ "$RELEASE" = "dnsdist-15" -a "$VERSION" = "8" ]; then
+        cat <<EOF >> Dockerfile.$RELEASE.$OS-$VERSION
+RUN dnf install -y 'dnf-command(config-manager)'
+RUN dnf config-manager --set-enabled PowerTools
 EOF
     fi
 
@@ -97,7 +104,7 @@ RUN apt-get install -y $PKG
 EOF
 
     if [ "$RELEASE" = "rec-43" ]; then
-    cat <<EOF >> Dockerfile.$RELEASE.$OS-$VERSION
+        cat <<EOF >> Dockerfile.$RELEASE.$OS-$VERSION
 
 RUN mkdir /var/run/pdns-recursor
 EOF

--- a/build-scripts/docker/generate-repo-files.sh
+++ b/build-scripts/docker/generate-repo-files.sh
@@ -6,6 +6,20 @@
 #     - `dnsdist --verbose 9.9.9.9`
 #     - `pdns_recursor`
 #     - `pdns_server`
+#
+# Remi contributed this snippet:
+#
+#     #!/bin/bash
+#
+#     readonly product=dnsdist-15
+#
+#     for version in centos-6 centos-7 centos-8 debian-buster debian-stretch ubuntu-bionic ubuntu-xenial; do
+#       docker build --no-cache --pull --file Dockerfile.${product}.${version} --tag ${product}.${version} .
+#     done
+#
+#     for version in centos-6 centos-7 centos-8 debian-buster debian-stretch ubuntu-bionic ubuntu-xenial; do
+#       docker run -it ${product}.${version} dnsdist -v 9.9.9.9
+#     done
 
 if [ "$1" = "" -o "$1" = "-?" -o "$1" = "-h" -o "$1" = "--help" ]; then
     echo "Usage: generate-repo-files.sh RELEASE"


### PR DESCRIPTION
Tested using dnsdist-1.5.0-rc1 and most work but CentOS 8 gives the following error:

```
Step 4/5 : RUN yum install -y dnsdist
 ---> Running in 1cc64a74c4e1
PowerDNS repository for dnsdist - version 1.5.X  24 kB/s | 2.2 kB     00:00    
Extra Packages for Enterprise Linux Modular 8 - 126 kB/s | 116 kB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64  1.6 MB/s | 6.3 MB     00:03    
Error: 
 Problem: cannot install the best candidate for the job
  - nothing provides libcdb.so.1()(64bit) needed by dnsdist-1.5.0-0.rc1.1pdns.el8.x86_64
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
The command '/bin/sh -c yum install -y dnsdist' returned a non-zero code: 1
```