### PR TITLE
dnsdist: Fix several bugs in the TCP code path, add unit tests

### DIFF
--- a/docs/manpages/sdig.1.rst
+++ b/docs/manpages/sdig.1.rst
@@ -43,6 +43,8 @@ dot
     use DoT instead of UDP to send a query. Implies tcp.
 insecure
     when using DoT, do not validate the server certificate.
+fastOpen
+    when using TCP or, DoT, enable TCP Fast Open
 subjectName *name*
     when using DoT, verify the server certificate is issued for *name*. The `openssl` provider will accept an empty name and still
     make sure the certificate is issued by a trusted CA, `gnutls` will only do the validation if a name is given.

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -615,6 +615,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "setStaleCacheEntriesTTL", true, "n", "allows using cache entries expired for at most n seconds when there is no backend available to answer for a query" },
   { "setSyslogFacility", true, "facility", "set the syslog logging facility to 'facility'. Defaults to LOG_DAEMON" },
   { "setTCPDownstreamCleanupInterval", true, "interval", "minimum interval in seconds between two cleanups of the idle TCP downstream connections" },
+  { "setTCPInternalPipeBufferSize", true, "size", "Set the size in bytes of the internal buffer of the pipes used internally to distribute connections to TCP (and DoT) workers threads" },
   { "setTCPUseSinglePipe", true, "bool", "whether the incoming TCP connections should be put into a single queue instead of using per-thread queues. Defaults to false" },
   { "setTCPRecvTimeout", true, "n", "set the read timeout on TCP connections from the client, in seconds" },
   { "setTCPSendTimeout", true, "n", "set the write timeout on TCP connections from the client, in seconds" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1817,6 +1817,8 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       g_useTCPSinglePipe = flag;
     });
 
