### PR TITLE
dnsdist: Add prometheus metrics for top Dynamic Blocks entries

### DIFF
--- a/pdns/bpf-filter.cc
+++ b/pdns/bpf-filter.cc
@@ -36,7 +36,7 @@ static __u64 ptr_to_u64(void *ptr)
 }
 
 int bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size,
-		   int max_entries)
+                   int max_entries)
 {
   union bpf_attr attr;
   memset(&attr, 0, sizeof(attr));
@@ -214,7 +214,7 @@ void BPFFilter::removeSocket(int sock)
 
 void BPFFilter::block(const ComboAddress& addr)
 {
-  std::unique_lock<std::mutex> lock(d_mutex);
+  std::lock_guard<std::mutex> lock(d_mutex);
 
   uint64_t counter = 0;
   int res = 0;
@@ -263,7 +263,7 @@ void BPFFilter::block(const ComboAddress& addr)
 
 void BPFFilter::unblock(const ComboAddress& addr)
 {
-  std::unique_lock<std::mutex> lock(d_mutex);
+  std::lock_guard<std::mutex> lock(d_mutex);
 
   int res = 0;
   if (addr.sin4.sin_family == AF_INET) {
@@ -307,7 +307,7 @@ void BPFFilter::block(const DNSName& qname, uint16_t qtype)
   memcpy(key.qname, keyStr.c_str(), keyStr.size());
 
   {
-    std::unique_lock<std::mutex> lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
     if (d_qNamesCount >= d_maxQNames) {
       throw std::runtime_error("Table full when trying to block " + qname.toLogString());
     }
@@ -340,7 +340,7 @@ void BPFFilter::unblock(const DNSName& qname, uint16_t qtype)
   memcpy(key.qname, keyStr.c_str(), keyStr.size());
 
   {
-    std::unique_lock<std::mutex> lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     int res = bpf_delete_elem(d_qnamemap.fd, &key);
     if (res == 0) {
@@ -355,7 +355,7 @@ void BPFFilter::unblock(const DNSName& qname, uint16_t qtype)
 std::vector<std::pair<ComboAddress, uint64_t> > BPFFilter::getAddrStats()
 {
   std::vector<std::pair<ComboAddress, uint64_t> > result;
-  std::unique_lock<std::mutex> lock(d_mutex);
+  std::lock_guard<std::mutex> lock(d_mutex);
 
   uint32_t v4Key = 0;
   uint32_t nextV4Key;
@@ -404,7 +404,7 @@ std::vector<std::pair<ComboAddress, uint64_t> > BPFFilter::getAddrStats()
 std::vector<std::tuple<DNSName, uint16_t, uint64_t> > BPFFilter::getQNameStats()
 {
   std::vector<std::tuple<DNSName, uint16_t, uint64_t> > result;
-  std::unique_lock<std::mutex> lock(d_mutex);
+  std::lock_guard<std::mutex> lock(d_mutex);
 
   struct QNameKey key = { { 0 } };
   struct QNameKey nextKey = { { 0 } };

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -522,6 +522,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "setConsoleOutputMaxMsgSize", true, "messageSize", "set console message maximum size in bytes, default is 10 MB" },
   { "setDefaultBPFFilter", true, "filter", "When used at configuration time, the corresponding BPFFilter will be attached to every bind" },
   { "setDynBlocksAction", true, "action", "set which action is performed when a query is blocked. Only DNSAction.Drop (the default) and DNSAction.Refused are supported" },
+  { "setDynBlocksPurgeInterval", true, "sec", "set how often the expired dynamic block entries should be removed" },
   { "SetECSAction", true, "v4[, v6]", "Set the ECS prefix and prefix length sent to backends to an arbitrary value" },
   { "setECSOverride", true, "bool", "whether to override an existing EDNS Client Subnet value in the query" },
   { "setECSSourcePrefixV4", true, "prefix-length", "the EDNS Client Subnet prefix-length used for IPv4 queries" },

--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -381,6 +381,8 @@ public:
   static std::map<std::string, std::list<std::pair<DNSName, unsigned int>>> getTopSuffixes();
   static void purgeExpired(const struct timespec& now);
 
+  static time_t s_expiredDynBlocksPurgeInterval;
+
 private:
   static void collectMetrics();
   static void generateMetrics();

--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -314,6 +314,8 @@ public:
     d_beQuiet = quiet;
   }
 
+  void purgeExpired(const struct timespec& now);
+
 private:
 
   bool checkIfQueryTypeMatches(const Rings::Query& query);
@@ -366,3 +368,27 @@ private:
   dnsdist_ffi_stat_node_visitor_t d_smtVisitorFFI;
   bool d_beQuiet{false};
 };
+
+class DynBlockRulesMetricsCache
+{
+public:
+  DynBlockRulesMetricsCache(size_t topN, unsigned int validity): d_validityPeriod(validity), d_topN(topN)
+  {
+  }
+
+  std::map<std::string, std::list<std::pair<Netmask, unsigned int>>> getTopNetmasks();
+  std::map<std::string, std::list<std::pair<DNSName, unsigned int>>> getTopSuffixes();
+  void invalidate();
+  void setParameters(size_t topN, unsigned int validity);
+
+private:
+  std::map<std::string, std::list<std::pair<Netmask, unsigned int>>> d_cachedNetmasks;
+  std::map<std::string, std::list<std::pair<DNSName, unsigned int>>> d_cachedSuffixes;
+  std::mutex d_mutex;
+  time_t d_netmasksValidUntil{0};
+  time_t d_suffixesValidUntil{0};
+  unsigned int d_validityPeriod{0};
+  size_t d_topN{0};
+};
+
+extern DynBlockRulesMetricsCache g_dynBlocksMetricsCache;

--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -394,6 +394,8 @@ private:
     std::map<std::string, std::list<std::pair<DNSName, unsigned int>>> smtData;
   };
 
+  /* Protects s_topNMGsByReason and s_topSMTsByReason. s_metricsData should only be accessed
+     by the dynamic blocks maintenance thread so it does not need a lock. */
   static std::mutex s_topsMutex;
   // need N+1 datapoints to be able to do the diff after a collection point has been reached
   static std::list<MetricsSnapshot> s_metricsData;

--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -63,6 +63,7 @@ private:
     std::map<uint8_t, uint64_t> d_rcodeCounts;
     std::map<uint16_t, uint64_t> d_qtypeCounts;
     uint64_t queries{0};
+    uint64_t responses{0};
     uint64_t respBytes{0};
   };
 
@@ -377,8 +378,8 @@ public:
   static std::map<std::string, std::list<std::pair<DNSName, unsigned int>>> getHitsForTopSuffixes();
 
   /* get the the top offenders based on the current value of the counters */
-  static std::map<std::string, std::list<std::pair<Netmask, unsigned int>>> getTopNetmasks();
-  static std::map<std::string, std::list<std::pair<DNSName, unsigned int>>> getTopSuffixes();
+  static std::map<std::string, std::list<std::pair<Netmask, unsigned int>>> getTopNetmasks(size_t topN);
+  static std::map<std::string, std::list<std::pair<DNSName, unsigned int>>> getTopSuffixes(size_t topN);
   static void purgeExpired(const struct timespec& now);
 
   static time_t s_expiredDynBlocksPurgeInterval;

--- a/pdns/dnsdist-dynbpf.cc
+++ b/pdns/dnsdist-dynbpf.cc
@@ -26,7 +26,7 @@
 bool DynBPFFilter::block(const ComboAddress& addr, const struct timespec& until)
 {
   bool inserted = false;
-  std::unique_lock<std::mutex> lock(d_mutex);
+  std::lock_guard<std::mutex> lock(d_mutex);
 
   if (d_excludedSubnets.match(addr)) {
     /* do not add a block for excluded subnets */
@@ -49,7 +49,7 @@ bool DynBPFFilter::block(const ComboAddress& addr, const struct timespec& until)
 
 void DynBPFFilter::purgeExpired(const struct timespec& now)
 {
-  std::unique_lock<std::mutex> lock(d_mutex);
+  std::lock_guard<std::mutex> lock(d_mutex);
 
   typedef nth_index<container_t,1>::type ordered_until;
   ordered_until& ou = get<1>(d_entries);
@@ -74,6 +74,7 @@ std::vector<std::tuple<ComboAddress, uint64_t, struct timespec> > DynBPFFilter::
   }
 
   const auto& stats = d_bpf->getAddrStats();
+  result.reserve(stats.size());
   for (const auto& stat : stats) {
     const container_t::iterator it = d_entries.find(stat.first);
     if (it != d_entries.end()) {

--- a/pdns/dnsdist-dynbpf.hh
+++ b/pdns/dnsdist-dynbpf.hh
@@ -43,10 +43,12 @@ public:
   }
   void excludeRange(const Netmask& range)
   {
+    std::unique_lock<std::mutex> lock(d_mutex);
     d_excludedSubnets.addMask(range);
   }
   void includeRange(const Netmask& range)
   {
+    std::unique_lock<std::mutex> lock(d_mutex);
     d_excludedSubnets.addMask(range, false);
   }
   /* returns true if the addr wasn't already blocked, false otherwise */

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -33,6 +33,7 @@
 
 #include "dnsdist.hh"
 #include "dnsdist-console.hh"
+#include "dnsdist-dynblocks.hh"
 #include "dnsdist-ecs.hh"
 #include "dnsdist-healthchecks.hh"
 #include "dnsdist-lua.hh"
@@ -1253,6 +1254,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         g_outputBuffer="Dynamic blocks action cannot be altered at runtime!\n";
       }
     });
+
+  luaCtx.writeFunction("setDynBlocksPurgeInterval", [](unsigned int interval) {
+    DynBlockMaintenance::s_expiredDynBlocksPurgeInterval = interval;
+  });
 
   luaCtx.writeFunction("addDNSCryptBind", [](const std::string& addr, const std::string& providerName, boost::variant<std::string, std::vector<std::pair<int, std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int, std::string>>> keyFiles, boost::optional<localbind_t> vars) {
       if (g_configurationDone) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1148,8 +1148,9 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       boost::format fmt("%-24s %8d %8d %-10s %-20s %s\n");
       g_outputBuffer = (fmt % "What" % "Seconds" % "Blocks" % "Warning" % "Action" % "Reason").str();
       for(const auto& e: slow) {
-	if(now < e.second.until)
-	  g_outputBuffer+= (fmt % e.first.toString() % (e.second.until.tv_sec - now.tv_sec) % e.second.blocks % (e.second.warning ? "true" : "false") % DNSAction::typeToString(e.second.action != DNSAction::Action::None ? e.second.action : g_dynBlockAction) % e.second.reason).str();
+        if (now < e.second.until) {
+          g_outputBuffer+= (fmt % e.first.toString() % (e.second.until.tv_sec - now.tv_sec) % e.second.blocks % (e.second.warning ? "true" : "false") % DNSAction::typeToString(e.second.action != DNSAction::Action::None ? e.second.action : g_dynBlockAction) % e.second.reason).str();
+        }
       }
       auto slow2 = g_dynblockSMT.getCopy();
       slow2.visit([&now, &fmt](const SuffixMatchTree<DynBlock>& node) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1235,7 +1235,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 			     db.blocks=count;
                              if(!got || expired)
                                warnlog("Inserting dynamic block for %s for %d seconds: %s", domain, actualSeconds, msg);
-			     slow.add(domain, db);
+			     slow.add(domain, std::move(db));
 			   }
 			   g_dynblockSMT.setState(slow);
 			 });

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -668,21 +668,21 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
   addRulesToPrometheusOutput(output, g_cachehitresprulactions);
   addRulesToPrometheusOutput(output, g_selfansweredresprulactions);
 
-  output << "# HELP dnsdist_dynblocks_nmg_top_offenders " << "Top offenders blocked by Dynamic Blocks (netmasks)" << "\n";
-  output << "# TYPE dnsdist_dynblocks_nmg_top_offenders " << "gauge" << "\n";
-  auto topNetmasksByReason = g_dynBlocksMetricsCache.getTopNetmasks();
+  output << "# HELP dnsdist_dynblocks_nmg_top_offenders_hits_per_second " << "Number of hits per second blocked by Dynamic Blocks (netmasks) for the top offenders, averaged over the last 60s" << "\n";
+  output << "# TYPE dnsdist_dynblocks_nmg_top_offenders_hits_per_second " << "gauge" << "\n";
+  auto topNetmasksByReason = DynBlockMaintenance::getHitsForTopNetmasks();
   for (const auto& entry : topNetmasksByReason) {
     for (const auto& netmask : entry.second) {
-      output << "dnsdist_dynblocks_nmg_top_offenders{reason=\"" << entry.first << "\",netmask=\"" << netmask.first.toString() << "\"} " << netmask.second << "\n";
+      output << "dnsdist_dynblocks_nmg_top_offenders_hits_per_second{reason=\"" << entry.first << "\",netmask=\"" << netmask.first.toString() << "\"} " << netmask.second << "\n";
     }
   }
 
-  output << "# HELP dnsdist_dynblocks_smt_top_offenders " << "Top offenders blocked by Dynamic Blocks (suffixes)" << "\n";
-  output << "# TYPE dnsdist_dynblocks_smt_top_offenders " << "gauge" << "\n";
-  auto topSuffixesByReason = g_dynBlocksMetricsCache.getTopSuffixes();
+  output << "# HELP dnsdist_dynblocks_smt_top_offenders_hits_per_second " << "Number of this per second blocked by Dynamic Blocks (suffixes) for the top offenders, averaged over the last 60s" << "\n";
+  output << "# TYPE dnsdist_dynblocks_smt_top_offenders_hits_per_second " << "gauge" << "\n";
+  auto topSuffixesByReason = DynBlockMaintenance::getHitsForTopSuffixes();
   for (const auto& entry : topSuffixesByReason) {
     for (const auto& suffix : entry.second) {
-      output << "dnsdist_dynblocks_smt_top_offenders{reason=\"" << entry.first << "\",suffix=\"" << suffix.first.toString() << "\"} " << suffix.second << "\n";
+      output << "dnsdist_dynblocks_smt_top_offenders_hits_per_second{reason=\"" << entry.first << "\",suffix=\"" << suffix.first.toString() << "\"} " << suffix.second << "\n";
     }
   }
 

--- a/pdns/dnsdistdist/dnsdist-dynblocks.cc
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.cc
@@ -475,13 +475,10 @@ void DynBlockMaintenance::collectMetrics()
   snapshot.smtData = getTopSuffixes(s_topN * 5);
   snapshot.nmgData = getTopNetmasks(s_topN * 5);
 
-  {
-    std::lock_guard<std::mutex> lock(s_topsMutex);
-    if (s_metricsData.size() >= 7) {
-      s_metricsData.pop_front();
-    }
-    s_metricsData.push_back(std::move(snapshot));
+  if (s_metricsData.size() >= 7) {
+    s_metricsData.pop_front();
   }
+  s_metricsData.push_back(std::move(snapshot));
 }
 
 void DynBlockMaintenance::generateMetrics()

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1158,6 +1158,17 @@ Dynamic Blocks
   Set which action is performed when a query is blocked.
   Only DNSAction.Drop (the default), DNSAction.NoOp, DNSAction.NXDomain, DNSAction.Refused, DNSAction.Truncate and DNSAction.NoRecurse are supported.
 
+.. function:: setDynBlocksPurgeInterval(sec)
+
+  .. versionadded:: 1.6.0
+
+  Set at which interval, in seconds, the expired dynamic blocks entries will be effectively removed from the tree. Entries are not applied anymore as
+  soon as they expire, but they remain in the tree for a while for performance reasons. Removing them makes the addition of new entries faster and
+  frees up the memory they use.
+  Setting this value to 0 disable the purging mechanism, so entries will remain in the tree.
+
+  :param int sec: The interval between two runs of the cleaning algorithm, in seconds. Default is 300 (5 minutes), 0 means disabled.
+
 .. _exceedfuncs:
 
 Getting addresses that exceeded parameters

--- a/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
+++ b/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
@@ -714,8 +714,7 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
     /* now we ask for the top 20 offenders for each reason */
     StopWatch sw;
     sw.start();
-    DynBlockRulesMetricsCache cache(20, 1);
-    auto top = cache.getTopNetmasks();
+    auto top = DynBlockMaintenance::getTopNetmasks();
     BOOST_REQUIRE_EQUAL(top.size(), 1U);
     auto offenders = top.at(reason);
     BOOST_REQUIRE_EQUAL(offenders.size(), 20U);
@@ -728,7 +727,7 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
 
     struct timespec expired = now;
     expired.tv_sec += blockDuration + 1;
-    dbrg.purgeExpired(expired);
+    DynBlockMaintenance::purgeExpired(expired);
     BOOST_CHECK_EQUAL(g_dynblockNMG.getLocal()->size(), 0U);
   }
 
@@ -771,8 +770,7 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
     /* now we ask for the top 20 offenders for each reason */
     StopWatch sw;
     sw.start();
-    DynBlockRulesMetricsCache cache(20, 1);
-    auto top = cache.getTopSuffixes();
+    auto top = DynBlockMaintenance::getTopSuffixes();
     BOOST_REQUIRE_EQUAL(top.size(), 1U);
     auto suffixes = top.at(reason);
     BOOST_REQUIRE_EQUAL(suffixes.size(), 20U);
@@ -785,10 +783,11 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
 
     struct timespec expired = now;
     expired.tv_sec += blockDuration + 1;
-    dbrg.purgeExpired(expired);
+    DynBlockMaintenance::purgeExpired(expired);
     BOOST_CHECK(g_dynblockSMT.getLocal()->getNodes().empty());
   }
 
+#define BENCH_DYNBLOCKS
 #ifdef BENCH_DYNBLOCKS
   {
     /* now insert 1M names */
@@ -827,14 +826,13 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
     cerr<<"added 1000000 entries in "<<std::to_string(sw.udiff()/1024)<<"ms"<<endl;
 
     sw.start();
-    DynBlockRulesMetricsCache cache(20, 1);
-    auto top = cache.getTopSuffixes();
+    auto top = DynBlockMaintenance::getTopSuffixes();
     cerr<<"scanned 1000000 entries in "<<std::to_string(sw.udiff()/1024)<<"ms"<<endl;
 
     struct timespec expired = now;
     expired.tv_sec += blockDuration + 1;
     sw.start();
-    dbrg.purgeExpired(expired);
+    DynBlockMaintenance::purgeExpired(expired);
     cerr<<"removed 1000000 entries in "<<std::to_string(sw.udiff()/1024)<<"ms"<<endl;
   }
 #endif
@@ -871,14 +869,13 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
     BOOST_CHECK_EQUAL(g_dynblockNMG.getLocal()->size(), 1000000U);
 
     sw.start();
-    DynBlockRulesMetricsCache cache(20, 1);
-    auto top = cache.getTopNetmasks();
+    auto top = DynBlockMaintenance::getTopNetmasks();
     cerr<<"scanned "<<g_dynblockNMG.getLocal()->size()<<" entries in "<<std::to_string(sw.udiff()/1024)<<"ms"<<endl;
 
     struct timespec expired = now;
     expired.tv_sec += blockDuration + 1;
     sw.start();
-    dbrg.purgeExpired(expired);
+    DynBlockMaintenance::purgeExpired(expired);
     cerr<<"removed 1000000 entries in "<<std::to_string(sw.udiff()/1024)<<"ms"<<endl;
     BOOST_CHECK_EQUAL(g_dynblockNMG.getLocal()->size(), 0U);
   }

--- a/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
+++ b/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
@@ -787,7 +787,6 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
     BOOST_CHECK(g_dynblockSMT.getLocal()->getNodes().empty());
   }
 
