### PR TITLE
auth: cleanup warnings in ueberbackend, dbdnsseckeeper

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -618,7 +618,7 @@ void DNSSECKeeper::getPreRRSIGs(UeberBackend& db, vector<DNSZoneRecord>& rrs, ui
 
   db.lookup(QType(QType::RRSIG), !rr.wildcardname.empty() ? rr.wildcardname : rr.dr.d_name, rr.domain_id);
   while(db.get(dzr)) {
-    rrsig = std::move(getRR<RRSIGRecordContent>(dzr.dr));
+    rrsig = getRR<RRSIGRecordContent>(dzr.dr);
     if(rrsig->d_type == rr.dr.d_type) {
       if(!rr.wildcardname.empty()) {
         dzr.dr.d_name = rr.dr.d_name;

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -469,7 +469,7 @@ UeberBackend::UeberBackend(const string &pname)
   d_cached=0;
   d_cache_ttl = ::arg().asNum("query-cache-ttl");
   d_negcache_ttl = ::arg().asNum("negquery-cache-ttl");
-
+  d_qtype = 0;
   d_stale = false;
 
   backends=BackendMakers().all(pname=="key-only");
@@ -682,6 +682,7 @@ UeberBackend::handle::handle()
   d_hinterBackend=NULL;
   pkt_p=NULL;
   i=0;
+  zoneId = -1;
 }
 
 UeberBackend::handle::~handle()


### PR DESCRIPTION
### Short description
Should clean up:
```
>>>     CID 1435947:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "d_qtype" is not initialized in this constructor nor in any functions that it calls.
>>>     CID 1030015:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "zoneId" is not initialized in this constructor nor in any functions that it calls.
```

and:

```
dbdnsseckeeper.cc:621:13: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
rrsig = std::move(getRR<RRSIGRecordContent>(dzr.dr));
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
