### PR TITLE
auth: backport to 4.3.x: Do not send out of zone lookups to the backends

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -472,16 +472,17 @@ int PacketHandler::doAdditionalProcessingAndDropAA(DNSPacket& p, std::unique_ptr
       else
         continue;
 
+      if(!lookup.isPartOf(soadata.qname)) {
+        continue;
+      }
+
       B.lookup(QType(d_doIPv6AdditionalProcessing ? QType::ANY : QType::A), lookup, soadata.domain_id, &p);
 
       while(B.get(rr)) {
         if(rr.dr.d_type != QType::A && rr.dr.d_type!=QType::AAAA)
           continue;
-        if(!rr.dr.d_name.isPartOf(soadata.qname)) {
-          // FIXME we might still pass on the record if it is occluded and the
-          // backend uses a single id for all zones
-          continue;
-        }
+        // FIXME we might still pass on the record if it is occluded and the
+        // backend uses a single id for all zones
         rr.dr.d_place=DNSResourceRecord::ADDITIONAL;
         toAdd.push_back(rr);
       }


### PR DESCRIPTION
### Short description
This is more efficient and some backends cannot deal with out of zone lookups. (lmdb)
Derived from #9478

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
