### PR TITLE
Shorter timestamps with fractional seconds if relevant

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -123,7 +123,7 @@ void declareArguments()
   ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";
   ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
   ::arg().set("log-timestamp","Print timestamps in log lines")="yes";
-  ::arg().set("log-timeformat","The strftime(3) format string used to print timestamps")=Logger::s_timeFormat;
+  ::arg().set("log-timestampformat","The strftime(3) format string used to print timestamps")=Logger::s_defaultTimestampFormat;
   ::arg().set("default-soa-name","name to insert in the SOA record if none set in the backend")="a.misconfigured.powerdns.server";
   ::arg().set("default-soa-mail","mail address to insert in the SOA record if none set in the backend")="";
   ::arg().set("distributor-threads","Default number of Distributor (backend) threads to start")="3";

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -123,6 +123,7 @@ void declareArguments()
   ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="4";
   ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
   ::arg().set("log-timestamp","Print timestamps in log lines")="yes";
+  ::arg().set("log-timeformat","The strftime(3) format string used to print timestamps")=Logger::s_timeFormat;
   ::arg().set("default-soa-name","name to insert in the SOA record if none set in the backend")="a.misconfigured.powerdns.server";
   ::arg().set("default-soa-mail","mail address to insert in the SOA record if none set in the backend")="";
   ::arg().set("distributor-threads","Default number of Distributor (backend) threads to start")="3";

--- a/pdns/logger.cc
+++ b/pdns/logger.cc
@@ -34,6 +34,7 @@ extern StatBag S;
 #include "namespaces.hh"
 
 thread_local Logger::PerThread Logger::t_perThread;
