### PR TITLE
auth: Fix a few code ql warnings

### DIFF
--- a/pdns/dnsbulktest.cc
+++ b/pdns/dnsbulktest.cc
@@ -81,13 +81,13 @@ struct SendReceive
               boost::accumulators::tag::mean(immediate)
               >
     > acc_t;
-  acc_t* d_acc;
+  unique_ptr<acc_t> d_acc;
   
   boost::array<double, 11> d_probs;
   
   SendReceive(const std::string& remoteAddr, uint16_t port) : d_probs({{0.001,0.01, 0.025, 0.1, 0.25,0.5,0.75,0.9,0.975, 0.99,0.9999}})
   {
-    d_acc = new acc_t(boost::accumulators::tag::extended_p_square::probabilities=d_probs);
+    d_acc = make_unique<acc_t>(acc_t(boost::accumulators::tag::extended_p_square::probabilities=d_probs));
     // 
     //d_acc = acc_t
     d_socket = socket(AF_INET, SOCK_DGRAM, 0);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -26,7 +26,6 @@
 #include "dynlistener.hh"
 #include "ws-auth.hh"
 #include "json.hh"
-#include "webserver.hh"
 #include "logger.hh"
 #include "statbag.hh"
 #include "misc.hh"
@@ -66,7 +65,7 @@ AuthWebServer::AuthWebServer() :
   d_min1(0)
 {
   if(arg().mustDo("webserver") || arg().mustDo("api")) {
-    d_ws = new WebServer(arg()["webserver-address"], arg().asNum("webserver-port"));
+    d_ws = unique_ptr<WebServer>(new WebServer(arg()["webserver-address"], arg().asNum("webserver-port")));
     d_ws->setApiKey(arg()["api-key"]);
     d_ws->setPassword(arg()["webserver-password"]);
     d_ws->setLogLevel(arg()["webserver-loglevel"]);

--- a/pdns/ws-auth.hh
+++ b/pdns/ws-auth.hh
@@ -27,6 +27,7 @@
 #include <pthread.h>
 #include "misc.hh"
 #include "namespaces.hh"
+#include "webserver.hh"
 
 class Ewma
 {
@@ -67,10 +68,6 @@ private:
   double d_10, d_5, d_1, d_max;
 };
 
-class WebServer;
-class HttpRequest;
-class HttpResponse;
-
 class AuthWebServer
 {
 public:
@@ -92,7 +89,7 @@ private:
   double d_min10, d_min5, d_min1;
   Ewma d_queries, d_cachehits, d_cachemisses;
   Ewma d_qcachehits, d_qcachemisses;
-  WebServer *d_ws{nullptr};
+  unique_ptr<WebServer> d_ws{nullptr};
 };
 
 void apiDocs(HttpRequest* req, HttpResponse* resp);

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -141,7 +141,7 @@ static void emitRecord(const DNSName& zoneName, const DNSName &DNSqname, const s
   int disabled=0;
   string recordcomment;
 
-  if(g_doJSONComments & !comment.empty()) {
+  if(g_doJSONComments && !comment.empty()) {
     string::size_type pos = comment.find("json={");
     if(pos!=string::npos) {
       string json = comment.substr(pos+5);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

The WebServer one might be controversial;, since it requires me to pull in ``webserver,hh`` in the `ws-auth.hh` file. THat is becausse `unique_ptr` woiuld otherwise complain:

```
/usr/include/c++/v1/memory:2335:19: error: invalid application of 'sizeof' to an incomplete type 'WebServer'
    static_assert(sizeof(_Tp) > 0,
                  ^~~~~~~~~~~
/usr/include/c++/v1/memory:2652:7: note: in instantiation of member function 'std::__1::default_delete<WebServer>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
/usr/include/c++/v1/memory:2606:19: note: in instantiation of member function 'std::__1::unique_ptr<WebServer, std::__1::default_delete<WebServer> >::reset' requested here
  ~unique_ptr() { reset(); }
                  ^
./ws-auth.hh:74:7: note: in instantiation of member function 'std::__1::unique_ptr<WebServer, std::__1::default_delete<WebServer> >::~unique_ptr' requested here
class AuthWebServer
      ^
./ws-auth.hh:70:7: note: forward declaration of 'WebServer'
class WebServer;
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
