### PR TITLE
fix the initialization order in the class.

### DIFF
--- a/pdns/axfr-retriever.hh
+++ b/pdns/axfr-retriever.hh
@@ -48,9 +48,9 @@ class AXFRRetriever : public boost::noncopyable
     int d_sock;
     int d_soacount;
     ComboAddress d_remote;
+    TSIGRecordContent d_trc;
     TSIGTCPVerifier d_tsigVerifier;
 
     size_t d_receivedBytes;
     size_t d_maxReceivedBytes;
-    TSIGRecordContent d_trc;
 };


### PR DESCRIPTION
### Short description
```
The uninitialized class member 'd_trc' is used to initialize the 'd_tsigVerifier' member.
```

According to the language standard, class members are initialized in the constructor in the same order as they are declared inside the class.

Your code contains a constructor where the initialization of one class member depends on another.

```cpp
AXFRRetriever::AXFRRetriever(const ComboAddress& remote,
                             const DNSName& domain,
                             const TSIGTriplet& tt, 
                             const ComboAddress* laddr,
                             size_t maxReceivedBytes,
                             uint16_t timeout)
  : d_tsigVerifier(tt, remote, d_trc), d_receivedBytes(0), d_maxReceivedBytes(maxReceivedBytes)
```
At the same time, a variable used for initialization is not yet initialized itself.


To fix the bug, we need to put the declaration of the 'd_trc' class member before the declaration of the 'd_tsigVerifier' class member.
  
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
