### PR TITLE
rec: Implement rfc 8198 - Aggressive Use of DNSSEC-Validated Cache

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -326,19 +326,22 @@ struct SuffixMatchTree
     }
   }
 
-  void remove(const DNSName &name) const
+  void remove(const DNSName &name, bool subtree=false) const
   {
     auto labels = name.getRawLabels();
-    remove(labels);
+    remove(labels, subtree);
   }
 
   /* Removes the node at `labels`, also make sure that no empty
    * children will be left behind in memory
    */
-  void remove(std::vector<std::string>& labels) const
+  void remove(std::vector<std::string>& labels, bool subtree = false) const
   {
     if (labels.empty()) { // this allows removal of the root
       endNode = false;
+      if (subtree) {
+        children.clear();
+      }
       return;
     }
 
@@ -354,6 +357,10 @@ struct SuffixMatchTree
     if (labels.empty()) {
       // The child is no longer an endnode
       child->endNode = false;
+
+      if (subtree) {
+        child->children.clear();
+      }
 
       // If the child has no further children, just remove it from the set.
       if (child->children.empty()) {

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -726,6 +726,10 @@ public:
   {
     return d_bitmap.count();
   }
+  bool isOptOut() const
+  {
+    return d_flags & 1;
+  }
 
 private:
   NSECBitmap d_bitmap;

--- a/pdns/lock.hh
+++ b/pdns/lock.hh
@@ -36,7 +36,6 @@ public:
   }
 
   ~ReadWriteLock() {
-    /* might have been moved */
     pthread_rwlock_destroy(&d_lock);
   }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5516,7 +5516,7 @@ int main(int argc, char **argv)
 
     ::arg().setSwitch("extended-resolution-errors", "If set, send an EDNS Extended Error extension on resolution failures, like DNSSEC validation errors")="no";
 
-    ::arg().setSwitch("aggressive-nsec", "If set, and DNSSEC validation is enabled, the recursor will look at cached NSEC and NSEC3 records to generate negative answers, as defined in rfc8198")="no";
+    ::arg().setSwitch("aggressive-nsec", "If set, and DNSSEC validation is enabled, the recursor will cache NSEC and NSEC3 records to generate negative answers, as defined in rfc8198")="no";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print version string");

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3514,7 +3514,7 @@ static void houseKeeping(void *)
         g_recCache->doPrune(g_maxCacheEntries);
         g_negCache->prune(g_maxCacheEntries / 10);
         if (g_aggressiveNSECCache) {
-          g_aggressiveNSECCache->prune();
+          g_aggressiveNSECCache->prune(now.tv_sec);
         }
         last_RC_prune = now.tv_sec;
       }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -68,6 +68,7 @@
 #include "malloctrace.hh"
 #endif
 #include <netinet/tcp.h>
+#include "aggressive_nsec.hh"
 #include "capabilities.hh"
 #include "dnsparser.hh"
 #include "dnswriter.hh"
@@ -4740,6 +4741,15 @@ static int serviceMain(int argc, char*argv[])
 
   s_addExtendedResolutionDNSErrors = ::arg().mustDo("extended-resolution-errors");
 
+  if (::arg().mustDo("aggressive-nsec")) {
+    if (g_dnssecmode == DNSSECMode::ValidateAll || g_dnssecmode == DNSSECMode::ValidateForLog) {
+      g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+    }
+    else {
+      g_log<<Logger::Warning<<"Aggressive NSEC/NSEC3 caching is enabled but DNSSEC validation is not set to 'validate' or 'log-fail', ignoring"<<endl;
+    }
+  }
+
   {
     SuffixMatchNode dontThrottleNames;
     vector<string> parts;
@@ -5505,6 +5515,8 @@ int main(int argc, char **argv)
 #endif /* NOD_ENABLED */
 
     ::arg().setSwitch("extended-resolution-errors", "If set, send an EDNS Extended Error extension on resolution failures, like DNSSEC validation errors")="no";
+
+    ::arg().setSwitch("aggressive-nsec", "If set, and DNSSEC validation is enabled, the recursor will look at cached NSEC and NSEC3 records to generate negative answers, as defined in rfc8198")="no";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print version string");

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4746,11 +4746,11 @@ static int serviceMain(int argc, char*argv[])
   s_addExtendedResolutionDNSErrors = ::arg().mustDo("extended-resolution-errors");
 
   if (::arg().asNum("aggressive-nsec-cache-size") > 0) {
-    if (g_dnssecmode == DNSSECMode::ValidateAll || g_dnssecmode == DNSSECMode::ValidateForLog) {
+    if (g_dnssecmode == DNSSECMode::ValidateAll || g_dnssecmode == DNSSECMode::ValidateForLog || g_dnssecmode == DNSSECMode::Process) {
       g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(::arg().asNum("aggressive-nsec-cache-size"));
     }
     else {
-      g_log<<Logger::Warning<<"Aggressive NSEC/NSEC3 caching is enabled but DNSSEC validation is not set to 'validate' or 'log-fail', ignoring"<<endl;
+      g_log<<Logger::Warning<<"Aggressive NSEC/NSEC3 caching is enabled but DNSSEC validation is not set to 'validate', 'log-fail' or 'process', ignoring"<<endl;
     }
   }
 
@@ -5520,7 +5520,7 @@ int main(int argc, char **argv)
 
     ::arg().setSwitch("extended-resolution-errors", "If set, send an EDNS Extended Error extension on resolution failures, like DNSSEC validation errors")="no";
 
-    ::arg().setSwitch("aggressive-nsec-cache-size", "The number of records to cache in the aggressive cache. If set to a value greater than 0, and DNSSEC validation is enabled, the recursor will cache NSEC and NSEC3 records to generate negative answers, as defined in rfc8198")="0";
+    ::arg().setSwitch("aggressive-nsec-cache-size", "The number of records to cache in the aggressive cache. If set to a value greater than 0, and DNSSEC validation is enabled, the recursor will cache NSEC and NSEC3 records to generate negative answers, as defined in rfc8198")="100000";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print version string");

--- a/pdns/rec-snmp.cc
+++ b/pdns/rec-snmp.cc
@@ -125,6 +125,11 @@ static const oid nodLookupsDroppedOversizeOID[] = { RECURSOR_STATS_OID, 104 };
 static const oid taskQueuePushedOID[] = { RECURSOR_STATS_OID, 105 };
 static const oid taskQueueExpiredOID[] = { RECURSOR_STATS_OID, 106 };
 static const oid taskQueueSizeOID[] = { RECURSOR_STATS_OID, 107 };
+static const oid aggressiveNSECCacheEntriesOID[] = { RECURSOR_STATS_OID, 108 };
+static const oid aggressiveNSECCacheNSECHitsOID[] = { RECURSOR_STATS_OID, 109 };
+static const oid aggressiveNSECCacheNSEC3HitsOID[] = { RECURSOR_STATS_OID, 110 };
+static const oid aggressiveNSECCacheNSECWCHitsOID[] = { RECURSOR_STATS_OID, 111 };
+static const oid aggressiveNSECCacheNSEC3WCHitsOID[] = { RECURSOR_STATS_OID, 112 };
 
 static std::unordered_map<oid, std::string> s_statsMap;
 
@@ -341,5 +346,10 @@ RecursorSNMPAgent::RecursorSNMPAgent(const std::string& name, const std::string&
   registerCounter64Stat("tasqueue-pushed", taskQueuePushedOID, OID_LENGTH(taskQueuePushedOID));
   registerCounter64Stat("taskqueue-expired", taskQueueExpiredOID, OID_LENGTH(taskQueueExpiredOID));
   registerCounter64Stat("taskqueue-size", taskQueueSizeOID, OID_LENGTH(taskQueueSizeOID));
+  registerCounter64Stat("aggressive-nsec-cache-entries", aggressiveNSECCacheEntriesOID, OID_LENGTH(aggressiveNSECCacheEntriesOID));
+  registerCounter64Stat("aggressive-nsec-cache-nsec-hits", aggressiveNSECCacheNSECHitsOID, OID_LENGTH(aggressiveNSECCacheNSECHitsOID));
+  registerCounter64Stat("aggressive-nsec-cache-nsec3-hits", aggressiveNSECCacheNSEC3HitsOID, OID_LENGTH(aggressiveNSECCacheNSEC3HitsOID));
+  registerCounter64Stat("aggressive-nsec-cache-nsec-wc-hits", aggressiveNSECCacheNSECWCHitsOID, OID_LENGTH(aggressiveNSECCacheNSECWCHitsOID));
+  registerCounter64Stat("aggressive-nsec-cache-nsec-wc3-hits", aggressiveNSECCacheNSEC3WCHitsOID, OID_LENGTH(aggressiveNSECCacheNSEC3WCHitsOID));
 #endif /* HAVE_NET_SNMP */
 }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -31,6 +31,7 @@
 #include "responsestats.hh"
 #include "rec-lua-conf.hh"
 
+#include "aggressive_nsec.hh"
 #include "validate-recursor.hh"
 #include "filterpo.hh"
 
@@ -1047,7 +1048,13 @@ static void registerAllStats1()
   addGetStat("packetcache-misses", doGetPacketCacheMisses); 
   addGetStat("packetcache-entries", doGetPacketCacheSize); 
   addGetStat("packetcache-bytes", doGetPacketCacheBytes); 
-  
+
+  addGetStat("aggressive-nsec-cache-entries", [](){ return g_aggressiveNSECCache ? g_aggressiveNSECCache->getEntriesCount() : 0; });
+  addGetStat("aggressive-nsec-cache-nsec-hits", [](){ return g_aggressiveNSECCache ? g_aggressiveNSECCache->getNSECHits() : 0; });
+  addGetStat("aggressive-nsec-cache-nsec3-hits", [](){ return g_aggressiveNSECCache ? g_aggressiveNSECCache->getNSEC3Hits() : 0; });
+  addGetStat("aggressive-nsec-cache-nsec-wc-hits", [](){ return g_aggressiveNSECCache ? g_aggressiveNSECCache->getNSECWildcardHits() : 0; });
+  addGetStat("aggressive-nsec-cache-nsec3-wc-hits", [](){ return g_aggressiveNSECCache ? g_aggressiveNSECCache->getNSEC3WildcardHits() : 0; });
+
   addGetStat("malloc-bytes", doGetMallocated);
   
   addGetStat("servfail-answers", &g_stats.servFails);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -442,6 +442,9 @@ static string doWipeCache(T begin, T end, uint16_t qtype)
       count += g_recCache->doWipeCache(wipe.first, wipe.second, qtype);
       pcount += broadcastAccFunction<uint64_t>([=]{ return pleaseWipePacketCache(wipe.first, wipe.second, qtype);});
       countNeg += g_negCache->wipe(wipe.first, wipe.second);
+      if (g_aggressiveNSECCache) {
+        g_aggressiveNSECCache->removeZoneInfo(wipe.first, wipe.second);
+      }
     }
     catch (const std::exception& e) {
       g_log<<Logger::Warning<<", failed: "<<e.what()<<endl;
@@ -550,6 +553,9 @@ static string doAddNTA(T begin, T end)
     g_recCache->doWipeCache(who, true, 0xffff);
     broadcastAccFunction<uint64_t>([=]{return pleaseWipePacketCache(who, true, 0xffff);});
     g_negCache->wipe(who, true);
+    if (g_aggressiveNSECCache) {
+      g_aggressiveNSECCache->removeZoneInfo(who, true);
+    }
   }
   catch (std::exception& e) {
     g_log<<Logger::Warning<<", failed: "<<e.what()<<endl;
@@ -604,6 +610,9 @@ static string doClearNTA(T begin, T end)
       g_recCache->doWipeCache(entry, true, 0xffff);
       broadcastAccFunction<uint64_t>([=]{return pleaseWipePacketCache(entry, true, 0xffff);});
       g_negCache->wipe(entry, true);
+      if (g_aggressiveNSECCache) {
+        g_aggressiveNSECCache->removeZoneInfo(entry, true);
+      }
       if (!first) {
         first = false;
         removed += ",";
@@ -667,6 +676,9 @@ static string doAddTA(T begin, T end)
     g_recCache->doWipeCache(who, true, 0xffff);
     broadcastAccFunction<uint64_t>([=]{return pleaseWipePacketCache(who, true, 0xffff);});
     g_negCache->wipe(who, true);
+    if (g_aggressiveNSECCache) {
+      g_aggressiveNSECCache->removeZoneInfo(who, true);
+    }
     g_log<<Logger::Warning<<endl;
     return "Added Trust Anchor for " + who.toStringRootDot() + " with data " + what + "\n";
   }
@@ -714,6 +726,9 @@ static string doClearTA(T begin, T end)
       g_recCache->doWipeCache(entry, true, 0xffff);
       broadcastAccFunction<uint64_t>([=]{return pleaseWipePacketCache(entry, true, 0xffff);});
       g_negCache->wipe(entry, true);
+      if (g_aggressiveNSECCache) {
+        g_aggressiveNSECCache->removeZoneInfo(entry, true);
+      }
       if (!first) {
         first = false;
         removed += ",";

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -440,7 +440,7 @@ void MemRecursorCache::replace(time_t now, const DNSName &qname, const QType qt,
   time_t maxTTD=std::numeric_limits<time_t>::max();
   CacheEntry ce=*stored; // this is a COPY
   ce.d_qtype=qt.getCode();
-  
+
   if(!auth && ce.d_auth) {  // unauth data came in, we have some auth data, but is it fresh?
     if(ce.d_ttd > now) { // we still have valid data, ignore unauth data
       return;

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -275,6 +275,7 @@ testrunner_SOURCES = \
 	stable-bloom.hh \
 	svc-records.cc svc-records.hh \
 	syncres.cc syncres.hh \
+	test-aggressive_nsec_cc.cc \
 	test-arguments_cc.cc \
 	test-base32_cc.cc \
 	test-base64_cc.cc \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -94,6 +94,7 @@ check-local:
 endif
 
 pdns_recursor_SOURCES = \
+	aggressive_nsec.cc aggressive_nsec.hh \
 	arguments.cc \
 	ascii.hh \
 	axfr-retriever.hh axfr-retriever.cc \
@@ -226,6 +227,7 @@ pdns_recursor_LDFLAGS += \
 endif
 
 testrunner_SOURCES = \
+	aggressive_nsec.cc aggressive_nsec.hh \
 	arguments.cc \
 	axfr-retriever.hh axfr-retriever.cc \
 	base32.cc \

--- a/pdns/recursordist/RECURSOR-MIB.txt
+++ b/pdns/recursordist/RECURSOR-MIB.txt
@@ -33,6 +33,9 @@ rec MODULE-IDENTITY
     REVISION "202002170000Z"
     DESCRIPTION "Added proxyProtocolInvalid metric."
 
+    REVISION "202101050000Z"
+    DESCRIPTION "Added Aggressive NSEC cache metrics."
+
     ::= { powerdns 2 }
 
 powerdns		OBJECT IDENTIFIER ::= { enterprises 43315 }
@@ -895,6 +898,46 @@ taskQueueSize OBJECT-TYPE
         "Number of tasks currenlty in the taskqueues"
     ::= { stats 107 }
 
+aggressiveNSECCacheEntries OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of entries in the aggressive NSEC cache"
+    ::= { stats 108 }
+
+aggressiveNSECCacheNSECHits OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of NSEC-related hits from the aggressive NSEC cache"
+    ::= { stats 109 }
+
+aggressiveNSECCacheNSEC3Hits OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of NSEC3-related hits from the aggressive NSEC cache"
+    ::= { stats 110 }
+
+aggressiveNSECCacheNSECWcHits OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of answers synthesized from the NSEC aggressive cache"
+    ::= { stats 111 }
+
+aggressiveNSECCacheNSEC3WcHits OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of answers synthesized from the NSEC3 aggressive cache"
+    ::= { stats 112 }
+
 ---
 --- Traps / Notifications
 ---
@@ -1045,7 +1088,12 @@ recGroup OBJECT-GROUP
         nodLookupsDroppedOversize,
         taskQueuePushed,
         taskQueueExpired,
-        taskQueueSize
+        taskQueueSize,
+        aggressiveNSECCacheEntries,
+        aggressiveNSECCacheNSECHits,
+        aggressiveNSECCacheNSEC3Hits,
+        aggressiveNSECCacheNSECWcHits,
+        aggressiveNSECCacheNSEC3WcHits
     }
     STATUS current
     DESCRIPTION "Objects conformance group for PowerDNS Recursor"

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -172,6 +172,7 @@ void AggressiveNSECCache::insertNSEC(const DNSName& zone, const DNSName& owner, 
       entry->d_entries.insert({record.d_content, signatures, owner, std::move(next), record.d_ttl});
     }
   }
+  ++d_entriesCount;
 }
 
 bool AggressiveNSECCache::getNSECBefore(time_t now, std::shared_ptr<AggressiveNSECCache::ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry) {
@@ -219,6 +220,7 @@ bool AggressiveNSECCache::getNSECBefore(time_t now, std::shared_ptr<AggressiveNS
 
   if (it->d_ttd <= now) {
     idx.erase(it);
+    --d_entriesCount;
     return false;
   }
 
@@ -245,6 +247,7 @@ bool AggressiveNSECCache::getNSEC3(time_t now, std::shared_ptr<AggressiveNSECCac
 
     if (it->d_ttd <= now) {
       idx.erase(it);
+      --d_entriesCount;
       return false;
     }
 
@@ -332,6 +335,7 @@ bool AggressiveNSECCache::synthesizeFromNSEC3Wildcard(time_t now, const DNSName&
   /* and of course we won't deny the wildcard either */
 
   LOG("Synthesized valid answer from NSEC3s and wildcard!"<<endl);
+  ++d_nsec3WildcardHits;
   return true;
 }
 
@@ -351,6 +355,7 @@ bool AggressiveNSECCache::synthesizeFromNSECWildcard(time_t now, const DNSName& 
   addRecordToRRSet(now, nsec.d_owner, QType::NSEC3, nsec.d_ttd - now, nsec.d_record, nsec.d_signatures, doDNSSEC, ret);
 
   LOG("Synthesized valid answer from NSECs and wildcard!"<<endl);
+  ++d_nsecWildcardHits;
   return true;
 }
 
@@ -389,6 +394,7 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<AggressiveN
     }
 
     LOG(": done!"<<endl);
+    ++d_nsec3Hits;
     res = RCode::NoError;
     addToRRSet(now, soaSet, soaSignatures, zoneEntry->d_zone, doDNSSEC, ret);
     addRecordToRRSet(now, exactNSEC3.d_owner, QType::NSEC3, exactNSEC3.d_ttd - now, exactNSEC3.d_record, exactNSEC3.d_signatures, doDNSSEC, ret);
@@ -477,6 +483,7 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<AggressiveN
   addRecordToRRSet(now, wcEntry.d_owner, QType::NSEC3, wcEntry.d_ttd - now, wcEntry.d_record, wcEntry.d_signatures, doDNSSEC, ret);
 
   LOG("Found valid NSEC3s covering the requested name and type!"<<endl);
+  ++d_nsec3Hits;
   return true;
 }
 
@@ -589,5 +596,6 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
   }
 
   LOG("Found valid NSECs covering the requested name and type!"<<endl);
+  ++d_nsecHits;
   return true;
 }

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -1,0 +1,578 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "aggressive_nsec.hh"
+#include "recursor_cache.hh"
+#include "validate.hh"
+
+std::unique_ptr<AggressiveNSECCache> g_aggressiveNSECCache{nullptr};
+
+/* this is defined in syncres.hh and we are not importing that here */
+extern std::unique_ptr<MemRecursorCache> g_recCache;
+
+std::shared_ptr<AggressiveNSECCache::ZoneEntry> AggressiveNSECCache::getBestZone(const DNSName& zone)
+{
+  std::shared_ptr<AggressiveNSECCache::ZoneEntry> entry{nullptr};
+  {
+    ReadLock rl(d_lock);
+    auto got = d_zones.lookup(zone);
+    if (got) {
+      return *got;
+    }
+  }
+  return entry;
+}
+
+std::shared_ptr<AggressiveNSECCache::ZoneEntry> AggressiveNSECCache::getZone(const DNSName& zone)
+{
+  std::shared_ptr<AggressiveNSECCache::ZoneEntry> entry{nullptr};
+  {
+    ReadLock rl(d_lock);
+    auto got = d_zones.lookup(zone);
+    if (got && *got && (*got)->d_zone == zone) {
+      return *got;
+    }
+  }
+
+  entry = std::make_shared<ZoneEntry>();
+  entry->d_zone = zone;
+
+  {
+    WriteLock wl(d_lock);
+    /* it might have been inserted in the mean time */
+    auto got = d_zones.lookup(zone);
+    if (got && *got && (*got)->d_zone == zone) {
+      return *got;
+    }
+    d_zones.add(zone, std::shared_ptr<ZoneEntry>(entry));
+    return entry;
+  }
+}
+
+void AggressiveNSECCache::insertNSEC(const DNSName& zone, const DNSName& owner, const DNSRecord& record, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures, bool nsec3)
+{
+  std::shared_ptr<AggressiveNSECCache::ZoneEntry> entry = getZone(zone);
+  {
+    std::lock_guard<std::mutex> lock(entry->d_lock);
+    if (nsec3 && !entry->d_nsec3) {
+      entry->d_entries.clear();
+      entry->d_nsec3 = true;
+    }
+
+    DNSName next;
+    if (!nsec3) {
+      auto content = getRR<NSECRecordContent>(record);
+      if (!content) {
+        throw std::runtime_error("Error getting the content from a NSEC record");
+      }
+      next = content->d_next;
+    }
+    else {
+      auto content = getRR<NSEC3RecordContent>(record);
+      if (!content) {
+        throw std::runtime_error("Error getting the content from a NSEC3 record");
+      }
+      next = DNSName(content->d_nexthash) + zone;
+      entry->d_iterations = content->d_iterations;
+      entry->d_salt = content->d_salt;
+    }
+
+    /* the TTL is already a TTD by now */
+    entry->d_entries.insert({record.d_content, signatures, owner, std::move(next), record.d_ttl});
+  }
+}
+
+bool AggressiveNSECCache::getNSECBefore(time_t now, std::shared_ptr<AggressiveNSECCache::ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry) {
+
+  std::lock_guard<std::mutex> lock(zoneEntry->d_lock);
+  if (zoneEntry->d_entries.empty()) {
+    return false;
+  }
+
+  auto& idx = zoneEntry->d_entries.get<ZoneEntry::OrderedTag>();
+  auto it = idx.lower_bound(name);
+  bool end = false;
+
+  while (!end && (it == idx.end() || (it->d_owner != name && !it->d_owner.canonCompare(name))))
+  {
+    if (it == idx.end()) {
+      cerr<<"GOT END"<<endl;
+    }
+    else {
+      cerr<<"got "<<it->d_owner<<endl;
+    }
+
+    if (it == idx.begin()) {
+      // can't go further, but perhaps we wrapped?
+      it = idx.end();
+      it--;
+      if (!it->d_owner.canonCompare(name) && it->d_next.canonCompare(name)) {
+        break;
+      }
+      end = true;
+      break;
+    }
+    else {
+      it--;
+       cerr<<"looping with "<<it->d_owner<<endl;
+    }
+  }
+
+  if (end) {
+     cerr<<"nothing left"<<endl;
+    return false;
+  }
+
+  cerr<<"considering "<<it->d_owner<<" "<<it->d_next<<endl;
+
+  if (it->d_ttd <= now) {
+     cerr<<"not using it"<<endl;
+    return false;
+  }
+
+  entry = *it;
+  return true;
+}
+
+bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType& type, std::vector<DNSRecord>&ret, int& res, const ComboAddress& who, const boost::optional<std::string>& routingTag, bool doDNSSEC)
+{
+  auto zoneEntry = getBestZone(name);
+  if (!zoneEntry) {
+    cerr<<"zone info not found"<<endl;
+    return false;
+  }
+
+  vState cachedState;
+  std::vector<DNSRecord> soaSet;
+  std::vector<std::shared_ptr<RRSIGRecordContent>> soaSignatures;
+  if (g_recCache->get(now, zoneEntry->d_zone, QType::SOA, true, &soaSet, who, false, routingTag, doDNSSEC ? &soaSignatures : nullptr, nullptr, nullptr, &cachedState) <= 0 || cachedState != vState::Secure) {
+    cerr<<"could not find SOA"<<endl;
+    return false;
+  }
+
+  if (zoneEntry->d_nsec3) {
+    cerr<<"nsec 3"<<endl;
+    return false;
+    //return doAggressiveNSEC3Cache(prefix, qname, qtype, zone, salt, iterations, ret, res, state);
+  }
+
+  ZoneEntry::CacheEntry entry;
+  ZoneEntry::CacheEntry wcEntry;
+  bool covered = false;
+  bool needWildcard = false;
+
+  cerr<<"looking for nsec before "<<name<<endl;
+  if (!getNSECBefore(now, zoneEntry, name, entry)) {
+    cerr<<"nothing found in aggressive cache either"<<endl;
+    return false;
+  }
+
+  auto content = std::dynamic_pointer_cast<NSECRecordContent>(entry.d_record);
+  if (!content) {
+    return false;
+  }
+
+  cerr<<"nsecFound "<<entry.d_owner<<endl;
+  auto denial = matchesNSEC(name, type.getCode(), entry.d_owner, content, entry.d_signatures);
+  if (denial == dState::NXQTYPE) {
+    covered = true;
+    res = RCode::NoError;
+  }
+  else if (denial == dState::NXDOMAIN) {
+    if (name.countLabels() > 1) {
+      DNSName wc(name);
+      wc.chopOff();
+      wc = g_wildcarddnsname + wc;
+
+      cerr<<"looking for nsec before "<<wc<<endl;
+      if (!getNSECBefore(now, zoneEntry, wc, wcEntry)) {
+         cerr<<"nothing found in aggressive cache for Wildcard"<<endl;
+        return false;
+      }
+
+      cerr<<"wc nsec found "<<wcEntry.d_owner<<endl;
+      if (wcEntry.d_owner == entry.d_owner) {
+        covered = true;
+        res = RCode::NXDomain;
+      }
+      else {
+        if (wcEntry.d_owner == wc) {
+#warning FIXME: if the wc does exist but the type does not, it is actually quite simple
+          /* too complicated for now */
+          return false;
+        }
+        else if (isCoveredByNSEC(wc, wcEntry.d_owner, wcEntry.d_next)) {
+          cerr<<"next is "<<wcEntry.d_next<<endl;
+          covered = true;
+          res = RCode::NXDomain;
+          needWildcard = true;
+        }
+      }
+    }
+  }
+
+  if (!covered) {
+    return false;
+  }
+
+  uint32_t ttl=0;
+
+  ret.reserve(ret.size() + soaSet.size() + soaSignatures.size() + /* NSEC */ 1 + entry.d_signatures.size() + (needWildcard ? (/* NSEC */ 1 + wcEntry.d_signatures.size()) : 0));
+
+  for (auto& record : soaSet) {
+    if (record.d_class != QClass::IN) {
+      continue;
+    }
+
+    record.d_ttl -= now;
+    ttl = record.d_ttl;
+    ret.push_back(std::move(record));
+  }
+
+  if (doDNSSEC) {
+    for (auto& signature : soaSignatures) {
+      DNSRecord dr;
+      dr.d_type = QType::RRSIG;
+      dr.d_name = zoneEntry->d_zone;
+      dr.d_ttl = ttl;
+      dr.d_content = std::move(signature);
+      dr.d_place = DNSResourceRecord::AUTHORITY;
+      dr.d_class = QClass::IN;
+      ret.push_back(std::move(dr));
+    }
+  }
+
+  DNSRecord nsecRec;
+  nsecRec.d_type = QType::NSEC;
+  nsecRec.d_name = entry.d_owner;
+  nsecRec.d_ttl = entry.d_ttd - now;
+  ttl = nsecRec.d_ttl;
+  nsecRec.d_content = std::move(entry.d_record);
+  nsecRec.d_place = DNSResourceRecord::AUTHORITY;
+  nsecRec.d_class = QClass::IN;
+  ret.push_back(std::move(nsecRec));
+
+  if (doDNSSEC) {
+    for (auto& signature : entry.d_signatures) {
+      DNSRecord dr;
+      dr.d_type = QType::RRSIG;
+      dr.d_name = entry.d_owner;
+      dr.d_ttl = ttl;
+      dr.d_content = std::move(signature);
+      dr.d_place = DNSResourceRecord::AUTHORITY;
+      dr.d_class = QClass::IN;
+      ret.push_back(std::move(dr));
+    }
+  }
+
+  if (needWildcard) {
+    DNSRecord wcNsecRec;
+    wcNsecRec.d_type = QType::NSEC;
+    wcNsecRec.d_name = wcEntry.d_owner;
+    wcNsecRec.d_ttl = wcEntry.d_ttd - now;
+    ttl = wcNsecRec.d_ttl;
+    wcNsecRec.d_content = std::move(wcEntry.d_record);
+    wcNsecRec.d_place = DNSResourceRecord::AUTHORITY;
+    wcNsecRec.d_class = QClass::IN;
+    ret.push_back(std::move(wcNsecRec));
+
+    if (doDNSSEC) {
+      for (auto& signature : wcEntry.d_signatures) {
+        DNSRecord dr;
+        dr.d_type = QType::RRSIG;
+        dr.d_name = wcEntry.d_owner;
+        dr.d_ttl = ttl;
+        dr.d_content = std::move(signature);
+        dr.d_place = DNSResourceRecord::AUTHORITY;
+        dr.d_class = QClass::IN;
+        ret.push_back(std::move(dr));
+      }
+    }
+  }
+
+  return true;
+}
+
+#if 0
+
+bool SyncRes::doAggressiveNSEC3Cache(const std::string& prefix, const DNSName& qname, const QType& qtype, const DNSName& zone, const std::string& salt, uint16_t iterations, vector<DNSRecord>&ret, int& res, vState& state)
+{
+#warning FIXME: nsec3
+  cerr<<"nsec3, sorry"<<endl;
+  if (g_maxNSEC3Iterations && iterations > g_maxNSEC3Iterations) {
+    return false;
+  }
+
+  vector<DNSRecord> cset;
+  vector<std::shared_ptr<RRSIGRecordContent>> signatures;
+  vState cachedState;
+
+  auto qnameHash = toBase32Hex(hashQNameWithSalt(salt, iterations, qname));
+
+  cerr<<"looking for nsec3 "<<(DNSName(qnameHash) + zone)<<endl;
+  DNSName nsec3Found;
+  if (g_recCache->get(d_now.tv_sec, DNSName(qnameHash) + zone, QType::NSEC3, true, &cset, d_cacheRemote, false, d_routingTag, d_doDNSSEC ? &signatures : nullptr, nullptr, nullptr, &cachedState, nullptr, &zone) > 0) {
+    cerr<<"found direct match "<<qnameHash<<endl;
+    if (cachedState == vState::Secure) {
+      cerr<<"but not secure"<<endl;
+      return false;
+    }
+
+    return false;
+  }
+
+  cerr<<"no direct match, looking for closest encloser"<<endl;
+  DNSName closestEncloser(qname);
+  bool found = false;
+  while (!found && closestEncloser.chopOff()) {
+    auto closestHash = toBase32Hex(hashQNameWithSalt(salt, iterations, closestEncloser));
+    cerr<<"looking for nsec3 "<<(DNSName(closestHash) + zone)<<endl;
+
+    if (g_recCache->get(d_now.tv_sec, DNSName(closestHash) + zone, QType::NSEC3, true, &cset, d_cacheRemote, false, d_routingTag, d_doDNSSEC ? &signatures : nullptr, nullptr, nullptr, &cachedState, nullptr, &zone) > 0) {
+      cerr<<"found direct match for closest encloser "<<closestHash<<endl;
+      found = true;
+      break;
+    }
+  }
+
+  if (!found) {
+    cerr<<"nothing found in aggressive cache either"<<endl;
+    return false;
+  }
+
+  unsigned int labelIdx = qname.countLabels() - closestEncloser.countLabels();
+  if (labelIdx < 1) {
+    return false;
+  }
+
+  DNSName nsecFound;
+  DNSName nextCloser(closestEncloser);
+  nextCloser.prependRawLabel(qname.getRawLabel(labelIdx - 1));
+  auto nextCloserHash = toBase32Hex(hashQNameWithSalt(salt, iterations, nextCloser));
+  cerr<<"looking for a NSEC3 covering the next closer "<<nextCloser<<": "<<nextCloserHash<<endl;
+
+  if (!g_recCache->getNSECBefore(d_now.tv_sec, zone, DNSName(nextCloserHash) + zone, QType::NSEC3, nsecFound, cset, signatures, cachedState)) {
+    cerr<<"nothing found for the next closer in aggressive cache"<<endl;
+    return false;
+  }
+
+  DNSName wildcard(g_wildcarddnsname + closestEncloser);
+  auto wcHash = toBase32Hex(hashQNameWithSalt(salt, iterations, wildcard));
+  cerr<<"looking for a NSEC3 covering the wildcard "<<wildcard<<": "<<wcHash<<endl;
+
+  if (!g_recCache->getNSECBefore(d_now.tv_sec, zone, DNSName(wcHash) + zone, QType::NSEC3, nsecFound, cset, signatures, cachedState)) {
+    cerr<<"nothing found for the wildcard in aggressive cache"<<endl;
+    return false;
+  }
+
+  return false;
+}
+
+bool SyncRes::doAggressiveNSECCacheCheck(const std::string& prefix, const DNSName& qname, const QType& qtype, vector<DNSRecord>&ret, int& res, vState& state)
+{
+  if (!g_aggressiveNSECCache) {
+    cerr<<"no aggressive NSEC"<<endl;
+    return false;
+  }
+
+  DNSName zone(qname);
+  std::string salt;
+  uint16_t iterations = 0;
+  bool nsec3 = false;
+  if (!g_aggressiveNSECCache->getBestZoneInfo(zone, nsec3, salt, iterations)) {
+    cerr<<"zone info not found"<<endl;
+    return false;
+  }
+
+  vState cachedState;
+  std::vector<DNSRecord> soaSet;
+  std::vector<std::shared_ptr<RRSIGRecordContent>> soaSignatures;
+  if (g_recCache->get(d_now.tv_sec, zone, QType::SOA, true, &soaSet, d_cacheRemote, false, d_routingTag, d_doDNSSEC ? &soaSignatures : nullptr, nullptr, nullptr, &cachedState) <= 0 || cachedState != vState::Secure) {
+    cerr<<"could not find SOA"<<endl;
+    return false;
+  }
+
+  vector<DNSRecord> cset;
+  vector<std::shared_ptr<RRSIGRecordContent>> signatures;
+
+  if (nsec3) {
+    return doAggressiveNSEC3Cache(prefix, qname, qtype, zone, salt, iterations, ret, res, state);
+  }
+
+  DNSName nsecFound;
+  std::vector<DNSRecord> wcSet;
+  std::vector<std::shared_ptr<RRSIGRecordContent>> wcSignatures;
+
+   cerr<<"looking for nsec before "<<qname<<endl;
+   if (!g_recCache->getNSECBefore(d_now.tv_sec, zone, qname, QType::NSEC, nsecFound, cset, signatures, cachedState)) {
+     cerr<<"nothing found in aggressive cache either"<<endl;
+    return false;
+  }
+
+   cerr<<"nsecFound "<<nsecFound<<endl;
+  if (cset.empty() || cachedState != vState::Secure) {
+    return false;
+  }
+
+  bool covered = false;
+   cerr<<"Got "<<cset.size()<<" records"<<endl;
+  const auto& nsecRecord = cset.at(0);
+  auto content = getRR<NSECRecordContent>(nsecRecord);
+  if (!content) {
+    return false;
+  }
+
+   cerr<<"next is "<<content->d_next<<endl;
+  auto denial = matchesNSEC(qname, qtype.getCode(), nsecRecord, signatures);
+  if (denial == dState::NXQTYPE) {
+    covered = true;
+    res = RCode::NoError;
+  }
+  else if (denial == dState::NXDOMAIN) {
+    if (qname.countLabels() > 1) {
+      DNSName wc = qname;
+      wc.chopOff();
+      wc = g_wildcarddnsname + wc;
+
+       cerr<<"looking for nsec before "<<wc<<endl;
+      DNSName wcNSEC;
+      if (!g_recCache->getNSECBefore(d_now.tv_sec, zone, wc, QType::NSEC, wcNSEC, wcSet, wcSignatures, cachedState)) {
+         cerr<<"nothing found in aggressive cache for Wildcard"<<endl;
+        return false;
+      }
+
+      if (wcSet.empty() || cachedState != vState::Secure) {
+        cerr<<"nothing usable"<<endl;
+        return false;
+      }
+
+      cerr<<"wc nsec found "<<wcNSEC<<endl;
+      if (wcNSEC == nsecFound) {
+        wcSet.clear();
+        wcSignatures.clear();
+        covered = true;
+        res = RCode::NXDomain;
+      }
+      else {
+        const auto& wcNsecRecord = wcSet.at(0);
+        auto wcContent = getRR<NSECRecordContent>(wcNsecRecord);
+        if (!wcContent) {
+          return false;
+        }
+
+        if (wcNSEC == wc) {
+          /* too complicated for now */
+          return false;
+        }
+        else if (isCoveredByNSEC(wc, wcNsecRecord.d_name, wcContent->d_next)) {
+          cerr<<"next is "<<wcContent->d_next<<endl;
+          covered = true;
+          res = RCode::NXDomain;
+        }
+      }
+    }
+  }
+
+  if (!covered) {
+    return false;
+  }
+
+  LOG(prefix<<qname<<": Found aggressive NSEC cache hit for "<<qtype.getName()<<endl);
+
+  uint32_t ttl=0;
+  uint32_t capTTL = std::numeric_limits<uint32_t>::max();
+
+  ret.reserve(ret.size() + soaSet.size() + soaSignatures.size() + cset.size() + signatures.size() + wcSet.size() + wcSignatures.size());
+
+  for (auto& record : soaSet) {
+    if (record.d_class != QClass::IN) {
+      continue;
+    }
+
+    record.d_ttl -= d_now.tv_sec;
+    record.d_ttl = std::min(record.d_ttl, capTTL);
+    ttl = record.d_ttl;
+    ret.push_back(std::move(record));
+  }
+
+  for (auto& signature : soaSignatures) {
+    DNSRecord dr;
+    dr.d_type = QType::RRSIG;
+    dr.d_name = zone;
+    dr.d_ttl = ttl;
+    dr.d_content = std::move(signature);
+    dr.d_place = DNSResourceRecord::ANSWER;
+    dr.d_class = QClass::IN;
+    ret.push_back(std::move(dr));
+  }
+
+  for (auto& record : cset) {
+    if (record.d_class != QClass::IN) {
+      continue;
+    }
+
+    record.d_ttl -= d_now.tv_sec;
+    record.d_ttl = std::min(record.d_ttl, capTTL);
+    ttl = record.d_ttl;
+    ret.push_back(std::move(record));
+  }
+
+  for (auto& signature : signatures) {
+    DNSRecord dr;
+    dr.d_type = QType::RRSIG;
+    dr.d_name = qname;
+    dr.d_ttl = ttl;
+    dr.d_content = std::move(signature);
+    dr.d_place = DNSResourceRecord::ANSWER;
+    dr.d_class = QClass::IN;
+    ret.push_back(std::move(dr));
+  }
+
+  for (auto& record : wcSet) {
+    if (record.d_class != QClass::IN) {
+      continue;
+    }
+
+    record.d_ttl -= d_now.tv_sec;
+    record.d_ttl = std::min(record.d_ttl, capTTL);
+    ttl = record.d_ttl;
+    ret.push_back(std::move(record));
+  }
+
+  for (auto& signature : wcSignatures) {
+    DNSRecord dr;
+    dr.d_type = QType::RRSIG;
+    dr.d_name = qname;
+    dr.d_ttl = ttl;
+    dr.d_content = std::move(signature);
+    dr.d_place = DNSResourceRecord::ANSWER;
+    dr.d_class = QClass::IN;
+    ret.push_back(std::move(dr));
+  }
+
+  /* we would have given up otherwise */
+  state = vState::Secure;
+
+  return true;
+}
+
+#endif

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -112,6 +112,7 @@ void AggressiveNSECCache::insertNSEC(const DNSName& zone, const DNSName& owner, 
         return;
       }
 
+#warning Ponder storing everything in raw form, without the zone instead. It still needs to be a DNSName for NSEC, though
       next = DNSName(toBase32Hex(content->d_nexthash)) + zone;
       entry->d_iterations = content->d_iterations;
       entry->d_salt = content->d_salt;
@@ -477,6 +478,11 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
       denial = matchesNSEC(wc, type.getCode(), wcEntry.d_owner, nsecContent, wcEntry.d_signatures);
       if (denial == dState::NODENIAL) {
         /* too complicated for now */
+        /* we would need:
+           - to store wildcard entries in the non-expanded form in the record cache, in addition to their expanded form ;
+           - do a lookup to retrieve them ;
+           - expand them and the NSEC
+        */
         return false;
       }
       else if (denial == dState::NXQTYPE) {
@@ -491,30 +497,6 @@ bool AggressiveNSECCache::getDenial(time_t now, const DNSName& name, const QType
       if (wcEntry.d_owner != wc) {
         needWildcard = true;
       }
-#if 0
-      if (wcEntry.d_owner == wc) {
-        if (!nsecContent) {
-          return false;
-        }
-        if (nsecContent->isSet(type.getCode())) {
-          /* too complicated for now */
-          return false;
-        }
-        if (nsecContent->isSet(QType::CNAME)) {
-          /* too complicated for now */
-          return false;
-        }
-
-        covered = true;
-        res = RCode::NoError;
-      }
-      else if (isCoveredByNSEC(wc, wcEntry.d_owner, wcEntry.d_next)) {
-        cerr<<"next is "<<wcEntry.d_next<<endl;
-        covered = true;
-        res = RCode::NXDomain;
-        needWildcard = true;
-      }
-#endif
     }
   }
 

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -298,13 +298,18 @@ void AggressiveNSECCache::insertNSEC(const DNSName& zone, const DNSName& owner, 
     /* the TTL is already a TTD by now */
     if (!nsec3 && isWildcardExpanded(owner.countLabels(), signatures.at(0))) {
       DNSName realOwner = getNSECOwnerName(owner, signatures);
-      entry->d_entries.insert({record.d_content, signatures, std::move(realOwner), std::move(next), record.d_ttl});
+      auto pair = entry->d_entries.insert({record.d_content, signatures, std::move(realOwner), std::move(next), record.d_ttl});
+      if (pair.second) {
+        ++d_entriesCount;
+      }
     }
     else {
-      entry->d_entries.insert({record.d_content, signatures, owner, std::move(next), record.d_ttl});
+      auto pair = entry->d_entries.insert({record.d_content, signatures, owner, std::move(next), record.d_ttl});
+      if (pair.second) {
+        ++d_entriesCount;
+      }
     }
   }
-  ++d_entriesCount;
 }
 
 bool AggressiveNSECCache::getNSECBefore(time_t now, std::shared_ptr<AggressiveNSECCache::ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry)

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -191,6 +191,14 @@ void AggressiveNSECCache::prune(time_t now)
   }
 
   d_entriesCount -= erased;
