### PR TITLE
rec: Count DNSSEC stats for some names in a different set of counters

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1847,10 +1847,6 @@ static void startDoResolve(void *p)
             }
           }
 
-          if(sr.doLog()) {
-            g_log<<Logger::Warning<<"Starting validation of answer to "<<dc->d_mdp.d_qname<<"|"<<QType(dc->d_mdp.d_qtype).getName()<<x_marker<<" for "<<dc->getRemote()<<endl;
-          }
-
           if(state == vState::Secure) {
             if(sr.doLog()) {
               g_log<<Logger::Warning<<"Answer to "<<dc->d_mdp.d_qname<<"|"<<QType(dc->d_mdp.d_qtype).getName()<<x_marker<<" for "<<dc->getRemote()<<" validates correctly"<<endl;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1198,6 +1198,14 @@ static void registerAllStats1()
     }
     return total;
   });
+  addGetStat("x-dnssec-result-bogus", []() {
+    static std::set<vState> const bogusStates = { vState::BogusNoValidDNSKEY, vState::BogusInvalidDenial, vState::BogusUnableToGetDSs, vState::BogusUnableToGetDNSKEYs, vState::BogusSelfSignedDS, vState::BogusNoRRSIG, vState::BogusNoValidRRSIG, vState::BogusMissingNegativeIndication, vState::BogusSignatureNotYetValid, vState::BogusSignatureExpired, vState::BogusUnsupportedDNSKEYAlgo, vState::BogusUnsupportedDSDigestType, vState::BogusNoZoneKeyBitSet, vState::BogusRevokedDNSKEY, vState::BogusInvalidDNSKEYProtocol };
+    uint64_t total = 0;
+    for (const auto& state : bogusStates) {
+      total += g_stats.xdnssecResults[state];
+    }
+    return total;
+  });
   addGetStat("dnssec-result-bogus-no-valid-dnskey", &g_stats.dnssecResults[vState::BogusNoValidDNSKEY]);
   addGetStat("dnssec-result-bogus-invalid-denial", &g_stats.dnssecResults[vState::BogusInvalidDenial]);
   addGetStat("dnssec-result-bogus-unable-to-get-dss", &g_stats.dnssecResults[vState::BogusUnableToGetDSs]);
@@ -1216,6 +1224,25 @@ static void registerAllStats1()
   addGetStat("dnssec-result-indeterminate", &g_stats.dnssecResults[vState::Indeterminate]);
   addGetStat("dnssec-result-nta", &g_stats.dnssecResults[vState::NTA]);
 
