### PR TITLE
rec: fix recursor caches to handle timestamps > 2038

### DIFF
--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -57,7 +57,7 @@ public:
 
   typedef boost::optional<std::string> OptTag;
 
-int32_t get(time_t, const DNSName &qname, const QType& qt, bool requireAuth, vector<DNSRecord>* res, const ComboAddress& who, bool refresh = false, const OptTag& routingTag = boost::none, vector<std::shared_ptr<RRSIGRecordContent>>* signatures=nullptr, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs=nullptr, bool* variable=nullptr, vState* state=nullptr, bool* wasAuth=nullptr, DNSName* fromAuthZone=nullptr);
+time_t get(time_t, const DNSName &qname, const QType& qt, bool requireAuth, vector<DNSRecord>* res, const ComboAddress& who, bool refresh = false, const OptTag& routingTag = boost::none, vector<std::shared_ptr<RRSIGRecordContent>>* signatures=nullptr, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs=nullptr, bool* variable=nullptr, vState* state=nullptr, bool* wasAuth=nullptr, DNSName* fromAuthZone=nullptr);
 
   void replace(time_t, const DNSName &qname, const QType& qt,  const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs, bool auth, const DNSName& authZone, boost::optional<Netmask> ednsmask=boost::none, const OptTag& routingTag = boost::none, vState state=vState::Indeterminate, boost::optional<ComboAddress> from=boost::none);
 
@@ -231,13 +231,13 @@ private:
     return d_maps[qname.hash() % d_maps.size()];
   }
 
-  static int32_t fakeTTD(OrderedTagIterator_t& entry, const DNSName& qname, uint16_t qtype, int32_t ret, time_t now, uint32_t origTTL, bool refresh);
+  static time_t fakeTTD(OrderedTagIterator_t& entry, const DNSName& qname, uint16_t qtype, time_t ret, time_t now, uint32_t origTTL, bool refresh);
 
   bool entryMatches(OrderedTagIterator_t& entry, uint16_t qt, bool requireAuth, const ComboAddress& who);
   Entries getEntries(MapCombo& map, const DNSName &qname, const QType& qt, const OptTag& rtag);
   cache_t::const_iterator getEntryUsingECSIndex(MapCombo& map, time_t now, const DNSName &qname, uint16_t qtype, bool requireAuth, const ComboAddress& who);
 
-  int32_t handleHit(MapCombo& map, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, vector<std::shared_ptr<RRSIGRecordContent>>* signatures, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone);
+  time_t handleHit(MapCombo& map, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, vector<std::shared_ptr<RRSIGRecordContent>>* signatures, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone);
 
 public:
   struct lock {

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(test_get_entry2038)
   DNSName qname("www2.powerdns.com");
   DNSName auth("powerdns.com");
 
-  struct timeval now{INT_MAX - 300, 0};
+  timeval now{INT_MAX - 300, 0};
 
   NegCache cache;
   cache.add(genNegCacheEntry(qname, auth, now));

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -69,6 +69,30 @@ BOOST_AUTO_TEST_CASE(test_get_entry)
   BOOST_CHECK_EQUAL(ne.d_auth, auth);
 }
 
