### PR TITLE
Sync string_view definition in lmdb-safe

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -16,12 +16,16 @@
 using std::string_view;
 #else
 #include <boost/version.hpp>
-#if BOOST_VERSION >= 106100
+#if BOOST_VERSION >= 106400
+// string_view already exists in 1.61.0 but string_view::at() is not usable with modern compilers, see:
+// https://github.com/boostorg/utility/pull/26
 #include <boost/utility/string_view.hpp>
 using boost::string_view;
-#else
+#elif BOOST_VERSION >= 105300
 #include <boost/utility/string_ref.hpp>
 using string_view = boost::string_ref;
+#else
+using string_view = std::string;
 #endif
 #endif
 

--- a/ext/lmdb-safe/lmdb-safe.hh
+++ b/ext/lmdb-safe/lmdb-safe.hh
@@ -16,9 +16,7 @@
 using std::string_view;
 #else
 #include <boost/version.hpp>
-#if BOOST_VERSION >= 106400
-// string_view already exists in 1.61.0 but string_view::at() is not usable with modern compilers, see:
-// https://github.com/boostorg/utility/pull/26
+#if BOOST_VERSION >= 106100
 #include <boost/utility/string_view.hpp>
 using boost::string_view;
 #elif BOOST_VERSION >= 105300

--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -429,7 +429,7 @@ uint32_t DNSDistPacketCache::getKey(const DNSName::string_t& qname, uint16_t con
   if (packetLen > ((sizeof(dnsheader) + consumed))) {
     if (!d_cookieHashing) {
       /* skip EDNS Cookie options if any */
-      result = PacketCache::hashAfterQname(string_view(reinterpret_cast<const char*>(packet), packetLen), result, sizeof(dnsheader) + consumed, false);
+      result = PacketCache::hashAfterQname(pdns_string_view(reinterpret_cast<const char*>(packet), packetLen), result, sizeof(dnsheader) + consumed, false);
     }
     else {
       result = burtle(packet + sizeof(dnsheader) + consumed, packetLen - (sizeof(dnsheader) + consumed), result);

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -710,15 +710,15 @@ static void doh_dispatch_query(DOHServerConfig* dsc, h2o_handler_t* self, h2o_re
 }
 
 /* can only be called from the main DoH thread */
-static bool getHTTPHeaderValue(const h2o_req_t* req, const std::string& headerName, string_view& value)
+static bool getHTTPHeaderValue(const h2o_req_t* req, const std::string& headerName, pdns_string_view& value)
 {
   bool found = false;
   /* early versions of boost::string_ref didn't have the ability to compare to string */
-  string_view headerNameView(headerName);
+  pdns_string_view headerNameView(headerName);
 
   for (size_t i = 0; i < req->headers.size; ++i) {
-    if (string_view(req->headers.entries[i].name->base, req->headers.entries[i].name->len) == headerNameView) {
-      value = string_view(req->headers.entries[i].value.base, req->headers.entries[i].value.len);
+    if (pdns_string_view(req->headers.entries[i].name->base, req->headers.entries[i].name->len) == headerNameView) {
+      value = pdns_string_view(req->headers.entries[i].value.base, req->headers.entries[i].value.len);
       /* don't stop there, we might have more than one header with the same name, and we want the last one */
       found = true;
     }
@@ -731,12 +731,12 @@ static bool getHTTPHeaderValue(const h2o_req_t* req, const std::string& headerNa
 static void processForwardedForHeader(const h2o_req_t* req, ComboAddress& remote)
 {
   static const std::string headerName = "x-forwarded-for";
-  string_view value;
+  pdns_string_view value;
 
   if (getHTTPHeaderValue(req, headerName, value)) {
     try {
       auto pos = value.rfind(',');
-      if (pos != string_view::npos) {
+      if (pos != pdns_string_view::npos) {
         ++pos;
         for (; pos < value.size() && value[pos] == ' '; ++pos)
         {

--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -34,7 +34,7 @@ public:
      - EDNS Cookie options, if any ;
      - EDNS Client Subnet options, if any and skipECS is true.
   */
-  static uint32_t hashAfterQname(const string_view& packet, uint32_t currentHash, size_t pos, bool skipECS)
+  static uint32_t hashAfterQname(const pdns_string_view& packet, uint32_t currentHash, size_t pos, bool skipECS)
   {
     const size_t packetSize = packet.size();
     assert(packetSize >= sizeof(dnsheader));

--- a/pdns/views.hh
+++ b/pdns/views.hh
@@ -23,18 +23,18 @@
 #pragma once
 
 #ifdef __cpp_lib_string_view
-using std::string_view;
+using pdns_string_view = std::string_view;
 #else
 #include <boost/version.hpp>
 #if BOOST_VERSION >= 106400
 // string_view already exists in 1.61.0 but string_view::at() is not usable with modern compilers, see:
 // https://github.com/boostorg/utility/pull/26
 #include <boost/utility/string_view.hpp>
-using boost::string_view;
+using pdns_string_view = boost::string_view;
 #elif BOOST_VERSION >= 105300
 #include <boost/utility/string_ref.hpp>
-using string_view = boost::string_ref;
+using pdns_string_view = boost::string_ref;
 #else
-using string_view = std::string;
+using pdns_string_view = std::string;
 #endif
 #endif


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
While we do not actually care about `string_view::at()` in lmdb-safe, we need to keep the two in sync so the type aliases do not collide.
Perhaps we should consider using `pdns_string_view` as an alias (outside of lmdb-safe) instead?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
