### PR TITLE
auth: make sure the metadata cache is not filled from within an api transaction

### DIFF
--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -192,7 +192,7 @@ public:
   static void clearCaches(const DNSName& name);
 
   bool doesDNSSEC();
-  bool isSecuredZone(const DNSName& zone);
+  bool isSecuredZone(const DNSName& zone, bool useCache=true);
   keyset_t getEntryPoints(const DNSName& zname);
   keyset_t getKeys(const DNSName& zone, bool useCache = true);
   DNSSECPrivateKey getKeyById(const DNSName& zone, unsigned int id);
@@ -205,12 +205,12 @@ public:
   bool unpublishKey(const DNSName& zname, unsigned int id);
   bool checkKeys(const DNSName& zname, vector<string>* errorMessages = nullptr);
 
-  bool getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* n3p=0, bool* narrow=0);
+  bool getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* n3p=0, bool* narrow=0, bool useCache=true);
   bool checkNSEC3PARAM(const NSEC3PARAMRecordContent& ns3p, string& msg);
   bool setNSEC3PARAM(const DNSName& zname, const NSEC3PARAMRecordContent& n3p, const bool& narrow=false);
   bool unsetNSEC3PARAM(const DNSName& zname);
   bool getPreRRSIGs(UeberBackend& db, const DNSName& signer, const DNSName& qname, const DNSName& wildcardname, const QType& qtype, DNSResourceRecord::Place, vector<DNSZoneRecord>& rrsigs, uint32_t signTTL);
-  bool isPresigned(const DNSName& zname);
+  bool isPresigned(const DNSName& zname, bool useCache=true);
   bool setPresigned(const DNSName& zname);
   bool unsetPresigned(const DNSName& zname);
   bool setPublishCDNSKEY(const DNSName& zname);
@@ -235,7 +235,7 @@ public:
   
   void getFromMetaOrDefault(const DNSName& zname, const std::string& key, std::string& value, const std::string& defaultvalue);
   bool getFromMeta(const DNSName& zname, const std::string& key, std::string& value);
-  void getSoaEdit(const DNSName& zname, std::string& value);
+  void getSoaEdit(const DNSName& zname, std::string& value, bool useCache=true);
   bool unSecureZone(const DNSName& zone, std::string& error, std::string& info);
   bool rectifyZone(const DNSName& zone, std::string& error, std::string& info, bool doTransaction);
 
@@ -243,6 +243,8 @@ public:
 
   typedef std::map<std::string, std::vector<std::string> > METAValues;
 private:
+  bool getFromMetaNoCache(const DNSName& name, const std::string& kind, std::string& value);
+
   int64_t d_metaCacheCleanAction{0};
 
   struct KeyCacheEntry


### PR DESCRIPTION
### Short description
And use rectify for full zone rectifies in the rfc2136 code

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