+BOOST_AUTO_TEST_CASE(test_get_entry2038)
+{
+  /* Add a full name negative entry to the cache and attempt to get an entry for
+   * the A record. Should yield the full name does not exist entry
+   */
+  DNSName qname("www2.powerdns.com");
+  DNSName auth("powerdns.com");
+
+  struct timeval now{INT_MAX - 300, 0};
+
+  NegCache cache;
+  cache.add(genNegCacheEntry(qname, auth, now));
+
+  BOOST_CHECK_EQUAL(cache.size(), 1U);
+
+  NegCache::NegCacheEntry ne;
+  bool ret = cache.get(qname, QType(1), now, ne);
+
+  BOOST_CHECK(ret);
+  BOOST_CHECK_EQUAL(ne.d_name, qname);
+  BOOST_CHECK_EQUAL(ne.d_qtype.getName(), QType(0).getName());
+  BOOST_CHECK_EQUAL(ne.d_auth, auth);
+}
+
 BOOST_AUTO_TEST_CASE(test_get_entry_exact_type)
 {
   /* Add a full name negative entry to the cache and attempt to get an entry for

--- a/pdns/recursordist/test-negcache_cc.cc
+++ b/pdns/recursordist/test-negcache_cc.cc
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(test_get_entry2038)
   BOOST_CHECK_EQUAL(cache.size(), 1U);
 
   NegCache::NegCacheEntry ne;
-  bool ret = cache.get(qname, QType(1), now, ne);
+  bool ret = cache.get(qname, QType(QType::A), now, ne);
 
   BOOST_CHECK(ret);
   BOOST_CHECK_EQUAL(ne.d_name, qname);

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
   std::vector<std::shared_ptr<DNSRecord>> authRecords;
   std::vector<std::shared_ptr<RRSIGRecordContent>> signatures;
   const DNSName authZone(".");
-  time_t now = time(nullptr);
+  time_t now = INT_MAX - 15;
 
   time_t ttd = now + 30;
   DNSName power("powerdns.com.");

--- a/pdns/recursordist/test-recursorcache_cc.cc
+++ b/pdns/recursordist/test-recursorcache_cc.cc
@@ -11,7 +11,7 @@
 
 BOOST_AUTO_TEST_SUITE(recursorcache_cc)
 
-BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
+static void simple(time_t now)
 {
   MemRecursorCache MRC;
 
@@ -19,7 +19,6 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
   std::vector<std::shared_ptr<DNSRecord>> authRecords;
   std::vector<std::shared_ptr<RRSIGRecordContent>> signatures;
   const DNSName authZone(".");
-  time_t now = INT_MAX - 15;
 
   time_t ttd = now + 30;
   DNSName power("powerdns.com.");
@@ -29,7 +28,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
   dr0.d_type = QType::AAAA;
   dr0.d_class = QClass::IN;
   dr0.d_content = std::make_shared<AAAARecordContent>(dr0Content);
-  dr0.d_ttl = static_cast<uint32_t>(ttd);
+  dr0.d_ttl = static_cast<uint32_t>(ttd); // XXX truncation
   dr0.d_place = DNSResourceRecord::ANSWER;
 
   records.push_back(dr0);
@@ -87,7 +86,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
     dr1.d_type = QType::AAAA;
     dr1.d_class = QClass::IN;
     dr1.d_content = std::make_shared<AAAARecordContent>(dr1Content);
-    dr1.d_ttl = static_cast<uint32_t>(ttd);
+    dr1.d_ttl = static_cast<uint32_t>(ttd); // XXX truncation
     dr1.d_place = DNSResourceRecord::ANSWER;
 
     DNSRecord dr2;
@@ -96,7 +95,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
     dr2.d_type = QType::A;
     dr2.d_class = QClass::IN;
     dr2.d_content = std::make_shared<ARecordContent>(dr2Content);
-    dr2.d_ttl = static_cast<uint32_t>(ttd);
+    dr2.d_ttl = static_cast<uint32_t>(ttd); // XXX truncation
     // the place should not matter to the cache
     dr2.d_place = DNSResourceRecord::AUTHORITY;
 
@@ -235,7 +234,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
     dr3.d_type = QType::A;
     dr3.d_class = QClass::IN;
     dr3.d_content = std::make_shared<ARecordContent>(dr3Content);
-    dr3.d_ttl = static_cast<uint32_t>(ttd + 100);
+    dr3.d_ttl = static_cast<uint32_t>(ttd + 100); // XXX truncation
     // the place should not matter to the cache
     dr3.d_place = DNSResourceRecord::AUTHORITY;
 
@@ -315,7 +314,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
     dr4.d_type = QType::A;
     dr4.d_class = QClass::IN;
     dr4.d_content = std::make_shared<ARecordContent>(dr4Content);
-    dr4.d_ttl = static_cast<uint32_t>(ttd);
+    dr4.d_ttl = static_cast<uint32_t>(ttd); // XXX truncation
     dr4.d_place = DNSResourceRecord::AUTHORITY;
 
     // insert another entry but for 192.168.0.1/31
@@ -363,6 +362,29 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple)
+{
+  simple(time(nullptr));
+}
+
+BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple2038)
+{
+  simple(INT_MAX - 15);
+}
+
+BOOST_AUTO_TEST_CASE(test_RecursorCacheSimple2038bis)
+{
+  simple(time_t(INT_MAX) + 10000);
+}
+
+#if 0
+BOOST_AUTO_TEST_CASE(test_RecursorCacheSimpleDistantFuture)
+{
+  // Fails due to using 32-bit ttl values in records for absolute time, see handleHit()
+  simple(2 * time_t(INT_MAX));
+}
+#endif
+
 BOOST_AUTO_TEST_CASE(test_RecursorCacheGhost)
 {
   MemRecursorCache MRC;
@@ -383,7 +405,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheGhost)
   ns1.d_type = QType::NS;
   ns1.d_class = QClass::IN;
   ns1.d_content = std::make_shared<NSRecordContent>(ns1Content);
-  ns1.d_ttl = static_cast<uint32_t>(ttd);
+  ns1.d_ttl = static_cast<uint32_t>(ttd); // XXX truncation
   ns1.d_place = DNSResourceRecord::ANSWER;
   records.push_back(ns1);
   MRC.replace(now, ns1.d_name, QType(ns1.d_type), records, signatures, authRecords, true, DNSName("powerdns.com."), boost::none);
@@ -392,7 +414,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCacheGhost)
   /* try to raise the TTL, simulating the delegated authoritative server
      raising the TTL so the zone stays alive */
   records.clear();
-  ns1.d_ttl = static_cast<uint32_t>(ttd + 3600);
+  ns1.d_ttl = static_cast<uint32_t>(ttd + 3600); // XXX truncation
   records.push_back(ns1);
   MRC.replace(now, ns1.d_name, QType(ns1.d_type), records, signatures, authRecords, true, DNSName("ghost.powerdns.com."), boost::none);
   BOOST_CHECK_EQUAL(MRC.size(), 1U);
@@ -427,7 +449,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCache_ExpungingExpiredEntries)
   dr1.d_type = QType::AAAA;
   dr1.d_class = QClass::IN;
   dr1.d_content = std::make_shared<AAAARecordContent>(dr1Content);
-  dr1.d_ttl = static_cast<uint32_t>(ttd);
+  dr1.d_ttl = static_cast<uint32_t>(ttd); // XXX truncation
   dr1.d_place = DNSResourceRecord::ANSWER;
 
   /* entry for power1, which expired 30 ago too */
@@ -437,7 +459,7 @@ BOOST_AUTO_TEST_CASE(test_RecursorCache_ExpungingExpiredEntries)
   dr2.d_type = QType::AAAA;
   dr2.d_class = QClass::IN;
   dr2.d_content = std::make_shared<AAAARecordContent>(dr2Content);
-  dr2.d_ttl = static_cast<uint32_t>(ttd);
+  dr2.d_ttl = static_cast<uint32_t>(ttd); // XXX truncation
   dr2.d_place = DNSResourceRecord::ANSWER;
 
   /* insert both entries */


### PR DESCRIPTION
Recursor cache one was failing, a few functions return `int32_t` instead of `time_t`.

This is a demonstration of the type of issues #10000 talks about.

There are still issues caused by using `DNSRecord`'s `d_ttl` field (a 32-bit quantity since it corresponds to the phycial representation) for absolute time.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
