### PR TITLE
adds supports for invoking a Lua script on the end of incoming AXFR zone transfer

### DIFF
--- a/docs/domainmetadata.rst
+++ b/docs/domainmetadata.rst
@@ -28,6 +28,7 @@ The following options can only be read (not written to) via the HTTP API metadat
 * API-RECTIFY
 * AXFR-MASTER-TSIG
 * LUA-AXFR-SCRIPT
+* LUA-AXFR-END-SCRIPT
 * NSEC3NARROW
 * NSEC3PARAM
 * PRESIGNED
@@ -144,6 +145,13 @@ LUA-AXFR-SCRIPT
 
 Script to be used to edit incoming AXFRs, see :ref:`modes-of-operation-axfrfilter`.
 This value will override the :ref:`setting-lua-axfr-script` setting. Use
+'NONE' to remove a global script.
+
+LUA-AXFR-END-SCRIPT
+---------------
+
+Script to be used on AXFR END, see :ref:`modes-of-operation-axfrend`.
+This value will override the :ref:`setting-lua-axfr-end-script` setting. Use
 'NONE' to remove a global script.
 
 NSEC3NARROW

--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -326,3 +326,56 @@ of 99 seconds and the specified string. TXT Records with names starting
 with ``_tstamp.`` get their value (rdata) set to the current time stamp.
 A records are appended with a TXT record. All other records are
 unhandled.
+
+.. _modes-of-operation-axfrend:
+
+Signaling end of an AXFR transfer for specific zone(s) using a script
+---------------------------------------------------------------------
+
+The PowerDNS Authoritative Server can invoke a Lua script on the of
+incoming AXFR zone transfer. The user-defined function ``axfr_end(zone)``
+within your script is invoked for each zone that has LUA-AXFR-END-SCRIPT
+defined in the ``domainmetadata``.
+
+What you can accomplish using a Lua script:
+
+- trigger a notification for a post processing event downstream
+- perform specific operation on the zone as a whole vs specific record/RRset
+
+To enable a Lua script for a particular slave zone, determine the
+``domain_id`` for the zone from the ``domains`` table, and add a row to
+the ``domainmetadata`` table for the domain. Supposing the domain we
+want has an ``id`` of 3, the following SQL statement will enable the Lua
+script ``axfr-end.lua`` for that domain:
+
+.. code-block:: SQL
+
+    INSERT INTO domainmetadata (domain_id, kind, content) VALUES (3, "LUA-AXFR-END-SCRIPT", "/lua/axfr-end.lua");
+
+.. warning::
+  The Lua script must both exist and be syntactically
+  correct; 
+
+Returning negative result code in your axfr_end(zone) function indicates
+an error condition; returning 0 or greater result code signals
+successful operation
+
+Example:
+
+.. code-block:: lua
+
+        function axfr_end(zone)
+                -- call queue
+                update_queue(zone)
+                -- notify an API endpoint
+                notify_api_endpoint(zone)
+
+                return 0
+
+        function update_queue(zone)
+                -- update queue DB
+                return 0
+
+        function notify_api_endpoint(zone)
+                -- execute HTTP call to API endpoint
+                return 0

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -873,6 +873,16 @@ e.g. error = 3, warning = 4, notice = 5, info = 6
 
 Script to be used to edit incoming AXFRs, see :ref:`modes-of-operation-axfrfilter`
 
