### PR TITLE
docs: ecswho is a Netmask, not a ComboAddress

### DIFF
--- a/docs/lua-records/functions.rst
+++ b/docs/lua-records/functions.rst
@@ -27,11 +27,11 @@ Client variables
 ~~~~~~~~~~~~~~~~
 ``ecswho``
   The EDNS Client Subnet, should one have been set on the query. Unset
-  otherwise. This is a :class:`ComboAddress`.
+  otherwise. This is a :class:`Netmask`.
 ``bestwho``
   In absence of ECS, this is set to the IP address of requesting resolver.
   Otherwise set to the network part of the EDNS Client Subnet supplied by the
-  resolver. A :class:`ComboAddress`
+  resolver. This is a :class:`ComboAddress`.
 ``who``
   IP address of requesting resolver as a :class:`ComboAddress`.
 


### PR DESCRIPTION
### Short description
`ecswho` is documented to be a `ComboAddress`, but I'm 99.9% sure it's a `Netmask` instead.

```
    lua.writeVariable("ecswho", dnsp.getRealRemote());
```
```
Netmask DNSPacket::getRealRemote() const
```

`bestwho` on the other hand is correctly documented as a `ComboAddress`:

```
    s_lua_record_ctx->bestwho = dnsp.getRealRemote().getNetwork();
```

The second line of the diff is just for style.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)