### PR TITLE
dnsdist: Fix size check during trailing data addition, regression tests

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -208,6 +208,9 @@ bool DNSQuestion::setTrailingData(const std::string& tail)
   const uint16_t messageLen = getDNSPacketLength(message, this->data.size());
   this->data.resize(messageLen);
   if (tail.size() > 0) {
+    if (!hasRoomFor(tail.size())) {
+      return false;
+    }
     this->data.insert(this->data.end(), tail.begin(), tail.end());
   }
   return true;

--- a/regression-tests.dnsdist/test_Trailing.py
+++ b/regression-tests.dnsdist/test_Trailing.py
@@ -24,7 +24,10 @@ class TestTrailingDataToBackend(DNSDistTest):
     addAction("added.trailing.tests.powerdns.com.", LuaAction(replaceTrailingData))
 
     function fillBuffer(dq)
-        local available = 4096
+        local available = 4096 - dq.len
+        if dq.tcp then
+            available = 65535 - dq.len
+        end
         local tail = string.rep("A", available)
         local success = dq:setTrailingData(tail)
         if not success then
@@ -35,7 +38,10 @@ class TestTrailingDataToBackend(DNSDistTest):
     addAction("max.trailing.tests.powerdns.com.", LuaAction(fillBuffer))
 
     function exceedBuffer(dq)
-        local available = dq.size - dq.len
+        local available = 4096 - dq.len
+        if dq.tcp then
+            available = 65535 - dq.len
+        end
         local tail = string.rep("A", available + 1)
         local success = dq:setTrailingData(tail)
         if not success then


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The size check was missing since the `PacketBuffer` refactoring in 1.6, and the regression test was broken at roughly the same time because `dq.size` does not exist anymore.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
