### PR TITLE
Some platforms actually have an unsigned msghdr.msg_iovlen even though Posix says it should be an int.

### DIFF
--- a/pdns/calidns.cc
+++ b/pdns/calidns.cc
@@ -108,7 +108,7 @@ static void* recvThread(const vector<std::unique_ptr<Socket>>* sockets)
           continue;
         }
         g_recvcounter++;
-        for (int i = 0; i < buf.msg_iovlen; i++)
+        for (decltype(buf.msg_iovlen) i = 0; i < buf.msg_iovlen; i++)
           g_recvbytes += buf.msg_iov[i].iov_len;
 #endif
       }


### PR DESCRIPTION

So use the power of C++ to make the var the same type as msghdr.msg_iovlen.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
