### PR TITLE
auth: run deleteDomain() inside a transaction

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1328,6 +1328,10 @@ bool GSQLBackend::createSlaveDomain(const string &ip, const DNSName &domain, con
 
 bool GSQLBackend::deleteDomain(const DNSName &domain)
 {
+  if (!d_inTransaction) {
+    throw PDNSException("deleteDomain called outside of transaction");
+  }
+
   DomainInfo di;
   if (!getDomainInfo(domain, di)) {
     return false;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -819,8 +819,18 @@ static int deleteZone(const DNSName &zone) {
     return EXIT_FAILURE;
   }
 
-  if(di.backend->deleteDomain(zone))
-    return EXIT_SUCCESS;
+  di.backend->startTransaction(zone, -1);
+  try {
+    if(di.backend->deleteDomain(zone)) {
+      di.backend->commitTransaction();
+      return EXIT_SUCCESS;
+    }
+  } catch (...) {
+    di.backend->abortTransaction();
+    throw;
+  }
+
+  di.backend->abortTransaction();
 
   cerr<<"Failed to delete domain '"<<zone<<"'"<<endl;;
   return EXIT_FAILURE;


### PR DESCRIPTION
### Short description
deleteDomain() is running a few queries to delete domain data from different tables. If one of those queries is failing (for example due to locks) a partial deleted domain is left behind.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
