### PR TITLE
auth: implement AXFR priority level queue code

### DIFF
--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -140,6 +140,12 @@ Slave operation can also be programmed using several
 command is especially useful as it triggers an immediate retrieval of
 the zone from the configured master.
 
+Zone transfers are added to a queue and processed according to priority
+and order of addition. Order levels are (from high to low): pdns control,
+api, notify, serial changed during refresh and signatures changed during
+refresh. High priority zone transfers are always processed first, in a 
+first in first out order.
+
 PowerDNS supports multiple masters. For the BIND backend, the native
 BIND configuration language suffices to specify multiple masters, for
 SQL based backends, list all master servers separated by commas in the

--- a/docs/modes-of-operation.rst
+++ b/docs/modes-of-operation.rst
@@ -140,7 +140,7 @@ Slave operation can also be programmed using several
 command is especially useful as it triggers an immediate retrieval of
 the zone from the configured master.
 
-Zone transfers are added to a queue and processed according to priority
+Since 4.5.0, zone transfers are added to a queue and processed according to priority
 and order of addition. Order levels are (from high to low): pdns control,
 api, notify, serial changed during refresh and signatures changed during
 refresh. High priority zone transfers are always processed first, in a 

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1352,6 +1352,7 @@ testrunner_SOURCES = \
 	test-base64_cc.cc \
 	test-bindparser_cc.cc \
 	test-common.hh \
+	test-communicator_hh.cc \
 	test-digests_hh.cc \
 	test-distributor_hh.cc \
 	test-dns_random_hh.cc \

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -50,9 +50,15 @@ void CommunicatorClass::retrievalLoopThread()
       std::lock_guard<std::mutex> l(d_lock);
       if(d_suckdomains.empty()) 
         continue;
+
+      domains_by_queuepos_t& queueindex = boost::multi_index::get<QueueTag>(d_suckdomains);
+      auto firstItem = queueindex.begin();
         
-      sr=d_suckdomains.front();
-      d_suckdomains.pop_front();
+      sr=*firstItem;
+      queueindex.erase(firstItem);
+      if (d_suckdomains.empty()) {
+        d_sorthelper = 0;
+      }
     }
     suck(sr.domain, sr.master, sr.force);
   }

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -51,11 +51,10 @@ void CommunicatorClass::retrievalLoopThread()
       if(d_suckdomains.empty()) 
         continue;
 
-      domains_by_queuepos_t& queueindex = boost::multi_index::get<QueueTag>(d_suckdomains);
-      auto firstItem = queueindex.begin();
+      auto firstItem = d_suckdomains.begin();
         
       sr=*firstItem;
-      queueindex.erase(firstItem);
+      d_suckdomains.erase(firstItem);
       if (d_suckdomains.empty()) {
         d_sorthelper = 0;
       }

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -46,22 +46,36 @@ struct SuckRequest
   DNSName domain;
   ComboAddress master;
   bool force;
+  uint8_t priority;
+  uint64_t sortHelper;
   bool operator<(const SuckRequest& b) const
   {
     return tie(domain, master) < tie(b.domain, b.master);
   }
 };
 
+struct suckQueueCmp
+{
+  bool operator()(const SuckRequest& a, const SuckRequest& b) const {
+    if (a.priority == b.priority) {
+      return a.sortHelper < b.sortHelper;
+    }
+    return a.priority < b.priority;
+  };
+};
+
 struct IDTag{};
+struct QueueTag{};
 
 typedef multi_index_container<
   SuckRequest,
   indexed_by<
-    sequenced<>,
+    ordered_non_unique<tag<QueueTag>, identity<SuckRequest>, suckQueueCmp>,
     ordered_unique<tag<IDTag>, identity<SuckRequest> >
   >
 > UniQueue;
 typedef UniQueue::index<IDTag>::type domains_by_name_t;
+typedef UniQueue::index<QueueTag>::type domains_by_queuepos_t;
 
 class NotificationQueue
 {
@@ -155,6 +169,7 @@ public:
     d_nsock4 = -1;
     d_nsock6 = -1;
     d_preventSelfNotification = false;
+    d_sorthelper = 0;
   }
   time_t doNotifications(PacketHandler *P);
   void go();
@@ -162,7 +177,7 @@ public:
   
   void drillHole(const DNSName &domain, const string &ip);
   bool justNotified(const DNSName &domain, const string &ip);
