### PR TITLE
rec-4.4.x: Avoid a CNAME loop detection issue with DNS64

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1186,7 +1186,16 @@ int followCNAMERecords(vector<DNSRecord>& ret, const QType& qtype)
 
 int getFakeAAAARecords(const DNSName& qname, ComboAddress prefix, vector<DNSRecord>& ret)
 {
-  int rcode = directResolve(qname, QType(QType::A), QClass::IN, ret);
+  /* we pass a separate vector of records because we will be resolving the initial qname
+     again, possibly encountering the same CNAME(s), and we don't want to trigger the CNAME
+     loop detection. */
+  vector<DNSRecord> newRecords;
+  int rcode = directResolve(qname, QType(QType::A), QClass::IN, newRecords);
+
+  ret.reserve(ret.size() + newRecords.size());
+  for (auto& record : newRecords) {
+    ret.push_back(std::move(record));
+  }
 
   // Remove double CNAME records
   std::set<DNSName> seenCNAMEs;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When the requested qname is a CNAME to a second CNAME, the CNAME loop detection might get incorrectly triggered because the CNAMEs were already present in the vector of result records.

Backport of #9696 to rel/rec-4.4.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
