### PR TITLE
rec: treat the .localhost domain as special

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -202,7 +202,7 @@ bool SyncRes::doSpecialNamesResolve(const DNSName &qname, const QType &qtype, co
       answers.push_back({QType::PTR, "localhost."});
   }
 
-  if (qname == localhost &&
+  if (qname.isPartOf(localhost) &&
       qclass == QClass::IN) {
     handled = true;
     if (qtype == QType::A || qtype == QType::ANY)

--- a/regression-tests.recursor-dnssec/test_Simple.py
+++ b/regression-tests.recursor-dnssec/test_Simple.py
@@ -85,6 +85,15 @@ auth-zones=authzone.example=configs/%s/authzone.zone""" % _confdir
         self.assertRcodeEqual(resPTR, dns.rcode.NOERROR)
         self.assertRRsetInAnswer(resPTR, expectedPTR)
 
+    def testLocalhostSubdomain(self):
+        queryA = dns.message.make_query('foo.localhost', 'A', want_dnssec=True)
+        expectedA = dns.rrset.from_text('foo.localhost.', 0, 'IN', 'A', '127.0.0.1')
+
+        resA = self.sendUDPQuery(queryA)
+
+        self.assertRcodeEqual(resA, dns.rcode.NOERROR)
+        self.assertRRsetInAnswer(resA, expectedA)
+
     def testIslandOfSecurity(self):
         query = dns.message.make_query('cname-to-islandofsecurity.secure.example.', 'A', want_dnssec=True)
 

--- a/regression-tests.recursor-dnssec/test_SimpleTCP.py
+++ b/regression-tests.recursor-dnssec/test_SimpleTCP.py
@@ -85,6 +85,15 @@ auth-zones=authzone.example=configs/%s/authzone.zone""" % _confdir
         self.assertRcodeEqual(resPTR, dns.rcode.NOERROR)
         self.assertRRsetInAnswer(resPTR, expectedPTR)
 
+    def testLocalhostSubdomain(self):
+        queryA = dns.message.make_query('foo.localhost', 'A', want_dnssec=True)
+        expectedA = dns.rrset.from_text('foo.localhost.', 0, 'IN', 'A', '127.0.0.1')
+
+        resA = self.sendTCPQuery(queryA)
+
+        self.assertRcodeEqual(resA, dns.rcode.NOERROR)
+        self.assertRRsetInAnswer(resA, expectedA)
+
     def testIslandOfSecurity(self):
         query = dns.message.make_query('cname-to-islandofsecurity.secure.example.', 'A', want_dnssec=True)
 


### PR DESCRIPTION
### Short description
This satisfies the SHOULD in RFC6761 section 6.3 point 4.

The RFC mentions in 6.3.

```
   The domain "localhost." and any names falling within ".localhost."
   are special in the following ways:

[.....]

   4.  Caching DNS servers SHOULD recognize localhost names as special
       and SHOULD NOT attempt to look up NS records for them, or
       otherwise query authoritative DNS servers in an attempt to
       resolve localhost names.  Instead, caching DNS servers SHOULD,
       for all such address queries, generate an immediate positive
       response giving the IP loopback address, and for all other query
       types, generate an immediate negative response.  This is to avoid
       unnecessary load on the root name servers and other name servers.
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)