### PR TITLE
auth-4.4.x: run deleteDomain() inside a transaction

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1328,6 +1328,10 @@ bool GSQLBackend::createSlaveDomain(const string &ip, const DNSName &domain, con
 
 bool GSQLBackend::deleteDomain(const DNSName &domain)
 {
+  if (!d_inTransaction) {
+    throw PDNSException("deleteDomain called outside of transaction");
+  }
+
   DomainInfo di;
   if (!getDomainInfo(domain, di)) {
     return false;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -819,8 +819,18 @@ static int deleteZone(const DNSName &zone) {
     return EXIT_FAILURE;
   }
 
-  if(di.backend->deleteDomain(zone))
-    return EXIT_SUCCESS;
+  di.backend->startTransaction(zone, -1);
+  try {
+    if(di.backend->deleteDomain(zone)) {
+      di.backend->commitTransaction();
+      return EXIT_SUCCESS;
+    }
+  } catch (...) {
+    di.backend->abortTransaction();
+    throw;
+  }
+
+  di.backend->abortTransaction();
 
   cerr<<"Failed to delete domain '"<<zone<<"'"<<endl;;
   return EXIT_FAILURE;

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1793,8 +1793,17 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
   }
   else if(req->method == "DELETE") {
     // delete domain
-    if(!di.backend->deleteDomain(zonename))
-      throw ApiException("Deleting domain '"+zonename.toString()+"' failed: backend delete failed/unsupported");
+
+    di.backend->startTransaction(zonename, -1);
+    try {
+      if(!di.backend->deleteDomain(zonename))
+        throw ApiException("Deleting domain '"+zonename.toString()+"' failed: backend delete failed/unsupported");
+
+      di.backend->commitTransaction();
+    } catch (...) {
+      di.backend->abortTransaction();
+      throw;
+    }
 
     // clear caches
     DNSSECKeeper::clearCaches(zonename);


### PR DESCRIPTION
### Short description
Backport of: #10037 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] checked that this code was merged to master
