### PR TITLE
Rec: shared and sharded negcache

### DIFF
--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -144,7 +144,7 @@ template <typename S, typename C, typename T> uint64_t pruneMutexCollectionsVect
 
   for (auto& mc : maps) {
     const typename C::lock l(mc);
-    mc.d_cachecachevalid = false;
+    mc.invalidate();
     auto& sidx = boost::multi_index::get<S>(mc.d_map);
     uint64_t erased = 0, lookedAt = 0;
     for (auto i = sidx.begin(); i != sidx.end(); lookedAt++) {
@@ -178,7 +178,7 @@ template <typename S, typename C, typename T> uint64_t pruneMutexCollectionsVect
     size_t pershard = toTrim / maps_size + 1;
     for (auto& mc : maps) {
       const typename C::lock l(mc);
-      mc.d_cachecachevalid = false;
+      mc.invalidate();
       auto& sidx = boost::multi_index::get<S>(mc.d_map);
       size_t removed = 0;
       for (auto i = sidx.begin(); i != sidx.end() && removed < pershard; removed++) {

--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -249,13 +249,13 @@ template <typename N, typename T> uint64_t purgeExactLockedCollection(T& mc, con
 }
 
 template<typename S, typename Index>
-std::pair<typename Index::iterator,bool>
-lruReplacingInsert(Index& i,const typename Index::value_type& x)
+bool lruReplacingInsert(Index& i, const typename Index::value_type& x)
 {
-  std::pair<typename Index::iterator,bool> res = i.insert(x);
-  if (!res.second) {
-    moveCacheItemToBack<S>(i, res.first);
-    res.second = i.replace(res.first, x);
+  auto inserted = i.insert(x);
+  if (!inserted.second) {
+    moveCacheItemToBack<S>(i, inserted.first);
+    i.replace(inserted.first, x);
+    return false;
   }
-  return res;
+  return true;
 }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -207,7 +207,7 @@ static uint64_t dumpNegCache(int fd)
   }
   uint64_t ret;
   fprintf(fp.get(), "; negcache dump follows\n;\n");
-  ret = s_negcache->dumpToFile(fp.get());
+  ret = g_negCache->dumpToFile(fp.get());
   return ret;
 }
 
@@ -281,7 +281,7 @@ static string doDumpCache(T begin, T end)
     return "Error opening dump file for writing: "+stringerror()+"\n";
   uint64_t total = 0;
   try {
-    total = s_RC->doDump(fd) + dumpNegCache(fd) + broadcastAccFunction<uint64_t>([=]{ return pleaseDump(fd); });
+    total = g_recCache->doDump(fd) + dumpNegCache(fd) + broadcastAccFunction<uint64_t>([=]{ return pleaseDump(fd); });
   }
   catch(...){}
   
@@ -396,7 +396,7 @@ static string doDumpFailedServers(T begin, T end)
 
 uint64_t* pleaseWipeCache(const DNSName& canon, bool subtree, uint16_t qtype)
 {
-  return new uint64_t(s_RC->doWipeCache(canon, subtree));
+  return new uint64_t(g_recCache->doWipeCache(canon, subtree));
 }
 
 uint64_t* pleaseWipePacketCache(const DNSName& canon, bool subtree, uint16_t qtype)
@@ -407,7 +407,7 @@ uint64_t* pleaseWipePacketCache(const DNSName& canon, bool subtree, uint16_t qty
 
 uint64_t* pleaseWipeAndCountNegCache(const DNSName& canon, bool subtree)
 {
-  uint64_t ret = s_negcache->wipe(canon, subtree);
+  uint64_t ret = g_negCache->wipe(canon, subtree);
   return new uint64_t(ret);
 }
 
@@ -907,7 +907,7 @@ static uint64_t getThrottleSize()
 
 uint64_t* pleaseGetNegCacheSize()
 {
-  uint64_t tmp = s_negcache->size();
+  uint64_t tmp = g_negCache->size();
   return new uint64_t(tmp);
 }
 
@@ -959,7 +959,7 @@ static uint64_t getConcurrentQueries()
 
 static uint64_t doGetCacheSize()
 {
-  return s_RC->size();
+  return g_recCache->size();
 }
 
 static uint64_t doGetAvgLatencyUsec()
@@ -969,17 +969,17 @@ static uint64_t doGetAvgLatencyUsec()
 
 static uint64_t doGetCacheBytes()
 {
-  return s_RC->bytes();
+  return g_recCache->bytes();
 }
 
 static uint64_t doGetCacheHits()
 {
-  return s_RC->cacheHits;
+  return g_recCache->cacheHits;
 }
 
 static uint64_t doGetCacheMisses()
 {
-  return s_RC->cacheMisses;
+  return g_recCache->cacheMisses;
 }
 
 uint64_t* pleaseGetPacketCacheSize()
@@ -1048,8 +1048,8 @@ void registerAllStats()
   addGetStat("max-cache-entries", []() { return g_maxCacheEntries.load(); });
   addGetStat("max-packetcache-entries", []() { return g_maxPacketCacheEntries.load();}); 
   addGetStat("cache-bytes", doGetCacheBytes); 
-  addGetStat("record-cache-contended", []() { return s_RC->stats().first;});
-  addGetStat("record-cache-acquired", []() { return s_RC->stats().second;});
+  addGetStat("record-cache-contended", []() { return g_recCache->stats().first;});
+  addGetStat("record-cache-acquired", []() { return g_recCache->stats().second;});
   
   addGetStat("packetcache-hits", doGetPacketCacheHits);
   addGetStat("packetcache-misses", doGetPacketCacheMisses); 

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -214,6 +214,11 @@ private:
     std::atomic<uint64_t> d_entriesCount{0};
     uint64_t d_contended_count{0};
     uint64_t d_acquired_count{0};
+
+    void invalidate()
+    {
+      d_cachecachevalid = false;
+    }
   };
 
   vector<MapCombo> d_maps;

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -104,7 +104,7 @@ bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeva
   auto& map = getMap(qname);
   const lock l(map);
 
-  const auto& idx = map.d_map.get<2>();
+  const auto& idx = map.d_map.get<NegCacheEntry>();
   auto range = idx.equal_range(qname);
   auto ni = range.first;
 
@@ -112,7 +112,7 @@ bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeva
     // We have an entry
     if ((!typeMustMatch && ni->d_qtype.getCode() == 0) || ni->d_qtype == qtype) {
       // We match the QType or the whole name is denied
-      auto firstIndexIterator = map.d_map.project<0>(ni);
+      auto firstIndexIterator = map.d_map.project<CompositeKey>(ni);
 
       if (now.tv_sec < ni->d_ttd) {
         // Not expired

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -26,6 +26,32 @@
 #include "cachecleaner.hh"
 #include "utility.hh"
 
+NegCache::NegCache(size_t mapsCount) : d_maps(mapsCount)
+{
+}
+
+NegCache::~NegCache()
+{
+  try {
+    typedef std::unique_ptr<lock> lock_t;
+    vector<lock_t> locks;
+    for (auto& map : d_maps) {
+      locks.push_back(lock_t(new lock(map)));
+    }
+  }
+  catch(...) {
+  }
+}
+
+size_t NegCache::size()
+{
+  size_t count = 0;
+  for (auto& map : d_maps) {
+    count += map.d_entriesCount;
+  }
+  return count;
+}
+
 /*!
  * Set ne to the NegCacheEntry for the last label in qname and return true if there
  * was one.
@@ -44,16 +70,20 @@ bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, N
   // An 'ENT' QType entry, used as "whole name" in the neg-cache context.
   static const QType qtnull(0);
   DNSName lastLabel = qname.getLastLabel();
-  negcache_t::const_iterator ni = d_negcache.find(tie(lastLabel, qtnull));
 
-  while (ni != d_negcache.end() && ni->d_name == lastLabel && ni->d_auth.isRoot() && ni->d_qtype == qtnull) {
+  auto& map = getMap(lastLabel);
+  const lock l(map);
+
+  negcache_t::const_iterator ni = map.d_map.find(tie(lastLabel, qtnull));
+
+  while (ni != map.d_map.end() && ni->d_name == lastLabel && ni->d_auth.isRoot() && ni->d_qtype == qtnull) {
     // We have something
-    if ((uint32_t)now.tv_sec < ni->d_ttd) {
+    if (now.tv_sec < ni->d_ttd) {
       ne = *ni;
-      moveCacheItemToBack<SequenceTag>(d_negcache, ni);
+      moveCacheItemToBack<SequenceTag>(map.d_map, ni);
       return true;
     }
-    moveCacheItemToFront<SequenceTag>(d_negcache, ni);
+    moveCacheItemToFront<SequenceTag>(map.d_map, ni);
     ++ni;
   }
   return false;
@@ -70,7 +100,10 @@ bool NegCache::getRootNXTrust(const DNSName& qname, const struct timeval& now, N
  */
 bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne, bool typeMustMatch)
 {
-  const auto& idx = d_negcache.get<2>();
+  auto& map = getMap(qname);
+  const lock l(map);
+
+  const auto& idx = map.d_map.get<2>();
   auto range = idx.equal_range(qname);
   auto ni = range.first;
 
@@ -78,16 +111,16 @@ bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeva
     // We have an entry
     if ((!typeMustMatch && ni->d_qtype.getCode() == 0) || ni->d_qtype == qtype) {
       // We match the QType or the whole name is denied
-      auto firstIndexIterator = d_negcache.project<0>(ni);
+      auto firstIndexIterator = map.d_map.project<0>(ni);
 
-      if ((uint32_t)now.tv_sec < ni->d_ttd) {
+      if (now.tv_sec < ni->d_ttd) {
         // Not expired
         ne = *ni;
-        moveCacheItemToBack<SequenceTag>(d_negcache, firstIndexIterator);
+        moveCacheItemToBack<SequenceTag>(map.d_map, firstIndexIterator);
         return true;
       }
       // expired
-      moveCacheItemToFront<SequenceTag>(d_negcache, firstIndexIterator);
+      moveCacheItemToFront<SequenceTag>(map.d_map, firstIndexIterator);
     }
     ++ni;
   }
@@ -101,7 +134,12 @@ bool NegCache::get(const DNSName& qname, const QType& qtype, const struct timeva
  */
 void NegCache::add(const NegCacheEntry& ne)
 {
-  lruReplacingInsert<SequenceTag>(d_negcache, ne);
+  auto& map = getMap(ne.d_name);
+  const lock l(map);
+  bool inserted = lruReplacingInsert<SequenceTag>(map.d_map, ne);
+  if (inserted) {
+    map.d_entriesCount++;
+  }
 }
 
 /*!
@@ -111,9 +149,11 @@ void NegCache::add(const NegCacheEntry& ne)
  * \param qtype The type of the entry to replace
  * \param newState The new validation state
  */
-void NegCache::updateValidationStatus(const DNSName& qname, const QType& qtype, const vState newState, boost::optional<uint32_t> capTTD)
+void NegCache::updateValidationStatus(const DNSName& qname, const QType& qtype, const vState newState, boost::optional<time_t> capTTD)
 {
-  auto range = d_negcache.equal_range(tie(qname, qtype));
+  auto& map = getMap(qname);
+  const lock l(map);
+  auto range = map.d_map.equal_range(tie(qname, qtype));
 
   if (range.first != range.second) {
     range.first->d_validationState = newState;
@@ -128,9 +168,11 @@ void NegCache::updateValidationStatus(const DNSName& qname, const QType& qtype, 
  *
  * \param qname The name of the entries to be counted
  */
-uint64_t NegCache::count(const DNSName& qname) const
+size_t NegCache::count(const DNSName& qname)
 {
-  return d_negcache.count(tie(qname));
+  auto& map = getMap(qname);
+  const lock l(map);
+  return map.d_map.count(tie(qname));
 }
 
 /*!
@@ -139,9 +181,11 @@ uint64_t NegCache::count(const DNSName& qname) const
  * \param qname The name of the entries to be counted
  * \param qtype The type of the entries to be counted
  */
-uint64_t NegCache::count(const DNSName& qname, const QType qtype) const
+size_t NegCache::count(const DNSName& qname, const QType qtype)
 {
-  return d_negcache.count(tie(qname, qtype));
+  auto& map = getMap(qname);
+  const lock l(map);
+  return map.d_map.count(tie(qname, qtype));
 }
 
 /*!
@@ -151,22 +195,32 @@ uint64_t NegCache::count(const DNSName& qname, const QType qtype) const
  * \param name    The DNSName of the entries to wipe
  * \param subtree Should all entries under name be removed?
  */
-uint64_t NegCache::wipe(const DNSName& name, bool subtree)
+size_t NegCache::wipe(const DNSName& name, bool subtree)
 {
-  uint64_t ret(0);
+  size_t ret = 0;
   if (subtree) {
-    for (auto i = d_negcache.lower_bound(tie(name)); i != d_negcache.end();) {
-      if (!i->d_name.isPartOf(name))
-        break;
-      i = d_negcache.erase(i);
-      ret++;
+    for (auto& m : d_maps) {
+      const lock l(m);
+      for (auto i = m.d_map.lower_bound(tie(name)); i != m.d_map.end();) {
+        if (!i->d_name.isPartOf(name))
+          break;
+        i = m.d_map.erase(i);
+        ret++;
+        m.d_entriesCount--;
+      }
     }
     return ret;
   }
 
-  ret = count(name);
-  auto range = d_negcache.equal_range(tie(name));
-  d_negcache.erase(range.first, range.second);
+  auto& map = getMap(name);
+  const lock l(map);
+  auto range = map.d_map.equal_range(tie(name));
+  auto i = range.first;
+  while (i != range.second) {
+    i = map.d_map.erase(i);
+    ret++;
+    map.d_entriesCount--;
+  }
   return ret;
 }
 
@@ -175,7 +229,11 @@ uint64_t NegCache::wipe(const DNSName& name, bool subtree)
  */
 void NegCache::clear()
 {
-  d_negcache.clear();
+  for (auto& m : d_maps) {
+    const lock l(m);
+    m.d_map.clear();
+    m.d_entriesCount = 0;
+  }
 }
 
 /*!
@@ -185,7 +243,8 @@ void NegCache::clear()
  */
 void NegCache::prune(size_t maxEntries)
 {
-  pruneCollection<SequenceTag>(*this, d_negcache, maxEntries, 200);
+  size_t cacheSize = size();
+  pruneMutexCollectionsVector<SequenceTag>(*this, d_maps, maxEntries, cacheSize);
 }
 
 /*!
@@ -193,27 +252,30 @@ void NegCache::prune(size_t maxEntries)
  *
  * \param fp A pointer to an open FILE object
  */
-uint64_t NegCache::dumpToFile(FILE* fp)
+size_t NegCache::dumpToFile(FILE* fp)
 {
-  uint64_t ret(0);
+  size_t ret(0);
   struct timeval now;
   Utility::gettimeofday(&now, nullptr);
 
-  negcache_sequence_t& sidx = d_negcache.get<SequenceTag>();
-  for (const NegCacheEntry& ne : sidx) {
-    ret++;
-    fprintf(fp, "%s %" PRId64 " IN %s VIA %s ; (%s)\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), ne.d_qtype.getName().c_str(), ne.d_auth.toString().c_str(), vStateToString(ne.d_validationState).c_str());
-    for (const auto& rec : ne.authoritySOA.records) {
-      fprintf(fp, "%s %" PRId64 " IN %s %s ; (%s)\n", rec.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStateToString(ne.d_validationState).c_str());
-    }
-    for (const auto& sig : ne.authoritySOA.signatures) {
-      fprintf(fp, "%s %" PRId64 " IN RRSIG %s ;\n", sig.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str());
-    }
-    for (const auto& rec : ne.DNSSECRecords.records) {
-      fprintf(fp, "%s %" PRId64 " IN %s %s ; (%s)\n", rec.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStateToString(ne.d_validationState).c_str());
-    }
-    for (const auto& sig : ne.DNSSECRecords.signatures) {
-      fprintf(fp, "%s %" PRId64 " IN RRSIG %s ;\n", sig.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str());
+  for (auto& m : d_maps) {
+    const lock l(m);
+    auto& sidx = m.d_map.get<SequenceTag>();
+    for (const NegCacheEntry& ne : sidx) {
+      ret++;
+      fprintf(fp, "%s %" PRId64 " IN %s VIA %s ; (%s)\n", ne.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), ne.d_qtype.getName().c_str(), ne.d_auth.toString().c_str(), vStateToString(ne.d_validationState).c_str());
+      for (const auto& rec : ne.authoritySOA.records) {
+        fprintf(fp, "%s %" PRId64 " IN %s %s ; (%s)\n", rec.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStateToString(ne.d_validationState).c_str());
+      }
+      for (const auto& sig : ne.authoritySOA.signatures) {
+        fprintf(fp, "%s %" PRId64 " IN RRSIG %s ;\n", sig.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str());
+      }
+      for (const auto& rec : ne.DNSSECRecords.records) {
+        fprintf(fp, "%s %" PRId64 " IN %s %s ; (%s)\n", rec.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), DNSRecordContent::NumberToType(rec.d_type).c_str(), rec.d_content->getZoneRepresentation().c_str(), vStateToString(ne.d_validationState).c_str());
+      }
+      for (const auto& sig : ne.DNSSECRecords.signatures) {
+        fprintf(fp, "%s %" PRId64 " IN RRSIG %s ;\n", sig.d_name.toString().c_str(), static_cast<int64_t>(ne.d_ttd - now.tv_sec), sig.d_content->getZoneRepresentation().c_str());
+      }
     }
   }
   return ret;

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -26,7 +26,8 @@
 #include "cachecleaner.hh"
 #include "utility.hh"
 
-NegCache::NegCache(size_t mapsCount) : d_maps(mapsCount)
+NegCache::NegCache(size_t mapsCount) :
+  d_maps(mapsCount)
 {
 }
 
@@ -39,7 +40,7 @@ NegCache::~NegCache()
       locks.push_back(lock_t(new lock(map)));
     }
   }
-  catch(...) {
+  catch (...) {
   }
 }
 

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -115,7 +115,7 @@ private:
     std::atomic<uint64_t> d_entriesCount{0};
     mutable uint64_t d_contended_count{0};
     mutable uint64_t d_acquired_count{0};
-    bool d_cachecachevalid{false}; // XXX
+    void invalidate() {}
   };
 
   vector<MapCombo> d_maps;

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -49,7 +49,6 @@ typedef struct
 class NegCache : public boost::noncopyable
 {
 public:
-
   NegCache(size_t mapsCount = 1024);
   ~NegCache();
 
@@ -109,8 +108,8 @@ private:
   struct MapCombo
   {
     MapCombo() {}
-    MapCombo(const MapCombo &) = delete;
-    MapCombo & operator=(const MapCombo &) = delete;
+    MapCombo(const MapCombo&) = delete;
+    MapCombo& operator=(const MapCombo&) = delete;
     negcache_t d_map;
     mutable std::mutex mutex;
     std::atomic<uint64_t> d_entriesCount{0};
@@ -121,17 +120,20 @@ private:
 
   vector<MapCombo> d_maps;
 
-  MapCombo& getMap(const DNSName &qname)
+  MapCombo& getMap(const DNSName& qname)
   {
     return d_maps[qname.hash() % d_maps.size()];
   }
-  const MapCombo& getMap(const DNSName &qname) const
+  const MapCombo& getMap(const DNSName& qname) const
   {
     return d_maps[qname.hash() % d_maps.size()];
   }
+
 public:
-  struct lock {
-    lock(const MapCombo& map) : m(map.mutex)
+  struct lock
+  {
+    lock(const MapCombo& map) :
+      m(map.mutex)
     {
       if (!m.try_lock()) {
         m.lock();
@@ -139,11 +141,12 @@ public:
       }
       map.d_acquired_count++;
     }
-    ~lock() {
+    ~lock()
+    {
       m.unlock();
     }
-  private:
-    std::mutex &m;
-  };
 
+  private:
+    std::mutex& m;
+  };
 };

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -47,36 +47,36 @@ typedef struct
 class NegCache : public boost::noncopyable
 {
 public:
+
+  NegCache(size_t mapsCount = 1024);
+  ~NegCache();
+
   struct NegCacheEntry
   {
-    DNSName d_name; // The denied name
-    QType d_qtype; // The denied type
-    DNSName d_auth; // The denying name (aka auth)
-    mutable uint32_t d_ttd; // Timestamp when this entry should die
     recordsAndSignatures authoritySOA; // The upstream SOA record and RRSIGs
     recordsAndSignatures DNSSECRecords; // The upstream NSEC(3) and RRSIGs
+    DNSName d_name; // The denied name
+    DNSName d_auth; // The denying name (aka auth)
+    mutable time_t d_ttd; // Timestamp when this entry should die
     mutable vState d_validationState{vState::Indeterminate};
-    uint32_t getTTD() const
+    QType d_qtype; // The denied type
+    time_t getTTD() const
     {
       return d_ttd;
     };
   };
 
   void add(const NegCacheEntry& ne);
-  void updateValidationStatus(const DNSName& qname, const QType& qtype, const vState newState, boost::optional<uint32_t> capTTD);
+  void updateValidationStatus(const DNSName& qname, const QType& qtype, const vState newState, boost::optional<time_t> capTTD);
   bool get(const DNSName& qname, const QType& qtype, const struct timeval& now, NegCacheEntry& ne, bool typeMustMatch = false);
   bool getRootNXTrust(const DNSName& qname, const struct timeval& now, NegCacheEntry& ne);
-  uint64_t count(const DNSName& qname) const;
-  uint64_t count(const DNSName& qname, const QType qtype) const;
+  size_t count(const DNSName& qname);
+  size_t count(const DNSName& qname, const QType qtype);
   void prune(size_t maxEntries);
   void clear();
-  uint64_t dumpToFile(FILE* fd);
-  uint64_t wipe(const DNSName& name, bool subtree = false);
-
-  uint64_t size()
-  {
-    return d_negcache.size();
-  };
+  size_t dumpToFile(FILE* fd);
+  size_t wipe(const DNSName& name, bool subtree = false);
+  size_t size();
 
   void preRemoval(const NegCacheEntry& entry)
   {
@@ -104,9 +104,40 @@ private:
         member<NegCacheEntry, DNSName, &NegCacheEntry::d_name>>>>
     negcache_t;
 
-  // Required for the cachecleaner
-  typedef negcache_t::nth_index<1>::type negcache_sequence_t;
+  struct MapCombo
+  {
+    MapCombo() {}
+    MapCombo(const MapCombo &) = delete;
+    MapCombo & operator=(const MapCombo &) = delete;
+    negcache_t d_map;
+    std::mutex mutex;
+    std::atomic<uint64_t> d_entriesCount{0};
+    uint64_t d_contended_count{0};
+    uint64_t d_acquired_count{0};
+    bool d_cachecachevalid{false}; // XXX
+  };
 
-  // Stores the negative cache entries
-  negcache_t d_negcache;
+  vector<MapCombo> d_maps;
+
+  MapCombo& getMap(const DNSName &qname)
+  {
+    return d_maps[qname.hash() % d_maps.size()];
+  }
+public:
+  struct lock {
+    lock(MapCombo& map) : m(map.mutex)
+    {
+      if (!m.try_lock()) {
+        m.lock();
+        map.d_contended_count++;
+      }
+      map.d_acquired_count++;
+    }
+    ~lock() {
+      m.unlock();
+    }
+  private:
+    std::mutex &m;
+  };
+
 };

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(test_clear)
 
 BOOST_AUTO_TEST_CASE(test_dumpToFile)
 {
-  NegCache cache;
+  NegCache cache(1);
   vector<string> expected;
   expected.push_back("www1.powerdns.com. 600 IN TYPE0 VIA powerdns.com. ; (Indeterminate)\n");
   expected.push_back("powerdns.com. 600 IN SOA ns1. hostmaster. 1 2 3 4 5 ; (Indeterminate)\n");

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -11,6 +11,7 @@ GlobalStateHolder<LuaConfigItems> g_luaconfs;
 GlobalStateHolder<SuffixMatchNode> g_dontThrottleNames;
 GlobalStateHolder<NetmaskGroup> g_dontThrottleNetmasks;
 std::unique_ptr<MemRecursorCache> s_RC{nullptr};
+std::unique_ptr<NegCache> s_negcache{nullptr};
 unsigned int g_numThreads = 1;
 bool g_lowercaseOutgoing = false;
 
@@ -54,6 +55,8 @@ bool primeHints(void)
   vector<DNSRecord> nsset;
   if (!s_RC)
     s_RC = std::unique_ptr<MemRecursorCache>(new MemRecursorCache());
+  if (!s_negcache)
+    s_negcache = std::unique_ptr<NegCache>(new NegCache());
 
   DNSRecord arr, aaaarr, nsrr;
   nsrr.d_name = g_rootdnsname;
@@ -112,6 +115,7 @@ void initSR(bool debug)
   }
 
   s_RC = std::unique_ptr<MemRecursorCache>(new MemRecursorCache());
+  s_negcache = std::unique_ptr<NegCache>(new NegCache());
 
   SyncRes::s_maxqperq = 50;
   SyncRes::s_maxnsaddressqperq = 10;
@@ -198,7 +202,7 @@ void initSR(std::unique_ptr<SyncRes>& sr, bool dnssec, bool debug, time_t fakeNo
   sr->setLogMode(debug == false ? SyncRes::LogNone : SyncRes::Log);
 
   SyncRes::setDomainMap(std::make_shared<SyncRes::domainmap_t>());
-  SyncRes::clearNegCache();
+  s_negcache->clear();
 }
 
 void setDNSSECValidation(std::unique_ptr<SyncRes>& sr, const DNSSECMode& mode)

--- a/pdns/recursordist/test-syncres_cc2.cc
+++ b/pdns/recursordist/test-syncres_cc2.cc
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   /* one for target1 and one for the entire TLD */
-  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust)
   BOOST_REQUIRE_EQUAL(ret.size(), 1U);
   BOOST_CHECK_LE(ret[0].d_ttl, SyncRes::s_maxnegttl);
   /* one for target1 and one for the entire TLD */
-  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 2U);
 
   /* we should have sent only one query */
   BOOST_CHECK_EQUAL(queriesCount, 1U);
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust_specific)
 
   /* even with root-nx-trust on and a NX answer from the root,
      we should not have cached the entire TLD this time. */
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust_specific)
   BOOST_REQUIRE(ret[0].d_type == QType::A);
   BOOST_CHECK(getRR<ARecordContent>(ret[0])->getCA() == ComboAddress("192.0.2.2"));
 
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   BOOST_CHECK_EQUAL(queriesCount, 3U);
 }
@@ -442,14 +442,14 @@ BOOST_AUTO_TEST_CASE(test_root_nx_dont_trust)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   /* one for target1 */
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   /* one for target1 */
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   /* we should have sent three queries */
   BOOST_CHECK_EQUAL(queriesCount, 3U);
@@ -492,28 +492,28 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target4, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   // Now test without RFC 8020 to see the cache and query count grow
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::No;
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   // New query
   ret.clear();
@@ -532,21 +532,21 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 3U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 3U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 3U);
 
   ret.clear();
   res = sr->beginResolve(target4, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 5U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 4U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 4U);
 
   // reset
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;
@@ -658,7 +658,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
@@ -666,7 +666,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
@@ -674,7 +674,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target4, QType(QType::A), QClass::IN, ret);
@@ -682,7 +682,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   // Now test without RFC 8020 to see the cache and query count grow
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::No;
@@ -694,7 +694,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   // New query
   ret.clear();
@@ -703,7 +703,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 11U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
@@ -711,7 +711,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 13U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 3U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 3U);
 
   ret.clear();
   res = sr->beginResolve(target4, QType(QType::A), QClass::IN, ret);
@@ -719,7 +719,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 15U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 4U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 4U);
 
   // reset
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;
@@ -775,28 +775,28 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nodata)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target1, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 3U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 2U);
 }
 
 BOOST_AUTO_TEST_CASE(test_rfc8020_nodata_bis)
