### PR TITLE
improved implementation of the operator=.

### DIFF
--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -583,6 +583,10 @@ public:
   }
   NSECBitmap& operator=(const NSECBitmap& rhs)
   {
+    if (this == &rhs) {
+      return *this;
+    }
+
     d_set = rhs.d_set;
 
     if (rhs.d_bitset) {


### PR DESCRIPTION
### Short description
In the implementation of operator = of the NSECBitmap class, there is no check for assigning an object to itself.
However, the memory allocation is performed in the function itself.
This is a potentially dangerous place, as memory leaks can occur during use.

You can fix this area in various ways, even using assert.
But considering how a similar check was applied in another class.

```cpp
  DNSName& operator=(const DNSName& rhs)
  {
    if (this != &rhs) {
      d_storage = rhs.d_storage;
    }
    return *this;
  }
```
I propose this fix.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
