### PR TITLE
dnsdist: Remove forgotten warning about source interface selection

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -52,7 +52,6 @@ IOState TCPConnectionToBackend::sendQuery(std::shared_ptr<TCPConnectionToBackend
 {
   DEBUGLOG("sending query to backend "<<conn->getDS()->getName()<<" over FD "<<conn->d_handler->getDescriptor());
 
-#warning FIXME: TODO: this drops 1/ source selection other than SO_BINDTODEVICE, perhaps we should look into IP_SENDIF?
   IOState state = conn->d_handler->tryWrite(conn->d_currentQuery.d_buffer, conn->d_currentPos, conn->d_currentQuery.d_buffer.size());
 
   if (state != IOState::Done) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This removes a warning introduced in #10108.

Before that PR we supported source interface selection over UDP and TCP when talking to our backends, via:
- the "generic" way, binding with the right source address, and passing the interface index down to the actual `sendmsg` call via `IP_PKTINFO` and `IPV6_PKTINFO` in case that was not enough ;
- `SO_BINDTODEVICE` on Linux, which was reported as the only working solution on Linux in https://github.com/PowerDNS/pdns/issues/8284.

After that PR we don't set the interface index anymore on the TCP path, and instead rely on:
- binding with the right source address being good enough on most OS ;
- setting `SO_BINDTODEVICE` on Linux.

As far as I can tell there is no other option, `IP_SENDIF` never made it to the BSD world, but from what I read binding the socket should be enough on all non-Linux systems, and `SO_BINDTODEVICE` should fix these.

If we find out that this is not enough, we will need to pass the interface down to the actual `sendmsg` call again, but note that this will not work once we start doing `DoT` or `DoQ` toward the backends because right now the TLS libraries handle these calls themselves. 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
