### PR TITLE
auth: Refuse queries for QType values of zero or OPT

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1261,6 +1261,11 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
     if(p.qclass==QClass::ANY)
       r->setA(false);
 
+    /* rfc6895 section 3.1 */
+    if (p.qtype.getCode() == 0 || p.qtype.getCode() == QType::OPT) {
+      r->setRcode(RCode::Refused);
+      return r;
+    }
 
   retargeted:;
     if(retargetcount > 10) {    // XXX FIXME, retargetcount++?


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Follow-up of https://github.com/PowerDNS/pdns/pull/9290 for the authoritative server.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
