### PR TITLE
auth: fix tcp answer counters

### DIFF
--- a/pdns/responsestats-auth.cc
+++ b/pdns/responsestats-auth.cc
@@ -7,7 +7,7 @@ extern StatBag S;
  *  Function that creates all the stats
  *  when udpOrTCP is true, it is udp
  */
-void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP) {
+void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP, bool last) {
   const string& buf=p.getString();
   static AtomicCounter &udpnumanswered=*S.getPointer("udp-answers");
   static AtomicCounter &udpnumanswered4=*S.getPointer("udp4-answers");
@@ -44,14 +44,19 @@ void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP) {
       udpbytesanswered6+=buf.length();
     }
   } else { //tcp
-    tcpnumanswered++;
     tcpbytesanswered+=buf.length();
     if(p.d_remote.sin4.sin_family==AF_INET) {
-      tcpnumanswered4++;
       tcpbytesanswered4+=buf.length();
     } else {
-      tcpnumanswered6++;
       tcpbytesanswered6+=buf.length();
+    }
+    if(last) {
+     tcpnumanswered++;
+     if(p.d_remote.sin4.sin_family==AF_INET) {
+      tcpnumanswered4++;
+     } else {
+      tcpnumanswered6++;
+     }
     }
   }
 

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -30,7 +30,7 @@ class ResponseStats
 public:
   ResponseStats();
 
-  void submitResponse(DNSPacket &p, bool udpOrTCP);
+  void submitResponse(DNSPacket &p, bool udpOrTCP, bool last=true);
   void submitResponse(uint16_t qtype, uint16_t respsize, bool udpOrTCP);
   void submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rcode, bool udpOrTCP);
   map<uint16_t, uint64_t> getQTypeResponseCounts();

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -168,9 +168,9 @@ static void writenWithTimeout(int fd, const void *buffer, unsigned int n, unsign
   }
 }
 
-void TCPNameserver::sendPacket(std::unique_ptr<DNSPacket>& p, int outsock)
+void TCPNameserver::sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last)
 {
-  g_rs.submitResponse(*p, false);
+  g_rs.submitResponse(*p, false, last);
 
   uint16_t len=htons(p->getString().length());
   string buffer((const char*)&len, 2);
@@ -186,15 +186,6 @@ try
 }
 catch(NetworkError& ae) {
   throw NetworkError("Error reading DNS data from TCP client "+remote.toString()+": "+ae.what());
-}
-
-static void incTCPAnswerCount(const ComboAddress& remote)
-{
-  S.inc("tcp-answers");
-  if(remote.sin4.sin_family == AF_INET6)
-    S.inc("tcp6-answers");
-  else
-    S.inc("tcp4-answers");
 }
 
 static bool maxConnectionDurationReached(unsigned int maxConnectionDuration, time_t start, unsigned int& remainingTime)
@@ -301,14 +292,12 @@ void TCPNameserver::doConnection(int fd)
         break;
       
       if(packet->qtype.getCode()==QType::AXFR) {
-        if(doAXFR(packet->qdomain, packet, fd))
-          incTCPAnswerCount(remote);
+        doAXFR(packet->qdomain, packet, fd);
         continue;
       }
 
       if(packet->qtype.getCode()==QType::IXFR) {
-        if(doIXFR(packet, fd))
-          incTCPAnswerCount(remote);
+        doIXFR(packet, fd);
         continue;
       }
 
@@ -597,7 +586,7 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
   if(haveTSIGDetails && !tsigkeyname.empty())
     outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac); // first answer is 'normal'
   
-  sendPacket(outpacket, outsock);
+  sendPacket(outpacket, outsock, false);
   
   trc.d_mac = outpacket->d_trc.d_mac;
   outpacket = getFreshAXFRPacket(q);
@@ -855,7 +844,7 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
         if(!outpacket->getRRS().empty()) {
           if(haveTSIGDetails && !tsigkeyname.empty())
             outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-          sendPacket(outpacket, outsock);
+          sendPacket(outpacket, outsock, false);
           trc.d_mac=outpacket->d_trc.d_mac;
           outpacket=getFreshAXFRPacket(q);
         }
@@ -908,7 +897,7 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
               if(!outpacket->getRRS().empty()) {
                 if(haveTSIGDetails && !tsigkeyname.empty())
                   outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true);
-                sendPacket(outpacket, outsock);
+                sendPacket(outpacket, outsock, false);
                 trc.d_mac=outpacket->d_trc.d_mac;
                 outpacket=getFreshAXFRPacket(q);
               }
@@ -942,7 +931,7 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
           if(!outpacket->getRRS().empty()) {
             if(haveTSIGDetails && !tsigkeyname.empty())
               outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); 
-            sendPacket(outpacket, outsock);
+            sendPacket(outpacket, outsock, false);
             trc.d_mac=outpacket->d_trc.d_mac;
             outpacket=getFreshAXFRPacket(q);
           }
@@ -963,7 +952,7 @@ int TCPNameserver::doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, 
     if(!outpacket->getRRS().empty()) {
       if(haveTSIGDetails && !tsigkeyname.empty())
         outpacket->setTSIGDetails(trc, tsigkeyname, tsigsecret, trc.d_mac, true); // first answer is 'normal'
-      sendPacket(outpacket, outsock);
+      sendPacket(outpacket, outsock, false);
       trc.d_mac=outpacket->d_trc.d_mac;
       outpacket=getFreshAXFRPacket(q);
     }

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -48,7 +48,7 @@ public:
   unsigned int numTCPConnections();
 private:
 
-  static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock);
+  static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last=true);
   static int readLength(int fd, ComboAddress *remote);
   static void getQuestion(int fd, char *mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);
   static int doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, int outsock);


### PR DESCRIPTION
### Short description
AXFR was counting packets as answers and added one extra answer after the AXFR was finished.

Fixes #4146

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
