### PR TITLE
auth: fix direct-dnskey in AXFR-out

### DIFF
--- a/regression-tests/backends/gsqlite3-master
+++ b/regression-tests/backends/gsqlite3-master
@@ -12,6 +12,7 @@ module-dir=./modules
 launch=gsqlite3
 gsqlite3-database=pdns.sqlite3
 consistent-backends
+direct-dnskey
 __EOF__
 
 		gsql_master gsqlite3 nodyndns

--- a/regression-tests/backends/gsqlite3-slave
+++ b/regression-tests/backends/gsqlite3-slave
@@ -8,6 +8,7 @@ launch=gsqlite3
 gsqlite3-database=pdns.sqlite32
 gsqlite3-pragma-synchronous=0
 consistent-backends
+direct-dnskey
 __EOF__
 
 	if [[ $context != *nodnssec* ]]


### PR DESCRIPTION
### Short description
direct-dnskey in AXFR-out was misbehaving like this:

| direct-dnskey | presigned | signed|
|-|-|-|
|  yes | remove all DNSKEY, CDNSKEY, CDS | remove all CDNSKEY, CDS / add backend DNSKEY|
| no | add bakend CDNSKEY, CDNSKEY, CDS | add backend DNSKEY, CDNSKEY, CDS  |

This pull fixes direct-dnskey behaviour and will make sure backend (C)DNSKEY and CDS records use the proper ttl in AXFR-out.

Fixes #9868  

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