+  luaCtx.writeFunction("setTCPInternalPipeBufferSize", [](size_t size) { g_tcpInternalPipeBufferSize = size; });
+
   luaCtx.writeFunction("snmpAgent", [client,configCheck](bool enableTraps, boost::optional<std::string> daemonSocket) {
       if(client || configCheck)
         return;

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -912,15 +912,13 @@ void IncomingTCPConnectionState::handleIO(std::shared_ptr<IncomingTCPConnectionS
         if (!state->d_lastIOBlocked && state->active() && iostate == IOState::Done) {
           // if the query has been passed to a backend, or dropped, and the responses have been sent,
           // we can start reading again
-          if (!state->d_isXFR) {
-            if (state->canAcceptNewQueries(now)) {
-              state->resetForNewQuery();
-              iostate = IOState::NeedRead;
-            }
-            else {
-              state->d_state = IncomingTCPConnectionState::State::idle;
-              iostate = IOState::Done;
-            }
+          if (state->canAcceptNewQueries(now)) {
+            state->resetForNewQuery();
+            iostate = IOState::NeedRead;
+          }
+          else {
+            state->d_state = IncomingTCPConnectionState::State::idle;
+            iostate = IOState::Done;
           }
         }
       }

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -1014,12 +1014,25 @@ static void tcpClientThread(int pipefd)
       DownstreamConnectionsManager::cleanupClosedTCPConnections();
       lastTCPCleanup = now.tv_sec;
 
-      /*
+#if 0
+      /* just to keep things clean in the output, debug only */
+      static std::mutex s_lock;
+      std::lock_guard<decltype(s_lock)> lck(s_lock);
       data.mplexer->runForAllWatchedFDs([](bool isRead, int fd, const FDMultiplexer::funcparam_t& param, struct timeval ttd)
       {
-        cerr<<"- "<<isRead<<" "<<fd<<": "<<param.type().name()<<" "<<ttd.tv_sec<<endl;
+        struct timeval lnow;
+        gettimeofday(&lnow, 0);
+        cerr<<"- "<<isRead<<" "<<fd<<": "<<" "<<(ttd.tv_sec-lnow.tv_sec)<<endl;
+        if (param.type() == typeid(std::shared_ptr<IncomingTCPConnectionState>)) {
+          auto state = boost::any_cast<std::shared_ptr<IncomingTCPConnectionState>>(param);
+          cerr<<" - "<<state->toString()<<endl;
+        }
+        else if (param.type() == typeid(std::shared_ptr<TCPConnectionToBackend>)) {
+          auto conn = boost::any_cast<std::shared_ptr<TCPConnectionToBackend>>(param);
+          cerr<<" - "<<conn->toString()<<endl;
+        }
       });
-      */
+#endif
     }
 
     if (now.tv_sec > lastTimeoutScan) {

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -329,7 +329,7 @@ static void handleResponseSent(std::shared_ptr<IncomingTCPConnectionState>& stat
     const auto& ids = currentResponse.d_idstate;
     double udiff = ids.sentTime.udiff();
     g_rings.insertResponse(answertime, state->d_ci.remote, ids.qname, ids.qtype, static_cast<unsigned int>(udiff), static_cast<unsigned int>(currentResponse.d_buffer.size()), currentResponse.d_cleartextDH, ds->remote);
-    vinfolog("Got answer from %s, relayed to %s (%s), took %f usec", ds->remote.toStringWithPort(), ids.origRemote.toStringWithPort(), (state->d_ci.cs->tlsFrontend ? "DoT" : "TCP"), udiff);
+    vinfolog("Got answer from %s, relayed to %s (%s, %d bytes), took %f usec", ds->remote.toStringWithPort(), ids.origRemote.toStringWithPort(), (state->d_ci.cs->tlsFrontend ? "DoT" : "TCP"), currentResponse.d_buffer.size(), udiff);
   }
 
   switch (currentResponse.d_cleartextDH.rcode) {

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -166,6 +166,11 @@ IncomingTCPConnectionState::~IncomingTCPConnectionState()
     auto diff = now - d_connectionStartTime;
     d_ci.cs->updateTCPMetrics(d_queriesCount, diff.tv_sec * 1000.0 + diff.tv_usec / 1000.0);
   }
+
+  // would have been done when the object is destroyed anyway,
+  // but that way we make sure it's done before the ConnectionInfo is destroyed,
+  // closing the descriptor, instead of relying on the declaration order of the objects in the class
+  d_handler.close();
 }
 
 std::shared_ptr<TCPConnectionToBackend> IncomingTCPConnectionState::getDownstreamConnection(std::shared_ptr<DownstreamState>& ds, const std::unique_ptr<std::vector<ProxyProtocolValue>>& tlvs, const struct timeval& now)

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -133,8 +133,6 @@ GlobalStateHolder<servers_t> g_dstates;
 GlobalStateHolder<NetmaskTree<DynBlock>> g_dynblockNMG;
 GlobalStateHolder<SuffixMatchTree<DynBlock>> g_dynblockSMT;
 DNSAction::Action g_dynBlockAction = DNSAction::Action::Drop;
-int g_tcpRecvTimeout{2};
-int g_tcpSendTimeout{2};
 int g_udpTimeout{2};
 
 bool g_servFailOnNoPolicy{false};

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -879,6 +879,7 @@ struct DownstreamState
   std::mutex socketsLock;
   std::mutex connectLock;
   std::unique_ptr<FDMultiplexer> mplexer{nullptr};
+  std::shared_ptr<TLSCtx> d_tlsCtx{nullptr};
   std::thread tid;
   const ComboAddress remote;
   QPSLimiter qps;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1183,6 +1183,7 @@ extern uint64_t g_maxTCPQueuedConnections;
 extern size_t g_maxTCPQueriesPerConn;
 extern size_t g_maxTCPConnectionDuration;
 extern size_t g_maxTCPConnectionsPerClient;
+extern size_t g_tcpInternalPipeBufferSize;
 extern pdns::stat16_t g_cacheCleaningDelay;
 extern pdns::stat16_t g_cacheCleaningPercentage;
 extern uint32_t g_staleCacheEntriesTTL;

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -831,30 +831,7 @@ class TCPClientCollection {
   const bool d_useSinglePipe;
 public:
 
-  TCPClientCollection(size_t maxThreads, bool useSinglePipe=false): d_tcpclientthreads(maxThreads), d_maxthreads(maxThreads), d_singlePipe{-1,-1}, d_useSinglePipe(useSinglePipe)
-
-  {
-    if (d_useSinglePipe) {
-      if (pipe(d_singlePipe) < 0) {
-        int err = errno;
-        throw std::runtime_error("Error creating the TCP single communication pipe: " + stringerror(err));
-      }
-
-      if (!setNonBlocking(d_singlePipe[0])) {
-        int err = errno;
-        close(d_singlePipe[0]);
-        close(d_singlePipe[1]);
-        throw std::runtime_error("Error setting the TCP single communication pipe non-blocking: " + stringerror(err));
-      }
-
-      if (!setNonBlocking(d_singlePipe[1])) {
-        int err = errno;
-        close(d_singlePipe[0]);
-        close(d_singlePipe[1]);
-        throw std::runtime_error("Error setting the TCP single communication pipe non-blocking: " + stringerror(err));
-      }
-    }
-  }
+  TCPClientCollection(size_t maxThreads, bool useSinglePipe=false);
   int getThread()
   {
     if (d_numthreads == 0) {

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -240,8 +240,8 @@ testrunner_SOURCES = \
 	dnsdist-lua-vars.cc \
 	dnsdist-proxy-protocol.cc dnsdist-proxy-protocol.hh \
 	dnsdist-rings.cc dnsdist-rings.hh \
-	dnsdist-tcp.cc \
 	dnsdist-tcp-downstream.cc \
+	dnsdist-tcp.cc \
 	dnsdist-xpf.cc dnsdist-xpf.hh \
 	dnsdist.hh \
 	dnslabeltext.cc \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -230,6 +230,7 @@ testrunner_SOURCES = \
 	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
 	dnsdist-kvs.cc dnsdist-kvs.hh \
+	dnsdist-idstate.cc \
 	dnsdist-lbpolicies.cc dnsdist-lbpolicies.hh \
 	dnsdist-lua-bindings-dnsquestion.cc \
 	dnsdist-lua-bindings-kvs.cc \
@@ -237,7 +238,10 @@ testrunner_SOURCES = \
 	dnsdist-lua-ffi-interface.h dnsdist-lua-ffi-interface.inc \
 	dnsdist-lua-ffi.cc dnsdist-lua-ffi.hh \
 	dnsdist-lua-vars.cc \
+	dnsdist-proxy-protocol.cc dnsdist-proxy-protocol.hh \
 	dnsdist-rings.cc dnsdist-rings.hh \
+	dnsdist-tcp.cc \
+	dnsdist-tcp-downstream.cc \
 	dnsdist-xpf.cc dnsdist-xpf.hh \
 	dnsdist.hh \
 	dnslabeltext.cc \
@@ -275,6 +279,7 @@ testrunner_SOURCES = \
 	test-dnsdistpacketcache_cc.cc \
 	test-dnsdistrings_cc.cc \
 	test-dnsdistrules_cc.cc \
+	test-dnsdisttcp_cc.cc \
 	test-dnsparser_cc.cc \
 	test-iputils_hh.cc \
 	test-luawrapper.cc \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -229,8 +229,8 @@ testrunner_SOURCES = \
 	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \
 	dnsdist-dynbpf.cc dnsdist-dynbpf.hh \
 	dnsdist-ecs.cc dnsdist-ecs.hh \
-	dnsdist-kvs.cc dnsdist-kvs.hh \
 	dnsdist-idstate.cc \
+	dnsdist-kvs.cc dnsdist-kvs.hh \
 	dnsdist-lbpolicies.cc dnsdist-lbpolicies.hh \
 	dnsdist-lua-bindings-dnsquestion.cc \
 	dnsdist-lua-bindings-kvs.cc \

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -52,7 +52,7 @@ public:
 
   ~TCPConnectionToBackend()
   {
-    if (d_ds && d_socket) {
+    if (d_ds && d_handler) {
       --d_ds->tcpCurrentConnections;
       struct timeval now;
       gettimeofday(&now, nullptr);
@@ -66,11 +66,11 @@ public:
 
   int getHandle() const
   {
-    if (!d_socket) {
+    if (!d_handler) {
       throw std::runtime_error("Attempt to get the socket handle from a non-established TCP connection");
     }
 
-    return d_socket->getHandle();
+    return d_handler->getDescriptor();
   }
 
   const std::shared_ptr<DownstreamState>& getDS() const
@@ -172,7 +172,7 @@ public:
   std::string toString() const
   {
     ostringstream o;
-    o << "TCP connection to backend "<<(d_ds ? d_ds->getName() : "empty")<<" over FD "<<(d_socket ? std::to_string(d_socket->getHandle()) : "no socket")<<", state is "<<(int)d_state<<", io state is "<<(d_ioState ? std::to_string((int)d_ioState->getState()) : "empty")<<", queries count is "<<d_queries<<", pending queries count is "<<d_pendingQueries.size()<<", "<<d_pendingResponses.size()<<" pending responses, linked to "<<(d_clientConn ? " a client" : "no client");
+    o << "TCP connection to backend "<<(d_ds ? d_ds->getName() : "empty")<<" over FD "<<(d_handler ? std::to_string(d_handler->getDescriptor()) : "no socket")<<", state is "<<(int)d_state<<", io state is "<<(d_ioState ? std::to_string((int)d_ioState->getState()) : "empty")<<", queries count is "<<d_queries<<", pending queries count is "<<d_pendingQueries.size()<<", "<<d_pendingResponses.size()<<" pending responses, linked to "<<(d_clientConn ? " a client" : "no client");
     return o.str();
   }
 
@@ -228,7 +228,7 @@ private:
   std::deque<TCPQuery> d_pendingQueries;
   std::unordered_map<uint16_t, TCPQuery> d_pendingResponses;
   std::unique_ptr<std::vector<ProxyProtocolValue>> d_proxyProtocolValuesSent{nullptr};
-  std::unique_ptr<Socket> d_socket{nullptr};
+  std::unique_ptr<TCPIOHandler> d_handler{nullptr};
   std::unique_ptr<IOStateHandler> d_ioState{nullptr};
   std::shared_ptr<DownstreamState> d_ds{nullptr};
   std::shared_ptr<IncomingTCPConnectionState> d_clientConn;

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -18,6 +18,8 @@ struct TCPQuery
 
   IDState d_idstate;
   PacketBuffer d_buffer;
+  std::string d_proxyProtocolPayload;
+  bool d_proxyProtocolPayloadAdded{false};
 };
 
 class TCPConnectionToBackend;
@@ -165,8 +167,6 @@ public:
   void handleTimeout(const struct timeval& now, bool write);
   void release();
 
-  void setProxyProtocolPayload(std::string&& payload);
-  void setProxyProtocolPayloadAdded(bool added);
   void setProxyProtocolValuesSent(std::unique_ptr<std::vector<ProxyProtocolValue>>&& proxyProtocolValuesSent);
 
   std::string toString() const
@@ -191,6 +191,10 @@ private:
   uint16_t getQueryIdFromResponse();
   bool reconnect();
   void notifyAllQueriesFailed(const struct timeval& now, FailureReason reason);
+  bool needProxyProtocolPayload() const
+  {
+    return !d_proxyProtocolPayloadSent && (d_ds && d_ds->useProxyProtocol);
+  }
 
   boost::optional<struct timeval> getBackendReadTTD(const struct timeval& now) const
   {
@@ -232,7 +236,6 @@ private:
   std::unique_ptr<IOStateHandler> d_ioState{nullptr};
   std::shared_ptr<DownstreamState> d_ds{nullptr};
   std::shared_ptr<IncomingTCPConnectionState> d_clientConn;
-  std::string d_proxyProtocolPayload;
   TCPQuery d_currentQuery;
   struct timeval d_connectionStartTime;
   size_t d_currentPos{0};
@@ -244,5 +247,5 @@ private:
   bool d_enableFastOpen{false};
   bool d_connectionDied{false};
   bool d_usedForXFR{false};
-  bool d_proxyProtocolPayloadAdded{false};
+  bool d_proxyProtocolPayloadSent{false};
 };

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -169,6 +169,13 @@ public:
   void setProxyProtocolPayloadAdded(bool added);
   void setProxyProtocolValuesSent(std::unique_ptr<std::vector<ProxyProtocolValue>>&& proxyProtocolValuesSent);
 
+  std::string toString() const
+  {
+    ostringstream o;
+    o << "TCP connection to backend "<<(d_ds ? d_ds->getName() : "empty")<<" over FD "<<(d_socket ? std::to_string(d_socket->getHandle()) : "no socket")<<", state is "<<(int)d_state<<", io state is "<<(d_ioState ? std::to_string((int)d_ioState->getState()) : "empty")<<", queries count is "<<d_queries<<", pending queries count is "<<d_pendingQueries.size()<<", "<<d_pendingResponses.size()<<" pending responses, linked to "<<(d_clientConn ? " a client" : "no client");
+    return o.str();
+  }
+
 private:
   /* waitingForResponseFromBackend is a state where we have not yet started reading the size,
      so we can still switch to sending instead */

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -151,6 +151,8 @@ public:
     return d_threadData.mplexer;
   }
 
+  static void clearAllDownstreamConnections();
+
   static void handleIO(std::shared_ptr<IncomingTCPConnectionState>& conn, const struct timeval& now);
   static void handleIOCallback(int fd, FDMultiplexer::funcparam_t& param);
   static void notifyIOError(std::shared_ptr<IncomingTCPConnectionState>& state, IDState&& query, const struct timeval& now);
@@ -210,4 +212,5 @@ public:
   bool d_xfrStarted{false};
   bool d_proxyProtocolPayloadHasTLV{false};
   bool d_lastIOBlocked{false};
+  bool d_hadErrors{false};
 };

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -209,7 +209,6 @@ public:
   State d_state{State::doingHandshake};
   bool d_readingFirstQuery{true};
   bool d_isXFR{false};
-  bool d_xfrStarted{false};
   bool d_proxyProtocolPayloadHasTLV{false};
   bool d_lastIOBlocked{false};
   bool d_hadErrors{false};

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -44,6 +44,7 @@ struct ConnectionInfo
       close(fd);
       fd = -1;
     }
+
     if (cs) {
       --cs->tcpCurrentConnections;
     }
@@ -65,6 +66,8 @@ public:
     if (getsockname(d_ci.fd, reinterpret_cast<sockaddr*>(&d_origDest), &socklen)) {
       d_origDest = d_ci.cs->local;
     }
+    /* belongs to the handler now */
+    d_ci.fd = -1;
     d_proxiedDestination = d_origDest;
     d_proxiedRemote = d_ci.remote;
   }
@@ -159,6 +162,7 @@ public:
   static void handleXFRResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response);
   static void handleTimeout(std::shared_ptr<IncomingTCPConnectionState>& state, bool write);
 
+  void terminateClientConnection();
   void queueQuery(TCPQuery&& query);
 
   bool canAcceptNewQueries() const;
@@ -171,7 +175,7 @@ public:
   std::string toString() const
   {
     ostringstream o;
-    o << "Incoming TCP connection from "<<d_ci.remote.toStringWithPort()<<" over FD "<<d_ci.fd<<", state is "<<(int)d_state<<", io state is "<<(d_ioState ? std::to_string((int)d_ioState->getState()) : "empty")<<", queries count is "<<d_queriesCount<<", current queries count is "<<d_currentQueriesCount<<", "<<d_queuedResponses.size()<<" queued responses, "<<d_activeConnectionsToBackend.size()<<" active connections to a backend";
+    o << "Incoming TCP connection from "<<d_ci.remote.toStringWithPort()<<" over FD "<<d_handler.getDescriptor()<<", state is "<<(int)d_state<<", io state is "<<(d_ioState ? std::to_string((int)d_ioState->getState()) : "empty")<<", queries count is "<<d_queriesCount<<", current queries count is "<<d_currentQueriesCount<<", "<<d_queuedResponses.size()<<" queued responses, "<<d_activeConnectionsToBackend.size()<<" active connections to a backend";
     return o.str();
   }
 

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -151,7 +151,7 @@ public:
     return d_threadData.mplexer;
   }
 
-  static void clearAllDownstreamConnections();
+  static size_t clearAllDownstreamConnections();
 
   static void handleIO(std::shared_ptr<IncomingTCPConnectionState>& conn, const struct timeval& now);
   static void handleIOCallback(int fd, FDMultiplexer::funcparam_t& param);

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -168,6 +168,13 @@ public:
     return d_ioState != nullptr;
   }
 
+  std::string toString() const
+  {
+    ostringstream o;
+    o << "Incoming TCP connection from "<<d_ci.remote.toStringWithPort()<<" over FD "<<d_ci.fd<<", state is "<<(int)d_state<<", io state is "<<(d_ioState ? std::to_string((int)d_ioState->getState()) : "empty")<<", queries count is "<<d_queriesCount<<", current queries count is "<<d_currentQueriesCount<<", "<<d_queuedResponses.size()<<" queued responses, "<<d_activeConnectionsToBackend.size()<<" active connections to a backend";
+    return o.str();
+  }
+
   enum class State { doingHandshake, readingProxyProtocolHeader, readingQuerySize, readingQuery, sendingResponse, idle /* in case of XFR, we stop processing queries */ };
 
   std::map<std::shared_ptr<DownstreamState>, std::deque<std::shared_ptr<TCPConnectionToBackend>>> d_activeConnectionsToBackend;

--- a/pdns/dnsdistdist/docs/advanced/tuning.rst
+++ b/pdns/dnsdistdist/docs/advanced/tuning.rst
@@ -21,7 +21,7 @@ If all the TCP threads are busy, new TCP connections are queued while they wait 
 Before 1.4.0, a TCP thread could only handle a single incoming connection at a time. Starting with 1.4.0 the handling of TCP connections is now event-based, so a single TCP worker can handle a large number of TCP incoming connections simultaneously.
 Note that before 1.6.0 the TCP worker threads were created at runtime, adding a new thread when the existing ones seemed to struggle with the load, until the maximum number of threads had been reached. Starting with 1.6.0 the configured number of worker threads are immediately created at startup.
 
-The maximum number of queued connections can be configured with :func:`setMaxTCPQueuedConnections` and defaults to 1000.
+The maximum number of queued connections can be configured with :func:`setMaxTCPQueuedConnections` and defaults to 1000. Note that the size of the internal pipe used to distribute queries might need to be increased as well, using :func:`setTCPInternalPipeBufferSize`.
 Any value larger than 0 will cause new connections to be dropped if there are already too many queued.
 By default, every TCP worker thread has its own queue, and the incoming TCP connections are dispatched to TCP workers on a round-robin basis.
 This might cause issues if some connections are taking a very long time, since incoming ones will be waiting until the TCP worker they have been assigned to has finished handling its current query, while other TCP workers might be available.

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -63,6 +63,14 @@ Tuning related functions
 
   :param int num:
 
+.. function:: setTCPInternalPipeBufferSize(size)
+
+  .. versionadded:: 1.6.0
+
+  Set the size in bytes of the internal buffer of the pipes used internally to distribute connections to TCP (and DoT) workers threads. Requires support for ``F_SETPIPE_SZ`` which is present in Linux since 2.6.35. The actual size might be rounded up to a multiple of a page size. 0 means that the OS default size is used.
+
+  :param int size: The size in bytes.
+
 .. function:: setTCPUseSinglePipe(val)
 
   Whether the incoming TCP connections should be put into a single queue instead of using per-thread queues. Defaults to false

--- a/pdns/dnsdistdist/tcpiohandler-mplexer.hh
+++ b/pdns/dnsdistdist/tcpiohandler-mplexer.hh
@@ -85,6 +85,10 @@ public:
     }
     else if (iostate == IOState::NeedWrite) {
       if (d_currentState == IOState::NeedWrite) {
+        if (ttd) {
+          /* let's update the TTD ! */
+          d_mplexer->setWriteTTD(d_fd, *ttd, /* we pass 0 here because we already have a TTD */0);
+        }
         return;
       }
 

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -1,0 +1,481 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include "dnswriter.hh"
+#include "dnsdist.hh"
+#include "dnsdist-rings.hh"
+#include "dnsdist-tcp-downstream.hh"
+#include "dnsdist-tcp-upstream.hh"
+
+struct DNSDistStats g_stats;
+GlobalStateHolder<NetmaskGroup> g_ACL;
+GlobalStateHolder<vector<DNSDistRuleAction> > g_rulactions;
+GlobalStateHolder<vector<DNSDistResponseRuleAction> > g_resprulactions;
+GlobalStateHolder<vector<DNSDistResponseRuleAction> > g_cachehitresprulactions;
+GlobalStateHolder<vector<DNSDistResponseRuleAction> > g_selfansweredresprulactions;
+GlobalStateHolder<servers_t> g_dstates;
+
+QueryCount g_qcount;
+
+
+bool checkDNSCryptQuery(const ClientState& cs, PacketBuffer& query, std::shared_ptr<DNSCryptQuery>& dnsCryptQuery, time_t now, bool tcp)
+{
+  return false;
+}
+
+bool processResponse(PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted)
+{
+  return false;
+}
+
+bool checkQueryHeaders(const struct dnsheader* dh)
+{
+  return true;
+}
+
+bool responseContentMatches(const PacketBuffer& response, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote, unsigned int& qnameWireLength)
+{
+  return true;
+}
+
+uint64_t uptimeOfProcess(const std::string& str)
+{
+  return 0;
+}
+
+uint64_t getLatencyCount(const std::string&)
+{
+  return 0;
+}
+
+static std::function<ProcessQueryResult(DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend)> s_processQuery;
+
+ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend)
+{
+  if (s_processQuery) {
+    return s_processQuery(dq, cs, holders, selectedBackend);
+  }
+
+  return ProcessQueryResult::Drop;
+}
+
+BOOST_AUTO_TEST_SUITE(test_dnsdisttcp_cc)
+
+struct ExpectedStep
+{
+public:
+  enum class ExpectedRequest { handshake, connect, read, write, close };
+
+  ExpectedStep(ExpectedRequest r, IOState n): ExpectedStep(r, n, 0)
+  {
+  }
+
+  ExpectedStep(ExpectedRequest r, IOState n, size_t b): request(r), nextState(n), bytes(b)
+  {
+  }
+
+  ExpectedRequest request;
+  IOState nextState;
+  size_t bytes{0};
+};
+
+static std::deque<ExpectedStep> s_steps;
+static ExpectedStep getStep()
+{
+  BOOST_REQUIRE(!s_steps.empty());
+  auto res = s_steps.front();
+  s_steps.pop_front();
+  return res;
+}
+
+static boost::optional<PacketBuffer> s_readBuffer;
+static PacketBuffer s_writeBuffer;
+
+std::ostream& operator<<(std::ostream &os, const ExpectedStep::ExpectedRequest d);
+
+std::ostream& operator<<(std::ostream &os, const ExpectedStep::ExpectedRequest d)
+{
+  static const std::vector<std::string> requests = { "handshake", "connect", "read", "write", "close" };
+  os<<requests.at(static_cast<size_t>(d));
+  return os;
+}
+
+class MockupTLSConnection : public TLSConnection
+{
+private:
+public:
+  ~MockupTLSConnection() { }
+
+  IOState tryHandshake() override
+  {
+    auto step = getStep();
+    BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::handshake);
+    return step.nextState;
+  }
+
+  IOState tryWrite(const PacketBuffer& buffer, size_t& pos, size_t toWrite) override
+  {
+    if (buffer.size() < toWrite || pos >= toWrite) {
+      throw std::out_of_range("Calling tryWrite() with a too small buffer (" + std::to_string(buffer.size()) + ") for a write of " + std::to_string(toWrite - pos) + " bytes starting at " + std::to_string(pos));
+    }
+
+    auto step = getStep();
+    BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::write);
+
+    if (step.bytes == 0) {
+      throw std::runtime_error("Remote host closed the connection");
+    }
+
+    toWrite -= pos;
+    BOOST_REQUIRE_GE(buffer.size(), pos + toWrite);
+
+    if (step.bytes < toWrite) {
+      toWrite = step.bytes;
+    }
+
+    s_writeBuffer.insert(s_writeBuffer.end(), buffer.begin() + pos, buffer.begin() + pos + toWrite);
+    pos += toWrite;
+
+    return step.nextState;
+  }
+
+  IOState tryRead(PacketBuffer& buffer, size_t& pos, size_t toRead) override
+  {
+    if (buffer.size() < toRead || pos >= toRead) {
+      throw std::out_of_range("Calling tryRead() with a too small buffer (" + std::to_string(buffer.size()) + ") for a read of " + std::to_string(toRead - pos) + " bytes starting at " + std::to_string(pos));
+    }
+
+    auto step = getStep();
+    BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::read);
+
+    if (step.bytes == 0) {
+      throw std::runtime_error("Remote host closed the connection");
+    }
+
+    if (s_readBuffer) {
+      toRead -= pos;
+
+      if (step.bytes < toRead) {
+        toRead = step.bytes;
+      }
+      BOOST_REQUIRE_GE(buffer.size(), toRead);
+      BOOST_REQUIRE_GE(s_readBuffer->size(), toRead);
+
+      std::copy(s_readBuffer->begin(), s_readBuffer->begin() + toRead, buffer.begin() + pos);
+      pos += toRead;
+      s_readBuffer->erase(s_readBuffer->begin(), s_readBuffer->begin() + toRead);
+    }
+
+    return step.nextState;
+  }
+
+  void close() override
+  {
+    auto step = getStep();
+    BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::close);
+  }
+
+  bool hasBufferedData() const override
+  {
+    return false;
+  }
+
+  std::string getServerNameIndication() const override
+  {
+    return "";
+  }
+
+  LibsslTLSVersion getTLSVersion() const override
+  {
+    return LibsslTLSVersion::TLS13;
+  }
+
+  bool hasSessionBeenResumed() const override
+  {
+    return false;
+  }
+
+  /* unused in that context, don't bother */
+  void doHandshake() override
+  {
+  }
+
+  void connect(bool fastOpen, const ComboAddress& remote, unsigned int timeout) override
+  {
+  }
+
+  IOState tryConnect(bool fastOpen, const ComboAddress& remote) override
+  {
+    return IOState::Done;
+  }
+
+  size_t read(void* buffer, size_t bufferSize, unsigned int readTimeout, unsigned int totalTimeout=0) override
+  {
+    return 0;
+  }
+
+  size_t write(const void* buffer, size_t bufferSize, unsigned int writeTimeout) override
+  {
+    return 0;
+  }
+};
+
+class MockupTLSCtx : public TLSCtx
+{
+public:
+  ~MockupTLSCtx()
+  {
+  }
+
+  std::unique_ptr<TLSConnection> getConnection(int socket, unsigned int timeout, time_t now) override
+  {
+    return std::make_unique<MockupTLSConnection>();
+  }
+
+  void rotateTicketsKey(time_t now) override
+  {
+  }
+
+  size_t getTicketsKeysCount() override
+  {
+    return 0;
+  }
+
+  std::unique_ptr<TLSConnection> getClientConnection(const std::string& host, int socket, unsigned int timeout) override
+  {
+    return nullptr;
+  }
+};
+
+class MockupFDMultiplexer : public FDMultiplexer
+{
+public:
+  MockupFDMultiplexer()
+  {
+  }
+
+  ~MockupFDMultiplexer()
+  {
+  }
+
+  int run(struct timeval* tv, int timeout=500) override
+  {
+    int ret = 0;
+
+    gettimeofday(tv, nullptr); // MANDATORY
+
+    for (const auto fd : ready) {
+      {
+        const auto& it = d_readCallbacks.find(fd);
+
+        if (it != d_readCallbacks.end()) {
+          it->d_callback(it->d_fd, it->d_parameter);
+          continue; // so we don't refind ourselves as writable!
+        }
+      }
+
+      {
+        const auto& it = d_writeCallbacks.find(fd);
+
+        if (it != d_writeCallbacks.end()) {
+          it->d_callback(it->d_fd, it->d_parameter);
+        }
+      }
+    }
+
+    return ret;
+  }
+
+  void getAvailableFDs(std::vector<int>& fds, int timeout) override
+  {
+  }
+
+  void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const funcparam_t& parameter, const struct timeval* ttd=nullptr) override
+  {
+    accountingAddFD(cbmap, fd, toDo, parameter, ttd);
+  }
+
+  void removeFD(callbackmap_t& cbmap, int fd) override
+  {
+    accountingRemoveFD(cbmap, fd);
+  }
+
+  void alterFD(callbackmap_t& from, callbackmap_t& to, int fd, callbackfunc_t toDo, const funcparam_t& parameter, const struct timeval* ttd) override
+  {
+    accountingRemoveFD(from, fd);
+    accountingAddFD(to, fd, toDo, parameter, ttd);
+  }
+
+  string getName() const override
+  {
+    return "mockup";
+  }
+
+  void setReady(int fd)
+  {
+    ready.insert(fd);
+  }
+
+  void setNotdReady(int fd)
+  {
+    ready.erase(fd);
+  }
+
+private:
+  std::set<int> ready;
+};
+
+BOOST_AUTO_TEST_CASE(test_IncomingConnection)
+{
+  //int sockets[2];
+  //int res = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+  //BOOST_REQUIRE_EQUAL(res, 0);
+  ComboAddress local("192.0.2.1:80");
+  ClientState localCS(local, true, false, false, "", {});
+  auto tlsCtx = std::make_shared<MockupTLSCtx>();
+  localCS.tlsFrontend = std::make_shared<TLSFrontend>(tlsCtx);
+
+  TCPClientThreadData threadData;
+  threadData.mplexer = std::make_unique<MockupFDMultiplexer>();
+
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, DNSName("powerdns.com."), QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+
+  uint16_t querySize = static_cast<uint16_t>(query.size());
+  const uint8_t sizeBytes[] = { static_cast<uint8_t>(querySize / 256), static_cast<uint8_t>(querySize % 256) };
+  query.insert(query.begin(), sizeBytes, sizeBytes + 2);
+
+  g_verbose = true;
+
+  {
+    /* drop right away */
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    s_processQuery = [](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      return ProcessQueryResult::Drop;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0);
+  }
+
+  {
+    /* self-generated REFUSED, client closes connection right away */
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 65537 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    s_processQuery = [](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      // Would be nicer to actually turn it into a response
+      return ProcessQueryResult::SendAnswer;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
+  }
+
+  {
+    /* short read on the size, then on the query itself,
+       self-generated REFUSED, short write on the response, 
+       client closes connection right away */
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::NeedRead, 1 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 1 },
+      { ExpectedStep::ExpectedRequest::read, IOState::NeedRead, query.size() - 3 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 1 },
+      { ExpectedStep::ExpectedRequest::write, IOState::NeedWrite, query.size() - 1},
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 1 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    s_processQuery = [](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      // Would be nicer to actually turn it into a response
+      return ProcessQueryResult::SendAnswer;
+    };
+
+    /* mark the incoming FD as always ready */
+    dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(-1);
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
+      threadData.mplexer->run(&now);
+    }
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
+  }
+
+  {
+#if 0
+    /* 10k self-generated REFUSED on the same connection */
+    size_t count = 10000;
+    s_readBuffer->clear();
+    s_writeBuffer.clear();
+    s_steps = { { ExpectedStep::ExpectedRequest::handshake, IOState::Done } };
+
+    for (size_t idx = 0; idx < count; idx++) {
+      s_readBuffer->insert(s_readBuffer->end(), query.begin(), query.end());
+      s_steps.push_back({ ExpectedStep::ExpectedRequest::read, IOState::Done, 2 });
+      s_steps.push_back({ ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 });
+      s_steps.push_back({ ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() + 2 });
+    };
+    s_steps.push_back({ ExpectedStep::ExpectedRequest::read, IOState::Done, 0 });
+    s_steps.push_back({ ExpectedStep::ExpectedRequest::close, IOState::Done });
+
+    size_t counter = 0;
+    s_processQuery = [&counter](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      // Would be nicer to actually turn it into a response
+      return ProcessQueryResult::SendAnswer;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size() * count);
+#endif
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -41,23 +41,12 @@ GlobalStateHolder<servers_t> g_dstates;
 
 QueryCount g_qcount;
 
-
 bool checkDNSCryptQuery(const ClientState& cs, PacketBuffer& query, std::shared_ptr<DNSCryptQuery>& dnsCryptQuery, time_t now, bool tcp)
 {
   return false;
 }
 
-bool processResponse(PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted)
-{
-  return false;
-}
-
 bool checkQueryHeaders(const struct dnsheader* dh)
-{
-  return true;
-}
-
-bool responseContentMatches(const PacketBuffer& response, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote, unsigned int& qnameWireLength)
 {
   return true;
 }
@@ -83,6 +72,28 @@ ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& 
   return ProcessQueryResult::Drop;
 }
 
