### PR TITLE
builder: add arch-specific targets

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.centos-7
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-7
@@ -3,7 +3,13 @@
 
 # This defines the distribution base layer
 # Put only the bare minimum of common commands here, without dev tools
+@IF [ ${BUILDER_TARGET} = centos-7 ]
 FROM centos:7 as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = centos-7-amd64 ]
+FROM amd64/centos:7 as dist-base
+@ENDIF
+
 ARG BUILDER_CACHE_BUSTER=
 RUN touch /var/lib/rpm/* && yum install -y epel-release centos-release-scl-rh
 RUN touch /var/lib/rpm/* && yum install -y --nogpgcheck devtoolset-8-gcc-c++

--- a/builder-support/dockerfiles/Dockerfile.target.centos-7-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-7-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.centos-7

--- a/builder-support/dockerfiles/Dockerfile.target.centos-8
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-8
@@ -3,7 +3,15 @@
 
 # This defines the distribution base layer
 # Put only the bare minimum of common commands here, without dev tools
+@IF [ ${BUILDER_TARGET} = centos-8 ]
 FROM centos:8 as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = centos-8-amd64 ]
+FROM amd64/centos:8 as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = centos-8-arm64 ]
+FROM arm64v8/centos:8 as dist-base
+@ENDIF
 ARG BUILDER_CACHE_BUSTER=
 RUN touch /var/lib/rpm/* && yum install -y epel-release && \
     dnf install -y 'dnf-command(config-manager)' && \

--- a/builder-support/dockerfiles/Dockerfile.target.centos-8-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-8-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.centos-8

--- a/builder-support/dockerfiles/Dockerfile.target.centos-8-arm64
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-8-arm64
@@ -1,0 +1,1 @@
+Dockerfile.target.centos-8

--- a/builder-support/dockerfiles/Dockerfile.target.debian-buster
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-buster
@@ -1,7 +1,16 @@
 # First do the source builds
 @INCLUDE Dockerfile.target.sdist
 
+@IF [ ${BUILDER_TARGET} = debian-buster ]
 FROM debian:buster as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = debian-buster-amd64 ]
+FROM amd64/debian:buster as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = debian-buster-arm64 ]
+FROM arm64v8/debian:buster as dist-base
+@ENDIF
+
 ARG BUILDER_CACHE_BUSTER=
 ARG APT_URL
 RUN apt-get update && apt-get -y dist-upgrade

--- a/builder-support/dockerfiles/Dockerfile.target.debian-buster-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-buster-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.debian-buster

--- a/builder-support/dockerfiles/Dockerfile.target.debian-buster-arm64
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-buster-arm64
@@ -1,0 +1,1 @@
+Dockerfile.target.debian-buster

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-bionic
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-bionic
@@ -1,7 +1,15 @@
 # First do the source builds
 @INCLUDE Dockerfile.target.sdist
 
+@IF [ ${BUILDER_TARGET} = ubuntu-bionic ]
 FROM ubuntu:bionic as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = ubuntu-bionic-amd64 ]
+FROM amd64/ubuntu:bionic as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = ubuntu-bionic-arm64 ]
+FROM arm64v8/ubuntu:bionic as dist-base
+@ENDIF
 ARG BUILDER_CACHE_BUSTER=
 ARG APT_URL
 RUN apt-get update && apt-get -y dist-upgrade

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-bionic-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-bionic-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.ubuntu-bionic

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-bionic-arm64
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-bionic-arm64
@@ -1,0 +1,1 @@
+Dockerfile.target.ubuntu-bionic

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-focal
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-focal
@@ -1,7 +1,15 @@
 # First do the source builds
 @INCLUDE Dockerfile.target.sdist
 
+@IF [ ${BUILDER_TARGET} = ubuntu-focal ]
 FROM ubuntu:focal as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = ubuntu-focal-amd64 ]
+FROM amd64/ubuntu:focal as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = ubuntu-focal-arm64 ]
+FROM arm64v8/ubuntu:focal as dist-base
+@ENDIF
 ARG BUILDER_CACHE_BUSTER=
 ARG APT_URL
 RUN apt-get update && apt-get -y dist-upgrade

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-focal-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-focal-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.ubuntu-focal

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-focal-arm64
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-focal-arm64
@@ -1,0 +1,1 @@
+Dockerfile.target.ubuntu-focal


### PR DESCRIPTION
### Short description
This allows us to be specific about what architecture to build for. The 'base' target remains, for anybody that just wants to build for their default arch. It might make sense to disable the base targets at some point.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master