### PR TITLE
auth: debian postinst / do not fail on user creation if it already exists

### DIFF
--- a/builder-support/debian/authoritative/debian-buster/pdns-server.postinst
+++ b/builder-support/debian/authoritative/debian-buster/pdns-server.postinst
@@ -8,8 +8,8 @@ fi
 
 case "$1" in
   configure)
-    addgroup --quiet --system pdns
-    adduser --quiet --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns
+    addgroup --quiet --system pdns || true
+    adduser --quiet --system --home /var/spool/powerdns --shell /bin/false --ingroup pdns --disabled-password --disabled-login --gecos "PowerDNS" pdns || true
     chown root:pdns /etc/powerdns/pdns.conf || true
     chmod 0640 /etc/powerdns/pdns.conf || true
   ;;


### PR DESCRIPTION
### Short description
Since pdns-server version 4.4.1, package configuration on Debian systems already provided with a system pdns user fails, which makes package upgrade impossible.
This PR provides a fix preventing package configuration from aborting at the groupe and user creation in case it already exists.

A similar PR can be found here on the recursor https://github.com/PowerDNS/pdns/pull/8639

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
