### PR TITLE
rec: Add the ability to log validation failures for selected names

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4181,6 +4181,22 @@ static int serviceMain(int argc, char*argv[])
     exit(1);
   }
 
+  if (!::arg()["dnssec-validation-failures-log-filter"].empty()) {
+    std::vector<string> names;
+    stringtok(names, ::arg()["dnssec-validation-failures-log-filter"], ", ");
+    for (auto& name : names) {
+      if (name.empty()) {
+        continue;
+      }
+      bool exact = false;
+      if (name.at(name.size()-1) == '$') {
+        name = name.substr(0, name.size()-1);
+        exact = true;
+      }
+      SyncRes::addToValidationFilter(DNSName(name), exact);
+    }
+  }
+
   g_signatureInceptionSkew = ::arg().asNum("signature-inception-skew");
   if (g_signatureInceptionSkew < 0) {
     g_log<<Logger::Error<<"A negative value for 'signature-inception-skew' is not allowed"<<endl;
@@ -4932,6 +4948,7 @@ int main(int argc, char **argv)
     ::arg().set("trace","if we should output heaps of logging. set to 'fail' to only log failing domains")="off";
     ::arg().set("dnssec", "DNSSEC mode: off/process-no-validate (default)/process/log-fail/validate")="process-no-validate";
     ::arg().set("dnssec-log-bogus", "Log DNSSEC bogus validations")="no";
+    ::arg().set("dnssec-validation-failures-log-filter", "List of suffixes or exact names (ending with a '$') for which a summary will be logged in case of DNSSEC validation failures")="";
     ::arg().set("signature-inception-skew", "Allow the signature inception to be off by this number of seconds")="60";
     ::arg().set("daemon","Operate as a daemon")="no";
     ::arg().setSwitch("write-pid","Write a PID file")="yes";

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -431,6 +431,19 @@ Full blown DNSSEC validation. Send SERVFAIL to clients on bogus responses.
 Log every DNSSEC validation failure.
 **Note**: This is not logged per-query but every time records are validated as Bogus.
 
+.. _setting-dnssec-validation-failures-log-filter:
+
+``dnssec-validation-failures-log-filter``
+-----------------------------------------
+.. versionadded:: 4.4.0
+
+-  List of DNS names
+-  Default: empty
+
+List of DNS names, suffixes or exact matches (when followed by a '$') for which a short summary will be logged in case of DNSSEC validation failures.
+For example, passing "powerdns.com$, dnssec.powerdns.com" will log a short summary if the DNSSEC validation ever fails for powerdns.com, dnssec.powerdns.com
+or every names below dnssec.powerdns.com.
+
 .. _setting-dont-query:
 
 ``dont-query``

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -730,6 +730,15 @@ public:
     return d_queryValidationState;
   }
 
+  static void addToValidationFilter(const DNSName& name, bool exact)
+  {
+    ValidationLogFilterEntry entry;
+    entry.name = name;
+    entry.exact = exact;
+
+    s_validationLogFilter.add(name, std::move(entry));
+  }
+
   static thread_local ThreadLocalStorage t_sstorage;
 
   static std::atomic<uint64_t> s_queries;
@@ -801,6 +810,13 @@ private:
   static LogMode s_lm;
   static std::unique_ptr<NetmaskGroup> s_dontQuery;
   const static std::unordered_set<uint16_t> s_redirectionQTypes;
+  struct ValidationLogFilterEntry
+  {
+    DNSName name;
+    bool exact{false};
+  };
+
+  static SuffixMatchTree<ValidationLogFilterEntry> s_validationLogFilter;
 
   struct GetBestNSAnswer
   {
@@ -870,6 +886,8 @@ private:
 
   bool lookForCut(const DNSName& qname, unsigned int depth, const vState existingState, vState& newState);
   void computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned int depth);
+
+  void logFailedDNSSECValidation(const std::string& prefix, const DNSName& name, const char* function, int lineNumber, const std::string& reason) const;
 
   void setUpdatingRootNS()
   {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is a very rough draft, the general idea is to add the ability to get a one-line summary in the logs when a DNSSEC failure happens for selected domains, or suffixes. This is not as useful as getting a full trace, but can stay enabled pretty much forever since the summary line is only logged when the validation is done, and not when the entry is retrieved from the cache.
Comments welcome! 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
