### PR TITLE
dnsdist: Silence clang 12 warning

### DIFF
--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -446,6 +446,10 @@ public:
     d_prev.start();
   }
 
+  virtual ~BasicQPSLimiter()
+  {
+  }
+
   bool check(unsigned int rate, unsigned int burst) const // this is not quite fair
   {
     if (checkOnly(rate, burst)) {


### PR DESCRIPTION
destructor called on non-final 'QPSLimiter' that has virtual functions but non-virtual destructor

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
