### PR TITLE
Fix warnings on autoconf 2.70

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,10 @@
-AC_PREREQ([2.61])
+AC_PREREQ([2.69])
 
 AC_INIT([pdns], m4_esyscmd([builder-support/gen-version]))
 
 AC_CONFIG_SRCDIR([pdns/receiver.cc])
 AC_CONFIG_MACRO_DIR([m4])
+AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -25,7 +26,6 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 PDNS_CHECK_BISON
 PDNS_CHECK_FLEX
-AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
 AC_PROG_CXX
@@ -34,10 +34,6 @@ AS_IF([test "x$CXX" = "xno" || test "x$CXX:x$GXX" = "xg++:x"],
 )
 
 AC_LANG([C++])
-
-AC_DEFINE([_GNU_SOURCE], [1],
-  [Define _GNU_SOURCE so that we get all necessary prototypes]
-)
 
 # Warn when pkg.m4 is missing
 m4_pattern_forbid([^_?PKG_[A-Z_]+$], [*** pkg.m4 missing, please install pkg-config])

--- a/configure.ac
+++ b/configure.ac
@@ -1,12 +1,19 @@
 AC_PREREQ([2.69])
 
 AC_INIT([pdns], m4_esyscmd([builder-support/gen-version]))
-
+AC_CONFIG_AUX_DIR([build-aux])
+AM_INIT_AUTOMAKE([foreign dist-bzip2 no-dist-gzip tar-ustar -Wno-portability subdir-objects parallel-tests 1.11])
+AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([pdns/receiver.cc])
 AC_CONFIG_MACRO_DIR([m4])
+
 AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_AUX_DIR([build-aux])
