### PR TITLE
Rec: refactor latency and histogram calculations

### DIFF
--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <vector>
+#include <sstream>
+
+namespace pdns {
+
+// By convention, we are using microsecond units
+struct Bucket
+{
+  std::string d_name;
+  uint64_t d_boundary;
+  uint64_t d_count;
+};
+
+inline bool operator<(uint64_t b, const Bucket& bu)
+{
+  // we are using less-or-equal
+  return b <= bu.d_boundary;
+}
+
+struct AtomicBucket
+{
+  // We need the constrcutors in this case, since atomics have a disabled
+  // copy constructor.
+  AtomicBucket() {}
+  AtomicBucket(std::string name, uint64_t boundary, uint64_t val) : d_name(std::move(name)), d_boundary(boundary), d_count(val) {}
+  AtomicBucket(const AtomicBucket& rhs) : d_name(rhs.d_name), d_boundary(rhs.d_boundary), d_count(rhs.d_count.load()) {}
+
+  std::string d_name;
+  uint64_t d_boundary;
+  std::atomic<uint64_t> d_count;
+};
+
+inline bool operator<(uint64_t b, const AtomicBucket& bu)
+{
+  // we are using less-or-equal
+  return b <= bu.d_boundary;
+}
+
+template<class B>
+class BaseHistogram
+{
+public:
+  BaseHistogram(const std::string& prefix, const std::vector<uint64_t>& boundaries)
+  {
+    if (!std::is_sorted(boundaries.cbegin(), boundaries.cend())) {
+      throw std::invalid_argument("boundary array must be sorted");
+    }
+    if (boundaries.size() == 0) {
+      throw std::invalid_argument("boundary array must not be empty");
+    }
+    if (boundaries[0] == 0) {
+      throw std::invalid_argument("boundary array's first element should not be zero");
+    }
+    d_buckets.reserve(boundaries.size() + 1);
+    for (auto b: boundaries) {
+      // to_string gives too many .00000's
+      std::ostringstream str;
+      str << prefix << "le-" << b;
+      d_buckets.push_back(B{str.str(), b, 0});
+    }
+    // everything above last boundary, plus NaN, Inf etc
+    d_buckets.push_back(B{prefix + "le-max", std::numeric_limits<uint64_t>::max(), 0});
+  }
+
+  const std::vector<B>& getRawData() const
+  {
+    return d_buckets;
+  }
+
+  uint64_t getCount(size_t i) const
+  {
+    return d_buckets[i].d_count;
+  }
+
+  std::vector<B> getCumulativeBuckets() const
+  {
+    std::vector<B> ret;
+    ret.reserve(d_buckets.size());
+    uint64_t c{0};
+    for (const auto& b : d_buckets) {
+      c += b.d_count;
+      ret.push_back(B{b.d_name, b.d_boundary, c});
+    }
+    return ret;
+  }
+
+  std::vector<uint64_t> getCumulativeCounts() const
+  {
+    std::vector<uint64_t> ret;
+    ret.reserve(d_buckets.size());
+    uint64_t c = 0;
+    for (const auto& b : d_buckets) {
+      c += b.d_count;
+      ret.push_back(c);
+    }
+    return ret;
+  }
+
+  inline void operator()(uint64_t d)
+  {
+    auto index = std::upper_bound(d_buckets.begin(), d_buckets.end(), d);
+    // out index is always valid
+    ++index->d_count;
+  }
+
+private:
+  std::vector<B> d_buckets;
+};
+
+template<class T>
+using Histogram = BaseHistogram<Bucket>;
+
+template<class T>
+using AtomicHistogram = BaseHistogram<AtomicBucket>;
+
+} // namespace pdns

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -312,6 +312,10 @@ inline float makeFloat(const struct timeval& tv)
 {
   return tv.tv_sec + tv.tv_usec/1000000.0f;
 }