+.. _setting-lua-axfr-end-script:
+
+``lua-axfr-end-script``
+-------------------
+
+-  String
+-  Default: empty
+
+Script to be used to on AXFR transfer end, see :ref:`modes-of-operation-axfrend`
+
 .. _setting-lua-health-checks-expire-delay:
 
 ``lua-health-checks-expire-delay``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -881,7 +881,7 @@ Script to be used to edit incoming AXFRs, see :ref:`modes-of-operation-axfrfilte
 -  String
 -  Default: empty
 
-Script to be used to on AXFR transfer end, see :ref:`modes-of-operation-axfrend`
+Script to be used on AXFR transfer end, see :ref:`modes-of-operation-axfrend`
 
 .. _setting-lua-health-checks-expire-delay:
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -233,6 +233,7 @@ void declareArguments()
   ::arg().setSwitch("axfr-lower-serial", "Also AXFR a zone from a master with a lower serial")="no";
 
   ::arg().set("lua-axfr-script", "Script to be used to edit incoming AXFRs")="";
+  ::arg().set("lua-axfr-end-script", "Script to be used on AXFRs transfer end")="";
   ::arg().set("xfr-max-received-mbytes", "Maximum number of megabytes received from an incoming XFR")="100";
   ::arg().set("axfr-fetch-timeout", "Maximum time in seconds for inbound AXFR to start or be idle after starting")="10";
 

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -91,7 +91,7 @@ void AuthLua4::postLoad() {
   d_update_policy = d_lw->readVariable<boost::optional<luacall_update_policy_t>>("updatepolicy").get_value_or(0);
   d_axfr_filter = d_lw->readVariable<boost::optional<luacall_axfr_filter_t>>("axfrfilter").get_value_or(0);
   d_prequery = d_lw->readVariable<boost::optional<luacall_prequery_t>>("prequery").get_value_or(0);
-  d_axfr_finished = d_lw->readVariable<boost::optional<luacall_axfr_finished_t>>("axfr_finished").get_value_or(0);
+  d_axfr_end = d_lw->readVariable<boost::optional<luacall_axfr_end_t>>("axfr_end").get_value_or(0);
 }
 
 bool AuthLua4::axfrfilter(const ComboAddress& remote, const DNSName& zone, const DNSResourceRecord& in, vector<DNSResourceRecord>& out) {
@@ -171,12 +171,12 @@ std::unique_ptr<DNSPacket> AuthLua4::prequery(const DNSPacket& q) {
   return nullptr;
 }
 
-bool AuthLua4::axfr_finished(const DNSName& zone) {
-  luacall_axfr_finished_t::result_type rcode;
+bool AuthLua4::axfr_end(const DNSName& zone) {
+  luacall_axfr_end_t::result_type rcode;
   
-  if (d_axfr_finished == NULL) return false;
+  if (d_axfr_end == NULL) return false;
 
-  rcode = d_axfr_finished(zone);
+  rcode = d_axfr_end(zone);
   
   if (rcode < 0) {
     // failed to execute the AFXR finished notification
@@ -187,7 +187,7 @@ bool AuthLua4::axfr_finished(const DNSName& zone) {
     return true;
   }
   else
-    throw PDNSException("Cannot understand return code "+std::to_string(rcode)+" in axfr finished response");
+    throw PDNSException("Cannot understand return code "+std::to_string(rcode)+" in axfr end response");
 
   return true;
 }

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -91,6 +91,7 @@ void AuthLua4::postLoad() {
   d_update_policy = d_lw->readVariable<boost::optional<luacall_update_policy_t>>("updatepolicy").get_value_or(0);
   d_axfr_filter = d_lw->readVariable<boost::optional<luacall_axfr_filter_t>>("axfrfilter").get_value_or(0);
   d_prequery = d_lw->readVariable<boost::optional<luacall_prequery_t>>("prequery").get_value_or(0);
+  d_axfr_finished = d_lw->readVariable<boost::optional<luacall_axfr_finished_t>>("axfr_finished").get_value_or(0);
 }
 
 bool AuthLua4::axfrfilter(const ComboAddress& remote, const DNSName& zone, const DNSResourceRecord& in, vector<DNSResourceRecord>& out) {
@@ -143,7 +144,6 @@ bool AuthLua4::axfrfilter(const ComboAddress& remote, const DNSName& zone, const
   return true;
 }
 
-
 bool AuthLua4::updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, const DNSPacket& packet) {
   // default decision is all goes
   if (d_update_policy == nullptr) return true;
@@ -169,6 +169,27 @@ std::unique_ptr<DNSPacket> AuthLua4::prequery(const DNSPacket& q) {
     return r;
 
   return nullptr;
+}
+
+bool AuthLua4::axfr_finished(const DNSName& zone) {
+  luacall_axfr_finished_t::result_type rcode;
+  
+  if (d_axfr_finished == NULL) return false;
+
+  rcode = d_axfr_finished(zone);
+  
+  if (rcode < 0) {
+    // failed to execute the AFXR finished notification
+    return false;
+  }
+  else if (rcode == 0) {
+    // success
+    return true;
+  }
+  else
+    throw PDNSException("Cannot understand return code "+std::to_string(rcode)+" in axfr finished response");
+
+  return true;
 }
 
 AuthLua4::~AuthLua4() { }

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -173,16 +173,16 @@ std::unique_ptr<DNSPacket> AuthLua4::prequery(const DNSPacket& q) {
 
 bool AuthLua4::axfr_end(const DNSName& zone) {
   luacall_axfr_end_t::result_type rcode;
-  
+
   if (d_axfr_end == NULL) return false;
 
   rcode = d_axfr_end(zone);
-  
+
   if (rcode < 0) {
-    // failed to execute the AFXR finished notification
+    // failed to execute the AFXR end notification
     return false;
   }
-  else if (rcode == 0) {
+  else if (rcode >= 0) {
     // success
     return true;
   }

--- a/pdns/lua-auth4.hh
+++ b/pdns/lua-auth4.hh
@@ -15,6 +15,7 @@ public:
   AuthLua4();
   bool updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, const DNSPacket& packet);
   bool axfrfilter(const ComboAddress&, const DNSName&, const DNSResourceRecord&, std::vector<DNSResourceRecord>&);
+  bool axfr_finished(const DNSName&);
   LuaContext* getLua();
 
   std::unique_ptr<DNSPacket> prequery(const DNSPacket& p);
@@ -37,10 +38,13 @@ private:
   typedef std::function<bool(const UpdatePolicyQuery&)> luacall_update_policy_t;
   typedef std::function<std::tuple<int, std::unordered_map<int, std::unordered_map<std::string,boost::variant<unsigned int,std::string> > > >(const ComboAddress&, const DNSName&, const DNSResourceRecord&)> luacall_axfr_filter_t;
   typedef std::function<bool(DNSPacket*)> luacall_prequery_t;
+  typedef std::function<int(const DNSName&)> luacall_axfr_finished_t;
 
   luacall_update_policy_t d_update_policy;
   luacall_axfr_filter_t d_axfr_filter;
   luacall_prequery_t d_prequery;
+  luacall_axfr_finished_t d_axfr_finished;
 };
+
 std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& qname,
                                                    const DNSName& zone, int zoneid, const DNSPacket& dnsp, uint16_t qtype);

--- a/pdns/lua-auth4.hh
+++ b/pdns/lua-auth4.hh
@@ -15,7 +15,7 @@ public:
   AuthLua4();
   bool updatePolicy(const DNSName &qname, QType qtype, const DNSName &zonename, const DNSPacket& packet);
   bool axfrfilter(const ComboAddress&, const DNSName&, const DNSResourceRecord&, std::vector<DNSResourceRecord>&);
-  bool axfr_finished(const DNSName&);
+  bool axfr_end(const DNSName&);
   LuaContext* getLua();
 
   std::unique_ptr<DNSPacket> prequery(const DNSPacket& p);
@@ -38,12 +38,12 @@ private:
   typedef std::function<bool(const UpdatePolicyQuery&)> luacall_update_policy_t;
   typedef std::function<std::tuple<int, std::unordered_map<int, std::unordered_map<std::string,boost::variant<unsigned int,std::string> > > >(const ComboAddress&, const DNSName&, const DNSResourceRecord&)> luacall_axfr_filter_t;
   typedef std::function<bool(DNSPacket*)> luacall_prequery_t;
-  typedef std::function<int(const DNSName&)> luacall_axfr_finished_t;
+  typedef std::function<int(const DNSName&)> luacall_axfr_end_t;
 
   luacall_update_policy_t d_update_policy;
   luacall_axfr_filter_t d_axfr_filter;
   luacall_prequery_t d_prequery;
-  luacall_axfr_finished_t d_axfr_finished;
+  luacall_axfr_end_t d_axfr_end;
 };
 
 std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, const DNSName& qname,

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -80,8 +80,7 @@ struct ZoneStatus
 };
 
 
-void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, unique_ptr<AuthLua4>& pdl,
-                                 ZoneStatus& zs, vector<DNSRecord>* axfr)
+void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, const ComboAddress& laddr, const ComboAddress& remote, unique_ptr<AuthLua4>& pdl, ZoneStatus& zs, vector<DNSRecord>* axfr)
 {
   string logPrefix="IXFR-in zone '"+domain.toLogString()+"', primary '"+remote.toString()+"', ";
 

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -622,18 +622,18 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
     unique_ptr<AuthLua4> laes{nullptr};
     vector<string> axfr_end_scripts;
     string axfr_end_script=::arg()["lua-axfr-end-script"];
-    if(B.getDomainMetadata(domain, "LUA-AXFR-END-SCRIPT", axfr_end_scripts) && !afxr_end_scripts.empty()) {
-      if (pdns_iequals(afxr_end_scripts[0], "NONE")) {
-        afxr_end_script.clear();
+    if(B.getDomainMetadata(domain, "LUA-AXFR-END-SCRIPT", axfr_end_scripts) && !axfr_end_scripts.empty()) {
+      if (pdns_iequals(axfr_end_scripts[0], "NONE")) {
+        axfr_end_script.clear();
       } else {
-        afxr_end_script=afxr_end_scripts[0];
+        axfr_end_script=axfr_end_scripts[0];
       }
     }
     if(!axfr_end_script.empty()){
       try {
         laes = make_unique<AuthLua4>();
         laes->loadFile(axfr_end_script);
-        g_log<<Logger::Info<<logPrefix<<"loaded Lua script '"<<afxr_end_script<<"'"<<endl;
+        g_log<<Logger::Info<<logPrefix<<"loaded Lua script '"<<axfr_end_script<<"'"<<endl;
       }
       catch(std::exception& e) {
         g_log<<Logger::Error<<logPrefix<<"failed to load Lua script '"<<axfr_end_script<<"': "<<e.what()<<endl;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -116,22 +116,20 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
       const auto& remove = d.first;
       const auto& add = d.second;
       //      cout<<"Delta sizes: "<<remove.size()<<", "<<add.size()<<endl;
-      
+
       if(remove.empty()) { // we got passed an AXFR!
         *axfr = add;
         return;
       }
-        
 
       // our hammer is 'replaceRRSet(domain_id, qname, qt, vector<DNSResourceRecord>& rrset)
       // which thinks in terms of RRSETs
       // however, IXFR does not, and removes and adds *records* (bummer)
       // this means that we must group updates by {qname,qtype}, retrieve the RRSET, apply
       // the add/remove updates, and replaceRRSet the whole thing. 
-      
-      
+
       map<pair<DNSName,uint16_t>, pair<vector<DNSRecord>, vector<DNSRecord> > > grouped;
-      
+
       for(const auto& x: remove)
         grouped[{x.d_name, x.d_type}].first.push_back(x);
       for(const auto& x: add)
@@ -170,7 +168,7 @@ void CommunicatorClass::ixfrSuck(const DNSName &domain, const TSIGTriplet& tt, c
             auto sr = getRR<SOARecordContent>(dr);
             zs.soa_serial=sr->d_st.serial;
           }
-          
+
           replacement.push_back(rr);
         }
 
@@ -293,15 +291,14 @@ static vector<DNSResourceRecord> doAxfr(const ComboAddress& raddr, const DNSName
     }
   }
   return rrs;
-}   
-
+}
 
 void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, bool force)
 {
   {
     std::lock_guard<std::mutex> l(d_lock);
     if(d_inprogress.count(domain)) {
-      return; 
+      return;
     }
     d_inprogress.insert(domain);
   }
@@ -342,7 +339,6 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
         return;
       }
     }
-
 
     unique_ptr<AuthLua4> pdl{nullptr};
     vector<string> scripts;
@@ -393,7 +389,6 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
     bool hadNSEC3 = false;
     NSEC3PARAMRecordContent hadNs3pr;
     bool hadNarrow=false;
-
 
     vector<DNSResourceRecord> rrs;
     if(dk.isSecuredZone(domain)) {
@@ -470,7 +465,6 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
         g_log<<Logger::Debug<<logPrefix<<"zone is narrow, only setting 'auth' fields"<<endl;
     }
 
-
     transaction=di.backend->startTransaction(domain, zs.domain_id);
     g_log<<Logger::Info<<logPrefix<<"storage transaction started"<<endl;
 
@@ -515,7 +509,6 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
     DNSName shorter, ordername;
     set<DNSName> rrterm;
     map<DNSName,bool> nonterm;
-
 
     for(DNSResourceRecord& rr :  rrs) {
       if(!zs.isPresigned) {
@@ -641,9 +634,9 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
     }
 
     if (laes) {
-      g_log<<Logger::Info << logPrefix << "Initiated LUA-AXFR-END-SCRIPT for zone: " << domain << endl;
+      g_log<<Logger::Debug << logPrefix << "Initiated LUA-AXFR-END-SCRIPT for zone: " << domain << endl;
       laes->axfr_end(domain);
-      g_log<<Logger::Info << logPrefix << "Completed LUA-AXFR-END-SCRIPT for zone: " << domain << endl;
+      g_log<<Logger::Debug << logPrefix << "Completed LUA-AXFR-END-SCRIPT for zone: " << domain << endl;
     }
   }
   catch(DBException &re) {

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -640,10 +640,11 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
         return;
       }
     }
-    
-    if (!laes) {
-      laes->axfr_finished(domain);
-      g_log<<Logger::Info << logPrefix << "Executed LUA-AXFR-END-SCRIPT for zone: " << domain << endl;
+
+    if (laes) {
+      g_log<<Logger::Info << logPrefix << "Initiated LUA-AXFR-END-SCRIPT for zone: " << domain << endl;
+      laes->axfr_end(domain);
+      g_log<<Logger::Info << logPrefix << "Completed LUA-AXFR-END-SCRIPT for zone: " << domain << endl;
     }
   }
   catch(DBException &re) {

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -618,6 +618,33 @@ void CommunicatorClass::suck(const DNSName &domain, const ComboAddress& remote, 
       notifyDomain(domain, &B);
     }
 
+    // Execute LUA-AXFR-END-SCRIPT script
+    unique_ptr<AuthLua4> laes{nullptr};
+    vector<string> axfr_end_scripts;
+    string axfr_end_script=::arg()["lua-axfr-end-script"];
+    if(B.getDomainMetadata(domain, "LUA-AXFR-END-SCRIPT", axfr_end_scripts) && !afxr_end_scripts.empty()) {
+      if (pdns_iequals(afxr_end_scripts[0], "NONE")) {
+        afxr_end_script.clear();
+      } else {
+        afxr_end_script=afxr_end_scripts[0];
+      }
+    }
+    if(!axfr_end_script.empty()){
+      try {
+        laes = make_unique<AuthLua4>();
+        laes->loadFile(axfr_end_script);
+        g_log<<Logger::Info<<logPrefix<<"loaded Lua script '"<<afxr_end_script<<"'"<<endl;
+      }
+      catch(std::exception& e) {
+        g_log<<Logger::Error<<logPrefix<<"failed to load Lua script '"<<axfr_end_script<<"': "<<e.what()<<endl;
+        return;
+      }
+    }
+    
+    if (!laes) {
+      laes->axfr_finished(domain);
+      g_log<<Logger::Info << logPrefix << "Executed LUA-AXFR-END-SCRIPT for zone: " << domain << endl;
+    }
   }
   catch(DBException &re) {
     g_log<<Logger::Error<<logPrefix<<"unable to feed record: "<<re.reason<<endl;


### PR DESCRIPTION
### Short description

This PR adds support for invoking a Lua script on the end of an incoming AXFR zone transfer.

The user-defined function ``axfr_end(zone)`` within your script is invoked for each zone 
that has LUA-AXFR-END-SCRIPT defined in the ``domainmetadata``.

What you can accomplish using a Lua script:

- trigger a notification for a post processing event downstream
- perform specific operation on the zone as a whole vs specific record/RRset

To enable a Lua script for a particular slave zone, determine the
``domain_id`` for the zone from the ``domains`` table, and add a row to
the ``domainmetadata`` table for the domain. Supposing the domain we
want has an ``id`` of 3, the following SQL statement will enable the Lua
script ``axfr-end.lua`` for that domain:

```sql
INSERT INTO domainmetadata (domain_id, kind, content) VALUES (3, "LUA-AXFR-END-SCRIPT", "/lua/axfr-end.lua");
```

### Checklist

I have:
- [ x ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ x ] compiled this code
- [ x ] tested this code
- [ x ] included documentation (including possible behaviour changes)
- [ x ] documented the code
- [ x ] tested regression-tests suite 
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
