### PR TITLE
rec: Backport 9297 to rec 4.3.x: Ignore cache-only for DNSKEYs and DS retrieval 

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2326,11 +2326,14 @@ vState SyncRes::getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int 
   LOG(d_prefix<<"Retrieving DNSKeys for "<<signer<<endl);
 
   vState state = Indeterminate;
+
   /* following CNAME might lead to us to the wrong DNSKEY */
   bool oldSkipCNAME = d_skipCNAMECheck;
   d_skipCNAMECheck = true;
+  const bool oldCacheOnly = setCacheOnly(false);
   int rcode = doResolve(signer, QType(QType::DNSKEY), records, depth + 1, beenthere, state);
   d_skipCNAMECheck = oldSkipCNAME;
+  setCacheOnly(oldCacheOnly);
 
   if (rcode == RCode::NoError) {
     if (state == Secure) {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2052,8 +2052,10 @@ vState SyncRes::getDSRecords(const DNSName& zone, dsmap_t& ds, bool taOnly, unsi
   std::vector<DNSRecord> dsrecords;
 
   vState state = Indeterminate;
+  const bool oldCacheOnly = setCacheOnly(false);
   int rcode = doResolve(zone, QType(QType::DS), dsrecords, depth + 1, beenthere, state);
   d_skipCNAMECheck = oldSkipCNAME;
+  setCacheOnly(oldCacheOnly);
 
   if (rcode == RCode::NoError || (rcode == RCode::NXDomain && !bogusOnNXD)) {
     uint8_t bestDigestType = 0;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #9297 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
