### PR TITLE
autoconf: correctly detect pthread symbols

### DIFF
--- a/m4/pdns_check_pthread_np.m4
+++ b/m4/pdns_check_pthread_np.m4
@@ -1,3 +1,6 @@
 AC_DEFUN([PDNS_CHECK_PTHREAD_NP],[
   AC_SEARCH_LIBS([pthread_setaffinity_np], [pthread], [AC_DEFINE(HAVE_PTHREAD_SETAFFINITY_NP, [1], [Define to 1 if you have pthread_setaffinity_np])])
+  AC_SEARCH_LIBS([pthread_getattr_np], [pthread], [AC_DEFINE(HAVE_PTHREAD_GETATTR_NP, [1], [Define to 1 if you have pthread_getattr_np])])
+  AC_SEARCH_LIBS([pthread_get_stackaddr_np], [pthread], [AC_DEFINE(HAVE_PTHREAD_GET_STACKADDR_NP, [1], [Define to 1 if you have pthread_get_stackaddr_np])])
+  AC_SEARCH_LIBS([pthread_get_stacksize_np], [pthread], [AC_DEFINE(HAVE_PTHREAD_GET_STACKSIZE_NP, [1], [Define to 1 if you have pthread_get_stacksize_np])])
 ])

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -93,7 +93,7 @@ PDNS_CHECK_CURL
 
 dnl the *_r functions are in posix so we can use them unconditionally, but the ext/yahttp code is
 dnl using the defines.
-AC_CHECK_FUNCS_ONCE([localtime_r gmtime_r strcasestr getrandom arc4random pthread_getattr_np pthread_get_stackaddr_np pthread_get_stacksize_np])
+AC_CHECK_FUNCS_ONCE([localtime_r gmtime_r strcasestr getrandom arc4random])
 
 PDNS_CHECK_PTHREAD_NP
 


### PR DESCRIPTION
### Short description
The previous version did not include `pthread.h` and thus could not find the symbols on some systems, including at least Debian Buster.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master