### PR TITLE
auth: delay local-ipv6 and query-local-address6 removal to 4.5.0 together

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1309,7 +1309,8 @@ the network).
 ``query-local-address6``
 ------------------------
 .. deprecated:: 4.4.0
-  Removed. Use :ref:`setting-query-local-address`.
+  Use :ref:`setting-query-local-address`. The default has been changed
+  from '::' to unset.
 
 -  IPv6 Address
 -  Default: unset

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -815,9 +815,6 @@ Fail to start if one or more of the
 
 ``local-ipv6``
 --------------
-.. versionchanged:: 4.4.0
-  removed, use :ref:`setting-local-address`
-
 .. deprecated:: 4.3.0
   This setting has been deprecated, use :ref:`setting-local-address`
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -97,10 +97,12 @@ void declareArguments()
   ::arg().setSwitch("log-dns-details","If PDNS should log DNS non-erroneous details")="no";
   ::arg().setSwitch("log-dns-queries","If PDNS should log all incoming DNS queries")="no";
   ::arg().set("local-address","Local IP addresses to which we bind")="0.0.0.0, ::";
+  ::arg().set("local-ipv6","DEPRECATED, will be removed, move your IPs to local-address")="";
   ::arg().setSwitch("local-address-nonexist-fail","Fail to start if one or more of the local-address's do not exist on this server")="yes";
   ::arg().setSwitch("non-local-bind", "Enable binding to non-local addresses by using FREEBIND / BINDANY socket options")="no";
   ::arg().setSwitch("reuseport","Enable higher performance on compliant kernels by using SO_REUSEPORT allowing each receiver thread to open its own socket")="no";
   ::arg().set("query-local-address","Source IP addresses for sending queries")="0.0.0.0 ::";
+  ::arg().set("query-local-address6","DEPRECATED: Use query-local-address. Source IPv6 address for sending queries")="";
   ::arg().set("overload-queue-length","Maximum queuelength moving to packetcache only")="0";
   ::arg().set("max-queue-length","Maximum queuelength before considering situation lost")="5000";
 
@@ -632,6 +634,10 @@ void mainthread()
   }
 
   pdns::parseQueryLocalAddress(::arg()["query-local-address"]);
+  if (!::arg()["query-local-address6"].empty()) {
+    g_log<<Logger::Warning<<"query-local-address6 is deprecated and will be removed in a future version. Please use query-local-address for IPv6 addresses as well"<<endl;
+    pdns::parseQueryLocalAddress(::arg()["query-local-address6"]);
+  }
 
   // NOW SAFE TO CREATE THREADS!
   dl->go();

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -635,7 +635,7 @@ void mainthread()
 
   pdns::parseQueryLocalAddress(::arg()["query-local-address"]);
   if (!::arg()["query-local-address6"].empty()) {
-    g_log<<Logger::Warning<<"query-local-address6 is deprecated and will be removed in a future version. Please use query-local-address for IPv6 addresses as well"<<endl;
+    g_log<<Logger::Error<<"NOTE: query-local-address6 is deprecated and will be removed in a future version. Please use query-local-address for IPv6 addresses as well"<<endl;
     pdns::parseQueryLocalAddress(::arg()["query-local-address6"]);
   }
 

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -89,6 +89,10 @@ vector<ComboAddress> g_localaddresses; // not static, our unit tests need to pok
 void UDPNameserver::bindAddresses()
 {
   vector<string>locals;
+  stringtok(locals,::arg()["local-ipv6"]," ,");
+  if (!locals.empty()) {
+    g_log<<Logger::Error<<"NOTE: Deprecated local-ipv6 setting used. Please move those addresses to the local-address setting."<<endl;
+  }
   stringtok(locals,::arg()["local-address"]," ,");
 
   int one = 1;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1142,6 +1142,7 @@ TCPNameserver::TCPNameserver()
   d_maxTCPConnections = ::arg().asNum( "max-tcp-connections" );
 
   vector<string>locals;
+  stringtok(locals,::arg()["local-ipv6"]," ,");
   stringtok(locals,::arg()["local-address"]," ,");
   if(locals.empty())
     throw PDNSException("No local addresses specified");


### PR DESCRIPTION
### Short description
It turns out the query-local-address6 settings merging was not released in 4.3.0.
We're now delaying both removals to keep everything simple for the users.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master