### PR TITLE
Add version 'statistic' to prometheus

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -804,6 +804,10 @@ static void connectionThread(int sock, ComboAddress remote)
           }
         }
 
+        output << "# HELP dnsdist_info " << "Info from dnsdist, value is always 1" << "\n";
+        output << "# TYPE dnsdist_info " << "gauge" << "\n";
+        output << "dnsdist_info{version=\"" << VERSION << "\"} " << "1" << "\n";
+
         resp.body = output.str();
         resp.headers["Content-Type"] = "text/plain";
     }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2274,6 +2274,10 @@ static void prometheusMetrics(HttpRequest* req, HttpResponse* resp) {
     output << prometheusMetricName << " " << S.read(metricName) << "\n";
   }
 
+  output << "# HELP pdns_auth_info " << "Info from PowerDNS, value is always 1" << "\n";
+  output << "# TYPE pdns_auth_info " << "gauge" << "\n";
+  output << "pdns_auth_info{version=\"" << VERSION << "\"} " << "1" << "\n";
+
   resp->body = output.str();
   resp->headers["Content-Type"] = "text/plain";
   resp->status = 200;

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -458,6 +458,10 @@ static void prometheusMetrics(HttpRequest *req, HttpResponse *resp) {
         output << prometheusMetricName << " " << tup.second << "\n";
     }
 
+    output << "# HELP pdns_recursor_info " << "Info from pdns_recursor, value is always 1" << "\n";
+    output << "# TYPE pdns_recursor_info " << "gauge" << "\n";
+    output << "pdns_recursor_info{version=\"" << VERSION << "\"} " << "1" << "\n";
+
     resp->body = output.str();
     resp->headers["Content-Type"] = "text/plain";
     resp->status = 200;


### PR DESCRIPTION
### Short description
This PR adds a metric called `${SERVICE}_info` that is always `1`. But its labels are then used to ship the version number. This is similar to `node_exporter`'s `node_uname_info` metric.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)