### PR TITLE
Allow setting a fake-ish version number when building release images

### DIFF
--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -28,11 +28,18 @@ COPY m4 /source/m4
 COPY ext /source/ext
 COPY .git /source/.git
 ADD configure.ac Makefile.am /source/
+COPY builder/helpers/set-configure-ac-version.sh /usr/local/bin
 
 ARG MAKEFLAGS=
 ENV MAKEFLAGS ${MAKEFLAGS:--j2}
 
-RUN BUILDER_MODULES=authoritative autoreconf -vfi
+ARG DOCKER_FAKE_RELEASE=NO
+ENV DOCKER_FAKE_RELEASE ${DOCKER_FAKE_RELEASE}
+
+RUN if [ "${DOCKER_FAKE_RELEASE}" = "YES" ]; then \
+      BUILDER_VERSION="$(BUILDER_MODULES=authoritative ./builder-support/gen-version | sed 's/\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/')" set-configure-ac-version.sh;\
+    fi && \
+    BUILDER_MODULES=authoritative autoreconf -vfi
 
 # simplify repeated -C calls with SUBDIRS?
 RUN mkdir /build && \

--- a/Dockerfile-dnsdist
+++ b/Dockerfile-dnsdist
@@ -19,6 +19,7 @@ COPY pdns /source/pdns
 COPY build-aux /source/build-aux
 COPY m4 /source/m4
 COPY ext /source/ext
+COPY builder/helpers/set-configure-ac-version.sh /usr/local/bin
 COPY .git /source/.git
 
 # build and install (TODO: before we hit this line, rearrange /source structure if we are coming from a tarball)
@@ -27,9 +28,15 @@ WORKDIR /source/pdns/dnsdistdist
 ARG MAKEFLAGS=
 ENV MAKEFLAGS ${MAKEFLAGS:--j2}
 
+ARG DOCKER_FAKE_RELEASE=NO
+ENV DOCKER_FAKE_RELEASE ${DOCKER_FAKE_RELEASE}
+
 RUN touch dnsdist.1 # avoid having to install pandoc and venv
 
-RUN BUILDER_MODULES=dnsdist autoreconf -vfi
+RUN if [ "${DOCKER_FAKE_RELEASE}" = "YES" ]; then \
+      BUILDER_VERSION="$(BUILDER_MODULES=dnsdist ./builder-support/gen-version | sed 's/\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/')" set-configure-ac-version.sh;\
+    fi && \
+    BUILDER_MODULES=dnsdist autoreconf -vfi
 
 RUN mkdir /build && \
     ./configure \

--- a/Dockerfile-recursor
+++ b/Dockerfile-recursor
@@ -25,6 +25,7 @@ COPY build-aux /source/build-aux
 COPY m4 /source/m4
 COPY ext /source/ext
 COPY .git /source/.git
+COPY builder/helpers/set-configure-ac-version.sh /usr/local/bin
 
 # build and install (TODO: before we hit this line, rearrange /source structure if we are coming from a tarball)
 WORKDIR /source/pdns/recursordist
@@ -32,13 +33,19 @@ WORKDIR /source/pdns/recursordist
 ARG MAKEFLAGS=
 ENV MAKEFLAGS ${MAKEFLAGS:--j2}
 
+ARG DOCKER_FAKE_RELEASE=NO
+ENV DOCKER_FAKE_RELEASE ${DOCKER_FAKE_RELEASE}
+
 # Manpage deps
 # RUN apt-get install -y virtualenv && apt-get clean
 
 # Manpage prevent
 RUN touch pdns_recursor.1 rec_control.1 # avoid installing pandoc
 
-RUN BUILDER_MODULES=recursor autoreconf -vfi
+RUN if [ "${DOCKER_FAKE_RELEASE}" = "YES" ]; then \
+      BUILDER_VERSION="$(BUILDER_MODULES=recursor ./builder-support/gen-version | sed 's/\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/')" set-configure-ac-version.sh;\
+    fi && \
+    BUILDER_MODULES=recursor autoreconf -vfi
 
 RUN mkdir /build && \
     ./configure \

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -174,7 +174,7 @@ AS_IF([test "x$pdns_configure_args" != "x"],
   [summary_conf_opts=$pdns_configure_args],
   [summary_conf_opts="(no options)"]
 )
-AC_MSG_NOTICE([PowerDNS Recursor configured with: $summary_conf_opts])
+AC_MSG_NOTICE([PowerDNS Recursor $VERSION configured with: $summary_conf_opts])
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([CC: $CC])
 AC_MSG_NOTICE([CXX: $CXX])


### PR DESCRIPTION
### Short description
This requires setting DOCKER_FAKE_RELEASE to YES as a build arg (on the docker hub). Combined with automatic builds based on tags (also on the docker hub) will lead to binaries with the correct version number

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