+  addGetStat("x-dnssec-result-bogus-no-valid-dnskey", &g_stats.xdnssecResults[vState::BogusNoValidDNSKEY]);
+  addGetStat("x-dnssec-result-bogus-invalid-denial", &g_stats.xdnssecResults[vState::BogusInvalidDenial]);
+  addGetStat("x-dnssec-result-bogus-unable-to-get-dss", &g_stats.xdnssecResults[vState::BogusUnableToGetDSs]);
+  addGetStat("x-dnssec-result-bogus-unable-to-get-dnskeys", &g_stats.xdnssecResults[vState::BogusUnableToGetDNSKEYs]);
+  addGetStat("x-dnssec-result-bogus-self-signed-ds", &g_stats.xdnssecResults[vState::BogusSelfSignedDS]);
+  addGetStat("x-dnssec-result-bogus-no-rrsig", &g_stats.xdnssecResults[vState::BogusNoRRSIG]);
+  addGetStat("x-dnssec-result-bogus-no-valid-rrsig", &g_stats.xdnssecResults[vState::BogusNoValidRRSIG]);
+  addGetStat("x-dnssec-result-bogus-missing-negative-indication", &g_stats.xdnssecResults[vState::BogusMissingNegativeIndication]);
+  addGetStat("x-dnssec-result-bogus-signature-not-yet-valid", &g_stats.xdnssecResults[vState::BogusSignatureNotYetValid]);
+  addGetStat("x-dnssec-result-bogus-signature-expired", &g_stats.xdnssecResults[vState::BogusSignatureExpired]);
+  addGetStat("x-dnssec-result-bogus-unsupported-dnskey-algo", &g_stats.xdnssecResults[vState::BogusUnsupportedDNSKEYAlgo]);
+  addGetStat("x-dnssec-result-bogus-unsupported-ds-digest-type", &g_stats.xdnssecResults[vState::BogusUnsupportedDSDigestType]);
+  addGetStat("x-dnssec-result-bogus-no-zone-key-bit-set", &g_stats.xdnssecResults[vState::BogusNoZoneKeyBitSet]);
+  addGetStat("x-dnssec-result-bogus-revoked-dnskey", &g_stats.xdnssecResults[vState::BogusRevokedDNSKEY]);
+  addGetStat("x-dnssec-result-bogus-invalid-dnskey-protocol", &g_stats.xdnssecResults[vState::BogusInvalidDNSKEYProtocol]);
+  addGetStat("x-dnssec-result-indeterminate", &g_stats.xdnssecResults[vState::Indeterminate]);
+  addGetStat("x-dnssec-result-nta", &g_stats.xdnssecResults[vState::NTA]);
+
+  
   addGetStat("policy-result-noaction", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NoAction]);
   addGetStat("policy-result-drop", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Drop]);
   addGetStat("policy-result-nxdomain", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NXDOMAIN]);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1191,21 +1191,14 @@ static void registerAllStats1()
   addGetStat("dnssec-result-insecure", &g_stats.dnssecResults[vState::Insecure]);
   addGetStat("dnssec-result-secure", &g_stats.dnssecResults[vState::Secure]);
   addGetStat("dnssec-result-bogus", []() {
-    static std::set<vState> const bogusStates = { vState::BogusNoValidDNSKEY, vState::BogusInvalidDenial, vState::BogusUnableToGetDSs, vState::BogusUnableToGetDNSKEYs, vState::BogusSelfSignedDS, vState::BogusNoRRSIG, vState::BogusNoValidRRSIG, vState::BogusMissingNegativeIndication, vState::BogusSignatureNotYetValid, vState::BogusSignatureExpired, vState::BogusUnsupportedDNSKEYAlgo, vState::BogusUnsupportedDSDigestType, vState::BogusNoZoneKeyBitSet, vState::BogusRevokedDNSKEY, vState::BogusInvalidDNSKEYProtocol };
+    std::set<vState> const bogusStates = { vState::BogusNoValidDNSKEY, vState::BogusInvalidDenial, vState::BogusUnableToGetDSs, vState::BogusUnableToGetDNSKEYs, vState::BogusSelfSignedDS, vState::BogusNoRRSIG, vState::BogusNoValidRRSIG, vState::BogusMissingNegativeIndication, vState::BogusSignatureNotYetValid, vState::BogusSignatureExpired, vState::BogusUnsupportedDNSKEYAlgo, vState::BogusUnsupportedDSDigestType, vState::BogusNoZoneKeyBitSet, vState::BogusRevokedDNSKEY, vState::BogusInvalidDNSKEYProtocol };
     uint64_t total = 0;
     for (const auto& state : bogusStates) {
       total += g_stats.dnssecResults[state];
     }
     return total;
   });
-  addGetStat("x-dnssec-result-bogus", []() {
-    static std::set<vState> const bogusStates = { vState::BogusNoValidDNSKEY, vState::BogusInvalidDenial, vState::BogusUnableToGetDSs, vState::BogusUnableToGetDNSKEYs, vState::BogusSelfSignedDS, vState::BogusNoRRSIG, vState::BogusNoValidRRSIG, vState::BogusMissingNegativeIndication, vState::BogusSignatureNotYetValid, vState::BogusSignatureExpired, vState::BogusUnsupportedDNSKEYAlgo, vState::BogusUnsupportedDSDigestType, vState::BogusNoZoneKeyBitSet, vState::BogusRevokedDNSKEY, vState::BogusInvalidDNSKEYProtocol };
-    uint64_t total = 0;
-    for (const auto& state : bogusStates) {
-      total += g_stats.xdnssecResults[state];
-    }
-    return total;
-  });
+
   addGetStat("dnssec-result-bogus-no-valid-dnskey", &g_stats.dnssecResults[vState::BogusNoValidDNSKEY]);
   addGetStat("dnssec-result-bogus-invalid-denial", &g_stats.dnssecResults[vState::BogusInvalidDenial]);
   addGetStat("dnssec-result-bogus-unable-to-get-dss", &g_stats.dnssecResults[vState::BogusUnableToGetDSs]);
