### PR TITLE
dnsdist make: two fixes

### DIFF
--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -26,10 +26,9 @@ htmlfiles.h: $(srcdir)/html/*
 	@mv $@.tmp $@
 
 dnsdist-lua-ffi-interface.inc: dnsdist-lua-ffi-interface.h
-	echo 'R"FFIContent(' > $@
-	cat $< >> $@
-	echo ')FFIContent"' >> $@
-
+	$(AM_V_GEN)echo 'R"FFIContent(' > $@
+	@cat $< >> $@
+	@echo ')FFIContent"' >> $@
 SRC_JS_FILES := $(wildcard src_js/*.js)
 MIN_JS_FILES := $(patsubst src_js/%.js,html/js/%.min.js,$(SRC_JS_FILES))
 
@@ -113,6 +112,7 @@ check-local:
 endif
 
 dnsdist-web.$(OBJEXT): htmlfiles.h
+dnsdist-lua-ffi.$(OBJEXT): dnsdist-lua-ffi-interface.inc
 
 dnsdist_SOURCES = \
 	ascii.hh \


### PR DESCRIPTION
### Short description
* make sure dnsdist-lua-ffi-interface.inc is built before dnsdist-lua-ffi.o
* cleaner output while building that .inc

by Pieter Lexis

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master