### PR TITLE
auth testing: disable unbound's trust anchor signaling

### DIFF
--- a/regression-tests/tests/00dnssec-grabkeys/command
+++ b/regression-tests/tests/00dnssec-grabkeys/command
@@ -21,6 +21,7 @@ done
 echo "server:" >> unbound-host.conf
 echo "  do-not-query-address: 192.168.0.0/16" >> unbound-host.conf
 echo '  trust-anchor-file: "trustedkeys"' >> unbound-host.conf
+echo '  trust-anchor-signaling: no' >> unbound-host.conf
 
 #if [ -e trustedkeys ]
 #then


### PR DESCRIPTION
### Short description
unbound-host fires off the _ta query and does not wait for the answer.
This means that the response sometimes ends up with sdig, which was
not expecting it, breaking tests.

This PR MUST be CI checked.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master