### PR TITLE
dnsdist: Clean up the internal queues use for self-answered and trailing test responses

### DIFF
--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -174,17 +174,17 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             cls._ResponderIncrementCounter()
             if not fromQueue.empty():
                 toQueue.put(request, True, cls._queueTimeout)
-                if synthesize is None:
-                    response = fromQueue.get(True, cls._queueTimeout)
-                    if response:
-                        response = copy.copy(response)
-                        response.id = request.id
+                response = fromQueue.get(True, cls._queueTimeout)
+                if response:
+                  response = copy.copy(response)
+                  response.id = request.id
+
+        if synthesize is not None:
+          response = dns.message.make_response(request)
+          response.set_rcode(synthesize)
 
         if not response:
-            if synthesize is not None:
-                response = dns.message.make_response(request)
-                response.set_rcode(synthesize)
-            elif cls._answerUnexpected:
+            if cls._answerUnexpected:
                 response = dns.message.make_response(request)
                 response.set_rcode(dns.rcode.SERVFAIL)
 
@@ -307,7 +307,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
     @classmethod
     def sendUDPQuery(cls, query, response, useQueue=True, timeout=2.0, rawQuery=False):
-        if useQueue:
+        if useQueue and response is not None:
             cls._toResponderQueue.put(response, True, timeout)
 
         if timeout:

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -647,7 +647,7 @@ class TestAdvancedDNSSEC(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(doquery, response)
+            (_, receivedResponse) = sender(doquery, response=None, useQueue=False)
             self.assertEquals(receivedResponse, None)
 
 class TestAdvancedQClass(DNSDistTest):
@@ -666,7 +666,7 @@ class TestAdvancedQClass(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(query, response=None)
+            (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertEquals(receivedResponse, None)
 
     def testAdvancedQClassINAllow(self):
@@ -710,7 +710,7 @@ class TestAdvancedOpcode(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(query, response=None)
+            (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertEquals(receivedResponse, None)
 
     def testAdvancedOpcodeUpdateINAllow(self):
@@ -1569,7 +1569,7 @@ class TestAdvancedEDNSOptionRule(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(query, response=None)
+            (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertEquals(receivedResponse, None)
 
     def testReplied(self):
@@ -1688,7 +1688,7 @@ class TestAdvancedEDNSVersionRule(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(query, response=None)
+            (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertEquals(receivedResponse, expectedResponse)
 
     def testNoEDNS0Pass(self):

--- a/regression-tests.dnsdist/test_Trailing.py
+++ b/regression-tests.dnsdist/test_Trailing.py
@@ -133,7 +133,7 @@ class TestTrailingDataToBackend(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(query, response)
+            (_, receivedResponse) = sender(query, response, useQueue=False)
             self.assertTrue(receivedResponse)
             self.assertEquals(receivedResponse, expectedResponse)
 
@@ -246,7 +246,7 @@ class TestTrailingDataToDnsdist(DNSDistTest):
             self.assertEquals(response, receivedResponse)
 
             # Verify that queries with trailing data don't make it through.
-            (_, receivedResponse) = sender(raw, response, rawQuery=True)
+            (_, receivedResponse) = sender(raw, response, rawQuery=True, useQueue=False)
             self.assertEquals(receivedResponse, None)
 
     def testTrailingRemoved(self):
@@ -298,7 +298,7 @@ class TestTrailingDataToDnsdist(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(raw, response, rawQuery=True)
+            (_, receivedResponse) = sender(raw, response=None, rawQuery=True, useQueue=False)
             self.assertTrue(receivedResponse)
             expectedResponse.flags = receivedResponse.flags
             self.assertEquals(receivedResponse, expectedResponse)
@@ -325,7 +325,7 @@ class TestTrailingDataToDnsdist(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(raw, response, rawQuery=True)
+            (_, receivedResponse) = sender(raw, response=None, rawQuery=True, useQueue=False)
             self.assertTrue(receivedResponse)
             expectedResponse.flags = receivedResponse.flags
             self.assertEquals(receivedResponse, expectedResponse)
@@ -352,7 +352,7 @@ class TestTrailingDataToDnsdist(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(raw, response, rawQuery=True)
+            (_, receivedResponse) = sender(raw, response=None, rawQuery=True, useQueue=False)
             self.assertTrue(receivedResponse)
             expectedResponse.flags = receivedResponse.flags
             self.assertEquals(receivedResponse, expectedResponse)
@@ -379,7 +379,7 @@ class TestTrailingDataToDnsdist(DNSDistTest):
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
-            (_, receivedResponse) = sender(raw, response, rawQuery=True)
+            (_, receivedResponse) = sender(raw, response=None, rawQuery=True, useQueue=False)
             self.assertTrue(receivedResponse)
             expectedResponse.flags = receivedResponse.flags
             self.assertEquals(receivedResponse, expectedResponse)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Hopefully it might help with the transient failures of the trailing data regression test we are recurrently experiencing in CI.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
