### PR TITLE
sdig: report non-zero ID in response

### DIFF
--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -105,6 +105,9 @@ static void fillPacket(vector<uint8_t>& packet, const string& q, const string& t
 static void printReply(const string& reply, bool showflags, bool hidesoadetails)
 {
   MOADNSParser mdp(false, reply);
+  if (mdp.d_header.id) {
+    cout << "ID is not zero, this response was not meant for us!"<<endl;
+  }
   cout << "Reply to question for qname='" << mdp.d_qname.toString()
        << "', qtype=" << DNSRecordContent::NumberToType(mdp.d_qtype) << endl;
   cout << "Rcode: " << mdp.d_header.rcode << " ("


### PR DESCRIPTION
### Short description
During auth test runs, we occasionally see replies meant for unbound-host (ran just before sdig) end up on sdig's reply socket. This message should make that situation slightly less baffling.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master