### PR TITLE
rec: FIx a few "warning: comparison of integers of different signs" on clang.OpenBSD

### DIFF
--- a/pdns/recursordist/test-syncres_cc10.cc
+++ b/pdns/recursordist/test-syncres_cc10.cc
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(test_outgoing_v4_only)
   BOOST_REQUIRE_EQUAL(v4Hit, true);
   BOOST_REQUIRE_EQUAL(v6Hit, false);
   BOOST_CHECK_EQUAL(rcode, RCode::NoError);
-  BOOST_CHECK_EQUAL(ret.size(), 1);
+  BOOST_CHECK_EQUAL(ret.size(), 1U);
 }
 
 BOOST_AUTO_TEST_CASE(test_outgoing_v4_only_no_A_in_delegation)
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(test_outgoing_v4_only_no_A_in_delegation)
   rcode = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
   BOOST_REQUIRE_EQUAL(queries, 14); // We keep trying all parent nameservers, this is wrong!
   BOOST_CHECK_EQUAL(rcode, RCode::ServFail);
-  BOOST_CHECK_EQUAL(ret.size(), 0);
+  BOOST_CHECK_EQUAL(ret.size(), 0U);
 }
 
 BOOST_AUTO_TEST_CASE(test_outgoing_v6_only_no_AAAA_in_delegation)
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(test_outgoing_v6_only_no_AAAA_in_delegation)
   rcode = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
   BOOST_REQUIRE_EQUAL(queries, 14); // The recursor tries all parent nameservers... this needs to be fixed
   BOOST_CHECK_EQUAL(rcode, RCode::ServFail);
-  BOOST_CHECK_EQUAL(ret.size(), 0);
+  BOOST_CHECK_EQUAL(ret.size(), 0U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION


### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
