### PR TITLE
Sort *_SOURCES and add a checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,6 +520,17 @@ jobs:
             git --no-pager diff
             exit $(git diff | wc -l)
           working_directory: ~/project
+      - run:
+          name: Check Makefile.am SOURCES sort order
+          command: |
+            exitcode=0
+            for f in $(find . -type f -name 'Makefile.am'); do
+              ./build-scripts/test-sources-sorted.py ${f}
+              if [ $? -ne 0 ]; then
+                exitcode=1
+              fi
+            done
+            exit ${exitcode}
 
   build-auth:
     docker:

--- a/build-scripts/test-sources-sorted.py
+++ b/build-scripts/test-sources-sorted.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+
+REGEX = re.compile(r'(?s)[a-z0-9][a-z0-9_]+_SOURCES ?= ?\\.*?^$', re.MULTILINE)
+
+
+def test_sources(fname) -> int:
+    text = ""
+    with open(fname, mode="r") as f:
+        text = f.read()
+
+    matches = re.findall(REGEX, text)
+    ret = 0
+    for match in matches:
+        lines = match.split(" \\\n\t")
+        elem = lines[0].rstrip(' =')
+        lines = lines[1:]
+        sorted_lines = sorted(lines)
+
+        if sorted_lines != lines:
+            ret = 1
+            print(f'Source files for {elem} in {fname} is not sorted properly'
+                  .format(elem=elem, fname=fname))
+    return ret
+
+
+if __name__ == "__main__":
+    sys.exit(test_sources(sys.argv[1]))

--- a/modules/geoipbackend/Makefile.am
+++ b/modules/geoipbackend/Makefile.am
@@ -4,9 +4,11 @@ EXTRA_DIST = OBJECTFILES OBJECTLIBS
 
 pkglib_LTLIBRARIES = libgeoipbackend.la
 
-libgeoipbackend_la_SOURCES = geoipbackend.cc geoipbackend.hh \
-	geoipinterface.cc geoipinterface.hh \
+libgeoipbackend_la_SOURCES = \
+	geoipbackend.cc geoipbackend.hh \
 	geoipinterface-dat.cc \
-	geoipinterface-mmdb.cc
+	geoipinterface-mmdb.cc \
+	geoipinterface.cc geoipinterface.hh
+
 libgeoipbackend_la_LDFLAGS = -module -avoid-version
 libgeoipbackend_la_LIBADD = $(YAML_LIBS) $(GEOIP_LIBS) $(MMDB_LIBS)

--- a/modules/ldapbackend/Makefile.am
+++ b/modules/ldapbackend/Makefile.am
@@ -11,12 +11,14 @@ dist_doc_DATA = \
     pdns-domaininfo.schema
 
 libldapbackend_la_SOURCES = \
+	exceptions.hh \
+	ldapauthenticator.hh ldapauthenticator_p.hh ldapauthenticator.cc \
 	ldapbackend.cc ldapbackend.hh \
-  master.cc native.cc \
-	powerldap.cc powerldap.hh \
-	utils.hh exceptions.hh \
 	ldaputils.hh ldaputils.cc \
-	ldapauthenticator.hh ldapauthenticator_p.hh ldapauthenticator.cc
+	master.cc \
+	native.cc \
+	powerldap.cc powerldap.hh \
+	utils.hh
 
 libldapbackend_la_LDFLAGS = -module -avoid-version
 libldapbackend_la_LIBADD = $(LDAP_LIBS) $(KRB5_LIBS)

--- a/modules/lmdbbackend/Makefile.am
+++ b/modules/lmdbbackend/Makefile.am
@@ -4,8 +4,9 @@ pkglib_LTLIBRARIES = liblmdbbackend.la
 
 EXTRA_DIST = OBJECTFILES OBJECTLIBS
 
-liblmdbbackend_la_SOURCES = lmdbbackend.cc lmdbbackend.hh \
+liblmdbbackend_la_SOURCES = \
+	../../ext/lmdb-safe/lmdb-safe.hh ../../ext/lmdb-safe/lmdb-safe.cc \
 	../../ext/lmdb-safe/lmdb-typed.hh ../../ext/lmdb-safe/lmdb-typed.cc \
-	../../ext/lmdb-safe/lmdb-safe.hh ../../ext/lmdb-safe/lmdb-safe.cc
+	lmdbbackend.cc lmdbbackend.hh
 liblmdbbackend_la_LDFLAGS = -module -avoid-version
 liblmdbbackend_la_LIBADD = $(LMDB_LIBS) $(BOOST_SERIALIZATION_LIBS)

--- a/modules/lua2backend/Makefile.am
+++ b/modules/lua2backend/Makefile.am
@@ -6,8 +6,8 @@ EXTRA_DIST = OBJECTFILES OBJECTLIBS
 pkglib_LTLIBRARIES = liblua2backend.la
 
 liblua2backend_la_SOURCES = \
-	lua2backend.cc lua2backend.hh \
-	lua2api2.hh lua2api2.cc
+	lua2api2.hh lua2api2.cc \
+	lua2backend.cc lua2backend.hh
 
 liblua2backend_la_LDFLAGS = -module -avoid-version
 liblua2backend_la_LIBADD = $(LUA_LIBS)

--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -37,11 +37,11 @@ clean-local:
 pkglib_LTLIBRARIES = libremotebackend.la
 
 libremotebackend_la_SOURCES = \
-	remotebackend.hh \
-	remotebackend.cc \
-	unixconnector.cc \
 	httpconnector.cc \
 	pipeconnector.cc \
+	remotebackend.cc \
+	remotebackend.hh \
+	unixconnector.cc \
 	zmqconnector.cc
 
 libremotebackend_la_LDFLAGS = -module -avoid-version
