### PR TITLE
RFC: addRRSigs/getPreRRSIGs: use internal UeberBackend

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -567,19 +567,20 @@ bool DNSSECKeeper::checkKeys(const DNSName& zone, vector<string>* errorMessages)
   return retval;
 }
 
-bool DNSSECKeeper::getPreRRSIGs(UeberBackend& db, const DNSName& signer, const DNSName& qname,
+// A fully functional UeberBackend is required.
+bool DNSSECKeeper::getPreRRSIGs(const DNSName& signer, const DNSName& qname,
         const DNSName& wildcardname, const QType& qtype,
         DNSResourceRecord::Place signPlace, vector<DNSZoneRecord>& rrsigs, uint32_t signTTL)
 {
   // cerr<<"Doing DB lookup for precomputed RRSIGs for '"<<(wildcardname.empty() ? qname : wildcardname)<<"'"<<endl;
         SOAData sd;
-        if(!db.getSOAUncached(signer, sd)) {
+        if(!d_keymetadb->getSOAUncached(signer, sd)) {
                 DLOG(g_log<<"Could not get SOA for domain"<<endl);
                 return false;
         }
-        db.lookup(QType(QType::RRSIG), wildcardname.countLabels() ? wildcardname : qname, sd.domain_id);
+        d_keymetadb->lookup(QType(QType::RRSIG), wildcardname.countLabels() ? wildcardname : qname, sd.domain_id);
         DNSZoneRecord rr;
-        while(db.get(rr)) {
+        while(d_keymetadb->get(rr)) {
           auto rrsig = getRR<RRSIGRecordContent>(rr.dr);
           if(rrsig->d_type == qtype.getCode() && rrsig->d_signer==signer) {
             if (wildcardname.countLabels())

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -27,8 +27,6 @@
 #include <map>
 #include "misc.hh"
 
-class UeberBackend;
-
 // rules of the road: Algorithm must be set in 'make' for each KeyEngine, and will NEVER change!
 
 class DNSCryptoKeyEngine
@@ -167,7 +165,7 @@ string hashQNameWithSalt(const std::string& salt, unsigned int iterations, const
 void incrementHash(std::string& raw);
 void decrementHash(std::string& raw);
 
-void addRRSigs(DNSSECKeeper& dk, UeberBackend& db, const std::set<DNSName>& authMap, vector<DNSZoneRecord>& rrs);
+void addRRSigs(DNSSECKeeper& dk, const std::set<DNSName>& authMap, vector<DNSZoneRecord>& rrs);
 
 void addTSIG(DNSPacketWriter& pw, TSIGRecordContent& trc, const DNSName& tsigkeyname, const string& tsigsecret, const string& tsigprevious, bool timersonly);
 bool validateTSIG(const std::string& packet, size_t sigPos, const TSIGTriplet& tt, const TSIGRecordContent& trc, const std::string& previousMAC, const std::string& theirMAC, bool timersOnly, unsigned int dnsHeaderOffset=0);

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -207,7 +207,7 @@ public:
   bool checkNSEC3PARAM(const NSEC3PARAMRecordContent& ns3p, string& msg);
   bool setNSEC3PARAM(const DNSName& zname, const NSEC3PARAMRecordContent& n3p, const bool& narrow=false);
   bool unsetNSEC3PARAM(const DNSName& zname);
-  bool getPreRRSIGs(UeberBackend& db, const DNSName& signer, const DNSName& qname, const DNSName& wildcardname, const QType& qtype, DNSResourceRecord::Place, vector<DNSZoneRecord>& rrsigs, uint32_t signTTL);
+  bool getPreRRSIGs(const DNSName& signer, const DNSName& qname, const DNSName& wildcardname, const QType& qtype, DNSResourceRecord::Place, vector<DNSZoneRecord>& rrsigs, uint32_t signTTL);
   bool isPresigned(const DNSName& zname);
   bool setPresigned(const DNSName& zname);
   bool unsetPresigned(const DNSName& zname);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1563,7 +1563,7 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
       }
     }
     if(doSigs)
-      addRRSigs(d_dk, B, authSet, r->getRRS());
+      addRRSigs(d_dk, authSet, r->getRRS());
       
     if(PC.enabled() && !noCache && p.couldBeCached())
       PC.insert(p, *r, r->getMinTTL()); // in the packet cache

--- a/pdns/signingpipe.cc
+++ b/pdns/signingpipe.cc
@@ -283,7 +283,7 @@ try
     try {
       set<DNSName> authSet;
       authSet.insert(d_signer);
-      addRRSigs(dk, db, authSet, *chunk);
+      addRRSigs(dk, authSet, *chunk);
       ++d_signed;
 
       writen2(fd, &chunk, sizeof(chunk));

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -615,7 +615,7 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
   if(securedZone && !presignedZone) {
     set<DNSName> authSet;
     authSet.insert(target);
-    addRRSigs(dk, db, authSet, outpacket->getRRS());
+    addRRSigs(dk, authSet, outpacket->getRRS());
   }
   
   if(haveTSIGDetails && !tsigkeyname.empty())
@@ -1134,7 +1134,7 @@ int TCPNameserver::doIXFR(std::unique_ptr<DNSPacket>& q, int outsock)
     if(securedZone && outpacket->d_dnssecOk) {
       set<DNSName> authSet;
       authSet.insert(target);
-      addRRSigs(dk, signatureDB, authSet, outpacket->getRRS());
+      addRRSigs(dk, authSet, outpacket->getRRS());
     }
 
     if(haveTSIGDetails && !tsigkeyname.empty())


### PR DESCRIPTION
To start a discussion!

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

From my analysis of the code calling these functions, everybody passes the same UeberBackend that is used to construct the DBDNSSECKeeper on which the functions are called. So this is no practical change, and it makes the code simpler to follow.

I also see some optimisations that can be done if this is acceptable.

It certainly takes away the theoretical possibility of passing in another UeberBackend, but this does not appear to be useful today.

NB: yes, some callers of addRRSigs pass in a keymeta-only UeberBackend, but this is fine, as they don't hit the codepath leading to any list/get calls. I'd propose splitting up addRRSigs in a later step, possibly as part of the optimisation mentioned above. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
