### PR TITLE
dnsdist: Add 'spoof' and 'spoofRaw' Lua bindings

### DIFF
--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -151,6 +151,30 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
     return result;
   });
 
+  luaCtx.registerFunction<void(DNSQuestion::*)(const std::vector<std::pair<int, ComboAddress>>& responses)>("spoof", [](DNSQuestion& dq, const std::vector<std::pair<int, ComboAddress>>& responses) {
+    std::vector<ComboAddress> cas;
+    cas.reserve(responses.size());
+    for (const auto& addr : responses) {
+      cas.push_back(addr.second);
+    }
+
+    std::string result;
+    SpoofAction sa(cas);
+    sa(&dq, &result);
+  });
+
+  luaCtx.registerFunction<void(DNSQuestion::*)(const std::vector<std::pair<int, std::string>>& responses)>("spoofRaw", [](DNSQuestion& dq, const std::vector<std::pair<int, std::string>>& responses) {
+    std::vector<std::string> data;
+    data.reserve(responses.size());
+    for (const auto& resp : responses) {
+      data.push_back(resp.second);
+    }
+
+    std::string result;
+    SpoofAction sa(data);
+    sa(&dq, &result);
+  });
+
   /* LuaWrapper doesn't support inheritance */
   luaCtx.registerMember<const ComboAddress (DNSResponse::*)>("localaddr", [](const DNSResponse& dq) -> const ComboAddress { return *dq.local; }, [](DNSResponse& dq, const ComboAddress newLocal) { (void) newLocal; });
   luaCtx.registerMember<const DNSName (DNSResponse::*)>("qname", [](const DNSResponse& dq) -> const DNSName { return *dq.qname; }, [](DNSResponse& dq, const DNSName newName) { (void) newName; });

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -241,6 +241,17 @@ This state can be modified from the various hooks.
     :param string tail: The new data
     :returns: true if the operation succeeded, false otherwise
 
+  .. method:: DNSQuestion:spoof(ip|ips|raw|raws)
+
+    .. versionadded:: 1.6.0
+
+    Forge a response with the specified record data as raw bytes. If you specify list of raws (it is assumed they match the query type), all will get spoofed in.
+
+    :param ComboAddress ip: The `ComboAddress` to be spoofed, e.g. `newCA("192.0.2.1")`.
+    :param table ComboAddresses ips: The `ComboAddress`es to be spoofed, e.g. `{ newCA("192.0.2.1"), newCA("192.0.2.2") }`.
+    :param string raw: The raw string to be spoofed, e.g. `"\\192\\000\\002\\001"`.
+    :param table raws: The raw strings to be spoofed, e.g. `{ "\\192\\000\\002\\001", "\\192\\000\\002\\002" }`.
+
 .. _DNSResponse:
 
 DNSResponse object

--- a/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
@@ -5,6 +5,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "dnsdist.hh"
+#include "dnsdist-lua.hh"
 #include "dnsdist-lua-ffi.hh"
 #include "dolog.hh"
 
@@ -81,6 +82,11 @@ bool DNSDistSNMPAgent::sendDNSTrap(const DNSQuestion& dq, const std::string& rea
 
 void setLuaNoSideEffect()
 {
+}
+
+DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, std::string* ruleresult) const
+{
+  return DNSAction::Action::None;
 }
 
 string g_outputBuffer;


### PR DESCRIPTION
This commits makes it possible to spoof multiple values from Lua:

```
function myfunc(dq)
  local ret = { newCA("192.0.2.1"), newCA("192.0.2.2") }
  dq:spoof(ret)
  return DNSAction.HeaderModify
end

addAction(AllRule(), LuaAction(myfunc))
```

<strike>Barely tested, need tests and documentation.</strike>
Now with documentation and tests courtesy of tjikkun, thanks a lot!

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