+
+  if (!emptyEntries.empty())
+  {
+    WriteLock rl(d_lock);
+    for (const auto& entry : emptyEntries) {
+      d_zones.remove(entry);
+    }
+  }
 }
 
 static bool isMinimallyCoveringNSEC(const DNSName& owner, const std::shared_ptr<NSECRecordContent>& nsec)

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -289,7 +289,8 @@ void AggressiveNSECCache::insertNSEC(const DNSName& zone, const DNSName& owner, 
         return;
       }
 
-#warning Ponder storing everything in raw form, without the zone instead. It still needs to be a DNSName for NSEC, though
+      // XXX: Ponder storing everything in raw form, without the zone instead. It still needs to be a DNSName for NSEC, though,
+      // but doing the conversion on cache hits only might be faster
       next = DNSName(toBase32Hex(content->d_nexthash)) + zone;
 
       if (entry->d_iterations != content->d_iterations || entry->d_salt != content->d_salt) {

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -136,7 +136,7 @@ bool AggressiveNSECCache::getNSECBefore(time_t now, std::shared_ptr<AggressiveNS
     return false;
   }
 
-#if 0
+#if 1
   cerr<<"We have:"<<endl;
   for (const auto& ent : zoneEntry->d_entries) {
     cerr<<"- "<<ent.d_owner<<" -> "<<ent.d_next<<endl;

--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -35,6 +35,7 @@ std::shared_ptr<AggressiveNSECCache::ZoneEntry> AggressiveNSECCache::getBestZone
 {
   std::shared_ptr<AggressiveNSECCache::ZoneEntry> entry{nullptr};
   {
+    #warning tryreadlock?
     ReadLock rl(d_lock);
     auto got = d_zones.lookup(zone);
     if (got) {
@@ -205,8 +206,9 @@ void AggressiveNSECCache::insertNSEC(const DNSName& zone, const DNSName& owner, 
   ++d_entriesCount;
 }
 
-bool AggressiveNSECCache::getNSECBefore(time_t now, std::shared_ptr<AggressiveNSECCache::ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry) {
-
+bool AggressiveNSECCache::getNSECBefore(time_t now, std::shared_ptr<AggressiveNSECCache::ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry)
+{
+  #warning try?
   std::lock_guard<std::mutex> lock(zoneEntry->d_lock);
   if (zoneEntry->d_entries.empty()) {
     return false;
@@ -260,8 +262,9 @@ bool AggressiveNSECCache::getNSECBefore(time_t now, std::shared_ptr<AggressiveNS
   return true;
 }
 
-bool AggressiveNSECCache::getNSEC3(time_t now, std::shared_ptr<AggressiveNSECCache::ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry) {
-
+bool AggressiveNSECCache::getNSEC3(time_t now, std::shared_ptr<AggressiveNSECCache::ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry)
+{
+  #warning try?
   std::lock_guard<std::mutex> lock(zoneEntry->d_lock);
   if (zoneEntry->d_entries.empty()) {
     return false;

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -72,7 +72,8 @@ public:
     return d_nsec3WildcardHits;
   }
 
-  void prune();
+  void prune(time_t now);
+  size_t dumpToFile(std::unique_ptr<FILE, int(*)(FILE*)>& fp, const struct timeval& now);
 
 private:
 

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -41,8 +41,32 @@ public:
   void insertNSEC(const DNSName& zone, const DNSName& owner, const DNSRecord& record, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures, bool nsec3);
   bool getDenial(time_t, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, const ComboAddress& who, const boost::optional<std::string>& routingTag, bool doDNSSEC);
 
-  //bool getBestZoneInfo(DNSName& lookup, bool& nsec3, std::string& salt, uint16_t& iterations);
   //void removeZoneInfo(const DNSName& zone);
+
+  uint64_t getEntriesCount() const
+  {
+    return d_entriesCount;
+  }
+
+  uint64_t getNSECHits() const
+  {
+    return d_nsecHits;
+  }
+
+  uint64_t getNSEC3Hits() const
+  {
+    return d_nsec3Hits;
+  }
+
+  uint64_t getNSECWildcardHits() const
+  {
+    return d_nsecWildcardHits;
+  }
+
+  uint64_t getNSEC3WildcardHits() const
+  {
+    return d_nsec3WildcardHits;
+  }
 
 private:
 
@@ -102,6 +126,11 @@ private:
 
   SuffixMatchTree<std::shared_ptr<ZoneEntry>> d_zones;
   ReadWriteLock d_lock;
+  std::atomic<uint64_t> d_entriesCount{0};
+  std::atomic<uint64_t> d_nsecHits{0};
+  std::atomic<uint64_t> d_nsec3Hits{0};
+  std::atomic<uint64_t> d_nsecWildcardHits{0};
+  std::atomic<uint64_t> d_nsec3WildcardHits{0};
 };
 
 

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -38,6 +38,10 @@
 class AggressiveNSECCache
 {
 public:
+  AggressiveNSECCache(uint64_t entries): d_maxEntries(entries)
+  {
+  }
+
   void insertNSEC(const DNSName& zone, const DNSName& owner, const DNSRecord& record, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures, bool nsec3);
   bool getDenial(time_t, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, const ComboAddress& who, const boost::optional<std::string>& routingTag, bool doDNSSEC);
 
@@ -67,6 +71,8 @@ public:
   {
     return d_nsec3WildcardHits;
   }
+
+  void prune();
 
 private:
 
@@ -134,7 +140,7 @@ private:
   std::atomic<uint64_t> d_nsecWildcardHits{0};
   std::atomic<uint64_t> d_nsec3WildcardHits{0};
   std::atomic<uint64_t> d_entriesCount{0};
+  uint64_t d_maxEntries{0};
 };
-
 
 extern std::unique_ptr<AggressiveNSECCache> g_aggressiveNSECCache;

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -41,7 +41,7 @@ public:
   void insertNSEC(const DNSName& zone, const DNSName& owner, const DNSRecord& record, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures, bool nsec3);
   bool getDenial(time_t, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, const ComboAddress& who, const boost::optional<std::string>& routingTag, bool doDNSSEC);
 
-  //void removeZoneInfo(const DNSName& zone);
+  void removeZoneInfo(const DNSName& zone, bool subzones);
 
   uint64_t getEntriesCount() const
   {
@@ -124,13 +124,16 @@ private:
   bool synthesizeFromNSEC3Wildcard(time_t now, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC, ZoneEntry::CacheEntry& nextCloser, const DNSName& wildcardName);
   bool synthesizeFromNSECWildcard(time_t now, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC, ZoneEntry::CacheEntry& nsec, const DNSName& wildcardName);
 
+  /* slowly updates d_entriesCount */
+  void updateEntriesCount();
+
   SuffixMatchTree<std::shared_ptr<ZoneEntry>> d_zones;
   ReadWriteLock d_lock;
-  std::atomic<uint64_t> d_entriesCount{0};
   std::atomic<uint64_t> d_nsecHits{0};
   std::atomic<uint64_t> d_nsec3Hits{0};
   std::atomic<uint64_t> d_nsecWildcardHits{0};
   std::atomic<uint64_t> d_nsec3WildcardHits{0};
+  std::atomic<uint64_t> d_entriesCount{0};
 };
 
 

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -30,6 +30,7 @@
 #include <boost/multi_index/key_extractors.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 
+#include "base32.hh"
 #include "dnsname.hh"
 #include "dnsrecords.hh"
 #include "lock.hh"
@@ -94,6 +95,8 @@ private:
   std::shared_ptr<ZoneEntry> getZone(const DNSName& zone);
   std::shared_ptr<ZoneEntry> getBestZone(const DNSName& zone);
   bool getNSECBefore(time_t now, std::shared_ptr<ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry);
+  bool getNSEC3(time_t now, std::shared_ptr<ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry);
+  bool getNSEC3Denial(time_t now, std::shared_ptr<ZoneEntry>& zoneEntry, std::vector<DNSRecord>& soaSet, std::vector<std::shared_ptr<RRSIGRecordContent>>& soaSignatures, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC);
 
   SuffixMatchTree<std::shared_ptr<ZoneEntry>> d_zones;
   ReadWriteLock d_lock;

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -97,6 +97,8 @@ private:
   bool getNSECBefore(time_t now, std::shared_ptr<ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry);
   bool getNSEC3(time_t now, std::shared_ptr<ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry);
   bool getNSEC3Denial(time_t now, std::shared_ptr<ZoneEntry>& zoneEntry, std::vector<DNSRecord>& soaSet, std::vector<std::shared_ptr<RRSIGRecordContent>>& soaSignatures, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC);
+  bool synthesizeFromNSEC3Wildcard(time_t now, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC, ZoneEntry::CacheEntry& nextCloser, const DNSName& wildcardName);
+  bool synthesizeFromNSECWildcard(time_t now, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, bool doDNSSEC, ZoneEntry::CacheEntry& nsec, const DNSName& wildcardName);
 
   SuffixMatchTree<std::shared_ptr<ZoneEntry>> d_zones;
   ReadWriteLock d_lock;

--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -1,0 +1,103 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <mutex>
+
+#include <boost/utility.hpp>
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+
+#include "dnsname.hh"
+#include "dnsrecords.hh"
+#include "lock.hh"
+
+class AggressiveNSECCache
+{
+public:
+  void insertNSEC(const DNSName& zone, const DNSName& owner, const DNSRecord& record, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures, bool nsec3);
+  bool getDenial(time_t, const DNSName& name, const QType& type, std::vector<DNSRecord>& ret, int& res, const ComboAddress& who, const boost::optional<std::string>& routingTag, bool doDNSSEC);
+
+  //bool getBestZoneInfo(DNSName& lookup, bool& nsec3, std::string& salt, uint16_t& iterations);
+  //void removeZoneInfo(const DNSName& zone);
+
+private:
+
+  struct ZoneEntry
+  {
+    ZoneEntry()
+    {
+    }
+
+    ZoneEntry(const DNSName& zone, const std::string& salt, uint16_t iterations, bool nsec3): d_zone(zone), d_salt(salt), d_iterations(iterations), d_nsec3(nsec3)
+    {
+    }
+
+    struct HashedTag {};
+    struct SequencedTag {};
+    struct OrderedTag {};
+
+    struct CacheEntry
+    {
+      std::shared_ptr<DNSRecordContent> d_record;
+      std::vector<std::shared_ptr<RRSIGRecordContent>> d_signatures;
+
+      DNSName d_owner;
+      DNSName d_next;
+      time_t d_ttd;
+    };
+
+    typedef multi_index_container<
+      CacheEntry,
+      indexed_by <
+        ordered_unique<tag<OrderedTag>,
+                       member<CacheEntry,DNSName,&CacheEntry::d_owner>,
+                       CanonDNSNameCompare
+                       >,
+        sequenced<tag<SequencedTag> >,
+        hashed_non_unique<tag<HashedTag>,
+                          member<CacheEntry,DNSName,&CacheEntry::d_owner>
+                          >
+        >
+      > cache_t;
+
+    cache_t d_entries;
+    DNSName d_zone;
+    std::string d_salt;
+    std::mutex d_lock;
+    uint16_t d_iterations{0};
+    bool d_nsec3{false};
+  };
+
+  std::shared_ptr<ZoneEntry> getZone(const DNSName& zone);
+  std::shared_ptr<ZoneEntry> getBestZone(const DNSName& zone);
+  bool getNSECBefore(time_t now, std::shared_ptr<ZoneEntry>& zoneEntry, const DNSName& name, ZoneEntry::CacheEntry& entry);
+
+  SuffixMatchTree<std::shared_ptr<ZoneEntry>> d_zones;
+  ReadWriteLock d_lock;
+};
+
+
+extern std::unique_ptr<AggressiveNSECCache> g_aggressiveNSECCache;

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -88,6 +88,30 @@ It should be noted that answers0-1 + answers1-10 + answers10-100 + answers100-10
 
 Also note that unauthorized-tcp and unauthorized-udp packets do not end up in the 'questions' count.
 
+aggressive-nsec-cache-entries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.5
+
+number of entries in the aggressive NSEC cache
+
+aggressive-nsec-cache-nsec-hits
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.5
+
+number of negative answers generated from NSEC entries by the aggressive NSEC cache
+
+aggressive-nsec-cache-nsec3-wc-hits
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.5
+
+number of answers synthesized from NSEC entries and wildcards by the NSEC aggressive cache
+
+aggressive-nsec-cache-nsec3-wc-hits
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.5
+
+number of answers synthesized from NSEC entries and wildcards by the NSEC3 aggressive cache
+
 all-outqueries
 ^^^^^^^^^^^^^^
 counts the number of outgoing UDP queries since starting

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -21,16 +21,16 @@ variable to act as base setting. This is mostly useful for
   forward-zones += bar.example.com=[1234::abcde]:5353;
 
 
-.. _setting-aggressive-nsec:
+.. _setting-aggressive-nsec-cache-size:
 
-``aggressive-nsec``
--------------------
+``aggressive-nsec-cache-size``
+------------------------------
 .. versionadded:: 4.5.0
 
--  Boolean
--  Default: no
+-  Integer
+-  Default: 0
 
-If set, and DNSSEC validation is enabled, the recursor cache NSEC and NSEC3 records to generate negative answers, and use cached wildcards to synthesize positive answsers, as defined in :rfc:`8198`.
+The number of records to cache in the aggressive cache. If set to a value greater than 0, and DNSSEC validation is enabled, the recursor will cache NSEC and NSEC3 records to generate negative answers, as defined in :rfc:`8198`.
 This setting requires DNSSEC validation to be enabled via the `dnssec_` setting.
 
 .. _setting-allow-from:

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -20,6 +20,19 @@ variable to act as base setting. This is mostly useful for
   forward-zones = foo.example.com=192.168.100.1;
   forward-zones += bar.example.com=[1234::abcde]:5353;
 
+
+.. _setting-aggressive-nsec:
+
+``aggressive-nsec``
+-------------------
+.. versionadded:: 4.5.0
+
+-  Boolean
+-  Default: no
+
+If set, and DNSSEC validation is enabled, the recursor cache NSEC and NSEC3 records to generate negative answers, and use cached wildcards to synthesize positive answsers, as defined in :rfc:`8198`.
+This setting requires DNSSEC validation to be enabled via the `dnssec_` setting.
+
 .. _setting-allow-from:
 
 ``allow-from``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -28,7 +28,7 @@ variable to act as base setting. This is mostly useful for
 .. versionadded:: 4.5.0
 
 -  Integer
--  Default: 0
+-  Default: 100000
 
 The number of records to cache in the aggressive cache. If set to a value greater than 0, and DNSSEC validation is enabled, the recursor will cache NSEC and NSEC3 records to generate negative answers, as defined in :rfc:`8198`.
 This setting requires DNSSEC validation to be enabled via the `dnssec_` setting.

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -1,0 +1,190 @@
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include "aggressive_nsec.hh"
+#include "test-syncres_cc.hh"
+
+BOOST_AUTO_TEST_SUITE(aggressive_nsec_cc)
+
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nxdomain)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  /* we are lucky enough that our hashes will cover g.powerdns.com. as well */
+  const DNSName target1("b.powerdns.com.");
+  const DNSName target2("g.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([target1, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (domain != DNSName("powerdns.com.") && domain.isPartOf(DNSName("powerdns.com."))) {
+        /* no cut, NSEC3 */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys, false, boost::none, true);
+      }
+      else if (domain == DNSName("com.")) {
+        /* no cut */
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, false);
+      }
+      else if (domain == DNSName("powerdns.com.")) {
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys);
+      }
+      else {
+        /* cut */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+      }
+    }
+    else {
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53")) {
+        if (domain == target1) {
+          setLWResult(res, RCode::NXDomain, true, false, true);
+          /* no data */
+          addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* no record for this name */
+          /* first the closest encloser */
+          addNSEC3UnhashedRecordToLW(DNSName("powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* then the next closer */
+          addNSEC3UnhashedRecordToLW(DNSName("a.powerdns.com."), DNSName("powerdns.com."), "v", {QType::RRSIG, QType::NSEC}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* no wildcard */
+          addNSEC3NarrowRecordToLW(DNSName("*.powerdns.com."), DNSName("powerdns.com."), {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+          return LWResult::Result::Success;
+        }
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target1, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NXDomain);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 8U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+
+  ret.clear();
+  res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NXDomain);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 8U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+}
+
+#if 0
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target1("a.powerdns.com.");
+  const DNSName target2("b.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([target1, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (domain != DNSName("powerdns.com.") && domain.isPartOf(DNSName("powerdns.com."))) {
+        /* no cut, NSEC3 */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys, false, boost::none, true);
+      }
+      else if (domain == DNSName("com.")) {
+        /* no cut */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys, false);
+      }
+      else {
+        /* cut */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+      }
+    }
+    else {
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53")) {
+        if (domain == target1) {
+          setLWResult(res, 0, true, false, true);
+          /* no data */
+          addRecordToLW(res, DNSName("com."), QType::SOA, "com. com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+          addRRSIG(keys, res->d_records, DNSName("com."), 300);
+          /* no record for this name */
+          /* first the closest encloser */
+          addNSEC3UnhashedRecordToLW(DNSName("com."), DNSName("com."), "whatever", {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("com."), 300);
+          /* then the next closer */
+          addNSEC3NarrowRecordToLW(domain, DNSName("com."), {QType::RRSIG, QType::NSEC}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("com."), 300);
+          /* a wildcard matches but has no record for this type */
+          addNSEC3UnhashedRecordToLW(DNSName("*.com."), DNSName("com."), "whatever", {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("com"), 300, false, boost::none, DNSName("*.com"));
+          return LWResult::Result::Success;
+        }
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 8U);
+  BOOST_CHECK_EQUAL(queriesCount, 6U);
+
+  /* again, to test the cache */
+  ret.clear();
+  res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 8U);
+  BOOST_CHECK_EQUAL(queriesCount, 6U);
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -6,6 +6,374 @@
 
 BOOST_AUTO_TEST_SUITE(aggressive_nsec_cc)
 
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec_nxdomain)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  /* we first ask b.powerdns.com., get a NXD, then check that the aggressive
+     NSEC cache will use the NSEC (a -> h) to prove that g.powerdns.com. does not exist
+     either */
+  const DNSName target1("b.powerdns.com.");
+  const DNSName target2("g.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([target1, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (domain != DNSName("powerdns.com.") && domain.isPartOf(DNSName("powerdns.com."))) {
+        /* no cut, NSEC, name does not exist (the generic version will generate an exact NSEC for the target, which we don't want) */
+        setLWResult(res, RCode::NoError, true, false, true);
+        /* no data */
+        addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* no record for this name */
+        addNSECRecordToLW(DNSName("a.powerdns.com."), DNSName("h.powerdns.com."), {QType::A, QType::TXT, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* no wildcard either */
+        addNSECRecordToLW(DNSName(").powerdns.com."), DNSName("a.powerdns.com."), {QType::AAAA, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+        return LWResult::Result::Success;
+      }
+      else if (domain == DNSName("com.")) {
+        /* no cut */
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, false);
+      }
+      else if (domain == DNSName("powerdns.com.")) {
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys);
+      }
+      else {
+        /* cut */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+      }
+    }
+    else {
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53")) {
+        if (domain == target1) {
+          setLWResult(res, RCode::NXDomain, true, false, true);
+          addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* no record for this name */
+          addNSECRecordToLW(DNSName("a.powerdns.com."), DNSName("h.powerdns.com."), {QType::A, QType::TXT, QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* no wildcard either */
+          addNSECRecordToLW(DNSName(").powerdns.com."), DNSName("a.powerdns.com."), {QType::AAAA, QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+          return LWResult::Result::Success;
+        }
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target1, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NXDomain);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 6U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+
+  ret.clear();
+  res = sr->beginResolve(target2, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NXDomain);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 6U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+}
+
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec_nodata)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  /* we first ask a.powerdns.com. | A, get a NODATA, then check that the aggressive
+     NSEC cache will use the NSEC to prove that the AAAA does not exist either */
+  const DNSName target("a.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([target, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (domain != DNSName("powerdns.com.") && domain.isPartOf(DNSName("powerdns.com."))) {
+        /* no cut, NSEC */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys, false);
+      }
+      else if (domain == DNSName("com.")) {
+        /* no cut */
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, false);
+      }
+      else if (domain == DNSName("powerdns.com.")) {
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys);
+      }
+      else {
+        /* cut */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+      }
+    }
+    else {
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53")) {
+        if (domain == target && type == QType::A) {
+          setLWResult(res, RCode::NoError, true, false, true);
+          /* no data */
+          addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* no record for this name */
+          /* exact match */
+          addNSECRecordToLW(DNSName("a.powerdns.com."), DNSName("powerdns.com."), {QType::TXT, QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* no need for wildcard in that case */
+          return LWResult::Result::Success;
+        }
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+
+  ret.clear();
+  res = sr->beginResolve(target, QType(QType::AAAA), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+}
+
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec_nodata_wildcard)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  /* we first ask a.powerdns.com. | A, get a NODATA (no exact match but there is a wildcard match),
+     then check that the aggressive NSEC cache will use the NSEC to prove that the AAAA does not exist either */
+  const DNSName target("a.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([target, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (domain != DNSName("powerdns.com.") && domain.isPartOf(DNSName("powerdns.com."))) {
+        /* no cut, NSEC, name does not exist but there is a wildcard (the generic version will generate an exact NSEC for the target, which we don't want) */
+        setLWResult(res, RCode::NoError, true, false, true);
+        /* no data */
+        addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* the name does not exist, a wildcard applies but does not have this type */
+        addNSECRecordToLW(DNSName("*.powerdns.com."), DNSName("z.powerdns.com."), {QType::TXT, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300, false, boost::none, DNSName("*.powerdns.com"));
+        return LWResult::Result::Success;
+      }
+      else if (domain == DNSName("com.")) {
+        /* no cut */
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, false);
+      }
+      else if (domain == DNSName("powerdns.com.")) {
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys);
+      }
+      else {
+        /* cut */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+      }
+    }
+    else {
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53")) {
+        if (domain == target && type == QType::A) {
+          setLWResult(res, RCode::NoError, true, false, true);
+          /* no data */
+          addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* the name does not exist, a wildcard applies but does not have this type */
+          addNSECRecordToLW(DNSName("*.powerdns.com."), DNSName("z.powerdns.com."), {QType::TXT, QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300, false, boost::none, DNSName("*.powerdns.com"));
+          return LWResult::Result::Success;
+        }
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+
+  ret.clear();
+  res = sr->beginResolve(target, QType(QType::AAAA), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+}
+
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wildcard_synthesis)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  /* we first ask a.powerdns.com. | A, get an answer synthesized from the wildcard,
+     then check that the aggressive NSEC cache will use the wildcard to synthesize an answer
+     for b.powerdns.com */
+  const DNSName target("a.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([target, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (domain != DNSName("powerdns.com.") && domain.isPartOf(DNSName("powerdns.com."))) {
+        /* no cut, NSEC, name does not exist but there is a wildcard (the generic version will generate an exact NSEC for the target, which we don't want) */
+        setLWResult(res, RCode::NoError, true, false, true);
+        /* no data */
+        addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* the name does not exist, a wildcard applies and have the requested type but no DS */
+        addNSECRecordToLW(DNSName("*.powerdns.com."), DNSName("z.powerdns.com."), {QType::A, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300, false, boost::none, DNSName("*.powerdns.com"));
+        return LWResult::Result::Success;
+      }
+      else if (domain == DNSName("com.")) {
+        /* no cut */
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, false);
+      }
+      else if (domain == DNSName("powerdns.com.")) {
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys);
+      }
+      else {
+        /* cut */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+      }
+    }
+    else {
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53")) {
+        setLWResult(res, RCode::NoError, true, false, true);
+        addRecordToLW(res, domain, QType::A, "192.0.2.1");
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300, false, boost::none, DNSName("*.powerdns.com"));
+        /* the name does not exist, a wildcard applies and has the requested type */
+        addNSECRecordToLW(DNSName("*.powerdns.com."), DNSName("z.powerdns.com."), {QType::A, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300, false, boost::none, DNSName("*.powerdns.com"));
+        return LWResult::Result::Success;
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(ret.at(0).d_name, target);
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);  
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+
+  ret.clear();
+  res = sr->beginResolve(DNSName("b.powerdns.com."), QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(ret.at(0).d_name, DNSName("b.powerdns.com."));
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);  
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+}
+
 BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nxdomain)
 {
   std::unique_ptr<SyncRes> sr;
@@ -15,7 +383,10 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nxdomain)
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
   primeHints();
-  /* we are lucky enough that our hashes will cover g.powerdns.com. as well */
+  /* we are lucky enough that our hashes will cover g.powerdns.com. as well,
+     so we first ask b.powerdns.com., get a NXD, then check that the aggressive
+     NSEC cache will use the NSEC3 to prove that g.powerdns.com. does not exist
+     either */
   const DNSName target1("b.powerdns.com.");
   const DNSName target2("g.powerdns.com.");
   testkeysset_t keys;
@@ -61,18 +432,17 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nxdomain)
       else if (ip == ComboAddress("192.0.2.1:53")) {
         if (domain == target1) {
           setLWResult(res, RCode::NXDomain, true, false, true);
-          /* no data */
           addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
           /* no record for this name */
           /* first the closest encloser */
-          addNSEC3UnhashedRecordToLW(DNSName("powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, res->d_records);
+          addNSEC3UnhashedRecordToLW(DNSName("powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::A, QType::TXT, QType::RRSIG}, 600, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
           /* then the next closer */
-          addNSEC3UnhashedRecordToLW(DNSName("a.powerdns.com."), DNSName("powerdns.com."), "v", {QType::RRSIG, QType::NSEC}, 600, res->d_records);
+          addNSEC3UnhashedRecordToLW(DNSName("a.powerdns.com."), DNSName("powerdns.com."), "v", {QType::RRSIG}, 600, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
           /* no wildcard */
-          addNSEC3NarrowRecordToLW(DNSName("*.powerdns.com."), DNSName("powerdns.com."), {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records);
+          addNSEC3NarrowRecordToLW(DNSName("*.powerdns.com."), DNSName("powerdns.com."), {QType::AAAA, QType::RRSIG}, 600, res->d_records);
           addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
           return LWResult::Result::Success;
         }
@@ -97,7 +467,6 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nxdomain)
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 }
 
-#if 0
 BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata)
 {
   std::unique_ptr<SyncRes> sr;
@@ -107,8 +476,9 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata)
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
   primeHints();
-  const DNSName target1("a.powerdns.com.");
-  const DNSName target2("b.powerdns.com.");
+  /* we first ask a.powerdns.com. | A, get a NODATA, then check that the aggressive
+     NSEC cache will use the NSEC3 to prove that the AAAA does not exist either */
+  const DNSName target("a.powerdns.com.");
   testkeysset_t keys;
 
   auto luaconfsCopy = g_luaconfs.getCopy();
@@ -120,7 +490,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata)
 
   size_t queriesCount = 0;
 
-  sr->setAsyncCallback([target1, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+  sr->setAsyncCallback([target, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
 
     if (type == QType::DS || type == QType::DNSKEY) {
@@ -130,7 +500,10 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata)
       }
       else if (domain == DNSName("com.")) {
         /* no cut */
-        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys, false);
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, false);
+      }
+      else if (domain == DNSName("powerdns.com.")) {
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys);
       }
       else {
         /* cut */
@@ -147,21 +520,119 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata)
         return LWResult::Result::Success;
       }
       else if (ip == ComboAddress("192.0.2.1:53")) {
-        if (domain == target1) {
-          setLWResult(res, 0, true, false, true);
+        if (domain == target && type == QType::A) {
+          setLWResult(res, RCode::NoError, true, false, true);
           /* no data */
-          addRecordToLW(res, DNSName("com."), QType::SOA, "com. com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
-          addRRSIG(keys, res->d_records, DNSName("com."), 300);
+          addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
           /* no record for this name */
+          /* exact match */
+          addNSEC3UnhashedRecordToLW(DNSName("a.powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::TXT, QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* no need for next closer or wildcard in that case */
+          return LWResult::Result::Success;
+        }
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+
+  ret.clear();
+  res = sr->beginResolve(target, QType(QType::AAAA), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+}
+
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata_wildcard)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  /* we first ask a.powerdns.com. | A, get a NODATA (no exact match but there is a wildcard match),
+     then check that the aggressive NSEC cache will use the NSEC3 to prove that the AAAA does not exist either */
+  const DNSName target("a.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([target, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (domain != DNSName("powerdns.com.") && domain.isPartOf(DNSName("powerdns.com."))) {
+        /* no cut, NSEC3, name does not exist but there is a wildcard (the generic version will generate an exact NSEC3 for the target, which we don't want) */
+        setLWResult(res, RCode::NoError, true, false, true);
+        /* no data */
+        addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* first the closest encloser */
+        addNSEC3UnhashedRecordToLW(DNSName("powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::A, QType::TXT, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* then the next closer */
+        addNSEC3UnhashedRecordToLW(DNSName("+.powerdns.com."), DNSName("powerdns.com."), "v", {QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* a wildcard applies but does not have this type */
+        addNSEC3UnhashedRecordToLW(DNSName("*.powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::TXT, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
+        return LWResult::Result::Success;
+      }
+      else if (domain == DNSName("com.")) {
+        /* no cut */
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, false);
+      }
+      else if (domain == DNSName("powerdns.com.")) {
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys);
+      }
+      else {
+        /* cut */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+      }
+    }
+    else {
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53")) {
+        if (domain == target && type == QType::A) {
+          setLWResult(res, RCode::NoError, true, false, true);
+          /* no data */
+          addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
           /* first the closest encloser */
-          addNSEC3UnhashedRecordToLW(DNSName("com."), DNSName("com."), "whatever", {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, res->d_records);
-          addRRSIG(keys, res->d_records, DNSName("com."), 300);
+          addNSEC3UnhashedRecordToLW(DNSName("powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::A, QType::TXT, QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
           /* then the next closer */
-          addNSEC3NarrowRecordToLW(domain, DNSName("com."), {QType::RRSIG, QType::NSEC}, 600, res->d_records);
-          addRRSIG(keys, res->d_records, DNSName("com."), 300);
-          /* a wildcard matches but has no record for this type */
-          addNSEC3UnhashedRecordToLW(DNSName("*.com."), DNSName("com."), "whatever", {QType::AAAA, QType::NSEC, QType::RRSIG}, 600, res->d_records);
-          addRRSIG(keys, res->d_records, DNSName("com"), 300, false, boost::none, DNSName("*.com"));
+          addNSEC3UnhashedRecordToLW(DNSName("+.powerdns.com."), DNSName("powerdns.com."), "v", {QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+          /* a wildcard applies but does not have this type */
+          addNSEC3UnhashedRecordToLW(DNSName("*.powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::TXT, QType::RRSIG}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
           return LWResult::Result::Success;
         }
       }
@@ -175,16 +646,115 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 8U);
-  BOOST_CHECK_EQUAL(queriesCount, 6U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
 
-  /* again, to test the cache */
   ret.clear();
-  res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  res = sr->beginResolve(target, QType(QType::AAAA), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 8U);
-  BOOST_CHECK_EQUAL(queriesCount, 6U);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
 }
-#endif
+
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_wildcard_synthesis)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  /* we first ask a.powerdns.com. | A, get an answer synthesized from the wildcard,
+     then check that the aggressive NSEC cache will use the wildcard to synthesize an answer
+     for b.powerdns.com */
+  const DNSName target("a.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([target, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (domain != DNSName("powerdns.com.") && domain.isPartOf(DNSName("powerdns.com."))) {
+        /* no cut, NSEC3, name does not exist but there is a wildcard (the generic version will generate an exact NSEC3 for the target, which we don't want) */
+        setLWResult(res, RCode::NoError, true, false, true);
+        /* no data */
+        addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "powerdns.com. powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* first the closest encloser */
+        addNSEC3UnhashedRecordToLW(DNSName("powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::A, QType::TXT, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* then the next closer */
+        addNSEC3UnhashedRecordToLW(DNSName("+.powerdns.com."), DNSName("powerdns.com."), "v", {QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* a wildcard applies but does not have this type */
+        addNSEC3UnhashedRecordToLW(DNSName("*.powerdns.com."), DNSName("powerdns.com."), "whatever", {QType::A, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, boost::none, DNSName("*.powerdns.com"));
+        return LWResult::Result::Success;
+      }
+      else if (domain == DNSName("com.")) {
+        /* no cut */
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, false);
+      }
+      else if (domain == DNSName("powerdns.com.")) {
+        return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys);
+      }
+      else {
+        /* cut */
+        return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+      }
+    }
+    else {
+      if (isRootServer(ip)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "powerdns.com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      else if (ip == ComboAddress("192.0.2.1:53")) {
+        setLWResult(res, RCode::NoError, true, false, true);
+        addRecordToLW(res, domain, QType::A, "192.0.2.1");
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300, false, boost::none, DNSName("*.powerdns.com"));
+        /* no need for the closest encloser since we have a positive answer expanded from a wildcard */
+        /* the next closer */
+        addNSEC3UnhashedRecordToLW(DNSName("+.powerdns.com."), DNSName("powerdns.com."), "v", {QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        /* and of course we don't deny the wildcard itself */
+        return LWResult::Result::Success;
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(ret.at(0).d_name, target);
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);  
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+
+  ret.clear();
+  res = sr->beginResolve(DNSName("b.powerdns.com."), QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(ret.at(0).d_name, DNSName("b.powerdns.com."));
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);  
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_nxdomain)
 {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
-  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(10000);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_nodata)
 {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
-  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(10000);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_nodata_wildcard)
 {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
-  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(10000);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wildcard_synthesis)
 {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
-  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(10000);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wildcard_synthesis)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(ret.at(0).d_name, target);
-  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);  
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 
   ret.clear();
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wildcard_synthesis)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(ret.at(0).d_name, DNSName("b.powerdns.com."));
-  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);  
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 }
 
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nxdomain)
 {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
-  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(10000);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata)
 {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
-  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(10000);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
@@ -557,7 +557,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_nodata_wildcard)
 {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
-  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(10000);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
@@ -660,7 +660,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_wildcard_synthesis)
 {
   std::unique_ptr<SyncRes> sr;
   initSR(sr, true);
-  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>();
+  g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(10000);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 
@@ -744,7 +744,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_wildcard_synthesis)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(ret.at(0).d_name, target);
-  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);  
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 
   ret.clear();
@@ -753,7 +753,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_wildcard_synthesis)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(ret.at(0).d_name, DNSName("b.powerdns.com."));
-  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);  
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 }
 

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wildcard_synthesis)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(ret.at(0).d_name, target);
-  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType(QType::A).getCode());
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 
   ret.clear();
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wildcard_synthesis)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(ret.at(0).d_name, DNSName("b.powerdns.com."));
-  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType(QType::A).getCode());
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 }
 
@@ -757,7 +757,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_wildcard_synthesis)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(ret.at(0).d_name, target);
-  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType(QType::A).getCode());
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 
   ret.clear();
@@ -766,7 +766,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_wildcard_synthesis)
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Secure);
   BOOST_REQUIRE_EQUAL(ret.size(), 4U);
   BOOST_CHECK_EQUAL(ret.at(0).d_name, DNSName("b.powerdns.com."));
