### PR TITLE
rec: backport 9790 to rec-4.4.x: Do not chase CNAME during qname minization step 4

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -770,9 +770,12 @@ int SyncRes::doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecor
 
       // Step 4
       QLOG("Step4 Resolve A for child");
+      bool oldFollowCNAME = d_followCNAME;
+      d_followCNAME = false;
       retq.resize(0);
       StopAtDelegation stopAtDelegation = Stop;
       res = doResolveNoQNameMinimization(child, QType::A, retq, depth, beenthere, state, NULL, &stopAtDelegation);
+      d_followCNAME = oldFollowCNAME;
       QLOG("Step4 Resolve A result is " << RCode::to_s(res) << "/" << retq.size() << "/" << stopAtDelegation);
       if (stopAtDelegation == Stopped) {
         QLOG("Delegation seen, continue at step 1");
@@ -1018,9 +1021,11 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   bool oldCacheOnly = setCacheOnly(cacheOnly);
   bool oldRequireAuthData = d_requireAuthData;
   bool oldValidationRequested = d_DNSSECValidationRequested;
+  bool oldFollowCNAME = d_followCNAME;
   const unsigned int startqueries = d_outqueries;
   d_requireAuthData = false;
   d_DNSSECValidationRequested = false;
+  d_followCNAME = true;
 
   try {
     vState newState = vState::Indeterminate;
@@ -1076,6 +1081,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   d_requireAuthData = oldRequireAuthData;
   d_DNSSECValidationRequested = oldValidationRequested;
   setCacheOnly(oldCacheOnly);
+  d_followCNAME = oldFollowCNAME;
 
   /* we need to remove from the nsSpeeds collection the existing IPs
      for this nameserver that are no longer in the set, even if there
@@ -1443,7 +1449,7 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
       DNSName newTarget;
       if (foundQT == QType::DNAME) {
         if (qtype == QType::DNAME && qname == foundName) { // client wanted the DNAME, no need to synthesize a CNAME
-          res = 0;
+          res = RCode::NoError;
           return true;
         }
         // Synthesize a CNAME
@@ -1472,12 +1478,12 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
       }
 
       if(qtype == QType::CNAME) { // perhaps they really wanted a CNAME!
-        res = 0;
+        res = RCode::NoError;
         return true;
       }
 
       if (qtype == QType::DS || qtype == QType::DNSKEY) {
-        res = 0;
+        res = RCode::NoError;
         return true;
       }
 
@@ -1502,6 +1508,11 @@ bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector
         string msg = "got a CNAME referral (from cache) to child, disabling QM";
         LOG(prefix<<qname<<": "<<msg<<endl);
         setQNameMinimization(false);
+      }
+
+      if (!d_followCNAME) {
+        res = RCode::NoError;
+        return true;
       }
 
       // Check to see if we already have seen the new target as a previous target
@@ -3678,6 +3689,11 @@ void SyncRes::handleNewTarget(const std::string& prefix, const DNSName& qname, c
   if (depth > 10) {
     LOG(prefix<<qname<<": status=got a CNAME referral, but recursing too deep, returning SERVFAIL"<<endl);
     rcode = RCode::ServFail;
+    return;
+  }
+
+  if (!d_followCNAME) {
+    rcode = RCode::NoError;
     return;
   }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -914,6 +914,7 @@ private:
   bool d_wasVariable{false};
   bool d_qNameMinimization{false};
   bool d_queryReceivedOverTCP{false};
+  bool d_followCNAME{true};
 
   LogMode d_lm;
 };


### PR DESCRIPTION
(cherry picked from commit 7373cea835239f1b18a72000821bb17b516d954b)

Backport of #9790

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