+static std::function<bool(const PacketBuffer& response, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote, unsigned int& qnameWireLength)> s_responseContentMatches;
+
+bool responseContentMatches(const PacketBuffer& response, const DNSName& qname, const uint16_t qtype, const uint16_t qclass, const ComboAddress& remote, unsigned int& qnameWireLength)
+{
+  if (s_responseContentMatches) {
+    return s_responseContentMatches(response, qname, qtype, qclass, remote, qnameWireLength);
+  }
+
+  return true;
+}
+
+static std::function<bool(PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted)> s_processResponse;
+
+bool processResponse(PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted)
+{
+  if (s_processResponse) {
+    return s_processResponse(response, localRespRulactions, dr, muted);
+  }
+
+  return false;
+}
+
 BOOST_AUTO_TEST_SUITE(test_dnsdisttcp_cc)
 
 struct ExpectedStep
@@ -90,14 +101,11 @@ struct ExpectedStep
 public:
   enum class ExpectedRequest { handshake, connect, read, write, close };
 
-  ExpectedStep(ExpectedRequest r, IOState n): ExpectedStep(r, n, 0)
+  ExpectedStep(ExpectedRequest r, IOState n, size_t b = 0, std::function<void(int descriptor, const ExpectedStep& step)> fn = nullptr): cb(fn), request(r), nextState(n), bytes(b)
   {
   }
 
