### PR TITLE
Remove all documentation irrelevant after 4.4.0

### DIFF
--- a/docs/appendices/compiling.rst
+++ b/docs/appendices/compiling.rst
@@ -64,17 +64,11 @@ ed25519 support with libsodium
 The PowerDNS Authoritative Server can link with `libsodium <https://download.libsodium.org/doc/>`_ to support ed25519 (DNSSEC algorithm 15).
 To detect libsodium, use the ``--with-libsodium`` configure option.
 
-.. versionchanged:: 4.2.0
-  This option was previously ``--enable-libsodium``
-
 ed25519 and ed448 support with libdecaf
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `libdecaf <https://sourceforge.net/projects/ed448goldilocks/>`_ is a library that allows the PowerDNS Authoritative Server to support ed25519 and Ed448 (DNSSEC algorithms 15 and 16).
 To detect libdecaf, use the ``--with-libdecaf`` configure option.
-
-.. versionchanged:: 4.2.0
-  This option was previously ``--enable-libdecaf``
 
 systemd notify support
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/appendices/types.rst
+++ b/docs/appendices/types.rst
@@ -48,8 +48,6 @@ A specialised record type for the 'Andrew Filesystem'. Stored as:
 ALIAS
 -----
 
-.. versionadded:: 4.0.0
-
 The ALIAS pseudo-record type is supported to provide
 CNAME-like mechanisms on a zone's apex. See the :doc:`howto <../guides/alias>` for information
 on how to configure PowerDNS to serve records synthesized from ALIAS
@@ -60,16 +58,12 @@ records.
 APL
 -----
 
-.. versionadded:: 4.4.0
-
 The APL record, specified in :rfc:`3123`, is used to specify a DNS RR type "APL" for address prefix lists.
 
 .. _types-caa:
 
 CAA
 ---
-
-.. versionadded:: 4.0.0
 
 The "Certification Authority Authorization" record,
 specified in :rfc:`6844`, is used
@@ -88,16 +82,12 @@ Specialised record type for storing certificates, defined in :rfc:`2538`.
 CDNSKEY
 -------
 
-.. versionadded:: 4.0.0
-
 The CDNSKEY (:rfc:`Child DNSKEY <7344#section-3.2>`) type is supported.
 
 .. _types-cds:
 
 CDS
 ---
-
-.. versionadded:: 4.0.0
 
 The CDS (:rfc:`Child DS <7344#section-3.1>`) type is supported.
 

--- a/docs/backends/generic-mysql.rst
+++ b/docs/backends/generic-mysql.rst
@@ -128,7 +128,6 @@ Use the InnoDB READ-COMMITTED transaction isolation level. Default: yes.
 
 ``gmysql-ssl``
 ^^^^^^^^^^^^^^^^^^
-.. versionadded:: 4.2.1
 
 Send the CLIENT_SSL capability flag to the server. SSL support is announced by the server via CLIENT_SSL and is enabled if the client returns the same capability. Default: no.
 
@@ -144,7 +143,6 @@ server. A value of 0 will disable the timeout. Default: 10
 
 ``gmysql-thread-cleanup``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-.. versionadded:: 4.1.8
 
 Older versions (such as those shipped on RHEL 7) of the MySQL/MariaDB client libraries leak memory unless applications explicitly report the end of each thread to the library. Enabling ``gmysql-thread-cleanup`` tells PowerDNS to call ``mysql_thread_end()`` whenever a thread ends.
 

--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -50,12 +50,6 @@ defaults suit you.
 ``geoip-database-files``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 4.2.0
-  The syntax of the argument has been changed.
-
-.. versionchanged:: 4.2.0
-  Support for MMDB has been added.
-
 Comma, tab or space separated list of files to open. You can use
 `geoip-cvs-to-dat <https://github.com/dankamongmen/sprezzos-world/blob/master/packaging/geoip/debian/src/geoip-csv-to-dat.cpp>`__.
 to generate your own.
@@ -76,18 +70,6 @@ Drivers and options
 
   :mode: The caching mode for data, only ``mmap`` is supported
   :language: The language to use, ``en`` by default
