### PR TITLE
rec: backport 9569 to rec 4.4.x: Don't parse any config with `--version`

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5212,6 +5212,12 @@ int main(int argc, char **argv)
     g_log.toConsole(Logger::Info);
     ::arg().laxParse(argc,argv); // do a lax parse
 
+    if(::arg().mustDo("version")) {
+      showProductVersion();
+      showBuildConfiguration();
+      exit(0);
+    }
+
     string configname=::arg()["config-dir"]+"/recursor.conf";
     if(::arg()["config-name"]!="") {
       configname=::arg()["config-dir"]+"/recursor-"+::arg()["config-name"]+".conf";
@@ -5280,11 +5286,6 @@ int main(int argc, char **argv)
     if(::arg().mustDo("help")) {
       cout<<"syntax:"<<endl<<endl;
       cout<<::arg().helpstring(::arg()["help"])<<endl;
-      exit(0);
-    }
-    if(::arg().mustDo("version")) {
-      showProductVersion();
-      showBuildConfiguration();
       exit(0);
     }
 


### PR DESCRIPTION
This ensures we don't log anything _apart_ from the version info.
Spotted in https://github.com/PowerDNS/pdns_recursor-ansible/issues/66

(cherry picked from commit 2733183fc0b35ed2b59c87aab5aaaa86688db778)

Backport of #9569 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
