### PR TITLE
rec: Insert hints as non-auth into cache

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3514,8 +3514,8 @@ static void houseKeeping(void *)
         }
         last_RC_prune = now.tv_sec;
       }
-      // XXX !!! global
-      if (now.tv_sec - last_rootupdate > 7200) {
+      // Divide by 12 to get the original 2 hour cycle if s_maxcachettl is default (1 day)
+      if (now.tv_sec - last_rootupdate > max(SyncRes::s_maxcachettl / 12, 10U)) {
         int res = SyncRes::getRootNS(g_now, nullptr, 0);
         if (!res) {
           last_rootupdate=now.tv_sec;

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -102,13 +102,13 @@ bool primeHints(time_t now)
     arr.d_content = std::make_shared<ARecordContent>(ComboAddress(rootIps4[c - 'a']));
     vector<DNSRecord> aset;
     aset.push_back(arr);
-    g_recCache->replace(now, DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname); // auth, nuke it all
+    g_recCache->replace(now, DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname);
     if (rootIps6[c - 'a'] != NULL) {
       aaaarr.d_content = std::make_shared<AAAARecordContent>(ComboAddress(rootIps6[c - 'a']));
 
       vector<DNSRecord> aaaaset;
       aaaaset.push_back(aaaarr);
-      g_recCache->replace(now, DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname);
+      g_recCache->replace(now, DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname);
     }
 
     nsset.push_back(nsrr);

--- a/pdns/recursordist/test-syncres_cc1.cc
+++ b/pdns/recursordist/test-syncres_cc1.cc
@@ -14,18 +14,18 @@ BOOST_AUTO_TEST_CASE(test_root_primed)
 
   const DNSName target("a.root-servers.net.");
   try {
-  /* we are primed, but only with non-auth data so we cannot resolve A a.root-servers.net. without any query */
-  vector<DNSRecord> ret;
-  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
-  BOOST_CHECK_EQUAL(res, RCode::ServFail);
-  BOOST_REQUIRE_EQUAL(ret.size(), 0U);
+    /* we are primed, but only with non-auth data so we cannot resolve A a.root-servers.net. without any query */
+    vector<DNSRecord> ret;
+    int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+    BOOST_CHECK_EQUAL(res, RCode::ServFail);
+    BOOST_REQUIRE_EQUAL(ret.size(), 0U);
 
-  ret.clear();
-  res = sr->beginResolve(target, QType(QType::AAAA), QClass::IN, ret);
-  BOOST_CHECK_EQUAL(res, RCode::ServFail);
-  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Indeterminate);
-  BOOST_REQUIRE_EQUAL(ret.size(), 0U);
-  BOOST_CHECK(false);
+    ret.clear();
+    res = sr->beginResolve(target, QType(QType::AAAA), QClass::IN, ret);
+    BOOST_CHECK_EQUAL(res, RCode::ServFail);
+    BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Indeterminate);
+    BOOST_REQUIRE_EQUAL(ret.size(), 0U);
+    BOOST_CHECK(false);
   }
   catch (const ImmediateServFailException) {
     // Expected

--- a/pdns/recursordist/test-syncres_cc1.cc
+++ b/pdns/recursordist/test-syncres_cc1.cc
@@ -13,22 +13,23 @@ BOOST_AUTO_TEST_CASE(test_root_primed)
   primeHints();
 
   const DNSName target("a.root-servers.net.");
-
-  /* we are primed, we should be able to resolve A a.root-servers.net. without any query */
+  try {
+  /* we are primed, but only with non-auth data so we cannot resolve A a.root-servers.net. without any query */
   vector<DNSRecord> ret;
   int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
-  BOOST_CHECK_EQUAL(res, RCode::NoError);
-  BOOST_REQUIRE_EQUAL(ret.size(), 1U);
-  BOOST_CHECK(ret[0].d_type == QType::A);
-  BOOST_CHECK_EQUAL(ret[0].d_name, target);
+  BOOST_CHECK_EQUAL(res, RCode::ServFail);
+  BOOST_REQUIRE_EQUAL(ret.size(), 0U);
 
   ret.clear();
   res = sr->beginResolve(target, QType(QType::AAAA), QClass::IN, ret);
-  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(res, RCode::ServFail);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Indeterminate);
-  BOOST_REQUIRE_EQUAL(ret.size(), 1U);
-  BOOST_CHECK(ret[0].d_type == QType::AAAA);
-  BOOST_CHECK_EQUAL(ret[0].d_name, target);
+  BOOST_REQUIRE_EQUAL(ret.size(), 0U);
+  BOOST_CHECK(false);
+  }
+  catch (const ImmediateServFailException) {
+    // Expected
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_root_primed_ns)
@@ -186,6 +187,66 @@ BOOST_AUTO_TEST_CASE(test_root_ns_poison_resistance)
   res = sr->beginResolve(g_rootdnsname, QType(QType::NS), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_REQUIRE_EQUAL(ret.size(), 13U);
+}
+
+BOOST_AUTO_TEST_CASE(test_root_primed_ns_update)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr);
+
+  primeHints();
+  const DNSName target(".");
+  const DNSName aroot("a.root-servers.net.");
+  const string newA = "1.2.3.4";
+  const string newAAAA = "1::2";
+
+  /* we are primed, but we should not be able to NS . without any query
+   because the . NS entry is not stored as authoritative */
+
+  size_t queriesCount = 0;
+
+  auto asynccb = [target, &queriesCount, aroot, newA, newAAAA](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (domain == target && type == QType::NS) {
+
+      setLWResult(res, 0, true, false, true);
+      char addr[] = "a.root-servers.net.";
+      for (char idx = 'a'; idx <= 'm'; idx++) {
+        addr[0] = idx;
+        addRecordToLW(res, g_rootdnsname, QType::NS, std::string(addr), DNSResourceRecord::ANSWER, 3600);
+      }
+
+      addRecordToLW(res, aroot.toString(), QType::A, newA, DNSResourceRecord::ADDITIONAL, 3600);
+      addRecordToLW(res, aroot.toString(), QType::AAAA, newAAAA, DNSResourceRecord::ADDITIONAL, 3600);
+
+      return LWResult::Result::Success;
+    }
+    return LWResult::Result::Timeout;
+  };
+
+  sr->setAsyncCallback(asynccb);
+
+  struct timeval now;
+  Utility::gettimeofday(&now, nullptr);
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::NS), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_REQUIRE_EQUAL(ret.size(), 13U);
+  BOOST_CHECK_EQUAL(queriesCount, 1U);
+
+  ret.clear();
+  time_t cached = g_recCache->get(now.tv_sec, aroot, QType::A, false, &ret, ComboAddress());
+  BOOST_CHECK(cached > 0);
+  BOOST_REQUIRE_EQUAL(ret.size(), 1U);
+  BOOST_CHECK(getRR<ARecordContent>(ret[0])->getCA() == ComboAddress(newA));
+
+  ret.clear();
+  cached = g_recCache->get(now.tv_sec, aroot, QType::AAAA, false, &ret, ComboAddress());
+  BOOST_CHECK(cached > 0);
+  BOOST_REQUIRE_EQUAL(ret.size(), 1U);
+  BOOST_CHECK(getRR<AAAARecordContent>(ret[0])->getCA() == ComboAddress(newAAAA));
 }
 
 static void test_edns_formerr_fallback_f(bool sample)

