### PR TITLE
dnsdist: Prevent a possible overflow via large Proxy Protocol values

### DIFF
--- a/pdns/dnsdistdist/dnsdist-proxy-protocol.cc
+++ b/pdns/dnsdistdist/dnsdist-proxy-protocol.cc
@@ -41,6 +41,10 @@ bool addProxyProtocol(std::vector<uint8_t>& buffer, bool tcp, const ComboAddress
   auto payload = makeProxyHeader(tcp, source, destination, values);
 
   auto previousSize = buffer.size();
+  if (payload.size() > (std::numeric_limits<size_t>::max() - previousSize)) {
+    return false;
+  }
+
   buffer.resize(previousSize + payload.size());
   std::copy_backward(buffer.begin(), buffer.begin() + previousSize, buffer.end());
   std::copy(payload.begin(), payload.end(), buffer.begin());

--- a/pdns/proxy-protocol.cc
+++ b/pdns/proxy-protocol.cc
@@ -65,9 +65,12 @@ std::string makeProxyHeader(bool tcp, const ComboAddress& source, const ComboAdd
 
   size_t valuesSize = 0;
   for (const auto& value : values) {
-    valuesSize += sizeof(uint8_t) + sizeof(uint8_t) * 2 + value.content.size();    
-    if (valuesSize > std::numeric_limits<uint16_t>::max()) {
+    if (value.content.size() > std::numeric_limits<uint16_t>::max()) {
       throw std::runtime_error("The size of proxy protocol values is limited to " + std::to_string(std::numeric_limits<uint16_t>::max()) + ", trying to add a value of size " + std::to_string(value.content.size()));
+    }
+    valuesSize += sizeof(uint8_t) + sizeof(uint8_t) * 2 + value.content.size();
+    if (valuesSize > std::numeric_limits<uint16_t>::max()) {
+      throw std::runtime_error("The total size of proxy protocol values is limited to " + std::to_string(std::numeric_limits<uint16_t>::max()));
     }
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
If the dnsdist's configuration tries to add a very large number (more than `std::numeric_limits<size_t>::max()` bytes, which in theory could be 65535, in practice is 2^32 for 32-bit systems and 2^64 for 64-bit ones on every platforms we care about) of Proxy Protocol values, via actions or custom Lua code, the variable holding the size might overflow, causing a heap-based out-of-bounds write.

Found and reported by @ihsinme via Hacker One (many thanks!).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
