### PR TITLE
Avoid throwing an exception in Logger::log().

### DIFF
--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -50,7 +50,7 @@ Logger& getLogger()
   return log;
 }
 
-void Logger::log(const string &msg, Urgency u)
+void Logger::log(const string &msg, Urgency u) noexcept
 {
 #ifndef RECURSOR
   bool mustAccount(false);
@@ -113,8 +113,14 @@ void Logger::log(const string &msg, Urgency u)
   }
 
 #ifndef RECURSOR
-  if(mustAccount)
-    S.ringAccount("logmessages",msg);
+  if(mustAccount) {
+      try {
+        S.ringAccount("logmessages",msg);
+      }
+      catch (const runtime_error& e) {
+        cerr << e.what() << endl;
+      }
+  }
 #endif
 }
 

--- a/pdns/logger.hh
+++ b/pdns/logger.hh
@@ -45,7 +45,7 @@ public:
       \param msg Message you wish to log
       \param u Urgency of the message you wish to log
   */
-  void log(const string &msg, Urgency u=Notice);
+  void log(const string &msg, Urgency u=Notice) noexcept;
 
   void setFacility(int f){d_facility=f;open();} //!< Choose logging facility
   void setFlag(int f){flags|=f;open();} //!< set a syslog flag


### PR DESCRIPTION
Throwing an exception in the logger almost cetainly will cause
trouble. Coverity 1428667 shows this can happen in
LdapBackend::~LdapBackend().

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
