### PR TITLE
dnsmessage.proto: make CC0 Public Domain

### DIFF
--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -1,23 +1,16 @@
 /*
- * This file is part of PowerDNS or dnsdist.
- * Copyright -- PowerDNS.COM B.V. and its contributors
+ * This file describes the message format used by the protobuf logging feature in PowerDNS and dnsdist.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * Written by PowerDNS.COM B.V. and its contributors.
+ * 
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this file to the public
+ * domain worldwide. This file is distributed without any warranty.
  *
- * In addition, for the avoidance of any doubt, permission is granted to
- * link this program with OpenSSL and to (re)distribute the binaries
- * produced as the result of such linking.
+ * You should have received a copy of the CC0 Public Domain Dedication along
+ * with this file. If not, see:
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 syntax = "proto2";
 


### PR DESCRIPTION
### Short description

Relicense `dnsmessage.proto` as CC0 Public Domain. GPLv2 makes no sense as this is an interface, not code.

CC0 was chosen because `dnstap.proto` also uses it and it seemed a good fit. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
