### PR TITLE
rec: Fix getEDNSExtendedErrorOptFromString() on CentOS 6

### DIFF
--- a/pdns/recursordist/ednsextendederror.cc
+++ b/pdns/recursordist/ednsextendederror.cc
@@ -22,7 +22,7 @@
 #include "ednsextendederror.hh"
 #include "views.hh"
 
-static bool getEDNSExtendedErrorOptFromString(const pdns_string_view option, EDNSExtendedError& eee)
+static bool getEDNSExtendedErrorOptFromStringView(const pdns_string_view& option, EDNSExtendedError& eee)
 {
   if (option.size() < sizeof(uint16_t)) {
     return false;
@@ -38,12 +38,12 @@ static bool getEDNSExtendedErrorOptFromString(const pdns_string_view option, EDN
 
 bool getEDNSExtendedErrorOptFromString(const string& option, EDNSExtendedError& eee)
 {
-  return getEDNSExtendedErrorOptFromString(pdns_string_view(option), eee);
+  return getEDNSExtendedErrorOptFromStringView(pdns_string_view(option), eee);
 }
 
 bool getEDNSExtendedErrorOptFromString(const char* option, unsigned int len, EDNSExtendedError& eee)
 {
-  return getEDNSExtendedErrorOptFromString(pdns_string_view(option, len), eee);
+  return getEDNSExtendedErrorOptFromStringView(pdns_string_view(option, len), eee);
 }
 
 string makeEDNSExtendedErrorOptString(const EDNSExtendedError& eee)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`pdns_string_view` falls back to a regular string there, so there was an ambiguity on which overloaded function to call.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
