### PR TITLE
rec draft: Lua/C++ teamwork for MX additionals

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -24,6 +24,7 @@
 #include "logger.hh"
 #include "dnsparser.hh"
 #include "syncres.hh"
+#include "resolver.hh"
 #include "namespaces.hh"
 #include "rec_channel.hh"
 #include "ednsoptions.hh"
@@ -416,6 +417,19 @@ void RecursorLua4::postPrepareContext()
     if (event.discardedPolicies) {
       (*event.discardedPolicies)[policy] = true;
     }
+  });
+
+  d_lw->writeFunction("cacheLookup", [](DNSName& qname, uint16_t qtype) {
+    vector<DNSRecord> res;
+    auto ret = g_recCache->get(g_now.tv_sec, qname, QType(qtype), true, &res, ComboAddress("127.0.0.1"));
+
+    std::vector<std::pair<int, std::string> > out;
+    int n = 0;
+    for(const auto &i : res) {
+      out.push_back({n++, i.d_content->getZoneRepresentation()});
+    }
+    cout<<"res.length()="<<res.size()<<endl;
+    return out;
   });
 }
 

--- a/pdns/recursordist/additionals-mx.lua
+++ b/pdns/recursordist/additionals-mx.lua
@@ -1,0 +1,33 @@
+local function nameFromMX(s)
+    return string.match(s, '%d+ (.+)')
+end
+
+function postresolve(dq)
+    print(dq.qname)
+    local mxes = {}
+    for k,v in pairs(dq:getRecords())
+    do
+        if v.type == pdns.MX
+        then
+            table.insert(mxes, v:getContent())
+        end
+    end
+
+    for i,v in ipairs(mxes)
+    do
+        -- print('lookup', v)
+        local name = newDN(nameFromMX(v))
+        l = cacheLookup(name, pdns.A)
+        for k,v in pairs(l)
+        do
+            dq:addRecord(pdns.A, v, 3, nil, name:toString()) -- FIXME docs say DNSName not string
+        end
+    end
+-- print(l)
+-- for k,v in pairs(l)
+-- do
+--  print(k,v)
+-- end
+    -- dq:addRecord(pdns.A, '1.2.3.4', 3)
+    return true
+end


### PR DESCRIPTION
### Short description
With the packetcache disabled (could probably do something smarter with `dq.variable`) this allows filling IPs (v4) in ADDITIONALS for MX records in ANSWER, strictly from the recursor cache.

Unfinished; posting this to see if we feel something that has this shape could still go into rec 4.4. Then for 4.5 (perhaps also with some more experience from this small thing) we could do it better in (mostly) C++.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
