### PR TITLE
gsql,bind: allow seamless serving of newly-supported TYPExxx records

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1731,6 +1731,25 @@ of reflection attacks. Maximum value is 65535, but values above
   1232 is the largest number of payload bytes that can fit in the smallest IPv6 packet.
   IPv6 has a minimum MTU of 1280 bytes (:rfc:`RFC 8200, section 5 <8200#section-5>`), minus 40 bytes for the IPv6 header, minus 8 bytes for the UDP header gives 1232, the maximum payload size for the DNS response.
 
+.. _setting-upgrade-unknown-types:
+
+``upgrade-unknown-types``
+-------------------------
+
+-  Boolean
+-  Default: no
+
+.. versionadded:: 4.4.0
+
+Transparently upgrade records stored as `TYPE#xxx` and RFC 3597 (hex format)
+contents, if the type is natively supported.
+When this is disabled, records stored in this format cannot be served.
+
+Recommendation: keep disabled for better performance.
+Enable for testing PowerDNS upgrades, without changing stored records.
+
+This option is supported by the bind and Generic SQL backends. 
+
 .. _setting-version-string:
 
 ``version-string``

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -485,7 +485,7 @@ void Bind2Backend::parseZoneFile(BB2DomainInfo *bbd)
     nsec3zone=getNSEC3PARAM(bbd->d_name, &ns3pr);
 
   auto records = std::make_shared<recordstorage_t>();
-  ZoneParserTNG zpt(bbd->d_filename, bbd->d_name, s_binddirectory);
+  ZoneParserTNG zpt(bbd->d_filename, bbd->d_name, s_binddirectory, d_upgradeContent);
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
   DNSResourceRecord rr;
   string hashed;
@@ -725,6 +725,7 @@ Bind2Backend::Bind2Backend(const string &suffix, bool loadZones)
   d_hybrid=mustDo("hybrid");
   d_transaction_id=0;
   s_ignore_broken_records=mustDo("ignore-broken-records");
+  d_upgradeContent=::arg().mustDo("upgrade-unknown-types");
 
   if (!loadZones && d_hybrid)
     return;

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -298,6 +298,7 @@ private:
   int d_transaction_id;
   static bool s_ignore_broken_records;
   bool d_hybrid;
+  bool d_upgradeContent;
 
   BB2DomainInfo createDomainEntry(const DNSName& domain, const string &filename); //!< does not insert in s_state
 

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -411,4 +411,5 @@ protected:
   std::unique_ptr<SSql> d_db{nullptr};
   bool d_dnssecQueries;
   bool d_inTransaction{false};
+  bool d_upgradeContent{false};
 };

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -238,6 +238,7 @@ void declareArguments()
   ::arg().set("tcp-fast-open", "Enable TCP Fast Open support on the listening sockets, using the supplied numerical value as the queue size")="0";
 
   ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
+  ::arg().setSwitch("upgrade-unknown-types","Transparently upgrade known TYPExxx records. Recommended to keep off, except for PowerDNS upgrades until data sources are cleaned up")="no";
 
   ::arg().set("rng", "Specify the random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
   ::arg().setDefaults();

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -102,6 +102,7 @@ static void loadMainConfig(const std::string& configdir)
   ::arg().set("max-signature-cache-entries", "Maximum number of signatures cache entries")="";
   ::arg().set("rng", "Specify random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
   ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
+  ::arg().setSwitch("upgrade-unknown-types","Transparently upgrade known TYPExxx records. Recommended to keep off, except for PowerDNS upgrades until data sources are cleaned up")="no";
   ::arg().laxFile(configname.c_str());
 
   if(!::arg()["load-modules"].empty()) {

--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -154,4 +154,15 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_tng_upgrade) {
+  reportAllTypes();
+
+  ZoneParserTNG zp(std::vector<std::string>({"foo.test. 86400 IN TYPE1 \\# 4 c0000304"}), DNSName("test"), true);
+  DNSResourceRecord rr;
+  zp.get(rr);
+
+  BOOST_CHECK_EQUAL(rr.qtype.getName(), QType(QType::A).getName());
+  BOOST_CHECK_EQUAL(rr.content, std::string("192.0.3.4"));
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -30,8 +30,8 @@
 class ZoneParserTNG
 {
 public:
-  ZoneParserTNG(const string& fname, const DNSName& zname=g_rootdnsname, const string& reldir="");
-  ZoneParserTNG(const vector<string> zonedata, const DNSName& zname);
+  ZoneParserTNG(const string& fname, const DNSName& zname=g_rootdnsname, const string& reldir="", bool upgradeContent=false);
+  ZoneParserTNG(const vector<string> zonedata, const DNSName& zname, bool upgradeContent=false);
 
   ~ZoneParserTNG();
   bool get(DNSResourceRecord& rr, std::string* comment=0);
@@ -77,4 +77,5 @@ private:
   bool d_havedollarttl;
   bool d_fromfile;
   bool d_generateEnabled{true};
+  bool d_upgradeContent;
 };


### PR DESCRIPTION
### Short description

When upgrading to a release supporting new record types, all existing database entries using the TYPExxx format stop working. This prevents testing of a "master" release while preserving compatibility with a production database.

Makes TYPExxx work by always sending them through UnknownRecordContent and deserialising that using the specific QType handler.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
