### PR TITLE
auth: rectify() do not update ordernames/auth when there is no need

### DIFF
--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -95,7 +95,7 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=0 and name=?");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=0 and name=? and domain_id=?");
 
-    declare(suffix, "list-query", "AXFR query", record_query + " (disabled=0 OR ?) and domain_id=? order by name, type");
+    declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type");
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=0 and (name=? OR name like ?) and domain_id=?");
 
     declare(suffix, "remove-empty-non-terminals-from-zone-query", "remove all empty non-terminals from zone", "delete from records where domain_id=? and type is null");

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -75,7 +75,7 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=0 and name=?");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=0 and name=? and domain_id=?");
 
-    declare(suffix, "list-query", "AXFR query", record_query + " (disabled=0 OR disabled=?) and domain_id=? order by name, type");
+    declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,CONVERT(varchar(255), ordername, 0) FROM records WHERE (disabled=0 OR disabled=?) and domain_id=? order by name, type");
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=0 and (name=? OR name like ?) and domain_id=?");
 
     declare(suffix, "remove-empty-non-terminals-from-zone-query", "remove all empty non-terminals from zone", "delete from records where domain_id=? and type is null");

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -102,7 +102,7 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=false and name=$1");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=false and name=$1 and domain_id=$2");
 
-    declare(suffix, "list-query", "AXFR query", record_query + " (disabled=false OR $1) and domain_id=$2 order by name, type");
+    declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int,ordername FROM records WHERE (disabled=false OR $1) and domain_id=$2 order by name, type");
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=false and (name=$1 OR name like $2) and domain_id=$3");
 
     declare(suffix, "remove-empty-non-terminals-from-zone-query", "remove all empty non-terminals from zone", "delete from records where domain_id=$1 and type is null");

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -88,7 +88,7 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=0 and name=:qname");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=0 and name=:qname and domain_id=:domain_id");
 
-    declare(suffix, "list-query", "AXFR query", record_query + " (disabled=0 OR :include_disabled) and domain_id=:domain_id order by name, type");
+    declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR :include_disabled) and domain_id=:domain_id order by name, type");
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=0 and (name=:zone OR name like :wildzone) and domain_id=:domain_id");
 
     declare(suffix, "remove-empty-non-terminals-from-zone-query", "remove all empty non-terminals from zone", "delete from records where domain_id=:domain_id and type is null");

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1900,7 +1900,7 @@ void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)
 
   r.domain_id=pdns_stou(row[4]);
 
-  if (row.size() > 8) {
+  if (row.size() > 8) {   // if column 8 exists, it holds an ordername
     if (!row.at(8).empty()) {
       r.ordername=DNSName(boost::replace_all_copy(row.at(8), " ", ".")).labelReverse();
     }

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1144,6 +1144,7 @@ void GSQLBackend::lookup(const QType &qtype,const DNSName &qname, int domain_id,
     throw PDNSException("GSQLBackend unable to lookup '" + qname.toLogString() + "|" + qtype.getName() + "':"+e.txtReason());
   }
 
+  d_list=false;
   d_qname=qname;
 }
 
@@ -1165,7 +1166,9 @@ bool GSQLBackend::list(const DNSName &target, int domain_id, bool include_disabl
     throw PDNSException("GSQLBackend unable to list domain '" + target.toLogString() + "': "+e.txtReason());
   }
 
+  d_list=true;
   d_qname.clear();
+
   return true;
 }
 
@@ -1187,7 +1190,10 @@ bool GSQLBackend::listSubZone(const DNSName &zone, int domain_id) {
   catch(SSqlException &e) {
     throw PDNSException("GSQLBackend unable to list SubZones for domain '" + zone.toLogString() + "': "+e.txtReason());
   }
+
+  d_list=false;
   d_qname.clear();
+
   return true;
 }
 
