### PR TITLE
rec: More fail-safe handling of NOD files

### DIFF
--- a/pdns/nod.hh
+++ b/pdns/nod.hh
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include <boost/filesystem.hpp>
 #include "dnsname.hh"
 #include "stable-bloom.hh"
 
@@ -59,7 +60,7 @@ namespace nod {
       return d_sbf.testAndAdd(data); 
     }
   private:
-    void remove_tmp_files();
+    void remove_tmp_files(const boost::filesystem::path&, std::lock_guard<std::mutex>&);
 
     bool d_init{false};
     bf::stableBF d_sbf; // Stable Bloom Filter

--- a/pdns/nod.hh
+++ b/pdns/nod.hh
@@ -59,6 +59,8 @@ namespace nod {
       return d_sbf.testAndAdd(data); 
     }
   private:
+    void remove_tmp_files();
+
     bool d_init{false};
     bf::stableBF d_sbf; // Stable Bloom Filter
     std::string d_cachedir;

--- a/pdns/recursordist/stable-bloom.hh
+++ b/pdns/recursordist/stable-bloom.hh
@@ -123,13 +123,12 @@ public:
       throw std::runtime_error("SBF: read failed (file too short?)");
     }
     bitstr_len = ntohl(bitstr_len);
-    char* bitcstr = new char[bitstr_len];
-    is.read((char*)bitcstr, bitstr_len);
+    unique_ptr<char[]> bitcstr = make_unique<char[]>(bitstr_len);
+    is.read(bitcstr.get(), bitstr_len);
     if (is.fail()) {
       throw std::runtime_error("SBF: read failed (file too short?)");
     }
-    std::string bitstr(bitcstr, bitstr_len);
-    delete[] bitcstr;
+    std::string bitstr(bitcstr.get(), bitstr_len);
     stableBF tempbf(k, num_cells, p, bitstr);
     swap(tempbf);
   }

--- a/pdns/recursordist/stable-bloom.hh
+++ b/pdns/recursordist/stable-bloom.hh
@@ -123,6 +123,9 @@ public:
       throw std::runtime_error("SBF: read failed (file too short?)");
     }
     bitstr_len = ntohl(bitstr_len);
+    if (bitstr_len > 2 * 64 * 1024 * 1024U) { // twice the current size
+      throw std::runtime_error("SBF: read failed (bitstr_len too big)");
+    }
     unique_ptr<char[]> bitcstr = make_unique<char[]>(bitstr_len);
     is.read(bitcstr.get(), bitstr_len);
     if (is.fail()) {

--- a/pdns/recursordist/stable-bloom.hh
+++ b/pdns/recursordist/stable-bloom.hh
@@ -106,13 +106,28 @@ public:
     uint8_t k, p;
     uint32_t num_cells, bitstr_len;
     is.read((char*)&k, sizeof(k));
+    if (is.fail()) {
+      throw std::runtime_error("SBF: read failed (file too short?)");
+    }
     is.read((char*)&num_cells, sizeof(num_cells));
+    if (is.fail()) {
+      throw std::runtime_error("SBF: read failed (file too short?)");
+    }
     num_cells = ntohl(num_cells);
     is.read((char*)&p, sizeof(p));
+    if (is.fail()) {
+      throw std::runtime_error("SBF: read failed (file too short?)");
+    }
     is.read((char*)&bitstr_len, sizeof(bitstr_len));
+    if (is.fail()) {
+      throw std::runtime_error("SBF: read failed (file too short?)");
+    }
     bitstr_len = ntohl(bitstr_len);
     char* bitcstr = new char[bitstr_len];
     is.read((char*)bitcstr, bitstr_len);
+    if (is.fail()) {
+      throw std::runtime_error("SBF: read failed (file too short?)");
+    }
     std::string bitstr(bitcstr, bitstr_len);
     delete[] bitcstr;
     stableBF tempbf(k, num_cells, p, bitstr);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Current code does not take into account file operation failures in a safe way.

This PR makes sure we write to a temp file and rename only after a succesful write, plus we do not crash on corrupt files, we remove them.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
