### PR TITLE
Add SQLITE_BUSY wait for schema migration.

### DIFF
--- a/pdns/bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql
+++ b/pdns/bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql
@@ -1,3 +1,4 @@
+PRAGMA busy_timeout = 60000;
 BEGIN TRANSACTION;
   CREATE TABLE cryptokeys_temp (
     id                  INTEGER PRIMARY KEY,


### PR DESCRIPTION
A schema migration can fail if the dnssec db is used by pdns
when the script runs, as the database may be locked.

Add a 60 second SQLITE_BUSY timeout, so that the migration will
wait up to 60 total seconds if it initially fails to acquire the
lock.

### Short description
If the schema migration script bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql runs at a time when the dnssec db happens to be in use, it can fail to acquire a lock for the transaction. This will abort the schema migration script, and no change gets made.

The change in this PR ensures that the sqlite queries will wait for up to 60 seconds if it cannot acquire the lock.

I did not do any unit test, as I'm unsure of how to script this, but manual testing can be done as follows:
1. Start with an older dnssec db.
2. In one terminal, use "sqlite3 /path/to/dnssec.db", and then force a lock with "BEGIN EXCLUSIVE TRANSACTION;"
3. In another terminal, run the schema migration script "sqlite3 /path/to/dnssec.db < /path/to/bind-dnssec.4.2.0_to_4.3.0_schema.sqlite3.sql"

Prior to the PR, this step would fail immediately, leaving the schema in the old format. With this PR, it should wait for up to 60 seconds.

4. Quickly (before the 60 second time limit) switch to your other terminal and quit the sqlite3 session with ".q" -- this should allow the schema migration to proceed as it releases the lock.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code (N/A -- the change is not in a compiled portion of code)
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
