### PR TITLE
dnsdist: Fix a few warnings reported by clang's static analyzer and cppcheck

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -204,7 +204,7 @@ public:
     class WrongTypeException : public std::runtime_error
     {
     public:
-        WrongTypeException(std::string luaType_, const std::type_info& destination_) :
+        WrongTypeException(const std::string& luaType_, const std::type_info& destination_) :
             std::runtime_error("Trying to cast a lua variable from \"" + luaType_ + "\" to \"" + destination_.name() + "\""),
             luaType(luaType_),
             destination(destination_)

--- a/ext/yahttp/yahttp/router.cpp
+++ b/ext/yahttp/yahttp/router.cpp
@@ -53,7 +53,6 @@ namespace YaHTTP {
             pname = pname.substr(1);
             // this matches whatever comes after it, basically end of string
             pos2 = req->url.path.size();
-            matched = true;
             if (pname != "") 
               params[pname] = funcptr::tie(pos1,pos2);
             k1 = url.size();

--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -175,7 +175,12 @@ class DNSCryptQuery
 public:
   DNSCryptQuery(const std::shared_ptr<DNSCryptContext>& ctx): d_ctx(ctx)
   {
+    memset(&d_header, 0, sizeof(d_header));
+#ifdef HAVE_CRYPTO_BOX_EASY_AFTERNM
+    memset(&d_sharedKey, 0, sizeof(d_sharedKey));
+#endif /* HAVE_CRYPTO_BOX_EASY_AFTERNM */
   }
+
   ~DNSCryptQuery();
 
   bool isValid() const

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -75,7 +75,14 @@ static std::unordered_map<unsigned int, vector<boost::variant<string,double>>> g
     else
       ret.insert({count++, {rc.second.toString(), rc.first, 100.0*rc.first/total}});
   }
-  ret.insert({count, {"Rest", rest, total > 0 ? 100.0*rest/total : 100.0}});
+
+  if (total > 0) {
+    ret.insert({count, {"Rest", rest, 100.0*rest/total}});
+  }
+  else {
+    ret.insert({count, {"Rest", rest, 100.0 }});
+  }
+
   return ret;
 }
 
@@ -302,7 +309,14 @@ void setupLuaInspection(LuaContext& luaCtx)
 	else
 	  ret.insert({count++, {rc.second.toString(), rc.first, 100.0*rc.first/total}});
       }
-      ret.insert({count, {"Rest", rest, total > 0 ? 100.0*rest/total : 100.0}});
+
+      if (total > 0) {
+        ret.insert({count, {"Rest", rest, 100.0*rest/total}});
+      }
+      else {
+        ret.insert({count, {"Rest", rest, 100.0}});
+      }
+
       return ret;
 
     });

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -897,7 +897,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
     });
 
-  typedef std::unordered_map<std::string, boost::variant<bool, size_t, std::string, std::map<std::string, std::string>> > webserveropts_t;
+  typedef std::unordered_map<std::string, boost::variant<bool, std::string, std::map<std::string, std::string>> > webserveropts_t;
 
   luaCtx.writeFunction("setWebserverConfig", [](boost::optional<webserveropts_t> vars) {
       setLuaSideEffect();
@@ -935,7 +935,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       }
 
       if (vars->count("maxConcurrentConnections")) {
-        setWebserverMaxConcurrentConnections(boost::get<size_t>(vars->at("maxConcurrentConnections")));
+        setWebserverMaxConcurrentConnections(std::stoi(boost::get<std::string>(vars->at("maxConcurrentConnections"))));
       }
     });
 

--- a/pdns/dnsdist-rings.cc
+++ b/pdns/dnsdist-rings.cc
@@ -147,7 +147,7 @@ size_t Rings::loadFromFile(const std::string& filepath, const struct timespec& n
     DNSName qname(parts.at(idx++));
     QType qtype(QType::chartocode(parts.at(idx++).c_str()));
 
-    if (!isResponse) {
+    if (isResponse) {
       insertResponse(when, from, qname, qtype.getCode(), 0, 0, dh, to);
     }
     else {

--- a/pdns/dnsdist-rings.cc
+++ b/pdns/dnsdist-rings.cc
@@ -78,7 +78,14 @@ std::unordered_map<int, vector<boost::variant<string,double>>> Rings::getTopBand
       ret.insert({count++, {rc.second.toString(), rc.first, 100.0*rc.first/total}});
     }
   }
-  ret.insert({count, {"Rest", rest, total > 0 ? 100.0*rest/total : 100.0}});
+
+  if (total > 0) {
+    ret.insert({count, {"Rest", rest, 100.0*rest/total}});
+  }
+  else {
+    ret.insert({count, {"Rest", rest, 100.0 }});
+  }
+
   return ret;
 }
 

