### PR TITLE
dnsdist: Add limits for cached TCP connections, metrics

### DIFF
--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -104,6 +104,7 @@ void carbonDumpThread()
             str<<base<<"tcpwritetimeouts" << ' '<< state->tcpWriteTimeouts.load() << " " << now << "\r\n";
             str<<base<<"tcpconnecttimeouts" << ' '<< state->tcpConnectTimeouts.load() << " " << now << "\r\n";
             str<<base<<"tcpcurrentconnections" << ' '<< state->tcpCurrentConnections.load() << " " << now << "\r\n";
+            str<<base<<"tcpmaxconcurrentconnections" << ' '<< state->tcpMaxConcurrentConnections.load() << " " << now << "\r\n";
             str<<base<<"tcpnewconnections" << ' '<< state->tcpNewConnections.load() << " " << now << "\r\n";
             str<<base<<"tcpreusedconnections" << ' '<< state->tcpReusedConnections.load() << " " << now << "\r\n";
             str<<base<<"tcpavgqueriesperconnection" << ' '<< state->tcpAvgQueriesPerConnection.load() << " " << now << "\r\n";
@@ -132,6 +133,7 @@ void carbonDumpThread()
             str<<base<<"tcpclientimeouts" << ' '<< front->tcpClientTimeouts.load() << " " << now << "\r\n";
             str<<base<<"tcpdownstreamtimeouts" << ' '<< front->tcpDownstreamTimeouts.load() << " " << now << "\r\n";
             str<<base<<"tcpcurrentconnections" << ' '<< front->tcpCurrentConnections.load() << " " << now << "\r\n";
+            str<<base<<"tcpmaxconcurrentconnections" << ' '<< front->tcpMaxConcurrentConnections.load() << " " << now << "\r\n";
             str<<base<<"tcpavgqueriesperconnection" << ' '<< front->tcpAvgQueriesPerConnection.load() << " " << now << "\r\n";
             str<<base<<"tcpavgconnectionduration" << ' '<< front->tcpAvgConnectionDuration.load() << " " << now << "\r\n";
             str<<base<<"tls10-queries" << ' ' << front->tls10queries.load() << " " << now << "\r\n";

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -586,6 +586,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "setECSSourcePrefixV6", true, "prefix-length", "the EDNS Client Subnet prefix-length used for IPv6 queries" },
   { "setKey", true, "key", "set access key to that key" },
   { "setLocal", true, "addr [, {doTCP=true, reusePort=false, tcpFastOpenQueueSize=0, interface=\"\", cpus={}}]", "reset the list of addresses we listen on to this address" },
+  { "setMaxCachedTCPConnectionsPerDownstream", true, "max", "Set the maximum number of inactive TCP connections to a backend cached by each worker TCP thread" },
   { "setMaxTCPClientThreads", true, "n", "set the maximum of TCP client threads, handling TCP connections" },
   { "setMaxTCPConnectionDuration", true, "n", "set the maximum duration of an incoming TCP connection, in seconds. 0 means unlimited" },
   { "setMaxTCPConnectionsPerClient", true, "n", "set the maximum number of TCP connections per client. 0 means unlimited" },

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -601,24 +601,24 @@ void setupLuaInspection(LuaContext& luaCtx)
       ret << endl;
 
       ret << "Frontends:" << endl;
-      fmt = boost::format("%-3d %-20.20s %-20d %-20d %-25d %-20d %-20d %-20d %-20f %-20f %-20d %-20d %-25d %-25d %-15d %-15d %-15d %-15d %-15d");
-      ret << (fmt % "#" % "Address" % "Connections" % "Died reading query" % "Died sending response" % "Gave up" % "Client timeouts" % "Downstream timeouts" % "Avg queries/conn" % "Avg duration" % "TLS new sessions" % "TLS Resumptions" % "TLS unknown ticket keys" % "TLS inactive ticket keys" % "TLS 1.0" % "TLS 1.1" % "TLS 1.2" % "TLS 1.3" % "TLS other") << endl;
+      fmt = boost::format("%-3d %-20.20s %-20d %-20d %-20d %-25d %-20d %-20d %-20d %-20f %-20f %-20d %-20d %-25d %-25d %-15d %-15d %-15d %-15d %-15d");
+      ret << (fmt % "#" % "Address" % "Connections" % "Max concurrent conn" % "Died reading query" % "Died sending response" % "Gave up" % "Client timeouts" % "Downstream timeouts" % "Avg queries/conn" % "Avg duration" % "TLS new sessions" % "TLS Resumptions" % "TLS unknown ticket keys" % "TLS inactive ticket keys" % "TLS 1.0" % "TLS 1.1" % "TLS 1.2" % "TLS 1.3" % "TLS other") << endl;
 
       size_t counter = 0;
       for(const auto& f : g_frontends) {
-        ret << (fmt % counter % f->local.toStringWithPort() % f->tcpCurrentConnections % f->tcpDiedReadingQuery % f->tcpDiedSendingResponse % f->tcpGaveUp % f->tcpClientTimeouts % f->tcpDownstreamTimeouts % f->tcpAvgQueriesPerConnection % f->tcpAvgConnectionDuration % f->tlsNewSessions % f->tlsResumptions % f->tlsUnknownTicketKey % f->tlsInactiveTicketKey % f->tls10queries % f->tls11queries % f->tls12queries % f->tls13queries % f->tlsUnknownqueries) << endl;
+        ret << (fmt % counter % f->local.toStringWithPort() % f->tcpCurrentConnections % f->tcpMaxConcurrentConnections % f->tcpDiedReadingQuery % f->tcpDiedSendingResponse % f->tcpGaveUp % f->tcpClientTimeouts % f->tcpDownstreamTimeouts % f->tcpAvgQueriesPerConnection % f->tcpAvgConnectionDuration % f->tlsNewSessions % f->tlsResumptions % f->tlsUnknownTicketKey % f->tlsInactiveTicketKey % f->tls10queries % f->tls11queries % f->tls12queries % f->tls13queries % f->tlsUnknownqueries) << endl;
         ++counter;
       }
       ret << endl;
 
       ret << "Backends:" << endl;
