### PR TITLE
dnsdist-1.5.x: Only add EDNS on negative answers if the query had EDNS

### DIFF
--- a/pdns/dnsdist-ecs.cc
+++ b/pdns/dnsdist-ecs.cc
@@ -945,7 +945,7 @@ bool setNegativeAndAdditionalSOA(DNSQuestion& dq, bool nxd, const DNSName& zone,
 
   dq.dh->arcount = htons(1);
 
-  if (g_addEDNSToSelfGeneratedResponses) {
+  if (hadEDNS) {
     /* now we need to add a new OPT record */
     return addEDNS(dq.dh, dq.len, dq.size, dnssecOK, g_PayloadSizeSelfGenAnswers, dq.ednsRCode);
   }

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -1922,12 +1922,19 @@ BOOST_AUTO_TEST_CASE(test_setNegativeAndAdditionalSOA) {
   DNSName name("www.powerdns.com.");
 
   vector<uint8_t> query;
+  vector<uint8_t> queryWithEDNS;
   DNSPacketWriter pw(query, name, QType::A, QClass::IN, 0);
   pw.getHeader()->rd = 1;
   const uint16_t len = query.size();
+  DNSPacketWriter pwEDNS(queryWithEDNS, name, QType::A, QClass::IN, 0);
+  pwEDNS.getHeader()->rd = 1;
+  pwEDNS.addOpt(1232, 0, 0);
+  pwEDNS.commit();
+  const uint16_t ednsLen = queryWithEDNS.size();
 
   /* test NXD */
   {
+    /* no incoming EDNS */
     char packet[1500];
     memcpy(packet, query.data(), query.size());
 
@@ -1946,6 +1953,32 @@ BOOST_AUTO_TEST_CASE(test_setNegativeAndAdditionalSOA) {
     BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
     BOOST_CHECK_EQUAL(mdp.d_header.ancount, 0U);
     BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
+    BOOST_CHECK_EQUAL(mdp.d_header.arcount, 1U);
+    BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 1U);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_type, static_cast<uint16_t>(QType::SOA));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_class, QClass::IN);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_name, DNSName("zone."));
+  }
+  {
+    /* now with incoming EDNS */
+    char packet[1500];
+    memcpy(packet, queryWithEDNS.data(), queryWithEDNS.size());
+
+    unsigned int consumed = 0;
+    uint16_t qtype;
+    DNSName qname(packet, ednsLen, sizeof(dnsheader), false, &qtype, nullptr, &consumed);
+    auto dh = reinterpret_cast<dnsheader*>(packet);
+    DNSQuestion dq(&qname, qtype, QClass::IN, qname.wirelength(), &remote, &remote, dh, sizeof(packet), queryWithEDNS.size(), false, &queryTime);
+
+    BOOST_CHECK(setNegativeAndAdditionalSOA(dq, true, DNSName("zone."), 42, DNSName("mname."), DNSName("rname."), 1, 2, 3, 4 , 5));
+    BOOST_CHECK(static_cast<size_t>(dq.len) > queryWithEDNS.size());
+    MOADNSParser mdp(true, packet, dq.len);
+
+    BOOST_CHECK_EQUAL(mdp.d_qname.toString(), "www.powerdns.com.");
+    BOOST_CHECK_EQUAL(mdp.d_header.rcode, RCode::NXDomain);
+    BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.ancount, 0U);
+    BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
     BOOST_CHECK_EQUAL(mdp.d_header.arcount, 2U);
     BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 2U);
     BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_type, static_cast<uint16_t>(QType::SOA));
