### PR TITLE
dnsdist: Set OpenSSL to release buffers when idle, saves 35 kB per connection

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -223,6 +223,10 @@ static void parseTLSConfig(TLSConfig& config, const std::string& context, boost:
     g_outputBuffer = "TLS Key logging has been enabled using the 'keyLogFile' parameter to " + context + "(), but this version of OpenSSL does not support it";
 #endif
   }
+
+  if (vars->count("releaseBuffers")) {
+    config.d_releaseBuffers = boost::get<bool>((*vars)["releaseBuffers"]);
+  }
 }
 
 #endif // defined(HAVE_DNS_OVER_TLS) || defined(HAVE_DNS_OVER_HTTPS)

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -105,7 +105,7 @@ Listen Sockets
     ``url`` now defaults to ``/dns-query`` instead of ``/``, and does exact matching instead of accepting sub-paths. Added ``tcpListenQueueSize`` parameter.
 
   .. versionchanged:: 1.6.0
-    ``exactPathMatching`` option added.
+    ``exactPathMatching`` and ``releaseBuffers`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over HTTPS connections, presenting the specified X.509 certificate.
   If no certificate (or key) files are specified, listen for incoming DNS over HTTP connections instead.
@@ -143,6 +143,7 @@ Listen Sockets
   * ``tcpListenQueueSize=SOMAXCONN``: int - Set the size of the listen queue. Default is ``SOMAXCONN``.
   * ``internalPipeBufferSize=0``: int - Set the size in bytes of the internal buffer of the pipes used internally to pass queries and responses between threads. Requires support for ``F_SETPIPE_SZ`` which is present in Linux since 2.6.35. The actual size might be rounded up to a multiple of a page size. 0 means that the OS default size is used.
   * ``exactPathMatching=true``: bool - Whether to do exact path matching of the query path against the paths configured in ``urls`` (true, the default since 1.5.0) or to accepts sub-paths (false, and was the default before 1.5.0).
+  * ``releaseBuffers=true``: bool - Whether OpenSSL should release its I/O buffers when a connection goes idle, saving roughly 35 kB of memory per connection.
 
 .. function:: addTLSLocal(address, certFile(s), keyFile(s) [, options])
 
@@ -151,7 +152,7 @@ Listen Sockets
   .. versionchanged:: 1.5.0
     ``sessionTimeout`` and ``tcpListenQueueSize`` options added.
   .. versionchanged:: 1.6.0
-    Added ``maxInFlight`` parameter.
+    ``maxInFlight`` and ``releaseBuffers`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
@@ -182,6 +183,7 @@ Listen Sockets
   * ``keyLogFile``: str - Write the TLS keys in the specified file so that an external program can decrypt TLS exchanges, in the format described in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format. Note that this feature requires OpenSSL >= 1.1.1.
   * ``tcpListenQueueSize=SOMAXCONN``: int - Set the size of the listen queue. Default is ``SOMAXCONN``.
   * ``maxInFlight=0``: int - Maximum number of in-flight queries. The default is 0, which disables out-of-order processing.
+  * ``releaseBuffers=true``: bool - Whether OpenSSL should release its I/O buffers when a connection goes idle, saving roughly 35 kB of memory per connection.
 
 .. function:: setLocal(address[, options])
 

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -697,6 +697,12 @@ std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> libssl_init_server_context(const TLS
     SSL_CTX_sess_set_cache_size(ctx.get(), config.d_maxStoredSessions);
   }
 
+#ifdef SSL_MODE_RELEASE_BUFFERS
+  if (config.d_releaseBuffers) {
+    SSL_CTX_set_mode(ctx.get(), SSL_MODE_RELEASE_BUFFERS);
+  }
+#endif
+
   /* we need to set this callback to acknowledge the server name sent by the client,
      otherwise it will not stored in the session and will not be accessible when the
      session is resumed, causing SSL_get_servername to return nullptr */

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -31,6 +31,9 @@ public:
 
   bool d_preferServerCiphers{true};
   bool d_enableTickets{true};
+  /* whether OpenSSL will release I/O buffers when the connection
+     becomes idle, saving memory */
+  bool d_releaseBuffers{true};
 };
 
 struct TLSErrorCounters


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It is enabled by default by nginx, haproxy, Dovecot, Tor...

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
