### PR TITLE
dnsdist-1.5.x: Fix SNI on resumed sessions by acknowledging the name sent by the client

### DIFF
--- a/pdns/dnsdistdist/libssl.cc
+++ b/pdns/dnsdistdist/libssl.cc
@@ -161,6 +161,18 @@ int libssl_ticket_key_callback(SSL *s, OpenSSLTLSTicketKeysRing& keyring, unsign
   return 1;
 }
 
+static long libssl_server_name_callback(SSL* ssl, int* al, void* arg)
+{
+  (void) al;
+  (void) arg;
+
+  if (SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name)) {
+    return SSL_TLSEXT_ERR_OK;
+  }
+
+  return SSL_TLSEXT_ERR_NOACK;
+}
+
 static void libssl_info_callback(const SSL *ssl, int where, int ret)
 {
   SSL_CTX* sslCtx = SSL_get_SSL_CTX(ssl);
@@ -681,6 +693,11 @@ std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> libssl_init_server_context(const TLS
     SSL_CTX_set_session_cache_mode(ctx.get(), SSL_SESS_CACHE_SERVER);
     SSL_CTX_sess_set_cache_size(ctx.get(), config.d_maxStoredSessions);
   }
+
+  /* we need to set this callback to acknowledge the server name sent by the client,
+     otherwise it will not stored in the session and will not be accessible when the
+     session is resumed, causing SSL_get_servername to return nullptr */
+  SSL_CTX_set_tlsext_servername_callback(ctx.get(), &libssl_server_name_callback);
 
   std::vector<int> keyTypes;
   /* load certificate and private key */

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -164,7 +164,8 @@ class TLSTests(object):
         receivedResponse = self.recvTCPResponseOverConnection(sslsock, useQueue=False)
         self.assertTrue(receivedResponse)
         self.assertEquals(expectedResponse, receivedResponse)
-        self.assertFalse(sslsock.session_reused)
+        if hasattr(sslsock, 'session_reused'):
+            self.assertFalse(sslsock.session_reused)
         session = sslsock.session
 
         # this one should not (different SNI)
@@ -181,7 +182,8 @@ class TLSTests(object):
         receivedQuery.id = query.id
         self.assertEquals(query, receivedQuery)
         self.assertEquals(response, receivedResponse)
-        self.assertFalse(sslsock.session_reused)
+        if hasattr(sslsock, 'session_reused'):
+            self.assertFalse(sslsock.session_reused)
 
         # and now we should be able to resume the session
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -195,7 +197,8 @@ class TLSTests(object):
         receivedResponse = self.recvTCPResponseOverConnection(sslsock, useQueue=False)
         self.assertTrue(receivedResponse)
         self.assertEquals(expectedResponse, receivedResponse)
-        self.assertTrue(sslsock.session_reused)
+        if hasattr(sslsock, 'session_reused'):
+            self.assertTrue(sslsock.session_reused)
 
 class TestOpenSSL(DNSDistTest, TLSTests):
 

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -150,8 +150,8 @@ class TLSTests(object):
 
         # this SNI should match so we should get a spoofed answer
         sslctx = ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2)
-        sslctx.check_hostname = True
         sslctx.verify_mode = ssl.CERT_REQUIRED
+        sslctx.check_hostname = True
         sslctx.load_verify_locations(self._caCert)
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -160,12 +160,14 @@ class TLSTests(object):
         sslsock = sslctx.wrap_socket(sock, server_hostname='powerdns.com')
         sslsock.connect(("127.0.0.1", self._tlsServerPort))
 
+        if not hasattr(sslsock, 'session') or not hasattr(sslsock, 'session_reused'):
+            self.skipTest('the python ssl library does not have TLS session support')
+
         self.sendTCPQueryOverConnection(sslsock, query, response=None)
         receivedResponse = self.recvTCPResponseOverConnection(sslsock, useQueue=False)
         self.assertTrue(receivedResponse)
         self.assertEquals(expectedResponse, receivedResponse)
-        if hasattr(sslsock, 'session_reused'):
-            self.assertFalse(sslsock.session_reused)
+        self.assertFalse(sslsock.session_reused)
         session = sslsock.session
 
         # this one should not (different SNI)
@@ -182,8 +184,7 @@ class TLSTests(object):
         receivedQuery.id = query.id
         self.assertEquals(query, receivedQuery)
         self.assertEquals(response, receivedResponse)
-        if hasattr(sslsock, 'session_reused'):
-            self.assertFalse(sslsock.session_reused)
+        self.assertFalse(sslsock.session_reused)
 
         # and now we should be able to resume the session
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -197,8 +198,7 @@ class TLSTests(object):
         receivedResponse = self.recvTCPResponseOverConnection(sslsock, useQueue=False)
         self.assertTrue(receivedResponse)
         self.assertEquals(expectedResponse, receivedResponse)
-        if hasattr(sslsock, 'session_reused'):
-            self.assertTrue(sslsock.session_reused)
+        self.assertTrue(sslsock.session_reused)
 
 class TestOpenSSL(DNSDistTest, TLSTests):
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise `SSL_get_servername()` only returns true when the session has been freshly established, and will return `nullptr` when it is resumed.

(cherry picked from commit 767a9d3a727a4a3b4073f01fab4b2c1d7c55d73e)

Backport of #9921 on rel/dnsdist-1.5.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
