### PR TITLE
rec: Throttle servers sending invalid data and rcodes

### DIFF
--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -43,12 +43,6 @@
 #include "fstrm_logger.hh"
 #include "resolve-context.hh"
 
-
-int asendto(const char *data, size_t len, int flags, const ComboAddress& ip, uint16_t id,
-            const DNSName& domain, uint16_t qtype,  int* fd);
-int arecvfrom(std::string& packet, int flags, const ComboAddress& ip, size_t *d_len, uint16_t id,
-              const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now);
-
 class LWResException : public PDNSException
 {
 public:
@@ -61,6 +55,8 @@ class LWResult
 public:
   LWResult() : d_usec(0) {}
 
+  enum class Result : uint8_t { Timeout=0, Success=1, PermanentError=2 /* not transport related */, OSLimitError=3 };
+
   vector<DNSRecord> d_records;
   int d_rcode{0};
   bool d_validpacket{false};
@@ -69,4 +65,9 @@ public:
   bool d_haveEDNS{false};
 };
 
-int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstrmLoggers, const std::set<uint16_t>& exportTypes, LWResult* res, bool* chained);
+LWResult::Result asendto(const char *data, size_t len, int flags, const ComboAddress& ip, uint16_t id,
+                         const DNSName& domain, uint16_t qtype,  int* fd);
+LWResult::Result arecvfrom(std::string& packet, int flags, const ComboAddress& ip, size_t *d_len, uint16_t id,
+                           const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now);
+
+LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstrmLoggers, const std::set<uint16_t>& exportTypes, LWResult* res, bool* chained);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -389,8 +389,7 @@ static bool isHandlerThread()
 
 static void handleTCPClientWritable(int fd, FDMultiplexer::funcparam_t& var);
 
-// -1 is error, 0 is timeout, 1 is success
-int asendtcp(const string& data, Socket* sock)
+LWResult::Result asendtcp(const string& data, Socket* sock)
 {
   PacketID pident;
   pident.sock=sock;
@@ -399,21 +398,25 @@ int asendtcp(const string& data, Socket* sock)
   t_fdm->addWriteFD(sock->getHandle(), handleTCPClientWritable, pident);
   string packet;
 
-  int ret=MT->waitEvent(pident, &packet, g_networkTimeoutMsec);
-
-  if(!ret || ret==-1) { // timeout
+  int ret = MT->waitEvent(pident, &packet, g_networkTimeoutMsec);
+  if (ret == 0) { //timeout
     t_fdm->removeWriteFD(sock->getHandle());
+    return LWResult::Result::Timeout;
   }
-  else if(packet.size() !=data.size()) { // main loop tells us what it sent out, or empty in case of an error
-    return -1;
+  else if (ret == -1) { // error
+    t_fdm->removeWriteFD(sock->getHandle());
+    return LWResult::Result::PermanentError;
   }
-  return ret;
+  else if (packet.size() != data.size()) { // main loop tells us what it sent out, or empty in case of an error
+    return LWResult::Result::PermanentError;
+  }
+
+  return LWResult::Result::Success;
 }
 
 static void handleTCPClientReadable(int fd, FDMultiplexer::funcparam_t& var);
 
-// -1 is error, 0 is timeout, 1 is success
-int arecvtcp(string& data, size_t len, Socket* sock, bool incompleteOkay)
+LWResult::Result arecvtcp(string& data, const size_t len, Socket* sock, const bool incompleteOkay)
 {
   data.clear();
   PacketID pident;
@@ -422,15 +425,20 @@ int arecvtcp(string& data, size_t len, Socket* sock, bool incompleteOkay)
   pident.inIncompleteOkay=incompleteOkay;
   t_fdm->addReadFD(sock->getHandle(), handleTCPClientReadable, pident);
 
-  int ret=MT->waitEvent(pident,&data, g_networkTimeoutMsec);
-  if(!ret || ret==-1) { // timeout
+  int ret = MT->waitEvent(pident,&data, g_networkTimeoutMsec);
+  if (ret == 0) {
     t_fdm->removeReadFD(sock->getHandle());
+    return LWResult::Result::Timeout;
   }
-  else if(data.empty()) {// error, EOF or other
-    return -1;
+  else if (ret == -1) {
+    t_fdm->removeWriteFD(sock->getHandle());
+    return LWResult::Result::PermanentError;
+  }
+  else if (data.empty()) {// error, EOF or other
+    return LWResult::Result::PermanentError;
   }
 
-  return ret;
+  return LWResult::Result::Success;
 }
 
 static void handleGenUDPQueryResponse(int fd, FDMultiplexer::funcparam_t& var)
@@ -528,12 +536,12 @@ public:
   {
   }
 
-  // returning -2 means: temporary OS error (ie, out of files), -1 means error related to remote
-  int getSocket(const ComboAddress& toaddr, int* fd)
+  LWResult::Result getSocket(const ComboAddress& toaddr, int* fd)
   {
-    *fd=makeClientSocket(toaddr.sin4.sin_family);
-    if(*fd < 0) // temporary error - receive exception otherwise
-      return -2;
+    *fd = makeClientSocket(toaddr.sin4.sin_family);
+    if(*fd < 0) { // temporary error - receive exception otherwise
+      return LWResult::Result::OSLimitError;
+    }
 
     if(connect(*fd, (struct sockaddr*)(&toaddr), toaddr.getSocklen()) < 0) {
       int err = errno;
@@ -544,13 +552,15 @@ public:
         g_log<<Logger::Error<<"Error closing UDP socket after connect() failed: "<<e.reason<<endl;
       }
 
-      if(err==ENETUNREACH) // Seth "My Interfaces Are Like A Yo Yo" Arnold special
-        return -2;
-      return -1;
+      if (err == ENETUNREACH) { // Seth "My Interfaces Are Like A Yo Yo" Arnold special
+        return LWResult::Result::OSLimitError;
+      }
+
+      return LWResult::Result::PermanentError;
     }
 
     d_numsocks++;
-    return 0;
+    return LWResult::Result::Success;
   }
 
   // return a socket to the pool, or simply erase it
@@ -629,9 +639,8 @@ private:
 static thread_local std::unique_ptr<UDPClientSocks> t_udpclientsocks;
 
 /* these two functions are used by LWRes */
-// -2 is OS error, -1 is error that depends on the remote, > 0 is success
-int asendto(const char *data, size_t len, int flags,
-            const ComboAddress& toaddr, uint16_t id, const DNSName& domain, uint16_t qtype, int* fd)
+LWResult::Result asendto(const char *data, size_t len, int flags,
+                         const ComboAddress& toaddr, uint16_t id, const DNSName& domain, uint16_t qtype, int* fd)
 {
 
   PacketID pident;
@@ -651,32 +660,34 @@ int asendto(const char *data, size_t len, int flags,
       */
       chain.first->key.chain.insert(id); // we can chain
       *fd=-1;                            // gets used in waitEvent / sendEvent later on
-      return 1;
+      return LWResult::Result::Success;
     }
   }
 
-  int ret=t_udpclientsocks->getSocket(toaddr, fd);
-  if(ret < 0)
+  auto ret = t_udpclientsocks->getSocket(toaddr, fd);
+  if (ret != LWResult::Result::Success) {
     return ret;
+  }
 
   pident.fd=*fd;
   pident.id=id;
 
   t_fdm->addReadFD(*fd, handleUDPServerResponse, pident);
-  ret = send(*fd, data, len, 0);
+  ssize_t sent = send(*fd, data, len, 0);
 
   int tmp = errno;
 
-  if(ret < 0)
+  if (sent < 0) {
     t_udpclientsocks->returnSocket(*fd);
+    errno = tmp; // this is for logging purposes only
+    return LWResult::Result::PermanentError;
+  }
 
-  errno = tmp; // this is for logging purposes only
-  return ret;
+  return LWResult::Result::Success;
 }
 
-// -1 is error, 0 is timeout, 1 is success
-int arecvfrom(std::string& packet, int flags, const ComboAddress& fromaddr, size_t *d_len,
-              uint16_t id, const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now)
+LWResult::Result arecvfrom(std::string& packet, int flags, const ComboAddress& fromaddr, size_t *d_len,
+                           uint16_t id, const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now)
 {
   static optional<unsigned int> nearMissLimit;
   if(!nearMissLimit)
@@ -692,25 +703,30 @@ int arecvfrom(std::string& packet, int flags, const ComboAddress& fromaddr, size
   int ret=MT->waitEvent(pident, &packet, g_networkTimeoutMsec, now);
 
   /* -1 means error, 0 means timeout, 1 means a result from handleUDPServerResponse() which might still be an error */
-  if(ret > 0) {
+  if (ret > 0) {
     /* handleUDPServerResponse() will close the socket for us no matter what */
-    if(packet.empty()) // means "error"
-      return -1;
+    if (packet.empty()) { // means "error"
+      return LWResult::Result::PermanentError;
+    }
 
     *d_len=packet.size();
 
-    if(*nearMissLimit && pident.nearMisses > *nearMissLimit) {
+    if (*nearMissLimit && pident.nearMisses > *nearMissLimit) {
       g_log<<Logger::Error<<"Too many ("<<pident.nearMisses<<" > "<<*nearMissLimit<<") bogus answers for '"<<domain<<"' from "<<fromaddr.toString()<<", assuming spoof attempt."<<endl;
       g_stats.spoofCount++;
-      return -1;
+      return LWResult::Result::PermanentError;
     }
+
+    return LWResult::Result::Success;
   }
   else {
     /* getting there means error or timeout, it's up to us to close the socket */
-    if(fd >= 0)
+    if (fd >= 0) {
       t_udpclientsocks->returnSocket(fd);
+    }
   }
-  return ret;
+
+  return ret == 0 ? LWResult::Result::Timeout : LWResult::Result::PermanentError;
 }
 
 static void writePid(void)

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -66,11 +66,13 @@ try
       msg = str.str();
     }
 
-    int ret=asendtcp(msg, &s);     // this will actually do the right thing waiting on the connect
-    if(ret < 0)
-      g_log<<Logger::Warning<<"Error writing carbon data to "<<remote.toStringWithPort()<<": "<<stringerror()<<endl;
-    if(ret==0)
+    auto ret = asendtcp(msg, &s);     // this will actually do the right thing waiting on the connect
+    if (ret == LWResult::Result::Timeout) {
       g_log<<Logger::Warning<<"Timeout connecting/writing carbon data to "<<remote.toStringWithPort()<<endl;
+    }
+    else if (ret != LWResult::Result::Success) {
+      g_log<<Logger::Warning<<"Error writing carbon data to "<<remote.toStringWithPort()<<": "<<stringerror()<<endl;
+    }
   }
  }
 catch(PDNSException& e)

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -37,9 +37,9 @@ bool RecursorLua4::policyHitEventFilter(const ComboAddress& remote, const DNSNam
   return false;
 }
 
-int asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstrmLoggers, const std::set<uint16_t>& exportTypes, LWResult* res, bool* chained)
+LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstrmLoggers, const std::set<uint16_t>& exportTypes, LWResult* res, bool* chained)
 {
-  return 0;
+  return LWResult::Result::Timeout;
 }
 
 /* primeHints() is only here for now because it
@@ -426,7 +426,7 @@ void generateKeyMaterial(const DNSName& name, unsigned int algo, uint8_t digest,
   dsAnchors[name].insert(keys[name].second);
 }
 
-int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth, int type, const testkeysset_t& keys, bool proveCut, boost::optional<time_t> now, bool nsec3, bool optOut)
+LWResult::Result genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth, int type, const testkeysset_t& keys, bool proveCut, boost::optional<time_t> now, bool nsec3, bool optOut)
 {
   if (type == QType::DS) {
     auth.chopOff();
@@ -461,48 +461,48 @@ int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth
       }
     }
 
-    return 1;
+    return LWResult::Result::Success;
   }
 
   if (type == QType::DNSKEY) {
     setLWResult(res, 0, true, false, true);
     addDNSKEY(keys, domain, 300, res->d_records);
     addRRSIG(keys, res->d_records, domain, 300);
-    return 1;
+    return LWResult::Result::Success;
   }
 
-  return 0;
+  return LWResult::Result::Timeout;
 }
 
-int basicRecordsForQnameMinimization(LWResult* res, const DNSName& domain, int type)
+LWResult::Result basicRecordsForQnameMinimization(LWResult* res, const DNSName& domain, int type)
 {
   if (domain == DNSName(".") && type == QType::A) {
     setLWResult(res, 0, true);
     addRecordToLW(res, DNSName("."), QType::SOA, "a.root-servers.net. nstld.verisign-grs.com. 2019042400 1800 900 604800 86400", DNSResourceRecord::AUTHORITY);
-    return 1;
+    return LWResult::Result::Success;
   }
   if (domain == DNSName("com") && type == QType::A) {
     setLWResult(res, 0, true);
     addRecordToLW(res, DNSName("com"), QType::NS, "ns1.com", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, DNSName("ns1.com"), QType::A, "1.2.3.4", DNSResourceRecord::ADDITIONAL);
-    return 1;
+    return LWResult::Result::Success;
   }
   if (domain == DNSName("ns1.com") && type == QType::A) {
     setLWResult(res, 0, true);
     addRecordToLW(res, DNSName("ns1.com"), QType::A, "1.2.3.4");
-    return 1;
+    return LWResult::Result::Success;
   }
   if (domain == DNSName("powerdns.com") && type == QType::A) {
     setLWResult(res, 0, true);
     addRecordToLW(res, domain, QType::NS, "ns1.powerdns.com", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, DNSName("ns1.powerdns.com"), QType::A, "4.5.6.7", DNSResourceRecord::ADDITIONAL);
-    return 1;
+    return LWResult::Result::Success;
   }
   if (domain == DNSName("powerdns.com") && type == QType::NS) {
     setLWResult(res, 0, true);
     addRecordToLW(res, domain, QType::NS, "ns1.powerdns.com");
     addRecordToLW(res, DNSName("ns1.powerdns.com"), QType::A, "4.5.6.7", DNSResourceRecord::ADDITIONAL);
-    return 1;
+    return LWResult::Result::Success;
   }
-  return 0;
+  return LWResult::Result::Timeout;
 }

--- a/pdns/recursordist/test-syncres_cc.hh
+++ b/pdns/recursordist/test-syncres_cc.hh
@@ -66,6 +66,6 @@ void generateKeyMaterial(const DNSName& name, unsigned int algo, uint8_t digest,
 
 void generateKeyMaterial(const DNSName& name, unsigned int algo, uint8_t digest, testkeysset_t& keys, map<DNSName, dsmap_t>& dsAnchors);
 
-int genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth, int type, const testkeysset_t& keys, bool proveCut = true, boost::optional<time_t> now = boost::none, bool nsec3 = false, bool optOut = false);
+LWResult::Result genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain, DNSName auth, int type, const testkeysset_t& keys, bool proveCut = true, boost::optional<time_t> now = boost::none, bool nsec3 = false, bool optOut = false);
 
-int basicRecordsForQnameMinimization(LWResult* res, const DNSName& domain, int type);
+LWResult::Result basicRecordsForQnameMinimization(LWResult* res, const DNSName& domain, int type);

--- a/pdns/recursordist/test-syncres_cc1.cc
+++ b/pdns/recursordist/test-syncres_cc1.cc
@@ -414,7 +414,8 @@ BOOST_AUTO_TEST_CASE(test_all_nss_network_error)
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_all_nss_send_tc_then_garbage_over_tcp) {
+BOOST_AUTO_TEST_CASE(test_all_nss_send_tc_then_garbage_over_tcp)
+{
   std::unique_ptr<SyncRes> sr;
   initSR(sr);
 
@@ -423,7 +424,6 @@ BOOST_AUTO_TEST_CASE(test_all_nss_send_tc_then_garbage_over_tcp) {
   std::set<ComboAddress> downServers;
 
   sr->setAsyncCallback([&downServers](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
-
     if (isRootServer(ip)) {
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "lock-up.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
@@ -459,7 +459,8 @@ BOOST_AUTO_TEST_CASE(test_all_nss_send_tc_then_garbage_over_tcp) {
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_all_nss_send_garbage_over_udp) {
+BOOST_AUTO_TEST_CASE(test_all_nss_send_garbage_over_udp)
+{
   std::unique_ptr<SyncRes> sr;
   initSR(sr);
 
@@ -469,7 +470,6 @@ BOOST_AUTO_TEST_CASE(test_all_nss_send_garbage_over_udp) {
   size_t queriesCount = 0;
 
   sr->setAsyncCallback([&queriesCount, &downServers](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
-
     if (isRootServer(ip)) {
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "lock-up.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
@@ -503,7 +503,8 @@ BOOST_AUTO_TEST_CASE(test_all_nss_send_garbage_over_udp) {
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_regular_ns_send_refused) {
+BOOST_AUTO_TEST_CASE(test_regular_ns_send_refused)
+{
   std::unique_ptr<SyncRes> sr;
   initSR(sr);
 
@@ -513,7 +514,6 @@ BOOST_AUTO_TEST_CASE(test_regular_ns_send_refused) {
   size_t queriesCount = 0;
 
   sr->setAsyncCallback([&queriesCount, &downServers](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
-
     if (isRootServer(ip)) {
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "refused.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
@@ -547,7 +547,8 @@ BOOST_AUTO_TEST_CASE(test_regular_ns_send_refused) {
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_forward_ns_send_refused) {
+BOOST_AUTO_TEST_CASE(test_forward_ns_send_refused)
+{
   std::unique_ptr<SyncRes> sr;
   initSR(sr);
 
@@ -559,13 +560,12 @@ BOOST_AUTO_TEST_CASE(test_forward_ns_send_refused) {
   const DNSName target("www.refused.");
 
   SyncRes::AuthDomain ad;
-  const std::vector<ComboAddress> forwardedNSs { ComboAddress("192.0.2.42:53"), ComboAddress("192.0.2.43:53") };
+  const std::vector<ComboAddress> forwardedNSs{ComboAddress("192.0.2.42:53"), ComboAddress("192.0.2.43:53")};
   ad.d_rdForward = false;
   ad.d_servers = forwardedNSs;
   (*SyncRes::t_sstorage.domainmap)[target] = ad;
 
   sr->setAsyncCallback([&queriesCount, &downServers](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
-
     if (isRootServer(ip)) {
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "refused.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
@@ -598,7 +598,8 @@ BOOST_AUTO_TEST_CASE(test_forward_ns_send_refused) {
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_forward_ns_send_servfail) {
+BOOST_AUTO_TEST_CASE(test_forward_ns_send_servfail)
+{
   std::unique_ptr<SyncRes> sr;
   initSR(sr);
 
@@ -610,13 +611,12 @@ BOOST_AUTO_TEST_CASE(test_forward_ns_send_servfail) {
   const DNSName target("www.refused.");
 
   SyncRes::AuthDomain ad;
-  const std::vector<ComboAddress> forwardedNSs { ComboAddress("192.0.2.42:53"), ComboAddress("192.0.2.43:53") };
+  const std::vector<ComboAddress> forwardedNSs{ComboAddress("192.0.2.42:53"), ComboAddress("192.0.2.43:53")};
   ad.d_rdForward = false;
   ad.d_servers = forwardedNSs;
   (*SyncRes::t_sstorage.domainmap)[DNSName("refused.")] = ad;
 
   sr->setAsyncCallback([&queriesCount, &downServers](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
-
     if (isRootServer(ip)) {
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "refused.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);

--- a/pdns/recursordist/test-syncres_cc1.cc
+++ b/pdns/recursordist/test-syncres_cc1.cc
@@ -59,10 +59,10 @@ BOOST_AUTO_TEST_CASE(test_root_primed_ns)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -88,10 +88,10 @@ BOOST_AUTO_TEST_CASE(test_root_not_primed)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* we are not primed yet, so SyncRes will have to call primeHints()
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(test_root_not_primed_and_no_response)
   */
   sr->setAsyncCallback([&downServers](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     downServers.insert(ip);
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -146,7 +146,7 @@ static void test_edns_formerr_fallback_f(bool sample)
       noEDNSServer = ip;
 
       setLWResult(res, RCode::FormErr);
-      return 1;
+      return LWResult::Result::Success;
     }
 
     queriesWithoutEDNS++;
@@ -154,10 +154,10 @@ static void test_edns_formerr_fallback_f(bool sample)
     if (domain == DNSName("powerdns.com") && type == QType::A && !doTCP) {
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.1");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return sample ? basicRecordsForQnameMinimization(res, domain, type) : 0;
+    return sample ? basicRecordsForQnameMinimization(res, domain, type) : LWResult::Result::Timeout;
   });
 
   primeHints();
