### PR TITLE
pdns: setPipeBufferSize - Fix comparison sign mismatch

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1510,7 +1510,7 @@ size_t getPipeBufferSize(int fd)
 bool setPipeBufferSize(int fd, size_t size)
 {
 #ifdef F_SETPIPE_SZ
-  if (size > std::numeric_limits<int>::max()) {
+  if (size > static_cast<size_t>(std::numeric_limits<int>::max())) {
     errno = EINVAL;
     return false;
   }


### PR DESCRIPTION
### Short description
Fixes compiler warning

misc.cc:1513:12: warning: comparison of integer expressions of different signedness:
size_t {aka long unsigned int} and int [-Wsign-compare]

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
