### PR TITLE
Switch default TTL override to 1.

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5344,7 +5344,7 @@ int main(int argc, char **argv)
     ::arg().set("ecs-ipv4-cache-bits", "Maximum number of bits of IPv4 mask to cache ECS response")="24";
     ::arg().set("ecs-ipv6-bits", "Number of bits of IPv6 address to pass for EDNS Client Subnet")="56";
     ::arg().set("ecs-ipv6-cache-bits", "Maximum number of bits of IPv6 mask to cache ECS response")="56";
-    ::arg().set("ecs-minimum-ttl-override", "Set under adverse conditions, a minimum TTL for records in ECS-specific answers")="0";
+    ::arg().set("ecs-minimum-ttl-override", "The minimum TTL for records in ECS-specific answers")="1";
     ::arg().set("ecs-cache-limit-ttl", "Minimum TTL to cache ECS response")="0";
     ::arg().set("edns-subnet-whitelist", "List of netmasks and domains that we should enable EDNS subnet for")="";
     ::arg().set("ecs-add-for", "List of client netmasks for which EDNS Client Subnet will be added")="0.0.0.0/0, ::/0, " LOCAL_NETS_INVERSE;
@@ -5357,7 +5357,7 @@ int main(int argc, char **argv)
     ::arg().setSwitch("gettag-needs-edns-options", "If EDNS Options should be extracted before calling the gettag() hook")="no";
     ::arg().set("udp-truncation-threshold", "Maximum UDP response size before we truncate")="1232";
     ::arg().set("edns-outgoing-bufsize", "Outgoing EDNS buffer size")="1232";
-    ::arg().set("minimum-ttl-override", "Set under adverse conditions, a minimum TTL")="0";
+    ::arg().set("minimum-ttl-override", "The minimum TTL")="1";
     ::arg().set("max-qperq", "Maximum outgoing queries per query")="60";
     ::arg().set("max-ns-address-qperq", "Maximum outgoing NS address queries per query")="10";
     ::arg().set("max-total-msec", "Maximum total wall-clock time per query in milliseconds, 0 for unlimited")="7000";

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -514,10 +514,10 @@ That is, only if both the limits apply, the record will not be cached.
 ``ecs-minimum-ttl-override``
 ----------------------------
 -  Integer
--  Default: 0 (disabled)
+-  Default: 1
 
 This setting artificially raises the TTLs of records in the ANSWER section of ECS-specific answers to be at least this long.
-While this is a gross hack, and violates RFCs, under conditions of DoS, it may enable you to continue serving your customers.
+Setting this to a value greater than 1 technically is an RFC violation, but might improve performance a lot.
 Can be set at runtime using ``rec_control set-ecs-minimum-ttl 3600``.
 
 .. _setting-ecs-cache-limit-ttl:
@@ -1064,10 +1064,10 @@ returning back to normal processing and handling other events.
 ``minimum-ttl-override``
 ------------------------
 -  Integer
--  Default: 0 (disabled)
+-  Default: 1
 
 This setting artificially raises all TTLs to be at least this long.
-While this is a gross hack, and violates RFCs, under conditions of DoS, it may enable you to continue serving your customers.
+Setting this to a value greater than 1 technically is an RFC violation, but might improve performance a lot.
 Can be set at runtime using ``rec_control set-minimum-ttl 3600``.
 
 .. _setting-new-domain-tracking:

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -513,6 +513,9 @@ That is, only if both the limits apply, the record will not be cached.
 
 ``ecs-minimum-ttl-override``
 ----------------------------
+.. versionchanged:: 4.5.0
+  Old versions used default 0.
+
 -  Integer
 -  Default: 1
 
@@ -1063,6 +1066,9 @@ returning back to normal processing and handling other events.
 
 ``minimum-ttl-override``
 ------------------------
+.. versionchanged:: 4.5.0
+  Old versions used default 0.
+
 -  Integer
 -  Default: 1
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -521,6 +521,8 @@ That is, only if both the limits apply, the record will not be cached.
 
 This setting artificially raises the TTLs of records in the ANSWER section of ECS-specific answers to be at least this long.
 Setting this to a value greater than 1 technically is an RFC violation, but might improve performance a lot.
+Using a value of 0 impacts performance of TTL 0 records greatly, since it forces the recursor to contact
+authoritative servers each time a client requests them.
 Can be set at runtime using ``rec_control set-ecs-minimum-ttl 3600``.
 
 .. _setting-ecs-cache-limit-ttl:
@@ -1074,6 +1076,8 @@ returning back to normal processing and handling other events.
 
 This setting artificially raises all TTLs to be at least this long.
 Setting this to a value greater than 1 technically is an RFC violation, but might improve performance a lot.
+Using a value of 0 impacts performance of TTL 0 records greatly, since it forces the recursor to contact
+authoritative servers each time a client requests them.
 Can be set at runtime using ``rec_control set-minimum-ttl 3600``.
 
 .. _setting-new-domain-tracking:

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -522,7 +522,7 @@ That is, only if both the limits apply, the record will not be cached.
 This setting artificially raises the TTLs of records in the ANSWER section of ECS-specific answers to be at least this long.
 Setting this to a value greater than 1 technically is an RFC violation, but might improve performance a lot.
 Using a value of 0 impacts performance of TTL 0 records greatly, since it forces the recursor to contact
-authoritative servers each time a client requests them.
+authoritative servers every time a client requests them.
 Can be set at runtime using ``rec_control set-ecs-minimum-ttl 3600``.
 
 .. _setting-ecs-cache-limit-ttl:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

TTL 0 causes a lot of extra needless work both for recursor and auth. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