-
-``geoip-database-cache``
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. deprecated:: 4.2.0
-
-  This setting is removed
-
-Specifies the kind of caching that is done on the database. This is one
-of "standard", "memory", "index" or "mmap". These options map to the
-caching options described
-`here <https://github.com/maxmind/geoip-api-c/blob/master/README.md#memory-caching-and-other-options>`__
 
 .. _setting-geoip-zones-file:
 
@@ -232,19 +214,6 @@ Following placeholder allows custom mapping:
 
   - %mp to expand user defined custom formats.
 
-.. versionadded:: 4.2.0
-
-  These placeholders have been added in version 4.2.0:
-
-  - %lat, %lon, %loc to expand for geographic location, if available in backend. %loc in particular can be safely used with LOC record type.
-  - %ip4 and %ip6 that will expand to the IP address when AFI matches, and empty otherwise. Can be particularly used with A and AAAA record types.
-
-.. versionadded:: 4.1.0
-
-  These placeholders have been added in version 4.1.0:
-
-  - %cc = 2 letter country code
-
 Using the ``weight`` attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -280,11 +249,6 @@ For instance, this configuration will send the correct response for both A and S
 If your services match wildcard records in your zone file then these will be returned as CNAMEs.
 This will only be an issue if you are trying to use a service record at the apex of your domain where you need other record types to be present (such as NS and SOA records).
 Per :rfc:`2181`, CNAME records cannot appear in the same label as NS or SOA records.
-
-.. versionchanged:: 4.2.0
-
-  Before, a record expanded to an empty value would cause a SERVFAIL response.
-  Since 4.2.0 such expansions for non-TXT record types are not included in response.
 
 Caching and the GeoIP Backend
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/common/api/endpoint-statistics.rst
+++ b/docs/common/api/endpoint-statistics.rst
@@ -10,8 +10,6 @@ Statistics endpoint
 
   :param server_id: The name of the server
 
-  .. versionadded:: 4.2.0
-
   :query statistic: If set to the name of a specific statistic, only this value is returned. If no statistic with that name exists, the response has a 422 status and an error message
 
   **Example response:**

--- a/docs/dnssec/operational.rst
+++ b/docs/dnssec/operational.rst
@@ -153,32 +153,6 @@ format. Uses localtime to find the day for inception time.
 This changes a serial of 2015120810 to 2016010701 on Wednesday 13th of
 January 2016.
 
-INCEPTION (not recommended)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. deprecated:: 4.1.0
-  Removed in this release
-
-Sets the SOA serial to the last inception time in YYYYMMDD01 format.
-Uses localtime to find the day for inception time.
-
-.. warning::
-  The SOA serial will only change on inception day, so
-  changes to the zone will get visible on slaves only on the following
-  inception day.
-
-INCEPTION-WEEK (not recommended)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. deprecated:: 4.1.0
-  Removed in this release
-
-Sets the SOA serial to the number of weeks since the epoch, which is the
-last inception time in weeks.
-
-.. warning::
-  Same problem as INCEPTION.
-
 EPOCH
 ^^^^^
 

--- a/docs/dnsupdate.rst
+++ b/docs/dnsupdate.rst
@@ -444,8 +444,6 @@ PowerDNS.
 Update policy
 -------------
 
-.. versionadded:: 4.1.0
-
 You can define a Lua script to handle DNS UPDATE message
 authorization. The Lua script is to contain at least function called
 ``updatepolicy`` which accepts one parameter. This parameter is an

--- a/docs/http-api/cryptokey.rst
+++ b/docs/http-api/cryptokey.rst
@@ -1,7 +1,5 @@
 Cryptokeys
 ==========
-.. versionadded:: 4.1.0
-
 Allows for modifying DNSSEC key material via the API.
 
 Endpoints

--- a/docs/http-api/index.rst
+++ b/docs/http-api/index.rst
@@ -304,10 +304,6 @@ Add these lines to the ``pdns.conf``::
   api=yes
   api-key=changeme
 
-.. versionchanged:: 4.1.0
-
-  Setting :ref:`setting-api` also implicitly enables the webserver.
-
 And restart, the following examples should start working::
 
   curl -v -H 'X-API-Key: changeme' http://127.0.0.1:8081/api/v1/servers/localhost | jq .

--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -186,10 +186,6 @@ can not serve IXFR updates.
 Supermaster: automatic provisioning of slaves
 ---------------------------------------------
 
