### PR TITLE
builder: improve shipped config files

### DIFF
--- a/builder-support/debian/authoritative/debian-buster/rules
+++ b/builder-support/debian/authoritative/debian-buster/rules
@@ -55,7 +55,7 @@ override_dh_installinit:
 
 override_dh_install:
 	dh_install
-	./pdns/pdns_server --no-config --config | sed \
+	./pdns/pdns_server --no-config --config=default | sed \
 	  -e 's!# module-dir=.*!!' \
 	  -e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/pdns.d!' \
 	  -e 's!# launch=.*!&\nlaunch=!' \

--- a/builder-support/debian/authoritative/debian-jessie/rules
+++ b/builder-support/debian/authoritative/debian-jessie/rules
@@ -52,7 +52,7 @@ override_dh_installinit:
 
 override_dh_install:
 	dh_install
-	./pdns/pdns_server --no-config --config | sed \
+	./pdns/pdns_server --no-config --config=default | sed \
 	  -e 's!# module-dir=.*!!' \
 	  -e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/pdns.d!' \
 	  -e 's!# launch=.*!&\nlaunch=!' \

--- a/builder-support/debian/authoritative/debian-stretch/rules
+++ b/builder-support/debian/authoritative/debian-stretch/rules
@@ -51,7 +51,7 @@ override_dh_installinit:
 
 override_dh_install:
 	dh_install
-	./pdns/pdns_server --no-config --config | sed \
+	./pdns/pdns_server --no-config --config=default | sed \
 	  -e 's!# module-dir=.*!!' \
 	  -e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/pdns.d!' \
 	  -e 's!# launch=.*!&\nlaunch=!' \

--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -53,6 +53,7 @@ override_dh_auto_install:
 		-e 's!# setgid=.*!setgid=pdns!' \
 		-e 's!# setuid=.*!setuid=pdns!' \
 		-e 's!# hint-file=.*!&\nhint-file=/usr/share/dns/root.hints!' \
+		-e '/^# version-string=.*/d' \
 		> debian/pdns-recursor/etc/powerdns/recursor.conf
 
 override_dh_strip:

--- a/builder-support/debian/recursor/debian-buster/rules
+++ b/builder-support/debian/recursor/debian-buster/rules
@@ -44,7 +44,7 @@ override_dh_auto_install:
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
 	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist
-	./pdns_recursor --no-config --config | sed \
+	./pdns_recursor --no-config --config=default | sed \
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
 		-e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \

--- a/builder-support/debian/recursor/debian-jessie/rules
+++ b/builder-support/debian/recursor/debian-jessie/rules
@@ -43,7 +43,7 @@ override_dh_auto_install:
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
 	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	rm -f debian/tmp/etc/powerdns/recursor.conf-dist
-	./pdns_recursor --no-config --config | sed \
+	./pdns_recursor --no-config --config=default | sed \
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
 		-e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \

--- a/builder-support/debian/recursor/debian-jessie/rules
+++ b/builder-support/debian/recursor/debian-jessie/rules
@@ -52,6 +52,7 @@ override_dh_auto_install:
 		-e 's!# setgid=.*!setgid=pdns!' \
 		-e 's!# setuid=.*!setuid=pdns!' \
 		-e 's!# hint-file=.*!&\nhint-file=/usr/share/dns/root.hints!' \
+		-e '/^# version-string=.*/d' \
 		> debian/tmp/etc/powerdns/recursor.conf
 
 override_dh_strip:

--- a/builder-support/debian/recursor/debian-stretch/rules
+++ b/builder-support/debian/recursor/debian-stretch/rules
@@ -53,6 +53,7 @@ override_dh_auto_install:
 		-e 's!# setgid=.*!setgid=pdns!' \
 		-e 's!# setuid=.*!setuid=pdns!' \
 		-e 's!# hint-file=.*!&\nhint-file=/usr/share/dns/root.hints!' \
+		-e '/^# version-string=.*/d' \
 		> debian/pdns-recursor/etc/powerdns/recursor.conf
 
 override_dh_strip:

--- a/builder-support/debian/recursor/debian-stretch/rules
+++ b/builder-support/debian/recursor/debian-stretch/rules
@@ -44,7 +44,7 @@ override_dh_auto_install:
 	install -m 644 -t debian/pdns-recursor/usr/share/pdns-recursor/lua-config debian/lua-config/rootkeys.lua
 	install -m 644 -t debian/pdns-recursor/etc/powerdns debian/recursor.lua
 	rm -f debian/pdns-recursor/etc/powerdns/recursor.conf-dist
-	./pdns_recursor --no-config --config | sed \
+	./pdns_recursor --no-config --config=default | sed \
 		-e 's!# config-dir=.*!config-dir=/etc/powerdns!' \
 		-e 's!# include-dir=.*!&\ninclude-dir=/etc/powerdns/recursor.d!' \
 		-e 's!# local-address=.*!local-address=127.0.0.1!' \

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -238,7 +238,7 @@ make install DESTDIR=%{buildroot}
 %{__install} -D -p %{SOURCE1} %{buildroot}%{_initrddir}/pdns
 %endif
 
-%{buildroot}/usr/sbin/pdns_server --no-config --config | sed \
+%{buildroot}/usr/sbin/pdns_server --no-config --config=default | sed \
   -e 's!# daemon=.*!daemon=no!' \
   -e 's!# guardian=.*!guardian=no!' \
   -e 's!# launch=.*!&\\nlaunch=!' \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

- #8094 introduced --config=default, but the official packages did not get updated to use that.
- Also the pdns-recursor.conf on Debian changes with each update as it contains the version string. Even if there are no other changes, this causes a conffile prompt for each update, which is annoying when using the master repositories + automatic upgrades.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