-  ExpectedStep(ExpectedRequest r, IOState n, size_t b): request(r), nextState(n), bytes(b)
-  {
-  }
-
+  std::function<void(int descriptor, const ExpectedStep& step)> cb{nullptr};
   ExpectedRequest request;
   IOState nextState;
   size_t bytes{0};
@@ -112,8 +120,10 @@ static ExpectedStep getStep()
   return res;
 }
 
-static boost::optional<PacketBuffer> s_readBuffer;
+static PacketBuffer s_readBuffer;
 static PacketBuffer s_writeBuffer;
+static PacketBuffer s_backendReadBuffer;
+static PacketBuffer s_backendWriteBuffer;
 
 std::ostream& operator<<(std::ostream &os, const ExpectedStep::ExpectedRequest d);
 
@@ -126,14 +136,18 @@ std::ostream& operator<<(std::ostream &os, const ExpectedStep::ExpectedRequest d
 
 class MockupTLSConnection : public TLSConnection
 {
-private:
 public:
+  MockupTLSConnection(int descriptor, bool client = false): d_descriptor(descriptor), d_client(client)
+  {
+  }
+
   ~MockupTLSConnection() { }
 
   IOState tryHandshake() override
   {
     auto step = getStep();
     BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::handshake);
+
     return step.nextState;
   }
 
@@ -147,6 +161,9 @@ public:
     BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::write);
 
     if (step.bytes == 0) {
+      if (step.nextState == IOState::NeedWrite) {
+        return step.nextState;
+      }
       throw std::runtime_error("Remote host closed the connection");
     }
 