@@ -1224,25 +1217,36 @@ static void registerAllStats1()
   addGetStat("dnssec-result-indeterminate", &g_stats.dnssecResults[vState::Indeterminate]);
   addGetStat("dnssec-result-nta", &g_stats.dnssecResults[vState::NTA]);
 
-  addGetStat("x-dnssec-result-bogus-no-valid-dnskey", &g_stats.xdnssecResults[vState::BogusNoValidDNSKEY]);
-  addGetStat("x-dnssec-result-bogus-invalid-denial", &g_stats.xdnssecResults[vState::BogusInvalidDenial]);
-  addGetStat("x-dnssec-result-bogus-unable-to-get-dss", &g_stats.xdnssecResults[vState::BogusUnableToGetDSs]);
-  addGetStat("x-dnssec-result-bogus-unable-to-get-dnskeys", &g_stats.xdnssecResults[vState::BogusUnableToGetDNSKEYs]);
-  addGetStat("x-dnssec-result-bogus-self-signed-ds", &g_stats.xdnssecResults[vState::BogusSelfSignedDS]);
-  addGetStat("x-dnssec-result-bogus-no-rrsig", &g_stats.xdnssecResults[vState::BogusNoRRSIG]);
-  addGetStat("x-dnssec-result-bogus-no-valid-rrsig", &g_stats.xdnssecResults[vState::BogusNoValidRRSIG]);
-  addGetStat("x-dnssec-result-bogus-missing-negative-indication", &g_stats.xdnssecResults[vState::BogusMissingNegativeIndication]);
-  addGetStat("x-dnssec-result-bogus-signature-not-yet-valid", &g_stats.xdnssecResults[vState::BogusSignatureNotYetValid]);
-  addGetStat("x-dnssec-result-bogus-signature-expired", &g_stats.xdnssecResults[vState::BogusSignatureExpired]);
-  addGetStat("x-dnssec-result-bogus-unsupported-dnskey-algo", &g_stats.xdnssecResults[vState::BogusUnsupportedDNSKEYAlgo]);
-  addGetStat("x-dnssec-result-bogus-unsupported-ds-digest-type", &g_stats.xdnssecResults[vState::BogusUnsupportedDSDigestType]);
-  addGetStat("x-dnssec-result-bogus-no-zone-key-bit-set", &g_stats.xdnssecResults[vState::BogusNoZoneKeyBitSet]);
-  addGetStat("x-dnssec-result-bogus-revoked-dnskey", &g_stats.xdnssecResults[vState::BogusRevokedDNSKEY]);
-  addGetStat("x-dnssec-result-bogus-invalid-dnskey-protocol", &g_stats.xdnssecResults[vState::BogusInvalidDNSKEYProtocol]);
-  addGetStat("x-dnssec-result-indeterminate", &g_stats.xdnssecResults[vState::Indeterminate]);
-  addGetStat("x-dnssec-result-nta", &g_stats.xdnssecResults[vState::NTA]);
+  if (::arg()["x-dnssec-names"].length() > 0) {
+    addGetStat("x-dnssec-result-bogus", []() {
+      std::set<vState> const bogusStates = { vState::BogusNoValidDNSKEY, vState::BogusInvalidDenial, vState::BogusUnableToGetDSs, vState::BogusUnableToGetDNSKEYs, vState::BogusSelfSignedDS, vState::BogusNoRRSIG, vState::BogusNoValidRRSIG, vState::BogusMissingNegativeIndication, vState::BogusSignatureNotYetValid, vState::BogusSignatureExpired, vState::BogusUnsupportedDNSKEYAlgo, vState::BogusUnsupportedDSDigestType, vState::BogusNoZoneKeyBitSet, vState::BogusRevokedDNSKEY, vState::BogusInvalidDNSKEYProtocol };
+      uint64_t total = 0;
+      for (const auto& state : bogusStates) {
+        total += g_stats.xdnssecResults[state];
+      }
+      return total;
+    });
+    addGetStat("x-dnssec-result-bogus-no-valid-dnskey", &g_stats.xdnssecResults[vState::BogusNoValidDNSKEY]);
+    addGetStat("x-dnssec-result-bogus-invalid-denial", &g_stats.xdnssecResults[vState::BogusInvalidDenial]);
+    addGetStat("x-dnssec-result-bogus-unable-to-get-dss", &g_stats.xdnssecResults[vState::BogusUnableToGetDSs]);
+    addGetStat("x-dnssec-result-bogus-unable-to-get-dnskeys", &g_stats.xdnssecResults[vState::BogusUnableToGetDNSKEYs]);
+    addGetStat("x-dnssec-result-bogus-self-signed-ds", &g_stats.xdnssecResults[vState::BogusSelfSignedDS]);
+    addGetStat("x-dnssec-result-bogus-no-rrsig", &g_stats.xdnssecResults[vState::BogusNoRRSIG]);
+    addGetStat("x-dnssec-result-bogus-no-valid-rrsig", &g_stats.xdnssecResults[vState::BogusNoValidRRSIG]);
+    addGetStat("x-dnssec-result-bogus-missing-negative-indication", &g_stats.xdnssecResults[vState::BogusMissingNegativeIndication]);
+    addGetStat("x-dnssec-result-bogus-signature-not-yet-valid", &g_stats.xdnssecResults[vState::BogusSignatureNotYetValid]);
+    addGetStat("x-dnssec-result-bogus-signature-expired", &g_stats.xdnssecResults[vState::BogusSignatureExpired]);
+    addGetStat("x-dnssec-result-bogus-unsupported-dnskey-algo", &g_stats.xdnssecResults[vState::BogusUnsupportedDNSKEYAlgo]);
+    addGetStat("x-dnssec-result-bogus-unsupported-ds-digest-type", &g_stats.xdnssecResults[vState::BogusUnsupportedDSDigestType]);
+    addGetStat("x-dnssec-result-bogus-no-zone-key-bit-set", &g_stats.xdnssecResults[vState::BogusNoZoneKeyBitSet]);
+    addGetStat("x-dnssec-result-bogus-revoked-dnskey", &g_stats.xdnssecResults[vState::BogusRevokedDNSKEY]);
+    addGetStat("x-dnssec-result-bogus-invalid-dnskey-protocol", &g_stats.xdnssecResults[vState::BogusInvalidDNSKEYProtocol]);
+    addGetStat("x-dnssec-result-indeterminate", &g_stats.xdnssecResults[vState::Indeterminate]);
+    addGetStat("x-dnssec-result-nta", &g_stats.xdnssecResults[vState::NTA]);
+    addGetStat("x-dnssec-result-insecure", &g_stats.xdnssecResults[vState::Insecure]);
+    addGetStat("x-dnssec-result-secure", &g_stats.xdnssecResults[vState::Secure]);
+  }
 
