### PR TITLE
Do a mdb_reader_check to clean up stale readers on database load

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -46,6 +46,12 @@ Various other options may also need to be set before opening the handle, e.g. md
     mdb_env_close(d_env);
     throw std::runtime_error("Unable to open database file "+std::string(fname)+": " + MDBError(rc));
   }
+
+  if ((flags & MDB_RDONLY) == 0) {
+    // Check for stale readers to prevent unbridled database growth.
+    // Only do this when in RW mode since it affects the file.
+    mdb_reader_check(d_env, nullptr);
+  }
 }
 
 void MDBEnv::incROTX()


### PR DESCRIPTION
### Short description
While a reader is kept open all write transactions lead to a increase in DB size due to the CoW mechanics. mdb_readers_check cleans up any readers left behind by crashed instances. We only do this when we open a DB in RW mode since we don't want to affect the DB when opening it in read only mode.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] documented the code
