### PR TITLE
Rec: refresh almost expired

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -37,6 +37,8 @@
 #include "secpoll-recursor.hh"
 #include "pubsuffix.hh"
 #include "namespaces.hh"
+#include "rec-taskqueue.hh"
+
 std::mutex g_carbon_config_lock;
 
 static map<string, const uint32_t*> d_get32bitpointers;
@@ -1231,6 +1233,10 @@ void registerAllStats()
 
   addGetStat("nod-lookups-dropped-oversize", &g_stats.nodLookupsDroppedOversize);
 
+  addGetStat("taskqueue-pushed",  []() { return getTaskPushes(); });
+  addGetStat("taskqueue-expired",  []() { return getTaskExpired(); });
+  addGetStat("taskqueue-size",  []() { return getTaskSize(); });
+  
   /* make sure that the ECS stats are properly initialized */
   SyncRes::clearECSStats();
   for (size_t idx = 0; idx < SyncRes::s_ecsResponsesBySubnetSize4.size(); idx++) {
@@ -1663,7 +1669,6 @@ static string clearDontThrottleNetmasks(T begin, T end) {
   g_log<<Logger::Info<<ret<<", requested via control channel"<<endl;
   return ret + "\n";
 }
-
 
 string RecursorControlParser::getAnswer(const string& question, RecursorControlParser::func_t** command)
 {

--- a/pdns/recpacketcache.hh
+++ b/pdns/recpacketcache.hh
@@ -49,6 +49,8 @@ using namespace ::boost::multi_index;
 class RecursorPacketCache: public PacketCache
 {
 public:
+  static unsigned int s_refresh_ttlperc;
+
   struct PBData {
     std::string d_message;
     std::string d_response;
@@ -92,11 +94,16 @@ private:
     uint16_t d_type;
     uint16_t d_class;
     mutable vState d_vstate;
+    mutable bool d_submitted;   // whether this entry has been queued for refetch
     inline bool operator<(const struct Entry& rhs) const;
 
     time_t getTTD() const
     {
       return d_ttd;
+    }
+
+    uint32_t getOrigTTL() const {
+      return d_ttd - d_creation;
     }
   };
 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -152,6 +152,7 @@ pdns_recursor_SOURCES = \
 	rec-lua-conf.hh rec-lua-conf.cc \
 	rec-protozero.cc rec-protozero.hh \
 	rec-snmp.hh rec-snmp.cc \
+	rec-taskqueue.cc rec-taskqueue.hh \
 	rec_channel.cc rec_channel.hh rec_metrics.hh \
 	rec_channel_rec.cc \
 	recpacketcache.cc recpacketcache.hh \
@@ -175,6 +176,7 @@ pdns_recursor_SOURCES = \
 	stable-bloom.hh \
 	svc-records.cc svc-records.hh \
 	syncres.cc syncres.hh \
+	taskqueue.cc taskqueue.hh \
 	threadname.hh threadname.cc \
 	tsigverifier.cc tsigverifier.hh \
 	ueberbackend.hh \

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1414,6 +1414,20 @@ contention as reported by
 ``record-cache-contented/record-cache-acquired``, you can try to
 enlarge this value or run with fewer threads.
 
+.. _setting-refresh-on-ttl-perc:
+
+``refresh-on-ttl-perc``
+-----------------------
+.. versionadded: 4.5.0
+
+-  Integer
+-  Default: 0
+
+Sets the "refresh almost expired" percentage of the record cache. Whenever a record is fetched from the packet or record cache
+and only ``refresh-on-ttl-perc`` percent or less of its original TTL is left, a task is queued to refetch the name/type combination to
+update the record cache. In most cases this causes future queries to always see a non-expired record cache entry.
+A typical value is 10. If the value is zero, this functionality is disabled.
+
 .. _setting-reuseport:
 
 ``reuseport``

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -1,0 +1,51 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "rec-taskqueue.hh"
+#include "taskqueue.hh"
+#include "syncres.hh"
+
+static thread_local pdns::TaskQueue t_taskQueue;
+
+void runTaskOnce(bool logErrors)
+{
+  t_taskQueue.runOnce(logErrors);
+}
+
+void pushTask(const DNSName& qname, uint16_t qtype, time_t deadline)
+{
+  t_taskQueue.push({qname, qtype, deadline, true});
+}
+
+uint64_t getTaskPushes()
+{
+  return broadcastAccFunction<uint64_t>([] { return t_taskQueue.getPushes(); });
+}
+
+uint64_t getTaskExpired()
+{
+  return broadcastAccFunction<uint64_t>([] { return t_taskQueue.getExpired(); });
+}
+
+uint64_t getTaskSize()
+{
+  return broadcastAccFunction<uint64_t>([] { return t_taskQueue.getSize(); });
+}

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -1,0 +1,30 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "dnsname.hh"
+
+void runTaskOnce(bool logErrors);
+void pushTask(const DNSName& qname, uint16_t qtype, time_t deadline);
+uint64_t getTaskPushes();
+uint64_t getTaskExpired();
+uint64_t getTaskSize();

--- a/pdns/recursordist/taskqueue.cc
+++ b/pdns/recursordist/taskqueue.cc
@@ -1,0 +1,124 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "taskqueue.hh"
+
+#include "logger.hh"
+#include "syncres.hh"
+
+namespace pdns
+{
+
+bool TaskQueue::empty() const
+{
+  return d_queue.empty();
+}
+
+size_t TaskQueue::size() const
+{
+  return d_queue.size();
+}
+
+void TaskQueue::push(const ResolveTask&& task)
+{
+  // Insertion fails if it's already there, no problem since we're already scheduled
+  // and the deadline would remain the same anyway.
+  auto result = d_queue.insert(std::move(task));
+  if (result.second) {
+    d_pushes++;
+  }
+}
+
+ResolveTask TaskQueue::pop()
+{
+  ResolveTask ret = d_queue.get<SequencedTag>().front();
+  d_queue.get<SequencedTag>().pop_front();
+  return ret;
+}
+
+bool TaskQueue::runOnce(bool logErrors)
+{
+  if (d_queue.empty()) {
+    return false;
+  }
+  ResolveTask task = pop();
+  struct timeval now;
+  gettimeofday(&now, 0);
+  if (task.d_deadline >= now.tv_sec) {
+    SyncRes sr(now);
+    vector<DNSRecord> ret;
+    sr.setRefreshAlmostExpired(task.d_refreshMode);
+    try {
+      g_log << Logger::Debug << "TaskQueue: resolving " << task.d_qname.toString() << '|' << QType(task.d_qtype).getName() << endl;
+      sr.beginResolve(task.d_qname, QType(task.d_qtype), QClass::IN, ret);
+    }
+    catch (const std::exception& e) {
+      g_log << Logger::Error << "Exception while running the background task queue: " << e.what() << endl;
+    }
+    catch (const PDNSException& e) {
+      g_log << Logger::Notice << "Exception while running the background task queue: " << e.reason << endl;
+    }
+    catch (const ImmediateServFailException& e) {
+      if (logErrors) {
+        g_log << Logger::Notice << "Exception while running the background task queue: " << e.reason << endl;
+      }
+    }
+    catch (const PolicyHitException& e) {
+      if (logErrors) {
+        g_log << Logger::Notice << "Policy hit while running the background task queue" << endl;
+      }
+    }
+    catch (...) {
+      g_log << Logger::Error << "Exception while running the background task queue" << endl;
+    }
+  }
+  else {
+    // Deadline passed
+    g_log << Logger::Debug << "TaskQueue: deadline for " << task.d_qname.toString() << '|' << QType(task.d_qtype).getName() << " passed" << endl;
+    d_expired++;
+  }
+  return true;
+}
+
+void TaskQueue::runAll(bool logErrors)
+{
+  while (runOnce(logErrors)) {
+    /* empty */
+  }
+}
+
+uint64_t* TaskQueue::getPushes() const
+{
+  return new uint64_t(d_pushes);
+}
+
+uint64_t* TaskQueue::getExpired() const
+{
+  return new uint64_t(d_expired);
+}
+
+uint64_t* TaskQueue::getSize() const
+{
+  return new uint64_t(size());
+}
+
+} /* namespace pdns */

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -1,0 +1,87 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <thread>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/tag.hpp>
+#include <boost/tuple/tuple_comparison.hpp>
+
+#include "dnsname.hh"
+#include "qtype.hh"
+
+using namespace ::boost::multi_index;
+
+namespace pdns
+{
+
+struct ResolveTask
+{
+  DNSName d_qname;
+  uint16_t d_qtype;
+  time_t d_deadline;
+  bool d_refreshMode; // Whether to run this task in regular mode (false) or in the mode that refreshes almost expired tasks
+};
+
+struct HashTag
+{
+};
+struct SequencedTag
+{
+};
+
+typedef multi_index_container<
+  ResolveTask,
+  indexed_by<
+    hashed_unique<tag<HashTag>,
+      composite_key<ResolveTask,
+        member<ResolveTask, DNSName, &ResolveTask::d_qname>,
+        member<ResolveTask, uint16_t, &ResolveTask::d_qtype>,
+        member<ResolveTask, bool, &ResolveTask::d_refreshMode>>>,
+    sequenced<tag<SequencedTag>>>>
+  queue_t;
+
+class TaskQueue
+{
+public:
+  bool empty() const;
+  size_t size() const;
+  void push(const ResolveTask&& task);
+  ResolveTask pop();
+  bool runOnce(bool logErrors); // Run one task if the queue is not empty
+  void runAll(bool logErrors);
+  uint64_t* getPushes() const;
+  uint64_t* getExpired() const;
+  uint64_t* getSize() const;
+
+private:
+  queue_t d_queue;
+  uint64_t d_pushes{0};
+  uint64_t d_expired{0};
+};
+
+}

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -4,6 +4,7 @@
 #include "base32.hh"
 #include "lua-recursor4.hh"
 #include "root-dnssec.hh"
+#include "rec-taskqueue.hh"
 #include "test-syncres_cc.hh"
 
 RecursorStats g_stats;
@@ -529,4 +530,8 @@ LWResult::Result basicRecordsForQnameMinimization(LWResult* res, const DNSName& 
     return LWResult::Result::Success;
   }
   return LWResult::Result::Timeout;
+}
+
+void pushTask(const DNSName& qname, uint16_t qtype, time_t deadline)
+{
 }

--- a/pdns/recursordist/test-syncres_cc3.cc
+++ b/pdns/recursordist/test-syncres_cc3.cc
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(test_answer_no_aa)
   const ComboAddress who;
   vector<DNSRecord> cached;
   vector<std::shared_ptr<RRSIGRecordContent>> signatures;
-  BOOST_REQUIRE_EQUAL(g_recCache->get(now, target, QType(QType::A), false, &cached, who, boost::none, &signatures), -1);
+  BOOST_REQUIRE_EQUAL(g_recCache->get(now, target, QType(QType::A), false, &cached, who, 0, boost::none, &signatures), -1);
 }
 
 BOOST_AUTO_TEST_CASE(test_special_types)

--- a/pdns/recursordist/test-syncres_cc7.cc
+++ b/pdns/recursordist/test-syncres_cc7.cc
@@ -1583,7 +1583,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cut_with_cname_at_apex)
   BOOST_CHECK_EQUAL(queriesCount, 11U);
 
   /* now we remove the denial of powerdns.com DS from the cache and ask www2 */
