### PR TITLE
rec: Backport 9343 to rec 4.3.x: Resize hostname to final size in getCarbonHostname()

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1597,6 +1597,7 @@ std::string getCarbonHostName()
   }
 
   boost::replace_all(hostname, ".", "_");
+  hostname.resize(strlen(hostname.c_str()));
 
   return hostname;
 }

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -208,6 +208,10 @@ BOOST_AUTO_TEST_CASE(test_getCarbonHostName)
 
   BOOST_CHECK_EQUAL(gethostname(buffer, sizeof buffer), 0);
   std::string my_hostname(buffer);
+  auto pos = my_hostname.find(".");
+  if (pos != std::string::npos) {
+    my_hostname.resize(pos);
+  }
   boost::replace_all(my_hostname, ".", "_");
 
   std::string hostname = getCarbonHostName();

--- a/pdns/test-misc_hh.cc
+++ b/pdns/test-misc_hh.cc
@@ -202,5 +202,19 @@ BOOST_AUTO_TEST_CASE(test_rfc1982LessThan) {
   BOOST_CHECK(rfc1982check<uint64_t>(UINT64_MAX/2, UINT64_MAX-10));
 }
 
+BOOST_AUTO_TEST_CASE(test_getCarbonHostName)
+{
+  char buffer[4096];
+
+  BOOST_CHECK_EQUAL(gethostname(buffer, sizeof buffer), 0);
+  std::string my_hostname(buffer);
+  boost::replace_all(my_hostname, ".", "_");
+
+  std::string hostname = getCarbonHostName();
+  // ensure it matches what we get
+  BOOST_CHECK_EQUAL(my_hostname, hostname);
+  BOOST_CHECK_EQUAL(my_hostname.size(), hostname.size());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Note that the test had to be adapted since older `getCarbonHostname()` always truncates at dot.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
