### PR TITLE
Rec: rpz store trigger in appliedPolicy and protobuf message

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1477,6 +1477,7 @@ policyactions
 policyevent
 policykinds
 policyname
+policytypes
 pollmplexer
 Ponomarev
 poolers

--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -80,6 +80,7 @@ message PBDNSMessage {
     optional uint32 queryTimeUsec = 6;          // Time of the corresponding query reception (additional micro-seconds)
     optional PolicyType appliedPolicyType = 7;  // Type of the filtering policy (RPZ or Lua) applied
     optional string appliedPolicyTrigger = 8;   // The RPZ trigger
+    optional string appliedPolicyHit = 9;       // The value (qname or IP) that caused the hit
   }
 
   optional DNSResponse response = 13;

--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -79,6 +79,7 @@ message PBDNSMessage {
     optional uint32 queryTimeSec = 5;           // Time of the corresponding query reception (seconds since epoch)
     optional uint32 queryTimeUsec = 6;          // Time of the corresponding query reception (additional micro-seconds)
     optional PolicyType appliedPolicyType = 7;  // Type of the filtering policy (RPZ or Lua) applied
+    optional string appliedPolicyTrigger = 8;   // The RPZ trigger
   }
 
   optional DNSResponse response = 13;

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -27,6 +27,14 @@
 #include "namespaces.hh"
 #include "dnsrecords.hh"
 
+static const string rpzDropName("rpz-drop."),
+  rpzTruncateName("rpz-tcp-only."),
+  rpzNoActionName("rpz-passthru."),
+  rpzClientIPName("rpz-client-ip"),
+  rpzIPName("rpz-ip."),
+  rpzNSDnameName("rpz-nsdname."),
+  rpzNSIPName("rpz-nsip.");
+
 DNSFilterEngine::DNSFilterEngine()
 {
 }
@@ -174,7 +182,7 @@ bool DNSFilterEngine::getProcessingPolicy(const DNSName& qname, const std::unord
       if (z->findExactNSPolicy(wc, pol)) {
         // cerr<<"Had a hit on the nameserver ("<<qname<<") used to process the query"<<endl;
         pol.d_trigger = wc;
-        pol.d_trigger.appendRawLabel("rpz-nsdname");
+        pol.d_trigger.appendRawLabel(rpzNSDnameName);
         return true;
       }
     }
@@ -200,7 +208,7 @@ bool DNSFilterEngine::getProcessingPolicy(const ComboAddress& address, const std
       //      cerr<<"Had a hit on the nameserver ("<<address.toString()<<") used to process the query"<<endl;
       // XXX should use ns RPZ
       pol.d_trigger = Zone::maskToRPZ(address);
-      pol.d_trigger.appendRawLabel("rpz-nsip");
+      pol.d_trigger.appendRawLabel(rpzNSIPName);
       return true;
     }
   }
@@ -593,22 +601,19 @@ std::vector<DNSRecord> DNSFilterEngine::Policy::getCustomRecords(const DNSName& 
 
 std::string DNSFilterEngine::getKindToString(DNSFilterEngine::PolicyKind kind)
 {
-  static const DNSName drop("rpz-drop."), truncate("rpz-tcp-only."), noaction("rpz-passthru.");
-  static const DNSName rpzClientIP("rpz-client-ip"), rpzIP("rpz-ip"),
-    rpzNSDname("rpz-nsdname"), rpzNSIP("rpz-nsip.");
-  static const std::string rpzPrefix("rpz-");
+  //static const std::string rpzPrefix("rpz-");
 
   switch(kind) {
   case DNSFilterEngine::PolicyKind::NoAction:
-    return noaction.toString();
+    return rpzNoActionName;
   case DNSFilterEngine::PolicyKind::Drop:
-    return drop.toString();
+    return rpzDropName;
   case DNSFilterEngine::PolicyKind::NXDOMAIN:
     return g_rootdnsname.toString();
   case PolicyKind::NODATA:
     return g_wildcarddnsname.toString();
   case DNSFilterEngine::PolicyKind::Truncate:
-    return truncate.toString();
+    return rpzTruncateName;
   default:
     throw std::runtime_error("Unexpected DNSFilterEngine::Policy kind");
   }
@@ -729,19 +734,19 @@ void DNSFilterEngine::Zone::dump(FILE* fp) const
   }
 
   for (const auto& pair : d_propolName) {
-    dumpNamedPolicy(fp, pair.first + DNSName("rpz-nsdname.") + d_domain, pair.second);
+    dumpNamedPolicy(fp, pair.first + DNSName(rpzNSDnameName) + d_domain, pair.second);
   }
 
   for (const auto& pair : d_qpolAddr) {
-    dumpAddrPolicy(fp, pair.first, DNSName("rpz-client-ip.") + d_domain, pair.second);
+    dumpAddrPolicy(fp, pair.first, DNSName(rpzClientIPName) + d_domain, pair.second);
   }
 
   for (const auto& pair : d_propolNSAddr) {
-    dumpAddrPolicy(fp, pair.first, DNSName("rpz-nsip.") + d_domain, pair.second);
+    dumpAddrPolicy(fp, pair.first, DNSName(rpzNSIPName) + d_domain, pair.second);
   }
 
   for (const auto& pair : d_postpolAddr) {
-    dumpAddrPolicy(fp, pair.first, DNSName("rpz-ip.") + d_domain, pair.second);
+    dumpAddrPolicy(fp, pair.first, DNSName(rpzIPName) + d_domain, pair.second);
   }
 }
 

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -103,6 +103,7 @@ bool DNSFilterEngine::Zone::findNamedPolicy(const std::unordered_map<DNSName, DN
     if(iter != polmap.end()) {
       pol=iter->second;
       pol.d_trigger = g_wildcarddnsname+s;
+      pol.d_hit = qname.toString();
       return true;
     }
   }
