### PR TITLE
rec: backport 9790 to rec-4.3.x: Do not chase CNAME during qname minization step 4

### DIFF
--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -904,6 +904,7 @@ private:
   bool d_wasOutOfBand{false};
   bool d_wasVariable{false};
   bool d_qNameMinimization{false};
+  bool d_followCNAME{true};
 
   LogMode d_lm;
 };


### PR DESCRIPTION
(cherry picked from commit 7373cea835239f1b18a72000821bb17b516d954b)

Backport of #9790

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
