### PR TITLE
Add wheel to pip

### DIFF
--- a/regression-tests.api/runtests
+++ b/regression-tests.api/runtests
@@ -5,6 +5,7 @@ if [ ! -d .venv ]; then
 fi
 . .venv/bin/activate
 python -V
+pip install -U pip wheel | cat
 pip install -r requirements.txt | cat
 
 if [ -z "${SDIG}" ]; then

--- a/regression-tests.auth-py/runtests
+++ b/regression-tests.auth-py/runtests
@@ -7,6 +7,7 @@ fi
 
 . .venv/bin/activate
 python -V
+pip install -U pip wheel | cat
 pip install -q -r requirements.txt | cat
 
 mkdir -p configs

--- a/regression-tests.dnsdist/runtests
+++ b/regression-tests.dnsdist/runtests
@@ -19,6 +19,7 @@ then
     export CPPFLAGS=-I/usr/local/opt/openssl/include
   fi
 fi
+pip install -U pip wheel | cat
 pip install -r requirements.txt | cat
 
 protoc -I=../pdns/ --python_out=. ../pdns/dnsmessage.proto

--- a/regression-tests.ixfrdist/runtests
+++ b/regression-tests.ixfrdist/runtests
@@ -6,6 +6,7 @@ if [ ! -d .venv ]; then
 fi
 . .venv/bin/activate
 python -V
+pip install -U pip wheel | cat
 pip install -r requirements.txt | cat
 
 if [ -z "${IXFRDISTBIN}" ]; then


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
CI on CircleCI triggers spurious complaints about `bdist_wheel`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master

### Sample errors
<details><summary>test-dnsdist-regression
</summary>

https://app.circleci.com/pipelines/github/PowerDNS/pdns/4091/workflows/eba4d9a3-ea2d-4f3f-bf14-a68e3047c992/jobs/74657
```
#!/bin/bash -eo pipefail
DNSDISTBIN="/opt/dnsdist/bin/dnsdist" \
./runtests
...
Collecting ply (from pysmi->pysnmp>=4.3.4->-r requirements.txt (line 6))
  Downloading https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl (49kB)
Building wheels for collected packages: future, pycurl, lmdb
  Running setup.py bdist_wheel for future: started
  Running setup.py bdist_wheel for future: finished with status 'error'
  Complete output from command /opt/project/regression-tests.dnsdist/.venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-sfr223oh/future/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-wccnue7u --python-tag cp37:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for future
  Running setup.py clean for future
  Running setup.py bdist_wheel for pycurl: started
  Running setup.py bdist_wheel for pycurl: finished with status 'error'
  Complete output from command /opt/project/regression-tests.dnsdist/.venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-sfr223oh/pycurl/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-mumlkmrc --python-tag cp37:
  Using curl-config (libcurl 7.64.0)
  Using SSL library: OpenSSL/LibreSSL/BoringSSL
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for pycurl
  Running setup.py clean for pycurl
  Running setup.py bdist_wheel for lmdb: started
  Running setup.py bdist_wheel for lmdb: finished with status 'error'
  Complete output from command /opt/project/regression-tests.dnsdist/.venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-sfr223oh/lmdb/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-4n8gyr8y --python-tag cp37:
  py-lmdb: Using bundled liblmdb with py-lmdb patches; override with LMDB_FORCE_SYSTEM=1 or LMDB_PURE=1.
  patching file lmdb.h
  patching file mdb.c
  py-lmdb: Using CPython extension; override with LMDB_FORCE_CFFI=1.
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for lmdb
```
</details>


<details><summary>test-ixfrdist-regression
</summary>

https://app.circleci.com/pipelines/github/PowerDNS/pdns/4091/workflows/eba4d9a3-ea2d-4f3f-bf14-a68e3047c992/jobs/74657

```
#!/bin/bash -eo pipefail
IXFRDISTBIN="/opt/pdns-auth/bin/ixfrdist" \
./runtests
...
Collecting idna<3,>=2.5 (from requests->-r requirements.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/a2/38/928ddce2273eaa564f6f50de919327bf3a00f091b5baba8dfa9460f3a8a8/idna-2.10-py2.py3-none-any.whl (58kB)
Building wheels for collected packages: xfrserver
  Running setup.py bdist_wheel for xfrserver: started
  Running setup.py bdist_wheel for xfrserver: finished with status 'error'
  Complete output from command /opt/project/regression-tests.ixfrdist/.venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-req-build-ugj7zyhy/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-03sq0ite --python-tag cp37:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for xfrserver
  Running setup.py clean for xfrserver
Failed to build xfrserver
Installing collected packages: dnspython, nose, urllib3, chardet, certifi, idna, requests, xfrserver
  Running setup.py install for xfrserver: started
    Running setup.py install for xfrserver: finished with status 'done'
```
</details>


<details><summary>test-recursor-api
</summary>

https://app.circleci.com/pipelines/github/PowerDNS/pdns/4091/workflows/eba4d9a3-ea2d-4f3f-bf14-a68e3047c992/jobs/74655

```
#!/bin/bash -eo pipefail
PDNSRECURSOR="/opt/pdns-recursor/sbin/pdns_recursor" \
./runtests recursor
...
Collecting chardet<3.1.0,>=3.0.2 (from requests==2.20.0->-r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
Building wheels for collected packages: nose
  Running setup.py bdist_wheel for nose: started
  Running setup.py bdist_wheel for nose: finished with status 'error'
  Complete output from command /opt/project/regression-tests.api/.venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-xna6octc/nose/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-c54j0nos --python-tag cp37:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for nose
  Running setup.py clean for nose
Failed to build nose
Installing collected packages: certifi, idna, urllib3, chardet, requests, nose, parameterized
```
</details>

I'm not sure how many of these files need to be changed (nor whether this will actually work).