-  void addSuckRequest(const DNSName &domain, const ComboAddress& master, bool force=false);
+  void addSuckRequest(const DNSName &domain, const ComboAddress& master, bool force=false, uint8_t priority = 0);
   void addSlaveCheckRequest(const DomainInfo& di, const ComboAddress& remote);
   void addTrySuperMasterRequest(const DNSPacket& p);
   void notify(const DNSName &domain, const string &ip);
@@ -187,6 +202,7 @@ private:
   void masterUpdateCheck(PacketHandler *P);
   std::mutex d_lock;
   
+  uint64_t d_sorthelper;
   UniQueue d_suckdomains;
   set<DNSName> d_inprogress;
   

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -46,7 +46,8 @@ struct SuckRequest
   DNSName domain;
   ComboAddress master;
   bool force;
-  std::pair<uint8_t, uint64_t> priorityAndOrder;
+  enum RequestPriority : uint8_t { PdnsControl, Api, Notify, SerialRefresh, SignaturesRefresh };
+  std::pair<RequestPriority, uint64_t> priorityAndOrder;
   bool operator<(const SuckRequest& b) const
   {
     return tie(domain, master) < tie(b.domain, b.master);
@@ -59,7 +60,7 @@ struct QueueTag{};
 typedef multi_index_container<
   SuckRequest,
   indexed_by<
-    ordered_unique<tag<QueueTag>, member<SuckRequest,std::pair<uint8_t,uint64_t>,&SuckRequest::priorityAndOrder>>,
+    ordered_unique<tag<QueueTag>, member<SuckRequest,std::pair<SuckRequest::RequestPriority,uint64_t>,&SuckRequest::priorityAndOrder>>,
     ordered_unique<tag<IDTag>, identity<SuckRequest> >
   >
 > UniQueue;
@@ -166,7 +167,7 @@ public:
   
   void drillHole(const DNSName &domain, const string &ip);
   bool justNotified(const DNSName &domain, const string &ip);
-  void addSuckRequest(const DNSName &domain, const ComboAddress& master, bool force=false, uint8_t priority = 0);
+  void addSuckRequest(const DNSName &domain, const ComboAddress& master, SuckRequest::RequestPriority, bool force=false);
   void addSlaveCheckRequest(const DomainInfo& di, const ComboAddress& remote);
   void addTrySuperMasterRequest(const DNSPacket& p);
   void notify(const DNSName &domain, const string &ip);

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -46,22 +46,11 @@ struct SuckRequest
   DNSName domain;
   ComboAddress master;
   bool force;
-  uint8_t priority;
-  uint64_t sortHelper;
+  std::pair<uint8_t, uint64_t> priorityAndOrder;
   bool operator<(const SuckRequest& b) const
   {
     return tie(domain, master) < tie(b.domain, b.master);
   }
-};
-
-struct suckQueueCmp
-{
-  bool operator()(const SuckRequest& a, const SuckRequest& b) const {
-    if (a.priority == b.priority) {
-      return a.sortHelper < b.sortHelper;
-    }
-    return a.priority < b.priority;
-  };
 };
 
 struct IDTag{};
@@ -70,7 +59,7 @@ struct QueueTag{};
 typedef multi_index_container<
   SuckRequest,
   indexed_by<
-    ordered_non_unique<tag<QueueTag>, identity<SuckRequest>, suckQueueCmp>,
+    ordered_unique<tag<QueueTag>, member<SuckRequest,std::pair<uint8_t,uint64_t>,&SuckRequest::priorityAndOrder>>,
     ordered_unique<tag<IDTag>, identity<SuckRequest> >
   >
 > UniQueue;

--- a/pdns/communicator.hh
+++ b/pdns/communicator.hh
@@ -55,17 +55,15 @@ struct SuckRequest
 };
 
 struct IDTag{};
-struct QueueTag{};
 
 typedef multi_index_container<
   SuckRequest,
   indexed_by<
-    ordered_unique<tag<QueueTag>, member<SuckRequest,std::pair<SuckRequest::RequestPriority,uint64_t>,&SuckRequest::priorityAndOrder>>,
+    ordered_unique<member<SuckRequest,std::pair<SuckRequest::RequestPriority,uint64_t>,&SuckRequest::priorityAndOrder>>,
     ordered_unique<tag<IDTag>, identity<SuckRequest> >
   >
 > UniQueue;
 typedef UniQueue::index<IDTag>::type domains_by_name_t;