@@ -157,7 +174,8 @@ public:
       toWrite = step.bytes;
     }
 
-    s_writeBuffer.insert(s_writeBuffer.end(), buffer.begin() + pos, buffer.begin() + pos + toWrite);
+    auto& externalBuffer = d_client ? s_backendWriteBuffer : s_writeBuffer;
+    externalBuffer.insert(externalBuffer.end(), buffer.begin() + pos, buffer.begin() + pos + toWrite);
     pos += toWrite;
 
     return step.nextState;
@@ -173,21 +191,35 @@ public:
     BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::read);
 
     if (step.bytes == 0) {
+      if (step.nextState == IOState::NeedRead) {
+        return step.nextState;
+      }
       throw std::runtime_error("Remote host closed the connection");
     }
 
-    if (s_readBuffer) {
-      toRead -= pos;
+    auto& externalBuffer = d_client ? s_backendReadBuffer : s_readBuffer;
+    toRead -= pos;
 
-      if (step.bytes < toRead) {
-        toRead = step.bytes;
-      }
-      BOOST_REQUIRE_GE(buffer.size(), toRead);
-      BOOST_REQUIRE_GE(s_readBuffer->size(), toRead);
+    if (step.bytes < toRead) {
+      toRead = step.bytes;
+    }
+    BOOST_REQUIRE_GE(buffer.size(), toRead);
+    BOOST_REQUIRE_GE(externalBuffer.size(), toRead);
 
-      std::copy(s_readBuffer->begin(), s_readBuffer->begin() + toRead, buffer.begin() + pos);
-      pos += toRead;
-      s_readBuffer->erase(s_readBuffer->begin(), s_readBuffer->begin() + toRead);
+    std::copy(externalBuffer.begin(), externalBuffer.begin() + toRead, buffer.begin() + pos);
+    pos += toRead;
+    externalBuffer.erase(externalBuffer.begin(), externalBuffer.begin() + toRead);
+
+    return step.nextState;
+  }
+
+  IOState tryConnect(bool fastOpen, const ComboAddress& remote) override
+  {
+    auto step = getStep();
+    BOOST_REQUIRE_EQUAL(step.request, ExpectedStep::ExpectedRequest::connect);
+
+    if (step.cb) {
+      step.cb(d_descriptor, step);
     }
 
     return step.nextState;
@@ -228,11 +260,6 @@ public:
   {
   }
 
-  IOState tryConnect(bool fastOpen, const ComboAddress& remote) override
-  {
-    return IOState::Done;
-  }
-
   size_t read(void* buffer, size_t bufferSize, unsigned int readTimeout, unsigned int totalTimeout=0) override
   {
     return 0;
@@ -242,6 +269,9 @@ public:
   {
     return 0;
   }
+private:
+  const int d_descriptor;
+  bool d_client{false};
 };
 
 class MockupTLSCtx : public TLSCtx
@@ -253,7 +283,12 @@ public:
 
   std::unique_ptr<TLSConnection> getConnection(int socket, unsigned int timeout, time_t now) override
   {
-    return std::make_unique<MockupTLSConnection>();
+    return std::make_unique<MockupTLSConnection>(socket);
+  }
+
+  std::unique_ptr<TLSConnection> getClientConnection(const std::string& host, int socket, unsigned int timeout) override
+  {
+    return std::make_unique<MockupTLSConnection>(socket, true);
   }
 
   void rotateTicketsKey(time_t now) override
@@ -263,11 +298,6 @@ public:
   size_t getTicketsKeysCount() override
   {
     return 0;
-  }
-
-  std::unique_ptr<TLSConnection> getClientConnection(const std::string& host, int socket, unsigned int timeout) override
-  {
-    return nullptr;
   }
 };
 
@@ -349,8 +379,6 @@ private:
   std::set<int> ready;
 };
 
-#warning TODO: outgoing proxy protocol, out-of-order query from cache while pending response (short write) from backend, exception while processing the response
-
 BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
 {
   ComboAddress local("192.0.2.1:80");
@@ -372,10 +400,11 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
   const uint8_t sizeBytes[] = { static_cast<uint8_t>(querySize / 256), static_cast<uint8_t>(querySize % 256) };
   query.insert(query.begin(), sizeBytes, sizeBytes + 2);
 
-  g_verbose = true;
+  g_proxyProtocolACL.clear();
 
   {
     /* drop right away */
+    cerr<<"=> drop right away"<<endl;
     s_readBuffer = query;
     s_writeBuffer.clear();
     s_steps = {
@@ -390,11 +419,12 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
     IncomingTCPConnectionState::handleIO(state, now);
-    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
   }
 
   {
     /* self-generated REFUSED, client closes connection right away */
+    cerr<<"=> self-gen"<<endl;
     s_readBuffer = query;
     s_writeBuffer.clear();
     s_steps = {
@@ -417,6 +447,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
   }
 
   {
+    cerr<<"=> shorts"<<endl;
     /* need write then read during handshake,
        short read on the size, then on the query itself,
        self-generated REFUSED, short write on the response,
@@ -454,6 +485,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
   }
 
   {
+    cerr<<"=> exception while handling the query"<<endl;
     /* Exception raised while handling the query */
     s_readBuffer = query;
     s_writeBuffer.clear();
@@ -469,19 +501,21 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
     IncomingTCPConnectionState::handleIO(state, now);
-    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
   }
 
   {
 #if 0
+    cerr<<"=> 10k self-generated pipelined on the same connection"<<endl;
+
     /* 10k self-generated REFUSED pipelined on the same connection */
     size_t count = 10000;
-    s_readBuffer->clear();
+    s_readBuffer.clear();
     s_writeBuffer.clear();
     s_steps = { { ExpectedStep::ExpectedRequest::handshake, IOState::Done } };
 
     for (size_t idx = 0; idx < count; idx++) {
-      s_readBuffer->insert(s_readBuffer->end(), query.begin(), query.end());
+      s_readBuffer.insert(s_readBuffer.end(), query.begin(), query.end());
       s_steps.push_back({ ExpectedStep::ExpectedRequest::read, IOState::Done, 2 });
       s_steps.push_back({ ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 });
       s_steps.push_back({ ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() + 2 });
@@ -502,6 +536,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
   }
 
   {
+    cerr<<"=> timeout while reading the query"<<endl;
     /* timeout while reading the query */
     s_readBuffer = query;
     s_writeBuffer.clear();
@@ -522,7 +557,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
     IncomingTCPConnectionState::handleIO(state, now);
-    BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0);
+    BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0U);
     struct timeval later = now;
     later.tv_sec += g_tcpRecvTimeout + 1;
     auto expiredReadConns = threadData.mplexer->getTimeouts(later, false);
@@ -534,10 +569,11 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
         cbState->handleTimeout(cbState, false);
       }
     }
-    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
   }
 
   {
+    cerr<<"=> timeout while writing the response"<<endl;
     /* timeout while writing the response */
     s_readBuffer = query;
     s_writeBuffer.clear();
@@ -557,7 +593,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
     IncomingTCPConnectionState::handleIO(state, now);
-    BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0);
+    BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0U);
     struct timeval later = now;
     later.tv_sec += g_tcpRecvTimeout + 1;
     auto expiredWriteConns = threadData.mplexer->getTimeouts(later, true);
@@ -569,21 +605,47 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
         cbState->handleTimeout(cbState, false);
       }
     }
-    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 1);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 1U);
   }
 