@@ -212,10 +212,10 @@ BOOST_AUTO_TEST_CASE(test_edns_formerr_but_edns_enabled)
       if (EDNS0Level > 0) {
         res->d_haveEDNS = true;
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   primeHints();
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(test_meta_types)
 
     sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
       queriesCount++;
-      return 0;
+      return LWResult::Result::Timeout;
     });
 
     primeHints();
@@ -266,15 +266,15 @@ BOOST_AUTO_TEST_CASE(test_tc_fallback_to_tcp)
   sr->setAsyncCallback([](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     if (!doTCP) {
       setLWResult(res, 0, false, true, false);
-      return 1;
+      return LWResult::Result::Success;
     }
     if (domain == DNSName("powerdns.com") && type == QType::A && doTCP) {
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.1");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   primeHints();
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(test_tc_over_tcp)
   sr->setAsyncCallback([&tcpQueriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     if (!doTCP) {
       setLWResult(res, 0, true, true, false);
-      return 1;
+      return LWResult::Result::Success;
     }
 
     /* first TCP query is answered with a TC response */
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(test_tc_over_tcp)
     }
 
     addRecordToLW(res, domain, QType::A, "192.0.2.1");
-    return 1;
+    return LWResult::Result::Success;
   });
 
   primeHints();
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(test_all_nss_down)
       addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
       setLWResult(res, 0, false, false, true);
@@ -343,11 +343,11 @@ BOOST_AUTO_TEST_CASE(test_all_nss_down)
       addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::AAAA, "2001:DB8::2", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 172800);
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
       downServers.insert(ip);
-      return 0;
+      return LWResult::Result::Timeout;
     }
   });
 
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE(test_all_nss_network_error)
       addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
       setLWResult(res, 0, false, false, true);
@@ -390,11 +390,11 @@ BOOST_AUTO_TEST_CASE(test_all_nss_network_error)
       addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::AAAA, "2001:DB8::2", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 172800);
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
       downServers.insert(ip);
-      return 0;
+      return LWResult::Result::Timeout;
     }
   });
 
@@ -438,7 +438,7 @@ BOOST_AUTO_TEST_CASE(test_only_one_ns_up_resolving_itself_with_glue)
         addRecordToLW(res, "pdns-public-ns2.powerdns.net.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 172800);
         addRecordToLW(res, "pdns-public-ns2.powerdns.net.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 172800);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.3:53")) {
       setLWResult(res, 0, true, false, true);
@@ -458,9 +458,9 @@ BOOST_AUTO_TEST_CASE(test_only_one_ns_up_resolving_itself_with_glue)
           addRecordToLW(res, domain, QType::AAAA, "2001:DB8::1");
         }
       }
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -483,7 +483,7 @@ BOOST_AUTO_TEST_CASE(test_os_limit_errors)
       addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
       setLWResult(res, 0, false, false, true);
