### PR TITLE
dnsdist: Add option to spoofRawAction to spoof multiple answers

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -667,7 +667,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "SNMPTrapResponseAction", true, "[reason]", "send an SNMP trap, adding the optional `reason` string as the response description"},
   { "SpoofAction", true, "ip|list of ips [, options]", "forge a response with the specified IPv4 (for an A query) or IPv6 (for an AAAA). If you specify multiple addresses, all that match the query type (A, AAAA or ANY) will get spoofed in" },
   { "SpoofCNAMEAction", true, "cname [, options]", "Forge a response with the specified CNAME value" },
-  { "SpoofRawAction", true, "raw [, options]", "Forge a response with the specified record data as raw bytes" },
+  { "SpoofRawAction", true, "raw|list of raws [, options]", "Forge a response with the specified record data as raw bytes. If you specify multiple raws (it is assumed they match the query type), all will get spoofed in" },
   { "SuffixMatchNodeRule", true, "smn[, quiet]", "Matches based on a group of domain suffixes for rapid testing of membership. Pass true as second parameter to prevent listing of all domains matched" },
   { "TagRule", true, "name [, value]", "matches if the tag named 'name' is present, with the given 'value' matching if any" },
   { "TCAction", true, "", "create answer to query with TC and RD bits set, to move to TCP" },

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -55,7 +55,7 @@ public:
   {
   }
 
-  SpoofAction(const std::string& raw): d_rawResponse(raw)
+  SpoofAction(const vector<std::string>& raws): d_rawResponses(raws)
   {
   }
 
@@ -67,7 +67,7 @@ public:
     if (!d_cname.empty()) {
       ret += d_cname.toString() + " ";
     }
-    else if (!d_rawResponse.empty()) {
+    if (d_rawResponses.size() > 0) {
       ret += "raw bytes ";
     }
     else {
@@ -83,7 +83,7 @@ private:
   static thread_local std::default_random_engine t_randomEngine;
   std::vector<ComboAddress> d_addrs;
   std::set<uint16_t> d_types;
-  std::string d_rawResponse;
+  std::vector<std::string> d_rawResponses;
   DNSName d_cname;
 };
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -735,7 +735,9 @@ static void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent,
   string result;
 
   if (raw) {
-    SpoofAction sa(spoofContent);
+    std::vector<std::string> raws;
+    stringtok(raws, spoofContent, ",");
+    SpoofAction sa(raws);
     sa(&dq, &result);
   }
   else {

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1373,15 +1373,19 @@ The following actions exist.
   * ``ttl``: int - The TTL of the record.
 
 .. function:: SpoofRawAction(rawAnswer [, options])
+              SpoofRawAction(rawAnswers [, options])
 
   .. versionadded:: 1.5.0
+
+  .. versionchanged:: 1.6.0
+    Up to 1.6.0, it was only possible to spoof one answer.
 
   Forge a response with the specified raw bytes as record data.
 
   .. code-block:: Lua
 
-    -- select queries for the 'raw.powerdns.com.' name and TXT type, and answer with a "aaa" "bbb" TXT record:
-    addAction(AndRule({QNameRule('raw.powerdns.com.'), QTypeRule(DNSQType.TXT)}), SpoofRawAction("\003aaa\004bbbb"))
+    -- select queries for the 'raw.powerdns.com.' name and TXT type, and answer with both a "aaa" "bbbb" and "ccc" TXT record:
+    addAction(AndRule({QNameRule('raw.powerdns.com.'), QTypeRule(DNSQType.TXT)}), SpoofRawAction({"\003aaa\004bbbb", "\003ccc"}))
     -- select queries for the 'raw-srv.powerdns.com.' name and SRV type, and answer with a '0 0 65535 srv.powerdns.com.' SRV record, setting the AA bit to 1 and the TTL to 3600s
     addAction(AndRule({QNameRule('raw-srv.powerdns.com.'), QTypeRule(DNSQType.SRV)}), SpoofRawAction("\000\000\000\000\255\255\003srv\008powerdns\003com\000", { aa=true, ttl=3600 }))
     -- select reverse queries for '127.0.0.1' and answer with 'localhost'
@@ -1390,6 +1394,7 @@ The following actions exist.
   :func:`DNSName:toDNSString` is convenient for converting names to wire format for passing to ``SpoofRawAction``.
 
   :param string rawAnswer: The raw record data
+  :param {string} rawAnswers: A table of raw record data to spoof
   :param table options: A table with key: value pairs with options.
 
   Options:


### PR DESCRIPTION
### Short description
This adds the option to specify multiple responses with spoofRawAction

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
