### PR TITLE
rec: Detach snmp thread to avoid trouble when trying to quit nicely.

### DIFF
--- a/pdns/snmp-agent.hh
+++ b/pdns/snmp-agent.hh
@@ -24,6 +24,7 @@ public:
   virtual ~SNMPAgent()
   {
 #ifdef HAVE_NET_SNMP
+    
     close(d_trapPipe[0]);
     close(d_trapPipe[1]);
 #endif /* HAVE_NET_SNMP */
@@ -33,6 +34,7 @@ public:
   {
 #ifdef HAVE_NET_SNMP
   d_thread = std::thread(&SNMPAgent::worker, this);
+  d_thread.detach();
 #endif /* HAVE_NET_SNMP */
   }
 


### PR DESCRIPTION
This avoids a case where the thread object and the RecursorSNMPAgent
object get destroyed in the wrong order.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
```#0  thrkill () at /tmp/-:3
#1  0x000008fc7b1a55ee in _libc_abort () at /usr/src/lib/libc/stdlib/abort.c:51
#2  0x000008fc60181b3c in abort_message (format=<optimized out>) at /usr/src/lib/libcxxabi/src/abort_message.cpp:77
#3  0x000008fc60181f5f in demangling_terminate_handler () at /usr/src/lib/libcxxabi/src/cxa_default_handlers.cpp:76
#4  0x000008fc6016153f in std::__terminate (func=0x0) at /usr/src/lib/libcxxabi/src/cxa_handlers.cpp:60
#5  0x000008fc601614a9 in std::terminate () at /usr/src/lib/libcxxabi/src/cxa_handlers.cpp:91
#6  0x000008fc23cbc835 in std::__1::thread::~thread (this=0x0) at /usr/src/lib/libcxx/src/thread.cpp:44
#7  0x000008f9e1d8d0df in std::__1::__shared_count::__release_shared (this=0x8fc34474d00)
    at /usr/include/c++/v1/memory:3544
#8  std::__1::__shared_weak_count::__release_shared (this=0x8fc34474d00) at /usr/include/c++/v1/memory:3586
#9  std::__1::shared_ptr<RecursorSNMPAgent>::~shared_ptr (this=<optimized out>) at /usr/include/c++/v1/memory:4522
#10 0x000008fc7b207de3 in _libc___cxa_finalize (dso=<optimized out>) at /usr/src/lib/libc/stdlib/atexit.c:177
#11 0x000008fc7b1d82c1 in _libc_exit (status=0) at /usr/src/lib/libc/stdlib/exit.c:54
#12 0x000008f9e1ad9588 in ___start ()
#13 0x0000000000000000 in ?? ()
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
