### PR TITLE
rec: Account for the NSEC(3) denial TTL in expanded wildcard answers

### DIFF
--- a/pdns/recursordist/test-syncres_cc5.cc
+++ b/pdns/recursordist/test-syncres_cc5.cc
@@ -788,10 +788,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard)
           }
         }
         else {
-          addRecordToLW(res, domain, QType::A, "192.0.2.42");
+          addRecordToLW(res, domain, QType::A, "192.0.2.42", DNSResourceRecord::ANSWER, 600);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
           /* we need to add the proof that this name does not exist, so the wildcard may apply */
-          addNSECRecordToLW(DNSName("a.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
+          addNSECRecordToLW(DNSName("a.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 60, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
         }
         return LWResult::Result::Success;
@@ -814,6 +814,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  for (const auto& rec : ret) {
+    /* check that we applied the lowest TTL, here this is from the NSEC proving that the exact name did not exist */
+    BOOST_CHECK_LE(rec.d_ttl, 60U);
+  }
   BOOST_CHECK_EQUAL(queriesCount, 9U);
 }
 
@@ -903,10 +907,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_proof_before_rrsig)
           }
         }
         else {
-          addRecordToLW(res, domain, QType::A, "192.0.2.42");
+          addRecordToLW(res, domain, QType::A, "192.0.2.42", DNSResourceRecord::ANSWER, 600);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
           /* we need to add the proof that this name does not exist, so the wildcard may apply */
-          addNSECRecordToLW(DNSName("a.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
+          addNSECRecordToLW(DNSName("a.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 60, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
           /* now this is the important part! We are swapping the first RRSIG and the NSEC, to make sure we still gather the NSEC proof that the
              exact name does not exist even though we have not seen the RRSIG whose label count is smaller than the target name yet */
@@ -932,6 +936,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_proof_before_rrsig)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  for (const auto& rec : ret) {
+    /* check that we applied the lowest TTL, here this is from the NSEC proving that the exact name did not exist */
+    BOOST_CHECK_LE(rec.d_ttl, 60U);
+  }
   BOOST_CHECK_EQUAL(queriesCount, 9U);
 }
 
@@ -1378,14 +1386,14 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard)
           }
         }
         else {
-          addRecordToLW(res, domain, QType::A, "192.0.2.42");
+          addRecordToLW(res, domain, QType::A, "192.0.2.42", DNSResourceRecord::ANSWER, 600);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
           /* we need to add the proof that this name does not exist, so the wildcard may apply */
           /* first the closest encloser */
           addNSEC3UnhashedRecordToLW(DNSName("powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
           /* then the next closer */
-          addNSEC3NarrowRecordToLW(DNSName("sub.powerdns.com."), DNSName("powerdns.com."), {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, res->d_records);
+          addNSEC3NarrowRecordToLW(DNSName("sub.powerdns.com."), DNSName("powerdns.com."), {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 60, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
         }
         return LWResult::Result::Success;
@@ -1408,6 +1416,10 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec3_wildcard)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 6U);
+  for (const auto& rec : ret) {
+    /* check that we applied the lowest TTL, here this is from the NSEC3 proving that the exact name did not exist (next closer) */
+    BOOST_CHECK_LE(rec.d_ttl, 60U);
+  }
   BOOST_CHECK_EQUAL(queriesCount, 10U);
 }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -848,7 +848,7 @@ private:
   boost::optional<Netmask> getEDNSSubnetMask(const DNSName&dn, const ComboAddress& rem);
 
   bool validationEnabled() const;
-  uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, uint32_t signaturesTTL) const;
+  uint32_t computeLowestTTD(const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, uint32_t signaturesTTL, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs) const;
   void updateValidationState(vState& state, const vState stateUpdate);
   vState validateRecordsWithSigs(unsigned int depth, const DNSName& qname, const QType& qtype, const DNSName& name, const QType& type, const std::vector<DNSRecord>& records, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
   vState validateDNSKeys(const DNSName& zone, const std::vector<DNSRecord>& dnskeys, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures, unsigned int depth);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We need to take into account the TTL of NSEC(3) proofs in expanded wildcard answers, as well as the expiration time of their signatures.

Fixes #9967.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
