### PR TITLE
Return a unique_ptr instead of a shared one for DNSCryptoKeyEngine

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -176,7 +176,8 @@ DNSSECPrivateKey DNSSECKeeper::getKeyById(const DNSName& zname, unsigned int id)
     
     DNSSECPrivateKey dpk;
     DNSKEYRecordContent dkrc;
-    dpk.setKey(shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content)));
+    auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
+    dpk.setKey(key);
     dpk.d_flags = kd.flags;
     dpk.d_algorithm = dkrc.d_algorithm;
     
@@ -535,8 +536,8 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
   for(const DNSBackend::KeyData &keydata : dbkeyset) {
     DNSSECPrivateKey dpk;
     DNSKEYRecordContent dkrc;
-
-    dpk.setKey(shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, keydata.content)));
+    auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, keydata.content));
+    dpk.setKey(key);
 
     if(keydata.active) {
       if(keydata.flags == 257)
@@ -552,8 +553,8 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const DNSName& zone, bool useCache)
   {
     DNSSECPrivateKey dpk;
     DNSKEYRecordContent dkrc;
-
-    dpk.setKey(shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content)));
+    auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
+    dpk.setKey(key);
 
     dpk.d_flags = kd.flags;
     dpk.d_algorithm = dkrc.d_algorithm;
@@ -598,7 +599,7 @@ bool DNSSECKeeper::checkKeys(const DNSName& zone, vector<string>* errorMessages)
 
   for(const DNSBackend::KeyData &keydata : dbkeyset) {
     DNSKEYRecordContent dkrc;
-    shared_ptr<DNSCryptoKeyEngine> dke(DNSCryptoKeyEngine::makeFromISCString(dkrc, keydata.content));
+    auto dke = DNSCryptoKeyEngine::makeFromISCString(dkrc, keydata.content);
     retval = dke->checkKey(errorMessages) && retval;
   }
 

--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -29,9 +29,9 @@ public:
   void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) override
   {}
 
-  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
+  static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return std::make_shared<DecafED25519DNSCryptoKeyEngine>(algorithm);
+    return make_unique<DecafED25519DNSCryptoKeyEngine>(algorithm);
   }
 
 private:
@@ -165,9 +165,9 @@ public:
   void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) override
   {}
 
-  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
+  static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return std::make_shared<DecafED448DNSCryptoKeyEngine>(algorithm);
+    return make_unique<DecafED448DNSCryptoKeyEngine>(algorithm);
   }
 
 private:

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -69,15 +69,15 @@ class DNSCryptoKeyEngine
     {
       return true;
     }
-    static shared_ptr<DNSCryptoKeyEngine> makeFromISCFile(DNSKEYRecordContent& drc, const char* fname);
-    static shared_ptr<DNSCryptoKeyEngine> makeFromISCString(DNSKEYRecordContent& drc, const std::string& content);
-    static shared_ptr<DNSCryptoKeyEngine> makeFromPEMString(DNSKEYRecordContent& drc, const std::string& raw);
-    static shared_ptr<DNSCryptoKeyEngine> makeFromPublicKeyString(unsigned int algorithm, const std::string& raw);
-    static shared_ptr<DNSCryptoKeyEngine> make(unsigned int algorithm);
+    static std::unique_ptr<DNSCryptoKeyEngine> makeFromISCFile(DNSKEYRecordContent& drc, const char* fname);
+    static std::unique_ptr<DNSCryptoKeyEngine> makeFromISCString(DNSKEYRecordContent& drc, const std::string& content);
+    static std::unique_ptr<DNSCryptoKeyEngine> makeFromPEMString(DNSKEYRecordContent& drc, const std::string& raw);
+    static std::unique_ptr<DNSCryptoKeyEngine> makeFromPublicKeyString(unsigned int algorithm, const std::string& raw);
+    static std::unique_ptr<DNSCryptoKeyEngine> make(unsigned int algorithm);
     static bool isAlgorithmSupported(unsigned int algo);
     static bool isDigestSupported(uint8_t digest);
     
-    typedef shared_ptr<DNSCryptoKeyEngine> maker_t(unsigned int algorithm);
+    typedef std::unique_ptr<DNSCryptoKeyEngine> maker_t(unsigned int algorithm);
     
     static void report(unsigned int algorithm, maker_t* maker, bool fallback=false);
     static void testMakers(unsigned int algorithm, maker_t* creator, maker_t* signer, maker_t* verifier);
@@ -109,23 +109,30 @@ struct DNSSECPrivateKey
     return getDNSKEY().getTag();
   }
   
