### PR TITLE
 auth-4.4.x: fix rounding inaccuracy in latency statistics

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -58,7 +58,7 @@ std::unique_ptr<DNSProxy> DP{nullptr};
 std::unique_ptr<DynListener> dl{nullptr};
 CommunicatorClass Communicator;
 shared_ptr<UDPNameserver> N;
-int avg_latency;
+double avg_latency{0.0};
 unique_ptr<TCPNameserver> TN;
 static vector<DNSDistributor*> g_distributors;
 vector<std::shared_ptr<UDPNameserver> > g_udpReceivers;
@@ -295,7 +295,7 @@ catch(PDNSException& e)
 
 static uint64_t getLatency(const std::string& str) 
 {
-  return avg_latency;
+  return round(avg_latency);
 }
 
 void declareStats(void)
@@ -399,7 +399,7 @@ static void sendout(std::unique_ptr<DNSPacket>& a)
   N->send(*a);
 
   int diff=a->d_dt.udiff();
-  avg_latency=(int)(0.999*avg_latency+0.001*diff);
+  avg_latency=0.999*avg_latency+0.001*diff;
 }
 
 //! The qthread receives questions over the internet via the Nameserver class, and hands them to the Distributor for further processing
@@ -484,7 +484,7 @@ try
         cached.commitD(); // commit d to the packet                        inlined
         NS->send(cached); // answer it then                              inlined
         diff=question.d_dt.udiff();
-        avg_latency=(int)(0.999*avg_latency+0.001*diff); // 'EWMA'
+        avg_latency=0.999*avg_latency+0.001*diff; // 'EWMA'
         continue;
       }
     }

--- a/pdns/common_startup.hh
+++ b/pdns/common_startup.hh
@@ -43,7 +43,7 @@ extern std::unique_ptr<DynListener> dl;
 extern CommunicatorClass Communicator;
 extern std::shared_ptr<UDPNameserver> N;
 extern vector<std::shared_ptr<UDPNameserver> > g_udpReceivers;
-extern int avg_latency;
+extern double avg_latency;
 extern std::unique_ptr<TCPNameserver> TN;
 extern void declareArguments();
 extern void declareStats();


### PR DESCRIPTION
### Short description
Backport of #9768

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] checked that this code was merged to master
