### PR TITLE
rectifyZone: do not update ordernames/auth when there is no update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ built_pkgs
 *-shm
 __pycache__
 .circleci/config.yml-local
+.idea

--- a/docs/backends/generic-sql.rst
+++ b/docs/backends/generic-sql.rst
@@ -377,11 +377,11 @@ basic-query for the Generic MySQL backend would appear as:
 
 ::
 
-    gmysql-basic-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and type=? and name=?
+    gmysql-basic-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE disabled=0 and type=? and name=?
 
 Queries can span multiple lines, like this:
 
 ::
 
-    gmysql-basic-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth \
+    gmysql-basic-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername \
     FROM records WHERE disabled=0 and type=? and name=?

--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -85,7 +85,7 @@ public:
 
     declare(suffix,"dnssec","Enable DNSSEC processing","no");
 
-    string record_query = "SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE";
+    string record_query = "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE";
 
     declare(suffix, "basic-query", "Basic query", record_query+" disabled=0 and type=? and name=?");
     declare(suffix, "id-query", "Basic with ID query", record_query+" disabled=0 and type=? and name=? and domain_id=?");

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -68,7 +68,7 @@ public:
     declare( suffix, "password", "Password to connect with","");
     declare(suffix,"dnssec","Enable DNSSEC processing","no");
 
-    string record_query = "SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE";
+    string record_query = "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE";
 
     declare(suffix, "basic-query", "Basic query", record_query+" disabled=0 and type=? and name=?");
     declare(suffix, "id-query", "Basic with ID query", record_query+" disabled=0 and type=? and name=? and domain_id=?");

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -90,7 +90,7 @@ public:
 
     declare(suffix,"dnssec","Enable DNSSEC processing","no");
 
-    string record_query = "SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int FROM records WHERE";
+    string record_query = "SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int,ordername FROM records WHERE";
 
     declare(suffix, "basic-query", "Basic query", record_query+" disabled=false and type=$1 and name=$2");
     declare(suffix, "id-query", "Basic with ID query", record_query+" disabled=false and type=$1 and name=$2 and domain_id=$3");

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -81,7 +81,7 @@ public:
 
     declare(suffix, "dnssec", "Enable DNSSEC processing","no");
 
