### PR TITLE
dnsdist: Create TCP worker threads before acceptors ones

### DIFF
--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -857,6 +857,10 @@ public:
   }
   int getThread()
   {
+    if (d_numthreads == 0) {
+      throw std::runtime_error("No TCP worker thread yet");
+    }
+
     uint64_t pos = d_pos++;
     ++d_queued;
     return d_tcpclientthreads.at(pos % d_numthreads);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise we might crash when the first TCP query arrives because we are dividing by zero when trying to select a worker.
This PR also adds an explicit check to turn the crash into an exception if we ever manage to break that again.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
