### PR TITLE
dnsbackend: log error on catching std::exception

### DIFF
--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -211,6 +211,13 @@ vector<DNSBackend *> BackendMakerClass::all(bool metadataOnly)
       delete i;
     }
     throw;
+  } catch (const std::exception &e) {
+    g_log<<Logger::Error<<"Caught an exception instantiating a backend: "<<e.what()<<endl;
+    g_log<<Logger::Error<<"Cleaning up"<<endl;
+    for (auto i : ret) {
+      delete i;
+    }
+    throw;
   } catch(...) {
     // and cleanup
     g_log<<Logger::Error<<"Caught an exception instantiating a backend, cleaning up"<<endl;


### PR DESCRIPTION
### Short description
This prevents the following logging when an std::exception is thrown by a backend.

```
Sep 16 07:39:31 debian-9 pdns_server[3011]: Caught an exception instantiating a backend, cleaning up
Sep 16 07:39:31 debian-9 pdns_server[3011]: Uncaught exception of unknown type - sorry
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)