@@ -849,28 +849,28 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nodata_bis)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target1, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 3U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::TXT), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::TXT), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 2U);
 }
 
 BOOST_AUTO_TEST_CASE(test_skip_negcache_for_variable_response)
@@ -927,7 +927,7 @@ BOOST_AUTO_TEST_CASE(test_skip_negcache_for_variable_response)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 2U);
   /* no negative cache entry because the response was variable */
-  BOOST_CHECK_EQUAL(s_negcache->size(), 0U);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 0U);
 }
 
 BOOST_AUTO_TEST_CASE(test_ecs_cache_limit_allowed)
@@ -965,7 +965,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_limit_allowed)
   /* should have been cached */
   const ComboAddress who("192.0.2.128");
   vector<DNSRecord> cached;
-  BOOST_REQUIRE_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
 }
 
@@ -1004,7 +1004,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_limit_no_ttl_limit_allowed)
   /* should have been cached because /24 is more specific than /16 but TTL limit is nof effective */
   const ComboAddress who("192.0.2.128");
   vector<DNSRecord> cached;
-  BOOST_REQUIRE_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
 }
 
@@ -1043,7 +1043,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_ttllimit_allowed)
   /* should have been cached */
   const ComboAddress who("192.0.2.128");
   vector<DNSRecord> cached;
