### PR TITLE
rec: Set the start of the stack right away to avoid an ASAN issue

### DIFF
--- a/pdns/mtasker.cc
+++ b/pdns/mtasker.cc
@@ -277,6 +277,9 @@ template<class Key, class Val>void MTasker<Key,Val>::makeThread(tfunc_t *start, 
   ++d_threadsCount;
   auto& thread = d_threads[d_maxtid];
   auto mt = this;
+  // we will get a better approximation when the task is executed, but that prevents notifying a stack at nullptr
+  // on the first invocation
+  d_threads[d_maxtid].startOfStack = &uc->uc_stack[uc->uc_stack.size()-1];
   thread.start = [start, val, mt]() {
       char dummy;
       mt->d_threads[mt->d_tid].startOfStack = mt->d_threads[mt->d_tid].highestStackSeen = &dummy;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to wait until the first invocation of a `MTask` to set the start of the stack, but that sometimes resulted in passing the `nullptr` address to `ASAN` when calling a task for the first time. It resulted in `ASAN` skipping the stack switch, logging something like:
```
WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0x000000020000; bottom 0x7f18f174a000; size: 0xffff80e70e8d6000 (-139745106763776)
False positive error reports may follow
```
Then almost right away complaining about a stack-use-after-scope, or a stack-based overflow.

This changes sets the end of the memory allocation before the first invocation, so that we always notify a valid value. A closer
approximation is still set during the first invocation, as before.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
