### PR TITLE
rec: Change dnssec default to `process`

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5320,7 +5320,7 @@ int main(int argc, char **argv)
     ::arg().set("local-address","IP addresses to listen on, separated by spaces or commas. Also accepts ports.")="127.0.0.1";
     ::arg().setSwitch("non-local-bind", "Enable binding to non-local addresses by using FREEBIND / BINDANY socket options")="no";
     ::arg().set("trace","if we should output heaps of logging. set to 'fail' to only log failing domains")="off";
-    ::arg().set("dnssec", "DNSSEC mode: off/process-no-validate (default)/process/log-fail/validate")="process-no-validate";
+    ::arg().set("dnssec", "DNSSEC mode: off/process-no-validate/process (default)/log-fail/validate")="process";
     ::arg().set("dnssec-log-bogus", "Log DNSSEC bogus validations")="no";
     ::arg().set("signature-inception-skew", "Allow the signature inception to be off by this number of seconds")="60";
     ::arg().set("daemon","Operate as a daemon")="no";

--- a/pdns/recursordist/docs/dnssec.rst
+++ b/pdns/recursordist/docs/dnssec.rst
@@ -14,13 +14,15 @@ The PowerDNS Recursor will not set the DNSSEC OK (DO) bit in the outgoing querie
 
 ``process-no-validate``
 ^^^^^^^^^^^^^^^^^^^^^^^
-The default mode.
+The default mode until PowerDNS Recursor 4.5.0.
 
 In this mode the Recursor acts as a "security aware, non-validating" nameserver, meaning it will set the DO-bit on outgoing queries and will provide DNSSEC related RRsets (NSEC, RRSIG) to clients that ask for them (by means of a DO-bit in the query), except for zones provided through the ``auth-zones`` setting.
 It will not do any validation in this mode, not even when requested by the client.
 
 ``process``
 ^^^^^^^^^^^
+The default mode since PowerDNS Recursor 4.5.0.
+
 When :ref:`setting-dnssec` is set to ``process`` the behaviour is similar to `process-no-validate`_.
 However, the recursor will try to validate the data if at least one of the DO or AD bits is set in the query;
 in that case, it will set the AD-bit in the response when the data is validated successfully, or send SERVFAIL when the validation comes up bogus.

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -415,8 +415,11 @@ See :doc:`dns64` for more flexible but slower alternatives using Lua.
 ----------
 .. versionadded:: 4.0.0
 
+.. versionchanged:: 4.5.0
+   The default changed from ``process-no-validate`` to ``process``
+
 -  One of ``off``, ``process-no-validate``, ``process``, ``log-fail``, ``validate``, String
--  Default: ``process-no-validate``
+-  Default: ``process``
 
 Set the mode for DNSSEC processing, as detailed in :doc:`dnssec`.
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -36,6 +36,7 @@ Deprecated and changed settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - The :ref:`setting-minimum-ttl-override` and :ref:`setting-ecs-minimum-ttl-override` defaults have ben changed from 0 to 1.
 - The :ref:`setting-spoof-nearmiss-max` default has been changed from 20 to 1.
+- The :ref:`setting-dnssec` default has changed from ``process-no-validate`` to ``process``.
 
 Removed settings
 ^^^^^^^^^^^^^^^^

--- a/regression-tests.recursor-dnssec/test_DNS64.py
+++ b/regression-tests.recursor-dnssec/test_DNS64.py
@@ -5,6 +5,11 @@ from recursortests import RecursorTest
 
 class DNS64RecursorTest(RecursorTest):
 
+    _auth_zones = {
+        '8': {'threads': 1,
+              'zones': ['ROOT']}
+    }
+
     _confdir = 'DNS64'
     _config_template = """
     auth-zones=example.dns64=configs/%s/example.dns64.zone
@@ -13,23 +18,6 @@ class DNS64RecursorTest(RecursorTest):
 
     dns64-prefix=64:ff9b::/96
     """ % (_confdir, _confdir, _confdir)
-
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
 
     @classmethod
     def generateRecursorConfig(cls, confdir):

--- a/regression-tests.recursor-dnssec/test_PacketCache.py
+++ b/regression-tests.recursor-dnssec/test_PacketCache.py
@@ -8,6 +8,11 @@ from recursortests import RecursorTest
 
 class PacketCacheRecursorTest(RecursorTest):
 
+    _auth_zones = {
+        '8': {'threads': 1,
+              'zones': ['ROOT']}
+    }
+
     _confdir = 'PacketCache'
     _wsPort = 8042
     _wsTimeout = 2