-  
   addGetStat("policy-result-noaction", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NoAction]);
   addGetStat("policy-result-drop", &g_stats.policyResults[DNSFilterEngine::PolicyKind::Drop]);
   addGetStat("policy-result-nxdomain", &g_stats.policyResults[DNSFilterEngine::PolicyKind::NXDOMAIN]);

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -224,9 +224,14 @@ dnssec-queries
 ^^^^^^^^^^^^^^
 number of queries received with the DO bit set
 
+.. _stat-dnssec-result-bogus:
+
 dnssec-result-bogus
 ^^^^^^^^^^^^^^^^^^^
 number of DNSSEC validations that had the   Bogus state. Since 4.4.2 detailed counters are available, see below.
+Since 4.5.0, if :ref:`setting-x-dnssec-names` is set, a separate set of ``x-dnssec-result-...`` metrics become available, counting
+the DNSSEC validation results for names suffix-matching a name in ``x-dnssec-names``.
+
 
 dnssec-result-bogus-no-valid-dnskey
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -727,3 +732,9 @@ x-ourtime-slow
 
 Counts responses where more than 32 milliseconds was spent within the Recursor.
 See :ref:`stat-x-our-latency` for further details.
+
+x-dnssec-result-...
+^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.5.0
+
+See :ref:`stat-dnssec-result-bogus`.

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -2086,3 +2086,18 @@ should be done on the proxy.
 
 This option sets the resource record code to use for XPF records, as long as an official code has not been assigned to it.
 0 means that XPF is disabled.
