### PR TITLE
-Werror experiment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,8 @@ AC_CONFIG_HEADERS([config.h])
 
 AC_CANONICAL_HOST
 # Add some default CFLAGS and CXXFLAGS, can be appended to using the environment variables
-CFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CFLAGS"
-CXXFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CXXFLAGS"
+CFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Werror -Wno-error=missing-declarations -Wno-error=redundant-decls -Wno-error=shadow $CFLAGS"
+CXXFLAGS="-g -O2 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Werror -Wno-error=missing-declarations -Wno-error=redundant-decls -Wno-error=shadow $CXXFLAGS"
 
 AC_SUBST([pdns_configure_args], ["$ac_configure_args"])
 AC_DEFINE_UNQUOTED([PDNS_CONFIG_ARGS],

--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -632,7 +632,7 @@ namespace cxx17
   namespace test_auto_brace_init_list
   {
 
-    auto foo = {5};
+    auto foo = {test_constexpr_lambdas::foo};
     auto bar {5};
 
     static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -16,8 +16,8 @@ AC_DEFINE([DNSDIST], [1],
 LT_PREREQ([2.2.2])
 LT_INIT([disable-static])
 
-CFLAGS="-g -O3 -Wall -Wextra -Wshadow -Wno-unused-parameter $CFLAGS"
-CXXFLAGS="-g -O3 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls $CXXFLAGS"
+CFLAGS="-g -O3 -Wall -Wextra -Wshadow -Wno-unused-parameter -Werror -Wno-error=missing-declarations -Wno-error=redundant-decls -Wno-error=shadow $CFLAGS"
+CXXFLAGS="-g -O3 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Werror -Wno-error=missing-declarations -Wno-error=redundant-decls -Wno-error=shadow $CXXFLAGS"
 
 PDNS_WITH_LIBSODIUM
 PDNS_CHECK_DNSTAP([auto])

--- a/pdns/recursordist/configure.ac
+++ b/pdns/recursordist/configure.ac
@@ -12,8 +12,8 @@ AC_CONFIG_HEADERS([config.h])
 
 AC_CANONICAL_HOST
 # Add some default CFLAGS and CXXFLAGS, can be appended to using the environment variables
-CFLAGS="-Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -g -O2 $CFLAGS"
-CXXFLAGS="-Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -g -O2 $CXXFLAGS"
+CFLAGS="-Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Werror -Wno-error=missing-declarations -Wno-error=redundant-decls -Wno-error=shadow -g -O2 $CFLAGS"
+CXXFLAGS="-Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarations -Wredundant-decls -Werror -Wno-error=missing-declarations -Wno-error=redundant-decls -Wno-error=shadow -g -O2 $CXXFLAGS"
 
 AC_SUBST([pdns_configure_args],["$ac_configure_args"])
 AC_DEFINE_UNQUOTED([PDNS_CONFIG_ARGS],


### PR DESCRIPTION
### Short description

See if `-Werror` is feasible. 

Its a bit complicated, since not all compiler agree on warnings. I had to use `-Wno-error=xyz` for a few things. Let's see how this fares with the various toolsets. 

It still might make the lives of maintainers harder since their environment might need more `Wno-error=...`. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
