### PR TITLE
Auth: remove a '// HACK FIXME400' and fix the bugs it was hiding

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -612,6 +612,9 @@ Enable/Disable DNS update (RFC2136) support. See :doc:`dnsupdate` for more.
 -  Boolean
 -  Default: yes
 
+.. versionchanged:: 4.4.0
+  This setting has been removed
+
 Perform AAAA additional processing. This sends AAAA records in the
 ADDITIONAL section when sending a referral.
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -595,6 +595,11 @@ void LMDBBackend::lookup(const QType &type, const DNSName &qdomain, int zoneId, 
   }
     
   DNSName relqname = qdomain.makeRelative(hunt);
+
+  if(relqname.empty()) {
+    throw DBException("lookup for out of zone rrset");
+  }
+
   //  cout<<"get will look for "<<relqname<< " in zone "<<hunt<<" with id "<<zoneId<<endl;
   d_rotxn = getRecordsROTransaction(zoneId, d_rwtxn);
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -166,7 +166,6 @@ void declareArguments()
   ::arg().set("webserver-loglevel", "Amount of logging in the webserver (none, normal, detailed)") = "normal";
   ::arg().set("webserver-max-bodysize","Webserver/API maximum request/response body size in megabytes")="2";
 
-  ::arg().setSwitch("do-ipv6-additional-processing", "Do AAAA additional processing")="yes";
   ::arg().setSwitch("query-logging","Hint backends that queries should be logged")="no";
 
   ::arg().set("carbon-namespace", "If set overwrites the first part of the carbon string")="pdns";

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -256,8 +256,9 @@ DNSName DNSName::makeRelative(const DNSName& zone) const
 {
   DNSName ret(*this);
   ret.makeUsRelative(zone);
-  return ret.empty() ? zone : ret; // HACK FIXME400
+  return ret;
 }
+
 void DNSName::makeUsRelative(const DNSName& zone) 
 {
   if (isPartOf(zone)) {

--- a/pdns/packethandler.hh
+++ b/pdns/packethandler.hh
@@ -74,7 +74,7 @@ private:
   bool addCDNSKEY(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd);
   bool addCDS(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd);
   bool addNSEC3PARAM(const DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd);
-  int doAdditionalProcessingAndDropAA(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd, bool retargeted);
+  void doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const SOAData& sd);
   void addNSECX(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName &target, const DNSName &wildcard, const DNSName &auth, int mode);
   void addNSEC(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName &target, const DNSName &wildcard, const DNSName& auth, int mode);
   void addNSEC3(DNSPacket& p, std::unique_ptr<DNSPacket>& r, const DNSName &target, const DNSName &wildcard, const DNSName& auth, const NSEC3PARAMRecordContent& nsec3param, bool narrow, int mode);
@@ -104,7 +104,6 @@ private:
   static AtomicCounter s_count;
   static std::mutex s_rfc2136lock;
   bool d_logDNSDetails;
-  bool d_doIPv6AdditionalProcessing;
   bool d_doDNAME;
   bool d_doExpandALIAS;
   bool d_dnssec;

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -175,29 +175,14 @@ static void emitRecord(const DNSName& zoneName, const DNSName &DNSqname, const s
     trim_left(content);
   }
 
-  bool auth = true;
-  if(qtype == "NS" && !pdns_iequals(qname, zname)) {
-    auth=false;
-  }
+  cout<<"insert into records (domain_id, name, type,content,ttl,prio,disabled) select id ,"<<
+    sqlstr(toLower(qname))<<", "<<
+    sqlstr(qtype)<<", "<<
+    sqlstr(stripDotContent(content))<<", "<<ttl<<", "<<prio<<", "<<(g_mode==POSTGRES ? (disabled ? "'t'" : "'f'") : std::to_string(disabled))<<
+    " from domains where name="<<toLower(sqlstr(zname))<<";\n";
 
-  if(g_mode==MYSQL || g_mode==SQLITE) {
-    cout<<"insert into records (domain_id, name, type,content,ttl,prio,disabled) select id ,"<<
-      sqlstr(toLower(qname))<<", "<<
-      sqlstr(qtype)<<", "<<
-      sqlstr(stripDotContent(content))<<", "<<ttl<<", "<<prio<<", "<<disabled<<
-      " from domains where name="<<toLower(sqlstr(zname))<<";\n";
-
-    if(!recordcomment.empty()) {
-      cout<<"insert into comments (domain_id,name,type,modified_at, comment) select id, "<<toLower(sqlstr(stripDot(qname)))<<", "<<sqlstr(qtype)<<", "<<time(0)<<", "<<sqlstr(recordcomment)<<" from domains where name="<<toLower(sqlstr(zname))<<";\n";
-    }
-  }
-  else if(g_mode==POSTGRES) {
-    cout<<"insert into records (domain_id, name, ordername, auth, type,content,ttl,prio,disabled) select id ,"<<
-      sqlstr(toLower(qname))<<", "<<
-      sqlstr(DNSName(qname).makeRelative(DNSName(zname)).makeLowerCase().labelReverse().toString(" ", false))<<", '"<< (auth  ? 't' : 'f') <<"', "<<
-      sqlstr(qtype)<<", "<<
-      sqlstr(stripDotContent(content))<<", "<<ttl<<", "<<prio<<", '"<<(disabled ? 't': 'f') <<
-      "' from domains where name="<<toLower(sqlstr(zname))<<";\n";
+  if(!recordcomment.empty()) {
+    cout<<"insert into comments (domain_id,name,type,modified_at, comment) select id, "<<toLower(sqlstr(stripDot(qname)))<<", "<<sqlstr(qtype)<<", "<<time(0)<<", "<<sqlstr(recordcomment)<<" from domains where name="<<toLower(sqlstr(zname))<<";\n";
   }
 }
 


### PR DESCRIPTION
### Short description
- LMDB backend was not handling out of zone additionals well.
- doAdditionalProcessingAndDropAA() was wasting backend queries for out of zone records (this was triggering the lmdb bug)
- Remove the 'do-ipv6-additional-processing' setting, processing is now always on (hey, it is 2020 ;) )
- Some cleanup in zone2sql and doAdditionalProcessingAndDropAA()

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