@@ -119,6 +120,7 @@ bool DNSFilterEngine::Zone::findExactNamedPolicy(const std::unordered_map<DNSNam
   if (it != polmap.end()) {
     pol = it->second;
     pol.d_trigger = qname;
+    pol.d_hit = qname.toString();
     return true;
   }
 
@@ -175,6 +177,7 @@ bool DNSFilterEngine::getProcessingPolicy(const DNSName& qname, const std::unord
       // cerr<<"Had a hit on the nameserver ("<<qname<<") used to process the query"<<endl;
       pol.d_trigger = qname;
       pol.d_trigger.appendRawLabel("rpz-nsdname");
+      pol.d_hit = qname.toString();
       return true;
     }
 
@@ -183,6 +186,7 @@ bool DNSFilterEngine::getProcessingPolicy(const DNSName& qname, const std::unord
         // cerr<<"Had a hit on the nameserver ("<<qname<<") used to process the query"<<endl;
         pol.d_trigger = wc;
         pol.d_trigger.appendRawLabel(rpzNSDnameName);
+        pol.d_hit = qname.toString();
         return true;
       }
     }
@@ -209,6 +213,7 @@ bool DNSFilterEngine::getProcessingPolicy(const ComboAddress& address, const std
       // XXX should use ns RPZ
       pol.d_trigger = Zone::maskToRPZ(address);
       pol.d_trigger.appendRawLabel(rpzNSIPName);
+      pol.d_hit = address.toString();
       return true;
     }
   }