@@ -493,18 +493,18 @@ BOOST_AUTO_TEST_CASE(test_os_limit_errors)
       addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::AAAA, "2001:DB8::2", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 172800);
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
       if (downServers.size() < 3) {
         /* only the last one will answer */
         downServers.insert(ip);
-        return -2;
+        return LWResult::Result::OSLimitError;
       }
       else {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, "powerdns.com.", QType::A, "192.0.2.42");
-        return 1;
+        return LWResult::Result::Success;
       }
     }
   });
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(test_glued_referral)
   sr->setAsyncCallback([target](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     /* this will cause issue with qname minimization if we ever implement it */
     if (domain != target) {
-      return 0;
+      return LWResult::Result::Timeout;
     }
 
     if (isRootServer(ip)) {
@@ -545,7 +545,7 @@ BOOST_AUTO_TEST_CASE(test_glued_referral)
       addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
       setLWResult(res, 0, false, false, true);
@@ -555,15 +555,15 @@ BOOST_AUTO_TEST_CASE(test_glued_referral)
       addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::AAAA, "2001:DB8::2", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 172800);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.2:53") || ip == ComboAddress("192.0.2.3:53") || ip == ComboAddress("[2001:DB8::2]:53") || ip == ComboAddress("[2001:DB8::3]:53")) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, target, QType::A, "192.0.2.4");
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
-      return 0;
+      return LWResult::Result::Timeout;
     }
   });
 
@@ -596,43 +596,43 @@ BOOST_AUTO_TEST_CASE(test_glueless_referral)
       }
       else {
         setLWResult(res, RCode::NXDomain, false, false, true);
-        return 1;
+        return LWResult::Result::Success;
       }
 
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
       if (domain == target) {
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, "powerdns.com.", QType::NS, "pdns-public-ns1.powerdns.org.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "powerdns.com.", QType::NS, "pdns-public-ns2.powerdns.org.", DNSResourceRecord::AUTHORITY, 172800);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == DNSName("pdns-public-ns1.powerdns.org.")) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, "pdns-public-ns1.powerdns.org.", QType::A, "192.0.2.2");
         addRecordToLW(res, "pdns-public-ns1.powerdns.org.", QType::AAAA, "2001:DB8::2");
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == DNSName("pdns-public-ns2.powerdns.org.")) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, "pdns-public-ns2.powerdns.org.", QType::A, "192.0.2.3");
         addRecordToLW(res, "pdns-public-ns2.powerdns.org.", QType::AAAA, "2001:DB8::3");
-        return 1;
+        return LWResult::Result::Success;
       }
 
       setLWResult(res, RCode::NXDomain, false, false, true);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.2:53") || ip == ComboAddress("192.0.2.3:53") || ip == ComboAddress("[2001:DB8::2]:53") || ip == ComboAddress("[2001:DB8::3]:53")) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, target, QType::A, "192.0.2.4");
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
-      return 0;
+      return LWResult::Result::Timeout;
     }
   });
 
@@ -670,7 +670,7 @@ BOOST_AUTO_TEST_CASE(test_edns_subnet_by_domain)
       /* this one did not use the ECS info */
       srcmask = boost::none;
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
@@ -680,10 +680,10 @@ BOOST_AUTO_TEST_CASE(test_edns_subnet_by_domain)
       /* this one did, but only up to a precision of /16, not the full /24 */
       srcmask = Netmask("192.0.0.0/16");
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   SyncRes::s_ecsqueries = 0;
@@ -725,7 +725,7 @@ BOOST_AUTO_TEST_CASE(test_edns_subnet_by_addr)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
@@ -734,10 +734,10 @@ BOOST_AUTO_TEST_CASE(test_edns_subnet_by_addr)
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   SyncRes::s_ecsqueries = 0;
@@ -777,7 +777,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_use_requestor)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
@@ -786,10 +786,10 @@ BOOST_AUTO_TEST_CASE(test_ecs_use_requestor)
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -821,7 +821,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_use_scope_zero)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
@@ -830,10 +830,10 @@ BOOST_AUTO_TEST_CASE(test_ecs_use_scope_zero)
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -866,7 +866,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_honor_incoming_mask)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
@@ -875,10 +875,10 @@ BOOST_AUTO_TEST_CASE(test_ecs_honor_incoming_mask)
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -911,7 +911,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_honor_incoming_mask_zero)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
@@ -920,10 +920,10 @@ BOOST_AUTO_TEST_CASE(test_ecs_honor_incoming_mask_zero)
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -949,24 +949,24 @@ BOOST_AUTO_TEST_CASE(test_following_cname)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
       if (domain == target) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::CNAME, cnameTarget.toString());
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == cnameTarget) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::A, "192.0.2.2");
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -994,7 +994,7 @@ BOOST_AUTO_TEST_CASE(test_cname_nxdomain)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "powerdns.com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
@@ -1006,13 +1006,13 @@ BOOST_AUTO_TEST_CASE(test_cname_nxdomain)
       else if (domain == cnameTarget) {
         setLWResult(res, RCode::NXDomain, true, false, false);
         addRecordToLW(res, "powerdns.com.", QType::SOA, "a.powerdns.com. nstld.verisign-grs.com. 2017032800 1800 900 604800 86400", DNSResourceRecord::AUTHORITY, 86400);
-        return 1;
+        return LWResult::Result::Success;
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1054,7 +1054,7 @@ BOOST_AUTO_TEST_CASE(test_included_poisonous_cname)
 
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
@@ -1062,18 +1062,18 @@ BOOST_AUTO_TEST_CASE(test_included_poisonous_cname)
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::CNAME, cnameTarget.toString());
         addRecordToLW(res, cnameTarget, QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == cnameTarget) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, cnameTarget, QType::A, "192.0.2.3");
-        return 1;
+        return LWResult::Result::Success;
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1106,20 +1106,20 @@ BOOST_AUTO_TEST_CASE(test_cname_loop)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
       if (domain == target) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::CNAME, domain.toString());
-        return 1;
+        return LWResult::Result::Success;
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1159,35 +1159,35 @@ BOOST_AUTO_TEST_CASE(test_cname_long_loop)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
       if (domain == target1) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::CNAME, target2.toString());
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == target2) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::CNAME, target3.toString());
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == target3) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::CNAME, target4.toString());
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == target4) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::CNAME, target1.toString());
-        return 1;
+        return LWResult::Result::Success;
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1222,17 +1222,17 @@ BOOST_AUTO_TEST_CASE(test_cname_depth)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::CNAME, std::to_string(depth) + "-cname.powerdns.com");
       depth++;
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1263,16 +1263,16 @@ BOOST_AUTO_TEST_CASE(test_time_limit)
 
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* Set the maximum time to 1 ms */
@@ -1317,13 +1317,13 @@ BOOST_AUTO_TEST_CASE(test_dname_processing)
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, dnameOwner, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain.isPartOf(dnameTarget)) {
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, dnameTarget, QType::NS, "b.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "b.gtld-servers.net.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
@@ -1331,7 +1331,7 @@ BOOST_AUTO_TEST_CASE(test_dname_processing)
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, dnameOwner, QType::DNAME, dnameTarget.toString());
         addRecordToLW(res, domain, QType::CNAME, cnameTarget.toString());
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.2:53")) {
@@ -1343,9 +1343,9 @@ BOOST_AUTO_TEST_CASE(test_dname_processing)
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::A, "192.0.2.3");
       }
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1464,13 +1464,13 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_secure)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain.countLabels() == 1 && type == QType::DS) { // powerdns|DS or example|DS
         setLWResult(res, 0, true, false, true);
         addDS(domain, 300, res->d_records, keys, DNSResourceRecord::ANSWER);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       // For the rest, delegate!
       if (domain.isPartOf(dnameOwner)) {
@@ -1479,7 +1479,7 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_secure)
         addDS(dnameOwner, 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain.isPartOf(dnameTarget)) {
         setLWResult(res, 0, false, false, true);
@@ -1487,7 +1487,7 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_secure)
         addDS(dnameTarget, 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "b.gtld-servers.net.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
@@ -1495,7 +1495,7 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_secure)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain == target && type == QType::DS) { // dname.powerdns|DS
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys, false);
@@ -1505,7 +1505,7 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_secure)
         addRecordToLW(res, dnameOwner, QType::DNAME, dnameTarget.toString());
         addRRSIG(keys, res->d_records, dnameOwner, 300);
         addRecordToLW(res, domain, QType::CNAME, cnameTarget.toString()); // CNAME from a DNAME is not signed
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.2:53")) {
@@ -1513,7 +1513,7 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_secure)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain == cnameTarget && type == QType::DS) { // dname.example|DS
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys, false);
@@ -1523,9 +1523,9 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_secure)
         addRecordToLW(res, domain, QType::A, "192.0.2.2");
         addRRSIG(keys, res->d_records, dnameTarget, 300);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1615,13 +1615,13 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_insecure)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain == dnameOwner && type == QType::DS) { // powerdns|DS
         setLWResult(res, 0, true, false, true);
         addDS(domain, 300, res->d_records, keys, DNSResourceRecord::ANSWER);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain == dnameTarget && type == QType::DS) { // example|DS
         return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys);
@@ -1633,7 +1633,7 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_insecure)
         addDS(dnameOwner, 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain.isPartOf(dnameTarget)) {
         setLWResult(res, 0, false, false, true);
@@ -1641,7 +1641,7 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_insecure)
         addDS(dnameTarget, 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "b.gtld-servers.net.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
@@ -1649,7 +1649,7 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_insecure)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain == target && type == QType::DS) { // dname.powerdns|DS
         return genericDSAndDNSKEYHandler(res, domain, dnameOwner, type, keys, false);
@@ -1659,7 +1659,7 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_insecure)
         addRecordToLW(res, dnameOwner, QType::DNAME, dnameTarget.toString());
         addRRSIG(keys, res->d_records, dnameOwner, 300);
         addRecordToLW(res, domain, QType::CNAME, cnameTarget.toString()); // CNAME from a DNAME is not signed
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.2:53")) {
@@ -1670,9 +1670,9 @@ BOOST_AUTO_TEST_CASE(test_dname_dnssec_insecure)
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::A, "192.0.2.2");
       }
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1744,13 +1744,13 @@ BOOST_AUTO_TEST_CASE(test_dname_processing_no_CNAME)
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, dnameOwner, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain.isPartOf(dnameTarget)) {
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, dnameTarget, QType::NS, "b.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "b.gtld-servers.net.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
@@ -1758,7 +1758,7 @@ BOOST_AUTO_TEST_CASE(test_dname_processing_no_CNAME)
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, dnameOwner, QType::DNAME, dnameTarget.toString());
         // No CNAME, recursor should synth
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.2:53")) {
@@ -1766,9 +1766,9 @@ BOOST_AUTO_TEST_CASE(test_dname_processing_no_CNAME)
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::A, "192.0.2.2");
       }
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;