-  BOOST_REQUIRE_EQUAL(g_negCache->wipe(target, false), 1);
+  BOOST_REQUIRE_EQUAL(g_negCache->wipe(target, false), 1U);
   ret.clear();
   res = sr->beginResolve(DNSName("www2.powerdns.com."), QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
@@ -1706,7 +1706,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_cname_inside_secure_zone)
   BOOST_CHECK_EQUAL(queriesCount, 10U);
 
   /* now we remove the denial of powerdns.com DS from the cache and ask www2 */
-  BOOST_REQUIRE_EQUAL(g_negCache->wipe(target, false), 1);
+  BOOST_REQUIRE_EQUAL(g_negCache->wipe(target, false), 1U);
   ret.clear();
   res = sr->beginResolve(DNSName("www2.powerdns.com."), QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -822,7 +822,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_cache_validity)
   const ComboAddress who;
   vector<DNSRecord> cached;
   vector<std::shared_ptr<RRSIGRecordContent>> signatures;
-  BOOST_REQUIRE_EQUAL(g_recCache->get(tnow, target, QType(QType::A), true, &cached, who, boost::none, &signatures), 1);
+  BOOST_REQUIRE_EQUAL(g_recCache->get(tnow, target, QType(QType::A), true, &cached, who, 0, boost::none, &signatures), 1);
   BOOST_REQUIRE_EQUAL(cached.size(), 1U);
   BOOST_REQUIRE_EQUAL(signatures.size(), 1U);
   BOOST_CHECK_EQUAL((cached[0].d_ttl - tnow), 1);

