### PR TITLE
Fix typo in Recursor UDR documentation

### DIFF
--- a/pdns/recursordist/docs/nod_udr.rst
+++ b/pdns/recursordist/docs/nod_udr.rst
@@ -50,7 +50,7 @@ This is because well-behaved domains tend to return fairly stable results to DNS
 
 UDR is disabled by default - to enable it, set ``unique-response-tracking=yes`` in recursor.conf.
 
-The data is persisted to /var/log/pdns-recursor/udr by default, which can be changed with the setting ``unique-response-history-dir=<new directory>``.
+The data is persisted to /var/lib/pdns-recursor/udr by default, which can be changed with the setting ``unique-response-history-dir=<new directory>``.
 
 The SBF (which is maintained separately per recursor thread) cell size defaults to 67108864, which can be changed using the setting ``unique-response-db-size``. The same caveats regarding FPs/FNs apply as for NOD.
 


### PR DESCRIPTION
### Short description
Fix typo in Recursor UDR documentation

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
