### PR TITLE
rec: Introduce settings to never cache EDNS Client (v4/v6) Subnet carrying replies

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4612,6 +4612,8 @@ static int serviceMain(int argc, char*argv[])
   SyncRes::clearECSStats();
   SyncRes::s_ecsipv4cachelimit = ::arg().asNum("ecs-ipv4-cache-bits");
   SyncRes::s_ecsipv6cachelimit = ::arg().asNum("ecs-ipv6-cache-bits");
+  SyncRes::s_ecsipv4nevercache = ::arg().mustDo("ecs-ipv4-never-cache");
+  SyncRes::s_ecsipv6nevercache = ::arg().mustDo("ecs-ipv6-never-cache");
   SyncRes::s_ecscachelimitttl = ::arg().asNum("ecs-cache-limit-ttl");
 
   SyncRes::s_qnameminimization = ::arg().mustDo("qname-minimization");

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5397,6 +5397,8 @@ int main(int argc, char **argv)
     ::arg().set("ecs-ipv4-cache-bits", "Maximum number of bits of IPv4 mask to cache ECS response")="24";
     ::arg().set("ecs-ipv6-bits", "Number of bits of IPv6 address to pass for EDNS Client Subnet")="56";
     ::arg().set("ecs-ipv6-cache-bits", "Maximum number of bits of IPv6 mask to cache ECS response")="56";
+    ::arg().setSwitch("ecs-ipv4-never-cache", "If we should never cache IPv4 ECS responses")="no";
+    ::arg().setSwitch("ecs-ipv6-never-cache", "If we should never cache IPv6 ECS responses")="no";
     ::arg().set("ecs-minimum-ttl-override", "The minimum TTL for records in ECS-specific answers")="1";
     ::arg().set("ecs-cache-limit-ttl", "Minimum TTL to cache ECS response")="0";
     ::arg().set("edns-subnet-whitelist", "List of netmasks and domains that we should enable EDNS subnet for (deprecated)")="";

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -483,7 +483,7 @@ Number of bits of client IPv4 address to pass when sending EDNS Client Subnet ad
 -  Default: 24
 
 Maximum number of bits of client IPv4 address used by the authoritative server (as indicated by the EDNS Client Subnet scope in the answer) for an answer to be inserted into the query cache. This condition applies in conjunction with ``ecs-cache-limit-ttl``.
-That is, only if both the limits apply, the record will not be cached.
+That is, only if both the limits apply, the record will not be cached. This decision can be overridden by ``ecs-ipv4-never-cache`` and ``ecs-ipv6-never-cache``.
 
 .. _setting-ecs-ipv6-bits:
 
@@ -506,7 +506,31 @@ Number of bits of client IPv6 address to pass when sending EDNS Client Subnet ad
 -  Default: 56
 
 Maximum number of bits of client IPv6 address used by the authoritative server (as indicated by the EDNS Client Subnet scope in the answer) for an answer to be inserted into the query cache. This condition applies in conjunction with ``ecs-cache-limit-ttl``.
-That is, only if both the limits apply, the record will not be cached.
+That is, only if both the limits apply, the record will not be cached. This decision can be overridden by ``ecs-ipv4-never-cache`` and ``ecs-ipv6-never-cache``.
+
+.. _setting-ecs-ipv4-never-cache:
+
+``ecs-ipv4-never-cache``
+------------------------
+.. versionadded:: 4.5.0
+
+-  Boolean
+-  Default: no
+
+When set, never cache replies carrying EDNS IPv4 Client Subnet scope in the record cache.
+In this case the decision made by ```ecs-ipv4-cache-bits`` and ``ecs-cache-limit-ttl`` is no longer relevant.
+
+.. _setting-ecs-ipv6-never-cache:
+
+``ecs-ipv6-never-cache``
+------------------------
+.. versionadded:: 4.5.0
+
+-  Boolean
+-  Default: no
+
+When set, never cache replies carrying EDNS IPv6 Client Subnet scope in the record cache.
+In this case the decision made by ```ecs-ipv6-cache-bits`` and ``ecs-cache-limit-ttl`` is no longer relevant.
 
 .. _setting-ecs-minimum-ttl-override:
 
