### PR TITLE
dnsdist: Fix compilation on OpenBSD/amd64

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -25,6 +25,8 @@
 #include <thread>
 
 #if defined (__OpenBSD__) || defined(__NetBSD__)
+// If this is not undeffed, __attribute__ wil be redefined by /usr/include/readline/rlstdc.h
+#undef __STRICT_ANSI__
 #include <readline/readline.h>
 #include <readline/history.h>
 #else

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -32,6 +32,8 @@
 #include <unistd.h>
 
 #if defined (__OpenBSD__) || defined(__NetBSD__)
+// If this is not undeffed, __attribute__ wil be redefined by /usr/include/readline/rlstdc.h
+#undef __STRICT_ANSI__
 #include <readline/readline.h>
 #else
 #include <editline/readline.h>


### PR DESCRIPTION
Due to some yet undiagnosed interaction of the standard and boost include
files, we hit a syntax error when compiling the boost uuid code on
OpenBSD.  This is fixed by using -std=gnu++11.  This only happens
when compiling dnsdist.cc.  In other places compiling uuid-utils.hh
with -std=c++11 does not trigger an error.

The erorr is:
```
In file included from dnsdist.cc:39:
In file included from ./uuid-utils.hh:24:
In file included from /usr/local/include/boost/uuid/uuid.hpp:203:
In file included from /usr/local/include/boost/uuid/detail/uuid_x86.ipp:22:
In file included from /usr/lib/clang/8.0.1/include/emmintrin.h:27:
In file included from /usr/lib/clang/8.0.1/include/xmmintrin.h:27:
/usr/lib/clang/8.0.1/include/mmintrin.h:81:40: error: cannot initialize a parameter of type '__attribute__((__vector_size__(2 * sizeof(int)))) int' (vector of 2 'int' values) with an rvalue of type '__v2si' (aka 'int')
    return __builtin_ia32_vec_ext_v2si((__v2si)__m, 0);
```
Looking at the preprocessed source the `__attribute__((__vector_size__(16)))` was lost in the declaration of `__v4si`

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