-      fmt = boost::format("%-3d %-20.20s %-20.20s %-20d %-20d %-25d %-20d %-20d %-20d %-20d %-20d %20d %-20f %-20f");
-      ret << (fmt % "#" % "Name" % "Address" % "Connections" % "Died sending query" % "Died reading response" % "Gave up" % "Read timeouts" % "Write timeouts" % "Connect timeouts" % "Total connections" % "Reused connections" % "Avg queries/conn" % "Avg duration") << endl;
+      fmt = boost::format("%-3d %-20.20s %-20.20s %-20d %-20d %-25d %-20d %-20d %-20d %-20d %-20d %-20d %-20d %-20f %-20f");
+      ret << (fmt % "#" % "Name" % "Address" % "Connections" % " Max concurrent conn" % "Died sending query" % "Died reading response" % "Gave up" % "Read timeouts" % "Write timeouts" % "Connect timeouts" % "Total connections" % "Reused connections" % "Avg queries/conn" % "Avg duration") << endl;
 
       auto states = g_dstates.getLocal();
       counter = 0;
       for(const auto& s : *states) {
-        ret << (fmt % counter % s->getName() % s->remote.toStringWithPort() % s->tcpCurrentConnections % s->tcpDiedSendingQuery % s->tcpDiedReadingResponse % s->tcpGaveUp % s->tcpReadTimeouts % s->tcpWriteTimeouts % s->tcpConnectTimeouts % s->tcpNewConnections % s->tcpReusedConnections % s->tcpAvgQueriesPerConnection % s->tcpAvgConnectionDuration) << endl;
+        ret << (fmt % counter % s->getName() % s->remote.toStringWithPort() % s->tcpCurrentConnections % s->tcpMaxConcurrentConnections % s->tcpDiedSendingQuery % s->tcpDiedReadingResponse % s->tcpGaveUp % s->tcpReadTimeouts % s->tcpWriteTimeouts % s->tcpConnectTimeouts % s->tcpNewConnections % s->tcpReusedConnections % s->tcpAvgQueriesPerConnection % s->tcpAvgConnectionDuration) << endl;
         ++counter;
       }
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -99,7 +99,7 @@ void resetLuaSideEffect()
 
 typedef std::unordered_map<std::string, boost::variant<bool, int, std::string, std::vector<std::pair<int,int> >, std::vector<std::pair<int, std::string> >, std::map<std::string,std::string>  > > localbind_t;
 
-static void parseLocalBindVars(boost::optional<localbind_t> vars, bool& reusePort, int& tcpFastOpenQueueSize, std::string& interface, std::set<int>& cpus, int& tcpListenQueueSize, size_t& maxInFlightQueriesPerConnection)
+static void parseLocalBindVars(boost::optional<localbind_t> vars, bool& reusePort, int& tcpFastOpenQueueSize, std::string& interface, std::set<int>& cpus, int& tcpListenQueueSize, size_t& maxInFlightQueriesPerConnection, size_t& tcpMaxConcurrentConnections)
 {
   if (vars) {
     if (vars->count("reusePort")) {
@@ -110,6 +110,9 @@ static void parseLocalBindVars(boost::optional<localbind_t> vars, bool& reusePor
     }
     if (vars->count("tcpListenQueueSize")) {
       tcpListenQueueSize = boost::get<int>((*vars)["tcpListenQueueSize"]);
+    }
+    if (vars->count("maxConcurrentTCPConnections")) {
+      tcpMaxConcurrentConnections = boost::get<int>((*vars)["maxConcurrentTCPConnections"]);
     }
     if (vars->count("maxInFlight")) {
       maxInFlightQueriesPerConnection = boost::get<int>((*vars)["maxInFlight"]);
@@ -602,10 +605,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       int tcpFastOpenQueueSize = 0;
       int tcpListenQueueSize = 0;
       size_t maxInFlightQueriesPerConn = 0;
+      size_t tcpMaxConcurrentConnections = 0;
       std::string interface;
       std::set<int> cpus;
 
-      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn);
+      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections);
 
       try {
 	ComboAddress loc(addr, 53);
@@ -628,6 +632,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         if (maxInFlightQueriesPerConn > 0) {
           tcpCS->d_maxInFlightQueriesPerConn = maxInFlightQueriesPerConn;
         }
+        if (tcpMaxConcurrentConnections > 0) {
+          tcpCS->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConnections;
+        }
+
         g_frontends.push_back(std::move(tcpCS));
       }
       catch(const std::exception& e) {
@@ -647,10 +655,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       int tcpFastOpenQueueSize = 0;
       int tcpListenQueueSize = 0;
       size_t maxInFlightQueriesPerConn = 0;
+      size_t tcpMaxConcurrentConnections = 0;
       std::string interface;
       std::set<int> cpus;
 
-      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn);
+      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections);
 
       try {
 	ComboAddress loc(addr, 53);
@@ -662,6 +671,9 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         }
         if (maxInFlightQueriesPerConn > 0) {
           tcpCS->d_maxInFlightQueriesPerConn = maxInFlightQueriesPerConn;
+        }
+        if (tcpMaxConcurrentConnections > 0) {
+          tcpCS->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConnections;
         }
         g_frontends.push_back(std::move(tcpCS));
       }
@@ -1336,11 +1348,12 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       int tcpFastOpenQueueSize = 0;
       int tcpListenQueueSize = 0;
       size_t maxInFlightQueriesPerConn = 0;
+      size_t tcpMaxConcurrentConnections = 0;
       std::string interface;
       std::set<int> cpus;
       std::vector<DNSCryptContext::CertKeyPaths> certKeys;
 
