### PR TITLE
rec: backport 9375 to rec 4.3.x: Allow some more depth headroom for the no-qname-minimization fallback case

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -955,6 +955,8 @@ This setting, which defaults to 3600 seconds, puts a maximum on the amount of ti
 Total maximum number of internal recursion calls the server may use to answer a single query.
 0 means unlimited.
 The value of `stack-size`_ should be increased together with this one to prevent the stack from overflowing.
+If `qname-minimization`_ is enabled, the fallback code in case of a failing resolve is allowed an additional `max-recursion-depth/2`.
+
 
 .. versionchanged:: 4.1.0
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -739,6 +739,9 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
         // Case 5: unexpected answer
         QLOG("Step5: other rcode, last effort final resolve");
         setQNameMinimization(false);
+        // We might have hit a depth level check, but we still want to allow some recursion levels in the fallback
+        // no-qname-minimization case. This has the effect that a qname minimization fallback case might reach 150% of
+        // maxdepth.
         res = doResolveNoQNameMinimization(qname, qtype, ret, depth/2, beenthere, state);
 
         if(res == RCode::NoError) {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -739,7 +739,7 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
         // Case 5: unexpected answer
         QLOG("Step5: other rcode, last effort final resolve");
         setQNameMinimization(false);
-        res = doResolveNoQNameMinimization(qname, qtype, ret, depth, beenthere, state);
+        res = doResolveNoQNameMinimization(qname, qtype, ret, depth/2, beenthere, state);
 
         if(res == RCode::NoError) {
           s_qnameminfallbacksuccess++;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #9375 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