-typedef UniQueue::index<QueueTag>::type domains_by_queuepos_t;
 
 class NotificationQueue
 {

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -46,7 +46,7 @@ class DNSPacket;
 class DNSBackend;  
 struct DomainInfo
 {
-  DomainInfo() : last_check(0), backend(nullptr), id(0), notified_serial(0), serial(0), kind(DomainInfo::Native) {}
+  DomainInfo() : last_check(0), backend(nullptr), id(0), notified_serial(0), receivedNotify(false), serial(0), kind(DomainInfo::Native) {}
 
   DNSName zone;
   time_t last_check;
@@ -56,6 +56,8 @@ struct DomainInfo
 
   uint32_t id;
   uint32_t notified_serial;
+
+  bool receivedNotify;
 
   uint32_t serial;
   enum DomainKind : uint8_t { Master, Slave, Native } kind;

--- a/pdns/dynhandler.cc
+++ b/pdns/dynhandler.cc
@@ -278,7 +278,7 @@ string DLNotifyRetrieveHandler(const vector<string>&parts, Utility::pid_t ppid)
 
   shuffle(di.masters.begin(), di.masters.end(), pdns::dns_random_engine());
   const auto& master = di.masters.front();
-  Communicator.addSuckRequest(domain, master, override_master);
+  Communicator.addSuckRequest(domain, master, SuckRequest::PdnsControl, override_master);
   g_log<<Logger::Warning<<"Retrieval request for domain '"<<domain<<"' from master '"<<master<<"' received from operator"<<endl;
   return "Added retrieval request for '"+domain.toLogString()+"' from master "+master.toLogString();
 }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1030,6 +1030,7 @@ int PacketHandler::processNotify(const DNSPacket& p)
 
   if(::arg().mustDo("slave")) {
     g_log<<Logger::Notice<<"Received NOTIFY for "<<p.qdomain<<" from "<<p.getRemote()<<" - queueing check"<<endl;
+    di.receivedNotify = true;
     Communicator.addSlaveCheckRequest(di, p.d_remote);
   }
   return 0;

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -55,8 +55,8 @@ void CommunicatorClass::addSuckRequest(const DNSName &domain, const ComboAddress
   sr.domain = domain;
   sr.master = master;
   sr.force = force;
-  sr.priority = priority;
-  sr.sortHelper = d_sorthelper++;
+  sr.priorityAndOrder.first = priority;
+  sr.priorityAndOrder.second = d_sorthelper++;
   pair<UniQueue::iterator, bool>  res;
 
   res=d_suckdomains.insert(sr);
@@ -70,10 +70,9 @@ void CommunicatorClass::addSuckRequest(const DNSName &domain, const ComboAddress
       // bit weird, but ok
       return;
     }
-    nameindex.modify(iter, [priority = priority, sorthelper = sr.sortHelper] (SuckRequest& so) {
-      if (priority < so.priority) {
-        so.priority = priority;
-        so.sortHelper = sorthelper;
+    nameindex.modify(iter, [priorityAndOrder = sr.priorityAndOrder] (SuckRequest& so) {
+      if (priorityAndOrder.first < so.priorityAndOrder.first) {
+        so.priorityAndOrder = priorityAndOrder;
       }
     });
   }

--- a/pdns/test-communicator_hh.cc
+++ b/pdns/test-communicator_hh.cc
@@ -1,0 +1,97 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <unistd.h>
+#include <boost/test/unit_test.hpp>
+#include "communicator.hh"
+
+BOOST_AUTO_TEST_SUITE(test_communicator_hh)
+
+BOOST_AUTO_TEST_CASE(test_axfr_queue_priority_order) {
+  SuckRequest sr[5] = {
+    {DNSName("test1.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::SignaturesRefresh,0}},
+    {DNSName("test2.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::SerialRefresh,1}},
+    {DNSName("test3.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::Notify,2}},
+    {DNSName("test4.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::Api,3}},
+    {DNSName("test5.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::PdnsControl,4}},
+  };
+
+  UniQueue suckDomains;
+
+  suckDomains.insert(sr[0]);
+  suckDomains.insert(sr[1]);
+  suckDomains.insert(sr[2]);
+  suckDomains.insert(sr[3]);
+  suckDomains.insert(sr[4]);
+
+  for (int i = 4; i >= 0; i--) {
+    auto iter = suckDomains.begin();
+    BOOST_CHECK_EQUAL(iter->domain, sr[i].domain);
+    suckDomains.erase(iter);
+  }
+  BOOST_CHECK(suckDomains.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_axfr_queue_insert_and_priority_order) {
+  SuckRequest sr[5] = {
+    {DNSName("test1.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::Api,2}},
+    {DNSName("test2.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::Api,1}},
+    {DNSName("test3.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::Api,0}},
+    {DNSName("test4.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::PdnsControl,4}},
+    {DNSName("test5.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::PdnsControl,3}},
+  };
+
+  UniQueue suckDomains;
+
+  suckDomains.insert(sr[0]);
+  suckDomains.insert(sr[1]);
+  suckDomains.insert(sr[2]);
+  suckDomains.insert(sr[3]);
+  suckDomains.insert(sr[4]);
+
+  for (int i = 4; i >= 0; i--) {
+    auto iter = suckDomains.begin();
+    BOOST_CHECK_EQUAL(iter->domain, sr[i].domain);
+    suckDomains.erase(iter);
+  }
+  BOOST_CHECK(suckDomains.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_axfr_queue_insert_and_priority_order_after_modify) {
+  SuckRequest sr[5] = {
+    {DNSName("test1.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::Api,1}},
+    {DNSName("test2.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::Api,0}},
+    {DNSName("test3.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::Api,2}},
+    {DNSName("test4.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::PdnsControl,4}},
+    {DNSName("test5.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::PdnsControl,3}},
+  };
+  SuckRequest rr = {DNSName("test3.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::PdnsControl,5}};
+
+  UniQueue suckDomains;
+
+  suckDomains.insert(sr[0]);
+  suckDomains.insert(sr[1]);
+  suckDomains.insert(sr[2]);
+  suckDomains.insert(sr[3]);
+  suckDomains.insert(sr[4]);
+
+  auto res = suckDomains.insert(rr);
+  BOOST_CHECK(!res.second);
+  suckDomains.modify(res.first, [priorityAndOrder = rr.priorityAndOrder] (SuckRequest& so) {
+    if (priorityAndOrder.first < so.priorityAndOrder.first) {
+      so.priorityAndOrder = priorityAndOrder;
+    }
+  });
+
+  for (int i = 4; i >= 0; i--) {
+    auto iter = suckDomains.begin();
+    BOOST_CHECK_EQUAL(iter->domain, sr[i].domain);
+    suckDomains.erase(iter);
+  }
+  BOOST_CHECK(suckDomains.empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-communicator_hh.cc
+++ b/pdns/test-communicator_hh.cc
@@ -69,6 +69,7 @@ BOOST_AUTO_TEST_CASE(test_axfr_queue_insert_and_priority_order_after_modify) {
     {DNSName("test5.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::PdnsControl,3}},
   };
   SuckRequest rr = {DNSName("test3.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::PdnsControl,5}};
+  SuckRequest rr2 = {DNSName("test4.com"),ComboAddress("0.0.0.0"),false,{SuckRequest::Api,6}};
 
   UniQueue suckDomains;
 
@@ -81,6 +82,14 @@ BOOST_AUTO_TEST_CASE(test_axfr_queue_insert_and_priority_order_after_modify) {
   auto res = suckDomains.insert(rr);
   BOOST_CHECK(!res.second);
   suckDomains.modify(res.first, [priorityAndOrder = rr.priorityAndOrder] (SuckRequest& so) {
+    if (priorityAndOrder.first < so.priorityAndOrder.first) {
+      so.priorityAndOrder = priorityAndOrder;
+    }
+  });
+
+  res = suckDomains.insert(rr2);
+  BOOST_CHECK(!res.second);
+  suckDomains.modify(res.first, [priorityAndOrder = rr2.priorityAndOrder] (SuckRequest& so) {
     if (priorityAndOrder.first < so.priorityAndOrder.first) {
       so.priorityAndOrder = priorityAndOrder;
     }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1876,7 +1876,7 @@ static void apiServerZoneAxfrRetrieve(HttpRequest* req, HttpResponse* resp) {
     throw ApiException("Domain '"+zonename.toString()+"' is not a slave domain (or has no master defined)");
 
   shuffle(di.masters.begin(), di.masters.end(), pdns::dns_random_engine());
-  Communicator.addSuckRequest(zonename, di.masters.front());
+  Communicator.addSuckRequest(zonename, di.masters.front(), SuckRequest::Api);
   resp->setSuccessResult("Added retrieval request for '"+zonename.toString()+"' from master "+di.masters.front().toLogString());
 }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR makes it possible to have AXFR requests of a different priority, where requests with the highest priority get handled first. closes #10190

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