-  BOOST_REQUIRE_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
 }
 
@@ -1083,7 +1083,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_ttllimit_and_scope_allowed)
   /* should have been cached */
   const ComboAddress who("192.0.2.128");
   vector<DNSRecord> cached;
-  BOOST_REQUIRE_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
 }
 
@@ -1123,7 +1123,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_ttllimit_notallowed)
   /* should have NOT been cached because TTL of 60 is too small and /24 is more specific than /16 */
   const ComboAddress who("192.0.2.128");
   vector<DNSRecord> cached;
-  BOOST_REQUIRE_LT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_REQUIRE_LT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 0U);
 }
 
@@ -1231,7 +1231,7 @@ BOOST_AUTO_TEST_CASE(test_flawed_nsset)
   std::vector<shared_ptr<RRSIGRecordContent>> sigs;
   addRecordToList(records, target, QType::NS, "pdns-public-ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, now + 3600);
 
-  s_RC->replace(now, target, QType(QType::NS), records, sigs, vector<std::shared_ptr<DNSRecord>>(), true, boost::optional<Netmask>());
+  g_recCache->replace(now, target, QType(QType::NS), records, sigs, vector<std::shared_ptr<DNSRecord>>(), true, boost::optional<Netmask>());
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
@@ -1337,7 +1337,7 @@ BOOST_AUTO_TEST_CASE(test_cache_hit)
   std::vector<shared_ptr<RRSIGRecordContent>> sigs;
 
   addRecordToList(records, target, QType::A, "192.0.2.1", DNSResourceRecord::ANSWER, now + 3600);
-  s_RC->replace(now, target, QType(QType::A), records, sigs, vector<std::shared_ptr<DNSRecord>>(), true, boost::optional<Netmask>());
+  g_recCache->replace(now, target, QType(QType::A), records, sigs, vector<std::shared_ptr<DNSRecord>>(), true, boost::optional<Netmask>());
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
@@ -1410,13 +1410,13 @@ BOOST_AUTO_TEST_CASE(test_cache_min_max_ttl)
 
   const ComboAddress who;
   vector<DNSRecord> cached;
-  BOOST_REQUIRE_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
   BOOST_REQUIRE_GT(cached[0].d_ttl, now);
   BOOST_CHECK_EQUAL((cached[0].d_ttl - now), SyncRes::s_minimumTTL);
 
   cached.clear();
-  BOOST_REQUIRE_GT(s_RC->get(now, target, QType(QType::NS), false, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::NS), false, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
   BOOST_REQUIRE_GT(cached[0].d_ttl, now);
   BOOST_CHECK_LE((cached[0].d_ttl - now), SyncRes::s_maxcachettl);
@@ -1474,19 +1474,19 @@ BOOST_AUTO_TEST_CASE(test_cache_min_max_ecs_ttl)
 
   const ComboAddress who("192.0.2.128");
   vector<DNSRecord> cached;
-  BOOST_REQUIRE_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
   BOOST_REQUIRE_GT(cached[0].d_ttl, now);
   BOOST_CHECK_EQUAL((cached[0].d_ttl - now), SyncRes::s_minimumECSTTL);
 
   cached.clear();
-  BOOST_REQUIRE_GT(s_RC->get(now, target, QType(QType::NS), false, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::NS), false, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
   BOOST_REQUIRE_GT(cached[0].d_ttl, now);
   BOOST_CHECK_LE((cached[0].d_ttl - now), SyncRes::s_maxcachettl);
 
   cached.clear();
-  BOOST_REQUIRE_GT(s_RC->get(now, DNSName("a.gtld-servers.net."), QType(QType::A), false, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, DNSName("a.gtld-servers.net."), QType(QType::A), false, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
   BOOST_REQUIRE_GT(cached[0].d_ttl, now);
   BOOST_CHECK_LE((cached[0].d_ttl - now), SyncRes::s_minimumTTL);
@@ -1526,7 +1526,7 @@ BOOST_AUTO_TEST_CASE(test_cache_expired_ttl)
   std::vector<shared_ptr<RRSIGRecordContent>> sigs;
   addRecordToList(records, target, QType::A, "192.0.2.42", DNSResourceRecord::ANSWER, now - 60);
 
-  s_RC->replace(now - 3600, target, QType(QType::A), records, sigs, vector<std::shared_ptr<DNSRecord>>(), true, boost::optional<Netmask>());
+  g_recCache->replace(now - 3600, target, QType(QType::A), records, sigs, vector<std::shared_ptr<DNSRecord>>(), true, boost::optional<Netmask>());
 
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);

--- a/pdns/recursordist/test-syncres_cc2.cc
+++ b/pdns/recursordist/test-syncres_cc2.cc
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   /* one for target1 and one for the entire TLD */
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 2U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust)
   BOOST_REQUIRE_EQUAL(ret.size(), 1U);
   BOOST_CHECK_LE(ret[0].d_ttl, SyncRes::s_maxnegttl);
   /* one for target1 and one for the entire TLD */
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 2U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
 
   /* we should have sent only one query */
   BOOST_CHECK_EQUAL(queriesCount, 1U);
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust_specific)
 
   /* even with root-nx-trust on and a NX answer from the root,
      we should not have cached the entire TLD this time. */
-  BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust_specific)
   BOOST_REQUIRE(ret[0].d_type == QType::A);
   BOOST_CHECK(getRR<ARecordContent>(ret[0])->getCA() == ComboAddress("192.0.2.2"));
 
-  BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   BOOST_CHECK_EQUAL(queriesCount, 3U);
 }
