### PR TITLE
GeoIpBackend add ISP support

### DIFF
--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -208,6 +208,9 @@ Following placeholders are supported, and support subnet caching with EDNS:
 :%loc: LOC record style expansion of location
 :%lat: Decimal degree latitude
 :%lon: Decimal degree longitude
+:%isp: ISP name
+:%org: ISP Organization
+:%nsp: ISP name with underscore (_ no spaces)
 
 These placeholders disable caching for the record completely:
 

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -516,6 +516,14 @@ static string queryGeoIP(const Netmask& addr, GeoIPInterface::GeoIPQueryAttribut
       if (addr.isIPv6()) found = gi->queryNameV6(val, gl, ip);
       else found = gi->queryName(val, gl, ip);
       break;
+    case GeoIPInterface::ISP:
+      if (addr.isIPv6()) found = gi->queryISPV6(val, gl, ip);
+      else found = gi->queryISP(val, gl, ip);
+      break;
+    case GeoIPInterface::Org:
+      if (addr.isIPv6()) found = gi->queryOrgV6(val, gl, ip);
+      else found = gi->queryOrg(val, gl, ip);
+      break;
     case GeoIPInterface::Continent:
       if (addr.isIPv6()) found = gi->queryContinentV6(val, gl, ip);
       else found = gi->queryContinent(val, gl, ip);

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -629,6 +629,20 @@ string GeoIPBackend::format2str(string sformat, const Netmask& addr, GeoIPNetmas
       rep = queryGeoIP(addr, GeoIPInterface::Name, tmp_gl);
     } else if (!sformat.compare(cur,3,"%ci")) {
       rep = queryGeoIP(addr, GeoIPInterface::City, tmp_gl);
+    } else if (!sformat.compare(cur,4,"%nsp")) {
+      rep = queryGeoIP(addr, GeoIPInterface::ISP, tmp_gl);
+      for (long unsigned int i = 0; i < rep.length(); i++) {
+        if (rep[i] == ' ') {
+          rep[i] = '_';
+        }
+      }
+      nrep = 4;
+    } else if (!sformat.compare(cur,4,"%isp")) {
+      rep = queryGeoIP(addr, GeoIPInterface::ISP, tmp_gl);
+      nrep = 4;
+    } else if (!sformat.compare(cur,4,"%org")) {
+      rep = queryGeoIP(addr, GeoIPInterface::Org, tmp_gl);
+      nrep = 4;
     } else if (!sformat.compare(cur,4,"%loc")) {
       char ns, ew;
       int d1, d2, m1, m2;

--- a/modules/geoipbackend/geoipinterface-dat.cc
+++ b/modules/geoipbackend/geoipinterface-dat.cc
@@ -348,6 +348,80 @@ public:
     return false;
   }
 
+  bool queryISP(string &ret, GeoIPNetmask& gl, const string &ip) override {
+    GeoIPLookup tmp_gl = {
+      .netmask = gl.netmask,
+    };
+    if (d_db_type == GEOIP_ISP_EDITION) {
+      char* result = GeoIP_name_by_addr_gl(d_gi.get(), ip.c_str(), &tmp_gl);
+      if (result != nullptr) {
+        ret = result;
+        free(result);
+        gl.netmask = tmp_gl.netmask;
+        // reduce space to dash
+        ret = boost::replace_all_copy(ret, " ", "-");
+        return true;
+      }
+
+    }
+    return false;
+  }
+
+  bool queryISPV6(string &ret, GeoIPNetmask& gl, const string &ip) override {
+    GeoIPLookup tmp_gl = {
+      .netmask = gl.netmask,
+    };
+    if (d_db_type == GEOIP_ISP_EDITION_V6) {
+      char* result = GeoIP_name_by_addr_v6_gl(d_gi.get(), ip.c_str(), &tmp_gl);
+      if (result != nullptr) {
+        ret = result;
+        free(result);
+        gl.netmask = tmp_gl.netmask;
+        // reduce space to dash
+        ret = boost::replace_all_copy(ret, " ", "-");
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool queryOrg(string &ret, GeoIPNetmask& gl, const string &ip) override {
+    GeoIPLookup tmp_gl = {
+      .netmask = gl.netmask,
+    };
+    if (d_db_type == GEOIP_ORG_EDITION) {
+      char* result = GeoIP_name_by_addr_gl(d_gi.get(), ip.c_str(), &tmp_gl);
+      if (result != nullptr) {
+        ret = result;
+        free(result);
+        gl.netmask = tmp_gl.netmask;
+        // reduce space to dash
+        ret = boost::replace_all_copy(ret, " ", "-");
+        return true;
+      }
+
+    }
+    return false;
+  }
+
+  bool queryOrgV6(string &ret, GeoIPNetmask& gl, const string &ip) override {
+    GeoIPLookup tmp_gl = {
+      .netmask = gl.netmask,
+    };
+    if (d_db_type == GEOIP_ORG_EDITION_V6) {
+      char* result = GeoIP_name_by_addr_v6_gl(d_gi.get(), ip.c_str(), &tmp_gl);
+      if (result != nullptr) {
+        ret = result;
+        free(result);
+        gl.netmask = tmp_gl.netmask;
+        // reduce space to dash
+        ret = boost::replace_all_copy(ret, " ", "-");
+        return true;
+      }
+    }
+    return false;
+  }
+
   bool queryRegion(string &ret, GeoIPNetmask& gl, const string &ip) override {
     GeoIPLookup tmp_gl = {
       .netmask = gl.netmask,

--- a/modules/geoipbackend/geoipinterface-mmdb.cc
+++ b/modules/geoipbackend/geoipinterface-mmdb.cc
@@ -148,6 +148,50 @@ public:
     return true;
   }
 
+    bool queryISP(string &ret, GeoIPNetmask& gl, const string &ip) override {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, false, gl, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "isp", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    ret = string(data.utf8_string, data.data_size);
+    return true;
+  }
+
+  bool queryISPV6(string &ret, GeoIPNetmask& gl, const string &ip) override {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, true, gl, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "isp", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    ret = string(data.utf8_string, data.data_size);
+    return true;
+  }
+
+  bool queryOrg(string &ret, GeoIPNetmask& gl, const string &ip) override {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, false, gl, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "organization", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    ret = string(data.utf8_string, data.data_size);
+    return true;
+  }
+
+  bool queryOrgV6(string &ret, GeoIPNetmask& gl, const string &ip) override {
+    MMDB_entry_data_s data;
+    MMDB_lookup_result_s res;
+    if (!mmdbLookup(ip, true, gl, res))
+      return false;
+    if (MMDB_get_value(&res.entry, &data, "organization", NULL) != MMDB_SUCCESS || !data.has_data)
+      return false;
+    ret = string(data.utf8_string, data.data_size);
+    return true;
+  }
+
   bool queryRegion(string &ret, GeoIPNetmask& gl, const string &ip) override {
     MMDB_entry_data_s data;
     MMDB_lookup_result_s res;

--- a/modules/geoipbackend/geoipinterface.hh
+++ b/modules/geoipbackend/geoipinterface.hh
@@ -34,7 +34,9 @@ public:
     Country2,
     Name,
     Region,
-    Location
+    Location,
+    ISP,
+    Org
   };
 
   virtual bool queryCountry(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
@@ -47,6 +49,10 @@ public:
   virtual bool queryNameV6(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
   virtual bool queryASnum(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
   virtual bool queryASnumV6(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
+  virtual bool queryISP(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
+  virtual bool queryISPV6(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
+  virtual bool queryOrg(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
+  virtual bool queryOrgV6(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
   virtual bool queryRegion(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
   virtual bool queryRegionV6(string &ret, GeoIPNetmask& gl, const string &ip) = 0;
   virtual bool queryCity(string &ret, GeoIPNetmask& gl, const string &ip) = 0;


### PR DESCRIPTION
### Short description
GeoIp2 ISP db also support ISP name and organization, this is very useful to return specific address so users can access the services thru the best ISP link.

### Checklist
I have:
- [ X ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ X ] compiled this code
- [ X ] tested this code
- [ X ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