-  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType::A);
+  BOOST_CHECK_EQUAL(ret.at(0).d_type, QType(QType::A).getCode());
   BOOST_CHECK_EQUAL(queriesCount, 7U);
 }
 

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -796,27 +796,27 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_wiping)
   rrsig = std::make_shared<RRSIGRecordContent>("NSEC3 5 3 10 20370101000000 20370101000000 24567 dummy. data");
   cache->insertNSEC(DNSName("powerdns.org"), rec.d_name, rec, {rrsig}, true);
 
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3U);
 
   /* remove just that zone */
   cache->removeZoneInfo(DNSName("powerdns.org"), false);
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2U);
 
   /* add it back */
   cache->insertNSEC(DNSName("powerdns.org"), rec.d_name, rec, {rrsig}, true);
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3U);
 
   /* remove everything under .org (which should end up in the same way) */
   cache->removeZoneInfo(DNSName("org."), true);
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2U);
 
   /* add it back */
   cache->insertNSEC(DNSName("powerdns.org"), rec.d_name, rec, {rrsig}, true);
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3U);
 
   /* remove everything */
   cache->removeZoneInfo(DNSName("."), true);
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 0);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 0U);
 }
 
 BOOST_AUTO_TEST_CASE(test_aggressive_nsec_pruning)
