### PR TITLE
opensslsigners: Add missing 'static' keyword

### DIFF
--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -46,7 +46,7 @@
 static std::vector<std::mutex> openssllocks;
 
 extern "C" {
-void openssl_pthreads_locking_callback(int mode, int type, const char *file, int line)
+static void openssl_pthreads_locking_callback(int mode, int type, const char *file, int line)
 {
   if (mode & CRYPTO_LOCK) {
     openssllocks.at(type).lock();
@@ -56,7 +56,7 @@ void openssl_pthreads_locking_callback(int mode, int type, const char *file, int
   }
 }
 
-unsigned long openssl_pthreads_id_callback()
+static unsigned long openssl_pthreads_id_callback(void)
 {
   return (unsigned long)pthread_self();
 }


### PR DESCRIPTION
### Short description

openssl_pthreads_locking_callback and openssl_pthreads_id_callback are local functions, so they need static.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
