### PR TITLE
rec: Set the Protocol Buffer 'inBytes' field for zero-length messages

### DIFF
--- a/pdns/protozero.hh
+++ b/pdns/protozero.hh
@@ -87,9 +87,7 @@ namespace pdns {
 
       void setInBytes(uint64_t len)
       {
-        if (len) {
-          add_uint64(d_message, Field::inBytes, len);
-        }
+        add_uint64(d_message, Field::inBytes, len);
       }
 
       void setTime()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The existing Protocol Buffer code used to do that, so existing receivers might expect that field to be present.
And yes, this time I _did_ make sure to run every single Protocol Buffer and dnstap related tests :)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
