### PR TITLE
Rec: make parse ip:port a bit smarter

### DIFF
--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -437,15 +437,15 @@ bool isTCPSocketUsable(int sock)
   return false;
 }
 /* mission in life: parse four cases
-   1) 1.2.3.4
-   2) 1.2.3.4:5300
-   3) 2001::1
-   4) [2002::1]:53
+   1) [2002::1]:53
+   2) 1.2.3.4
+   3) 1.2.3.4:5300
+   4) 2001::1 no port allowed
 */
 
 ComboAddress parseIPAndPort(const std::string& input, uint16_t port)
 {
-  if (input[0] == '[') { // case 4
+  if (input[0] == '[') { // case 1
     auto both = splitField(input.substr(1), ']');
     return ComboAddress(both.first, both.second.empty() ? port : static_cast<uint16_t>(pdns_stou(both.second.substr(1))));
   }
@@ -460,9 +460,9 @@ ComboAddress parseIPAndPort(const std::string& input, uint16_t port)
     }
   }
   switch (count) {
-  case 0: // case 1
+  case 0: // case 2
     return ComboAddress(input, port);
-  case 1: { // case 2
+  case 1: { // case 3
     string::size_type cpos = input.rfind(':');
     pair<std::string,std::string> both;
     both.first = input.substr(0, cpos);
@@ -471,7 +471,7 @@ ComboAddress parseIPAndPort(const std::string& input, uint16_t port)
     uint16_t newport = static_cast<uint16_t>(pdns_stou(both.second));
     return ComboAddress(both.first, newport);
   }
-  default: // case 3
+  default: // case 4
     return ComboAddress(input, port);
   }
 }

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -436,7 +436,7 @@ bool isTCPSocketUsable(int sock)
 
   return false;
 }
