### PR TITLE
Always check sscanf's return value

### DIFF
--- a/ext/yahttp/yahttp/reqresp.cpp
+++ b/ext/yahttp/yahttp/reqresp.cpp
@@ -173,7 +173,9 @@ namespace YaHTTP {
           buffer.copy(buf, pos);
           buf[pos]=0; // just in case...
           buffer.erase(buffer.begin(), buffer.begin()+pos+1); // remove line from buffer
-          sscanf(buf, "%x", &chunk_size);
+          if (sscanf(buf, "%x", &chunk_size) != 1) {
+            throw ParseError("Unable to parse chunk size");
+          }
           if (chunk_size == 0) { state = 3; break; } // last chunk
         } else {
           int crlf=1;

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1107,7 +1107,9 @@ string getMACAddress(const ComboAddress& ca)
       if(parts.size() < 4)
         return ret;
       unsigned int tmp[6];
-      sscanf(parts[3].c_str(), "%02x:%02x:%02x:%02x:%02x:%02x", tmp, tmp+1, tmp+2, tmp+3, tmp+4, tmp+5);
+      if (sscanf(parts[3].c_str(), "%02x:%02x:%02x:%02x:%02x:%02x", tmp, tmp+1, tmp+2, tmp+3, tmp+4, tmp+5) != 6) {
+        return ret;
+      }
       for(int i = 0 ; i< 6 ; ++i)
         ret.append(1, (char)tmp[i]);
       return ret;

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -95,9 +95,11 @@ void RecordTextReader::xfrTime(uint32_t &val)
 
   tmp<<itmp;
 
-  sscanf(tmp.str().c_str(), "%04d%02d%02d" "%02d%02d%02d", 
-         &tm.tm_year, &tm.tm_mon, &tm.tm_mday, 
-         &tm.tm_hour, &tm.tm_min, &tm.tm_sec);
+  if (sscanf(tmp.str().c_str(), "%04d%02d%02d" "%02d%02d%02d",
+             &tm.tm_year, &tm.tm_mon, &tm.tm_mday,
+             &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 6) {
+    throw RecordTextException("unable to parse '"+std::to_string(itmp)+"' into a valid time at position "+std::to_string(d_pos)+" in '"+d_string+"'");
+  }
 
   tm.tm_year-=1900;
   tm.tm_mon-=1;

--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -61,38 +61,97 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
   if(!p)
     p = ".";
   pathbuf << p << "/../regression-tests/zones/unit2.test";
-  ZoneParserTNG zp(pathbuf.str(), DNSName("unit2.test"));
 
-  vector<string> expected = {
-    "0.01.0003.000005.00000007.unit2.test.",
-    "1.02.0004.000006.00000008.unit2.test.",
-    "2.03.0005.000007.00000009.unit2.test.",
-    "3.04.0006.000008.0000000a.unit2.test.",
-    "4.05.0007.000009.0000000b.unit2.test.",
-    "5.06.0008.00000A.0000000c.unit2.test.",
-    "6.07.0009.00000B.0000000d.unit2.test.",
-    "7.10.0010.00000C.0000000e.unit2.test.",
-    "8.11.0011.00000D.0000000f.unit2.test.",
-    "9.12.0012.00000E.00000010.unit2.test.",
-    "10.13.0013.00000F.00000011.unit2.test.",
-    "11.14.0014.000010.00000012.unit2.test.",
-    "12.15.0015.000011.00000013.unit2.test.",
-    "13.16.0016.000012.00000014.unit2.test.",
-    "14.17.0017.000013.00000015.unit2.test.",
-    "15.20.0018.000014.00000016.unit2.test.",
-    "16.21.0019.000015.00000017.unit2.test."
-  };
+  {
+    /* simple case */
+    ZoneParserTNG zp(pathbuf.str(), DNSName("unit2.test"));
 
-  for (auto const & exp : expected) {
-    DNSResourceRecord rr;
-    zp.get(rr);
-    BOOST_CHECK_EQUAL(rr.qname.toString(), exp);
-    BOOST_CHECK_EQUAL(rr.ttl, 86400U);
-    BOOST_CHECK_EQUAL(rr.qclass, 1U);
-    BOOST_CHECK_EQUAL(rr.qtype.getName(), "A");
-    BOOST_CHECK_EQUAL(rr.content, "1.2.3.4");
+    const vector<string> expected = {
+      "0.01.0003.000005.00000007.unit2.test.",
+      "1.02.0004.000006.00000008.unit2.test.",
+      "2.03.0005.000007.00000009.unit2.test.",
+      "3.04.0006.000008.0000000a.unit2.test.",
+      "4.05.0007.000009.0000000b.unit2.test.",
+      "5.06.0008.00000A.0000000c.unit2.test.",
+      "6.07.0009.00000B.0000000d.unit2.test.",
+      "7.10.0010.00000C.0000000e.unit2.test.",
+      "8.11.0011.00000D.0000000f.unit2.test.",
+      "9.12.0012.00000E.00000010.unit2.test.",
+      "10.13.0013.00000F.00000011.unit2.test.",
+      "11.14.0014.000010.00000012.unit2.test.",
+      "12.15.0015.000011.00000013.unit2.test.",
+      "13.16.0016.000012.00000014.unit2.test.",
+      "14.17.0017.000013.00000015.unit2.test.",
+      "15.20.0018.000014.00000016.unit2.test.",
+      "16.21.0019.000015.00000017.unit2.test."
+    };
+
+    for (auto const & exp : expected) {
+      DNSResourceRecord rr;
+      zp.get(rr);
+      BOOST_CHECK_EQUAL(rr.qname.toString(), exp);
+      BOOST_CHECK_EQUAL(rr.ttl, 86400U);
+      BOOST_CHECK_EQUAL(rr.qclass, 1U);
+      BOOST_CHECK_EQUAL(rr.qtype.getName(), "A");
+      BOOST_CHECK_EQUAL(rr.content, "1.2.3.4");
+    }
   }
 
+  {
+    /* GENERATE with a step of 2, and the template radix defaulting to 'd' */
+    ZoneParserTNG zp(std::vector<std::string>({"$GENERATE 0-4/2 $.${1,2,o}.${3,4}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("unit2.test"));
+
+    const vector<string> expected = {
+      "0.01.0003.000005.00000007.unit2.test.",
+      "2.03.0005.000007.00000009.unit2.test.",
+      "4.05.0007.000009.0000000b.unit2.test.",
+    };
+
+    for (auto const & exp : expected) {
+      DNSResourceRecord rr;
+      zp.get(rr);
+      BOOST_CHECK_EQUAL(rr.qname.toString(), exp);
+      BOOST_CHECK_EQUAL(rr.ttl, 86400U);
+      BOOST_CHECK_EQUAL(rr.qclass, 1U);
+      BOOST_CHECK_EQUAL(rr.qtype.getName(), "A");
+      BOOST_CHECK_EQUAL(rr.content, "1.2.3.4");
+    }
+  }
+
+  {
+    /* test invalid generate parameters: stop greater than start */
+    ZoneParserTNG zp(std::vector<std::string>({"$GENERATE 5-4 $.${1,2,o}.${3,4,d}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("test"));
+    DNSResourceRecord rr;
+    BOOST_CHECK_THROW(zp.get(rr), std::exception);
+  }
+
+  {
+    /* test invalid generate parameters: no stop */
+    ZoneParserTNG zp(std::vector<std::string>({"$GENERATE 5 $.${1,2,o}.${3,4,d}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("test"));
+    DNSResourceRecord rr;
+    BOOST_CHECK_THROW(zp.get(rr), std::exception);
+  }
+
+  {
+    /* test invalid generate parameters: invalid step */
+    ZoneParserTNG zp(std::vector<std::string>({"$GENERATE 0-4/0 $.${1,2,o}.${3,4,d}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("test"));
+    DNSResourceRecord rr;
+    BOOST_CHECK_THROW(zp.get(rr), std::exception);
+  }
+
+  {
+    /* test invalid generate parameters: no offset */
+    ZoneParserTNG zp(std::vector<std::string>({"$GENERATE 0-4/1 $.${}.${3,4,d}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("test"));
+    DNSResourceRecord rr;
+    BOOST_CHECK_THROW(zp.get(rr), PDNSException);
+  }
+
+  {
+    /* test invalid generate parameters: invalid offset */
+    ZoneParserTNG zp(std::vector<std::string>({"$GENERATE 0-4/1 $.${a,2,o}.${3,4,d}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("test"));
+    DNSResourceRecord rr;
+    BOOST_CHECK_THROW(zp.get(rr), PDNSException);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
These remaining cases are not in any way a security issue since the variables are initialized before the call. This mostly improves the reporting, and make sure we fail earlier.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
