### PR TITLE
rec: two OpenBSD improvemenst wrt UDP sockets: port randomization and EGAIN errors

### DIFF
--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -242,7 +242,8 @@ int sendOnNBSocket(int fd, const struct msghdr *msgh)
 {
   int sendErr = 0;
 #ifdef __OpenBSD__
-  for (int i = 0; i < 10; i++) {
+  // OpenBSD can and does return EAGIN on non-blocking datagram sockets
+  for (int i = 0; i < 10; i++) { // Arbitrary upper bound
     if (sendmsg(fd, msgh, 0) != -1) {
       sendErr = 0;
       break;

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -242,7 +242,7 @@ int sendOnNBSocket(int fd, const struct msghdr *msgh)
 {
   int sendErr = 0;
 #ifdef __OpenBSD__
-  // OpenBSD can and does return EAGIN on non-blocking datagram sockets
+  // OpenBSD can and does return EAGAIN on non-blocking datagram sockets
   for (int i = 0; i < 10; i++) { // Arbitrary upper bound
     if (sendmsg(fd, msgh, 0) != -1) {
       sendErr = 0;
@@ -497,4 +497,3 @@ ComboAddress parseIPAndPort(const std::string& input, uint16_t port)
     return ComboAddress(input, port);
   }
 }
-

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -238,6 +238,27 @@ bool IsAnyAddress(const ComboAddress& addr)
   
   return false;
 }
+int sendOnNBSocket(int fd, const struct msghdr *msgh)
+{
+  int sendErr = 0;
+#ifdef __OpenBSD__
+  for (int i = 0; i < 10; i++) {
+    if (sendmsg(fd, msgh, 0) != -1) {
+      sendErr = 0;
+      break;
+    }
+    sendErr = errno;
+    if (sendErr != EAGAIN) {
+      break;
+    }
+  }
+#else
+  if (sendmsg(fd, msgh, 0) == -1) {
+    sendErr = errno;
+  }
+#endif
+  return sendErr;
+}
 
 ssize_t sendfromto(int sock, const char* data, size_t len, int flags, const ComboAddress& from, const ComboAddress& to)
 {

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1433,6 +1433,7 @@ bool IsAnyAddress(const ComboAddress& addr);
 bool HarvestDestinationAddress(const struct msghdr* msgh, ComboAddress* destination);
 bool HarvestTimestamp(struct msghdr* msgh, struct timeval* tv);
 void fillMSGHdr(struct msghdr* msgh, struct iovec* iov, cmsgbuf_aligned* cbuf, size_t cbufsize, char* data, size_t datalen, ComboAddress* addr);
+int sendOnNBSocket(int fd, const struct msghdr *msgh);
 ssize_t sendfromto(int sock, const char* data, size_t len, int flags, const ComboAddress& from, const ComboAddress& to);
 size_t sendMsgWithOptions(int fd, const char* buffer, size_t len, const ComboAddress* dest, const ComboAddress* local, unsigned int localItf, int flags);
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -592,7 +592,7 @@ private:
 #if !defined( __OpenBSD__)
     int tries = 10;
 #else
-    int tries = 2; // hit the reliable kernel random case for OpenBSD immediately, using sysctl net.inet.udp.baddynamic to exclude ports
+    int tries = 2; // hit the reliable kernel random case for OpenBSD immediately (because it will match tries==1 below), using sysctl net.inet.udp.baddynamic to exclude ports
 #endif
     ComboAddress sin;
     while (--tries) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -194,7 +194,7 @@ typedef vector<int> tcpListenSockets_t;
 typedef map<int, ComboAddress> listenSocketsAddresses_t; // is shared across all threads right now
 
 static listenSocketsAddresses_t g_listenSocketsAddresses; // is shared across all threads right now
-static set<int> g_fromtosockets; // listen sockets that use 'sendfromto()' mechanism
+static set<int> g_fromtosockets; // listen sockets that use 'sendfromto()' mechanism (without actually using sendfromto())
 static AtomicCounter counter;
 static std::shared_ptr<SyncRes::domainmap_t> g_initialDomainMap; // new threads needs this to be setup
 static std::shared_ptr<NetmaskGroup> g_initialAllowFrom; // new thread needs to be setup with this
@@ -578,50 +578,50 @@ private:
   // returns -1 for errors which might go away, throws for ones that won't
   static int makeClientSocket(int family)
   {
-    int ret=socket(family, SOCK_DGRAM, 0 ); // turns out that setting CLO_EXEC and NONBLOCK from here is not a performance win on Linux (oddly enough)
+    int ret = socket(family, SOCK_DGRAM, 0); // turns out that setting CLO_EXEC and NONBLOCK from here is not a performance win on Linux (oddly enough)
 
-    if(ret < 0 && errno==EMFILE) // this is not a catastrophic error
+    if (ret < 0 && errno ==  EMFILE) { // this is not a catastrophic error
       return ret;
+    }
+    if (ret < 0) {
+      throw PDNSException("Making a socket for resolver (family = " + std::to_string(family) + "): " + stringerror());
+    }
 
-    if(ret<0)
-      throw PDNSException("Making a socket for resolver (family = "+std::to_string(family)+"): "+stringerror());
-
-    //    setCloseOnExec(ret); // we're not going to exec
-
-    int tries=10;
+#ifndef __OpenBSD__
+    int tries = 10;
+#else
+    int tries = 2; // hit the reliable kernel random case for OpenBSD, using sysctl net.inet.udp.baddynamic to exclude ports
+#endif
     ComboAddress sin;
-    while(--tries) {
-      uint16_t port;
+    while (--tries) {
+      in_port_t port;
 
-      if(tries==1)  // fall back to kernel 'random'
+      if (tries == 1) {  // fall back to kernel 'random'
         port = 0;
-      else {
+      } else {
         do {
           port = s_minUdpSourcePort + dns_random(s_maxUdpSourcePort - s_minUdpSourcePort + 1);
-        }
-        while (s_avoidUdpSourcePorts.count(port));
+        } while (s_avoidUdpSourcePorts.count(port));
       }
 
-      sin=pdns::getQueryLocalAddress(family, port); // does htons for us
-
-      if (::bind(ret, (struct sockaddr *)&sin, sin.getSocklen()) >= 0)
+      sin = pdns::getQueryLocalAddress(family, port); // does htons for us
+      if (::bind(ret, reinterpret_cast<struct sockaddr*>(&sin), sin.getSocklen()) >= 0)
         break;
     }
 
-    if(!tries) {
+    if (!tries) {
       closesocket(ret);
-      throw PDNSException("Resolver binding to local query client socket on "+sin.toString()+": "+stringerror());
+      throw PDNSException("Resolver binding to local query client socket on " + sin.toString() + ": " + stringerror());
     }
 
     try {
       setReceiveSocketErrors(ret, family);
       setNonBlocking(ret);
     }
-    catch(...) {
+    catch (...) {
       closesocket(ret);
       throw;
     }
-
     return ret;
   }
 };
@@ -1900,10 +1900,10 @@ static void startDoResolve(void *p)
       if(g_fromtosockets.count(dc->d_socket)) {
         addCMsgSrcAddr(&msgh, &cbuf, &dc->d_local, 0);
       }
-      if(sendmsg(dc->d_socket, &msgh, 0) < 0 && g_logCommonErrors) {
-        int err = errno;
+      int sendErr = sendOnNBSocket(dc->d_socket, &msgh);
+      if (sendErr && g_logCommonErrors) {
         g_log << Logger::Warning << "Sending UDP reply to client " << dc->getRemote() << " failed with: "
-              << strerror(err) << endl;
+              << strerror(sendErr) << endl;
       }
 
       if(variableAnswer || sr.wasVariable()) {
@@ -2717,11 +2717,11 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
       if(g_fromtosockets.count(fd)) {
         addCMsgSrcAddr(&msgh, &cbuf, &destaddr, 0);
       }
-      if(sendmsg(fd, &msgh, 0) < 0 && g_logCommonErrors) {
-        int err = errno;
+      int sendErr = sendOnNBSocket(fd, &msgh);
+      if (sendErr && g_logCommonErrors) {
         g_log << Logger::Warning << "Sending UDP reply to client " << source.toStringWithPort()
               << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << " failed with: "
-              << strerror(err) << endl;
+              << strerror(sendErr) << endl;
       }
       if(response.length() >= sizeof(struct dnsheader)) {
         struct dnsheader tmpdh;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -587,16 +587,18 @@ private:
       throw PDNSException("Making a socket for resolver (family = " + std::to_string(family) + "): " + stringerror());
     }
 
-#ifndef __OpenBSD__
+    // The loop below runs the body with [tries-1 tries-2 ... 1]. Last iteration with tries == 1 is special: it uses a kernel
+    // allocated UDP port.
+#if !defined( __OpenBSD__)
     int tries = 10;
 #else
-    int tries = 2; // hit the reliable kernel random case for OpenBSD, using sysctl net.inet.udp.baddynamic to exclude ports
+    int tries = 2; // hit the reliable kernel random case for OpenBSD immediately, using sysctl net.inet.udp.baddynamic to exclude ports
 #endif
     ComboAddress sin;
     while (--tries) {
       in_port_t port;
 
-      if (tries == 1) {  // fall back to kernel 'random'
+      if (tries == 1) {  // last iteration: fall back to kernel 'random'
         port = 0;
       } else {
         do {


### PR DESCRIPTION
Use OpenBSD's reliable local UDP port randomization instead of a home-grown mechanism and retry on sendmsg EAGAIN. The latter can and does happen on non-blocking UDP sockets on OpenBSD.

This makes running multiple recursor threads on OpenBSD much more reliable on heavy load. Previously
you would see quite some EAGAINs (leading to reply loss) on e.g. a dnsperf load test with threads > 1.
The arbitrary max loop count is a bit unsatisfactory....

There might be more systems that return EAGAIN once in a while on sendmsg(2) on a non-blocking UDP socket.

Apology for the white-space changes.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
