### PR TITLE
UUID: Use the non-cryptographic variant of the boost::uuid

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -891,7 +891,8 @@ speedtest_SOURCES = \
 	speedtest.cc \
 	statbag.cc \
 	svc-records.cc svc-records.hh \
-	unix_utility.cc
+        unix_utility.cc \
+        uuid-utils.cc
 
 speedtest_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
 speedtest_LDADD = $(LIBCRYPTO_LIBS) \

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -8,6 +8,7 @@
 #include "dnsrecords.hh"
 #include "iputils.hh"
 #include <fstream>
+#include "uuid-utils.hh"
 
 #ifndef RECURSOR
 #include "statbag.hh"
@@ -833,6 +834,15 @@ struct NetmaskTreeTest
   }
 };
 
+struct UUIDGenTest
+{
+  string getName() const { return "UUIDGenTest"; }
+
+  void operator()() const {
+    getUniqueID();
+  }
+};
+
 int main(int argc, char** argv)
 try
 {
@@ -917,6 +927,8 @@ try
   doRun(DNSNameRootTest());
 
   doRun(NetmaskTreeTest());
+
+  doRun(UUIDGenTest());
 
 #ifndef RECURSOR
   S.doRings();

--- a/pdns/uuid-utils.cc
+++ b/pdns/uuid-utils.cc
@@ -32,10 +32,15 @@
 
 #include <boost/uuid/uuid_generators.hpp>
 
-thread_local boost::uuids::random_generator t_uuidGenerator;
+// The default of:
+// boost::uuids::random_generator
+// is safe for crypto operations since 1.67.0, but much slower.
+thread_local boost::uuids::basic_random_generator<boost::random::mt19937> t_uuidGenerator;
 
 boost::uuids::uuid getUniqueID()
 {
+  // not safe for crypto, but it could be with Boost >= 1.67.0 by using boost::uuids::random_generator,
+  // which is slower
   return t_uuidGenerator();
 }
 

--- a/pdns/uuid-utils.hh
+++ b/pdns/uuid-utils.hh
@@ -24,5 +24,6 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+/* Not safe for crypto, see the definition for more information */
 boost::uuids::uuid getUniqueID();
 boost::uuids::uuid getUniqueID(const std::string& str);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since Boost 1.67.0 the default UUID generator is cryptographically strong, which is neat but quite slower. Since we don't need that, just use the fastest version.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
