### PR TITLE
rec: Ignore cache-only for DNSKEYs retrieval

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2330,7 +2330,9 @@ vState SyncRes::getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int 
   LOG(d_prefix<<"Retrieving DNSKeys for "<<signer<<endl);
 
   vState state = Indeterminate;
+  const bool oldCacheOnly = setCacheOnly(false);
   int rcode = doResolve(signer, QType(QType::DNSKEY), records, depth + 1, beenthere, state);
+  setCacheOnly(oldCacheOnly);
 
   if (rcode == RCode::NoError) {
     if (state == Secure) {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2062,7 +2062,9 @@ vState SyncRes::getDSRecords(const DNSName& zone, dsmap_t& ds, bool taOnly, unsi
   std::vector<DNSRecord> dsrecords;
 
   vState state = Indeterminate;
+  const bool oldCacheOnly = setCacheOnly(false);
   int rcode = doResolve(zone, QType(QType::DS), dsrecords, depth + 1, beenthere, state);
+  setCacheOnly(oldCacheOnly);
 
   if (rcode == RCode::NoError || (rcode == RCode::NXDomain && !bogusOnNXD)) {
     uint8_t bestDigestType = 0;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When the DNSKEYs are needed for validation, the initial RD flag should not prevent us from going to the network. This was fine in most cases because the DNSKEYs are usually retrieved during the computation of the zone cuts, where we already ignore the RD flag, but we might also need to retrieve the DNSKEYs during just-in-time validation later on.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
