### PR TITLE
check-spelling: Try checking out merge/head appropriately

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -17,9 +17,16 @@ jobs:
     name: Spell checking
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2.0.0
+    - name: checkout-merge
+      if: "contains(github.event_name, 'pull_request')"
+      uses: actions/checkout@v2.0.0
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: refs/pull/${{github.event.pull_request.number}}/merge
+        fetch-depth: 5
+    - name: checkout
+      if: "!contains(github.event_name, 'pull_request')"
+      uses: actions/checkout@v2.0.0
+      with:
         fetch-depth: 5
     - uses: check-spelling/check-spelling@0.0.17-alpha
       with:


### PR DESCRIPTION
### Short description
#10066 switched from checking a potential merge to checking the PR head because I couldn't find a good way to check the merge. This code switches PRs to checking the merge.
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

#### Behavior change:
If someone had a PR from before the 0.0.17-alpha upgrade, and made a PR before this merges, they'd get complaints about items that were fixed on master between their branch point and master.

With this change, those errors that have already been resolved in master will be treated as resolved.

Note: I have no idea what happens if there are merge conflicts. I half expect GitHub to scream in some fun way. But, technically this wasn't a new problem, it's close to before the upgrade.

You can experiment with the repository here: https://github.com/check-spelling/pdns/pull/1#issuecomment-780865943  -- note that at some point long after this PR is merged, I will probably delete this repository, so this isn't a long term thing, if you're reading this in the future, you'll just see how it worked after this merges :-).