### PR TITLE
dnsdist: Fix typo in DNSNameSet documentation

### DIFF
--- a/pdns/dnsdistdist/docs/reference/dnsnameset.rst
+++ b/pdns/dnsdistdist/docs/reference/dnsnameset.rst
@@ -17,7 +17,7 @@ The set can be filled by func:`DNSNameSet:add`::
 Functions and methods of a ``DNSNameSet``
 -----------------------------------------
 
-.. function:: newDNSNameSet(name) -> DNSNameSet
+.. function:: newDNSNameSet() -> DNSNameSet
 
   Returns the :class:`DNSNameSet`.
 


### PR DESCRIPTION
### Short description
The `newDNSNameSet()` function has no name argument.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
