### PR TITLE
rec: Log when going Bogus because of a missing SOA in authority

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -3712,6 +3712,7 @@ bool SyncRes::processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qn
     LOG(prefix<<qname<<": status=NXDOMAIN, we are done "<<(negindic ? "(have negative SOA)" : "")<<endl);
 
     if (state == vState::Secure && (lwr.d_aabit || sendRDQuery) && !negindic) {
+      LOG(prefix<<qname<<": NXDOMAIN without a negative indication (missing SOA in authority) in a DNSSEC secure zone, going Bogus"<<endl);
       updateValidationState(state, vState::Bogus);
     }
 
@@ -3726,6 +3727,7 @@ bool SyncRes::processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qn
     LOG(prefix<<qname<<": status=noerror, other types may exist, but we are done "<<(negindic ? "(have negative SOA) " : "")<<(lwr.d_aabit ? "(have aa bit) " : "")<<endl);
 
     if(state == vState::Secure && (lwr.d_aabit || sendRDQuery) && !negindic) {
+      LOG(prefix<<qname<<": NODATA without a negative indication (missing SOA in authority) in a DNSSEC secure zone, going Bogus"<<endl);
       updateValidationState(state, vState::Bogus);
     }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
A missing SOA in the authority section of negative (NXDOMAIN, NODATA) answers in a DNSSEC-secure zone currently leads to a Bogus result, because the needed NSEC/NSEC3 could not be validated.

Perhaps we could try to detect such a case and check for a valid denial of proof if a NSEC/NSEC3 record shows up in authority?

In the meantime this PR makes it clearer why the DNSSEC status was updated to Bogus in the trace.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
