### PR TITLE
rec: if we have an NS in cache, use it in the forwarder case

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -85,7 +85,7 @@ public:
   explicit DNSName(const std::string& str) : DNSName(str.c_str(), str.length()) {}; //!< Constructs from a human formatted, escaped presentation
   DNSName(const char* p, int len, int offset, bool uncompress, uint16_t* qtype=nullptr, uint16_t* qclass=nullptr, unsigned int* consumed=nullptr, uint16_t minOffset=0); //!< Construct from a DNS Packet, taking the first question if offset=12. If supplied, consumed is set to the number of bytes consumed from the packet, which will not be equal to the wire length of the resulting name in case of compression.
   
-  bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name?
+  bool isPartOf(const DNSName& rhs) const;   //!< Are we part of the rhs name? Note that name.isPartOf(name).
   inline bool operator==(const DNSName& rhs) const; //!< DNS-native comparison (case insensitive) - empty compares to empty
   bool operator!=(const DNSName& other) const { return !(*this == other); }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1163,12 +1163,12 @@ DNSName SyncRes::getBestNSNamesFromCache(const DNSName &qname, const QType& qtyp
   getBestNSFromCache(qname, qtype, bestns, flawedNSSet, depth, beenthere);
 
   // Pick up the auth domain
-  for (auto k = bestns.cbegin(); k != bestns.cend(); ++k) {
-    const auto nsContent = getRR<NSRecordContent>(*k);
+  for (const auto& k : bestns) {
+    const auto nsContent = getRR<NSRecordContent>(k);
     if (nsContent) {
-      nsFromCacheDomain = k->d_name;
+      nsFromCacheDomain = k.d_name;
+      break;
     }
-    break;
   }
 
   if (iter != t_sstorage.domainmap->end()) {
@@ -1176,7 +1176,8 @@ DNSName SyncRes::getBestNSNamesFromCache(const DNSName &qname, const QType& qtyp
       LOG(prefix << qname << " authOrForwDomain: " << authOrForwDomain << " nsFromCacheDomain: " << nsFromCacheDomain << " isPartof: " << authOrForwDomain.isPartOf(nsFromCacheDomain) << endl);
     }
 
-    // If the forwarder is better or equal to what's found in the cache, use forwarder
+    // If the forwarder is better or equal to what's found in the cache, use forwarder. Note that name.isPartOf(name).
+    // So queries that get NS for authOrForwDomain itself go to the forwarder
     if (authOrForwDomain.isPartOf(nsFromCacheDomain)) {
       if (doLog()) {
         LOG(prefix << qname << ": using forwarder as NS" << endl);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1132,31 +1132,45 @@ DNSName SyncRes::getBestNSNamesFromCache(const DNSName &qname, const QType& qtyp
   DNSName authdomain(qname);
 
   domainmap_t::const_iterator iter=getBestAuthZone(&authdomain);
-  if(iter!=t_sstorage.domainmap->end()) {
-    if( iter->second.isAuth() )
+  // We have an auth, forwarder of forwarder-recurse
+  if (iter != t_sstorage.domainmap->end()) {
+    if (iter->second.isAuth()) {
       // this gets picked up in doResolveAt, the empty DNSName, combined with the
       // empty vector means 'we are auth for this zone'
       nsset.insert({DNSName(), {{}, false}});
-    else {
-      // Again, picked up in doResolveAt. An empty DNSName, combined with a
-      // non-empty vector of ComboAddresses means 'this is a forwarded domain'
-      // This is actually picked up in retrieveAddressesForNS called from doResolveAt.
-      nsset.insert({DNSName(), {iter->second.d_servers, iter->second.shouldRecurse() }});
+      return authdomain;
     }
-    return authdomain;
+    else {
+      if (iter->second.shouldRecurse()) {
+        // Again, picked up in doResolveAt. An empty DNSName, combined with a
+        // non-empty vector of ComboAddresses means 'this is a forwarded domain'
+        // This is actually picked up in retrieveAddressesForNS called from doResolveAt.
+        nsset.insert({DNSName(), {iter->second.d_servers, true }});
+        return authdomain;
+      }
+    }
   }
 
+  // We might have a (non-recursive) forwarder, but maybe the cache already contains
+  // a better NS
   DNSName subdomain(qname);
   vector<DNSRecord> bestns;
   getBestNSFromCache(subdomain, qtype, bestns, flawedNSSet, depth, beenthere);
 
-  for(auto k=bestns.cbegin() ; k != bestns.cend(); ++k) {
+  // If the forwarder is better or equal to what's found in the cache, use forwarder
+  if (iter != t_sstorage.domainmap->end() && authdomain.isPartOf(subdomain)) {
+    nsset.insert({DNSName(), {iter->second.d_servers, false }});
+    return authdomain;
+  }
+
+  for (auto k=bestns.cbegin(); k != bestns.cend(); ++k) {
     // The actual resolver code will not even look at the ComboAddress or bool
     const auto nsContent = getRR<NSRecordContent>(*k);
     if (nsContent) {
       nsset.insert({nsContent->getNS(), {{}, false}});
-      if(k==bestns.cbegin())
+      if (k == bestns.cbegin()) {
         subdomain=k->d_name;
+      }
     }
   }
   return subdomain;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -823,10 +823,10 @@ private:
   bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state);
 
   int doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state);
-  int doResolveNoQNameMinimization(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool* fromCache = NULL, StopAtDelegation* stopAtDelegation = NULL);
+  int doResolveNoQNameMinimization(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool* fromCache = NULL, StopAtDelegation* stopAtDelegation = NULL, bool considerforwards = true);
   bool doOOBResolve(const AuthDomain& domain, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int& res);
   bool doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res);
-  bool isForwardOrAuth(const DNSName &qname) const;
+  bool isRecursiveForwardOrAuth(const DNSName &qname) const;
   domainmap_t::const_iterator getBestAuthZone(DNSName* qname) const;
   bool doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state, bool wasAuthZone, bool wasForwardRecurse);
   bool doCacheCheck(const DNSName &qname, const DNSName& authname, bool wasForwardedOrAuthZone, bool wasAuthZone, bool wasForwardRecurse, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This changes the logic for finding NS records. If a regular (non-recursive) forward zone is hit, we *will* look in the cache to see if we have NS records available. Next we check if they are more specific as the forward domain, and use those instead of asking the forwarder.

This allows having a stub zone for the root. The whole thing does not work properly with qname minimization yet. If e.g. a root forward zone is specified, qname minimization will be switched off by the `isForwardOrAuth` check.
Just fixing this check to return false for non-recursive (stub) forward zones does not work since the Step0 cache check is fooled by the forwarding case in the first part of `doResolveNoQNameMinimization`: a forwarder is always consulted and if it answers with en empty ANSWER record set  (as happens with delegations)  we're doomed.

Given that, this seems to work in my test cases, and unit test and regression tests work.

~ATM this is a draft. The code to determine the actual NS domain could be integrated into `getBestNSFromCache` and it would be nice to handle the qname minimization case. But maybe that is something for the future.~

For now, I decided not to do the above point since it would complicate the already complicated `getBestNSFromCache`.

Should fix #9227

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