-#define BENCH_DYNBLOCKS
 #ifdef BENCH_DYNBLOCKS
   {
     /* now insert 1M names */

--- a/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
+++ b/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
@@ -714,7 +714,7 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
     /* now we ask for the top 20 offenders for each reason */
     StopWatch sw;
     sw.start();
-    auto top = DynBlockMaintenance::getTopNetmasks();
+    auto top = DynBlockMaintenance::getTopNetmasks(20);
     BOOST_REQUIRE_EQUAL(top.size(), 1U);
     auto offenders = top.at(reason);
     BOOST_REQUIRE_EQUAL(offenders.size(), 20U);
@@ -770,7 +770,7 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
     /* now we ask for the top 20 offenders for each reason */
     StopWatch sw;
     sw.start();
-    auto top = DynBlockMaintenance::getTopSuffixes();
+    auto top = DynBlockMaintenance::getTopSuffixes(20);
     BOOST_REQUIRE_EQUAL(top.size(), 1U);
     auto suffixes = top.at(reason);
     BOOST_REQUIRE_EQUAL(suffixes.size(), 20U);
@@ -825,7 +825,7 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
     cerr<<"added 1000000 entries in "<<std::to_string(sw.udiff()/1024)<<"ms"<<endl;
 
     sw.start();
-    auto top = DynBlockMaintenance::getTopSuffixes();
+    auto top = DynBlockMaintenance::getTopSuffixes(20);
     cerr<<"scanned 1000000 entries in "<<std::to_string(sw.udiff()/1024)<<"ms"<<endl;
 
     struct timespec expired = now;
@@ -868,7 +868,7 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
     BOOST_CHECK_EQUAL(g_dynblockNMG.getLocal()->size(), 1000000U);
 
     sw.start();
-    auto top = DynBlockMaintenance::getTopNetmasks();
+    auto top = DynBlockMaintenance::getTopNetmasks(20);
     cerr<<"scanned "<<g_dynblockNMG.getLocal()->size()<<" entries in "<<std::to_string(sw.udiff()/1024)<<"ms"<<endl;
 
     struct timespec expired = now;

--- a/pdns/statnode.hh
+++ b/pdns/statnode.hh
@@ -21,7 +21,6 @@
  */
 #pragma once
 #include "dnsname.hh"
-#include <deque>
 #include <map>
 #include "iputils.hh"
 
@@ -56,7 +55,7 @@ public:
   Stat s;
   std::string name;
   std::string fullname;
-  unsigned int labelsCount{0};
+  uint8_t labelsCount{0};
 
   void submit(const DNSName& domain, int rcode, unsigned int bytes, boost::optional<const ComboAddress&> remote);
 

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -523,9 +523,10 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch) {
 BOOST_AUTO_TEST_CASE(test_suffixmatch_tree) {
   SuffixMatchTree<DNSName> smt;
   DNSName ezdns("ezdns.it.");
-  smt.add(ezdns, ezdns);
+  smt.add(ezdns, DNSName(ezdns));
 
-  smt.add(DNSName("org.").getRawLabels(), DNSName("org."));
+  auto labels = DNSName("org.").getRawLabels();
+  smt.add(labels, DNSName("org."));
 
   DNSName wwwpowerdnscom("www.powerdns.com.");
   DNSName wwwezdnsit("www.ezdns.it.");
@@ -548,14 +549,14 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch_tree) {
   BOOST_CHECK(smt.lookup(DNSName("images.bbc.co.uk.")) == nullptr);
   BOOST_CHECK(smt.lookup(DNSName("www.news.gov.uk.")) == nullptr);
 
-  smt.add(g_rootdnsname, g_rootdnsname); // block the root
+  smt.add(g_rootdnsname, DNSName(g_rootdnsname)); // block the root
   BOOST_REQUIRE(smt.lookup(DNSName("a.root-servers.net.")));
   BOOST_CHECK_EQUAL(*smt.lookup(DNSName("a.root-servers.net.")), g_rootdnsname);
 
   DNSName apowerdnscom("a.powerdns.com.");
   DNSName bpowerdnscom("b.powerdns.com.");
-  smt.add(apowerdnscom, apowerdnscom);
-  smt.add(bpowerdnscom, bpowerdnscom);
+  smt.add(apowerdnscom, DNSName(apowerdnscom));
+  smt.add(bpowerdnscom, DNSName(bpowerdnscom));
   BOOST_REQUIRE(smt.lookup(apowerdnscom));
   BOOST_CHECK_EQUAL(*smt.lookup(apowerdnscom), apowerdnscom);
   BOOST_REQUIRE(smt.lookup(bpowerdnscom));
@@ -563,8 +564,8 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch_tree) {
 
   DNSName examplenet("example.net.");
   DNSName net("net.");
-  smt.add(examplenet, examplenet);
-  smt.add(net, net);
+  smt.add(examplenet, DNSName(examplenet));
+  smt.add(net, DNSName(net));
   BOOST_REQUIRE(smt.lookup(examplenet));
   BOOST_CHECK_EQUAL(*smt.lookup(examplenet), examplenet);
   BOOST_REQUIRE(smt.lookup(net));
@@ -577,10 +578,10 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch_tree) {
   BOOST_CHECK_EQUAL(*smt.lookup(examplenet), examplenet);
 
   smt = SuffixMatchTree<DNSName>();
-  smt.add(examplenet, examplenet);
-  smt.add(net, net);
+  smt.add(examplenet, DNSName(examplenet));
+  smt.add(net, DNSName(net));
   smt.add(DNSName("news.bbc.co.uk."), DNSName("news.bbc.co.uk."));
-  smt.add(apowerdnscom, apowerdnscom);
+  smt.add(apowerdnscom, DNSName(apowerdnscom));
 
   smt.remove(DNSName("not-such-entry.news.bbc.co.uk."));
   BOOST_REQUIRE(smt.lookup(DNSName("news.bbc.co.uk.")));
@@ -596,8 +597,8 @@ BOOST_AUTO_TEST_CASE(test_suffixmatch_tree) {
   BOOST_CHECK(smt.lookup(net) == nullptr);
   BOOST_CHECK(smt.lookup(examplenet) == nullptr);
 
-  smt.add(examplenet, examplenet);
-  smt.add(net, net);
+  smt.add(examplenet, DNSName(examplenet));
+  smt.add(net, DNSName(net));
   BOOST_REQUIRE(smt.lookup(examplenet));
   BOOST_CHECK_EQUAL(*smt.lookup(examplenet), examplenet);
   BOOST_REQUIRE(smt.lookup(net));

--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -934,7 +934,9 @@ class TestDynBlockGroupServFails(DynBlocksTest):
 
 class TestDynBlockGroupServFailsRatio(DynBlocksTest):
 
-    _dynBlockPeriod = 2
+    # we need this period to be quite long because we request the valid
+    # queries to be still looked at to reach the 20 queries count!
+    _dynBlockPeriod = 6
     _dynBlockDuration = 5
     _config_params = ['_dynBlockPeriod', '_dynBlockDuration', '_testServerPort']
     _config_template = """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR is a work-in-progress, but the idea is to export the top 20 dynamic blocks for each `reason`, for SMT and NMG dynamic blocks. Since scanning every single entry might take a long time, these metrics are cached for 60s, which is currently hardcoded but could easily be made configurable.

The current metrics looks like this:
```
# HELP dnsdist_dynblocks_nmg_top_offenders Top offenders blocked by Dynamic Blocks (netmasks)
# TYPE dnsdist_dynblocks_nmg_top_offenders gauge
dnsdist_dynblocks_nmg_top_offenders{reason="Exceeded query rate",netmask="127.0.0.1/32"} 6
# HELP dnsdist_dynblocks_smt_top_offenders Top offenders blocked by Dynamic Blocks (suffixes)
# TYPE dnsdist_dynblocks_smt_top_offenders gauge
dnsdist_dynblocks_smt_top_offenders{reason="Pseudo-Random Subdomain Attack",suffix="prsd.powerdns.com."} 0
```

@SrX @wojas I'm pretty sure I'm holding the prometheus metrics wrong, feedback welcome :-)

We could also expose them to the API. It currently can request all dynamic block entries which is very slow, so exposing the top N would likely make sense there as well. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