+inline double makeDouble(const struct timeval& tv)
+{
+  return tv.tv_sec + tv.tv_usec/1000000.0;
+}
 
 inline bool operator<(const struct timeval& lhs, const struct timeval& rhs)
 {

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -312,9 +312,9 @@ inline float makeFloat(const struct timeval& tv)
 {
   return tv.tv_sec + tv.tv_usec/1000000.0f;
 }
-inline double makeDouble(const struct timeval& tv)
+inline uint64_t uSec(const struct timeval& tv)
 {
-  return tv.tv_sec + tv.tv_usec/1000000.0;
+  return tv.tv_sec * 1000000 + tv.tv_usec;
 }
 
 inline bool operator<(const struct timeval& lhs, const struct timeval& rhs)

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2143,7 +2143,7 @@ static void startDoResolve(void *p)
     }
 
     // Originally this code used a mix of floats, doubles, uint64_t with different units.
-    // Now it always uses an integral number of microseconds, expect for avarages, which are using doubles
+    // Now it always uses an integral number of microseconds, except for averages, which use doubles
     uint64_t spentUsec = uSec(sr.getNow() - dc->d_now);
     if (!g_quiet) {
       g_log<<Logger::Error<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] answer to "<<(dc->d_mdp.d_header.rd?"":"non-rd ")<<"question '"<<dc->d_mdp.d_qname<<"|"<<DNSRecordContent::NumberToType(dc->d_mdp.d_qtype);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2142,7 +2142,7 @@ static void startDoResolve(void *p)
       finishTCPReply(dc, hadError, true);
     }
 
-    float spent=makeFloat(sr.getNow()-dc->d_now);
+    double spent = makeDouble(sr.getNow() - dc->d_now);
     if (!g_quiet) {
       g_log<<Logger::Error<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] answer to "<<(dc->d_mdp.d_header.rd?"":"non-rd ")<<"question '"<<dc->d_mdp.d_qname<<"|"<<DNSRecordContent::NumberToType(dc->d_mdp.d_qtype);
       g_log<<"': "<<ntohs(pw.getHeader()->ancount)<<" answers, "<<ntohs(pw.getHeader()->arcount)<<" additional, took "<<sr.d_outqueries<<" packets, "<<
@@ -2162,9 +2162,9 @@ static void startDoResolve(void *p)
       g_recCache->cacheHits++;
     }
 
-    if(spent < 0.001)
+    if (spent < 0.001)
       g_stats.answers0_1++;
-    else if(spent < 0.010)
+    else if(spent < 0.01)
       g_stats.answers1_10++;
     else if(spent < 0.1)
       g_stats.answers10_100++;
@@ -2173,12 +2173,12 @@ static void startDoResolve(void *p)
     else
       g_stats.answersSlow++;
 
-    uint64_t newLat=(uint64_t)(spent*static_cast<uint64_t>(1000000));
-    newLat = min(newLat,(uint64_t)(((uint64_t) g_networkTimeoutMsec)*1000)); // outliers of several minutes exist..
-    g_stats.avgLatencyUsec=(1-1.0/g_latencyStatSize)*g_stats.avgLatencyUsec + (float)newLat/g_latencyStatSize;
+    double newLat = spent * 1000000.0;
+    newLat = min(newLat, g_networkTimeoutMsec * 1000.0); // outliers of several minutes exist..
+    g_stats.avgLatencyUsec = (1.0 - 1.0 / g_latencyStatSize) * g_stats.avgLatencyUsec + newLat / g_latencyStatSize;
     // no worries, we do this for packet cache hits elsewhere
 
-    auto ourtime = 1000.0*spent-sr.d_totUsec/1000.0; // in msec
+    double ourtime = 1000.0 * spent - sr.d_totUsec / 1000.0; // in msec
     if(ourtime < 1)
       g_stats.ourtime0_1++;
     else if(ourtime < 2)
