### PR TITLE
Fix the DNSName move assignment operator

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -71,7 +71,7 @@ public:
     }
     return *this;
   }
-  DNSName& operator=(const DNSName&& rhs)
+  DNSName& operator=(DNSName&& rhs)
   {
     if (this != &rhs) {
       d_storage = std::move(rhs.d_storage);

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -504,13 +504,13 @@ void PacketHandler::doAdditionalProcessing(DNSPacket& p, std::unique_ptr<DNSPack
     if(rr.dr.d_place != DNSResourceRecord::ADDITIONAL) {
       switch(rr.dr.d_type) {
         case QType::NS:
-          content=std::move(getRR<NSRecordContent>(rr.dr)->getNS());
+          content=getRR<NSRecordContent>(rr.dr)->getNS();
           break;
         case QType::MX:
-          content=std::move(getRR<MXRecordContent>(rr.dr)->d_mxname);
+          content=getRR<MXRecordContent>(rr.dr)->d_mxname;
           break;
         case QType::SRV:
-          content=std::move(getRR<SRVRecordContent>(rr.dr)->d_target);
+          content=getRR<SRVRecordContent>(rr.dr)->d_target;
           break;
         case QType::SVCB: {
           auto rrc = getRR<SVCBRecordContent>(rr.dr);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
A misplaced 'const' prevented it from being called, making every move of a DNSName into a full copy.

Introduced in d720eb8add5ebda11867e8b404125e0b68ed2911.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
