### PR TITLE
rec: Backport 9680 to rec 4.4.x: If a.b.c CNAME x.a.b.c is encoutered, switch off QM

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1499,7 +1499,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
 
       if (newTarget.isPartOf(qname)) {
         // a.b.c. CNAME x.a.b.c will go to great depths with QM on
-        string msg = "got a CNAME referral (from cache) to child, switching off QM";
+        string msg = "got a CNAME referral (from cache) to child, disabling QM";
         LOG(prefix<<qname<<": "<<msg<<endl);
         setQNameMinimization(false);
       }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1497,6 +1497,13 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
         throw ImmediateServFailException(msg);
       }
 
+      if (newTarget.isPartOf(qname)) {
+        // a.b.c. CNAME x.a.b.c will go to great depths with QM on
+        string msg = "got a CNAME referral (from cache) to child, switching off QM";
+        LOG(prefix<<qname<<": "<<msg<<endl);
+        setQNameMinimization(false);
+      }
+
       // Check to see if we already have seen the new target as a previous target
       if (scanForCNAMELoop(newTarget, ret)) {
         string msg = "got a CNAME referral (from cache) that causes a loop";
@@ -3661,6 +3668,11 @@ void SyncRes::handleNewTarget(const std::string& prefix, const DNSName& qname, c
     ret.clear();
     rcode = RCode::ServFail;
     return;
+  }
+  if (newtarget.isPartOf(qname)) {
+    // a.b.c. CNAME x.a.b.c will go to great depths with QM on
+    LOG(prefix<<qname<<": status=got a CNAME referral to child, disabling QM"<<endl);
+    setQNameMinimization(false);
   }
 
   if (depth > 10) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #9680 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
