### PR TITLE
rec: Backport 10064 to 4.4.x: Return current rcode instead of 0 if there are no CNAME records to follow

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -658,7 +658,7 @@ loop:;
     
     if(!dq.followupFunction.empty()) {
       if(dq.followupFunction=="followCNAMERecords") {
-        ret = followCNAMERecords(dq.records, QType(dq.qtype));
+        ret = followCNAMERecords(dq.records, QType(dq.qtype), ret);
       }
       else if(dq.followupFunction=="getFakeAAAARecords") {
         ret=getFakeAAAARecords(dq.followupName, ComboAddress(dq.followupPrefix), dq.records);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1164,7 +1164,7 @@ static bool udrCheckUniqueDNSRecord(const DNSName& dname, uint16_t qtype, const 
 }
 #endif /* NOD_ENABLED */
 
-int followCNAMERecords(vector<DNSRecord>& ret, const QType& qtype)
+int followCNAMERecords(vector<DNSRecord>& ret, const QType& qtype, int rcode)
 {
   vector<DNSRecord> resolved;
   DNSName target;
@@ -1179,10 +1179,10 @@ int followCNAMERecords(vector<DNSRecord>& ret, const QType& qtype)
   }
 
   if(target.empty()) {
-    return 0;
+    return rcode;
   }
 
-  int rcode = directResolve(target, qtype, QClass::IN, resolved);
+  rcode = directResolve(target, qtype, QClass::IN, resolved);
 
   for(DNSRecord& rr :  resolved) {
     ret.push_back(std::move(rr));
@@ -1508,7 +1508,7 @@ static void startDoResolve(void *p)
         ret = std::move(dc->d_records);
         res = *dc->d_rcode;
         if (res == RCode::NoError && dc->d_followCNAMERecords) {
-          res = followCNAMERecords(ret, QType(dc->d_mdp.d_qtype));
+          res = followCNAMERecords(ret, QType(dc->d_mdp.d_qtype), res);
         }
         goto haveAnswer;
       }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1109,7 +1109,7 @@ void broadcastFunction(const pipefunc_t& func);
 void distributeAsyncFunction(const std::string& question, const pipefunc_t& func);
 
 int directResolve(const DNSName& qname, const QType& qtype, int qclass, vector<DNSRecord>& ret);
-int followCNAMERecords(std::vector<DNSRecord>& ret, const QType& qtype);
+int followCNAMERecords(std::vector<DNSRecord>& ret, const QType& qtype, int oldret);
 int getFakeAAAARecords(const DNSName& qname, ComboAddress prefix, vector<DNSRecord>& ret);
 int getFakePTRRecords(const DNSName& qname, vector<DNSRecord>& ret);
 


### PR DESCRIPTION

Note that this is a change in behaviour. While it is for the good, it might
be existing code depends on the old 0 value...

(cherry picked from commit 558d47eba7d2edd3fb5991af428d9d432fec1dfa)

Backport of #10064 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
