### PR TITLE
Fix docs for DNSName::equal()

### DIFF
--- a/pdns/recursordist/docs/lua-scripting/dnsname.rst
+++ b/pdns/recursordist/docs/lua-scripting/dnsname.rst
@@ -50,8 +50,10 @@ A small example of the functionality of a :class:`DNSName` is shown below:
   .. method:: DNSName:equal(name) -> bool
 
     Returns true when both names are equal for the DNS, i.e case insensitive.
+    
+    To compare two ``DNSName`` objects, use ``==``.
 
-    :param DNSName name: The name to compare against.
+    :param DNSName string: The name to compare against.
 
   .. method:: DNSName:isPartOf(name) -> bool
 


### PR DESCRIPTION
Since overloading Lua wrapper functions does not seem to be possible,
fix docs for DNSName:equal(). But note that == is defined for DNSNames.

Fixes #7510

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Also zap a duplicated line in `lua-base4.cc`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
