### PR TITLE
rec: Setup env properly to skip v6 test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1275,7 +1275,6 @@ jobs:
         environment:
           UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1'
           ASAN_OPTIONS: detect_leaks=0
-          SKIP_IPV6_TESTS: y
     steps:
       - add-auth-repo
       - run: apt-get --no-install-recommends install -qq -y pdns-server pdns-backend-bind pdns-tools daemontools authbind jq libfaketime lua-posix lua-socket moreutils bc python3-venv protobuf-compiler
@@ -1298,6 +1297,7 @@ jobs:
           command: |
             PDNSRECURSOR=/opt/pdns-recursor/sbin/pdns_recursor \
             RECCONTROL=/opt/pdns-recursor/bin/rec_control \
+            SKIP_IPV6_TESTS=y \
             ./build-scripts/test-recursor
 
   test-recursor-bulk:


### PR DESCRIPTION
CicleCI docs indeed suggest the environment setting under docker do not apply
to the jobs steps.

So specify it explicitly for the test run itself.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
