### PR TITLE
Improve the way QType behaves by defining proper conversion operators and a hash function.

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -86,7 +86,7 @@ bool DNSResourceRecord::operator==(const DNSResourceRecord& rhs)
     tie(rhs.qname, rhs.qtype, rcontent, rhs.ttl);
 }
 
-boilerplate_conv(A, QType::A, conv.xfrIP(d_ip));
+boilerplate_conv(A, conv.xfrIP(d_ip));
 
 ARecordContent::ARecordContent(uint32_t ip) 
 {
@@ -132,32 +132,32 @@ void ARecordContent::doRecordCheck(const DNSRecord& dr)
     throw MOADNSException("Wrong size for A record ("+std::to_string(dr.d_clen)+")");
 }
 
-boilerplate_conv(AAAA, QType::AAAA, conv.xfrIP6(d_ip6); );
+boilerplate_conv(AAAA, conv.xfrIP6(d_ip6); );
 
-boilerplate_conv(NS, QType::NS, conv.xfrName(d_content, true));
-boilerplate_conv(PTR, QType::PTR, conv.xfrName(d_content, true));
-boilerplate_conv(CNAME, QType::CNAME, conv.xfrName(d_content, true));
-boilerplate_conv(ALIAS, QType::ALIAS, conv.xfrName(d_content, false));
-boilerplate_conv(DNAME, QType::DNAME, conv.xfrName(d_content));
-boilerplate_conv(MB, QType::MB, conv.xfrName(d_madname, true));
-boilerplate_conv(MG, QType::MG, conv.xfrName(d_mgmname, true));
-boilerplate_conv(MR, QType::MR, conv.xfrName(d_alias, true));
-boilerplate_conv(MINFO, QType::MINFO, conv.xfrName(d_rmailbx, true); conv.xfrName(d_emailbx, true));
-boilerplate_conv(TXT, QType::TXT, conv.xfrText(d_text, true));
+boilerplate_conv(NS, conv.xfrName(d_content, true));
+boilerplate_conv(PTR, conv.xfrName(d_content, true));
+boilerplate_conv(CNAME, conv.xfrName(d_content, true));
+boilerplate_conv(ALIAS, conv.xfrName(d_content, false));
+boilerplate_conv(DNAME, conv.xfrName(d_content));
+boilerplate_conv(MB, conv.xfrName(d_madname, true));
+boilerplate_conv(MG, conv.xfrName(d_mgmname, true));
+boilerplate_conv(MR, conv.xfrName(d_alias, true));
+boilerplate_conv(MINFO, conv.xfrName(d_rmailbx, true); conv.xfrName(d_emailbx, true));
+boilerplate_conv(TXT, conv.xfrText(d_text, true));
 #ifdef HAVE_LUA_RECORDS
-boilerplate_conv(LUA, QType::LUA, conv.xfrType(d_type); conv.xfrText(d_code, true));
+boilerplate_conv(LUA, conv.xfrType(d_type); conv.xfrText(d_code, true));
 #endif
-boilerplate_conv(ENT, 0, );
-boilerplate_conv(SPF, 99, conv.xfrText(d_text, true));
-boilerplate_conv(HINFO, QType::HINFO,  conv.xfrText(d_cpu);   conv.xfrText(d_host));
+boilerplate_conv(ENT, );
+boilerplate_conv(SPF, conv.xfrText(d_text, true));
+boilerplate_conv(HINFO, conv.xfrText(d_cpu);   conv.xfrText(d_host));
 
-boilerplate_conv(RP, QType::RP,
+boilerplate_conv(RP,
                  conv.xfrName(d_mbox);   
                  conv.xfrName(d_info)
                  );
 
 
-boilerplate_conv(OPT, QType::OPT, 
+boilerplate_conv(OPT,
                    conv.xfrBlob(d_data)
                  );
 
@@ -194,7 +194,7 @@ void OPTRecordContent::getData(vector<pair<uint16_t, string> >& options)
   }
 }
 