@@ -442,14 +442,14 @@ BOOST_AUTO_TEST_CASE(test_root_nx_dont_trust)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   /* one for target1 */
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   /* one for target1 */
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   /* we should have sent three queries */
   BOOST_CHECK_EQUAL(queriesCount, 3U);
@@ -492,28 +492,28 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target4, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   // Now test without RFC 8020 to see the cache and query count grow
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::No;
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   // New query
   ret.clear();
@@ -532,21 +532,21 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 3U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 2U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 3U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 3U);
 
   ret.clear();
   res = sr->beginResolve(target4, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 5U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 4U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 4U);
 
   // reset
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;
@@ -658,7 +658,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
@@ -666,7 +666,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
@@ -674,7 +674,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target4, QType(QType::A), QClass::IN, ret);
@@ -682,7 +682,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   // Now test without RFC 8020 to see the cache and query count grow
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::No;
@@ -694,7 +694,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 9U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   // New query
   ret.clear();
@@ -703,7 +703,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 11U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 2U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
@@ -711,7 +711,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 13U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 3U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 3U);
 
   ret.clear();
   res = sr->beginResolve(target4, QType(QType::A), QClass::IN, ret);
@@ -719,7 +719,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_CHECK_EQUAL(ret.size(), 6U);
   BOOST_CHECK_EQUAL(queriesCount, 15U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 4U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 4U);
 
   // reset
   SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;
