### PR TITLE
rec: We only want to do QName Minimization for the names in a forwarded domain.

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -725,17 +725,23 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
     for (int tries = 0; tries < 2 && bestns.empty(); ++tries) {
       bool flawedNSSet = false;
       set<GetBestNSAnswer> beenthereIgnored;
-      getBestNSFromCache(nsdomain, qtype, bestns, &flawedNSSet, depth, beenthereIgnored);
+      getBestNSFromCache(nsdomain, qtype, bestns, &flawedNSSet, depth, beenthereIgnored, forwarded ? fwdomain : g_rootdnsname);
+      if (forwarded) {
+        break;
+      }
     }
 
     if (bestns.size() == 0) {
-      // Something terrible is wrong
-      QLOG("Step1 No ancestor found return ServFail");
-      return RCode::ServFail;
+      if (!forwarded) {
+        // Something terrible is wrong
+        QLOG("Step1 No ancestor found return ServFail");
+        return RCode::ServFail;
+      }
+    } else {
+      QLOG("Step1 Ancestor from cache is " << bestns[0].d_name);
     }
-    QLOG("Step1 Ancestor from cache is " << bestns[0].d_name);
-
-    const DNSName& ancestor(!forwarded || bestns[0].d_name.isPartOf(fwdomain) ? bestns[0].d_name : fwdomain);
+    const DNSName& ancestor(!forwarded || (bestns.size() > 0 && bestns[0].d_name.isPartOf(fwdomain)) ?
+                            bestns[0].d_name : fwdomain);
     if (forwarded) {
       QLOG("Step1 Final Ancestor (using forwarding info) is " << ancestor);
     }
@@ -1110,7 +1116,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   return ret;
 }
 
