### PR TITLE
dnsreplay: Add an option to spoof the initial source IP

### DIFF
--- a/docs/manpages/dnsreplay.1.rst
+++ b/docs/manpages/dnsreplay.1.rst
@@ -33,17 +33,21 @@ PORT
 --ecs-mask <VAL>          When EDNS forwarding an IP address, mask out first octet with this value
 --ecs-stamp <FLAG>        Add original IP address as EDNS Client Subnet Option when 
                           forwarding to reference server
---pcap-dns-port <VAL>     Look at packets from or to this port in the PCAP. Default is 53.
 --packet-limit <NUM>      Stop after replaying *NUM* packets. Default for *NUM* is 0, which
                           means no limit.
+--pcap-dns-port <VAL>     Look at packets from or to this port in the PCAP. Default is 53.
 --quiet <FLAG>            If *FLAG* is set to 1. dnsreplay will not be very noisy with its
                           output. This is the default.
 --recursive <FLAG>        If *FLAG* is set to 1. dnsreplay will only replay queries with
                           recursion desired flag set. This is the default.
 --source-from-pcap <FLAG> If *FLAG* is set to 1. dnsreplay will send the replayed queries from the
-                          source IP address present in the PCAP file. This requires IP_TRANSPARENT
-                          support. Default is 0 which means replayed queries will be sent from a
-                          local address.
+                          source IP address and port present in the PCAP file. This requires
+                          IP_TRANSPARENT support. Default is 0 which means replayed queries will be
+                          sent from a local address.
+--source-ip <VAL>         Send the replayed queries from the source IP specified in *VAL*. Default
+                          is to send send them from a local address.
+--source-port <VAL>       Send the replayed queries from the source port specified in *VAL*.
+                          Default is to send from a random port selected by the kernel.
 --speedup <FACTOR>        Replay queries with this speedup *FACTOR*. Default is 1.
 --timeout-msec <MSEC>     Wait at least *MSEC* milliseconds for a reply. Default is 500.
 

--- a/docs/manpages/dnsreplay.1.rst
+++ b/docs/manpages/dnsreplay.1.rst
@@ -29,19 +29,23 @@ ADDRESS
 PORT
     if omitted, 53 will be used.
 
---help, -h               Show summary of options.
---ecs-mask <VAL>         When EDNS forwarding an IP address, mask out first octet with this value
---ecs-stamp <FLAG>       Add original IP address as EDNS Client Subnet Option when 
-                         forwarding to reference server
---pcap-dns-port <VAL>    Look at packets from or to this port in the PCAP. Default is 53.
---packet-limit <NUM>     Stop after replaying *NUM* packets. Default for *NUM* is 0, which
-                         means no limit.
---quiet <FLAG>           If *FLAG* is set to 1. dnsreplay will not be very noisy with its
-                         output. This is the default.
---recursive <FLAG>       If *FLAG* is set to 1. dnsreplay will only replay queries with
-                         recursion desired flag set. This is the default.
---speedup <FACTOR>       Replay queries with this speedup *FACTOR*. Default is 1.
---timeout-msec <MSEC>    Wait at least *MSEC* milliseconds for a reply. Default is 500.
+--help, -h                Show summary of options.
+--ecs-mask <VAL>          When EDNS forwarding an IP address, mask out first octet with this value
+--ecs-stamp <FLAG>        Add original IP address as EDNS Client Subnet Option when 
+                          forwarding to reference server
+--pcap-dns-port <VAL>     Look at packets from or to this port in the PCAP. Default is 53.
+--packet-limit <NUM>      Stop after replaying *NUM* packets. Default for *NUM* is 0, which
+                          means no limit.
+--quiet <FLAG>            If *FLAG* is set to 1. dnsreplay will not be very noisy with its
+                          output. This is the default.
+--recursive <FLAG>        If *FLAG* is set to 1. dnsreplay will only replay queries with
+                          recursion desired flag set. This is the default.
+--source-from-pcap <FLAG> If *FLAG* is set to 1. dnsreplay will send the replayed queries from the
+                          source IP address present in the PCAP file. This requires IP_TRANSPARENT
+                          support. Default is 0 which means replayed queries will be sent from a
+                          local address.
+--speedup <FACTOR>        Replay queries with this speedup *FACTOR*. Default is 1.
+--timeout-msec <MSEC>     Wait at least *MSEC* milliseconds for a reply. Default is 500.
 
 Bugs
 ----

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -810,7 +810,7 @@ try
 
   bool usePCAPSourceIP = g_vm["source-from-pcap"].as<bool>();
   if (usePCAPSourceIP && !checkIPTransparentUsability()) {
-    cerr << "--source-from-pcap requested but IP_TRANSPARENT support is not working properly" << endl;
+    cerr << "--source-from-pcap requested but IP_TRANSPARENT support is unavailable or not working properly" << endl;
     exit(EXIT_FAILURE);
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Needs more polishing, but I needed that option to investigate an issue and I don't want to have to write that code again the next time I need it :)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