@@ -838,11 +838,11 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_pruning)
   rec.d_content = getRecordContent(QType::NSEC, "zz.powerdns.com. AAAA RRSIG NSEC");
   cache->insertNSEC(DNSName("powerdns.com"), rec.d_name, rec, {rrsig}, false);
 
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2U);
   /* we are at the limit of the number of entries, so we will scan 1/5th of the entries,
      and prune the expired ones, which mean we should not remove anything */
   cache->prune(now.tv_sec);
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2U);
 
   rec.d_name = DNSName("www.powerdns.org");
   rec.d_type = QType::NSEC3;
@@ -851,23 +851,23 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_pruning)
   rrsig = std::make_shared<RRSIGRecordContent>("NSEC3 5 3 10 20370101000000 20370101000000 24567 dummy. data");
   cache->insertNSEC(DNSName("powerdns.org"), rec.d_name, rec, {rrsig}, true);
 
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3U);
 
   /* we have set a upper bound to 2 entries, so we are above,
      and all entries are actually expired, so we will prune one entry
      to get below the limit */
   cache->prune(now.tv_sec + 600);
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 2U);
 
   /* now we are at the limit, so we will scan 1/5th of the entries,
      and prune the expired ones, which mean we will also remove only one */
   cache->prune(now.tv_sec + 600);
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 1);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 1U);
 
   /* now we are below the limit, so we will scan 1/5th of the entries again,
      and prune the expired ones, which mean we will remove the last one */
   cache->prune(now.tv_sec + 600);
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 0);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 0U);
 }
 
 BOOST_AUTO_TEST_CASE(test_aggressive_nsec_dump)
