### PR TITLE
Auth: make it possible to replace now supported TYPExxx records

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1443,6 +1443,14 @@ bool GSQLBackend::replaceRRSet(uint32_t domain_id, const DNSName& qname, const Q
     }
 
     if (qt != QType::ANY) {
+      if (d_upgradeContent) {
+        d_DeleteRRSetQuery_stmt->
+          bind("domain_id", domain_id)->
+          bind("qname", qname)->
+          bind("qtype", "TYPE"+itoa(qt.getCode()))->
+          execute()->
+          reset();
+      }
       d_DeleteRRSetQuery_stmt->
         bind("domain_id", domain_id)->
         bind("qname", qname)->

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1853,7 +1853,7 @@ void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)
 
   r.qtype=row[3];
 
-  if (d_upgradeContent && DNSRecordContent::isUnknownType(row[3])) {
+  if (d_upgradeContent && DNSRecordContent::isUnknownType(row[3]) && r.qtype.isSupportedType()) {
     r.content = DNSRecordContent::upgradeContent(r.qname, r.qtype, row[0]);
   }
   else if (r.qtype==QType::MX || r.qtype==QType::SRV) {


### PR DESCRIPTION
### Short description
It was impossible to edit/upgrade now supported TYPExxx records, since the old TYPExxx variant was never deleted in replaceRRSet(). This pull will slow down updates when upgrade-unknown-types is enabled. There is already a warning about the performance impact of this option in the documentation.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

