### PR TITLE
Pdns AXFR, IXFR loglevels

### DIFF
--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -66,7 +66,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
           const ComboAddress caIp(*k, 53);
           if(!d_preventSelfNotification || !AddressIsUs(caIp)) {
             if(!d_onlyNotify.match(&caIp))
-              g_log<<Logger::Info<<"Skipped notification of domain '"<<di.zone<<"' to "<<*j<<" because it does not match only-notify."<<endl;
+              g_log<<Logger::Notice<<"Skipped notification of domain '"<<di.zone<<"' to "<<*j<<" because it does not match only-notify."<<endl;
             else
               ips.insert(caIp.toStringWithPort());
           }
@@ -74,7 +74,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
     }
 
     for(set<string>::const_iterator j=ips.begin();j!=ips.end();++j) {
-      g_log<<Logger::Warning<<"Queued notification of domain '"<<di.zone<<"' to "<<*j<<endl;
+      g_log<<Logger::Notice<<"Queued notification of domain '"<<di.zone<<"' to "<<*j<<endl;
       d_nq.add(di.zone,*j);
       hasQueuedItem=true;
     }
@@ -96,7 +96,7 @@ void CommunicatorClass::queueNotifyDomain(const DomainInfo& di, UeberBackend* B)
   for(set<string>::const_iterator j=alsoNotify.begin();j!=alsoNotify.end();++j) {
     try {
       const ComboAddress caIp(*j, 53);
-      g_log<<Logger::Warning<<"Queued also-notification of domain '"<<di.zone<<"' to "<<caIp.toStringWithPort()<<endl;
+      g_log<<Logger::Notice<<"Queued also-notification of domain '"<<di.zone<<"' to "<<caIp.toStringWithPort()<<endl;
       if (!ips.count(caIp.toStringWithPort())) {
         ips.insert(caIp.toStringWithPort());
         d_nq.add(di.zone, caIp.toStringWithPort());
@@ -117,7 +117,7 @@ bool CommunicatorClass::notifyDomain(const DNSName &domain, UeberBackend* B)
 {
   DomainInfo di;
   if(!B->getDomainInfo(domain, di)) {
-    g_log<<Logger::Error<<"No such domain '"<<domain<<"' in our database"<<endl;
+    g_log<<Logger::Warning<<"No such domain '"<<domain<<"' in our database"<<endl;
     return false;
   }
   queueNotifyDomain(di, B);
@@ -147,12 +147,12 @@ void CommunicatorClass::masterUpdateCheck(PacketHandler *P)
   
   if(cmdomains.empty()) {
     if(d_masterschanged)
-      g_log<<Logger::Warning<<"No master domains need notifications"<<endl;
+      g_log<<Logger::Info<<"No master domains need notifications"<<endl;
     d_masterschanged=false;
   }
   else {
     d_masterschanged=true;
-    g_log<<Logger::Error<<cmdomains.size()<<" domain"<<(cmdomains.size()>1 ? "s" : "")<<" for which we are master need"<<
+    g_log<<Logger::Notice<<cmdomains.size()<<" domain"<<(cmdomains.size()>1 ? "s" : "")<<" for which we are master need"<<
       (cmdomains.size()>1 ? "" : "s")<<
       " notifications"<<endl;
   }
@@ -196,7 +196,7 @@ time_t CommunicatorClass::doNotifications(PacketHandler *P)
       g_log<<Logger::Warning<<"Received unsuccessful notification report for '"<<p.qdomain<<"' from "<<from.toStringWithPort()<<", error: "<<RCode::to_s(p.d.rcode)<<endl;      
 
     if(d_nq.removeIf(from.toStringWithPort(), p.d.id, p.qdomain))
-      g_log<<Logger::Warning<<"Removed from notification list: '"<<p.qdomain<<"' to "<<from.toStringWithPort()<<" "<< (p.d.rcode ? RCode::to_s(p.d.rcode) : "(was acknowledged)")<<endl;      
+      g_log<<Logger::Notice<<"Removed from notification list: '"<<p.qdomain<<"' to "<<from.toStringWithPort()<<" "<< (p.d.rcode ? RCode::to_s(p.d.rcode) : "(was acknowledged)")<<endl;
     else {
       g_log<<Logger::Warning<<"Received spurious notify answer for '"<<p.qdomain<<"' from "<< from.toStringWithPort()<<endl;
       //d_nq.dump();
@@ -226,11 +226,11 @@ time_t CommunicatorClass::doNotifications(PacketHandler *P)
         drillHole(domain, ip);
       }
       catch(ResolverException &re) {
-        g_log<<Logger::Error<<"Error trying to resolve '"<<ip<<"' for notifying '"<<domain<<"' to server: "<<re.reason<<endl;
+        g_log<<Logger::Warning<<"Error trying to resolve '"<<ip<<"' for notifying '"<<domain<<"' to server: "<<re.reason<<endl;
       }
     }
     else
-      g_log<<Logger::Error<<"Notification for "<<domain<<" to "<<ip<<" failed after retries"<<endl;
+      g_log<<Logger::Warning<<"Notification for "<<domain<<" to "<<ip<<" failed after retries"<<endl;
   }
 
   return d_nq.earliest();
@@ -255,7 +255,7 @@ void CommunicatorClass::sendNotification(int sock, const DNSName& domain, const 
 
   if (tsigkeyname.empty() == false) {
     if (!B->getTSIGKey(tsigkeyname, &tsigalgorithm, &tsigsecret64)) {
-      g_log<<Logger::Error<<"TSIG key '"<<tsigkeyname<<"' for domain '"<<domain<<"' not found"<<endl;
+      g_log<<Logger::Warning<<"TSIG key '"<<tsigkeyname<<"' for domain '"<<domain<<"' not found"<<endl;
       return;
     }
     TSIGRecordContent trc;


### PR DESCRIPTION
### Short description
Decrease the verbosity of AXFR and IXFR in the logs

Inspired by and successor of #9658 This pull will change the log levels for both, primary and secondary.

Closes #9658 #9514

Most XFR related events are now logged at notice level. And will not show up in the logs at the default log level.

This is the only (non error) message still logged at warning level on the primary:
```
Nov 09 13:33:31 AXFR of domain 'example.com' initiated by 127.0.0.2:36543
```

The secondary is only showing this at warning level:
```
Nov 09 13:33:31 AXFR done for 'example.com', zone committed with serial number 2005092501
```

You can argue about these two lines, but in my opinion it is important to not completely hide XFR at default log level.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
