### PR TITLE
rec: Backport 9812 to 4.4.x: Handle failure to start the web server more gracefully

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3453,7 +3453,7 @@ static bool trySendingQueryToWorker(unsigned int target, ThreadMSG* tmsg)
   auto& targetInfo = s_threadInfos[target];
   if(!targetInfo.isWorker) {
     g_log<<Logger::Error<<"distributeAsyncFunction() tried to assign a query to a non-worker thread"<<endl;
-    exit(1);
+    _exit(1);
   }
 
   const auto& tps = targetInfo.pipes;
@@ -3526,7 +3526,7 @@ void distributeAsyncFunction(const string& packet, const pipefunc_t& func)
 {
   if (!isDistributorThread()) {
     g_log<<Logger::Error<<"distributeAsyncFunction() has been called by a worker ("<<t_id<<")"<<endl;
-    exit(1);
+    _exit(1);
   }
 
   unsigned int hash = hashQuestion(packet.c_str(), packet.length(), g_disthashseed);
@@ -3608,7 +3608,7 @@ template<class T> T broadcastAccFunction(const boost::function<T*()>& func)
 {
   if (!isHandlerThread()) {
     g_log<<Logger::Error<<"broadcastAccFunction has been called by a worker ("<<t_id<<")"<<endl;
-    exit(1);
+    _exit(1);
   }
 
   unsigned int n = 0;
@@ -3859,7 +3859,7 @@ static FDMultiplexer* getMultiplexer()
     }
   }
   g_log<<Logger::Error<<"No working multiplexer found!"<<endl;
-  exit(1);
+  _exit(1);
 }
 
 
@@ -4882,9 +4882,9 @@ try
       try {
         rws = new RecursorWebServer(t_fdm);
       }
-      catch(PDNSException &e) {
-        g_log<<Logger::Error<<"Exception: "<<e.reason<<endl;
-        exit(99);
+      catch (const PDNSException &e) {
+        g_log<<Logger::Error<<"Unable to start the internal web server: "<<e.reason<<endl;
+        _exit(99);
       }
     }
     g_log<<Logger::Info<<"Enabled '"<< t_fdm->getName() << "' multiplexer"<<endl;

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -509,7 +509,8 @@ RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
 {
   registerAllStats();
 
-  d_ws = std::unique_ptr<AsyncWebServer>(new AsyncWebServer(fdm, arg()["webserver-address"], arg().asNum("webserver-port")));
+  d_ws = make_unique<AsyncWebServer>(fdm, arg()["webserver-address"], arg().asNum("webserver-port"));
+
   d_ws->setApiKey(arg()["api-key"]);
   d_ws->setPassword(arg()["webserver-password"]);
   d_ws->setLogLevel(arg()["webserver-loglevel"]);
@@ -534,8 +535,10 @@ RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
   d_ws->registerApiHandler("/api/v1/servers", &apiServer);
   d_ws->registerApiHandler("/api", &apiDiscovery);
 
-  for(const auto& u : g_urlmap) 
+  for (const auto& u : g_urlmap) {
     d_ws->registerWebHandler("/"+u.first, serveStuff);
+  }
+
   d_ws->registerWebHandler("/", serveStuff);
   d_ws->registerWebHandler("/metrics", prometheusMetrics);
   d_ws->go();


### PR DESCRIPTION
At this point we already have several threads so calling exit()
will cause problem by trying to destruct objects that are in use
by other threads, so call _exit() instead.
Also mention the web server in the error message so that the root
cause is easier to identify.

(cherry picked from commit ce715f38fcedf752220cd5056e1a3945330041fd)

Backport of #9812 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
