### PR TITLE
protozero: make internal includes work

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -6,7 +6,8 @@ AM_CPPFLAGS += \
 	$(LIBEDIT_CFLAGS) \
 	$(LIBCRYPTO_INCLUDES) \
 	$(SYSTEMD_CFLAGS) \
-	$(YAML_CFLAGS)
+	$(YAML_CFLAGS) \
+	-I$(top_srcdir)/ext/protozero/include
 
 AM_CXXFLAGS = \
 	-DSYSCONFDIR=\"$(sysconfdir)\" \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -6,6 +6,7 @@ AM_CPPFLAGS += $(SYSTEMD_CFLAGS) \
 	$(YAHTTP_CFLAGS) \
 	$(NET_SNMP_CFLAGS) \
 	$(LIBCAP_CFLAGS) \
+	-I$(top_srcdir)/ext/protozero/include \
 	-DSYSCONFDIR=\"${sysconfdir}\"
 
 ACLOCAL_AMFLAGS = -I m4

--- a/pdns/dnstap.cc
+++ b/pdns/dnstap.cc
@@ -3,7 +3,7 @@
 #include "gettime.hh"
 #include "dnstap.hh"
 
-#include "ext/protozero/include/protozero/pbf_writer.hpp"
+#include <protozero/pbf_writer.hpp>
 
 namespace DnstapBaseFields {
   enum : protozero::pbf_tag_type { identity = 1, version = 2, extra = 3, message = 14, type = 15 };

--- a/pdns/protozero.hh
+++ b/pdns/protozero.hh
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include "ext/protozero/include/protozero/pbf_writer.hpp"
+#include <protozero/pbf_writer.hpp>
 
 #include "config.h"
 #include "iputils.hh"

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -5,6 +5,7 @@ AM_CPPFLAGS = $(LUA_CFLAGS) $(YAHTTP_CFLAGS) $(BOOST_CPPFLAGS) $(LIBSODIUM_CFLAG
 
 AM_CPPFLAGS += \
 	-I$(top_srcdir)/ext/json11 \
+	-I$(top_srcdir)/ext/protozero/include \
 	$(YAHTTP_CFLAGS) \
 	$(LIBCRYPTO_INCLUDES)
 


### PR DESCRIPTION
### Short description
On platforms with different byte orders (like s390x), protozero wants to include its own `byteswap.hpp`, but fails. This PR is one way to fix that.

Alternatively, also suitable for upstreaming:
```diff
diff --git a/ext/protozero/include/protozero/basic_pbf_writer.hpp b/ext/protozero/include/protozero/basic_pbf_writer.hpp
index f167c4d1d..b783293f1 100644
--- a/ext/protozero/include/protozero/basic_pbf_writer.hpp
+++ b/ext/protozero/include/protozero/basic_pbf_writer.hpp
@@ -23,7 +23,7 @@ documentation.
 #include "varint.hpp"
 
 #if PROTOZERO_BYTE_ORDER != PROTOZERO_LITTLE_ENDIAN
-# include <protozero/byteswap.hpp>
+# include "byteswap.hpp"
 #endif
 
 #include <cstddef>
diff --git a/ext/protozero/include/protozero/iterators.hpp b/ext/protozero/include/protozero/iterators.hpp
index ee8ef8ecf..cb964bb38 100644
--- a/ext/protozero/include/protozero/iterators.hpp
+++ b/ext/protozero/include/protozero/iterators.hpp
@@ -20,7 +20,7 @@ documentation.
 #include "varint.hpp"
 
 #if PROTOZERO_BYTE_ORDER != PROTOZERO_LITTLE_ENDIAN
-# include <protozero/byteswap.hpp>
+# include "byteswap.hpp"
 #endif
 
 #include <algorithm>
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master