### PR TITLE
auth: bindbackend: 'rediscover' changes to 'type'

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -938,11 +938,14 @@ void Bind2Backend::loadConfig(string* status)
         bbd.d_masters=i->masters;
         bbd.d_also_notify=i->alsoNotify;
 
-        bbd.d_kind = DomainInfo::Native;
+        DomainInfo::DomainKind kind = DomainInfo::Native;
         if (i->type == "master")
-          bbd.d_kind = DomainInfo::Master;
+          kind = DomainInfo::Master;
         if (i->type == "slave")
-          bbd.d_kind = DomainInfo::Slave;
+          kind = DomainInfo::Slave;
+
+        bool kindChanged = (bbd.d_kind!=kind);
+        bbd.d_kind = kind;
 
         newnames.insert(bbd.d_name);
         if(filenameChanged || !bbd.d_loaded || !bbd.current()) {
@@ -987,7 +990,7 @@ void Bind2Backend::loadConfig(string* status)
             rejected++;
           }
           safePutBBDomainInfo(bbd);
-        } else if(addressesChanged) {
+        } else if(addressesChanged || kindChanged) {
           safePutBBDomainInfo(bbd);
         }
       }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Makes rediscover detect changes to the `type` property of zones in named.conf. 
Without this a restart is required for a change to the kind of a zone to apply (f.e. `native` -> `master`).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
