### PR TITLE
use std::string_view when available

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -12,8 +12,9 @@
 #include <vector>
 #include <algorithm>
 
-// apple compiler somehow has string_view even in c++11!
-#if __cplusplus < 201703L && !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__FreeBSD__)
+#ifdef __cpp_lib_string_view
+using std::string_view;
+#else
 #include <boost/version.hpp>
 #if BOOST_VERSION >= 106100
 #include <boost/utility/string_view.hpp>
@@ -22,8 +23,6 @@ using boost::string_view;
 #include <boost/utility/string_ref.hpp>
 using string_view = boost::string_ref;
 #endif
-#else // C++17
-using std::string_view;
 #endif
 
 

--- a/pdns/dnsdistdist/views.hh
+++ b/pdns/dnsdistdist/views.hh
@@ -22,8 +22,9 @@
 
 #pragma once
 
-// apple compiler somehow has string_view even in c++11!
-#if __cplusplus < 201703L && !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__FreeBSD__)
+#ifdef __cpp_lib_string_view
+using std::string_view;
+#else
 #include <boost/version.hpp>
 #if BOOST_VERSION >= 106100
 #include <boost/utility/string_view.hpp>
@@ -32,6 +33,4 @@ using boost::string_view;
 #include <boost/utility/string_ref.hpp>
 using string_view = boost::string_ref;
 #endif
-#else // C++17
-using std::string_view;
 #endif


### PR DESCRIPTION
There's a standard C++ macro to check for its existence.

libstdc++ from GCC makes it available under C++17 and up. libcxx from
LLVM makes it available everywhere.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

I have:
- [x ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

