### PR TITLE
Fix typo in dnsdist docs for SuffixMatchNodeRule

### DIFF
--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -699,7 +699,7 @@ These ``DNSRule``\ s be one of the following items:
 
   To match domain names exactly, see :func:`QNameSetRule`.
 
-  :param SuffixMatchNode smb: The SuffixMatchNode to match on
+  :param SuffixMatchNode smn: The SuffixMatchNode to match on
   :param bool quiet: Do not display the list of matched domains in Rules. Default is false.
 
 .. function:: TagRule(name [, value])


### PR DESCRIPTION
### Short description
Fixes typo in dnsdist documentation for SuffixMatchNodeRule param name listing (smb vs smn).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] checked that this code was merged to master
