### PR TITLE
auth: bindbackend: 'rediscover' changes to master and also-notifies

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -934,6 +934,7 @@ void Bind2Backend::loadConfig(string* status)
         // overwrite what we knew about the domain
         bbd.d_name=i->name;
         bool filenameChanged = (bbd.d_filename!=i->filename);
+        bool addressesChanged = (bbd.d_masters!=i->masters || bbd.d_also_notify!=i->alsoNotify);
         bbd.d_filename=i->filename;
         bbd.d_masters=i->masters;
         bbd.d_also_notify=i->alsoNotify;
@@ -986,8 +987,9 @@ void Bind2Backend::loadConfig(string* status)
             g_log<<Logger::Warning<<d_logprefix<<msg.str()<<endl;
             rejected++;
           }
-	  safePutBBDomainInfo(bbd);
-	  
+          safePutBBDomainInfo(bbd);
+        } else if(addressesChanged) {
+          safePutBBDomainInfo(bbd);
         }
       }
     vector<DNSName> diff;


### PR DESCRIPTION
### Short description
Makes `rediscover` detect changes to `masters` and/or `also-notify` in named.conf. Without this a restart is required for a new master to be used.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
