### PR TITLE
Avoid accidental removal of generated files

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -87,7 +87,11 @@ mans/.complete: .venv
 	html-docs.tar.bz2
 
 clean-local:
+if !HAVE_MANPAGES
+# don't clean these files if they were present
+# at 'configure' time (e.g. from a source dist)
 	rm -f latex/PowerDNS-Authoritative.pdf $(MANPAGES_DIST) html-docs.tar.bz2
+endif
 	rm -rf mans
 
 html-docs: common/** manpages/** .venv *.rst

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -72,9 +72,15 @@ CLEANFILES = \
 	backends/gsql/gsqlbackend.gcov \
 	dnsmessage.pb.cc dnsmessage.pb.h \
 	pdns.conf-dist \
-	apidocfiles.h \
+	apidocfiles.h
+
+if !HAVE_API_SWAGGER_JSON
+# don't clean these files if they were present
+# at 'configure' time (e.g. from a source dist)
+CLEANFILES += \
 	api-swagger.yaml \
 	api-swagger.json
+endif
 
 # use a $(wildcard) wrapper here to allow build to proceed if output
 # file is present but input file is not (e.g. in a dist tarball)


### PR DESCRIPTION
### Short description
When generated files (man pages, api-swagger files, etc.) are in the tree because they were part of a source distribution
but were not locally generated, 'make clean' should not remove them. Doing so results in a broken tree, as the Makefiles
expect the files to be present, and running 'configure' again will introduce the additional dependencies required to
generate them.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
