### PR TITLE
auth: Document resolver setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1277,7 +1277,7 @@ Number of receiver (listening) threads to start. See :doc:`performance`.
 ``resolver``
 ------------
 
--  IP Address with port
+-  IP Address with optional port
 -  Default: unset
 
 Recursive DNS server to use for ALIAS lookups and the internal stub resolver. Only one address can be given.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1272,6 +1272,21 @@ Maximum number of milliseconds to queue a query. See :doc:`performance`.
 
 Number of receiver (listening) threads to start. See :doc:`performance`.
 
+.. _setting-resolver:
+
+``resolver``
+------------
+
+-  IP Address with port
+-  Default: unset
+
+Recursive DNS server to use for ALIAS lookups and the internal stub resolver. Only one address can be given.
+
+Examples::
+
+  resolver=127.0.0.1
+  resolver=[::1]:5300
+
 .. _setting-retrieval-threads:
 
 ``retrieval-threads``


### PR DESCRIPTION
### Short description
`resolver=` was not documented, and references to it were shown as "setting-resolver" instead.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
