### PR TITLE
dnsdist: Add a metric for TCP listen queue full events

### DIFF
--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -152,6 +152,7 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::metrics{
   { "udp-noport-errors",      MetricDefinition(PrometheusMetricType::counter, "From /proc/net/snmp NoPorts") },
   { "udp-recvbuf-errors",     MetricDefinition(PrometheusMetricType::counter, "From /proc/net/snmp RcvbufErrors") },
   { "udp-sndbuf-errors",      MetricDefinition(PrometheusMetricType::counter, "From /proc/net/snmp SndbufErrors") },
+  { "tcp-listen-overflows",   MetricDefinition(PrometheusMetricType::counter, "From /proc/net/netstat ListenOverflows") },
   { "proxy-protocol-invalid", MetricDefinition(PrometheusMetricType::counter, "Number of queries dropped because of an invalid Proxy Protocol header") },
 };
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -369,6 +369,7 @@ struct DNSDistStats
     {"udp-noport-errors", boost::bind(udpErrorStats, "udp-noport-errors")},
     {"udp-recvbuf-errors", boost::bind(udpErrorStats, "udp-recvbuf-errors")},
     {"udp-sndbuf-errors", boost::bind(udpErrorStats, "udp-sndbuf-errors")},
+    {"tcp-listen-overflows", std::bind(tcpErrorStats, "ListenOverflows")},
     {"noncompliant-queries", &nonCompliantQueries},
     {"noncompliant-responses", &nonCompliantResponses},
     {"proxy-protocol-invalid", &proxyProtocolInvalid},

--- a/pdns/dnsdistdist/docs/statistics.rst
+++ b/pdns/dnsdistdist/docs/statistics.rst
@@ -227,6 +227,12 @@ servfail-responses
 ------------------
 Number of servfail answers received from backends.
 
+tcp-listen-overflows
+--------------------
+.. versionadded:: 1.6.0
+
+From /proc/net/netstat ListenOverflows.
+
 trunc-failures
 --------------
 Number of errors encountered while truncating an answer.

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1147,6 +1147,31 @@ uint64_t udpErrorStats(const std::string& str)
   return 0;
 }
 
+uint64_t tcpErrorStats(const std::string& str)
+{
+#ifdef __linux__
+  ifstream ifs("/proc/net/netstat");
+  if (!ifs) {
+    return 0;
+  }
+
+  string line;
+  vector<string> parts;
+  while (getline(ifs,line)) {
+    if (line.size() > 9 && boost::starts_with(line, "TcpExt: ") && isdigit(line.at(8))) {
+      stringtok(parts, line, " \n\t\r");
+
+      if (parts.size() < 21) {
+        break;
+      }
+
+      return std::stoull(parts.at(20));
+    }
+  }
+#endif
+  return 0;
+}
+
 uint64_t getCPUIOWait(const std::string& str)
 {
 #ifdef __linux__

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -561,6 +561,7 @@ size_t getPipeBufferSize(int fd);
 bool setPipeBufferSize(int fd, size_t size);
 
 uint64_t udpErrorStats(const std::string& str);
+uint64_t tcpErrorStats(const std::string& str);
 uint64_t getRealMemoryUsage(const std::string&);
 uint64_t getSpecialMemoryUsage(const std::string&);
 uint64_t getOpenFileDescriptors(const std::string&);

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -240,7 +240,7 @@ class TestAPIBasics(DNSDistTest):
                     'cache-misses', 'cpu-iowait', 'cpu-steal', 'cpu-sys-msec', 'cpu-user-msec', 'fd-usage', 'dyn-blocked',
                     'dyn-block-nmg-size', 'rule-servfail', 'rule-truncated', 'security-status',
                     'udp-in-errors', 'udp-noport-errors', 'udp-recvbuf-errors', 'udp-sndbuf-errors',
-                    'doh-query-pipe-full', 'doh-response-pipe-full', 'proxy-protocol-invalid']
+                    'doh-query-pipe-full', 'doh-response-pipe-full', 'proxy-protocol-invalid', 'tcp-listen-overflows']
 
         for key in expected:
             self.assertIn(key, values)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Making it easier to spot when the TCP / DoT or DoH acceptor threads are overloaded.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