-      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn);
+      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections);
 
       if (certFiles.type() == typeid(std::string) && keyFiles.type() == typeid(std::string)) {
         auto certFile = boost::get<std::string>(certFiles);
@@ -1381,6 +1394,12 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         cs->dnscryptCtx = ctx;
         if (tcpListenQueueSize > 0) {
           cs->tcpListenQueueSize = tcpListenQueueSize;
+        }
+        if (maxInFlightQueriesPerConn > 0) {
+            cs->d_maxInFlightQueriesPerConn = maxInFlightQueriesPerConn;
+        }
+        if (tcpMaxConcurrentConnections > 0) {
+          cs->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConnections;
         }
 
         g_frontends.push_back(std::move(cs));
@@ -2139,11 +2158,12 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     int tcpFastOpenQueueSize = 0;
     int tcpListenQueueSize = 0;
     size_t maxInFlightQueriesPerConn = 0;
+    size_t tcpMaxConcurrentConnections = 0;
     std::string interface;
     std::set<int> cpus;
 
     if (vars) {
-      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn);
+      parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConnections);
 
       if (vars->count("idleTimeout")) {
         frontend->d_idleTimeout = boost::get<int>((*vars)["idleTimeout"]);
@@ -2184,7 +2204,9 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     if (tcpListenQueueSize > 0) {
       cs->tcpListenQueueSize = tcpListenQueueSize;
     }
-
+    if (tcpMaxConcurrentConnections > 0) {
+      cs->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConnections;
+    }
     g_frontends.push_back(std::move(cs));
 #else
     throw std::runtime_error("addDOHLocal() called but DNS over HTTPS support is not present!");
@@ -2330,11 +2352,12 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         int tcpFastOpenQueueSize = 0;
         int tcpListenQueueSize = 0;
         size_t maxInFlightQueriesPerConn = 0;
+        size_t tcpMaxConcurrentConns = 0;
         std::string interface;
         std::set<int> cpus;
 
         if (vars) {
-          parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn);
+          parseLocalBindVars(vars, reusePort, tcpFastOpenQueueSize, interface, cpus, tcpListenQueueSize, maxInFlightQueriesPerConn, tcpMaxConcurrentConns);
 
           if (vars->count("provider")) {
             frontend->d_provider = boost::get<const string>((*vars)["provider"]);
@@ -2364,6 +2387,9 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
           }
           if (maxInFlightQueriesPerConn > 0) {
             cs->d_maxInFlightQueriesPerConn = maxInFlightQueriesPerConn;
+          }
+          if (tcpMaxConcurrentConns > 0) {
+            cs->d_tcpConcurrentConnectionsLimit = tcpMaxConcurrentConns;
           }
 
           g_tlslocals.push_back(cs->tlsFrontend);

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1188,6 +1188,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       }
     });
 
+  luaCtx.writeFunction("setMaxCachedTCPConnectionsPerDownstream", [](size_t max) {
+    setMaxCachedTCPConnectionsPerDownstream(max);
+    });
+
   luaCtx.writeFunction("setCacheCleaningDelay", [](uint32_t delay) { g_cacheCleaningDelay = delay; });
 
   luaCtx.writeFunction("setCacheCleaningPercentage", [](uint16_t percentage) { if (percentage < 100) g_cacheCleaningPercentage = percentage; else g_cacheCleaningPercentage = 100; });

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -1241,6 +1241,10 @@ void tcpAcceptorThread(ClientState* cs)
 #endif
       // will be decremented when the ConnectionInfo object is destroyed, no matter the reason
       auto concurrentConnections = ++cs->tcpCurrentConnections;
+      if (cs->d_tcpConcurrentConnectionsLimit > 0 && concurrentConnections > cs->d_tcpConcurrentConnectionsLimit) {
+        continue;
+      }
+
       if (concurrentConnections > cs->tcpMaxConcurrentConnections) {
         cs->tcpMaxConcurrentConnections = concurrentConnections;
       }

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -127,13 +127,12 @@ public:
 
     const auto& ds = conn->getDS();
     auto& list = t_downstreamConnections[ds];
-    if (list.size() >= s_maxCachedConnectionsPerDownstream) {
+    while (list.size() >= s_maxCachedConnectionsPerDownstream) {
       /* too many connections queued already */
-      conn.reset();
+      list.pop_front();
     }
-    else {
-      list.push_back(std::move(conn));
-    }
+
+    list.push_back(std::move(conn));
   }
 
   static void cleanupClosedTCPConnections(struct timeval now)
@@ -183,13 +182,23 @@ public:
     return count;
   }
 
+  static void setMaxCachedConnectionsPerDownstream(size_t max)
+  {
+    s_maxCachedConnectionsPerDownstream = max;
+  }
+
 private:
   static thread_local map<std::shared_ptr<DownstreamState>, std::deque<std::shared_ptr<TCPConnectionToBackend>>> t_downstreamConnections;
-  static const size_t s_maxCachedConnectionsPerDownstream;
+  static size_t s_maxCachedConnectionsPerDownstream;
 };
 
+void setMaxCachedTCPConnectionsPerDownstream(size_t max)
+{
+  DownstreamConnectionsManager::setMaxCachedConnectionsPerDownstream(max);
+}
+
 thread_local map<std::shared_ptr<DownstreamState>, std::deque<std::shared_ptr<TCPConnectionToBackend>>> DownstreamConnectionsManager::t_downstreamConnections;