+
+AC_CANONICAL_HOST
+# Add some default CFLAGS and CXXFLAGS, can be appended to using the environment variables
+CFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CFLAGS"
+CXXFLAGS="-std=c++17 -g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CXXFLAGS"
 
 AC_SUBST([pdns_configure_args], ["$ac_configure_args"])
 AC_DEFINE_UNQUOTED([PDNS_CONFIG_ARGS],
@@ -14,37 +21,25 @@ AC_DEFINE_UNQUOTED([PDNS_CONFIG_ARGS],
   [pdns configure arguments]
 )
 
-AM_INIT_AUTOMAKE([foreign dist-bzip2 no-dist-gzip tar-ustar -Wno-portability subdir-objects parallel-tests 1.11])
-AM_SILENT_RULES([yes])
-
-AC_CANONICAL_HOST
-# Add some default CFLAGS and CXXFLAGS, can be appended to using the environment variables
-CFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CFLAGS"
-CXXFLAGS="-std=c++17 -g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CXXFLAGS"
-
 AC_PROG_CC
-AM_PROG_CC_C_O
+# AM_PROG_CC_C_O
+AC_PROG_CXX
+AC_LANG([C++])
 PDNS_CHECK_BISON
 PDNS_CHECK_FLEX
-AC_PROG_MAKE_SET
-
-AC_PROG_CXX
-AS_IF([test "x$CXX" = "xno" || test "x$CXX:x$GXX" = "xg++:x"],
-  [AC_MSG_ERROR([no C++ compiler found])]
-)
-
-AC_LANG([C++])
 
 # Warn when pkg.m4 is missing
 m4_pattern_forbid([^_?PKG_[A-Z_]+$], [*** pkg.m4 missing, please install pkg-config])
+
+AX_CXX_COMPILE_STDCXX_17([noext], [mandatory])
+LT_PREREQ([2.2.2])
+LT_INIT([disable-static dlopen])
 
 PDNS_CHECK_OS
 PTHREAD_SET_NAME
 
 PDNS_WITH_LUA([mandatory])
 PDNS_CHECK_LUA_HPP
-
-AX_CXX_COMPILE_STDCXX_17([noext], [mandatory])
 
 AC_MSG_CHECKING([whether we will enable compiler security checks])
 AC_ARG_ENABLE([hardening],
@@ -65,9 +60,6 @@ AS_IF([test "x$enable_hardening" != "xno"], [
 PDNS_ENABLE_KISS
 
 PDNS_CHECK_NETWORK_LIBS
-
-LT_PREREQ([2.2.2])
-LT_INIT([disable-static dlopen])
 
 
 MC_TM_GMTOFF

--- a/m4/pdns_check_flex.m4
+++ b/m4/pdns_check_flex.m4
@@ -1,5 +1,5 @@
 AC_DEFUN([PDNS_CHECK_FLEX], [
-  AC_REQUIRE([AC_PROG_LEX])
+  AC_PROG_LEX(noyywrap)
   AC_REQUIRE([AC_PROG_EGREP])
 
   AC_CACHE_CHECK([if the lexer is flex],[pdns_cv_prog_flex],[

--- a/m4/pdns_check_lmdb.m4
+++ b/m4/pdns_check_lmdb.m4
@@ -2,7 +2,7 @@ dnl invoking this makes lmdb a requirement
 AC_DEFUN([PDNS_CHECK_LMDB], [
   AC_MSG_CHECKING([where to find the lmdb library and headers])
   AC_ARG_WITH([lmdb],
-    AC_HELP_STRING([--with-lmdb], [lmdb library to use @<:@default=auto@:>@]),[
+    AS_HELP_STRING([--with-lmdb], [lmdb library to use @<:@default=auto@:>@]),[
     with_lmdb=$withval
     ],[
     with_lmdb=auto

--- a/m4/pdns_enable_remotebackend_zeromq.m4
+++ b/m4/pdns_enable_remotebackend_zeromq.m4
@@ -38,7 +38,7 @@ AC_DEFUN([PDNS_ENABLE_REMOTEBACKEND_ZEROMQ],[
           CXXFLAGS="$old_CXXFLAGS"
           LDFLAGS="$old_LDFLAGS"
         ],
-        [AC_MSG_ERROR([remotebackend \"zeromq\" selected but the \"remote\" backend itself is not selected. Please add \"remote\" to your modules or dynmodules list and re-run configure!])]
+        [AC_MSG_ERROR([remotebackend "zeromq" selected but the "remote" backend itself is not selected. Please add "remote" to your modules or dynmodules list and re-run configure!])]
       )
     ]
   )

--- a/m4/tm-gmtoff.m4
+++ b/m4/tm-gmtoff.m4
@@ -3,12 +3,20 @@ dnl (Borrowed from the Gaim project)
 dnl The Gaim Project (now know as Pidgin) is licensed under the GPLv2
 
 AC_DEFUN([MC_TM_GMTOFF],
-[AC_REQUIRE([AC_STRUCT_TM])dnl
-AC_CACHE_CHECK([for tm_gmtoff in struct tm], ac_cv_struct_tm_gmtoff,
-[AC_TRY_COMPILE([#include <sys/types.h>
-#include <$ac_cv_struct_tm>], [struct tm tm; tm.tm_gmtoff;],
-  ac_cv_struct_tm_gmtoff=yes, ac_cv_struct_tm_gmtoff=no)])
-if test "$ac_cv_struct_tm_gmtoff" = yes; then
-  AC_DEFINE(HAVE_TM_GMTOFF, 1, [tm_gmtoff is available.])
-fi
+  [AC_REQUIRE([AC_STRUCT_TM])dnl
+  AC_CACHE_CHECK([for tm_gmtoff in struct tm],
+    ac_cv_struct_tm_gmtoff,
+    [
+      AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#include <sys/types.h>
+#include <$ac_cv_struct_tm>
+struct tm tm; tm.tm_gmtoff;
+      ]]),
+      ac_cv_struct_tm_gmtoff=yes,
+      ac_cv_struct_tm_gmtoff=no])
+    ]
+  )
+  if test "$ac_cv_struct_tm_gmtoff" = yes; then
+    AC_DEFINE(HAVE_TM_GMTOFF, 1, [tm_gmtoff is available.])
+  fi
 ])

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.61])
+AC_PREREQ([2.69])
 
 AC_INIT([dnsdist], m4_esyscmd(build-aux/gen-version))
 AM_INIT_AUTOMAKE([foreign dist-bzip2 no-dist-gzip parallel-tests 1.11 subdir-objects])
@@ -8,7 +8,6 @@ AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
 AC_PROG_CXX
 AC_LANG([C++])
-AC_GNU_SOURCE
 
 AC_DEFINE([DNSDIST], [1],
   [This is dnsdist]

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.61])
+AC_PREREQ([2.69])
 
 AC_INIT([pdns-recursor], m4_esyscmd(build-aux/gen-version))
 AC_CONFIG_AUX_DIR([build-aux])
@@ -7,6 +7,7 @@ AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([pdns_recursor.cc])
 AC_CONFIG_MACRO_DIR([m4])
 
+AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_HEADERS([config.h])
 
 AC_CANONICAL_HOST
@@ -24,8 +25,6 @@ AC_PROG_CC
 AC_PROG_CXX
 AC_LANG([C++])
 
-AC_GNU_SOURCE
-
 AC_DEFINE([RECURSOR], [1],
   [This is the PowerDNS Recursor]
 )
@@ -34,7 +33,7 @@ AC_DEFINE([RECURSOR], [1],
 m4_pattern_forbid([^_?PKG_[A-Z_]+$], [*** pkg.m4 missing, please install pkg-config])
 
 AX_CXX_COMPILE_STDCXX_17([noext], [mandatory])
-AC_PROG_LIBTOOL
+LT_INIT()
 
 PDNS_CHECK_OS
 PDNS_CHECK_NETWORK_LIBS


### PR DESCRIPTION
### Short description
This bumps the minimal autoconf requirement to 2.69 as well. This
version is on Ubuntu 16.04 (EOL due in 3 months) and CentOS 7.

Closes #9918

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)