### PR TITLE
misc.cc: Resize hostname to final size in getCarbonHostname()

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1589,6 +1589,7 @@ std::string getCarbonHostName()
   }
 
   boost::replace_all(hostname, ".", "_");
+  hostname.resize(strlen(hostname.c_str()));
 
   return hostname;
 }

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -213,4 +213,18 @@ BOOST_AUTO_TEST_CASE(test_reverse_name_to_ip)
   BOOST_CHECK_EQUAL(reverseNameFromIP(v6).toString(), "2.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.");
 }
 
+BOOST_AUTO_TEST_CASE(test_getCarbonHostName)
+{
+  char buffer[4096];
+
+  BOOST_CHECK_EQUAL(gethostname(buffer, sizeof buffer), 0);
+  std::string my_hostname(buffer);
+  boost::replace_all(my_hostname, ".", "_");
+
+  std::string hostname = getCarbonHostName();
+  // ensure it matches what we get
+  BOOST_CHECK_EQUAL(my_hostname, hostname);
+  BOOST_CHECK_EQUAL(my_hostname.size(), hostname.size());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Short description
In 5c21b47fbc35ddcb8d939eb8541c6c3bad1080a8 we change how hostname is allocated. We allocate getMaxHostNameSize for string, then give the raw buffer for gethostname function, but forget to resize the string into actual result length, causing the carbon output to include trailing NUL bytes after hostname.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)