### PR TITLE
auth lmdb: avoid reading freed memory

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -763,7 +763,7 @@ bool LMDBBackend::get(DNSZoneRecord& rr)
       key = d_currentKey.get<string_view>();
     }
 
-    const auto& drr = d_currentrrset[d_currentrrsetpos++];
+    const auto& drr = d_currentrrset.at(d_currentrrsetpos++);
 
     rr.dr.d_name = compoundOrdername::getQName(key) + d_lookupdomain;
     rr.domain_id = compoundOrdername::getDomainID(key);


### PR DESCRIPTION
### Short description
`pdnsutil delete-rrset` and other operations caused empty values to appear in LMDB databases (fixed in #9664).
Those empty values cause get() to (re)read freed memory.
This PR turns the valgrind warnings + a parse error into a vector out of range exception.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master