### PR TITLE
Recursor 4.3.1: Fix compilation on FreeBSD

### DIFF
--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -40,16 +40,16 @@ try
     namespace_name="pdns";
   }
   if(hostname.empty()) {
-    char tmp[HOST_NAME_MAX+1];
-    memset(tmp, 0, sizeof(tmp));
-    if (gethostname(tmp, sizeof(tmp)) != 0) {
+    char *tmp = (char*) calloc(HOST_NAME_MAX+1, sizeof(char));
+    if (gethostname(tmp, HOST_NAME_MAX+1) != 0) {
       throw std::runtime_error("The 'carbon-ourname' setting has not been set and we are unable to determine the system's hostname: " + stringerror());
     }
     char *p = strchr(tmp, '.');
     if(p) *p=0;
 
     hostname=tmp;
-    boost::replace_all(hostname, ".", "_");    
+    boost::replace_all(hostname, ".", "_");
+    free(tmp);
   }
   if(instance_name.empty()) {
     instance_name="recursor";

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -9,6 +9,13 @@
 #include "arguments.hh"
 #include "lock.hh"
 
+#ifndef HOST_NAME_MAX
+#ifdef _SC_HOST_NAME_MAX
+#define HOST_NAME_MAX sysconf(_SC_HOST_NAME_MAX)
+#else
+#define HOST_NAME_MAX 1024
+#endif
+#endif
 
 void doCarbonDump(void*)
 try
@@ -17,10 +24,6 @@ try
   string instance_name;
   string namespace_name;
   vector<string> carbonServers;
-
-  long hostmax = sysconf(_SC_HOST_NAME_MAX);
-  if (hostmax < 0)
-    hostmax = _POSIX_HOST_NAME_MAX;
 
   {
     std::lock_guard<std::mutex> l(g_carbon_config_lock);
@@ -37,7 +40,7 @@ try
     namespace_name="pdns";
   }
   if(hostname.empty()) {
-    char tmp[hostmax+1];
+    char tmp[HOST_NAME_MAX+1];
     memset(tmp, 0, sizeof(tmp));
     if (gethostname(tmp, sizeof(tmp)) != 0) {
       throw std::runtime_error("The 'carbon-ourname' setting has not been set and we are unable to determine the system's hostname: " + stringerror());

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -18,6 +18,10 @@ try
   string namespace_name;
   vector<string> carbonServers;
 
+  long hostmax = sysconf(_SC_HOST_NAME_MAX);
+  if (hostmax < 0)
+    hostmax = _POSIX_HOST_NAME_MAX;
+
   {
     std::lock_guard<std::mutex> l(g_carbon_config_lock);
     stringtok(carbonServers, arg()["carbon-server"], ", ");
@@ -33,7 +37,7 @@ try
     namespace_name="pdns";
   }
   if(hostname.empty()) {
-    char tmp[HOST_NAME_MAX+1];
+    char tmp[hostmax+1];
     memset(tmp, 0, sizeof(tmp));
     if (gethostname(tmp, sizeof(tmp)) != 0) {
       throw std::runtime_error("The 'carbon-ourname' setting has not been set and we are unable to determine the system's hostname: " + stringerror());


### PR DESCRIPTION
Fix compilation of Recursor 4.3.1 on FreeBSD. Hopefully this works on other platforms as well.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ X ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ X ] compiled this code
- [ X ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