--- a/pdns/dnsdist-xpf.cc
+++ b/pdns/dnsdist-xpf.cc
@@ -52,6 +52,7 @@ bool addXPF(DNSQuestion& dq, uint16_t optionCode)
   pos += sizeof(drh);
   memcpy(reinterpret_cast<char*>(&data.at(pos)), payload.data(), payload.size());
   pos += payload.size();
+  (void) pos;
 
   dq.getHeader()->arcount = htons(ntohs(dq.getHeader()->arcount) + 1);
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2184,8 +2184,10 @@ int main(int argc, char** argv)
       }
     }
 
-    argc-=optind;
-    argv+=optind;
+    argc -= optind;
+    argv += optind;
+    (void) argc;
+
     for(auto p = argv; *p; ++p) {
       if(g_cmdLine.beClient) {
         clientAddress = ComboAddress(*p, 5199);

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -138,8 +138,8 @@ public:
   struct DOHUnit* du{nullptr};
   int delayMsec{0};
   boost::optional<uint32_t> tempFailureTTL;
-  uint32_t cacheKeyNoECS;
-  uint32_t cacheKey;
+  uint32_t cacheKeyNoECS{0};
+  uint32_t cacheKey{0};
   const uint16_t qtype;
   const uint16_t qclass;
   uint16_t ecsPrefixLength;
@@ -492,7 +492,7 @@ public:
 
 protected:
   mutable StopWatch d_prev;
-  mutable double d_tokens;
+  mutable double d_tokens{0.0};
 };
 
 class QPSLimiter : public BasicQPSLimiter
@@ -538,8 +538,8 @@ public:
   }
 
 private:
-  unsigned int d_rate;
-  unsigned int d_burst;
+  unsigned int d_rate{0};
+  unsigned int d_burst{0};
   bool d_passthrough{true};
 };
 
@@ -681,13 +681,13 @@ struct IDState
   std::shared_ptr<QTag> qTag{nullptr};
   const ClientState* cs{nullptr};
   DOHUnit* du{nullptr};
-  uint32_t cacheKey;                                          // 4
-  uint32_t cacheKeyNoECS;                                     // 4
-  uint16_t age;                                               // 4
-  uint16_t qtype;                                             // 2
-  uint16_t qclass;                                            // 2
-  uint16_t origID;                                            // 2
-  uint16_t origFlags;                                         // 2
+  uint32_t cacheKey{0};                                       // 4
+  uint32_t cacheKeyNoECS{0};                                  // 4
+  uint16_t age{0};                                            // 4
+  uint16_t qtype{0};                                          // 2
+  uint16_t qclass{0};                                         // 2
+  uint16_t origID{0};                                         // 2
+  uint16_t origFlags{0};                                      // 2
   int origFD{-1};
   int delayMsec{0};
   boost::optional<uint32_t> tempFailureTTL;

--- a/pdns/dnsdistdist/dnsdist-lbpolicies.cc
+++ b/pdns/dnsdistdist/dnsdist-lbpolicies.cc
@@ -106,7 +106,7 @@ static shared_ptr<DownstreamState> valrandom(unsigned int val, const ServerPolic
   }
 
   // Catch poss & sum are empty to avoid SIGFPE
