### PR TITLE
rec: Better exception handling in houseKeeping / handlePolicyHit

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3187,7 +3187,25 @@ static void houseKeeping(void *)
         int res = SyncRes::getRootNS(g_now, nullptr, 0);
         if (!res) {
           last_rootupdate=now.tv_sec;
-          primeRootNSZones(g_dnssecmode != DNSSECMode::Off, 0);
+          try {
+            primeRootNSZones(g_dnssecmode != DNSSECMode::Off, 0);
+          }
+          catch (const std::exception& e) {
+            g_log<<Logger::Error<<"Exception while priming the root NS zones: "<<e.what()<<endl;
+          }
+          catch (const PDNSException& e) {
+            g_log<<Logger::Error<<"Exception while priming the root NS zones: "<<e.reason<<endl;
+          }
+          catch (const ImmediateServFailException& e) {
+            g_log<<Logger::Error<<"Exception while priming the root NS zones: "<<e.reason<<endl;
+          }
+          catch (const PolicyHitException& e) {
+            g_log<<Logger::Error<<"Policy hit while priming the root NS zones"<<endl;
+          }
+          catch (...)
+          {
+            g_log<<Logger::Error<<"Exception while priming the root NS zones"<<endl;
+          }
         }
       }
 
@@ -3195,22 +3213,22 @@ static void houseKeeping(void *)
 	try {
 	  doSecPoll(&last_secpoll);
 	}
-	catch(const std::exception& e)
+	catch (const std::exception& e)
         {
           g_log<<Logger::Error<<"Exception while performing security poll: "<<e.what()<<endl;
         }
-        catch(const PDNSException& e)
+        catch (const PDNSException& e)
         {
           g_log<<Logger::Error<<"Exception while performing security poll: "<<e.reason<<endl;
         }
-        catch(const ImmediateServFailException &e)
+        catch (const ImmediateServFailException &e)
         {
           g_log<<Logger::Error<<"Exception while performing security poll: "<<e.reason<<endl;
         }
-        catch(const PolicyHitException& e) {
+        catch (const PolicyHitException& e) {
           g_log<<Logger::Error<<"Policy hit while performing security poll"<<endl;
         }
-        catch(...)
+        catch (...)
         {
           g_log<<Logger::Error<<"Exception while performing security poll"<<endl;
         }
@@ -3232,14 +3250,20 @@ static void houseKeeping(void *)
         }
       }
     }
-    s_running=false;
+    s_running = false;
   }
-  catch(PDNSException& ae)
-    {
-      s_running=false;
-      g_log<<Logger::Error<<"Fatal error in housekeeping thread: "<<ae.reason<<endl;
-      throw;
-    }
+  catch (const PDNSException& ae)
+  {
+    s_running = false;
+    g_log<<Logger::Error<<"Fatal error in housekeeping thread: "<<ae.reason<<endl;
+    throw;
+  }
+  catch (...)
+  {
+    s_running = false;
+    g_log<<Logger::Error<<"Uncaught exception in housekeeping thread"<<endl;
+    throw;
+  }
 }
 
 static void makeThreadPipes()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- An uncaught exception being raised in `houseKeeping` could prevent it from being run again because `s_running` would stay true. That could for example happen when an `ImmediateServFailException` was raised during a call to `primeRootNSZones()` ;
- An `ImmediateServFailException` being raised during the call to `SyncRes::beginResolve()` from `handleRPZCustom()` could lead to the resolution process to stop without any response being sent:
```
Any other exception in a resolver context (www.example.net/A from 127.0.0.1:4242)
```
This commit turns into a ServFail answer instead.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

