### PR TITLE
rec: Terminate TCP connections instead of 'ignoring' errors

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -339,6 +339,20 @@ void MOADNSParser::init(bool query, const std::string& packet)
   }
 }
 
+bool MOADNSParser::hasEDNS() const
+{
+  if (d_header.arcount == 0 || d_answers.empty()) {
+    return false;
+  }
+
+  for (const auto& record : d_answers) {
+    if (record.first.d_place == DNSResourceRecord::ADDITIONAL && record.first.d_type == QType::OPT) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 void PacketReader::getDnsrecordheader(struct dnsrecordheader &ah)
 {

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -388,6 +388,9 @@ public:
   {
     return d_tsigPos;
   }
+
+  bool hasEDNS() const;
+
 private:
   void init(bool query, const std::string& packet);
   uint16_t d_tsigPos;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -810,7 +810,7 @@ static void sendErrorOverTCP(std::unique_ptr<DNSComboWriter>& dc, int rcode)
     }
   }
 
-  dnsheader& header = reinterpret_cast<dnsheader&>(packet.at(0));;
+  dnsheader& header = reinterpret_cast<dnsheader&>(packet.at(0));
   header.aa = 0;
   header.ra = 1;
   header.qr = 1;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to ignore questions that we consider invalid (unexpected opcode, qdcount != 1, QR=1, parse error, ...) but also those
received from source addresses blocked by ipfilter, still waiting for a new question to come up on the socket.
That might be fine for clients that will keep sending queries, even though they will still end up wondering what happened to the ignored queries, but some clients like dnsdist will wait until a response is sent, or a time out occurs.
Closing the TCP connection instead allows dnsdist to keep going, possibly retrying over a new connection but finally giving up,
instead of keeping the connection alive.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
