### PR TITLE
rec: docs: Update the allow-from setting default

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -17,7 +17,7 @@ As an example:
 ``allow-from``
 --------------
 -  IP ranges, separated by commas
--  Default: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+-  Default: 127.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 169.254.0.0/16, 192.168.0.0/16, 172.16.0.0/12, ::1/128, fc00::/7, fe80::/10
 
 Netmasks (both IPv4 and IPv6) that are allowed to use the server.
 The default allows access only from :rfc:`1918` private IP addresses.


### PR DESCRIPTION
### Short description
The `allow-from` setting's default value is `LOCAL_NETS`, but the copy of it in the documentation was incomplete.

https://github.com/PowerDNS/pdns/blob/d39c2ed05975d7dcf4fe396edb781beed3dde30e/pdns/pdns_recursor.cc#L260
https://github.com/PowerDNS/pdns/blob/d39c2ed05975d7dcf4fe396edb781beed3dde30e/pdns/pdns_recursor.cc#L3845

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)