### PR TITLE
dnsdist: Gracefully handle a failure to remove FD on (re)-connection

### DIFF
--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -79,8 +79,14 @@ bool DownstreamState::reconnect()
     for (auto& fd : sockets) {
       if (fd != -1) {
         if (sockets.size() > 1) {
-          std::lock_guard<std::mutex> lock(socketsLock);
-          mplexer->removeReadFD(fd);
+          try {
+            std::lock_guard<std::mutex> lock(socketsLock);
+            mplexer->removeReadFD(fd);
+          }
+          catch (const FDMultiplexerException& e) {
+            /* some sockets might not have been added to the multiplexer
+               yet, that's fine */
+          }
         }
         /* shutdown() is needed to wake up recv() in the responderThread */
         shutdown(fd, SHUT_RDWR);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When more than one socket per backend is used, we might not have added all the socket descriptors to the multiplexer and that's fine.

The error is harmless except for an error message and a leaked file descriptor (which is not an issue unless new servers are added in a loop and fail).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

