### PR TITLE
amazonlinux-2 packaging improvements

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.target.amazon-2
+++ b/builder-support/dockerfiles/Dockerfile.target.amazon-2
@@ -5,7 +5,7 @@
 # Put only the bare minimum of common commands here, without dev tools
 FROM amazonlinux:2 as dist-base
 ARG BUILDER_CACHE_BUSTER=
-RUN touch /var/lib/rpm/* && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN touch /var/lib/rpm/* && amazon-linux-extras install epel -y
 
 # Do the actual rpm build
 @INCLUDE Dockerfile.rpmbuild

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -166,6 +166,7 @@ BuildRequires: tinycdb-devel
 %description backend-tinydns
 This package contains the TinyDNS backend for %{name}
 
+%if 0%{?amzn} != 2
 %package ixfrdist
 BuildRequires: yaml-cpp-devel
 Summary: A progrm to redistribute zones over AXFR and IXFR
@@ -173,6 +174,7 @@ Group: System Environment/Daemons
 
 %description ixfrdist
 This package contains the ixfrdist program.
+%endif
 
 %prep
 %autosetup -p1 -n %{name}-%{getenv:BUILDER_VERSION}
@@ -191,11 +193,13 @@ export CPPFLAGS="-DLDAP_DEPRECATED"
   --with-dynmodules='%{backends} random' \
   --enable-tools \
   --with-libsodium \
+%if 0%{?amzn} != 2
+  --enable-ixfrdist \
+%endif
   --enable-unit-tests \
   --enable-lua-records \
   --enable-experimental-pkcs11 \
-  --enable-systemd \
-  --enable-ixfrdist
+  --enable-systemd
 
 make %{?_smp_mflags}
 
@@ -367,6 +371,7 @@ systemctl daemon-reload ||:
 %files backend-tinydns
 %{_libdir}/%{name}/libtinydnsbackend.so
 
+%if 0%{?amzn} != 2
 %files ixfrdist
 %{_bindir}/ixfrdist
 %{_mandir}/man1/ixfrdist.1.gz
@@ -374,3 +379,4 @@ systemctl daemon-reload ||:
 %{_sysconfdir}/%{name}/ixfrdist.example.yml
 %{_unitdir}/ixfrdist.service
 %{_unitdir}/ixfrdist@.service
+%endif


### PR DESCRIPTION
### Short description
Just to match their docs more closely. This does not switch the build to an actually different EPEL repo.

Sidenote: the auth build for amazonlinux-2 is currently broken, but only because of something between ixfrdist and yaml-cpp. I've decided to not investigate that right now.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master