### PR TITLE
rec: fix double "Configuration endpoint" in docs

### DIFF
--- a/pdns/recursordist/docs/http-api/endpoint-servers-config.rst
+++ b/pdns/recursordist/docs/http-api/endpoint-servers-config.rst
@@ -1,6 +1,3 @@
-Configuration endpoint
-======================
-
 .. include:: ../common/api/endpoint-servers-config.rst
 
 .. http:put:: /api/v1/servers/:server_id/config/:config_setting_name


### PR DESCRIPTION
Due to include structure we have a double "Configuration endpoint" header

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
