### PR TITLE
"data" size is unreliable, start using RES, as it seem reliable and relavant

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1270,7 +1270,9 @@ uint64_t getRealMemoryUsage(const std::string&)
   uint64_t size, resident, shared, text, lib, data;
   ifs >> size >> resident >> shared >> text >> lib >> data;
 
-  return data * getpagesize();
+  // We used to use "data" here, but it proves unreliable and even is marked "broken"
+  // in https://www.kernel.org/doc/html/latest/filesystems/proc.html 
+  return resident * getpagesize();
 #else
   struct rusage ru;
   if (getrusage(RUSAGE_SELF, &ru) != 0)


### PR DESCRIPTION
According to https://www.kernel.org/doc/html/latest/filesystems/proc.html "data" aka "drs" is broken. 
In practice most of the time it shows a number somewhere between RES and VIRT, but it seems to be completely off in multi-threaded processed once in a while.

So move to the same number top(1) displays as "RES". This number is not marked broken and top(1) and the metrics agreed all the time in my tests.

Should fix #7591

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
