### PR TITLE
auth API cryptokeys: add cds array when configured to do so. Closes #10215

### DIFF
--- a/docs/http-api/swagger/authoritative-api-swagger.yaml
+++ b/docs/http-api/swagger/authoritative-api-swagger.yaml
@@ -1262,6 +1262,11 @@ definitions:
         items:
           type: string
         description: 'An array of DS records for this key'
+      cds:
+        type: array
+        items:
+          type: string
+        description: 'An array of DS records for this key, filtered by CDS publication settings'
       privatekey:
         type: string
         description: 'The private key in ISC format'

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -967,6 +967,8 @@ static void apiZoneMetadata(HttpRequest* req, HttpResponse *resp) {
       throw ApiException("Could not update metadata entries for domain '" +
         zonename.toString() + "'");
 
+    DNSSECKeeper::clearMetaCache(zonename);
+
     Json::array respMetadata;
     for (const string& s : vecMetadata)
       respMetadata.push_back(s);
@@ -1032,6 +1034,8 @@ static void apiZoneMetadataKind(HttpRequest* req, HttpResponse* resp) {
     if (!B.setDomainMetadata(zonename, kind, vecMetadata))
       throw ApiException("Could not update metadata entries for domain '" + zonename.toString() + "'");
 
+    DNSSECKeeper::clearMetaCache(zonename);
+
     Json::object key {
       { "type", "Metadata" },
       { "kind", kind },
@@ -1046,6 +1050,8 @@ static void apiZoneMetadataKind(HttpRequest* req, HttpResponse* resp) {
     vector<string> md;  // an empty vector will do it
     if (!B.setDomainMetadata(zonename, kind, md))
       throw ApiException("Could not delete metadata for domain '" + zonename.toString() + "' (" + kind + ")");
+
+    DNSSECKeeper::clearMetaCache(zonename);
   } else
     throw HttpMethodNotAllowedException();
 }


### PR DESCRIPTION
### Short description
When CDS publication for a zone is configured, also add a `"cds"` entry to the auth API cryptokeys object.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master