### PR TITLE
dnsdist: Unify certificate reloading syntaxes

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2444,16 +2444,43 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         return g_tlslocals.size();
       });
 
-    luaCtx.registerFunction<void(std::shared_ptr<TLSCtx>::*)()>("rotateTicketsKey", [](std::shared_ptr<TLSCtx> ctx) {
+    luaCtx.registerFunction<void(std::shared_ptr<TLSCtx>::*)()>("rotateTicketsKey", [](std::shared_ptr<TLSCtx>& ctx) {
         if (ctx != nullptr) {
           ctx->rotateTicketsKey(time(nullptr));
         }
       });
 
-    luaCtx.registerFunction<void(std::shared_ptr<TLSCtx>::*)(const std::string&)>("loadTicketsKeys", [](std::shared_ptr<TLSCtx> ctx, const std::string& file) {
+    luaCtx.registerFunction<void(std::shared_ptr<TLSCtx>::*)(const std::string&)>("loadTicketsKeys", [](std::shared_ptr<TLSCtx>& ctx, const std::string& file) {
         if (ctx != nullptr) {
           ctx->loadTicketsKeys(file);
         }
+      });
+
+    luaCtx.registerFunction<void(std::shared_ptr<TLSFrontend>::*)()>("rotateTicketsKey", [](std::shared_ptr<TLSFrontend>& frontend) {
+        if (frontend == nullptr) {
+          return;
+        }
+        auto ctx = frontend->getContext();
+        if (ctx) {
+          ctx->rotateTicketsKey(time(nullptr));
+        }
+      });
+
+    luaCtx.registerFunction<void(std::shared_ptr<TLSFrontend>::*)(const std::string&)>("loadTicketsKeys", [](std::shared_ptr<TLSFrontend>& frontend, const std::string& file) {
+        if (frontend == nullptr) {
+          return;
+        }
+        auto ctx = frontend->getContext();
+        if (ctx) {
+          ctx->loadTicketsKeys(file);
+        }
+      });
+
+    luaCtx.registerFunction<void(std::shared_ptr<TLSFrontend>::*)()>("reloadCertificates", [](std::shared_ptr<TLSFrontend>& frontend) {
+        if (frontend == nullptr) {
+          return;
+        }
+        frontend->setupTLS();
       });
 
     luaCtx.registerFunction<void(std::shared_ptr<TLSFrontend>::*)(boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles)>("loadNewCertificatesAndKeys", [](std::shared_ptr<TLSFrontend>& frontend, boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles) {

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
@@ -33,6 +33,7 @@ void setupLuaBindingsDNSCrypt(LuaContext& luaCtx)
     luaCtx.registerFunction<std::string(DNSCryptContext::*)()const>("getProviderName", [](const DNSCryptContext& ctx) { return ctx.getProviderName().toStringNoDot(); });
     luaCtx.registerFunction("markActive", &DNSCryptContext::markActive);
     luaCtx.registerFunction("markInactive", &DNSCryptContext::markInactive);
+    luaCtx.registerFunction("reloadCertificates", &DNSCryptContext::reloadCertificates);
     luaCtx.registerFunction("removeInactiveCertificate", &DNSCryptContext::removeInactiveCertificate);
     luaCtx.registerFunction<void(std::shared_ptr<DNSCryptContext>::*)(const std::string& certFile, const std::string& keyFile, boost::optional<bool> active)>("loadNewCertificate", [](std::shared_ptr<DNSCryptContext> ctx, const std::string& certFile, const std::string& keyFile, boost::optional<bool> active) {
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1536,16 +1536,16 @@ TLSContext
 
   This object represents an address and port dnsdist is listening on for DNS over TLS queries.
 
-  .. method:: TLSContext:rotateTicketsKey()
-
-     Replace the current TLS tickets key by a new random one.
-
   .. method:: TLSContext:loadTicketsKeys(ticketsKeysFile)
 
      Load new tickets keys from the selected file, replacing the existing ones. These keys should be rotated often and never written to persistent storage to preserve forward secrecy. The default is to generate a random key. The OpenSSL provider supports several tickets keys to be able to decrypt existing sessions after the rotation, while the GnuTLS provider only supports one key.
      See :doc:`guides/tls-sessions-management` for more information.
 
     :param str ticketsKeysFile: The path to a file from where TLS tickets keys should be loaded.
+
+  .. method:: TLSContext:rotateTicketsKey()
+
+     Replace the current TLS tickets key by a new random one.
 
 TLSFrontend
 ~~~~~~~~~~~
@@ -1554,12 +1554,33 @@ TLSFrontend
 
   This object represents the configuration of a listening frontend for DNS over TLS queries. To each frontend is associated a TLSContext.
 
-  .. method:: TLSContext:loadNewCertificatesAndKeys(certFile(s), keyFile(s))
+  .. method:: TLSFrontend:loadNewCertificatesAndKeys(certFile(s), keyFile(s))
 
      Create and switch to a new TLS context using the same options than were passed to the corresponding `addTLSLocal()` directive, but loading new certificates and keys from the selected files, replacing the existing ones.
 
   :param str certFile(s): The path to a X.509 certificate file in PEM format, or a list of paths to such files.
   :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones.
+
+  .. method:: TLSFrontend:loadTicketsKeys(ticketsKeysFile)
+
+  .. versionadded:: 1.6.0
+
+     Load new tickets keys from the selected file, replacing the existing ones. These keys should be rotated often and never written to persistent storage to preserve forward secrecy. The default is to generate a random key. The OpenSSL provider supports several tickets keys to be able to decrypt existing sessions after the rotation, while the GnuTLS provider only supports one key.
+     See :doc:`guides/tls-sessions-management` for more information.
+
+    :param str ticketsKeysFile: The path to a file from where TLS tickets keys should be loaded.
+
+  .. method:: TLSFrontend:reloadCertificates()
+
+  .. versionadded:: 1.6.0
+
+     Reload the current TLS certificate and key pairs.
+
+  .. method:: TLSFrontend:rotateTicketsKey()
+
+  .. versionadded:: 1.6.0
+
+     Replace the current TLS tickets key by a new random one.
 
 EDNS on Self-generated answers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pdns/dnsdistdist/docs/reference/dnscrypt.rst
+++ b/pdns/dnsdistdist/docs/reference/dnscrypt.rst
@@ -194,6 +194,12 @@ Context
 
     Print all the certificates.
 
+  .. method:: DNSCryptContext:reloadCertificates()
+
+    .. versionadded:: 1.6.0
+
+    Reload the current TLS certificate and key pairs.
+
   .. method:: DNSCryptContext:removeInactiveCertificate(serial)
 
     Remove the certificate with serial `serial`. It will not be possible to answer queries tied


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR unifies the way of reloading certificates over the different types of frontends (DNSCrypt, DoT and DoH). It also paves the way for the deprecation of the `TLSCtx` class by making every method available from the `TLSFrontend` class.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