+}
+
+BOOST_AUTO_TEST_CASE(test_IncomingConnectionWithProxyProtocol_SelfAnswered)
+{
+  ComboAddress local("192.0.2.1:80");
+  ClientState localCS(local, true, false, false, "", {});
+  auto tlsCtx = std::make_shared<MockupTLSCtx>();
+  localCS.tlsFrontend = std::make_shared<TLSFrontend>(tlsCtx);
+
+  TCPClientThreadData threadData;
+  threadData.mplexer = std::make_unique<MockupFDMultiplexer>();
+
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, DNSName("powerdns.com."), QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+
+  uint16_t querySize = static_cast<uint16_t>(query.size());
+  const uint8_t sizeBytes[] = { static_cast<uint8_t>(querySize / 256), static_cast<uint8_t>(querySize % 256) };
+  query.insert(query.begin(), sizeBytes, sizeBytes + 2);
+
+  g_proxyProtocolACL.clear();
+  g_proxyProtocolACL.addMask("0.0.0.0/0");
+
   {
+    cerr<<"=> reading PP"<<endl;
     /* reading a proxy protocol payload */
     auto proxyPayload = makeProxyHeader(true, ComboAddress("192.0.2.1"), ComboAddress("192.0.2.2"), {});
     BOOST_REQUIRE_GT(proxyPayload.size(), s_proxyProtocolMinimumHeaderSize);
     s_readBuffer = query;
     // preprend the proxy protocol payload
-    s_readBuffer->insert(s_readBuffer->begin(), proxyPayload.begin(), proxyPayload.end());
+    s_readBuffer.insert(s_readBuffer.begin(), proxyPayload.begin(), proxyPayload.end());
     // append a second query
-    s_readBuffer->insert(s_readBuffer->end(), query.begin(), query.end());
+    s_readBuffer.insert(s_readBuffer.end(), query.begin(), query.end());
     s_writeBuffer.clear();
-    g_proxyProtocolACL.clear();
-    g_proxyProtocolACL.addMask("0.0.0.0/0");
+
     s_steps = {
       { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
       { ExpectedStep::ExpectedRequest::read, IOState::Done, s_proxyProtocolMinimumHeaderSize },
@@ -606,22 +668,48 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
     IncomingTCPConnectionState::handleIO(state, now);
-    BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0);
+    BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0U);
     BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size() * 2U);
   }
 
   {
+    cerr<<"=> Invalid PP"<<endl;
+    /* reading a (broken) proxy protocol payload */
+    auto proxyPayload = std::vector<uint8_t>(s_proxyProtocolMinimumHeaderSize);
+    std::fill(proxyPayload.begin(), proxyPayload.end(), 0);
+
+    s_readBuffer = query;
+    // preprend the proxy protocol payload
+    s_readBuffer.insert(s_readBuffer.begin(), proxyPayload.begin(), proxyPayload.end());
+    s_writeBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, s_proxyProtocolMinimumHeaderSize },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    s_processQuery = [](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      return ProcessQueryResult::SendAnswer;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+  }
+
+  {
+    cerr<<"=> timeout while reading PP"<<endl;
     /* timeout while reading the proxy protocol payload */
     auto proxyPayload = makeProxyHeader(true, ComboAddress("192.0.2.1"), ComboAddress("192.0.2.2"), {});
     BOOST_REQUIRE_GT(proxyPayload.size(), s_proxyProtocolMinimumHeaderSize);
     s_readBuffer = query;
     // preprend the proxy protocol payload
-    s_readBuffer->insert(s_readBuffer->begin(), proxyPayload.begin(), proxyPayload.end());
+    s_readBuffer.insert(s_readBuffer.begin(), proxyPayload.begin(), proxyPayload.end());
     // append a second query
-    s_readBuffer->insert(s_readBuffer->end(), query.begin(), query.end());
+    s_readBuffer.insert(s_readBuffer.end(), query.begin(), query.end());
     s_writeBuffer.clear();
-    g_proxyProtocolACL.clear();
-    g_proxyProtocolACL.addMask("0.0.0.0/0");
+
     s_steps = {
       { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
       { ExpectedStep::ExpectedRequest::read, IOState::Done, s_proxyProtocolMinimumHeaderSize },
@@ -637,7 +725,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
 
     auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
     IncomingTCPConnectionState::handleIO(state, now);
-    BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0);
+    BOOST_CHECK_EQUAL(threadData.mplexer->run(&now), 0U);
     struct timeval later = now;
     later.tv_sec += g_tcpRecvTimeout + 1;
     auto expiredReadConns = threadData.mplexer->getTimeouts(later, false);
@@ -649,16 +737,846 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
         cbState->handleTimeout(cbState, false);
       }
     }
