### PR TITLE
dnsdist: Handle EINTR in DelayPipe

### DIFF
--- a/pdns/delaypipe.hh
+++ b/pdns/delaypipe.hh
@@ -43,8 +43,7 @@ public:
   ObjectPipe();
   ~ObjectPipe();
   void write(T& t);
-  bool read(T* t); // returns false on EOF
-  int readTimeout(T* t, double msec); //!< -1 is timeout, 0 is no data, 1 is data. msec<0 waits infinitely wrong. msec==0 = undefined
+  int readTimeout(T* t, double msec); //!< -1 is timeout, 0 is no data, 1 is data. msec<0 waits infinitely long. msec==0 = undefined
   void close(); 
 private:
   int d_fds[2];

--- a/pdns/dnsdistdist/test-delaypipe_hh.cc
+++ b/pdns/dnsdistdist/test-delaypipe_hh.cc
@@ -15,13 +15,13 @@ BOOST_AUTO_TEST_CASE(test_object_pipe) {
 
   int i;
   for(int n=0; n < 100; ++n) {
-    bool res=op.read(&i);
-    BOOST_CHECK_EQUAL(res, true);
+    int res=op.readTimeout(&i, -1);
+    BOOST_CHECK_EQUAL(res, 1);
     BOOST_CHECK_EQUAL(n, i);
   }
 
   op.close();
-  BOOST_CHECK_EQUAL(op.read(&i), false);
+  BOOST_CHECK_EQUAL(op.readTimeout(&i, 1), 0);
 
 };
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise the `DelayPipe` thread might stop because the read() operation has been interrupted by a signal (like `SIGWINCH`, which is quite annoying).
Also remove the unused `read()` operation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
