### PR TITLE
Avoid unnecessary allocations and copies with DNSName::toDNSString()

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -537,7 +537,7 @@ DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, std::string* ruleresu
   uint16_t numberOfRecords = 0;
   if (!d_cname.empty()) {
     qtype = QType::CNAME;
-    totrdatalen += d_cname.toDNSString().size();
+    totrdatalen += d_cname.getStorage().size();
     numberOfRecords = 1;
   } else if (!d_rawResponse.empty()) {
     totrdatalen += d_rawResponse.size();
@@ -592,7 +592,7 @@ DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, std::string* ruleresu
   bool raw = false;
 
   if (qtype == QType::CNAME) {
-    const std::string wireData = d_cname.toDNSString(); // Note! This doesn't do compression!
+    const auto& wireData = d_cname.getStorage(); // Note! This doesn't do compression!
     uint16_t rdataLen = htons(wireData.length());
     qtype = htons(qtype);
     memcpy(&recordstart[2], &qtype, sizeof(qtype));
@@ -732,7 +732,7 @@ public:
     }
     else {
       if (d_binary) {
-        std::string out = dq->qname->toDNSString();
+        const auto& out = dq->qname->getStorage();
         if (d_includeTimestamp) {
           uint64_t tv_sec = static_cast<uint64_t>(dq->queryTime->tv_sec);
           uint32_t tv_nsec = static_cast<uint32_t>(dq->queryTime->tv_nsec);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -311,8 +311,8 @@ static bool fixUpResponse(char** response, uint16_t* responseLen, size_t* respon
     return true;
   }
 
-  if(g_fixupCase) {
-    string realname = qname.toDNSString();
+  if (g_fixupCase) {
+    const auto& realname = qname.getStorage();
     if (*responseLen >= (sizeof(dnsheader) + realname.length())) {
       memcpy(*response + sizeof(dnsheader), realname.c_str(), realname.length());
     }

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -208,7 +208,9 @@ std::string DNSName::toDNSString() const
 
 std::string DNSName::toDNSStringLC() const
 {
-  return toLower(toDNSString()); // label lengths are always < 'A'
+  auto result = toDNSString();
+  toLowerInPlace(result); // label lengths are always < 'A'
+  return result;
 }
 
 /**

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -94,7 +94,7 @@ shared_ptr<DNSRecordContent> DNSRecordContent::deserialize(const DNSName& qname,
 
   /* will look like: dnsheader, 5 bytes, encoded qname, dns record header, serialized data */
 
-  string encoded=qname.toDNSString();
+  const auto& encoded = qname.getStorage();
 
   packet.resize(sizeof(dnsheader) + 5 + encoded.size() + sizeof(struct dnsrecordheader) + serialized.size());
 

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -235,7 +235,7 @@ inline void toLowerInPlace(string& str)
 {
   const size_t length = str.length();
   char c;
-  for (unsigned int i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     c = dns_tolower(str[i]);
     if (c != str[i]) {
       str[i] = c;

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -152,6 +152,7 @@ size_t readn2(int fd, void* buffer, size_t len);
 size_t readn2WithTimeout(int fd, void* buffer, size_t len, int idleTimeout, int totalTimeout=0);
 size_t writen2WithTimeout(int fd, const void * buffer, size_t len, int timeout);
 
+void toLowerInPlace(string& str);
 const string toLower(const string &upper);
 const string toLowerCanonic(const string &upper);
 bool IpToU32(const string &str, uint32_t *ip);
@@ -230,16 +231,24 @@ inline int DTime::udiffNoReset()
   return ret;
 }
 
+inline void toLowerInPlace(string& str)
+{
+  const size_t length = str.length();
+  char c;
+  for (unsigned int i = 0; i < length; ++i) {
+    c = dns_tolower(str[i]);
+    if (c != str[i]) {
+      str[i] = c;
+    }
+  }
+}
+
 inline const string toLower(const string &upper)
 {
   string reply(upper);
-  const size_t length = reply.length();
-  char c;
-  for(unsigned int i = 0; i < length; ++i) {
-    c = dns_tolower(upper[i]);
-    if( c != upper[i])
-      reply[i] = c;
-  }
+
+  toLowerInPlace(reply);
+
   return reply;
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It should provide a small speed-up for KVS lookups, `SpoofAction`, `LogAction` and `fixup case` handling in dnsdist. It might save a few allocations for DNSSEC validation in the rec, and perhaps in some cases in the LMDB backend as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
