### PR TITLE
rec: backport 9860 to 4.4.x: Get rid of warnings when compiling with Boost 1.74

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -3,7 +3,7 @@
 #endif
 #include "utility.hh"
 #include "rec_channel.hh"
-#include <boost/bind.hpp>
+
 #include <vector>
 #ifdef MALLOC_TRACE
 #include "malloctrace.hh"
@@ -1175,26 +1175,27 @@ void registerAllStats()
   addGetStat("noedns-outqueries", &g_stats.noEdnsOutQueries);
 
   addGetStat("uptime", calculateUptime);
-  addGetStat("real-memory-usage", boost::bind(getRealMemoryUsage, string()));
-  addGetStat("special-memory-usage", boost::bind(getSpecialMemoryUsage, string()));
-  addGetStat("fd-usage", boost::bind(getOpenFileDescriptors, string()));
+  addGetStat("real-memory-usage", []{ return getRealMemoryUsage(string()); });
+  addGetStat("special-memory-usage", []{ return getSpecialMemoryUsage(string()); });
+  addGetStat("fd-usage", []{ return getOpenFileDescriptors(string()); });
 
   //  addGetStat("query-rate", getQueryRate);
   addGetStat("user-msec", getUserTimeMsec);
   addGetStat("sys-msec", getSysTimeMsec);
 
 #ifdef __linux__
-  addGetStat("cpu-iowait", boost::bind(getCPUIOWait, string()));
-  addGetStat("cpu-steal", boost::bind(getCPUSteal, string()));
+  addGetStat("cpu-iowait", []{ return getCPUIOWait(string()); });
+  addGetStat("cpu-steal", []{ return getCPUSteal(string()); });
 #endif
 
-  for(unsigned int n=0; n < g_numThreads; ++n)
-    addGetStat("cpu-msec-thread-"+std::to_string(n), boost::bind(&doGetThreadCPUMsec, n));
+  for (unsigned int n = 0; n < g_numThreads; ++n) {
+    addGetStat("cpu-msec-thread-"+std::to_string(n), [n]{ return doGetThreadCPUMsec(n);});
+  }
 
 #ifdef MALLOC_TRACE
-  addGetStat("memory-allocs", boost::bind(&MallocTracer::getAllocs, g_mtracer, string()));
-  addGetStat("memory-alloc-flux", boost::bind(&MallocTracer::getAllocFlux, g_mtracer, string()));
-  addGetStat("memory-allocated", boost::bind(&MallocTracer::getTotAllocated, g_mtracer, string()));
+  addGetStat("memory-allocs", []{ return g_mtracer->getAllocs(string()); });
+  addGetStat("memory-alloc-flux", []{ return g_mtracer->getAllocFlux(string()); });
+  addGetStat("memory-allocated", []{ return g_mtracer->getTotAllocated(string()); });
 #endif
 
   addGetStat("dnssec-validations", &g_stats.dnssecValidations);

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -1,14 +1,16 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
-#include <boost/assign/std/map.hpp>
+
+#include <cmath>
 #include <numeric>
-#include <math.h>
+#include <unordered_set>
+
 #include "dnsname.hh"
 #include "misc.hh"
 #include "dnswriter.hh"
 #include "dnsrecords.hh"
-#include <unordered_set>
+
 using namespace boost;
 using std::string;
 


### PR DESCRIPTION
(cherry picked from commit b2dd79dc04e2939fb84e3a4ee3df9a191bebe529)

Backport of #9860 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