@@ -1200,7 +1206,12 @@ skiprow:
   if((*d_query_stmt)->hasNextRow()) {
     try {
       (*d_query_stmt)->nextRow(row);
-      ASSERT_ROW_COLUMNS(d_query_name, row, 8);
+      if (!d_list) {
+        ASSERT_ROW_COLUMNS(d_query_name, row, 8); // lookup(), listSubZone()
+      }
+      else {
+        ASSERT_ROW_COLUMNS(d_query_name, row, 9); // list()
+      }
     } catch (SSqlException &e) {
       throw PDNSException("GSQLBackend get: "+e.txtReason());
     }
@@ -1888,6 +1899,18 @@ void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)
   r.disabled = !row[5].empty() && row[5][0]=='1';
 
   r.domain_id=pdns_stou(row[4]);
+
+  if (row.size() > 8) {
+    if (!row.at(8).empty()) {
+      r.ordername=DNSName(boost::replace_all_copy(row.at(8), " ", ".")).labelReverse();
+    }
+    else {
+      r.ordername.clear();
+    }
+  }
+  else {
+    r.ordername.clear();
+  }
 }
 
 void GSQLBackend::extractComment(SSqlStatement::row_t& row, Comment& comment)

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -264,6 +264,7 @@ protected:
     return d_inTransaction;
   }
 
+  bool d_list{false};
   string d_query_name;
   DNSName d_qname;
   SSqlStatement::result_t d_result;

--- a/pdns/dns.hh
+++ b/pdns/dns.hh
@@ -90,6 +90,7 @@ public:
 
   // data
   DNSName qname; //!< the name of this record, for example: www.powerdns.com
+  DNSName ordername;
   DNSName wildcardname;
   string content; //!< what this record points to. Example: 10.1.2.3
 

