### PR TITLE
rec: Backport 9651 to rec 4.4.x: Allow to specify a name in getMetric() that is used for Prometheus export only.

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -354,8 +354,8 @@ void RecursorLua4::postPrepareContext()
 
   d_pd.push_back({"now", &g_now});
 
-  d_lw->writeFunction("getMetric", [](const std::string& str) {
-      return DynMetric{getDynMetric(str)};
+  d_lw->writeFunction("getMetric", [](const std::string& str, boost::optional<std::string> prometheusName) {
+    return DynMetric{getDynMetric(str, prometheusName ? *prometheusName : "")};
     });
 
   d_lw->registerFunction("inc", &DynMetric::inc);

--- a/pdns/rec-carbon.cc
+++ b/pdns/rec-carbon.cc
@@ -54,14 +54,13 @@ try
     s.connect(remote);  // we do the connect so the first attempt happens while we gather stats
  
     if(msg.empty()) {
-      typedef map<string,string> all_t;
-      all_t all=getAllStatsMap(StatComponent::Carbon);
+      auto all = getAllStatsMap(StatComponent::Carbon);
       
       ostringstream str;
       time_t now=time(0);
       
-      for(const all_t::value_type& val :  all) {
-        str<<namespace_name<<'.'<<hostname<<'.'<<instance_name<<'.'<<val.first<<' '<<val.second<<' '<<now<<"\r\n";
+      for(const auto& val : all) {
+        str<<namespace_name<<'.'<<hostname<<'.'<<instance_name<<'.'<<val.first<<' '<<val.second.d_value<<' '<<now<<"\r\n";
       }
       msg = str.str();
     }

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -72,7 +72,7 @@ public:
 
 enum class StatComponent { API, Carbon, RecControl, SNMP };
 
-std::map<std::string, std::string> getAllStatsMap(StatComponent component);
+std::map<std::string, std::string> getAllStatsMap(StatComponent component, bool prometheusName = false);
 extern std::mutex g_carbon_config_lock;
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetQueryRing();
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetServfailQueryRing();
@@ -83,7 +83,7 @@ std::vector<ComboAddress>* pleaseGetBogusRemotes();
 std::vector<ComboAddress>* pleaseGetLargeAnswerRemotes();
 std::vector<ComboAddress>* pleaseGetTimeouts();
 DNSName getRegisteredName(const DNSName& dom);
-std::atomic<unsigned long>* getDynMetric(const std::string& str);
+std::atomic<unsigned long>* getDynMetric(const std::string& str, const std::string& prometheusName);
 optional<uint64_t> getStatByName(const std::string& name);
 bool isStatBlacklisted(StatComponent component, const std::string& name);
 void blacklistStat(StatComponent component, const string& name);

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -72,7 +72,13 @@ public:
 
 enum class StatComponent { API, Carbon, RecControl, SNMP };
 
-std::map<std::string, std::string> getAllStatsMap(StatComponent component, bool prometheusName = false);
+struct StatsMapEntry {
+  std::string d_prometheusName;
+  std::string d_value;
+};
+typedef std::map<std::string, StatsMapEntry> StatsMap;
+StatsMap getAllStatsMap(StatComponent component);
+
 extern std::mutex g_carbon_config_lock;
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetQueryRing();
 std::vector<std::pair<DNSName, uint16_t> >* pleaseGetServfailQueryRing();

--- a/pdns/recursordist/docs/lua-scripting/statistics.rst
+++ b/pdns/recursordist/docs/lua-scripting/statistics.rst
@@ -14,11 +14,15 @@ Create a custom metric with:
 
   myMetric=getMetric("myspecialmetric")
 
-.. function:: getMetric(name) -> Metric
+.. function:: getMetric(name [, prometheusName]) -> Metric
 
   Returns the :class:`Metric` object with the name ``name``, creating the metric if it does not exist.
 
   :param str name: The metric to retrieve
+
+  .. versionadded:: 4.5.0
+
+  :param string prometheusName: The optional Prometheus specific name.
 
 .. class:: Metric
 

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -50,8 +50,12 @@ using json11::Json;
 
 void productServerStatisticsFetch(map<string,string>& out)
 {
-  map<string,string> stats = getAllStatsMap(StatComponent::API);
-  out.swap(stats);
+  auto stats = getAllStatsMap(StatComponent::API);
+  map<string,string> ret;
+  for (const auto& entry: stats) {
+    ret.insert(make_pair(entry.first, entry.second.d_value));
+  }
+  out.swap(ret);
 }
 
 boost::optional<uint64_t> productServerStatisticsFetch(const std::string& name)
@@ -434,17 +438,14 @@ static void prometheusMetrics(HttpRequest *req, HttpResponse *resp) {
 
     registerAllStats();
 
-
     std::ostringstream output;
-    typedef map <string, string> varmap_t;
-    
+
     // Argument controls blacklisting of any stats. So
     // stats-api-blacklist will be used to block returned stats.
-    // Second arg tells to use the prometheus names.
-    varmap_t varmap = getAllStatsMap(StatComponent::API, true);
-    for (const auto &tup :  varmap) {
+    auto varmap = getAllStatsMap(StatComponent::API);
+    for (const auto& tup : varmap) {
         std::string metricName = tup.first;
-        std::string prometheusMetricName = "pdns_recursor_" + metricName;
+        std::string prometheusMetricName = tup.second.d_prometheusName;
 
         MetricDefinition metricDetails;
 
@@ -460,7 +461,7 @@ static void prometheusMetrics(HttpRequest *req, HttpResponse *resp) {
           output << "# HELP " << prometheusMetricName << " " << metricDetails.description << "\n";
           output << "# TYPE " << prometheusMetricName << " " << prometheusTypeName << "\n";
         }
-        output << prometheusMetricName << " " << tup.second << "\n";
+        output << prometheusMetricName << " " << tup.second.d_value << "\n";
     }
 
     output << "# HELP pdns_recursor_info " << "Info from pdns_recursor, value is always 1" << "\n";
@@ -470,7 +471,6 @@ static void prometheusMetrics(HttpRequest *req, HttpResponse *resp) {
     resp->body = output.str();
     resp->headers["Content-Type"] = "text/plain";
     resp->status = 200;
-
 }
 
 

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -437,13 +437,14 @@ static void prometheusMetrics(HttpRequest *req, HttpResponse *resp) {
 
     std::ostringstream output;
     typedef map <string, string> varmap_t;
-    varmap_t varmap = getAllStatsMap(
-            StatComponent::API); // Argument controls blacklisting of any stats. So stats-api-blacklist will be used to block returned stats.
+    
+    // Argument controls blacklisting of any stats. So
+    // stats-api-blacklist will be used to block returned stats.
+    // Second arg tells to use the prometheus names.
+    varmap_t varmap = getAllStatsMap(StatComponent::API, true);
     for (const auto &tup :  varmap) {
         std::string metricName = tup.first;
-
-        // Prometheus suggest using '_' instead of '-'
-        std::string prometheusMetricName = "pdns_recursor_" + boost::replace_all_copy(metricName, "-", "_");
+        std::string prometheusMetricName = "pdns_recursor_" + metricName;
 
         MetricDefinition metricDetails;
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #9651 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