-/* mission in life: parse three cases
+/* mission in life: parse four cases
    1) 1.2.3.4
    2) 1.2.3.4:5300
    3) 2001::1
@@ -445,27 +445,34 @@ bool isTCPSocketUsable(int sock)
 
 ComboAddress parseIPAndPort(const std::string& input, uint16_t port)
 {
-  if (input.find(':') == string::npos || input.empty()) { // common case
-    return ComboAddress(input, port);
+  if (input[0] == '[') { // case 4
+    auto both = splitField(input.substr(1), ']');
+    return ComboAddress(both.first, both.second.empty() ? port : static_cast<uint16_t>(pdns_stou(both.second.substr(1))));
   }
 
-  pair<string,string> both;
-  try { // case 2
+  string::size_type count = 0;
+  for (char c : input) {
+    if (c == ':') {
+      count++;
+    }
+    if (count > 1) {
+      break;
+    }
+  }
+  switch (count) {
+  case 0: // case 1
+    return ComboAddress(input, port);
+  case 1: { // case 2
     string::size_type cpos = input.rfind(':');
+    pair<std::string,std::string> both;
     both.first = input.substr(0, cpos);
     both.second = input.substr(cpos + 1);
 
     uint16_t newport = static_cast<uint16_t>(pdns_stou(both.second));
     return ComboAddress(both.first, newport);
   }
-  catch(...) {
+  default: // case 3
+    return ComboAddress(input, port);
   }
-
-  if (input[0] == '[') { // case 4
-    both = splitField(input.substr(1), ']');
-    return ComboAddress(both.first, both.second.empty() ? port : static_cast<uint16_t>(pdns_stou(both.second.substr(1))));
-  }
-
-  return ComboAddress(input, port); // case 3
 }
 

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1440,3 +1440,5 @@ size_t sendMsgWithOptions(int fd, const char* buffer, size_t len, const ComboAdd
 bool isTCPSocketUsable(int sock);
 
 extern template class NetmaskTree<bool>;
+ComboAddress parseIPAndPort(const std::string& input, uint16_t port);
+

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -250,42 +250,6 @@ static void makeIPToNamesZone(std::shared_ptr<SyncRes::domainmap_t> newMap, cons
   }
 }
 
-
-
-/* mission in life: parse three cases
-   1) 1.2.3.4
-   2) 1.2.3.4:5300
-   3) 2001::1
-   4) [2002::1]:53
-*/
-
-ComboAddress parseIPAndPort(const std::string& input, uint16_t port)
-{
-  if (input.find(':') == string::npos || input.empty()) { // common case
-    return ComboAddress(input, port);
-  }
-
-  pair<string,string> both;
-  try { // case 2
-    string::size_type cpos = input.rfind(':');
-    both.first = input.substr(0, cpos);
-    both.second = input.substr(cpos + 1);
-
-    uint16_t newport = static_cast<uint16_t>(pdns_stou(both.second));
-    return ComboAddress(both.first, newport);
-  }
-  catch(...) {
-  }
-
-  if (input[0] == '[') { // case 4
-    both = splitField(input.substr(1), ']');
-    return ComboAddress(both.first, both.second.empty() ? port : static_cast<uint16_t>(pdns_stou(both.second.substr(1))));
-  }
-
-  return ComboAddress(input, port); // case 3
-}
-
-
 static void convertServersForAD(const std::string& input, SyncRes::AuthDomain& ad, const char* sepa, bool verbose=true)
 {
   vector<string> servers;

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -261,20 +261,24 @@ static void makeIPToNamesZone(std::shared_ptr<SyncRes::domainmap_t> newMap, cons
 
 ComboAddress parseIPAndPort(const std::string& input, uint16_t port)
 {
-  if(input.find(':') == string::npos || input.empty()) // common case
+  if (input.find(':') == string::npos || input.empty()) { // common case
     return ComboAddress(input, port);
+  }
 
   pair<string,string> both;
-
   try { // case 2
-    both=splitField(input,':');
-    uint16_t newport=static_cast<uint16_t>(pdns_stou(both.second));
-    return ComboAddress(both.first, newport);
-  } 
-  catch(...){}
+    string::size_type cpos = input.rfind(':');
+    both.first = input.substr(0, cpos);
+    both.second = input.substr(cpos + 1);
 
-  if(input[0]=='[') { // case 4
-    both=splitField(input.substr(1),']');
+    uint16_t newport = static_cast<uint16_t>(pdns_stou(both.second));
+    return ComboAddress(both.first, newport);
+  }
+  catch(...) {
+  }
+
+  if (input[0] == '[') { // case 4
+    both = splitField(input.substr(1), ']');
     return ComboAddress(both.first, both.second.empty() ? port : static_cast<uint16_t>(pdns_stou(both.second.substr(1))));
   }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1080,7 +1080,6 @@ extern bool g_lowercaseOutgoing;
 
 
 std::string reloadAuthAndForwards();
-ComboAddress parseIPAndPort(const std::string& input, uint16_t port);
 typedef boost::function<void*(void)> pipefunc_t;
 void broadcastFunction(const pipefunc_t& func);
 void distributeAsyncFunction(const std::string& question, const pipefunc_t& func);

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -820,4 +820,35 @@ BOOST_AUTO_TEST_CASE(test_ComboAddress_caContainerToString) {
   BOOST_CHECK_EQUAL(caVectorStr, "192.0.2.1:53,192.0.2.2:5300,[2001:db8:53::3]:53,[2001:db8:53::4]:5300");
 }
 
+BOOST_AUTO_TEST_CASE(test_parseIPAndPort)
+{
+  struct {
+    std::string str;
+    uint16_t port;
+    std::string result;
+    bool ex;
+  } tests[] = {
+    { "", 0, "", true },
+    { "1.2.3.a", 53, "", true },
+    { "1::g3", 99, "", true },
+    { "1.2.3.4", 0, "1.2.3.4:0", false },
+    { "1.2.3.4", 999, "1.2.3.4:999", false },
+    { "1::", 999, "[1::]:999", false },
+    { "1::33:99", 0, "[1::33]:99", false },
+    { "[1::33]:99", 0, "[1::33]:99", false },
+    { "1:33::99", 0, "1:33::99", false },
+    { "[1:33::]:99", 0, "[1:33::]:99", false },
+    { "2003:1234::f561", 53, "[2003:1234::f561]:53", false },
+  };
+
+  for (const auto& t : tests) {
+    if (t.ex) {
+      BOOST_CHECK_THROW(parseIPAndPort(t.str, t.port), PDNSException);
+    } else {
+      ComboAddress a = parseIPAndPort(t.str, t.port);
+      BOOST_CHECK_EQUAL(a.toString(), ComboAddress(t.result).toString());
+    }
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -834,11 +834,12 @@ BOOST_AUTO_TEST_CASE(test_parseIPAndPort)
     { "1.2.3.4", 0, "1.2.3.4:0", false },
     { "1.2.3.4", 999, "1.2.3.4:999", false },
     { "1::", 999, "[1::]:999", false },
-    { "1::33:99", 0, "[1::33]:99", false },
+    { "1::33:99", 0, "[1::33:99]", false },
     { "[1::33]:99", 0, "[1::33]:99", false },
     { "1:33::99", 0, "1:33::99", false },
     { "[1:33::]:99", 0, "[1:33::]:99", false },
     { "2003:1234::f561", 53, "[2003:1234::f561]:53", false },
+    { "2003:1234::f561:53", 54, "[2003:1234::f561:53]:54", false },
   };
 
   for (const auto& t : tests) {
@@ -846,7 +847,7 @@ BOOST_AUTO_TEST_CASE(test_parseIPAndPort)
       BOOST_CHECK_THROW(parseIPAndPort(t.str, t.port), PDNSException);
     } else {
       ComboAddress a = parseIPAndPort(t.str, t.port);
-      BOOST_CHECK_EQUAL(a.toString(), ComboAddress(t.result).toString());
+      BOOST_CHECK_EQUAL(a.toStringWithPort(), ComboAddress(t.result).toStringWithPort());
     }
   }
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Currently an IPv6 addres makes it use the explicit port case, interpreting the prefix as an IPv4 address.
Fix this by looking from the right for a colon. Also add unit tests. Fixes #7743
I'm moving this function to iputils as well (linking reczones with testrunner does no go smoothly).

There still remains an ambiguity I'm not really happy with: `string:port` can either be a full IPv6 address or a IPv6:port combo. If the string happens to parse as an IPv6 address the latter is returned. 
e.g.:
```
1::33:99 -> [1::33]:99
1:33::99 -> [1:33::99]
```
To avoid ambiguity always use square brackets for IPv6 addresss.
Since the original code allowed for naked IPv6 addresses we cannot just force that, alas. Or can we?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