@@ -286,6 +291,7 @@ bool DNSFilterEngine::getQueryPolicy(const DNSName& qname, const std::unordered_
     if (z->findExactQNamePolicy(qname, pol)) {
       // cerr<<"Had a hit on the name of the query"<<endl;
       pol.d_trigger = qname;
+      pol.d_hit = qname.toString();
       return true;
     }
 
@@ -293,6 +299,7 @@ bool DNSFilterEngine::getQueryPolicy(const DNSName& qname, const std::unordered_
       if (z->findExactQNamePolicy(wc, pol)) {
         // cerr<<"Had a hit on the name of the query"<<endl;
         pol.d_trigger = wc;
+        pol.d_hit = qname.toString();
         return true;
       }
     }
@@ -346,7 +353,8 @@ bool DNSFilterEngine::getPostPolicy(const DNSRecord& record, const std::unordere
 
     if (z->findResponsePolicy(ca, pol)) {
       pol.d_trigger = Zone::maskToRPZ(ca);
-      pol.d_trigger.appendRawLabel("rpz-ip");
+      pol.d_trigger.appendRawLabel(rpzIPName);
+      pol.d_hit = ca.toString();
       return true;
     }
   }

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -27,7 +27,7 @@
 #include "namespaces.hh"
 #include "dnsrecords.hh"
 
-// Names below are RPZ Actions and end with a dot (execpt "Local Data")
+// Names below are RPZ Actions and end with a dot (except "Local Data")
 static const std::string rpzDropName("rpz-drop."),
   rpzTruncateName("rpz-tcp-only."),
   rpzNoActionName("rpz-passthru."),
@@ -106,7 +106,7 @@ bool DNSFilterEngine::Zone::findNamedPolicy(const std::unordered_map<DNSName, DN
     iter = polmap.find(g_wildcarddnsname+s);
     if(iter != polmap.end()) {
       pol=iter->second;
-      pol.d_trigger = g_wildcarddnsname+s;
+      pol.d_trigger = iter->first;
       pol.d_hit = qname.toStringNoDot();
       return true;
     }

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -157,6 +157,7 @@ public:
 
     std::vector<std::shared_ptr<DNSRecordContent>> d_custom;
     std::shared_ptr<PolicyZoneData> d_zoneData{nullptr};
+    DNSName d_trigger;
     /* Yup, we are currently using the same TTL for every record for a given name */
     int32_t d_ttl;
     PolicyKind d_kind;
@@ -280,13 +281,15 @@ public:
       d_zoneData->d_priority = p;
     }
     
+    static DNSName maskToRPZ(const Netmask& nm);
+
   private:
     void addNameTrigger(std::unordered_map<DNSName,Policy>& map, const DNSName& n, Policy&& pol, bool ignoreDuplicate, PolicyType ptype);
     void addNetmaskTrigger(NetmaskTree<Policy>& nmt, const Netmask& nm, Policy&& pol, bool ignoreDuplicate, PolicyType ptype);
     bool rmNameTrigger(std::unordered_map<DNSName,Policy>& map, const DNSName& n, const Policy& pol);
     bool rmNetmaskTrigger(NetmaskTree<Policy>& nmt, const Netmask& nm, const Policy& pol);
 
-    static DNSName maskToRPZ(const Netmask& nm);
+  private:
     static bool findExactNamedPolicy(const std::unordered_map<DNSName, DNSFilterEngine::Policy>& polmap, const DNSName& qname, DNSFilterEngine::Policy& pol);
     static bool findNamedPolicy(const std::unordered_map<DNSName, DNSFilterEngine::Policy>& polmap, const DNSName& qname, DNSFilterEngine::Policy& pol);
     static void dumpNamedPolicy(FILE* fp, const DNSName& name, const Policy& pol);

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -152,6 +152,7 @@ public:
       return (d_type != DNSFilterEngine::PolicyType::None && d_kind != DNSFilterEngine::PolicyKind::NoAction);
     }
 
+    std::string getLogString() const;
     std::vector<DNSRecord> getCustomRecords(const DNSName& qname, uint16_t qtype) const;
     std::vector<DNSRecord> getRecords(const DNSName& qname) const;
 

--- a/pdns/filterpo.hh
+++ b/pdns/filterpo.hh
@@ -158,6 +158,7 @@ public:
     std::vector<std::shared_ptr<DNSRecordContent>> d_custom;
     std::shared_ptr<PolicyZoneData> d_zoneData{nullptr};
     DNSName d_trigger;
+    string d_hit;
     /* Yup, we are currently using the same TTL for every record for a given name */
     int32_t d_ttl;
     PolicyKind d_kind;

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -189,6 +189,7 @@ void RecursorLua4::postPrepareContext()
   d_lw->registerMember("policyType", &DNSFilterEngine::Policy::d_type);
   d_lw->registerMember("policyTTL", &DNSFilterEngine::Policy::d_ttl);
   d_lw->registerMember("policyTrigger", &DNSFilterEngine::Policy::d_trigger);