--- a/pdns/recursordist/test-syncres_cc10.cc
+++ b/pdns/recursordist/test-syncres_cc10.cc
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(test_outgoing_v4_only)
         addRecordToLW(res, "ns1.powerdns.com.", QType::AAAA, "2001:DB8:1::53", DNSResourceRecord::ADDITIONAL, 3600);
         addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
       setLWResult(res, 0, true, false, false);
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(test_outgoing_v4_only)
       if (domain == DNSName("powerdns.com.")) {
         addRecordToLW(res, domain, QType::A, "192.0.2.2");
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("[2001:DB8:1::53]:53")) {
       setLWResult(res, 0, true, false, false);
@@ -43,9 +43,9 @@ BOOST_AUTO_TEST_CASE(test_outgoing_v4_only)
       if (domain == DNSName("powerdns.com.")) {
         addRecordToLW(res, domain, QType::A, "192.0.2.2");
       }
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -77,16 +77,16 @@ BOOST_AUTO_TEST_CASE(test_outgoing_v4_only_no_A_in_delegation)
         addRecordToLW(res, domain, QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "ns1.powerdns.com.", QType::AAAA, "2001:DB8:1::53", DNSResourceRecord::ADDITIONAL, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("[2001:DB8:1::53]:53")) {
       setLWResult(res, 0, true, false, false);
       if (domain == DNSName("powerdns.com.")) {
         addRecordToLW(res, domain, QType::A, "192.0.2.2");
       }
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -115,16 +115,16 @@ BOOST_AUTO_TEST_CASE(test_outgoing_v6_only_no_AAAA_in_delegation)
         addRecordToLW(res, domain, QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
       setLWResult(res, 0, true, false, false);
       if (domain == DNSName("powerdns.com.")) {
         addRecordToLW(res, domain, QType::A, "192.0.2.2");
       }
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;

--- a/pdns/recursordist/test-syncres_cc2.cc
+++ b/pdns/recursordist/test-syncres_cc2.cc
@@ -38,7 +38,7 @@ static void do_test_referral_depth(bool limited)
         addRecordToLW(res, "ns4.powerdns.org.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
       setLWResult(res, 0, true, false, false);
@@ -48,10 +48,10 @@ static void do_test_referral_depth(bool limited)
       else {
         addRecordToLW(res, domain, QType::A, "192.0.2.1");
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   if (limited) {
@@ -127,31 +127,31 @@ BOOST_AUTO_TEST_CASE(test_glueless_referral_loop)
       }
       else {
         setLWResult(res, RCode::NXDomain, false, false, true);
-        return 1;
+        return LWResult::Result::Success;
       }
 
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
       if (domain.isPartOf(target1)) {
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, "powerdns.com.", QType::NS, "ns1.powerdns.org.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "powerdns.com.", QType::NS, "ns2.powerdns.org.", DNSResourceRecord::AUTHORITY, 172800);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain.isPartOf(target2)) {
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, "powerdns.org.", QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "powerdns.org.", QType::NS, "ns2.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
-        return 1;
+        return LWResult::Result::Success;
       }
       setLWResult(res, RCode::NXDomain, false, false, true);
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
-      return 0;
+      return LWResult::Result::Timeout;
     }
   });
 
@@ -180,16 +180,16 @@ BOOST_AUTO_TEST_CASE(test_cname_qperq)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::CNAME, std::to_string(queries) + "-cname.powerdns.com");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* Set the maximum number of questions very low */
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(test_throttled_server)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
@@ -231,10 +231,10 @@ BOOST_AUTO_TEST_CASE(test_throttled_server)
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* mark ns as down */
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(test_dont_query_server)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
@@ -317,10 +317,10 @@ BOOST_AUTO_TEST_CASE(test_dont_query_server)
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* prevent querying this NS */
@@ -361,17 +361,17 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust)
         addRecordToLW(res, "a.gtld-servers.net.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   SyncRes::s_maxnegttl = 3600;
@@ -426,17 +426,17 @@ BOOST_AUTO_TEST_CASE(test_root_nx_trust_specific)
         addRecordToLW(res, "a.gtld-servers.net.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -488,17 +488,17 @@ BOOST_AUTO_TEST_CASE(test_root_nx_dont_trust)
         addRecordToLW(res, "a.gtld-servers.net.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   SyncRes::s_rootNXTrust = false;
@@ -543,14 +543,14 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "powerdns.com.", QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "ns1.powerdns.com.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
       setLWResult(res, RCode::NXDomain, true, false, false);
       addRecordToLW(res, "powerdns.com.", QType::SOA, "ns1.powerdns.com. hostmaster.powerdns.com. 2017032800 1800 900 604800 86400", DNSResourceRecord::AUTHORITY, 86400);
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -659,7 +659,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
         addRRSIG(keys, res->d_records, auth, 300);
         addNSECRecordToLW(DNSName("wwa.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::RRSIG, QType::NSEC}, 600, res->d_records);
         addRRSIG(keys, res->d_records, auth, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
@@ -672,7 +672,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -689,7 +689,7 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         if (type == QType::NS) {
@@ -711,11 +711,11 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nothing_underneath_dnssec)
           addNSECRecordToLW(DNSName("powerdns.com."), DNSName("a.powerdns.com."), {QType::RRSIG, QType::NSEC}, 600, res->d_records);
           addRRSIG(keys, res->d_records, auth, 300);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -812,28 +812,28 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nodata)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "powerdns.com.", QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "ns1.powerdns.com.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
       if (domain == target1) { // NODATA for TXT, NOERROR for A
         if (type == QType::TXT) {
           setLWResult(res, RCode::NoError, true);
           addRecordToLW(res, "powerdns.com.", QType::SOA, "ns1.powerdns.com. hostmaster.powerdns.com. 2017032800 1800 900 604800 86400", DNSResourceRecord::AUTHORITY, 86400);
-          return 1;
+          return LWResult::Result::Success;
         }
         if (type == QType::A) {
           setLWResult(res, RCode::NoError, true);
           addRecordToLW(res, domain, QType::A, "192.0.2.1", DNSResourceRecord::ANSWER, 86400);
-          return 1;
+          return LWResult::Result::Success;
         }
       }
       if (domain == target2 || domain == target3) {
         setLWResult(res, RCode::NXDomain, true);
         addRecordToLW(res, "powerdns.com.", QType::SOA, "ns1.powerdns.com. hostmaster.powerdns.com. 2017032800 1800 900 604800 86400", DNSResourceRecord::AUTHORITY, 86400);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -886,28 +886,28 @@ BOOST_AUTO_TEST_CASE(test_rfc8020_nodata_bis)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "powerdns.com.", QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "ns1.powerdns.com.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
       if (domain == target1) { // NODATA for TXT, NOERROR for A
         if (type == QType::TXT) {
           setLWResult(res, RCode::NoError, true);
           addRecordToLW(res, "powerdns.com.", QType::SOA, "ns1.powerdns.com. hostmaster.powerdns.com. 2017032800 1800 900 604800 86400", DNSResourceRecord::AUTHORITY, 86400);
-          return 1;
+          return LWResult::Result::Success;
         }
         if (type == QType::A) {
           setLWResult(res, RCode::NoError, true);
           addRecordToLW(res, domain, QType::A, "192.0.2.1", DNSResourceRecord::ANSWER, 86400);
-          return 1;
+          return LWResult::Result::Success;
         }
       }
       if (domain == target2 || domain == target3) {
         setLWResult(res, RCode::NXDomain, true);
         addRecordToLW(res, "powerdns.com.", QType::SOA, "ns1.powerdns.com. hostmaster.powerdns.com. 2017032800 1800 900 604800 86400", DNSResourceRecord::AUTHORITY, 86400);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -966,7 +966,7 @@ BOOST_AUTO_TEST_CASE(test_skip_negcache_for_variable_response)
 
       srcmask = boost::none;
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
       if (domain == target) {
@@ -982,10 +982,10 @@ BOOST_AUTO_TEST_CASE(test_skip_negcache_for_variable_response)
         addRecordToLW(res, "powerdns.com", QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1019,7 +1019,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_limit_allowed)
     setLWResult(res, 0, true, false, true);
     addRecordToLW(res, target, QType::A, "192.0.2.1");
 
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -1058,7 +1058,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_limit_no_ttl_limit_allowed)
     setLWResult(res, 0, true, false, true);
     addRecordToLW(res, target, QType::A, "192.0.2.1");
 
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -1097,7 +1097,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_ttllimit_allowed)
     setLWResult(res, 0, true, false, true);
     addRecordToLW(res, target, QType::A, "192.0.2.1");
 
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -1137,7 +1137,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_ttllimit_and_scope_allowed)
     setLWResult(res, 0, true, false, true);
     addRecordToLW(res, target, QType::A, "192.0.2.1");
 
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -1177,7 +1177,7 @@ BOOST_AUTO_TEST_CASE(test_ecs_cache_ttllimit_notallowed)
     setLWResult(res, 0, true, false, true);
     addRecordToLW(res, target, QType::A, "192.0.2.1");
 
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -1218,7 +1218,7 @@ BOOST_AUTO_TEST_CASE(test_ns_speed)
       addRecordToLW(res, "pdns-public-ns3.powerdns.com.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "pdns-public-ns3.powerdns.com.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
       nsCounts[ip]++;
@@ -1227,20 +1227,20 @@ BOOST_AUTO_TEST_CASE(test_ns_speed)
         BOOST_CHECK_LT(nsCounts.size(), 3U);
 
         /* let's time out on pdns-public-ns2.powerdns.com. */
-        return 0;
+        return LWResult::Result::Timeout;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         BOOST_CHECK_EQUAL(nsCounts.size(), 3U);
 
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::A, "192.0.2.254");
-        return 1;
+        return LWResult::Result::Success;
       }
 
-      return 0;
+      return LWResult::Result::Timeout;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   struct timeval now = sr->getNow();
@@ -1280,15 +1280,15 @@ BOOST_AUTO_TEST_CASE(test_flawed_nsset)
 
       addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.254");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* we populate the cache with a flawed NSset, i.e. there is a NS entry but no corresponding glue */
@@ -1322,15 +1322,15 @@ BOOST_AUTO_TEST_CASE(test_completely_flawed_nsset)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "pdns-public-ns2.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, domain, QType::NS, "pdns-public-ns3.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == DNSName("pdns-public-ns2.powerdns.com.") || domain == DNSName("pdns-public-ns3.powerdns.com.")) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, ".", QType::SOA, "a.root-servers.net. nstld.verisign-grs.com. 2017032800 1800 900 604800 86400", DNSResourceRecord::AUTHORITY, 86400);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1361,14 +1361,14 @@ BOOST_AUTO_TEST_CASE(test_completely_flawed_big_nsset)
         string n = string("pdns-public-ns") + std::to_string(i) + string(".powerdns.com.");
         addRecordToLW(res, domain, QType::NS, n, DNSResourceRecord::AUTHORITY, 172800);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain.toString().length() > 14 && domain.toString().substr(0, 14) == "pdns-public-ns") {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, ".", QType::SOA, "a.root-servers.net. nstld.verisign-grs.com. 2017032800 1800 900 604800 86400", DNSResourceRecord::AUTHORITY, 86400);
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1394,7 +1394,7 @@ BOOST_AUTO_TEST_CASE(test_cache_hit)
   const DNSName target("powerdns.com.");
 
   sr->setAsyncCallback([target](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* we populate the cache with everything we need */
@@ -1425,7 +1425,7 @@ BOOST_AUTO_TEST_CASE(test_no_rd)
 
   sr->setAsyncCallback([target, &queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1451,17 +1451,17 @@ BOOST_AUTO_TEST_CASE(test_cache_min_max_ttl)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 7200);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2", DNSResourceRecord::ANSWER, 10);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -1514,17 +1514,17 @@ BOOST_AUTO_TEST_CASE(test_cache_min_max_ecs_ttl)
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 20);
       srcmask = boost::none;
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
       setLWResult(res, 0, true, false, false);
       addRecordToLW(res, domain, QType::A, "192.0.2.2", DNSResourceRecord::ANSWER, 10);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -1574,15 +1574,15 @@ BOOST_AUTO_TEST_CASE(test_cache_expired_ttl)
 
       addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.2");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* we populate the cache with entries that expired 60s ago*/

--- a/pdns/recursordist/test-syncres_cc3.cc
+++ b/pdns/recursordist/test-syncres_cc3.cc
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(test_cache_auth)
     addRecordToLW(res, domain, QType::A, "192.0.2.2", DNSResourceRecord::ANSWER, 10);
     addRecordToLW(res, domain, QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 10);
 
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -60,16 +60,16 @@ BOOST_AUTO_TEST_CASE(test_delegation_only)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -92,16 +92,16 @@ BOOST_AUTO_TEST_CASE(test_unauth_any)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
 
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -126,7 +126,7 @@ static void test_no_data_f(bool qmin)
       struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context,
       LWResult* res, bool* chained) {
       setLWResult(res, 0, true, false, true);
-      return 1;
+      return LWResult::Result::Success;
     });
 
   vector<DNSRecord> ret;
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(test_skip_opt_any)
     addRecordToLW(res, domain, QType::A, "192.0.2.42");
     addRecordToLW(res, domain, QType::ANY, "\\# 0");
     addRecordToLW(res, domain, QType::OPT, "");
-    return 1;
+    return LWResult::Result::Success;
   });
 
   vector<DNSRecord> ret;
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(test_nodata_nsec_nodnssec)
     addRecordToLW(res, domain, QType::NSEC, "deadbeef", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, domain, QType::RRSIG, "NSEC 5 2 600 2100010100000000 2100010100000000 24567 dummy data", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, domain, QType::RRSIG, "SOA 5 3 600 2100010100000000 2100010100000000 24567 dummy data", DNSResourceRecord::AUTHORITY);
