### PR TITLE
pdnsutil load-zone: reject zones with broken rrs

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1278,6 +1278,17 @@ static int loadZone(const DNSName& zone, const string& fname) {
       else
         haveSOA = true;
     }
+    try {
+      DNSRecordContent::mastermake(rr.qtype, QClass::IN, rr.content);
+    }
+    catch (const PDNSException &pe) {
+      cerr<<"Bad record content in record for "<<rr.qname<<"|"<<rr.qtype.getName()<<": "<<pe.reason<<endl;
+      return EXIT_FAILURE;
+    }
+    catch (const std::exception &e) {
+      cerr<<"Bad record content in record for "<<rr.qname<<"|"<<rr.qtype.getName()<<": "<<e.what()<<endl;
+      return EXIT_FAILURE;
+    }
     db->feedRecord(rr, DNSName());
   }
   db->commitTransaction();


### PR DESCRIPTION
### Short description
Fixes the underlying issue from #7203.

```
$ cat broken-rr.example.zone
$ORIGIN broken-rr.example.

@ IN SOA foo bar 1 2 3 4 5
@ IN MX 10 . bla ;; This is broken

$ pdnsutil --config-dir=. load-zone broken-rr.example. broken-rr.example.zone
Creating 'broken-rr.example'
Bad record content in record for broken-rr.example|MX: When parsing MX trailing data was not parsed: ' bla'
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)