### PR TITLE
Do not use `using namespace std;` 

### DIFF
--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -31,8 +31,6 @@
 #include "threadname.hh"
 #include "views.hh"
 
-using namespace std;
-
 /* So, how does this work. We use h2o for our http2 and TLS needs.
    If the operator has configured multiple IP addresses to listen on,
    we launch multiple h2o listener threads. We can hook in to multiple
@@ -837,7 +835,7 @@ try
   }
   return 0;
 }
-catch(const exception& e)
+ catch(const std::exception& e)
 {
   errlog("DOH Handler function failed with error %s", e.what());
   return 0;


### PR DESCRIPTION
it causes ambiguity if both std::string_view and boost::string_view are in scope
As seen on OpenBSD (sorry to have missed that earlier):
```
doh.cc:658:85: error: reference to 'string_view' is ambiguous
static bool getHTTPHeaderValue(const h2o_req_t* req, const std::string& headerName, string_view& value)
                                                                                    ^
./views.hh:31:14: note: candidate found by name lookup is 'string_view'
using boost::string_view;
             ^
/usr/include/c++/v1/string_view:771:37: note: candidate found by name lookup is 'std::__1::string_view'
typedef basic_string_view<char>     string_view;
                                    ^
doh.cc:662:3: error: reference to 'string_view' is ambiguous
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
