### PR TITLE
docker builds: stop using yum on EL8 derivatives

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.centos-8
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-8
@@ -5,7 +5,7 @@
 # Put only the bare minimum of common commands here, without dev tools
 FROM centos:8 as dist-base
 ARG BUILDER_CACHE_BUSTER=
-RUN touch /var/lib/rpm/* && yum install -y epel-release && \
+RUN touch /var/lib/rpm/* && dnf install -y epel-release && \
     dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled powertools
 

--- a/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8
+++ b/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8
@@ -5,7 +5,7 @@
 # Put only the bare minimum of common commands here, without dev tools
 FROM oraclelinux:8 as dist-base
 ARG BUILDER_CACHE_BUSTER=
-RUN touch /var/lib/rpm/* && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+RUN touch /var/lib/rpm/* && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled ol8_codeready_builder
 

--- a/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8
+++ b/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8
@@ -6,7 +6,7 @@
 FROM oraclelinux:8 as dist-base
 ARG BUILDER_CACHE_BUSTER=
 RUN touch /var/lib/rpm/* && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf install -y 'dnf-command(config-manager)' && \
+    dnf install -y 'dnf-command(config-manager)' yum && \
     dnf config-manager --set-enabled ol8_codeready_builder
 
 # Do the actual rpm build


### PR DESCRIPTION
### Short description
The oraclelinux:8 image lost yum this week. The centos:8 image also prefers dnf.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master