### PR TITLE
dnsdist: Fix a hang when removing a server with more than one socket

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -535,7 +535,7 @@ static void pickBackendSocketsReadyForReceiving(const std::shared_ptr<Downstream
 
   {
     std::lock_guard<std::mutex> lock(state->socketsLock);
-    state->mplexer->getAvailableFDs(ready, -1);
+    state->mplexer->getAvailableFDs(ready, 1000);
   }
 }
 
@@ -555,10 +555,14 @@ try {
   std::vector<int> sockets;
   sockets.reserve(dss->sockets.size());
 
-  for(; !dss->isStopped(); ) {
+  for(;;) {
     dnsheader* dh = reinterpret_cast<struct dnsheader*>(packet);
     try {
       pickBackendSocketsReadyForReceiving(dss, sockets);
+      if (dss->isStopped()) {
+        break;
+      }
+
       for (const auto& fd : sockets) {
         ssize_t got = recv(fd, packet, sizeof(packet), 0);
         char * response = packet;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
There was a lock starvation issue when removing a server with more than one socket in use (`sockets` greater than 1 on the corresponding `newServer` directive), because the mutex protecting the sockets array would never be released long enough by the responder thread to allow the thread stopping the server to acquire it.
This commit fixes that by marking the server as stopped right away, before acquiring the lock, and also making sure that the responder thread is woken up regularly (every second, even without any query to process) and that it checks whether the server has been stopped just after that.

The issue was introduced in be55a20ce9bb7140071279d70bcb460f1f2b7b7d, and backported to 1.5.1 in f0d48318cce0dd80ae73c529362bdb2921d8c5c9.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