-    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
+{
+  ComboAddress local("192.0.2.1:80");
+  ClientState localCS(local, true, false, false, "", {});
+  auto tlsCtx = std::make_shared<MockupTLSCtx>();
+  localCS.tlsFrontend = std::make_shared<TLSFrontend>(tlsCtx);
+
+  TCPClientThreadData threadData;
+  threadData.mplexer = std::make_unique<MockupFDMultiplexer>();
+
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, DNSName("powerdns.com."), QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+
+  uint16_t querySize = static_cast<uint16_t>(query.size());
+  const uint8_t sizeBytes[] = { static_cast<uint8_t>(querySize / 256), static_cast<uint8_t>(querySize % 256) };
+  query.insert(query.begin(), sizeBytes, sizeBytes + 2);
+
+  g_verbose = true;
+
+  g_proxyProtocolACL.clear();
+
+  {
+    /* pass to backend, backend answers right away, client closes the connection */
+    cerr<<"=> Query to backend, backend answers right away"<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer = query;
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing a connection to the backend */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    s_processQuery = [tlsCtx](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);
+      selectedBackend->d_tlsCtx = tlsCtx;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
+    BOOST_CHECK(s_writeBuffer == query);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
+    BOOST_CHECK(s_backendWriteBuffer == query);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* pass to backend, backend answers right away, exception while handling the response */
+    cerr<<"=> Exception while handling the response sent by the backend"<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer = query;
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing a connection to the backend */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    s_processQuery = [tlsCtx](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);
+      selectedBackend->d_tlsCtx = tlsCtx;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      throw std::runtime_error("Unexpected error while processing the response");
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
+    BOOST_CHECK(s_backendWriteBuffer == query);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* pass to backend, backend answers right away, processResponse() fails */
+    cerr<<"=> Response processing fails "<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer = query;
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing a connection to the backend */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    s_processQuery = [tlsCtx](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);
+      selectedBackend->d_tlsCtx = tlsCtx;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return false;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
+    BOOST_CHECK(s_backendWriteBuffer == query);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* pass to backend, backend answers right away, ID matching fails */
+    cerr<<"=> ID matching fails "<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    auto response = query;
+    /* mess with the transaction ID */
+    response.at(3) ^= 42;
+
+    s_backendReadBuffer = response;
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing a connection to the backend */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    s_processQuery = [tlsCtx](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);
+      selectedBackend->d_tlsCtx = tlsCtx;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
+    BOOST_CHECK(s_backendWriteBuffer == query);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* connect in progress, short write to the backend, short read from the backend, client */
+    cerr<<"=> Short read and write to backend"<<endl;
+    s_readBuffer = query;
+    // append a second query
+    s_readBuffer.insert(s_readBuffer.end(), query.begin(), query.end());
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer = query;
+    // append a second query
+    s_backendReadBuffer.insert(s_backendReadBuffer.end(), query.begin(), query.end());
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* connect to backend */
+      { ExpectedStep::ExpectedRequest::connect, IOState::NeedWrite, 0, [&threadData](int desc, const ExpectedStep& step) {
+          /* set the outgoing descriptor (backend connection) as ready */
+          dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(desc);
+        }
+      },
+      /* send query */
+      { ExpectedStep::ExpectedRequest::write, IOState::NeedWrite, 1 },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() - 1 },
+      /* read response */
+      { ExpectedStep::ExpectedRequest::read, IOState::NeedRead, 1 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 1 },
+      { ExpectedStep::ExpectedRequest::read, IOState::NeedRead, query.size() - 3 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 1 },
+      /* write response to client */
+      { ExpectedStep::ExpectedRequest::write, IOState::NeedWrite, query.size() - 1 },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 1 },
+      /* read second query */
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* write second query to backend */
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      /* read second response */
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* write second response */
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      /* read from client */
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      /* close connection to client */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* close connection to the backend, eventually */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+
+    auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);
+    backend->d_tlsCtx = tlsCtx;
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    /* set the incoming descriptor as ready! */
+    dynamic_cast<MockupFDMultiplexer*>(threadData.mplexer.get())->setReady(-1);
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    while (threadData.mplexer->getWatchedFDCount(false) != 0 || threadData.mplexer->getWatchedFDCount(true) != 0) {
+      threadData.mplexer->run(&now);
+    }
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size() * 2U);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size() * 2U);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* connection refused by the backend */
+    cerr<<"=> Connection refused by the backend "<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer.clear();
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend (5 tries by default) */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done, 0, [](int descriptor, const ExpectedStep& step) {
+          throw NetworkError("Connection refused by the backend");
+        }
+      },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done, 0, [](int descriptor, const ExpectedStep& step) {
+          throw NetworkError("Connection refused by the backend");
+        }
+      },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done, 0, [](int descriptor, const ExpectedStep& step) {
+          throw NetworkError("Connection refused by the backend");
+        }
+      },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done, 0, [](int descriptor, const ExpectedStep& step) {
+          throw NetworkError("Connection refused by the backend");
+        }
+      },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done, 0, [](int descriptor, const ExpectedStep& step) {
+          throw NetworkError("Connection refused by the backend");
+        }
+      },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);
+    backend->d_tlsCtx = tlsCtx;
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), 0U);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* timeout from the backend (write) */
+    cerr<<"=> Timeout from the backend (write) "<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer.clear();
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend (retrying 5 times) */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::NeedWrite },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);;
+    backend->d_tlsCtx = tlsCtx;
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    struct timeval later = now;
+    later.tv_sec += backend->tcpSendTimeout + 1;
+    auto expiredWriteConns = threadData.mplexer->getTimeouts(later, true);
+    BOOST_CHECK_EQUAL(expiredWriteConns.size(), 1U);
+    for (const auto& cbData : expiredWriteConns) {
+      if (cbData.second.type() == typeid(std::shared_ptr<TCPConnectionToBackend>)) {
+        auto cbState = boost::any_cast<std::shared_ptr<TCPConnectionToBackend>>(cbData.second);
+        cbState->handleTimeout(later, true);
+      }
+    }
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), 0U);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* timeout from the backend (read) */
+    cerr<<"=> Timeout from the backend (read) "<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer.clear();
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::NeedRead, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);;
+    backend->d_tlsCtx = tlsCtx;
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    struct timeval later = now;
+    later.tv_sec += backend->tcpRecvTimeout + 1;
+    auto expiredConns = threadData.mplexer->getTimeouts(later, false);
+    BOOST_CHECK_EQUAL(expiredConns.size(), 1U);
+    for (const auto& cbData : expiredConns) {
+      if (cbData.second.type() == typeid(std::shared_ptr<TCPConnectionToBackend>)) {
+        auto cbState = boost::any_cast<std::shared_ptr<TCPConnectionToBackend>>(cbData.second);
+        cbState->handleTimeout(later, false);
+      }
+    }
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* connection closed from the backend (write) */
+    cerr<<"=> Connection closed from the backend (write) "<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer.clear();
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend, connection closed on first write (5 attempts) */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);;
+    backend->d_tlsCtx = tlsCtx;
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), 0U);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* connection closed from the backend (write) 4 times then succeeds */
+    cerr<<"=> Connection closed from the backend (write) 4 times then succeeds"<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer = query;
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend, connection closed on first write (5 attempts) */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      /* reading the response */
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* send the response to the client */
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      /* client closes the connection */
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* then eventually the backend one */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);;
+    backend->d_tlsCtx = tlsCtx;
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
+    BOOST_CHECK(s_writeBuffer == query);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* connection closed from the backend (read) */
+    cerr<<"=> Connection closed from the backend (read) "<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer.clear();
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend, connection closed on read, 5 attempts, last one succeeds */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);;
+    backend->d_tlsCtx = tlsCtx;
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), 0U);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size() * backend->retries);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+    /* connection closed from the backend (read) 4 times then succeeds */
+    cerr<<"=> Connection closed from the backend (read) 4 times then succeeds "<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer = query;
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend, connection closed on read, 5 attempts, last one succeeds */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* this time it works */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* sending the response to the client */
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      /* client closes the connection */
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* the eventually the backend one */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+    auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);;
+    backend->d_tlsCtx = tlsCtx;
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
+    BOOST_CHECK(s_writeBuffer == query);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size() * backend->retries);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
+
+  {
+#if 0
+    /* 101 queries on the same connection, check that the maximum number of queries kicks in */
+    cerr<<"=> 101 queries on the same connection"<<endl;
+
+    g_maxTCPQueriesPerConn = 100;
+
+    size_t count = 101;
+
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+
+    s_backendReadBuffer.clear();
+    s_backendWriteBuffer.clear();
+
+    s_readBuffer.clear();
+    s_writeBuffer.clear();
+
+    for (size_t idx = 0; idx < count; idx++) {
+      s_readBuffer.insert(s_readBuffer.end(), query.begin(), query.end());
+      s_backendReadBuffer.insert(s_backendReadBuffer.end(), query.begin(), query.end());
+    }
+
+    s_steps = { { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+                { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+                { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+                /* opening a connection to the backend */
+                { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+                { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() + 2 },
+                { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+                { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+                { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() + 2 }
+    };
+
+    for (size_t idx = 0; idx < count - 1; idx++) {
+      /* read a new query */
+      s_steps.push_back({ ExpectedStep::ExpectedRequest::read, IOState::Done, 2 });
+      s_steps.push_back({ ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 });
+      /* pass it to the backend */
+      s_steps.push_back({ ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() + 2 });
+      s_steps.push_back({ ExpectedStep::ExpectedRequest::read, IOState::Done, 2 });
+      s_steps.push_back({ ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 });
+      /* send the response */
+      s_steps.push_back({ ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() + 2 });
+    };
+    /* close the connection with the client */
+    s_steps.push_back({ ExpectedStep::ExpectedRequest::close, IOState::Done });
+    /* eventually with the backend as well */
+    s_steps.push_back({ ExpectedStep::ExpectedRequest::close, IOState::Done });
+
+    auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);;
+    backend->d_tlsCtx = tlsCtx;
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size() * count);
+
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+
+    g_maxTCPQueriesPerConn = 0;
+#endif
   }
 
 }
 
-BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendAnswersRightAway)
+BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
 {
-//int sockets[2];
-//int res = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
-//BOOST_REQUIRE_EQUAL(res, 0);
+  ComboAddress local("192.0.2.1:80");
+  ClientState localCS(local, true, false, false, "", {});
+  /* enable out-of-order on the front side */
+  localCS.d_maxInFlightQueriesPerConn = 65536;
+
+  auto tlsCtx = std::make_shared<MockupTLSCtx>();
+  localCS.tlsFrontend = std::make_shared<TLSFrontend>(tlsCtx);
+
+  auto backend = std::make_shared<DownstreamState>(ComboAddress("192.0.2.42:53"), ComboAddress("0.0.0.0:0"), 0, std::string(), 1, false);
+  backend->d_tlsCtx = tlsCtx;
+  /* enable out-of-order on the backend side as well */
+  backend->d_maxInFlightQueriesPerConn = 65536;
+
+  TCPClientThreadData threadData;
+  threadData.mplexer = std::make_unique<MockupFDMultiplexer>();
+
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
+  PacketBuffer query;
+  GenericDNSPacketWriter<PacketBuffer> pwQ(query, DNSName("powerdns.com."), QType::A, QClass::IN, 0);
+  pwQ.getHeader()->rd = 1;
+
+  uint16_t querySize = static_cast<uint16_t>(query.size());
+  const uint8_t sizeBytes[] = { static_cast<uint8_t>(querySize / 256), static_cast<uint8_t>(querySize % 256) };
+  query.insert(query.begin(), sizeBytes, sizeBytes + 2);
+
+  g_verbose = true;
+
+  g_proxyProtocolACL.clear();
+
+  {
+    cerr<<"=> 5 OOOR queries to the backend, backend responds out of order"<<endl;
+    s_readBuffer = query;
+    s_writeBuffer.clear();
+#warning TODOOOOOOOOOO
+    s_backendReadBuffer = query;
+    s_backendWriteBuffer.clear();
+
+    s_steps = {
+      { ExpectedStep::ExpectedRequest::handshake, IOState::Done },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      /* opening a connection to the backend */
+      { ExpectedStep::ExpectedRequest::connect, IOState::Done },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 2 },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, query.size() - 2 },
+      { ExpectedStep::ExpectedRequest::write, IOState::Done, query.size() },
+      { ExpectedStep::ExpectedRequest::read, IOState::Done, 0 },
+      /* closing client connection */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+      /* closing a connection to the backend */
+      { ExpectedStep::ExpectedRequest::close, IOState::Done },
+    };
+
+    s_processQuery = [backend](DNSQuestion& dq, ClientState& cs, LocalHolders& holders, std::shared_ptr<DownstreamState>& selectedBackend) -> ProcessQueryResult {
+      selectedBackend = backend;
+      return ProcessQueryResult::PassToBackend;
+    };
+    s_processResponse = [](PacketBuffer& response, LocalStateHolder<vector<DNSDistResponseRuleAction> >& localRespRulactions, DNSResponse& dr, bool muted) -> bool {
+      return true;
+    };
+
+    auto state = std::make_shared<IncomingTCPConnectionState>(ConnectionInfo(&localCS), threadData, now);
+    IncomingTCPConnectionState::handleIO(state, now);
+    BOOST_CHECK_EQUAL(s_writeBuffer.size(), query.size());
+    BOOST_CHECK(s_writeBuffer == query);
+    BOOST_CHECK_EQUAL(s_backendWriteBuffer.size(), query.size());
+    BOOST_CHECK(s_backendWriteBuffer == query);
+    /* we need to clear them now, otherwise we end up with dangling pointers to the steps via the TLS context, etc */
+    IncomingTCPConnectionState::clearAllDownstreamConnections();
+  }
 }