@@ -775,28 +775,28 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nodata)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target1, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 3U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 2U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 2U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
 }
 
 BOOST_AUTO_TEST_CASE(test_rfc8020_nodata_bis)
@@ -849,28 +849,28 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nodata_bis)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 2U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target1, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 3U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 1U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
 
   ret.clear();
   res = sr->beginResolve(target2, QType(QType::TXT), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 2U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
 
   ret.clear();
   res = sr->beginResolve(target3, QType(QType::TXT), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 2U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 2U);
 }
 
 BOOST_AUTO_TEST_CASE(test_skip_negcache_for_variable_response)
@@ -927,7 +927,7 @@ BOOST_AUTO_TEST_CASE(test_skip_negcache_for_variable_response)
   BOOST_CHECK_EQUAL(res, RCode::NXDomain);
   BOOST_CHECK_EQUAL(ret.size(), 2U);
   /* no negative cache entry because the response was variable */
-  BOOST_CHECK_EQUAL(SyncRes::getNegCacheSize(), 0U);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 0U);
 }
 
 BOOST_AUTO_TEST_CASE(test_ecs_cache_limit_allowed)

--- a/pdns/recursordist/test-syncres_cc3.cc
+++ b/pdns/recursordist/test-syncres_cc3.cc
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(test_cache_auth)
   /* check that we correctly cached only the answer entry, not the additional one */
   const ComboAddress who;
   vector<DNSRecord> cached;
