### PR TITLE
dnsdist: add ability to set ACL from a file

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -511,6 +511,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "roundrobin", false, "", "Simple round robin over available servers" },
   { "sendCustomTrap", true, "str", "send a custom `SNMP` trap from Lua, containing the `str` string"},
   { "setACL", true, "{netmask, netmask}", "replace the ACL set with these netmasks. Use `setACL({})` to reset the list, meaning no one can use us" },
+  { "setACLFromFile", true, "file", "replace the ACL set with netmasks in this file" },
   { "setAddEDNSToSelfGeneratedResponses", true, "add", "set whether to add EDNS to self-generated responses, provided that the initial query had EDNS" },
   { "setAllowEmptyResponse", true, "allow", "Set to true (defaults to false) to allow empty responses (qdcount=0) with a NoError or NXDomain rcode (default) from backends" },
   { "setAPIWritable", true, "bool, dir", "allow modifications via the API. if `dir` is set, it must be a valid directory where the configuration files will be written by the API" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -675,6 +675,31 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       g_ACL.setState(nmg);
   });
 
+  luaCtx.writeFunction("setACLFromFile", [](const std::string& file) {
+      setLuaSideEffect();
+      NetmaskGroup nmg;
+
+      ifstream ifs(file);
+      if(!ifs) {
+        throw std::runtime_error("Could not open '"+file+"': "+stringerror());
+      }
+
+      string::size_type pos;
+      string line;
+      while(getline(ifs,line)) {
+        pos=line.find('#');
+        if(pos!=string::npos)
+          line.resize(pos);
+        boost::trim(line);
+        if(line.empty())
+          continue;
+
+        nmg.addMask(line);
+      }
+
+      g_ACL.setState(nmg);
+  });
+
   luaCtx.writeFunction("showACL", []() {
       setLuaNoSideEffect();
       vector<string> vec;

--- a/pdns/dnsdistdist/docs/advanced/acl.rst
+++ b/pdns/dnsdistdist/docs/advanced/acl.rst
@@ -66,3 +66,9 @@ dnsdist also has the :func:`setACL` function that accepts a list of netmasks and
 
   setACL({'192.0.2.0/25', '2001:db8:15::bea/64'})
 
+
+To set the ACL from a file containing a list of netmasks, use :func:`setACLFromFile`:
+
+.. code-block:: lua
+  setACLFromFile('/etc/dnsdist/query.acl')
+

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -420,6 +420,14 @@ Access Control Lists
 
   :param {str} netmasks: A table of CIDR netmask, e.g. ``{"192.0.2.0/24", "2001:DB8:14::/56"}``. Without a subnetmask, only the specific address is allowed.
 
+.. function:: setACLFromFile(fname)
+
+  .. versionadded:: 1.6.0
+
+  Reset the ACL to the list of netmasks from the given file. See :ref:`ACL` for more information.
+
+  :param str fname: The path to a file containing a list of netmasks. Empty lines or lines starting with "#" are ignored.
+
 .. function:: showACL()
 
   Print a list of all netmasks allowed to send queries over UDP, TCP, DNS over TLS and DNS over HTTPS. See :ref:`ACL` for more information.


### PR DESCRIPTION
### Short description
Adds the ability to set (and reload) the dnsdist ACL from a file. File is parsed in exactly the same way as in recursor, and also errors in the file leave the previous ACL untouched.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