@@ -1957,6 +1990,7 @@ BOOST_AUTO_TEST_CASE(test_setNegativeAndAdditionalSOA) {
 
   /* test No Data */
   {
+    /* no incoming EDNS */
     char packet[1500];
     memcpy(packet, query.data(), query.size());
 
@@ -1968,6 +2002,32 @@ BOOST_AUTO_TEST_CASE(test_setNegativeAndAdditionalSOA) {
 
     BOOST_CHECK(setNegativeAndAdditionalSOA(dq, false, DNSName("zone."), 42, DNSName("mname."), DNSName("rname."), 1, 2, 3, 4 , 5));
     BOOST_CHECK(static_cast<size_t>(dq.len) > query.size());
+    MOADNSParser mdp(true, packet, dq.len);
+
+    BOOST_CHECK_EQUAL(mdp.d_qname.toString(), "www.powerdns.com.");
+    BOOST_CHECK_EQUAL(mdp.d_header.rcode, RCode::NoError);
+    BOOST_CHECK_EQUAL(mdp.d_header.qdcount, 1U);
+    BOOST_CHECK_EQUAL(mdp.d_header.ancount, 0U);
+    BOOST_CHECK_EQUAL(mdp.d_header.nscount, 0U);
+    BOOST_CHECK_EQUAL(mdp.d_header.arcount, 1U);
+    BOOST_REQUIRE_EQUAL(mdp.d_answers.size(), 1U);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_type, static_cast<uint16_t>(QType::SOA));
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_class, QClass::IN);
+    BOOST_CHECK_EQUAL(mdp.d_answers.at(0).first.d_name, DNSName("zone."));
+  }
+  {
+    /* now with incoming EDNS */
+    char packet[1500];
+    memcpy(packet, queryWithEDNS.data(), queryWithEDNS.size());
+
+    unsigned int consumed = 0;
+    uint16_t qtype;
+    DNSName qname(packet, ednsLen, sizeof(dnsheader), false, &qtype, nullptr, &consumed);
+    auto dh = reinterpret_cast<dnsheader*>(packet);
+    DNSQuestion dq(&qname, qtype, QClass::IN, qname.wirelength(), &remote, &remote, dh, sizeof(packet), queryWithEDNS.size(), false, &queryTime);
+
+    BOOST_CHECK(setNegativeAndAdditionalSOA(dq, false, DNSName("zone."), 42, DNSName("mname."), DNSName("rname."), 1, 2, 3, 4 , 5));
+    BOOST_CHECK(static_cast<size_t>(dq.len) > queryWithEDNS.size());
     MOADNSParser mdp(true, packet, dq.len);
 
     BOOST_CHECK_EQUAL(mdp.d_qname.toString(), "www.powerdns.com.");

--- a/regression-tests.dnsdist/clientsubnetoption.py
+++ b/regression-tests.dnsdist/clientsubnetoption.py
@@ -35,6 +35,7 @@ Requirements:
 from __future__ import print_function
 from __future__ import division
 
+import math
 import socket
 import struct
 import dns
@@ -125,7 +126,7 @@ class ClientSubnetOption(dns.edns.Option):
         """" Determines whether this instance is using the draft option code """
         return self.option == DRAFT_OPTION_CODE
 
-    def to_wire(self, file):
+    def to_wire(self, file=None):
         """Create EDNS packet as defined in draft-vandergaast-edns-client-subnet-01."""
 
         ip = self.calculate_ip()
@@ -142,7 +143,10 @@ class ClientSubnetOption(dns.edns.Option):
 
         format = "!HBB%ds" % (mask_bits // 8)
         data = struct.pack(format, self.family, self.mask, self.scope, test)
-        file.write(data)
+        if file:
+            file.write(data)
+        else:
+            return data
 
     def from_wire(cls, otype, wire, current, olen):
         """Read EDNS packet as defined in draft-vandergaast-edns-client-subnet-01.
@@ -172,6 +176,23 @@ class ClientSubnetOption(dns.edns.Option):
         return cls(ip, mask, scope, otype)
 
     from_wire = classmethod(from_wire)
+
+    # needed in 2.0.0..
+    @classmethod
+    def from_wire_parser(cls, otype, parser):
+        family, src, scope = parser.get_struct('!HBB')
+        addrlen = int(math.ceil(src / 8.0))
+        prefix = parser.get_bytes(addrlen)
+        if family == 1:
+            pad = 4 - addrlen
+            addr = dns.ipv4.inet_ntoa(prefix + b'\x00' * pad)
+        elif family == 2:
+            pad = 16 - addrlen
+            addr = dns.ipv6.inet_ntoa(prefix + b'\x00' * pad)
+        else:
+            raise ValueError('unsupported family')
+
+        return cls(addr, src, scope, otype)
 
     def __repr__(self):
         if self.family == FAMILY_IPV4:

--- a/regression-tests.dnsdist/cookiesoption.py
+++ b/regression-tests.dnsdist/cookiesoption.py
@@ -22,12 +22,18 @@ class CookiesOption(dns.edns.Option):
         self.client = client
         self.server = server
 
-    def to_wire(self, file):
+    def to_wire(self, file=None):
         """Create EDNS packet as defined in draft-ietf-dnsop-cookies-09."""
 
-        file.write(self.client)
         if self.server and len(self.server) > 0:
-            file.write(self.server)
+            data = self.client + self.server
+        else:
+            data = self.client
+
+        if file:
+            file.write(data)
+        else:
+            return data
 
     def from_wire(cls, otype, wire, current, olen):
         """Read EDNS packet as defined in draft-ietf-dnsop-cookies-09.
@@ -49,6 +55,22 @@ class CookiesOption(dns.edns.Option):
         return cls(client, server)
 
     from_wire = classmethod(from_wire)
+
+    # needed in 2.0.0
+    @classmethod
+    def from_wire_parser(cls, otype, parser):
+        data = parser.get_remaining()
+
+        if len(data) != 8 and (len(data) < 16 or len(data) > 40):
+            raise Exception('Invalid EDNS Cookies option')
+
+        client = data[:8]
+        if len(data) > 8:
+            server = data[8:]
+        else:
+            server = None
+
+        return cls(client, server)
 
     def __repr__(self):
         return '%s(%s, %s)' % (
@@ -74,4 +96,3 @@ class CookiesOption(dns.edns.Option):
 
 
 dns.edns._type_to_class[0x000A] = CookiesOption
-

--- a/regression-tests.dnsdist/test_Basics.py
+++ b/regression-tests.dnsdist/test_Basics.py
@@ -161,10 +161,9 @@ class TestBasics(DNSDistTest):
         """
         name = 'atruncatetc.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, want_dnssec=True)
-        response = dns.message.make_response(query)
         # force a different responder payload than the one in the query,
         # so we check that we don't just mirror it
-        response.payload = 4242
+        response = dns.message.make_response(query, our_payload=4242)
         rrset = dns.rrset.from_text(name,
                                     3600,
                                     dns.rdataclass.IN,
@@ -173,8 +172,7 @@ class TestBasics(DNSDistTest):
 
         response.answer.append(rrset)
         response.flags |= dns.flags.TC
-        expectedResponse = dns.message.make_response(query)
-        expectedResponse.payload = 4242
+        expectedResponse = dns.message.make_response(query, our_payload=4242)
         expectedResponse.flags |= dns.flags.TC
 
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)

--- a/regression-tests.dnsdist/test_RecordsCount.py
+++ b/regression-tests.dnsdist/test_RecordsCount.py
@@ -71,6 +71,12 @@ class TestRecordsCountOnlyOneAR(DNSDistTest):
                                                     '127.0.0.1'))
         expectedResponse = dns.message.make_response(query)
         expectedResponse.set_rcode(dns.rcode.REFUSED)
+        # this is not great, we should fix that!
+        expectedResponse.additional.append(dns.rrset.from_text(name,
+                                                               3600,
+                                                               dns.rdataclass.IN,
+                                                               dns.rdatatype.A,
+                                                               '127.0.0.1'))
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)

--- a/regression-tests.dnsdist/test_XPF.py
+++ b/regression-tests.dnsdist/test_XPF.py
@@ -41,7 +41,7 @@ class XPFTest(DNSDistTest):
         # and finally the ports, zeroed because we have no way to know them beforehand
         xpfData = "\# 14 04117f0000017f00000100000000"
         rdata = dns.rdata.from_text(dns.rdataclass.IN, self._xpfCode, xpfData)
-        rrset = dns.rrset.from_rdata(name, 60, rdata)
+        rrset = dns.rrset.from_rdata(".", 0, rdata)
         expectedQuery.additional.append(rrset)
 
         response = dns.message.make_response(expectedQuery)
@@ -52,7 +52,6 @@ class XPFTest(DNSDistTest):
         receivedQuery.id = expectedQuery.id
         receivedResponse.id = response.id
 
-        self.assertEquals(receivedQuery, expectedQuery)
         self.checkMessageHasXPF(receivedQuery, xpfData)
         self.assertEquals(response, receivedResponse)
 
@@ -61,7 +60,7 @@ class XPFTest(DNSDistTest):
         # and finally the ports, zeroed because we have no way to know them beforehand
         xpfData = "\# 14 04067f0000017f00000100000000"
         rdata = dns.rdata.from_text(dns.rdataclass.IN, self._xpfCode, xpfData)
-        rrset = dns.rrset.from_rdata(name, 60, rdata)
+        rrset = dns.rrset.from_rdata(".", 0, rdata)
         expectedQuery.additional.append(rrset)
 
         response = dns.message.make_response(expectedQuery)
@@ -72,6 +71,5 @@ class XPFTest(DNSDistTest):
         receivedQuery.id = expectedQuery.id
         receivedResponse.id = response.id
 
-        self.assertEquals(receivedQuery, expectedQuery)
         self.checkMessageHasXPF(receivedQuery, xpfData)
         self.assertEquals(response, receivedResponse)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #9553 to dnsdist-1.5.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
