### PR TITLE
Rec and sdig: support tcp fastopen connect

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -153,6 +153,7 @@ Binero
 binlog
 bitmaps
 bla
+blackhole
 Bleker
 blockfilter
 blockquote
@@ -523,6 +524,7 @@ Faerch
 faf
 failedservers
 failover
+fastopen
 favicon
 FBAE
 fbe

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -332,7 +332,7 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
           s.setFastOpenConnect();
         }
         catch (const NetworkError& e) {
-          g_log << Logger::Error << "tcp-fast-connect enabled but returned error: " << e.what() << endl;
+          // Ignore error, we did a pre-check in pdns_recursor.cc:checkTFOconnect()
         }
       }
 

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -327,8 +327,7 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
       Socket s(ip.sin4.sin_family, SOCK_STREAM);
 
       s.setNonBlocking();
-      // v6 tcp does not seem to have fast open
-      if (ip.sin4.sin_family == AF_INET && SyncRes::s_tcp_fast_open_connect) {
+      if (SyncRes::s_tcp_fast_open_connect) {
         try {
           s.setFastOpenConnect();
         }

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -328,11 +328,14 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
 
       s.setNonBlocking();
       ComboAddress local = pdns::getQueryLocalAddress(ip.sin4.sin_family, 0);
+      if (SyncRes::s_tcp_fast_open > 0) {
+        s.setFastOpen(SyncRes::s_tcp_fast_open);
+      }
 
       s.bind(local);
-        
+
       s.connect(ip);
-      
+
       uint16_t tlen=htons(vpacket.size());
       char *lenP=(char*)&tlen;
       const char *msgP=(const char*)&*vpacket.begin();
@@ -341,7 +344,7 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
       if (ret != LWResult::Result::Success) {
         return ret;
       }
-      
+
       packet.clear();
       ret = arecvtcp(packet, 2, &s, false);
       if (ret != LWResult::Result::Success) {

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -329,7 +329,7 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
       s.setNonBlocking();
       ComboAddress local = pdns::getQueryLocalAddress(ip.sin4.sin_family, 0);
       if (SyncRes::s_tcp_fast_open > 0) {
-        s.setFastOpen(SyncRes::s_tcp_fast_open);
+        s.setFastOpenConnect();
       }
 
       s.bind(local);

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -334,7 +334,7 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
 
       s.bind(local);
 
-      s.connect(ip);
+      s.connect(ip, g_networkTimeoutMsec * 1000); // needed for fastopen EINPROGRESS and better anyway than the system wide connect timeout
 
       uint16_t tlen=htons(vpacket.size());
       char *lenP=(char*)&tlen;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3236,11 +3236,23 @@ static void checkFastOpenSysctl(bool active)
     }
   }
   else {
-    g_log << Logger::Error << "Cannot determine if kernel setting allow fast-open" << endl;
+    g_log << Logger::Notice << "Cannot determine if kernel settings allow fast-open" << endl;
  }
 #else
-  g_log << Logger::Error << "Cannot determine if kernel setting allow fast-open" << endl;
+  g_log << Logger::Notice << "Cannot determine if kernel settings allow fast-open" << endl;
 #endif
+}
+
+static void checkTFOconnect()
+{
+  try {
+    Socket s(AF_INET, SOCK_STREAM);
+    s.setNonBlocking();
+    s.setFastOpenConnect();
+  }
+  catch (const NetworkError& e) {
+    g_log << Logger::Error << "tcp-fast-open-connect enabled but returned error: " << e.what() << endl;
+  }
 }
 
 static void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcpSockets)
@@ -4698,6 +4710,7 @@ static int serviceMain(int argc, char*argv[])
 
   if (SyncRes::s_tcp_fast_open_connect) {
     checkFastOpenSysctl(true);
+    checkTFOconnect();
   }
 
   if(SyncRes::s_serverID.empty()) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3292,7 +3292,7 @@ static void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcp
 
     if (SyncRes::s_tcp_fast_open > 0) {
 #ifdef TCP_FASTOPEN
-      if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, &SyncRes::tcp_fast_open, sizeof SyncRes::tcp_fast_open) < 0) {
+      if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, &SyncRes::s_tcp_fast_open, sizeof SyncRes::s_tcp_fast_open) < 0) {
         int err = errno;
         g_log<<Logger::Error<<"Failed to enable TCP Fast Open for listening socket: "<<strerror(err)<<endl;
       }

