### PR TITLE
Make sure we can install unsigned packages.

### DIFF
--- a/build-scripts/docker/generate-repo-files.sh
+++ b/build-scripts/docker/generate-repo-files.sh
@@ -57,7 +57,7 @@ EOF
 
     cat <<EOF >> Dockerfile.$RELEASE.$OS-$VERSION
 RUN curl -o /etc/yum.repos.d/powerdns-$RELEASE.repo https://repo.powerdns.com/repo-files/$OS-$RELEASE.repo
-RUN yum install -y $PKG
+RUN yum install --assumeyes --nobest $PKG
 EOF
 
     if [ "$RELEASE" = "rec-43"  -o "$RELEASE" = "rec-44" ]; then

--- a/build-scripts/docker/generate-repo-files.sh
+++ b/build-scripts/docker/generate-repo-files.sh
@@ -106,7 +106,7 @@ EOF
 FROM $OS:$VERSION
 
 RUN apt-get update
-RUN apt-get install -y curl gnupg dnsutils
+RUN apt-get install -y curl gnupg dnsutils apt-transport-https
 
 COPY dnsdist.debian-and-ubuntu /etc/apt/preferences.d/dnsdist
 COPY pdns.debian-and-ubuntu /etc/apt/preferences.d/pdns


### PR DESCRIPTION
Sometimes we need to install unsigned packages from our own ad-hoc repo,
installing `apt-transport-https` makes sure we can do this (at least on
Debian Stretch).