### PR TITLE
docs: fix lua reverse example for IPv6 records

### DIFF
--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -270,8 +270,8 @@ Reverse DNS functions
   
   Example records::
   
-    *.1.0.0.2.ip6.arpa IN    LUA    PTR "createReverse('%33%.static6.example.com')"
-    *.2.0.0.2.ip6.arpa IN    LUA    PTR "createReverse('%34%.%35%.static6.example.com')"
+    *.1.0.0.2.ip6.arpa IN    LUA    PTR "createReverse6('%33%.static6.example.com')"
+    *.2.0.0.2.ip6.arpa IN    LUA    PTR "createReverse6('%34%.%35%.static6.example.com')"
  
   When queried::
   


### PR DESCRIPTION
### Short description
The example called the createReverse function on a PTR record for an
IPv6 address instead of the createReverse6 - which when mindlessly
copy and pasted resulted in a lengthy servfail error

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