@@ -99,6 +99,8 @@ libtestremotebackend_la_SOURCES = \
 	../../pdns/auth-querycache.cc ../../pdns/auth-querycache.hh \
 	../../pdns/base32.cc \
 	../../pdns/base64.cc \
+	../../pdns/dns.hh ../../pdns/dns.cc \
+	../../pdns/dns_random_urandom.cc \
 	../../pdns/dnsbackend.hh ../../pdns/dnsbackend.cc \
 	../../pdns/dnslabeltext.cc \
 	../../pdns/dnsname.cc ../../pdns/dnsname.hh \
@@ -106,31 +108,29 @@ libtestremotebackend_la_SOURCES = \
 	../../pdns/dnsparser.cc \
 	../../pdns/dnsrecords.cc \
 	../../pdns/dnssecinfra.cc \
-	../../pdns/ednssubnet.cc \
+	../../pdns/dnswriter.cc \
 	../../pdns/ednsoptions.cc ../../pdns/ednsoptions.hh \
+	../../pdns/ednssubnet.cc \
 	../../pdns/iputils.cc \
+	../../pdns/json.hh ../../pdns/json.cc \
 	../../pdns/logger.cc \
 	../../pdns/misc.cc \
+	../../pdns/nameserver.cc \
 	../../pdns/nsecrecords.cc \
 	../../pdns/packetcache.hh \
 	../../pdns/qtype.cc \
+	../../pdns/rcpgenerator.cc \
+	../../pdns/shuffle.hh ../../pdns/shuffle.cc \
 	../../pdns/sillyrecords.cc \
 	../../pdns/statbag.cc \
-	../../pdns/ueberbackend.hh ../../pdns/ueberbackend.cc \
-	../../pdns/dns.hh ../../pdns/dns.cc \
-	../../pdns/dns_random_urandom.cc \
-	../../pdns/dnswriter.cc \
-	../../pdns/nameserver.cc \
-	../../pdns/rcpgenerator.cc \
-	../../pdns/unix_utility.cc \
 	../../pdns/svc-records.cc ../../pdns/svc-records.hh \
-	../../pdns/json.hh ../../pdns/json.cc \
-	../../pdns/shuffle.hh ../../pdns/shuffle.cc \
+	../../pdns/ueberbackend.hh ../../pdns/ueberbackend.cc \
+	../../pdns/unix_utility.cc \
 	httpconnector.cc \
 	pipeconnector.cc \
+	remotebackend.hh remotebackend.cc \
 	unixconnector.cc \
-	zmqconnector.cc \
-	remotebackend.hh remotebackend.cc
+	zmqconnector.cc
 
 libtestremotebackend_la_CPPFLAGS = $(AM_CPPFLAGS)
 
@@ -162,43 +162,43 @@ libtestremotebackend_la_CPPFLAGS += \
 endif
 
 remotebackend_http_test_SOURCES = \
-	test-remotebackend.cc \
 	test-remotebackend-http.cc \
-	test-remotebackend-keys.hh
+	test-remotebackend-keys.hh \
+	test-remotebackend.cc
 
 remotebackend_http_test_LDADD = libtestremotebackend.la
 
 remotebackend_json_test_SOURCES = \
-	test-remotebackend.cc \
 	test-remotebackend-json.cc \
-	test-remotebackend-keys.hh
+	test-remotebackend-keys.hh \
+	test-remotebackend.cc
 
 remotebackend_json_test_LDADD = libtestremotebackend.la
 
 remotebackend_pipe_test_SOURCES = \
-	test-remotebackend.cc \
+	test-remotebackend-keys.hh \
 	test-remotebackend-pipe.cc \
-	test-remotebackend-keys.hh 
+	test-remotebackend.cc
 
 remotebackend_pipe_test_LDADD = libtestremotebackend.la
 
 remotebackend_post_test_SOURCES = \
-	test-remotebackend.cc \
+	test-remotebackend-keys.hh \
 	test-remotebackend-post.cc \
-	test-remotebackend-keys.hh
+	test-remotebackend.cc
 
 remotebackend_post_test_LDADD = libtestremotebackend.la
 
 remotebackend_unix_test_SOURCES = \
-	test-remotebackend.cc \
+	test-remotebackend-keys.hh \
 	test-remotebackend-unix.cc \
-	test-remotebackend-keys.hh
+	test-remotebackend.cc
 
 remotebackend_unix_test_LDADD = libtestremotebackend.la
 
 remotebackend_zeromq_test_SOURCES = \
-	test-remotebackend.cc \
+	test-remotebackend-keys.hh \
 	test-remotebackend-zeromq.cc \
-	test-remotebackend-keys.hh
+	test-remotebackend.cc
 
 remotebackend_zeromq_test_LDADD = libtestremotebackend.la

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -143,10 +143,11 @@ EXTRA_PROGRAMS = \
 pdns_server_SOURCES = \
 	arguments.cc arguments.hh \
 	ascii.hh \
-	auth-carbon.cc \
 	auth-caches.cc auth-caches.hh \
+	auth-carbon.cc \
 	auth-packetcache.cc auth-packetcache.hh \
 	auth-querycache.cc auth-querycache.hh \
+	axfr-retriever.cc axfr-retriever.hh \
 	backends/gsql/gsqlbackend.cc backends/gsql/gsqlbackend.hh \
 	backends/gsql/ssql.hh \
 	base32.cc base32.hh \
@@ -185,8 +186,8 @@ pdns_server_SOURCES = \
 	json.cc json.hh \
 	lock.hh \
 	logger.cc logger.hh \
-	lua-base4.cc lua-base4.hh \
 	lua-auth4.cc lua-auth4.hh \
