### PR TITLE
auth: gsqlite3backend: add missing indexes

### DIFF
--- a/builder-support/debian/authoritative/debian-buster/pdns-backend-sqlite3.docs
+++ b/builder-support/debian/authoritative/debian-buster/pdns-backend-sqlite3.docs
@@ -1,6 +1,7 @@
 modules/gsqlite3backend/3.4.0_to_4.0.0_schema.sqlite3.sql
 modules/gsqlite3backend/4.0.0_to_4.2.0_schema.sqlite3.sql
 modules/gsqlite3backend/4.2.0_to_4.3.0_schema.sqlite3.sql
+modules/gsqlite3backend/4.3.0_to_4.3.1_schema.sqlite3.sql
 modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/schema.sqlite3.sql

--- a/builder-support/debian/authoritative/debian-jessie/pdns-backend-sqlite3.docs
+++ b/builder-support/debian/authoritative/debian-jessie/pdns-backend-sqlite3.docs
@@ -1,6 +1,7 @@
 modules/gsqlite3backend/3.4.0_to_4.0.0_schema.sqlite3.sql
 modules/gsqlite3backend/4.0.0_to_4.2.0_schema.sqlite3.sql
 modules/gsqlite3backend/4.2.0_to_4.3.0_schema.sqlite3.sql
+modules/gsqlite3backend/4.3.0_to_4.3.1_schema.sqlite3.sql
 modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/schema.sqlite3.sql

--- a/builder-support/debian/authoritative/debian-stretch/pdns-backend-sqlite3.docs
+++ b/builder-support/debian/authoritative/debian-stretch/pdns-backend-sqlite3.docs
@@ -1,6 +1,7 @@
 modules/gsqlite3backend/3.4.0_to_4.0.0_schema.sqlite3.sql
 modules/gsqlite3backend/4.0.0_to_4.2.0_schema.sqlite3.sql
 modules/gsqlite3backend/4.2.0_to_4.3.0_schema.sqlite3.sql
+modules/gsqlite3backend/4.3.0_to_4.3.1_schema.sqlite3.sql
 modules/gsqlite3backend/dnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/nodnssec-3.x_to_3.4.0_schema.sqlite3.sql
 modules/gsqlite3backend/schema.sqlite3.sql

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -412,6 +412,7 @@ fi
 %doc modules/gsqlite3backend/3.4.0_to_4.0.0_schema.sqlite3.sql
 %doc modules/gsqlite3backend/4.0.0_to_4.2.0_schema.sqlite3.sql
 %doc modules/gsqlite3backend/4.2.0_to_4.3.0_schema.sqlite3.sql
+%doc modules/gsqlite3backend/4.3.0_to_4.3.1_schema.sqlite3.sql
 %{_libdir}/%{name}/libgsqlite3backend.so
 
 %if 0%{?rhel} >= 7

--- a/modules/gsqlite3backend/4.3.0_to_4.3.1_schema.sqlite3.sql
+++ b/modules/gsqlite3backend/4.3.0_to_4.3.1_schema.sqlite3.sql
@@ -1,0 +1,15 @@
+CREATE INDEX records_lookup_idx ON records(name, type);
+CREATE INDEX records_lookup_id_idx ON records(domain_id, name, type);
+CREATE INDEX records_order_idx ON records(domain_id, ordername);
+
+DROP INDEX IF EXISTS rec_name_index;
+DROP INDEX IF EXISTS nametype_index;
+DROP INDEX IF EXISTS domain_id;
+DROP INDEX IF EXISTS orderindex;
+
+CREATE INDEX comments_idx ON comments(domain_id, name, type);
+
+DROP INDEX IF EXISTS comments_domain_id_index;
+DROP INDEX IF EXISTS comments_nametype_index;
+
+ANALYZE;

--- a/modules/gsqlite3backend/Makefile.am
+++ b/modules/gsqlite3backend/Makefile.am
@@ -10,6 +10,7 @@ dist_doc_DATA = \
 	3.4.0_to_4.0.0_schema.sqlite3.sql \
 	4.0.0_to_4.2.0_schema.sqlite3.sql \
 	4.2.0_to_4.3.0_schema.sqlite3.sql \
+	4.3.0_to_4.3.1_schema.sqlite3.sql \
 	schema.sqlite3.sql
 
 libgsqlite3backend_la_SOURCES = gsqlite3backend.cc gsqlite3backend.hh

--- a/modules/gsqlite3backend/schema.sqlite3.sql
+++ b/modules/gsqlite3backend/schema.sqlite3.sql
@@ -27,10 +27,9 @@ CREATE TABLE records (
   FOREIGN KEY(domain_id) REFERENCES domains(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
-CREATE INDEX rec_name_index ON records(name);
-CREATE INDEX nametype_index ON records(name,type);
-CREATE INDEX domain_id ON records(domain_id);
-CREATE INDEX orderindex ON records(ordername);
+CREATE INDEX records_lookup_idx ON records(name, type);
+CREATE INDEX records_lookup_id_idx ON records(domain_id, name, type);
+CREATE INDEX records_order_idx ON records(domain_id, ordername);
 
 
 CREATE TABLE supermasters (
@@ -53,8 +52,7 @@ CREATE TABLE comments (
   FOREIGN KEY(domain_id) REFERENCES domains(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
-CREATE INDEX comments_domain_id_index ON comments (domain_id);
-CREATE INDEX comments_nametype_index ON comments (name, type);
+CREATE INDEX comments_idx ON comments(domain_id, name, type);
 CREATE INDEX comments_order_idx ON comments (domain_id, modified_at);
 
 


### PR DESCRIPTION
### Short description
Sqlite3 backend was performing terrible in environments with many updates.
On a slaved root zone the performance increase was huge, 71ms -> 1ms per uncached query.
Since the lack of proper indexes is causing a lot of trouble in larger environments, I target this update at 4.3.1

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