+
+.. _setting-x-dnssec-names:
+
+``x-dnssec-names``
+------------------
+.. versionadded:: 4.5.0
+
+-  Comma separated list of domain-names
+-  Default: (empty)
+
+List of names whose DNSSEC validation metrics will be counted in a separate set of metrics that start
+with ``x-dnssec-result-``.
+The names are suffix-matched.
+This can be used to not count known failing (test) name validations in the ordinary DNSSEC metrics.
+

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -9,6 +9,7 @@
 
 RecursorStats g_stats;
 GlobalStateHolder<LuaConfigItems> g_luaconfs;
+GlobalStateHolder<SuffixMatchNode> g_xdnssec;
 GlobalStateHolder<SuffixMatchNode> g_dontThrottleNames;
 GlobalStateHolder<NetmaskGroup> g_dontThrottleNetmasks;
 std::unique_ptr<MemRecursorCache> g_recCache{nullptr};

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -167,7 +167,12 @@ int SyncRes::beginResolve(const DNSName &qname, const QType qtype, uint16_t qcla
     if (d_queryValidationState != vState::Indeterminate) {
       g_stats.dnssecValidations++;
     }
-    increaseDNSSECStateCounter(d_queryValidationState);
+    auto xdnssec = g_xdnssec.getLocal();
+    if (xdnssec->check(qname)) {
+      increaseXDNSSECStateCounter(d_queryValidationState);
+    } else {
+      increaseDNSSECStateCounter(d_queryValidationState);
+    }
   }
 
   return res;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -61,6 +61,7 @@
 #include "fstrm_logger.hh"
 #endif /* HAVE_FSTRM */
 
+extern GlobalStateHolder<SuffixMatchNode> g_xdnssec;
 extern GlobalStateHolder<SuffixMatchNode> g_dontThrottleNames;
 extern GlobalStateHolder<NetmaskGroup> g_dontThrottleNetmasks;
 
@@ -1017,6 +1018,7 @@ struct RecursorStats
   unsigned int maxMThreadStackUsage;
   std::atomic<uint64_t> dnssecValidations; // should be the sum of all dnssecResult* stats
   std::map<vState, std::atomic<uint64_t> > dnssecResults;
+  std::map<vState, std::atomic<uint64_t> > xdnssecResults;
   std::map<DNSFilterEngine::PolicyKind, std::atomic<uint64_t> > policyResults;
   std::atomic<uint64_t> rebalancedQueries{0};
   std::atomic<uint64_t> proxyProtocolInvalidCount{0};

--- a/pdns/validate-recursor.cc
+++ b/pdns/validate-recursor.cc
@@ -29,6 +29,12 @@ vState increaseDNSSECStateCounter(const vState& state)
   return state;
 }
 