-    return 1;
+    return LWResult::Result::Success;
   });
 
   vector<DNSRecord> ret;
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(test_nodata_nsec_dnssec)
     addRecordToLW(res, domain, QType::NSEC, "deadbeef", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, domain, QType::RRSIG, "NSEC 5 2 600 2100010100000000 2100010100000000 24567 dummy data", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, domain, QType::RRSIG, "SOA 5 3 600 2100010100000000 2100010100000000 24567 dummy data", DNSResourceRecord::AUTHORITY);
-    return 1;
+    return LWResult::Result::Success;
   });
 
   vector<DNSRecord> ret;
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(test_nx_nsec_nodnssec)
     addRecordToLW(res, domain, QType::NSEC, "deadbeef", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, domain, QType::RRSIG, "NSEC 5 2 600 2100010100000000 2100010100000000 24567 dummy data", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, domain, QType::RRSIG, "SOA 5 3 600 2100010100000000 2100010100000000 24567 dummy data", DNSResourceRecord::AUTHORITY);
-    return 1;
+    return LWResult::Result::Success;
   });
 
   vector<DNSRecord> ret;
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(test_nx_nsec_dnssec)
     addRecordToLW(res, domain, QType::NSEC, "deadbeef", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, domain, QType::RRSIG, "NSEC 5 2 600 2100010100000000 2100010100000000 24567 dummy data", DNSResourceRecord::AUTHORITY);
     addRecordToLW(res, domain, QType::RRSIG, "SOA 5 3 600 2100010100000000 2100010100000000 24567 dummy data", DNSResourceRecord::AUTHORITY);
-    return 1;
+    return LWResult::Result::Success;
   });
 
   vector<DNSRecord> ret;
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(test_qclass_none)
 
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   const DNSName target("powerdns.com.");
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE(test_answer_no_aa)
   sr->setAsyncCallback([target](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     setLWResult(res, 0, false, false, true);
     addRecordToLW(res, domain, QType::A, "192.0.2.1");
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(test_special_types)
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     cerr << "asyncresolve called to ask " << ip.toStringWithPort() << " about " << domain.toString() << " / " << QType(type).getName() << " over " << (doTCP ? "TCP" : "UDP") << " (rd: " << sendRDQuery << ", EDNS0 level: " << EDNS0Level << ")" << endl;
     queriesCount++;
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   const DNSName target("powerdns.com.");
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE(test_special_names)
 
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -498,16 +498,16 @@ BOOST_AUTO_TEST_CASE(test_nameserver_ipv4_rpz)
       setLWResult(res, false, true, false, true);
       addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   DNSFilterEngine::Policy pol;
@@ -539,16 +539,16 @@ BOOST_AUTO_TEST_CASE(test_nameserver_ipv6_rpz)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   DNSFilterEngine::Policy pol;
@@ -581,16 +581,16 @@ BOOST_AUTO_TEST_CASE(test_nameserver_name_rpz)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, nsName.toString(), DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, nsName, QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   DNSFilterEngine::Policy pol;
@@ -623,16 +623,16 @@ BOOST_AUTO_TEST_CASE(test_nameserver_name_rpz_disabled)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::NS, nsName.toString(), DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, nsName, QType::A, ns.toString(), DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ns) {
 
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   DNSFilterEngine::Policy pol;
@@ -677,10 +677,10 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_nord)
 
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* simulate a no-RD query */
@@ -718,10 +718,10 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_rd)
       /* set AA=0, we are a recursor */
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -764,10 +764,10 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord)
 
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* simulate a no-RD query */
@@ -801,10 +801,10 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd)
 
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, "192.0.2.42");
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -847,7 +847,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec)
     BOOST_CHECK_EQUAL(sendRDQuery, true);
 
     if (ip != forwardedNS) {
-      return 0;
+      return LWResult::Result::Timeout;
     }
 
     if (type == QType::DS || type == QType::DNSKEY) {
@@ -861,9 +861,9 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec)
       addRRSIG(keys, res->d_records, domain, 300);
       addRecordToLW(res, cnameTarget, QType::A, "192.0.2.1");
 
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -937,7 +937,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord_dnssec)
     }
 
     if (ip != forwardedNS) {
-      return 0;
+      return LWResult::Result::Timeout;
     }
 
     if (domain == target1 && type == QType::A) {
@@ -946,7 +946,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord_dnssec)
       addRecordToLW(res, target1, QType::A, "192.0.2.1");
       addRRSIG(keys, res->d_records, parent, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     if (domain == target2 && type == QType::A) {
 
@@ -954,10 +954,10 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord_dnssec)
       addRecordToLW(res, target2, QType::A, "192.0.2.2");
       addRRSIG(keys, res->d_records, parent, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1022,7 +1022,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_bogus)
     BOOST_CHECK_EQUAL(sendRDQuery, true);
 
     if (ip != forwardedNS) {
-      return 0;
+      return LWResult::Result::Timeout;
     }
 
     if (type == QType::DS || type == QType::DNSKEY) {
@@ -1037,9 +1037,9 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_bogus)
       addRecordToLW(res, cnameTarget, QType::A, "192.0.2.1");
       /* no RRSIG in a signed zone, Bogus ! */
 
-      return 1;
+      return LWResult::Result::Success;
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1090,7 +1090,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_nodata_bogus)
     BOOST_CHECK_EQUAL(sendRDQuery, true);
 
     if (ip != forwardedNS) {
-      return 0;
+      return LWResult::Result::Timeout;
     }
 
     if (type == QType::DS || type == QType::DNSKEY) {
@@ -1099,10 +1099,10 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_nodata_bogus)
     else {
 
       setLWResult(res, 0, false, false, true);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1149,7 +1149,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_oob)
 
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1217,7 +1217,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_oob_cname)
 
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1290,7 +1290,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone)
     queriesCount++;
     setLWResult(res, 0, true, false, true);
     addRecordToLW(res, domain, QType::A, "192.0.2.42");
-    return 1;
+    return LWResult::Result::Success;
   });
 
   vector<DNSRecord> ret;
@@ -1341,10 +1341,10 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_cname_lead_to_oob)
     if (domain == target) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, target, QType::CNAME, authZone.toString(), DNSResourceRecord::ANSWER, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1397,10 +1397,10 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_oob_lead_to_outgoing_queryb)
     if (domain == externalCNAME) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, externalCNAME, QType::A, addr.toString(), DNSResourceRecord::ANSWER, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_nodata)
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_nx)
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -152,10 +152,10 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_delegation)
     if (ip == ComboAddress(nsAddr.toString(), 53) && domain == target) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   sr->setDNSSECValidationRequested(true);
@@ -216,10 +216,10 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_delegation_point)
     if (ip == ComboAddress(nsAddr.toString(), 53) && domain == target) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_wildcard)
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_wildcard_with_ent)
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_wildcard_nodata)
   sr->setAsyncCallback([&queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_cache_only)
     queriesCount++;
     setLWResult(res, 0, true, false, true);
     addRecordToLW(res, domain, QType::A, "192.0.2.42");
-    return 1;
+    return LWResult::Result::Success;
   });
 
   /* simulate a no-RD query */
@@ -498,7 +498,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_root_validation_csk)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -507,10 +507,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_root_validation_csk)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_root_validation_ksk_zsk)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -595,10 +595,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_root_validation_ksk_zsk)
       addDNSKEY(zskeys, domain, 300, res->d_records);
       addRRSIG(kskeys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -653,7 +653,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_no_dnskey)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -661,10 +661,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_no_dnskey)
 
       /* No DNSKEY */
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -729,7 +729,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_without_zone_flag)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -738,10 +738,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_without_zone_flag)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -806,7 +806,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_revoked)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -815,10 +815,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_revoked)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -892,7 +892,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_doesnt_match_ds)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -901,10 +901,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_doesnt_match_ds)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* === with validation enabled === */
@@ -1004,7 +1004,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_rrsig_signed_with_unknown_dnskey)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -1013,10 +1013,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_rrsig_signed_with_unknown_dnskey)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(rrsigkeys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1071,7 +1071,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_no_rrsig)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -1080,10 +1080,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_no_rrsig)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   SyncRes::s_maxcachettl = 86400;
@@ -1161,7 +1161,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_algorithm)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -1170,10 +1170,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_algorithm)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1242,7 +1242,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_digest)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -1251,10 +1251,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_digest)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1311,7 +1311,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_bad_sig)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -1320,10 +1320,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_bad_sig)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1380,7 +1380,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_bad_algo)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -1389,10 +1389,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_bad_algo)
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1439,8 +1439,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_unsigned_ds)
     DNSName auth = domain;
 
     if (type == QType::DS || type == QType::DNSKEY) {
-      if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys) == 0) {
-        return 0;
+      if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys) == LWResult::Result::Timeout) {
+        return LWResult::Result::Timeout;
       }
 
       if (type == QType::DS && domain == target) {
@@ -1448,7 +1448,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_unsigned_ds)
         res->d_records.pop_back();
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (isRootServer(ip)) {
@@ -1457,17 +1457,17 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_unsigned_ds)
       /* Include the DS but omit the RRSIG*/
       addDS(DNSName("com."), 300, res->d_records, keys);
       addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.1:53")) {
       setLWResult(res, RCode::NoError, true, false, true);
       addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
       addRRSIG(keys, res->d_records, auth, 300);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1520,8 +1520,8 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_unsigned_ds_direct)
     DNSName auth = domain;
 
     if (type == QType::DS || type == QType::DNSKEY) {
-      if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys) == 0) {
-        return 0;
+      if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys) == LWResult::Result::Timeout) {
+        return LWResult::Result::Timeout;
       }
 
       if (type == QType::DS && domain == target) {
@@ -1529,7 +1529,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_unsigned_ds_direct)
         res->d_records.pop_back();
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (isRootServer(ip)) {
@@ -1538,10 +1538,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_unsigned_ds_direct)
       /* Include the DS but omit the RRSIG*/
       addDS(DNSName("com."), 300, res->d_records, keys);
       addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;

--- a/pdns/recursordist/test-syncres_cc5.cc
+++ b/pdns/recursordist/test-syncres_cc5.cc
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_various_algos)
       addDS(DNSName("com."), 300, res->d_records, keys);
       addRRSIG(keys, res->d_records, DNSName("."), 300, false, boost::none, boost::none, fixedNow);
       addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.1:53")) {
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_various_algos)
         addRRSIG(keys, res->d_records, DNSName("com."), 300, false, boost::none, boost::none, fixedNow);
         addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.2:53")) {