+
+#warning TODO:
+
+// proxy protocol to backend?
+
+// OOOR: OOOR enabled but packet cache hit
+// OOOR: OOOR enabled but backend answers very fast
+// OOOR: OOOR, get 10 queries before the backend can answer. backend doesn't support OOOR, we should get 10 connections. Check that we do reuse them on two subsequent queries
+// OOOR: OOOR, get 10 queries before the backend can answer. backend does support OOOR, respond out of order we should only have 1 connections. Check that we do reuse them on two subsequent queries
+// OOOR: OOOR, get 10 queries before the backend can answer. backend does support OOOR but only up to 5 conns, respond out of order, we should only have 2 connections. Check that we do reuse one of them on two subsequent queries
+// OOOR: get one query, sent it to the backend, start reading the response, get two new queries during that time, finish getting the first answer, send it, timeout read on the client, get the last two answers and send them
+// out-of-order query from cache while pending response (short write) from backend, exception while processing the response
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -522,7 +522,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_SelfAnswered)
   }
 
   {
-#if 0
+#if 1
     TEST_INIT("=> 10k self-generated pipelined on the same connection");
 
     /* 10k self-generated REFUSED pipelined on the same connection */
@@ -1548,7 +1548,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
   }
 
   {
-#if 0
+#if 1
     /* 101 queries on the same connection, check that the maximum number of queries kicks in */
     TEST_INIT("=> 101 queries on the same connection");
 

--- a/pdns/epollmplexer.cc
+++ b/pdns/epollmplexer.cc
@@ -107,7 +107,7 @@ void EpollFDMultiplexer::addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo
   eevent.data.u64=0; // placate valgrind (I love it so much)
   eevent.data.fd=fd;
 
-  if(epoll_ctl(d_epollfd, EPOLL_CTL_ADD, fd, &eevent) < 0) {
+  if (epoll_ctl(d_epollfd, EPOLL_CTL_ADD, fd, &eevent) < 0) {
     cbmap.erase(fd);
     throw FDMultiplexerException("Adding fd to epoll set: "+stringerror());
   }

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -410,7 +410,7 @@ try {
     uint16_t counter = 0;
     Socket sock(dest.sin4.sin_family, SOCK_STREAM);
     SConnectWithTimeout(sock.getHandle(), dest, timeout);
-    TCPIOHandler handler(subjectName, sock.getHandle(), timeout, tlsCtx, time(nullptr));
+    TCPIOHandler handler(subjectName, sock.releaseHandle(), timeout, tlsCtx, time(nullptr));
     handler.connect(fastOpen, dest, timeout);
     // we are writing the proxyheader inside the TLS connection. Is that right?
     if (proxyheader.size() > 0 && handler.write(proxyheader.data(), proxyheader.size(), timeout) != proxyheader.size()) {

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -39,7 +39,7 @@ static void usage()
   cerr << "sdig" << endl;
   cerr << "Syntax: sdig IP-ADDRESS-OR-DOH-URL PORT QNAME QTYPE "
           "[dnssec] [ednssubnet SUBNET/MASK] [hidesoadetails] [hidettl] [recurse] [showflags] "
-          "[tcp] [dot] [insecure] [subjectName name] [caStore file] [tlsProvider openssl|gnutls] "
+          "[tcp] [dot] [insecure] [fastOpen] [subjectName name] [caStore file] [tlsProvider openssl|gnutls] "
           "[xpf XPFDATA] [class CLASSNUM] "
           "[proxy UDP(0)/TCP(1) SOURCE-IP-ADDRESS-AND-PORT DESTINATION-IP-ADDRESS-AND-PORT]"
        << endl;
@@ -260,6 +260,8 @@ try {
         dot = true;
       else if (strcmp(argv[i], "insecure") == 0)
         insecureDoT = true;
+      else if (strcmp(argv[i], "fastOpen") == 0)
+        fastOpen = true;
       else if (strcmp(argv[i], "ednssubnet") == 0) {
         if (argc < i + 2) {
           cerr << "ednssubnet needs an argument" << endl;
@@ -409,6 +411,7 @@ try {
     }
     uint16_t counter = 0;
     Socket sock(dest.sin4.sin_family, SOCK_STREAM);
+    setTCPNoDelay(sock.getHandle()); // disable NAGLE, which does not play nicely with delayed ACKs
     TCPIOHandler handler(subjectName, sock.releaseHandle(), timeout, tlsCtx, time(nullptr));
     handler.connect(fastOpen, dest, timeout);
     // we are writing the proxyheader inside the TLS connection. Is that right?

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -409,7 +409,6 @@ try {
     }
     uint16_t counter = 0;
     Socket sock(dest.sin4.sin_family, SOCK_STREAM);
-    SConnectWithTimeout(sock.getHandle(), dest, timeout);
     TCPIOHandler handler(subjectName, sock.releaseHandle(), timeout, tlsCtx, time(nullptr));
     handler.connect(fastOpen, dest, timeout);
     // we are writing the proxyheader inside the TLS connection. Is that right?

--- a/pdns/sstuff.hh
+++ b/pdns/sstuff.hh
@@ -351,7 +351,14 @@ public:
   {
     return d_socket;
   }
-  
+
+  int releaseHandle()
+  {
+    int ret = d_socket;
+    d_socket = -1;
+    return ret;
+  }
+
 private:
   static const size_t s_buflen{4096};
   std::string d_buffer;

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -234,7 +234,7 @@ public:
     }
   }
 
-  IOState tryWrite(PacketBuffer& buffer, size_t& pos, size_t toWrite) override
+  IOState tryWrite(const PacketBuffer& buffer, size_t& pos, size_t toWrite) override
   {
     do {
       int res = SSL_write(d_conn.get(), reinterpret_cast<const char *>(&buffer.at(pos)), static_cast<int>(toWrite - pos));
@@ -846,7 +846,7 @@ public:
     throw std::runtime_error("Error accepting a new connection");
   }
 
-  IOState tryWrite(PacketBuffer& buffer, size_t& pos, size_t toWrite) override
+  IOState tryWrite(const PacketBuffer& buffer, size_t& pos, size_t toWrite) override
   {
     do {
       ssize_t res = gnutls_record_send(d_conn.get(), reinterpret_cast<const char *>(&buffer.at(pos)), toWrite - pos);

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -839,7 +839,7 @@ public:
         return IOState::NeedRead;
       }
       else if (gnutls_error_is_fatal(ret) || ret == GNUTLS_E_WARNING_ALERT_RECEIVED) {
-        throw std::runtime_error("Error accepting a new connection");
+        throw std::runtime_error("Error accepting a new connection: " + std::string(gnutls_strerror(ret)));
       }
     } while (ret == GNUTLS_E_INTERRUPTED);
 

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -1029,7 +1029,7 @@ public:
   void close() override
   {
     if (d_conn) {
-      gnutls_bye(d_conn.get(), GNUTLS_SHUT_WR);
+      gnutls_bye(d_conn.get(), GNUTLS_SHUT_RDWR);
     }
   }
 

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -198,11 +198,19 @@ public:
 
   ~TCPIOHandler()
   {
+    close();
+  }
+
+  /* Prepare the connection but does not close the descriptor */
+  void close()
+  {
     if (d_conn) {
       d_conn->close();
+      d_conn.reset();
     }
     else if (d_socket != -1) {
       shutdown(d_socket, SHUT_RDWR);
+      d_socket = -1;
     }
   }
 

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -18,7 +18,7 @@ public:
   virtual IOState tryHandshake() = 0;
   virtual size_t read(void* buffer, size_t bufferSize, unsigned int readTimeout, unsigned int totalTimeout=0) = 0;
   virtual size_t write(const void* buffer, size_t bufferSize, unsigned int writeTimeout) = 0;
-  virtual IOState tryWrite(PacketBuffer& buffer, size_t& pos, size_t toWrite) = 0;
+  virtual IOState tryWrite(const PacketBuffer& buffer, size_t& pos, size_t toWrite) = 0;
   virtual IOState tryRead(PacketBuffer& buffer, size_t& pos, size_t toRead) = 0;
   virtual bool hasBufferedData() const = 0;
   virtual std::string getServerNameIndication() const = 0;
@@ -106,6 +106,14 @@ protected:
 class TLSFrontend
 {
 public:
+  TLSFrontend()
+  {
+  }
+
+  TLSFrontend(std::shared_ptr<TLSCtx> ctx): d_ctx(std::move(ctx))
+  {
+  }
+
   bool setupTLS();
 
   void rotateTicketsKey(time_t now)
@@ -122,7 +130,7 @@ public:
     }
   }
 
-  std::shared_ptr<TLSCtx> getContext()
+  std::shared_ptr<TLSCtx>& getContext()
   {
     return d_ctx;
   }
@@ -173,7 +181,7 @@ public:
   ComboAddress d_addr;
   std::string d_provider;
 
-private:
+protected:
   std::shared_ptr<TLSCtx> d_ctx{nullptr};
 };
 
@@ -302,7 +310,7 @@ public:
      return Done when toWrite bytes have been written, needRead or needWrite if the IO operation
      would block.
   */
-  IOState tryWrite(PacketBuffer& buffer, size_t& pos, size_t toWrite)
+  IOState tryWrite(const PacketBuffer& buffer, size_t& pos, size_t toWrite)
   {
     if (buffer.size() < toWrite || pos >= toWrite) {
       throw std::out_of_range("Calling tryWrite() with a too small buffer (" + std::to_string(buffer.size()) + ") for a write of " + std::to_string(toWrite - pos) + " bytes starting at " + std::to_string(pos));

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -201,17 +201,23 @@ public:
     close();
   }
 
-  /* Prepare the connection but does not close the descriptor */
   void close()
   {
     if (d_conn) {
       d_conn->close();
       d_conn.reset();
     }
-    else if (d_socket != -1) {
+
+    if (d_socket != -1) {
       shutdown(d_socket, SHUT_RDWR);
+      ::close(d_socket);
       d_socket = -1;
     }
+  }
+
+  int getDescriptor() const
+  {
+    return d_socket;
   }
 
   IOState tryConnect(bool fastOpen, const ComboAddress& remote)

--- a/pdns/test-dnscrypt_cc.cc
+++ b/pdns/test-dnscrypt_cc.cc
@@ -30,7 +30,7 @@
 #include "dnswriter.hh"
 #include <unistd.h>
 
-bool g_verbose{true};
+bool g_verbose{false};
 bool g_syslog{true};
 
 BOOST_AUTO_TEST_SUITE(test_dnscrypt_cc)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR fixes several issues in corner cases, introduced during the refactoring for out-of-order support. It also adds a lot of unit tests for that TCP code, which was planned for 1.7.0 but fast-forwarded because of issues reported with 1.6.0-alpha1.

It also adds a new configuration option, `setTCPInternalPipeBufferSize`, that can be used to set the size of the buffer of the internal pipe used to pass queries to TCP worker threads, thus allowing a smoother handling of incoming TCP connections peaks.

The diff seems huge but most of that (3200 out of 3900 additions) comes from the new unit tests, which actually amount to more lines of code than the TCP code itself and provides a very nice code coverage (which unfortunately does not prevent bugs from still hiding in a unexpected state.. ;-)).

One caveat is that this drops source selection support other than via `SO_BINDTODEVICE`, because having to pass the source interface name and index down to the actual `sendmsg` code is very annoying. Perhaps we should at least look into supporting `IP_SENDIF` in addition to `SO_BINDTODEVICE`?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
