### PR TITLE
lua: don't destroy keys during table iteration

### DIFF
--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2690,12 +2690,12 @@ struct LuaContext::Reader<std::string>
         size_t len;
         const auto val = lua_tolstring(state, -1, &len);
 
-        if (val != 0)
+        if (val != nullptr)
           result.assign(val, len);
 
         lua_pop(state, 1);
 
-        return val != 0 ? boost::optional<std::string>{ std::move(result) } : boost::none;
+        return val != nullptr ? boost::optional<std::string>{ std::move(result) } : boost::none;
     }
 };
 

--- a/ext/luawrapper/include/LuaContext.hpp
+++ b/ext/luawrapper/include/LuaContext.hpp
@@ -2681,11 +2681,21 @@ struct LuaContext::Reader<std::string>
     static auto read(lua_State* state, int index)
         -> boost::optional<std::string>
     {
+        std::string result;
+
+        // lua_tolstring might convert the variable that would confuse lua_next, so we
+        //   make a copy of the variable.
+        lua_pushvalue(state, index);
+
         size_t len;
-        const auto val = lua_tolstring(state, index, &len);
-        if (val == 0)
-            return boost::none;
-        return std::string(val, len);
+        const auto val = lua_tolstring(state, -1, &len);
+
+        if (val != 0)
+          result.assign(val, len);
+
+        lua_pop(state, 1);
+
+        return val != 0 ? boost::optional<std::string>{ std::move(result) } : boost::none;
     }
 };
 


### PR DESCRIPTION
via https://github.com/ahupowerdns/luawrapper/pull/38


### Short description
This avoids a dnsdist crash when code returns an array-shaped table (i.e. `return {1,2,3}`).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master