### PR TITLE
Check if transaction is active in LMDB

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -364,6 +364,10 @@ bool LMDBBackend::startTransaction(const DNSName &domain, int domain_id)
 bool LMDBBackend::commitTransaction()
 {
   // cout<<"Commit transaction" <<endl;
+  if (!d_rwtxn) {
+    throw DBException("Attempt to commit a transaction while there isn't one open");
+  }
+
   d_rwtxn->txn->commit();
   d_rwtxn.reset();
   return true;
@@ -372,6 +376,10 @@ bool LMDBBackend::commitTransaction()
 bool LMDBBackend::abortTransaction()
 {
   // cout<<"Abort transaction"<<endl;
+  if (!d_rwtxn) {
+      throw DBException("Attempt to abort a transaction while there isn't one open");
+  }
+
   d_rwtxn->txn->abort();
   d_rwtxn.reset();
 


### PR DESCRIPTION
Check in both commitTransaction and abortTransaction of the lmdbbackend whether a transaction is actually active

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
