### PR TITLE
dnsdist: Improve reporting of possible overflow via large Proxy Protocol values

### DIFF
--- a/pdns/dnsdistdist/dnsdist-proxy-protocol.cc
+++ b/pdns/dnsdistdist/dnsdist-proxy-protocol.cc
@@ -41,6 +41,10 @@ bool addProxyProtocol(std::vector<uint8_t>& buffer, bool tcp, const ComboAddress
   auto payload = makeProxyHeader(tcp, source, destination, values);
 
   auto previousSize = buffer.size();
+  if (payload.size() > (std::numeric_limits<size_t>::max() - previousSize)) {
+    return false;
+  }
+
   buffer.resize(previousSize + payload.size());
   std::copy_backward(buffer.begin(), buffer.begin() + previousSize, buffer.end());
   std::copy(payload.begin(), payload.end(), buffer.begin());

--- a/pdns/proxy-protocol.cc
+++ b/pdns/proxy-protocol.cc
@@ -65,9 +65,12 @@ std::string makeProxyHeader(bool tcp, const ComboAddress& source, const ComboAdd
 
   size_t valuesSize = 0;
   for (const auto& value : values) {
-    valuesSize += sizeof(uint8_t) + sizeof(uint8_t) * 2 + value.content.size();    
-    if (valuesSize > std::numeric_limits<uint16_t>::max()) {
+    if (value.content.size() > std::numeric_limits<uint16_t>::max()) {
       throw std::runtime_error("The size of proxy protocol values is limited to " + std::to_string(std::numeric_limits<uint16_t>::max()) + ", trying to add a value of size " + std::to_string(value.content.size()));
+    }
+    valuesSize += sizeof(uint8_t) + sizeof(uint8_t) * 2 + value.content.size();
+    if (valuesSize > std::numeric_limits<uint16_t>::max()) {
+      throw std::runtime_error("The total size of proxy protocol values is limited to " + std::to_string(std::numeric_limits<uint16_t>::max()));
     }
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR makes the error message a bit more helpful when trying to send a too large value, instead of the size of cumulated values being too large.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
