### PR TITLE
rec: the clock can tick while the negcache test is running.

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -210,7 +210,10 @@ static uint64_t dumpNegCache(int fd)
     return 0;
   }
   fprintf(fp.get(), "; negcache dump follows\n;\n");
-  return g_negCache->dumpToFile(fp.get());
+
+  struct timeval now;
+  Utility::gettimeofday(&now, nullptr);
+  return g_negCache->dumpToFile(fp.get(), now);
 }
 
 static uint64_t* pleaseDump(int fd)

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -253,11 +253,9 @@ void NegCache::prune(size_t maxEntries)
  *
  * \param fp A pointer to an open FILE object
  */
-size_t NegCache::dumpToFile(FILE* fp) const
+size_t NegCache::dumpToFile(FILE* fp, const struct timeval& now) const
 {
   size_t ret = 0;
-  struct timeval now;
-  Utility::gettimeofday(&now, nullptr);
 
   for (const auto& m : d_maps) {
     const lock l(m);

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -75,7 +75,7 @@ public:
   size_t count(const DNSName& qname, const QType qtype) const;
   void prune(size_t maxEntries);
   void clear();
-  size_t dumpToFile(FILE* fd) const;
+  size_t dumpToFile(FILE* fd, const struct timeval& now) const;
   size_t wipe(const DNSName& name, bool subtree = false);
   size_t size() const;
 

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -444,19 +444,19 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile)
   size_t len = 0;
   ssize_t read;
 
-  for (const auto& str : expected) {
+  for (auto str : expected) {
     read = getline(&line, &len, fp.get());
     if (read == -1)
       BOOST_FAIL("Unable to read a line from the temp file");
-    BOOST_CHECK_EQUAL(line, str);
+    // The clock might have ticked so the 600 becomes 599
+    auto pos = str.find("600");
+    BOOST_CHECK(line == str || line == str.replace(pos, 3, "599"));
   }
 
-  if (line != nullptr) {
-    /* getline() allocates a buffer when called with a nullptr,
-       then reallocates it when needed, but we need to free the
-       last allocation if any. */
-    free(line);
-  }
+  /* getline() allocates a buffer when called with a nullptr,
+     then reallocates it when needed, but we need to free the
+     last allocation if any. */
+  free(line);
 }
 
 BOOST_AUTO_TEST_CASE(test_count)

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -437,7 +437,7 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile)
   if (!fp)
     BOOST_FAIL("Temporary file could not be opened");
 
-  cache.dumpToFile(fp.get());
+  cache.dumpToFile(fp.get(), now);
 
   rewind(fp.get());
   char* line = nullptr;
@@ -449,8 +449,7 @@ BOOST_AUTO_TEST_CASE(test_dumpToFile)
     if (read == -1)
       BOOST_FAIL("Unable to read a line from the temp file");
     // The clock might have ticked so the 600 becomes 599
-    auto pos = str.find("600");
-    BOOST_CHECK(line == str || line == str.replace(pos, 3, "599"));
+    BOOST_CHECK(line == str);
   }
 
   /* getline() allocates a buffer when called with a nullptr,


### PR DESCRIPTION
I'm assuming the test always finishes within 1 second...

Fix tested by waiting in a loop until the second is *almost* over and then run the test.

While there zap a redundant test: it's legal to call `free(nullptr)`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
