### PR TITLE
Add Policy Kind / RPZ action to Protobuf messages

### DIFF
--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -74,6 +74,7 @@ message PBDNSMessage {
     optional PolicyType appliedPolicyType = 7;  // Type of the filtering policy (RPZ or Lua) applied
     optional string appliedPolicyTrigger = 8;   // The RPZ trigger
     optional string appliedPolicyHit = 9;       // The value (qname or IP) that caused the hit
+    optional string appliedPolicyKind = 10;     // The Kind (RPZ action) applied by the hit
   }
 
   optional DNSResponse response = 13;

--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -37,6 +37,14 @@ message PBDNSMessage {
     NSDNAME = 5;                                // Policy matched on the name of one nameserver involved
     NSIP = 6;                                   // Policy matched on the IP of one nameserver involved
   }
+  enum PolicyKind {
+    NoAction = 1;                               // No action taken
+    Drop = 2;                                   // https://tools.ietf.org/html/draft-vixie-dns-rpz-04 3.4
+    NXDOMAIN = 3;                               // https://tools.ietf.org/html/draft-vixie-dns-rpz-04 3.1
+    NODATA = 4;                                 // https://tools.ietf.org/html/draft-vixie-dns-rpz-04 3.2
+    Truncate= 5;                                // https://tools.ietf.org/html/draft-vixie-dns-rpz-04 3.5
+    Custom = 6;                                 // https://tools.ietf.org/html/draft-vixie-dns-rpz-04 3.6
+  }
   required Type type = 1;
   optional bytes messageId = 2;                 // UUID, shared by the query and the response
   optional bytes serverIdentity = 3;            // ID of the server emitting the protobuf message
@@ -74,7 +82,7 @@ message PBDNSMessage {
     optional PolicyType appliedPolicyType = 7;  // Type of the filtering policy (RPZ or Lua) applied
     optional string appliedPolicyTrigger = 8;   // The RPZ trigger
     optional string appliedPolicyHit = 9;       // The value (qname or IP) that caused the hit
-    optional string appliedPolicyKind = 10;     // The Kind (RPZ action) applied by the hit
+    optional PolicyKind appliedPolicyKind = 10; // The Kind (RPZ action) applied by the hit
   }
 
   optional DNSResponse response = 13;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2055,6 +2055,7 @@ static void startDoResolve(void *p)
         pbMessage.setAppliedPolicyType(appliedPolicy.d_type);
         pbMessage.setAppliedPolicyTrigger(appliedPolicy.d_trigger);
         pbMessage.setAppliedPolicyHit(appliedPolicy.d_hit);
+        pbMessage.setAppliedPolicyKind(appliedPolicy.d_kind);
       }
       pbMessage.addPolicyTags(dc->d_policyTags);
       pbMessage.setInBytes(packet.size());

--- a/pdns/protozero.hh
+++ b/pdns/protozero.hh
@@ -235,9 +235,33 @@ namespace pdns {
         writer.add_uint64(static_cast<protozero::pbf_tag_type>(type), value);
       }
 
-      static void add_bytes(protozero::pbf_writer& writer, Field type, const char* data, size_t len)
+      void setAppliedPolicyKind(const DNSFilterEngine::PolicyKind& kind)
       {
-        writer.add_bytes(static_cast<protozero::pbf_tag_type>(type), data, len);
+        uint32_t k;
+
+        switch(kind) {
+	case DNSFilterEngine::PolicyKind::NoAction:
+          k = 1;
+          break;
+	case DNSFilterEngine::PolicyKind::Drop:
+          k = 2;
+          break;
+	case DNSFilterEngine::PolicyKind::NXDOMAIN:
+          k = 3;
+          break;
+	case DNSFilterEngine::PolicyKind::NODATA:
+          k = 4;
+          break;
+	case DNSFilterEngine::PolicyKind::Truncate:
+          k = 5;
+          break;
+	case DNSFilterEngine::PolicyKind::Custom:
+          k = 6;
+          break;
+        default:
+          throw std::runtime_error("Unsupported protobuf policy kind");
+        }
+        d_response.add_uint32(10, k);
       }
 
       static void add_string(protozero::pbf_writer& writer, Field type, const std::string& str)

