### PR TITLE
rec: Specify a storage type for validation states

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -1106,3 +1106,15 @@ DNSName getSigner(const std::vector<std::shared_ptr<RRSIGRecordContent> >& signa
 
   return DNSName();
 }
+
+std::ostream& operator<<(std::ostream &os, const vState d)
+{
+  os<<vStates[d];
+  return os;
+}
+
+std::ostream& operator<<(std::ostream &os, const dState d)
+{
+  os<<dStates[d];
+  return os;
+}

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -33,12 +33,15 @@ extern time_t g_signatureInceptionSkew;
 extern uint16_t g_maxNSEC3Iterations;
 
 // 4033 5
-enum vState { Indeterminate, Bogus, Insecure, Secure, NTA, TA };
+enum vState : uint8_t { Indeterminate, Bogus, Insecure, Secure, NTA, TA };
 extern const char *vStates[];
 
 // NSEC(3) results
-enum dState { NODATA, NXDOMAIN, NXQTYPE, ENT, INSECURE, OPTOUT};
+enum dState : uint8_t { NODATA, NXDOMAIN, NXQTYPE, ENT, INSECURE, OPTOUT};
 extern const char *dStates[];
+
+std::ostream& operator<<(std::ostream &os, const vState d);
+std::ostream& operator<<(std::ostream &os, const dState d);
 
 class DNSRecordOracle
 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR specifies a storage type for the validation state enumerations and defines the corresponding `<<` operators. This should save some space in memory and make it easier to read validation traces by printing a user-friendly name instead of an integer value in several cases.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
