### PR TITLE
statbag: handle key redeclarations better

### DIFF
--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -636,7 +636,13 @@ int main(int argc, char **argv)
     exit(1);
   }
   
-  declareStats();
+  try {
+    declareStats();
+  }
+  catch(PDNSException &PE) {
+    g_log<<Logger::Error<<"Exiting because: "<<PE.reason<<endl;
+    exit(1);
+  }
   S.blacklist("special-memory-usage");
 
   DLOG(g_log<<Logger::Warning<<"Verbose logging in effect"<<endl);

--- a/pdns/statbag.cc
+++ b/pdns/statbag.cc
@@ -38,6 +38,7 @@
 StatBag::StatBag()
 {
   d_doRings=false;
+  d_allowRedeclare=false;
 }
 
 void StatBag::exists(const string &key)
@@ -106,8 +107,13 @@ StatType StatBag::getStatType(const string &item)
 void StatBag::declare(const string &key, const string &descrip, StatType statType)
 {
   if(d_stats.count(key)) {
-    *d_stats[key] = 0;
-    return;
+    if (d_allowRedeclare) {
+      *d_stats[key] = 0;
+      return;
+    }
+    else {
+      throw PDNSException("Attempt to re-declare statbag '"+key+"'");
+    }
   }
 
   auto i=make_unique<AtomicCounter>(0);
@@ -118,6 +124,10 @@ void StatBag::declare(const string &key, const string &descrip, StatType statTyp
 
 void StatBag::declare(const string &key, const string &descrip, StatBag::func_t func, StatType statType)
 {
+  if(d_funcstats.count(key) && !d_allowRedeclare) {
+    throw PDNSException("Attempt to re-declare func statbag '"+key+"'");
+  }
+
   d_funcstats[key]=func;
   d_keyDescrips[key]=descrip;
   d_statTypes[key]=statType;

--- a/pdns/statbag.cc
+++ b/pdns/statbag.cc
@@ -105,6 +105,11 @@ StatType StatBag::getStatType(const string &item)
 
 void StatBag::declare(const string &key, const string &descrip, StatType statType)
 {
+  if(d_stats.count(key)) {
+    *d_stats[key] = 0;
+    return;
+  }
+
   auto i=make_unique<AtomicCounter>(0);
   d_stats[key]=std::move(i);
   d_keyDescrips[key]=descrip;

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -80,6 +80,7 @@ class StatBag
   typedef map<string, func_t> funcstats_t;
   funcstats_t d_funcstats;
   bool d_doRings;
+
   std::set<string> d_blacklist;
 
   void registerRingStats(const string& name);
@@ -147,6 +148,8 @@ public:
   string getValueStr(const string &key); //!< read a value behind a key, and return it as a string
   string getValueStrZero(const string &key); //!< read a value behind a key, and return it as a string, and zero afterwards
   void blacklist(const string &str);
+
+  bool d_allowRedeclare; // only set this true during tests, never in production code
 };
 
 inline void StatBag::deposit(const string &key, int value)

--- a/pdns/testrunner.cc
+++ b/pdns/testrunner.cc
@@ -27,5 +27,6 @@ static bool init_unit_test() {
 // entry point:
 int main(int argc, char* argv[])
 {
+  S.d_allowRedeclare = true;
   return boost::unit_test::unit_test_main( &init_unit_test, argc, argv );
 }


### PR DESCRIPTION
### Short description
This avoids auth testrunner failures on 32 bit architectures. Possibly it also avoids silent memory corruption on 64 bit architectures.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master