-boilerplate_conv(TSIG, QType::TSIG,
+boilerplate_conv(TSIG,
                  conv.xfrName(d_algoName);
                  conv.xfr48BitInt(d_time);
                  conv.xfr16BitInt(d_fudge);
@@ -212,17 +212,17 @@ MXRecordContent::MXRecordContent(uint16_t preference, DNSName  mxname):  d_prefe
 {
 }
 
-boilerplate_conv(MX, QType::MX, 
+boilerplate_conv(MX,
                  conv.xfr16BitInt(d_preference);
                  conv.xfrName(d_mxname, true);
                  )
 
-boilerplate_conv(KX, QType::KX, 
+boilerplate_conv(KX,
                  conv.xfr16BitInt(d_preference);
                  conv.xfrName(d_exchanger, false);
                  )
 
-boilerplate_conv(IPSECKEY, QType::IPSECKEY,
+boilerplate_conv(IPSECKEY,
    conv.xfr8BitInt(d_preference);
    conv.xfr8BitInt(d_gatewaytype);
    conv.xfr8BitInt(d_algorithm);
@@ -256,18 +256,18 @@ boilerplate_conv(IPSECKEY, QType::IPSECKEY,
    }
 ) 
 
-boilerplate_conv(DHCID, 49, 
+boilerplate_conv(DHCID,
                  conv.xfrBlob(d_content);
                  )
 
 
-boilerplate_conv(AFSDB, QType::AFSDB, 
+boilerplate_conv(AFSDB,
                  conv.xfr16BitInt(d_subtype);
                  conv.xfrName(d_hostname);
                  )
 
 
-boilerplate_conv(NAPTR, QType::NAPTR,
+boilerplate_conv(NAPTR,
                  conv.xfr16BitInt(d_order);    conv.xfr16BitInt(d_preference);
                  conv.xfrText(d_flags);        conv.xfrText(d_services);         conv.xfrText(d_regexp);
                  conv.xfrName(d_replacement);
@@ -278,7 +278,7 @@ SRVRecordContent::SRVRecordContent(uint16_t preference, uint16_t weight, uint16_
 : d_weight(weight), d_port(port), d_target(std::move(target)), d_preference(preference)
 {}
 
-boilerplate_conv(SRV, QType::SRV, 
+boilerplate_conv(SRV,
                  conv.xfr16BitInt(d_preference);   conv.xfr16BitInt(d_weight);   conv.xfr16BitInt(d_port);
                  conv.xfrName(d_target); 
                  )
@@ -288,7 +288,7 @@ SOARecordContent::SOARecordContent(DNSName  mname, DNSName  rname, const struct 
 {
 }
 
-boilerplate_conv(SOA, QType::SOA,
+boilerplate_conv(SOA,
                  conv.xfrName(d_mname, true);
                  conv.xfrName(d_rname, true);
                  conv.xfr32BitInt(d_st.serial);
@@ -298,14 +298,14 @@ boilerplate_conv(SOA, QType::SOA,
                  conv.xfr32BitInt(d_st.minimum);
                  );
 #undef KEY
-boilerplate_conv(KEY, QType::KEY, 
+boilerplate_conv(KEY,
                  conv.xfr16BitInt(d_flags); 
                  conv.xfr8BitInt(d_protocol); 
                  conv.xfr8BitInt(d_algorithm); 
                  conv.xfrBlob(d_certificate);
                  );
 
-boilerplate_conv(CERT, 37, 
+boilerplate_conv(CERT,
                  conv.xfr16BitInt(d_type); 
                  if (d_type == 0) throw MOADNSException("CERT type 0 is reserved");
 
@@ -314,18 +314,18 @@ boilerplate_conv(CERT, 37,
                  conv.xfrBlob(d_certificate);
                  )
 
-boilerplate_conv(TLSA, 52, 
+boilerplate_conv(TLSA,
                  conv.xfr8BitInt(d_certusage); 
                  conv.xfr8BitInt(d_selector); 
                  conv.xfr8BitInt(d_matchtype); 
                  conv.xfrHexBlob(d_cert, true);
                  )                 
                  
-boilerplate_conv(OPENPGPKEY, 61,
+boilerplate_conv(OPENPGPKEY,
                  conv.xfrBlob(d_keyring);
                  )
 
-boilerplate_conv(SVCB, 64,
+boilerplate_conv(SVCB,
                  conv.xfr16BitInt(d_priority);
                  conv.xfrName(d_target, false, true);
                  if (d_priority != 0) {
@@ -333,7 +333,7 @@ boilerplate_conv(SVCB, 64,
                  }
                  )
 
-boilerplate_conv(HTTPS, 65,
+boilerplate_conv(HTTPS,
                  conv.xfr16BitInt(d_priority);
                  conv.xfrName(d_target, false, true);
                  if (d_priority != 0) {
@@ -341,7 +341,7 @@ boilerplate_conv(HTTPS, 65,
                  }
                  )
 
-boilerplate_conv(SMIMEA, 53,
+boilerplate_conv(SMIMEA,
                  conv.xfr8BitInt(d_certusage);
                  conv.xfr8BitInt(d_selector);
                  conv.xfr8BitInt(d_matchtype);
@@ -349,7 +349,7 @@ boilerplate_conv(SMIMEA, 53,
                  )
 
 DSRecordContent::DSRecordContent() {}
-boilerplate_conv(DS, 43, 
+boilerplate_conv(DS,
                  conv.xfr16BitInt(d_tag); 
                  conv.xfr8BitInt(d_algorithm); 
                  conv.xfr8BitInt(d_digesttype); 
@@ -357,7 +357,7 @@ boilerplate_conv(DS, 43,
                  )
 
 CDSRecordContent::CDSRecordContent() {}
-boilerplate_conv(CDS, 59, 
+boilerplate_conv(CDS,
                  conv.xfr16BitInt(d_tag); 
                  conv.xfr8BitInt(d_algorithm); 
                  conv.xfr8BitInt(d_digesttype); 
@@ -365,7 +365,7 @@ boilerplate_conv(CDS, 59,
                  )
 
 DLVRecordContent::DLVRecordContent() {}
-boilerplate_conv(DLV,32769 , 
+boilerplate_conv(DLV,
                  conv.xfr16BitInt(d_tag); 
                  conv.xfr8BitInt(d_algorithm); 
                  conv.xfr8BitInt(d_digesttype); 
@@ -373,13 +373,13 @@ boilerplate_conv(DLV,32769 ,
                  )
 
 
-boilerplate_conv(SSHFP, 44, 
+boilerplate_conv(SSHFP,
                  conv.xfr8BitInt(d_algorithm); 
                  conv.xfr8BitInt(d_fptype); 
                  conv.xfrHexBlob(d_fingerprint, true);
                  )
 
-boilerplate_conv(RRSIG, 46, 
+boilerplate_conv(RRSIG,
                  conv.xfrType(d_type); 
                    conv.xfr8BitInt(d_algorithm); 
                    conv.xfr8BitInt(d_labels); 
@@ -393,7 +393,7 @@ boilerplate_conv(RRSIG, 46,
                  
 RRSIGRecordContent::RRSIGRecordContent() {}
 
-boilerplate_conv(DNSKEY, 48, 
+boilerplate_conv(DNSKEY,
                  conv.xfr16BitInt(d_flags); 
                  conv.xfr8BitInt(d_protocol); 
                  conv.xfr8BitInt(d_algorithm); 
@@ -401,7 +401,7 @@ boilerplate_conv(DNSKEY, 48,
                  )
 DNSKEYRecordContent::DNSKEYRecordContent() {}
 
-boilerplate_conv(CDNSKEY, 60, 
+boilerplate_conv(CDNSKEY,
                  conv.xfr16BitInt(d_flags); 
                  conv.xfr8BitInt(d_protocol); 
                  conv.xfr8BitInt(d_algorithm); 
@@ -409,7 +409,7 @@ boilerplate_conv(CDNSKEY, 60,
                  )
 CDNSKEYRecordContent::CDNSKEYRecordContent() {}
 
-boilerplate_conv(RKEY, 57, 
+boilerplate_conv(RKEY,
                  conv.xfr16BitInt(d_flags); 
                  conv.xfr8BitInt(d_protocol); 
                  conv.xfr8BitInt(d_algorithm); 
@@ -716,7 +716,7 @@ string APLRecordContent::getZoneRepresentation(bool noDot) const {
 
 /* APL end */
 
-boilerplate_conv(TKEY, QType::TKEY,
+boilerplate_conv(TKEY,
                  conv.xfrName(d_algo);
                  conv.xfr32BitInt(d_inception);
                  conv.xfr32BitInt(d_expiration);
@@ -729,13 +729,13 @@ boilerplate_conv(TKEY, QType::TKEY,
                  )
 TKEYRecordContent::TKEYRecordContent() { d_othersize = 0; } // fix CID#1288932
 
-boilerplate_conv(URI, QType::URI,
+boilerplate_conv(URI,
                  conv.xfr16BitInt(d_priority);
                  conv.xfr16BitInt(d_weight);
                  conv.xfrText(d_target, true, false);
                  )
 
-boilerplate_conv(CAA, QType::CAA,
+boilerplate_conv(CAA,
                  conv.xfr8BitInt(d_flags);
                  conv.xfrUnquotedText(d_tag, true);
                  conv.xfrText(d_value, true, false); /* no lenField */

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -870,7 +870,7 @@ class CAARecordContent : public DNSRecordContent {
     string d_tag, d_value;
 };
 
-#define boilerplate(RNAME, RTYPE)                                                                         \
+#define boilerplate(RNAME)                                                                         \
 std::shared_ptr<RNAME##RecordContent::DNSRecordContent> RNAME##RecordContent::make(const DNSRecord& dr, PacketReader& pr) \
 {                                                                                                  \
   return std::make_shared<RNAME##RecordContent>(dr, pr);                                           \
@@ -894,13 +894,13 @@ void RNAME##RecordContent::toPacket(DNSPacketWriter& pw)                        
                                                                                                    \
 void RNAME##RecordContent::report(void)                                                            \
 {                                                                                                  \
-  regist(1, RTYPE, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);              \
-  regist(254, RTYPE, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);            \
+  regist(1, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);              \
+  regist(254, QType::RNAME, &RNAME##RecordContent::make, &RNAME##RecordContent::make, #RNAME);            \
 }                                                                                                  \
 void RNAME##RecordContent::unreport(void)                                                          \
 {                                                                                                  \
-  unregist(1, RTYPE);                                                                              \
-  unregist(254, RTYPE);                                                                            \
+  unregist(1, QType::RNAME);                                                                              \
+  unregist(254, QType::RNAME);                                                                            \
 }                                                                                                  \
                                                                                                    \
 RNAME##RecordContent::RNAME##RecordContent(const string& zoneData)                                 \
@@ -923,8 +923,8 @@ string RNAME##RecordContent::getZoneRepresentation(bool noDot) const            
 }                                                                                                  
                                                                                            
 
-#define boilerplate_conv(RNAME, TYPE, CONV)                       \
-boilerplate(RNAME, TYPE)                                          \
+#define boilerplate_conv(RNAME, CONV)                             \
+boilerplate(RNAME)                                                \
 template<class Convertor>                                         \
 void RNAME##RecordContent::xfrPacket(Convertor& conv, bool noDot) \
 {                                                                 \

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1352,7 +1352,7 @@ static bool udrCheckUniqueDNSRecord(const DNSName& dname, uint16_t qtype, const 
 }
 #endif /* NOD_ENABLED */
 
-int followCNAMERecords(vector<DNSRecord>& ret, const QType& qtype, int rcode)
+int followCNAMERecords(vector<DNSRecord>& ret, const QType qtype, int rcode)
 {
   vector<DNSRecord> resolved;
   DNSName target;

--- a/pdns/qtype.cc
+++ b/pdns/qtype.cc
@@ -30,23 +30,80 @@
 
 static_assert(sizeof(QType) == 2, "QType is not 2 bytes in size, something is wrong!");
 
-vector<QType::namenum> QType::names;
-// XXX FIXME we need to do something with initializer order here!
-QType::init QType::initializer; 
+const vector<QType::namenum> QType::names = {
+  {"A", 1},
+  {"NS", 2},
+  {"CNAME", 5},
+  {"SOA", 6},
+  {"MB", 7},
+  {"MG", 8},
+  {"MR", 9},
+  {"PTR", 12},
+  {"HINFO", 13},
+  {"MINFO", 14},
+  {"MX", 15},
+  {"TXT", 16},
+  {"RP", 17},
+  {"AFSDB", 18},
+  {"SIG", 24},
+  {"KEY", 25},
+  {"AAAA", 28},
+  {"LOC", 29},
+  {"SRV", 33},
+  {"NAPTR", 35},
+  {"KX", 36},
+  {"CERT", 37},
+  {"A6", 38},
+  {"DNAME", 39},
+  {"OPT", 41},
+  {"APL", 42},
+  {"DS", 43},
+  {"SSHFP", 44},
+  {"IPSECKEY", 45},
+  {"RRSIG", 46},
+  {"NSEC", 47},
+  {"DNSKEY", 48},
+  {"DHCID", 49},
+  {"NSEC3", 50},
+  {"NSEC3PARAM", 51},
+  {"TLSA", 52},
+  {"SMIMEA", 53},
+  {"RKEY", 57},
+  {"CDS", 59},
+  {"CDNSKEY", 60},
+  {"OPENPGPKEY", 61},
+  {"SVCB", 64},
+  {"HTTPS", 65},
+  {"SPF", 99},
+  {"EUI48", 108},
+  {"EUI64", 109},
+  {"TKEY", 249},
+  //      {"TSIG", 250},
+  {"IXFR", 251},
+  {"AXFR", 252},
+  {"MAILB", 253},
+  {"MAILA", 254},
+  {"ANY", 255},
+  {"URI", 256},
+  {"CAA", 257},
+  {"DLV", 32769},
+  {"ADDR", 65400},
+  {"ALIAS", 65401},
+  {"LUA", 65402},
+};
 
-QType::QType()
+bool QType::isSupportedType() const
 {
-  code = 0;
-}
-
-bool QType::isSupportedType() {
-  for(vector<namenum>::iterator pos=names.begin();pos<names.end();++pos)
-    if(pos->second==code)
+  for (const auto& pos : names) {
+    if (pos.second == code) {
       return true;
+    }
+  }
   return false;
 }
 
-bool QType::isMetadataType() {
+bool QType::isMetadataType() const
+{
   if (code == QType::AXFR ||
       code == QType::MAILA ||
       code == QType::MAILB ||
@@ -57,60 +114,44 @@ bool QType::isMetadataType() {
   return false;
 }
 
-uint16_t QType::getCode() const
-{
-  return code;
-}
-
 const string QType::getName() const
 {
-  vector<namenum>::iterator pos;
-  for(pos=names.begin();pos<names.end();++pos)
-    if(pos->second==code)
-      return pos->first;
-
-  return "TYPE"+itoa(code);
+  for (const auto& pos : names) {
+    if (pos.second == code) {
+      return pos.first;
+    }
+  }
+  return "TYPE" + itoa(code);
 }
 
-QType &QType::operator=(uint16_t n)
-{
-  code=n;
-  return *this;
-}
-
-int QType::chartocode(const char *p)
+uint16_t QType::chartocode(const char *p)
 {
   string P = toUpper(p);
-  vector<namenum>::iterator pos;
 
-  for(pos=names.begin(); pos < names.end(); ++pos)
-    if(pos->first == P)
-      return pos->second;
-
-  if(*p=='#') {
-    return atoi(p+1);
+  for(const auto& pos: names) {
+    if (pos.first == P) {
+      return pos.second;
+    }
+  }
+  if (*p == '#') {
+    return static_cast<uint16_t>(atoi(p+1));
   }
 
-  if(boost::starts_with(P, "TYPE"))
-    return atoi(p+4);
+  if (boost::starts_with(P, "TYPE")) {
+    return static_cast<uint16_t>(atoi(p+4));
+  }
 
   return 0;
 }
 
 QType &QType::operator=(const char *p)
 {
-  code=chartocode(p);
+  code = chartocode(p);
   return *this;
 }
 
 QType &QType::operator=(const string &s)
 {
-  code=chartocode(s.c_str());
+  code = chartocode(s.c_str());
   return *this;
-}
-
-
-QType::QType(uint16_t n): QType()
-{
-  code=n;
 }

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -138,6 +138,11 @@ namespace std {
   };
 }
 
+// Used by e.g. boost multi-index
+inline size_t hash_value(const QType qtype) {
+  return qtype.getCode();
+}
+
 struct QClass
 {
   enum QClassEnum { IN = 1, CHAOS = 3, NONE = 254, ANY = 255 };

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -40,23 +40,8 @@ class QType
 {
 public:
   QType(uint16_t qtype = 0) : code(qtype) {}
-  QType(const QType& orig) : code(orig.code) {}
-  QType &operator=(uint16_t arg)
-  {
-    code = arg;
-    return *this;
-  }
   QType &operator=(const char *);
   QType &operator=(const string &);
-  QType &operator=(const QType& rhs)
-  {
-    code = rhs.code;
-    return *this;
-  }
-  bool operator<(const QType rhs) const
-  {
-    return code < rhs.code;
-  }
 
   operator uint16_t() const {
     return code;
@@ -67,6 +52,7 @@ public:
   {
     return code;
   }
+
   bool isSupportedType() const;
   bool isMetadataType() const;
 
@@ -135,8 +121,8 @@ public:
     LUA = 65402
   };
 
-  typedef pair<string, uint16_t> namenum;
-  const static vector<namenum> names;
+  const static map<const string, uint16_t> names;
+  const static map<uint16_t, const string> numbers;
 
 private:
 

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -20,8 +20,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include <string>
-#include <vector>
 #include "namespaces.hh"
 
 /** The QType class is meant to deal easily with the different kind of resource types, like 'A', 'NS',
@@ -38,206 +36,123 @@
 
 */
 
-
-
 class QType
 {
 public:
-  QType(); //!< Naked constructor
-  explicit QType(uint16_t); //!< convert from an integer to a QType
-  QType(const QType& orig) : code(orig.code)
+  QType(uint16_t qtype = 0) : code(qtype) {}
+  QType(const QType& orig) : code(orig.code) {}
+  QType &operator=(uint16_t arg)
   {
-  }
-  QType &operator=(uint16_t);  //!< Assigns integers to us
-  QType &operator=(const char *); //!< Assigns strings to us
-  QType &operator=(const string &); //!< Assigns strings to us
-  QType &operator=(const QType&rhs)  //!< Assigns strings to us
-  {
-    code=rhs.code;
+    code = arg;
     return *this;
   }
-
-  bool operator<(const QType& rhs) const 
+  QType &operator=(const char *);
+  QType &operator=(const string &);
+  QType &operator=(const QType& rhs)
+  {
+    code = rhs.code;
+    return *this;
+  }
+  bool operator<(const QType rhs) const
   {
     return code < rhs.code;
   }
 
-  const string getName() const; //!< Get a string representation of this type
-  uint16_t getCode() const; //!< Get the integer representation of this type
-  bool isSupportedType();
-  bool isMetadataType();
+  operator uint16_t() const {
+    return code;
+  }
 
-  static int chartocode(const char *p); //!< convert a character string to a code
+  const string getName() const;
+  uint16_t getCode() const
+  {
+    return code;
+  }
+  bool isSupportedType() const;
+  bool isMetadataType() const;
+
+  static uint16_t chartocode(const char* p);
+  
   enum typeenum : uint16_t {
-    ENT=0,
-    A=1,
-    NS=2,
-    CNAME=5,
-    SOA=6,
-    MB=7,
-    MG=8,
-    MR=9,
-    PTR=12,
-    HINFO=13,
-    MINFO=14,
-    MX=15,
-    TXT=16,
-    RP=17,
-    AFSDB=18,
-    SIG=24,
-    KEY=25,
-    AAAA=28,
-    LOC=29,
-    SRV=33,
-    NAPTR=35,
-    KX=36,
-    CERT=37,
-    A6=38,
-    DNAME=39,
-    OPT=41,
-    APL=42,
-    DS=43,
-    SSHFP=44,
-    IPSECKEY=45,
-    RRSIG=46,
-    NSEC=47,
-    DNSKEY=48,
-    DHCID=49,
-    NSEC3=50,
-    NSEC3PARAM=51,
-    TLSA=52,
-    SMIMEA=53,
-    RKEY=57,
-    CDS=59,
-    CDNSKEY=60,
-    OPENPGPKEY=61,
-    SVCB=64,
-    HTTPS=65,
-    SPF=99,
-    EUI48=108,
-    EUI64=109,
-    TKEY=249,
-    TSIG=250,
-    IXFR=251,
-    AXFR=252,
-    MAILB=253,
-    MAILA=254,
-    ANY=255,
-    URI=256,
-    CAA=257,
-    DLV=32769,
-    ADDR=65400,
-    ALIAS=65401,
-    LUA=65402
+    ENT = 0,
+    A = 1,
+    NS = 2,
+    CNAME = 5,
+    SOA = 6,
+    MB = 7,
+    MG = 8,
+    MR = 9,
+    PTR = 12,
+    HINFO = 13,
+    MINFO = 14,
+    MX = 15,
+    TXT = 16,
+    RP = 17,
+    AFSDB = 18,
+    SIG = 24,
+    KEY = 25,
+    AAAA = 28,
+    LOC = 29,
+    SRV = 33,
+    NAPTR = 35,
+    KX = 36,
+    CERT = 37,
+    A6 = 38,
+    DNAME = 39,
+    OPT = 41,
+    APL = 42,
+    DS = 43,
+    SSHFP = 44,
+    IPSECKEY = 45,
+    RRSIG = 46,
+    NSEC = 47,
+    DNSKEY = 48,
+    DHCID = 49,
+    NSEC3 = 50,
+    NSEC3PARAM = 51,
+    TLSA = 52,
+    SMIMEA = 53,
+    RKEY = 57,
+    CDS = 59,
+    CDNSKEY = 60,
+    OPENPGPKEY = 61,
+    SVCB = 64,
+    HTTPS = 65,
+    SPF = 99,
+    EUI48 = 108,
+    EUI64 = 109,
+    TKEY = 249,
+    TSIG = 250,
+    IXFR = 251,
+    AXFR = 252,
+    MAILB = 253,
+    MAILA = 254,
+    ANY = 255,
+    URI = 256,
+    CAA = 257,
+    DLV = 32769,
+    ADDR = 65400,
+    ALIAS = 65401,
+    LUA = 65402
   };
 
-  QType(typeenum orig) : code(orig)
-  {
-  }
-
-  typedef pair<string,uint16_t> namenum;
-  static vector<namenum> names;
-
-  inline bool operator==(const QType &comp) const {
-    return(comp.code==code);
-  }
-
-  inline bool operator!=(const QType &comp) const {
-    return(comp.code!=code);
-  }
-
-  inline bool operator==(QType::typeenum comp) const {
-    return(comp==code);
-  }
-
-  inline bool operator!=(QType::typeenum comp) const {
-    return(comp!=code);
-  }
-
-  inline bool operator==(uint16_t comp) const {
-    return(comp==code);
-  }
-
-  inline bool operator!=(uint16_t comp) const {
-    return(comp!=code);
-  }
+  typedef pair<string, uint16_t> namenum;
+  const static vector<namenum> names;
 
 private:
-  static class init {
-    public:
-    void qtype_insert(const char* a, uint16_t num) 
-    {
-      names.push_back(make_pair(string(a), num));
-    }
-
-    init()
-    {
-      qtype_insert("A", 1);
-      qtype_insert("NS", 2);
-      qtype_insert("CNAME", 5);
-      qtype_insert("SOA", 6);
-      qtype_insert("MB", 7);
-      qtype_insert("MG", 8);
-      qtype_insert("MR", 9);
-      qtype_insert("PTR", 12);
-      qtype_insert("HINFO", 13);
-      qtype_insert("MINFO", 14);
-      qtype_insert("MX", 15);
-      qtype_insert("TXT", 16);
-      qtype_insert("RP", 17);
-      qtype_insert("AFSDB", 18);
-      qtype_insert("SIG", 24);
-      qtype_insert("KEY", 25);
-      qtype_insert("AAAA", 28);
-      qtype_insert("LOC", 29);
-      qtype_insert("SRV", 33);
-      qtype_insert("NAPTR", 35);
-      qtype_insert("KX", 36);
-      qtype_insert("CERT", 37);
-      qtype_insert("A6", 38);
-      qtype_insert("DNAME", 39);
-      qtype_insert("OPT", 41);
-      qtype_insert("APL", 42);
-      qtype_insert("DS", 43);
-      qtype_insert("SSHFP", 44);
-      qtype_insert("IPSECKEY", 45);
-      qtype_insert("RRSIG", 46);
-      qtype_insert("NSEC", 47);
-      qtype_insert("DNSKEY", 48);
-      qtype_insert("DHCID", 49);
-      qtype_insert("NSEC3", 50);
-      qtype_insert("NSEC3PARAM", 51);
-      qtype_insert("TLSA", 52);
-      qtype_insert("SMIMEA", 53);
-      qtype_insert("RKEY", 57);
-      qtype_insert("CDS", 59);
-      qtype_insert("CDNSKEY", 60);
-      qtype_insert("OPENPGPKEY", 61);
-      qtype_insert("SVCB", 64);
-      qtype_insert("HTTPS", 65);
-      qtype_insert("SPF", 99);
-      qtype_insert("EUI48", 108);
-      qtype_insert("EUI64", 109);
-      qtype_insert("TKEY", 249);
-//      qtype_insert("TSIG", 250);
-      qtype_insert("IXFR", 251);
-      qtype_insert("AXFR", 252);
-      qtype_insert("MAILB", 253);
-      qtype_insert("MAILA", 254);
-      qtype_insert("ANY", 255);
-      qtype_insert("URI", 256);
-      qtype_insert("CAA", 257);
-      qtype_insert("DLV", 32769);
-      qtype_insert("ADDR", 65400);
-      qtype_insert("ALIAS", 65401);
-      qtype_insert("LUA", 65402);
-    }
-  } initializer;
 
   uint16_t code;
 };
 
+// Define hash function on QType. See https://en.cppreference.com/w/cpp/utility/hash
+namespace std {
+  template<> struct hash<QType> {
+    std::size_t operator()(QType qtype) const noexcept {
+      return std::hash<uint16_t>{}(qtype.getCode());
+    }
+  };
+}
+
 struct QClass
 {
-  enum QClassEnum {IN=1, CHAOS=3, NONE=254, ANY=255};
+  enum QClassEnum { IN = 1, CHAOS = 3, NONE = 254, ANY = 255 };
 };

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -186,7 +186,7 @@ int SyncRes::beginResolve(const DNSName &qname, const QType qtype, uint16_t qcla
  * - trustanchor.server CH TXT
  * - negativetrustanchor.server CH TXT
  */
-bool SyncRes::doSpecialNamesResolve(const DNSName &qname, QType qtype, const uint16_t qclass, vector<DNSRecord> &ret)
+bool SyncRes::doSpecialNamesResolve(const DNSName &qname, const QType qtype, const uint16_t qclass, vector<DNSRecord> &ret)
 {
   static const DNSName arpa("1.0.0.127.in-addr.arpa."), ip6_arpa("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa."),
     localhost("localhost."), versionbind("version.bind."), idserver("id.server."), versionpdns("version.pdns."), trustanchorserver("trustanchor.server."),
@@ -292,7 +292,7 @@ void SyncRes::AuthDomain::addSOA(std::vector<DNSRecord>& records) const
   }
 }
 
-int SyncRes::AuthDomain::getRecords(const DNSName& qname, QType qtype, std::vector<DNSRecord>& records) const
+int SyncRes::AuthDomain::getRecords(const DNSName& qname, const QType qtype, std::vector<DNSRecord>& records) const
 {
   int result = RCode::NoError;
   records.clear();
@@ -381,16 +381,16 @@ int SyncRes::AuthDomain::getRecords(const DNSName& qname, QType qtype, std::vect
   return result;
 }
 
-bool SyncRes::doOOBResolve(const AuthDomain& domain, const DNSName &qname, QType qtype, vector<DNSRecord>&ret, int& res)
+bool SyncRes::doOOBResolve(const AuthDomain& domain, const DNSName &qname, const QType qtype, vector<DNSRecord>&ret, int& res)
 {
   d_authzonequeries++;
   s_authzonequeries++;
 
-  res = domain.getRecords(qname, qtype.getCode(), ret);
+  res = domain.getRecords(qname, qtype, ret);
   return true;
 }
 
-bool SyncRes::doOOBResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, int& res)
+bool SyncRes::doOOBResolve(const DNSName &qname, const QType qtype, vector<DNSRecord>&ret, unsigned int depth, int& res)
 {
   string prefix;
   if(doLog()) {
@@ -641,7 +641,7 @@ LWResult::Result SyncRes::asyncresolveWrapper(const ComboAddress& ip, bool ednsM
 
 #define QLOG(x) LOG(prefix << " child=" <<  child << ": " << x << endl)
 
-int SyncRes::doResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state) {
+int SyncRes::doResolve(const DNSName &qname, const QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state) {
 
   string prefix = d_prefix;
   prefix.append(depth, ' ');
@@ -818,7 +818,7 @@ int SyncRes::doResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret,
  * \param stopAtDelegation if non-nullptr and pointed-to value is Stop requests the callee to stop at a delegation, if so pointed-to value is set to Stopped
  * \return DNS RCODE or -1 (Error)
  */
-int SyncRes::doResolveNoQNameMinimization(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool *fromCache, StopAtDelegation *stopAtDelegation, bool considerforwards)
+int SyncRes::doResolveNoQNameMinimization(const DNSName &qname, const QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool *fromCache, StopAtDelegation *stopAtDelegation, bool considerforwards)
 {
   string prefix;
   if(doLog()) {
@@ -1157,7 +1157,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
   return ret;
 }
 
-void SyncRes::getBestNSFromCache(const DNSName &qname, QType qtype, vector<DNSRecord>& bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const boost::optional<DNSName>& cutOffDomain)
+void SyncRes::getBestNSFromCache(const DNSName &qname, const QType qtype, vector<DNSRecord>& bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const boost::optional<DNSName>& cutOffDomain)
 {
   string prefix;
   DNSName subdomain(qname);
@@ -1269,7 +1269,7 @@ SyncRes::domainmap_t::const_iterator SyncRes::getBestAuthZone(DNSName* qname) co
 }
 
 /** doesn't actually do the work, leaves that to getBestNSFromCache */
-DNSName SyncRes::getBestNSNamesFromCache(const DNSName &qname, QType qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere)
+DNSName SyncRes::getBestNSNamesFromCache(const DNSName &qname, const QType qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere)
 {
   string prefix;
   if (doLog()) {
@@ -1342,7 +1342,7 @@ DNSName SyncRes::getBestNSNamesFromCache(const DNSName &qname, QType qtype, NsSe
   return nsFromCacheDomain;
 }
 
-void SyncRes::updateValidationStatusInCache(const DNSName &qname, const QType& qt, bool aa, vState newState) const
+void SyncRes::updateValidationStatusInCache(const DNSName &qname, const QType qt, bool aa, vState newState) const
 {
   if (qt == QType::ANY || qt == QType::ADDR) {
     // not doing that
@@ -1369,7 +1369,7 @@ static bool scanForCNAMELoop(const DNSName& name, const vector<DNSRecord>& recor
   return false;
 }
 
-bool SyncRes::doCNAMECacheCheck(const DNSName &qname, QType qtype, vector<DNSRecord>& ret, unsigned int depth, int &res, vState& state, bool wasAuthZone, bool wasForwardRecurse)
+bool SyncRes::doCNAMECacheCheck(const DNSName &qname, const QType qtype, vector<DNSRecord>& ret, unsigned int depth, int &res, vState& state, bool wasAuthZone, bool wasForwardRecurse)
 {
   string prefix;
   if(doLog()) {
@@ -1640,7 +1640,7 @@ static void addTTLModifiedRecords(vector<DNSRecord>& records, const uint32_t ttl
   }
 }
 
-void SyncRes::computeNegCacheValidationStatus(const NegCache::NegCacheEntry& ne, const DNSName& qname, const QType& qtype, const int res, vState& state, unsigned int depth)
+void SyncRes::computeNegCacheValidationStatus(const NegCache::NegCacheEntry& ne, const DNSName& qname, const QType qtype, const int res, vState& state, unsigned int depth)
 {
   DNSName subdomain(qname);
   /* if we are retrieving a DS, we only care about the state of the parent zone */
@@ -2081,7 +2081,7 @@ static void addNXNSECS(vector<DNSRecord>&ret, const vector<DNSRecord>& records)
   ret.insert(ret.end(), ne.DNSSECRecords.signatures.begin(), ne.DNSSECRecords.signatures.end());
 }
 
-static bool rpzHitShouldReplaceContent(const DNSName& qname, const QType& qtype, const std::vector<DNSRecord>& records)
+static bool rpzHitShouldReplaceContent(const DNSName& qname, const QType qtype, const std::vector<DNSRecord>& records)
 {
   if (qtype == QType::CNAME) {
     return true;
@@ -2104,7 +2104,7 @@ static bool rpzHitShouldReplaceContent(const DNSName& qname, const QType& qtype,
   return true;
 }
 
-static void removeConflictingRecord(std::vector<DNSRecord>& records, const DNSName& name, QType dtype)
+static void removeConflictingRecord(std::vector<DNSRecord>& records, const DNSName& name, const QType dtype)
 {
   for (auto it = records.begin(); it != records.end(); ) {
     bool remove = false;
@@ -2134,7 +2134,7 @@ static void removeConflictingRecord(std::vector<DNSRecord>& records, const DNSNa
   }
 }
 
-void SyncRes::handlePolicyHit(const std::string& prefix, const DNSName& qname, const QType& qtype, std::vector<DNSRecord>& ret, bool& done, int& rcode, unsigned int depth)
+void SyncRes::handlePolicyHit(const std::string& prefix, const DNSName& qname, const QType qtype, std::vector<DNSRecord>& ret, bool& done, int& rcode, unsigned int depth)
 {
   if (d_pdl && d_pdl->policyHitEventFilter(d_requestor, qname, qtype, d_queryReceivedOverTCP, d_appliedPolicy, d_policyTags, d_discardedPolicies)) {
     /* reset to no match */
@@ -2287,7 +2287,7 @@ vector<ComboAddress> SyncRes::retrieveAddressesForNS(const std::string& prefix, 
   return result;
 }
 
-bool SyncRes::throttledOrBlocked(const std::string& prefix, const ComboAddress& remoteIP, const DNSName& qname, const QType& qtype, bool pierceDontQuery)
+bool SyncRes::throttledOrBlocked(const std::string& prefix, const ComboAddress& remoteIP, const DNSName& qname, const QType qtype, bool pierceDontQuery)
 {
   if(t_sstorage.throttle.shouldThrottle(d_now.tv_sec, boost::make_tuple(remoteIP, "", 0))) {
     LOG(prefix<<qname<<": server throttled "<<endl);
@@ -2746,7 +2746,7 @@ vState SyncRes::getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int 
   return vState::BogusUnableToGetDNSKEYs;
 }
 
-vState SyncRes::validateRecordsWithSigs(unsigned int depth, const DNSName& qname, const QType& qtype, const DNSName& name, const QType& type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures)
+vState SyncRes::validateRecordsWithSigs(unsigned int depth, const DNSName& qname, const QType qtype, const DNSName& name, const QType type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures)
 {
   skeyset_t keys;
   if (!signatures.empty()) {
@@ -2818,7 +2818,7 @@ static bool allowAdditionalEntry(std::unordered_set<DNSName>& allowedAdditionals
   }
 }
 
-void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DNSName& qname, const QType& qtype, const DNSName& auth, bool wasForwarded, bool rdQuery)
+void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DNSName& qname, const QType qtype, const DNSName& auth, bool wasForwarded, bool rdQuery)
 {
   const bool wasForwardRecurse = wasForwarded && rdQuery;
   /* list of names for which we will allow A and AAAA records in the additional section
@@ -2945,7 +2945,7 @@ void SyncRes::sanitizeRecords(const std::string& prefix, LWResult& lwr, const DN
   }
 }
 
-RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, const DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, vState& state, bool& needWildcardProof, bool& gatherWildcardProof, unsigned int& wildcardLabelsCount, bool rdQuery, const ComboAddress& remoteIP)
+RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType qtype, const DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, vState& state, bool& needWildcardProof, bool& gatherWildcardProof, unsigned int& wildcardLabelsCount, bool rdQuery, const ComboAddress& remoteIP)
 {
   bool wasForwardRecurse = wasForwarded && rdQuery;
   tcache_t tcache;
@@ -3330,7 +3330,7 @@ dState SyncRes::getDenialValidationState(const NegCache::NegCacheEntry& ne, cons
   return getDenial(csp, ne.d_name, ne.d_qtype.getCode(), referralToUnsigned, expectedState == dState::NXQTYPE);
 }
 
-bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, const QType& qtype, const DNSName& auth, LWResult& lwr, const bool sendRDQuery, vector<DNSRecord>& ret, set<DNSName>& nsset, DNSName& newtarget, DNSName& newauth, bool& realreferral, bool& negindic, vState& state, const bool needWildcardProof, const bool gatherWildcardProof, const unsigned int wildcardLabelsCount, int& rcode, unsigned int depth)
+bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, const QType qtype, const DNSName& auth, LWResult& lwr, const bool sendRDQuery, vector<DNSRecord>& ret, set<DNSName>& nsset, DNSName& newtarget, DNSName& newauth, bool& realreferral, bool& negindic, vState& state, const bool needWildcardProof, const bool gatherWildcardProof, const unsigned int wildcardLabelsCount, int& rcode, unsigned int depth)
 {
   bool done = false;
   DNSName dnameTarget, dnameOwner;
@@ -3600,7 +3600,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
   return done;
 }
 
-bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType& qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool& truncated, bool& spoofed)
+bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool& truncated, bool& spoofed)
 {
   bool chained = false;
   LWResult::Result resolveret = LWResult::Result::Success;
@@ -3779,7 +3779,7 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
   return true;
 }
 
-void SyncRes::handleNewTarget(const std::string& prefix, const DNSName& qname, const DNSName& newtarget, QType qtype, std::vector<DNSRecord>& ret, int& rcode, int depth, const std::vector<DNSRecord>& recordsFromAnswer, vState& state)
+void SyncRes::handleNewTarget(const std::string& prefix, const DNSName& qname, const DNSName& newtarget, const QType qtype, std::vector<DNSRecord>& ret, int& rcode, int depth, const std::vector<DNSRecord>& recordsFromAnswer, vState& state)
 {
   if (newtarget == qname) {
     LOG(prefix<<qname<<": status=got a CNAME referral to self, returning SERVFAIL"<<endl);
@@ -3832,7 +3832,7 @@ void SyncRes::handleNewTarget(const std::string& prefix, const DNSName& qname, c
   updateValidationState(state, cnameState);
 }
 
-bool SyncRes::processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state, const ComboAddress& remoteIP)
+bool SyncRes::processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state, const ComboAddress& remoteIP)
 {
   string prefix;
   if(doLog()) {
@@ -3951,7 +3951,7 @@ bool SyncRes::processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qn
  *  -1 in case of no results
  *  rcode otherwise
  */
-int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, QType qtype,
+int SyncRes::doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, const QType qtype,
                          vector<DNSRecord>&ret,
                          unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation)
 {
@@ -4217,7 +4217,7 @@ void SyncRes::parseEDNSSubnetAddFor(const std::string& subnetlist)
 }
 
 // used by PowerDNSLua - note that this neglects to add the packet count & statistics back to pdns_ercursor.cc
-int directResolve(const DNSName& qname, const QType& qtype, int qclass, vector<DNSRecord>& ret)
+int directResolve(const DNSName& qname, const QType qtype, int qclass, vector<DNSRecord>& ret)
 {
   struct timeval now;
   gettimeofday(&now, 0);

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -345,7 +345,7 @@ public:
     DNSName d_name;
     bool d_rdForward{false};
 
-    int getRecords(const DNSName& qname, uint16_t qtype, std::vector<DNSRecord>& records) const;
+    int getRecords(const DNSName& qname, QType qtype, std::vector<DNSRecord>& records) const;
     bool isAuth() const
     {
       return d_servers.empty();
@@ -585,7 +585,7 @@ public:
 
   explicit SyncRes(const struct timeval& now);
 
-  int beginResolve(const DNSName &qname, const QType &qtype, uint16_t qclass, vector<DNSRecord>&ret, unsigned int depth = 0);
+  int beginResolve(const DNSName &qname, QType qtype, uint16_t qclass, vector<DNSRecord>&ret, unsigned int depth = 0);
 
   void setId(int id)
   {
@@ -793,7 +793,7 @@ private:
   static EDNSSubnetOpts s_ecsScopeZero;
   static LogMode s_lm;
   static std::unique_ptr<NetmaskGroup> s_dontQuery;
-  const static std::unordered_set<uint16_t> s_redirectionQTypes;
+  const static std::unordered_set<QType> s_redirectionQTypes;
 
   struct GetBestNSAnswer
   {
@@ -810,21 +810,21 @@ private:
   typedef std::map<DNSName,vState> zonesStates_t;
   enum StopAtDelegation { DontStop, Stop, Stopped };
 
-  int doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret,
+  int doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, QType qtype, vector<DNSRecord>&ret,
                   unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation);
   bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType& qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool& truncated, bool& spoofed);
   bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state, const ComboAddress& remoteIP);
 
-  int doResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state);
-  int doResolveNoQNameMinimization(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool* fromCache = NULL, StopAtDelegation* stopAtDelegation = NULL, bool considerforwards = true);
-  bool doOOBResolve(const AuthDomain& domain, const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, int& res);
-  bool doOOBResolve(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res);
+  int doResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state);
+  int doResolveNoQNameMinimization(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool* fromCache = NULL, StopAtDelegation* stopAtDelegation = NULL, bool considerforwards = true);
+  bool doOOBResolve(const AuthDomain& domain, const DNSName &qname, QType qtype, vector<DNSRecord>&ret, int& res);
+  bool doOOBResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, int &res);
   bool isRecursiveForwardOrAuth(const DNSName &qname) const;
   domainmap_t::const_iterator getBestAuthZone(DNSName* qname) const;
-  bool doCNAMECacheCheck(const DNSName &qname, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state, bool wasAuthZone, bool wasForwardRecurse);
-  bool doCacheCheck(const DNSName &qname, const DNSName& authname, bool wasForwardedOrAuthZone, bool wasAuthZone, bool wasForwardRecurse, const QType &qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state);
-  void getBestNSFromCache(const DNSName &qname, const QType &qtype, vector<DNSRecord>&bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const boost::optional<DNSName>& cutOffDomain = boost::none);
-  DNSName getBestNSNamesFromCache(const DNSName &qname, const QType &qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere);
+  bool doCNAMECacheCheck(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state, bool wasAuthZone, bool wasForwardRecurse);
+  bool doCacheCheck(const DNSName &qname, const DNSName& authname, bool wasForwardedOrAuthZone, bool wasAuthZone, bool wasForwardRecurse, QType qtype, vector<DNSRecord>&ret, unsigned int depth, int &res, vState& state);
+  void getBestNSFromCache(const DNSName &qname, QType qtype, vector<DNSRecord>&bestns, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>& beenthere, const boost::optional<DNSName>& cutOffDomain = boost::none);
+  DNSName getBestNSNamesFromCache(const DNSName &qname, QType qtype, NsSet& nsset, bool* flawedNSSet, unsigned int depth, set<GetBestNSAnswer>&beenthere);
 
   inline vector<std::pair<DNSName, float>> shuffleInSpeedOrder(NsSet &nameservers, const string &prefix);
   inline vector<ComboAddress> shuffleForwardSpeed(const vector<ComboAddress> &rnameservers, const string &prefix, const bool wasRd);
@@ -841,7 +841,7 @@ private:
   RCode::rcodes_ updateCacheFromRecords(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, const DNSName& auth, bool wasForwarded, const boost::optional<Netmask>, vState& state, bool& needWildcardProof, bool& gatherWildcardProof, unsigned int& wildcardLabelsCount, bool sendRDQuery, const ComboAddress& remoteIP);
   bool processRecords(const std::string& prefix, const DNSName& qname, const QType& qtype, const DNSName& auth, LWResult& lwr, const bool sendRDQuery, vector<DNSRecord>& ret, set<DNSName>& nsset, DNSName& newtarget, DNSName& newauth, bool& realreferral, bool& negindic, vState& state, const bool needWildcardProof, const bool gatherwildcardProof, const unsigned int wildcardLabelsCount, int& rcode, unsigned int depth);
 
-  bool doSpecialNamesResolve(const DNSName &qname, const QType &qtype, const uint16_t qclass, vector<DNSRecord> &ret);
+  bool doSpecialNamesResolve(const DNSName &qname, QType qtype, const uint16_t qclass, vector<DNSRecord> &ret);
 
   LWResult::Result asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, const DNSName& auth, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res, bool* chained) const;
 
@@ -864,7 +864,7 @@ private:
   bool lookForCut(const DNSName& qname, unsigned int depth, const vState existingState, vState& newState);
   void computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned int depth);
 
-  void handleNewTarget(const std::string& prefix, const DNSName& qname, const DNSName& newtarget, uint16_t qtype, std::vector<DNSRecord>& ret, int& rcode, int depth, const std::vector<DNSRecord>& recordsFromAnswer, vState& state);
+  void handleNewTarget(const std::string& prefix, const DNSName& qname, const DNSName& newtarget, QType qtype, std::vector<DNSRecord>& ret, int& rcode, int depth, const std::vector<DNSRecord>& recordsFromAnswer, vState& state);
 
   void handlePolicyHit(const std::string& prefix, const DNSName& qname, const QType& qtype, vector<DNSRecord>& ret, bool& done, int& rcode, unsigned int depth);
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -812,8 +812,8 @@ private:
 
   int doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, QType qtype, vector<DNSRecord>&ret,
                   unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation);
-  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType& qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool& truncated, bool& spoofed);
-  bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state, const ComboAddress& remoteIP);
+  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool& truncated, bool& spoofed);
+  bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state, const ComboAddress& remoteIP);
 
   int doResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state);
   int doResolveNoQNameMinimization(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool* fromCache = NULL, StopAtDelegation* stopAtDelegation = NULL, bool considerforwards = true);
@@ -833,13 +833,13 @@ private:
 
   bool nameserversBlockedByRPZ(const DNSFilterEngine& dfe, const NsSet& nameservers);
   bool nameserverIPBlockedByRPZ(const DNSFilterEngine& dfe, const ComboAddress&);
-  bool throttledOrBlocked(const std::string& prefix, const ComboAddress& remoteIP, const DNSName& qname, const QType& qtype, bool pierceDontQuery);
+  bool throttledOrBlocked(const std::string& prefix, const ComboAddress& remoteIP, const DNSName& qname, QType qtype, bool pierceDontQuery);
 
   vector<ComboAddress> retrieveAddressesForNS(const std::string& prefix, const DNSName& qname, vector<std::pair<DNSName, float>>::const_iterator& tns, const unsigned int depth, set<GetBestNSAnswer>& beenthere, const vector<std::pair<DNSName, float>>& rnameservers, NsSet& nameservers, bool& sendRDQuery, bool& pierceDontQuery, bool& flawedNSSet, bool cacheOnly, unsigned int& addressQueriesForNS);
 
-  void sanitizeRecords(const std::string& prefix, LWResult& lwr, const DNSName& qname, const QType& qtype, const DNSName& auth, bool wasForwarded, bool rdQuery);
-  RCode::rcodes_ updateCacheFromRecords(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType& qtype, const DNSName& auth, bool wasForwarded, const boost::optional<Netmask>, vState& state, bool& needWildcardProof, bool& gatherWildcardProof, unsigned int& wildcardLabelsCount, bool sendRDQuery, const ComboAddress& remoteIP);
-  bool processRecords(const std::string& prefix, const DNSName& qname, const QType& qtype, const DNSName& auth, LWResult& lwr, const bool sendRDQuery, vector<DNSRecord>& ret, set<DNSName>& nsset, DNSName& newtarget, DNSName& newauth, bool& realreferral, bool& negindic, vState& state, const bool needWildcardProof, const bool gatherwildcardProof, const unsigned int wildcardLabelsCount, int& rcode, unsigned int depth);
+  void sanitizeRecords(const std::string& prefix, LWResult& lwr, const DNSName& qname, const QType qtype, const DNSName& auth, bool wasForwarded, bool rdQuery);
+  RCode::rcodes_ updateCacheFromRecords(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType qtype, const DNSName& auth, bool wasForwarded, const boost::optional<Netmask>, vState& state, bool& needWildcardProof, bool& gatherWildcardProof, unsigned int& wildcardLabelsCount, bool sendRDQuery, const ComboAddress& remoteIP);
+  bool processRecords(const std::string& prefix, const DNSName& qname, const QType qtype, const DNSName& auth, LWResult& lwr, const bool sendRDQuery, vector<DNSRecord>& ret, set<DNSName>& nsset, DNSName& newtarget, DNSName& newauth, bool& realreferral, bool& negindic, vState& state, const bool needWildcardProof, const bool gatherwildcardProof, const unsigned int wildcardLabelsCount, int& rcode, unsigned int depth);
 
   bool doSpecialNamesResolve(const DNSName &qname, QType qtype, const uint16_t qclass, vector<DNSRecord> &ret);
 
@@ -850,23 +850,23 @@ private:
   bool validationEnabled() const;
   uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, uint32_t signaturesTTL, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs) const;
   void updateValidationState(vState& state, const vState stateUpdate);
-  vState validateRecordsWithSigs(unsigned int depth, const DNSName& qname, const QType& qtype, const DNSName& name, const QType& type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
+  vState validateRecordsWithSigs(unsigned int depth, const DNSName& qname, const QType qtype, const DNSName& name, const QType type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth);
   vState getDNSKeys(const DNSName& signer, skeyset_t& keys, unsigned int depth);
   dState getDenialValidationState(const NegCache::NegCacheEntry& ne, const vState state, const dState expectedState, bool referralToUnsigned);
   void updateDenialValidationState(vState& neValidationState, const DNSName& neName, vState& state, const dState denialState, const dState expectedState, bool allowOptOut);
-  void computeNegCacheValidationStatus(const NegCache::NegCacheEntry& ne, const DNSName& qname, const QType& qtype, const int res, vState& state, unsigned int depth);
+  void computeNegCacheValidationStatus(const NegCache::NegCacheEntry& ne, const DNSName& qname, QType qtype, const int res, vState& state, unsigned int depth);
   vState getTA(const DNSName& zone, dsmap_t& ds);
   bool haveExactValidationStatus(const DNSName& domain);
   vState getValidationStatus(const DNSName& subdomain, bool allowIndeterminate=true);
-  void updateValidationStatusInCache(const DNSName &qname, const QType& qt, bool aa, vState newState) const;
+  void updateValidationStatusInCache(const DNSName &qname, QType qt, bool aa, vState newState) const;
 
   bool lookForCut(const DNSName& qname, unsigned int depth, const vState existingState, vState& newState);
   void computeZoneCuts(const DNSName& begin, const DNSName& end, unsigned int depth);
 
   void handleNewTarget(const std::string& prefix, const DNSName& qname, const DNSName& newtarget, QType qtype, std::vector<DNSRecord>& ret, int& rcode, int depth, const std::vector<DNSRecord>& recordsFromAnswer, vState& state);
 
-  void handlePolicyHit(const std::string& prefix, const DNSName& qname, const QType& qtype, vector<DNSRecord>& ret, bool& done, int& rcode, unsigned int depth);
+  void handlePolicyHit(const std::string& prefix, const DNSName& qname, QType qtype, vector<DNSRecord>& ret, bool& done, int& rcode, unsigned int depth);
 
   void setUpdatingRootNS()
   {
@@ -1093,8 +1093,8 @@ typedef boost::function<void*(void)> pipefunc_t;
 void broadcastFunction(const pipefunc_t& func);
 void distributeAsyncFunction(const std::string& question, const pipefunc_t& func);
 
-int directResolve(const DNSName& qname, const QType& qtype, int qclass, vector<DNSRecord>& ret);
-int followCNAMERecords(std::vector<DNSRecord>& ret, const QType& qtype, int oldret);
+int directResolve(const DNSName& qname, const QType qtype, int qclass, vector<DNSRecord>& ret);
+int followCNAMERecords(std::vector<DNSRecord>& ret, const QType qtype, int oldret);
 int getFakeAAAARecords(const DNSName& qname, ComboAddress prefix, vector<DNSRecord>& ret);
 int getFakePTRRecords(const DNSName& qname, vector<DNSRecord>& ret);
 


### PR DESCRIPTION
I converted syncres.* for starters to stop using uint16_t for qtype
and use QType everywhere.  Note that I also changed const QType&
in arg lists by QType, since it makes little sense to pass a 16 bit value
by const reference.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