@@ -534,7 +558,7 @@ Can be set at runtime using ``rec_control set-ecs-minimum-ttl 3600``.
 -  Default: 0 (disabled)
 
 The minimum TTL for an ECS-specific answer to be inserted into the query cache. This condition applies in conjunction with ``ecs-ipv4-cache-bits`` or ``ecs-ipv6-cache-bits``.
-That is, only if both the limits apply, the record will not be cached.
+That is, only if both the limits apply, the record will not be cached. This decision can be overridden by ``ecs-ipv4-never-cache`` and ``ecs-ipv6-never-cache``.
 
 .. _setting-ecs-scope-zero-address:
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -29,8 +29,8 @@ trouble.
 New Settings
 ^^^^^^^^^^^^
 - The :ref:`setting-extended-resolution-errors` has been added, enabling adding EDNS Extended Errors to responses.
-- The :ref:`setting-refresh-on-ttl-perc`, enabling an automatic cache-refresh mechanism,
-- The :ref:`setting-ecs-ipv4-never-cache` and :ref:`setting-ecs-ipv6-never-cache` settings have been added, allowing an overrule of the existing decision whether to to cache EDNS responses carrying subnet information.
+- The :ref:`setting-refresh-on-ttl-perc`, enabling an automatic cache-refresh mechanism.
+- The :ref:`setting-ecs-ipv4-never-cache` and :ref:`setting-ecs-ipv6-never-cache` settings have been added, allowing an overrule of the existing decision whether to cache EDNS responses carrying subnet information.
 
 Deprecated and changed settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -20,16 +20,26 @@ Synonyms for various settings names containing ``master``, ``slave``,
 - For :ref:`setting-new-domain-whitelist` use  :ref:`setting-new-domain-ignore-list`.
 - For :ref:`setting-snmp-master-socket` use :ref:`setting-snmp-daemon-socket`.
 - For the LUA config function :func:`rpzMaster` use :func:`rpzPrimary`.
-  
+
 Currently, the older setting names are also accepted and used.
 The next release will start deprecating them.
 Users are advised to start using the new names to avoid future
 trouble.
 
+New Settings
+^^^^^^^^^^^^
+- The :ref:`setting-extended-resolution-errors` has been added, enabling adding EDNS Extended Errors to responses.
+- The :ref:`setting-refresh-on-ttl-perc`, enabling an automatic cache-refresh mechanism,
+- The :ref:`setting-ecs-ipv4-never-cache` and :ref:`setting-ecs-ipv6-never-cache` settings have been added, allowing an overrule of the existing decision whether to to cache EDNS responses carrying subnet information.
+
 Deprecated and changed settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - The :ref:`setting-minimum-ttl-override` and :ref:`setting-ecs-minimum-ttl-override` defaults have ben changed from 0 to 1.
 - The :ref:`setting-spoof-nearmiss-max` default has been changed from 20 to 1.
+
+Removed settings
+^^^^^^^^^^^^^^^^
+- The :ref:`setting-query-local-address6` has been removed. It already was deprecated.
 
 4.3.x to 4.4.0
 --------------

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -759,6 +759,9 @@ public:
   static uint8_t s_ecsipv6limit;
   static uint8_t s_ecsipv4cachelimit;
   static uint8_t s_ecsipv6cachelimit;
+  static bool s_ecsipv4nevercache;
+  static bool s_ecsipv6nevercache;
+
   static bool s_doIPv4;
   static bool s_doIPv6;
   static bool s_noEDNSPing;


### PR DESCRIPTION
While there, add a few entries to the upgrade guide.

The current ways of makeing that deccisoi does not allow for the case: cache some v6 replies, but never cache v6 or vice versa.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