@@ -85,10 +85,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_various_algos)
         addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
         addRRSIG(keys, res->d_records, auth, 300, false, boost::none, boost::none, fixedNow);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_a_then_ns)
       addDS(DNSName("com."), 300, res->d_records, keys);
       addRRSIG(keys, res->d_records, DNSName("."), 300);
       addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.1:53")) {
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_a_then_ns)
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.2:53")) {
@@ -180,10 +180,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_a_then_ns)
         addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
         addRRSIG(keys, res->d_records, auth, 300);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_a_then_ns)
       addDS(DNSName("com."), 300, res->d_records, keys);
       addRRSIG(keys, res->d_records, DNSName("."), 300);
       addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.1:53")) {
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_a_then_ns)
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.2:53")) {
@@ -281,10 +281,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_a_then_ns)
         setLWResult(res, RCode::NoError, true, false, true);
         addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_with_nta)
       addDS(DNSName("com."), 300, res->d_records, keys);
       addRRSIG(keys, res->d_records, DNSName("."), 300);
       addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.1:53")) {
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_with_nta)
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.2:53")) {
@@ -389,10 +389,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_with_nta)
         addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
         addRRSIG(keys, res->d_records, auth, 300);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -444,14 +444,14 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_with_nta)
     if (type == QType::DS || type == QType::DNSKEY) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
       if (isRootServer(ip)) {
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -464,7 +464,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_with_nta)
           addRecordToLW(res, domain, QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 3600);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         if (type == QType::NS) {
@@ -476,11 +476,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_with_nta)
           setLWResult(res, RCode::NoError, true, false, true);
           addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* There is TA for root but no DS/DNSKEY/RRSIG, should be Bogus, but.. */
@@ -535,7 +535,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -552,7 +552,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         if (type == QType::NS) {
@@ -569,11 +569,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec)
           addNSECRecordToLW(domain, DNSName("z.powerdns.com."), {QType::NS, QType::DNSKEY}, 600, res->d_records);
           addRRSIG(keys, res->d_records, domain, 300);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -627,7 +627,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nxdomain_nsec)
         addRRSIG(keys, res->d_records, auth, 300);
         addNSECRecordToLW(DNSName("nw.powerdns.com."), DNSName("ny.powerdns.com."), {QType::RRSIG, QType::NSEC}, 600, res->d_records);
         addRRSIG(keys, res->d_records, auth, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
@@ -640,7 +640,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nxdomain_nsec)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -657,7 +657,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nxdomain_nsec)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         if (type == QType::NS) {
@@ -685,11 +685,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nxdomain_nsec)
           addNSECRecordToLW(DNSName("powerdns.com."), DNSName("a.powerdns.com."), {QType::RRSIG, QType::NSEC}, 600, res->d_records);
           addRRSIG(keys, res->d_records, auth, 300);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -739,7 +739,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard)
         addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
         addNSECRecordToLW(DNSName("www.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -752,7 +752,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -794,11 +794,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard)
           addNSECRecordToLW(DNSName("a.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -850,7 +850,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_nodata_nowildcard)
         /* add a NSEC denying the DS AND the existence of a cut (no NS) */
         addNSECRecordToLW(domain, DNSName("z") + domain, {QType::NSEC}, 600, res->d_records);
         addRRSIG(keys, res->d_records, auth, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
     }
@@ -861,7 +861,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_nodata_nowildcard)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         setLWResult(res, 0, true, false, true);
@@ -874,11 +874,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_nodata_nowildcard)
         /* a wildcard matches but has no record for this type */
         addNSECRecordToLW(DNSName("*.com."), DNSName("com."), {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com"), 300, false, boost::none, DNSName("*.com"));
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -937,7 +937,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard)
         /* a wildcard matches but has no record for this type */
         addNSEC3UnhashedRecordToLW(DNSName("*.com."), DNSName("com."), "whatever", {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com"), 300, false, boost::none, DNSName("*.com"));
-        return 1;
+        return LWResult::Result::Success;
       }
       return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
     }
@@ -948,7 +948,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         setLWResult(res, 0, true, false, true);
@@ -965,11 +965,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard)
         /* a wildcard matches but has no record for this type */
         addNSEC3UnhashedRecordToLW(DNSName("*.com."), DNSName("com."), "whatever", {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com"), 300, false, boost::none, DNSName("*.com"));
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1028,7 +1028,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard_duplicated_n
         /* a wildcard matches but has no record for this type */
         addNSEC3UnhashedRecordToLW(DNSName("*.com."), DNSName("com."), "whatever", {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com"), 300, false, boost::none, DNSName("*.com"));
-        return 1;
+        return LWResult::Result::Success;
       }
       return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
     }
@@ -1039,7 +1039,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard_duplicated_n
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         setLWResult(res, 0, true, false, true);
@@ -1058,11 +1058,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard_duplicated_n
         /* a wildcard matches but has no record for this type */
         addNSEC3UnhashedRecordToLW(DNSName("*.com."), DNSName("com."), "whatever", {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com"), 300, false, boost::none, DNSName("*.com"));
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1123,7 +1123,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard_too_many_ite
         /* a wildcard matches but has no record for this type */
         addNSEC3UnhashedRecordToLW(DNSName("*.com."), DNSName("com."), "whatever", {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records, g_maxNSEC3Iterations + 100);
         addRRSIG(keys, res->d_records, DNSName("com"), 300, false, boost::none, DNSName("*.com"));
-        return 1;
+        return LWResult::Result::Success;
       }
       return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
     }
@@ -1134,7 +1134,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard_too_many_ite
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         setLWResult(res, 0, true, false, true);
@@ -1151,11 +1151,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_nodata_nowildcard_too_many_ite
         /* a wildcard matches but has no record for this type */
         addNSEC3UnhashedRecordToLW(DNSName("*.com."), DNSName("com."), "whatever", {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records, g_maxNSEC3Iterations + 100);
         addRRSIG(keys, res->d_records, DNSName("com"), 300, false, boost::none, DNSName("*.com"));
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* we are generating NSEC3 with more iterations than we allow, so we should go Insecure */
@@ -1211,7 +1211,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard)
           addNSECRecordToLW(DNSName("www.sub.powerdns.com."), DNSName("wwz.sub.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         }
         addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -1224,7 +1224,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -1241,7 +1241,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -1270,11 +1270,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard)
           addNSEC3NarrowRecordToLW(DNSName("sub.powerdns.com."), DNSName("powerdns.com."), {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1324,7 +1324,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard_too_many_iterations)
         addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
         addNSECRecordToLW(DNSName("www.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -1337,7 +1337,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard_too_many_iterations)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -1354,7 +1354,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard_too_many_iterations)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -1383,11 +1383,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard_too_many_iterations)
           addNSEC3NarrowRecordToLW(DNSName("www.powerdns.com."), DNSName("powerdns.com."), {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, res->d_records, g_maxNSEC3Iterations + 100);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* the NSEC3 providing the denial of existence proof for the next closer has too many iterations,
@@ -1439,7 +1439,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_missing)
         addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
         addNSECRecordToLW(DNSName("www.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -1452,7 +1452,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_missing)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -1469,7 +1469,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_missing)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -1491,11 +1491,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_missing)
           addRecordToLW(res, domain, QType::A, "192.0.2.42");
           addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1545,7 +1545,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_wildcard_expanded_onto_itself)
         std::set<uint16_t> types = {QType::NSEC};
         addNSECRecordToLW(domain, DNSName("z") + domain, types, 600, res->d_records);
         addRRSIG(keys, res->d_records, auth, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
     }
@@ -1557,7 +1557,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_wildcard_expanded_onto_itself)
          it's the wildcard itself, but let's do it so other validators don't choke on it */
       addNSECRecordToLW(DNSName("*.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
       addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
-      return 1;
+      return LWResult::Result::Success;
     }
   });
 
@@ -1598,7 +1598,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_wildcard_like_expanded_from_wildcard
         addRRSIG(keys, res->d_records, auth, 300);
         addNSECRecordToLW(DNSName("*.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == DNSName("sub.powerdns.com.")) {
         const auto auth = DNSName("powerdns.com.");
@@ -1609,7 +1609,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_wildcard_like_expanded_from_wildcard
         /* add a NSEC denying the DS */
         addNSECRecordToLW(DNSName("*.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
-        return 1;
+        return LWResult::Result::Success;
       }
       return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
     }
@@ -1619,7 +1619,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_wildcard_like_expanded_from_wildcard
       addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300, false, boost::none, DNSName("*.powerdns.com"));
       addNSECRecordToLW(DNSName("*.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
       addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
-      return 1;
+      return LWResult::Result::Success;
     }
   });
 
@@ -1683,7 +1683,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_incomplete_cache_zonecut_qm)
       else {
         BOOST_ASSERT(0);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
     else if (ip == ComboAddress("192.0.2.1:53")) {
@@ -1705,7 +1705,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_incomplete_cache_zonecut_qm)
       else {
         BOOST_ASSERT(0);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.2:53")) {
       DNSName hero("herokuapp.com.");
@@ -1737,10 +1737,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_incomplete_cache_zonecut_qm)
       else {
         BOOST_ASSERT(0);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     BOOST_ASSERT(0);
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1796,7 +1796,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_servfail_ds)
 
     if (type == QType::DS && domain == DNSName("powerdns.com.")) {
       /* time out */
-      return 0;
+      return LWResult::Result::Timeout;
     }
 
     if (type == QType::DS || type == QType::DNSKEY) {
@@ -1809,7 +1809,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_servfail_ds)
       addDS(DNSName("com."), 300, res->d_records, keys);
       addRRSIG(keys, res->d_records, DNSName("."), 300, false, boost::none, boost::none, fixedNow);
       addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.1:53")) {
@@ -1828,7 +1828,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_servfail_ds)
         //addRRSIG(keys, res->d_records, DNSName("com."), 300, false, boost::none, boost::none, fixedNow);
         addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.2:53")) {
@@ -1844,10 +1844,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_servfail_ds)
         addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
         addRRSIG(keys, res->d_records, auth, 300, false, boost::none, boost::none, fixedNow);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1907,7 +1907,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_servfail_dnskey)
 
     if (type == QType::DNSKEY && domain == DNSName("powerdns.com.")) {
       /* time out */
-      return 0;
+      return LWResult::Result::Timeout;
     }
 
     if (type == QType::DS || type == QType::DNSKEY) {
@@ -1920,7 +1920,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_servfail_dnskey)
       addDS(DNSName("com."), 300, res->d_records, keys);
       addRRSIG(keys, res->d_records, DNSName("."), 300, false, boost::none, boost::none, fixedNow);
       addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.1:53")) {
@@ -1938,7 +1938,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_servfail_dnskey)
         addRRSIG(keys, res->d_records, DNSName("com."), 300, false, boost::none, boost::none, fixedNow);
         addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
     if (ip == ComboAddress("192.0.2.2:53")) {
@@ -1954,10 +1954,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_servfail_dnskey)
         addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
         addRRSIG(keys, res->d_records, auth, 300, false, boost::none, boost::none, fixedNow);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;

--- a/pdns/recursordist/test-syncres_cc6.cc
+++ b/pdns/recursordist/test-syncres_cc6.cc
@@ -36,22 +36,22 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_secure)
       dsQueriesCount++;
 
       if (domain == target) {
-        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys, false) == 0) {
-          return 0;
+        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys, false) == LWResult::Result::Timeout) {
+          return LWResult::Result::Timeout;
         }
-        return 1;
+        return LWResult::Result::Success;
       }
 
       setLWResult(res, 0, true, false, true);
       addDS(domain, 300, res->d_records, keys, DNSResourceRecord::ANSWER);
       addRRSIG(keys, res->d_records, auth, 300);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (type == QType::DNSKEY) {
       setLWResult(res, 0, true, false, true);
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
       if (isRootServer(ip)) {
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_secure)
         addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
         /* No DS on referral, and no denial of the DS either */
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_secure)
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
           /* No DS on referral, and no denial of the DS either */
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -98,11 +98,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_secure)
           addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
         }
 
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -161,13 +161,13 @@ BOOST_AUTO_TEST_CASE(test_dnssec_ds_sign_loop)
         addDS(domain, 300, res->d_records, keys, DNSResourceRecord::ANSWER);
         addRRSIG(keys, res->d_records, auth, 300);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (type == QType::DNSKEY) {
       setLWResult(res, 0, true, false, true);
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
       if (isRootServer(ip)) {
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_ds_sign_loop)
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_ds_sign_loop)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         if (type == QType::NS) {
@@ -215,11 +215,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_ds_sign_loop)
           addRRSIG(keys, res->d_records, DNSName("www.powerdns.com"), 300);
         }
 
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -266,10 +266,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_ds_root)
       addRRSIG(keys, res->d_records, DNSName("."), 300);
       addNSECRecordToLW(domain, DNSName("aaa."), {QType::DNSKEY, QType::SOA, QType::NS, QType::NSEC, QType::RRSIG}, 600, res->d_records);
       addRRSIG(keys, res->d_records, DNSName("."), 300);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_dnskey_signed_child)
       setLWResult(res, 0, true, false, true);
       addDS(domain, 300, res->d_records, keys, DNSResourceRecord::ANSWER);
       addRRSIG(keys, res->d_records, auth, 300);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (type == QType::DNSKEY) {
       setLWResult(res, 0, true, false, true);
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_dnskey_signed_child)
       else {
         addRRSIG(keys, res->d_records, domain, 300);
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
       if (isRootServer(ip)) {
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_dnskey_signed_child)
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_dnskey_signed_child)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         if (type == QType::NS) {
@@ -375,11 +375,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_dnskey_signed_child)
           addRRSIG(keys, res->d_records, domain, 300);
         }
 
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -437,13 +437,13 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_insecure)
         addNSECRecordToLW(domain, DNSName("powerdnt.com."), {QType::NS}, 600, res->d_records);
       }
       addRRSIG(keys, res->d_records, auth, 300);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (type == QType::DNSKEY) {
       setLWResult(res, 0, true, false, true);
       addDNSKEY(keys, domain, 300, res->d_records);
       addRRSIG(keys, res->d_records, domain, 300);
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
       if (isRootServer(ip)) {
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_insecure)
         addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
         /* No DS on referral, and no denial of the DS either */
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -467,7 +467,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_insecure)
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
           /* No DS on referral, and no denial of the DS either */
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -483,11 +483,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ds_on_referral_insecure)
         else {
           addRecordToLW(res, domain, QType::A, "192.0.2.42");
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_bogus_unsigned_nsec)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -558,7 +558,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_bogus_unsigned_nsec)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -572,11 +572,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_bogus_unsigned_nsec)
           addNSECRecordToLW(domain, DNSName("z.powerdns.com."), {QType::NS, QType::DNSKEY}, 600, res->d_records);
           /* NO RRSIG for the NSEC record! */
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* NSEC record without the corresponding RRSIG in a secure zone, should be Bogus! */
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_bogus_no_nsec)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -646,7 +646,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_bogus_no_nsec)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -660,11 +660,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_bogus_no_nsec)
 
           /* NO NSEC record! */
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   /* no NSEC record in a secure zone, should be Bogus! */
@@ -715,7 +715,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure)
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         addNSECRecordToLW(domain, DNSName("z.powerdns.com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -726,12 +726,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -741,7 +741,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -758,7 +758,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -768,11 +768,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure)
         else {
           addRecordToLW(res, domain, QType::A, targetAddr.toString());
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -831,7 +831,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_optout)
         /* next closer */
         addNSEC3UnhashedRecordToLW(DNSName("oowerdns.com."), DNSName("com."), DNSName("qowerdns.com.").toStringNoDot(), {QType::NS}, 600, res->d_records, 10, true);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys, true, boost::none, true, true);
@@ -842,12 +842,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_optout)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -857,7 +857,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_optout)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -878,7 +878,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_optout)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -888,11 +888,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_optout)
         else {
           addRecordToLW(res, domain, QType::A, targetAddr.toString());
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -948,7 +948,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nxd_optout)
         /* next closer */
         addNSEC3UnhashedRecordToLW(DNSName("oowerdns.com."), DNSName("com."), DNSName("qowerdns.com.").toStringNoDot(), {QType::NS}, 600, res->d_records, 10, true);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys, true, boost::none, true, true);
