### PR TITLE
Reword zone xfr log message to remove ordinal number naming errors.

### DIFF
--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -653,7 +653,7 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
         newCount = d_failedSlaveRefresh[domain].first + 1;
       time_t nextCheck = now + std::min(newCount * d_tickinterval, (uint64_t)::arg().asNum("default-ttl"));
       d_failedSlaveRefresh[domain] = {newCount, nextCheck};
-      g_log<<Logger::Warning<<logPrefix<<"unable to xfr zone (ResolverException): "<<re.reason<<" (This was the "<<(newCount == 1 ? "first" : std::to_string(newCount) + "th")<<" time. Excluding zone from slave-checks until "<<nextCheck<<")"<<endl;
+      g_log<<Logger::Warning<<logPrefix<<"unable to xfr zone (ResolverException): "<<re.reason<<" (This was attempt number "<<newCount<<". Excluding zone from slave-checks until "<<nextCheck<<")"<<endl;
     }
     if(di.backend && transaction) {
       g_log<<Logger::Info<<"aborting possible open transaction"<<endl;


### PR DESCRIPTION
### Short description
Correct the wording used in log entries created by zone xfr errors.

A sample of the current word is as follows:
```
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was the first time. Excluding zone from slave-checks until 166552654)
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was the 2th time. Excluding zone from slave-checks until 166552654)
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was the 3th time. Excluding zone from slave-checks until 166552654)
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was the 4th time. Excluding zone from slave-checks until 166552654)
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was the 5th time. Excluding zone from slave-checks until 166552654)
```
The ordinal numbers are inconsistently logged in word form then numeral form.  The second and third forms are incorrect, they should be `2nd` and `3rd`.  The code to handle the ordinal cases is too simplistic and this log message doesn't merit more complex code.

The code change proposes a rewording of the log message and removal of the ordinal test code to produce the following output:
```
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was attempt number 1. Excluding zone from slave-checks until 166552654)
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was attempt number 2. Excluding zone from slave-checks until 166552654)
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was attempt number 3. Excluding zone from slave-checks until 166552654)
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was attempt number 4. Excluding zone from slave-checks until 166552654)
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was attempt number 5. Excluding zone from slave-checks until 166552654)
unable to xfr zone (ResolverException): AXFR chunk error: Server Failure (This was attempt number 6. Excluding zone from slave-checks until 166552654)
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

