### PR TITLE
Rec: validate signatures after 2038 and more

### DIFF
--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -75,7 +75,7 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
 
 #include "root-addresses.hh"
 
-bool primeHints(void)
+bool primeHints(time_t now)
 {
   vector<DNSRecord> nsset;
   if (!g_recCache)
@@ -88,7 +88,7 @@ bool primeHints(void)
   arr.d_type = QType::A;
   aaaarr.d_type = QType::AAAA;
   nsrr.d_type = QType::NS;
-  arr.d_ttl = aaaarr.d_ttl = nsrr.d_ttl = time(nullptr) + 3600000;
+  arr.d_ttl = aaaarr.d_ttl = nsrr.d_ttl = now + 3600000;
 
   for (char c = 'a'; c <= 'm'; ++c) {
     char templ[40];
@@ -100,18 +100,18 @@ bool primeHints(void)
     arr.d_content = std::make_shared<ARecordContent>(ComboAddress(rootIps4[c - 'a']));
     vector<DNSRecord> aset;
     aset.push_back(arr);
-    g_recCache->replace(time(nullptr), DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname); // auth, nuke it all
+    g_recCache->replace(now, DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname); // auth, nuke it all
     if (rootIps6[c - 'a'] != NULL) {
       aaaarr.d_content = std::make_shared<AAAARecordContent>(ComboAddress(rootIps6[c - 'a']));
 
       vector<DNSRecord> aaaaset;
       aaaaset.push_back(aaaarr);
-      g_recCache->replace(time(nullptr), DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname);
+      g_recCache->replace(now, DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname);
     }
 
     nsset.push_back(nsrr);
   }
-  g_recCache->replace(time(nullptr), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname); // and stuff in the cache
+  g_recCache->replace(now, g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname); // and stuff in the cache
   return true;
 }
 
@@ -492,7 +492,7 @@ LWResult::Result genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain,
   if (type == QType::DNSKEY) {
     setLWResult(res, 0, true, false, true);
     addDNSKEY(keys, domain, 300, res->d_records);
-    addRRSIG(keys, res->d_records, domain, 300);
+    addRRSIG(keys, res->d_records, domain, 300, false, boost::none, boost::none, now);
     return LWResult::Result::Success;
   }
 

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -42,7 +42,7 @@ static void insertIntoRootNSZones(const DNSName &name) {
   }
 }
 
-bool primeHints(void)
+bool primeHints(time_t ignored)
 {
   // prime root cache
   const vState validationState = vState::Insecure;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1110,7 +1110,7 @@ uint64_t* pleaseGetPacketCacheHits();
 uint64_t* pleaseGetPacketCacheSize();
 uint64_t* pleaseWipePacketCache(const DNSName& canon, bool subtree, uint16_t qtype=0xffff);
 void doCarbonDump(void*);
-bool primeHints(void);
+bool primeHints(time_t now = time(nullptr));
 void primeRootNSZones(bool, unsigned int depth);
 
 extern __thread struct timeval g_now;

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -763,11 +763,13 @@ static const vector<DNSName> getZoneCuts(const DNSName& begin, const DNSName& en
 
 bool isRRSIGNotExpired(const time_t now, const shared_ptr<RRSIGRecordContent>& sig)
 {
+  // Should use https://www.rfc-editor.org/rfc/rfc4034.txt section 3.1.5 
   return sig->d_sigexpire >= now;
 }
 
 bool isRRSIGIncepted(const time_t now, const shared_ptr<RRSIGRecordContent>& sig)
 {
+  // Should use https://www.rfc-editor.org/rfc/rfc4034.txt section 3.1.5 
   return sig->d_siginception - g_signatureInceptionSkew <= now;
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This PR allows the test code to run unit tests for SyncRes at a specific point in time and uses that to test valdiating resolution at those points in time. Currently this fails in the year 2106, since the expiry and inceptions validation code in `validate.cc` does not take rfc 4034 into account. 2038 is OK.

Part of the work for #10000

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