@@ -959,12 +959,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nxd_optout)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, DNSName("com."), QType::SOA, "a.gtld-servers.com. hostmastercom. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -974,7 +974,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nxd_optout)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -994,11 +994,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nxd_optout)
           addNSEC3UnhashedRecordToLW(DNSName("oowerdns.com."), DNSName("com."), DNSName("qowerdns.com.").toStringNoDot(), {QType::NS}, 600, res->d_records, 10, true);
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1057,11 +1057,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_direct_ds)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1123,11 +1123,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_direct_ds)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1184,12 +1184,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_skipped_cut)
         addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
         addNSECRecordToLW(domain, DNSName("z.powerdns.com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == DNSName("www.sub.powerdns.com.")) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, DNSName("sub.powerdns.com."), QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -1200,12 +1200,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_skipped_cut)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -1215,7 +1215,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_skipped_cut)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -1231,7 +1231,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_skipped_cut)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -1250,11 +1250,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_skipped_cut)
         else {
           addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;

--- a/pdns/recursordist/test-syncres_cc7.cc
+++ b/pdns/recursordist/test-syncres_cc7.cc
@@ -54,14 +54,14 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_ta_skipped_cut)
           addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
         }
       }
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (type == QType::DNSKEY) {
       if (domain == g_rootdnsname || domain == DNSName("sub.powerdns.com.")) {
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_ta_skipped_cut)
         addNSECRecordToLW(DNSName("com."), DNSName("dom."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_ta_skipped_cut)
           addRecordToLW(res, DNSName("powerdns.com."), QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 3600);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -108,11 +108,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_ta_skipped_cut)
           addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
           addRRSIG(keys, res->d_records, DNSName("sub.powerdns.com."), 300);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nodata)
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         addNSECRecordToLW(domain, DNSName("z.powerdns.com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -174,12 +174,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nodata)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nodata)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nodata)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         if (type == QType::NS) {
@@ -218,11 +218,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_nodata)
           setLWResult(res, 0, true, false, true);
           addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname)
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         addNSECRecordToLW(domain, DNSName("z.power-dns.com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -289,12 +289,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         setLWResult(res, 0, false, false, true);
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname)
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
 
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -352,11 +352,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname)
           }
         }
 
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -408,7 +408,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname_glue)
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         addNSECRecordToLW(domain, DNSName("z.power-dns.com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname_glue)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         setLWResult(res, 0, false, false, true);
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname_glue)
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
 
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -475,11 +475,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cname_glue)
           }
         }
 
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -530,7 +530,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_secure_cname)
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         addNSECRecordToLW(domain, DNSName("z.power-dns.com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -541,12 +541,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_secure_cname)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -556,7 +556,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_secure_cname)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -578,7 +578,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_secure_cname)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -601,11 +601,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_to_secure_cname)
             addRRSIG(keys, res->d_records, domain, 300);
           }
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -660,7 +660,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_secure_cname)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -677,7 +677,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_secure_cname)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -697,11 +697,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_secure_cname)
             addRRSIG(keys, res->d_records, domain, 300);
           }
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -756,7 +756,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_bogus_cname)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -773,7 +773,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_bogus_cname)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -793,11 +793,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_bogus_cname)
             /* No RRSIG, leading to bogus */
           }
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -852,7 +852,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_secure_cname)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -869,7 +869,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_secure_cname)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -889,11 +889,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_secure_cname)
             addRRSIG(keys, res->d_records, domain, 300);
           }
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -945,7 +945,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_insecure_cname)
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
         addNSECRecordToLW(domain, DNSName("z.power-dns.com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("com."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
@@ -956,12 +956,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_insecure_cname)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -971,7 +971,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_insecure_cname)
         addDS(DNSName("com."), 300, res->d_records, keys);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == DNSName("com.")) {
@@ -993,7 +993,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_insecure_cname)
           addRRSIG(keys, res->d_records, DNSName("com."), 300);
           addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -1010,11 +1010,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_to_insecure_cname)
             addRecordToLW(res, domain, QType::A, targetCNameAddr.toString());
           }
         }
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1064,12 +1064,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == DNSName("com.")) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, ". yop. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -1079,7 +1079,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta)
         addNSECRecordToLW(DNSName("com."), DNSName("com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (target == domain) {
@@ -1092,7 +1092,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta)
           addRecordToLW(res, domain, QType::NS, "a.gtld-servers.com.");
           addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -1103,11 +1103,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta)
           addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
         }
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1160,12 +1160,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta_norrsig)
         setLWResult(res, 0, true, false, true);
         addDNSKEY(keys, domain, 300, res->d_records);
         addRRSIG(keys, res->d_records, domain, 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == DNSName("com.")) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, domain, QType::SOA, ". yop. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else {
@@ -1175,7 +1175,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta_norrsig)
         addNSECRecordToLW(DNSName("com."), DNSName("com."), {QType::NS}, 600, res->d_records);
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (target == domain) {
@@ -1188,7 +1188,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta_norrsig)
           addRecordToLW(res, domain, QType::NS, "a.gtld-servers.com.");
           addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
         }
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == target && ip == ComboAddress("192.0.2.2:53")) {
         setLWResult(res, 0, true, false, true);
@@ -1199,11 +1199,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_ta_norrsig)
           addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
         }
         /* No RRSIG in a now (thanks to TA) Secure zone -> Bogus*/
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1263,7 +1263,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_nta)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (domain == target && type == QType::DNSKEY) {
 
@@ -1271,10 +1271,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_nta)
 
       /* No DNSKEY */
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1327,10 +1327,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_no_ta)
       addRecordToLW(res, "a.root-servers.net.", QType::A, "198.41.0.4", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.root-servers.net.", QType::AAAA, "2001:503:ba3e::2:30", DNSResourceRecord::ADDITIONAL, 3600);
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1379,10 +1379,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nodata)
     else {
 
       setLWResult(res, 0, true, false, true);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1432,10 +1432,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_nxdomain)
     else {
 
       setLWResult(res, RCode::NXDomain, true, false, true);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -667,10 +667,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity)
       addRRSIG(keys, res->d_records, domain, 300);
       addNSECRecordToLW(domain, DNSName("z."), {QType::NSEC, QType::RRSIG}, 600, res->d_records);
       addRRSIG(keys, res->d_records, domain, 1, false, boost::none, boost::none, fixedNow);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -735,10 +735,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_bogus_validity)
       addRRSIG(keys, res->d_records, domain, 86400);
       addNSECRecordToLW(domain, DNSName("z."), {QType::NSEC, QType::RRSIG}, 86400, res->d_records);
       /* no RRSIG */
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   SyncRes::s_maxnegttl = 3600;
@@ -805,10 +805,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_cache_validity)
       setLWResult(res, RCode::NoError, true, false, true);
       addRecordToLW(res, domain, QType::A, targetAddr.toString(), DNSResourceRecord::ANSWER, 3600);
       addRRSIG(keys, res->d_records, domain, 1, false, boost::none, boost::none, tnow);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -871,11 +871,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_cache_secure)
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, target, QType::A, "192.0.2.1");
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -936,11 +936,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_cache_insecure)
       if (domain == target && type == QType::A) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, target, QType::A, "192.0.2.1");
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -1003,11 +1003,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_cache_bogus)
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, target, QType::A, "192.0.2.1", DNSResourceRecord::ANSWER, 86400);
         /* no RRSIG */
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   SyncRes::s_maxbogusttl = 3600;
@@ -1091,17 +1091,17 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_cache_secure_any)
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, target, QType::A, "192.0.2.1");
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == target && type == QType::AAAA) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, target, QType::AAAA, "2001:db8::1");
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;

