### PR TITLE
rec: Use a short-lived NSEC3 hashes cache for denial validation

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -90,14 +90,15 @@ static std::string getHashFromNSEC3(const DNSName& qname, const std::shared_ptr<
     return result;
   }
 
-  auto it = cache.find({qname, nsec3->d_salt, nsec3->d_iterations});
+  auto key = std::make_tuple(qname, nsec3->d_salt, nsec3->d_iterations);
+  auto it = cache.find(key);
   if (it != cache.end())
   {
     return it->second;
   }
 
   result = hashQNameWithSalt(nsec3->d_salt, nsec3->d_iterations, qname);
-  cache[{qname, nsec3->d_salt, nsec3->d_iterations}] = result;
+  cache[key] = result;
   return result;
 }
 

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -80,7 +80,7 @@ static bool nsecProvesENT(const DNSName& name, const DNSName& begin, const DNSNa
   return begin.canonCompare(name) && next != name && next.isPartOf(name);
 }
 
-using nsec3HashesCache = std::map<std::tuple<DNSName, std::string&, uint16_t>, std::string>;
+using nsec3HashesCache = std::map<std::tuple<DNSName, std::string, uint16_t>, std::string>;
 
 static std::string getHashFromNSEC3(const DNSName& qname, const std::shared_ptr<NSEC3RecordContent>& nsec3, nsec3HashesCache& cache)
 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It turns out that computing those SHA1 hashes is far from cheap, and in almost all cases the salt and iterations are identical
so no need to compute them several times.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
