### PR TITLE
Fix error checking on one getaddrinfo call

### DIFF
--- a/pdns/notify.cc
+++ b/pdns/notify.cc
@@ -97,7 +97,7 @@ try
        parts.push_back("domain");
      else if (parts.size() != 2)
        throw runtime_error("Invalid hostname:port syntax");
-     if (getaddrinfo(parts[0].c_str(), parts[1].c_str(), NULL, &info) < 0)
+     if (getaddrinfo(parts[0].c_str(), parts[1].c_str(), NULL, &info) != 0)
        throw runtime_error("Cannot resolve '" + string(argv[1]) +"'");
      for(auto ptr = info; ptr != NULL; ptr = ptr->ai_next)
        addrs.emplace(ComboAddress{ptr->ai_addr, ptr->ai_addrlen});


### PR DESCRIPTION
### Short description
Noticed this while looking at something related.

`getaddrinfo(3)` documents the return values as only zero meaning success. Indeed all other `getaddrinfo` call sites already check this correctly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