-void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vector<DNSRecord>& bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere)
+void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vector<DNSRecord>& bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const DNSName& cutOffDomain)
 {
   string prefix;
   DNSName subdomain(qname);
@@ -1121,6 +1127,9 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vecto
   bestns.clear();
   bool brokeloop;
   do {
+    if (!subdomain.isPartOf(cutOffDomain)) {
+      break;
+    }
     brokeloop=false;
     LOG(prefix<<qname<<": Checking if we have NS in cache for '"<<subdomain<<"'"<<endl);
     vector<DNSRecord> ns;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -725,7 +725,7 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
     for (int tries = 0; tries < 2 && bestns.empty(); ++tries) {
       bool flawedNSSet = false;
       set<GetBestNSAnswer> beenthereIgnored;
-      getBestNSFromCache(nsdomain, qtype, bestns, &flawedNSSet, depth, beenthereIgnored, forwarded ? fwdomain : g_rootdnsname);
+      getBestNSFromCache(nsdomain, qtype, bestns, &flawedNSSet, depth, beenthereIgnored, boost::make_optional(forwarded, fwdomain));
       if (forwarded) {
         break;
       }
@@ -1116,7 +1116,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   return ret;
 }
 
-void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vector<DNSRecord>& bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const DNSName& cutOffDomain)
+void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vector<DNSRecord>& bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const boost::optional<DNSName>& cutOffDomain)
 {
   string prefix;
   DNSName subdomain(qname);
@@ -1127,7 +1127,7 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType& qtype, vecto
   bestns.clear();
   bool brokeloop;
   do {
-    if (!subdomain.isPartOf(cutOffDomain)) {
+    if (cutOffDomain && (subdomain == *cutOffDomain || !subdomain.isPartOf(*cutOffDomain))) {
       break;
     }
     brokeloop=false;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -714,22 +714,30 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
     if (qtype == QType::DS) {
       nsdomain.chopOff();
     }
-    // the two retries allow getBestNSFromCache&co to reprime the root
-    // hints, in case they ever go missing
-    for (int tries = 0; tries < 2 && bestns.empty(); ++tries) {
-      bool flawedNSSet = false;
-      set<GetBestNSAnswer> beenthereIgnored;
-      getBestNSFromCache(nsdomain, qtype, bestns, &flawedNSSet, depth, beenthereIgnored);
+
+    DNSName fwdomain(qname);
+    bool forwarded = getBestAuthZone(&fwdomain) != t_sstorage.domainmap->end();
+    if (forwarded) {
+      QLOG("Step1 qname is in a forwarded domain");
+    } else {
+      // the two retries allow getBestNSFromCache&co to reprime the root
+      // hints, in case they ever go missing
+      for (int tries = 0; tries < 2 && bestns.empty(); ++tries) {
+        bool flawedNSSet = false;
+        set<GetBestNSAnswer> beenthereIgnored;
+        getBestNSFromCache(nsdomain, qtype, bestns, &flawedNSSet, depth, beenthereIgnored);
+      }
+
+      if (bestns.size() == 0) {
+        // Something terrible is wrong
+        QLOG("Step1 No ancestor found return ServFail");
+        return RCode::ServFail;
+      }
+      QLOG("Step1 Ancestor from cache is " << bestns[0].d_name);
     }
 
-    if (bestns.size() == 0) {
-      // Something terrible is wrong
-      QLOG("Step1 No ancestor found return ServFail");
-      return RCode::ServFail;
-    }
+    const DNSName& ancestor(forwarded ? fwdomain : bestns[0].d_name);
 
-    const DNSName& ancestor(bestns[0].d_name);
-    QLOG("Step1 Ancestor from cache is " << ancestor.toString());
     child = ancestor;
 
     unsigned int targetlen = std::min(child.countLabels() + (i > 3 ? 3 : 1), qnamelen);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -737,16 +737,16 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
         QLOG("Step1 No ancestor found return ServFail");
         return RCode::ServFail;
       }
+      child = fwdomain;
     } else {
       QLOG("Step1 Ancestor from cache is " << bestns[0].d_name);
+      if (forwarded) {
+        child = bestns[0].d_name.isPartOf(fwdomain) ? bestns[0].d_name : fwdomain;
+        QLOG("Step1 Final Ancestor (using forwarding info) is " << child);
+      } else {
+        child = bestns[0].d_name;
+      }
     }
-    const DNSName& ancestor(!forwarded || (bestns.size() > 0 && bestns[0].d_name.isPartOf(fwdomain)) ?
-                            bestns[0].d_name : fwdomain);
-    if (forwarded) {
-      QLOG("Step1 Final Ancestor (using forwarding info) is " << ancestor);
-    }
-
-    child = ancestor;
 
     unsigned int targetlen = std::min(child.countLabels() + (i > 3 ? 3 : 1), qnamelen);
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -836,7 +836,7 @@ private:
   domainmap_t::const_iterator getBestAuthZone(DNSName* qname) const;
   bool doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state, bool wasAuthZone, bool wasForwardRecurse);
   bool doCacheCheck(const DNSName &qname, const DNSName& authname, bool wasForwardedOrAuthZone, bool wasAuthZone, bool wasForwardRecurse, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state);
-  void getBestNSFromCache(const DNSName &qname, const QType &qtype, vector<DNSRecord>&bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere);
+  void getBestNSFromCache(const DNSName &qname, const QType &qtype, vector<DNSRecord>&bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const DNSName& cutOffDomain = g_rootdnsname);
   DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere);
 
   inline vector<std::pair<DNSName, float>> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -836,7 +836,7 @@ private:
   domainmap_t::const_iterator getBestAuthZone(DNSName* qname) const;
   bool doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state, bool wasAuthZone, bool wasForwardRecurse);
   bool doCacheCheck(const DNSName &qname, const DNSName& authname, bool wasForwardedOrAuthZone, bool wasAuthZone, bool wasForwardRecurse, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state);
-  void getBestNSFromCache(const DNSName &qname, const QType &qtype, vector<DNSRecord>&bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const DNSName& cutOffDomain = g_rootdnsname);
+  void getBestNSFromCache(const DNSName &qname, const QType &qtype, vector<DNSRecord>&bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const boost::optional<DNSName>& cutOffDomain = boost::none);
   DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere);
 
   inline vector<std::pair<DNSName, float>> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);


### PR DESCRIPTION
E.g. if foo.bar.com is forwarded and the qname is x.foo.bar.com,
start the QM process with ancestor foo.bar.com, so the query is
directed to the forwarder.  But if the qname is baz.bar.com, we do
regular QM, starting with the regular ancestor.

Should fix #9438 without breaking having forward for dot.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