+  d_lw->registerMember("policyHit", &DNSFilterEngine::Policy::d_hit);
   d_lw->registerMember<DNSFilterEngine::Policy, std::string>("policyCustom",
     [](const DNSFilterEngine::Policy& pol) -> std::string {
       std::string result;

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -188,6 +188,7 @@ void RecursorLua4::postPrepareContext()
   d_lw->registerMember("policyKind", &DNSFilterEngine::Policy::d_kind);
   d_lw->registerMember("policyType", &DNSFilterEngine::Policy::d_type);
   d_lw->registerMember("policyTTL", &DNSFilterEngine::Policy::d_ttl);
+  d_lw->registerMember("policyTrigger", &DNSFilterEngine::Policy::d_trigger);
   d_lw->registerMember<DNSFilterEngine::Policy, std::string>("policyCustom",
     [](const DNSFilterEngine::Policy& pol) -> std::string {
       std::string result;
@@ -329,6 +330,15 @@ void RecursorLua4::postPrepareContext()
     {"NODATA",   (int)DNSFilterEngine::PolicyKind::NODATA  },
     {"Truncate", (int)DNSFilterEngine::PolicyKind::Truncate},
     {"Custom",   (int)DNSFilterEngine::PolicyKind::Custom  }
+    }});
+
+  d_pd.push_back({"policytypes", in_t {
+    {"None",       (int)DNSFilterEngine::PolicyType::None       },
+    {"QName",      (int)DNSFilterEngine::PolicyType::QName      },
+    {"ClientIP",   (int)DNSFilterEngine::PolicyType::ClientIP   },
+    {"ResponseIP", (int)DNSFilterEngine::PolicyType::ResponseIP },
+    {"NSDName",    (int)DNSFilterEngine::PolicyType::NSDName    },
+    {"NSIP",       (int)DNSFilterEngine::PolicyType::NSIP       }
     }});
 
   for(const auto& n : QType::names)

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1569,6 +1569,10 @@ static void startDoResolve(void *p)
           goto haveAnswer;
         }
         else if (policyResult == PolicyResult::Drop) {
+          if (sr.doLog()) {
+            g_log << Logger::Warning << dc->d_mdp.d_qname << "|" << QType(dc->d_mdp.d_qtype).getName() << appliedPolicy.getLogString() << endl;
+          }
+          g_stats.policyDrops++;
           return;
         }
       }
@@ -1616,6 +1620,9 @@ static void startDoResolve(void *p)
             g_log<<Logger::Warning<< line << endl;
         }
       }
+    }
+    if (sr.doLog() &&  appliedPolicy.d_type != DNSFilterEngine::PolicyType::None) {
+      g_log << Logger::Warning << dc->d_mdp.d_qname << "|" << QType(dc->d_mdp.d_qtype).getName() << appliedPolicy.getLogString() << endl;
     }
 
     if(res == -1) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -889,6 +889,10 @@ static PolicyResult handlePolicyHit(const DNSFilterEngine::Policy& appliedPolicy
     ++g_stats.policyResults[appliedPolicy.d_kind];
   }
 
+  if (sr.doLog() &&  appliedPolicy.d_type != DNSFilterEngine::PolicyType::None) {
+    g_log << Logger::Warning << dc->d_mdp.d_qname << "|" << QType(dc->d_mdp.d_qtype).getName() << appliedPolicy.getLogString() << endl;
+  }
+
   switch (appliedPolicy.d_kind) {
 
   case DNSFilterEngine::PolicyKind::NoAction:
@@ -1569,10 +1573,6 @@ static void startDoResolve(void *p)
           goto haveAnswer;
         }
         else if (policyResult == PolicyResult::Drop) {
-          if (sr.doLog()) {
-            g_log << Logger::Warning << dc->d_mdp.d_qname << "|" << QType(dc->d_mdp.d_qtype).getName() << appliedPolicy.getLogString() << endl;
-          }
-          g_stats.policyDrops++;
           return;
         }
       }
@@ -1620,9 +1620,6 @@ static void startDoResolve(void *p)
             g_log<<Logger::Warning<< line << endl;
         }
       }
-    }
-    if (sr.doLog() &&  appliedPolicy.d_type != DNSFilterEngine::PolicyType::None) {
-      g_log << Logger::Warning << dc->d_mdp.d_qname << "|" << QType(dc->d_mdp.d_qtype).getName() << appliedPolicy.getLogString() << endl;
     }
 
     if(res == -1) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1777,6 +1777,7 @@ static void startDoResolve(void *p)
       if (!appliedPolicy.getName().empty()) {
         pbMessage->setAppliedPolicy(appliedPolicy.getName());
         pbMessage->setAppliedPolicyType(appliedPolicy.d_type);
+        pbMessage->setAppliedPolicyTrigger(appliedPolicy.d_trigger);
       }
       pbMessage->setPolicyTags(dc->d_policyTags);
       if (g_useKernelTimestamp && dc->d_kernelTimestamp.tv_sec) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1778,6 +1778,7 @@ static void startDoResolve(void *p)
         pbMessage->setAppliedPolicy(appliedPolicy.getName());
         pbMessage->setAppliedPolicyType(appliedPolicy.d_type);
         pbMessage->setAppliedPolicyTrigger(appliedPolicy.d_trigger);