-  BOOST_REQUIRE_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_REQUIRE_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
   BOOST_REQUIRE_EQUAL(QType(cached.at(0).d_type).getName(), QType(QType::A).getName());
   BOOST_CHECK_EQUAL(getRR<ARecordContent>(cached.at(0))->getCA().toString(), ComboAddress("192.0.2.2").toString());
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(test_answer_no_aa)
   const ComboAddress who;
   vector<DNSRecord> cached;
   vector<std::shared_ptr<RRSIGRecordContent>> signatures;
-  BOOST_REQUIRE_EQUAL(s_RC->get(now, target, QType(QType::A), false, &cached, who, boost::none, &signatures), -1);
+  BOOST_REQUIRE_EQUAL(g_recCache->get(now, target, QType(QType::A), false, &cached, who, boost::none, &signatures), -1);
 }
 
 BOOST_AUTO_TEST_CASE(test_special_types)

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -927,8 +927,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_doesnt_match_ds)
 
   /* === first without validation, then with (just-in-time validation) === */
   /* clear the caches */
-  s_RC = std::unique_ptr<MemRecursorCache>(new MemRecursorCache());
-  s_negcache = std::unique_ptr<NegCache>(new NegCache());
+  g_recCache = std::unique_ptr<MemRecursorCache>(new MemRecursorCache());
+  g_negCache = std::unique_ptr<NegCache>(new NegCache());
   sr->setDNSSECValidationRequested(false);
   primeHints();
 

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -928,7 +928,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_doesnt_match_ds)
   /* === first without validation, then with (just-in-time validation) === */
   /* clear the caches */
   s_RC = std::unique_ptr<MemRecursorCache>(new MemRecursorCache());
-  SyncRes::clearNegCache();
+  s_negcache = std::unique_ptr<NegCache>(new NegCache());
   sr->setDNSSECValidationRequested(false);
   primeHints();
 

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -682,8 +682,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity)
 
   /* check that the entry has not been negatively cached for longer than the RRSIG validity */
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1U);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_ttd, fixedNow + 1);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Secure);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
@@ -753,8 +753,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_bogus_validity)
 
   /* check that the entry has been negatively cached but not longer than s_maxbogusttl */
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1U);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_ttd, fixedNow + SyncRes::s_maxbogusttl);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Bogus);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -682,8 +682,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity)
 
   /* check that the entry has not been negatively cached for longer than the RRSIG validity */
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
-  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(g_negCache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_ttd, fixedNow + 1);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Secure);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
@@ -753,8 +753,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_bogus_validity)
 
   /* check that the entry has been negatively cached but not longer than s_maxbogusttl */
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
-  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(g_negCache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_ttd, fixedNow + SyncRes::s_maxbogusttl);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Bogus);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
@@ -822,7 +822,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_cache_validity)
   const ComboAddress who;
   vector<DNSRecord> cached;
   vector<std::shared_ptr<RRSIGRecordContent>> signatures;
-  BOOST_REQUIRE_EQUAL(s_RC->get(tnow, target, QType(QType::A), true, &cached, who, boost::none, &signatures), 1);
+  BOOST_REQUIRE_EQUAL(g_recCache->get(tnow, target, QType(QType::A), true, &cached, who, boost::none, &signatures), 1);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
   BOOST_REQUIRE_EQUAL(signatures.size(), 1U);
   BOOST_CHECK_EQUAL((cached[0].d_ttl - tnow), 1);

--- a/pdns/recursordist/test-syncres_cc9.cc
+++ b/pdns/recursordist/test-syncres_cc9.cc
@@ -388,8 +388,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure)
   BOOST_CHECK_EQUAL(queriesCount, 1U);
   /* check that the entry has been negatively cached */
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
-  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(g_negCache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Indeterminate);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);
@@ -404,8 +404,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
-  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(g_negCache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Secure);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);
@@ -526,8 +526,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_insecure)
   BOOST_CHECK_EQUAL(queriesCount, 1U);
   /* check that the entry has not been negatively cached */
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
-  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(g_negCache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Indeterminate);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 0U);
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_insecure)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
   BOOST_REQUIRE_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 1U);
-  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_REQUIRE_EQUAL(g_negCache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Insecure);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 0U);
@@ -613,8 +613,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus)
   }
   BOOST_CHECK_EQUAL(queriesCount, 1U);
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
-  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(g_negCache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(g_negCache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Indeterminate);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus)
     BOOST_CHECK_EQUAL(record.d_ttl, SyncRes::s_maxbogusttl);
   }
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_REQUIRE_EQUAL(g_negCache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Bogus);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);
@@ -653,7 +653,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus)
     BOOST_CHECK_EQUAL(record.d_ttl, SyncRes::s_maxbogusttl);
   }
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_REQUIRE_EQUAL(g_negCache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Bogus);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);
@@ -937,7 +937,7 @@ BOOST_AUTO_TEST_CASE(test_cname_plus_authority_ns_ttl)
   vector<DNSRecord> cached;
   bool wasAuth = false;
 
-  auto ttl = s_RC->get(now, DNSName("powerdns.com."), QType(QType::NS), false, &cached, who, boost::none, nullptr, nullptr, nullptr, nullptr, &wasAuth);
+  auto ttl = g_recCache->get(now, DNSName("powerdns.com."), QType(QType::NS), false, &cached, who, boost::none, nullptr, nullptr, nullptr, nullptr, &wasAuth);
   BOOST_REQUIRE_GE(ttl, 1);
   BOOST_REQUIRE_LE(ttl, 42);
   BOOST_CHECK_EQUAL(cached.size(), 1U);
