### PR TITLE
Clarify allow-axfr-ips behaviour in combination with TSIG

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -35,7 +35,12 @@ Allow 8 bit DNS queries.
 -  Default: 127.0.0.0/8,::1
 
 If set, only these IP addresses or netmasks will be able to perform
-AXFR.
+AXFR without TSIG.
+
+.. warning::
+   This setting only applies to AXFR without TSIG keys. If you allow a TSIG key to perform an AXFR,
+   this setting will not be checked for that transfer, and the client will be able to perform the AXFR
+   from everywhere.
 
 .. _setting-allow-dnsupdate-from:
 

--- a/docs/tsig.rst
+++ b/docs/tsig.rst
@@ -35,7 +35,7 @@ with the key name in the content field. For example::
 
 .. warning::
   Any host with the correct TSIG key will be able to perform the AXFR, even
-  if the host is not within the define ``allow-axfr-ips`` ranges.
+  if the host is not within the defined ``allow-axfr-ips`` ranges.
 
 Another way of importing and activating TSIG keys into the database is using
 :doc:`pdnsutil <manpages/pdnsutil.1>`:

--- a/docs/tsig.rst
+++ b/docs/tsig.rst
@@ -33,6 +33,10 @@ with the key name in the content field. For example::
 
     $ dig -t axfr powerdnssec.org @127.0.0.1 -y 'test:kp4/24gyYsEzbuTVJRUMoqGFmN3LYgVDzJ/3oRSP7ys='
 
+.. warning::
+  Any host with the correct TSIG key will be able to perform the AXFR, even
+  if the host is not within the define ``allow-axfr-ips`` ranges.
+
 Another way of importing and activating TSIG keys into the database is using
 :doc:`pdnsutil <manpages/pdnsutil.1>`:
 


### PR DESCRIPTION
### Short description
``allow-axfr-ips`` is ignored when a TSIG key is defined for outbound AXFRs for a zone. This fact is not documented.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