--- a/pdns/recursordist/docs/performance.rst
+++ b/pdns/recursordist/docs/performance.rst
@@ -113,7 +113,7 @@ TCP Fast Open Support
 ---------------------
 On Linux systems, the recursor can use TCP Fast Open for passive (incoming, since 4.1) and active (outgoing, since 4.5) TCP connections.
 TCP Fast Open allows the initial SYN packet to carry data, saving one network round-trip.
-For details, consult RFC 7413.
+For details, consult `:rfc:7413`.
 
 To enable TCP Fast Open, it might be need change the value of the ``net.ipv4.tcp_fastopen`` sysctl.
 Value 0 means Fast Open is disabled, 1 is only use Fast Open for active connections, 2 is only for passive connections and 3 is for both.

--- a/pdns/recursordist/docs/performance.rst
+++ b/pdns/recursordist/docs/performance.rst
@@ -124,9 +124,9 @@ The operation of TCP Fast Open can be monitored by looking at these kernel metri
 
 Please note that if active TCP Fast Open attempts fail in particular ways, the Linux kernel stops using active TCP Fast Open for a while for all connections, even connection to servers that previously worked.
 This behaviour can be monitored by watching the ``TCPFastOpenBlackHole`` kernel metric and influenced by setting the ``net.ipv4.tcp_fastopen_blackhole_timeout_sec`` sysctl.
+While developing active TCP Fast Open, it was needed to set ``net.ipv4.tcp_fastopen_blackhole_timeout_sec`` to zero to circumvent the issue, since it was triggered regularly while forcing TCP connections to nameservers for popular domains.
 
-At the moment of writing, the Google operated nameservers (both recursive and authoritative) trigger the pause in use of TCP Fast Open, since they indicate Fast Open support in the TCP handshake, but do not accept the cookie they sent previously and send a new one for each connection.
-While developing active TCP Fast Open, it was needed to set ``net.ipv4.tcp_fastopen_blackhole_timeout_sec`` to zero to circumvent the issue.
+At the moment of writing, the Google operated nameservers (both recursive and authoritative) indicate Fast Open support in the TCP handshake, but do not accept the cookie they sent previously and send a new one for each connection.
 We can only hope Google will fix this issue soon.
 
 If you operate an anycast pool of machines, make them share the TCP Fast Open Key by setting the ``net.ipv4.tcp_fastopen_key`` sysctl, otherwise you wil create a similar issue the Google servers have.

--- a/pdns/recursordist/docs/performance.rst
+++ b/pdns/recursordist/docs/performance.rst
@@ -107,6 +107,34 @@ The settings can be made permanent by using the ``--permanent`` flag::
 
 Following the instructions above, you should be able to attain very high query rates.
 
+.. _tcp-fast-open-support:
+
+TCP Fast Open Support
+---------------------
+On Linux systems, the recursor can use TCP Fast Open for passive (incoming, since 4.1) and active (outgoing, since 4.5) TCP connections.
+TCP Fast Open allows the initial SYN packet to carry data, saving one network round-trip.
+For details, consult RFC 7413.
+
+To enable TCP Fast Open, it might be need change the value of the ``net.ipv4.tcp_fastopen`` sysctl.
+Value 0 means Fast Open is disabled, 1 is only use Fast Open for active connections, 2 is only for passive connections and 3 is for both.
+
+The operation of TCP Fast Open can be monitored by looking at these kernel metrics::
+
+    netstat -s | grep TCPFastOpen
+
+Please note that if active TCP Fast Open attempts fail in particular ways, the Linux kernel stops using active TCP Fast Open for a while for all connections, even connection to servers that previously worked.
+This behaviour can be monitored by watching the ``TCPFastOpenBlackHole`` kernel metric and influenced by setting the ``net.ipv4.tcp_fastopen_blackhole_timeout_sec`` sysctl.
+
+At the moment of writing, the Google operated nameservers (both recursive and authoritative) trigger the pause in use of TCP Fast Open, since they indicate Fast Open support in the TCP handshake, but do not accept the cookie they sent previously and send a new one for each connection.
+While developing active TCP Fast Open, it was needed to set ``net.ipv4.tcp_fastopen_blackhole_timeout_sec`` to zero to circumvent the issue.
+We can only hope Google will fix this issue soon.
+
+If you operate an anycast pool of machines, make them share the TCP Fast Open Key by setting the ``net.ipv4.tcp_fastopen_key`` sysctl, otherwise you wil create a similar issue the Google servers have.
+
+To determine a good value for the :ref:`setting-tcp-fast-open` setting, watch the ``TCPFastOpenListenOverflow`` metric.
+If this value increases often, the value might be too low for your traffic, but note that increasing it will use kernel resources.
+
+
 Recursor Caches
 ---------------
 

