### PR TITLE
Bunch of signed vs unsigned warnings

### DIFF
--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -108,7 +108,7 @@ static void* recvThread(const vector<std::unique_ptr<Socket>>* sockets)
           continue;
         }
         g_recvcounter++;
-        for (unsigned int i = 0; i < buf.msg_iovlen; i++)
+        for (int i = 0; i < buf.msg_iovlen; i++)
           g_recvbytes += buf.msg_iov[i].iov_len;
 #endif
       }

--- a/pdns/recursordist/test-syncres_cc7.cc
+++ b/pdns/recursordist/test-syncres_cc7.cc
@@ -1583,7 +1583,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_secure_to_insecure_cut_with_cname_at_apex)
   BOOST_CHECK_EQUAL(queriesCount, 11U);
 
   /* now we remove the denial of powerdns.com DS from the cache and ask www2 */
-  BOOST_REQUIRE_EQUAL(g_negCache->wipe(target, false), 1);
+  BOOST_REQUIRE_EQUAL(g_negCache->wipe(target, false), 1U);
   ret.clear();
   res = sr->beginResolve(DNSName("www2.powerdns.com."), QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
@@ -1706,7 +1706,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_cname_inside_secure_zone)
   BOOST_CHECK_EQUAL(queriesCount, 10U);
 
   /* now we remove the denial of powerdns.com DS from the cache and ask www2 */
-  BOOST_REQUIRE_EQUAL(g_negCache->wipe(target, false), 1);
+  BOOST_REQUIRE_EQUAL(g_negCache->wipe(target, false), 1U);
   ret.clear();
   res = sr->beginResolve(DNSName("www2.powerdns.com."), QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(test_addXPF)
     DNSQuestion dq(&qname, qtype, QClass::IN, &remote, &remote, packet, false, &queryTime);
 
     BOOST_REQUIRE(!addXPF(dq, xpfOptionCode));
-    BOOST_CHECK_EQUAL(packet.size(), 4096);
+    BOOST_CHECK_EQUAL(packet.size(), 4096U);
     packet.resize(query.size());
     validateQuery(packet, false, false);
   }
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(addECSWithoutEDNSAlreadyParsed)
 
   BOOST_CHECK(handleEDNSClientSubnet(dq2, ednsAdded, ecsAdded));
   BOOST_CHECK_GT(packet.size(), query.size());
-  BOOST_CHECK_LT(packet.size(), 2048);
+  BOOST_CHECK_LT(packet.size(), 2048U);
   BOOST_CHECK_EQUAL(ednsAdded, true);
   BOOST_CHECK_EQUAL(ecsAdded, true);
   validateQuery(packet);
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(addECSWithEDNSNoECSAlreadyParsed) {
 
   BOOST_CHECK(handleEDNSClientSubnet(dq2, ednsAdded, ecsAdded));
   BOOST_CHECK_GT(packet.size(), query.size());
-  BOOST_CHECK_LT(packet.size(), 2048);
+  BOOST_CHECK_LT(packet.size(), 2048U);
   BOOST_CHECK_EQUAL(ednsAdded, false);
   BOOST_CHECK_EQUAL(ecsAdded, true);
   validateQuery(packet);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

As seen with clang on both OpenBSD and MacOS. Only really interesting is the `msg_iovlen` one, which indeed Posix defines as an `int`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
