### PR TITLE
auth lmdb: fill di.backend in getUnfreshSlaveInfos and getAllDomains

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -926,6 +926,7 @@ void LMDBBackend::getAllDomains(vector<DomainInfo> *domains, bool include_disabl
     } else if(!include_disabled) {
       continue;
     }
+    di.backend = this;
     domains->push_back(di);
   }
 }
@@ -965,6 +966,7 @@ void LMDBBackend::getUnfreshSlaveInfos(vector<DomainInfo>* domains)
     DomainInfo di=*iter;    
     di.id = iter.getID();
     di.serial = serial;
+    di.backend = this;
 
     domains->push_back(di);
   }


### PR DESCRIPTION
### Short description
Improves on #9646

(but does not fix the 'serial 0 means the domain is missing' problem in #9470)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master