### PR TITLE
auth: quote/escape PG connection parameters

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -17,6 +17,12 @@ upgrade notes if your version is older than 3.4.2.
 The in-database format of the ``IPSECKEY`` has changed from 'generic' format to its specialized format.
 It is recommended to re-transfer, using ``pdns_control retrieve ZONE``, all zones that have ``IPSECKEY`` or ``TYPE45`` records.
 
+PostgreSQL configuration escaping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We now correctly quote/escape Postgres connection parameters.
+If you used single quotes around your Postgres password because it contained spaces, you now need to remove those quotes.
+
 4.3.0 to 4.3.1
 --------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -21,7 +21,7 @@ PostgreSQL configuration escaping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We now correctly quote/escape Postgres connection parameters.
-If you used single quotes around your Postgres password because it contained spaces, you now need to remove those quotes.
+If you used single quotes (or some other form of escaping) around your Postgres password because it contained spaces, you now need to put your unmodified, unescaped, unquoted password in your configuration.
 
 4.3.0 to 4.3.1
 --------------

--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -277,6 +277,15 @@ private:
 
 bool SPgSQL::s_dolog;
 
+static string escapeForPQparam(const string &v)
+{
+  string ret = v;
+  boost::replace_all(ret, "\\", "\\\\");
+  boost::replace_all(ret, "'", "\\'");
+
+  return string("'")+ret+string("'");
+}
+
 SPgSQL::SPgSQL(const string &database, const string &host, const string& port, const string &user,
                const string &password, const string &extra_connection_parameters, const bool use_prepared)
 {
@@ -286,16 +295,16 @@ SPgSQL::SPgSQL(const string &database, const string &host, const string& port, c
   d_nstatements = 0;
 
   if (!database.empty())
-    d_connectstr+="dbname="+database;
+    d_connectstr+="dbname="+escapeForPQparam(database);
 
   if (!user.empty())
-    d_connectstr+=" user="+user;
+    d_connectstr+=" user="+escapeForPQparam(user);
 
   if(!host.empty())
-    d_connectstr+=" host="+host;
+    d_connectstr+=" host="+escapeForPQparam(host);
 
   if(!port.empty())
-    d_connectstr+=" port="+port;
+    d_connectstr+=" port="+escapeForPQparam(port);
 
   if(!extra_connection_parameters.empty())
     d_connectstr+=" " + extra_connection_parameters;
@@ -304,7 +313,7 @@ SPgSQL::SPgSQL(const string &database, const string &host, const string& port, c
 
   if(!password.empty()) {
     d_connectlogstr+=" password=<HIDDEN>";
-    d_connectstr+=" password="+password;
+    d_connectstr+=" password="+escapeForPQparam(password);
   }
 
   d_use_prepared = use_prepared;


### PR DESCRIPTION
### Short description
This avoids weird parsing errors when your password contains spaces or single quotes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master