### PR TITLE
Wrap pthread objects

### DIFF
--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -187,7 +187,7 @@ public:
   void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) override;
 
   static DNSBackend *maker();
-  static pthread_mutex_t s_startup_lock;
+  static std::mutex s_startup_lock;
 
   void setFresh(uint32_t domain_id) override;
   void setNotified(uint32_t id, uint32_t serial) override;
@@ -221,7 +221,7 @@ public:
 					       ordered_unique<tag<NameTag>, member<BB2DomainInfo, DNSName, &BB2DomainInfo::d_name> >
 					       > > state_t;
   static state_t s_state;
-  static pthread_rwlock_t s_state_lock;
+  static ReadWriteLock s_state_lock;
 
   void parseZoneFile(BB2DomainInfo *bbd);
   void rediscover(string *status=nullptr) override;
@@ -229,7 +229,7 @@ public:
 
   // for supermaster support
   bool superMasterBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db) override;
-  static pthread_mutex_t s_supermaster_config_lock;
+  static std::mutex s_supermaster_config_lock;
   bool createSlaveDomain(const string &ip, const DNSName &domain, const string &nameserver, const string &account) override;
 
 private:

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -32,7 +32,7 @@
 #include <fstream>
 #include <yaml-cpp/yaml.h>
 
-pthread_rwlock_t GeoIPBackend::s_state_lock=PTHREAD_RWLOCK_INITIALIZER;
+ReadWriteLock GeoIPBackend::s_state_lock;
 
 struct GeoIPDNSResourceRecord: DNSResourceRecord {
   int weight;

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -67,7 +67,7 @@ public:
   bool unpublishDomainKey(const DNSName& name, unsigned int id) override;
 
 private:
-  static pthread_rwlock_t s_state_lock;
+  static ReadWriteLock s_state_lock;
 
   void initialize();
   string format2str(string format, const Netmask &addr, GeoIPNetmask& gl);

--- a/modules/gmysqlbackend/smysql.cc
+++ b/modules/gmysqlbackend/smysql.cc
@@ -65,7 +65,7 @@ private:
 static thread_local MySQLThreadCloser threadcloser;
 
 bool SMySQL::s_dolog;
-pthread_mutex_t SMySQL::s_myinitlock = PTHREAD_MUTEX_INITIALIZER;
+std::mutex SMySQL::s_myinitlock;
 
 class SMySQLStatement: public SSqlStatement
 {
@@ -440,7 +440,7 @@ void SMySQL::connect()
 {
   int retry=1;
 
-  Lock l(&s_myinitlock);
+  std::lock_guard<std::mutex> l(s_myinitlock);
   if (d_threadCleanup) {
     threadcloser.enable();
   }

--- a/modules/gmysqlbackend/smysql.hh
+++ b/modules/gmysqlbackend/smysql.hh
@@ -20,6 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
+#include <mutex>
+
 #include <mysql.h>
 #include "pdns/backends/gsql/ssql.hh"
 #include "pdns/utility.hh"
@@ -48,7 +50,7 @@ private:
   void connect();
 
   static bool s_dolog;
-  static pthread_mutex_t s_myinitlock;
+  static std::mutex s_myinitlock;
 
   MYSQL d_db;
   std::string d_database;

--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -29,7 +29,7 @@
 
 static string backendname="[TinyDNSBackend] ";
 uint32_t TinyDNSBackend::s_lastId;
-pthread_mutex_t TinyDNSBackend::s_domainInfoLock=PTHREAD_MUTEX_INITIALIZER;
+std::mutex TinyDNSBackend::s_domainInfoLock;
 TinyDNSBackend::TDI_suffix_t TinyDNSBackend::s_domainInfo;
 
 vector<string> TinyDNSBackend::getLocations()
@@ -90,7 +90,7 @@ TinyDNSBackend::TinyDNSBackend(const string &suffix)
 }
 
 void TinyDNSBackend::getUpdatedMasters(vector<DomainInfo>* retDomains) {
-  Lock l(&s_domainInfoLock); //TODO: We could actually lock less if we do it per suffix.
+  std::lock_guard<std::mutex> l(s_domainInfoLock); //TODO: We could actually lock less if we do it per suffix.
 
   if (! s_domainInfo.count(d_suffix)) {
     TDI_t tmp;
@@ -133,7 +133,7 @@ void TinyDNSBackend::getUpdatedMasters(vector<DomainInfo>* retDomains) {
 }
 
 void TinyDNSBackend::setNotified(uint32_t id, uint32_t serial) {
-  Lock l(&s_domainInfoLock);
+  std::lock_guard<std::mutex> l(s_domainInfoLock);
   if (!s_domainInfo.count(d_suffix)) {
     throw PDNSException("Can't get list of domains to set the serial.");
   }

--- a/modules/tinydnsbackend/tinydnsbackend.hh
+++ b/modules/tinydnsbackend/tinydnsbackend.hh
@@ -32,6 +32,7 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
+#include <mutex>
 
 using namespace ::boost;
 using namespace ::boost::multi_index;
@@ -102,7 +103,7 @@ private:
   string d_suffix;
 
   // Statics
-  static pthread_mutex_t s_domainInfoLock;
+  static std::mutex s_domainInfoLock;
   static TDI_suffix_t s_domainInfo;
   static uint32_t s_lastId; // used to give a domain an id.
 };

--- a/pdns/auth-packetcache.cc
+++ b/pdns/auth-packetcache.cc
@@ -46,13 +46,11 @@ AuthPacketCache::AuthPacketCache(size_t mapsCount): d_maps(mapsCount), d_lastcle
 AuthPacketCache::~AuthPacketCache()
 {
   try {
-    vector<WriteLock*> locks;
+    vector<WriteLock> locks;
     for(auto& mc : d_maps) {
-      locks.push_back(new WriteLock(&mc.d_mut));
+      locks.push_back(WriteLock(mc.d_mut));
     }
-    for(auto wl : locks) {
-      delete wl;
-    }
+    locks.clear();
   }
   catch(...) {
   }

--- a/pdns/auth-packetcache.hh
+++ b/pdns/auth-packetcache.hh
@@ -108,17 +108,15 @@ private:
   struct MapCombo
   {
     MapCombo() {
-      pthread_rwlock_init(&d_mut, nullptr);
     }
     ~MapCombo() {
-      pthread_rwlock_destroy(&d_mut);
     }
     MapCombo(const MapCombo&) = delete; 
     MapCombo& operator=(const MapCombo&) = delete;
 
     void reserve(size_t numberOfEntries);
 
-    pthread_rwlock_t d_mut;
+    ReadWriteLock d_mut;
     cmap_t d_map;
   };
 

--- a/pdns/auth-querycache.cc
+++ b/pdns/auth-querycache.cc
@@ -47,13 +47,11 @@ AuthQueryCache::AuthQueryCache(size_t mapsCount): d_maps(mapsCount), d_lastclean
 AuthQueryCache::~AuthQueryCache()
 {
   try {
-    vector<WriteLock*> locks;
+    vector<WriteLock> locks;
     for(auto& mc : d_maps) {
-      locks.push_back(new WriteLock(&mc.d_mut));
+      locks.push_back(WriteLock(mc.d_mut));
     }
-    for(auto wl : locks) {
-      delete wl;
-    }
+    locks.clear();
   }
   catch(...) {
   }

--- a/pdns/auth-querycache.hh
+++ b/pdns/auth-querycache.hh
@@ -91,17 +91,15 @@ private:
   struct MapCombo
   {
     MapCombo() {
-      pthread_rwlock_init(&d_mut, nullptr);
     }
     ~MapCombo() {
-      pthread_rwlock_destroy(&d_mut);
     }
     MapCombo(const MapCombo &) = delete; 
     MapCombo & operator=(const MapCombo &) = delete;
 
     void reserve(size_t numberOfEntries);
 
-    pthread_rwlock_t d_mut;
+    ReadWriteLock d_mut;
     cmap_t d_map;
   };
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -506,18 +506,14 @@ catch(PDNSException& pe)
   _exit(1);
 }
 
-static void* dummyThread(void *)
+static void dummyThread()
 {
-  void* ignore=0;
-  pthread_exit(ignore);
 }
 
 static void triggerLoadOfLibraries()
 {
-  pthread_t tid;
-  pthread_create(&tid, 0, dummyThread, 0);
-  void* res;
-  pthread_join(tid, &res);
+  std::thread dummy(dummyThread);
+  dummy.join();
 }
 
 void mainthread()

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -47,8 +47,8 @@ using namespace boost::assign;
 
 DNSSECKeeper::keycache_t DNSSECKeeper::s_keycache;
 DNSSECKeeper::metacache_t DNSSECKeeper::s_metacache;
-pthread_rwlock_t DNSSECKeeper::s_metacachelock = PTHREAD_RWLOCK_INITIALIZER;
-pthread_rwlock_t DNSSECKeeper::s_keycachelock = PTHREAD_RWLOCK_INITIALIZER;
+ReadWriteLock DNSSECKeeper::s_metacachelock;
+ReadWriteLock DNSSECKeeper::s_keycachelock;
 AtomicCounter DNSSECKeeper::s_ops;
 time_t DNSSECKeeper::s_last_prune;
 size_t DNSSECKeeper::s_maxEntries = 0;
@@ -276,7 +276,7 @@ void DNSSECKeeper::getSoaEdit(const DNSName& zname, std::string& value)
 uint64_t DNSSECKeeper::dbdnssecCacheSizes(const std::string& str)
 {
   if(str=="meta-cache-size") {
-    ReadLock l(&s_metacachelock); 
+    ReadLock l(&s_metacachelock);
     return s_metacache.size();
   }
   else if(str=="key-cache-size") {

--- a/pdns/dnscrypt.cc
+++ b/pdns/dnscrypt.cc
@@ -25,7 +25,6 @@
 #include "dolog.hh"
 #include "dnscrypt.hh"
 #include "dnswriter.hh"
-#include "lock.hh"
 
 DNSCryptPrivateKey::DNSCryptPrivateKey()
 {
@@ -125,20 +124,15 @@ DNSCryptQuery::~DNSCryptQuery()
 
 
 DNSCryptContext::~DNSCryptContext() {
-  pthread_rwlock_destroy(&d_lock);
 }
 
 DNSCryptContext::DNSCryptContext(const std::string& pName, const std::vector<CertKeyPaths>& certKeys): d_certKeyPaths(certKeys), providerName(pName)
 {
-  pthread_rwlock_init(&d_lock, 0);
-
   reloadCertificates();
 }
 
 DNSCryptContext::DNSCryptContext(const std::string& pName, const DNSCryptCert& certificate, const DNSCryptPrivateKey& pKey): providerName(pName)
 {
-  pthread_rwlock_init(&d_lock, 0);
-
   addNewCertificate(certificate, pKey);
 }
 

--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -51,6 +51,7 @@ private:
 #include <sodium.h>
 
 #include "dnsname.hh"
+#include "lock.hh"
 
 #define DNSCRYPT_PROVIDER_PUBLIC_KEY_SIZE (crypto_sign_ed25519_PUBLICKEYBYTES)
 #define DNSCRYPT_PROVIDER_PRIVATE_KEY_SIZE (crypto_sign_ed25519_SECRETKEYBYTES)
@@ -285,7 +286,7 @@ private:
 
   void addNewCertificate(std::shared_ptr<DNSCryptCertificatePair>& newCert, bool reload=false);
 
-  pthread_rwlock_t d_lock;
+  ReadWriteLock d_lock;
   std::vector<std::shared_ptr<DNSCryptCertificatePair>> d_certs;
   std::vector<CertKeyPaths> d_certKeyPaths;
   DNSName providerName;

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -92,22 +92,18 @@ private:
   public:
     CacheShard(): d_entriesCount(0)
     {
-      pthread_rwlock_init(&d_lock, nullptr);
     }
     CacheShard(const CacheShard& old): d_entriesCount(0)
     {
-      pthread_rwlock_init(&d_lock, nullptr);
     }
-    ~CacheShard() {
-      pthread_rwlock_destroy(&d_lock);
-    }
+
     void setSize(size_t maxSize)
     {
       d_map.reserve(maxSize);
     }
 
     std::unordered_map<uint32_t,CacheValue> d_map;
-    pthread_rwlock_t d_lock;
+    ReadWriteLock d_lock;
     std::atomic<uint64_t> d_entriesCount;
   };
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -574,15 +574,13 @@ typedef std::function<std::tuple<bool, string>(const DNSQuestion* dq)> QueryCoun
 struct QueryCount {
   QueryCount()
   {
-    pthread_rwlock_init(&queryLock, nullptr);
   }
   ~QueryCount()
   {
-    pthread_rwlock_destroy(&queryLock);
   }
   QueryCountRecords records;
   QueryCountFilter filter;
-  pthread_rwlock_t queryLock;
+  ReadWriteLock queryLock;
   bool enabled{false};
 };
 
@@ -771,11 +769,10 @@ struct DownstreamState
         fd = -1;
       }
     }
-    pthread_rwlock_destroy(&d_lock);
   }
   boost::uuids::uuid id;
   std::vector<unsigned int> hashes;
-  mutable pthread_rwlock_t d_lock;
+  mutable ReadWriteLock d_lock;
   std::vector<int> sockets;
   const std::string sourceItfName;
   std::mutex socketsLock;
@@ -913,11 +910,9 @@ struct ServerPool
 {
   ServerPool()
   {
-    pthread_rwlock_init(&d_lock, nullptr);
   }
   ~ServerPool()
   {
-    pthread_rwlock_destroy(&d_lock);
   }
 
   const std::shared_ptr<DNSDistPacketCache> getCache() const { return packetCache; };
@@ -997,7 +992,7 @@ struct ServerPool
 
 private:
   ServerPolicy::NumberedServerVector d_servers;
-  pthread_rwlock_t d_lock;
+  ReadWriteLock d_lock;
   bool d_useECS{false};
 };
 

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -137,7 +137,6 @@ void DownstreamState::setWeight(int newWeight)
 
 DownstreamState::DownstreamState(const ComboAddress& remote_, const ComboAddress& sourceAddr_, unsigned int sourceItf_, const std::string& sourceItfName_, size_t numberOfSockets, bool connect=true): sourceItfName(sourceItfName_), remote(remote_), sourceAddr(sourceAddr_), sourceItf(sourceItf_), name(remote_.toStringWithPort()), nameWithAddr(remote_.toStringWithPort())
 {
-  pthread_rwlock_init(&d_lock, nullptr);
   id = getUniqueID();
   threadStarted.clear();
 

--- a/pdns/dnsdistdist/dnsdist-kvs.cc
+++ b/pdns/dnsdistdist/dnsdist-kvs.cc
@@ -117,7 +117,6 @@ bool LMDBKVStore::keyExists(const std::string& key)
 
 CDBKVStore::CDBKVStore(const std::string& fname, time_t refreshDelay): d_fname(fname), d_refreshDelay(refreshDelay)
 {
-  pthread_rwlock_init(&d_lock, nullptr);
   d_refreshing.clear();
 
   time_t now = time(nullptr);
@@ -129,7 +128,6 @@ CDBKVStore::CDBKVStore(const std::string& fname, time_t refreshDelay): d_fname(f
 }
 
 CDBKVStore::~CDBKVStore() {
-  pthread_rwlock_destroy(&d_lock);
 }
 
 bool CDBKVStore::reload(const struct stat& st)

--- a/pdns/dnsdistdist/dnsdist-kvs.hh
+++ b/pdns/dnsdistdist/dnsdist-kvs.hh
@@ -193,7 +193,7 @@ private:
 
   std::unique_ptr<CDB> d_cdb{nullptr};
   std::string d_fname;
-  pthread_rwlock_t d_lock;
+  ReadWriteLock d_lock;
   time_t d_mtime{0};
   time_t d_nextCheck{0};
   time_t d_refreshDelay{0};

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -234,13 +234,9 @@ private:
 public:
   TimedIPSetRule()
   {
-    pthread_rwlock_init(&d_lock4, 0);
-    pthread_rwlock_init(&d_lock6, 0);
   }
   ~TimedIPSetRule()
   {
-    pthread_rwlock_destroy(&d_lock4);
-    pthread_rwlock_destroy(&d_lock6);
   }
   bool matches(const DNSQuestion* dq) const override
   {
@@ -302,7 +298,7 @@ public:
 
   void cleanup()
   {
-    time_t now=time(0);
+    time_t now = time(nullptr);
     {
       WriteLock rl(&d_lock4);
 
@@ -360,8 +356,8 @@ private:
   };
   std::unordered_map<IPv6, time_t, IPv6Hash> d_ip6s;
   std::unordered_map<uint32_t, time_t> d_ip4s;
-  mutable pthread_rwlock_t d_lock4;
-  mutable pthread_rwlock_t d_lock6;
+  mutable ReadWriteLock d_lock4;
+  mutable ReadWriteLock d_lock6;
 };
 
 

--- a/pdns/dnsdistdist/libssl.cc
+++ b/pdns/dnsdistdist/libssl.cc
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <fstream>
 #include <cstring>
+#include <mutex>
 #include <pthread.h>
 
 #include <openssl/conf.h>
@@ -21,16 +22,18 @@
 
 #if (OPENSSL_VERSION_NUMBER < 0x1010000fL || (defined LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2090100fL)
 /* OpenSSL < 1.1.0 needs support for threading/locking in the calling application. */
-static pthread_mutex_t *openssllocks{nullptr};
+
+#include "lock.hh"
+static std::vector<std::mutex> openssllocks;
 
 extern "C" {
 static void openssl_pthreads_locking_callback(int mode, int type, const char *file, int line)
 {
   if (mode & CRYPTO_LOCK) {
-    pthread_mutex_lock(&(openssllocks[type]));
+    openssllocks.at(type).lock();
 
   } else {
-    pthread_mutex_unlock(&(openssllocks[type]));
+    openssllocks.at(type).unlock();
   }
 }
 
@@ -42,24 +45,15 @@ static unsigned long openssl_pthreads_id_callback()
 
 static void openssl_thread_setup()
 {
-  openssllocks = (pthread_mutex_t*)OPENSSL_malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t));
-
-  for (int i = 0; i < CRYPTO_num_locks(); i++)
-    pthread_mutex_init(&(openssllocks[i]), NULL);
-
-  CRYPTO_set_id_callback(openssl_pthreads_id_callback);
-  CRYPTO_set_locking_callback(openssl_pthreads_locking_callback);
+  openssllocks = std::vector<std::mutex>(CRYPTO_num_locks());
+  CRYPTO_set_id_callback(&openssl_pthreads_id_callback);
+  CRYPTO_set_locking_callback(&openssl_pthreads_locking_callback);
 }
 
 static void openssl_thread_cleanup()
 {
-  CRYPTO_set_locking_callback(NULL);
-
-  for (int i=0; i<CRYPTO_num_locks(); i++) {
-    pthread_mutex_destroy(&(openssllocks[i]));
-  }
-
-  OPENSSL_free(openssllocks);
+  CRYPTO_set_locking_callback(nullptr);
+  openssllocks.clear();
 }
 
 #endif /* (OPENSSL_VERSION_NUMBER < 0x1010000fL || (defined LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2090100fL) */
@@ -487,13 +481,11 @@ bool libssl_set_min_tls_version(std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)>& ctx
 
 OpenSSLTLSTicketKeysRing::OpenSSLTLSTicketKeysRing(size_t capacity)
 {
-  pthread_rwlock_init(&d_lock, nullptr);
   d_ticketKeys.set_capacity(capacity);
 }
 
 OpenSSLTLSTicketKeysRing::~OpenSSLTLSTicketKeysRing()
 {
-  pthread_rwlock_destroy(&d_lock);
 }
 
 void OpenSSLTLSTicketKeysRing::addKey(std::shared_ptr<OpenSSLTLSTicketKey> newKey)

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -22,11 +22,14 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#include <sys/types.h>
+#include <thread>
+
 #include "packetcache.hh"
 #include "utility.hh"
 #include "dnsproxy.hh"
 #include "pdnsexception.hh"
-#include <sys/types.h>
 #include "dns.hh"
 #include "logger.hh"
 #include "statbag.hh"
@@ -39,7 +42,6 @@ extern StatBag S;
 
 DNSProxy::DNSProxy(const string &remote)
 {
-  pthread_mutex_init(&d_lock,0);
   d_resanswers=S.getPointer("recursing-answers");
   d_resquestions=S.getPointer("recursing-questions");
   d_udpanswers=S.getPointer("udp-answers");
@@ -83,8 +85,8 @@ DNSProxy::DNSProxy(const string &remote)
 
 void DNSProxy::go()
 {
-  pthread_t tid;
-  pthread_create(&tid,0,&launchhelper,this);
+  std::thread t(std::bind(&DNSProxy::mainloop, this));
+  t.detach();
 }
 
 //! look up qname target with r->qtype, plonk it in the answer section of 'r' with name aname
@@ -129,7 +131,7 @@ bool DNSProxy::completePacket(std::unique_ptr<DNSPacket>& r, const DNSName& targ
   uint16_t id;
   uint16_t qtype = r->qtype.getCode();
   {
-    Lock l(&d_lock);
+    std::lock_guard<std::mutex> l(d_lock);
     id=getID_locked();
 
     ConntrackEntry ce;
@@ -216,7 +218,7 @@ void DNSProxy::mainloop(void)
       dnsheader d;
       memcpy(&d,buffer,sizeof(d));
       {
-        Lock l(&d_lock);
+        std::lock_guard<std::mutex> l(d_lock);
 #if BYTE_ORDER == BIG_ENDIAN
         // this is needed because spoof ID down below does not respect the native byteorder
         d.id = ( 256 * (uint16_t)buffer[1] ) + (uint16_t)buffer[0];  

--- a/pdns/dnsproxy.hh
+++ b/pdns/dnsproxy.hh
@@ -20,8 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include <pthread.h>
 #include <map>
+#include <mutex>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -56,11 +56,6 @@ public:
   bool completePacket(std::unique_ptr<DNSPacket>& r, const DNSName& target,const DNSName& aname, const uint8_t scopeMask);
 
   void mainloop();                  //!< this is the main loop that receives reply packets and sends them out again
-  static void *launchhelper(void *p)
-  {
-    static_cast<DNSProxy *>(p)->mainloop();
-    return 0;
-  }
   bool recurseFor(DNSPacket* p);
 private:
   struct ConntrackEntry
@@ -84,7 +79,7 @@ private:
   AtomicCounter* d_resanswers;
   AtomicCounter* d_udpanswers;
   AtomicCounter* d_resquestions;
-  pthread_mutex_t d_lock;
+  std::mutex d_lock;
   map_t d_conntrack;
   int d_sock;
   int getID_locked();

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -33,6 +33,7 @@
 #include "dnssecinfra.hh"
 #include "dnsrecords.hh"
 #include "ueberbackend.hh"
+#include "lock.hh"
 
 using namespace ::boost::multi_index;
 
@@ -298,8 +299,8 @@ private:
 
   static keycache_t s_keycache;
   static metacache_t s_metacache;
-  static pthread_rwlock_t s_metacachelock;
-  static pthread_rwlock_t s_keycachelock;
+  static ReadWriteLock s_metacachelock;
+  static ReadWriteLock s_keycachelock;
   static AtomicCounter s_ops;
   static time_t s_last_prune;
   static size_t s_maxEntries;

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -33,7 +33,7 @@
 #include "statbag.hh"
 extern StatBag S;
 
-static pthread_rwlock_t g_signatures_lock = PTHREAD_RWLOCK_INITIALIZER;
+static ReadWriteLock g_signatures_lock;
 typedef map<pair<string, string>, string> signaturecache_t;
 static signaturecache_t g_signatures;
 static int g_cacheweekno;

--- a/pdns/dynlistener.hh
+++ b/pdns/dynlistener.hh
@@ -22,7 +22,6 @@
 #pragma once
 #include <string>
 #include <vector>
-#include <pthread.h>
 #include <sys/types.h>
 #include <errno.h>
 #include <iostream>
@@ -45,7 +44,6 @@ public:
   ~DynListener();
   void go();
   void theListener();
-  static void *theListenerHelper(void *p);
 
   typedef string g_funk_t(const vector<string> &parts, Utility::pid_t ppid); // guido!
   typedef struct { g_funk_t *func; string args; string usage; } g_funkwithusage_t;
@@ -66,7 +64,6 @@ private:
   NetmaskGroup d_tcprange;
   int d_s{-1};
   int d_client{-1};
-  pthread_t d_tid{0};
   bool d_nonlocal;
   bool d_tcp{false};
   pid_t d_ppid{0};

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -94,7 +94,7 @@ public:
 
 private:
   boost::circular_buffer<std::shared_ptr<OpenSSLTLSTicketKey> > d_ticketKeys;
-  pthread_rwlock_t d_lock;
+  ReadWriteLock d_lock;
 };
 
 void* libssl_get_ticket_key_callback_data(SSL* s);

--- a/pdns/lock.hh
+++ b/pdns/lock.hh
@@ -27,33 +27,6 @@
 
 extern bool g_singleThreaded;
 
-class Lock
-{
-  pthread_mutex_t *d_lock;
-public:
-  Lock(const Lock& rhs) = delete;
-  Lock& operator=(const Lock& rhs) = delete;
-
-  Lock(pthread_mutex_t *lock) : d_lock(lock)
-  {
-    if(g_singleThreaded)
-      return;
-
-    int err;
-    if((err = pthread_mutex_lock(d_lock))) {
-      errno = err;
-      throw PDNSException("error acquiring lock: "+stringerror());
-    }
-  }
-  ~Lock()
-  {
-    if(g_singleThreaded)
-      return;
-
-    pthread_mutex_unlock(d_lock);
-  }
-};
-
 class ReadWriteLock
 {
 public:

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -22,13 +22,15 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#include <mutex>
+
 #include "logger.hh"
 #include "misc.hh"
 #ifndef RECURSOR
 #include "statbag.hh"
 extern StatBag S;
 #endif
-#include "lock.hh"
 #include "namespaces.hh"
 
 thread_local Logger::PerThread Logger::t_perThread;
@@ -96,8 +98,8 @@ void Logger::log(const string &msg, Urgency u)
       }
     }
 
-    static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
-    Lock l(&m); // the C++-2011 spec says we need this, and OSX actually does
+    static std::mutex m;
+    std::lock_guard<std::mutex> l(m); // the C++-2011 spec says we need this, and OSX actually does
     clog << string(buffer) + prefix + msg <<endl;
 #ifndef RECURSOR
     mustAccount=true;

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -71,15 +71,13 @@ private:
     std::atomic<time_t> lastAccess{0};
   };
 
-  pthread_rwlock_t d_lock;
+  ReadWriteLock d_lock;
 public:
   IsUpOracle()
   {
-    pthread_rwlock_init(&d_lock, nullptr);
   }
   ~IsUpOracle()
   {
-    pthread_rwlock_destroy(&d_lock);
   }
   bool isUp(const ComboAddress& remote, const opts_t& opts);
   bool isUp(const ComboAddress& remote, const std::string& url, const opts_t& opts);

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -280,13 +280,13 @@ void CommunicatorClass::sendNotification(int sock, const DNSName& domain, const 
 
 void CommunicatorClass::drillHole(const DNSName &domain, const string &ip)
 {
-  Lock l(&d_holelock);
+  std::lock_guard<std::mutex> l(d_holelock);
   d_holes[make_pair(domain,ip)]=time(0);
 }
 
 bool CommunicatorClass::justNotified(const DNSName &domain, const string &ip)
 {
-  Lock l(&d_holelock);
+  std::lock_guard<std::mutex> l(d_holelock);
   if(d_holes.find(make_pair(domain,ip))==d_holes.end()) // no hole
     return false;
 

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -65,8 +65,6 @@
 #  include <sched.h>
 #endif
 
-bool g_singleThreaded;
-
 size_t writen2(int fd, const void *buf, size_t count)
 {
   const char *ptr = (char*)buf;

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -102,7 +102,7 @@ private:
   void tkeyHandler(const DNSPacket& p, std::unique_ptr<DNSPacket>& r); //<! process TKEY record, and adds TKEY record to (r)eply, or error code.
 
   static AtomicCounter s_count;
-  static pthread_mutex_t s_rfc2136lock;
+  static std::mutex s_rfc2136lock;
   bool d_logDNSDetails;
   bool d_doIPv6AdditionalProcessing;
   bool d_doDNAME;

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -19,7 +19,7 @@ try
   vector<string> carbonServers;
 
   {
-    Lock l(&g_carbon_config_lock);
+    std::lock_guard<std::mutex> l(g_carbon_config_lock);
     stringtok(carbonServers, arg()["carbon-server"], ", ");
     namespace_name=arg()["carbon-namespace"];
     hostname=arg()["carbon-ourname"];

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -73,7 +73,7 @@ public:
 enum class StatComponent { API, Carbon, RecControl, SNMP };
 
 std::map<std::string, std::string> getAllStatsMap(StatComponent component);
-extern pthread_mutex_t g_carbon_config_lock;
+extern std::mutex g_carbon_config_lock;
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetQueryRing();
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetServfailQueryRing();
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetBogusQueryRing();

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -25,8 +25,8 @@
 #endif
 
 #include <atomic>
-#include <condition_variable>
 #include <queue>
+#include <mutex>
 #include <thread>
 
 #include "iputils.hh"

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -20,7 +20,7 @@
 extern StatBag S;
 extern CommunicatorClass Communicator;
 
-pthread_mutex_t PacketHandler::s_rfc2136lock=PTHREAD_MUTEX_INITIALIZER;
+std::mutex PacketHandler::s_rfc2136lock;
 
 // Implement section 3.2.1 and 3.2.2 of RFC2136
 int PacketHandler::checkUpdatePrerequisites(const DNSRecord *rr, DomainInfo *di) {
@@ -823,7 +823,7 @@ int PacketHandler::processUpdate(DNSPacket& p) {
   }
 
 
-  Lock l(&s_rfc2136lock); //TODO: i think this lock can be per zone, not for everything
+  std::lock_guard<std::mutex> l(s_rfc2136lock); //TODO: i think this lock can be per zone, not for everything
   g_log<<Logger::Info<<msgPrefix<<"starting transaction."<<endl;
   if (!di.backend->startTransaction(p.qdomain, -1)) { // Not giving the domain_id means that we do not delete the existing records.
     g_log<<Logger::Error<<msgPrefix<<"Backend for domain "<<p.qdomain<<" does not support transaction. Can't do Update packet."<<endl;

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -105,7 +105,7 @@ struct GetTimeTest
   }
 };
 
-pthread_mutex_t s_testlock=PTHREAD_MUTEX_INITIALIZER;
+std::mutex s_testlock;
 
 struct GetLockUncontendedTest
 {
@@ -116,8 +116,8 @@ struct GetLockUncontendedTest
 
   void operator()() const
   {
-    pthread_mutex_lock(&s_testlock);
-    pthread_mutex_unlock(&s_testlock);
+    s_testlock.lock();
+    s_testlock.unlock();
   }
 };
 

--- a/pdns/stubresolver.cc
+++ b/pdns/stubresolver.cc
@@ -23,7 +23,7 @@
 // s_resolversForStub contains the ComboAddresses that are used by
 // stubDoResolve
 static vector<ComboAddress> s_resolversForStub;
-static pthread_rwlock_t s_resolversForStubLock = PTHREAD_RWLOCK_INITIALIZER;
+static ReadWriteLock s_resolversForStubLock;
 static bool s_stubResolvConfigured = false;
 
 // /etc/resolv.conf last modification time

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -54,15 +54,13 @@ private:
   static int doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, int outsock);
   static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock);
   static bool canDoAXFR(std::unique_ptr<DNSPacket>& q);
-  static void *doConnection(void *data);
-  static void *launcher(void *data);
+  static void doConnection(int fd);
   static void decrementClientCount(const ComboAddress& remote);
   void thread(void);
-  static pthread_mutex_t s_plock;
+  static std::mutex s_plock;
   static std::mutex s_clientsCountMutex;
   static std::map<ComboAddress,size_t,ComboAddress::addressOnlyLessThan> s_clientsCount;
   static std::unique_ptr<PacketHandler> s_P;
-  pthread_t d_tid;
   static std::unique_ptr<Semaphore> d_connectionroom_sem;
   static unsigned int d_maxTCPConnections;
   static NetmaskGroup d_ng;

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -24,8 +24,9 @@
 #include <map>
 #include <string>
 #include <algorithm>
-#include <pthread.h>
 #include <semaphore.h>
+#include <mutex>
+#include <condition_variable>
 
 #include <unistd.h>
 #include <sys/stat.h>
@@ -56,7 +57,7 @@ public:
       existing threads of new modules 
   */
   static vector<UeberBackend *>instances;
-  static pthread_mutex_t instances_lock;
+  static std::mutex instances_lock;
 
   static bool loadmodule(const string &name);
   static bool loadModules(const vector<string>& modules, const string& path);
@@ -134,13 +135,12 @@ public:
   bool searchRecords(const string &pattern, int maxResults, vector<DNSResourceRecord>& result);
   bool searchComments(const string &pattern, int maxResults, vector<Comment>& result);
 private:
-  pthread_t d_tid;
   handle d_handle;
   vector<DNSZoneRecord> d_answers;
   vector<DNSZoneRecord>::const_iterator d_cachehandleiter;
 
-  static pthread_mutex_t d_mut;
-  static pthread_cond_t d_cond;
+  static std::mutex d_mut;
+  static std::condition_variable d_cond;
 
   struct Question
   {

--- a/pdns/ws-auth.hh
+++ b/pdns/ws-auth.hh
@@ -78,8 +78,6 @@ public:
   static string makePercentage(const double& val);
 
 private:
-  static void *webThreadHelper(void *);
-  static void *statThreadHelper(void *p);
   void indexfunction(HttpRequest* req, HttpResponse* resp);
   void cssfunction(HttpRequest* req, HttpResponse* resp);
   void jsonstat(HttpRequest* req, HttpResponse* resp);
@@ -88,7 +86,6 @@ private:
   void printargs(ostringstream &ret);
   void webThread();
   void statThread();
-  pthread_t d_tid;
 
   time_t d_start;
   double d_min10, d_min5, d_min1;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR wraps the remaining `pthread_*` objects in our code base:
- `pthread_mutex_t` -> `std::mutex` (always correctly initialized, can't be copied, properly destroyed via RAII) ;
- `pthread_rwlock_t` -> `ReadWriteLock` (light wrapper, always correctly initialized, can't be copied, properly destroyed via RAII) ;
- `pthread_create` -> `std::thread` (no need of an awkward wrapper to pass the parameters, easier to join or detach).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