+	lua-base4.cc lua-base4.hh \
 	mastercommunicator.cc \
 	misc.cc misc.hh \
 	nameserver.cc nameserver.hh \
@@ -199,14 +200,12 @@ pdns_server_SOURCES = \
 	qtype.cc qtype.hh \
 	query-local-address.hh query-local-address.cc \
 	rcpgenerator.cc \
-	svc-records.cc svc-records.hh \
 	receiver.cc \
 	resolver.cc resolver.hh \
-	axfr-retriever.cc axfr-retriever.hh \
 	responsestats.cc responsestats.hh responsestats-auth.cc \
 	rfc2136handler.cc \
-	secpoll.cc secpoll.hh \
 	secpoll-auth.cc secpoll-auth.hh \
+	secpoll.cc secpoll.hh \
 	serialtweaker.cc \
 	sha.hh \
 	shuffle.cc shuffle.hh \
@@ -215,16 +214,17 @@ pdns_server_SOURCES = \
 	slavecommunicator.cc \
 	statbag.cc statbag.hh \
 	stubresolver.cc stubresolver.hh \
+	svc-records.cc svc-records.hh \
 	tcpreceiver.cc tcpreceiver.hh \
 	threadname.hh threadname.cc \
-	tsigverifier.cc tsigverifier.hh \
-	tsigutils.hh tsigutils.cc \
 	tkey.cc \
+	tsigutils.hh tsigutils.cc \
+	tsigverifier.cc tsigverifier.hh \
 	ueberbackend.cc ueberbackend.hh \
-	uuid-utils.hh uuid-utils.cc \
 	unix_semaphore.cc \
 	unix_utility.cc \
 	utility.hh \
+	uuid-utils.hh uuid-utils.cc \
 	version.cc version.hh \
 	views.hh \
 	webserver.cc webserver.hh \
@@ -290,13 +290,13 @@ pdnsutil_SOURCES = \
 	cachecleaner.hh \
 	circular_buffer.hh \
 	dbdnsseckeeper.cc \
-	dnsbackend.cc \
 	dns.cc \
+	dns_random.cc \
+	dnsbackend.cc \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dnspacket.cc \
 	dnsparser.cc dnsparser.hh \
-	dns_random.cc \
 	dnsrecords.cc \
 	dnssecinfra.cc dnssecinfra.hh \
 	dnssecsigner.cc \
@@ -316,7 +316,6 @@ pdnsutil_SOURCES = \
 	pdnsutil.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	serialtweaker.cc \
 	shuffle.cc shuffle.hh \
 	signingpipe.cc \
@@ -324,6 +323,7 @@ pdnsutil_SOURCES = \
 	sstuff.hh \
 	statbag.cc \
 	stubresolver.cc stubresolver.hh \
+	svc-records.cc svc-records.hh \
 	threadname.hh threadname.cc \
 	tsigutils.hh tsigutils.cc \
 	ueberbackend.cc \
@@ -381,8 +381,8 @@ zone2sql_SOURCES = \
 	bindparserclasses.hh \
 	dns.cc \
 	dns_random_urandom.cc \
-	dnsname.cc dnsname.hh \
 	dnslabeltext.cc \
+	dnsname.cc dnsname.hh \
 	dnsparser.cc \
 	dnsrecords.cc \
 	dnswriter.cc \
@@ -392,9 +392,9 @@ zone2sql_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	zone2sql.cc \
 	zoneparser-tng.cc
@@ -420,9 +420,9 @@ zone2json_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	zone2json.cc \
 	zoneparser-tng.cc
@@ -447,8 +447,8 @@ zone2ldap_SOURCES = \
 	bindparser.yy \
 	bindparserclasses.hh \
 	dns_random_urandom.cc \
-	dnsname.cc dnsname.hh \
 	dnslabeltext.cc \
+	dnsname.cc dnsname.hh \
 	dnsparser.cc \
 	dnsrecords.cc \
 	dnswriter.cc \
@@ -457,9 +457,9 @@ zone2ldap_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	zone2ldap.cc \
 	zoneparser-tng.cc
@@ -483,11 +483,11 @@ sdig_SOURCES = \
 	proxy-protocol.cc proxy-protocol.hh \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sdig.cc \
 	sillyrecords.cc \
 	sstuff.hh \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc
 
 sdig_LDADD = $(LIBCRYPTO_LIBS)
@@ -516,10 +516,10 @@ calidns_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	sstuff.hh \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc
 
 calidns_LDADD = $(LIBCRYPTO_LIBS) \
@@ -534,18 +534,18 @@ dumresp_SOURCES = \
 	iputils.cc iputils.hh \
 	logger.cc \
 	misc.cc misc.hh \
+	qtype.cc \
 	statbag.cc \
-	unix_utility.cc \
-	qtype.cc 
+	unix_utility.cc
 
 kvresp_SOURCES = \
 	dnslabeltext.cc dnsname.cc dnsname.hh \
 	kvresp.cc \
 	logger.cc \
 	misc.cc misc.hh \
+	qtype.cc \
 	statbag.cc \
-	unix_utility.cc \
-	qtype.cc 
+	unix_utility.cc
 
 stubquery_SOURCES = \
 	arguments.cc arguments.hh \
@@ -563,11 +563,11 @@ stubquery_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
-	stubresolver.cc stubresolver.hh \
 	stubquery.cc \
+	stubresolver.cc stubresolver.hh \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc
 
 stubquery_LDADD = $(LIBCRYPTO_LIBS)
@@ -589,11 +589,11 @@ saxfr_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	saxfr.cc \
 	sillyrecords.cc \
 	sstuff.hh \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc
 
 saxfr_LDADD = $(LIBCRYPTO_LIBS)
