### PR TITLE
Stop enforcing format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,39 +529,6 @@ jobs:
           paths:
             - project
 
-  check-formatting:
-    docker:
-      - image: debian:buster
-        auth:
-          username: powerdnsreadonly
-          password: $DOCKERHUB_PASSWORD
-    steps:
-      - run:
-          name: Install dependencies
-          command: |
-            echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
-            apt-get update && apt-get -qq --no-install-recommends install git
-            apt-get -qq -t buster-backports --no-install-recommends install clang-format-8
-      - get-workspace
-      - run:
-          name: Check formatting
-          command: |
-            ./build-scripts/format-code pdns/recursordist/*.[ch][ch]
-            git --no-pager diff
-            exit $(git diff | wc -l)
-          working_directory: ~/project
-      - run:
-          name: Check Makefile.am SOURCES sort order
-          command: |
-            exitcode=0
-            for f in $(find . -type f -name 'Makefile.am'); do
-              ./build-scripts/test-sources-sorted.py ${f}
-              if [ $? -ne 0 ]; then
-                exitcode=1
-              fi
-            done
-            exit ${exitcode}
-
   build-auth:
     docker:
       - image: debian:buster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1896,9 +1896,6 @@ workflows:
       - test-auth-regress-tinydns:
           requires:
             - build-auth
-      - check-formatting:
-          requires:
-            - checkout
       - build-recursor:
           requires:
             - checkout


### PR DESCRIPTION
Most important reason: not all version of check-format do the same. I still encourage people to use the script `build-scrips/format-code` though.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
