### PR TITLE
Optimize IXFR-to-AXFR fallback path

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1102,7 +1102,6 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock)
 
     UeberBackend db;
     DNSSECKeeper dk(&db);
-    DNSSECKeeper::clearCaches(target);
 
     bool haveTSIGDetails = q->getTSIGDetails(&trc, &tsigkeyname);
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes #7795.

Avoid making new backends when we are going to either deny the XFR, or
fall back to AXFR anyway.

This cuts down the number of new backends from four (three for IXFR
pre-checks plus one for AXFR) to one (just the AXFR one).
When replying in IXFR mode, we keep making _one_ new backend, which is
also better than before.

While we now hold the s_plock for a while longer, we only take it once
in doIXFR; before we took it twice -- for TSIG retrieval, which now
re-uses the IXFR backend.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
