### PR TITLE
rec: Remove unused getQueryLocalAddress stub in the unit tests

### DIFF
--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -224,6 +224,7 @@ endif
 
 testrunner_SOURCES = \
 	arguments.cc \
+	axfr-retriever.hh axfr-retriever.cc \
 	base32.cc \
 	base64.cc base64.hh \
 	circular_buffer.hh \
@@ -263,7 +264,6 @@ testrunner_SOURCES = \
 	responsestats.cc \
 	rpzloader.cc rpzloader.hh \
 	resolver.hh resolver.cc \
-	axfr-retriever.hh axfr-retriever.cc \
 	root-dnssec.hh \
 	secpoll.cc \
 	sillyrecords.cc \

--- a/pdns/recursordist/test-rpzloader_cc.cc
+++ b/pdns/recursordist/test-rpzloader_cc.cc
@@ -11,12 +11,6 @@
 
 // Provide stubs for some symbols
 bool g_logRPZChanges{false};
-ComboAddress getQueryLocalAddress(int family, uint16_t port)
-{
-  cerr << "getQueryLocalAddress() STUBBED IN TEST!" << endl;
-  BOOST_ASSERT(false);
-  return ComboAddress();
-}
 
 BOOST_AUTO_TEST_SUITE(rpzloader_cc)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The real function moved to the pdns namespace anyway.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