-const size_t DownstreamConnectionsManager::s_maxCachedConnectionsPerDownstream{20};
+size_t DownstreamConnectionsManager::s_maxCachedConnectionsPerDownstream{10};
 
 static void decrementTCPClientCount(const ComboAddress& client)
 {

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -1231,7 +1231,10 @@ void tcpAcceptorThread(ClientState* cs)
       ci->fd = accept(cs->tcpFD, reinterpret_cast<struct sockaddr*>(&remote), &remlen);
 #endif
       // will be decremented when the ConnectionInfo object is destroyed, no matter the reason
-      ++cs->tcpCurrentConnections;
+      auto concurrentConnections = ++cs->tcpCurrentConnections;
+      if (concurrentConnections > cs->tcpMaxConcurrentConnections) {
+        cs->tcpMaxConcurrentConnections = concurrentConnections;
+      }
 
       if (ci->fd < 0) {
         throw std::runtime_error((boost::format("accepting new connection on socket: %s") % stringerror()).str());

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -447,46 +447,48 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
   auto states = g_dstates.getLocal();
   const string statesbase = "dnsdist_server_";
 
-  output << "# HELP " << statesbase << "status "                 << "Whether this backend is up (1) or down (0)"                        << "\n";
-  output << "# TYPE " << statesbase << "status "                 << "gauge"                                                             << "\n";
-  output << "# HELP " << statesbase << "queries "                << "Amount of queries relayed to server"                               << "\n";
-  output << "# TYPE " << statesbase << "queries "                << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "responses "              << "Amount of responses received from this server"                     << "\n";
-  output << "# TYPE " << statesbase << "responses "              << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "drops "                  << "Amount of queries not answered by server"                          << "\n";
-  output << "# TYPE " << statesbase << "drops "                  << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "latency "                << "Server's latency when answering questions in milliseconds"         << "\n";
-  output << "# TYPE " << statesbase << "latency "                << "gauge"                                                             << "\n";
-  output << "# HELP " << statesbase << "senderrors "             << "Total number of OS send errors while relaying queries"             << "\n";
-  output << "# TYPE " << statesbase << "senderrors "             << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "outstanding "            << "Current number of queries that are waiting for a backend response" << "\n";
-  output << "# TYPE " << statesbase << "outstanding "            << "gauge"                                                             << "\n";
-  output << "# HELP " << statesbase << "order "                  << "The order in which this server is picked"                          << "\n";
-  output << "# TYPE " << statesbase << "order "                  << "gauge"                                                             << "\n";
-  output << "# HELP " << statesbase << "weight "                 << "The weight within the order in which this server is picked"        << "\n";
-  output << "# TYPE " << statesbase << "weight "                 << "gauge"                                                             << "\n";
-  output << "# HELP " << statesbase << "tcpdiedsendingquery "    << "The number of TCP I/O errors while sending the query"              << "\n";
-  output << "# TYPE " << statesbase << "tcpdiedsendingquery "    << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "tcpdiedreadingresponse " << "The number of TCP I/O errors while reading the response"           << "\n";
-  output << "# TYPE " << statesbase << "tcpdiedreadingresponse " << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "tcpgaveup "              << "The number of TCP connections failing after too many attempts"     << "\n";
-  output << "# TYPE " << statesbase << "tcpgaveup "              << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "tcpconnecttimeouts "     << "The number of TCP connect timeouts"                                << "\n";
-  output << "# TYPE " << statesbase << "tcpconnecttimeouts "     << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "tcpreadtimeouts "        << "The number of TCP read timeouts"                                   << "\n";
-  output << "# TYPE " << statesbase << "tcpreadtimeouts "        << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "tcpwritetimeouts "       << "The number of TCP write timeouts"                                  << "\n";
-  output << "# TYPE " << statesbase << "tcpwritetimeouts "       << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "tcpcurrentconnections "  << "The number of current TCP connections"                             << "\n";
-  output << "# TYPE " << statesbase << "tcpcurrentconnections "  << "gauge"                                                             << "\n";
-  output << "# HELP " << statesbase << "tcpnewconnections "      << "The number of established TCP connections in total"                << "\n";
-  output << "# TYPE " << statesbase << "tcpnewconnections "      << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "tcpreusedconnections "   << "The number of times a TCP connection has been reused"              << "\n";
-  output << "# TYPE " << statesbase << "tcpreusedconnections "   << "counter"                                                           << "\n";
-  output << "# HELP " << statesbase << "tcpavgqueriesperconn "   << "The average number of queries per TCP connection"                  << "\n";
-  output << "# TYPE " << statesbase << "tcpavgqueriesperconn "   << "gauge"                                                             << "\n";
-  output << "# HELP " << statesbase << "tcpavgconnduration "     << "The average duration of a TCP connection (ms)"                     << "\n";
-  output << "# TYPE " << statesbase << "tcpavgconnduration "     << "gauge"                                                             << "\n";
+  output << "# HELP " << statesbase << "status "                      << "Whether this backend is up (1) or down (0)"                        << "\n";
+  output << "# TYPE " << statesbase << "status "                      << "gauge"                                                             << "\n";
+  output << "# HELP " << statesbase << "queries "                     << "Amount of queries relayed to server"                               << "\n";
+  output << "# TYPE " << statesbase << "queries "                     << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "responses "                   << "Amount of responses received from this server"                     << "\n";
+  output << "# TYPE " << statesbase << "responses "                   << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "drops "                       << "Amount of queries not answered by server"                          << "\n";
+  output << "# TYPE " << statesbase << "drops "                       << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "latency "                     << "Server's latency when answering questions in milliseconds"         << "\n";
+  output << "# TYPE " << statesbase << "latency "                     << "gauge"                                                             << "\n";
+  output << "# HELP " << statesbase << "senderrors "                  << "Total number of OS send errors while relaying queries"             << "\n";
+  output << "# TYPE " << statesbase << "senderrors "                  << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "outstanding "                 << "Current number of queries that are waiting for a backend response" << "\n";
+  output << "# TYPE " << statesbase << "outstanding "                 << "gauge"                                                             << "\n";
+  output << "# HELP " << statesbase << "order "                       << "The order in which this server is picked"                          << "\n";
+  output << "# TYPE " << statesbase << "order "                       << "gauge"                                                             << "\n";
+  output << "# HELP " << statesbase << "weight "                      << "The weight within the order in which this server is picked"        << "\n";
+  output << "# TYPE " << statesbase << "weight "                      << "gauge"                                                             << "\n";
+  output << "# HELP " << statesbase << "tcpdiedsendingquery "         << "The number of TCP I/O errors while sending the query"              << "\n";
+  output << "# TYPE " << statesbase << "tcpdiedsendingquery "         << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "tcpdiedreadingresponse "      << "The number of TCP I/O errors while reading the response"           << "\n";
+  output << "# TYPE " << statesbase << "tcpdiedreadingresponse "      << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "tcpgaveup "                   << "The number of TCP connections failing after too many attempts"     << "\n";
+  output << "# TYPE " << statesbase << "tcpgaveup "                   << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "tcpconnecttimeouts "          << "The number of TCP connect timeouts"                                << "\n";
+  output << "# TYPE " << statesbase << "tcpconnecttimeouts "          << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "tcpreadtimeouts "             << "The number of TCP read timeouts"                                   << "\n";
+  output << "# TYPE " << statesbase << "tcpreadtimeouts "             << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "tcpwritetimeouts "            << "The number of TCP write timeouts"                                  << "\n";
+  output << "# TYPE " << statesbase << "tcpwritetimeouts "            << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "tcpcurrentconnections "       << "The number of current TCP connections"                             << "\n";
+  output << "# TYPE " << statesbase << "tcpcurrentconnections "       << "gauge"                                                             << "\n";
+  output << "# HELP " << statesbase << "tcpmaxconcurrentconnections " << "The maximum number of concurrent TCP connections"                  << "\n";
+  output << "# TYPE " << statesbase << "tcpmaxconcurrentconnections " << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "tcpnewconnections "           << "The number of established TCP connections in total"                << "\n";
+  output << "# TYPE " << statesbase << "tcpnewconnections "           << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "tcpreusedconnections "        << "The number of times a TCP connection has been reused"              << "\n";
+  output << "# TYPE " << statesbase << "tcpreusedconnections "        << "counter"                                                           << "\n";
+  output << "# HELP " << statesbase << "tcpavgqueriesperconn "        << "The average number of queries per TCP connection"                  << "\n";
+  output << "# TYPE " << statesbase << "tcpavgqueriesperconn "        << "gauge"                                                             << "\n";
+  output << "# HELP " << statesbase << "tcpavgconnduration "          << "The average duration of a TCP connection (ms)"                     << "\n";
+  output << "# TYPE " << statesbase << "tcpavgconnduration "          << "gauge"                                                             << "\n";
 
   for (const auto& state : *states) {
     string serverName;
@@ -501,26 +503,27 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
     const std::string label = boost::str(boost::format("{server=\"%1%\",address=\"%2%\"}")
                                          % serverName % state->remote.toStringWithPort());
 
-    output << statesbase << "status"                 << label << " " << (state->isUp() ? "1" : "0")       << "\n";
-    output << statesbase << "queries"                << label << " " << state->queries.load()             << "\n";
-    output << statesbase << "responses"              << label << " " << state->responses.load()           << "\n";
-    output << statesbase << "drops"                  << label << " " << state->reuseds.load()             << "\n";
-    output << statesbase << "latency"                << label << " " << state->latencyUsec/1000.0         << "\n";
-    output << statesbase << "senderrors"             << label << " " << state->sendErrors.load()          << "\n";
-    output << statesbase << "outstanding"            << label << " " << state->outstanding.load()         << "\n";
-    output << statesbase << "order"                  << label << " " << state->order                      << "\n";
-    output << statesbase << "weight"                 << label << " " << state->weight                     << "\n";
-    output << statesbase << "tcpdiedsendingquery"    << label << " " << state->tcpDiedSendingQuery        << "\n";
-    output << statesbase << "tcpdiedreadingresponse" << label << " " << state->tcpDiedReadingResponse     << "\n";
-    output << statesbase << "tcpgaveup"              << label << " " << state->tcpGaveUp                  << "\n";
-    output << statesbase << "tcpreadtimeouts"        << label << " " << state->tcpReadTimeouts            << "\n";
-    output << statesbase << "tcpwritetimeouts"       << label << " " << state->tcpWriteTimeouts           << "\n";
-    output << statesbase << "tcpconnecttimeouts"     << label << " " << state->tcpConnectTimeouts         << "\n";
-    output << statesbase << "tcpcurrentconnections"  << label << " " << state->tcpCurrentConnections      << "\n";
-    output << statesbase << "tcpnewconnections"      << label << " " << state->tcpNewConnections          << "\n";
-    output << statesbase << "tcpreusedconnections"   << label << " " << state->tcpReusedConnections       << "\n";
-    output << statesbase << "tcpavgqueriesperconn"   << label << " " << state->tcpAvgQueriesPerConnection << "\n";
-    output << statesbase << "tcpavgconnduration"     << label << " " << state->tcpAvgConnectionDuration   << "\n";
+    output << statesbase << "status"                       << label << " " << (state->isUp() ? "1" : "0")        << "\n";
+    output << statesbase << "queries"                      << label << " " << state->queries.load()              << "\n";
+    output << statesbase << "responses"                    << label << " " << state->responses.load()            << "\n";
+    output << statesbase << "drops"                        << label << " " << state->reuseds.load()              << "\n";
+    output << statesbase << "latency"                      << label << " " << state->latencyUsec/1000.0          << "\n";
+    output << statesbase << "senderrors"                   << label << " " << state->sendErrors.load()           << "\n";
+    output << statesbase << "outstanding"                  << label << " " << state->outstanding.load()          << "\n";
+    output << statesbase << "order"                        << label << " " << state->order                       << "\n";
+    output << statesbase << "weight"                       << label << " " << state->weight                      << "\n";
+    output << statesbase << "tcpdiedsendingquery"          << label << " " << state->tcpDiedSendingQuery         << "\n";
+    output << statesbase << "tcpdiedreadingresponse"       << label << " " << state->tcpDiedReadingResponse      << "\n";
+    output << statesbase << "tcpgaveup"                    << label << " " << state->tcpGaveUp                   << "\n";
+    output << statesbase << "tcpreadtimeouts"              << label << " " << state->tcpReadTimeouts             << "\n";
+    output << statesbase << "tcpwritetimeouts"             << label << " " << state->tcpWriteTimeouts            << "\n";
+    output << statesbase << "tcpconnecttimeouts"           << label << " " << state->tcpConnectTimeouts         << "\n";
+    output << statesbase << "tcpcurrentconnections"        << label << " " << state->tcpCurrentConnections       << "\n";
+    output << statesbase << "tcpmaxconcurrentconnections"  << label << " " << state->tcpMaxConcurrentConnections << "\n";
+    output << statesbase << "tcpnewconnections"            << label << " " << state->tcpNewConnections           << "\n";
+    output << statesbase << "tcpreusedconnections"         << label << " " << state->tcpReusedConnections        << "\n";
+    output << statesbase << "tcpavgqueriesperconn"         << label << " " << state->tcpAvgQueriesPerConnection  << "\n";
+    output << statesbase << "tcpavgconnduration"           << label << " " << state->tcpAvgConnectionDuration    << "\n";
   }
 
   const string frontsbase = "dnsdist_frontend_";
@@ -540,6 +543,8 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
   output << "# TYPE " << frontsbase << "tcpdownstreamtimeouts " << "counter" << "\n";
   output << "# HELP " << frontsbase << "tcpcurrentconnections " << "Amount of current incoming TCP connections from clients" << "\n";
   output << "# TYPE " << frontsbase << "tcpcurrentconnections " << "gauge" << "\n";
+  output << "# HELP " << frontsbase << "tcpmaxconcurrentconnections " << "Maximum number of concurrent incoming TCP connections from clients" << "\n";
+  output << "# TYPE " << frontsbase << "tcpmaxconcurrentconnections " << "counter" << "\n";
   output << "# HELP " << frontsbase << "tcpavgqueriesperconnection " << "The average number of queries per TCP connection" << "\n";
   output << "# TYPE " << frontsbase << "tcpavgqueriesperconnection " << "gauge" << "\n";
   output << "# HELP " << frontsbase << "tcpavgconnectionduration " << "The average duration of a TCP connection (ms)" << "\n";
@@ -584,6 +589,7 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
       output << frontsbase << "tcpclientimeouts" << label << front->tcpClientTimeouts.load() << "\n";
       output << frontsbase << "tcpdownstreamtimeouts" << label << front->tcpDownstreamTimeouts.load() << "\n";
       output << frontsbase << "tcpcurrentconnections" << label << front->tcpCurrentConnections.load() << "\n";
+      output << frontsbase << "tcpmaxconcurrentconnections" << label << front->tcpMaxConcurrentConnections.load() << "\n";
       output << frontsbase << "tcpavgqueriesperconnection" << label << front->tcpAvgQueriesPerConnection.load() << "\n";
       output << frontsbase << "tcpavgconnectionduration" << label << front->tcpAvgConnectionDuration.load() << "\n";
       if (front->hasTLS()) {
@@ -909,6 +915,7 @@ static void handleStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
       {"tcpReadTimeouts", (double)a->tcpReadTimeouts},
       {"tcpWriteTimeouts", (double)a->tcpWriteTimeouts},
       {"tcpCurrentConnections", (double)a->tcpCurrentConnections},
+      {"tcpMaxConcurrentConnections", (double)a->tcpMaxConcurrentConnections},
       {"tcpNewConnections", (double)a->tcpNewConnections},
       {"tcpReusedConnections", (double)a->tcpReusedConnections},
       {"tcpAvgQueriesPerConnection", (double)a->tcpAvgQueriesPerConnection},
@@ -943,6 +950,7 @@ static void handleStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
       { "tcpClientTimeouts", (double) front->tcpClientTimeouts },
       { "tcpDownstreamTimeouts", (double) front->tcpDownstreamTimeouts },
       { "tcpCurrentConnections", (double) front->tcpCurrentConnections },
+      { "tcpMaxConcurrentConnections", (double) front->tcpMaxConcurrentConnections },
       { "tcpAvgQueriesPerConnection", (double) front->tcpAvgQueriesPerConnection },
       { "tcpAvgConnectionDuration", (double) front->tcpAvgConnectionDuration },
       { "tlsNewSessions", (double) front->tlsNewSessions },

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1229,6 +1229,8 @@ struct LocalHolders
 vector<std::function<void(void)>> setupLua(bool client, const std::string& config);
 
 void tcpAcceptorThread(ClientState* p);
+void setMaxCachedTCPConnectionsPerDownstream(size_t max);
+
 #ifdef HAVE_DNS_OVER_HTTPS
 void dohThread(ClientState* cs);
 #endif /* HAVE_DNS_OVER_HTTPS */

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -736,7 +736,10 @@ struct ClientState
   stat_t tcpGaveUp{0};
   stat_t tcpClientTimeouts{0};
   stat_t tcpDownstreamTimeouts{0};
+  /* current number of connections to this frontend */
   stat_t tcpCurrentConnections{0};
+  /* maximum number of concurrent connections to this frontend */
+  stat_t tcpMaxConcurrentConnections{0};
   stat_t tlsNewSessions{0}; // A new TLS session has been negotiated, no resumption
   stat_t tlsResumptions{0}; // A TLS session has been resumed, either via session id or via a TLS ticket
   stat_t tlsUnknownTicketKey{0}; // A TLS ticket has been presented but we don't have the associated key (might have expired)
@@ -907,7 +910,10 @@ struct DownstreamState
   stat_t tcpReadTimeouts{0};
   stat_t tcpWriteTimeouts{0};
   stat_t tcpConnectTimeouts{0};
+  /* current number of connections to this backend */
   stat_t tcpCurrentConnections{0};
+  /* maximum number of concurrent connections to this backend */
+  stat_t tcpMaxConcurrentConnections{0};
   stat_t tcpReusedConnections{0};
   stat_t tcpNewConnections{0};
   pdns::stat_t_trait<double> tcpAvgQueriesPerConnection{0.0};

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -738,7 +738,7 @@ struct ClientState
   stat_t tcpDownstreamTimeouts{0};
   /* current number of connections to this frontend */
   stat_t tcpCurrentConnections{0};
-  /* maximum number of concurrent connections to this frontend seen */
+  /* maximum number of concurrent connections to this frontend reached */
   stat_t tcpMaxConcurrentConnections{0};
   stat_t tlsNewSessions{0}; // A new TLS session has been negotiated, no resumption
   stat_t tlsResumptions{0}; // A TLS session has been resumed, either via session id or via a TLS ticket
@@ -913,7 +913,7 @@ struct DownstreamState
   stat_t tcpConnectTimeouts{0};
   /* current number of connections to this backend */
   stat_t tcpCurrentConnections{0};
-  /* maximum number of concurrent connections to this backend */
+  /* maximum number of concurrent connections to this backend reached */
   stat_t tcpMaxConcurrentConnections{0};
   stat_t tcpReusedConnections{0};
   stat_t tcpNewConnections{0};

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -738,7 +738,7 @@ struct ClientState
   stat_t tcpDownstreamTimeouts{0};
   /* current number of connections to this frontend */
   stat_t tcpCurrentConnections{0};
-  /* maximum number of concurrent connections to this frontend */
+  /* maximum number of concurrent connections to this frontend seen */
   stat_t tcpMaxConcurrentConnections{0};
   stat_t tlsNewSessions{0}; // A new TLS session has been negotiated, no resumption
   stat_t tlsResumptions{0}; // A TLS session has been resumed, either via session id or via a TLS ticket
@@ -753,6 +753,7 @@ struct ClientState
   /* in ms */
   pdns::stat_t_trait<double> tcpAvgConnectionDuration{0.0};
   size_t d_maxInFlightQueriesPerConn{1};
+  size_t d_tcpConcurrentConnectionsLimit{0};
   int udpFD{-1};
   int tcpFD{-1};
   int tcpListenQueueSize{SOMAXCONN};
@@ -921,6 +922,7 @@ struct DownstreamState
   pdns::stat_t_trait<double> tcpAvgConnectionDuration{0.0};
   size_t socketsOffset{0};
   size_t d_maxInFlightQueriesPerConn{1};
+  size_t d_tcpConcurrentConnectionsLimit{0};
   double queryLoad{0.0};
   double dropRate{0.0};
   double latencyUsec{0.0};

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -352,6 +352,9 @@ bool TCPConnectionToBackend::reconnect()
 
       d_handler = std::move(handler);
       ++d_ds->tcpCurrentConnections;
+      if (d_ds->tcpCurrentConnections > d_ds->tcpMaxConcurrentConnections) {
+        d_ds->tcpMaxConcurrentConnections = d_ds->tcpCurrentConnections;
+      }
       return true;
     }
     catch (const std::runtime_error& e) {

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -72,7 +72,7 @@ Listen Sockets
     Added ``tcpListenQueueSize`` parameter.
 
   .. versionchanged:: 1.6.0
-    Added ``maxInFlight`` parameter.
+    Added ``maxInFlight`` and ``maxConcurrentTCPConnections`` parameters.
 
   Add to the list of listen addresses.
 
@@ -89,6 +89,7 @@ Listen Sockets
   * ``cpus={}``: table - Set the CPU affinity for this listener thread, asking the scheduler to run it on a single CPU id, or a set of CPU ids. This parameter is only available if the OS provides the pthread_setaffinity_np() function.
   * ``tcpListenQueueSize=SOMAXCONN``: int - Set the size of the listen queue. Default is ``SOMAXCONN``.
   * ``maxInFlight=0``: int - Maximum number of in-flight queries. The default is 0, which disables out-of-order processing.
+  * ``maxConcurrentTCPConnections=0``: int - Maximum number of concurrent incoming TCP connections. The default is 0 which means unlimited.
 
   .. code-block:: lua
 
@@ -105,7 +106,7 @@ Listen Sockets
     ``url`` now defaults to ``/dns-query`` instead of ``/``, and does exact matching instead of accepting sub-paths. Added ``tcpListenQueueSize`` parameter.
 
   .. versionchanged:: 1.6.0
-    ``exactPathMatching``, ``releaseBuffers`` and ``enableRenegotiation`` options added.
+    ``enableRenegotiation``, ``exactPathMatching``, ``maxConcurrentTCPConnections`` and ``releaseBuffers`` options added.
     ``internalPipeBufferSize`` now defaults to 1048576 on Linux.
 
   Listen on the specified address and TCP port for incoming DNS over HTTPS connections, presenting the specified X.509 certificate.
@@ -144,6 +145,7 @@ Listen Sockets
   * ``tcpListenQueueSize=SOMAXCONN``: int - Set the size of the listen queue. Default is ``SOMAXCONN``.
   * ``internalPipeBufferSize=0``: int - Set the size in bytes of the internal buffer of the pipes used internally to pass queries and responses between threads. Requires support for ``F_SETPIPE_SZ`` which is present in Linux since 2.6.35. The actual size might be rounded up to a multiple of a page size. 0 means that the OS default size is used. The default value is 0, except on Linux where it is 1048576 since 1.6.0.
   * ``exactPathMatching=true``: bool - Whether to do exact path matching of the query path against the paths configured in ``urls`` (true, the default since 1.5.0) or to accepts sub-paths (false, and was the default before 1.5.0).
+  * ``maxConcurrentTCPConnections=0``: int - Maximum number of concurrent incoming TCP connections. The default is 0 which means unlimited.  
   * ``releaseBuffers=true``: bool - Whether OpenSSL should release its I/O buffers when a connection goes idle, saving roughly 35 kB of memory per connection.
   * ``enableRenegotiation=false``: bool - Whether secure TLS renegotiation should be enabled. Disabled by default since it increases the attack surface and is seldom used for DNS.
 
@@ -154,7 +156,7 @@ Listen Sockets
   .. versionchanged:: 1.5.0
     ``sessionTimeout`` and ``tcpListenQueueSize`` options added.
   .. versionchanged:: 1.6.0
-    ``maxInFlight``, ``releaseBuffers`` and ``enableRenegotiation`` options added.
+    ``enableRenegotiation``, ``maxConcurrentTCPConnections``, ``maxInFlight`` and ``releaseBuffers`` options added.
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
@@ -185,6 +187,7 @@ Listen Sockets
   * ``keyLogFile``: str - Write the TLS keys in the specified file so that an external program can decrypt TLS exchanges, in the format described in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format. Note that this feature requires OpenSSL >= 1.1.1.
   * ``tcpListenQueueSize=SOMAXCONN``: int - Set the size of the listen queue. Default is ``SOMAXCONN``.
   * ``maxInFlight=0``: int - Maximum number of in-flight queries. The default is 0, which disables out-of-order processing.
+  * ``maxConcurrentTCPConnections=0``: int - Maximum number of concurrent incoming TCP connections. The default is 0 which means unlimited.
   * ``releaseBuffers=true``: bool - Whether OpenSSL should release its I/O buffers when a connection goes idle, saving roughly 35 kB of memory per connection.
   * ``enableRenegotiation=false``: bool - Whether secure TLS renegotiation should be enabled (OpenSSL only, the GnuTLS provider does not support it). Disabled by default since it increases the attack surface and is seldom used for DNS.
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -145,7 +145,7 @@ Listen Sockets
   * ``tcpListenQueueSize=SOMAXCONN``: int - Set the size of the listen queue. Default is ``SOMAXCONN``.
   * ``internalPipeBufferSize=0``: int - Set the size in bytes of the internal buffer of the pipes used internally to pass queries and responses between threads. Requires support for ``F_SETPIPE_SZ`` which is present in Linux since 2.6.35. The actual size might be rounded up to a multiple of a page size. 0 means that the OS default size is used. The default value is 0, except on Linux where it is 1048576 since 1.6.0.
   * ``exactPathMatching=true``: bool - Whether to do exact path matching of the query path against the paths configured in ``urls`` (true, the default since 1.5.0) or to accepts sub-paths (false, and was the default before 1.5.0).
-  * ``maxConcurrentTCPConnections=0``: int - Maximum number of concurrent incoming TCP connections. The default is 0 which means unlimited.  
+  * ``maxConcurrentTCPConnections=0``: int - Maximum number of concurrent incoming TCP connections. The default is 0 which means unlimited.
   * ``releaseBuffers=true``: bool - Whether OpenSSL should release its I/O buffers when a connection goes idle, saving roughly 35 kB of memory per connection.
   * ``enableRenegotiation=false``: bool - Whether secure TLS renegotiation should be enabled. Disabled by default since it increases the attack surface and is seldom used for DNS.
 

--- a/pdns/dnsdistdist/docs/reference/dnscrypt.rst
+++ b/pdns/dnsdistdist/docs/reference/dnscrypt.rst
@@ -7,6 +7,12 @@ DNSCrypt objects and functions
     Removed ``doTCP`` from the options. A listen socket on TCP is always created.
     ``certFile(s)`` and ``keyFile(s)`` now accept a list of files.
 
+  .. versionchanged:: 1.5.0
+    Added ``tcpListenQueueSize`` parameter.
+
+  .. versionchanged:: 1.6.0
+    Added ``maxInFlight`` and ``maxConcurrentTCPConnections`` parameters.
+
   Adds a DNSCrypt listen socket on ``address``.
 
   :param string address: The address and port to listen on
@@ -22,6 +28,9 @@ DNSCrypt objects and functions
   * ``tcpFastOpenQueueSize=0``: int - Set the TCP Fast Open queue size, enabling TCP Fast Open when available and the value is larger than 0
   * ``interface=""``: str - Sets the network interface to use
   * ``cpus={}``: table - Set the CPU affinity for this listener thread, asking the scheduler to run it on a single CPU id, or a set of CPU ids. This parameter is only available if the OS provides the pthread_setaffinity_np() function.
+  * ``tcpListenQueueSize=SOMAXCONN``: int - Set the size of the listen queue. Default is ``SOMAXCONN``.
+  * ``maxInFlight=0``: int - Maximum number of in-flight queries. The default is 0, which disables out-of-order processing.
+  * ``maxConcurrentTCPConnections=0``: int - Maximum number of concurrent incoming TCP connections. The default is 0 which means unlimited.
 
 .. function:: generateDNSCryptProviderKeys(publicKey, privateKey)
 

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -1,6 +1,14 @@
 Tuning related functions
 ========================
 
+.. function:: setMaxCachedTCPConnectionsPerDownstream(max)
+
+  .. versionadded:: 1.6.0
+
+  Set the maximum number of inactive TCP connections to a backend cached by each TCP worker thread. These connections can be reused when a new query comes in, instead of having to establish a new connection. dnsdist regularly checks whether the other end has closed any cached connection, closing them in that case.
+
+  :param int max: The maximum number of inactive connections to keep. Default is 10, so 10 connections per backend and per TCP worker thread.
+
 .. function:: setMaxTCPClientThreads(num)
 
   .. versionchanged:: 1.6.0

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1194,7 +1194,11 @@ static void on_accept(h2o_socket_t *listener, const char *err)
   sock->on_close.data = &conn;
   sock->data = dsc;
 
-  ++dsc->cs->tcpCurrentConnections;
+  auto concurrentConnections = ++dsc->cs->tcpCurrentConnections;
+  if (concurrentConnections > dsc->cs->tcpMaxConcurrentConnections) {
+    dsc->cs->tcpMaxConcurrentConnections = concurrentConnections;
+  }
+
   ++dsc->df->d_httpconnects;
 
   h2o_accept(conn.d_acceptCtx->get(), sock);

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1169,18 +1169,26 @@ static void on_accept(h2o_socket_t *listener, const char *err)
   if (err != nullptr) {
     return;
   }
-  // do some dnsdist rules here to filter based on IP address
+
   if ((sock = h2o_evloop_socket_accept(listener)) == nullptr) {
     return;
   }
 
-  // ComboAddress remote;
-  // h2o_socket_getpeername(sock, reinterpret_cast<struct sockaddr*>(&remote));
-  //  cout<<"New HTTP accept for client "<<remote.toStringWithPort()<<": "<< listener->data << endl;
-
   const int descriptor = h2o_socket_get_fd(sock);
   if (descriptor == -1) {
+    h2o_socket_close(sock);
     return;
+  }
+
+  auto concurrentConnections = ++dsc->cs->tcpCurrentConnections;
+  if (dsc->cs->d_tcpConcurrentConnectionsLimit > 0 && concurrentConnections > dsc->cs->d_tcpConcurrentConnectionsLimit) {
+    --dsc->cs->tcpCurrentConnections;
+    h2o_socket_close(sock);
+    return;
+  }
+
+  if (concurrentConnections > dsc->cs->tcpMaxConcurrentConnections) {
+    dsc->cs->tcpMaxConcurrentConnections = concurrentConnections;
   }
 
   auto& conn = t_conns[descriptor];
@@ -1193,11 +1201,6 @@ static void on_accept(h2o_socket_t *listener, const char *err)
   sock->on_close.cb = on_socketclose;
   sock->on_close.data = &conn;
   sock->data = dsc;
-
-  auto concurrentConnections = ++dsc->cs->tcpCurrentConnections;
-  if (concurrentConnections > dsc->cs->tcpMaxConcurrentConnections) {
-    dsc->cs->tcpMaxConcurrentConnections = concurrentConnections;
-  }
 
   ++dsc->df->d_httpconnects;
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds a configuration option for the number of inactive TCP connections kept in cache by TCP workers for future use.
It also adds new metrics for the maximum number of TCP connections reached per backend, and per frontend, and new configuration options to limit the number of concurrent incoming connections per frontend.

<strike>It lacks an option to configure the maximum number of incoming connections per front-end.</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