-  const shared_ptr<DNSCryptoKeyEngine> getKey() const
+  const std::shared_ptr<DNSCryptoKeyEngine>& getKey() const
   {
     return d_key;
   }
   
-  void setKey(const shared_ptr<DNSCryptoKeyEngine> key)
+  void setKey(std::shared_ptr<DNSCryptoKeyEngine>& key)
   {
     d_key = key;
-    d_algorithm = key->getAlgorithm();
+    d_algorithm = d_key->getAlgorithm();
   }
+
+  void setKey(std::unique_ptr<DNSCryptoKeyEngine>&& key)
+  {
+    d_key = std::move(key);
+    d_algorithm = d_key->getAlgorithm();
+  }
+
   DNSKEYRecordContent getDNSKEY() const;
 
   uint16_t d_flags;
   uint8_t d_algorithm;
 
 private:
-  shared_ptr<DNSCryptoKeyEngine> d_key;
+  std::shared_ptr<DNSCryptoKeyEngine> d_key;
 };
 
 

--- a/pdns/opensslsigners.cc
+++ b/pdns/opensslsigners.cc
@@ -199,9 +199,9 @@ public:
   void fromPublicKeyString(const std::string& content) override;
   bool checkKey(vector<string> *errorMessages) const override;
 
-  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
+  static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return std::make_shared<OpenSSLRSADNSCryptoKeyEngine>(algorithm);
+    return make_unique<OpenSSLRSADNSCryptoKeyEngine>(algorithm);
   }
 
 private:
@@ -598,9 +598,9 @@ public:
   void fromPublicKeyString(const std::string& content) override;
   bool checkKey(vector<string> *errorMessages) const override;
 
-  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
+  static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return std::make_shared<OpenSSLECDSADNSCryptoKeyEngine>(algorithm);
+    return make_unique<OpenSSLECDSADNSCryptoKeyEngine>(algorithm);
   }
 
 private:
@@ -883,9 +883,9 @@ public:
   void fromPublicKeyString(const std::string& content) override;
   bool checkKey(vector<string> *errorMessages) const override;
 
-  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
+  static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return std::make_shared<OpenSSLEDDSADNSCryptoKeyEngine>(algorithm);
+    return make_unique<OpenSSLEDDSADNSCryptoKeyEngine>(algorithm);
   }
 
 private:

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -282,9 +282,9 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, con
     vector<DNSBackend::KeyData> dbkeyset;
     B.getDomainKeys(zone, dbkeyset);
 
-    for(DNSBackend::KeyData& kd : dbkeyset) {
+    for (DNSBackend::KeyData& kd : dbkeyset) {
       DNSKEYRecordContent dkrc;
-      shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content));
+      DNSCryptoKeyEngine::makeFromISCString(dkrc, kd.content);
 
       if(dkrc.d_algorithm == DNSSECKeeper::RSASHA1) {
         cout<<"[Error] zone '"<<zone<<"' has NSEC3 semantics, but the "<< (kd.active ? "" : "in" ) <<"active key with id "<<kd.id<<" has 'Algorithm: 5'. This should be corrected to 'Algorithm: 7' in the database (or NSEC3 should be disabled)."<<endl;
@@ -1768,10 +1768,10 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
 
       int bits = -1;
       try {
-        std::shared_ptr<DNSCryptoKeyEngine> engine(DNSCryptoKeyEngine::makeFromPublicKeyString(key.d_algorithm, key.d_key)); // throws on unknown algo or bad key
+        auto engine = DNSCryptoKeyEngine::makeFromPublicKeyString(key.d_algorithm, key.d_key); // throws on unknown algo or bad key
         bits=engine->getBits();
       }
-      catch(std::exception& e) {
+      catch (const std::exception& e) {
         cerr<<"Could not process key to extract metadata: "<<e.what()<<endl;
       }
       if (!exportDS) {
@@ -3413,7 +3413,7 @@ try
         return 1;
       }
 
-      std::shared_ptr<DNSCryptoKeyEngine> dke = nullptr;
+      std::unique_ptr<DNSCryptoKeyEngine> dke = nullptr;
       // lookup correct key
       for(DNSBackend::KeyData &kd :  keys) {
         if (kd.id == id) {

--- a/pdns/pkcs11signers.cc
+++ b/pdns/pkcs11signers.cc
@@ -3,7 +3,6 @@
 #endif
 #include <boost/assign/std/vector.hpp> // for 'operator+=()'
 #include <boost/assign/list_of.hpp>
-#include <boost/make_shared.hpp>
 
 #include <boost/format.hpp>
 #include <p11-kit/p11-kit.h>
@@ -1025,9 +1024,9 @@ void PKCS11DNSCryptoKeyEngine::fromISCMap(DNSKEYRecordContent& drc, stormap_t& s
       throw PDNSException("Could not log in to token (PIN wrong?)");
 };
 
-std::shared_ptr<DNSCryptoKeyEngine> PKCS11DNSCryptoKeyEngine::maker(unsigned int algorithm)
+std::unique_ptr<DNSCryptoKeyEngine> PKCS11DNSCryptoKeyEngine::maker(unsigned int algorithm)
 {
-  return std::make_shared<PKCS11DNSCryptoKeyEngine>(algorithm);
+  return make_unique<PKCS11DNSCryptoKeyEngine>(algorithm);
 }
 
 // this is called during program startup

--- a/pdns/pkcs11signers.hh
+++ b/pdns/pkcs11signers.hh
@@ -62,7 +62,7 @@ class PKCS11DNSCryptoKeyEngine : public DNSCryptoKeyEngine
     void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) override { throw "Unimplemented"; };
     void fromPublicKeyString(const std::string& content) override { throw "Unimplemented"; };
 
-    static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm);
+    static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm);
 };
 
 bool PKCS11ModuleSlotLogin(const std::string& module, const string& tokenId, const std::string& pin);

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -256,7 +256,7 @@ void computeRRSIG(const DNSSECPrivateKey& dpk, const DNSName& signer, const DNSN
     now = time(nullptr);
   }
   DNSKEYRecordContent drc = dpk.getDNSKEY();