+vState increaseXDNSSECStateCounter(const vState& state)
+{
+  g_stats.xdnssecResults[state]++;
+  return state;
+}
+
 // Returns true if dsAnchors were modified
 bool updateTrustAnchorsFromFile(const std::string &fname, map<DNSName, dsmap_t> &dsAnchors) {
   map<DNSName,dsmap_t> newDSAnchors;

--- a/pdns/validate-recursor.hh
+++ b/pdns/validate-recursor.hh
@@ -38,4 +38,5 @@ extern bool g_dnssecLogBogus;
 bool checkDNSSECDisabled();
 bool warnIfDNSSECDisabled(const string& msg);
 vState increaseDNSSECStateCounter(const vState& state);
+vState increaseXDNSSECStateCounter(const vState& state);
 bool updateTrustAnchorsFromFile(const std::string &fname, map<DNSName, dsmap_t> &dsAnchors);

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -618,6 +618,21 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::metrics =
   {"dnssec-result-secure",
    MetricDefinition(PrometheusMetricType::counter,
                     "Number of DNSSEC validations that had the Secure state")},
+  {"x-dnssec-result-bogus",
+   MetricDefinition(PrometheusMetricType::counter,
+                    "Number of DNSSEC validations that had the Bogus state")},
+  {"x-dnssec-result-indeterminate",
+   MetricDefinition(PrometheusMetricType::counter,
+                    "Number of DNSSEC validations that had the Indeterminate state")},
+  {"x-dnssec-result-insecure",
+   MetricDefinition(PrometheusMetricType::counter,
+                    "Number of DNSSEC validations that had the Insecure state")},
+  {"x-dnssec-result-nta",
+   MetricDefinition(PrometheusMetricType::counter,
+                    "Number of DNSSEC validations that had the (negative trust anchor) state")},
+  {"x-dnssec-result-secure",
+   MetricDefinition(PrometheusMetricType::counter,
+                    "Number of DNSSEC validations that had the Secure state")},
 
   {"dnssec-validations",
    MetricDefinition(PrometheusMetricType::counter,
@@ -930,6 +945,64 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::metrics =
   { "dnssec-result-bogus-unsupported-ds-digest-type",
     MetricDefinition(PrometheusMetricType::counter,
                      "number of DNSSEC validations that had the Bogus state because a DS RRset contained only unsupported digest types")},
+  { "x-dnssec-result-bogus-invalid-denial",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because a valid denial of existence proof could not be found")},
+
+  { "x-dnssec-result-bogus-invalid-dnskey-protocol",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because all DNSKEYs had invalid protocols")},
+
+  { "x-dnssec-result-bogus-missing-negative-indication",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because a NODATA or NXDOMAIN answer lacked the required SOA and/or NSEC(3) records")},
+
+  { "x-dnssec-result-bogus-no-rrsig",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because required RRSIG records were not present in an answer")},
+
+  { "x-dnssec-result-bogus-no-valid-dnskey",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because a valid DNSKEY could not be found")},
+
+  { "x-dnssec-result-bogus-no-valid-rrsig",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because only invalid RRSIG records were present in an answer")},
+
+  { "x-dnssec-result-bogus-no-zone-key-bit-set",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because no DNSKEY with the Zone Key bit set was found")},
+
+  { "x-dnssec-result-bogus-revoked-dnskey",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because all DNSKEYs were revoked")},
+
+  { "x-dnssec-result-bogus-self-signed-ds",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because a DS record was signed by itself")},
+
+  { "x-dnssec-result-bogus-signature-expired",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because the signature expired time in the RRSIG was in the past")},
+
+  { "x-dnssec-result-bogus-signature-not-yet-valid",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because the signature inception time in the RRSIG was not yet valid")},
+
+  { "x-dnssec-result-bogus-unable-to-get-dnskeys",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because a valid DNSKEY could not be retrieved")},
+
+  { "x-dnssec-result-bogus-unable-to-get-dss",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because a valid DS could not be retrieved")},
+  { "x-dnssec-result-bogus-unsupported-dnskey-algo",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because a DNSKEY RRset contained only unsupported DNSSEC algorithms")},
+
+  { "x-dnssec-result-bogus-unsupported-ds-digest-type",
+    MetricDefinition(PrometheusMetricType::counter,
+                     "number of DNSSEC validations that had the Bogus state because a DS RRset contained only unsupported digest types")},
 
   { "proxy-protocol-invalid",
     MetricDefinition(PrometheusMetricType::counter,
@@ -950,7 +1023,7 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::metrics =
   { "taskqueue-pushed",
     MetricDefinition(PrometheusMetricType::counter,
                      "number of tasks pushed to the taskqueues")},
- 
+
   { "taskqueue-size",
     MetricDefinition(PrometheusMetricType::gauge,
                      "number of tasks currenlty in the taskqueue")},


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This implements the feature as requested in #10058.

Idea is that you can set `x-dnssec-names` to a suffixmatch list. DNSSEC counting actions will then be done for on `x-dnssec-result-bogus-...` counter instead of the regular one.

Missing: 
- [ ] Adding suffixes using `rec_control`.
- [x] Marking of log lines as requested in the feature request.
- [x] Docs (settings + metrics)

This PR is mainly to gauge if this approach is the way forward. I'm also open for a better name than `x-dnssec...`

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