-  if (poss.empty()) {
+  if (poss.empty() || sum == 0) {
     return shared_ptr<DownstreamState>();
   }
 

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -267,6 +267,10 @@ size_t dnsdist_ffi_dnsquestion_get_edns_options(dnsdist_ffi_dnsquestion_t* dq, c
 {
   if (dq->dq->ednsOptions == nullptr) {
     parseEDNSOptions(*(dq->dq));
+
+    if (dq->dq->ednsOptions == nullptr) {
+      return 0;
+    }
   }
 
   size_t totalCount = 0;

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -552,14 +552,18 @@ void TCPConnectionToBackend::setProxyProtocolValuesSent(std::unique_ptr<std::vec
 
 bool TCPConnectionToBackend::matchesTLVs(const std::unique_ptr<std::vector<ProxyProtocolValue>>& tlvs) const
 {
-  if (tlvs == nullptr && d_proxyProtocolValuesSent == nullptr) {
-    return true;
+  if (tlvs == nullptr) {
+    if (d_proxyProtocolValuesSent == nullptr) {
+      return true;
+    }
+    else {
+      return false;
+    }
   }
-  if (tlvs == nullptr && d_proxyProtocolValuesSent != nullptr) {
+
+  if (d_proxyProtocolValuesSent == nullptr) {
     return false;
   }
-  if (tlvs != nullptr && d_proxyProtocolValuesSent == nullptr) {
-    return false;
-  }
+
   return *tlvs == *d_proxyProtocolValuesSent;
 }

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -251,7 +251,6 @@ void handleDOHTimeout(DOHUnit* oldDU)
   sendDoHUnitToTheMainThread(oldDU, "DoH timeout");
 
   oldDU->release();
-  oldDU = nullptr;
 }
 
 struct DOHConnection

--- a/pdns/dnsdistdist/tcpiohandler.cc
+++ b/pdns/dnsdistdist/tcpiohandler.cc
@@ -294,10 +294,8 @@ int OpenSSLTLSConnection::s_tlsConnIndex = -1;
 class OpenSSLTLSIOCtx: public TLSCtx
 {
 public:
-  OpenSSLTLSIOCtx(TLSFrontend& fe)
+  OpenSSLTLSIOCtx(TLSFrontend& fe): d_feContext(std::make_shared<OpenSSLFrontendContext>(fe.d_addr, fe.d_tlsConfig))
   {
-    d_feContext = std::make_shared<OpenSSLFrontendContext>(fe.d_addr, fe.d_tlsConfig);
-
     d_ticketsKeyRotationDelay = fe.d_tlsConfig.d_ticketsKeyRotationDelay;
 
     if (fe.d_tlsConfig.d_enableTickets && fe.d_tlsConfig.d_numberOfTicketsKeys > 0) {

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -111,6 +111,7 @@ shared_ptr<DNSRecordContent> DNSRecordContent::deserialize(const DNSName& qname,
   if (serialized.size() > 0) {
     memcpy(&packet[pos], serialized.c_str(), serialized.size());
     pos += (uint16_t) serialized.size();
+    (void) pos;
   }
 
   MOADNSParser mdp(false, (char*)&*packet.begin(), (unsigned int)packet.size());

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -208,7 +208,7 @@ struct DOHUnit
   std::string contentType;
   std::atomic<uint64_t> d_refcnt{1};
   size_t query_at{0};
-  int rsock;
+  int rsock{-1};
   /* the status_code is set from
      processDOHQuery() (which is executed in
      the DOH client thread) so that the correct

--- a/pdns/ednsoptions.cc
+++ b/pdns/ednsoptions.cc
@@ -37,6 +37,7 @@ bool getNextEDNSOption(const char* data, size_t dataLen, uint16_t& optionCode, u
 
   optionLen = (static_cast<uint16_t>(p[pos]) * 256) + p[pos + 1];
   pos += EDNS_OPTION_LENGTH_SIZE;
+  (void) pos;
 
   return true;
 }

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -390,7 +390,6 @@ size_t sendMsgWithOptions(int fd, const char* buffer, size_t len, const ComboAdd
       firstTry = false;
       iov.iov_len -= written;
       iov.iov_base = reinterpret_cast<void*>(reinterpret_cast<char*>(iov.iov_base) + written);
-      written = 0;
     }
     else if (res == 0) {
       return res;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -353,7 +353,7 @@ union ComboAddress {
 
       uint32_t ls_addr = ntohl(sin4.sin_addr.s_addr);
 
-      return ((ls_addr & (1<<index)) != 0x00000000);
+      return ((ls_addr & (1U<<index)) != 0x00000000);
     }
     if(isIPv6()) {
       if (index >= 128)
@@ -368,7 +368,7 @@ union ComboAddress {
       uint8_t byte_idx = index / 8;
       uint8_t bit_idx = index % 8;
 
-      return ((ls_addr[15-byte_idx] & (1 << bit_idx)) != 0x00);
+      return ((ls_addr[15-byte_idx] & (1U << bit_idx)) != 0x00);
     }
     return false;
   }
@@ -781,8 +781,8 @@ private:
       branch_node->parent = parent;
 
       // create second new leaf node for the new key
-      TreeNode* new_node = new TreeNode(key);
-      unique_ptr<TreeNode> new_child2(new_node);
+      unique_ptr<TreeNode> new_child2 = make_unique<TreeNode>(key);
+      TreeNode* new_node = new_child2.get();
 
       // attach the new child nodes below the branch node
       // (left or right depending on bit)

--- a/pdns/pdnsexception.hh
+++ b/pdns/pdnsexception.hh
@@ -29,7 +29,7 @@ class PDNSException
 {
 public:
   PDNSException() : reason("Unspecified") {};
-  PDNSException(string r) : reason(r) {};
+  PDNSException(const string& r) : reason(r) {};
   
   string reason; //! Print this to tell the user what went wrong
 };
@@ -38,5 +38,5 @@ class TimeoutException : public PDNSException
 {
 public:
   TimeoutException() : PDNSException() {}
-  TimeoutException(string r) : PDNSException(r) {}
+  TimeoutException(const string& r) : PDNSException(r) {}
 };

--- a/pdns/protozero.cc
+++ b/pdns/protozero.cc
@@ -107,6 +107,8 @@ void pdns::ProtoZero::Message::addRRsFromPacket(const char* packet, const size_t
   rrname = pr.getName();
   rrtype = pr.get16BitInt();
   rrclass = pr.get16BitInt();
+  (void) rrtype;
+  (void) rrclass;
 
   /* consume remaining qd if any */
   if (qdcount > 1) {

--- a/pdns/sodcrypto.hh
+++ b/pdns/sodcrypto.hh
@@ -32,13 +32,18 @@ struct SodiumNonce
   void init(){};
   void merge(const SodiumNonce& lower, const SodiumNonce& higher) {};
   void increment(){};
-  unsigned char value[1];
+  unsigned char value[1]{0};
 };
 #else
 #include <sodium.h>
 
 struct SodiumNonce
 {
+  SodiumNonce()
+  {
+    memset(&value, 0, sizeof(value));
+  }
+
   void init()
   {
     randombytes_buf(value, sizeof value);

--- a/pdns/test-dnscrypt_cc.cc
+++ b/pdns/test-dnscrypt_cc.cc
@@ -143,12 +143,6 @@ BOOST_AUTO_TEST_CASE(DNSCryptEncryptedQueryValid) {
   PacketBuffer plainQuery;
   GenericDNSPacketWriter<PacketBuffer> pw(plainQuery, name, QType::AAAA, QClass::IN, 0);
   pw.getHeader()->rd = 1;
-  size_t requiredSize = plainQuery.size() + sizeof(DNSCryptQueryHeader) + DNSCRYPT_MAC_SIZE;
-  if (requiredSize < DNSCryptQuery::s_minUDPLength) {
-    requiredSize = DNSCryptQuery::s_minUDPLength;
-  }
-
-  plainQuery.resize(requiredSize);
 
   size_t initialSize = plainQuery.size();
   int res = ctx->encryptQuery(plainQuery, 4096, clientPublicKey, clientPrivateKey, clientNonce, false, std::make_shared<DNSCryptCert>(resolverCert));
@@ -224,11 +218,6 @@ BOOST_AUTO_TEST_CASE(DNSCryptEncryptedQueryValidWithOldKey) {
   PacketBuffer plainQuery;
   GenericDNSPacketWriter<PacketBuffer> pw(plainQuery, name, QType::AAAA, QClass::IN, 0);
   pw.getHeader()->rd = 1;
-
-  size_t requiredSize = plainQuery.size() + sizeof(DNSCryptQueryHeader) + DNSCRYPT_MAC_SIZE;
-  if (requiredSize < DNSCryptQuery::s_minUDPLength) {
-    requiredSize = DNSCryptQuery::s_minUDPLength;
-  }
 
   size_t initialSize = plainQuery.size();
   int res = ctx->encryptQuery(plainQuery, 4096, clientPublicKey, clientPrivateKey, clientNonce, false, std::make_shared<DNSCryptCert>(resolverCert));

--- a/pdns/test-dnsdist_cc.cc
+++ b/pdns/test-dnsdist_cc.cc
@@ -1709,8 +1709,8 @@ BOOST_AUTO_TEST_CASE(test_isEDNSOptionInOpt) {
   */
   const ComboAddress lc("127.0.0.1");
   const ComboAddress rem("127.0.0.1");
-  size_t optContentStart;
-  uint16_t optContentLen;
+  size_t optContentStart{std::numeric_limits<size_t>::max()};
+  uint16_t optContentLen{0};
 
   const size_t optRDExpectedOffset = sizeof(dnsheader) + qname.wirelength() + DNS_TYPE_SIZE + DNS_CLASS_SIZE + /* root */ 1 + DNS_TYPE_SIZE + DNS_CLASS_SIZE + DNS_TTL_SIZE;
 

--- a/pdns/xpf.cc
+++ b/pdns/xpf.cc
@@ -108,6 +108,8 @@ bool parseXPFPayload(const char* payload, size_t len, ComboAddress& source, Comb
 
   memcpy(&destinationPort, payload + pos, sizeof(destinationPort));
   pos += sizeof(destinationPort);
+  (void) pos;
+
   if (destination != nullptr) {
     destination->sin4.sin_port = destinationPort;
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Mostly false positive that I'm tired of seeing, or performance tips in places we don't really care about performance.
But also a real bug in the code loading the ring buffers from a file (only used for debugging) and a few hardening measures (additional checks, initializations) that will not hurt and might prevent an issue later. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