@@ -906,14 +906,14 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec_dump)
   rrsig = std::make_shared<RRSIGRecordContent>("NSEC3 5 3 10 20370101000000 20370101000000 24567 dummy. data");
   cache->insertNSEC(DNSName("powerdns.org"), rec.d_name, rec, {rrsig}, true);
 
-  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3);
+  BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3U);
 
   auto fp = std::unique_ptr<FILE, int (*)(FILE*)>(tmpfile(), fclose);
   if (!fp) {
     BOOST_FAIL("Temporary file could not be opened");
   }
 
-  BOOST_CHECK_EQUAL(cache->dumpToFile(fp, now), 3);
+  BOOST_CHECK_EQUAL(cache->dumpToFile(fp, now), 3U);
 
   rewind(fp.get());
   char* line = nullptr;

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -1,6 +1,7 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
+#include "aggressive_nsec.hh"
 #include "base32.hh"
 #include "lua-recursor4.hh"
 #include "root-dnssec.hh"
@@ -199,6 +200,8 @@ void initSR(bool debug)
   g_dnssecmode = DNSSECMode::Off;
   g_dnssecLOG = debug;
   g_maxNSEC3Iterations = 2500;
+
+  g_aggressiveNSECCache.reset();
 
   ::arg().set("version-string", "string reported on version.pdns or version.bind") = "PowerDNS Unit Tests";
   ::arg().set("rng") = "auto";
