### PR TITLE
Rec: cumulative and Prometheus friendly histograms

### DIFF
--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -57,6 +57,7 @@ template <class B>
 class BaseHistogram
 {
 public:
+
   BaseHistogram(const std::string& prefix, const std::vector<uint64_t>& boundaries) : d_name(prefix)
   {
     if (!std::is_sorted(boundaries.cbegin(), boundaries.cend())) {
@@ -78,8 +79,19 @@ public:
       d_buckets.emplace_back(str, b, 0);
       prev = b;
     }
+
     // everything above last boundary
     d_buckets.emplace_back(prefix + "le-max", std::numeric_limits<uint64_t>::max(), 0);
+  }
+
+  BaseHistogram(const std::string& prefix, uint64_t start, int num) :
+    BaseHistogram(prefix, to125(start, num))
+  {
+  }
+
+  std::string getName() const
+  {
+    return d_name;
   }
 
   const std::vector<B>& getRawData() const
@@ -131,6 +143,31 @@ public:
 private:
   std::vector<B> d_buckets;
   std::string d_name;
+
+
+  std::vector<uint64_t> to125(uint64_t start, int num)
+  {
+    std::vector<uint64_t> boundaries;
+    boundaries.reserve(num);
+    boundaries.emplace_back(start);
+    int i = 0;
+    while (true) {
+      if (++i >= num) {
+        break;
+      }
+      boundaries.push_back(2 * start);
+      if (++i >= num) {
+        break;
+      }
+      boundaries.push_back(5 * start);
+      if (++i >= num) {
+        break;
+      }
+      boundaries.push_back(10 * start);
+      start *= 10;
+    }
+    return boundaries;
+  }
 };
 
 template <class T>

--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -53,7 +53,7 @@ struct AtomicBucket
   mutable std::atomic<uint64_t> d_count{0};
 };
 
-template <class B>
+template <class B, class SumType>
 class BaseHistogram
 {
 public:
@@ -92,6 +92,11 @@ public:
   std::string getName() const
   {
     return d_name;
+  }
+
+  uint64_t getSum() const
+  {
+    return d_sum;
   }
 
   const std::vector<B>& getRawData() const
@@ -138,11 +143,13 @@ public:
     auto index = std::upper_bound(d_buckets.begin(), d_buckets.end(), d, lessOrEqual);
     // our index is always valid
     ++index->d_count;
+    d_sum += d;
   }
 
 private:
   std::vector<B> d_buckets;
   std::string d_name;
+  mutable SumType d_sum{0};
 
   std::vector<uint64_t> to125(uint64_t start, int num)
   {
@@ -169,10 +176,8 @@ private:
   }
 };
 
-template <class T>
-using Histogram = BaseHistogram<Bucket>;
+using Histogram = BaseHistogram<Bucket, uint64_t>;
 
-template <class T>
-using AtomicHistogram = BaseHistogram<AtomicBucket>;
+using AtomicHistogram = BaseHistogram<AtomicBucket, std::atomic<uint64_t>>;
 
 } // namespace pdns