+        pbMessage->setAppliedPolicyHit(appliedPolicy.d_hit);
       }
       pbMessage->setPolicyTags(dc->d_policyTags);
       if (g_useKernelTimestamp && dc->d_kernelTimestamp.tv_sec) {

--- a/pdns/rec-protobuf.cc
+++ b/pdns/rec-protobuf.cc
@@ -177,6 +177,16 @@ void RecProtoBufMessage::setAppliedPolicyTrigger(const DNSName& trigger)
 #endif /* HAVE_PROTOBUF */
 }
 
+void RecProtoBufMessage::setAppliedPolicyHit(const string& hit)
+{
+#ifdef HAVE_PROTOBUF
+  PBDNSMessage_DNSResponse* response = d_message.mutable_response();
+  if (response && !hit.empty()) {
+    response->set_appliedpolicyhit(hit);
+  }
+#endif /* HAVE_PROTOBUF */
+}
+
 void RecProtoBufMessage::setPolicyTags(const std::unordered_set<std::string>& policyTags)
 {
 #ifdef HAVE_PROTOBUF

--- a/pdns/rec-protobuf.cc
+++ b/pdns/rec-protobuf.cc
@@ -167,6 +167,16 @@ void RecProtoBufMessage::setAppliedPolicyType(const DNSFilterEngine::PolicyType&
 #endif /* HAVE_PROTOBUF */
 }
 
+void RecProtoBufMessage::setAppliedPolicyTrigger(const DNSName& trigger)
+{
+#ifdef HAVE_PROTOBUF
+  PBDNSMessage_DNSResponse* response = d_message.mutable_response();
+  if (response && !trigger.empty()) {
+    response->set_appliedpolicytrigger(trigger.toString());
+  }
+#endif /* HAVE_PROTOBUF */
+}
+
 void RecProtoBufMessage::setPolicyTags(const std::unordered_set<std::string>& policyTags)
 {
 #ifdef HAVE_PROTOBUF

--- a/pdns/rec-protobuf.hh
+++ b/pdns/rec-protobuf.hh
@@ -52,6 +52,7 @@ public:
 #endif /* NOD_ENABLED */
   void setAppliedPolicy(const std::string& policy);
   void setAppliedPolicyType(const DNSFilterEngine::PolicyType& policyType);
+  void setAppliedPolicyTrigger(const DNSName& trigger);
   void setPolicyTags(const std::unordered_set<std::string>& policyTags);
   void addPolicyTag(const std::string& policyTag);
   void removePolicyTag(const std::string& policyTag);

--- a/pdns/rec-protobuf.hh
+++ b/pdns/rec-protobuf.hh
@@ -53,6 +53,7 @@ public:
   void setAppliedPolicy(const std::string& policy);
   void setAppliedPolicyType(const DNSFilterEngine::PolicyType& policyType);
   void setAppliedPolicyTrigger(const DNSName& trigger);
+  void setAppliedPolicyHit(const string& hit);
   void setPolicyTags(const std::unordered_set<std::string>& policyTags);
   void addPolicyTag(const std::string& policyTag);
   void removePolicyTag(const std::string& policyTag);

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -92,6 +92,14 @@ The DNSQuestion object contains at least the following fields:
 
         The TTL in seconds for the ``pdns.policyactions.Custom`` response
 
+    .. attribute:: DNSQuestion.appliedPolicy.policyTrigger
+
+        The trigger (left-hand) part of the RPZ rule that was matched
+
+  .. attribute:: DNSQuestion.appliedPolicy.policyHit
+
+        The value that was matched. This is a string representing a name or an address.
+
   .. attribute:: DNSQuestion.wantsRPZ
 
       A boolean that indicates the use of the Policy Engine.

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -62,9 +62,16 @@ The DNSQuestion object contains at least the following fields:
       Set by :ref:`policyName <rpz-policyName>` in the :func:`rpzFile` and :func:`rpzMaster` configuration items.
       It is advised to overwrite this when modifying the :attr:`DNSQuestion.appliedPolicy.policyKind`
 
-    .. attribute:: DNSQuestion.appliedPolicy.policyAction
+    .. attribute:: DNSQuestion.appliedPolicy.policyType
 
-        The action taken by the engine
+        The type of match for the policy.
+ 
+      -  ``pdns.policytypes.None``  the empty policy type
+      -  ``pdns.policytypes.QName`` a match on qname
+      -  ``pdns.policytypes.ClientIP`` a match on client IP
+      -  ``pdns.policytypes.ResponseIP`` a match on response IP
+      -  ``pdns.policytypes.NSDName`` a match on the name of a nameserver
+      -  ``pdns.policytypes.NSIP`` a match on the IP of a nameserver
 
     .. attribute:: DNSQuestion.appliedPolicy.policyCustom
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2028,6 +2028,10 @@ void SyncRes::handlePolicyHit(const std::string& prefix, const DNSName& qname, c
     ++g_stats.policyResults[d_appliedPolicy.d_kind];
   }
 
+  if (d_appliedPolicy.d_type != DNSFilterEngine::PolicyType::None) {
+    LOG(prefix << qname << "|" << qtype.getName() << d_appliedPolicy.getLogString() << endl);
+  }
+
   switch (d_appliedPolicy.d_kind) {
 
   case DNSFilterEngine::PolicyKind::NoAction:

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -194,12 +194,14 @@ class TestRecursorProtobuf(RecursorTest):
             self.assertEquals(record.ttl, rttl)
         self.assertTrue(record.HasField('rdata'))
 
-    def checkProtobufPolicy(self, msg, policyType, reason):
+    def checkProtobufPolicy(self, msg, policyType, reason, name):
         self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
         self.assertTrue(msg.response.HasField('appliedPolicyType'))
         self.assertTrue(msg.response.HasField('appliedPolicy'))
+        self.assertTrue(msg.response.HasField('appliedPolicyTrigger'))
         self.assertEquals(msg.response.appliedPolicy, reason)
         self.assertEquals(msg.response.appliedPolicyType, policyType)
+        self.assertEquals(msg.response.appliedPolicyTrigger, name)
 
     def checkProtobufTags(self, msg, tags):
         print(tags)
@@ -859,7 +861,7 @@ sub.test 3600 IN A 192.0.2.42
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
-        self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.')
+        self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.', '*.test.example.')
         self.assertEquals(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
@@ -926,7 +928,7 @@ sub.test 3600 IN A 192.0.2.42
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
-        self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.')
+        self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.', '*.test.example.')
         self.checkProtobufTags(msg, self._tags + self._tags_from_gettag + self._tags_from_rpz)
         self.assertEquals(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -194,14 +194,16 @@ class TestRecursorProtobuf(RecursorTest):
             self.assertEquals(record.ttl, rttl)
         self.assertTrue(record.HasField('rdata'))
 
-    def checkProtobufPolicy(self, msg, policyType, reason, name):
+    def checkProtobufPolicy(self, msg, policyType, reason, trigger, hit):
         self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
         self.assertTrue(msg.response.HasField('appliedPolicyType'))
         self.assertTrue(msg.response.HasField('appliedPolicy'))
         self.assertTrue(msg.response.HasField('appliedPolicyTrigger'))
+        self.assertTrue(msg.response.HasField('appliedPolicyHit'))
         self.assertEquals(msg.response.appliedPolicy, reason)
         self.assertEquals(msg.response.appliedPolicyType, policyType)
-        self.assertEquals(msg.response.appliedPolicyTrigger, name)
+        self.assertEquals(msg.response.appliedPolicyTrigger, trigger)
+        self.assertEquals(msg.response.appliedPolicyHit, hit)
 
     def checkProtobufTags(self, msg, tags):
         print(tags)
@@ -861,7 +863,7 @@ sub.test 3600 IN A 192.0.2.42
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
-        self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.', '*.test.example.')
+        self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.', '*.test.example.', 'sub.test.example')
         self.assertEquals(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
@@ -928,7 +930,7 @@ sub.test 3600 IN A 192.0.2.42
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
-        self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.', '*.test.example.')
+        self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.', '*.test.example.', 'sub.test.example')
         self.checkProtobufTags(msg, self._tags + self._tags_from_gettag + self._tags_from_rpz)
         self.assertEquals(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

In RPZ speak, the trigger is the lefthand side of an RPZ rule. If a RPZ rule is hit, store the value of this trigger in the `appliedPolicy.policyTrigger` field so LUA can access it and also store it in the protobuf message.
Also add the value that caused the hit. 

While working on this, I noticed the docs mention `appliedPolicy.policyAction`, but the code does not set it afaiks. I'm assuming `appliedPolicy.policyType` was meant. Adapt the code and docs to agree with respect to this  and add `policytypes` listing the possible values for `policyType`.

Also added code to use the information in appliedPolicy to do logging in a consistent manner.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
