### PR TITLE
Clear the LMDB set state when performing a new lookup or list to prevent corruption cases

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -679,6 +679,11 @@ bool LMDBBackend::list(const DNSName &target, int id, bool include_disabled)
   }
 
   d_lookupdomain = target;
+
+  // Make sure we start with fresh data
+  d_currentrrset.clear();
+  d_currentrrsetpos = 0;
+
   return true;
 }
 
@@ -739,6 +744,10 @@ void LMDBBackend::lookup(const QType &type, const DNSName &qdomain, int zoneId, 
   }
 
   d_lookupdomain = hunt;
+
+  // Make sure we start with fresh data
+  d_currentrrset.clear();
+  d_currentrrsetpos = 0;
 }
 
 


### PR DESCRIPTION
### Short description
Prevents errors of the following kind from occurring if LMDBBackend::get should throw an exception for some other reason:
```
Exception building answer packet for example.com/SOA (vector::_M_range_check: __n (which is 1410) >= this->size() (which is 1)) sending out servfail
```
Port of #9884 to master.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] documented the code