-.. versionchanged:: 4.2.0
-  Supermaster support needs to be explicitly enabled with the
-  :ref:`setting-superslave` setting.
-
 PowerDNS can recognize so called 'supermasters'. A supermaster is a host
 which is master for domains and for which we are to be a slave. When a
 master (re)loads a domain, it sends out a notification to its slaves.

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -81,11 +81,6 @@ Not all backends may benefit from the packet cache. If your backend is
 memory based and does not lead to context switches, the packet cache may
 actually hurt performance.
 
-.. versionchanged:: 4.1.0
-  The maximum size of the packet cache is controlled by the
-  :ref:`setting-max-packet-cache-entries` entries. Before that both the
-  query cache and the packet cache used the :ref:`setting-max-cache-entries` setting.
-
 .. _query-cache:
 
 Query Cache

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -22,8 +22,6 @@ means ``yes``.
 -  Boolean
 -  Default: no
 
-.. versionadded:: 4.0.0
-
 Allow 8 bit DNS queries.
 
 .. _setting-allow-axfr-ips:
@@ -63,21 +61,6 @@ Allow DNS updates from these IP ranges. Set to empty string to honour ``ALLOW-DN
 Allow AXFR NOTIFY from these IP ranges. Setting this to an empty string
 will drop all incoming notifies.
 
-.. _setting-allow-recursion:
-
-``allow-recursion``
--------------------
-
--  IP ranges, separated by commas
--  Default: 0.0.0.0/0
-
-.. deprecated:: 4.1.0
-  Recursion has been removed, see :doc:`guides/recursion`
-
-By specifying ``allow-recursion``, recursion can be restricted to
-netmasks specified. The default is to allow recursion from everywhere.
-Example: ``allow-recursion=198.51.100.0/24, 10.0.0.0/8, 192.0.2.4``.
-
 .. _setting-allow-unsigned-notify:
 
 ``allow-unsigned-notify``
@@ -85,8 +68,6 @@ Example: ``allow-recursion=198.51.100.0/24, 10.0.0.0/8, 192.0.2.4``.
 
 -  Boolean
 -  Default: yes
-
-.. versionadded:: 4.0.0
 
 Turning this off requires all notifications that are received to be
 signed by valid TSIG signature for the zone.
@@ -98,8 +79,6 @@ signed by valid TSIG signature for the zone.
 
 -  Boolean
 -  Default: yes
-
-.. versionadded:: 4.0.0
 
 Turning this off requires all supermaster notifications to be signed by
 valid TSIG signature. It will accept any existing key on slave.
@@ -124,9 +103,6 @@ the list in :ref:`setting-only-notify`.
 -  Boolean
 -  Default: yes
 
-.. versionchanged:: 4.0.1
-  was 'no' before.
-
 Answer questions for the ANY on UDP with a truncated packet that refers
 the remote server to TCP. Useful for mitigating reflection attacks.
 
@@ -147,23 +123,7 @@ Enable/disable the :doc:`http-api/index`.
 
 -  String
 
-.. versionadded:: 4.0.0
-
 Static pre-shared authentication key for access to the REST API.
-
-.. _setting-api-readonly:
-
-``api-readonly``
-----------------
-
--  Boolean
--  Default: no
-
-.. versionadded:: 4.0.0
-.. versionchanged:: 4.2.0
-  This setting has been removed in 4.2.0.
-
-Disallow data modification through the REST API when set.
 
 .. _setting-axfr-fetch-timeout:
 
@@ -185,8 +145,6 @@ Maximum time in seconds for inbound AXFR to start or be idle after starting.
 -  Boolean
 -  Default: no
 
-.. versionadded:: 4.0.4
-
 Also AXFR a zone from a master with a lower serial.
 
 .. _setting-cache-ttl:
@@ -206,8 +164,6 @@ Seconds to store packets in the :ref:`packet-cache`. A value of 0 will disable t
 
 -  String
 -  Default: auth
-
-.. versionadded:: 4.2.0
 
 Set the instance or third string of the metric key. Be careful not to include
 any dots in this setting, unless you know what you are doing.
@@ -231,8 +187,6 @@ See :ref:`metricscarbon`.
 
 -  String
 -  Default: pdns
