### PR TITLE
auth-4.4.x: clear the LMDB set state when performing a new lookup or list to prevent corruption cases

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -670,6 +670,11 @@ bool LMDBBackend::list(const DNSName &target, int id, bool include_disabled)
   }
 
   d_lookupdomain = target;
+
+  // Make sure we start with fresh data
+  d_currentrrset.clear();
+  d_currentrrsetpos = 0;
+
   return true;
 }
 
@@ -730,6 +735,10 @@ void LMDBBackend::lookup(const QType &type, const DNSName &qdomain, int zoneId, 
   }
 
   d_lookupdomain = hunt;
+
+  // Make sure we start with fresh data
+  d_currentrrset.clear();
+  d_currentrrsetpos = 0;
 }
 
 


### PR DESCRIPTION
### Short description
Prevents errors of the following kind from occurring if LMDBBackend::get should throw an exception for some other reason:
```
Exception building answer packet for example.com/SOA (vector::_M_range_check: __n (which is 1410) >= this->size() (which is 1)) sending out servfail
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] documented the code
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
