### PR TITLE
pdns_control: add show <prefix>

### DIFF
--- a/docs/manpages/pdns_control.1.rst
+++ b/docs/manpages/pdns_control.1.rst
@@ -77,7 +77,7 @@ when the server is running in guardian mode.
 list
 ^^^^
 
-Dump all variables and their values in a comma separated list,
+Dump all statistics and their values in a comma separated list,
 equivalent to ``show *``.
 
 list-zones [master,slave,native]
@@ -160,11 +160,17 @@ set *VARIABLE* *VALUE*
 Set the configuration parameter *VARIABLE* to *VALUE*. Currently
 only the query-logging can be set.
 
-show *VARIABLE*
-^^^^^^^^^^^^^^^
+show *STATISTIC*
+^^^^^^^^^^^^^^^^
 
 Show a single statistic, as present in the output of the list
 command.
+
+show *STATISTIC-PREFIX*\*
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Show all statistics which names start with the supplied *STATISTIC-PREFIX*,
+as a comma-separated list. Only one (ending) wildcard is allowed.
 
 status
 ^^^^^^

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -96,6 +96,8 @@ string DLShowHandler(const vector<string>&parts, Utility::pid_t ppid) {
     if (parts.size() == 2) {
       if (parts[1] == "*")
         ret = S.directory();
+      else if (parts[1].length() && parts[1][parts[1].length() - 1 ] == '*')
+        ret = S.directory(parts[1].substr(0, parts[1].length() - 1));
       else
         ret = S.getValueStr(parts[1]);
     }

--- a/pdns/statbag.cc
+++ b/pdns/statbag.cc
@@ -49,27 +49,30 @@ void StatBag::exists(const string &key)
     }
 }
 
-string StatBag::directory()
+string StatBag::directory(const string &prefix)
 {
   string dir;
   ostringstream o;
 
-  for(const auto& i: d_stats) {
-    if (d_blacklist.find(i.first) != d_blacklist.end())
+  for(const auto& val : d_stats) {
+    if (d_blacklist.find(val.first) != d_blacklist.end())
       continue;
-    o<<i.first<<"="<<*(i.second)<<",";
+    if (val.first.find(prefix) != 0)
+      continue;
+    o << val.first<<"="<<*(val.second)<<",";
   }
 
 
   for(const funcstats_t::value_type& val :  d_funcstats) {
     if (d_blacklist.find(val.first) != d_blacklist.end())
       continue;
+    if (val.first.find(prefix) != 0)
+      continue;
     o << val.first<<"="<<val.second(val.first)<<",";
   }
   dir=o.str();
   return dir;
 }
-
 
 vector<string>StatBag::getEntries()
 {

--- a/pdns/statbag.hh
+++ b/pdns/statbag.hh
@@ -134,7 +134,7 @@ public:
   uint64_t getRingSize(const string &name);
   uint64_t getRingEntriesCount(const string &name);
 
-  string directory(); //!< Returns a list of all data stored
+  string directory(const string &prefix = ""); //!< Returns a list of all data stored. If prefix is given, only stats named with this prefix are returned.
   vector<string> getEntries(); //!< returns a vector with datums (items)
   string getDescrip(const string &item); //!< Returns the description of this datum/item
   StatType getStatType(const string &item); //!< Returns the stats type for the metrics endpoint


### PR DESCRIPTION
### Short description
Adds a variant of the "SHOW" command, listing only statistics with a given prefix.

Example:
```
$ ../pdns/pdns_control show 'domain-cache*'
domain-cache-hit=0,domain-cache-miss=0,domain-cache-size=7,
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