@@ -946,7 +946,7 @@ BOOST_AUTO_TEST_CASE(test_cname_plus_authority_ns_ttl)
   cached.clear();
 
   /* Also check that the the part in additional is still not auth */
-  BOOST_REQUIRE_GE(s_RC->get(now, DNSName("a.gtld-servers.net."), QType(QType::A), false, &cached, who, boost::none, nullptr, nullptr, nullptr, nullptr, &wasAuth), -1);
+  BOOST_REQUIRE_GE(g_recCache->get(now, DNSName("a.gtld-servers.net."), QType(QType::A), false, &cached, who, boost::none, nullptr, nullptr, nullptr, nullptr, &wasAuth), -1);
   BOOST_CHECK_EQUAL(cached.size(), 1U);
   BOOST_CHECK_EQUAL(wasAuth, false);
 }
@@ -987,14 +987,14 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_general)
 
   const ComboAddress who;
   vector<DNSRecord> cached;
-  BOOST_CHECK_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   cached.clear();
-  BOOST_CHECK_LT(s_RC->get(now, target, QType(QType::AAAA), true, &cached, who), 0);
-  BOOST_CHECK_EQUAL(s_RC->get(now, DNSName("not-sanitization.powerdns.com."), QType(QType::DNAME), true, &cached, who), -1);
-  BOOST_CHECK_LT(s_RC->get(now, target, QType(QType::MX), true, &cached, who), 0);
-  BOOST_CHECK_EQUAL(s_RC->get(now, DNSName("not-sanitization.powerdns.com."), QType(QType::SOA), true, &cached, who), -1);
-  BOOST_CHECK_LT(s_RC->get(now, target, QType(QType::TXT), false, &cached, who), 0);
-  BOOST_CHECK_EQUAL(s_RC->get(now, DNSName("powerdns.com."), QType(QType::AAAA), false, &cached, who), -1);
+  BOOST_CHECK_LT(g_recCache->get(now, target, QType(QType::AAAA), true, &cached, who), 0);
+  BOOST_CHECK_EQUAL(g_recCache->get(now, DNSName("not-sanitization.powerdns.com."), QType(QType::DNAME), true, &cached, who), -1);
+  BOOST_CHECK_LT(g_recCache->get(now, target, QType(QType::MX), true, &cached, who), 0);
+  BOOST_CHECK_EQUAL(g_recCache->get(now, DNSName("not-sanitization.powerdns.com."), QType(QType::SOA), true, &cached, who), -1);
+  BOOST_CHECK_LT(g_recCache->get(now, target, QType(QType::TXT), false, &cached, who), 0);
+  BOOST_CHECK_EQUAL(g_recCache->get(now, DNSName("powerdns.com."), QType(QType::AAAA), false, &cached, who), -1);
 }
 
 BOOST_AUTO_TEST_CASE(test_records_sanitization_keep_relevant_additional_aaaa)
@@ -1022,11 +1022,11 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_keep_relevant_additional_aaaa)
 
   const ComboAddress who;
   vector<DNSRecord> cached;
-  BOOST_CHECK_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   cached.clear();
   /* not auth since it was in the additional section */
-  BOOST_CHECK_LT(s_RC->get(now, target, QType(QType::AAAA), true, &cached, who), 0);
-  BOOST_CHECK_GT(s_RC->get(now, target, QType(QType::AAAA), false, &cached, who), 0);
+  BOOST_CHECK_LT(g_recCache->get(now, target, QType(QType::AAAA), true, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, target, QType(QType::AAAA), false, &cached, who), 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_records_sanitization_keep_glue)
@@ -1082,21 +1082,21 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_keep_glue)
 
   const ComboAddress who;
   vector<DNSRecord> cached;
-  BOOST_CHECK_GT(s_RC->get(now, target, QType(QType::A), true, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, target, QType(QType::A), true, &cached, who), 0);
   cached.clear();
 
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("com."), QType(QType::NS), false, &cached, who), 0);
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("a.gtld-servers.net."), QType(QType::A), false, &cached, who), 0);
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("a.gtld-servers.net."), QType(QType::AAAA), false, &cached, who), 0);
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("powerdns.com."), QType(QType::NS), false, &cached, who), 0);
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("pdns-public-ns1.powerdns.com."), QType(QType::A), false, &cached, who), 0);
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("pdns-public-ns1.powerdns.com."), QType(QType::AAAA), false, &cached, who), 0);
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("pdns-public-ns2.powerdns.com."), QType(QType::A), false, &cached, who), 0);
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("pdns-public-ns2.powerdns.com."), QType(QType::AAAA), false, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("com."), QType(QType::NS), false, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("a.gtld-servers.net."), QType(QType::A), false, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("a.gtld-servers.net."), QType(QType::AAAA), false, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("powerdns.com."), QType(QType::NS), false, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("pdns-public-ns1.powerdns.com."), QType(QType::A), false, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("pdns-public-ns1.powerdns.com."), QType(QType::AAAA), false, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("pdns-public-ns2.powerdns.com."), QType(QType::A), false, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("pdns-public-ns2.powerdns.com."), QType(QType::AAAA), false, &cached, who), 0);
 
   cached.clear();
   /* check that we accepted the DS from the parent, and not from the child zone */
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("powerdns.com."), QType(QType::DS), false, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("powerdns.com."), QType(QType::DS), false, &cached, who), 0);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
   BOOST_CHECK_EQUAL(cached.at(0).d_content->getZoneRepresentation(), "1 8 2 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 }
@@ -1128,12 +1128,12 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_scrubs_ns_nxd)
 
   const ComboAddress who;
   vector<DNSRecord> cached;
-  BOOST_CHECK_GT(s_RC->get(now, DNSName("powerdns.com."), QType(QType::SOA), true, &cached, who), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("powerdns.com."), QType(QType::SOA), true, &cached, who), 0);
   cached.clear();
 
-  BOOST_CHECK_LT(s_RC->get(now, DNSName("powerdns.com."), QType(QType::NS), false, &cached, who), 0);
-  BOOST_CHECK_LT(s_RC->get(now, DNSName("spoofed.ns."), QType(QType::A), false, &cached, who), 0);
-  BOOST_CHECK_LT(s_RC->get(now, DNSName("spoofed.ns."), QType(QType::AAAA), false, &cached, who), 0);
+  BOOST_CHECK_LT(g_recCache->get(now, DNSName("powerdns.com."), QType(QType::NS), false, &cached, who), 0);
+  BOOST_CHECK_LT(g_recCache->get(now, DNSName("spoofed.ns."), QType(QType::A), false, &cached, who), 0);
+  BOOST_CHECK_LT(g_recCache->get(now, DNSName("spoofed.ns."), QType(QType::AAAA), false, &cached, who), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-syncres_cc9.cc
+++ b/pdns/recursordist/test-syncres_cc9.cc
@@ -388,8 +388,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure)
   BOOST_CHECK_EQUAL(queriesCount, 1U);
   /* check that the entry has been negatively cached */
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1U);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Indeterminate);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);
@@ -404,8 +404,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1U);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Secure);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);
@@ -526,8 +526,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_insecure)
   BOOST_CHECK_EQUAL(queriesCount, 1U);
   /* check that the entry has not been negatively cached */
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1U);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Indeterminate);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 0U);
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_insecure)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
   BOOST_REQUIRE_EQUAL(ret.size(), 1U);
   BOOST_CHECK_EQUAL(queriesCount, 1U);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Insecure);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 0U);
