### PR TITLE
dnsdist, rec: dnstap requires protobuf

### DIFF
--- a/m4/pdns_check_dnstap.m4
+++ b/m4/pdns_check_dnstap.m4
@@ -28,7 +28,7 @@ AC_DEFUN([PDNS_CHECK_DNSTAP], [
     AS_IF([test x"$FSTRM_LIBS" = "x"], [
       AC_MSG_ERROR([dnstap requested but libfstrm was not found])
     ])
-    AS_IF([test "x$PROTOBUF_LIBS" = "x" -a x"$PROTOC" = "x"], [
+    AS_IF([test "x$PROTOBUF_LIBS" = "x" -o x"$PROTOC" = "x"], [
       AC_MSG_ERROR([dnstap requested but protobuf was not found])
     ])
   ])

--- a/m4/pdns_check_dnstap.m4
+++ b/m4/pdns_check_dnstap.m4
@@ -1,4 +1,5 @@
 AC_DEFUN([PDNS_CHECK_DNSTAP], [
+  AC_REQUIRE([PDNS_WITH_PROTOBUF])
   AC_MSG_CHECKING([whether we will have dnstap])
   AC_ARG_ENABLE([dnstap],
     AS_HELP_STRING([--enable-dnstap],[enable dnstap support @<:@default=$1@:>@]),
@@ -26,6 +27,9 @@ AC_DEFUN([PDNS_CHECK_DNSTAP], [
   AS_IF([test "x$enable_dnstap" = "xyes"], [
     AS_IF([test x"$FSTRM_LIBS" = "x"], [
       AC_MSG_ERROR([dnstap requested but libfstrm was not found])
+    ])
+    AS_IF([test "x$PROTOBUF_LIBS" = "x" -a x"$PROTOC" = "x"], [
+      AC_MSG_ERROR([dnstap requested but protobuf was not found])
     ])
   ])
 ])


### PR DESCRIPTION
### Short description
Fail the configure when protobuf is disabled or not found but dnstap was
enabled.

Closes #9452

@omoerbeek @rgacogne Would it make sense to define a `HAVE_DNSTAP` that semi-replaces the `HAVE_FSTRM` for all dnstap related code?

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)