### PR TITLE
dnsdist: Clean up expired entries from all the packet cache's shards

### DIFF
--- a/pdns/dnsdist-cache.cc
+++ b/pdns/dnsdist-cache.cc
@@ -305,6 +305,7 @@ size_t DNSDistPacketCache::purgeExpired(size_t upTo, const time_t now)
 
   do {
     uint32_t shardIndex = (d_expungeIndex++ % d_shardCount);
+    scannedMaps++;
 
     WriteLock w(&d_shards.at(shardIndex).d_lock);
     auto& map = d_shards.at(shardIndex).d_map;
@@ -325,8 +326,6 @@ size_t DNSDistPacketCache::purgeExpired(size_t upTo, const time_t now)
         ++it;
       }
     }
-
-    scannedMaps++;
   }
   while (scannedMaps < d_shardCount);
 

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -39,7 +39,7 @@ public:
 
   void insert(uint32_t key, const boost::optional<Netmask>& subnet, uint16_t queryFlags, bool dnssecOK, const DNSName& qname, uint16_t qtype, uint16_t qclass, const PacketBuffer& response, bool tcp, uint8_t rcode, boost::optional<uint32_t> tempFailureTTL);
   bool get(DNSQuestion& dq, uint16_t queryId, uint32_t* keyOut, boost::optional<Netmask>& subnet, bool dnssecOK, uint32_t allowExpired = 0, bool skipAging = false);
-  size_t purgeExpired(size_t upTo=0);
+  size_t purgeExpired(size_t upTo, const time_t now);
   size_t expunge(size_t upTo=0);
   size_t expungeByName(const DNSName& name, uint16_t qtype=QType::ANY, bool suffixMatch=false);
   bool isFull();

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -136,7 +136,6 @@ private:
   pdns::stat_t d_ttlTooShorts{0};
 
   size_t d_maxEntries;
-  uint32_t d_expungeIndex{0};
   uint32_t d_shardCount;
   uint32_t d_maxTTL;
   uint32_t d_tempFailureTTL;

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -104,10 +104,10 @@ private:
   class CacheShard
   {
   public:
-    CacheShard(): d_entriesCount(0)
+    CacheShard()
     {
     }
-    CacheShard(const CacheShard& old): d_entriesCount(0)
+    CacheShard(const CacheShard& old)
     {
     }
 
@@ -118,7 +118,6 @@ private:
 
     std::unordered_map<uint32_t,CacheValue> d_map;
     ReadWriteLock d_lock;
-    std::atomic<uint64_t> d_entriesCount;
   };
 
   bool cachedValueMatches(const CacheValue& cachedValue, uint16_t queryFlags, const DNSName& qname, uint16_t qtype, uint16_t qclass, bool tcp, bool dnssecOK, const boost::optional<Netmask>& subnet) const;

--- a/pdns/dnsdist-cache.hh
+++ b/pdns/dnsdist-cache.hh
@@ -118,6 +118,7 @@ private:
 
     std::unordered_map<uint32_t,CacheValue> d_map;
     ReadWriteLock d_lock;
+    std::atomic<uint64_t> d_entriesCount{0};
   };
 
   bool cachedValueMatches(const CacheValue& cachedValue, uint16_t queryFlags, const DNSName& qname, uint16_t qtype, uint16_t qclass, bool tcp, bool dnssecOK, const boost::optional<Netmask>& subnet) const;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1645,6 +1645,7 @@ static void maintThread()
         }
       }
 
+      const time_t now = time(nullptr);
       for (auto pair : caches) {
         /* shall we keep expired entries ? */
         if (pair.second == true) {
@@ -1652,7 +1653,7 @@ static void maintThread()
         }
         auto& packetCache = pair.first;
         size_t upTo = (packetCache->getMaxEntries()* (100 - g_cacheCleaningPercentage)) / 100;
-        packetCache->purgeExpired(upTo);
+        packetCache->purgeExpired(upTo, now);
       }
       counter = 0;
     }

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -112,7 +112,9 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx)
     });
   luaCtx.registerFunction<size_t(std::shared_ptr<DNSDistPacketCache>::*)(size_t)>("purgeExpired", [](std::shared_ptr<DNSDistPacketCache>& cache, size_t upTo) {
       if (cache) {
-        return cache->purgeExpired(upTo);
+        const time_t now = time(nullptr);
+
+        return cache->purgeExpired(upTo, now);
       }
       return static_cast<size_t>(0);
     });

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -201,12 +201,12 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSharded) {
     BOOST_CHECK_EQUAL(expired, 0U);
 
     /* but after the TTL .. let's ask for at most 1k entries */
-    auto removed = PC.purgeExpired(1000, now + 7200 + 1);
+    auto removed = PC.purgeExpired(1000, now + 7200 + 3600);
     BOOST_CHECK_EQUAL(removed, remaining - 1000U);
     BOOST_CHECK_EQUAL(PC.getSize(), 1000U);
 
     /* now remove everything */
-    removed = PC.purgeExpired(0, now + 7200 + 1);
+    removed = PC.purgeExpired(0, now + 7200 + 3600);
     BOOST_CHECK_EQUAL(removed, 1000U);
     BOOST_CHECK_EQUAL(PC.getSize(), 0U);
   }

--- a/pdns/test-dnsdistpacketcache_cc.cc
+++ b/pdns/test-dnsdistpacketcache_cc.cc
@@ -112,6 +112,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSimple) {
     auto removed = PC.expungeByName(DNSName(" hello"), QType::ANY, true);
     BOOST_CHECK_EQUAL(PC.getSize(), 0U);
     BOOST_CHECK_EQUAL(removed, remaining);
+
+    /* nothing to remove */
+    BOOST_CHECK_EQUAL(PC.purgeExpired(0, now), 0U);
   }
   catch (const PDNSException& e) {
     cerr<<"Had error: "<<e.reason<<endl;
@@ -209,6 +212,9 @@ BOOST_AUTO_TEST_CASE(test_PacketCacheSharded) {
     removed = PC.purgeExpired(0, now + 7200 + 3600);
     BOOST_CHECK_EQUAL(removed, 1000U);
     BOOST_CHECK_EQUAL(PC.getSize(), 0U);
+
+    /* nothing to remove */
+    BOOST_CHECK_EQUAL(PC.purgeExpired(0, now), 0U);
   }
   catch (const PDNSException& e) {
     cerr<<"Had error: "<<e.reason<<endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Otherwise we might remove enough entries from the first shards only and stop there, which means that the other shards might remain full.
This might be fine if we clean up often enough since the next cleaning run will start with the remaining shards, but that's sub-optimal when we are often nearly full because it will prevent new entries from being inserted in the shards that are full.

This should improve https://github.com/PowerDNS/pdns/issues/10128.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