-    string record_query = "SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE";
+    string record_query = "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE";
 
     declare(suffix, "basic-query", "Basic query", record_query+" disabled=0 and type=:qtype and name=:qname");
     declare(suffix, "id-query", "Basic with ID query", record_query+" disabled=0 and type=:qtype and name=:qname and domain_id=:domain_id");

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1185,7 +1185,7 @@ skiprow:
   if((*d_query_stmt)->hasNextRow()) {
     try {
       (*d_query_stmt)->nextRow(row);
-      ASSERT_ROW_COLUMNS(d_query_name, row, 8);
+      ASSERT_ROW_COLUMNS(d_query_name, row, 9);
     } catch (SSqlException &e) {
       throw PDNSException("GSQLBackend get: "+e.txtReason());
     }
@@ -1743,7 +1743,7 @@ bool GSQLBackend::searchRecords(const string &pattern, int maxResults, vector<DN
       SSqlStatement::row_t row;
       DNSResourceRecord r;
       d_SearchRecordsQuery_stmt->nextRow(row);
-      ASSERT_ROW_COLUMNS("search-records-query", row, 8);
+      ASSERT_ROW_COLUMNS("search-records-query", row, 9);
       try {
         extractRecord(row, r);
       } catch (...) {
@@ -1821,6 +1821,9 @@ void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)
   }
 
   r.last_modified=0;
+
+  if (!row[8].empty())
+    r.ordername = DNSName(boost::replace_all_copy(row[8]," ",".")).labelReverse();
 
   if(d_dnssecQueries)
     r.auth = !row[7].empty() && row[7][0]=='1';

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -95,6 +95,7 @@ public:
   DNSName qname; //!< the name of this record, for example: www.powerdns.com
   DNSName wildcardname;
   string content; //!< what this record points to. Example: 10.1.2.3
+  DNSName ordername;
 
   // Aligned on 8-byte boundaries on systems where time_t is 8 bytes and int
   // is 4 bytes, aka modern linux on x86_64

--- a/regression-tests/backends/godbc_sqlite3-master
+++ b/regression-tests/backends/godbc_sqlite3-master
@@ -14,9 +14,9 @@ godbc-datasource=$GODBC_SQLITE3_DSN
 # ../pdns/pdns_server --module-dir=./modules/ --launch=gsqlite3 --config | grep gsqlite3 | grep query | grep = | cut -c3- | perl -pe 's/^gsqlite3/godbc/; s/:\w+/?/g'
 godbc-activate-domain-key-query=update cryptokeys set active=1 where domain_id=(select id from domains where name=?) and  cryptokeys.id=?
 godbc-add-domain-key-query=insert into cryptokeys (domain_id, flags, active, published, content) select id, ?, ?, ?, ? from domains where name=?
-godbc-any-id-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and name=? and domain_id=?
-godbc-any-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and name=?
-godbc-basic-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and type=? and name=?
+godbc-any-id-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE disabled=0 and name=? and domain_id=?
+godbc-any-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE disabled=0 and name=?
+godbc-basic-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE disabled=0 and type=? and name=?
 godbc-clear-domain-all-keys-query=delete from cryptokeys where domain_id=(select id from domains where name=?)
 godbc-clear-domain-all-metadata-query=delete from domainmetadata where domain_id=(select id from domains where name=?)
 godbc-clear-domain-metadata-query=delete from domainmetadata where domain_id=(select id from domains where name=?) and domainmetadata.kind=?
@@ -40,7 +40,7 @@ godbc-get-order-last-query=select ordername, name from records where disabled=0 
 godbc-get-tsig-key-query=select algorithm, secret from tsigkeys where name=?
 godbc-get-tsig-keys-query=select name,algorithm, secret from tsigkeys
 godbc-publish-domain-key-query=update cryptokeys set published=1 where domain_id=(select id from domains where name=?) and  cryptokeys.id=?
-godbc-id-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and type=? and name=? and domain_id=?
+godbc-id-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE disabled=0 and type=? and name=? and domain_id=?
 godbc-info-all-master-query=select id,name,master,last_check,notified_serial,type from domains where type='MASTER'
 godbc-info-all-slaves-query=select id,name,master,last_check from domains where type='SLAVE'
 godbc-info-zone-query=select id,name,master,last_check,notified_serial,type,account from domains where name=?
@@ -50,14 +50,14 @@ godbc-insert-record-query=insert into records (content,ttl,prio,type,domain_id,d
 godbc-insert-zone-query=insert into domains (type,name,master,account,last_check,notified_serial) values(?, ?, ?, ?, null, null)
 godbc-list-comments-query=SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE domain_id=?
 godbc-list-domain-keys-query=select cryptokeys.id, flags, active, published, content from domains, cryptokeys where cryptokeys.domain_id=domains.id and name=?
-godbc-list-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type
-godbc-list-subzone-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and (name=? OR name like ?) and domain_id=?
+godbc-list-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type
+godbc-list-subzone-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE disabled=0 and (name=? OR name like ?) and domain_id=?
 godbc-nullify-ordername-and-update-auth-query=update records set ordername=NULL,auth=? where domain_id=? and name=? and disabled=0
 godbc-nullify-ordername-and-update-auth-type-query=update records set ordername=NULL,auth=? where domain_id=? and name=? and type=? and disabled=0
 godbc-remove-domain-key-query=delete from cryptokeys where domain_id=(select id from domains where name=?) and cryptokeys.id=?
 godbc-remove-empty-non-terminals-from-zone-query=delete from records where domain_id=? and type is null
 godbc-search-comments-query=SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE name LIKE ? OR comment LIKE ? LIMIT ?
-godbc-search-records-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE name LIKE ? OR content LIKE ? LIMIT ?
+godbc-search-records-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE name LIKE ? OR content LIKE ? LIMIT ?
 godbc-set-domain-metadata-query=insert into domainmetadata (domain_id, kind, content) select id, ?, ? from domains where name=?
 godbc-set-tsig-key-query=replace into tsigkeys (name,algorithm,secret) values(?,?,?)
 godbc-supermaster-query=select account from supermasters where ip=? and nameserver=?


### PR DESCRIPTION
### Short description
Rectify-zone, triggered via API and CLI, computes and updates NSEC3 ordernames for _all_ rr sets in a given zone, but in many cases the time spend will result on no-op updates triggered in the backend. While both wastes CPU time, this PR removes no-op updates of NSEC3 ordernames. Removing the hash iterations that result in no-ops requires more elaborate changes and contribute less to the computational effort and is hence not part of this PR.

To be able to judge from within `DNSSECKeeper::rectifyZone` whether nor not an update of the ordername is required, the ordername is attached to `DNSResourceRecord` upon loading of the zone. Doing so should come at little computational cost.

In a test, I used a zone with ~100k rr sets and ~100k records. To benchmark `rectifyZone`, I inserted a new rr set via the API. The change in this commit increases performance by 600%, from before 30s and ~100k SQL queries updating ordernames down to 5s and 3 SQL queries that update ordernames. Similar numbers for CLI rectify-zone.

The current code has one backend-specific computation, `ordername.labelReverse().toString(" ", false)` which needs to be removed before merging. Any advise on how to proceed with this is appreciated.

I tested this against master and 4.2.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] documented the code

IMHO, these items do not apply for this PR:

- [ ] included documentation (including possible behaviour changes)
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
