### PR TITLE
rec: Better const-ness when dealing with timestamps

### DIFF
--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -47,7 +47,7 @@
 int asendto(const char *data, size_t len, int flags, const ComboAddress& ip, uint16_t id,
             const DNSName& domain, uint16_t qtype,  int* fd);
 int arecvfrom(std::string& packet, int flags, const ComboAddress& ip, size_t *d_len, uint16_t id,
-              const DNSName& domain, uint16_t qtype, int fd, struct timeval* now);
+              const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now);
 
 class LWResException : public PDNSException
 {

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -440,17 +440,6 @@ string humanDuration(time_t passed)
   return ret.str();
 }
 
-DTime::DTime()
-{
-//  set(); // saves lots of gettimeofday calls
-  d_set.tv_sec=d_set.tv_usec=0;
-}
-
-time_t DTime::time()
-{
-  return d_set.tv_sec;
-}
-
 const string unquotify(const string &item)
 {
   if(item.size()<2)

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -196,8 +196,12 @@ public:
   DTime & operator=(const DTime &dt) = default;
   time_t time();
   inline void set();  //!< Reset the timer
-  inline int udiff(); //!< Return the number of microseconds since the timer was last set.
-  inline int udiffNoReset(); //!< Return the number of microseconds since the timer was last set.
+  inline int udiff(bool reset = true); //!< Return the number of microseconds since the timer was last set.
+
+  int udiffNoReset() //!< Return the number of microseconds since the timer was last set.
+  {
+    return udiff(false);
+  }
   void setTimeval(const struct timeval& tv)
   {
     d_set=tv;
@@ -215,19 +219,17 @@ inline void DTime::set()
   gettimeofday(&d_set,0);
 }
 
-inline int DTime::udiff()
-{
-  int res=udiffNoReset();
-  gettimeofday(&d_set,0);
-  return res;
-}
-
-inline int DTime::udiffNoReset()
+inline int DTime::udiff(bool reset)
 {
   struct timeval now;
-
   gettimeofday(&now,0);
+
   int ret=1000000*(now.tv_sec-d_set.tv_sec)+(now.tv_usec-d_set.tv_usec);
+
+  if (reset) {
+    d_set = now;
+  }
+
   return ret;
 }
 

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -191,10 +191,11 @@ On 32 bits systems this means that 2147 seconds is the longest time that can be 
 class DTime
 {
 public:
-  DTime(); //!< Does not set the timer for you! Saves lots of gettimeofday() calls
+  //!< Does not set the timer for you! Saves lots of gettimeofday() calls
+  DTime() = default;
   DTime(const DTime &dt) = default;
   DTime & operator=(const DTime &dt) = default;
-  time_t time();
+  inline time_t time() const;
   inline void set();  //!< Reset the timer
   inline int udiff(bool reset = true); //!< Return the number of microseconds since the timer was last set.
 
@@ -206,23 +207,28 @@ public:
   {
     d_set=tv;
   }
-  struct timeval getTimeval()
+  struct timeval getTimeval() const
   {
     return d_set;
   }
 private:
-  struct timeval d_set;
+struct timeval d_set{0, 0};
 };
+
+inline time_t DTime::time() const
+{
+  return d_set.tv_sec;
+}
 
 inline void DTime::set()
 {
-  gettimeofday(&d_set,0);
+  gettimeofday(&d_set, nullptr);
 }
 
 inline int DTime::udiff(bool reset)
 {
   struct timeval now;
-  gettimeofday(&now,0);
+  gettimeofday(&now, nullptr);
 
   int ret=1000000*(now.tv_sec-d_set.tv_sec)+(now.tv_usec-d_set.tv_usec);
 

--- a/pdns/mtasker.cc
+++ b/pdns/mtasker.cc
@@ -170,7 +170,7 @@ int main()
     \return returns -1 in case of error, 0 in case of timeout, 1 in case of an answer 
 */
 
-template<class EventKey, class EventVal>int MTasker<EventKey,EventVal>::waitEvent(EventKey &key, EventVal *val, unsigned int timeoutMsec, struct timeval* now)
+template<class EventKey, class EventVal>int MTasker<EventKey,EventVal>::waitEvent(EventKey &key, EventVal *val, unsigned int timeoutMsec, const struct timeval* now)
 {
   if(d_waiters.count(key)) { // there was already an exact same waiter
     return -1;
@@ -301,7 +301,7 @@ template<class Key, class Val>void MTasker<Key,Val>::makeThread(tfunc_t *start, 
     \return Returns if there is more work scheduled and recalling schedule now would be useful
       
 */
-template<class Key, class Val>bool MTasker<Key,Val>::schedule(struct timeval*  now)
+template<class Key, class Val>bool MTasker<Key,Val>::schedule(const struct timeval*  now)
 {
   if(!d_runQueue.empty()) {
     d_tid=d_runQueue.front();

--- a/pdns/mtasker.hh
+++ b/pdns/mtasker.hh
@@ -119,12 +119,12 @@ public:
   }
 
   typedef void tfunc_t(void *); //!< type of the pointer that starts a thread 
-  int waitEvent(EventKey &key, EventVal *val=0, unsigned int timeoutMsec=0, struct timeval* now=0);
+  int waitEvent(EventKey &key, EventVal *val=nullptr, unsigned int timeoutMsec=0, const struct timeval* now=nullptr);
   void yield();
-  int sendEvent(const EventKey& key, const EventVal* val=0);
+  int sendEvent(const EventKey& key, const EventVal* val=nullptr);
   void getEvents(std::vector<EventKey>& events);
   void makeThread(tfunc_t *start, void* val);
-  bool schedule(struct timeval* now=0);
+  bool schedule(const struct timeval* now=nullptr);
   bool noProcesses() const;
   unsigned int numProcesses() const;
   int getTid() const;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -676,7 +676,7 @@ int asendto(const char *data, size_t len, int flags,
 
 // -1 is error, 0 is timeout, 1 is success
 int arecvfrom(std::string& packet, int flags, const ComboAddress& fromaddr, size_t *d_len,
-              uint16_t id, const DNSName& domain, uint16_t qtype, int fd, struct timeval* now)
+              uint16_t id, const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now)
 {
   static optional<unsigned int> nearMissLimit;
   if(!nearMissLimit)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR should have no functional impact, it just makes reviewing the code easier. It also saves a `gettimeofday()` call in `DTime::udiff()` which should not have any meaningful impact either.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
