### PR TITLE
auth: run lmdb init and upgrade code only once

### DIFF
--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -9,6 +9,7 @@ LMDB backend
 * DNSSEC: Yes
 * Disabled data: No
 * Comments: No
+* Multiple instances: No
 * Module name: lmdb
 * Launch name: ``lmdb``
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -58,6 +58,11 @@ static std::mutex s_lmdbStartupLock;
 
 LMDBBackend::LMDBBackend(const std::string& suffix)
 {
+  // overlapping domain ids in combination with relative names are a recipe for disater
+  if (!suffix.empty()) {
+    throw std::runtime_error("LMDB backend does not suport multiple instances");
+  }
+
   setArgPrefix("lmdb"+suffix);
   
   string syncMode = toLower(getArg("sync-mode"));

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -1,3 +1,25 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 #pragma once
 #include "pdns/dnsbackend.hh"
 #include "ext/lmdb-safe/lmdb-typed.hh"
@@ -216,7 +238,6 @@ private:
                    index_on<TSIGKey, DNSName, &TSIGKey::name>                   
           > ttsig_t;
   
-  int d_shards;
   int d_asyncFlag;
 
   struct RecordsDB


### PR DESCRIPTION
### Short description
Only lock until the first backend is ready.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

