### PR TITLE
pdns: bind-backend speedup feedRecord()

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -206,6 +206,7 @@ bool Bind2Backend::startTransaction(const DNSName &qname, int id)
   }
 
   d_transaction_id=id;
+  d_transaction_qname=qname;
   BB2DomainInfo bbd;
   if(safeGetBBDomainInfo(id, &bbd)) {
     d_transaction_tmpname = bbd.d_filename + "XXXXXX";
@@ -268,26 +269,25 @@ bool Bind2Backend::abortTransaction()
 
 bool Bind2Backend::feedRecord(const DNSResourceRecord &rr, const DNSName &ordername, bool ordernameIsNSEC3)
 {
-  BB2DomainInfo bbd;
-  if (!safeGetBBDomainInfo(d_transaction_id, &bbd))
-    return false;
+  if (d_transaction_id < 1) {
+    throw DBException("Bind2Backend::feedRecord() called outside of transaction");
+  }
 
   string qname;
-  string name = bbd.d_name.toString();
-  if (bbd.d_name.empty()) {
+  if (d_transaction_qname.empty()) {
     qname = rr.qname.toString();
   }
-  else if (rr.qname.isPartOf(bbd.d_name)) {
-    if (rr.qname == bbd.d_name) {
+  else if (rr.qname.isPartOf(d_transaction_qname)) {
+    if (rr.qname == d_transaction_qname) {
       qname = "@";
     }
     else {
-      DNSName relName = rr.qname.makeRelative(bbd.d_name);
+      DNSName relName = rr.qname.makeRelative(d_transaction_qname);
       qname = relName.toStringNoDot();
     }
   }
   else {
-    throw DBException("out-of-zone data '"+rr.qname.toLogString()+"' during AXFR of zone '"+bbd.d_name.toLogString()+"'");
+    throw DBException("out-of-zone data '"+rr.qname.toLogString()+"' during AXFR of zone '"+d_transaction_qname.toLogString()+"'");
   }
 
   shared_ptr<DNSRecordContent> drc(DNSRecordContent::mastermake(rr.qtype.getCode(), QClass::IN, rr.content));
@@ -300,7 +300,7 @@ bool Bind2Backend::feedRecord(const DNSResourceRecord &rr, const DNSName &ordern
   case QType::CNAME:
   case QType::DNAME:
   case QType::NS:
-    stripDomainSuffix(&content, name);
+    stripDomainSuffix(&content, d_transaction_qname.toString());
     // fallthrough
   default:
     if (d_of && *d_of) {

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -288,6 +288,7 @@ private:
   unique_ptr<SSqlStatement> d_deleteTSIGKeyQuery_stmt;
   unique_ptr<SSqlStatement> d_getTSIGKeysQuery_stmt;
 
+  DNSName d_transaction_qname;
   string d_transaction_tmpname;
   string d_logprefix;
   set<string> alsoNotify; //!< this is used to store the also-notify list of interested peers.


### PR DESCRIPTION
### Short description
safeGetBBDomainInfo() was called for every record to get the, already known, zone name.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
