### PR TITLE
Rec: rpz policy should override gettag_ffi answer by default

### DIFF
--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -80,6 +80,7 @@ public:
     std::unordered_set<std::string> d_tags;
     std::string d_name;
     Priority d_priority{maximumPriority};
+    bool d_policyOverridesGettag{true};
   };
 
   struct Policy
@@ -139,6 +140,13 @@ public:
       return notSet;
     }
 
+    bool policyOverridesGettag() const {
+      if (d_zoneData) {
+        return d_zoneData->d_policyOverridesGettag;
+      }
+      return true;
+    }
+
     std::vector<DNSRecord> getCustomRecords(const DNSName& qname, uint16_t qtype) const;
     std::vector<DNSRecord> getRecords(const DNSName& qname) const;
 
@@ -190,6 +198,10 @@ public:
     void setTags(std::unordered_set<std::string>&& tags)
     {
       d_zoneData->d_tags = std::move(tags);
+    }
+    void setPolicyOverridesGettag(bool flag)
+    {
+      d_zoneData->d_policyOverridesGettag = flag;
     }
     const std::string& getName() const
     {
@@ -262,6 +274,7 @@ public:
     void setPriority(Priority p) {
       d_zoneData->d_priority = p;
     }
+    
   private:
     static DNSName maskToRPZ(const Netmask& nm);
     static bool findExactNamedPolicy(const std::unordered_map<DNSName, DNSFilterEngine::Policy>& polmap, const DNSName& qname, DNSFilterEngine::Policy& pol);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1443,9 +1443,9 @@ static void startDoResolve(void *p)
     }
 
     // If we are doing RPZ and a policy was matched, it normally takes precedence over an answer from gettag.
-    // So process the gettag_ffi answer only if no RPZ action was done or matched or the policy indicates gettag should
+    // So process the gettag_ffi answer only if no RPZ action was matched or the policy indicates gettag should
     // have precedence.
-    if (!wantsRPZ || !appliedPolicy.policyOverridesGettag() || appliedPolicy.d_type == DNSFilterEngine::PolicyType::None || appliedPolicy.d_kind == DNSFilterEngine::PolicyKind::NoAction) {
+    if (!wantsRPZ || !appliedPolicy.policyOverridesGettag() || appliedPolicy.d_type == DNSFilterEngine::PolicyType::None) {
       if (dc->d_rcode != boost::none) {
         /* we have a response ready to go, most likely from gettag_ffi */
         ret = std::move(dc->d_records);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1442,10 +1442,10 @@ static void startDoResolve(void *p)
       }
     }
 
-    // If we are doing RPZ and a policy was matched, it takes precedence over an answer from gettag_ffi
-    // So process the gettag_ffi answer only if no RPZ action was done or matched
-    // This might need more sophistication for the type != None && kind == NoAction case...
-    if (!wantsRPZ || appliedPolicy.d_type == DNSFilterEngine::PolicyType::None || appliedPolicy.d_kind == DNSFilterEngine::PolicyKind::NoAction) {
+    // If we are doing RPZ and a policy was matched, it normally takes precedence over an answer from gettag.
+    // So process the gettag_ffi answer only if no RPZ action was done or matched or the policy indicates gettag should
+    // have precedence.
+    if (!wantsRPZ || !appliedPolicy.policyOverridesGettag() || appliedPolicy.d_type == DNSFilterEngine::PolicyType::None || appliedPolicy.d_kind == DNSFilterEngine::PolicyKind::NoAction) {
       if (dc->d_rcode != boost::none) {
         /* we have a response ready to go, most likely from gettag_ffi */
         ret = std::move(dc->d_records);

--- a/pdns/recursordist/docs/lua-config/rpz.rst
+++ b/pdns/recursordist/docs/lua-config/rpz.rst
@@ -117,7 +117,7 @@ overridesGettag
 .. versionadded:: 4.4.0
 
 `gettag_ffi` can set an answer to a query.
-By default an RPZ hit overrides this answer, unless the policy is `rpz-passthru` or this option is set to `false`.
+By default an RPZ hit overrides this answer, unless this option is set to `false`.
 The default is `true`.
 
 zoneSizeHint

--- a/pdns/recursordist/docs/lua-config/rpz.rst
+++ b/pdns/recursordist/docs/lua-config/rpz.rst
@@ -112,6 +112,14 @@ tags
 
 List of tags as string, that will be added to the policy tags exported over protobuf when a policy of this zone matches.
 
+overridesGettag
+^^^^^^^^^^^^^^^
+.. versionadded:: 4.4.0
+
+`gettag_ffi` can set an answer to a query.
+By default an RPZ hit overrides this answer, unless the policy is `rpz-passthru` or this option is set to `false`.
+The default is `true`.
+
 zoneSizeHint
 ^^^^^^^^^^^^
 An indication of the number of expected entries in the zone, speeding up the loading of huge zones by reserving space in advance.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

If an RPZ is active, an answer set by `gettag_ffi` should not be used unless there is no RPZ match. There are some subtle points;

1. If no policy is matched or it is `NoAction`, use the result from `gettag_ffi` if available.
2. You still might want to prefer the exising behaviour: set `overridesGettag=false` for that case when loading the RPZ.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