@@ -606,6 +606,7 @@ endif
 
 ixfrdist_SOURCES = \
 	arguments.cc \
+	axfr-retriever.cc \
 	base32.cc \
 	base64.cc base64.hh \
 	dns.cc \
@@ -618,24 +619,23 @@ ixfrdist_SOURCES = \
 	dnswriter.cc dnswriter.hh \
 	iputils.hh iputils.cc \
 	ixfr.cc ixfr.hh \
-	ixfrdist.cc \
-	ixfrutils.cc ixfrutils.hh \
 	ixfrdist-stats.hh ixfrdist-stats.cc \
 	ixfrdist-web.hh ixfrdist-web.cc \
+	ixfrdist.cc \
+	ixfrutils.cc ixfrutils.hh \
 	logger.cc logger.hh\
 	misc.cc misc.hh \
 	mplexer.hh \
 	nsecrecords.cc \
-	query-local-address.hh query-local-address.cc \
-	qtype.cc \
-	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
-	resolver.cc \
-	axfr-retriever.cc \
 	pollmplexer.cc \
+	qtype.cc \
+	query-local-address.hh query-local-address.cc \
+	rcpgenerator.cc rcpgenerator.hh \
+	resolver.cc \
 	sillyrecords.cc \
 	sstuff.hh \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	threadname.hh threadname.cc \
 	tsigverifier.cc tsigverifier.hh \
 	unix_utility.cc \
@@ -663,6 +663,7 @@ endif
 
 ixplore_SOURCES = \
 	arguments.cc \
+	axfr-retriever.cc \
 	base32.cc \
 	base64.cc base64.hh \
 	dns.cc \
@@ -674,21 +675,20 @@ ixplore_SOURCES = \
 	dnssecinfra.cc \
 	dnswriter.cc dnswriter.hh \
 	iputils.cc \
-	logger.cc \
-	misc.cc misc.hh \
-	nsecrecords.cc \
-	query-local-address.hh query-local-address.cc \
-	qtype.cc \
-	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
-	resolver.cc \
-	axfr-retriever.cc \
 	ixfr.cc ixfr.hh \
 	ixfrutils.cc ixfrutils.hh \
 	ixplore.cc \
+	logger.cc \
+	misc.cc misc.hh \
+	nsecrecords.cc \
+	qtype.cc \
+	query-local-address.hh query-local-address.cc \
+	rcpgenerator.cc rcpgenerator.hh \
+	resolver.cc \
 	sillyrecords.cc \
 	sstuff.hh \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	tsigverifier.cc tsigverifier.hh \
 	unix_utility.cc zoneparser-tng.cc
 
@@ -715,10 +715,10 @@ dnstcpbench_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	sstuff.hh \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	threadname.hh threadname.cc \
 	unix_utility.cc
 
@@ -734,8 +734,8 @@ dnstcpbench_LDADD = \
 nsec3dig_SOURCES = \
 	base32.cc \
 	base64.cc base64.hh \
-	dnsname.cc dnsname.hh \
 	dnslabeltext.cc \
+	dnsname.cc dnsname.hh \
 	dnsparser.cc dnsparser.hh \
 	dnsrecords.cc \
 	dnssecinfra.cc \
@@ -747,10 +747,10 @@ nsec3dig_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	sstuff.hh \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc
 
 nsec3dig_LDADD = $(LIBCRYPTO_LIBS)
@@ -765,8 +765,8 @@ toysdig_SOURCES = \
 	base32.cc \
 	base64.cc base64.hh \
 	dns_random_urandom.cc \
-	dnsname.cc dnsname.hh \
 	dnslabeltext.cc \
+	dnsname.cc dnsname.hh \
 	dnsparser.cc dnsparser.hh \
 	dnsrecords.cc \
 	dnssecinfra.cc \
@@ -779,16 +779,16 @@ toysdig_SOURCES = \
 	nsecrecords.cc \
 	opensslsigners.cc opensslsigners.hh \
 	qtype.cc \
-	root-dnssec.hh \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	rec-lua-conf.hh \
 	recursor_cache.hh \
+	root-dnssec.hh \
 	sholder.hh \
 	sillyrecords.cc \
 	sortlist.hh \
 	sstuff.hh \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	toysdig.cc \
 	unix_utility.cc \
 	validate.cc validate.hh
@@ -804,8 +804,8 @@ toysdig_LDADD += $(P11KIT1_LIBS)
 endif
 
 tsig_tests_SOURCES = \
-	axfr-retriever.cc \
 	arguments.cc \
+	axfr-retriever.cc \
 	base32.cc \
 	base64.cc base64.hh \
 	digests.hh \
@@ -821,14 +821,14 @@ tsig_tests_SOURCES = \
 	logger.cc \
 	misc.cc misc.hh \
 	nsecrecords.cc \
-	query-local-address.cc \
 	qtype.cc \
+	query-local-address.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	resolver.cc \
 	sillyrecords.cc \
 	sstuff.hh \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	tsig-tests.cc \
 	tsigverifier.cc tsigverifier.hh \
 	unix_utility.cc
@@ -849,17 +849,17 @@ speedtest_SOURCES = \
 	dnsparser.cc dnsparser.hh \
 	dnsrecords.cc \
 	dnswriter.cc dnswriter.hh \
+	iputils.cc \
 	logger.cc \
 	misc.cc misc.hh \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	speedtest.cc \
 	statbag.cc \
-	unix_utility.cc \
-	iputils.cc
+	svc-records.cc svc-records.hh \
+	unix_utility.cc
 
 speedtest_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
 speedtest_LDADD = $(LIBCRYPTO_LIBS) \
