### PR TITLE
svb-records: Initialize d_port

### DIFF
--- a/pdns/svc-records.hh
+++ b/pdns/svc-records.hh
@@ -92,7 +92,7 @@ class SvcParam {
     std::set<SvcParamKey> d_mandatory; // For mandatory
     std::vector<ComboAddress> d_ipHints; // For ipv{6,4}hints
     std::string d_echconfig; // For echconfig
-    uint16_t d_port; // For port
+    uint16_t d_port{0}; // For port
 
     static const std::map<std::string, SvcParamKey> SvcParams;
 };


### PR DESCRIPTION
### Short description
Should fix 6 coverity warnings.

Warnings were all:

```
________________________________________________________________________________________________________
*** CID 362685:  Uninitialized members  (UNINIT_CTOR)
/svc-records.cc: 66 in SvcParam::SvcParam(const SvcParam::SvcParamKey &)()
60     
61     SvcParam::SvcParam(const SvcParamKey &key) {
62       d_key = key;
63       if (d_key != SvcParamKey::no_default_alpn) {
64         throw std::invalid_argument("can not create non-empty SvcParam for key '" + keyToString(key) + "'");
65       }
>>>     CID 362685:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "d_port" is not initialized in this constructor nor in any functions that it calls.
66     }
67     
68     SvcParam::SvcParam(const SvcParamKey &key, const std::string &value) {
69       d_key = key;
70       if (d_key != SvcParamKey::echconfig && d_key < 7) {
71         throw std::invalid_argument("can not create SvcParam for " + keyToString(key) + " with a string value");
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)