### PR TITLE
rec: Backport 9495 to rec 4.4.x: Watch the descriptor again after an out-of-order read timeout 

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1918,7 +1918,7 @@ static void startDoResolve(void *p)
               t_fdm->setReadTTD(dc->d_socket, ttd, g_tcpTimeout);
             }
             catch (const FDMultiplexerException &) {
-              // but the FD was removed because of a timeout while we were sending a response,
+              // but if the FD was removed because of a timeout while we were sending a response,
               // we need to re-arm it. If it was an error it will error again.
               ttd.tv_sec += g_tcpTimeout;
               t_fdm->addReadFD(dc->d_socket, handleRunningTCPQuestion, dc->d_tcpConnection, &ttd);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #9495 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
