### PR TITLE
auth geoip: set netmask on all string formatting types

### DIFF
--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -635,6 +635,7 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
       double s1, s2;
       if (!queryGeoLocation(addr, gl, lat, lon, alt, prec)) {
         rep = "";
+        tmp_gl.netmask = (addr.isIPv6()?128:32);
       } else {
         ns = (lat>0) ? 'N' : 'S';
         ew = (lon>0) ? 'E' : 'W';
@@ -660,6 +661,7 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
     } else if (!sformat.compare(cur,4,"%lat")) {
       if (!queryGeoLocation(addr, gl, lat, lon, alt, prec)) {
         rep = "";
+        tmp_gl.netmask = (addr.isIPv6()?128:32);
       } else {
         rep = str(boost::format("%lf") % lat);
       }
@@ -667,6 +669,7 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
     } else if (!sformat.compare(cur,4,"%lon")) {
       if (!queryGeoLocation(addr, gl, lat, lon, alt, prec)) {
         rep = "";
+        tmp_gl.netmask = (addr.isIPv6()?128:32);
       } else {
         rep = str(boost::format("%lf") % lon);
       }


### PR DESCRIPTION
### Short description
(via Kees Monshouwer)

I noticed this failure while I was migrating geoip tests from Travis CI to Circle CI. We never noticed on Travis because the unbound-host there is too old to have qname minimisation, and thus it did not do the queries that ruin our cache.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master