### PR TITLE
rec: Backport to 4.4.x: Do not add request to a wait chain that's already processed or being processed.

### DIFF
--- a/pdns/mtasker.hh
+++ b/pdns/mtasker.hh
@@ -81,7 +81,7 @@ public:
     EventKey key;
     std::shared_ptr<pdns_ucontext_t> context;
     struct timeval ttd;
-    int tid;    
+    int tid;
   };
 
   typedef multi_index_container<

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -926,7 +926,7 @@ int arecvtcp(string& data, size_t len, Socket* sock, bool incompleteOkay);
 
 struct PacketID
 {
-  PacketID() : id(0), type(0), sock(0), inNeeded(0), inIncompleteOkay(false), outPos(0), nearMisses(0), fd(-1)
+  PacketID() : id(0), type(0), sock(0), inNeeded(0), inIncompleteOkay(false), outPos(0), nearMisses(0), fd(-1), closed(false)
   {
     remote.reset();
   }
@@ -948,6 +948,7 @@ struct PacketID
   mutable chain_t chain;
   mutable uint32_t nearMisses; // number of near misses - host correct, id wrong
   int fd;
+  mutable bool closed; // Processing already started, don't accept new chained ids
 
   bool operator<(const PacketID& b) const
   {


### PR DESCRIPTION

The following scenario can occur. Multiple concurrent clients doing the same query A
are needed to trigger it:

1. Incoming request A, which has a need for request X
2. Add request X to chain because we already have an identical outstanding request
3. We receive the reply for X
4. We process the chain
5. In the meantime a new request for X that's identical is added to the chain
6. The added id in step 5 is not being processed anymore -> timeout

This can happen if request X has TTL 0, otherwise the record cache would have a hit.

(cherry picked from commit c647a254a0f863aabeaea9d33f673afa26c60457)

Backport of #9707 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
