### PR TITLE
rec-4.4.x: Ensure socket-dir matches runtimedir on old systemd

### DIFF
--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -195,4 +195,5 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
         AM_CONDITIONAL([HAVE_SYSTEMD_RESTRICT_SUIDSGID], [ test x"$systemd_restrict_suidsgid" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_SYSTEM_CALL_ARCHITECTURES], [ test x"$systemd_system_call_architectures" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_SYSTEM_CALL_FILTER], [ test x"$systemd_system_call_filter" = "xy" ])
+        AM_CONDITIONAL([HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV], [ test $_systemd_version -ge 240 ])
 ])

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1583,6 +1583,9 @@ dnsdist:
 if HAVE_SYSTEMD
 pdns.service: pdns.service.in
 	$(AM_V_GEN)sed -e 's![@]sbindir[@]!$(sbindir)!' -e 's![@]service_user[@]!$(service_user)!' -e 's![@]service_group[@]!$(service_group)!' < $< > $@
+if !HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV
+	$(AM_V_GEN)sed -e 's!/pdns_server!& --socket-dir=%t/pdns!' -i $@
+endif
 if !HAVE_SYSTEMD_LOCK_PERSONALITY
 	$(AM_V_GEN)perl -ni -e 'print unless /^LockPersonality/' $@
 endif
@@ -1629,6 +1632,9 @@ pdns@.service: pdns.service
 	  -e 's!RuntimeDirectory=.*!&-%i!' \
 	  -e 's!SyslogIdentifier=.*!&-%i!' \
 	  < $< > $@
+if !HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV
+	$(AM_V_GEN)sed -e 's!--socket-dir=[^ ]\+!&-%i !' -i $@
+endif
 
 systemdsystemunitdir = $(SYSTEMD_DIR)
 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -511,6 +511,9 @@ endif
 if HAVE_SYSTEMD
 pdns-recursor.service: pdns-recursor.service.in
 	$(AM_V_GEN)sed -e 's![@]sbindir[@]!$(sbindir)!' -e 's![@]service_user[@]!$(service_user)!' -e 's![@]service_group[@]!$(service_group)!' < $< > $@
+if !HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV
+	$(AM_V_GEN)sed -e 's!/pdns_recursor!& --socket-dir=%t/pdns-recursor!' -i $@
+endif
 if !HAVE_SYSTEMD_LOCK_PERSONALITY
 	$(AM_V_GEN)perl -ni -e 'print unless /^LockPersonality/' $@
 endif
@@ -556,6 +559,9 @@ pdns-recursor@.service: pdns-recursor.service
 	  -e 's!Recursor!& %i!' \
 	  -e 's!RuntimeDirectory=.*!&-%i!' \
 	  < $< > $@
+if !HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV
+	$(AM_V_GEN)sed -e 's!--socket-dir=[^ ]\+!&-%i !' -i $@
+endif
 
 systemdsystemunitdir = $(SYSTEMD_DIR)
 


### PR DESCRIPTION
### Short description
Backport of #9574

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master