### PR TITLE
NetmaskTree: do not test node for null, the loop guarantees node is not null.

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -989,7 +989,7 @@ public:
 
     // we turn left on 0 and right on 1
     int bits = 0;
-    for(; node && bits < key.getBits(); bits++) {
+    for(; bits < key.getBits(); bits++) {
       bool vall = key.getBit(-1-bits);
 
       if (bits >= node->d_bits) {


### PR DESCRIPTION
Found by Coverity (1419400), which concludes that if node could be
null, the following node->node.first.getBits() would deref a nullptr.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