--- a/pdns/recursordist/test-syncres_cc9.cc
+++ b/pdns/recursordist/test-syncres_cc9.cc
@@ -937,7 +937,7 @@ BOOST_AUTO_TEST_CASE(test_cname_plus_authority_ns_ttl)
   vector<DNSRecord> cached;
   bool wasAuth = false;
 
-  auto ttl = g_recCache->get(now, DNSName("powerdns.com."), QType(QType::NS), false, &cached, who, boost::none, nullptr, nullptr, nullptr, nullptr, &wasAuth);
+  auto ttl = g_recCache->get(now, DNSName("powerdns.com."), QType(QType::NS), false, &cached, who, 0, boost::none, nullptr, nullptr, nullptr, nullptr, &wasAuth);
   BOOST_REQUIRE_GE(ttl, 1);
   BOOST_REQUIRE_LE(ttl, 42);
   BOOST_CHECK_EQUAL(cached.size(), 1U);
@@ -946,7 +946,7 @@ BOOST_AUTO_TEST_CASE(test_cname_plus_authority_ns_ttl)
   cached.clear();
 
   /* Also check that the the part in additional is still not auth */
-  BOOST_REQUIRE_GE(g_recCache->get(now, DNSName("a.gtld-servers.net."), QType(QType::A), false, &cached, who, boost::none, nullptr, nullptr, nullptr, nullptr, &wasAuth), -1);
+  BOOST_REQUIRE_GE(g_recCache->get(now, DNSName("a.gtld-servers.net."), QType(QType::A), false, &cached, who, 0, boost::none, nullptr, nullptr, nullptr, nullptr, &wasAuth), -1);
   BOOST_CHECK_EQUAL(cached.size(), 1U);
   BOOST_CHECK_EQUAL(wasAuth, false);
 }
