### PR TITLE
Install vim in docker-auth image

### DIFF
--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -71,8 +71,9 @@ FROM debian:10-slim
 # Reusable layer for base update - Should be cached from builder
 RUN apt-get update && apt-get -y dist-upgrade && apt-get clean
 
-# Ensure python3 and jinja2 is present (for startup script), and sqlite3 (for db schema), and tini (for signal management)
-RUN apt-get install -y python3 python3-jinja2 sqlite3 tini libcap2-bin && apt-get clean
+# Ensure python3 and jinja2 is present (for startup script), and sqlite3 (for db schema), and tini (for signal management),
+#   and vim (for pdnsutil edit-zone) 
+RUN apt-get install -y python3 python3-jinja2 sqlite3 tini libcap2-bin vim && apt-get clean
 
 # Output from builder
 COPY --from=builder /build /

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -73,7 +73,7 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get clean
 
 # Ensure python3 and jinja2 is present (for startup script), and sqlite3 (for db schema), and tini (for signal management),
 #   and vim (for pdnsutil edit-zone) 
-RUN apt-get install -y python3 python3-jinja2 sqlite3 tini libcap2-bin vim && apt-get clean
+RUN apt-get install -y python3 python3-jinja2 sqlite3 tini libcap2-bin vim-tiny && apt-get clean
 
 # Output from builder
 COPY --from=builder /build /


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`pdnsutil edit-zone` requires `EDITOR` to be set. Currently there's no editor installed at all. Adding vim, so that it can be used as default editor by `pdnsutil edit-zone`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
