### PR TITLE
tinydnsbackend: Ignore duplicate SOA in getAllDomains()

### DIFF
--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -163,9 +163,10 @@ void TinyDNSBackend::getAllDomains(vector<DomainInfo> *domains, bool include_dis
 
   d_cdbReader->searchAll();
   DNSResourceRecord rr;
+  std::unordered_set<DNSName> dupcheck;
 
   while (get(rr)) {
-    if (rr.qtype.getCode() == QType::SOA) {
+    if (rr.qtype.getCode() == QType::SOA && dupcheck.insert(rr.qname).second) {
       SOAData sd;
       fillSOAData(rr.content, sd);
 


### PR DESCRIPTION
### Short description
This patch prevents tinydns from providing same domain twice when listing all domains. This can happen if there is same SOA record more than once.

Fixes #9173 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
