### PR TITLE
Avoid "pthread_rwlock_destroy on rwlock with waiters!" on OpenBSD

### DIFF
--- a/pdns/test-lock_hh.cc
+++ b/pdns/test-lock_hh.cc
@@ -18,7 +18,6 @@ static void lthread()
   std::vector<ReadLock> rlocks;
   for(auto& pp : g_locks)
     rlocks.emplace_back(&*pp);
-  
 }
 
 BOOST_AUTO_TEST_CASE(test_pdns_lock)
@@ -54,12 +53,15 @@ BOOST_AUTO_TEST_CASE(test_pdns_lock)
   BOOST_CHECK(!gotit);
 
   wlocks.clear();
-  TryReadLock trl2(&*g_locks[0]);
-  BOOST_CHECK(trl2.gotIt());
-  
+
+  {
+    TryReadLock trl2(&*g_locks[0]);
+    BOOST_CHECK(trl2.gotIt());
+  }
+
   for(auto& pp : g_locks) {
     pthread_rwlock_destroy(pp.get());
-  }  
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