--- a/regression-tests/backends/godbc_sqlite3-master
+++ b/regression-tests/backends/godbc_sqlite3-master
@@ -50,7 +50,7 @@ godbc-insert-record-query=insert into records (content,ttl,prio,type,domain_id,d
 godbc-insert-zone-query=insert into domains (type,name,master,account,last_check,notified_serial) values(?, ?, ?, ?, null, null)
 godbc-list-comments-query=SELECT domain_id,name,type,modified_at,account,comment FROM comments WHERE domain_id=?
 godbc-list-domain-keys-query=select cryptokeys.id, flags, active, published, content from domains, cryptokeys where cryptokeys.domain_id=domains.id and name=?
-godbc-list-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type
+godbc-list-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type
 godbc-list-subzone-query=SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and (name=? OR name like ?) and domain_id=?
 godbc-nullify-ordername-and-update-auth-query=update records set ordername=NULL,auth=? where domain_id=? and name=? and disabled=0
 godbc-nullify-ordername-and-update-auth-type-query=update records set ordername=NULL,auth=? where domain_id=? and name=? and type=? and disabled=0


### PR DESCRIPTION
### Short description
inspired by and successor of #9064
closes #9064

Rectify must be able to correct the ordername under all circumstances. The previous pull was however making assumptions on the exiting rectify state. There is also an issue with empty vs NULL ordernames in the backends. For both values the backends do return an empty value. This is fine for the rest of pdns but is was confusing the smart rectify.
This pull is working around a these issues at the cost of slightly more update queries. Records with empty values are always updated. And the same applies to names with different ordername/auth values, mostly found in delegations.

Some numbers...

First rectify:
```
time ../pdns/pdnsutil --config-dir=. --config-name=gmysql rectify-all-zones example.com
Rectifying example.com: Adding NSEC ordering information for zone 'example.com', 20088 updates
Rectifying dnssec-parent.com: Adding NSEC ordering information for zone 'dnssec-parent.com', 33 updates
Rectifying test.com: Adding NSEC ordering information for zone 'test.com', 34 updates
Rectifying wtest.com: Adding NSEC ordering information for zone 'wtest.com', 14 updates
Rectifying minimal.com: Adding NSEC ordering information for zone 'minimal.com', 1 updates
Rectifying hiddencryptokeys.org: Adding NSEC ordering information for zone 'hiddencryptokeys.org', 1 updates
Rectifying insecure.dnssec-parent.com: Adding empty non-terminals for non-DNSSEC zone 'insecure.dnssec-parent.com', 1 updates
Rectifying 2.0.192.in-addr.arpa: Adding NSEC ordering information for zone '2.0.192.in-addr.arpa', 1 updates
Rectifying cryptokeys.org: Adding NSEC ordering information for zone 'cryptokeys.org', 19 updates
Rectifying test.dyndns: Adding NSEC ordering information for zone 'test.dyndns', 21 updates
Rectifying cdnskey-cds-test.com: Adding NSEC ordering information for zone 'cdnskey-cds-test.com', 3 updates
Rectifying sub.test.dyndns: Adding NSEC ordering information for zone 'sub.test.dyndns', 1 updates
Rectifying secure-delegated.dnssec-parent.com: Adding NSEC ordering information for zone 'secure-delegated.dnssec-parent.com', 4 updates
Rectifying tsig.com: Adding NSEC ordering information for zone 'tsig.com', 1 updates
Rectifying delegated.dnssec-parent.com: Adding NSEC ordering information for zone 'delegated.dnssec-parent.com', 5 updates
Rectifying nztest.com: Adding NSEC ordering information for zone 'nztest.com', 9 updates
Rectifying stest.com: Adding NSEC ordering information for zone 'stest.com', 1 updates
Rectified 17 zones.

real	0m3,326s
user	0m0,341s
sys	0m0,355s
```

Second rectify:
```
time ../pdns/pdnsutil --config-dir=. --config-name=gmysql rectify-all-zones example.com
Rectifying example.com: Adding NSEC ordering information for zone 'example.com', 27 updates
Rectifying dnssec-parent.com: Adding NSEC ordering information for zone 'dnssec-parent.com', 26 updates
Rectifying test.com: Adding NSEC ordering information for zone 'test.com', 11 updates
Rectifying wtest.com: Adding NSEC ordering information for zone 'wtest.com', 7 updates
Rectifying minimal.com: Adding NSEC ordering information for zone 'minimal.com', 1 updates
Rectifying hiddencryptokeys.org: Adding NSEC ordering information for zone 'hiddencryptokeys.org', 1 updates
Rectifying insecure.dnssec-parent.com: Adding empty non-terminals for non-DNSSEC zone 'insecure.dnssec-parent.com', 1 updates
Rectifying 2.0.192.in-addr.arpa: Adding NSEC ordering information for zone '2.0.192.in-addr.arpa', 1 updates
Rectifying cryptokeys.org: Adding NSEC ordering information for zone 'cryptokeys.org', 10 updates
Rectifying test.dyndns: Adding NSEC ordering information for zone 'test.dyndns', 5 updates
Rectifying cdnskey-cds-test.com: Adding NSEC ordering information for zone 'cdnskey-cds-test.com', 1 updates
Rectifying sub.test.dyndns: Adding NSEC ordering information for zone 'sub.test.dyndns', 1 updates
Rectifying secure-delegated.dnssec-parent.com: Adding NSEC ordering information for zone 'secure-delegated.dnssec-parent.com', 1 updates
Rectifying tsig.com: Adding NSEC ordering information for zone 'tsig.com', 1 updates
Rectifying delegated.dnssec-parent.com: Adding NSEC ordering information for zone 'delegated.dnssec-parent.com', 2 updates
Rectifying nztest.com: Adding NSEC ordering information for zone 'nztest.com', 7 updates
Rectifying stest.com: Adding NSEC ordering information for zone 'stest.com', 1 updates
Rectified 17 zones.

real	0m0,397s
user	0m0,148s
sys	0m0,030s
```

For NSEC3 the remaining number of updates is even somewhat lower (no update for apex, ect.)

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