--- a/pdns/protozero.hh
+++ b/pdns/protozero.hh
@@ -35,7 +35,7 @@ namespace pdns {
       enum class MessageType : int32_t { DNSQueryType = 1, DNSResponseType = 2, DNSOutgoingQueryType = 3, DNSIncomingResponseType = 4 };
       enum class Field : protozero::pbf_tag_type { type = 1, messageId = 2, serverIdentity = 3, socketFamily = 4, socketProtocol = 5, from = 6, to = 7, inBytes = 8, timeSec = 9, timeUsec = 10, id = 11, question = 12, response = 13, originalRequestorSubnet = 14, requestorId = 15, initialRequestId = 16, deviceId = 17, newlyObservedDomain = 18, deviceName = 19, fromPort = 20, toPort = 21 };
       enum class QuestionField : protozero::pbf_tag_type { qName = 1, qType = 2, qClass = 3};
-      enum class ResponseField : protozero::pbf_tag_type { rcode = 1, rrs = 2, appliedPolicy = 3, tags = 4, queryTimeSec = 5, queryTimeUsec = 6, appliedPolicyType = 7, appliedPolicyTrigger = 8, appliedPolicyHit = 9 };
+      enum class ResponseField : protozero::pbf_tag_type { rcode = 1, rrs = 2, appliedPolicy = 3, tags = 4, queryTimeSec = 5, queryTimeUsec = 6, appliedPolicyType = 7, appliedPolicyTrigger = 8, appliedPolicyHit = 9, appliedPolicyKind = 10 };
       enum class RRField : protozero::pbf_tag_type { name = 1, type = 2, class_ = 3, ttl = 4, rdata = 5, udr = 6 };
 
       Message(std::string& buffer): d_buffer(buffer), d_message{d_buffer}
@@ -235,33 +235,9 @@ namespace pdns {
         writer.add_uint64(static_cast<protozero::pbf_tag_type>(type), value);
       }
 
-      void setAppliedPolicyKind(const DNSFilterEngine::PolicyKind& kind)
+      static void add_bytes(protozero::pbf_writer& writer, Field type, const char* data, size_t len)
       {
-        uint32_t k;
-
-        switch(kind) {
-	case DNSFilterEngine::PolicyKind::NoAction:
-          k = 1;
-          break;
-	case DNSFilterEngine::PolicyKind::Drop:
-          k = 2;
-          break;
-	case DNSFilterEngine::PolicyKind::NXDOMAIN:
-          k = 3;
-          break;
-	case DNSFilterEngine::PolicyKind::NODATA:
-          k = 4;
-          break;
-	case DNSFilterEngine::PolicyKind::Truncate:
-          k = 5;
-          break;
-	case DNSFilterEngine::PolicyKind::Custom:
-          k = 6;
-          break;
-        default:
-          throw std::runtime_error("Unsupported protobuf policy kind");
-        }
-        d_response.add_uint32(10, k);
+        writer.add_bytes(static_cast<protozero::pbf_tag_type>(type), data, len);
       }
 
       static void add_string(protozero::pbf_writer& writer, Field type, const std::string& str)

--- a/pdns/recursordist/rec-protozero.hh
+++ b/pdns/recursordist/rec-protozero.hh
@@ -141,6 +141,35 @@ namespace ProtoZero
       d_response.add_string(static_cast<protozero::pbf_tag_type>(ResponseField::appliedPolicyHit), hit);
     }
 
+    void setAppliedPolicyKind(const DNSFilterEngine::PolicyKind& kind)
+    {
+        uint32_t k;
+
+        switch(kind) {
+	case DNSFilterEngine::PolicyKind::NoAction:
+          k = 1;
+          break;
+	case DNSFilterEngine::PolicyKind::Drop:
+          k = 2;
+          break;
+	case DNSFilterEngine::PolicyKind::NXDOMAIN:
+          k = 3;
+          break;
+	case DNSFilterEngine::PolicyKind::NODATA:
+          k = 4;
+          break;
+	case DNSFilterEngine::PolicyKind::Truncate:
+          k = 5;
+          break;
+	case DNSFilterEngine::PolicyKind::Custom:
+          k = 6;
+          break;
+        default:
+          throw std::runtime_error("Unsupported protobuf policy kind");
+        }
+        d_response.add_uint32(static_cast<protozero::pbf_tag_type>(ResponseField::appliedPolicyKind), k);
+    }
+
 #ifdef NOD_ENABLED
     void clearUDR(std::string&);
 #endif


### PR DESCRIPTION
### Short description
Add the Policy Kind to Protobuf message (issue #9653)

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes) (the description of the message format in documentation in included from the protobuf definition)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
