### PR TITLE
rec: backport 9749 to 4.4.x: Fix the DNSName move assignement operator

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -71,7 +71,7 @@ public:
     }
     return *this;
   }
-  DNSName& operator=(const DNSName&& rhs)
+  DNSName& operator=(DNSName&& rhs)
   {
     if (this != &rhs) {
       d_storage = std::move(rhs.d_storage);


### PR DESCRIPTION
A misplaced 'const' prevented it from being called, making every
move of a DNSName into a full copy.
Introduced in d720eb8add5ebda11867e8b404125e0b68ed2911.

(cherry picked from commit 8d1bb300460d5cc97b4599ea8eddeb7b6d35decf)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