@@ -613,8 +613,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus)
   }
   BOOST_CHECK_EQUAL(queriesCount, 1U);
   NegCache::NegCacheEntry ne;
-  BOOST_CHECK_EQUAL(SyncRes::t_sstorage.negcache.size(), 1U);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_CHECK_EQUAL(s_negcache->size(), 1U);
+  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Indeterminate);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus)
     BOOST_CHECK_EQUAL(record.d_ttl, SyncRes::s_maxbogusttl);
   }
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Bogus);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);
@@ -653,7 +653,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus)
     BOOST_CHECK_EQUAL(record.d_ttl, SyncRes::s_maxbogusttl);
   }
   BOOST_CHECK_EQUAL(queriesCount, 4U);
-  BOOST_REQUIRE_EQUAL(SyncRes::t_sstorage.negcache.get(target, QType(QType::A), sr->getNow(), ne), true);
+  BOOST_REQUIRE_EQUAL(s_negcache->get(target, QType(QType::A), sr->getNow(), ne), true);
   BOOST_CHECK_EQUAL(ne.d_validationState, vState::Bogus);
   BOOST_CHECK_EQUAL(ne.authoritySOA.records.size(), 1U);
   BOOST_CHECK_EQUAL(ne.authoritySOA.signatures.size(), 1U);

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -68,13 +68,13 @@ bool primeHints(void)
       arr.d_content=std::make_shared<ARecordContent>(ComboAddress(rootIps4[c-'a']));
       vector<DNSRecord> aset;
       aset.push_back(arr);
-      s_RC->replace(time(0), DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, boost::none, boost::none, validationState); // auth, nuke it all
+      g_recCache->replace(time(0), DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, boost::none, boost::none, validationState); // auth, nuke it all
       if (rootIps6[c-'a'] != NULL) {
         aaaarr.d_content=std::make_shared<AAAARecordContent>(ComboAddress(rootIps6[c-'a']));
 
         vector<DNSRecord> aaaaset;
         aaaaset.push_back(aaaarr);
-        s_RC->replace(time(0), DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, boost::none, boost::none, validationState);
+        g_recCache->replace(time(0), DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, boost::none, boost::none, validationState);
       }
       
       nsset.push_back(nsrr);
@@ -94,12 +94,12 @@ bool primeHints(void)
         seenA.insert(rr.qname);
         vector<DNSRecord> aset;
         aset.push_back(DNSRecord(rr));
-        s_RC->replace(time(0), rr.qname, QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, boost::none, boost::none, validationState); // auth, etc see above
+        g_recCache->replace(time(0), rr.qname, QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, boost::none, boost::none, validationState); // auth, etc see above
       } else if(rr.qtype.getCode()==QType::AAAA) {
         seenAAAA.insert(rr.qname);
         vector<DNSRecord> aaaaset;
         aaaaset.push_back(DNSRecord(rr));
-        s_RC->replace(time(0), rr.qname, QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, boost::none, boost::none, validationState);
+        g_recCache->replace(time(0), rr.qname, QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, boost::none, boost::none, validationState);
       } else if(rr.qtype.getCode()==QType::NS) {
         seenNS.insert(DNSName(rr.content));
         rr.content=toLower(rr.content);
@@ -134,8 +134,8 @@ bool primeHints(void)
     }
   }
 
-  s_RC->doWipeCache(g_rootdnsname, false, QType::NS);
-  s_RC->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, boost::none, boost::none, validationState); // and stuff in the cache
+  g_recCache->doWipeCache(g_rootdnsname, false, QType::NS);
+  g_recCache->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, boost::none, boost::none, validationState); // and stuff in the cache
   return true;
 }
 
@@ -163,7 +163,7 @@ void primeRootNSZones(bool dnssecmode, unsigned int depth)
   // so make a local copy
   set<DNSName> copy(t_rootNSZones);  
   for (const auto & qname: copy) {
-    s_RC->doWipeCache(qname, false, QType::NS);
+    g_recCache->doWipeCache(qname, false, QType::NS);
     vector<DNSRecord> ret;
     sr.beginResolve(qname, QType(QType::NS), QClass::IN, ret, depth + 1);
   }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -255,7 +255,7 @@ private:
   cont_t d_cont;
 };
 
-extern std::unique_ptr<NegCache> s_negcache;
+extern std::unique_ptr<NegCache> g_negCache;
 
 class SyncRes : public boost::noncopyable
 {
@@ -955,7 +955,7 @@ struct PacketIDBirthdayCompare: public std::binary_function<PacketID, PacketID, 
     return a.domain < b.domain;
   }
 };
-extern std::unique_ptr<MemRecursorCache> s_RC;
+extern std::unique_ptr<MemRecursorCache> g_recCache;
 extern thread_local std::unique_ptr<RecursorPacketCache> t_packetCache;
 typedef MTasker<PacketID,string> MT_t;
 MT_t* getMT();

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -255,6 +255,8 @@ private:
   cont_t d_cont;
 };
 
+extern std::unique_ptr<NegCache> s_negcache;
+
 class SyncRes : public boost::noncopyable
 {
 public:
@@ -400,7 +402,6 @@ public:
   };
 
   struct ThreadLocalStorage {
-    NegCache negcache;
     nsspeeds_t nsSpeeds;
     throttle_t throttle;
     ednsstatus_t ednsstatus;
@@ -552,32 +553,10 @@ public:
   {
     return t_sstorage.fails.value(server);
   }
-
-  static void clearNegCache()
-  {
-    t_sstorage.negcache.clear();
-  }
-
-  static uint64_t getNegCacheSize()
-  {
-    return t_sstorage.negcache.size();
-  }
-
-  static void pruneNegCache(unsigned int maxEntries)
-  {
-    t_sstorage.negcache.prune(maxEntries);
-  }
-
-  static uint64_t wipeNegCache(const DNSName& name, bool subtree = false)
-  {
-    return t_sstorage.negcache.wipe(name, subtree);
-  }
-
   static void setDomainMap(std::shared_ptr<domainmap_t> newMap)
   {
     t_sstorage.domainmap = newMap;
   }
-
   static const std::shared_ptr<domainmap_t> getDomainMap()
   {
     return t_sstorage.domainmap;

--- a/regression-tests.recursor/config.sh
+++ b/regression-tests.recursor/config.sh
@@ -580,6 +580,7 @@ local-port=5301
 socket-dir=/tmp/recursor-service3
 lua-config-file=$(pwd)/recursor-service3/config.lua
 lua-dns-script=$(pwd)/recursor-service3/script.lua
+security-poll-suffix=
 
 EOF
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

While the main record cache is shared between threads since some time, the negcache was not. This makes is so.

While there, simplify the `lruReplacingInsert()` result to just signal if an entry was inserted or replaced (this makes counting more easy) and generalize the invalidating of the per-shard cache used in the record cache so the code can be more easily be reused in the negcache.

This code keeps track of mutex acquired/contended counts. Don't know if this is going to stay, it is not exported in any way atm.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
