### PR TITLE
dnsdist-1.5.x: Add the 'clearConsoleHistory' command

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -187,7 +187,6 @@ void doClient(ComboAddress server, const std::string& command)
   }
 
   string histfile = historyFile();
-  set<string> dupper;
   {
     ifstream history(histfile);
     string line;
@@ -230,7 +229,6 @@ void doClient(ComboAddress server, const std::string& command)
 void doConsole()
 {
   string histfile = historyFile(true);
-  set<string> dupper;
   {
     ifstream history(histfile);
     string line;
@@ -362,10 +360,11 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "AndRule", true, "list of DNS rules", "matches if all sub-rules matches" },
   { "benchRule", true, "DNS Rule [, iterations [, suffix]]", "bench the specified DNS rule" },
   { "carbonServer", true, "serverIP, [ourname], [interval]", "report statistics to serverIP using our hostname, or 'ourname' if provided, every 'interval' seconds" },
-  { "controlSocket", true, "addr", "open a control socket on this address / connect to this address in client mode" },
+  { "clearConsoleHistory", true, "", "clear the internal (in-memory) history of console commands" },
   { "clearDynBlocks", true, "", "clear all dynamic blocks" },
   { "clearQueryCounters", true, "", "clears the query counter buffer" },
   { "clearRules", true, "", "remove all current rules" },
+  { "controlSocket", true, "addr", "open a control socket on this address / connect to this address in client mode" },
   { "ContinueAction", true, "action", "execute the specified action and continue the processing of the remaining rules, regardless of the return of the action" },
   { "DelayAction", true, "milliseconds", "delay the response by the specified amount of milliseconds (UDP-only)" },
   { "DelayResponseAction", true, "milliseconds", "delay the response by the specified amount of milliseconds (UDP-only)" },
@@ -821,4 +820,10 @@ catch(const std::exception& e)
 {
   close(fd);
   errlog("Control connection died: %s", e.what());
+}
+
+void clearConsoleHistory()
+{
+  clear_history();
+  g_confDelta.clear();
 }

--- a/pdns/dnsdist-console.hh
+++ b/pdns/dnsdist-console.hh
@@ -51,3 +51,4 @@ extern "C" {
 char** my_completion( const char * text , int start,  int end);
 }
 void controlThread(int fd, ComboAddress local);
+void clearConsoleHistory();

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1004,6 +1004,10 @@ static void setupLuaConfig(bool client, bool configCheck)
 	g_consoleKey=newkey;
     });
 
+  g_lua.writeFunction("clearConsoleHistory", []() {
+      clearConsoleHistory();
+    });
+
   g_lua.writeFunction("testCrypto", [](boost::optional<string> optTestMsg)
    {
      setLuaNoSideEffect();

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -232,6 +232,14 @@ Control Socket, Console and Webserver
 
   :param str netmask: A CIDR netmask, e.g. ``"192.0.2.0/24"``. Without a subnetmask, only the specific address is allowed.
 
+.. function:: clearConsoleHistory()
+
+  .. versionadded:: 1.6.0
+
+  Clear the internal (in-memory) buffers of console commands. These buffers are used to provide the :func:`delta` command and
+  console completion and history, and can end up being quite large when a lot of commands are issued via the console, consuming
+  a noticeable amount of memory.
+
 .. function:: controlSocket(address)
 
   Bind to ``addr`` and listen for a connection for the console. Since 1.3.0 only connections from local users are allowed
@@ -240,6 +248,10 @@ Control Socket, Console and Webserver
   local connections, since not enabling it allows any local user to connect to the console.
 
   :param str address: An IP address with optional port. By default, the port is 5199.
+
+.. function:: delta()
+
+  Issuing `delta` on the console will print the changes to the configuration that have been made since startup.
 
 .. function:: inClientStartup()
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #9379 to dnsdist-1.5.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
