### PR TITLE
Fix compilation on systems that do not define HOST_NAME_MAX

### DIFF
--- a/pdns/auth-carbon.cc
+++ b/pdns/auth-carbon.cc
@@ -40,16 +40,13 @@ try
 
   string namespace_name=arg()["carbon-namespace"];
   string hostname=arg()["carbon-ourname"];
-  if(hostname.empty()) {
-    char tmp[HOST_NAME_MAX+1];
-    memset(tmp, 0, sizeof(tmp));
-    if (gethostname(tmp, sizeof(tmp)) != 0) {
-      throw std::runtime_error("The carbon-ourname setting has not been set and we are unable to determine the system's hostname: " + stringerror());
+  if (hostname.empty()) {
+    try {
+      hostname = getCarbonHostName();
     }
-    char *p = strchr(tmp, '.');
-    if(p) *p=0;
-    hostname=tmp;
-    boost::replace_all(hostname, ".", "_");
+    catch(const std::exception& e) {
+      throw std::runtime_error(std::string("The 'carbon-ourname' setting has not been set and we are unable to determine the system's hostname: ") + e.what());
+    }
   }
   string instance_name=arg()["carbon-instance"];
 

--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -58,16 +58,13 @@ try
       const auto& server = conf.server;
       const std::string& namespace_name = conf.namespace_name;
       std::string hostname = conf.ourname;
-      if(hostname.empty()) {
-        char tmp[HOST_NAME_MAX+1];
-        memset(tmp, 0, sizeof(tmp));
-        if (gethostname(tmp, sizeof(tmp)) != 0) {
-          throw std::runtime_error("The 'ourname' setting in 'carbonServer()' has not been set and we are unable to determine the system's hostname: " + stringerror());
+      if (hostname.empty()) {
+        try {
+          hostname = getCarbonHostName();
         }
-        char *p = strchr(tmp, '.');
-        if(p) *p=0;
-        hostname=tmp;
-        boost::replace_all(hostname, ".", "_");
+        catch(const std::exception& e) {
+          throw std::runtime_error(std::string("The 'ourname' setting in 'carbonServer()' has not been set and we are unable to determine the system's hostname: ") + e.what());
+        }
       }
       const std::string& instance_name = conf.instance_name;
 

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -605,3 +605,5 @@ int mapThreadToCPUList(pthread_t tid, const std::set<int>& cpus);
 std::vector<ComboAddress> getResolvers(const std::string& resolvConfPath);
 
 DNSName reverseNameFromIP(const ComboAddress& ip);
+
+std::string getCarbonHostName();

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -32,17 +32,13 @@ try
   if(namespace_name.empty()) {
     namespace_name="pdns";
   }
-  if(hostname.empty()) {
-    char tmp[HOST_NAME_MAX+1];
-    memset(tmp, 0, sizeof(tmp));
-    if (gethostname(tmp, sizeof(tmp)) != 0) {
-      throw std::runtime_error("The 'carbon-ourname' setting has not been set and we are unable to determine the system's hostname: " + stringerror());
+  if (hostname.empty()) {
+    try {
+      hostname = getCarbonHostName();
     }
-    char *p = strchr(tmp, '.');
-    if(p) *p=0;
-
-    hostname=tmp;
-    boost::replace_all(hostname, ".", "_");    
+    catch(const std::exception& e) {
+      throw std::runtime_error(std::string("The 'carbon-ourname' setting has not been set and we are unable to determine the system's hostname: ") + e.what());
+    }
   }
   if(instance_name.empty()) {
     instance_name="recursor";


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
On FreeBSD at least, HOST_NAME_MAX is not defined and we need to use sysconf() to get the value at runtime instead.
Based on a work done by @RvdE to make the recursor compile on FreeBSD (many thanks!).

This PR generalizes the work done in #9125 to cover the authoritative server and dnsdist as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
