### PR TITLE
rec: Do not chase CNAME during qname minization step 4

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -771,9 +771,12 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
 
       // Step 4
       QLOG("Step4 Resolve A for child");
+      bool oldFollowCNAME = d_followCNAME;
+      d_followCNAME = false;
       retq.resize(0);
       StopAtDelegation stopAtDelegation = Stop;
       res = doResolveNoQNameMinimization(child, QType::A, retq, depth, beenthere, state, NULL, &stopAtDelegation);
+      d_followCNAME = oldFollowCNAME;
       QLOG("Step4 Resolve A result is " << RCode::to_s(res) << "/" << retq.size() << "/" << stopAtDelegation);
       if (stopAtDelegation == Stopped) {
         QLOG("Delegation seen, continue at step 1");
@@ -1019,9 +1022,11 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   bool oldCacheOnly = setCacheOnly(cacheOnly);
   bool oldRequireAuthData = d_requireAuthData;
   bool oldValidationRequested = d_DNSSECValidationRequested;
+  bool oldFollowCNAME = d_followCNAME;
   const unsigned int startqueries = d_outqueries;
   d_requireAuthData = false;
   d_DNSSECValidationRequested = false;
+  d_followCNAME = true;
 
   try {
     vState newState = vState::Indeterminate;
@@ -1077,6 +1082,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   d_requireAuthData = oldRequireAuthData;
   d_DNSSECValidationRequested = oldValidationRequested;
   setCacheOnly(oldCacheOnly);
+  d_followCNAME = oldFollowCNAME;
 
   /* we need to remove from the nsSpeeds collection the existing IPs
      for this nameserver that are no longer in the set, even if there
@@ -1444,7 +1450,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
       DNSName newTarget;
       if (foundQT == QType::DNAME) {
         if (qtype == QType::DNAME && qname == foundName) { // client wanted the DNAME, no need to synthesize a CNAME
-          res = 0;
+          res = RCode::NoError;
           return true;
         }
         // Synthesize a CNAME
@@ -1473,12 +1479,12 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
       }
 
       if(qtype == QType::CNAME) { // perhaps they really wanted a CNAME!
-        res = 0;
+        res = RCode::NoError;
         return true;
       }
 
       if (qtype == QType::DS || qtype == QType::DNSKEY) {
-        res = 0;
+        res = RCode::NoError;
         return true;
       }
 
@@ -1503,6 +1509,11 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
         string msg = "got a CNAME referral (from cache) to child, disabling QM";
         LOG(prefix<<qname<<": "<<msg<<endl);
         setQNameMinimization(false);
+      }
+
+      if (!d_followCNAME) {
+        res = RCode::NoError;
+        return true;
       }
 
       // Check to see if we already have seen the new target as a previous target
@@ -3719,6 +3730,11 @@ void SyncRes::handleNewTarget(const std::string& prefix, const DNSName& qname, c
   if (depth > 10) {
     LOG(prefix<<qname<<": status=got a CNAME referral, but recursing too deep, returning SERVFAIL"<<endl);
     rcode = RCode::ServFail;
+    return;
+  }
+
+  if (!d_followCNAME) {
+    rcode = RCode::NoError;
     return;
   }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -897,6 +897,7 @@ private:
   bool d_wasVariable{false};
   bool d_qNameMinimization{false};
   bool d_queryReceivedOverTCP{false};
+  bool d_followCNAME{true};
 
   LogMode d_lm;
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Not chasing CNAMEs while we are only trying to determine where the next zone cut lies helps with some broken domains.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
