### PR TITLE
dnsdist: Appease clang++ 12 asan on MacOS

### DIFF
--- a/pdns/test-dnscrypt_cc.cc
+++ b/pdns/test-dnscrypt_cc.cc
@@ -157,8 +157,8 @@ BOOST_AUTO_TEST_CASE(DNSCryptEncryptedQueryValid) {
     requiredSize = DNSCryptQuery::s_minUDPLength;
   }
 
-  plainQuery.reserve(requiredSize);
   uint16_t len = plainQuery.size();
+  plainQuery.resize(requiredSize);
   uint16_t encryptedResponseLen = 0;
 
   int res = ctx->encryptQuery((char*) plainQuery.data(), len, plainQuery.capacity(), clientPublicKey, clientPrivateKey, clientNonce, false, &encryptedResponseLen, std::make_shared<DNSCryptCert>(resolverCert));
@@ -245,9 +245,8 @@ BOOST_AUTO_TEST_CASE(DNSCryptEncryptedQueryValidWithOldKey) {
     requiredSize = DNSCryptQuery::s_minUDPLength;
   }
 
-  plainQuery.reserve(requiredSize);
-
   uint16_t len = plainQuery.size();
+  plainQuery.resize(requiredSize);
   uint16_t encryptedResponseLen = 0;
 
   int res = ctx->encryptQuery((char*) plainQuery.data(), len, plainQuery.capacity(), clientPublicKey, clientPrivateKey, clientNonce, false, &encryptedResponseLen, std::make_shared<DNSCryptCert>(resolverCert));
@@ -308,9 +307,8 @@ BOOST_AUTO_TEST_CASE(DNSCryptEncryptedQueryInvalidWithWrongKey) {
     requiredSize = DNSCryptQuery::s_minUDPLength;
   }
 
-  plainQuery.reserve(requiredSize);
-
   uint16_t len = plainQuery.size();
+  plainQuery.resize(requiredSize);
   uint16_t encryptedResponseLen = 0;
 
   int res = ctx->encryptQuery((char*) plainQuery.data(), len, plainQuery.capacity(), clientPublicKey, clientPrivateKey, clientNonce, false, &encryptedResponseLen, std::make_shared<DNSCryptCert>(resolverCert));


### PR DESCRIPTION
MacOS clang++ 12 with asan does not like to access a vector of bytes
outside it's begin()..end(), even thouh we assured there is capacity.
So make sure the size is set before groping inside the vector.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
