### PR TITLE
dnsbulktest: Initialize the 'rng' and 'entropy-source' arguments

### DIFF
--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -223,6 +223,9 @@ static void usage(po::options_description &desc) {
 int main(int argc, char** argv)
 try
 {
+  ::arg().set("rng", "Specify random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
+  ::arg().set("entropy-source", "If set, read entropy from this file")="/dev/urandom";
+
   po::options_description desc("Allowed options");
   desc.add_options()
     ("help,h", "produce help message")


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
They are required to use `dns_random()`, which is used by our DNS packet generation code.

Reported by @franklouwers (thanks!).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
