### PR TITLE
Two spec-file fixes for the recursor

### DIFF
--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -16,6 +16,7 @@ BuildRequires: systemd-devel
 BuildRequires: openssl-devel
 BuildRequires: net-snmp-devel
 BuildRequires: libsodium-devel
+BuildRequires: fstrm-devel
 
 %ifarch aarch64
 BuildRequires: lua-devel
@@ -27,10 +28,6 @@ BuildRequires: luajit-devel
 
 %ifarch ppc64 ppc64le
 BuildRequires: libatomic
-%endif
-
-%if 0%{?rhel} >= 7
-BuildRequires: fstrm-devel
 %endif
 
 Requires(pre): shadow-utils

--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -13,8 +13,6 @@ BuildRequires: boost-devel
 BuildRequires: libcap-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel
-BuildRequires: protobuf-compiler
-BuildRequires: protobuf-devel
 BuildRequires: openssl-devel
 BuildRequires: net-snmp-devel
 BuildRequires: libsodium-devel


### PR DESCRIPTION
### Short description
This PR stops pulling in the protobuf development libraries (no longer required because we use protozero) and always pulls in libfstrm (this was conditional on EL version, but we no longer support 6, where it was unavailable)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)