### PR TITLE
LDAP backend docs: Added missing spaces after OpenLDAP index directives

### DIFF
--- a/docs/backends/ldap.rst
+++ b/docs/backends/ldap.rst
@@ -551,7 +551,7 @@ performance improvement:
 
 ::
 
-    indexassociatedDomain pres,eq,sub
+    index associatedDomain pres,eq,sub
 
 Furthermore, if ``ldap-method=strict`` is set, it uses the aRecord and
 aAAARecord attribute for reverse mapping of IP addresses to names. To
@@ -560,8 +560,8 @@ performance of the LDAP server:
 
 ::
 
-    indexaAAARecord pres,eq
-    indexaRecord pres,eq
+    index aAAARecord pres,eq
+    index aRecord pres,eq
 
 All other attributes than associatedDomain, aRecord or aAAARecord are
 only read if the object matches the specified criteria. Thus,


### PR DESCRIPTION
### Short description
Examples for OpenLDAP index directives needs a space after keyword "index".

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
