### PR TITLE
dnsdist-1.5.x: Fix getEDNSOptions() for {AN,NS}COUNT != 0 and ARCOUNT = 0

### DIFF
--- a/pdns/dnsdist-ecs.cc
+++ b/pdns/dnsdist-ecs.cc
@@ -503,7 +503,12 @@ bool parseEDNSOptions(DNSQuestion& dq)
 
   dq.ednsOptions = std::make_shared<std::map<uint16_t, EDNSOptionView> >();
 
-  if (ntohs(dq.dh->ancount) != 0 || ntohs(dq.dh->nscount) != 0 || (ntohs(dq.dh->arcount) != 0 && ntohs(dq.dh->arcount) != 1)) {
+  if (ntohs(dq.dh->arcount) == 0) {
+    /* nothing in additional so no EDNS */
+    return false;
+  }
+
+  if (ntohs(dq.dh->ancount) != 0 || ntohs(dq.dh->nscount) != 0 || ntohs(dq.dh->arcount) > 1) {
     return slowParseEDNSOptions(reinterpret_cast<const char*>(dq.dh), dq.len, dq.ednsOptions);
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #9513 to dnsdist-1.5.x.

Since 1.5.0, calling `getEDNSOptions()` from Lua would result in a `ServFail` for queries that had no records in additional but at least one record in either the answer or authority section, such as a `NOTIFY`, because of a bug in `parseEDNSOptions()`. That last function incorrectly called `slowParseEDNSOptions()` in that case, triggering an exception to be raised because `slowParseEDNSOptions()` does not expect to be called for a packet with no record in the additional section.
`parseEDNSOptions()` now returns `false` for packets that have no record in the additional section.

(cherry picked from commit 38af359d79bccc500deaa598957a1b0d1ce11fd4)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
