### PR TITLE
dnsdist: Fix the handling of DoH queries with a non-zero ID

### DIFF
--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -535,7 +535,7 @@ static int processDOHQuery(DOHUnit* du)
     ids->du = du;
 
     ids->cs = &cs;
-    ids->origID = queryId;
+    ids->origID = htons(queryId);
     setIDStateFromDNSQuestion(*ids, dq, std::move(qname));
 
     dq.getHeader()->id = idOffset;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
rfc8484 states that clients "SHOULD use a DNS ID of 0 in every DNS request", not MUST, and it does indeed happen.
The issue was introduced in 341d2553b74c579df9d9843959f3ca6f5c3dc954 (between 1.5.x and 1.6.0-alpha1) when we moved to a safer PacketBuffer.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
