### PR TITLE
auth: change "misconfigured" SOA MNAME to not mention powerdns and be RFC6761 compliant

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -409,7 +409,7 @@ See the :ref:`metadata-publish-cdnskey-publish-cds` docs for more information.
 --------------------
 
 -  String
--  Default: a.misconfigured.powerdns.server hostmaster.@ 0 10800 3600 604800 3600
+-  Default: a.misconfigured.dns.server.invalid hostmaster.@ 0 10800 3600 604800 3600
 
 .. versionadded:: 4.4.0
 
@@ -456,7 +456,7 @@ Mail address to insert in the SOA record if none set in the backend.
 --------------------
 
 -  String
--  Default: a.misconfigured.powerdns.server
+-  Default: a.misconfigured.dns.server.invalid
 
 .. deprecated:: 4.2.0
   This setting has been removed in 4.4.0

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -176,7 +176,7 @@ void declareArguments()
   ::arg().set("negquery-cache-ttl","Seconds to store negative query results in the QueryCache")="60";
   ::arg().set("query-cache-ttl","Seconds to store query results in the QueryCache")="20";
   ::arg().set("server-id", "Returned when queried for 'id.server' TXT or NSID, defaults to hostname - disabled or custom")="";
-  ::arg().set("default-soa-content","Default SOA content")="a.misconfigured.powerdns.server hostmaster.@ 0 10800 3600 604800 3600";
+  ::arg().set("default-soa-content","Default SOA content")="a.misconfigured.dns.server.invalid hostmaster.@ 0 10800 3600 604800 3600";
   ::arg().set("default-soa-edit","Default SOA-EDIT value")="";
   ::arg().set("default-soa-edit-signed","Default SOA-EDIT value for signed zones")="";
   ::arg().set("dnssec-key-cache-ttl","Seconds to cache DNSSEC keys from the database")="30";

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -126,7 +126,7 @@ static void loadMainConfig(const std::string& configdir)
   ::arg().set("cache-ttl","Seconds to store packets in the PacketCache")="20";
   ::arg().set("negquery-cache-ttl","Seconds to store negative query results in the QueryCache")="60";
   ::arg().set("query-cache-ttl","Seconds to store query results in the QueryCache")="20";
-  ::arg().set("default-soa-content","Default SOA content")="a.misconfigured.powerdns.server hostmaster.@ 0 10800 3600 604800 3600";
+  ::arg().set("default-soa-content","Default SOA content")="a.misconfigured.dns.server.invalid hostmaster.@ 0 10800 3600 604800 3600";
   ::arg().set("chroot","Switch to this chroot jail")="";
   ::arg().set("dnssec-key-cache-ttl","Seconds to cache DNSSEC keys from the database")="30";
   ::arg().set("domain-metadata-cache-ttl","Seconds to cache domain metadata from the database")="60";

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -117,7 +117,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             if k in payload:
                 self.assertEquals(data[k], payload[k])
         # validate generated SOA
-        expected_soa = "a.misconfigured.powerdns.server. hostmaster." + name + " " + \
+        expected_soa = "a.misconfigured.dns.server.invalid. hostmaster." + name + " " + \
                        str(payload['serial']) + " 10800 3600 604800 3600"
         self.assertEquals(
             get_first_rec(data, name, 'SOA')['content'],
@@ -930,7 +930,7 @@ $ORIGIN %NAME%
         self.assertIn('zone', data)
         expected_data = [name + '\t3600\tIN\tNS\tns1.foo.com.',
                          name + '\t3600\tIN\tNS\tns2.foo.com.',
-                         name + '\t3600\tIN\tSOA\ta.misconfigured.powerdns.server. hostmaster.' + name +
+                         name + '\t3600\tIN\tSOA\ta.misconfigured.dns.server.invalid. hostmaster.' + name +
                          ' 0 10800 3600 604800 3600']
         self.assertEquals(data['zone'].strip().split('\n'), expected_data)
 
@@ -944,7 +944,7 @@ $ORIGIN %NAME%
         data = r.text.strip().split("\n")
         expected_data = [name + '\t3600\tIN\tNS\tns1.foo.com.',
                          name + '\t3600\tIN\tNS\tns2.foo.com.',
-                         name + '\t3600\tIN\tSOA\ta.misconfigured.powerdns.server. hostmaster.' + name +
+                         name + '\t3600\tIN\tSOA\ta.misconfigured.dns.server.invalid. hostmaster.' + name +
                          ' 0 10800 3600 604800 3600']
         self.assertEquals(data, expected_data)
 
@@ -1739,7 +1739,7 @@ $ORIGIN %NAME%
             {u'content': u'ns2.example.com.',
              u'zone_id': name, u'zone': name, u'object_type': u'record', u'disabled': False,
              u'ttl': 3600, u'type': u'NS', u'name': name},
-            {u'content': u'a.misconfigured.powerdns.server. hostmaster.'+name+' 22 10800 3600 604800 3600',
+            {u'content': u'a.misconfigured.dns.server.invalid. hostmaster.'+name+' 22 10800 3600 604800 3600',
              u'zone_id': name, u'zone': name, u'object_type': u'record', u'disabled': False,
              u'ttl': 3600, u'type': u'SOA', u'name': name},
         ])
@@ -1769,7 +1769,7 @@ $ORIGIN %NAME%
             {u'content': u'ns2.example.com.',
              u'zone_id': name, u'zone': name, u'object_type': u'record', u'disabled': False,
              u'ttl': 3600, u'type': u'NS', u'name': name},
-            {u'content': u'a.misconfigured.powerdns.server. hostmaster.'+name+' 22 10800 3600 604800 3600',
+            {u'content': u'a.misconfigured.dns.server.invalid. hostmaster.'+name+' 22 10800 3600 604800 3600',
              u'zone_id': name, u'zone': name, u'object_type': u'record', u'disabled': False,
              u'ttl': 3600, u'type': u'SOA', u'name': name},
         ])
@@ -2007,7 +2007,7 @@ class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):
         rec = get_first_rec(data, '.', 'SOA')
         self.assertEquals(
             rec['content'],
-            "a.misconfigured.powerdns.server. hostmaster. " + str(payload['serial']) +
+            "a.misconfigured.dns.server.invalid. hostmaster. " + str(payload['serial']) +
             " 10800 3600 604800 3600"
         )
         # Regression test: verify zone list works


### PR DESCRIPTION
### Short description
This might reduce the number of lawyers emailing the powerdns security contacts in error.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master