### PR TITLE
Don't copy the same salt for all iterations in hashQNameWithSalt()

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -491,6 +491,7 @@ string hashQNameWithSalt(const NSEC3PARAMRecordContent& ns3prc, const DNSName& q
 
 string hashQNameWithSalt(const std::string& salt, unsigned int iterations, const DNSName& qname)
 {
+  // rfc5155 section 5
   unsigned int times = iterations;
   unsigned char hash[SHA_DIGEST_LENGTH];
   string toHash(qname.toDNSStringLC() + salt);

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -492,16 +492,34 @@ string hashQNameWithSalt(const NSEC3PARAMRecordContent& ns3prc, const DNSName& q
 string hashQNameWithSalt(const std::string& salt, unsigned int iterations, const DNSName& qname)
 {
   unsigned int times = iterations;
-  unsigned char hash[20];
-  string toHash(qname.toDNSStringLC());
-
-  for(;;) {
-    toHash.append(salt);
-    SHA1((unsigned char*)toHash.c_str(), toHash.length(), hash);
-    toHash.assign((char*)hash, sizeof(hash));
-    if(!times--)
-      break;
+  unsigned char hash[SHA_DIGEST_LENGTH];
+  string toHash(qname.toDNSStringLC() + salt);
+  if (toHash.capacity() < (salt.size() + sizeof(hash))) {
+    toHash.reserve(salt.size() + sizeof(hash));
   }
+
+  for (;;) {
+    /* so the first time we hash the (lowercased) qname plus the salt,
+       then the result of the last iteration plus the salt */
+    SHA1(reinterpret_cast<const unsigned char*>(toHash.c_str()), toHash.length(), hash);
+    if (!times--) {
+      /* we are done, just copy the result and return it */
+      toHash.assign(reinterpret_cast<char*>(hash), sizeof(hash));
+      break;
+    }
+    if (times == (iterations-1)) {
+      /* first time, we need to replace the qname + salt with
+         the hash plus salt, since the qname will not likely
+         match the size of the hash */
+      toHash.assign(reinterpret_cast<char*>(hash), sizeof(hash));
+      toHash.append(salt);
+    }
+    else {
+      /* starting with the second iteration, the hash size does not change, so we don't need to copy the salt again */
+      std::copy(reinterpret_cast<char*>(hash), reinterpret_cast<char*>(hash) + sizeof(hash), toHash.begin());
+    }
+  }
+
   return toHash;
 }
 

--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -494,9 +494,6 @@ string hashQNameWithSalt(const std::string& salt, unsigned int iterations, const
   unsigned int times = iterations;
   unsigned char hash[SHA_DIGEST_LENGTH];
   string toHash(qname.toDNSStringLC() + salt);
-  if (toHash.capacity() < (salt.size() + sizeof(hash))) {
-    toHash.reserve(salt.size() + sizeof(hash));
-  }
 
   for (;;) {
     /* so the first time we hash the (lowercased) qname plus the salt,
@@ -511,6 +508,9 @@ string hashQNameWithSalt(const std::string& salt, unsigned int iterations, const
       /* first time, we need to replace the qname + salt with
          the hash plus salt, since the qname will not likely
          match the size of the hash */
+      if (toHash.capacity() < (sizeof(hash) + salt.size())) {
+        toHash.reserve(sizeof(hash) + salt.size());
+      }
       toHash.assign(reinterpret_cast<char*>(hash), sizeof(hash));
       toHash.append(salt);
     }

--- a/pdns/test-signers.cc
+++ b/pdns/test-signers.cc
@@ -259,27 +259,74 @@ BOOST_AUTO_TEST_CASE(test_ed448_signer) {
 #endif /* defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED448) */
 
 BOOST_AUTO_TEST_CASE(test_hash_qname_with_salt) {
-  const unsigned char salt[] = { 0xaa, 0xbb, 0xcc, 0xdd };
-  const unsigned int iterations{12};
-  const std::vector<std::pair<std::string, std::string>> namesToHashes = {
+  {
     // rfc5155 appendix A
-    { "example", "0p9mhaveqvm6t7vbl5lop2u3t2rp3tom" },
-    { "a.example", "35mthgpgcu1qg68fab165klnsnk3dpvl" },
-    { "ai.example", "gjeqe526plbf1g8mklp59enfd789njgi" },
-    { "ns1.example", "2t7b4g4vsa5smi47k61mv5bv1a22bojr" },
-    { "ns2.example", "q04jkcevqvmu85r014c7dkba38o0ji5r" },
-    { "w.example", "k8udemvp1j2f7eg6jebps17vp3n8i58h" },
-    { "*.w.example", "r53bq7cc2uvmubfu5ocmm6pers9tk9en" },
-    { "x.w.example", "b4um86eghhds6nea196smvmlo4ors995" },
-    { "y.w.example", "ji6neoaepv8b5o6k4ev33abha8ht9fgc" },
-    { "x.y.w.example", "2vptu5timamqttgl4luu9kg21e0aor3s" },
-    { "xx.example", "t644ebqk9bibcna874givr6joj62mlhv" },
-    { "2t7b4g4vsa5smi47k61mv5bv1a22bojr.example", "kohar7mbb8dc2ce8a9qvl8hon4k53uhi" },
-  };
+    const unsigned char salt[] = { 0xaa, 0xbb, 0xcc, 0xdd };
+    const unsigned int iterations{12};
+    const std::vector<std::pair<std::string, std::string>> namesToHashes = {
+      { "example", "0p9mhaveqvm6t7vbl5lop2u3t2rp3tom" },
+      { "a.example", "35mthgpgcu1qg68fab165klnsnk3dpvl" },
+      { "ai.example", "gjeqe526plbf1g8mklp59enfd789njgi" },
+      { "ns1.example", "2t7b4g4vsa5smi47k61mv5bv1a22bojr" },
+      { "ns2.example", "q04jkcevqvmu85r014c7dkba38o0ji5r" },
+      { "w.example", "k8udemvp1j2f7eg6jebps17vp3n8i58h" },
+      { "*.w.example", "r53bq7cc2uvmubfu5ocmm6pers9tk9en" },
+      { "x.w.example", "b4um86eghhds6nea196smvmlo4ors995" },
+      { "y.w.example", "ji6neoaepv8b5o6k4ev33abha8ht9fgc" },
+      { "x.y.w.example", "2vptu5timamqttgl4luu9kg21e0aor3s" },
+      { "xx.example", "t644ebqk9bibcna874givr6joj62mlhv" },
+      { "2t7b4g4vsa5smi47k61mv5bv1a22bojr.example", "kohar7mbb8dc2ce8a9qvl8hon4k53uhi" },
+    };
 
-  for (const auto& [name, expectedHash] : namesToHashes) {
-    auto hash = hashQNameWithSalt(std::string(reinterpret_cast<const char*>(salt), sizeof(salt)), iterations, DNSName(name));
-    BOOST_CHECK_EQUAL(toBase32Hex(hash), expectedHash);
+    for (const auto& [name, expectedHash] : namesToHashes) {
+      auto hash = hashQNameWithSalt(std::string(reinterpret_cast<const char*>(salt), sizeof(salt)), iterations, DNSName(name));
+      BOOST_CHECK_EQUAL(toBase32Hex(hash), expectedHash);
+    }
+  }
+
+  {
+    /* no additional iterations, very short salt */
+    const unsigned char salt[] = { 0xFF };
+    const unsigned int iterations{0};
+    const std::vector<std::pair<std::string, std::string>> namesToHashes = {
+      { "example", "s9dp8o2l6jgqgg26ecobtjooe7p019cs" },
+    };
+
+    for (const auto& [name, expectedHash] : namesToHashes) {
+      auto hash = hashQNameWithSalt(std::string(reinterpret_cast<const char*>(salt), sizeof(salt)), iterations, DNSName(name));
+      BOOST_CHECK_EQUAL(toBase32Hex(hash), expectedHash);
+    }
+  }
+
+  {
+    /* only one iteration */
+    const unsigned char salt[] = { 0xaa, 0xbb, 0xcc, 0xdd };
+    const unsigned int iterations{1};
+    const std::vector<std::pair<std::string, std::string>> namesToHashes = {
+      { "example", "ulddquehrj5jpf50ga76vgqr1oq40133" },
+    };
+
+    for (const auto& [name, expectedHash] : namesToHashes) {
+      auto hash = hashQNameWithSalt(std::string(reinterpret_cast<const char*>(salt), sizeof(salt)), iterations, DNSName(name));
+      BOOST_CHECK_EQUAL(toBase32Hex(hash), expectedHash);
+    }
+  }
+
+  {
+    /* 65535 iterations, long salt */
+    unsigned char salt[255];
+    for (unsigned char idx = 0; idx < 255; idx++) {
+      salt[idx] = idx;
+    };
+    const unsigned int iterations{65535};
+    const std::vector<std::pair<std::string, std::string>> namesToHashes = {
+      { "example", "no95j4cfile8avstr7bn4aj9he18trri" },
+    };
+
+    for (const auto& [name, expectedHash] : namesToHashes) {
+      auto hash = hashQNameWithSalt(std::string(reinterpret_cast<const char*>(salt), sizeof(salt)), iterations, DNSName(name));
+      BOOST_CHECK_EQUAL(toBase32Hex(hash), expectedHash);
+    }
   }
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The salt does not change between iterations, and the hash size is constant, so we can just overwrite the hash instead.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