@@ -2192,12 +2192,12 @@ static void startDoResolve(void *p)
     else if(ourtime < 32)
       g_stats.ourtime16_32++;
     else {
-      //      cerr<<"SLOW: "<<ourtime<<"ms -> "<<dc->d_mdp.d_qname<<"|"<<DNSRecordContent::NumberToType(dc->d_mdp.d_qtype)<<endl;
       g_stats.ourtimeSlow++;
     }
-    if(ourtime >= 0.0) {
-      newLat=ourtime*1000; // usec
-      g_stats.avgLatencyOursUsec=(1-1.0/g_latencyStatSize)*g_stats.avgLatencyOursUsec + (float)newLat/g_latencyStatSize;
+
+    if (ourtime >= 0) {
+      newLat = ourtime * 1000.0; // usec
+      g_stats.avgLatencyOursUsec = (1.0 - 1.0 / g_latencyStatSize) * g_stats.avgLatencyOursUsec + newLat / g_latencyStatSize;
     }
 
 #ifdef NOD_ENABLED

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2142,11 +2142,13 @@ static void startDoResolve(void *p)
       finishTCPReply(dc, hadError, true);
     }
 
-    double spent = makeDouble(sr.getNow() - dc->d_now);
+    // Originally this code used a mix of floats, doubles, uint64_t with different units.
+    // Now it always uses an integral number of microseconds, expect for avarages, which are using doubles
+    uint64_t spentUsec = uSec(sr.getNow() - dc->d_now);
     if (!g_quiet) {
       g_log<<Logger::Error<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] answer to "<<(dc->d_mdp.d_header.rd?"":"non-rd ")<<"question '"<<dc->d_mdp.d_qname<<"|"<<DNSRecordContent::NumberToType(dc->d_mdp.d_qtype);
       g_log<<"': "<<ntohs(pw.getHeader()->ancount)<<" answers, "<<ntohs(pw.getHeader()->arcount)<<" additional, took "<<sr.d_outqueries<<" packets, "<<
-	sr.d_totUsec/1000.0<<" netw ms, "<< spent*1000.0<<" tot ms, "<<
+	sr.d_totUsec/1000.0<<" netw ms, "<< spentUsec/1000.0<<" tot ms, "<<
 	sr.d_throttledqueries<<" throttled, "<<sr.d_timeouts<<" timeouts, "<<sr.d_tcpoutqueries<<" tcp connections, rcode="<< res;
 
       if(!shouldNotValidate && sr.isDNSSECValidationRequested()) {
@@ -2162,41 +2164,17 @@ static void startDoResolve(void *p)
       g_recCache->cacheHits++;
     }
 
-    if (spent < 0.001)
-      g_stats.answers0_1++;
-    else if(spent < 0.01)
-      g_stats.answers1_10++;
-    else if(spent < 0.1)
-      g_stats.answers10_100++;
-    else if(spent < 1.0)
-      g_stats.answers100_1000++;
-    else
-      g_stats.answersSlow++;
+    g_stats.answers(spentUsec);
 
-    double newLat = spent * 1000000.0;
+    double newLat = spentUsec;
     newLat = min(newLat, g_networkTimeoutMsec * 1000.0); // outliers of several minutes exist..
     g_stats.avgLatencyUsec = (1.0 - 1.0 / g_latencyStatSize) * g_stats.avgLatencyUsec + newLat / g_latencyStatSize;
     // no worries, we do this for packet cache hits elsewhere
 