-
-.. versionadded:: 4.2.0
 
 Set the namespace or first string of the metric key. Be careful not to include
 any dots in this setting, unless you know what you are doing.
@@ -347,8 +301,6 @@ Operate as a daemon.
 -  Boolean
 -  Default: yes
 
-.. versionadded:: 4.2.0
-
 The value of :ref:`metadata-api-rectify` if it is not set on the zone.
 
 .. note::
@@ -362,9 +314,6 @@ The value of :ref:`metadata-api-rectify` if it is not set on the zone.
 
 -  String
 -  Default: ecdsa256
-
-.. versionchanged:: 4.1.0
-  Renamed from ``default-ksk-algorithms``. No longer supports multiple algorithm names.
 
 The algorithm that should be used for the KSK when running
 :doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
@@ -498,9 +447,6 @@ TTL to use when none is provided.
 -  String
 -  Default: (empty)
 
-.. versionchanged:: 4.1.0
-  Renamed from ``default-zsk-algorithms``. Does no longer support multiple algorithm names.
-
 The algorithm that should be used for the ZSK when running
 :doc:`pdnsutil secure-zone <manpages/pdnsutil.1>` or using the :doc:`Zone API endpoint <http-api/cryptokey>`
 to enable DNSSEC. Must be one of:
@@ -575,19 +521,6 @@ inside a supervisor that handles logging (like systemd).
 .. warning::
   Do not use this setting in combination with :ref:`setting-daemon` as all
   logging will disappear.
-
-.. _setting-disable-tcp:
-
-``disable-tcp``
----------------
-
--  Boolean
--  Default: no
-
-.. versionchanged:: 4.2.0
-  This setting has been removed
-
-Do not listen to TCP queries. Breaks RFC compliance.
 
 .. _setting-distributor-threads:
 
@@ -675,8 +608,6 @@ Enables EDNS subnet processing, for backends that support it.
 -  One of ``no``, ``yes`` (or empty), or ``shared``, String
 -  Default: no
 
-.. versionadded:: 4.2.0
-
 Globally enable the :doc:`LUA records <lua-records/index>` feature.
 
 To use shared LUA states, set this to ``shared``, see :ref:`lua-records-shared-state`.
@@ -698,8 +629,6 @@ Entropy source file to use.
 
 -  Boolean
 -  Default: no
-
-.. versionadded:: 4.1.0
 
 If this is enabled, ALIAS records are expanded (synthesized to their
 A/AAAA).
@@ -909,8 +838,6 @@ to at least 5 to see the logs.
 - Bool
 - Default: yes
 
-.. versionadded:: 4.1.0
-
 When printing log lines to stdout, prefix them with timestamps.
 Disable this if the process supervisor timestamps these lines already.
 
@@ -943,8 +870,6 @@ e.g. error = 3, warning = 4, notice = 5, info = 6
 
 -  String
 -  Default: empty
-
-.. versionadded:: 4.1.0
 
 Script to be used to edit incoming AXFRs, see :ref:`modes-of-operation-axfrfilter`
 
@@ -1014,11 +939,6 @@ Turn on master support. See :ref:`master-operation`.
 -  Integer
 -  Default: 1000000
 
-.. versionchanged:: 4.1.0
-  The packet and query caches are distinct. Previously, this setting was used for
-  both the packet and query caches. See :ref:`setting-max-packet-cache-entries` for
-  the packet-cache setting.
-
 Maximum number of entries in the query cache. 1 million (the default)
 will generally suffice for most installations.
 
@@ -1037,8 +957,6 @@ protection measure to avoid database explosion due to long names.
 
 ``max-generate-steps``
 ----------------------
-
-.. versionadded:: 4.3.0
 
 -  Integer
 -  Default: 0
@@ -1066,8 +984,6 @@ For more information see :ref:`dnssec-operational-nsec-modes-params`.
 
 -  Integer
 -  Default: 1000000
-
-.. versionadded:: 4.1.0
 
 Maximum number of entries in the packet cache. 1 million (the default)
 will generally suffice for most installations.
@@ -1239,25 +1155,6 @@ To notify all IP addresses apart from the 192.168.0.0/24 subnet use the followin
 
     only-notify=0.0.0.0/0
 