@@ -884,8 +884,10 @@ dnswasher_LDFLAGS = 	$(AM_LDFLAGS) $(BOOST_PROGRAM_OPTIONS_LDFLAGS) $(LIBCRYPTO_
 dnswasher_LDADD = 	$(BOOST_PROGRAM_OPTIONS_LIBS) $(LIBCRYPTO_LIBS) $(IPCRYPT_LIBS)
 
 dnsbulktest_SOURCES = \
+	arguments.cc arguments.hh \
 	base32.cc \
 	base64.cc \
+	dns_random.cc dns_random.hh \
 	dnsbulktest.cc \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
@@ -897,12 +899,10 @@ dnsbulktest_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
-	unix_utility.cc \
-	arguments.cc arguments.hh \
-	dns_random.cc dns_random.hh
+	svc-records.cc svc-records.hh \
+	unix_utility.cc
 
 dnsbulktest_LDFLAGS = \
 	$(AM_LDFLAGS) \
@@ -928,9 +928,9 @@ comfun_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	zoneparser-tng.cc zoneparser-tng.hh
 
@@ -960,9 +960,9 @@ dnsscan_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	utility.hh
 
@@ -991,9 +991,9 @@ dnsreplay_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	utility.hh
 
@@ -1022,9 +1022,9 @@ nproxy_SOURCES = \
 	pollmplexer.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc
 
 nproxy_LDFLAGS = \
@@ -1041,6 +1041,7 @@ pdns_notify_SOURCES = \
 	base32.cc \
 	base64.cc base64.hh \
 	dns.cc \
+	dns_random.cc \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dnsparser.cc dnsparser.hh \
@@ -1053,11 +1054,10 @@ pdns_notify_SOURCES = \
 	pollmplexer.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
-	unix_utility.cc \
-	dns_random.cc
+	svc-records.cc svc-records.hh \
+	unix_utility.cc
 
 pdns_notify_LDFLAGS = \
 	$(AM_LDFLAGS) \
@@ -1091,10 +1091,10 @@ dnsscope_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
 	statnode.cc statnode.hh \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	utility.hh
 
@@ -1122,9 +1122,9 @@ dnsgram_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	utility.hh
 
@@ -1150,9 +1150,9 @@ dnsdemog_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	utility.hh
 
@@ -1181,9 +1181,9 @@ dnspcap2calidns_SOURCES = \
 	nsecrecords.cc \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	utility.hh
 
@@ -1224,9 +1224,9 @@ dnspcap2protobuf_SOURCES = \
 	protobuf.cc protobuf.hh \
 	qtype.cc \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	utility.hh \
 	uuid-utils.hh uuid-utils.cc
@@ -1271,8 +1271,8 @@ testrunner_SOURCES = \
 	dnssecinfra.cc \
 	dnssecsigner.cc \
 	dnswriter.cc \
-	ednsoptions.cc ednsoptions.hh \
 	ednscookies.cc ednscookies.hh \
+	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc \
 	gettime.cc gettime.hh \
 	ipcipher.cc ipcipher.hh \
@@ -1281,7 +1281,6 @@ testrunner_SOURCES = \
 	logger.cc \
 	lua-auth4.hh lua-auth4.cc \
 	lua-base4.hh lua-base4.cc \
-	stubresolver.hh stubresolver.cc \
 	misc.cc \
 	nameserver.cc \
 	nsecrecords.cc \
@@ -1290,24 +1289,25 @@ testrunner_SOURCES = \
 	proxy-protocol.cc proxy-protocol.hh \
 	qtype.cc \
 	rcpgenerator.cc \
-	svc-records.cc svc-records.hh \
-	responsestats.cc \
 	responsestats-auth.cc \
+	responsestats.cc \
 	shuffle.cc shuffle.hh \
 	sillyrecords.cc \
 	statbag.cc \
+	stubresolver.hh stubresolver.cc \
+	svc-records.cc svc-records.hh \
 	test-arguments_cc.cc \
 	test-base32_cc.cc \
 	test-base64_cc.cc \
 	test-bindparser_cc.cc \
 	test-common.hh \
-	test-dnsrecordcontent.cc \
 	test-digests_hh.cc \
 	test-distributor_hh.cc \
 	test-dns_random_hh.cc \
 	test-dnsname_cc.cc \
 	test-dnsparser_cc.cc \
 	test-dnsparser_hh.cc \
+	test-dnsrecordcontent.cc \
 	test-dnsrecords_cc.cc \
 	test-dnswriter_cc.cc \
 	test-ipcrypt_cc.cc \
@@ -1385,15 +1385,15 @@ endif
 
 pdns_control_SOURCES = \
 	arguments.cc \
+	dnslabeltext.cc \
+	dnsname.cc \
 	dynloader.cc \
 	dynmessenger.cc \
 	logger.cc \
 	misc.cc \
 	qtype.cc \
 	statbag.cc \
-	unix_utility.cc \
-	dnsname.cc \
-	dnslabeltext.cc
+	unix_utility.cc
 
 if UNIT_TESTS
 
@@ -1442,7 +1442,6 @@ fuzz_targets_ldflags = \
 fuzz_targets_deps = standalone_fuzz_target_runner.o
 
 fuzz_target_moadnsparser_SOURCES = \
-	fuzz_moadnsparser.cc \
 	base32.cc base32.hh \
 	base64.cc base64.hh \
 	dnslabeltext.cc \
@@ -1450,14 +1449,15 @@ fuzz_target_moadnsparser_SOURCES = \
 	dnsparser.cc dnsparser.hh \
 	dnsrecords.cc dnsrecords.hh \
 	dnswriter.cc dnswriter.hh \
+	fuzz_moadnsparser.cc \
 	logger.cc logger.hh \
 	misc.cc misc.hh \
 	nsecrecords.cc  \
 	qtype.cc qtype.hh \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc statbag.hh \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	utility.hh
 
@@ -1466,15 +1466,15 @@ fuzz_target_moadnsparser_LDFLAGS = $(fuzz_targets_ldflags)
 fuzz_target_moadnsparser_LDADD = $(fuzz_targets_libs)
 
 fuzz_target_packetcache_SOURCES = \
-	fuzz_packetcache.cc \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	ednsoptions.cc ednsoptions.hh \
+	fuzz_packetcache.cc \
 	misc.cc misc.hh \
-	svc-records.cc svc-records.hh \
 	packetcache.hh \
 	qtype.cc qtype.hh \
-	statbag.cc statbag.hh
+	statbag.cc statbag.hh \
+	svc-records.cc svc-records.hh
 
 fuzz_target_packetcache_DEPENDENCIES = $(fuzz_targets_deps)
 fuzz_target_packetcache_LDFLAGS = $(fuzz_targets_ldflags)
@@ -1491,7 +1491,6 @@ fuzz_target_proxyprotocol_LDFLAGS = $(fuzz_targets_ldflags)
 fuzz_target_proxyprotocol_LDADD = $(fuzz_targets_libs)
 
 fuzz_target_dnsdistcache_SOURCES = \
-	fuzz_dnsdistcache.cc \
 	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
 	dnslabeltext.cc \
@@ -1501,6 +1500,7 @@ fuzz_target_dnsdistcache_SOURCES = \
 	doh.hh \
 	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
+	fuzz_dnsdistcache.cc \
 	iputils.cc iputils.hh \
 	misc.cc misc.hh \
 	packetcache.hh \
@@ -1512,7 +1512,6 @@ fuzz_target_dnsdistcache_LDFLAGS = $(fuzz_targets_ldflags)
 fuzz_target_dnsdistcache_LDADD = $(fuzz_targets_libs)
 
 fuzz_target_zoneparsertng_SOURCES = \
-	fuzz_zoneparsertng.cc \
 	base32.cc base32.hh \
 	base64.cc base64.hh \
 	dnslabeltext.cc \
@@ -1520,14 +1519,15 @@ fuzz_target_zoneparsertng_SOURCES = \
 	dnsparser.cc dnsparser.hh \
 	dnsrecords.cc dnsrecords.hh \
 	dnswriter.cc dnswriter.hh \
+	fuzz_zoneparsertng.cc \
 	logger.cc logger.hh \
 	misc.cc misc.hh \
 	nsecrecords.cc  \
 	qtype.cc qtype.hh \
 	rcpgenerator.cc rcpgenerator.hh \
-	svc-records.cc svc-records.hh \
 	sillyrecords.cc \
 	statbag.cc statbag.hh \
+	svc-records.cc svc-records.hh \
 	unix_utility.cc \
 	utility.hh \
 	zoneparser-tng.cc zoneparser-tng.hh

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -123,33 +123,32 @@ dnsdist_SOURCES = \
 	circular_buffer.hh \
 	dns.cc dns.hh \
 	dnscrypt.cc dnscrypt.hh \
-	dnsdist.cc dnsdist.hh \
 	dnsdist-backend.cc \
-	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \
 	dnsdist-cache.cc dnsdist-cache.hh \
 	dnsdist-carbon.cc \
 	dnsdist-console.cc dnsdist-console.hh \
 	dnsdist-dnscrypt.cc \
 	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
+	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
 	dnsdist-healthchecks.cc dnsdist-healthchecks.hh \
 	dnsdist-idstate.cc \
 	dnsdist-kvs.hh dnsdist-kvs.cc \
 	dnsdist-lbpolicies.cc dnsdist-lbpolicies.hh \
-	dnsdist-lua.hh dnsdist-lua.cc \
 	dnsdist-lua-actions.cc \
-	dnsdist-lua-bindings.cc \
 	dnsdist-lua-bindings-dnscrypt.cc \
 	dnsdist-lua-bindings-dnsquestion.cc \
 	dnsdist-lua-bindings-kvs.cc \
 	dnsdist-lua-bindings-packetcache.cc \
 	dnsdist-lua-bindings-protobuf.cc \
-	dnsdist-lua-ffi.cc dnsdist-lua-ffi.hh \
+	dnsdist-lua-bindings.cc \
 	dnsdist-lua-ffi-interface.h dnsdist-lua-ffi-interface.inc \
-	dnsdist-lua-inspection.cc \
+	dnsdist-lua-ffi.cc dnsdist-lua-ffi.hh \
 	dnsdist-lua-inspection-ffi.cc dnsdist-lua-inspection-ffi.hh \
+	dnsdist-lua-inspection.cc \
 	dnsdist-lua-rules.cc \
 	dnsdist-lua-vars.cc \
+	dnsdist-lua.hh dnsdist-lua.cc \
 	dnsdist-prometheus.hh \
 	dnsdist-protobuf.cc dnsdist-protobuf.hh \
 	dnsdist-proxy-protocol.cc dnsdist-proxy-protocol.hh \
@@ -161,15 +160,22 @@ dnsdist_SOURCES = \
 	dnsdist-tcp.cc \
 	dnsdist-web.cc dnsdist-web.hh \
 	dnsdist-xpf.cc dnsdist-xpf.hh \
+	dnsdist.cc dnsdist.hh \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dnsparser.hh dnsparser.cc \
+	dnstap.cc dnstap.hh \
 	dnswriter.cc dnswriter.hh \
 	doh.hh doh.cc \
 	dolog.hh \
-	ednsoptions.cc ednsoptions.hh \
 	ednscookies.cc ednscookies.hh \
+	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
+	ext/incbin/incbin.h \
+	ext/json11/json11.cpp \
+	ext/json11/json11.hpp \
+	ext/libbpf/libbpf.h \
+	ext/luawrapper/include/LuaContext.hpp \
 	fstrm_logger.cc fstrm_logger.hh \
 	gettime.cc gettime.hh \
 	htmlfiles.h \
@@ -181,32 +187,68 @@ dnsdist_SOURCES = \
 	namespaces.hh \
 	packetcache.hh \
 	pdnsexception.hh \
+	pollmplexer.cc \
 	protobuf.cc protobuf.hh \
 	proxy-protocol.cc proxy-protocol.hh \
-	dnstap.cc dnstap.hh \
 	qtype.cc qtype.hh \
 	remote_logger.cc remote_logger.hh \
-	pollmplexer.cc \
 	sholder.hh \
 	snmp-agent.cc snmp-agent.hh \
 	sodcrypto.cc sodcrypto.hh \
 	sstuff.hh \
-	svc-records.cc svc-records.hh \
 	statnode.cc statnode.hh \
+	svc-records.cc svc-records.hh \
 	tcpiohandler.cc tcpiohandler.hh \
 	threadname.hh threadname.cc \
 	uuid-utils.hh uuid-utils.cc \
 	views.hh \
-	xpf.cc xpf.hh \
-	ext/luawrapper/include/LuaContext.hpp \
-	ext/json11/json11.cpp \
-	ext/json11/json11.hpp \
-	ext/incbin/incbin.h \
-	ext/libbpf/libbpf.h
+	xpf.cc xpf.hh
 
 testrunner_SOURCES = \
 	base64.hh \
+	bpf-filter.cc bpf-filter.hh \
+	cachecleaner.hh \
+	circular_buffer.hh \
 	dns.hh \
+	dnscrypt.cc dnscrypt.hh \
+	dnsdist-backend.cc \
+	dnsdist-cache.cc dnsdist-cache.hh \
+	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
+	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \
+	dnsdist-ecs.cc dnsdist-ecs.hh \
+	dnsdist-kvs.cc dnsdist-kvs.hh \
+	dnsdist-lbpolicies.cc dnsdist-lbpolicies.hh \
+	dnsdist-lua-bindings-dnsquestion.cc \
+	dnsdist-lua-bindings-kvs.cc \
+	dnsdist-lua-bindings.cc \
+	dnsdist-lua-ffi-interface.h dnsdist-lua-ffi-interface.inc \
+	dnsdist-lua-ffi.cc dnsdist-lua-ffi.hh \
+	dnsdist-lua-vars.cc \
+	dnsdist-rings.hh \
+	dnsdist-xpf.cc dnsdist-xpf.hh \
+	dnsdist.hh \
+	dnslabeltext.cc \
+	dnsname.cc dnsname.hh \
+	dnsparser.hh dnsparser.cc \
+	dnswriter.cc dnswriter.hh \
+	dolog.hh \
+	ednscookies.cc ednscookies.hh \
+	ednsoptions.cc ednsoptions.hh \
+	ednssubnet.cc ednssubnet.hh \
+	ext/luawrapper/include/LuaContext.hpp \
+	gettime.cc gettime.hh \
+	iputils.cc iputils.hh \
+	misc.cc misc.hh \
+	namespaces.hh \
+	pdnsexception.hh \
+	pollmplexer.cc \
+	proxy-protocol.cc proxy-protocol.hh \
+	qtype.cc qtype.hh \
+	sholder.hh \
+	sodcrypto.cc \
+	sstuff.hh \
+	statnode.cc statnode.hh \
+	svc-records.cc svc-records.hh \
 	test-base64_cc.cc \
 	test-delaypipe_hh.cc \
 	test-dnscrypt_cc.cc \
@@ -221,52 +263,10 @@ testrunner_SOURCES = \
 	test-iputils_hh.cc \
 	test-mplexer.cc \
 	test-proxy_protocol_cc.cc \
-	bpf-filter.cc bpf-filter.hh \
-	cachecleaner.hh \
-	circular_buffer.hh \
-	dnsdist.hh \
-	dnsdist-backend.cc \
-	dnsdist-cache.cc dnsdist-cache.hh \
-	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
-	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \
-	dnsdist-ecs.cc dnsdist-ecs.hh \
-	dnsdist-kvs.cc dnsdist-kvs.hh \
-	dnsdist-lbpolicies.cc dnsdist-lbpolicies.hh \
-	dnsdist-lua-bindings.cc \
-	dnsdist-lua-bindings-dnsquestion.cc \
-	dnsdist-lua-bindings-kvs.cc \
-	dnsdist-lua-ffi.cc dnsdist-lua-ffi.hh \
-	dnsdist-lua-ffi-interface.h dnsdist-lua-ffi-interface.inc \
-	dnsdist-lua-vars.cc \
-	dnsdist-rings.hh \
-	dnsdist-xpf.cc dnsdist-xpf.hh \
-	dnscrypt.cc dnscrypt.hh \
-	dnslabeltext.cc \
-	dnsname.cc dnsname.hh \
-	dnsparser.hh dnsparser.cc \
-	dnswriter.cc dnswriter.hh \
-	dolog.hh \
-	ednsoptions.cc ednsoptions.hh \
-	ednscookies.cc ednscookies.hh \
-	ednssubnet.cc ednssubnet.hh \
-	gettime.cc gettime.hh \
-	iputils.cc iputils.hh \
-	misc.cc misc.hh \
-	namespaces.hh \
-	pdnsexception.hh \
-	pollmplexer.cc \
-	proxy-protocol.cc proxy-protocol.hh \
-	qtype.cc qtype.hh \
-	sholder.hh \
-	sodcrypto.cc \
-	sstuff.hh \
-	statnode.cc statnode.hh \
-	svc-records.cc svc-records.hh \
-	threadname.hh threadname.cc \
 	testrunner.cc \
+	threadname.hh threadname.cc \
 	uuid-utils.hh uuid-utils.cc \
-	xpf.cc xpf.hh \
-	ext/luawrapper/include/LuaContext.hpp
+	xpf.cc xpf.hh
 
 dnsdist_LDFLAGS = \
 	$(AM_LDFLAGS) \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -98,6 +98,7 @@ endif
 pdns_recursor_SOURCES = \
 	arguments.cc \
 	ascii.hh \
+	axfr-retriever.hh axfr-retriever.cc \
 	base32.cc base32.hh \
 	base64.cc base64.hh \
 	cachecleaner.hh \
@@ -127,8 +128,8 @@ pdns_recursor_SOURCES = \
 	lock.hh \
 	logger.hh logger.cc \
 	lua-base4.cc lua-base4.hh \
-	lua-recursor4.cc lua-recursor4.hh \
 	lua-recursor4-ffi.hh \
+	lua-recursor4.cc lua-recursor4.hh \
 	lwres.cc lwres.hh \
 	misc.hh misc.cc \
 	mplexer.hh \
@@ -159,9 +160,8 @@ pdns_recursor_SOURCES = \
 	recursor_cache.cc recursor_cache.hh \
 	reczones.cc \
 	remote_logger.cc remote_logger.hh \
-	resolver.hh resolver.cc \
-	axfr-retriever.hh axfr-retriever.cc \
 	resolve-context.hh \
+	resolver.hh resolver.cc \
 	responsestats.hh responsestats.cc \
 	root-addresses.hh \
 	root-dnssec.hh \
@@ -248,11 +248,11 @@ testrunner_SOURCES = \
 	logger.cc logger.hh \
 	misc.cc misc.hh \
 	mtasker_context.cc \
-	negcache.hh negcache.cc \
 	namespaces.hh \
+	negcache.hh negcache.cc \
 	nsecrecords.cc \
-	pdnsexception.hh \
 	opensslsigners.cc opensslsigners.hh \
+	pdnsexception.hh \
 	pollmplexer.cc \
 	protobuf.cc protobuf.hh \
 	qtype.cc qtype.hh \
@@ -261,13 +261,13 @@ testrunner_SOURCES = \
 	rec-protobuf.cc rec-protobuf.hh \
 	recpacketcache.cc recpacketcache.hh \
 	recursor_cache.cc recursor_cache.hh \
-	responsestats.cc \
-	rpzloader.cc rpzloader.hh \
 	resolver.hh resolver.cc \
+	responsestats.cc \
 	root-dnssec.hh \
+	rpzloader.cc rpzloader.hh \
 	secpoll.cc \
-	sillyrecords.cc \
 	sholder.hh \
+	sillyrecords.cc \
 	sstuff.hh \
 	stable-bloom.hh \
 	svc-records.cc svc-records.hh \
@@ -276,18 +276,18 @@ testrunner_SOURCES = \
 	test-base32_cc.cc \
 	test-base64_cc.cc \
 	test-common.hh \
-	test-dnsrecordcontent.cc \
 	test-dns_random_hh.cc \
 	test-dnsname_cc.cc \
 	test-dnsparser_hh.cc \
+	test-dnsrecordcontent.cc \
 	test-dnsrecords_cc.cc \
 	test-ednsoptions_cc.cc \
 	test-filterpo_cc.cc \
 	test-iputils_hh.cc \
 	test-ixfr_cc.cc \
 	test-misc_hh.cc \
-	test-mtasker.cc \
 	test-mplexer.cc \
+	test-mtasker.cc \
 	test-negcache_cc.cc \
 	test-packetcache_hh.cc \
 	test-rcpgenerator_cc.cc \
@@ -296,9 +296,10 @@ testrunner_SOURCES = \
 	test-rpzloader_cc.cc \
 	test-secpoll_cc.cc \
 	test-signers.cc \
-	test-syncres_cc.hh \
 	test-syncres_cc.cc \
+	test-syncres_cc.hh \
 	test-syncres_cc1.cc \
+	test-syncres_cc10.cc \
 	test-syncres_cc2.cc \
 	test-syncres_cc3.cc \
 	test-syncres_cc4.cc \
@@ -307,15 +308,14 @@ testrunner_SOURCES = \
 	test-syncres_cc7.cc \
 	test-syncres_cc8.cc \
 	test-syncres_cc9.cc \
-	test-syncres_cc10.cc \
 	test-tsig.cc \
 	test-xpf_cc.cc \
 	testrunner.cc \
 	threadname.hh threadname.cc \
 	tsigverifier.cc tsigverifier.hh \
 	unix_utility.cc \
-	validate.cc validate.hh \
 	validate-recursor.cc validate-recursor.hh \
+	validate.cc validate.hh \
 	xpf.cc xpf.hh \
 	zoneparser-tng.cc zoneparser-tng.hh
 
@@ -432,8 +432,8 @@ endif
 
 rec_control_SOURCES = \
 	arguments.cc arguments.hh \
-	dnsname.hh dnsname.cc \
 	dnslabeltext.cc \
+	dnsname.hh dnsname.cc \
 	logger.cc \
 	misc.cc \
 	qtype.cc \


### PR DESCRIPTION
### Short description
Closes #9521 

This adds a script to circle-ci that fails check-formatting if the lines in all `_SOURCES` entries are not sorted properly.

See a check with a wrongly sorted file [here](https://app.circleci.com/pipelines/github/pieterlexis/pdns/478/workflows/b62f38bf-ca85-4673-945f-1c964cd9271a/jobs/7602)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)