### PR TITLE
Replace pthread_rwlock with std::shared_mutex

### DIFF
--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -22,6 +22,9 @@
 #pragma once
 
 #include <mutex>
+#include <boost/multi_index_container.hpp>
+
+#include "dnsname.hh"
 #include "lock.hh"
 
 // this function can clean any cache that has a getTTD() method on its entries, a preRemoval() method and a 'sequence' index as its second index
@@ -96,7 +99,7 @@ template <typename S, typename T> void moveCacheItemToBack(T& collection, typena
   moveCacheItemToFrontOrBack<S>(collection, iter, false);
 }
 
-template <typename S, typename T> uint64_t pruneLockedCollectionsVector(vector<T>& maps)
+template <typename S, typename T> uint64_t pruneLockedCollectionsVector(std::vector<T>& maps)
 {
   uint64_t totErased = 0;
   time_t now = time(nullptr);
@@ -122,7 +125,7 @@ template <typename S, typename T> uint64_t pruneLockedCollectionsVector(vector<T
   return totErased;
 }
 
-template <typename S, typename C, typename T> uint64_t pruneMutexCollectionsVector(C& container, vector<T>& maps, uint64_t maxCached, uint64_t cacheSize)
+template <typename S, typename C, typename T> uint64_t pruneMutexCollectionsVector(C& container, std::vector<T>& maps, uint64_t maxCached, uint64_t cacheSize)
 {
   time_t now = time(nullptr);
   uint64_t totErased = 0;
@@ -197,7 +200,7 @@ template <typename S, typename C, typename T> uint64_t pruneMutexCollectionsVect
   return totErased;
 }
 
-template <typename T> uint64_t purgeLockedCollectionsVector(vector<T>& maps)
+template <typename T> uint64_t purgeLockedCollectionsVector(std::vector<T>& maps)
 {
   uint64_t delcount=0;
 
@@ -210,10 +213,10 @@ template <typename T> uint64_t purgeLockedCollectionsVector(vector<T>& maps)
   return delcount;
 }
 
-template <typename N, typename T> uint64_t purgeLockedCollectionsVector(vector<T>& maps, const std::string& match)
+template <typename N, typename T> uint64_t purgeLockedCollectionsVector(std::vector<T>& maps, const std::string& match)
 {
   uint64_t delcount=0;
-  string prefix(match);
+  std::string prefix(match);
   prefix.resize(prefix.size()-1);
   DNSName dprefix(prefix);
   for(auto& mc : maps) {

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -578,7 +578,7 @@ OpenSSLTLSTicketKey::OpenSSLTLSTicketKey()
 #endif /* HAVE_LIBSODIUM */
 }
 
-OpenSSLTLSTicketKey::OpenSSLTLSTicketKey(ifstream& file)
+OpenSSLTLSTicketKey::OpenSSLTLSTicketKey(std::ifstream& file)
 {
   file.read(reinterpret_cast<char*>(d_name), sizeof(d_name));
   file.read(reinterpret_cast<char*>(d_cipherKey), sizeof(d_cipherKey));

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <fstream>
 #include <map>
 #include <memory>

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -872,9 +872,8 @@ struct ReadWriteLockSharedTest
   string getName() const { return "RW lock shared"; }
 
   void operator()() const {
-    for (size_t idx = 0; idx < 1000; ) {
+    for (size_t idx = 0; idx < 1000; idx++) {
       ReadLock wl(d_lock);
-      ++idx;
     }
   }
 
@@ -891,9 +890,8 @@ struct ReadWriteLockExclusiveTest
   string getName() const { return "RW lock exclusive"; }
 
   void operator()() const {
-    for (size_t idx = 0; idx < 1000; ) {
+    for (size_t idx = 0; idx < 1000; idx++) {
       WriteLock wl(d_lock);
-      ++idx;
     }
   }
 
@@ -910,7 +908,7 @@ struct ReadWriteLockExclusiveTryTest
   string getName() const { return "RW lock try exclusive - " + std::string(d_contended ? "contended" : "non-contended"); }
 
   void operator()() const {
-    for (size_t idx = 0; idx < 1000; ) {
+    for (size_t idx = 0; idx < 1000; idx++) {
       TryWriteLock wl(d_lock);
       if (!wl.gotIt() && !d_contended) {
         cerr<<"Error getting the lock"<<endl;
@@ -920,7 +918,6 @@ struct ReadWriteLockExclusiveTryTest
         cerr<<"Got a contended lock"<<endl;
         _exit(0);
       }
-      ++idx;
     }
   }
 
@@ -938,7 +935,7 @@ struct ReadWriteLockSharedTryTest
   string getName() const { return "RW lock try shared - " + std::string(d_contended ? "contended" : "non-contended"); }
 
   void operator()() const {
-    for (size_t idx = 0; idx < 1000; ) {
+    for (size_t idx = 0; idx < 1000; idx++) {
       TryReadLock wl(d_lock);
       if (!wl.gotIt() && !d_contended) {
         cerr<<"Error getting the lock"<<endl;
@@ -948,7 +945,6 @@ struct ReadWriteLockSharedTryTest
         cerr<<"Got a contended lock"<<endl;
         _exit(0);
       }
-      ++idx;
     }
   }
 

--- a/pdns/test-lock_hh.cc
+++ b/pdns/test-lock_hh.cc
@@ -4,8 +4,10 @@
 #include "config.h"
 #endif
 #include <boost/test/unit_test.hpp>
-#include "lock.hh"
 #include <thread>
+
+#include "lock.hh"
+#include "pdnsexception.hh"
 
 using namespace boost;
 
@@ -16,8 +18,9 @@ static std::vector<ReadWriteLock> g_locks(1000);
 static void lthread()
 {
   std::vector<ReadLock> rlocks;
-  for(auto& pp : g_locks)
+  for(auto& pp : g_locks) {
     rlocks.emplace_back(pp);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_pdns_lock)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Closes #10209.

The speed tests result looks good, except perhaps for a small regression in the "RW lock shared" case but since we are talking of 1 usec for 1000 operations, I believe we can live with that.

* master
```
'getlock-uncontended-test' 0.11 seconds: 112247847.3 runs/s, 0.01 usec/run
'RW lock shared' 0.11 seconds: 107827.9 runs/s, 9.27 usec/run
'RW lock exclusive' 0.11 seconds: 72534.4 runs/s, 13.79 usec/run
'RW lock try exclusive - non-contended' 0.11 seconds: 69176.3 runs/s, 14.46 usec/run
'RW lock try exclusive - contended' 0.11 seconds: 255326.8 runs/s, 3.92 usec/run
'RW lock try shared - non-contended' 0.11 seconds: 107123.5 runs/s, 9.34 usec/run
'RW lock try shared - contended' 0.11 seconds: 255821.4 runs/s, 3.91 usec/run

'getlock-uncontended-test' 0.11 seconds: 113262655.2 runs/s, 0.01 usec/run
'RW lock shared' 0.11 seconds: 108756.1 runs/s, 9.19 usec/run
'RW lock exclusive' 0.11 seconds: 73071.9 runs/s, 13.69 usec/run
'RW lock try exclusive - non-contended' 0.11 seconds: 69429.8 runs/s, 14.40 usec/run
'RW lock try exclusive - contended' 0.11 seconds: 257484.5 runs/s, 3.88 usec/run
'RW lock try shared - non-contended' 0.11 seconds: 108059.3 runs/s, 9.25 usec/run
'RW lock try shared - contended' 0.11 seconds: 257798.9 runs/s, 3.88 usec/run
```

* PR

```
'getlock-uncontended-test' 0.11 seconds: 111842329.5 runs/s, 0.01 usec/run
'RW lock shared' 0.11 seconds: 95161.0 runs/s, 10.51 usec/run
'RW lock exclusive' 0.11 seconds: 72660.4 runs/s, 13.76 usec/run
'RW lock try exclusive - non-contended' 0.11 seconds: 71733.0 runs/s, 13.94 usec/run
'RW lock try exclusive - contended' 0.11 seconds: 360459.7 runs/s, 2.77 usec/run
'RW lock try shared - non-contended' 0.11 seconds: 106830.7 runs/s, 9.36 usec/run
'RW lock try shared - contended' 0.11 seconds: 255051.5 runs/s, 3.92 usec/run

'getlock-uncontended-test' 0.11 seconds: 112064700.8 runs/s, 0.01 usec/run
'RW lock shared' 0.11 seconds: 96040.2 runs/s, 10.41 usec/run
'RW lock exclusive' 0.11 seconds: 72596.2 runs/s, 13.77 usec/run
'RW lock try exclusive - non-contended' 0.11 seconds: 71517.1 runs/s, 13.98 usec/run
'RW lock try exclusive - contended' 0.11 seconds: 360546.4 runs/s, 2.77 usec/run
'RW lock try shared - non-contended' 0.11 seconds: 107134.1 runs/s, 9.33 usec/run
'RW lock try shared - contended' 0.11 seconds: 255380.6 runs/s, 3.92 usec/run
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