-    double ourtime = 1000.0 * spent - sr.d_totUsec / 1000.0; // in msec
-    if(ourtime < 1)
-      g_stats.ourtime0_1++;
-    else if(ourtime < 2)
-      g_stats.ourtime1_2++;
-    else if(ourtime < 4)
-      g_stats.ourtime2_4++;
-    else if(ourtime < 8)
-      g_stats.ourtime4_8++;
-    else if(ourtime < 16)
-      g_stats.ourtime8_16++;
-    else if(ourtime < 32)
-      g_stats.ourtime16_32++;
-    else {
-      g_stats.ourtimeSlow++;
-    }
-
-    if (ourtime >= 0) {
-      newLat = ourtime * 1000.0; // usec
+    if (spentUsec >= sr.d_totUsec) {
+      uint64_t ourtime = spentUsec - sr.d_totUsec; 
+      g_stats.ourtime(ourtime);
+      newLat = ourtime; // usec
       g_stats.avgLatencyOursUsec = (1.0 - 1.0 / g_latencyStatSize) * g_stats.avgLatencyOursUsec + newLat / g_latencyStatSize;
     }
 
@@ -2389,6 +2367,11 @@ static bool checkForCacheHit(bool qnameParsed, unsigned int tag, const string& d
     }
     g_stats.avgLatencyUsec = (1.0 - 1.0 / g_latencyStatSize) * g_stats.avgLatencyUsec + 0.0; // we assume 0 usec
     g_stats.avgLatencyOursUsec = (1.0 - 1.0 / g_latencyStatSize) * g_stats.avgLatencyOursUsec + 0.0; // we assume 0 usec
+#if 0
+    // XXX changes behaviour compared to old code!
+    g_stats.answers(0);
+    g_stats.ourtime(0);
+#endif
   }
   return cacheHit;
 }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -969,11 +969,6 @@ static uint64_t doGetCacheSize()
   return g_recCache->size();
 }
 
