### PR TITLE
dockerfiles: do not claim equivs-dummy is sourced from pdns

### DIFF
--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -55,7 +55,7 @@ RUN mkdir /build && \
     make -C pdns install DESTDIR=/build && make -C modules install DESTDIR=/build && make clean && \
     strip /build/usr/local/bin/* /build/usr/local/sbin/* /build/usr/local/lib/pdns/*.so
 RUN cd /tmp && mkdir /build/tmp/ && mkdir debian && \
-    echo 'Source: pdns' > debian/control && \
+    echo 'Source: docker-deps-for-pdns' > debian/control && \
     dpkg-shlibdeps /build/usr/local/bin/* /build/usr/local/sbin/* /build/usr/local/lib/pdns/*.so && \
     sed 's/^shlibs:Depends=/Depends: /' debian/substvars >> debian/control && \
     equivs-build debian/control && \

--- a/Dockerfile-dnsdist
+++ b/Dockerfile-dnsdist
@@ -52,7 +52,7 @@ RUN mkdir /build && \
     make $MAKEFLAGS install DESTDIR=/build && make clean && \
     strip /build/usr/local/bin/*
 RUN cd /tmp && mkdir /build/tmp/ && mkdir debian && \
-    echo 'Source: pdns' > debian/control && \
+    echo 'Source: docker-deps-for-pdns' > debian/control && \
     dpkg-shlibdeps /build/usr/local/bin/dnsdist && \
     sed 's/^shlibs:Depends=/Depends: /' debian/substvars >> debian/control && \
     equivs-build debian/control && \

--- a/Dockerfile-recursor
+++ b/Dockerfile-recursor
@@ -57,7 +57,7 @@ RUN mkdir /build && \
       make $MAKEFLAGS install DESTDIR=/build && make clean && \
       strip /build/usr/local/bin/* /build/usr/local/sbin/*
 RUN cd /tmp && mkdir /build/tmp/ && mkdir debian && \
-    echo 'Source: pdns' > debian/control && \
+    echo 'Source: docker-deps-for-pdns' > debian/control && \
     dpkg-shlibdeps /build/usr/local/bin/rec_control /build/usr/local/sbin/pdns_recursor && \
     sed 's/^shlibs:Depends=/Depends: /' debian/substvars >> debian/control && \
     equivs-build debian/control && \


### PR DESCRIPTION
### Short description
.. because otherwise at least two security scanners will dig up every CVE since PowerDNS 1.0 and claim the image is vulnerable to it

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master