--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -57,8 +57,8 @@ template <class B>
 class BaseHistogram
 {
 public:
-
-  BaseHistogram(const std::string& prefix, const std::vector<uint64_t>& boundaries) : d_name(prefix)
+  BaseHistogram(const std::string& prefix, const std::vector<uint64_t>& boundaries) :
+    d_name(prefix)
   {
     if (!std::is_sorted(boundaries.cbegin(), boundaries.cend())) {
       throw std::invalid_argument("boundary array must be sorted");
@@ -143,7 +143,6 @@ public:
 private:
   std::vector<B> d_buckets;
   std::string d_name;
-
 
   std::vector<uint64_t> to125(uint64_t start, int num)
   {

--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -57,7 +57,7 @@ template <class B>
 class BaseHistogram
 {
 public:
-  BaseHistogram(const std::string& prefix, const std::vector<uint64_t>& boundaries)
+  BaseHistogram(const std::string& prefix, const std::vector<uint64_t>& boundaries) : d_name(prefix)
   {
     if (!std::is_sorted(boundaries.cbegin(), boundaries.cend())) {
       throw std::invalid_argument("boundary array must be sorted");
@@ -130,6 +130,7 @@ public:
 
 private:
   std::vector<B> d_buckets;
+  std::string d_name;
 };
 
 template <class T>

--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -148,7 +148,7 @@ public:
 
 private:
   std::vector<B> d_buckets;
-  std::string d_name;
+  const std::string d_name;
   mutable SumType d_sum{0};
 
   std::vector<uint64_t> to125(uint64_t start, int num)

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2317,6 +2317,7 @@ static void startDoResolve(void *p)
     }
 
     g_stats.answers(spentUsec);
+    g_stats.cumulativeAnswers(spentUsec);
 
     double newLat = spentUsec;
     newLat = min(newLat, g_networkTimeoutMsec * 1000.0); // outliers of several minutes exist..

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -95,7 +95,7 @@ struct StatsMapEntry {
   std::string d_value;
 };
 
-class SimpleNaturalCompare
+class PrefixDashNumberCompare
 {
 private:
   static std::pair<std::string, std::string> prefixAndTrailingNum(const std::string& a);
@@ -103,7 +103,7 @@ public:
   bool operator()(const std::string& a, const std::string& b) const;
 };
 
-typedef std::map<std::string, StatsMapEntry, SimpleNaturalCompare> StatsMap;
+typedef std::map<std::string, StatsMapEntry, PrefixDashNumberCompare> StatsMap;
 
 StatsMap getAllStatsMap(StatComponent component);
 

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -94,7 +94,17 @@ struct StatsMapEntry {
   std::string d_prometheusName;
   std::string d_value;
 };
-typedef std::map<std::string, StatsMapEntry> StatsMap;
+
+class SimpleNaturalCompare
+{
+private:
+  static std::pair<std::string, std::string> prefixAndTrailingNum(const std::string& a);
+public:
+  bool operator()(const std::string& a, const std::string& b) const;
+};
+
+typedef std::map<std::string, StatsMapEntry, SimpleNaturalCompare> StatsMap;
+
 StatsMap getAllStatsMap(StatComponent component);
 
 extern std::mutex g_carbon_config_lock;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -211,7 +211,7 @@ StatsMap getAllStatsMap(StatComponent component)
   }
 
   for(const auto& themultimember : d_getmultimembers) {
-    if (blacklistMap.count(themultimember.first) == 0) {
+    if (disabledlistMap.count(themultimember.first) == 0) {
       ret.merge(themultimember.second());
     }
   }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -40,7 +40,7 @@
 #include "namespaces.hh"
 #include "rec-taskqueue.hh"
 
-std::pair<std::string, std::string> SimpleNaturalCompare::prefixAndTrailingNum(const std::string& a)
+std::pair<std::string, std::string> PrefixDashNumberCompare::prefixAndTrailingNum(const std::string& a)
 {
   auto i = a.length();
   if (i == 0) {
@@ -59,7 +59,7 @@ std::pair<std::string, std::string> SimpleNaturalCompare::prefixAndTrailingNum(c
   return make_pair(a.substr(0, i + 1), a.substr(i + 1, a.size() - i - 1));
 }
 
-bool SimpleNaturalCompare::operator()(const std::string& a, const std::string& b) const
+bool PrefixDashNumberCompare::operator()(const std::string& a, const std::string& b) const
 {
   auto [aprefix, anum] = prefixAndTrailingNum(a);
   auto [bprefix, bnum] = prefixAndTrailingNum(b);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1116,16 +1116,18 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
   const auto& data = histogram.getCumulativeBuckets();
   const string pbasename = getPrometheusName(name);
   StatsMap entries;
+  char buf[32];
 
   for (const auto& bucket : data) {
-    char buf[32];
-    snprintf(buf, sizeof(buf), "%.0e", bucket.d_boundary / 1e6);
+    snprintf(buf, sizeof(buf), "%g", bucket.d_boundary / 1e6);
     std::string pname = pbasename + "seconds_bucket{" + "le=\"" +
       (bucket.d_boundary == std::numeric_limits<uint64_t>::max() ? "+Inf" : buf) + "\"}";
     entries.emplace(make_pair(bucket.d_name, StatsMapEntry{pname, std::to_string(bucket.d_count)}));
   }
-  entries.emplace(make_pair(name + "sum", StatsMapEntry{pbasename + "sum", std::to_string(histogram.getSum())}));
-  entries.emplace(make_pair(name + "count", StatsMapEntry{pbasename + "count", std::to_string(data.back().d_count)}));
+
+  snprintf(buf, sizeof(buf), "%g", histogram.getSum() / 1e6);
+  entries.emplace(make_pair(name + "sum", StatsMapEntry{pbasename + "seconds_sum", buf}));
+  entries.emplace(make_pair(name + "count", StatsMapEntry{pbasename + "seconds_count", std::to_string(data.back().d_count)}));
 
   return entries;
 }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -40,11 +40,45 @@
 #include "namespaces.hh"
 #include "rec-taskqueue.hh"
 
+std::pair<std::string, std::string> SimpleNaturalCompare::prefixAndTrailingNum(const std::string& a)
+{
+  auto i = a.length();
+  if (i == 0) {
+    return make_pair(a, "");
+  }
+  --i;
+  if (!std::isdigit(a[i])) {
+    return make_pair(a, "");
+  }
+  while (i > 0) {
+    if (!std::isdigit(a[i])) {
+      break;
+    }
+    --i;
+  }
+  return make_pair(a.substr(0, i + 1), a.substr(i + 1, a.size() - i - 1));
+}
+
+bool SimpleNaturalCompare::operator()(const std::string& a, const std::string& b) const
+{
+  auto [aprefix, anum] = prefixAndTrailingNum(a);
+  auto [bprefix, bnum] = prefixAndTrailingNum(b);
+
+  if (aprefix != bprefix || anum.length() == 0 || bnum.length() == 0) {
+    return a < b;
+  }
+  auto aa = std::stoull(anum);
+  auto bb = std::stoull(bnum);
+  return aa < bb;
+}
+
 std::mutex g_carbon_config_lock;
 
 static map<string, const uint32_t*> d_get32bitpointers;
 static map<string, const std::atomic<uint64_t>*> d_getatomics;
-static map<string, std::function< uint64_t() > >  d_get64bitmembers;
+static map<string, std::function<uint64_t()>>  d_get64bitmembers;
+static map<string, std::function<StatsMap()>> d_getmultimembers;
+
 static std::mutex d_dynmetricslock;
 struct dynmetrics {
   std::atomic<unsigned long> *d_ptr;
@@ -77,17 +111,22 @@ void disableStats(StatComponent component, const string& stats)
 
 static void addGetStat(const string& name, const uint32_t* place)
 {
-  d_get32bitpointers[name]=place;
+  d_get32bitpointers[name] = place;
 }
 
 static void addGetStat(const string& name, const std::atomic<uint64_t>* place)
 {
-  d_getatomics[name]=place;
+  d_getatomics[name] = place;
 }
 
-static void addGetStat(const string& name, std::function<uint64_t ()> f )
+static void addGetStat(const string& name, std::function<uint64_t()> f)
 {
-  d_get64bitmembers[name]=f;
+  d_get64bitmembers[name] = f;
+}
+
+static void addGetStat(const string& name, std::function<StatsMap()> f)
+{
+  d_getmultimembers[name] = f;
 }
 
 static std::string getPrometheusName(const std::string& arg)
@@ -132,7 +171,15 @@ static boost::optional<uint64_t> get(const string& name)
   auto f = rplookup(d_dynmetrics, name);
   if (f)
     return f->d_ptr->load();
-  
+
+  for(const auto& themultimember : d_getmultimembers) {
+    const auto items = themultimember.second();
+    const auto item = items.find(name);
+    if (item != items.end()) {
+      return std::stoull(item->second.d_value);
+    }
+  }
+
   return ret;
 }
 
@@ -160,6 +207,12 @@ StatsMap getAllStatsMap(StatComponent component)
   for(const auto& the64bitmembers :  d_get64bitmembers) {
     if (disabledlistMap.count(the64bitmembers.first) == 0) {
       ret.insert(make_pair(the64bitmembers.first, StatsMapEntry{getPrometheusName(the64bitmembers.first), std::to_string(the64bitmembers.second())}));
+    }
+  }
+
+  for(const auto& themultimember : d_getmultimembers) {
+    if (blacklistMap.count(themultimember.first) == 0) {
+      ret.merge(themultimember.second());
     }
   }
 
@@ -1058,6 +1111,17 @@ static uint64_t doGetMallocated()
   return 0;
 }
 
+static StatsMap toStatsMap(const string& name, const vector<pdns::AtomicBucket>& data)
+{
+  StatsMap entries;
+  for (const auto& bucket : data) {
+    std::string pname = getPrometheusName(name) + '{' + "le=\"" +
+      (bucket.d_boundary == std::numeric_limits<uint64_t>::max() ? "+Inf" : std::to_string(bucket.d_boundary)) + "\"}";
+    entries.emplace(make_pair(bucket.d_name, StatsMapEntry{pname, std::to_string(bucket.d_count)}));
+  }
+  return entries;
+}
+
 extern ResponseStats g_rs;
 
 static void registerAllStats1()
@@ -1300,6 +1364,16 @@ static void registerAllStats1()
     const std::string name = "ecs-v6-response-bits-" + std::to_string(idx + 1);
     addGetStat(name, &(SyncRes::s_ecsResponsesBySubnetSize6.at(idx)));
   }
+
+  addGetStat("cumulativeAnswers-usec-", []() {
+    return toStatsMap(g_stats.cumulativeAnswers.getName(), g_stats.cumulativeAnswers.getCumulativeBuckets());
+  });
+  addGetStat("cumulativeAuth4Answers-usec-", []() {
+    return toStatsMap(g_stats.cumulativeAuth4Answers.getName(), g_stats.cumulativeAuth4Answers.getCumulativeBuckets());
+  });
+  addGetStat("cumulativeAuth6Answers-usec-", []() {
+    return toStatsMap(g_stats.cumulativeAuth6Answers.getName(), g_stats.cumulativeAuth6Answers.getCumulativeBuckets());
+  });
 }
 
 void registerAllStats()

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1375,13 +1375,13 @@ static void registerAllStats1()
     addGetStat(name, &(SyncRes::s_ecsResponsesBySubnetSize6.at(idx)));
   }
 
-  addGetStat("cumulativeAnswers-usec-", []() {
+  addGetStat("cumul-answers", []() {
     return toStatsMap(g_stats.cumulativeAnswers.getName(), g_stats.cumulativeAnswers);
   });
-  addGetStat("cumulativeAuth4Answers-usec-", []() {
+  addGetStat("cumul-auth4answers", []() {
     return toStatsMap(g_stats.cumulativeAuth4Answers.getName(), g_stats.cumulativeAuth4Answers);
   });
-  addGetStat("cumulativeAuth6Answers-usec-", []() {
+  addGetStat("cumul-auth6answers", []() {
     return toStatsMap(g_stats.cumulativeAuth6Answers.getName(), g_stats.cumulativeAuth6Answers);
   });
 }

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -267,19 +267,19 @@ cpu-steal
 Stolen time, which is the time spent by the whole system in other operating systems when running in a virtualized environment, in units of USER_HZ.
 
 cumul-answers-le-x
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 Cumulative counts of answer times in buckets less or equal than x microseconds.
 These metrics include packet cache hits.
 These metrics are useful for Prometheus.
 
 
 cumul-auth4-answers-x
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 Cumulative counts of answer times of authoritative servers over IPv4 in buckets less than x microseconds.
 These metrics are useful for Prometheus.
 
 cumul-auth6-answers-x
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 Cumulative counts of answer times of authoritative servers over IPv6 in buckets less than x microseconds.
 These metrics are useful for Prometheus.
 

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -266,7 +266,7 @@ cpu-steal
 
 Stolen time, which is the time spent by the whole system in other operating systems when running in a virtualized environment, in units of USER_HZ.
 
-cumul-answers-le-x
+cumul-answers-x
 ^^^^^^^^^^^^^^^^^^
 Cumulative counts of answer times in buckets less or equal than x microseconds.
 These metrics include packet cache hits.

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -270,18 +270,18 @@ cumul-answers-le-x
 ^^^^^^^^^^^^^^^^^^
 Cumulative counts of answer times in buckets less or equal than x microseconds.
 These metrics include packet cache hits.
-These metrics are useful for Prometheus.
+These metrics are useful for Prometheus and not listed other outputs by default.
 
 
 cumul-auth4-answers-x
 ^^^^^^^^^^^^^^^^^^^^^
 Cumulative counts of answer times of authoritative servers over IPv4 in buckets less than x microseconds.
-These metrics are useful for Prometheus.
+These metrics are useful for Prometheus and not listed other outputs by default.
 
 cumul-auth6-answers-x
 ^^^^^^^^^^^^^^^^^^^^^
 Cumulative counts of answer times of authoritative servers over IPv6 in buckets less than x microseconds.
-These metrics are useful for Prometheus.
+These metrics are useful for Prometheus and not listed other outputs by default.
 
 
 dnssec-authentic-data-queries

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -266,6 +266,24 @@ cpu-steal
 
 Stolen time, which is the time spent by the whole system in other operating systems when running in a virtualized environment, in units of USER_HZ.
 
+cumul-answers-le-x
+^^^^^^^^^^^^^^^
+Cumulative counts of answer times in buckets less or equal than x microseconds.
+These metrics include packet cache hits.
+These metrics are useful for Prometheus.
+
+
+cumul-auth4-answers-x
+^^^^^^^^^^^^^^^
+Cumulative counts of answer times of authoritative servers over IPv4 in buckets less than x microseconds.
+These metrics are useful for Prometheus.
+
+cumul-auth6-answers-x
+^^^^^^^^^^^^^^^
+Cumulative counts of answer times of authoritative servers over IPv6 in buckets less than x microseconds.
+These metrics are useful for Prometheus.
+
+
 dnssec-authentic-data-queries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. versionadded:: 4.2

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1809,7 +1809,7 @@ These statistics can still be retrieved individually by specifically asking for 
 .. versionadded:: 4.5.0
 
 -  String
--  Default: "cache-bytes, packetcache-bytes, special-memory-usage, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+-  Default: "cache-bytes, packetcache-bytes, special-memory-usage, ecs-v4-response-bits-*, ecs-v6-response-bits-*, cumul-answers-*, cumul-auth4answers-*, cumul-auth6answers-*"
 
 A list of comma-separated statistic names, that are prevented from being exported via carbon for performance reasons.
 
@@ -1828,7 +1828,7 @@ A list of comma-separated statistic names, that are prevented from being exporte
 .. versionadded:: 4.5.0
 
 -  String
--  Default: "cache-bytes, packetcache-bytes, special-memory-usage, ecs-v4-response-bits-*, ecs-v6-response-bits-*"
+-  Default: "cache-bytes, packetcache-bytes, special-memory-usage, ecs-v4-response-bits-*, ecs-v6-response-bits-*, cumul-answers-*, cumul-auth4answers-*, cumul-auth6answers-*"
 
 A list of comma-separated statistic names, that are disabled when retrieving the complete list of statistics via `rec_control get-all`, for performance reasons.
 These statistics can still be retrieved individually.

--- a/pdns/recursordist/rec_metrics.hh
+++ b/pdns/recursordist/rec_metrics.hh
@@ -33,7 +33,8 @@
 enum class PrometheusMetricType : int
 {
   counter = 1,
-  gauge = 2
+  gauge = 2,
+  histogram = 3
 };
 
 // Keeps additional information about metrics
@@ -78,6 +79,9 @@ public:
       break;
     case PrometheusMetricType::gauge:
       return "gauge";
+      break;
+    case PrometheusMetricType::histogram:
+      return "histogram";
       break;
     default:
       return "";

--- a/pdns/recursordist/test-histogram_hh.cc
+++ b/pdns/recursordist/test-histogram_hh.cc
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_SUITE(histogram_hh)
 
 BOOST_AUTO_TEST_CASE(test_simple)
 {
-  auto h = pdns::AtomicHistogram<uint64_t>("myname-", {1, 3, 5, 10, 100});
+  auto h = pdns::AtomicHistogram("myname-", {1, 3, 5, 10, 100});
 
   h(0);
   h(1);

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -47,7 +47,7 @@ private:
 
   std::array<Counter, 65535> d_qtypecounters;
   std::array<Counter, 256> d_rcodecounters;
-  pdns::AtomicHistogram<uint64_t> d_sizecounters;
+  pdns::AtomicHistogram d_sizecounters;
 };
 
 extern ResponseStats g_rs;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -107,8 +107,10 @@ static inline void accountAuthLatency(uint64_t usec, int family)
 {
   if (family == AF_INET) {
     g_stats.auth4Answers(usec);
+    g_stats.cumulativeAuth4Answers(usec);
   } else  {
     g_stats.auth6Answers(usec);
+    g_stats.cumulativeAuth6Answers(usec);
   }
 }
 

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1058,9 +1058,9 @@ struct RecursorStats
     auth4Answers("auth4answers", { 1000, 10000, 100000, 1000000 }),
     auth6Answers("auth6answers", { 1000, 10000, 100000, 1000000 }),
     ourtime("ourtime", { 1000, 2000, 4000, 8000, 16000, 32000 }),
-    cumulativeAnswers("cumulAnswers-us", { 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600, 819200, 1638400, 3276800, 6553600 }),
-    cumulativeAuth4Answers("cumulAuth4Answers-us", { 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600, 819200, 1638400, 3276800, 6553600 }),
-    cumulativeAuth6Answers("cumulAuth6Answers-us", { 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600, 819200, 1638400, 3276800, 6553600 })
+    cumulativeAnswers("cumulAnswers-us", 10, 19),
+    cumulativeAuth4Answers("cumulAuth4Answers-us", 1000, 13),
+    cumulativeAuth6Answers("cumulAuth6Answers-us", 1000, 13)
   {
   }
 };

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1007,6 +1007,9 @@ struct RecursorStats
   pdns::AtomicHistogram<uint64_t> auth4Answers;
   pdns::AtomicHistogram<uint64_t> auth6Answers;
   pdns::AtomicHistogram<uint64_t> ourtime;
+  pdns::AtomicHistogram<uint64_t> cumulativeAnswers;
+  pdns::AtomicHistogram<uint64_t> cumulativeAuth4Answers;
+  pdns::AtomicHistogram<uint64_t> cumulativeAuth6Answers;
   std::atomic<double> avgLatencyUsec;
   std::atomic<double> avgLatencyOursUsec;
   std::atomic<uint64_t> qcounter;     // not increased for unauth packets
@@ -1052,9 +1055,12 @@ struct RecursorStats
 
   RecursorStats() :
     answers("answers", { 1000, 10000, 100000, 1000000 }),
-    auth4Answers("answers", { 1000, 10000, 100000, 1000000 }),
-    auth6Answers("answers", { 1000, 10000, 100000, 1000000 }),
-    ourtime("ourtime", { 1000, 2000, 4000, 8000, 16000, 32000 })
+    auth4Answers("auth4answers", { 1000, 10000, 100000, 1000000 }),
+    auth6Answers("auth6answers", { 1000, 10000, 100000, 1000000 }),
+    ourtime("ourtime", { 1000, 2000, 4000, 8000, 16000, 32000 }),
+    cumulativeAnswers("cumulAnswers-us", { 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600, 819200, 1638400, 3276800, 6553600 }),
+    cumulativeAuth4Answers("cumulAuth4Answers-us", { 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600, 819200, 1638400, 3276800, 6553600 }),
+    cumulativeAuth6Answers("cumulAuth6Answers-us", { 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600, 819200, 1638400, 3276800, 6553600 })
   {
   }
 };

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1058,9 +1058,9 @@ struct RecursorStats
     auth4Answers("auth4answers", { 1000, 10000, 100000, 1000000 }),
     auth6Answers("auth6answers", { 1000, 10000, 100000, 1000000 }),
     ourtime("ourtime", { 1000, 2000, 4000, 8000, 16000, 32000 }),
-    cumulativeAnswers("cumulAnswers-", 10, 19),
-    cumulativeAuth4Answers("cumulAuth4Answers-", 1000, 13),
-    cumulativeAuth6Answers("cumulAuth6Answers-", 1000, 13)
+    cumulativeAnswers("cumul-answers-", 10, 19),
+    cumulativeAuth4Answers("cumul-auth4answers-", 1000, 13),
+    cumulativeAuth6Answers("cumul-auth6answers-", 1000, 13)
   {
   }
 };

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1003,13 +1003,13 @@ struct RecursorStats
   std::atomic<uint64_t> servFails;
   std::atomic<uint64_t> nxDomains;
   std::atomic<uint64_t> noErrors;
-  pdns::AtomicHistogram<uint64_t> answers;
-  pdns::AtomicHistogram<uint64_t> auth4Answers;
-  pdns::AtomicHistogram<uint64_t> auth6Answers;
-  pdns::AtomicHistogram<uint64_t> ourtime;
-  pdns::AtomicHistogram<uint64_t> cumulativeAnswers;
-  pdns::AtomicHistogram<uint64_t> cumulativeAuth4Answers;
-  pdns::AtomicHistogram<uint64_t> cumulativeAuth6Answers;
+  pdns::AtomicHistogram answers;
+  pdns::AtomicHistogram auth4Answers;
+  pdns::AtomicHistogram auth6Answers;
+  pdns::AtomicHistogram ourtime;
+  pdns::AtomicHistogram cumulativeAnswers;
+  pdns::AtomicHistogram cumulativeAuth4Answers;
+  pdns::AtomicHistogram cumulativeAuth6Answers;
   std::atomic<double> avgLatencyUsec;
   std::atomic<double> avgLatencyOursUsec;
   std::atomic<uint64_t> qcounter;     // not increased for unauth packets
@@ -1058,9 +1058,9 @@ struct RecursorStats
     auth4Answers("auth4answers", { 1000, 10000, 100000, 1000000 }),
     auth6Answers("auth6answers", { 1000, 10000, 100000, 1000000 }),
     ourtime("ourtime", { 1000, 2000, 4000, 8000, 16000, 32000 }),
-    cumulativeAnswers("cumulAnswers-us", 10, 19),
-    cumulativeAuth4Answers("cumulAuth4Answers-us", 1000, 13),
-    cumulativeAuth6Answers("cumulAuth6Answers-us", 1000, 13)
+    cumulativeAnswers("cumulAnswers-", 10, 19),
+    cumulativeAuth4Answers("cumulAuth4Answers-", 1000, 13),
+    cumulativeAuth6Answers("cumulAuth6Answers-", 1000, 13)
   {
   }
 };

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -1048,7 +1048,7 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::metrics =
                      "histogram of authoritative answer times over IPV6")},
 };
 
-#define CHECK_PROMETHEUS_METRICS 1
+#define CHECK_PROMETHEUS_METRICS 0
 
 #if CHECK_PROMETHEUS_METRICS
 static void validatePrometheusMetrics()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
An aproach at #9077

Main things to consider:

1. All stats are new (to not disturb people using the old ones) and cumulative as this is the standard way for Prometheus
2. for cumulAnswers I also record packet cache hits (existing histograms do do not)
3. I use a 1-2-5 steps in microseconds. e.g:
```
# HELP pdns_recursor_cumul_answers_seconds histogram of our answer times
# TYPE pdns_recursor_cumul_answers_seconds histogram
pdns_recursor_cumul_answers_seconds_bucket{le="1e-05"} 0
pdns_recursor_cumul_answers_seconds_bucket{le="2e-05"} 0
pdns_recursor_cumul_answers_seconds_bucket{le="5e-05"} 1
pdns_recursor_cumul_answers_seconds_bucket{le="0.0001"} 1
pdns_recursor_cumul_answers_seconds_bucket{le="0.0002"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.0005"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.001"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.002"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.005"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.01"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.02"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.05"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.1"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.2"} 2
pdns_recursor_cumul_answers_seconds_bucket{le="0.5"} 3
pdns_recursor_cumul_answers_seconds_bucket{le="1"} 5
pdns_recursor_cumul_answers_seconds_bucket{le="2"} 5
pdns_recursor_cumul_answers_seconds_bucket{le="5"} 5
pdns_recursor_cumul_answers_seconds_bucket{le="10"} 5
pdns_recursor_cumul_answers_seconds_bucket{le="+Inf"} 5
pdns_recursor_cumul_answers_seconds_sum 1.84779
# HELP pdns_recursor_cumul_auth4answers_seconds histogram of authoritative answer times over IPv4
# TYPE pdns_recursor_cumul_auth4answers_seconds histogram
pdns_recursor_cumul_auth4answers_seconds_bucket{le="0.001"} 0
pdns_recursor_cumul_auth4answers_seconds_bucket{le="0.002"} 0
pdns_recursor_cumul_auth4answers_seconds_bucket{le="0.005"} 0
pdns_recursor_cumul_auth4answers_seconds_bucket{le="0.01"} 11
pdns_recursor_cumul_auth4answers_seconds_bucket{le="0.02"} 17
pdns_recursor_cumul_auth4answers_seconds_bucket{le="0.05"} 25
pdns_recursor_cumul_auth4answers_seconds_bucket{le="0.1"} 26
pdns_recursor_cumul_auth4answers_seconds_bucket{le="0.2"} 29
pdns_recursor_cumul_auth4answers_seconds_bucket{le="0.5"} 31
pdns_recursor_cumul_auth4answers_seconds_bucket{le="1"} 31
pdns_recursor_cumul_auth4answers_seconds_bucket{le="2"} 31
pdns_recursor_cumul_auth4answers_seconds_bucket{le="5"} 31
pdns_recursor_cumul_auth4answers_seconds_bucket{le="10"} 31
pdns_recursor_cumul_auth4answers_seconds_bucket{le="+Inf"} 31
pdns_recursor_cumul_auth4answers_seconds_sum 1.43869
# HELP pdns_recursor_cumul_auth6answers_seconds histogram of authoritative answer times over IPV6
# TYPE pdns_recursor_cumul_auth6answers_seconds histogram
pdns_recursor_cumul_auth6answers_seconds_bucket{le="0.001"} 0
pdns_recursor_cumul_auth6answers_seconds_bucket{le="0.002"} 0
pdns_recursor_cumul_auth6answers_seconds_bucket{le="0.005"} 0
pdns_recursor_cumul_auth6answers_seconds_bucket{le="0.01"} 0
pdns_recursor_cumul_auth6answers_seconds_bucket{le="0.02"} 6
pdns_recursor_cumul_auth6answers_seconds_bucket{le="0.05"} 14
pdns_recursor_cumul_auth6answers_seconds_bucket{le="0.1"} 14
pdns_recursor_cumul_auth6answers_seconds_bucket{le="0.2"} 16
pdns_recursor_cumul_auth6answers_seconds_bucket{le="0.5"} 16
pdns_recursor_cumul_auth6answers_seconds_bucket{le="1"} 16
pdns_recursor_cumul_auth6answers_seconds_bucket{le="2"} 16
pdns_recursor_cumul_auth6answers_seconds_bucket{le="5"} 16
pdns_recursor_cumul_auth6answers_seconds_bucket{le="10"} 16
pdns_recursor_cumul_auth6answers_seconds_bucket{le="+Inf"} 16
pdns_recursor_cumul_auth6answers_seconds_sum 0.578528

```
I ran the output through `promtool check metrics` and it is happy.

`rec_control | grep cumul` output is now empty because the stats are not listed by default for `rec_control`.

- [X] docs are missing
- [x] validate computed times for packet cache hits 
- [x] is this what we want?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