-  const std::shared_ptr<DNSCryptoKeyEngine> rc = dpk.getKey();
+  const auto& rc = dpk.getKey();
 
   rrc.d_type = signQType;
   rrc.d_labels = signQName.countLabels() - signQName.isWildcard();

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -437,12 +437,12 @@ BOOST_AUTO_TEST_CASE(test_dnssec_rrsig)
 {
   initSR();
 
-  auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   // cerr<<dcke->convertToISC()<<endl;
   DNSSECPrivateKey dpk;
   dpk.d_flags = 256;
-  dpk.setKey(dcke);
+  dpk.setKey(std::move(dcke));
 
   sortedRecords_t recordcontents;
   recordcontents.insert(getRecordContent(QType::A, "192.0.2.1"));
@@ -543,18 +543,18 @@ BOOST_AUTO_TEST_CASE(test_dnssec_root_validation_ksk_zsk)
   testkeysset_t kskeys;
 
   /* Generate key material for "." */
-  auto dckeZ = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dckeZ = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dckeZ->create(dckeZ->getBits());
   DNSSECPrivateKey ksk;
   ksk.d_flags = 257;
-  ksk.setKey(dckeZ);
+  ksk.setKey(std::move(dckeZ));
   DSRecordContent kskds = makeDSFromDNSKey(target, ksk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
-  auto dckeK = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dckeK = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dckeK->create(dckeK->getBits());
   DNSSECPrivateKey zsk;
   zsk.d_flags = 256;
-  zsk.setKey(dckeK);
+  zsk.setKey(std::move(dckeK));
   DSRecordContent zskds = makeDSFromDNSKey(target, zsk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   kskeys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(ksk, kskds);
@@ -696,11 +696,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_without_zone_flag)
   testkeysset_t keys;
 
   /* Generate key material for "." */
-  auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey csk;
   csk.d_flags = 0;
-  csk.setKey(dcke);
+  csk.setKey(std::move(dcke));
   DSRecordContent ds = makeDSFromDNSKey(target, csk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   keys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(csk, ds);
@@ -773,11 +773,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_revoked)
   testkeysset_t keys;
 
   /* Generate key material for "." */
-  auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey csk;
   csk.d_flags = 257 | 128;
-  csk.setKey(dcke);
+  csk.setKey(std::move(dcke));
   DSRecordContent ds = makeDSFromDNSKey(target, csk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   keys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(csk, ds);
@@ -850,18 +850,18 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_dnskey_doesnt_match_ds)
   testkeysset_t keys;
 
   /* Generate key material for "." */
-  auto dckeDS = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dckeDS = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dckeDS->create(dckeDS->getBits());
   DNSSECPrivateKey dskey;
   dskey.d_flags = 257;
-  dskey.setKey(dckeDS);
+  dskey.setKey(std::move(dckeDS));
   DSRecordContent drc = makeDSFromDNSKey(target, dskey.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
-  auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey dpk;
   dpk.d_flags = 256;
-  dpk.setKey(dcke);
+  dpk.setKey(std::move(dcke));
   DSRecordContent uselessdrc = makeDSFromDNSKey(target, dpk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   dskeys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(dskey, drc);
@@ -976,11 +976,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_bogus_rrsig_signed_with_unknown_dnskey)
   generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
   g_luaconfs.setState(luaconfsCopy);
 
-  auto dckeRRSIG = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dckeRRSIG = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dckeRRSIG->create(dckeRRSIG->getBits());
   DNSSECPrivateKey rrsigkey;
   rrsigkey.d_flags = 257;
-  rrsigkey.setKey(dckeRRSIG);
+  rrsigkey.setKey(std::move(dckeRRSIG));
   DSRecordContent rrsigds = makeDSFromDNSKey(target, rrsigkey.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
 
   rrsigkeys[target] = std::pair<DNSSECPrivateKey, DSRecordContent>(rrsigkey, rrsigds);
@@ -1123,11 +1123,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_algorithm)
   testkeysset_t keys;
 
   /* Generate key material for "." */
-  auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey dpk;
   dpk.d_flags = 256;
-  dpk.setKey(dcke);
+  dpk.setKey(std::move(dcke));
   /* Fake algorithm number (private) */
   dpk.d_algorithm = 253;
 
@@ -1206,11 +1206,11 @@ BOOST_AUTO_TEST_CASE(test_dnssec_insecure_unknown_ds_digest)
   testkeysset_t keys;
 
   /* Generate key material for "." */
-  auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256));
+  auto dcke = DNSCryptoKeyEngine::make(DNSSECKeeper::ECDSA256);
   dcke->create(dcke->getBits());
   DNSSECPrivateKey dpk;
   dpk.d_flags = 256;
-  dpk.setKey(dcke);
+  dpk.setKey(std::move(dcke));
   DSRecordContent drc = makeDSFromDNSKey(target, dpk.getDNSKEY(), DNSSECKeeper::DIGEST_SHA256);
   /* Fake digest number (reserved) */
   drc.d_digesttype = 0;

--- a/pdns/sodiumsigners.cc
+++ b/pdns/sodiumsigners.cc
@@ -24,9 +24,9 @@ public:
   void fromPEMString(DNSKEYRecordContent& drc, const std::string& raw) override
   {}
 
-  static std::shared_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
+  static std::unique_ptr<DNSCryptoKeyEngine> maker(unsigned int algorithm)
   {
-    return std::make_shared<SodiumED25519DNSCryptoKeyEngine>(algorithm);
+    return make_unique<SodiumED25519DNSCryptoKeyEngine>(algorithm);
   }
 
 private:

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -106,7 +106,7 @@ static const struct signerParams
 static void checkRR(const signerParams& signer)
 {
   DNSKEYRecordContent drc;
-  auto dcke = DNSCryptoKeyEngine::makeFromISCString(drc, signer.iscMap);
+  auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(drc, signer.iscMap));
   DNSSECPrivateKey dpk;
   dpk.setKey(dcke);
   dpk.d_flags = signer.rfcFlags;
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(test_generic_signers)
 {
   for (const auto& signer : signers) {
     DNSKEYRecordContent drc;
-    auto dcke = DNSCryptoKeyEngine::makeFromISCString(drc, signer.iscMap);
+    auto dcke = std::shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(drc, signer.iscMap));
 
     BOOST_CHECK_EQUAL(dcke->getAlgorithm(), signer.algorithm);
     BOOST_CHECK_EQUAL(dcke->getBits(), signer.bits);

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -764,7 +764,7 @@ static bool checkSignatureWithKey(time_t now, const shared_ptr<RRSIGRecordConten
        - The validator's notion of the current time MUST be greater than or equal to the time listed in the RRSIG RR's Inception field.
     */
     if (isRRSIGIncepted(now, sig) && isRRSIGNotExpired(now, sig)) {
-      std::shared_ptr<DNSCryptoKeyEngine> dke = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromPublicKeyString(key->d_algorithm, key->d_key));
+      auto dke = DNSCryptoKeyEngine::makeFromPublicKeyString(key->d_algorithm, key->d_key);
       result = dke->verify(msg, sig->d_signature);
       LOG("signature by key with tag "<<sig->d_tag<<" and algorithm "<<DNSSECKeeper::algorithm2name(sig->d_algorithm)<<" was " << (result ? "" : "NOT ")<<"valid"<<endl);
     }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We do not always need a shared pointer, and that saves memory barriers when we don't.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