-static uint64_t doGetAvgLatencyUsec()
-{
-  return (uint64_t) g_stats.avgLatencyUsec;
-}
-
 static uint64_t doGetCacheBytes()
 {
   return g_recCache->bytes();
@@ -1075,34 +1070,33 @@ static void registerAllStats1()
   addGetStat("truncated-drops", &g_stats.truncatedDrops);
   addGetStat("query-pipe-full-drops", &g_stats.queryPipeFullDrops);
 
-  addGetStat("answers0-1", &g_stats.answers0_1);
-  addGetStat("answers1-10", &g_stats.answers1_10);
-  addGetStat("answers10-100", &g_stats.answers10_100);
-  addGetStat("answers100-1000", &g_stats.answers100_1000);
-  addGetStat("answers-slow", &g_stats.answersSlow);
+  addGetStat("answers0-1", []() { return g_stats.answers.getCount(0); });
+  addGetStat("answers1-10", []() { return g_stats.answers.getCount(1); });
+  addGetStat("answers10-100", []() { return g_stats.answers.getCount(2); });
+  addGetStat("answers100-1000", []() { return g_stats.answers.getCount(3); });
+  addGetStat("answers-slow", []() { return g_stats.answers.getCount(4); });
 
-  addGetStat("x-ourtime0-1", &g_stats.ourtime0_1);
-  addGetStat("x-ourtime1-2", &g_stats.ourtime1_2);
-  addGetStat("x-ourtime2-4", &g_stats.ourtime2_4);
-  addGetStat("x-ourtime4-8", &g_stats.ourtime4_8);
-  addGetStat("x-ourtime8-16", &g_stats.ourtime8_16);
-  addGetStat("x-ourtime16-32", &g_stats.ourtime16_32);
-  addGetStat("x-ourtime-slow", &g_stats.ourtimeSlow);
+  addGetStat("x-ourtime0-1", []() { return g_stats.ourtime.getCount(0); });
+  addGetStat("x-ourtime1-2", []() { return g_stats.ourtime.getCount(1); });
+  addGetStat("x-ourtime2-4", []() { return g_stats.ourtime.getCount(2); });
+  addGetStat("x-ourtime4-8", []() { return g_stats.ourtime.getCount(3); });
+  addGetStat("x-ourtime8-16", []() { return g_stats.ourtime.getCount(4); });
+  addGetStat("x-ourtime16-32", []() { return g_stats.ourtime.getCount(5); });
+  addGetStat("x-ourtime-slow", []() { return g_stats.ourtime.getCount(6); });
 
-  addGetStat("auth4-answers0-1", &g_stats.auth4Answers0_1);
-  addGetStat("auth4-answers1-10", &g_stats.auth4Answers1_10);
-  addGetStat("auth4-answers10-100", &g_stats.auth4Answers10_100);
-  addGetStat("auth4-answers100-1000", &g_stats.auth4Answers100_1000);
-  addGetStat("auth4-answers-slow", &g_stats.auth4AnswersSlow);
+  addGetStat("auth4-answers0-1", []() { return g_stats.auth4Answers.getCount(0); });
+  addGetStat("auth4-answers1-10", []() { return g_stats.auth4Answers.getCount(1); });
+  addGetStat("auth4-answers10-100", []() { return g_stats.auth4Answers.getCount(2); });
+  addGetStat("auth4-answers100-1000", []() { return g_stats.auth4Answers.getCount(3); });
+  addGetStat("auth4-answers-slow", []() { return g_stats.auth4Answers.getCount(4); });
 
-  addGetStat("auth6-answers0-1", &g_stats.auth6Answers0_1);
-  addGetStat("auth6-answers1-10", &g_stats.auth6Answers1_10);
-  addGetStat("auth6-answers10-100", &g_stats.auth6Answers10_100);
-  addGetStat("auth6-answers100-1000", &g_stats.auth6Answers100_1000);
-  addGetStat("auth6-answers-slow", &g_stats.auth6AnswersSlow);
+  addGetStat("auth6-answers0-1", []() { return g_stats.auth6Answers.getCount(0); });
+  addGetStat("auth6-answers1-10", []() { return g_stats.auth6Answers.getCount(1); });
+  addGetStat("auth6-answers10-100", []() { return g_stats.auth6Answers.getCount(2); });
+  addGetStat("auth6-answers100-1000", []() { return g_stats.auth6Answers.getCount(3); });
+  addGetStat("auth6-answers-slow", []() { return g_stats.auth6Answers.getCount(4); });
 
-
-  addGetStat("qa-latency", doGetAvgLatencyUsec);
+  addGetStat("qa-latency", []() { return g_stats.avgLatencyUsec.load(); });
   addGetStat("x-our-latency", []() { return g_stats.avgLatencyOursUsec.load(); });
   addGetStat("unexpected-packets", &g_stats.unexpectedCount);
   addGetStat("case-mismatches", &g_stats.caseMismatchCount);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1103,7 +1103,7 @@ static void registerAllStats1()
 
 
   addGetStat("qa-latency", doGetAvgLatencyUsec);
-  addGetStat("x-our-latency", []() { return g_stats.avgLatencyOursUsec; });
+  addGetStat("x-our-latency", []() { return g_stats.avgLatencyOursUsec.load(); });
   addGetStat("unexpected-packets", &g_stats.unexpectedCount);
   addGetStat("case-mismatches", &g_stats.caseMismatchCount);
   addGetStat("spoof-prevents", &g_stats.spoofCount);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1096,8 +1096,8 @@ static void registerAllStats1()
   addGetStat("auth6-answers100-1000", []() { return g_stats.auth6Answers.getCount(3); });
   addGetStat("auth6-answers-slow", []() { return g_stats.auth6Answers.getCount(4); });
 
-  addGetStat("qa-latency", []() { return g_stats.avgLatencyUsec.load(); });
-  addGetStat("x-our-latency", []() { return g_stats.avgLatencyOursUsec.load(); });
+  addGetStat("qa-latency", []() { return round(g_stats.avgLatencyUsec.load()); });
+  addGetStat("x-our-latency", []() { return round(g_stats.avgLatencyOursUsec.load()); });
   addGetStat("unexpected-packets", &g_stats.unexpectedCount);
   addGetStat("case-mismatches", &g_stats.caseMismatchCount);
   addGetStat("spoof-prevents", &g_stats.spoofCount);

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -120,6 +120,7 @@ pdns_recursor_SOURCES = \
 	filterpo.cc filterpo.hh \
 	fstrm_logger.cc fstrm_logger.hh \
 	gettime.cc gettime.hh \
+	histogram.hh \
 	iputils.hh iputils.cc \
 	ixfr.cc ixfr.hh \
 	json.cc json.hh \
@@ -284,6 +285,7 @@ testrunner_SOURCES = \
 	test-dnsrecords_cc.cc \
 	test-ednsoptions_cc.cc \
 	test-filterpo_cc.cc \
+	test-histogram_hh.cc \
 	test-iputils_hh.cc \
 	test-ixfr_cc.cc \
 	test-luawrapper.cc \

--- a/pdns/recursordist/histogram.hh
+++ b/pdns/recursordist/histogram.hh
@@ -1,0 +1,1 @@
+../histogram.hh

--- a/pdns/recursordist/test-histogram_hh.cc
+++ b/pdns/recursordist/test-histogram_hh.cc
@@ -1,3 +1,25 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_NO_MAIN
 

--- a/pdns/recursordist/test-histogram_hh.cc
+++ b/pdns/recursordist/test-histogram_hh.cc
@@ -1,0 +1,42 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "histogram.hh"
+
+BOOST_AUTO_TEST_SUITE(histogram_hh)
+
+BOOST_AUTO_TEST_CASE(test_simple) {
+  auto h = pdns::AtomicHistogram<uint64_t>("myname-", {1, 3, 5, 10, 100});
+
+  h(0);
+  h(1);
+  h(1);
+  h(3);
+  h(4);
+  h(100);
+  h(101);
+  h(-1);
+
+  auto data = h.getRawData();
+  BOOST_CHECK_EQUAL(data.size(), 6U);
+  uint64_t expected[] = { 3, 1, 1, 0, 1, 2};
+  size_t i = 0;
+  for (auto e : expected) {
+	BOOST_CHECK_EQUAL(data[i++].d_count, e);
+  }
+
+  auto c = h.getCumulativeCounts();
+  BOOST_CHECK_EQUAL(data.size(), 6U);
+  uint64_t cexpected[] = { 3, 4, 5, 5, 6, 8};
+  i = 0;
+  for (auto e : cexpected) {
+	BOOST_CHECK_EQUAL(c[i++], e);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -98,32 +98,13 @@ unsigned int SyncRes::s_refresh_ttlperc;
 
 #define LOG(x) if(d_lm == Log) { g_log <<Logger::Warning << x; } else if(d_lm == Store) { d_trace << x; }
 
-static void accountAuthLatency(int usec, int family)
+static inline void accountAuthLatency(uint64_t usec, int family)
 {
-  if(family == AF_INET) {
-    if(usec < 1000)
-      g_stats.auth4Answers0_1++;
-    else if(usec < 10000)
-      g_stats.auth4Answers1_10++;
-    else if(usec < 100000)
-      g_stats.auth4Answers10_100++;
-    else if(usec < 1000000)
-      g_stats.auth4Answers100_1000++;
-    else
-      g_stats.auth4AnswersSlow++;
+  if (family == AF_INET) {
+    g_stats.auth4Answers(usec);
   } else  {
-    if(usec < 1000)
-      g_stats.auth6Answers0_1++;
-    else if(usec < 10000)
-      g_stats.auth6Answers1_10++;
-    else if(usec < 100000)
-      g_stats.auth6Answers10_100++;
-    else if(usec < 1000000)
-      g_stats.auth6Answers100_1000++;
-    else
-      g_stats.auth6AnswersSlow++;
+    g_stats.auth6Answers(usec);
   }
-
 }
 
 
@@ -867,7 +848,7 @@ int SyncRes::doResolveNoQNameMinimization(const DNSName &qname, const QType qtyp
           accountAuthLatency(lwr.d_usec, remoteIP.sin4.sin_family);
           if (fromCache)
             *fromCache = true;
-          
+
           // filter out the good stuff from lwr.result()
           if (resolveRet == LWResult::Result::Success) {
             for(const auto& rec : lwr.d_records) {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -51,6 +51,7 @@
 #include "negcache.hh"
 #include "proxy-protocol.hh"
 #include "sholder.hh"
+#include "histogram.hh"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -976,10 +977,10 @@ struct RecursorStats
   std::atomic<uint64_t> servFails;
   std::atomic<uint64_t> nxDomains;
   std::atomic<uint64_t> noErrors;
-  std::atomic<uint64_t> answers0_1, answers1_10, answers10_100, answers100_1000, answersSlow;
-  std::atomic<uint64_t> auth4Answers0_1, auth4Answers1_10, auth4Answers10_100, auth4Answers100_1000, auth4AnswersSlow;
-  std::atomic<uint64_t> auth6Answers0_1, auth6Answers1_10, auth6Answers10_100, auth6Answers100_1000, auth6AnswersSlow;
-  std::atomic<uint64_t> ourtime0_1, ourtime1_2, ourtime2_4, ourtime4_8, ourtime8_16, ourtime16_32, ourtimeSlow;
+  pdns::AtomicHistogram<uint64_t> answers;
+  pdns::AtomicHistogram<uint64_t> auth4Answers;
+  pdns::AtomicHistogram<uint64_t> auth6Answers;
+  pdns::AtomicHistogram<uint64_t> ourtime;
   std::atomic<double> avgLatencyUsec;
   std::atomic<double> avgLatencyOursUsec;
   std::atomic<uint64_t> qcounter;     // not increased for unauth packets
@@ -1021,6 +1022,14 @@ struct RecursorStats
   std::atomic<uint64_t> rebalancedQueries{0};
   std::atomic<uint64_t> proxyProtocolInvalidCount{0};
   std::atomic<uint64_t> nodLookupsDroppedOversize{0};
+
+  RecursorStats() :
+    answers("answers", { 1000, 10000, 100000, 1000000 }),
+    auth4Answers("answers", { 1000, 10000, 100000, 1000000 }),
+    auth6Answers("answers", { 1000, 10000, 100000, 1000000 }),
+    ourtime("ourtime", { 1000, 2000, 4000, 8000, 16000, 32000 })
+  {
+  }
 };
 
 //! represents a running TCP/IP client session

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -980,8 +980,8 @@ struct RecursorStats
   std::atomic<uint64_t> auth4Answers0_1, auth4Answers1_10, auth4Answers10_100, auth4Answers100_1000, auth4AnswersSlow;
   std::atomic<uint64_t> auth6Answers0_1, auth6Answers1_10, auth6Answers10_100, auth6Answers100_1000, auth6AnswersSlow;
   std::atomic<uint64_t> ourtime0_1, ourtime1_2, ourtime2_4, ourtime4_8, ourtime8_16, ourtime16_32, ourtimeSlow;
-  double avgLatencyUsec{0};
-  double avgLatencyOursUsec{0};
+  std::atomic<double> avgLatencyUsec;
+  std::atomic<double> avgLatencyOursUsec;
   std::atomic<uint64_t> qcounter;     // not increased for unauth packets
   std::atomic<uint64_t> ipv6qcounter;
   std::atomic<uint64_t> tcpqcounter;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This intended as code cleanup without changing externally observable behavior. It will make it easier to make the HIstogram configurable and add cumulative ones in the future.

Current latency computations are a mix of different types (float, double, uint64_t) and units (secs, millisecs, microsecs. Harmonize to always work in an integral number of microseconds, and only use doubles when needed to compute running averages.

Also make sure we use atomics for all data written to from different threads, specifically  `avgLatencyUsec` and `avgLatencyOursUsec`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
