### PR TITLE
Add support for FreeBSD's SO_REUSEPORT_LB

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -537,6 +537,7 @@ dumresp_SOURCES = \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dumresp.cc \
+	iputils.cc iputils.hh \
 	logger.cc \
 	misc.cc misc.hh \
 	statbag.cc \

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1839,14 +1839,12 @@ static void setUpLocalBind(std::unique_ptr<ClientState>& cs)
   }
 
   if (cs->reuseport) {
-#ifdef SO_REUSEPORT
-    SSetsockopt(fd, SOL_SOCKET, SO_REUSEPORT, 1);
-#else
-    if (warn) {
-      /* no need to warn again if configured but support is not available, we already did for UDP */
-      warnlog("SO_REUSEPORT has been configured on local address '%s' but is not supported", cs->local.toStringWithPort());
+    if (!setReusePort(fd)) {
+      if (warn) {
+        /* no need to warn again if configured but support is not available, we already did for UDP */
+        warnlog("SO_REUSEPORT has been configured on local address '%s' but is not supported", cs->local.toStringWithPort());
+      }
     }
-#endif
   }
 
   /* Only set this on IPv4 UDP sockets.

--- a/pdns/dumresp.cc
+++ b/pdns/dumresp.cc
@@ -105,12 +105,7 @@ catch(const std::exception& e) {
 static void tcpAcceptor(const ComboAddress local)
 {
   Socket tcpSocket(local.sin4.sin_family, SOCK_STREAM);
-#ifdef SO_REUSEPORT
-  int one=1;
-  if(setsockopt(tcpSocket.getHandle(), SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) < 0)
-    unixDie("setsockopt for REUSEPORT");
-#endif
-
+  setReusePort(tcpSocket.getHandle());
   tcpSocket.bind(local);
   tcpSocket.listen(1024);
 
@@ -187,12 +182,7 @@ try
   }
 
   Socket s(local.sin4.sin_family, SOCK_DGRAM);
-#ifdef SO_REUSEPORT
-  int one=1;
-  if(setsockopt(s.getHandle(), SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) < 0)
-    unixDie("setsockopt for REUSEPORT");
-#endif
-
+  setReusePort(s.getHandle());
   s.bind(local);
   cout<<"Bound to UDP "<<local.toStringWithPort()<<endl;
 

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -158,6 +158,28 @@ void setSocketIgnorePMTU(int sockfd)
 #endif /* defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_DONT) */
 }
 
+bool setReusePort(int sockfd)
+{
+#if defined(SO_REUSEPORT_LB)
+  try {
+    SSetsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT_LB, 1);
+    return true;
+  }
+  catch (const std::exception& e) {
+    return false;
+  }
+#elif defined(SO_REUSEPORT)
+  try {
+    SSetsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, 1);
+    return true;
+  }
+  catch (const std::exception& e) {
+    return false;
+  }
+#endif
+  return false;
+}
+
 bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv) 
 {
 #ifdef SO_TIMESTAMP

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1390,6 +1390,7 @@ int SAccept(int sockfd, ComboAddress& remote);
 int SListen(int sockfd, int limit);
 int SSetsockopt(int sockfd, int level, int opname, int value);
 void setSocketIgnorePMTU(int sockfd);
+bool setReusePort(int sockfd);
 
 #if defined(IP_PKTINFO)
   #define GEN_IP_PKTINFO IP_PKTINFO

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -141,11 +141,11 @@ void UDPNameserver::bindAddresses()
       }
     }
 
-#ifdef SO_REUSEPORT
-    if( d_can_reuseport )
-        if( setsockopt(s, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) )
-          d_can_reuseport = false;
-#endif
+    if (d_can_reuseport) {
+      if (!setReusePort(s)) {
+        d_can_reuseport = false;
+      }
+    }
 
     if( ::arg().mustDo("non-local-bind") )
       Utility::setBindAny(locala.sin4.sin_family, s);