@@ -1016,7 +1016,7 @@ BOOST_AUTO_TEST_CASE(test_bogus_does_not_replace_secure_in_the_cache)
   vector<DNSRecord> cached;
   bool wasAuth = false;
   vState retrievedState = vState::Insecure;
-  BOOST_CHECK_GT(g_recCache->get(now, DNSName("powerdns.com."), QType(QType::SOA), true, &cached, who, boost::none, nullptr, nullptr, nullptr, &retrievedState, &wasAuth), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("powerdns.com."), QType(QType::SOA), true, &cached, who, false, boost::none, nullptr, nullptr, nullptr, &retrievedState, &wasAuth), 0);
   BOOST_CHECK_EQUAL(vStateToString(retrievedState), vStateToString(vState::Secure));
   BOOST_CHECK_EQUAL(wasAuth, true);
 
@@ -1026,7 +1026,7 @@ BOOST_AUTO_TEST_CASE(test_bogus_does_not_replace_secure_in_the_cache)
   BOOST_REQUIRE_EQUAL(ret.size(), 2U);
 
   cached.clear();
-  BOOST_CHECK_GT(g_recCache->get(now, DNSName("powerdns.com."), QType(QType::SOA), true, &cached, who, boost::none, nullptr, nullptr, nullptr, &retrievedState, &wasAuth), 0);
+  BOOST_CHECK_GT(g_recCache->get(now, DNSName("powerdns.com."), QType(QType::SOA), true, &cached, who, false, boost::none, nullptr, nullptr, nullptr, &retrievedState, &wasAuth), 0);
   BOOST_CHECK_EQUAL(vStateToString(retrievedState), vStateToString(vState::Secure));
   BOOST_CHECK_EQUAL(wasAuth, true);
 }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -610,6 +610,13 @@ public:
     return old;
   }
 
