### PR TITLE
Auth: Add pdns_control command to the the list of XFR domains in queue

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -371,6 +371,7 @@ void declareStats(void)
   S.declare("latency","Average number of microseconds needed to answer a question", getLatency, StatType::gauge);
   S.declare("timedout-packets","Number of packets which weren't answered within timeout set");
   S.declare("security-status", "Security status based on regular polling", StatType::gauge);
+  S.declare("xfr-queue", "Size of the queue of domains to be XFRd", [](const string&) { return Communicator.getSuckRequestsWaiting(); }, StatType::gauge);
   S.declareDNSNameQTypeRing("queries","UDP Queries Received");
   S.declareDNSNameQTypeRing("nxdomain-queries","Queries for non-existent records within existent domains");
   S.declareDNSNameQTypeRing("noerror-queries","Queries for existing records, but for type we don't have");

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -169,6 +169,7 @@ public:
   void retrievalLoopThread();
   void sendNotification(int sock, const DNSName &domain, const ComboAddress& remote, uint16_t id, UeberBackend* B);
   bool notifyDomain(const DNSName &domain, UeberBackend* B);
+  vector<pair<DNSName, ComboAddress> > getSuckRequests();
 private:
   void loadArgsIntoSet(const char *listname, set<string> &listset);
   void makeNotifySockets();

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -170,6 +170,7 @@ public:
   void sendNotification(int sock, const DNSName &domain, const ComboAddress& remote, uint16_t id, UeberBackend* B);
   bool notifyDomain(const DNSName &domain, UeberBackend* B);
   vector<pair<DNSName, ComboAddress> > getSuckRequests();
+  size_t getSuckRequestsWaiting();
 private:
   void loadArgsIntoSet(const char *listname, set<string> &listset);
   void makeNotifySockets();

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -404,3 +404,11 @@ string DLTokenLogin(const vector<string>&parts, Utility::pid_t ppid)
   }
 #endif
 }
+
+string DLSuckRequests(const vector<string> &parts, Utility::pid_t ppid) {
+  string ret;
+  for (auto const &d: Communicator.getSuckRequests()) {
+    ret += d.first.toString() + " " + d.second.toString() + "\n";
+  }
+  return ret;
+}

--- a/pdns/dynhandler.hh
+++ b/pdns/dynhandler.hh
@@ -54,3 +54,4 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid);
 string DLCurrentConfigHandler(const vector<string>&parts, Utility::pid_t ppid);
 string DLListZones(const vector<string>&parts, Utility::pid_t ppid);
 string DLTokenLogin(const vector<string>&parts, Utility::pid_t ppid);
+string DLSuckRequests(const vector<string> &parts, Utility::pid_t ppid);

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -590,6 +590,7 @@ int main(int argc, char **argv)
     DynListener::registerFunc("CURRENT-CONFIG",&DLCurrentConfigHandler, "retrieve the current configuration", "[diff|default]");
     DynListener::registerFunc("LIST-ZONES",&DLListZones, "show list of zones", "[master|slave|native]");
     DynListener::registerFunc("TOKEN-LOGIN", &DLTokenLogin, "Login to a PKCS#11 token", "<module> <slot> <pin>");
+    DynListener::registerFunc("XFR-QUEUE", &DLSuckRequests, "Get all requests for XFR in queue");
 
     if(!::arg()["tcp-control-address"].empty()) {
       DynListener* dlTCP=new DynListener(ComboAddress(::arg()["tcp-control-address"], ::arg().asNum("tcp-control-port")));

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -1013,3 +1013,8 @@ vector<pair<DNSName, ComboAddress> > CommunicatorClass::getSuckRequests() {
   }
   return ret;
 }
+
+size_t CommunicatorClass::getSuckRequestsWaiting() {
+  std::lock_guard<std::mutex> l(d_lock);
+  return d_suckdomains.size();
+}

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -1003,3 +1003,13 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
     }
   }
 }
+
+vector<pair<DNSName, ComboAddress> > CommunicatorClass::getSuckRequests() {
+  vector<pair<DNSName, ComboAddress> > ret;
+  std::lock_guard<std::mutex> l(d_lock);
+  ret.reserve(d_suckdomains.size());
+  for (auto const &d : d_suckdomains) {
+    ret.push_back(make_pair(d.domain, d.master));
+  }
+  return ret;
+}

--- a/regression-tests.nobackend/counters/expected_result
+++ b/regression-tests.nobackend/counters/expected_result
@@ -62,3 +62,4 @@ udp4-queries=2
 udp6-answers-bytes=132
 udp6-answers=2
 udp6-queries=2
+xfr-queue=0


### PR DESCRIPTION
### Short description
This allows some insight into what the auth is doing

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)