### PR TITLE
auth slave: log successful NOTIFY

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -870,7 +870,7 @@ int PacketHandler::trySuperMasterSynchronous(const DNSPacket& p, const DNSName& 
 
 int PacketHandler::processNotify(const DNSPacket& p)
 {
-  /* now what? 
+  /* now what?
      was this notification from an approved address?
      was this notification approved by TSIG?
      We determine our internal SOA id (via UeberBackend)
@@ -948,7 +948,7 @@ int PacketHandler::processNotify(const DNSPacket& p)
   }
 
   if(::arg().mustDo("slave")) {
-    g_log<<Logger::Debug<<"Queueing slave check for "<<p.qdomain<<endl;
+    g_log<<Logger::Notice<<"Received NOTIFY for "<<p.qdomain<<" from "<<p.getRemote()<<" - queueing check"<<endl;
     Communicator.addSlaveCheckRequest(di, p.d_remote);
   }
   return 0;


### PR DESCRIPTION
### Short description

The Auth already logs all NOTIFY cases except the successful one on `Notice` or higher, lets do the same on success.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