+const std::string Logger::s_timeFormat = "%m-%dT%H:%M:%S";
 
 Logger& getLogger()
 {
@@ -56,13 +57,11 @@ void Logger::log(const string &msg, Urgency u) noexcept
   bool mustAccount(false);
 #endif
   if(u<=consoleUrgency) {
-    char buffer[50] = "";
+    char buffer[50];
     if (d_timestamps) {
-      struct tm tm;
-      time_t t;
-      time(&t);
-      localtime_r(&t, &tm);
-      strftime(buffer,sizeof(buffer),"%b %d %H:%M:%S ", &tm);
+      toTimeStrMill(buffer, sizeof(buffer));
+    } else {
+      buffer[0] = '\0';
     }
 
     string prefix;

--- a/pdns/nod.cc
+++ b/pdns/nod.cc
@@ -25,7 +25,6 @@
 #include "pdnsexception.hh"
 #include <iostream>
 #include <iomanip>
-#include <ctime>
 #include <thread>
 #include "threadname.hh"
 #include <unistd.h>

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4183,7 +4183,7 @@ static int serviceMain(int argc, char*argv[])
   g_log.setName(s_programname);
   g_log.disableSyslog(::arg().mustDo("disable-syslog"));
   g_log.setTimestamps(::arg().mustDo("log-timestamp"));
-  g_log.setTimeFormat(::arg()["log-timeformat"]);
+  g_log.setTimestampFormat(::arg()["log-timestampformat"]);
 
   if(!::arg()["logging-facility"].empty()) {
     int val=logFacilityToLOG(::arg().asNum("logging-facility") );
@@ -5013,7 +5013,7 @@ int main(int argc, char **argv)
     ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="6";
     ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
     ::arg().set("log-timestamp","Print timestamps in log lines, useful to disable when running with a tool that timestamps stdout already")="yes";
-    ::arg().set("log-timeformat","The strftime(3) format string used to print timestamps")=Logger::s_timeFormat;
+    ::arg().set("log-timestampformat","The strftime(3) format string used to print timestamps")=Logger::s_defaultTimestampFormat;
     ::arg().set("log-common-errors","If we should log rather common errors")="no";
     ::arg().set("chroot","switch to chroot jail")="";
     ::arg().set("setgid","If set, change group id to this gid for more security"

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4183,6 +4183,7 @@ static int serviceMain(int argc, char*argv[])
   g_log.setName(s_programname);
   g_log.disableSyslog(::arg().mustDo("disable-syslog"));
   g_log.setTimestamps(::arg().mustDo("log-timestamp"));
+  g_log.setTimeFormat(::arg()["log-timeformat"]);
 
   if(!::arg()["logging-facility"].empty()) {
     int val=logFacilityToLOG(::arg().asNum("logging-facility") );
@@ -5012,6 +5013,7 @@ int main(int argc, char **argv)
     ::arg().set("loglevel","Amount of logging. Higher is more. Do not set below 3")="6";
     ::arg().set("disable-syslog","Disable logging to syslog, useful when running inside a supervisor that logs stdout")="no";
     ::arg().set("log-timestamp","Print timestamps in log lines, useful to disable when running with a tool that timestamps stdout already")="yes";
+    ::arg().set("log-timeformat","The strftime(3) format string used to print timestamps")=Logger::s_timeFormat;
     ::arg().set("log-common-errors","If we should log rather common errors")="no";
     ::arg().set("chroot","switch to chroot jail")="";
     ::arg().set("setgid","If set, change group id to this gid for more security"

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -430,7 +430,7 @@ int main(int argc, char **argv)
     g_log.setLoglevel((Logger::Urgency)(::arg().asNum("loglevel")));
     g_log.disableSyslog(::arg().mustDo("disable-syslog"));
     g_log.setTimestamps(::arg().mustDo("log-timestamp"));
-    g_log.setTimeFormat(::arg()["log-timeformat"]);
+    g_log.setTimestampFormat(::arg()["log-timestampformat"]);
     g_log.toConsole((Logger::Urgency)(::arg().asNum("loglevel")));  
 
     if(::arg().mustDo("help") || ::arg().mustDo("config")) {

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -430,6 +430,7 @@ int main(int argc, char **argv)
     g_log.setLoglevel((Logger::Urgency)(::arg().asNum("loglevel")));
     g_log.disableSyslog(::arg().mustDo("disable-syslog"));
     g_log.setTimestamps(::arg().mustDo("log-timestamp"));
+    g_log.setTimeFormat(::arg()["log-timeformat"]);
     g_log.toConsole((Logger::Urgency)(::arg().asNum("loglevel")));  
 
     if(::arg().mustDo("help") || ::arg().mustDo("config")) {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -429,7 +429,7 @@ uint64_t SyncRes::doEDNSDump(int fd)
   fprintf(fp.get(),"; edns from thread follows\n;\n");
   for(const auto& eds : t_sstorage.ednsstatus) {
     count++;
-    fprintf(fp.get(), "%s\t%d\t%s\n", eds.address.toString().c_str(), (int)eds.mode, g_log.toTimeStr(eds.modeSetAt).c_str());
+    fprintf(fp.get(), "%s\t%d\t%s\n", eds.address.toString().c_str(), (int)eds.mode, g_log.toTimestampString(eds.modeSetAt).c_str());
   }
   return count;
 }
@@ -484,7 +484,7 @@ uint64_t SyncRes::doDumpThrottleMap(int fd)
   {
     count++;
     // remote IP, dns name, qtype, count, ttd
-    fprintf(fp.get(), "%s\t%s\t%d\t%u\t%s", i.thing.get<0>().toString().c_str(), i.thing.get<1>().toLogString().c_str(), i.thing.get<2>(), i.count, g_log.toTimeStr(i.ttd).c_str());
+    fprintf(fp.get(), "%s\t%s\t%d\t%u\t%s", i.thing.get<0>().toString().c_str(), i.thing.get<1>().toLogString().c_str(), i.thing.get<2>(), i.count, g_log.toTimestampString(i.ttd).c_str());
   }
 
   return count;
@@ -509,7 +509,7 @@ uint64_t SyncRes::doDumpFailedServers(int fd)
   {
     count++;
     fprintf(fp.get(), "%s\t%lld\t%s", i.address.toString().c_str(),
-            static_cast<long long>(i.value), g_log.toTimeStr(i.last).c_str());
+            static_cast<long long>(i.value), g_log.toTimestampString(i.last).c_str());
   }
 
   return count;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -429,8 +429,7 @@ uint64_t SyncRes::doEDNSDump(int fd)
   fprintf(fp.get(),"; edns from thread follows\n;\n");
   for(const auto& eds : t_sstorage.ednsstatus) {
     count++;
-    char tmp[26];
-    fprintf(fp.get(), "%s\t%d\t%s", eds.address.toString().c_str(), (int)eds.mode, ctime_r(&eds.modeSetAt, tmp));
+    fprintf(fp.get(), "%s\t%d\t%s\n", eds.address.toString().c_str(), (int)eds.mode, g_log.toTimeStr(eds.modeSetAt).c_str());
   }
   return count;
 }
@@ -484,9 +483,8 @@ uint64_t SyncRes::doDumpThrottleMap(int fd)
   for(const auto& i : throttleMap)
   {
     count++;
-    char tmp[26];
     // remote IP, dns name, qtype, count, ttd
-    fprintf(fp.get(), "%s\t%s\t%d\t%u\t%s", i.thing.get<0>().toString().c_str(), i.thing.get<1>().toLogString().c_str(), i.thing.get<2>(), i.count, ctime_r(&i.ttd, tmp));
+    fprintf(fp.get(), "%s\t%s\t%d\t%u\t%s", i.thing.get<0>().toString().c_str(), i.thing.get<1>().toLogString().c_str(), i.thing.get<2>(), i.count, g_log.toTimeStr(i.ttd).c_str());
   }
 
   return count;
@@ -510,10 +508,8 @@ uint64_t SyncRes::doDumpFailedServers(int fd)
   for(const auto& i : t_sstorage.fails.getMap())
   {
     count++;
-    char tmp[26];
-    ctime_r(&i.last, tmp);
     fprintf(fp.get(), "%s\t%lld\t%s", i.address.toString().c_str(),
-            static_cast<long long>(i.value), tmp);
+            static_cast<long long>(i.value), g_log.toTimeStr(i.last).c_str());
   }
 
   return count;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
e.g.:
```
09-22T11:12:46.003 This is a standalone pdns
```
Or by setting `log-timeformat=%H%M%S`:
```
111329.812 This is a standalone pdns
```

ToDo: docs

What's the proper default value: short, backwards compatible or something else?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