--- a/pdns/recursordist/docs/performance.rst
+++ b/pdns/recursordist/docs/performance.rst
@@ -115,7 +115,7 @@ On Linux systems, the recursor can use TCP Fast Open for passive (incoming, sinc
 TCP Fast Open allows the initial SYN packet to carry data, saving one network round-trip.
 For details, consult `:rfc:7413`.
 
-To enable TCP Fast Open, it might be need change the value of the ``net.ipv4.tcp_fastopen`` sysctl.
+To enable TCP Fast Open, it might be needed to change the value of the ``net.ipv4.tcp_fastopen`` sysctl.
 Value 0 means Fast Open is disabled, 1 is only use Fast Open for active connections, 2 is only for passive connections and 3 is for both.
 
 The operation of TCP Fast Open can be monitored by looking at these kernel metrics::
@@ -129,7 +129,7 @@ While developing active TCP Fast Open, it was needed to set ``net.ipv4.tcp_fasto
 At the moment of writing, the Google operated nameservers (both recursive and authoritative) indicate Fast Open support in the TCP handshake, but do not accept the cookie they sent previously and send a new one for each connection.
 We can only hope Google will fix this issue soon.
 
-If you operate an anycast pool of machines, make them share the TCP Fast Open Key by setting the ``net.ipv4.tcp_fastopen_key`` sysctl, otherwise you wil create a similar issue the Google servers have.
+If you operate an anycast pool of machines, make them share the TCP Fast Open Key by setting the ``net.ipv4.tcp_fastopen_key`` sysctl, otherwise you will create a similar issue the Google servers have.
 
 To determine a good value for the :ref:`setting-tcp-fast-open` setting, watch the ``TCPFastOpenListenOverflow`` metric.
 If this value increases often, the value might be too low for your traffic, but note that increasing it will use kernel resources.

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1849,7 +1849,7 @@ The numerical value supplied is used as the queue size, 0 meaning disabled. See 
 -  Boolean
 -  Default: no (disabled)
 
-Enable TCP Fast Open Connect support, if available, on the outgoing connections to authoritatively servers. See :ref:`tcp-fast-open-support`.
+Enable TCP Fast Open Connect support, if available, on the outgoing connections to authoritative servers. See :ref:`tcp-fast-open-support`.
 
 .. _setting-threads:
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1838,7 +1838,18 @@ A list of comma-separated statistic names, that are prevented from being exporte
 -  Default: 0 (Disabled)
 
 Enable TCP Fast Open support, if available, on the listening sockets.
-The numerical value supplied is used as the queue size, 0 meaning disabled.
+The numerical value supplied is used as the queue size, 0 meaning disabled. See :ref:`tcp-fast-open-support`.
+
+.. _setting-tcp-fast-open-connect:
+
+``tcp-fast-open-connect``
+-------------------------
+.. versionadded:: 4.5.0
+
+-  Boolean
+-  Default: no (disabled)
+
+Enable TCP Fast Open Connect support, if available, on the outgoing connections to authoritatively servers. See :ref:`tcp-fast-open-support`.
 
 .. _setting-threads:
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -57,6 +57,10 @@ Removed settings
 ^^^^^^^^^^^^^^^^
 - The :ref:`setting-query-local-address6` has been removed. It already was deprecated.
 
+New settings
+^^^^^^^^^^^^
+- A new setting :ref:`setting-tcp-fast-open-connect` has been introduced, it enables TCP Fast Connect for outgoing connections. Please read :ref:`tcp-fast-open-support` before enabling this feature.
+
 4.3.x to 4.4.0
 --------------
 

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -38,9 +38,14 @@ static void usage()
 {
   cerr << "sdig" << endl;
   cerr << "Syntax: sdig IP-ADDRESS-OR-DOH-URL PORT QNAME QTYPE "
+<<<<<<< HEAD
           "[dnssec] [ednssubnet SUBNET/MASK] [hidesoadetails] [hidettl] [recurse] [showflags] "
           "[tcp] [dot] [insecure] [fastOpen] [subjectName name] [caStore file] [tlsProvider openssl|gnutls] "
           "[xpf XPFDATA] [class CLASSNUM] "
+=======
+          "[dnssec] [ednssubnet SUBNET/MASK] [hidesoadetails] [hidettl] "
+          "[recurse] [showflags] [tcp] [fastopen] [xpf XPFDATA] [class CLASSNUM] "
+>>>>>>> 5b8fccd32 (sdig now works with fastopen)
           "[proxy UDP(0)/TCP(1) SOURCE-IP-ADDRESS-AND-PORT DESTINATION-IP-ADDRESS-AND-PORT]"
           "dumpluaraw"
        << endl;
@@ -212,6 +217,7 @@ try {
   bool dnssec = false;
   bool recurse = false;
   bool tcp = false;
+  bool fastopen = false;
   bool showflags = false;
   bool hidesoadetails = false;
   bool doh = false;
@@ -262,6 +268,7 @@ try {
         hidettl = true;
       else if (strcmp(argv[i], "tcp") == 0)
         tcp = true;
+<<<<<<< HEAD
       else if (strcmp(argv[i], "dot") == 0)
         dot = true;
       else if (strcmp(argv[i], "insecure") == 0)
@@ -269,6 +276,11 @@ try {
       else if (strcmp(argv[i], "fastOpen") == 0)
         fastOpen = true;
       else if (strcmp(argv[i], "ednssubnet") == 0) {
+=======
+      if (strcmp(argv[i], "fastopen") == 0)
+        fastopen = true;
+      if (strcmp(argv[i], "ednssubnet") == 0) {
+>>>>>>> 5b8fccd32 (sdig now works with fastopen)
         if (argc < i + 2) {
           cerr << "ednssubnet needs an argument" << endl;
           exit(EXIT_FAILURE);

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -38,14 +38,9 @@ static void usage()
 {
   cerr << "sdig" << endl;
   cerr << "Syntax: sdig IP-ADDRESS-OR-DOH-URL PORT QNAME QTYPE "
-<<<<<<< HEAD
           "[dnssec] [ednssubnet SUBNET/MASK] [hidesoadetails] [hidettl] [recurse] [showflags] "
           "[tcp] [dot] [insecure] [fastOpen] [subjectName name] [caStore file] [tlsProvider openssl|gnutls] "
           "[xpf XPFDATA] [class CLASSNUM] "
-=======
-          "[dnssec] [ednssubnet SUBNET/MASK] [hidesoadetails] [hidettl] "
-          "[recurse] [showflags] [tcp] [fastopen] [xpf XPFDATA] [class CLASSNUM] "
->>>>>>> 5b8fccd32 (sdig now works with fastopen)
           "[proxy UDP(0)/TCP(1) SOURCE-IP-ADDRESS-AND-PORT DESTINATION-IP-ADDRESS-AND-PORT]"
           "dumpluaraw"
        << endl;
@@ -268,7 +263,6 @@ try {
         hidettl = true;
       else if (strcmp(argv[i], "tcp") == 0)
         tcp = true;
-<<<<<<< HEAD
       else if (strcmp(argv[i], "dot") == 0)
         dot = true;
       else if (strcmp(argv[i], "insecure") == 0)
@@ -276,11 +270,6 @@ try {
       else if (strcmp(argv[i], "fastOpen") == 0)
         fastOpen = true;
       else if (strcmp(argv[i], "ednssubnet") == 0) {
-=======
-      if (strcmp(argv[i], "fastopen") == 0)
-        fastopen = true;
-      if (strcmp(argv[i], "ednssubnet") == 0) {
->>>>>>> 5b8fccd32 (sdig now works with fastopen)
         if (argc < i + 2) {
           cerr << "ednssubnet needs an argument" << endl;
           exit(EXIT_FAILURE);

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -212,7 +212,6 @@ try {
   bool dnssec = false;
   bool recurse = false;
   bool tcp = false;
-  bool fastopen = false;
   bool showflags = false;
   bool hidesoadetails = false;
   bool doh = false;

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <sys/select.h>
 #include <fcntl.h>
@@ -127,10 +128,12 @@ public:
     }
   }
 
-  void setFastOpen(int fastOpenQueueSize)
+  void setFastOpenConnect()
   {
 #ifdef TCP_FASTOPEN_CONNECT
-    setsockopt(d_socket, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, &fastOpenQueueSize, sizeof fastOpenQueueSize);
+    int on = 1;
+    if (setsockopt(d_socket, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, &on, sizeof(on)) < 0)
+      throw NetworkError("While setting TCP_FASTOPEN_CONNECT: " + stringerror());
 #endif
   }
 

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -279,9 +279,7 @@ public:
     while(bytes) {
       ret=::write(d_socket, ptr, bytes);
       if(ret < 0) {
-        // some systems (e.g. OpenBSD) return ENOTCONN on non-blocking sockets on which connect *has been* called
-        // we have to wait for the opportunity to write after the connect is done
-        if (errno == EAGAIN || errno == ENOTCONN) {
+        if(errno == EAGAIN) {
           ret=waitForRWData(d_socket, false, timeout, 0);
           if(ret < 0)
             throw NetworkError("Waiting for data write");

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -127,6 +127,13 @@ public:
     }
   }
 
+  void setFastOpen(int fastOpenQueueSize)
+  {
+#ifdef TCP_FASTOPEN_CONNECT
+    setsockopt(d_socket, IPPROTO_TCP, TCP_FASTOPEN_CONNECT, &fastOpenQueueSize, sizeof fastOpenQueueSize);
+#endif
+  }
+
   //! Bind the socket to a specified endpoint
   void bind(const ComboAddress &local, bool reuseaddr=true)
   {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -99,6 +99,7 @@ bool SyncRes::s_qnameminimization;
 SyncRes::HardenNXD SyncRes::s_hardenNXD;
 unsigned int SyncRes::s_refresh_ttlperc;
 int SyncRes::s_tcp_fast_open;
+bool SyncRes::s_tcp_fast_open_connect;
 
 #define LOG(x) if(d_lm == Log) { g_log <<Logger::Warning << x; } else if(d_lm == Store) { d_trace << x; }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -98,6 +98,7 @@ bool SyncRes::s_noEDNS;
 bool SyncRes::s_qnameminimization;
 SyncRes::HardenNXD SyncRes::s_hardenNXD;
 unsigned int SyncRes::s_refresh_ttlperc;
+int SyncRes::s_tcp_fast_open;
 
 #define LOG(x) if(d_lm == Log) { g_log <<Logger::Warning << x; } else if(d_lm == Store) { d_trace << x; }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -791,6 +791,7 @@ public:
   static bool s_qnameminimization;
   static HardenNXD s_hardenNXD;
   static unsigned int s_refresh_ttlperc;
+  static int s_tcp_fast_open;
 
   std::unordered_map<std::string,bool> d_discardedPolicies;
   DNSFilterEngine::Policy d_appliedPolicy;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -792,6 +792,7 @@ public:
   static HardenNXD s_hardenNXD;
   static unsigned int s_refresh_ttlperc;
   static int s_tcp_fast_open;
+  static bool s_tcp_fast_open_connect;
 
   std::unordered_map<std::string,bool> d_discardedPolicies;
   DNSFilterEngine::Policy d_appliedPolicy;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Start supporting `TCP_FASTOPEN` for outgoing TCP connections.
We originally did this for `sdig` and the recursor, but the `sdig` case is now handler by tcpiohandler and no longer part  of this PR.

Don't forget to do `sysctl -w net.ipv4.tcp_fastopen=3` if you want to use this (or `1` if you only want it for outgoing and `2` for incoming only.

While testing this, I had a hard time finding auths that actually support FAST_OPEN.
8.8.8.8 and the google auths appear to do so, but trying to use it, the cookie is rejected and a new cookie is sent, causing the client to retransmit the request payload.

Fixes #7982

TODO

- [ ] deciding if we want this since auth support seems to be almost non-existent or buggy.
- [x] separate setting for outgoing, e.g. `tcp-fast-open-connect`
- [x] add check of sysctl setting so people get a warning if `tcp-fast-open` (or `tcp-fast-open-connect`?) setting isn;t allowed by sysctl
- [X] docs incl mentioning sysctl and guidance for the value of `tcp-fast-open`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