-.. _setting-out-of-zone-additional-processing:
-
-``out-of-zone-additional-processing``
--------------------------------------
-
--  Boolean
--  Default: yes
-
-.. deprecated:: 4.2.0
-  This setting has been removed.
-
-Do out of zone additional processing. This means that if a malicious
-user adds a '.com' zone to your server, it is not used for other domains
-and will not contaminate answers. Do not enable this setting if you run
-a public DNS service with untrusted users.
-
-The docs had previously indicated that the default was "no", but the
-default has been "yes" since 2005.
-
 .. _setting-outgoing-axfr-expand-alias:
 
 ``outgoing-axfr-expand-alias``
@@ -1372,44 +1269,6 @@ Maximum number of milliseconds to queue a query. See :doc:`performance`.
 -  Default: 1
 
 Number of receiver (listening) threads to start. See :doc:`performance`.
-
-.. _setting-recursive-cache-ttl:
-
-``recursive-cache-ttl``
------------------------
-
--  Integer
--  Default: 10
-
-.. deprecated:: 4.1.0
-  Recursion has been removed, see :doc:`guides/recursion`
-
-Seconds to store recursive packets in the :ref:`packet-cache`.
-
-.. _setting-recursor:
-
-``recursor``
-------------
-
--  IP Address
-
-.. deprecated:: 4.1.0
-  Recursion has been removed, see :doc:`guides/recursion`
-
-If set, recursive queries will be handed to the recursor specified here.
-
-.. _setting-resolver:
-
-``resolver``
-------------
-
--  IP Addresses with optional port, separated by commas
-
-.. versionadded:: 4.1.0
-
-Use these resolver addresses for ALIAS and the internal stub resolver.
-If this is not set, ``/etc/resolv.conf`` is parsed for upstream
-resolvers.
 
 .. _setting-retrieval-threads:
 
@@ -1636,13 +1495,6 @@ and :doc:`Virtual Hosting <guides/virtual-instances>` how this can differ.
 -  Boolean
 -  Default: no
 
-.. versionadded:: 4.1.9
-  In versions before 4.1.9, this setting did not exist and supermaster support
-  was enabled by default.
-
-.. versionchanged:: 4.2.0
-  Before 4.2.0, the default was yes.
-
 Turn on supermaster support. See :ref:`supermaster-operation`.
 
 .. _setting-tcp-control-address:
@@ -1690,8 +1542,6 @@ Password for TCP control.
 -  Integer
 -  Default: 0 (Disabled)
 
-.. versionadded:: 4.1.0
-
 Enable TCP Fast Open support, if available, on the listening sockets.
 The numerical value supplied is used as the queue size, 0 meaning
 disabled.
@@ -1731,9 +1581,6 @@ IP address of incoming notification proxy
 
 ``udp-truncation-threshold``
 ----------------------------
-.. versionchanged:: 4.2.0
-  Before 4.2.0, the default was 1680
-
 -  Integer
 -  Default: 1232
 
@@ -1793,9 +1640,6 @@ can set this response to a custom value as well.
 
 Start a webserver for monitoring. See :doc:`performance`".
 
-.. versionchanged:: 4.1.0
-  It was necessary to enable the webserver to use the REST API, this is no longer the case.
-
 .. _setting-webserver-address:
 
 ``webserver-address``
@@ -1814,17 +1658,12 @@ IP Address for webserver/API to listen on.
 -  IP ranges, separated by commas or whitespace
 -  Default: 127.0.0.1,::1
 
-.. versionchanged:: 4.1.0
-
-    Default is now 127.0.0.1,::1, was 0.0.0.0/0,::/0 before.
-
 Webserver/API access is only allowed from these subnets.
 
 .. _setting-webserver-loglevel:
 
 ``webserver-loglevel``
 ----------------------
-.. versionadded:: 4.2.0
 
 -  String, one of "none", "normal", "detailed"
 
@@ -1865,7 +1704,6 @@ The value between the hooks is a UUID that is generated for each request. This c
 
 ``webserver-max-bodysize``
 --------------------------
-.. versionadded:: 4.2.0
 
 -  Integer
 -  Default: 2


### PR DESCRIPTION
### Short description
This removes settings that no longer exist since 4.2.0, and removes any
statements of settings and docs that were added or changed in 4.2.0 and below.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)