### PR TITLE
rec: Rec control pass fd

### DIFF
--- a/pdns/arguments.cc
+++ b/pdns/arguments.cc
@@ -347,7 +347,7 @@ void ArgvMap::parseOne(const string &arg, const string &parseOnly, bool lax)
     var=arg.substr(2);
     val="";
   }
-  else if(arg[0]=='-')
+  else if(arg[0]=='-' && arg.length() > 1)
   {
     var=arg.substr(1);
     val="";

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -16,13 +16,16 @@
 BaseLua4::BaseLua4() {
 }
 
-void BaseLua4::loadFile(const std::string &fname) {
+int BaseLua4::loadFile(const std::string &fname) {
+  int ret = 0;
   std::ifstream ifs(fname);
-  if(!ifs) {
+  if (!ifs) {
+    ret = errno;
     g_log<<Logger::Error<<"Unable to read configuration file from '"<<fname<<"': "<<stringerror()<<endl;
-    return;
+    return ret;
   }
   loadStream(ifs);
+  return 0;
 };
 
 void BaseLua4::loadString(const std::string &script) {

--- a/pdns/lua-base4.hh
+++ b/pdns/lua-base4.hh
@@ -13,7 +13,7 @@ protected:
 
 public:
   BaseLua4();
-  void loadFile(const std::string &fname);
+  int loadFile(const std::string &fname);
   void loadString(const std::string &script);
   void loadStream(std::istream &is);
   virtual ~BaseLua4(); // this is so unique_ptr works with an incomplete type

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3842,6 +3842,13 @@ static vector<pair<DNSName, uint16_t> >& operator+=(vector<pair<DNSName, uint16_
   return a;
 }
 
+static pair<int, string>& operator+=(std::pair<int, string>& a, const std::pair<int, string>& b)
+{
+  a.first |= b.first;
+  a.second += b.second;
+  return a;
+}
+
 /*
   This function should only be called by the handler to gather metrics, wipe the cache,
   reload the Lua script (not the Lua config) or change the current trace regex,
@@ -3884,6 +3891,7 @@ template<class T> T broadcastAccFunction(const boost::function<T*()>& func)
 }
 
 template string broadcastAccFunction(const boost::function<string*()>& fun); // explicit instantiation
+template std::pair<int, string> broadcastAccFunction(const boost::function<pair<int,string>*()>& fun); // explicit instantiation
 template uint64_t broadcastAccFunction(const boost::function<uint64_t*()>& fun); // explicit instantiation
 template vector<ComboAddress> broadcastAccFunction(const boost::function<vector<ComboAddress> *()>& fun); // explicit instantiation
 template vector<pair<DNSName,uint16_t> > broadcastAccFunction(const boost::function<vector<pair<DNSName, uint16_t> > *()>& fun); // explicit instantiation
@@ -3893,12 +3901,12 @@ static void handleRCC(int fd, FDMultiplexer::funcparam_t& var)
 {
   try {
     string remote;
-    string msg=s_rcc.recv(&remote);
+    string msg = s_rcc.recv(&remote).second;
     RecursorControlParser rcp;
     RecursorControlParser::func_t* command;
 
     g_log << Logger::Notice << "Received rec_control command '" << msg << "' from control socket" << endl;
-    string answer=rcp.getAnswer(fd, msg, &command);
+    auto answer = rcp.getAnswer(fd, msg, &command);
 
     // If we are inside a chroot, we need to strip
     if (!arg()["chroot"].empty()) {
@@ -4109,35 +4117,40 @@ static FDMultiplexer* getMultiplexer()
 }
 
 
-static string* doReloadLuaScript()
+static std::pair<int, string>* doReloadLuaScript()
 {
   string fname= ::arg()["lua-dns-script"];
   try {
     if(fname.empty()) {
       t_pdl.reset();
       g_log<<Logger::Info<<t_id<<" Unloaded current lua script"<<endl;
-      return new string("unloaded\n");
+      return new std::pair<int, string>(0, string("unloaded\n"));
     }
     else {
       t_pdl = std::make_shared<RecursorLua4>();
-      t_pdl->loadFile(fname);
+      int err = t_pdl->loadFile(fname);
+      if (err != 0) {
+        string msg = std::to_string(t_id) + " Retaining current script, could not read '" + fname + "': " + stringerror(err);
+        g_log<<Logger::Error<<msg<<endl;
+        return new std::pair<int, string>(1, msg + "\n");
+      }
     }
   }
   catch(std::exception& e) {
     g_log<<Logger::Error<<t_id<<" Retaining current script, error from '"<<fname<<"': "<< e.what() <<endl;
-    return new string("retaining current script, error from '"+fname+"': "+e.what()+"\n");
+    return new std::pair<int, string>(1, string("retaining current script, error from '"+fname+"': "+e.what()+"\n"));
   }
 
   g_log<<Logger::Warning<<t_id<<" (Re)loaded lua script from '"<<fname<<"'"<<endl;
-  return new string("(re)loaded '"+fname+"'\n");
+  return new std::pair<int, string>(0, string("(re)loaded '"+fname+"'\n"));
 }
 
-string doQueueReloadLuaScript(vector<string>::const_iterator begin, vector<string>::const_iterator end)
+std::pair<int,string> doQueueReloadLuaScript(vector<string>::const_iterator begin, vector<string>::const_iterator end)
 {
   if(begin != end)
     ::arg().set("lua-dns-script") = *begin;
 
-  return broadcastAccFunction<string>(doReloadLuaScript);
+  return broadcastAccFunction<std::pair<int, string>>(doReloadLuaScript);
 }
 
 static string* pleaseUseNewTraceRegex(const std::string& newRegex)

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3898,7 +3898,7 @@ static void handleRCC(int fd, FDMultiplexer::funcparam_t& var)
     RecursorControlParser::func_t* command;
 
     g_log << Logger::Notice << "Received rec_control command '" << msg << "' from control socket" << endl;
-    string answer=rcp.getAnswer(msg, &command);
+    string answer=rcp.getAnswer(fd, msg, &command);
 
     // If we are inside a chroot, we need to strip
     if (!arg()["chroot"].empty()) {

--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -226,10 +226,10 @@ RecursorControlChannel::Answer RecursorControlChannel::recv(std::string* remote,
   }
   int err;
   if (::recvfrom(d_fd, &err, sizeof(err), 0, (struct sockaddr*)&remoteaddr, &addrlen) != sizeof(err)) {
-    throw PDNSException("Unable to receive return status over control channel: " + stringerror());
+    throw PDNSException("Unable to receive return status over control channel1: " + stringerror());
   }
   if ((len = ::recvfrom(d_fd, buffer, sizeof(buffer), 0, (struct sockaddr*)&remoteaddr, &addrlen)) < 0) {
-    throw PDNSException("Unable to receive message over control channel: "+stringerror());
+    throw PDNSException("Unable to receive message over control channel2: "+stringerror());
   }
 
   if(remote) {

--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -144,7 +144,42 @@ void RecursorControlChannel::connect(const string& path, const string& fname)
   }
 }
 
-void RecursorControlChannel::send(const std::string& msg, const std::string* remote, unsigned int timeout)
+static void sendfd(int s, int fd, const string* remote)
+{
+  struct msghdr    msg;
+  struct cmsghdr  *cmsg;
+  union {
+    struct cmsghdr hdr;
+    unsigned char    buf[CMSG_SPACE(sizeof(int))];
+  } cmsgbuf;
+  struct iovec io_vector[1];
+  char ch = 'X';
+ 
+  io_vector[0].iov_base = &ch;
+  io_vector[0].iov_len = 1;
+
+  memset(&msg, 0, sizeof(msg));
+  if (remote) {
+    msg.msg_name = const_cast<char*>(remote->c_str());
+    msg.msg_namelen = remote->length();
+  }
+  msg.msg_control = &cmsgbuf.buf;
+  msg.msg_controllen = sizeof(cmsgbuf.buf);
+  msg.msg_iov = io_vector;
+  msg.msg_iovlen = 1;
+
+  cmsg = CMSG_FIRSTHDR(&msg);
+  cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_RIGHTS;
+  *(int *)CMSG_DATA(cmsg) = fd;
+
+  if (sendmsg(s, &msg, 0) == -1) {
+    throw PDNSException("Unable to send fd message over control channel: "+stringerror());
+  }
+}
+
+void RecursorControlChannel::send(const std::string& msg, const std::string* remote, unsigned int timeout, int fd)
 {
   int ret = waitForRWData(d_fd, false, timeout, 0);
   if(ret == 0) {
@@ -167,6 +202,10 @@ void RecursorControlChannel::send(const std::string& msg, const std::string* rem
   }
   else if(::send(d_fd, msg.c_str(), msg.length(), 0) < 0)
     throw PDNSException("Unable to send message over control channel: "+stringerror());
+
+  if (fd != -1) {
+    sendfd(d_fd, fd, remote);
+  }
 }
 
 string RecursorControlChannel::recv(std::string* remote, unsigned int timeout)

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -51,7 +51,7 @@ public:
 
   uint64_t getStat(const std::string& name);
 
-  void send(const std::string& msg, const std::string* remote=nullptr, unsigned int timeout=5);
+  void send(const std::string& msg, const std::string* remote=nullptr, unsigned int timeout=5, int fd = -1);
   std::string recv(std::string* remote=0, unsigned int timeout=5);
 
   int d_fd;
@@ -68,7 +68,7 @@ public:
   }
   static void nop(void){}
   typedef void func_t(void);
-  std::string getAnswer(const std::string& question, func_t** func);
+  std::string getAnswer(int s, const std::string& question, func_t** func);
 };
 
 enum class StatComponent { API, Carbon, RecControl, SNMP };

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -51,8 +51,8 @@ public:
 
   uint64_t getStat(const std::string& name);
 
-  void send(const std::string& msg, const std::string* remote=nullptr, unsigned int timeout=5, int fd = -1);
-  std::string recv(std::string* remote=0, unsigned int timeout=5);
+  void send(const std::pair<int, const std::string&>&, const std::string* remote=nullptr, unsigned int timeout=5, int fd = -1);
+  std::pair<int, std::string> recv(std::string* remote=0, unsigned int timeout=5);
 
   int d_fd;
   static volatile sig_atomic_t stop;
@@ -68,7 +68,7 @@ public:
   }
   static void nop(void){}
   typedef void func_t(void);
-  std::string getAnswer(int s, const std::string& question, func_t** func);
+  pair<int, std::string> getAnswer(int s, const std::string& question, func_t** func);
 };
 
 enum class StatComponent { API, Carbon, RecControl, SNMP };

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -51,11 +51,26 @@ public:
 
   uint64_t getStat(const std::string& name);
 
-  void send(const std::pair<int, const std::string&>&, const std::string* remote=nullptr, unsigned int timeout=5, int fd = -1);
-  std::pair<int, std::string> recv(std::string* remote=0, unsigned int timeout=5);
+  struct Answer
+  {
+    Answer& operator+=(const Answer& rhs)
+    {
+      if (d_ret == 0 && rhs.d_ret != 0) {
+        d_ret = rhs.d_ret;
+      }
+      d_str += rhs.d_str;
+      return *this;
+    }
+    int d_ret{0};
+    std::string d_str;
+  };
+
+  void send(const Answer&, const std::string* remote = nullptr, unsigned int timeout = 5, int fd = -1);
+  RecursorControlChannel::Answer recv(std::string* remote = nullptr, unsigned int timeout = 5);
 
   int d_fd;
   static volatile sig_atomic_t stop;
+
 private:
   struct sockaddr_un d_local;
 };
@@ -68,8 +83,10 @@ public:
   }
   static void nop(void){}
   typedef void func_t(void);
-  pair<int, std::string> getAnswer(int s, const std::string& question, func_t** func);
+
+  RecursorControlChannel::Answer getAnswer(int s, const std::string& question, func_t** func);
 };
+
 
 enum class StatComponent { API, Carbon, RecControl, SNMP };
 
@@ -101,3 +118,4 @@ void registerAllStats();
 void doExitGeneric(bool nicely);
 void doExit();
 void doExitNicely();
+RecursorControlChannel::Answer doQueueReloadLuaScript(vector<string>::const_iterator begin, vector<string>::const_iterator end);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -303,6 +303,7 @@ static uint64_t* pleaseDumpFailedServers(int fd)
   return new uint64_t(SyncRes::doDumpFailedServers(fd));
 }
 
+// Generic dump to file command
 static RecursorControlChannel::Answer doDumpToFile(int s, uint64_t* (*function)(int s), const string& name)
 {
   int fd = getfd(s);
@@ -323,13 +324,14 @@ static RecursorControlChannel::Answer doDumpToFile(int s, uint64_t* (*function)(
   catch(PDNSException& e)
   {
     close(fd);
-    return { 1, name + ": error dumping NS speeds: " + e.reason + "\n" };
+    return { 1, name + ": error dumping data: " + e.reason + "\n" };
   }
 
   close(fd);
-  return { 0, name+ ": dumped " + std::to_string(total)+" records\n" };
+  return { 0, name + ": dumped " + std::to_string(total) + " records\n" };
 }
 
+// Does not follow the generic dump to file pattern, has a more complex lambda
 static RecursorControlChannel::Answer doDumpCache(int s)
 {
   int fd = getfd(s);
@@ -347,6 +349,7 @@ static RecursorControlChannel::Answer doDumpCache(int s)
   return { 0, "dumped " + std::to_string(total) + " records\n" };
 }
 
+// Does not follow the generic dump to file pattern, has an argument
 template<typename T>
 static RecursorControlChannel::Answer doDumpRPZ(int s, T begin, T end)
 {

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -330,26 +330,19 @@ getfd(int s)
   return fd;
 }
 
-template<typename T>
-static string doDumpCache(int s, T begin, T end)
+static string doDumpCache(int s)
 {
-
   int fd = getfd(s);
-  
-  T i=begin;
-  string fname;
 
-  if(i!=end) 
-    fname=*i;
-
-  if(fd < 0) 
+  if(fd < 0) {
     return "Error opening dump file for writing: "+stringerror()+"\n";
+  }
   uint64_t total = 0;
   try {
     total = g_recCache->doDump(fd) + dumpNegCache(fd) + broadcastAccFunction<uint64_t>([=]{ return pleaseDump(fd); });
   }
   catch(...){}
-  
+
   close(fd);
   return "dumped "+std::to_string(total)+" records\n";
 }
@@ -1814,7 +1807,7 @@ string RecursorControlParser::getAnswer(int s, const string& question, RecursorC
   }
 
   if(cmd=="dump-cache")
-    return doDumpCache(s, begin, end);
+    return doDumpCache(s);
 
   if(cmd=="dump-ednsstatus" || cmd=="dump-edns")
     return doDumpEDNSStatus(begin, end);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1711,21 +1711,22 @@ static string clearDontThrottleNetmasks(T begin, T end) {
   return ret + "\n";
 }
 
-string RecursorControlParser::getAnswer(int s, const string& question, RecursorControlParser::func_t** command)
+
+std::pair<int, string> RecursorControlParser::getAnswer(int s, const string& question, RecursorControlParser::func_t** command)
 {
   *command=nop;
   vector<string> words;
   stringtok(words, question);
 
   if(words.empty())
-    return "invalid command\n";
+    return make_pair(1, "invalid command\n");
 
   string cmd=toLower(words[0]);
   vector<string>::const_iterator begin=words.begin()+1, end=words.end();
 
   // should probably have a smart dispatcher here, like auth has
   if(cmd=="help")
-    return
+    return make_pair(0,
 "add-dont-throttle-names [N...]   add names that are not allowed to be throttled\n"
 "add-dont-throttle-netmasks [N...]\n"
 "                                 add netmasks that are not allowed to be throttled\n"
@@ -1781,64 +1782,59 @@ string RecursorControlParser::getAnswer(int s, const string& question, RecursorC
 "unload-lua-script                unload Lua script\n"
 "version                          return Recursor version number\n"
 "wipe-cache domain0 [domain1] ..  wipe domain data from cache\n"
-"wipe-cache-typed type domain0 [domain1] ..  wipe domain data with qtype from cache\n";
+"wipe-cache-typed type domain0 [domain1] ..  wipe domain data with qtype from cache\n");
 
-  if(cmd=="get-all")
-    return getAllStats();
-
-  if(cmd=="get")
-    return doGet(begin, end);
-
-  if(cmd=="get-parameter")
-    return doGetParameter(begin, end);
-
-  if(cmd=="quit") {
+  if (cmd == "get-all") {
+    return make_pair(0, getAllStats());
+  }
+  if (cmd == "get") {
+    return make_pair(0, doGet(begin, end));
+  }
+  if (cmd == "get-parameter") {
+    return make_pair(0, doGetParameter(begin, end));
+  }
+  if (cmd == "quit") {
     *command=&doExit;
-    return "bye\n";
+    return make_pair(0, "bye\n");
   }
-
-  if(cmd=="version") {
-    return getPDNSVersion()+"\n";
+  if (cmd == "version") {
+    return make_pair(0, getPDNSVersion()+"\n");
   }
-
-  if(cmd=="quit-nicely") {
+  if (cmd == "quit-nicely") {
     *command=&doExitNicely;
-    return "bye nicely\n";
+    return make_pair(0, "bye nicely\n");
   }
-
-  if(cmd=="dump-cache")
-    return doDumpCache(s);
-
-  if(cmd=="dump-ednsstatus" || cmd=="dump-edns")
-    return doDumpEDNSStatus(begin, end);
-
-  if(cmd=="dump-nsspeeds")
-    return doDumpNSSpeeds(begin, end);
-
-  if(cmd=="dump-failedservers")
-    return doDumpFailedServers(begin, end);
-
-  if(cmd=="dump-rpz") {
-    return doDumpRPZ(begin, end);
+  if (cmd == "dump-cache") {
+    return make_pair(0, doDumpCache(s));
   }
-
-  if(cmd=="dump-throttlemap")
-   return doDumpThrottleMap(begin, end);
-
-  if(cmd=="wipe-cache" || cmd=="flushname")
-    return doWipeCache(begin, end, 0xffff);
-
-  if(cmd=="wipe-cache-typed") {
+  if (cmd == "dump-ednsstatus" || cmd == "dump-edns") {
+    return make_pair(0, doDumpEDNSStatus(begin, end));
+  }
+  if (cmd == "dump-nsspeeds") {
+    return make_pair(0, doDumpNSSpeeds(begin, end));
+  }
+  if (cmd == "dump-failedservers") {
+    return make_pair(0, doDumpFailedServers(begin, end));
+  }
+  if (cmd == "dump-rpz") {
+    return make_pair(0, doDumpRPZ(begin, end));
+  }
+  if (cmd == "dump-throttlemap") {
+    return make_pair(0, doDumpThrottleMap(begin, end));
+  }
+  if (cmd == "wipe-cache" || cmd == "flushname") {
+    return make_pair(0, doWipeCache(begin, end, 0xffff));
+  }
+  if (cmd == "wipe-cache-typed") {
     uint16_t qtype = QType::chartocode(begin->c_str());
     ++begin;
-    return doWipeCache(begin, end, qtype);
+    return make_pair(0, doWipeCache(begin, end, qtype));
   }
-
-  if(cmd=="reload-lua-script")
+  if (cmd == "reload-lua-script") {
     return doQueueReloadLuaScript(begin, end);
-
-  if(cmd=="reload-lua-config") {
-    if(begin != end)
+  }
+  if (cmd == "reload-lua-config") {
+    if (begin != end)
       ::arg().set("lua-config-file") = *begin;
 
     try {
@@ -1846,170 +1842,145 @@ string RecursorControlParser::getAnswer(int s, const string& question, RecursorC
       loadRecursorLuaConfig(::arg()["lua-config-file"], delayedLuaThreads);
       startLuaConfigDelayedThreads(delayedLuaThreads, g_luaconfs.getCopy().generation);
       g_log<<Logger::Warning<<"Reloaded Lua configuration file '"<<::arg()["lua-config-file"]<<"', requested via control channel"<<endl;
-      return "Reloaded Lua configuration file '"+::arg()["lua-config-file"]+"'\n";
+      return make_pair(0, "Reloaded Lua configuration file '"+::arg()["lua-config-file"]+"'\n");
     }
     catch(std::exception& e) {
-      return "Unable to load Lua script from '"+::arg()["lua-config-file"]+"': "+e.what()+"\n";
+      return make_pair(1, "Unable to load Lua script from '"+::arg()["lua-config-file"]+"': "+e.what()+"\n");
     }
     catch(const PDNSException& e) {
-      return "Unable to load Lua script from '"+::arg()["lua-config-file"]+"': "+e.reason+"\n";
+      return make_pair(1, "Unable to load Lua script from '"+::arg()["lua-config-file"]+"': "+e.reason+"\n");
     }
   }
-
-  if(cmd=="set-carbon-server")
-    return doSetCarbonServer(begin, end);
-
-  if(cmd=="trace-regex")
-    return doTraceRegex(begin, end);
-
-  if(cmd=="unload-lua-script") {
+  if (cmd == "set-carbon-server") {
+    return make_pair(0, doSetCarbonServer(begin, end));
+  }
+  if (cmd == "trace-regex") {
+    return make_pair(0, doTraceRegex(begin, end));
+  }
+  if (cmd == "unload-lua-script") {
     vector<string> empty;
     empty.push_back(string());
     return doQueueReloadLuaScript(empty.begin(), empty.end());
   }
-
-  if(cmd=="reload-acls") {
-    if(!::arg()["chroot"].empty()) {
+  if (cmd == "reload-acls") {
+    if (!::arg()["chroot"].empty()) {
       g_log<<Logger::Error<<"Unable to reload ACL when chroot()'ed, requested via control channel"<<endl;
-      return "Unable to reload ACL when chroot()'ed, please restart\n";
+      return make_pair(1, "Unable to reload ACL when chroot()'ed, please restart\n");
     }
 
     try {
       parseACLs();
-    } 
-    catch(std::exception& e) 
-    {
+    }
+    catch(std::exception& e) {
       g_log<<Logger::Error<<"Reloading ACLs failed (Exception: "<<e.what()<<")"<<endl;
-      return e.what() + string("\n");
+      return make_pair(1, e.what() + string("\n"));
     }
-    catch(PDNSException& ae)
-    {
+    catch(PDNSException& ae) {
       g_log<<Logger::Error<<"Reloading ACLs failed (PDNSException: "<<ae.reason<<")"<<endl;
-      return ae.reason + string("\n");
+      return make_pair(1, ae.reason + string("\n"));
     }
-    return "ok\n";
+    return make_pair(0, "ok\n");
   }
-
-
-  if(cmd=="top-remotes")
-    return doGenericTopRemotes(pleaseGetRemotes);
-
-  if(cmd=="top-queries")
-    return doGenericTopQueries(pleaseGetQueryRing);
-
-  if(cmd=="top-pub-queries")
-    return doGenericTopQueries(pleaseGetQueryRing, getRegisteredName);
-
-  if(cmd=="top-servfail-queries")
-    return doGenericTopQueries(pleaseGetServfailQueryRing);
-
-  if(cmd=="top-pub-servfail-queries")
-    return doGenericTopQueries(pleaseGetServfailQueryRing, getRegisteredName);
-
-  if(cmd=="top-bogus-queries")
-    return doGenericTopQueries(pleaseGetBogusQueryRing);
-
-  if(cmd=="top-pub-bogus-queries")
-    return doGenericTopQueries(pleaseGetBogusQueryRing, getRegisteredName);
-
-
-  if(cmd=="top-servfail-remotes")
-    return doGenericTopRemotes(pleaseGetServfailRemotes);
-
-  if(cmd=="top-bogus-remotes")
-    return doGenericTopRemotes(pleaseGetBogusRemotes);
-
-  if(cmd=="top-largeanswer-remotes")
-    return doGenericTopRemotes(pleaseGetLargeAnswerRemotes);
-
-  if(cmd=="top-timeouts")
-    return doGenericTopRemotes(pleaseGetTimeouts);
-
-
-  if(cmd=="current-queries")
-    return doCurrentQueries();
-  
-  if(cmd=="ping") {
-    return broadcastAccFunction<string>(nopFunction);
+  if (cmd == "top-remotes") {
+    return make_pair(0, doGenericTopRemotes(pleaseGetRemotes));
   }
-
-  if(cmd=="reload-zones") {
-    if(!::arg()["chroot"].empty()) {
+  if (cmd == "top-queries") {
+    return make_pair(0, doGenericTopQueries(pleaseGetQueryRing));
+  }
+  if (cmd == "top-pub-queries") {
+    return make_pair(0, doGenericTopQueries(pleaseGetQueryRing, getRegisteredName));
+  }
+  if (cmd == "top-servfail-queries") {
+    return make_pair(0, doGenericTopQueries(pleaseGetServfailQueryRing));
+  }
+  if (cmd == "top-pub-servfail-queries") {
+    return make_pair(0, doGenericTopQueries(pleaseGetServfailQueryRing, getRegisteredName));
+  }
+  if (cmd == "top-bogus-queries") {
+    return make_pair(0, doGenericTopQueries(pleaseGetBogusQueryRing));
+  }
+  if (cmd == "top-pub-bogus-queries") {
+    return make_pair(0, doGenericTopQueries(pleaseGetBogusQueryRing, getRegisteredName));
+  }
+  if (cmd == "top-servfail-remotes") {
+    return make_pair(0, doGenericTopRemotes(pleaseGetServfailRemotes));
+  }
+  if (cmd == "top-bogus-remotes") {
+    return make_pair(0, doGenericTopRemotes(pleaseGetBogusRemotes));
+  }
+  if (cmd == "top-largeanswer-remotes") {
+    return make_pair(0, doGenericTopRemotes(pleaseGetLargeAnswerRemotes));
+  }
+  if (cmd == "top-timeouts") {
+    return make_pair(0, doGenericTopRemotes(pleaseGetTimeouts));
+  }
+  if (cmd == "current-queries") {
+    return make_pair(0, doCurrentQueries());
+  }
+  if (cmd == "ping") {
+    return make_pair(0, broadcastAccFunction<string>(nopFunction));
+  }
+  if (cmd == "reload-zones") {
+    if (!::arg()["chroot"].empty()) {
       g_log<<Logger::Error<<"Unable to reload zones and forwards when chroot()'ed, requested via control channel"<<endl;
-      return "Unable to reload zones and forwards when chroot()'ed, please restart\n";
+      return make_pair(1, "Unable to reload zones and forwards when chroot()'ed, please restart\n");
     }
-    return reloadAuthAndForwards();
+    return make_pair(0, reloadAuthAndForwards());
   }
-
-  if(cmd=="set-ecs-minimum-ttl") {
-    return setMinimumECSTTL(begin, end);
+  if (cmd == "set-ecs-minimum-ttl") {
+    return make_pair(0, setMinimumECSTTL(begin, end));
   }
-
-  if(cmd=="set-max-cache-entries") {
-    return setMaxCacheEntries(begin, end);
+  if (cmd == "set-max-cache-entries") {
+    return make_pair(0, setMaxCacheEntries(begin, end));
   }
-  if(cmd=="set-max-packetcache-entries") {
-    return setMaxPacketCacheEntries(begin, end);
+  if (cmd == "set-max-packetcache-entries") {
+    return make_pair(0, setMaxPacketCacheEntries(begin, end));
   }
-  
-  if(cmd=="set-minimum-ttl") {
-    return setMinimumTTL(begin, end);
+  if (cmd == "set-minimum-ttl") {
+    return make_pair(0, setMinimumTTL(begin, end));
   }
-  
-  if(cmd=="get-qtypelist") {
-    return g_rs.getQTypeReport();
+  if (cmd == "get-qtypelist") {
+    return make_pair(0, g_rs.getQTypeReport());
   }
-
-  if(cmd=="add-nta") {
-    return doAddNTA(begin, end);
+  if (cmd == "add-nta") {
+    return make_pair(0, doAddNTA(begin, end));
   }
-
-  if(cmd=="clear-nta") {
-    return doClearNTA(begin, end);
+  if (cmd == "clear-nta") {
+    return make_pair(0, doClearNTA(begin, end));
   }
-
-  if(cmd=="get-ntas") {
-    return getNTAs();
+  if (cmd == "get-ntas") {
+    return make_pair(0, getNTAs());
   }
-
-  if(cmd=="add-ta") {
-    return doAddTA(begin, end);
+  if (cmd == "add-ta") {
+    return make_pair(0, doAddTA(begin, end));
   }
-
-  if(cmd=="clear-ta") {
-    return doClearTA(begin, end);
+  if (cmd == "clear-ta") {
+    return make_pair(0, doClearTA(begin, end));
   }
-
-  if(cmd=="get-tas") {
-    return getTAs();
+  if (cmd == "get-tas") {
+    return make_pair(0, getTAs());
   }
-
-  if (cmd=="set-dnssec-log-bogus")
-    return doSetDnssecLogBogus(begin, end);
-
+  if (cmd == "set-dnssec-log-bogus") {
+    return make_pair(0, doSetDnssecLogBogus(begin, end));
+  }
   if (cmd == "get-dont-throttle-names") {
-    return getDontThrottleNames();
+    return make_pair(0, getDontThrottleNames());
   }
-
   if (cmd == "get-dont-throttle-netmasks") {
-    return getDontThrottleNetmasks();
+    return make_pair(0, getDontThrottleNetmasks());
   }
-
   if (cmd == "add-dont-throttle-names") {
-    return addDontThrottleNames(begin, end);
+    return make_pair(0, addDontThrottleNames(begin, end));
   }
-
   if (cmd == "add-dont-throttle-netmasks") {
-    return addDontThrottleNetmasks(begin, end);
+    return make_pair(0, addDontThrottleNetmasks(begin, end));
   }
-
   if (cmd == "clear-dont-throttle-names") {
-    return clearDontThrottleNames(begin, end);
+    return make_pair(0, clearDontThrottleNames(begin, end));
   }
-
   if (cmd == "clear-dont-throttle-netmasks") {
-    return clearDontThrottleNetmasks(begin, end);
+    return make_pair(0, clearDontThrottleNetmasks(begin, end));
   }
 
-  return "Unknown command '"+cmd+"', try 'help'\n";
+  return make_pair(1, "Unknown command '"+cmd+"', try 'help'\n");
 }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1673,7 +1673,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
 "                                 remove netmasks that are not allowed to be throttled. If N is '*', remove all\n"
 "clear-nta [DOMAIN]...            Clear the Negative Trust Anchor for DOMAINs, if no DOMAIN is specified, remove all\n"
 "clear-ta [DOMAIN]...             Clear the Trust Anchor for DOMAINs\n"
-"dum-cache <filename>            dump cache contents to the named file\n"
+"dump-cache <filename>            dump cache contents to the named file\n"
 "dump-edns [status] <filename>    dump EDNS status to the named file\n"
 "dump-nsspeeds <filename>         dump nsspeeds statistics to the named file\n"
 "dump-rpz <zone name> <filename>  dump the content of a RPZ zone to the named file\n"

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -120,15 +120,15 @@ int main(int argc, char** argv)
     }
 
     auto timeout = arg().asNum("timeout");
-    rccS.send(make_pair(0, command), nullptr, timeout, fd);
+    rccS.send({0, command}, nullptr, timeout, fd);
 
     auto receive = rccS.recv(0, timeout);
-    if (receive.first != 0) {
-      cerr << receive.second;
+    if (receive.d_ret != 0) {
+      cerr << receive.d_str;
     } else {
-      cout << receive.second;
+      cout << receive.d_str;
     }
-    return receive.first;
+    return receive.d_ret;
   }
   catch(PDNSException& ae) {
     cerr<<"Fatal: "<<ae.reason<<"\n";

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -99,12 +99,16 @@ try
 
   const vector<string>&commands=arg().getCommands();
   string command;
+  int fd = -1;
   for(unsigned int i=0; i< commands.size(); ++i) {
     if(i>0)
       command+=" ";
+    if (commands[i] == "dump-cache") {
+      fd = STDOUT_FILENO; // XXX
+    }
     command+=commands[i];
   }
-  rccS.send(command, nullptr, arg().asNum("timeout"));
+  rccS.send(command, nullptr, arg().asNum("timeout"), fd);
   string receive=rccS.recv(0, arg().asNum("timeout"));
   if(receive.compare(0, 7, "Unknown") == 0) {
     cerr<<receive<<endl;

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -24,6 +24,7 @@
 #endif
 #include "rec_channel.hh"
 #include <iostream>
+#include <fcntl.h>
 #include "pdnsexception.hh"
 #include "arguments.hh"
 
@@ -103,10 +104,14 @@ try
   for(unsigned int i=0; i< commands.size(); ++i) {
     if(i>0)
       command+=" ";
-    if (commands[i] == "dump-cache") {
-      fd = STDOUT_FILENO; // XXX
-    }
     command+=commands[i];
+    if (commands[i] == "dump-cache" && i+1 < commands.size()) {
+      fd = open(commands[++i].c_str(), O_CREAT | O_EXCL | O_WRONLY, 0660);
+      if (fd == -1) {
+        int err = errno;
+        throw PDNSException("Error opening dump file for writing: " + stringerror(err));
+      }
+    }
   }
   rccS.send(command, nullptr, arg().asNum("timeout"), fd);
   string receive=rccS.recv(0, arg().asNum("timeout"));

--- a/pdns/rec_control.cc
+++ b/pdns/rec_control.cc
@@ -106,7 +106,12 @@ try
       command+=" ";
     command+=commands[i];
     if (commands[i] == "dump-cache" && i+1 < commands.size()) {
-      fd = open(commands[++i].c_str(), O_CREAT | O_EXCL | O_WRONLY, 0660);
+      ++i;
+      if (commands[i] == "stdout") {
+        fd = STDOUT_FILENO;
+      } else {
+        fd = open(commands[i].c_str(), O_CREAT | O_EXCL | O_WRONLY, 0660);
+      }
       if (fd == -1) {
         int err = errno;
         throw PDNSException("Error opening dump file for writing: " + stringerror(err));

--- a/pdns/recursordist/docs/manpages/rec_control.1.rst
+++ b/pdns/recursordist/docs/manpages/rec_control.1.rst
@@ -31,6 +31,12 @@ To dump the cache to disk, execute::
 
   # rec_control dump-cache /tmp/the-cache
 
+.. note::
+
+  Before version 4.5.0, for each command that writes to a file, :program:`pdns_recursor` would open the file to write to.
+  Starting with 4.5.0, the files are opened by the :program:`rec_control` command itself using the credentials and the current working directory of the user running :program:`rec_control`.
+  A single minus *-* can be used as a filename to write the data to the standard output stream.
+
 Options
 -------
 --help                provide this helpful message.
@@ -78,34 +84,18 @@ clear-ta [*DOMAIN*]...
 
 dump-cache *FILENAME*
     Dumps the entire cache to *FILENAME*. This file should not exist already,
-    PowerDNS will refuse to overwrite it. While dumping, the recursor will not
-    answer questions.
+    PowerDNS will refuse to overwrite it. While dumping, the recursor
+    might not answer questions.
 
     Typical PowerDNS Recursors run multiple threads, therefore you'll see
     duplicate, different entries for the same domains. The negative cache is
     also dumped to the same file. The per-thread positive and negative cache
     dumps are separated with an appropriate comment.
 
-    .. note::
-
-      :program:`pdns_recursor` often runs in a chroot. You can
-      retrieve the file using::
-
-        rec_control dump-cache /tmp/file
-        mv /proc/$(pidof pdns_recursor)/root/tmp/file /tmp/filename
-
 dump-edns *FILENAME*
     Dumps the EDNS status to the filename mentioned. This file should not exist
     already, PowerDNS will refuse to overwrite it. While dumping, the recursor
     will not answer questions.
-
-    .. note::
-
-      :program:`pdns_recursor` often runs in a chroot. You can
-      retrieve the file using::
-
-        rec_control dump-edns /tmp/file
-        mv /proc/$(pidof pdns_recursor)/root/tmp/file /tmp/filename
 
 dump-nsspeeds *FILENAME*
     Dumps the nameserver speed statistics to the *FILENAME* mentioned. This
@@ -113,27 +103,11 @@ dump-nsspeeds *FILENAME*
     dumping, the recursor will not answer questions. Statistics are kept per
     thread, and the dumps end up in the same file.
 
-    .. note::
-
-      :program:`pdns_recursor` often runs in a chroot. You can
-      retrieve the file using::
-
-        rec_control dump-nsspeeds /tmp/file
-        mv /proc/$(pidof pdns_recursor)/root/tmp/file /tmp/filename
-
 dump-rpz *ZONE NAME* *FILE NAME*
     Dumps the content of the RPZ zone named *ZONE NAME* to the *FILENAME*
     mentioned. This file should not exist already, PowerDNS will refuse to
     overwrite it otherwise. While dumping, the recursor will not answer
     questions.
-
-    .. note::
-
-      :program:`pdns_recursor` often runs in a chroot. You can
-      retrieve the file using::
-
-        rec_control dump-rpz ZONE_NAME /tmp/file
-        mv /proc/$(pidof pdns_recursor)/root/tmp/file /tmp/filename
 
 dump-throttlemap *FILENAME*
     Dump the contents of the throttle map to the *FILENAME* mentioned.
@@ -141,27 +115,11 @@ dump-throttlemap *FILENAME*
     overwrite it otherwise. While dumping, the recursor will not answer
     questions.
 
-    .. note::
-
-      :program:`pdns_recursor` often runs in a chroot. You can
-      retrieve the file using::
-
-        rec_control dump-throttlemap /tmp/file
-        mv /proc/$(pidof pdns_recursor)/root/tmp/file /tmp/filename
-
 dump-failedservers *FILENAME*
     Dump the contents of the failed server map to the *FILENAME* mentioned.
     This file should not exist already, PowerDNS will refuse to
     overwrite it otherwise. While dumping, the recursor will not answer
     questions.
-
-    .. note::
-
-      :program:`pdns_recursor` often runs in a chroot. You can
-      retrieve the file using::
-
-        rec_control dump-failedservers /tmp/file
-        mv /proc/$(pidof pdns_recursor)/root/tmp/file /tmp/filename
 
 get *STATISTIC* [*STATISTIC*]...
     Retrieve a statistic. For items that can be queried, see

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1077,7 +1077,6 @@ extern thread_local std::unique_ptr<addrringbuf_t> t_servfailremotes, t_largeans
 
 extern thread_local std::unique_ptr<boost::circular_buffer<pair<DNSName,uint16_t> > > t_queryring, t_servfailqueryring, t_bogusqueryring;
 extern thread_local std::shared_ptr<NetmaskGroup> t_allowFrom;
-std::pair<int, string> doQueueReloadLuaScript(vector<string>::const_iterator begin, vector<string>::const_iterator end);
 string doTraceRegex(vector<string>::const_iterator begin, vector<string>::const_iterator end);
 void parseACLs();
 extern RecursorStats g_stats;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1077,7 +1077,7 @@ extern thread_local std::unique_ptr<addrringbuf_t> t_servfailremotes, t_largeans
 
 extern thread_local std::unique_ptr<boost::circular_buffer<pair<DNSName,uint16_t> > > t_queryring, t_servfailqueryring, t_bogusqueryring;
 extern thread_local std::shared_ptr<NetmaskGroup> t_allowFrom;
-string doQueueReloadLuaScript(vector<string>::const_iterator begin, vector<string>::const_iterator end);
+std::pair<int, string> doQueueReloadLuaScript(vector<string>::const_iterator begin, vector<string>::const_iterator end);
 string doTraceRegex(vector<string>::const_iterator begin, vector<string>::const_iterator end);
 void parseACLs();
 extern RecursorStats g_stats;

--- a/regression-tests.recursor-dnssec/test_RoutingTag.py
+++ b/regression-tests.recursor-dnssec/test_RoutingTag.py
@@ -168,7 +168,7 @@ end
         return # remove this line to peek at cache
         rec_controlCmd = [os.environ['RECCONTROL'],
                           '--config-dir=%s' % 'configs/' + self._confdir,
-                          'dump-cache x']
+                          'dump-cache', 'x']
         try:
             expected = b'dumped 7 records\n'
             ret = subprocess.check_output(rec_controlCmd, stderr=subprocess.STDOUT)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This makes `rec_control` open the file used by `dump-cache` and other dumping command and pass the file descriptor over the socket. This makes it more easy to export data if the recursor is running with restricted file access (e.g. chroot).

Also allows to dump the data to stdout (`rec_control dump-cache -`). 

I also added code to separate the error code from the string returned. This principle could also be extended to any command that could return an error.

Note that this causes an incompatibility between `rec_control` and `pdns_recursor`. I don't think we ever promised the API between the two would be stable or compatible between versions, but you know, people will stumble over this anyway. A note in the upgrade guide will be needed.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
