### PR TITLE
auth: better (actual) fix for mem leak in SSQLite3::execute()

### DIFF
--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -235,26 +235,26 @@ std::unique_ptr<SSqlStatement> SSQLite3::prepare(const string& query, int nparam
 void SSQLite3::execute(const string& query) {
   char *errmsg;
   std::string errstr1;
-  int rc = sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg);
-  if (rc != 0) {
+  int rc = sqlite3_exec(m_pDB, query.c_str(), nullptr, nullptr, &errmsg);
+  if (rc != SQLITE_OK) {
     errstr1 = errmsg;
     sqlite3_free(errmsg);
   }
   if (rc == SQLITE_BUSY) {
     if (m_in_transaction) {
-      throw("Failed to execute query: " + errstr1);
+      throw SSqlException("Failed to execute query: " + errstr1);
     } else {
       rc = sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg);
       std::string errstr2;
-      if (rc != 0)  {
+      if (rc != SQLITE_OK)  {
         errstr2 = errmsg;
         sqlite3_free(errmsg);
       }
       if (rc != SQLITE_OK && rc != SQLITE_DONE && rc != SQLITE_ROW) {
-        throw("Failed to execute query: " + errstr2);
+        throw SSqlException("Failed to execute query: " + errstr2);
       }
     }
-  } else if (rc != 0) {
+  } else if (rc != SQLITE_OK) {
     throw("Failed to execute query: " + errstr1);
   }
 }

--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -249,13 +249,11 @@ void SSQLite3::execute(const string& query) {
       if (rc != SQLITE_OK)  {
         errstr2 = errmsg;
         sqlite3_free(errmsg);
-      }
-      if (rc != SQLITE_OK && rc != SQLITE_DONE && rc != SQLITE_ROW) {
         throw SSqlException("Failed to execute query: " + errstr2);
       }
     }
   } else if (rc != SQLITE_OK) {
-    throw("Failed to execute query: " + errstr1);
+    throw SSqlException("Failed to execute query: " + errstr1);
   }
 }
 

--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -236,15 +236,15 @@ void SSQLite3::execute(const string& query) {
   char *errmsg;
   int rc;
   if (sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg) == SQLITE_BUSY) {
+    std::string errstr1(errmsg);
+    sqlite3_free(errmsg);
     if (m_in_transaction) {
-      std::string errstr(errmsg);
-      sqlite3_free(errmsg);
-      throw("Failed to execute query: " + errstr);
+      throw("Failed to execute query: " + errstr1);
     } else {
       if ((rc = sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg) != SQLITE_OK) && rc != SQLITE_DONE && rc != SQLITE_ROW) {
-        std::string errstr(errmsg);
+        std::string errstr2(errmsg);
         sqlite3_free(errmsg);
-        throw("Failed to execute query: " + errstr);
+        throw("Failed to execute query: " + errstr2);
       }
     }
   }

--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -234,19 +234,28 @@ std::unique_ptr<SSqlStatement> SSQLite3::prepare(const string& query, int nparam
 
 void SSQLite3::execute(const string& query) {
   char *errmsg;
-  int rc;
-  if (sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg) == SQLITE_BUSY) {
-    std::string errstr1(errmsg);
+  std::string errstr1;
+  int rc = sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg);
+  if (rc != 0) {
+    errstr1 = errmsg;
     sqlite3_free(errmsg);
+  }
+  if (rc == SQLITE_BUSY) {
     if (m_in_transaction) {
       throw("Failed to execute query: " + errstr1);
     } else {
-      if ((rc = sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg) != SQLITE_OK) && rc != SQLITE_DONE && rc != SQLITE_ROW) {
-        std::string errstr2(errmsg);
+      rc = sqlite3_exec(m_pDB, query.c_str(), NULL, NULL, &errmsg);
+      std::string errstr2;
+      if (rc != 0)  {
+        errstr2 = errmsg;
         sqlite3_free(errmsg);
+      }
+      if (rc != SQLITE_OK && rc != SQLITE_DONE && rc != SQLITE_ROW) {
         throw("Failed to execute query: " + errstr2);
       }
     }
+  } else if (rc != 0) {
+    throw("Failed to execute query: " + errstr1);
   }
 }
 


### PR DESCRIPTION
Always free errmsg; use two diffferent string vars to avoid shadowing.
Coverity 1401969.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
