### PR TITLE
Fix help text for carbon-instance

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -169,7 +169,7 @@ void declareArguments()
 
   ::arg().set("carbon-namespace", "If set overwrites the first part of the carbon string")="pdns";
   ::arg().set("carbon-ourname", "If set, overrides our reported hostname for carbon stats")="";
-  ::arg().set("carbon-instance", "If set overwrites the the instance name default")="auth";
+  ::arg().set("carbon-instance", "If set overwrites the instance name default")="auth";
   ::arg().set("carbon-server", "If set, send metrics in carbon (graphite) format to this server IP address")="";
   ::arg().set("carbon-interval", "Number of seconds between carbon (graphite) updates")="30";
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5271,7 +5271,7 @@ int main(int argc, char **argv)
     ::arg().set("carbon-server", "If set, send metrics in carbon (graphite) format to this server IP address")="";
     ::arg().set("carbon-interval", "Number of seconds between carbon (graphite) updates")="30";
     ::arg().set("carbon-namespace", "If set overwrites the first part of the carbon string")="pdns";
-    ::arg().set("carbon-instance", "If set overwrites the the instance name default")="recursor";
+    ::arg().set("carbon-instance", "If set overwrites the instance name default")="recursor";
 
     ::arg().set("statistics-interval", "Number of seconds between printing of recursor statistics, 0 to disable")="1800";
     ::arg().set("quiet","Suppress logging of questions and answers")="";


### PR DESCRIPTION
### Short description

In the output of the help text, there's a line having "the the".

When running `pdns_recursor --help`, or `pdns_server --help`:

```
  --carbon-instance=...
	If set overwrites the the instance name default
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master

Honestly, I don't know what the last box really means. I've created a separate branch for my changes, branched from the master branch. I'm unsure if the line should be deleted, or if the box should be checked...

Kind regards,
Bernd