--- a/pdns/recursordist/test-syncres_cc1.cc
+++ b/pdns/recursordist/test-syncres_cc1.cc
@@ -107,6 +107,8 @@ BOOST_AUTO_TEST_CASE(test_root_not_primed_and_no_response)
 {
   std::unique_ptr<SyncRes> sr;
   initSR(sr);
+  // We expect an error, do not log it
+  g_log.toConsole(Logger::Critical);
   std::set<ComboAddress> downServers;
 
   /* we are not primed yet, so SyncRes will have to call primeHints()

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -75,13 +75,13 @@ bool primeHints(time_t ignored)
       aset.push_back(arr);
       /*
        * Originally the hint records were inserted with the auth flag set, with the consequence that data from AUTHORITY and
-       * ADDITIONAL sections (as seen in a ,. NS response) were not used. This (together with the long ttl) caused outdated
+       * ADDITIONAL sections (as seen in a . NS response) were not used. This (together with the long ttl) caused outdated
        * hint to be kept in cache. So insert as non-auth, and the extra sections in the . NS refreshing cause the cached
        * records to be updated with up-to-date information received from a real root server.
        *
        * Note that if a user query is done for one of the root-server.net names, it will be inserted into the cache with the
        * auth bit set. Further NS refreshes will not update that entry. If all root names are queried at the same time by a user,
-       * all root-server.net names will be marked auth and will expired at the same time. A re-prime is then triggered,
+       * all root-server.net names will be marked auth and will expire at the same time. A re-prime is then triggered,
        * as before, when the records were inserted with the auth bit set and the TTD comes.
        */
       g_recCache->replace(now, DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname, boost::none, boost::none, validationState, from); // auth, nuke it all

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -34,7 +34,8 @@ extern char** g_argv;
 
 static thread_local set<DNSName> t_rootNSZones;
 
-static void insertIntoRootNSZones(const DNSName &name) {
+static void insertIntoRootNSZones(const DNSName& name)
+{
   // do not insert dot, wiping dot's NS records from the cache in primeRootNSZones()
   // will cause infinite recursion
   if (!name.isRoot()) {
@@ -50,34 +51,48 @@ bool primeHints(time_t ignored)
   vector<DNSRecord> nsset;
   t_rootNSZones.clear();
 
-  if(::arg()["hint-file"].empty()) {
+  time_t now = time(nullptr);
+
+  if (::arg()["hint-file"].empty()) {
     DNSRecord arr, aaaarr, nsrr;
-    nsrr.d_name=g_rootdnsname;
-    arr.d_type=QType::A;
-    aaaarr.d_type=QType::AAAA;
-    nsrr.d_type=QType::NS;
-    arr.d_ttl=aaaarr.d_ttl=nsrr.d_ttl=time(0)+3600000;
-    
-    for(char c='a';c<='m';++c) {
+    nsrr.d_name = g_rootdnsname;
+    arr.d_type = QType::A;
+    aaaarr.d_type = QType::AAAA;
+    nsrr.d_type = QType::NS;
+
+    arr.d_ttl = aaaarr.d_ttl = nsrr.d_ttl = now + 3600000;
+
+    for (char c = 'a'; c <= 'm'; ++c) {
       char templ[40];
-      strncpy(templ,"a.root-servers.net.", sizeof(templ) - 1);
-      templ[sizeof(templ)-1] = '\0';
-      *templ=c;
-      aaaarr.d_name=arr.d_name=DNSName(templ);
+      strncpy(templ, "a.root-servers.net.", sizeof(templ) - 1);
+      templ[sizeof(templ) - 1] = '\0';
+      *templ = c;
+      aaaarr.d_name = arr.d_name = DNSName(templ);
       insertIntoRootNSZones(arr.d_name.getLastLabel());
-      nsrr.d_content=std::make_shared<NSRecordContent>(DNSName(templ));
-      arr.d_content=std::make_shared<ARecordContent>(ComboAddress(rootIps4[c-'a']));
+      nsrr.d_content = std::make_shared<NSRecordContent>(DNSName(templ));
+      arr.d_content = std::make_shared<ARecordContent>(ComboAddress(rootIps4[c - 'a']));
       vector<DNSRecord> aset;
       aset.push_back(arr);
-      g_recCache->replace(time(0), DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname, boost::none, boost::none, validationState, from); // auth, nuke it all
-      if (rootIps6[c-'a'] != NULL) {
-        aaaarr.d_content=std::make_shared<AAAARecordContent>(ComboAddress(rootIps6[c-'a']));
+      /*
+       * Originally the hint records were inserted with the auth flag set, with the consequence that data from AUTHORITY and
+       * ADDITIONAL sections (as seen in a ,. NS response) were not used. This (together with the long ttl) caused outdated
+       * hint to be kept in cache. So insert as non-auth, and the extra sections in the . NS refreshing cause the cached
+       * records to be updated with up-to-date information received from a real root server.
+       *
+       * Note that if a user query is done for one of the root-server.net names, it will be inserted into the cache with the
+       * auth bit set. Further NS refreshes will not update that entry. If all root names are queried at the same time by a user,
+       * all root-server.net names will be marked auth and will expired at the same time. A re-prime is then triggered,
+       * as before, when the records were inserted with the auth bit set and the TTD comes.
+       */
+      g_recCache->replace(now, DNSName(templ), QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname, boost::none, boost::none, validationState, from); // auth, nuke it all
+      if (rootIps6[c - 'a'] != NULL) {
+        aaaarr.d_content = std::make_shared<AAAARecordContent>(ComboAddress(rootIps6[c - 'a']));
 
         vector<DNSRecord> aaaaset;
         aaaaset.push_back(aaaarr);
-        g_recCache->replace(time(0), DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname, boost::none, boost::none, validationState, from);
+        g_recCache->replace(now, DNSName(templ), QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname, boost::none, boost::none, validationState, from);
       }
-      
+
       nsset.push_back(nsrr);
     }
   }
@@ -89,21 +104,23 @@ bool primeHints(time_t ignored)
     set<DNSName> seenA;
     set<DNSName> seenAAAA;
 
-    while(zpt.get(rr)) {
-      rr.ttl+=time(0);
-      if(rr.qtype.getCode()==QType::A) {
+    while (zpt.get(rr)) {
+      rr.ttl += now;
+      if (rr.qtype.getCode() == QType::A) {
         seenA.insert(rr.qname);
         vector<DNSRecord> aset;
         aset.push_back(DNSRecord(rr));
-        g_recCache->replace(time(0), rr.qname, QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname, boost::none, boost::none, validationState, from); // auth, etc see above
-      } else if(rr.qtype.getCode()==QType::AAAA) {
+        g_recCache->replace(now, rr.qname, QType(QType::A), aset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname, boost::none, boost::none, validationState, from); // auth, etc see above
+      }
+      else if (rr.qtype.getCode() == QType::AAAA) {
         seenAAAA.insert(rr.qname);
         vector<DNSRecord> aaaaset;
         aaaaset.push_back(DNSRecord(rr));
-        g_recCache->replace(time(0), rr.qname, QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname, boost::none, boost::none, validationState, from);
-      } else if(rr.qtype.getCode()==QType::NS) {
+        g_recCache->replace(now, rr.qname, QType(QType::AAAA), aaaaset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), true, g_rootdnsname, boost::none, boost::none, validationState, from);
+      }
+      else if (rr.qtype.getCode() == QType::NS) {
         seenNS.insert(DNSName(rr.content));
-        rr.content=toLower(rr.content);
+        rr.content = toLower(rr.content);
         nsset.push_back(DNSRecord(rr));
       }
       insertIntoRootNSZones(rr.qname.getLastLabel());
@@ -111,37 +128,36 @@ bool primeHints(time_t ignored)
 
     // Check reachability of A and AAAA records
     bool reachableA = false, reachableAAAA = false;
-    for (auto const& r: seenA) {
+    for (auto const& r : seenA) {
       if (seenNS.count(r)) {
         reachableA = true;
         break;
       }
     }
-    for (auto const& r: seenAAAA) {
+    for (auto const& r : seenAAAA) {
       if (seenNS.count(r)) {
         reachableAAAA = true;
         break;
       }
     }
     if (SyncRes::s_doIPv4 && !SyncRes::s_doIPv6 && !reachableA) {
-      g_log<<Logger::Error<<"Running IPv4 only but no IPv4 root hints"<<endl;
+      g_log << Logger::Error << "Running IPv4 only but no IPv4 root hints" << endl;
       return false;
     }
     if (!SyncRes::s_doIPv4 && SyncRes::s_doIPv6 && !reachableAAAA) {
-      g_log<<Logger::Error<<"Running IPv6 only but no IPv6 root hints"<<endl;
+      g_log << Logger::Error << "Running IPv6 only but no IPv6 root hints" << endl;
       return false;
     }
     if (SyncRes::s_doIPv4 && SyncRes::s_doIPv6 && !reachableA && !reachableAAAA) {
-      g_log<<Logger::Error<<"No valid root hints"<<endl;
+      g_log << Logger::Error << "No valid root hints" << endl;
       return false;
     }
   }
 
   g_recCache->doWipeCache(g_rootdnsname, false, QType::NS);
-  g_recCache->replace(time(0), g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname, boost::none, boost::none, validationState, from); // and stuff in the cache
+  g_recCache->replace(now, g_rootdnsname, QType(QType::NS), nsset, vector<std::shared_ptr<RRSIGRecordContent>>(), vector<std::shared_ptr<DNSRecord>>(), false, g_rootdnsname, boost::none, boost::none, validationState, from); // and stuff in the cache
   return true;
 }
-
 
 // Do not only put the root hints into the cache, but also make sure
 // the NS records of the top level domains of the names of the root
@@ -164,8 +180,8 @@ void primeRootNSZones(bool dnssecmode, unsigned int depth)
 
   // beginResolve() can yield to another mthread that could trigger t_rootNSZones updates,
   // so make a local copy
-  set<DNSName> copy(t_rootNSZones);  
-  for (const auto & qname: copy) {
+  set<DNSName> copy(t_rootNSZones);
+  for (const auto& qname : copy) {
     g_recCache->doWipeCache(qname, false, QType::NS);
     vector<DNSRecord> ret;
     sr.beginResolve(qname, QType(QType::NS), QClass::IN, ret, depth + 1);
@@ -175,101 +191,101 @@ void primeRootNSZones(bool dnssecmode, unsigned int depth)
 static void makeNameToIPZone(std::shared_ptr<SyncRes::domainmap_t> newMap, const DNSName& hostname, const string& ip)
 {
   SyncRes::AuthDomain ad;
-  ad.d_rdForward=false;
+  ad.d_rdForward = false;
 
   DNSRecord dr;
-  dr.d_name=hostname;
-  dr.d_place=DNSResourceRecord::ANSWER;
-  dr.d_ttl=86400;
-  dr.d_type=QType::SOA;
+  dr.d_name = hostname;
+  dr.d_place = DNSResourceRecord::ANSWER;
+  dr.d_ttl = 86400;
+  dr.d_type = QType::SOA;
   dr.d_class = 1;
   dr.d_content = DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800");
-  
-  ad.d_records.insert(dr);
-
-  dr.d_type=QType::NS;
-  dr.d_content=std::make_shared<NSRecordContent>("localhost.");
 
   ad.d_records.insert(dr);
-  
-  dr.d_type=QType::A;
+
+  dr.d_type = QType::NS;
+  dr.d_content = std::make_shared<NSRecordContent>("localhost.");
+
+  ad.d_records.insert(dr);
+
+  dr.d_type = QType::A;
   dr.d_content = DNSRecordContent::mastermake(QType::A, 1, ip);
   ad.d_records.insert(dr);
-  
-  if(newMap->count(dr.d_name)) {  
-    g_log<<Logger::Warning<<"Hosts file will not overwrite zone '"<<dr.d_name<<"' already loaded"<<endl;
+
+  if (newMap->count(dr.d_name)) {
+    g_log << Logger::Warning << "Hosts file will not overwrite zone '" << dr.d_name << "' already loaded" << endl;
   }
   else {
-    g_log<<Logger::Warning<<"Inserting forward zone '"<<dr.d_name<<"' based on hosts file"<<endl;
-    ad.d_name=dr.d_name;
-    (*newMap)[ad.d_name]=ad;
+    g_log << Logger::Warning << "Inserting forward zone '" << dr.d_name << "' based on hosts file" << endl;
+    ad.d_name = dr.d_name;
+    (*newMap)[ad.d_name] = ad;
   }
 }
 
 //! parts[0] must be an IP address, the rest must be host names
 static void makeIPToNamesZone(std::shared_ptr<SyncRes::domainmap_t> newMap, const vector<string>& parts)
 {
-  string address=parts[0];
+  string address = parts[0];
   vector<string> ipparts;
-  stringtok(ipparts, address,".");
-  
+  stringtok(ipparts, address, ".");
+
   SyncRes::AuthDomain ad;
-  ad.d_rdForward=false;
+  ad.d_rdForward = false;
 
   DNSRecord dr;
-  for(int n=ipparts.size()-1; n>=0 ; --n) {
+  for (int n = ipparts.size() - 1; n >= 0; --n) {
     dr.d_name.appendRawLabel(ipparts[n]);
   }
   dr.d_name.appendRawLabel("in-addr");
   dr.d_name.appendRawLabel("arpa");
   dr.d_class = 1;
-  dr.d_place=DNSResourceRecord::ANSWER;
-  dr.d_ttl=86400;
-  dr.d_type=QType::SOA;
-  dr.d_content=DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800");
-  
-  ad.d_records.insert(dr);
-
-  dr.d_type=QType::NS;
-  dr.d_content=std::make_shared<NSRecordContent>(DNSName("localhost."));
+  dr.d_place = DNSResourceRecord::ANSWER;
+  dr.d_ttl = 86400;
+  dr.d_type = QType::SOA;
+  dr.d_content = DNSRecordContent::mastermake(QType::SOA, 1, "localhost. root 1 604800 86400 2419200 604800");
 
   ad.d_records.insert(dr);
-  dr.d_type=QType::PTR;
 
-  if(ipparts.size()==4)  // otherwise this is a partial zone
-    for(unsigned int n=1; n < parts.size(); ++n) {
-      dr.d_content=DNSRecordContent::mastermake(QType::PTR, 1, DNSName(parts[n]).toString()); // XXX FIXME DNSNAME PAIN CAN THIS BE RIGHT?
+  dr.d_type = QType::NS;
+  dr.d_content = std::make_shared<NSRecordContent>(DNSName("localhost."));
+
+  ad.d_records.insert(dr);
+  dr.d_type = QType::PTR;
+
+  if (ipparts.size() == 4) // otherwise this is a partial zone
+    for (unsigned int n = 1; n < parts.size(); ++n) {
+      dr.d_content = DNSRecordContent::mastermake(QType::PTR, 1, DNSName(parts[n]).toString()); // XXX FIXME DNSNAME PAIN CAN THIS BE RIGHT?
       ad.d_records.insert(dr);
     }
 
-  if(newMap->count(dr.d_name)) {  
-    g_log<<Logger::Warning<<"Will not overwrite zone '"<<dr.d_name<<"' already loaded"<<endl;
+  if (newMap->count(dr.d_name)) {
+    g_log << Logger::Warning << "Will not overwrite zone '" << dr.d_name << "' already loaded" << endl;
   }
   else {
-    if(ipparts.size()==4)
-      g_log<<Logger::Warning<<"Inserting reverse zone '"<<dr.d_name<<"' based on hosts file"<<endl;
+    if (ipparts.size() == 4)
+      g_log << Logger::Warning << "Inserting reverse zone '" << dr.d_name << "' based on hosts file" << endl;
     ad.d_name = dr.d_name;
-    (*newMap)[ad.d_name]=ad;
+    (*newMap)[ad.d_name] = ad;
   }
 }
 
-static void convertServersForAD(const std::string& input, SyncRes::AuthDomain& ad, const char* sepa, bool verbose=true)
+static void convertServersForAD(const std::string& input, SyncRes::AuthDomain& ad, const char* sepa, bool verbose = true)
 {
   vector<string> servers;
   stringtok(servers, input, sepa);
   ad.d_servers.clear();
 
-  for(vector<string>::const_iterator iter = servers.begin(); iter != servers.end(); ++iter) {
-    if(verbose && iter != servers.begin()) 
-      g_log<<", ";
+  for (vector<string>::const_iterator iter = servers.begin(); iter != servers.end(); ++iter) {
+    if (verbose && iter != servers.begin())
+      g_log << ", ";
 
-    ComboAddress addr=parseIPAndPort(*iter, 53);
-    if(verbose)
-      g_log<<addr.toStringWithPort();
+    ComboAddress addr = parseIPAndPort(*iter, 53);
+    if (verbose)
+      g_log << addr.toStringWithPort();
     ad.d_servers.push_back(addr);
   }
-  if(verbose)
-    g_log<<endl;
+  if (verbose)
+    g_log << endl;
 }
 
 static void* pleaseUseNewSDomainsMap(std::shared_ptr<SyncRes::domainmap_t> newmap)
@@ -280,19 +296,19 @@ static void* pleaseUseNewSDomainsMap(std::shared_ptr<SyncRes::domainmap_t> newma
 
 string reloadAuthAndForwards()
 {
-  std::shared_ptr<SyncRes::domainmap_t> original=SyncRes::getDomainMap();
-  
-  try {
-    g_log<<Logger::Warning<<"Reloading zones, purging data from cache"<<endl;
+  std::shared_ptr<SyncRes::domainmap_t> original = SyncRes::getDomainMap();
 
-    string configname=::arg()["config-dir"]+"/recursor.conf";
-    if(::arg()["config-name"]!="") {
-      configname=::arg()["config-dir"]+"/recursor-"+::arg()["config-name"]+".conf";
+  try {
+    g_log << Logger::Warning << "Reloading zones, purging data from cache" << endl;
+
+    string configname = ::arg()["config-dir"] + "/recursor.conf";
+    if (::arg()["config-name"] != "") {
+      configname = ::arg()["config-dir"] + "/recursor-" + ::arg()["config-name"] + ".conf";
     }
     cleanSlashes(configname);
-    
-    if(!::arg().preParseFile(configname.c_str(), "forward-zones"))
-      throw runtime_error("Unable to re-parse configuration file '"+configname+"'");
+
+    if (!::arg().preParseFile(configname.c_str(), "forward-zones"))
+      throw runtime_error("Unable to re-parse configuration file '" + configname + "'");
     ::arg().preParseFile(configname.c_str(), "forward-zones-file");
     ::arg().preParseFile(configname.c_str(), "forward-zones-recurse");
     ::arg().preParseFile(configname.c_str(), "auth-zones");
@@ -305,14 +321,14 @@ string reloadAuthAndForwards()
     std::vector<std::string> extraConfigs;
     ::arg().gatherIncludes(extraConfigs);
 
-    for(const std::string& fn :  extraConfigs) {
-      if(!::arg().preParseFile(fn.c_str(), "forward-zones", ::arg()["forward-zones"]))
-        throw runtime_error("Unable to re-parse configuration file include '"+fn+"'");
+    for (const std::string& fn : extraConfigs) {
+      if (!::arg().preParseFile(fn.c_str(), "forward-zones", ::arg()["forward-zones"]))
+        throw runtime_error("Unable to re-parse configuration file include '" + fn + "'");
       ::arg().preParseFile(fn.c_str(), "forward-zones-file", ::arg()["forward-zones-file"]);
       ::arg().preParseFile(fn.c_str(), "forward-zones-recurse", ::arg()["forward-zones-recurse"]);
-      ::arg().preParseFile(fn.c_str(), "auth-zones",::arg()["auth-zones"]);
-      ::arg().preParseFile(fn.c_str(), "export-etc-hosts",::arg()["export-etc-hosts"]);
-      ::arg().preParseFile(fn.c_str(), "serve-rfc1918",::arg()["serve-rfc1918"]);
+      ::arg().preParseFile(fn.c_str(), "auth-zones", ::arg()["auth-zones"]);
+      ::arg().preParseFile(fn.c_str(), "export-etc-hosts", ::arg()["export-etc-hosts"]);
+      ::arg().preParseFile(fn.c_str(), "serve-rfc1918", ::arg()["serve-rfc1918"]);
     }
 
     ::arg().preParse(g_argc, g_argv, "forward-zones");
@@ -326,33 +342,33 @@ string reloadAuthAndForwards()
 
     // purge both original and new names
     std::set<DNSName> oldAndNewDomains;
-    for(const auto& i : *newDomainMap) {
+    for (const auto& i : *newDomainMap) {
       oldAndNewDomains.insert(i.first);
     }
 
-    if(original) {
-      for(const auto& i : *original) {
+    if (original) {
+      for (const auto& i : *original) {
         oldAndNewDomains.insert(i.first);
       }
     }
 
-    for(const auto& i : oldAndNewDomains) {
+    for (const auto& i : oldAndNewDomains) {
       g_recCache->doWipeCache(i, true, 0xffff);
-      broadcastAccFunction<uint64_t>([&]{return pleaseWipePacketCache(i, true, 0xffff);});
+      broadcastAccFunction<uint64_t>([&] { return pleaseWipePacketCache(i, true, 0xffff); });
       g_negCache->wipe(i, true);
     }
 
-    broadcastFunction([=]{return pleaseUseNewSDomainsMap(newDomainMap);});
+    broadcastFunction([=] { return pleaseUseNewSDomainsMap(newDomainMap); });
     return "ok\n";
   }
-  catch(std::exception& e) {
-    g_log<<Logger::Error<<"Encountered error reloading zones, keeping original data: "<<e.what()<<endl;
+  catch (std::exception& e) {
+    g_log << Logger::Error << "Encountered error reloading zones, keeping original data: " << e.what() << endl;
   }
-  catch(PDNSException& ae) {
-    g_log<<Logger::Error<<"Encountered error reloading zones, keeping original data: "<<ae.reason<<endl;
+  catch (PDNSException& ae) {
+    g_log << Logger::Error << "Encountered error reloading zones, keeping original data: " << ae.reason << endl;
   }
-  catch(...) {
-    g_log<<Logger::Error<<"Encountered unknown error reloading zones, keeping original data"<<endl;
+  catch (...) {
+    g_log << Logger::Error << "Encountered unknown error reloading zones, keeping original data" << endl;
   }
   return "reloading failed, see log\n";
 }
@@ -365,136 +381,137 @@ std::shared_ptr<SyncRes::domainmap_t> parseAuthAndForwards()
   auto newMap = std::make_shared<SyncRes::domainmap_t>();
 
   typedef vector<string> parts_t;
-  parts_t parts;  
-  const char *option_names[3]={"auth-zones", "forward-zones", "forward-zones-recurse"};
-  for(int n=0; n < 3 ; ++n ) {
+  parts_t parts;
+  const char* option_names[3] = {"auth-zones", "forward-zones", "forward-zones-recurse"};
+  for (int n = 0; n < 3; ++n) {
     parts.clear();
     stringtok(parts, ::arg()[option_names[n]], " ,\t\n\r");
-    for(parts_t::const_iterator iter = parts.begin(); iter != parts.end(); ++iter) {
+    for (parts_t::const_iterator iter = parts.begin(); iter != parts.end(); ++iter) {
       SyncRes::AuthDomain ad;
       if ((*iter).find('=') == string::npos)
         throw PDNSException("Error parsing '" + *iter + "', missing =");
-      pair<string,string> headers=splitField(*iter, '=');
+      pair<string, string> headers = splitField(*iter, '=');
       boost::trim(headers.first);
       boost::trim(headers.second);
       // headers.first=toCanonic("", headers.first);
-      if(n==0) {
+      if (n == 0) {
         ad.d_rdForward = false;
-        g_log<<Logger::Error<<"Parsing authoritative data for zone '"<<headers.first<<"' from file '"<<headers.second<<"'"<<endl;
+        g_log << Logger::Error << "Parsing authoritative data for zone '" << headers.first << "' from file '" << headers.second << "'" << endl;
         ZoneParserTNG zpt(headers.second, DNSName(headers.first));
         zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
         DNSResourceRecord rr;
-	DNSRecord dr;
-        while(zpt.get(rr)) {
+        DNSRecord dr;
+        while (zpt.get(rr)) {
           try {
-	    dr=DNSRecord(rr);
-	    dr.d_place=DNSResourceRecord::ANSWER;
+            dr = DNSRecord(rr);
+            dr.d_place = DNSResourceRecord::ANSWER;
           }
-          catch(std::exception &e) {
-            throw PDNSException("Error parsing record '"+rr.qname.toLogString()+"' of type "+rr.qtype.getName()+" in zone '"+headers.first+"' from file '"+headers.second+"': "+e.what());
+          catch (std::exception& e) {
+            throw PDNSException("Error parsing record '" + rr.qname.toLogString() + "' of type " + rr.qtype.getName() + " in zone '" + headers.first + "' from file '" + headers.second + "': " + e.what());
           }
-          catch(...) {
-            throw PDNSException("Error parsing record '"+rr.qname.toLogString()+"' of type "+rr.qtype.getName()+" in zone '"+headers.first+"' from file '"+headers.second+"'");
+          catch (...) {
+            throw PDNSException("Error parsing record '" + rr.qname.toLogString() + "' of type " + rr.qtype.getName() + " in zone '" + headers.first + "' from file '" + headers.second + "'");
           }
 
           ad.d_records.insert(dr);
         }
       }
       else {
-        g_log<<Logger::Error<<"Redirecting queries for zone '"<<headers.first<<"' ";
-        if(n == 2) {
-          g_log<<"with recursion ";
+        g_log << Logger::Error << "Redirecting queries for zone '" << headers.first << "' ";
+        if (n == 2) {
+          g_log << "with recursion ";
           ad.d_rdForward = true;
         }
-        else ad.d_rdForward = false;
-        g_log<<"to: ";
-        
+        else
+          ad.d_rdForward = false;
+        g_log << "to: ";
+
         convertServersForAD(headers.second, ad, ";");
-        if(n == 2) {
+        if (n == 2) {
           ad.d_rdForward = true;
         }
       }
 
       ad.d_name = DNSName(headers.first);
-      (*newMap)[ad.d_name]=ad;
+      (*newMap)[ad.d_name] = ad;
     }
   }
-  
-  if(!::arg()["forward-zones-file"].empty()) {
-    g_log<<Logger::Warning<<"Reading zone forwarding information from '"<<::arg()["forward-zones-file"]<<"'"<<endl;
+
+  if (!::arg()["forward-zones-file"].empty()) {
+    g_log << Logger::Warning << "Reading zone forwarding information from '" << ::arg()["forward-zones-file"] << "'" << endl;
     SyncRes::AuthDomain ad;
-    auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(::arg()["forward-zones-file"].c_str(), "r"), fclose);
-    if(!fp) {
-      throw PDNSException("Error opening forward-zones-file '"+::arg()["forward-zones-file"]+"': "+stringerror());
+    auto fp = std::unique_ptr<FILE, int (*)(FILE*)>(fopen(::arg()["forward-zones-file"].c_str(), "r"), fclose);
+    if (!fp) {
+      throw PDNSException("Error opening forward-zones-file '" + ::arg()["forward-zones-file"] + "': " + stringerror());
     }
 
     string line;
-    int linenum=0;
+    int linenum = 0;
     uint64_t before = newMap->size();
-    while(linenum++, stringfgets(fp.get(), line)) {
+    while (linenum++, stringfgets(fp.get(), line)) {
       boost::trim(line);
       if (line[0] == '#') // Comment line, skip to the next line
         continue;
       string domain, instructions;
-      tie(domain, instructions)=splitField(line, '=');
+      tie(domain, instructions) = splitField(line, '=');
       instructions = splitField(instructions, '#').first; // Remove EOL comments
       boost::trim(domain);
       boost::trim(instructions);
-      if(domain.empty() && instructions.empty()) { // empty line
+      if (domain.empty() && instructions.empty()) { // empty line
         continue;
       }
-      if(boost::starts_with(domain,"+")) {
-        domain=domain.c_str()+1;
+      if (boost::starts_with(domain, "+")) {
+        domain = domain.c_str() + 1;
         ad.d_rdForward = true;
       }
       else
         ad.d_rdForward = false;
-      if(domain.empty()) {
-        throw PDNSException("Error parsing line "+std::to_string(linenum)+" of " +::arg()["forward-zones-file"]);
+      if (domain.empty()) {
+        throw PDNSException("Error parsing line " + std::to_string(linenum) + " of " + ::arg()["forward-zones-file"]);
       }
 
       try {
         convertServersForAD(instructions, ad, ",; ", false);
       }
-      catch(...) {
-        throw PDNSException("Conversion error parsing line "+std::to_string(linenum)+" of " +::arg()["forward-zones-file"]);
+      catch (...) {
+        throw PDNSException("Conversion error parsing line " + std::to_string(linenum) + " of " + ::arg()["forward-zones-file"]);
       }
 
       ad.d_name = DNSName(domain);
-      (*newMap)[ad.d_name]=ad;
+      (*newMap)[ad.d_name] = ad;
     }
-    g_log<<Logger::Warning<<"Done parsing " << newMap->size() - before<<" forwarding instructions from file '"<<::arg()["forward-zones-file"]<<"'"<<endl;
+    g_log << Logger::Warning << "Done parsing " << newMap->size() - before << " forwarding instructions from file '" << ::arg()["forward-zones-file"] << "'" << endl;
   }
 
-  if(::arg().mustDo("export-etc-hosts")) {
+  if (::arg().mustDo("export-etc-hosts")) {
     string line;
-    string fname=::arg()["etc-hosts-file"];
-    
+    string fname = ::arg()["etc-hosts-file"];
+
     ifstream ifs(fname.c_str());
-    if(!ifs) {
-      g_log<<Logger::Warning<<"Could not open "<<fname<<" for reading"<<endl;
+    if (!ifs) {
+      g_log << Logger::Warning << "Could not open " << fname << " for reading" << endl;
     }
     else {
       string searchSuffix = ::arg()["export-etc-hosts-search-suffix"];
       string::size_type pos;
-      while(getline(ifs,line)) {
-        pos=line.find('#');
-        if(pos!=string::npos)
+      while (getline(ifs, line)) {
+        pos = line.find('#');
+        if (pos != string::npos)
           line.resize(pos);
         boost::trim(line);
-        if(line.empty())
+        if (line.empty())
           continue;
         parts.clear();
         stringtok(parts, line, "\t\r\n ");
-        if(parts[0].find(':')!=string::npos)
+        if (parts[0].find(':') != string::npos)
           continue;
-        
-        for(unsigned int n=1; n < parts.size(); ++n) {
-          if(searchSuffix.empty() || parts[n].find('.') != string::npos)
-	    makeNameToIPZone(newMap, DNSName(parts[n]), parts[0]);
+
+        for (unsigned int n = 1; n < parts.size(); ++n) {
+          if (searchSuffix.empty() || parts[n].find('.') != string::npos)
+            makeNameToIPZone(newMap, DNSName(parts[n]), parts[0]);
           else {
-	    DNSName canonic=toCanonic(DNSName(searchSuffix), parts[n]); /// XXXX DNSName pain
-	    if(canonic != DNSName(parts[n])) {   // XXX further DNSName pain
+            DNSName canonic = toCanonic(DNSName(searchSuffix), parts[n]); /// XXXX DNSName pain
+            if (canonic != DNSName(parts[n])) { // XXX further DNSName pain
               makeNameToIPZone(newMap, canonic, parts[0]);
             }
           }
@@ -503,19 +520,19 @@ std::shared_ptr<SyncRes::domainmap_t> parseAuthAndForwards()
       }
     }
   }
-  if(::arg().mustDo("serve-rfc1918")) {
-    g_log<<Logger::Warning<<"Inserting rfc 1918 private space zones"<<endl;
+  if (::arg().mustDo("serve-rfc1918")) {
+    g_log << Logger::Warning << "Inserting rfc 1918 private space zones" << endl;
     parts.clear();
     parts.push_back("127");
     makeIPToNamesZone(newMap, parts);
-    parts[0]="10";
+    parts[0] = "10";
     makeIPToNamesZone(newMap, parts);
 
-    parts[0]="192.168";
+    parts[0] = "192.168";
     makeIPToNamesZone(newMap, parts);
-    for(int n=16; n < 32; n++) {
-      parts[0]="172."+std::to_string(n);
-      makeIPToNamesZone(newMap,parts);
+    for (int n = 16; n < 32; n++) {
+      parts[0] = "172." + std::to_string(n);
+      makeIPToNamesZone(newMap, parts);
     }
   }
   return newMap;

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1259,10 +1259,10 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType qtype, vector
     if(subdomain.isRoot() && !brokeloop) {
       // We lost the root NS records
       primeHints();
-      primeRootNSZones(g_dnssecmode != DNSSECMode::Off, depth);
       LOG(prefix<<qname<<": reprimed the root"<<endl);
       /* let's prevent an infinite loop */
       if (!d_updatingRootNS) {
+        primeRootNSZones(g_dnssecmode != DNSSECMode::Off, depth);
         getRootNS(d_now, d_asyncResolve, depth);
       }
     }
@@ -4370,7 +4370,6 @@ int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigne
         throw PDNSException("Got Bogus validation result for .|NS");
       }
     }
-    return res;
   }
   catch(const PDNSException& e) {
     g_log<<Logger::Error<<"Failed to update . records, got an exception: "<<e.reason<<endl;


### PR DESCRIPTION
Insert hints as non-auth into cache, so info received from the net is recorded in the cache.

Also make sure the root NS refresh happens more often if `max-cache-ttl` is low.
This is needed as the records no longer maintain the 1000 hours TTL.
In the existing setup, a reprime (with potential outdated info) was done at that
point in time since all root-server address records would expire at the same
time.

Lastly, fix a infinite (caught by depth check) recursion in getBestNSFromCache().

Fixes #10177.

As a bonus, reformat `reczones.cc` to make it easier on the eyes. (Ignore whitespace to make the diff easier).

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