@@ -208,9 +208,7 @@ bool AddressIsUs(const ComboAddress& remote)
 
 UDPNameserver::UDPNameserver( bool additional_socket )
 {
-#ifdef SO_REUSEPORT
   d_can_reuseport = ::arg().mustDo("reuseport");
-#endif
   // Are we the main socket (false) or a rebinding using SO_REUSEPORT ?
   d_additional_socket = additional_socket;
 

--- a/pdns/nameserver.hh
+++ b/pdns/nameserver.hh
@@ -82,18 +82,12 @@ public:
   bool receive(DNSPacket& packet, std::string& buffer); //!< call this in a while or for(;;) loop to get packets
   void send(DNSPacket&); //!< send a DNSPacket. Will call DNSPacket::truncate() if over 512 bytes
   inline bool canReusePort() {
-#ifdef SO_REUSEPORT
     return d_can_reuseport;
-#else
-    return false;
-#endif
   };
   
 private:
   bool d_additional_socket;
-#ifdef SO_REUSEPORT
-  bool d_can_reuseport;
-#endif
+  bool d_can_reuseport{false};
   vector<int> d_sockets;
   void bindAddresses();
   vector<pollfd> d_rfds;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2905,12 +2905,23 @@ static void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcp
     if( ::arg().mustDo("non-local-bind") )
 	Utility::setBindAny(AF_INET, fd);
 
-#ifdef SO_REUSEPORT
-    if(g_reusePort) {
-      if(setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &tmp, sizeof(tmp)) < 0)
-        throw PDNSException("SO_REUSEPORT: "+stringerror());
-    }
+    if (g_reusePort) {
+#if defined(SO_REUSEPORT_LB)
+      try {
+        SSetsockopt(fd, SOL_SOCKET, SO_REUSEPORT_LB, 1);
+      }
+      catch (const std::exception& e) {
+        throw PDNSException(std::string("SO_REUSEPORT_LB: ") + e.what());
+      }
+#elif defined(SO_REUSEPORT)
+      try {
+        SSetsockopt(fd, SOL_SOCKET, SO_REUSEPORT, 1);
+      }
+      catch (const std::exception& e) {
+        throw PDNSException(std::string("SO_REUSEPORT: ") + e.what());
+      }
 #endif
+    }
 
     if (::arg().asNum("tcp-fast-open") > 0) {
 #ifdef TCP_FASTOPEN
@@ -2998,12 +3009,23 @@ static void makeUDPServerSockets(deferredAdd_t& deferredAdds)
     sin.sin4.sin_port = htons(st.port);
 
   
-#ifdef SO_REUSEPORT
-    if(g_reusePort) {
-      if(setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) < 0)
-        throw PDNSException("SO_REUSEPORT: "+stringerror());
-    }
+    if (g_reusePort) {
+#if defined(SO_REUSEPORT_LB)
+      try {
+        SSetsockopt(fd, SOL_SOCKET, SO_REUSEPORT_LB, 1);
+      }
+      catch (const std::exception& e) {
+        throw PDNSException(std::string("SO_REUSEPORT_LB: ") + e.what());
+      }
+#elif defined(SO_REUSEPORT)
+      try {
+        SSetsockopt(fd, SOL_SOCKET, SO_REUSEPORT, 1);
+      }
+      catch (const std::exception& e) {
+        throw PDNSException(std::string("SO_REUSEPORT: ") + e.what());
+      }
 #endif
+    }
 
     if (sin.isIPv4()) {
       try {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
On FreeBSD, `SO_REUSEPORT` "permits multiple instances of a program to each receive UDP/IP multicast or broadcast datagrams destined for the bound port", while `SO_REUSEPORT_LB` distributes them "among the sharing processes based on a hash function of local port number, foreign IP address and port number".

I tested that `SO_REUSEPORT` is still correctly enabled on Linux after this change, but not that `SO_REUSEPORT_LB` is actually enabled on FreeBSD.

Closes #9156.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
