### PR TITLE
dnsdist: Handle empty DNSNames in grepq()

### DIFF
--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -445,11 +445,18 @@ void setupLuaInspection()
       if(msec==-1) {
         for(const auto& c : qr) {
           bool nmmatch=true, dnmatch=true;
-          if(nm)
+          if (nm) {
             nmmatch = nm->match(c.requestor);
-          if(dn)
-            dnmatch = c.name.isPartOf(*dn);
-          if(nmmatch && dnmatch) {
+          }
+          if (dn) {
+            if (c.name.empty()) {
+              dnmatch = false;
+            }
+            else {
+              dnmatch = c.name.isPartOf(*dn);
+            }
+          }
+          if (nmmatch && dnmatch) {
             QType qt(c.qtype);
             std::string extra;
             if (c.dh.opcode != 0) {
@@ -468,26 +475,40 @@ void setupLuaInspection()
       string extra;
       for(const auto& c : rr) {
         bool nmmatch=true, dnmatch=true, msecmatch=true;
-        if(nm)
+        if (nm) {
           nmmatch = nm->match(c.requestor);
-        if(dn)
-          dnmatch = c.name.isPartOf(*dn);
-        if(msec != -1)
+        }
+        if (dn) {
+          if (c.name.empty()) {
+            dnmatch = false;
+          }
+          else {
+            dnmatch = c.name.isPartOf(*dn);
+          }
+        }
+        if (msec != -1) {
           msecmatch=(c.usec/1000 > (unsigned int)msec);
+        }
 
-        if(nmmatch && dnmatch && msecmatch) {
+        if (nmmatch && dnmatch && msecmatch) {
           QType qt(c.qtype);
-	  if(!c.dh.rcode)
+	  if (!c.dh.rcode) {
 	    extra=". " +std::to_string(htons(c.dh.ancount))+ " answers";
-	  else
+          }
+	  else {
 	    extra.clear();
-          if(c.usec != std::numeric_limits<decltype(c.usec)>::max())
-            out.insert(make_pair(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % c.ds.toStringWithPort() % htons(c.dh.id) % c.name.toString()  % qt.getName()  % (c.usec/1000.0) % (c.dh.tc ? "TC" : "") % (c.dh.rd? "RD" : "") % (c.dh.aa? "AA" : "") % (RCode::to_s(c.dh.rcode) + extra)).str()  )) ;
-          else
-            out.insert(make_pair(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % c.ds.toStringWithPort() % htons(c.dh.id) % c.name.toString()  % qt.getName()  % "T.O" % (c.dh.tc ? "TC" : "") % (c.dh.rd? "RD" : "") % (c.dh.aa? "AA" : "") % (RCode::to_s(c.dh.rcode) + extra)).str()  )) ;
+          }
 
-          if(limit && *limit==++num)
+          if (c.usec != std::numeric_limits<decltype(c.usec)>::max()) {
+            out.insert(make_pair(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % c.ds.toStringWithPort() % htons(c.dh.id) % c.name.toString()  % qt.getName()  % (c.usec/1000.0) % (c.dh.tc ? "TC" : "") % (c.dh.rd? "RD" : "") % (c.dh.aa? "AA" : "") % (RCode::to_s(c.dh.rcode) + extra)).str()  )) ;
+          }
+          else {
+            out.insert(make_pair(c.when, (fmt % DiffTime(now, c.when) % c.requestor.toStringWithPort() % c.ds.toStringWithPort() % htons(c.dh.id) % c.name.toString()  % qt.getName()  % "T.O" % (c.dh.tc ? "TC" : "") % (c.dh.rd? "RD" : "") % (c.dh.aa? "AA" : "") % (RCode::to_s(c.dh.rcode) + extra)).str()  )) ;
+          }
+
+          if (limit && *limit == ++num) {
             break;
+          }
         }
       }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We should not get an empty DNSName into the ring buffer, but let's
handle it gracefully if it does happen so we can investigate, instead
of getting:

> Caught exception: empty dnsnames aren't part of anything
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
