### PR TITLE
recursor: Add EDNS0 padding

### DIFF
--- a/pdns/packetcache.hh
+++ b/pdns/packetcache.hh
@@ -31,7 +31,7 @@ public:
 
   /* hash the packet from the provided position, which should point right after tje qname. This skips:
      - the query ID ;
-     - EDNS Cookie options, if any ;
+     - EDNS Cookie and PADDING options, if any ;
      - EDNS Client Subnet options, if any and skipECS is true.
   */
   static uint32_t hashAfterQname(const pdns_string_view& packet, uint32_t currentHash, size_t pos, bool skipECS)
@@ -84,13 +84,16 @@ public:
       }
 
       bool skip = false;
-      if (optionCode == EDNSOptionCode::COOKIE) {
-        skip = true;
-      }
-      else if (optionCode == EDNSOptionCode::ECS) {
-        if (skipECS) {
+      switch (optionCode) {
+        case EDNSOptionCode::COOKIE:
           skip = true;
-        }
+          break;
+        case EDNSOptionCode::ECS:
+          skip = skipECS;
+          break;
+        case EDNSOptionCode::PADDING:
+          skip = true;
+          break;
       }
 
       if (!skip) {
@@ -140,7 +143,7 @@ public:
 
   /* hash the packet from the beginning, including the qname. This skips:
      - the query ID ;
-     - EDNS Cookie options, if any ;
+     - EDNS Cookie or padding options, if any ;
      - EDNS Client Subnet options, if any and skipECS is true.
   */
   static uint32_t canHashPacket(const std::string& packet, bool skipECS)

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -579,6 +579,31 @@ found, the recursor fallbacks to sending 127.0.0.1.
 This is the value set for the EDNS0 buffer size in outgoing packets.
 Lower this if you experience timeouts.
 
+.. _setting-edns-padding:
+
+``edns-padding``
+----------------
+.. versionadded:: 4.5.0
+
+- Boolean
+- default: no
+
+Set to ``yes`` to respond with padded responses to queries with the EDNS0 'PADDING' option set (:rfc:`7830`).
+Enabling this options might lead to a reduce hitrate in the packetcache, depending
+on the padding lengths of the clients.
+
+.. _setting-edns-padding-max-bytes:
+
+``edns-padding-max-bytes``
+--------------------------
+.. versionadded:: 4.5.0
+
+- Integer
+- default: 512
+
+Maximum number of bytes to add to a padded response (see :ref:`setting-edns-padding`).
+Responses can contain fewer padding bytes, if adding the maximum number of bytes would make the packet go over the advertised EDNS buffer size of the client.
+
 .. _setting-edns-subnet-whitelist:
 
 ``edns-subnet-whitelist``

--- a/regression-tests.recursor-dnssec/test_EDNSPadding.py
+++ b/regression-tests.recursor-dnssec/test_EDNSPadding.py
@@ -1,0 +1,73 @@
+import dns
+
+from recursortests import RecursorTest
+
+
+class EDNSPaddingBase(RecursorTest):
+    """
+    These tests are designed to check if we correctly respond to queries with
+    ENDS PADDING options
+    """
+    _confdir = 'EDNSPadding'
+
+    _auth_zones = {}
+
+
+class EDNSPaddingTestDisabled(EDNSPaddingBase):
+    _confdir = 'EDNSPaddingDisabled'
+
+    _config_template = """
+edns-padding=%s
+edns-padding-max-bytes=%i
+""" % ('no', 512)
+
+    def testNoPaddinginQuery(self):
+        query = dns.message.make_query('version.bind.', 'TXT', 'CH',
+                                       use_edns=0, payload=4096)
+        response = self.sendUDPQuery(query)
+        self.assertRcodeEqual(response, dns.rcode.NOERROR)
+        self.assertEqual(response.options, ())
+
+    def testPaddinginQuery(self):
+        opt = dns.edns.GenericOption(dns.edns.PADDING, 20 * '\0')
+        query = dns.message.make_query('version.bind.', 'TXT', 'CH',
+                                       use_edns=0, payload=4096, options=[opt])
+        response = self.sendUDPQuery(query)
+        self.assertRcodeEqual(response, dns.rcode.NOERROR)
+        self.assertEqual(response.options, ())
+
+
+class EDNSPaddingTestEnabled(EDNSPaddingBase):
+    _confdir = 'EDNSPaddingEnabled'
+
+    _config_template = """
+edns-padding=%s
+edns-padding-max-bytes=%i
+""" % ('yes', 512)
+
+    def testNoPaddinginQuery(self):
+        query = dns.message.make_query('version.bind.', 'TXT', 'CH',
+                                       use_edns=0, payload=4096)
+        response = self.sendUDPQuery(query)
+        self.assertRcodeEqual(response, dns.rcode.NOERROR)
+        self.assertEqual(response.options, ())
+
+    def testPaddinginQuery(self):
+        opt = dns.edns.GenericOption(dns.edns.PADDING, 20 * '\0')
+        query = dns.message.make_query('version.bind.', 'TXT', 'CH',
+                                       use_edns=0, payload=4096, options=[opt])
+        response = self.sendUDPQuery(query)
+        self.assertRcodeEqual(response, dns.rcode.NOERROR)
+        self.assertEqual(len(response.options), 1)
+        self.assertEqual(response.options[0],
+                         dns.edns.GenericOption(dns.edns.PADDING, 512 * '\0'))
+
+    def testPaddingInQueryWithTooSmallBufsize(self):
+        opt = dns.edns.GenericOption(dns.edns.PADDING, 20 * '\0')
+        query = dns.message.make_query('version.bind.', 'TXT', 'CH',
+                                       use_edns=0, payload=512, options=[opt])
+        response = self.sendUDPQuery(query)
+        self.assertRcodeEqual(response, dns.rcode.NOERROR)
+        self.assertEqual(len(response.options), 1)
+        self.assertEqual(response.options[0],
+                         dns.edns.GenericOption(dns.edns.PADDING, 326 * '\0'))

--- a/regression-tests.recursor-dnssec/test_EDNSPadding.py
+++ b/regression-tests.recursor-dnssec/test_EDNSPadding.py
@@ -67,7 +67,9 @@ edns-padding-max-bytes=%i
         query = dns.message.make_query('version.bind.', 'TXT', 'CH',
                                        use_edns=0, payload=512, options=[opt])
         response = self.sendUDPQuery(query)
+        print(response)
         self.assertRcodeEqual(response, dns.rcode.NOERROR)
         self.assertEqual(len(response.options), 1)
+        print(response.options[0].to_wire())
         self.assertEqual(response.options[0],
                          dns.edns.GenericOption(dns.edns.PADDING, 326 * '\0'))


### PR DESCRIPTION
### Short description
This adds a very crude from of EDNS0 padding to the recursor.

When the client sends a PADDING option in the request, the recursor will send a padded response, with at most 512 padding bytes, limited by the buffersize of the UDP packet.

Do note that this is quite the packetcache-buster and might require some special handling.

This PR also needs tests.

~~This commit also ensures the EDNS0 options in the response are always sorted.~~

To consider:
 * [x] `edns-padding` config option: `off` (never send padded responses, `on-request` (send padded responses to queries with padding), `always` (always send a padded response to queries with EDNS0). Implemented as a single boolean now.
 * [x]  `edns-padding-max-bytes` option: a way to specify the maximum amount of padding to add (as it is fixed to 512 now)

In the future, we could consider adding several of the policies described in [RFC 8467](https://tools.ietf.org/html/rfc8467).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
