### PR TITLE
Support for backup servers

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -378,6 +378,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         ret->checkInterval=static_cast<unsigned int>(std::stoul(boost::get<string>(vars["checkInterval"])));
       }
 
+      if(vars.count("backup")) {
+        ret->is_backup=boost::get<bool>(vars["backup"]);
+      }
+
       if(vars.count("tcpConnectTimeout")) {
         ret->tcpConnectTimeout=std::stoi(boost::get<string>(vars["tcpConnectTimeout"]));
       }

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -815,6 +815,7 @@ struct DownstreamState
   int tcpSendTimeout{30};
   unsigned int checkInterval{1};
   unsigned int lastCheck{0};
+  bool is_backup{false};
   const unsigned int sourceItf{0};
   uint16_t retries{5};
   uint16_t xpfRRCode{0};


### PR DESCRIPTION
Not ready for merging, POC only for now.

This adds support for backup servers in newServer().
Works only for the roundrobin policy for now.

When a new server is registered using newServer() and backup is set to true, the server will not be used in the RR policy unless all other non-backup servers are down.

I will add support to all other policies if you think this PR is useful in general.

Use case:
Multiple equal downstream servers and some backup servers which should only be used if all primary ds servers are down.

Dont mind the debug code, only used for testing.

### Checklist
I have:
- [yes] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [yes] compiled this code
- [yes] tested this code
- [not yet] included documentation (including possible behaviour changes)
- [not needed] documented the code
- [not yet] added or modified regression test(s)
- [not yet] added or modified unit test(s)
