### PR TITLE
auth: Fix warnings reported by clang++ 10

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -344,6 +344,10 @@ static ComboAddress pickwhashed(const ComboAddress& bestwho, vector<pair<int,Com
     sum += i.first;
     pick.push_back({sum, i.second});
   }
+  if (sum == 0) {
+    /* we should not have any weight of zero, but better safe than sorry */
+    return ComboAddress();
+  }
   ComboAddress::addressOnlyHash aoh;
   int r = aoh(bestwho) % sum;
   auto p = upper_bound(pick.begin(), pick.end(), r, [](int rarg, const decltype(pick)::value_type& a) { return rarg < a.first; });

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -368,7 +368,7 @@ static bool getLatLon(const std::string& ip, string& loc)
   double latsec, lonsec;
   char lathem='X', lonhem='X';
 
-  double lat, lon;
+  double lat = 0, lon = 0;
   if(!getLatLon(ip, lat, lon))
     return false;
 
@@ -532,7 +532,7 @@ void setupLuaRecords()
   LuaContext& lua = *s_LUA->getLua();
 
   lua.writeFunction("latlon", []() {
-      double lat, lon;
+      double lat = 0, lon = 0;
       getLatLon(s_lua_record_ctx->bestwho.toString(), lat, lon);
       return std::to_string(lat)+" "+std::to_string(lon);
     });
@@ -559,7 +559,7 @@ void setupLuaRecords()
       auto labels= s_lua_record_ctx->qname.getRawLabels();
       if(labels.size()<4)
         return std::string("unknown");
-      double lat, lon;
+      double lat = 0, lon = 0;
       getLatLon(labels[3]+"."+labels[2]+"."+labels[1]+"."+labels[0], lat, lon);
       return std::to_string(lat)+" "+std::to_string(lon);
     });

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -777,9 +777,8 @@ int makeIPv6sockaddr(const std::string& addr, struct sockaddr_in6* ret)
     hints.ai_family = AF_INET6;
     hints.ai_flags = AI_NUMERICHOST;
 
-    int error;
     // getaddrinfo has anomalous return codes, anything nonzero is an error, positive or negative
-    if((error=getaddrinfo(ourAddr.c_str(), 0, &hints, &res))) {
+    if (getaddrinfo(ourAddr.c_str(), 0, &hints, &res) != 0) {
       return -1;
     }
 

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -784,7 +784,6 @@ void PKCS11DNSCryptoKeyEngine::create(unsigned int bits) {
   std::vector<P11KitAttribute> privAttr;
   CK_MECHANISM mech;
   CK_OBJECT_HANDLE pubKey, privKey;
-  CK_RV rv;
   std::shared_ptr<Pkcs11Token> d_slot;
   d_slot = Pkcs11Token::GetToken(d_module, d_slot_id, d_label, d_pub_label);
   if (d_slot->LoggedIn() == false)
@@ -819,7 +818,7 @@ void PKCS11DNSCryptoKeyEngine::create(unsigned int bits) {
   mech.pParameter = NULL;
   mech.ulParameterLen = 0;
 
-  if ((rv = d_slot->GenerateKeyPair(&mech, pubAttr, privAttr, &pubKey, &privKey))) {
+  if (d_slot->GenerateKeyPair(&mech, pubAttr, privAttr, &pubKey, &privKey)) {
     throw PDNSException("Keypair generation failed");
   }
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- 'value is never actually read' warnings ;
- Prevent reading uninitialized memory in Lua's `getLatLon()` ;
- Make sure we don't divide by zero in Lua's `pickwhashed()`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