@@ -36,23 +41,6 @@ d 3600 IN A 192.0.2.42
 e 3600 IN A 192.0.2.42
 """.format(soa=cls._SOA))
         super(PacketCacheRecursorTest, cls).generateRecursorConfig(confdir)
-
-    @classmethod
-    def setUpClass(cls):
-
-        # we don't need all the auth stuff
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
 
     def checkPacketCacheMetrics(self, expectedHits, expectedMisses):
         headers = {'x-api-key': self._apiKey}

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -79,6 +79,10 @@ class TestRecursorProtobuf(RecursorTest):
     protobufServer({"127.0.0.1:%d", "127.0.0.1:%d"})
     """ % (protobufServersParameters[0].port, protobufServersParameters[1].port)
 
+    _auth_zones = {
+        '8': {'threads': 1,
+              'zones': ['ROOT']}
+    }
 
     def getFirstProtobufMessage(self, retries=1, waitTime=1):
         msg = None
@@ -249,25 +253,13 @@ class TestRecursorProtobuf(RecursorTest):
         self.assertEquals(msg.deviceId, deviceId)
         self.assertEquals(msg.deviceName, deviceName)
 
-    @classmethod
-    def setUpClass(cls):
-
-        cls.setUpSockets()
-
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
     def setUp(self):
-      # Make sure the queue is empty, in case
-      # a previous test failed
-      for param in protobufServersParameters:
-        while not param.queue.empty():
-          param.queue.get(False)
+        super(TestRecursorProtobuf, self).setUp()
+        # Make sure the queue is empty, in case
+        # a previous test failed
+        for param in protobufServersParameters:
+            while not param.queue.empty():
+                param.queue.get(False)
 
     @classmethod
     def generateRecursorConfig(cls, confdir):
@@ -290,9 +282,6 @@ cname 3600 IN CNAME a.example.
 """.format(soa=cls._SOA))
         super(TestRecursorProtobuf, cls).generateRecursorConfig(confdir)
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
 
 class ProtobufDefaultTest(TestRecursorProtobuf):
     """

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -111,6 +111,7 @@ class TestRecursorProtobuf(RecursorTest):
           if oldmsg is not None:
             self.assertEquals(msg, oldmsg)
 
+        print(msg)
         return msg
 
     def checkNoRemainingMessage(self):
@@ -229,7 +230,7 @@ class TestRecursorProtobuf(RecursorTest):
         self.assertTrue(msg.question.HasField('qClass'))
         self.assertEquals(msg.question.qClass, qclass)
         self.assertTrue(msg.question.HasField('qType'))
-        self.assertEquals(msg.question.qClass, qtype)
+        self.assertEquals(msg.question.qType, qtype)
         self.assertTrue(msg.question.HasField('qName'))
         self.assertEquals(msg.question.qName, qname)
 

--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -221,6 +221,12 @@ class RPZRecursorTest(RecursorTest):
     _wsPassword = 'secretpassword'
     _apiKey = 'secretapikey'
     _confdir = 'RPZ'
+    _auth_zones = {
+        '8': {'threads': 1,
+              'zones': ['ROOT']},
+        '10': {'threads': 1,
+               'zones': ['example']},
+    }
     _lua_dns_script_file = """
 
     function prerpz(dq)
@@ -241,22 +247,6 @@ webserver-password=%s
 api-key=%s
 log-rpz-changes=yes
 """ % (_confdir, _wsPort, _wsPassword, _apiKey)
-
-    @classmethod
-    def setUpClass(cls):
-
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownRecursor()
 
     def checkBlocked(self, name, shouldBeBlocked=True, adQuery=False, singleCheck=False):
         query = dns.message.make_query(name, 'A', want_dnssec=True)
@@ -937,27 +927,6 @@ class RPZCNameChainCustomTest(RPZRecursorTest):
     rpzFile('configs/%s/zone.rpz', { policyName="zone.rpz."})
     """ % (_confdir)
     _config_template = ""
-
-    @classmethod
-    def setUpClass(cls):
-
-        cls.setUpSockets()
-        cls.startResponders()
-
-        confdir = os.path.join('configs', cls._confdir)
-        cls.createConfigDir(confdir)
-
-        cls.generateAllAuthConfig(confdir)
-        cls.startAuth(os.path.join(confdir, "auth-8"), cls._PREFIX + '.8')
-        cls.startAuth(os.path.join(confdir, "auth-10"), cls._PREFIX + '.10')
-
-        cls.generateRecursorConfig(confdir)
-        cls.startRecursor(confdir, cls._recursorPort)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tearDownAuth()
-        cls.tearDownRecursor()
 
     @classmethod
     def generateRecursorConfig(cls, confdir):


### PR DESCRIPTION
### Short description
This is a sane default nowadays. It will also greatly help if the aggressive NSEC cache (#10047) is enabled by default.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)