### PR TITLE
auth: Add dnskey-minimum-ttl-override

### DIFF
--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -248,3 +248,8 @@ Note that the NSEC/NSEC3 records proving those negatives will get the high TTL i
 
   NSEC(3) records now get the negative TTL (which is the lowest of the SOA TTL and the SOA minimum), which means their TTL matches that of an error such as NXDOMAIN.
   The warning about RFC8198 no longer applies.
+
+.. note::
+
+  Since 4.4.0, the DNSKEY TTL can be overridden using :ref:`setting-dnskey-minimum-ttl-override` if the SOA minimum TTL is too low.
+  This is a per server setting, mostly useful for secondary operators.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -583,6 +583,20 @@ See :doc:`performance`.
 Synthesise CNAME records from DNAME records as required. This
 approximately doubles query load. **Do not combine with DNSSEC!**
 
+.. _setting-dnskey-minimum-ttl-override:
+
+``dnskey-minimum-ttl-override``
+-------------------------------
+
+.. versionadded:: 4.4.0
+
+-  Integer
+-  Default: 0
+
+Lower bound TTL for DNSKEY records.
+The default of `0` implies no lower bound, and the SOA minimum value is used.
+Mostly useful for secondary nameserver operators.
+
 .. _setting-dnssec-key-cache-ttl:
 
 ``dnssec-key-cache-ttl``

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -178,7 +178,7 @@ void declareArguments()
   ::arg().set("cache-ttl","Seconds to store packets in the PacketCache")="20";
   ::arg().set("negquery-cache-ttl","Seconds to store negative query results in the QueryCache")="60";
   ::arg().set("query-cache-ttl","Seconds to store query results in the QueryCache")="20";
-  ::arg().set("soa-minimum-ttl","Default SOA minimum ttl")="3600";
+  ::arg().set("soa-minimum-ttl","Default SOA minimum TTL")="3600";
   ::arg().set("server-id", "Returned when queried for 'id.server' TXT or NSID, defaults to hostname - disabled or custom")="";
   ::arg().set("soa-refresh-default","Default SOA refresh")="10800";
   ::arg().set("soa-retry-default","Default SOA retry")="3600";
@@ -187,6 +187,7 @@ void declareArguments()
   ::arg().set("default-soa-edit-signed","Default SOA-EDIT value for signed zones")="";
   ::arg().set("dnssec-key-cache-ttl","Seconds to cache DNSSEC keys from the database")="30";
   ::arg().set("domain-metadata-cache-ttl","Seconds to cache domain metadata from the database")="60";
+  ::arg().set("dnskey-minimum-ttl-override","Lower boundary for the TTL of DNSKEY records")="0";
 
   ::arg().set("trusted-notification-proxy", "IP address of incoming notification proxy")="";
   ::arg().set("slave-renotify", "If we should send out notifications for slaved updates")="no";


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Secondary operators regularly do not have control over the SOA minimum field, which is used as the DNSKEY TTL in replies. This allows setting a minimum value for these replies.

Implements #9220.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
