### PR TITLE
dnsdist: Add a test for "Dynamic Block RCode rules messing up the queries count"

### DIFF
--- a/pdns/dnsdist-rings.hh
+++ b/pdns/dnsdist-rings.hh
@@ -191,6 +191,10 @@ struct Rings {
     d_deferredResponseInserts.store(0);
   }
 
+  /* load the content of the ring buffer from a file in the format emitted by grepq(),
+     only useful for debugging purposes */
+  size_t loadFromFile(const std::string& filepath, const struct timespec& now);
+
   std::vector<std::unique_ptr<Shard> > d_shards;
   std::atomic<uint64_t> d_blockingQueryInserts;
   std::atomic<uint64_t> d_blockingResponseInserts;

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -233,7 +233,7 @@ testrunner_SOURCES = \
 	dnsdist-lua-ffi-interface.h dnsdist-lua-ffi-interface.inc \
 	dnsdist-lua-ffi.cc dnsdist-lua-ffi.hh \
 	dnsdist-lua-vars.cc \
-	dnsdist-rings.hh \
+	dnsdist-rings.cc dnsdist-rings.hh \
 	dnsdist-xpf.cc dnsdist-xpf.hh \
 	dnsdist.hh \
 	dnslabeltext.cc \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Also add a debugging function to load the output of a `grepq()` command into the rings, in order to be able to reproduce a dynamic block issue.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