--- a/pdns/recursordist/test-syncres_cc9.cc
+++ b/pdns/recursordist/test-syncres_cc9.cc
@@ -43,17 +43,17 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_cname_cache_secure)
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, cnameTarget, QType::A, "192.0.2.1");
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == cnameTarget && type == QType::A) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, cnameTarget, QType::A, "192.0.2.1");
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -116,16 +116,16 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_cname_cache_insecure)
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, target, QType::CNAME, cnameTarget.toString());
         addRecordToLW(res, cnameTarget, QType::A, "192.0.2.1");
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == cnameTarget && type == QType::A) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, cnameTarget, QType::A, "192.0.2.1");
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -190,17 +190,17 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_cname_cache_bogus)
         addRecordToLW(res, target, QType::CNAME, cnameTarget.toString(), DNSResourceRecord::ANSWER, 86400);
         addRecordToLW(res, cnameTarget, QType::A, "192.0.2.1", DNSResourceRecord::ANSWER, 86400);
         /* no RRSIG */
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == cnameTarget && type == QType::A) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, cnameTarget, QType::A, "192.0.2.1", DNSResourceRecord::ANSWER, 86400);
         /* no RRSIG */
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   SyncRes::s_maxbogusttl = 60;
@@ -292,17 +292,17 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_additional_without_rrsig)
         addRRSIG(keys, res->d_records, DNSName("."), 300);
         addRecordToLW(res, addTarget, QType::A, "192.0.2.42", DNSResourceRecord::ADDITIONAL);
         /* no RRSIG for the additional record */
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == addTarget && type == QType::A) {
         setLWResult(res, 0, true, false, true);
         addRecordToLW(res, addTarget, QType::A, "192.0.2.42");
         addRRSIG(keys, res->d_records, DNSName("."), 300);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -372,10 +372,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure)
       addRRSIG(keys, res->d_records, domain, 300);
       addNSECRecordToLW(domain, DNSName("z."), {QType::NSEC, QType::RRSIG}, 600, res->d_records);
       addRRSIG(keys, res->d_records, domain, 1, false, boost::none, boost::none, fixedNow);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -453,7 +453,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_secure_ds)
       return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -510,10 +510,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_insecure)
     else {
       setLWResult(res, RCode::NoError, true, false, true);
       addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -589,10 +589,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_from_negcache_bogus)
       addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 86400);
       addRRSIG(keys, res->d_records, domain, 86400);
       /* no denial */
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   SyncRes::s_maxbogusttl = 60;
@@ -683,30 +683,30 @@ BOOST_AUTO_TEST_CASE(test_lowercase_outgoing)
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, "powerdns.com.", QType::NS, "pdns-public-ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       if (domain == cname) {
         setLWResult(res, 0, false, false, true);
         addRecordToLW(res, "powerdns.org.", QType::NS, "pdns-public-ns1.powerdns.org.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, "pdns-public-ns1.powerdns.org.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
       if (domain == target) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::CNAME, cname.toString());
-        return 1;
+        return LWResult::Result::Success;
       }
     }
     else if (ip == ComboAddress("192.0.2.2:53")) {
       if (domain == cname) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::A, "127.0.0.1");
-        return 1;
+        return LWResult::Result::Success;
       }
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   vector<DNSRecord> ret;
@@ -754,13 +754,13 @@ BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo)
     auth.chopOff();
     if (type == QType::DS || type == QType::DNSKEY) {
       if (domain == target) {
-        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != 1) {
-          return 0;
+        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != LWResult::Result::Success) {
+          return LWResult::Result::Timeout;
         }
       }
       return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   dsmap_t ds;
@@ -804,16 +804,16 @@ BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_all_sha)
     auth.chopOff();
     if (type == QType::DS || type == QType::DNSKEY) {
       if (domain == target) {
-        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != 1) {
-          return 0;
+        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != LWResult::Result::Success) {
+          return LWResult::Result::Timeout;
         }
-        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys3) != 1) {
-          return 0;
+        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys3) != LWResult::Result::Success) {
+          return LWResult::Result::Timeout;
         }
       }
       return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   dsmap_t ds;
@@ -857,16 +857,16 @@ BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_two_highest)
     auth.chopOff();
     if (type == QType::DS || type == QType::DNSKEY) {
       if (domain == target) {
-        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != 1) {
-          return 0;
+        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys2) != LWResult::Result::Success) {
+          return LWResult::Result::Timeout;
         }
-        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys3) != 1) {
-          return 0;
+        if (genericDSAndDNSKEYHandler(res, domain, auth, type, keys3) != LWResult::Result::Success) {
+          return LWResult::Result::Timeout;
         }
       }
       return genericDSAndDNSKEYHandler(res, domain, auth, type, keys);
     }
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   dsmap_t ds;
@@ -896,7 +896,7 @@ BOOST_AUTO_TEST_CASE(test_cname_plus_authority_ns_ttl)
       setLWResult(res, 0, false, false, true);
       addRecordToLW(res, DNSName("powerdns.com"), QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 42);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53")) {
       if (domain == target) {
@@ -905,17 +905,17 @@ BOOST_AUTO_TEST_CASE(test_cname_plus_authority_ns_ttl)
         addRecordToLW(res, cnameTarget, QType::A, "192.0.2.2");
         addRecordToLW(res, DNSName("powerdns.com."), QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
         addRecordToLW(res, DNSName("a.gtld-servers.net."), QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
-        return 1;
+        return LWResult::Result::Success;
       }
       else if (domain == cnameTarget) {
         setLWResult(res, 0, true, false, false);
         addRecordToLW(res, domain, QType::A, "192.0.2.2");
       }
 
-      return 1;
+      return LWResult::Result::Success;
     }
 
-    return 0;
+    return LWResult::Result::Timeout;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -975,7 +975,7 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_general)
     addRecordToLW(res, domain, QType::TXT, "TXT", DNSResourceRecord::ADDITIONAL);
     /* should be scrubbed because it doesn't match any of the accepted names in this answer (mostly 'domain') */
     addRecordToLW(res, DNSName("powerdns.com."), QType::AAAA, "2001:db8::1", DNSResourceRecord::ADDITIONAL);
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -1010,7 +1010,7 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_keep_relevant_additional_aaaa)
     setLWResult(res, 0, true, false, true);
     addRecordToLW(res, domain, QType::A, "192.0.2.1");
     addRecordToLW(res, domain, QType::AAAA, "2001:db8::1", DNSResourceRecord::ADDITIONAL);
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;
@@ -1048,7 +1048,7 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_keep_glue)
       addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.net.", DNSResourceRecord::AUTHORITY, 172800);
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
       addRecordToLW(res, "a.gtld-servers.net.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.1:53") || ip == ComboAddress("[2001:DB8::1]:53")) {
       setLWResult(res, 0, false, false, true);
@@ -1059,16 +1059,16 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_keep_glue)
       addRecordToLW(res, "pdns-public-ns1.powerdns.com.", QType::AAAA, "2001:DB8::2", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::A, "192.0.2.3", DNSResourceRecord::ADDITIONAL, 172800);
       addRecordToLW(res, "pdns-public-ns2.powerdns.com.", QType::AAAA, "2001:DB8::3", DNSResourceRecord::ADDITIONAL, 172800);
-      return 1;
+      return LWResult::Result::Success;
     }
     else if (ip == ComboAddress("192.0.2.2:53") || ip == ComboAddress("192.0.2.3:53") || ip == ComboAddress("[2001:DB8::2]:53") || ip == ComboAddress("[2001:DB8::3]:53")) {
       setLWResult(res, 0, true, false, true);
       addRecordToLW(res, target, QType::A, "192.0.2.4");
       addRecordToLW(res, "powerdns.com.", QType::DS, "2 8 2 BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBB", DNSResourceRecord::AUTHORITY);
-      return 1;
+      return LWResult::Result::Success;
     }
     else {
-      return 0;
+      return LWResult::Result::Timeout;
     }
   });
 
@@ -1116,7 +1116,7 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_scrubs_ns_nxd)
     addRecordToLW(res, "powerdns.com.", QType::NS, "spoofed.ns.", DNSResourceRecord::AUTHORITY, 172800);
     addRecordToLW(res, "spoofed.ns.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
     addRecordToLW(res, "spoofed.ns.", QType::AAAA, "2001:DB8::1", DNSResourceRecord::ADDITIONAL, 3600);
-    return 1;
+    return LWResult::Result::Success;
   });
 
   const time_t now = sr->getNow().tv_sec;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -261,7 +261,7 @@ class SyncRes : public boost::noncopyable
 {
 public:
   enum LogMode { LogNone, Log, Store};
-  typedef std::function<int(const ComboAddress& ip, const DNSName& qdomain, int qtype, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult *lwr, bool* chained)> asyncresolve_t;
+  typedef std::function<LWResult::Result(const ComboAddress& ip, const DNSName& qdomain, int qtype, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult *lwr, bool* chained)> asyncresolve_t;
 
   enum class HardenNXD { No, DNSSEC, Yes };
   
@@ -835,7 +835,7 @@ private:
 
   bool doSpecialNamesResolve(const DNSName &qname, const QType &qtype, const uint16_t qclass, vector<DNSRecord> &ret);
 
-  int asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, const DNSName& auth, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res, bool* chained) const;
+  LWResult::Result asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, const DNSName& auth, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res, bool* chained) const;
 
   boost::optional<Netmask> getEDNSSubnetMask(const DNSName&dn, const ComboAddress& rem);
 
@@ -899,9 +899,8 @@ private:
 
 class Socket;
 /* external functions, opaque to us */
-int asendtcp(const string& data, Socket* sock);
-int arecvtcp(string& data, size_t len, Socket* sock, bool incompleteOkay);
-
+LWResult::Result asendtcp(const string& data, Socket* sock);
+LWResult::Result arecvtcp(string& data, size_t len, Socket* sock, bool incompleteOkay);
 
 struct PacketID
 {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -493,6 +493,10 @@ public:
   {
     t_sstorage.nsSpeeds.clear();
   }
+  static float getNSSpeed(const DNSName& server, const ComboAddress& ca)
+  {
+    return t_sstorage.nsSpeeds[server].d_collection[ca].peek();
+  }
   static EDNSStatus::EDNSMode getEDNSStatus(const ComboAddress& server)
   {
     const auto& it = t_sstorage.ednsstatus.find(server);
@@ -804,7 +808,7 @@ private:
 
   int doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret,
                   unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation);
-  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType& qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool* truncated);
+  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType& qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool* truncated);
   bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state);
 
   int doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state);

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -701,8 +701,8 @@ void AsyncWebServer::serveConnection(std::shared_ptr<Socket> client) const {
     string data;
     try {
       while(!req.complete) {
-        int bytes = arecvtcp(data, 16384, client.get(), true);
-        if (bytes > 0) {
+        auto ret = arecvtcp(data, 16384, client.get(), true);
+        if (ret == LWResult::Result::Success) {
           req.complete = yarl.feed(data);
         } else {
           // read error OR EOF
@@ -729,7 +729,7 @@ void AsyncWebServer::serveConnection(std::shared_ptr<Socket> client) const {
     logResponse(resp, remote, logprefix);
 
     // now send the reply
-    if (asendtcp(reply, client.get()) == -1 || reply.empty()) {
+    if (asendtcp(reply, client.get()) != LWResult::Result::Success || reply.empty()) {
       g_log<<Logger::Error<<logprefix<<"Failed sending reply to HTTP client"<<endl;
     }
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Instead of throttling explicitly on ServFail and Refused, do it for all rcodes except `NoError` and `NXDomain`, with the exception of `FormError` which is handled earlier.
Also throttle servers sending data that we fail to parse.

This PR is huge because it adds a `LWResult::Result` type to stop dealing with numerical values all over the place, sorry about that.
Need more tests if the general idea is deemed correct.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
