### PR TITLE
rec: Switch off IPv4 for test_glueless_referral_loop test to make sure there's only one IP per nameserver

### DIFF
--- a/pdns/recursordist/test-syncres_cc2.cc
+++ b/pdns/recursordist/test-syncres_cc2.cc
@@ -101,6 +101,12 @@ BOOST_AUTO_TEST_CASE(test_glueless_referral_loop)
   std::unique_ptr<SyncRes> sr;
   initSR(sr);
 
+  // We only do v4, this avoids "beenthere" non-deterministic behavour. If we do both v4 and v6, there are multiple IPs
+  // per (root) nameserver, and the "beenthere" loop detection is influenced by the particular address family selected.
+  // To see the non-deterministic behaviour, uncomment the line below (you'll be seeing around 21-24 queries).
+  // See #9565
+  SyncRes::s_doIPv6 = false;
+
   primeHints();
 
   const DNSName target1("powerdns.com.");
@@ -153,9 +159,7 @@ BOOST_AUTO_TEST_CASE(test_glueless_referral_loop)
   int res = sr->beginResolve(target1, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::ServFail);
   BOOST_REQUIRE_EQUAL(ret.size(), 0U);
-  // Due to some non-deterministic behaviour in the recursor, this number varies.
-  // Investigate! See #9565
-  //BOOST_CHECK_EQUAL(queriesToNS, 22U);
+  BOOST_CHECK_EQUAL(queriesToNS, 16U);
 }
 
 BOOST_AUTO_TEST_CASE(test_cname_qperq)


### PR DESCRIPTION
This avoids the non-deterministic behaviour.

It is still worthwhile  to investigate the non-deterministic case (when both address familiies are available).

See #9559 and #9565 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
