### PR TITLE
Suppress PR based spell check for the rec-4.3.x branch

### DIFF
--- a/.github/actions/spell-check/only.txt
+++ b/.github/actions/spell-check/only.txt
@@ -1,0 +1,1 @@
+^only-check-this-file$


### PR DESCRIPTION
### Short description
This should suppress the spell check scheduled task for PRs to this branch.

A technical explanation:
`schedule` tries to protect branches that may/may not have the spell checker enabled from PRs that start from before the spell checker was added, as well as from users who haven't opted into spell checking, from silently introducing spelling errors.

If a PR doesn't have a configured data set, it imports the one from the default branch (schedule only runs tasks defined on the default branch).

https://github.com/check-spelling/check-spelling/blob/5f7f35b25e6bce7b1e5a8f226369a86ab19a623e/check-pull-requests.sh#L161

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master

This code is *not* to be merged to master. But it can be copied to other branches.
This code isn't actually tested, but I'm fairly confident it'll do the right thing.