### PR TITLE
rec: Switch to TCP in case of spoofing (near-miss) attempts

### DIFF
--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -55,7 +55,7 @@ class LWResult
 public:
   LWResult() : d_usec(0) {}
 
-  enum class Result : uint8_t { Timeout=0, Success=1, PermanentError=2 /* not transport related */, OSLimitError=3 };
+  enum class Result : uint8_t { Timeout=0, Success=1, PermanentError=2 /* not transport related */, OSLimitError=3, Spoofed=4 /* Spoofing attempt (too many near-misses) */ };
 
   vector<DNSRecord> d_records;
   int d_rcode{0};

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -693,7 +693,7 @@ LWResult::Result asendto(const char *data, size_t len, int flags,
 LWResult::Result arecvfrom(std::string& packet, int flags, const ComboAddress& fromaddr, size_t *d_len,
                            uint16_t id, const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now)
 {
-  static const boost::optional<unsigned int> nearMissLimit = ::arg().asNum("spoof-nearmiss-max");
+  static const unsigned int nearMissLimit = ::arg().asNum("spoof-nearmiss-max");
 
   PacketID pident;
   pident.fd=fd;
@@ -713,8 +713,8 @@ LWResult::Result arecvfrom(std::string& packet, int flags, const ComboAddress& f
 
     *d_len=packet.size();
 
-    if (*nearMissLimit && pident.nearMisses > *nearMissLimit) {
-      g_log<<Logger::Error<<"Too many ("<<pident.nearMisses<<" > "<<*nearMissLimit<<") bogus answers for '"<<domain<<"' from "<<fromaddr.toString()<<", assuming spoof attempt."<<endl;
+    if (nearMissLimit > 0 && pident.nearMisses > nearMissLimit) {
+      g_log<<Logger::Error<<"Too many ("<<pident.nearMisses<<" > "<<nearMissLimit<<") bogus answers for '"<<domain<<"' from "<<fromaddr.toString()<<", assuming spoof attempt."<<endl;
       g_stats.spoofCount++;
       return LWResult::Result::Spoofed;
     }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -693,9 +693,7 @@ LWResult::Result asendto(const char *data, size_t len, int flags,
 LWResult::Result arecvfrom(std::string& packet, int flags, const ComboAddress& fromaddr, size_t *d_len,
                            uint16_t id, const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now)
 {
-  static boost::optional<unsigned int> nearMissLimit;
-  if(!nearMissLimit)
-    nearMissLimit=::arg().asNum("spoof-nearmiss-max");
+  static const boost::optional<unsigned int> nearMissLimit = ::arg().asNum("spoof-nearmiss-max");
 
   PacketID pident;
   pident.fd=fd;
@@ -718,7 +716,7 @@ LWResult::Result arecvfrom(std::string& packet, int flags, const ComboAddress& f
     if (*nearMissLimit && pident.nearMisses > *nearMissLimit) {
       g_log<<Logger::Error<<"Too many ("<<pident.nearMisses<<" > "<<*nearMissLimit<<") bogus answers for '"<<domain<<"' from "<<fromaddr.toString()<<", assuming spoof attempt."<<endl;
       g_stats.spoofCount++;
-      return LWResult::Result::PermanentError;
+      return LWResult::Result::Spoofed;
     }
 
     return LWResult::Result::Success;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -652,7 +652,8 @@ LWResult::Result asendto(const char *data, size_t len, int flags,
   pident.remote = toaddr;
   pident.type = qtype;
 
-  // see if there is an existing outstanding request we can chain on to, using partial equivalence function
+  // see if there is an existing outstanding request we can chain on to, using partial equivalence function looking for the same
+  // query (qname and qtype) to the same host, but with a different message ID
   pair<MT_t::waiters_t::iterator, MT_t::waiters_t::iterator> chain=MT->d_waiters.equal_range(pident, PacketIDBirthdayCompare());
 
   for(; chain.first != chain.second; chain.first++) {
@@ -714,7 +715,9 @@ LWResult::Result arecvfrom(std::string& packet, int flags, const ComboAddress& f
     *d_len=packet.size();
 
     if (nearMissLimit > 0 && pident.nearMisses > nearMissLimit) {
-      g_log<<Logger::Error<<"Too many ("<<pident.nearMisses<<" > "<<nearMissLimit<<") bogus answers for '"<<domain<<"' from "<<fromaddr.toString()<<", assuming spoof attempt."<<endl;
+      /* we have received more than nearMissLimit answers on the right IP and port, from the right source (we are using connected sockets),
+         for the correct qname and qtype, but with an unexpected message ID. That looks like a spoofing attempt. */
+      g_log<<Logger::Error<<"Too many ("<<pident.nearMisses<<" > "<<nearMissLimit<<") answers with a wrong message ID for '"<<domain<<"' from "<<fromaddr.toString()<<", assuming spoof attempt."<<endl;
       g_stats.spoofCount++;
       return LWResult::Result::Spoofed;
     }
@@ -3920,9 +3923,12 @@ retryWithName:
     /* we did not find a match for this response, something is wrong */
 
     // we do a full scan for outstanding queries on unexpected answers. not too bad since we only accept them on the right port number, which is hard enough to guess
-    for(MT_t::waiters_t::iterator mthread=MT->d_waiters.begin(); mthread!=MT->d_waiters.end(); ++mthread) {
-      if(pident.fd==mthread->key.fd && mthread->key.remote==pident.remote &&  mthread->key.type == pident.type &&
+    for (MT_t::waiters_t::iterator mthread = MT->d_waiters.begin(); mthread != MT->d_waiters.end(); ++mthread) {
+      if (pident.fd == mthread->key.fd && mthread->key.remote == pident.remote &&  mthread->key.type == pident.type &&
          pident.domain == mthread->key.domain) {
+        /* we are expecting an answer from that exact source, on that exact port (since we are using connected sockets), for that qname/qtype,
+           but with a different message ID. That smells like a spoofing attempt. For now we will just increase the counter and will deal with
+           that later. */
         mthread->key.nearMisses++;
       }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -808,7 +808,7 @@ private:
 
   int doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret,
                   unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation);
-  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType& qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool* truncated);
+  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType& qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool& truncated, bool& spoofed);
   bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state);
 
   int doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Instead of treating this like an unrecoverable network error and trying the next server, let's switch to TCP instead. This might
prevent a DoS by making us try every single servers and failing, and will make the spoofing attempt a bit much harder.

Could use a regression test.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
