### PR TITLE
Rec: experimental NS endpoint type and TCP connection pooling 

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -38,6 +38,7 @@
 #include "pubsuffix.hh"
 #include "namespaces.hh"
 #include "rec-taskqueue.hh"
+#include "rec-tcp-out.hh"
 
 std::mutex g_carbon_config_lock;
 
@@ -1234,7 +1235,11 @@ void registerAllStats()
   addGetStat("taskqueue-pushed",  []() { return getTaskPushes(); });
   addGetStat("taskqueue-expired",  []() { return getTaskExpired(); });
   addGetStat("taskqueue-size",  []() { return getTaskSize(); });
-  
+
+  addGetStat("tcpout-created",  []() { return pdns::TCPOutConnectionManager::getAllConnectionsCreated(); });
+  addGetStat("tcpout-queries",  []() { return pdns::TCPOutConnectionManager::getAllQueriesDone(); });
+  addGetStat("tcpout-current",  []() { return pdns::TCPOutConnectionManager::getCurrentIdleConnections(); });
+
   /* make sure that the ECS stats are properly initialized */
   SyncRes::clearECSStats();
   for (size_t idx = 0; idx < SyncRes::s_ecsResponsesBySubnetSize4.size(); idx++) {

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -118,8 +118,6 @@ std::atomic<unsigned long>* getDynMetric(const std::string& str, const std::stri
 
 static boost::optional<uint64_t> get(const string& name)
 {
-  boost::optional<uint64_t> ret;
-
   if(d_get32bitpointers.count(name))
     return *d_get32bitpointers.find(name)->second;
   if(d_getatomics.count(name))
@@ -131,8 +129,8 @@ static boost::optional<uint64_t> get(const string& name)
   auto f = rplookup(d_dynmetrics, name);
   if (f)
     return f->d_ptr->load();
-  
-  return ret;
+
+  return boost::none;
 }
 
 boost::optional<uint64_t> getStatByName(const std::string& name)

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -154,6 +154,7 @@ pdns_recursor_SOURCES = \
 	rec-protozero.cc rec-protozero.hh \
 	rec-snmp.hh rec-snmp.cc \
 	rec-taskqueue.cc rec-taskqueue.hh \
+	rec-tcp-out.cc rec-tcp-out.hh \
 	rec_channel.cc rec_channel.hh rec_metrics.hh \
 	rec_channel_rec.cc \
 	recpacketcache.cc recpacketcache.hh \

--- a/pdns/recursordist/rec-tcp-out.cc
+++ b/pdns/recursordist/rec-tcp-out.cc
@@ -36,7 +36,6 @@ size_t TCPOutConnectionManager::maxQueries;
 size_t TCPOutConnectionManager::maxPerAuth;
 size_t TCPOutConnectionManager::maxPerThread;
 
-
 unique_ptr<TCPOutConnectionManager::TCPOutConnection> TCPOutConnectionManager::getConnection(const ComboAddress& address, const timeval& now, bool& isNew)
 {
   if (d_idle_connections.count(address) > 0) {
@@ -112,8 +111,9 @@ void TCPOutConnectionManager::cleanup(const timeval& now)
     while (i != d_idle_connections.end()) {
       // this will throw away 4/10 on average
       if (dis(gen) > fraction) {
-         i = d_idle_connections.erase(i);
-      } else {
+        i = d_idle_connections.erase(i);
+      }
+      else {
         ++i;
       }
     }

--- a/pdns/recursordist/rec-tcp-out.cc
+++ b/pdns/recursordist/rec-tcp-out.cc
@@ -1,0 +1,138 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <random>
+#include "rec-tcp-out.hh"
+#include "dns_random.hh"
+#include "query-local-address.hh"
+#include "syncres.hh"
+
+thread_local pdns::TCPOutConnectionManager t_tcpConnections;
+
+namespace pdns
+{
+
+timeval TCPOutConnectionManager::maxIdle;
+size_t TCPOutConnectionManager::maxQueries;
+size_t TCPOutConnectionManager::maxPerAuth;
+size_t TCPOutConnectionManager::maxPerThread;
+
+
+unique_ptr<TCPOutConnectionManager::TCPOutConnection> TCPOutConnectionManager::getConnection(const ComboAddress& address, const timeval& now, bool& isNew)
+{
+  if (d_idle_connections.count(address) > 0) {
+    // idle connection available
+    isNew = false;
+    auto nh = d_idle_connections.extract(address);
+    return std::move(nh.mapped());
+  }
+  // No idle connection available, make a new one. Caller will either discard it (fine) or call setIdle on it so it will be
+  // put in the pool of available connections
+  isNew = true;
+  auto s = make_unique<Socket>(address.sin4.sin_family, SOCK_STREAM);
+  s->setNonBlocking();
+  ComboAddress local = getQueryLocalAddress(address.sin4.sin_family, 0);
+  s->bind(local);
+  s->connect(address);
+  incCreated();
+  return make_unique<TCPOutConnection>(std::move(s), now);
+}
+
+void TCPOutConnectionManager::setIdle(const ComboAddress& address, unique_ptr<TCPOutConnection>&& tcp, const struct timeval& now)
+{
+  this->incQueries();
+  if (maxPerAuth == 0) {
+    // We're done, connectionds wil be destroyed since we do not hold on the idle connections
+    return;
+  }
+
+  auto count = d_idle_connections.count(address);
+  // Hold on to the connection if we have not reached maxQueries
+  if (maxQueries == 0 || tcp->getQueries() < maxQueries) {
+    tcp->setLastUsed(now);
+    tcp->incQueries();
+    d_idle_connections.emplace(address, std::move(tcp));
+    count++;
+  }
+  if (count > maxPerAuth) {
+    // erase the oldest by using a range, since multimap::find will return an random element
+    // see https://en.cppreference.com/w/cpp/container/multimap/equal_range
+    const auto& i = d_idle_connections.equal_range(address);
+    if (i.first != d_idle_connections.end()) {
+      d_idle_connections.erase(i.first);
+    }
+  }
+}
+
+void TCPOutConnectionManager::cleanup(const timeval& now)
+{
+  // Enforce maxIdle if it is set
+  if (timeval{0, 0} < maxIdle) {
+    auto i = d_idle_connections.begin();
+    while (i != d_idle_connections.end()) {
+      auto& conn = *i->second;
+      if (maxIdle < now - conn.getLastUsed()) {
+        i = d_idle_connections.erase(i);
+      }
+      else {
+        ++i;
+      }
+    }
+  }
+
+  // Still too many? Enforce maxPerThread by killing random connections
+  // One day we might want to start using a multi-index and use a LRU method
+  if (d_idle_connections.size() > maxPerThread) {
+    std::uniform_real_distribution<> dis(0.0, 1.0);
+    std::mt19937 gen(dns_random(0xffffffff));
+
+    // suppose we have 10 and max is 6
+    double fraction = double(maxPerThread) / d_idle_connections.size();
+    // fraction = 0.6
+    auto i = d_idle_connections.begin();
+    while (i != d_idle_connections.end()) {
+      // this will throw away 4/10 on average
+      if (dis(gen) > fraction) {
+         i = d_idle_connections.erase(i);
+      } else {
+        ++i;
+      }
+    }
+  }
+}
+
+uint64_t TCPOutConnectionManager::getAllQueriesDone()
+{
+  return broadcastAccFunction<uint64_t>([] { return t_tcpConnections.getQueries(); });
+}
+
+uint64_t TCPOutConnectionManager::getAllConnectionsCreated()
+{
+  return broadcastAccFunction<uint64_t>([] { return t_tcpConnections.getCreated(); });
+}
+
+uint64_t TCPOutConnectionManager::getCurrentIdleConnections()
+{
+  return broadcastAccFunction<uint64_t>([] { return t_tcpConnections.getSize(); });
+}
+
+} // namespace pdns

--- a/pdns/recursordist/rec-tcp-out.hh
+++ b/pdns/recursordist/rec-tcp-out.hh
@@ -1,0 +1,127 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "namespaces.hh"
+#include "iputils.hh"
+#include "sstuff.hh"
+
+namespace pdns
+{
+
+/*
+ * This class maintains TCP connections belonging to specific tread.
+ * The main data strructure is a multimap, it tracks idle connections to a specific address.
+ *
+ * ATM we do a send-query receive-answer make-idle mechanism. No OOO processing is done.
+ * So multiple connections to the same auth can be active. Hence the multimap.
+ * If a connection is in the multimap, it is idle and available to connect to the address. 
+ */
+class TCPOutConnectionManager
+{
+public:
+  class TCPOutConnection
+  {
+  public:
+    TCPOutConnection(unique_ptr<Socket>&& s, const timeval& now) :
+      d_socket(std::move(s)), d_last_used(now)
+    {
+    }
+    Socket& getSocket()
+    {
+      return *d_socket;
+    }
+    void setLastUsed(const timeval& now)
+    {
+      d_last_used = now;
+    }
+    struct timeval getLastUsed() const
+    {
+      return d_last_used;
+    }
+    size_t getQueries() const
+    {
+      return d_queries;
+    }
+    void incQueries()
+    {
+      ++d_queries;
+    }
+  private:
+    unique_ptr<Socket> d_socket;
+    struct timeval d_last_used;
+    size_t d_queries{0};
+  };
+
+  unique_ptr<TCPOutConnection> getConnection(const ComboAddress& address, const timeval& now, bool& isNew);
+  void setIdle(const ComboAddress& address, unique_ptr<TCPOutConnection>&& connection, const timeval& now);
+  size_t size() const
+  {
+    return d_idle_connections.size();
+  }
+  uint64_t* getSize() const
+  {
+    return new uint64_t(size());
+  }
+  void incCreated()
+  {
+    d_created++;
+  }
+  uint64_t* getCreated() const
+  {
+    return new uint64_t(d_created);
+  }
+  void incQueries()
+  {
+    d_queries++;
+  }
+  uint64_t* getQueries() const
+  {
+    return new uint64_t(d_queries);
+  }
+
+  void cleanup(const timeval& now);
+
+  // Max idle time for a connection, 0 is no timeout
+  static struct timeval maxIdle;
+  // Per thread maximum of idle connections for a specific destination, 0 means no idle connections will be kept open
+  static size_t maxPerAuth;
+  // Max number of queries to process per connection, 0 is no max
+  static size_t maxQueries;
+  // Per thread max # of connections, here 0 means a real limit
+  static size_t maxPerThread;
+
+  static uint64_t getAllQueriesDone();         // actually redundant, there's already "tcp-outqueries" maintained by Syncres
+  static uint64_t getAllConnectionsCreated();
+  static uint64_t getCurrentIdleConnections();
+
+private:
+  std::multimap<ComboAddress, unique_ptr<TCPOutConnection>> d_idle_connections;
+  uint64_t d_created{0};
+  uint64_t d_queries{0};
+};
+
+
+
+} // namespace pdns
+
+extern thread_local pdns::TCPOutConnectionManager t_tcpConnections;

--- a/pdns/recursordist/rec-tcp-out.hh
+++ b/pdns/recursordist/rec-tcp-out.hh
@@ -43,7 +43,8 @@ public:
   {
   public:
     TCPOutConnection(unique_ptr<Socket>&& s, const timeval& now) :
-      d_socket(std::move(s)), d_last_used(now)
+      d_socket(std::move(s)),
+      d_last_used(now)
     {
     }
     Socket& getSocket()
@@ -66,6 +67,7 @@ public:
     {
       ++d_queries;
     }
+
   private:
     unique_ptr<Socket> d_socket;
     struct timeval d_last_used;
@@ -110,7 +112,7 @@ public:
   // Per thread max # of connections, here 0 means a real limit
   static size_t maxPerThread;
 
-  static uint64_t getAllQueriesDone();         // actually redundant, there's already "tcp-outqueries" maintained by Syncres
+  static uint64_t getAllQueriesDone(); // actually redundant, there's already "tcp-outqueries" maintained by Syncres
   static uint64_t getAllConnectionsCreated();
   static uint64_t getCurrentIdleConnections();
 
@@ -119,8 +121,6 @@ private:
   uint64_t d_created{0};
   uint64_t d_queries{0};
 };
-
-
 
 } // namespace pdns
 

--- a/pdns/recursordist/test-syncres_cc1.cc
+++ b/pdns/recursordist/test-syncres_cc1.cc
@@ -560,8 +560,8 @@ BOOST_AUTO_TEST_CASE(test_forward_ns_send_refused)
   const DNSName target("www.refused.");
 
   SyncRes::AuthDomain ad;
-  const std::vector<EndPoint> forwardedNSs{{ComboAddress("192.0.2.42:53"), EndPoint::Unspecified},
-                                           {ComboAddress("192.0.2.43:53"), EndPoint::Unspecified}};
+  const std::vector<EndPoint> forwardedNSs{{ComboAddress("192.0.2.42:53")},
+                                           {ComboAddress("192.0.2.43:53")}};
   ad.d_rdForward = false;
   ad.d_servers = forwardedNSs;
   (*SyncRes::t_sstorage.domainmap)[target] = ad;

--- a/pdns/recursordist/test-syncres_cc1.cc
+++ b/pdns/recursordist/test-syncres_cc1.cc
@@ -561,7 +561,7 @@ BOOST_AUTO_TEST_CASE(test_forward_ns_send_refused)
 
   SyncRes::AuthDomain ad;
   const std::vector<EndPoint> forwardedNSs{{ComboAddress("192.0.2.42:53")},
-                                           {ComboAddress("192.0.2.43:53")}};
+    {ComboAddress("192.0.2.43:53")}};
   ad.d_rdForward = false;
   ad.d_servers = forwardedNSs;
   (*SyncRes::t_sstorage.domainmap)[target] = ad;

--- a/pdns/recursordist/test-syncres_cc3.cc
+++ b/pdns/recursordist/test-syncres_cc3.cc
@@ -664,7 +664,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_nord)
 
   const DNSName target("powerdns.com.");
   const ComboAddress ns("192.0.2.1:53");
-  const ComboAddress forwardedNS("192.0.2.42:53");
+  const EndPoint forwardedNS{ComboAddress{"192.0.2.42:53"}};
 
   SyncRes::AuthDomain ad;
   ad.d_rdForward = false;
@@ -672,7 +672,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_nord)
   (*SyncRes::t_sstorage.domainmap)[target] = ad;
 
   sr->setAsyncCallback([forwardedNS](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
-    if (ip == forwardedNS) {
+    if (ip == forwardedNS.d_address) {
       BOOST_CHECK_EQUAL(sendRDQuery, false);
 
       setLWResult(res, 0, true, false, true);
@@ -701,7 +701,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_rd)
 
   const DNSName target("powerdns.com.");
   const ComboAddress ns("192.0.2.1:53");
-  const ComboAddress forwardedNS("192.0.2.42:53");
+  const EndPoint forwardedNS{ComboAddress{"192.0.2.42:53"}};
 
   size_t queriesCount = 0;
   SyncRes::AuthDomain ad;
@@ -712,7 +712,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_rd)
   sr->setAsyncCallback([forwardedNS, &queriesCount](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
 
-    if (ip == forwardedNS) {
+    if (ip == forwardedNS.d_address) {
       BOOST_CHECK_EQUAL(sendRDQuery, true);
 
       /* set AA=0, we are a recursor */
@@ -751,7 +751,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord)
 
   const DNSName target("powerdns.com.");
   const ComboAddress ns("192.0.2.1:53");
-  const ComboAddress forwardedNS("192.0.2.42:53");
+  const EndPoint forwardedNS{ComboAddress{"192.0.2.42:53"}};
 
   SyncRes::AuthDomain ad;
   ad.d_rdForward = true;
@@ -759,7 +759,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord)
   (*SyncRes::t_sstorage.domainmap)[target] = ad;
 
   sr->setAsyncCallback([forwardedNS](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
-    if (ip == forwardedNS) {
+    if (ip == forwardedNS.d_address) {
       BOOST_CHECK_EQUAL(sendRDQuery, false);
 
       setLWResult(res, 0, true, false, true);
@@ -788,7 +788,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd)
 
   const DNSName target("powerdns.com.");
   const ComboAddress ns("192.0.2.1:53");
-  const ComboAddress forwardedNS("192.0.2.42:53");
+  const EndPoint forwardedNS{ComboAddress{"192.0.2.42:53"}};
 
   SyncRes::AuthDomain ad;
   ad.d_rdForward = true;
@@ -796,7 +796,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd)
   (*SyncRes::t_sstorage.domainmap)[target] = ad;
 
   sr->setAsyncCallback([forwardedNS](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
-    if (ip == forwardedNS) {
+    if (ip == forwardedNS.d_address) {
       BOOST_CHECK_EQUAL(sendRDQuery, true);
 
       setLWResult(res, 0, true, false, true);
@@ -833,7 +833,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec)
   generateKeyMaterial(target, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
   g_luaconfs.setState(luaconfsCopy);
 
-  const ComboAddress forwardedNS("192.0.2.42:53");
+  const EndPoint forwardedNS{ComboAddress{"192.0.2.42:53"}};
   size_t queriesCount = 0;
 
   SyncRes::AuthDomain ad;
@@ -846,7 +846,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec)
 
     BOOST_CHECK_EQUAL(sendRDQuery, true);
 
-    if (ip != forwardedNS) {
+    if (ip != forwardedNS.d_address) {
       return LWResult::Result::Timeout;
     }
 
@@ -903,7 +903,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord_dnssec)
   generateKeyMaterial(DNSName("test."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
   g_luaconfs.setState(luaconfsCopy);
 
-  const ComboAddress forwardedNS("192.0.2.42:53");
+  const EndPoint forwardedNS{ComboAddress{"192.0.2.42:53"}};
   size_t queriesCount = 0;
   size_t DSforParentCount = 0;
 
@@ -936,7 +936,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_nord_dnssec)
       addRecordToLW(res, "a.gtld-servers.net.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
     }
 
-    if (ip != forwardedNS) {
+    if (ip != forwardedNS.d_address) {
       return LWResult::Result::Timeout;
     }
 
@@ -1008,7 +1008,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_bogus)
   generateKeyMaterial(cnameTarget, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
   g_luaconfs.setState(luaconfsCopy);
 
-  const ComboAddress forwardedNS("192.0.2.42:53");
+  const EndPoint forwardedNS{ComboAddress{"192.0.2.42:53"}};
   size_t queriesCount = 0;
 
   SyncRes::AuthDomain ad;
@@ -1021,7 +1021,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_bogus)
 
     BOOST_CHECK_EQUAL(sendRDQuery, true);
 
-    if (ip != forwardedNS) {
+    if (ip != forwardedNS.d_address) {
       return LWResult::Result::Timeout;
     }
 
@@ -1076,7 +1076,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_nodata_bogus)
   generateKeyMaterial(DNSName("powerdns.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
   g_luaconfs.setState(luaconfsCopy);
 
-  const ComboAddress forwardedNS("192.0.2.42:53");
+  const EndPoint forwardedNS{ComboAddress{"192.0.2.42:53"}};
   SyncRes::AuthDomain ad;
   ad.d_rdForward = true;
   ad.d_servers.push_back(forwardedNS);
@@ -1089,7 +1089,7 @@ BOOST_AUTO_TEST_CASE(test_forward_zone_recurse_rd_dnssec_nodata_bogus)
 
     BOOST_CHECK_EQUAL(sendRDQuery, true);
 
-    if (ip != forwardedNS) {
+    if (ip != forwardedNS.d_address) {
       return LWResult::Result::Timeout;
     }
 

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -264,7 +264,7 @@ static void convertServersForAD(const std::string& input, SyncRes::AuthDomain& a
     ComboAddress addr=parseIPAndPort(*iter, 53);
     if(verbose)
       g_log<<addr.toStringWithPort();
-    ad.d_servers.push_back(addr);
+    ad.d_servers.push_back(EndPoint{addr, EndPoint::Unspecified});
   }
   if(verbose)
     g_log<<endl;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -68,9 +68,14 @@ class RecursorLua4;
 
 struct EndPoint
 {
-  enum Method : uint8_t { Unspecified, UDP, TCP, TLS };
+  enum Method : uint8_t { Do53, UDP, TCP, DoT };
   ComboAddress d_address;
-  Method d_method{Unspecified};
+  Method d_method{Do53};
+
+  string toString() const {
+    const std::array<string, 4> names = { "Do53/", "UDP/", "TCP/", "DoT/" };
+    return names[d_method] + d_address.toStringWithPort();
+  }
 };
 
 struct NSData

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -134,8 +134,8 @@ static void fillZone(const DNSName& zonename, HttpResponse* resp)
   const SyncRes::AuthDomain& zone = iter->second;
 
   Json::array servers;
-  for(const ComboAddress& server : zone.d_servers) {
-    servers.push_back(server.toStringWithPort());
+  for(const auto& ep  : zone.d_servers) {
+    servers.push_back(ep.d_address.toStringWithPort());
   }
 
   Json::array records;
@@ -285,8 +285,8 @@ static void apiServerZones(HttpRequest* req, HttpResponse* resp)
   for(const SyncRes::domainmap_t::value_type& val :  *SyncRes::t_sstorage.domainmap) {
     const SyncRes::AuthDomain& zone = val.second;
     Json::array servers;
-    for(const ComboAddress& server : zone.d_servers) {
-      servers.push_back(server.toStringWithPort());
+    for(const auto& ep : zone.d_servers) {
+      servers.push_back(ep.d_address.toStringWithPort());
     }
     // id is the canonical lookup key, which doesn't actually match the name (in some cases)
     string zoneId = apiZoneNameToId(val.first);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This is a experimental code, implementing two related features

- Ability to specify the type of connection to use for forwarding. e.g.  `forward-zones-recurse=.=TCP/8.8.8.8`
To be able to track what kind of connection to use for a specific NS, this records the type of endpoint for NS data. ATM, mostly `Unspecified` i.e. use regular UDP with fallback to TCP. In the future this can be extended to force DoT (or other?) connection methods to auths.
- A connection pooling  mechnism for outgoing TCP connections. This avoid having to set up a new TCP connection for every outgoing TCP query always. 

Mostly creating a PR to be able to run CI on it (now that forked repos are not supposed to do that) and making discussion the code more easy.

Note that this also contains a version of #10041

TODO:
- [ ] fix file descriptor limit code to avoid underflow
- [ ] imake sure we never grow the map beyond maxPerThread so the cleanup code can be much simpler
- [ ] change description (and maybe name of setting) of maxIdle: "after a connection has been idle for this time is it eligible for GC", there is no guarantee it will be GC'ed immediately
- [ ] tests!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