+  bool setRefreshAlmostExpired(bool doit)
+  {
+    auto old = d_refresh;
+    d_refresh = doit;
+    return old;
+  }
+
   void setQNameMinimization(bool state=true)
   {
     d_qNameMinimization=state;
@@ -760,6 +767,7 @@ public:
   static bool s_nopacketcache;
   static bool s_qnameminimization;
   static HardenNXD s_hardenNXD;
+  static unsigned int s_refresh_ttlperc;
 
   std::unordered_map<std::string,bool> d_discardedPolicies;
   DNSFilterEngine::Policy d_appliedPolicy;
@@ -892,6 +900,7 @@ private:
   bool d_qNameMinimization{false};
   bool d_queryReceivedOverTCP{false};
   bool d_followCNAME{true};
+  bool d_refresh{false};
 
   LogMode d_lm;
 };

--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -31,7 +31,7 @@ rm -f recursor.pid pdns_recursor.pid
 <measurement><name>system CPU seconds</name><value>%S</value></measurement>
 <measurement><name>wallclock seconds</name><value>%e</value></measurement>
 <measurement><name>%% CPU used</name><value>%P</value></measurement>
-'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address="0.0.0.0${QLA6}" --threads=$threads --record-cache-shards=$shards --disable-packetcache > recursor.log 2>&1 &
+'         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address="0.0.0.0${QLA6}" --threads=$threads --record-cache-shards=$shards --disable-packetcache --refresh-on-ttl-perc=10 > recursor.log 2>&1 &
 sleep 3
 
 # warm up the cache


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This add two related mechanisms to the record cache:

1. When run normally, determining that an RC entry is "almost expired" and adding it to a queue of "to be refetched" entries (filtering duplicates).

2. Running a query done by SyncRes in a mode that considers "almost expired" entries as expired, triggering re-fetch of the RC "almost expired" entries used to resolve the query (including e.g. NS records that are used and almost expired).

The queue of almost expired entries is processed by the handler thread atm (this should change). It will refetch the names in "refetch almost expired" mode.

The whole mechanism is enabled by setting `refresh-on-ttl-perc`, e.g. to 10

If you want to play with this, _disable the packetcache_, since the entries in the PC and the RC mostly "dance to the same beat" and the trigger mechanism is only implemented for the RC so far. If requests are served by PC hits, the RC refresh mechanism won't be triggered. *This is no longer needed, refetch triggered by PC is implemented now but tested only very lightly!*

This is WIP, but creating a draft PR so people can take a look. I suspect I won't be able to do much work on this the coming time.

Todo: 

- [x] use own thread instead of the handler thread,
- [x] trigger refetch from the PC
- [x] mark RC(PC) entries as already in the process of being re-fetched so the adding to the queue only happens once per record and not each time the RC/PC record is used and almost expired (done for PC where the impact is highest) 
- [x] performance measurements
- [ ] study interaction with client specific stuff like EDNS client subnet
- [x] check how this behaves with very low TTLs
- [x] logging (wtithout spamming) and catching exceptions

Should fix #440 in the end (after making it better and validating it is beneficial).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