@@ -476,7 +479,7 @@ LWResult::Result genericDSAndDNSKEYHandler(LWResult* res, const DNSName& domain,
         }
 
         if (!nsec3) {
-          addNSECRecordToLW(domain, DNSName("z") + domain, types, 600, res->d_records);
+          addNSECRecordToLW(domain, DNSName("+") + domain, types, 600, res->d_records);
         }
         else {
           addNSEC3UnhashedRecordToLW(domain, auth, (DNSName("z") + domain).toString(), types, 600, res->d_records, 10, optOut);

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -292,7 +292,6 @@ void computeRRSIG(const DNSSECPrivateKey& dpk, const DNSName& signer, const DNSN
   rrc.d_siginception = inception ? *inception : (*now - 10);
   rrc.d_sigexpire = *now + sigValidity;
   rrc.d_signer = signer;
-  rrc.d_tag = 0;
   rrc.d_tag = drc.getTag();
   rrc.d_algorithm = algo ? *algo : drc.d_algorithm;
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -287,7 +287,7 @@ void computeRRSIG(const DNSSECPrivateKey& dpk, const DNSName& signer, const DNSN
   const auto& rc = dpk.getKey();
 
   rrc.d_type = signQType;
-  rrc.d_labels = signQName.countLabels() - signQName.isWildcard();
+  rrc.d_labels = signQName.countLabels() - (signQName.isWildcard() ? 1 : 0);
   rrc.d_originalttl = signTTL;
   rrc.d_siginception = inception ? *inception : (*now - 10);
   rrc.d_sigexpire = *now + sigValidity;

--- a/pdns/recursordist/test-syncres_cc4.cc
+++ b/pdns/recursordist/test-syncres_cc4.cc
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_nx)
 BOOST_AUTO_TEST_CASE(test_auth_zone_delegation)
 {
   std::unique_ptr<SyncRes> sr;
-  initSR(sr, true, false);
+  initSR(sr, true);
 
   primeHints();
 
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_delegation)
   sr->setAsyncCallback([&queriesCount, target, targetAddr, nsAddr, authZone, keys, fixedNow](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
     queriesCount++;
     if (type == QType::DS || type == QType::DNSKEY) {
-      return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, domain == authZone, fixedNow);
+      return genericDSAndDNSKEYHandler(res, domain, DNSName("."), type, keys, domain == DNSName("com.") || domain == authZone, fixedNow);
     }
 
     if (ip == ComboAddress(nsAddr.toString(), 53) && domain == target) {
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(test_auth_zone_delegation)
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_REQUIRE_EQUAL(ret.size(), 1U);
   BOOST_CHECK(ret[0].d_type == QType::A);
-  BOOST_CHECK_EQUAL(queriesCount, 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 3U);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Indeterminate);
 }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1036,6 +1036,8 @@ int SyncRes::doResolveNoQNameMinimization(const DNSName &qname, const QType qtyp
 
   LOG(prefix<<qname<<": initial validation status for "<<qname<<" is "<<state<<endl);
 
+  #warning move aggressive NSEC check here? We know more about the zone and its status by now..
+
   res = doResolveAt(nsset, subdomain, flawedNSSet, qname, qtype, ret, depth, beenthere, state, stopAtDelegation);
 
   /* Apply Post filtering policies */

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -24,6 +24,7 @@
 #endif
 
 #include "arguments.hh"
+#include "aggressive_nsec.hh"
 #include "cachecleaner.hh"
 #include "dns_random.hh"
 #include "dnsparser.hh"
@@ -1942,6 +1943,18 @@ bool SyncRes::doCacheCheck(const DNSName &qname, const DNSName& authname, bool w
       LOG(prefix<<qname<<": cache had only stale entries"<<endl);
   }
 
+  /* let's check if we have a NSEC covering that record */
+  if (g_aggressiveNSECCache) {
+    cerr<<"calling get denial"<<endl;
+    if (g_aggressiveNSECCache->getDenial(d_now.tv_sec, qname, qtype, ret, res, d_cacheRemote, d_routingTag, d_doDNSSEC)) {
+      state = vState::Secure;
+      return true;
+    }
+  }
+  else {
+    cerr<<"no cache"<<endl;
+  }
+
   return false;
 }
 
@@ -3015,6 +3028,8 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr
   const unsigned int labelCount = qname.countLabels();
   bool isCNAMEAnswer = false;
   bool isDNAMEAnswer = false;
+  DNSName seenAuth;
+
   for (auto& rec : lwr.d_records) {
     if (rec.d_type == QType::OPT || rec.d_class != QClass::IN) {
       continue;
@@ -3022,12 +3037,16 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr
 
     rec.d_ttl = min(s_maxcachettl, rec.d_ttl);
 
-    if(!isCNAMEAnswer && rec.d_place == DNSResourceRecord::ANSWER && rec.d_type == QType::CNAME && (!(qtype==QType::CNAME)) && rec.d_name == qname && !isDNAMEAnswer) {
+    if (!isCNAMEAnswer && rec.d_place == DNSResourceRecord::ANSWER && rec.d_type == QType::CNAME && (!(qtype==QType::CNAME)) && rec.d_name == qname && !isDNAMEAnswer) {
       isCNAMEAnswer = true;
     }
-    if(!isDNAMEAnswer && rec.d_place == DNSResourceRecord::ANSWER && rec.d_type == QType::DNAME && qtype != QType::DNAME && qname.isPartOf(rec.d_name)) {
+    if (!isDNAMEAnswer && rec.d_place == DNSResourceRecord::ANSWER && rec.d_type == QType::DNAME && qtype != QType::DNAME && qname.isPartOf(rec.d_name)) {
       isDNAMEAnswer = true;
       isCNAMEAnswer = false;
+    }
+
+    if (rec.d_type == QType::SOA && rec.d_place == DNSResourceRecord::AUTHORITY && qname.isPartOf(rec.d_name)) {
+      seenAuth = rec.d_name;
     }
 
     if (rec.d_type == QType::RRSIG) {
@@ -3333,13 +3352,21 @@ RCode::rcodes_ SyncRes::updateCacheFromRecords(unsigned int depth, LWResult& lwr
           }
         }
       }
+
       if (doCache) {
         g_recCache->replace(d_now.tv_sec, i->first.name, i->first.type, i->second.records, i->second.signatures, authorityRecs, i->first.type == QType::DS ? true : isAA, auth, i->first.place == DNSResourceRecord::ANSWER ? ednsmask : boost::none, d_routingTag, recordState, remoteIP);
       }
     }
 
-    if(i->first.place == DNSResourceRecord::ANSWER && ednsmask)
+    if ((i->first.type == QType::NSEC || i->first.type == QType::NSEC3) && recordState == vState::Secure && !seenAuth.empty() && g_aggressiveNSECCache) {
+      cerr<<"Good candidate for aggressive NSEC caching"<<endl;
+
+      g_aggressiveNSECCache->insertNSEC(seenAuth, i->first.name, i->second.records.at(0), i->second.signatures, i->first.type == QType::NSEC3);
+    }
+
+    if (i->first.place == DNSResourceRecord::ANSWER && ednsmask) {
       d_wasVariable=true;
+    }
   }
 
   return RCode::NoError;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1944,7 +1944,7 @@ bool SyncRes::doCacheCheck(const DNSName &qname, const DNSName& authname, bool w
   }
 
   /* let's check if we have a NSEC covering that record */
-  if (g_aggressiveNSECCache) {
+  if (g_aggressiveNSECCache && !wasForwardedOrAuthZone) {
     if (g_aggressiveNSECCache->getDenial(d_now.tv_sec, qname, qtype, ret, res, d_cacheRemote, d_routingTag, d_doDNSSEC)) {
       state = vState::Secure;
       return true;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1036,7 +1036,9 @@ int SyncRes::doResolveNoQNameMinimization(const DNSName &qname, const QType qtyp
 
   LOG(prefix<<qname<<": initial validation status for "<<qname<<" is "<<state<<endl);
 
-  #warning move aggressive NSEC check here? We know more about the zone and its status by now..
+  // XXX: We could move aggressive NSEC check here? We know more about the zone and its status by now,
+  // but on the other hand it means we have already done the zone cut determination which is not good
+  // Perhaps delay that change until after the DNSSEC zone cut refactoring?
 
   res = doResolveAt(nsset, subdomain, flawedNSSet, qname, qtype, ret, depth, beenthere, state, stopAtDelegation);
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1951,9 +1951,6 @@ bool SyncRes::doCacheCheck(const DNSName &qname, const DNSName& authname, bool w
       return true;
     }
   }
-  else {
-    cerr<<"no cache"<<endl;
-  }
 
   return false;
 }

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -271,7 +271,7 @@ static bool provesNoDataWildCard(const DNSName& qname, const uint16_t qtype, con
 
         if (qname.isPartOf(wildcard)) {
           LOG("\tWildcard matches");
-          if (qtype == 0 || (!nsec->isSet(qtype) && !nsec->isSet(QType::CNAME))) {
+          if (qtype == 0 || (!nsec->isSet(qtype) && !nsec->isSet(QType::CNAME) && !nsec->isSet(QType::DNAME))) {
             LOG(" and proves that the type did not exist"<<endl);
             return true;
           }
@@ -368,7 +368,7 @@ static bool provesNSEC3NoWildCard(DNSName wildcard, uint16_t const qtype, const 
           if (wildcardExists) {
             *wildcardExists = true;
           }
-          if (qtype == 0 || (!nsec3->isSet(qtype) && !nsec3->isSet(QType::CNAME))) {
+          if (qtype == 0 || (!nsec3->isSet(qtype) && !nsec3->isSet(QType::CNAME) && !nsec3->isSet(QType::DNAME))) {
             LOG(" and proves that the type did not exist"<<endl);
             return true;
           }
@@ -416,6 +416,10 @@ dState matchesNSEC(const DNSName& name, uint16_t qtype, const DNSName& nsecOwner
 
     /* RFC 6840 section 4.3 */
     if (nsec->isSet(QType::CNAME)) {
+      return dState::NODENIAL;
+    }
+
+    if (nsec->isSet(QType::DNAME)) {
       return dState::NODENIAL;
     }
 
@@ -496,6 +500,11 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
 
           /* RFC 6840 section 4.3 */
           if (nsec->isSet(QType::CNAME)) {
+            LOG("However a CNAME exists"<<endl);
+            return dState::NODENIAL;
+          }
+
+          if (nsec->isSet(QType::DNAME)) {
             LOG("However a CNAME exists"<<endl);
             return dState::NODENIAL;
           }
@@ -618,6 +627,11 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
 
           /* RFC 6840 section 4.3 */
           if (nsec3->isSet(QType::CNAME)) {
+            LOG("However a CNAME exists"<<endl);
+            return dState::NODENIAL;
+          }
+
+          if (nsec3->isSet(QType::DNAME)) {
             LOG("However a CNAME exists"<<endl);
             return dState::NODENIAL;
           }

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -237,7 +237,6 @@ static bool isNSECAncestorDelegation(const DNSName& signer, const DNSName& owner
     signer.countLabels() < owner.countLabels();
 }
 
-#warning FIXME: should not be exported
 bool isNSEC3AncestorDelegation(const DNSName& signer, const DNSName& owner, const std::shared_ptr<NSEC3RecordContent>& nsec3)
 {
   return nsec3->isSet(QType::NS) &&

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -95,3 +95,5 @@ void updateDNSSECValidationState(vState& state, const vState stateUpdate);
 
 dState matchesNSEC(const DNSName& name, uint16_t qtype, const DNSName& nsecOwner, const std::shared_ptr<NSECRecordContent>& nsecRecord, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures);
 
+bool isNSEC3AncestorDelegation(const DNSName& signer, const DNSName& owner, const std::shared_ptr<NSEC3RecordContent>& nsec3);
+DNSName getNSECOwnerName(const DNSName& initialOwner, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -97,6 +97,7 @@ dState matchesNSEC(const DNSName& name, uint16_t qtype, const DNSName& nsecOwner
 
 bool isNSEC3AncestorDelegation(const DNSName& signer, const DNSName& owner, const std::shared_ptr<NSEC3RecordContent>& nsec3);
 DNSName getNSECOwnerName(const DNSName& initialOwner, const std::vector<std::shared_ptr<RRSIGRecordContent> >& signatures);
+DNSName getClosestEncloserFromNSEC(const DNSName& name, const DNSName& owner, const DNSName& next);
 
 template <typename NSEC> bool isTypeDenied(const NSEC& nsec, const QType& type)
 {

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -75,6 +75,8 @@ typedef set<shared_ptr<DNSKEYRecordContent>, sharedDNSKeyRecordContentCompare > 
 
 vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t& records, const vector<shared_ptr<RRSIGRecordContent> >& signatures, const skeyset_t& keys, bool validateAllSigs=true);
 bool isCoveredByNSEC(const DNSName& name, const DNSName& begin, const DNSName& next);
+bool isCoveredByNSEC3Hash(const std::string& h, const std::string& beginHash, const std::string& nextHash);
+bool isCoveredByNSEC3Hash(const DNSName& h, const DNSName& beginHash, const DNSName& nextHash);
 void validateWithKeySet(const cspmap_t& rrsets, cspmap_t& validated, const skeyset_t& keys);
 cspmap_t harvestCSPFromRecs(const vector<DNSRecord>& recs);
 vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, skeyset_t& keyset);

--- a/pdns/validate.hh
+++ b/pdns/validate.hh
@@ -72,7 +72,9 @@ struct sharedDNSKeyRecordContentCompare
 
 typedef set<shared_ptr<DNSKEYRecordContent>, sharedDNSKeyRecordContentCompare > skeyset_t;
 
+
 vState validateWithKeySet(time_t now, const DNSName& name, const sortedRecords_t& records, const vector<shared_ptr<RRSIGRecordContent> >& signatures, const skeyset_t& keys, bool validateAllSigs=true);
+bool isCoveredByNSEC(const DNSName& name, const DNSName& begin, const DNSName& next);
 void validateWithKeySet(const cspmap_t& rrsets, cspmap_t& validated, const skeyset_t& keys);
 cspmap_t harvestCSPFromRecs(const vector<DNSRecord>& recs);
 vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, skeyset_t& keyset);
@@ -88,3 +90,6 @@ bool isRRSIGIncepted(const time_t now, const shared_ptr<RRSIGRecordContent>& sig
 bool isWildcardExpanded(unsigned int labelCount, const std::shared_ptr<RRSIGRecordContent>& sign);
 bool isWildcardExpandedOntoItself(const DNSName& owner, unsigned int labelCount, const std::shared_ptr<RRSIGRecordContent>& sign);
 void updateDNSSECValidationState(vState& state, const vState stateUpdate);
+
+dState matchesNSEC(const DNSName& name, uint16_t qtype, const DNSName& nsecOwner, const std::shared_ptr<NSECRecordContent>& nsecRecord, const std::vector<std::shared_ptr<RRSIGRecordContent>>& signatures);
+

--- a/regression-tests.recursor-dnssec/test_AggressiveNSECCache.py
+++ b/regression-tests.recursor-dnssec/test_AggressiveNSECCache.py
@@ -1,0 +1,292 @@
+import dns
+from recursortests import RecursorTest
+import os
+import requests
+import subprocess
+
+class AggressiveNSECCacheBase(RecursorTest):
+    __test__ = False
+    _wsPort = 8042
+    _wsTimeout = 2
+    _wsPassword = 'secretpassword'
+    _apiKey = 'secretapikey'
+    _config_template = """
+    dnssec=validate
+    aggressive-nsec-cache-size=10000
+    webserver=yes
+    webserver-port=%d
+    webserver-address=127.0.0.1
+    webserver-password=%s
+    api-key=%s
+    """ % (_wsPort, _wsPassword, _apiKey)
+
+    @classmethod
+    def setUp(cls):
+        confdir = os.path.join('configs', cls._confdir)
+        cls.wipeRecursorCache(confdir)
+
+    def getMetric(self, name):
+        headers = {'x-api-key': self._apiKey}
+        url = 'http://127.0.0.1:' + str(self._wsPort) + '/api/v1/servers/localhost/statistics'
+        r = requests.get(url, headers=headers, timeout=self._wsTimeout)
+        self.assertTrue(r)
+        self.assertEquals(r.status_code, 200)
+        self.assertTrue(r.json())
+        content = r.json()
+
+        for entry in content:
+            if entry['name'] == name:
+                return int(entry['value'])
+
+        self.assertTrue(False)
+
+    def testNoData(self):
+
+        # first we query a non-existent type, to get the NSEC in our cache
+        entries = self.getMetric('aggressive-nsec-cache-entries')
+        res = self.sendQuery('host1.secure.example.', 'TXT')
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+        self.assertGreater(self.getMetric('aggressive-nsec-cache-entries'), entries)
+
+        # now we ask for a different type, we should generate the answer from the NSEC,
+        # and no outgoing query should be made
+        nbQueries = self.getMetric('all-outqueries')
+        entries = self.getMetric('aggressive-nsec-cache-entries')
+        res = self.sendQuery('host1.secure.example.', 'AAAA')
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEquals(self.getMetric('aggressive-nsec-cache-entries'), entries)
+
+class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
+    _confdir = 'AggressiveNSECCacheNSEC'
+    __test__ = True
+
+    # we can't use the same tests for NSEC and NSEC3 because the hashed NSEC3s
+    # do not deny the same names than the non-hashed NSECs do
+    def testNXD(self):
+
+        # first we query a non-existent name, to get the needed NSECs (name + widcard) in our cache
+        entries = self.getMetric('aggressive-nsec-cache-entries')
+        hits = self.getMetric('aggressive-nsec-cache-nsec-hits')
+        res = self.sendQuery('host2.secure.example.', 'TXT')
+        self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+        self.assertGreater(self.getMetric('aggressive-nsec-cache-entries'), entries)
+        self.assertEquals(self.getMetric('aggressive-nsec-cache-nsec-hits'), hits)
+
+        # now we ask for a different name that is covered by the NSEC,
+        # we should generate the answer from the NSEC and no outgoing query should be made
+        nbQueries = self.getMetric('all-outqueries')
+        entries = self.getMetric('aggressive-nsec-cache-entries')
+        hits = self.getMetric('aggressive-nsec-cache-nsec-hits')
+        res = self.sendQuery('host3.secure.example.', 'AAAA')
+        self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEquals(self.getMetric('aggressive-nsec-cache-entries'), entries)
+        self.assertGreater(self.getMetric('aggressive-nsec-cache-nsec-hits'), hits)
+
+    def testWildcard(self):
+
+        # first we query a non-existent name, but for which a wildcard matches,
+        # to get the NSEC in our cache
+        res = self.sendQuery('test1.wildcard.secure.example.', 'A')
+        expected = dns.rrset.from_text('test1.wildcard.secure.example.', 0, dns.rdataclass.IN, 'A', '{prefix}.10'.format(prefix=self._PREFIX))
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+        self.assertMessageIsAuthenticated(res)
+
+        # now we ask for a different name, we should generate the answer from the NSEC and the wildcard,
+        # and no outgoing query should be made
+        hits = self.getMetric('aggressive-nsec-cache-nsec-wc-hits')
+        nbQueries = self.getMetric('all-outqueries')
+        res = self.sendQuery('test2.wildcard.secure.example.', 'A')
+        expected = dns.rrset.from_text('test2.wildcard.secure.example.', 0, dns.rdataclass.IN, 'A', '{prefix}.10'.format(prefix=self._PREFIX))
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+        self.assertMessageIsAuthenticated(res)
+        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertGreater(self.getMetric('aggressive-nsec-cache-nsec-wc-hits'), hits)
+
+        # now we ask for a type that does not exist at the wildcard
+        hits = self.getMetric('aggressive-nsec-cache-nsec-hits')
+        nbQueries = self.getMetric('all-outqueries')
+        res = self.sendQuery('test1.wildcard.secure.example.', 'AAAA')
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertGreater(self.getMetric('aggressive-nsec-cache-nsec-hits'), hits)
+
+        # we can also ask a different type, for a different name that is covered
+        # by the NSEC and matches the wildcard (but the type does not exist)
+        hits = self.getMetric('aggressive-nsec-cache-nsec-wc-hits')
+        nbQueries = self.getMetric('all-outqueries')
+        res = self.sendQuery('test3.wildcard.secure.example.', 'TXT')
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertGreater(self.getMetric('aggressive-nsec-cache-nsec-hits'), hits)
+
+    def test_Bogus(self):
+        # query a name in a Bogus zone
+        entries = self.getMetric('aggressive-nsec-cache-entries')
+        res = self.sendQuery('ted1.bogus.example.', 'A')
+        self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
+        self.assertAnswerEmpty(res)
+
+        # disable validation
+        msg = dns.message.make_query('ted1.bogus.example.', 'A', want_dnssec=True)
+        msg.flags |= dns.flags.CD
+
+        res = self.sendUDPQuery(msg)
+        self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+
+        # check that we _do not_ use the aggressive NSEC cache
+        nbQueries = self.getMetric('all-outqueries')
+        msg = dns.message.make_query('ted2.bogus.example.', 'A', want_dnssec=True)
+        msg.flags |= dns.flags.CD
+
+        res = self.sendUDPQuery(msg)
+        self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertGreater(self.getMetric('all-outqueries'), nbQueries)
+        # we will accept a NSEC for root, which is secure..
+        self.assertEquals(entries + 1, self.getMetric('aggressive-nsec-cache-entries'))
+
+class AggressiveNSECCacheNSEC3(AggressiveNSECCacheBase):
+    _confdir = 'AggressiveNSECCacheNSEC3'
+    __test__ = True
+
+    @classmethod
+    def secureZone(cls, confdir, zonename, key=None):
+        zone = '.' if zonename == 'ROOT' else zonename
+        if not key:
+            pdnsutilCmd = [os.environ['PDNSUTIL'],
+                           '--config-dir=%s' % confdir,
+                           'secure-zone',
+                           zone]
+        else:
+            keyfile = os.path.join(confdir, 'dnssec.key')
+            with open(keyfile, 'w') as fdKeyfile:
+                fdKeyfile.write(key)
+
+            pdnsutilCmd = [os.environ['PDNSUTIL'],
+                           '--config-dir=%s' % confdir,
+                           'import-zone-key',
+                           zone,
+                           keyfile,
+                           'active',
+                           'ksk']
+
+        print(' '.join(pdnsutilCmd))
+        try:
+            subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
+
+        params = "1 0 100 AABBCCDDEEFF112233"
+
+        if zone == "optout.example":
+            params = "1 1 100 AABBCCDDEEFF112233"
+
+        pdnsutilCmd = [os.environ['PDNSUTIL'],
+                       '--config-dir=%s' % confdir,
+                       'set-nsec3',
+                       zone,
+                       params]
+
+        print(' '.join(pdnsutilCmd))
+        try:
+            subprocess.check_output(pdnsutilCmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            raise AssertionError('%s failed (%d): %s' % (pdnsutilCmd, e.returncode, e.output))
+
+    def testNXD(self):
+
+        # first we query a non-existent name, to get the needed NSEC3s in our cache
+        res = self.sendQuery('host2.secure.example.', 'TXT')
+        self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+
+        # now we ask for a different name that is covered by the NSEC3s,
+        # we should generate the answer from the NSEC3s and no outgoing query should be made
+        nbQueries = self.getMetric('all-outqueries')
+        res = self.sendQuery('host6.secure.example.', 'AAAA')
+        self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+
+    def testWildcard(self):
+
+        # first we query a non-existent name, but for which a wildcard matches,
+        # to get the NSEC3 in our cache
+        res = self.sendQuery('test5.wildcard.secure.example.', 'A')
+        expected = dns.rrset.from_text('test5.wildcard.secure.example.', 0, dns.rdataclass.IN, 'A', '{prefix}.10'.format(prefix=self._PREFIX))
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+        self.assertMessageIsAuthenticated(res)
+
+        # now we ask for a different name, we should generate the answer from the NSEC3s and the wildcard,
+        # and no outgoing query should be made
+        nbQueries = self.getMetric('all-outqueries')
+        res = self.sendQuery('test6.wildcard.secure.example.', 'A')
+        expected = dns.rrset.from_text('test6.wildcard.secure.example.', 0, dns.rdataclass.IN, 'A', '{prefix}.10'.format(prefix=self._PREFIX))
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertMatchingRRSIGInAnswer(res, expected)
+        self.assertMessageIsAuthenticated(res)
+        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+
+        # now we ask for a type that does not exist at the wildcard
+        nbQueries = self.getMetric('all-outqueries')
+        res = self.sendQuery('test5.wildcard.secure.example.', 'AAAA')
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+
+        # we can also ask a different type, for a different name that is covered
+        # by the NSEC3s and matches the wildcard (but the type does not exist)
+        nbQueries = self.getMetric('all-outqueries')
+        res = self.sendQuery('test6.wildcard.secure.example.', 'TXT')
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertMessageIsAuthenticated(res)
+        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+
+    def test_OptOut(self):
+        # query a name in an opt-out zone
+        res = self.sendQuery('ns2.optout.example.', 'A')
+        self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+
+        # check that we _do not_ use the aggressive NSEC cache
+        nbQueries = self.getMetric('all-outqueries')
+        res = self.sendQuery('ns3.optout.example.', 'A')
+        self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
+        self.assertAnswerEmpty(res)
+        self.assertAuthorityHasSOA(res)
+        self.assertGreater(self.getMetric('all-outqueries'), nbQueries)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is a work-in-progress PR, to see how it fares against our CI tests and get the feedback on the design choices.
Some of these are:
- using a separate cache instead of reusing/abusing the existing record cache: we don't store NSEC3 in the record cache, and the sharding makes it very hard to reuse it efficiently without writing some horrible hack, but more importantly I believe keeping the NSEC/NSEC3 ordered by zone reduce the amount of work doing the search by a nice margin.
- checking that new cache early means that we can be searching in the wrong zone, like in the root zone, even though we do have some information in our record cache about a more specific zone existing. This should not have any functional impact but likely has a performance impact. On the other hand doing the check after computing the zone cuts is not efficient at all. Perhaps we could do a quick cache-only lookup similar to what we do to get the best NSs? 

This PR needs regression tests before being moved from the draft status, at the very least.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
