### PR TITLE
tests: stop using deprecated unittest names

### DIFF
--- a/regression-tests.api/test_Basics.py
+++ b/regression-tests.api/test_Basics.py
@@ -8,11 +8,11 @@ class TestBasics(ApiTestCase):
 
     def test_unauth(self):
         r = requests.get(self.url("/api/v1/servers/localhost"))
-        self.assertEquals(r.status_code, requests.codes.unauthorized)
+        self.assertEqual(r.status_code, requests.codes.unauthorized)
 
     def test_index_html(self):
         r = requests.get(self.url("/"), auth=('admin', self.server_web_password))
-        self.assertEquals(r.status_code, requests.codes.ok)
+        self.assertEqual(r.status_code, requests.codes.ok)
 
     def test_split_request(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -40,9 +40,9 @@ class TestBasics(ApiTestCase):
         r = self.session.options(self.url("/api/v1/servers/localhost"))
         # look for CORS headers
 
-        self.assertEquals(r.status_code, requests.codes.ok)
-        self.assertEquals(r.headers['access-control-allow-origin'], "*")
-        self.assertEquals(r.headers['access-control-allow-headers'], 'Content-Type, X-API-Key')
-        self.assertEquals(r.headers['access-control-allow-methods'], 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
+        self.assertEqual(r.status_code, requests.codes.ok)
+        self.assertEqual(r.headers['access-control-allow-origin'], "*")
+        self.assertEqual(r.headers['access-control-allow-headers'], 'Content-Type, X-API-Key')
+        self.assertEqual(r.headers['access-control-allow-methods'], 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
 
         print("response", repr(r.headers))

--- a/regression-tests.api/test_Cache.py
+++ b/regression-tests.api/test_Cache.py
@@ -17,7 +17,7 @@ class Servers(ApiTestCase):
         self.assert_success_json(r)
         data = r.json()
         self.assertIn('count', data)
-        self.assertEquals(1, data['count'])
+        self.assertEqual(1, data['count'])
 
     @unittest.skipIf(not is_recursor(), "Not applicable")
     def test_flush_subtree(self):
@@ -27,12 +27,12 @@ class Servers(ApiTestCase):
         self.assert_success_json(r)
         data = r.json()
         self.assertIn('count', data)
-        self.assertEquals(1, data['count'])
+        self.assertEqual(1, data['count'])
         r = self.session.put(self.url("/api/v1/servers/localhost/cache/flush?domain=example.com.&subtree=true"))
         self.assert_success_json(r)
         data = r.json()
         self.assertIn('count', data)
-        self.assertEquals(2, data['count'])
+        self.assertEqual(2, data['count'])
 
     def test_flush_root(self):
         r = self.session.put(self.url("/api/v1/servers/localhost/cache/flush?domain=."))
@@ -44,9 +44,9 @@ class Servers(ApiTestCase):
     def test_flush_no_domain(self):
         r = self.session.put(
             self.url("/api/v1/servers/localhost/cache/flush"))
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
 
     def test_flush_unqualified(self):
         r = self.session.put(
             self.url("/api/v1/servers/localhost/cache/flush?domain=bar"))
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)

--- a/regression-tests.api/test_Discovery.py
+++ b/regression-tests.api/test_Discovery.py
@@ -7,4 +7,4 @@ class DiscoveryTest(ApiTestCase):
         r = self.session.get(self.url("/api"))
         self.assert_success_json(r)
         lst = r.json()
-        self.assertEquals(lst, [{'version': 1, 'url': '/api/v1'}])
+        self.assertEqual(lst, [{'version': 1, 'url': '/api/v1'}])

--- a/regression-tests.api/test_RecursorConfig.py
+++ b/regression-tests.api/test_RecursorConfig.py
@@ -19,8 +19,8 @@ class RecursorConfig(ApiTestCase):
         self.assert_success_json(r)
         data = r.json()
         self.assertIn("value", data)
-        self.assertEquals(len(data["value"]), 1)
-        self.assertEquals("127.0.0.1/32", data["value"][0])
+        self.assertEqual(len(data["value"]), 1)
+        self.assertEqual("127.0.0.1/32", data["value"][0])
 
     def test_config_allow_from_replace_error(self):
         """Test the error case, should return 422."""
@@ -29,6 +29,6 @@ class RecursorConfig(ApiTestCase):
             self.url("/api/v1/servers/localhost/config/allow-from"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         data = r.json()
         self.assertIn('Unable to convert', data['error'])

--- a/regression-tests.api/test_Servers.py
+++ b/regression-tests.api/test_Servers.py
@@ -9,11 +9,11 @@ class Servers(ApiTestCase):
         r = self.session.get(self.url("/api/v1/servers"))
         self.assert_success_json(r)
         lst = r.json()
-        self.assertEquals(len(lst), 1)  # only localhost allowed in there
+        self.assertEqual(len(lst), 1)  # only localhost allowed in there
         data = lst[0]
         for k in ('id', 'daemon_type', 'url'):
             self.assertIn(k, data)
-        self.assertEquals(data['id'], 'localhost')
+        self.assertEqual(data['id'], 'localhost')
 
     def test_servers_localhost(self):
         r = self.session.get(self.url("/api/v1/servers/localhost"))
@@ -21,8 +21,8 @@ class Servers(ApiTestCase):
         data = r.json()
         for k in ('id', 'type', 'version', 'daemon_type', 'url', 'zones_url', 'config_url'):
             self.assertIn(k, data)
-        self.assertEquals(data['id'], 'localhost')
-        self.assertEquals(data['type'], 'Server')
+        self.assertEqual(data['id'], 'localhost')
+        self.assertEqual(data['type'], 'Server')
         # or 'recursor' for recursors
         if is_auth():
             daemon_type = 'authoritative'
@@ -30,7 +30,7 @@ class Servers(ApiTestCase):
             daemon_type = 'recursor'
         else:
             raise RuntimeError('Unknown daemon type')
-        self.assertEquals(data['daemon_type'], daemon_type)
+        self.assertEqual(data['daemon_type'], daemon_type)
 
     def test_read_config(self):
         r = self.session.get(self.url("/api/v1/servers/localhost/config"))
@@ -68,7 +68,7 @@ class Servers(ApiTestCase):
 
     def test_read_one_non_existent_statistic(self):
         r = self.session.get(self.url("/api/v1/servers/localhost/statistics?statistic=uptimeAAAA"))
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("Unknown statistic name", r.json()['error'])
 
     def test_read_metrics(self):
@@ -87,5 +87,5 @@ class Servers(ApiTestCase):
     @unittest.skipIf(is_auth(), "Not applicable")
     def test_read_statistics_using_password(self):
         r = requests.get(self.url("/api/v1/servers/localhost/statistics"), auth=('admin', self.server_web_password))
-        self.assertEquals(r.status_code, requests.codes.ok)
+        self.assertEqual(r.status_code, requests.codes.ok)
         self.assert_success_json(r)

--- a/regression-tests.api/test_TSIG.py
+++ b/regression-tests.api/test_TSIG.py
@@ -22,7 +22,7 @@ class AuthTSIGHelperMixin(object):
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
         self.assert_success_json(r)
-        self.assertEquals(r.status_code, 201)
+        self.assertEqual(r.status_code, 201)
         reply = r.json()
         print("reply", reply)
         return name, payload, reply
@@ -38,7 +38,7 @@ class AuthTSIG(ApiTestCase, AuthTSIGHelperMixin):
         for k in ('id', 'name', 'algorithm', 'key', 'type'):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
+                self.assertEqual(data[k], payload[k])
 
     def test_create_key_with_key_data(self):
         """

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -57,7 +57,7 @@ class Zones(ApiTestCase):
         self.assert_success_json(r)
         domains = r.json()
         example_com = [domain for domain in domains if domain['name'] in ('example.com', 'example.com.')]
-        self.assertEquals(len(example_com), 1)
+        self.assertEqual(len(example_com), 1)
         example_com = example_com[0]
         print(example_com)
         required_fields = ['id', 'url', 'name', 'kind']
@@ -65,7 +65,7 @@ class Zones(ApiTestCase):
             required_fields = required_fields + ['masters', 'last_check', 'notified_serial', 'serial', 'account']
             if dnssec:
                 required_fields = required_fields = ['dnssec', 'edited_serial']
-            self.assertNotEquals(example_com['serial'], 0)
+            self.assertNotEqual(example_com['serial'], 0)
             if not dnssec:
                 self.assertNotIn('dnssec', example_com)
         elif is_recursor():
@@ -100,7 +100,7 @@ class AuthZonesHelperMixin(object):
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
         self.assert_success_json(r)
-        self.assertEquals(r.status_code, 201)
+        self.assertEqual(r.status_code, 201)
         reply = r.json()
         print("reply", reply)
         return name, payload, reply
@@ -115,11 +115,11 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'edited_serial', 'soa_edit_api', 'soa_edit', 'account'):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
+                self.assertEqual(data[k], payload[k])
         # validate generated SOA
         expected_soa = "a.misconfigured.dns.server.invalid. hostmaster." + name + " " + \
                        str(payload['serial']) + " 10800 3600 604800 3600"
-        self.assertEquals(
+        self.assertEqual(
             get_first_rec(data, name, 'SOA')['content'],
             expected_soa
         )
@@ -128,7 +128,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             # Because we had confusion about dots, check that the DB is without dots.
             dbrecs = get_db_records(name, 'SOA')
             self.assertEqual(dbrecs[0]['content'], expected_soa.replace('. ', ' '))
-            self.assertNotEquals(data['serial'], data['edited_serial'])
+            self.assertNotEqual(data['serial'], data['edited_serial'])
 
     def test_create_zone_with_soa_edit_api(self):
         # soa_edit_api wins over serial
@@ -136,13 +136,13 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         for k in ('soa_edit_api', ):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
+                self.assertEqual(data[k], payload[k])
         # generated EPOCH serial surely is > fixed serial we passed in
         print(data)
         self.assertGreater(data['serial'], payload['serial'])
         soa_serial = int(get_first_rec(data, name, 'SOA')['content'].split(' ')[2])
         self.assertGreater(soa_serial, payload['serial'])
-        self.assertEquals(soa_serial, data['serial'])
+        self.assertEqual(soa_serial, data['serial'])
 
     def test_create_zone_with_account(self):
         # soa_edit_api wins over serial
@@ -151,12 +151,12 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         for k in ('account', ):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
+                self.assertEqual(data[k], payload[k])
 
     def test_create_zone_default_soa_edit_api(self):
         name, payload, data = self.create_zone()
         print(data)
-        self.assertEquals(data['soa_edit_api'], 'DEFAULT')
+        self.assertEqual(data['soa_edit_api'], 'DEFAULT')
 
     def test_create_zone_exists(self):
         name, payload, data = self.create_zone()
@@ -170,16 +170,16 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 409)  # Conflict - already exists
+        self.assertEqual(r.status_code, 409)  # Conflict - already exists
 
     def test_create_zone_with_soa_edit(self):
         name, payload, data = self.create_zone(soa_edit='INCEPTION-INCREMENT', soa_edit_api='SOA-EDIT-INCREASE')
         print(data)
-        self.assertEquals(data['soa_edit'], 'INCEPTION-INCREMENT')
-        self.assertEquals(data['soa_edit_api'], 'SOA-EDIT-INCREASE')
+        self.assertEqual(data['soa_edit'], 'INCEPTION-INCREMENT')
+        self.assertEqual(data['soa_edit_api'], 'SOA-EDIT-INCREASE')
         soa_serial = get_first_rec(data, name, 'SOA')['content'].split(' ')[2]
         # These particular settings lead to the first serial set to YYYYMMDD01.
-        self.assertEquals(soa_serial[-2:], '01')
+        self.assertEqual(soa_serial[-2:], '01')
         rrset = {
             'changetype': 'replace',
             'name': name,
@@ -200,7 +200,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + data['id']))
         data = r.json()
         soa_serial = get_first_rec(data, name, 'SOA')['content'].split(' ')[2]
-        self.assertEquals(soa_serial[-2:], '02')
+        self.assertEqual(soa_serial[-2:], '02')
 
     def test_create_zone_with_records(self):
         name = unique_zone_name()
@@ -215,7 +215,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         }
         name, payload, data = self.create_zone(name=name, rrsets=[rrset])
         # check our record has appeared
-        self.assertEquals(get_rrset(data, name, 'A')['records'], rrset['records'])
+        self.assertEqual(get_rrset(data, name, 'A')['records'], rrset['records'])
 
     def test_create_zone_with_wildcard_records(self):
         name = unique_zone_name()
@@ -230,7 +230,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         }
         name, payload, data = self.create_zone(name=name, rrsets=[rrset])
         # check our record has appeared
-        self.assertEquals(get_rrset(data, rrset['name'], 'A')['records'], rrset['records'])
+        self.assertEqual(get_rrset(data, rrset['name'], 'A')['records'], rrset['records'])
 
     @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
     def test_create_zone_with_comments(self):
@@ -280,12 +280,12 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
           ]
         name, payload, data = self.create_zone(name=name, rrsets=rrsets)
         # NS records have been created
-        self.assertEquals(len(data['rrsets']), len(rrsets) + 1)
+        self.assertEqual(len(data['rrsets']), len(rrsets) + 1)
         # check our comment has appeared
-        self.assertEquals(get_rrset(data, name, 'SOA')['comments'], rrsets[0]['comments'])
-        self.assertEquals(get_rrset(data, name, 'A')['comments'], [])
-        self.assertEquals(get_rrset(data, name, 'TXT')['comments'], [])
-        self.assertEquals(get_rrset(data, name, 'AAAA')['comments'], rrsets[1]['comments'])
+        self.assertEqual(get_rrset(data, name, 'SOA')['comments'], rrsets[0]['comments'])
+        self.assertEqual(get_rrset(data, name, 'A')['comments'], [])
+        self.assertEqual(get_rrset(data, name, 'TXT')['comments'], [])
+        self.assertEqual(get_rrset(data, name, 'AAAA')['comments'], rrsets[1]['comments'])
 
     def test_create_zone_uncanonical_nameservers(self):
         name = unique_zone_name()
@@ -299,7 +299,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Nameserver is not canonical', r.json()['error'])
 
     def test_create_auth_zone_no_name(self):
@@ -313,7 +313,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('is not canonical', r.json()['error'])
 
     def test_create_zone_with_custom_soa(self):
@@ -329,7 +329,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             }],
         }
         name, payload, data = self.create_zone(name=name, rrsets=[rrset], soa_edit_api='')
-        self.assertEquals(get_rrset(data, name, 'SOA')['records'], rrset['records'])
+        self.assertEqual(get_rrset(data, name, 'SOA')['records'], rrset['records'])
         if not is_auth_lmdb():
             dbrecs = get_db_records(name, 'SOA')
             self.assertEqual(dbrecs[0]['content'], content.replace('. ', ' '))
@@ -346,7 +346,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Unable to parse DNS Name', r.json()['error'])
 
     def test_create_zone_restricted_chars(self):
@@ -361,7 +361,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('contains unsupported characters', r.json()['error'])
 
     def test_create_zone_mixed_nameservers_ns_rrset_zonelevel(self):
@@ -386,7 +386,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Nameservers list MUST NOT be mixed with zone-level NS in rrsets', r.json()['error'])
 
     def test_create_zone_mixed_nameservers_ns_rrset_below_zonelevel(self):
@@ -420,8 +420,8 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial'):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
-        self.assertEquals(data['id'], expected_id)
+                self.assertEqual(data[k], payload[k])
+        self.assertEqual(data['id'], expected_id)
         if not is_auth_lmdb():
             dbrecs = get_db_records(name, 'SOA')
             self.assertEqual(dbrecs[0]['name'], name.rstrip('.'))
@@ -439,7 +439,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
 
     def test_create_zone_with_dnssec(self):
         """
@@ -453,7 +453,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         for k in ('dnssec', ):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
+                self.assertEqual(data[k], payload[k])
 
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name + '/cryptokeys'))
 
@@ -461,11 +461,11 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
 
         print(keys)
 
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(len(keys), 1)
-        self.assertEquals(keys[0]['type'], 'Cryptokey')
-        self.assertEquals(keys[0]['active'], True)
-        self.assertEquals(keys[0]['keytype'], 'csk')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(len(keys), 1)
+        self.assertEqual(keys[0]['type'], 'Cryptokey')
+        self.assertEqual(keys[0]['active'], True)
+        self.assertEqual(keys[0]['keytype'], 'csk')
 
     def test_create_zone_with_dnssec_disable_dnssec(self):
         """
@@ -481,15 +481,15 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
 
         zoneinfo = r.json()
 
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(zoneinfo['dnssec'], False)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(zoneinfo['dnssec'], False)
 
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name + '/cryptokeys'))
 
         keys = r.json()
 
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(len(keys), 0)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(len(keys), 0)
 
     def test_create_zone_with_nsec3param(self):
         """
@@ -504,7 +504,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         for k in ('dnssec', 'nsec3param'):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
+                self.assertEqual(data[k], payload[k])
 
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name + '/metadata/NSEC3PARAM'))
 
@@ -512,10 +512,10 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
 
         print(data)
 
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(len(data['metadata']), 1)
-        self.assertEquals(data['kind'], 'NSEC3PARAM')
-        self.assertEquals(data['metadata'][0], nsec3param)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(len(data['metadata']), 1)
+        self.assertEqual(data['kind'], 'NSEC3PARAM')
+        self.assertEqual(data['metadata'][0], nsec3param)
 
     def test_create_zone_with_nsec3narrow(self):
         """
@@ -531,7 +531,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         for k in ('dnssec', 'nsec3param', 'nsec3narrow'):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
+                self.assertEqual(data[k], payload[k])
 
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name + '/metadata/NSEC3NARROW'))
 
@@ -539,10 +539,10 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
 
         print(data)
 
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(len(data['metadata']), 1)
-        self.assertEquals(data['kind'], 'NSEC3NARROW')
-        self.assertEquals(data['metadata'][0], '1')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(len(data['metadata']), 1)
+        self.assertEqual(data['kind'], 'NSEC3NARROW')
+        self.assertEqual(data['metadata'][0], '1')
 
     def test_create_zone_with_nsec3param_switch_to_nsec(self):
         """
@@ -556,8 +556,8 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             self.url("/api/v1/servers/localhost/zones/" + name))
         data = r.json()
 
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(data['nsec3param'], '')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(data['nsec3param'], '')
 
     def test_create_zone_dnssec_serial(self):
         """
@@ -568,7 +568,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         name, payload, data = self.create_zone()
 
         soa_serial = get_first_rec(data, name, 'SOA')['content'].split(' ')[2]
-        self.assertEquals(soa_serial[-2:], '01')
+        self.assertEqual(soa_serial[-2:], '01')
 
         self.session.put(self.url("/api/v1/servers/localhost/zones/" + name),
                          data=json.dumps({'dnssec': True}))
@@ -577,8 +577,8 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         data = r.json()
         soa_serial = get_first_rec(data, name, 'SOA')['content'].split(' ')[2]
 
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(soa_serial[-2:], '02')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(soa_serial[-2:], '02')
 
         self.session.put(self.url("/api/v1/servers/localhost/zones/" + name),
                          data=json.dumps({'dnssec': False}))
@@ -587,8 +587,8 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         data = r.json()
         soa_serial = get_first_rec(data, name, 'SOA')['content'].split(' ')[2]
 
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(soa_serial[-2:], '03')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(soa_serial[-2:], '03')
 
     def test_zone_absolute_url(self):
         name, payload, data = self.create_zone()
@@ -602,16 +602,16 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         r = self.session.post(self.url("/api/v1/servers/localhost/zones/example.com/metadata"),
                               data=json.dumps(payload_metadata))
         rdata = r.json()
-        self.assertEquals(r.status_code, 201)
-        self.assertEquals(rdata["metadata"], payload_metadata["metadata"])
+        self.assertEqual(r.status_code, 201)
+        self.assertEqual(rdata["metadata"], payload_metadata["metadata"])
 
     def test_create_zone_metadata_kind(self):
         payload_metadata = {"metadata": ["127.0.0.2"]}
         r = self.session.put(self.url("/api/v1/servers/localhost/zones/example.com/metadata/AXFR-SOURCE"),
                              data=json.dumps(payload_metadata))
         rdata = r.json()
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(rdata["metadata"], payload_metadata["metadata"])
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(rdata["metadata"], payload_metadata["metadata"])
 
     def test_create_protected_zone_metadata(self):
         # test whether it prevents modification of certain kinds
@@ -619,7 +619,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
             payload = {"metadata": ["FOO", "BAR"]}
             r = self.session.put(self.url("/api/v1/servers/localhost/zones/example.com/metadata/%s" % k),
                                  data=json.dumps(payload))
-            self.assertEquals(r.status_code, 422)
+            self.assertEqual(r.status_code, 422)
 
     def test_retrieve_zone_metadata(self):
         payload_metadata = {"type": "Metadata", "kind": "AXFR-SOURCE", "metadata": ["127.0.0.2"]}
@@ -627,30 +627,30 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
                           data=json.dumps(payload_metadata))
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/example.com/metadata"))
         rdata = r.json()
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertIn(payload_metadata, rdata)
 
     def test_delete_zone_metadata(self):
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/example.com/metadata/AXFR-SOURCE"))
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/example.com/metadata/AXFR-SOURCE"))
         rdata = r.json()
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(rdata["metadata"], [])
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(rdata["metadata"], [])
 
     def test_create_external_zone_metadata(self):
         payload_metadata = {"metadata": ["My very important message"]}
         r = self.session.put(self.url("/api/v1/servers/localhost/zones/example.com/metadata/X-MYMETA"),
                              data=json.dumps(payload_metadata))
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         rdata = r.json()
-        self.assertEquals(rdata["metadata"], payload_metadata["metadata"])
+        self.assertEqual(rdata["metadata"], payload_metadata["metadata"])
 
     def test_create_metadata_in_non_existent_zone(self):
         payload_metadata = {"type": "Metadata", "kind": "AXFR-SOURCE", "metadata": ["127.0.0.2"]}
         r = self.session.post(self.url("/api/v1/servers/localhost/zones/idonotexist.123.456.example./metadata"),
                               data=json.dumps(payload_metadata))
-        self.assertEquals(r.status_code, 404)
+        self.assertEqual(r.status_code, 404)
         # Note: errors should probably contain json (see #5988)
         # self.assertIn('Could not find domain ', r.json()['error'])
 
@@ -659,7 +659,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         name, payload, data = self.create_zone(kind='Slave', nameservers=None, masters=['127.0.0.2'])
         for k in ('name', 'masters', 'kind'):
             self.assertIn(k, data)
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
         print("payload:", payload)
         print("data:", data)
         # Because slave zones don't get a SOA, we need to test that they'll show up in the zone list.
@@ -673,7 +673,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         print("zone (fetched):", data)
         for k in ('name', 'masters', 'kind'):
             self.assertIn(k, data)
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
         self.assertEqual(data['serial'], 0)
         self.assertEqual(data['rrsets'], [])
 
@@ -683,7 +683,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         r = self.session.get(self.url("/api/v1/servers/localhost/zones?zone=" + name))
         data = r.json()
         print(data)
-        self.assertEquals(data[0]['name'], name)
+        self.assertEqual(data[0]['name'], name)
 
     def test_delete_slave_zone(self):
         name, payload, data = self.create_zone(kind='Slave', nameservers=None, masters=['127.0.0.2'])
@@ -718,7 +718,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'dnssec'):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
+                self.assertEqual(data[k], payload[k])
 
     def test_get_zone(self):
         r = self.session.get(self.url("/api/v1/servers/localhost/zones"))
@@ -729,7 +729,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         data = r.json()
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial'):
             self.assertIn(k, data)
-        self.assertEquals(data['name'], 'example.com.')
+        self.assertEqual(data['name'], 'example.com.')
 
     def test_import_zone_broken(self):
         payload = {
@@ -760,7 +760,7 @@ powerdns-broken.com.           86400   IN      SOA     powerdnssec1.ds9a.nl. ahu
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
 
     def test_import_zone_axfr_outofzone(self):
         # Ensure we don't create out-of-zone records
@@ -779,7 +779,7 @@ example.org.   3600    IN      AAAA    2001:888:2000:1d::2
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertEqual(r.json()['error'], 'RRset example.org. IN AAAA: Name is out of zone')
 
     def test_import_zone_axfr(self):
@@ -921,7 +921,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Conflicts with another RRset', r.json()['error'])
 
     def test_export_zone_json(self):
@@ -972,7 +972,7 @@ $ORIGIN %NAME%
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         for k in payload.keys():
             self.assertIn(k, data)
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
         # update, back to Native and empty(off)
         payload = {
             'kind': 'Native',
@@ -987,7 +987,7 @@ $ORIGIN %NAME%
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         for k in payload.keys():
             self.assertIn(k, data)
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
 
     def test_zone_rr_update(self):
         name, payload, zone = self.create_zone()
@@ -1042,7 +1042,7 @@ $ORIGIN %NAME%
         self.assert_success(r)
         # verify that (only) the new record is there
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
-        self.assertEquals(get_rrset(data, name, 'MX')['records'], rrset['records'])
+        self.assertEqual(get_rrset(data, name, 'MX')['records'], rrset['records'])
 
     def test_zone_rr_update_invalid_mx(self):
         name, payload, zone = self.create_zone()
@@ -1064,7 +1064,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones/" + name),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('non-hostname content', r.json()['error'])
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         self.assertIsNone(get_rrset(data, name, 'MX'))
@@ -1089,7 +1089,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones/" + name),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('OPT: invalid type given', r.json()['error'])
 
     def test_zone_rr_update_multiple_rrsets(self):
@@ -1127,8 +1127,8 @@ $ORIGIN %NAME%
         self.assert_success(r)
         # verify that all rrsets have been updated
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
-        self.assertEquals(get_rrset(data, name, 'NS')['records'], rrset1['records'])
-        self.assertEquals(get_rrset(data, name, 'MX')['records'], rrset2['records'])
+        self.assertEqual(get_rrset(data, name, 'NS')['records'], rrset1['records'])
+        self.assertEqual(get_rrset(data, name, 'MX')['records'], rrset2['records'])
 
     def test_zone_rr_update_duplicate_record(self):
         name, payload, zone = self.create_zone()
@@ -1150,7 +1150,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones/" + name),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Duplicate record in RRset', r.json()['error'])
 
     def test_zone_rr_update_duplicate_rrset(self):
@@ -1184,7 +1184,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones/" + name),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Duplicate RRset', r.json()['error'])
 
     def test_zone_rr_delete(self):
@@ -1232,7 +1232,7 @@ $ORIGIN %NAME%
         self.assert_success(r)
         # verify that (only) the new record is there
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
-        self.assertEquals(get_rrset(data, 'sub.' + name, 'CNAME')['records'], rrset2['records'])
+        self.assertEqual(get_rrset(data, 'sub.' + name, 'CNAME')['records'], rrset2['records'])
 
     def test_zone_disable_reenable(self):
         # This also tests that SOA-EDIT-API works.
@@ -1259,11 +1259,11 @@ $ORIGIN %NAME%
         # check SOA serial has been edited
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         soa_serial1 = get_first_rec(data, name, 'SOA')['content'].split()[2]
-        self.assertNotEquals(soa_serial1, '1')
+        self.assertNotEqual(soa_serial1, '1')
         # make sure domain is still in zone list (disabled SOA!)
         r = self.session.get(self.url("/api/v1/servers/localhost/zones"))
         domains = r.json()
-        self.assertEquals(len([domain for domain in domains if domain['name'] == name]), 1)
+        self.assertEqual(len([domain for domain in domains if domain['name'] == name]), 1)
         # sleep 1sec to ensure the EPOCH value changes for the next request
         time.sleep(1)
         # verify that modifying it still works
@@ -1277,8 +1277,8 @@ $ORIGIN %NAME%
         # check SOA serial has been edited again
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         soa_serial2 = get_first_rec(data, name, 'SOA')['content'].split()[2]
-        self.assertNotEquals(soa_serial2, '1')
-        self.assertNotEquals(soa_serial2, soa_serial1)
+        self.assertNotEqual(soa_serial2, '1')
+        self.assertNotEqual(soa_serial2, soa_serial1)
 
     def test_zone_rr_update_out_of_zone(self):
         name, payload, zone = self.create_zone()
@@ -1300,7 +1300,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones/" + name),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('out of zone', r.json()['error'])
 
     def test_zone_rr_update_restricted_chars(self):
@@ -1323,7 +1323,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones/" + name),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('contains unsupported characters', r.json()['error'])
 
     def test_rrset_unknown_type(self):
@@ -1343,7 +1343,7 @@ $ORIGIN %NAME%
         payload = {'rrsets': [rrset]}
         r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
                                headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('unknown type', r.json()['error'])
 
     @parameterized.expand([
@@ -1366,7 +1366,7 @@ $ORIGIN %NAME%
         payload = {'rrsets': [rrset]}
         r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
                                headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Conflicts with pre-existing RRset', r.json()['error'])
 
     @parameterized.expand([
@@ -1405,7 +1405,7 @@ $ORIGIN %NAME%
         payload = {'rrsets': [rrset]}
         r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
                                headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Conflicts with pre-existing RRset', r.json()['error'])
 
     @parameterized.expand([
@@ -1433,7 +1433,7 @@ $ORIGIN %NAME%
         payload = {'rrsets': [rrset]}
         r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
                                headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('IN ' + qtype + ' has more than one record', r.json()['error'])
 
     def test_rrset_zone_apex(self):
@@ -1520,7 +1520,7 @@ $ORIGIN %NAME%
         payload = {'rrsets': [rrset]}
         r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
                                headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Cannot have both NS and DNAME except in zone apex', r.json()['error'])
 
 ## FIXME: Enable this when it's time for it
@@ -1557,7 +1557,7 @@ $ORIGIN %NAME%
 #        payload = {'rrsets': [rrset]}
 #        r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
 #                               headers={'content-type': 'application/json'})
-#        self.assertEquals(r.status_code, 422)
+#        self.assertEqual(r.status_code, 422)
 #        self.assertIn('You cannot have record(s) under CNAME/DNAME', r.json()['error'])
 
     def test_create_zone_with_leading_space(self):
@@ -1578,7 +1578,7 @@ $ORIGIN %NAME%
         payload = {'rrsets': [rrset]}
         r = self.session.patch(self.url("/api/v1/servers/localhost/zones/" + name), data=json.dumps(payload),
                                headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('Not in expected format', r.json()['error'])
 
     @unittest.skipIf(is_auth_lmdb(), "No out-of-zone storage in LMDB")
@@ -1600,7 +1600,7 @@ $ORIGIN %NAME%
     def test_zone_delete(self):
         name, payload, zone = self.create_zone()
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/" + name))
-        self.assertEquals(r.status_code, 204)
+        self.assertEqual(r.status_code, 204)
         self.assertNotIn('Content-Type', r.headers)
 
     @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
@@ -1633,12 +1633,12 @@ $ORIGIN %NAME%
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         serverset = get_rrset(data, name, 'NS')
         print(serverset)
-        self.assertNotEquals(serverset['records'], [])
-        self.assertNotEquals(serverset['comments'], [])
+        self.assertNotEqual(serverset['records'], [])
+        self.assertNotEqual(serverset['comments'], [])
         # verify that modified_at has been set by pdns
-        self.assertNotEquals([c for c in serverset['comments']][0]['modified_at'], 0)
+        self.assertNotEqual([c for c in serverset['comments']][0]['modified_at'], 0)
         # verify that TTL is correct (regression test)
-        self.assertEquals(serverset['ttl'], 3600)
+        self.assertEqual(serverset['ttl'], 3600)
 
     @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
     def test_zone_comment_delete(self):
@@ -1660,8 +1660,8 @@ $ORIGIN %NAME%
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         serverset = get_rrset(data, name, 'NS')
         print(serverset)
-        self.assertNotEquals(serverset['records'], [])
-        self.assertEquals(serverset['comments'], [])
+        self.assertNotEqual(serverset['records'], [])
+        self.assertEqual(serverset['comments'], [])
 
     @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
     def test_zone_comment_out_of_range_modified_at(self):
@@ -1684,7 +1684,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones/" + name),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("Value for key 'modified_at' is out of range", r.json()['error'])
 
     @unittest.skipIf(is_auth_lmdb(), "No comments in LMDB")
@@ -1733,8 +1733,8 @@ $ORIGIN %NAME%
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name)).json()
         serverset = get_rrset(data, name, 'NS')
         print(serverset)
-        self.assertEquals(serverset['records'], rrset2['records'])
-        self.assertEquals(serverset['comments'], rrset['comments'])
+        self.assertEqual(serverset['records'], rrset2['records'])
+        self.assertEqual(serverset['comments'], rrset['comments'])
 
     @unittest.skipIf(is_auth_lmdb(), "No search in LMDB")
     def test_search_rr_exact_zone(self):
@@ -1764,7 +1764,7 @@ $ORIGIN %NAME%
         r = self.session.get(self.url("/api/v1/servers/localhost/search-data?q=" + name.rstrip('.') + "&object_type=" + data_type))
         self.assert_success_json(r)
         print(r.json())
-        self.assertEquals(r.json(), [
+        self.assertEqual(r.json(), [
             {u'object_type': u'zone', u'name': name, u'zone_id': name},
         ])
 
@@ -1797,7 +1797,7 @@ $ORIGIN %NAME%
         self.assert_success_json(r)
         print(r.json())
         # should return zone, SOA, ns1, ns2
-        self.assertEquals(len(r.json()), 4)
+        self.assertEqual(len(r.json()), 4)
 
     @unittest.skipIf(is_auth_lmdb(), "No search in LMDB")
     def test_search_rr_case_insensitive(self):
@@ -1807,7 +1807,7 @@ $ORIGIN %NAME%
         self.assert_success_json(r)
         print(r.json())
         # should return zone, SOA, ns1, ns2
-        self.assertEquals(len(r.json()), 4)
+        self.assertEqual(len(r.json()), 4)
 
     @unittest.skipIf(is_auth_lmdb(), "No search or comments in LMDB")
     def test_search_rr_comment(self):
@@ -1831,7 +1831,7 @@ $ORIGIN %NAME%
         self.assert_success_json(r)
         data = r.json()
         # should return the AAAA record
-        self.assertEquals(len(data), 1)
+        self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['object_type'], 'comment')
         self.assertEqual(data[0]['type'], 'AAAA')
         self.assertEqual(data[0]['name'], name)
@@ -1856,7 +1856,7 @@ $ORIGIN %NAME%
         self.assert_success_json(r)
         print(r.json())
         # should return zone, SOA, ns1, ns2, sub.sub A (but not the ENT)
-        self.assertEquals(len(r.json()), 5)
+        self.assertEqual(len(r.json()), 5)
 
     @unittest.skipIf(is_auth_lmdb(), "No get_db_records for LMDB")
     def test_default_api_rectify(self):
@@ -1920,7 +1920,7 @@ $ORIGIN %NAME%
         dbrecs = get_db_records(name, 'SOA')
         self.assertIsNone(dbrecs[0]['ordername'])
         r = self.session.put(self.url("/api/v1/servers/localhost/zones/" + data['id'] + "/rectify"))
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         dbrecs = get_db_records(name, 'SOA')
         self.assertIsNotNone(dbrecs[0]['ordername'])
 
@@ -1930,9 +1930,9 @@ $ORIGIN %NAME%
         r = self.session.put(self.url("/api/v1/servers/localhost/zones/" + data['id']),
             data=json.dumps({'kind': 'Slave'}),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
+        self.assertEqual(r.status_code, 204)
         r = self.session.put(self.url("/api/v1/servers/localhost/zones/" + data['id'] + "/rectify"))
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         if not is_auth_lmdb():
             dbrecs = get_db_records(name, 'SOA')
             self.assertIsNotNone(dbrecs[0]['ordername'])
@@ -1954,7 +1954,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones/" + zone['id']),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
+        self.assertEqual(r.status_code, 204)
         rrset = {
             'changetype': 'replace',
             'name': 'sub1.' + name,
@@ -1970,7 +1970,7 @@ $ORIGIN %NAME%
             self.url("/api/v1/servers/localhost/zones/" + zone['id']),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
+        self.assertEqual(r.status_code, 204)
 
     def test_rrset_parameter_post_false(self):
         name = unique_zone_name()
@@ -1985,8 +1985,8 @@ $ORIGIN %NAME%
             headers={'content-type': 'application/json'})
         print(r.json())
         self.assert_success_json(r)
-        self.assertEquals(r.status_code, 201)
-        self.assertEquals(r.json().get('rrsets'), None)
+        self.assertEqual(r.status_code, 201)
+        self.assertEqual(r.json().get('rrsets'), None)
 
     def test_rrset_false_parameter(self):
         name = unique_zone_name()
@@ -1994,7 +1994,7 @@ $ORIGIN %NAME%
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/"+name+"?rrsets=false"))
         self.assert_success_json(r)
         print(r.json())
-        self.assertEquals(r.json().get('rrsets'), None)
+        self.assertEqual(r.json().get('rrsets'), None)
 
     def test_rrset_true_parameter(self):
         name = unique_zone_name()
@@ -2002,13 +2002,13 @@ $ORIGIN %NAME%
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/"+name+"?rrsets=true"))
         self.assert_success_json(r)
         print(r.json())
-        self.assertEquals(len(r.json().get('rrsets')), 2)
+        self.assertEqual(len(r.json().get('rrsets')), 2)
 
     def test_wrong_rrset_parameter(self):
         name = unique_zone_name()
         self.create_zone(name=name, kind='Native')
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/"+name+"?rrsets=foobar"))
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("'rrsets' request parameter value 'foobar' is not supported", r.json()['error'])
 
     def test_put_master_tsig_key_ids_non_existent(self):
@@ -2021,7 +2021,7 @@ $ORIGIN %NAME%
         r = self.session.put(self.url('/api/v1/servers/localhost/zones/' + name),
                              data=json.dumps(payload),
                              headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('A TSIG key with the name', r.json()['error'])
 
     def test_put_slave_tsig_key_ids_non_existent(self):
@@ -2034,7 +2034,7 @@ $ORIGIN %NAME%
         r = self.session.put(self.url('/api/v1/servers/localhost/zones/' + name),
                              data=json.dumps(payload),
                              headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('A TSIG key with the name', r.json()['error'])
 
 
@@ -2051,10 +2051,10 @@ class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):
         for k in ('id', 'url', 'name', 'masters', 'kind', 'last_check', 'notified_serial', 'serial', 'soa_edit_api', 'soa_edit', 'account'):
             self.assertIn(k, data)
             if k in payload:
-                self.assertEquals(data[k], payload[k])
+                self.assertEqual(data[k], payload[k])
         # validate generated SOA
         rec = get_first_rec(data, '.', 'SOA')
-        self.assertEquals(
+        self.assertEqual(
             rec['content'],
             "a.misconfigured.dns.server.invalid. hostmaster. " + str(payload['serial']) +
             " 10800 3600 604800 3600"
@@ -2065,12 +2065,12 @@ class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):
         self.assertIn(payload['name'], [zone['name'] for zone in zonelist])
         # Also test that fetching the zone works.
         print("id:", data['id'])
-        self.assertEquals(data['id'], '=2E')
+        self.assertEqual(data['id'], '=2E')
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + data['id'])).json()
         print("zone (fetched):", data)
         for k in ('name', 'kind'):
             self.assertIn(k, data)
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
         self.assertEqual(data['rrsets'][0]['name'], '.')
 
     def test_update_zone(self):
@@ -2091,7 +2091,7 @@ class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + zone_id)).json()
         for k in payload.keys():
             self.assertIn(k, data)
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
         # update, back to Native and empty(off)
         payload = {
             'kind': 'Native',
@@ -2106,7 +2106,7 @@ class AuthRootZone(ApiTestCase, AuthZonesHelperMixin):
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + zone_id)).json()
         for k in payload.keys():
             self.assertIn(k, data)
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
 
 
 @unittest.skipIf(not is_recursor(), "Not applicable")
@@ -2133,7 +2133,7 @@ class RecursorZones(ApiTestCase):
     def test_create_auth_zone(self):
         payload, data = self.create_zone(kind='Native')
         for k in payload.keys():
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
 
     def test_create_zone_no_name(self):
         payload = {
@@ -2147,7 +2147,7 @@ class RecursorZones(ApiTestCase):
             self.url("/api/v1/servers/localhost/zones"),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn('is not canonical', r.json()['error'])
 
     def test_create_forwarded_zone(self):
@@ -2155,21 +2155,21 @@ class RecursorZones(ApiTestCase):
         # return values are normalized
         payload['servers'][0] += ':53'
         for k in payload.keys():
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
 
     def test_create_forwarded_rd_zone(self):
         payload, data = self.create_zone(name='google.com.', kind='Forwarded', rd=True, servers=['8.8.8.8'])
         # return values are normalized
         payload['servers'][0] += ':53'
         for k in payload.keys():
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
 
     def test_create_auth_zone_with_symbols(self):
         payload, data = self.create_zone(name='foo/bar.'+unique_zone_name(), kind='Native')
         expected_id = (payload['name'].replace('/', '=2F'))
         for k in payload.keys():
-            self.assertEquals(data[k], payload[k])
-        self.assertEquals(data['id'], expected_id)
+            self.assertEqual(data[k], payload[k])
+        self.assertEqual(data['id'], expected_id)
 
     def test_rename_auth_zone(self):
         payload, data = self.create_zone(kind='Native')
@@ -2187,13 +2187,13 @@ class RecursorZones(ApiTestCase):
         self.assert_success(r)
         data = self.session.get(self.url("/api/v1/servers/localhost/zones/" + payload['name'])).json()
         for k in payload.keys():
-            self.assertEquals(data[k], payload[k])
+            self.assertEqual(data[k], payload[k])
 
     def test_zone_delete(self):
         payload, zone = self.create_zone(kind='Native')
         name = payload['name']
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/" + name))
-        self.assertEquals(r.status_code, 204)
+        self.assertEqual(r.status_code, 204)
         self.assertNotIn('Content-Type', r.headers)
 
     def test_search_rr_exact_zone(self):
@@ -2202,7 +2202,7 @@ class RecursorZones(ApiTestCase):
         r = self.session.get(self.url("/api/v1/servers/localhost/search-data?q=" + name))
         self.assert_success_json(r)
         print(r.json())
-        self.assertEquals(r.json(), [{u'type': u'zone', u'name': name, u'zone_id': name}])
+        self.assertEqual(r.json(), [{u'type': u'zone', u'name': name, u'zone_id': name}])
 
     def test_search_rr_substring(self):
         name = 'search-rr-zone.name.'
@@ -2211,7 +2211,7 @@ class RecursorZones(ApiTestCase):
         self.assert_success_json(r)
         print(r.json())
         # should return zone, SOA
-        self.assertEquals(len(r.json()), 2)
+        self.assertEqual(len(r.json()), 2)
 
 @unittest.skipIf(not is_auth(), "Not applicable")
 class AuthZoneKeys(ApiTestCase, AuthZonesHelperMixin):
@@ -2235,7 +2235,7 @@ class AuthZoneKeys(ApiTestCase, AuthZonesHelperMixin):
             u'flags': 257,
             u'published': True,
             u'id': 1}
-        self.assertEquals(key0, expected)
+        self.assertEqual(key0, expected)
 
         keydata = keys[0]['dnskey'].split()
         self.assertEqual(len(keydata), 4)
@@ -2245,8 +2245,8 @@ class AuthZoneKeys(ApiTestCase, AuthZonesHelperMixin):
         r = self.session.post(self.url("/api/v1/servers/localhost/zones/powerdnssec.org./metadata"),
                               data=json.dumps(payload_metadata))
         rdata = r.json()
-        self.assertEquals(r.status_code, 201)
-        self.assertEquals(rdata["metadata"], payload_metadata["metadata"])
+        self.assertEqual(r.status_code, 201)
+        self.assertEqual(rdata["metadata"], payload_metadata["metadata"])
 
         r = self.session.get(
             self.url("/api/v1/servers/localhost/zones/powerdnssec.org./cryptokeys"))
@@ -2255,9 +2255,9 @@ class AuthZoneKeys(ApiTestCase, AuthZonesHelperMixin):
         self.assertGreater(len(keys), 0)
 
         key0 = deepcopy(keys[0])
-        self.assertEquals(len(key0['cds']), 1)
+        self.assertEqual(len(key0['cds']), 1)
         self.assertIn(key0['cds'][0], key0['ds'])
-        self.assertEquals(key0['cds'][0].split()[2], '4')
+        self.assertEqual(key0['cds'][0].split()[2], '4')
         del key0['dnskey']
         del key0['ds']
         del key0['cds']
@@ -2270,10 +2270,10 @@ class AuthZoneKeys(ApiTestCase, AuthZonesHelperMixin):
             u'flags': 257,
             u'published': True,
             u'id': 1}
-        self.assertEquals(key0, expected)
+        self.assertEqual(key0, expected)
 
         keydata = keys[0]['dnskey'].split()
         self.assertEqual(len(keydata), 4)
 
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/powerdnssec.org./metadata/PUBLISH-CDS"))
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)

--- a/regression-tests.api/test_cryptokeys.py
+++ b/regression-tests.api/test_cryptokeys.py
@@ -23,7 +23,7 @@ class Cryptokeys(ApiTestCase):
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
         self.assert_success_json(r)
-        self.assertEquals(r.status_code, 201)
+        self.assertEqual(r.status_code, 201)
 
     def tearDown(self):
         super(Cryptokeys, self).tearDown()
@@ -43,8 +43,8 @@ class Cryptokeys(ApiTestCase):
 
         #checks the status code. I don't know how to test explicit that the backend fail removing a key.
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid))
-        self.assertEquals(r.status_code, 204)
-        self.assertEquals(r.content, b"")
+        self.assertEqual(r.status_code, 204)
+        self.assertEqual(r.content, b"")
 
         # Check that the key is actually deleted
         out = pdnsutil("list-keys", self.zone)
@@ -53,25 +53,25 @@ class Cryptokeys(ApiTestCase):
     def test_get_wrong_zone(self):
         self.keyid = self.add_zone_key()
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/"+self.zone+"fail/cryptokeys/"+self.keyid))
-        self.assertEquals(r.status_code, 404)
+        self.assertEqual(r.status_code, 404)
 
     def test_delete_wrong_id(self):
         self.keyid = self.add_zone_key()
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/1234567"))
-        self.assertEquals(r.status_code, 404)
+        self.assertEqual(r.status_code, 404)
 
     def test_delete_wrong_zone(self):
         self.keyid = self.add_zone_key()
         #checks for not covered zonename
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+self.zone+"fail/cryptokeys/"+self.keyid))
-        self.assertEquals(r.status_code, 404)
+        self.assertEqual(r.status_code, 404)
 
     def test_delete_key_is_gone(self):
         self.keyid = self.add_zone_key()
         self.remove_zone_key(self.keyid)
         #checks for key is gone. Its ok even if no key had to be deleted. Or something went wrong with the backend.
         r = self.session.delete(self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid))
-        self.assertEquals(r.status_code, 404)
+        self.assertEqual(r.status_code, 404)
 
     # Prepares the json object for Post and sends it to the server
     def add_key(self, content='', type='ksk', active='true', algo='', bits=None):
@@ -97,10 +97,10 @@ class Cryptokeys(ApiTestCase):
     def post_helper(self, content='', algo='', bits=None):
         r = self.add_key(content=content, algo=algo, bits=bits)
         self.assert_success_json(r)
-        self.assertEquals(r.status_code, 201)
+        self.assertEqual(r.status_code, 201)
         response = r.json()
         # Only a ksk added, so expected type is csk
-        self.assertEquals(response['keytype'], 'csk')
+        self.assertEqual(response['keytype'], 'csk')
         self.keyid = response['id']
         # Check if the key is actually added
         out = pdnsutil("list-keys", self.zone_nodot)
@@ -138,53 +138,53 @@ class Cryptokeys(ApiTestCase):
     def test_post_wrong_key_format(self):
         r = self.add_key(content="trollololoooolll")
         self.assert_error_json(r)
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("Key could not be parsed. Make sure your key format is correct.",r.json()['error'])
 
     def test_post_wrong_keytype(self):
         r = self.add_key(type='sdfdhhgj')
         self.assert_error_json(r)
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("Invalid keytype",r.json()['error'])
 
     def test_post_wrong_bits_format(self):
         r = self.add_key(bits='sdfdhhgj')
         self.assert_error_json(r)
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("'bits' must be a positive integer value",r.json()['error'])
 
         r = self.add_key(bits='5.5')
         self.assert_error_json(r)
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("'bits' must be a positive integer value",r.json()['error'])
 
         r = self.add_key(bits='-6')
         self.assert_error_json(r)
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("'bits' must be a positive integer value",r.json()['error'])
 
     def test_post_unsupported_algorithm(self):
         r = self.add_key(algo='lkjhgf')
         self.assert_error_json(r)
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("Unknown algorithm:",r.json()['error'])
 
     def test_post_forgot_bits(self):
         r = self.add_key(algo="rsasha256")
         self.assert_error_json(r)
-        self.assertEquals(r.status_code, 422)
+        self.assertEqual(r.status_code, 422)
         self.assertIn("key requires the size (in bits) to be passed", r.json()['error'])
 
     def test_post_wrong_bit_size(self):
         r = self.add_key(algo=10, bits=30)
         self.assert_error_json(r)
-        self.assertEquals(r.status_code,422)
+        self.assertEqual(r.status_code,422)
         self.assertIn("The algorithm does not support the given bit size.", r.json()['error'])
 
     def test_post_can_not_guess_key_size(self):
         r = self.add_key(algo=17)
         self.assert_error_json(r)
-        self.assertEquals(r.status_code,422)
+        self.assertEqual(r.status_code,422)
         self.assertIn("Can not guess key size for algorithm", r.json()['error'])
 
     def test_put_activate_key(self):
@@ -198,8 +198,8 @@ class Cryptokeys(ApiTestCase):
             self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
-        self.assertEquals(r.content, b"")
+        self.assertEqual(r.status_code, 204)
+        self.assertEqual(r.content, b"")
 
         # check if key is activated
         out = pdnsutil("show-zone", self.zone_nodot)
@@ -217,8 +217,8 @@ class Cryptokeys(ApiTestCase):
             self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload2),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
-        self.assertEquals(r.content, b"")
+        self.assertEqual(r.status_code, 204)
+        self.assertEqual(r.content, b"")
 
         # check if key is deactivated
         out = pdnsutil("show-zone", self.zone_nodot)
@@ -237,8 +237,8 @@ class Cryptokeys(ApiTestCase):
             self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
-        self.assertEquals(r.content, b"")
+        self.assertEqual(r.status_code, 204)
+        self.assertEqual(r.content, b"")
 
         # check if key is still deactivated
         out = pdnsutil("show-zone", self.zone_nodot)
@@ -256,8 +256,8 @@ class Cryptokeys(ApiTestCase):
             self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload2),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
-        self.assertEquals(r.content, b"")
+        self.assertEqual(r.status_code, 204)
+        self.assertEqual(r.content, b"")
 
         # check if key is activated
         out = pdnsutil("show-zone", self.zone_nodot)
@@ -274,8 +274,8 @@ class Cryptokeys(ApiTestCase):
             self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
-        self.assertEquals(r.content, b"")
+        self.assertEqual(r.status_code, 204)
+        self.assertEqual(r.content, b"")
 
         # check if key is activated
         out = pdnsutil("show-zone", self.zone_nodot)
@@ -293,8 +293,8 @@ class Cryptokeys(ApiTestCase):
             self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload2),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
-        self.assertEquals(r.content, b"")
+        self.assertEqual(r.status_code, 204)
+        self.assertEqual(r.content, b"")
 
         # check if key is deactivated
         out = pdnsutil("show-zone", self.zone_nodot)
@@ -313,8 +313,8 @@ class Cryptokeys(ApiTestCase):
             self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
-        self.assertEquals(r.content, b"")
+        self.assertEqual(r.status_code, 204)
+        self.assertEqual(r.content, b"")
 
         # check if key is still deactivated
         out = pdnsutil("show-zone", self.zone_nodot)
@@ -332,8 +332,8 @@ class Cryptokeys(ApiTestCase):
             self.url("/api/v1/servers/localhost/zones/"+self.zone+"/cryptokeys/"+self.keyid),
             data=json.dumps(payload2),
             headers={'content-type': 'application/json'})
-        self.assertEquals(r.status_code, 204)
-        self.assertEquals(r.content, b"")
+        self.assertEqual(r.status_code, 204)
+        self.assertEqual(r.content, b"")
 
         # check if key is activated
         out = pdnsutil("show-zone", self.zone_nodot)

--- a/regression-tests.api/test_helper.py
+++ b/regression-tests.api/test_helper.py
@@ -48,11 +48,11 @@ class ApiTestCase(unittest.TestCase):
         except:
             print(result.content)
             raise
-        self.assertEquals(result.headers['Content-Type'], 'application/json')
+        self.assertEqual(result.headers['Content-Type'], 'application/json')
 
     def assert_error_json(self, result):
         self.assertTrue(400 <= result.status_code < 600, "Response has not an error code "+str(result.status_code))
-        self.assertEquals(result.headers['Content-Type'], 'application/json', "Response status code "+str(result.status_code))
+        self.assertEqual(result.headers['Content-Type'], 'application/json', "Response status code "+str(result.status_code))
 
     def assert_success(self, result):
         try:

--- a/regression-tests.auth-py/test_IXFR.py
+++ b/regression-tests.auth-py/test_IXFR.py
@@ -143,7 +143,7 @@ negquery-cache-ttl=60
         for expectedAnswer in expected:
             pos = 0
             for rec in expectedAnswer:
-                self.assertEquals(rec.ttl, answers[answerPos][pos].ttl)
+                self.assertEqual(rec.ttl, answers[answerPos][pos].ttl)
                 pos = pos + 1
             answerPos = answerPos + 1
 
@@ -198,11 +198,11 @@ newrecord.example.        8484    A       192.0.2.42
 
         response = self.sendUDPQuery(query)
 
-        self.assertEquals(expected, response)
+        self.assertEqual(expected, response)
         # check the TTLs
         pos = 0
         for rec in expected.answer:
-            self.assertEquals(rec.ttl, response.answer[pos].ttl)
+            self.assertEqual(rec.ttl, response.answer[pos].ttl)
             pos = pos + 1
 
     def test_b_UDP_SOA_not_loaded(self):
@@ -211,7 +211,7 @@ newrecord.example.        8484    A       192.0.2.42
         expected.set_rcode(dns.rcode.REFUSED)
 
         response = self.sendUDPQuery(query)
-        self.assertEquals(expected, response)
+        self.assertEqual(expected, response)
 
     def test_b_UDP_SOA_not_configured(self):
         query = dns.message.make_query('example3.', 'SOA')
@@ -219,7 +219,7 @@ newrecord.example.        8484    A       192.0.2.42
         expected.set_rcode(dns.rcode.REFUSED)
 
         response = self.sendUDPQuery(query)
-        self.assertEquals(expected, response)
+        self.assertEqual(expected, response)
 
     def test_d_XFR(self):
         self.waitUntilCorrectSerialIsLoaded(8)

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -543,43 +543,43 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         return response
 
     def compareOptions(self, a, b):
-        self.assertEquals(len(a), len(b))
+        self.assertEqual(len(a), len(b))
         for idx in range(len(a)):
-            self.assertEquals(a[idx], b[idx])
+            self.assertEqual(a[idx], b[idx])
 
     def checkMessageNoEDNS(self, expected, received):
-        self.assertEquals(expected, received)
-        self.assertEquals(received.edns, -1)
-        self.assertEquals(len(received.options), 0)
+        self.assertEqual(expected, received)
+        self.assertEqual(received.edns, -1)
+        self.assertEqual(len(received.options), 0)
 
     def checkMessageEDNSWithoutOptions(self, expected, received):
-        self.assertEquals(expected, received)
-        self.assertEquals(received.edns, 0)
-        self.assertEquals(expected.payload, received.payload)
+        self.assertEqual(expected, received)
+        self.assertEqual(received.edns, 0)
+        self.assertEqual(expected.payload, received.payload)
 
     def checkMessageEDNSWithoutECS(self, expected, received, withCookies=0):
-        self.assertEquals(expected, received)
-        self.assertEquals(received.edns, 0)
-        self.assertEquals(expected.payload, received.payload)
-        self.assertEquals(len(received.options), withCookies)
+        self.assertEqual(expected, received)
+        self.assertEqual(received.edns, 0)
+        self.assertEqual(expected.payload, received.payload)
+        self.assertEqual(len(received.options), withCookies)
         if withCookies:
             for option in received.options:
-                self.assertEquals(option.otype, 10)
+                self.assertEqual(option.otype, 10)
         else:
             for option in received.options:
-                self.assertNotEquals(option.otype, 10)
+                self.assertNotEqual(option.otype, 10)
 
     def checkMessageEDNSWithECS(self, expected, received, additionalOptions=0):
-        self.assertEquals(expected, received)
-        self.assertEquals(received.edns, 0)
-        self.assertEquals(expected.payload, received.payload)
-        self.assertEquals(len(received.options), 1 + additionalOptions)
+        self.assertEqual(expected, received)
+        self.assertEqual(received.edns, 0)
+        self.assertEqual(expected.payload, received.payload)
+        self.assertEqual(len(received.options), 1 + additionalOptions)
         hasECS = False
         for option in received.options:
             if option.otype == clientsubnetoption.ASSIGNED_OPTION_CODE:
                 hasECS = True
             else:
-                self.assertNotEquals(additionalOptions, 0)
+                self.assertNotEqual(additionalOptions, 0)
 
         self.compareOptions(expected.options, received.options)
         self.assertTrue(hasECS)

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -35,10 +35,10 @@ class TestAPIBasics(DNSDistTest):
         for path in self._basicOnlyPaths + self._statsPaths:
             url = 'http://127.0.0.1:' + str(self._webServerPort) + path
             r = requests.get(url, auth=('whatever', "evilsecret"), timeout=self._webTimeout)
-            self.assertEquals(r.status_code, 401)
+            self.assertEqual(r.status_code, 401)
             r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout)
             self.assertTrue(r)
-            self.assertEquals(r.status_code, 200)
+            self.assertEqual(r.status_code, 200)
 
     def testXAPIKey(self):
         """
@@ -49,7 +49,7 @@ class TestAPIBasics(DNSDistTest):
             url = 'http://127.0.0.1:' + str(self._webServerPort) + path
             r = requests.get(url, headers=headers, timeout=self._webTimeout)
             self.assertTrue(r)
-            self.assertEquals(r.status_code, 200)
+            self.assertEqual(r.status_code, 200)
 
     def testWrongXAPIKey(self):
         """
@@ -59,7 +59,7 @@ class TestAPIBasics(DNSDistTest):
         for path in self._apiOnlyPaths + self._statsPaths:
             url = 'http://127.0.0.1:' + str(self._webServerPort) + path
             r = requests.get(url, headers=headers, timeout=self._webTimeout)
-            self.assertEquals(r.status_code, 401)
+            self.assertEqual(r.status_code, 401)
 
     def testBasicAuthOnly(self):
         """
@@ -69,7 +69,7 @@ class TestAPIBasics(DNSDistTest):
         for path in self._basicOnlyPaths:
             url = 'http://127.0.0.1:' + str(self._webServerPort) + path
             r = requests.get(url, headers=headers, timeout=self._webTimeout)
-            self.assertEquals(r.status_code, 401)
+            self.assertEqual(r.status_code, 401)
 
     def testAPIKeyOnly(self):
         """
@@ -78,7 +78,7 @@ class TestAPIBasics(DNSDistTest):
         for path in self._apiOnlyPaths:
             url = 'http://127.0.0.1:' + str(self._webServerPort) + path
             r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout)
-            self.assertEquals(r.status_code, 401)
+            self.assertEqual(r.status_code, 401)
 
     def testServersLocalhost(self):
         """
@@ -88,11 +88,11 @@ class TestAPIBasics(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
 
-        self.assertEquals(content['daemon_type'], 'dnsdist')
+        self.assertEqual(content['daemon_type'], 'dnsdist')
 
         rule_groups = ['response-rules', 'cache-hit-response-rules', 'self-answered-response-rules', 'rules']
         for key in ['version', 'acl', 'local', 'servers', 'frontends', 'pools'] + rule_groups:
@@ -141,7 +141,7 @@ class TestAPIBasics(DNSDistTest):
         headers = {'x-api-key': self._webServerAPIKey}
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/idonotexist'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
-        self.assertEquals(r.status_code, 404)
+        self.assertEqual(r.status_code, 404)
 
     def testServersLocalhostConfig(self):
         """
@@ -151,7 +151,7 @@ class TestAPIBasics(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost/config'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         values = {}
@@ -159,7 +159,7 @@ class TestAPIBasics(DNSDistTest):
             for key in ['type', 'name', 'value']:
                 self.assertIn(key, entry)
 
-            self.assertEquals(entry['type'], 'ConfigSetting')
+            self.assertEqual(entry['type'], 'ConfigSetting')
             values[entry['name']] = entry['value']
 
         for key in ['acl', 'control-socket', 'ecs-override', 'ecs-source-prefix-v4',
@@ -183,19 +183,19 @@ class TestAPIBasics(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost/config/allow-from'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         for key in ['type', 'name', 'value']:
             self.assertIn(key, content)
 
-        self.assertEquals(content['name'], 'allow-from')
-        self.assertEquals(content['type'], 'ConfigSetting')
+        self.assertEqual(content['name'], 'allow-from')
+        self.assertEqual(content['type'], 'ConfigSetting')
         acl = content['value']
         expectedACL = ["127.0.0.1/32", "::1/128"]
         acl.sort()
         expectedACL.sort()
-        self.assertEquals(acl, expectedACL)
+        self.assertEqual(acl, expectedACL)
 
     def testServersLocalhostConfigAllowFromPut(self):
         """
@@ -211,7 +211,7 @@ class TestAPIBasics(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost/config/allow-from'
         r = requests.put(url, headers=headers, timeout=self._webTimeout, data=payload)
         self.assertFalse(r)
-        self.assertEquals(r.status_code, 405)
+        self.assertEqual(r.status_code, 405)
 
     def testServersLocalhostStatistics(self):
         """
@@ -221,7 +221,7 @@ class TestAPIBasics(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost/statistics'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         values = {}
@@ -229,7 +229,7 @@ class TestAPIBasics(DNSDistTest):
             self.assertIn('type', entry)
             self.assertIn('name', entry)
             self.assertIn('value', entry)
-            self.assertEquals(entry['type'], 'StatisticItem')
+            self.assertEqual(entry['type'], 'StatisticItem')
             values[entry['name']] = entry['value']
 
         expected = ['responses', 'servfail-responses', 'queries', 'acl-drops',
@@ -260,7 +260,7 @@ class TestAPIBasics(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/jsonstat?command=stats'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
 
@@ -288,7 +288,7 @@ class TestAPIBasics(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/jsonstat?command=dynblocklist'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
         content = r.json()
 
@@ -323,11 +323,11 @@ class TestAPIServerDown(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
 
-        self.assertEquals(content['servers'][0]['latency'], None)
+        self.assertEqual(content['servers'][0]['latency'], None)
 
 class TestAPIWritable(DNSDistTest):
 
@@ -353,14 +353,14 @@ class TestAPIWritable(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost/config/allow-from'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         acl = content['value']
         expectedACL = ["127.0.0.1/32", "::1/128"]
         acl.sort()
         expectedACL.sort()
-        self.assertEquals(acl, expectedACL)
+        self.assertEqual(acl, expectedACL)
 
         newACL = ["192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24"]
         payload = json.dumps({"name": "allow-from",
@@ -368,21 +368,21 @@ class TestAPIWritable(DNSDistTest):
                               "value": newACL})
         r = requests.put(url, headers=headers, timeout=self._webTimeout, data=payload)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         acl = content['value']
         acl.sort()
-        self.assertEquals(acl, newACL)
+        self.assertEqual(acl, newACL)
 
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         acl = content['value']
         acl.sort()
-        self.assertEquals(acl, newACL)
+        self.assertEqual(acl, newACL)
 
         configFile = self._APIWriteDir + '/' + 'acl.conf'
         self.assertTrue(os.path.isfile(configFile))
@@ -391,7 +391,7 @@ class TestAPIWritable(DNSDistTest):
             header = f.readline()
             body = f.readline()
 
-        self.assertEquals(header, """-- Generated by the REST API, DO NOT EDIT\n""")
+        self.assertEqual(header, """-- Generated by the REST API, DO NOT EDIT\n""")
 
         self.assertIn(body, {
             """setACL({"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24"})\n""",
@@ -433,8 +433,8 @@ class TestAPICustomHeaders(DNSDistTest):
 
         r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(r.headers.get('x-custom'), "custom")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.headers.get('x-custom'), "custom")
         self.assertFalse("x-frame-options" in r.headers)
 
     def testBasicHeadersUpdate(self):
@@ -446,8 +446,8 @@ class TestAPICustomHeaders(DNSDistTest):
         self.sendConsoleCommand('setWebserverConfig({customHeaders={["x-powered-by"]="dnsdist"}})')
         r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(r.headers.get('x-powered-by'), "dnsdist")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.headers.get('x-powered-by'), "dnsdist")
         self.assertTrue("x-frame-options" in r.headers)
 
 class TestStatsWithoutAuthentication(DNSDistTest):
@@ -483,30 +483,30 @@ class TestStatsWithoutAuthentication(DNSDistTest):
 
             r = requests.get(url, timeout=self._webTimeout)
             self.assertTrue(r)
-            self.assertEquals(r.status_code, 200)
+            self.assertEqual(r.status_code, 200)
 
         # these should still require basic authentication
         for path in [self._basicOnlyPath]:
             url = 'http://127.0.0.1:' + str(self._webServerPort) + path
 
             r = requests.get(url, timeout=self._webTimeout)
-            self.assertEquals(r.status_code, 401)
+            self.assertEqual(r.status_code, 401)
 
             r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout)
             self.assertTrue(r)
-            self.assertEquals(r.status_code, 200)
+            self.assertEqual(r.status_code, 200)
 
         # these should still require API authentication
         for path in [self._apiOnlyPath]:
             url = 'http://127.0.0.1:' + str(self._webServerPort) + path
 
             r = requests.get(url, timeout=self._webTimeout)
-            self.assertEquals(r.status_code, 401)
+            self.assertEqual(r.status_code, 401)
 
             headers = {'x-api-key': self._webServerAPIKey}
             r = requests.get(url, headers=headers, timeout=self._webTimeout)
             self.assertTrue(r)
-            self.assertEquals(r.status_code, 200)
+            self.assertEqual(r.status_code, 200)
 
 class TestAPIAuth(DNSDistTest):
 
@@ -542,11 +542,11 @@ class TestAPIAuth(DNSDistTest):
 
         r = requests.get(url, auth=('whatever', self._webServerBasicAuthPasswordNew), timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
         # Make sure the old password is not usable any more
         r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout)
-        self.assertEquals(r.status_code, 401)
+        self.assertEqual(r.status_code, 401)
 
     def testXAPIKeyChange(self):
         """
@@ -559,12 +559,12 @@ class TestAPIAuth(DNSDistTest):
         headers = {'x-api-key': self._webServerAPIKeyNew}
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
         # Make sure the old password is not usable any more
         headers = {'x-api-key': self._webServerAPIKey}
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
-        self.assertEquals(r.status_code, 401)
+        self.assertEqual(r.status_code, 401)
 
     def testBasicAuthOnlyChange(self):
         """
@@ -577,13 +577,13 @@ class TestAPIAuth(DNSDistTest):
         headers = {'x-api-key': self._webServerAPIKeyNew}
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
         # now disable apiKey
         self.sendConsoleCommand('setWebserverConfig({apiKey=""})')
 
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
-        self.assertEquals(r.status_code, 401)
+        self.assertEqual(r.status_code, 401)
 
 class TestAPIACL(DNSDistTest):
 
@@ -620,7 +620,7 @@ class TestAPIACL(DNSDistTest):
 
         r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
 class TestCustomLuaEndpoint(DNSDistTest):
 
@@ -676,9 +676,9 @@ class TestCustomLuaEndpoint(DNSDistTest):
         headers = {'customheader': 'foobar'}
         r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout, headers=headers)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(r.content, b'It works!')
-        self.assertEquals(r.headers.get('foo'), "Bar")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.content, b'It works!')
+        self.assertEqual(r.headers.get('foo'), "Bar")
 
 class TestWebConcurrentConnectionsL(DNSDistTest):
 
@@ -719,4 +719,4 @@ class TestWebConcurrentConnectionsL(DNSDistTest):
         # this should work
         r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -40,8 +40,8 @@ class TestAdvancedAllow(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testAdvancedAllowDropped(self):
         """
@@ -55,7 +55,7 @@ class TestAdvancedAllow(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
 class TestAdvancedFixupCase(DNSDistTest):
 
@@ -92,8 +92,8 @@ class TestAdvancedFixupCase(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(expectedResponse, receivedResponse)
 
 class TestAdvancedRemoveRD(DNSDistTest):
 
@@ -128,8 +128,8 @@ class TestAdvancedRemoveRD(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = expectedQuery.id
-            self.assertEquals(expectedQuery, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(expectedQuery, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testAdvancedKeepRD(self):
         """
@@ -155,8 +155,8 @@ class TestAdvancedRemoveRD(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 class TestAdvancedAddCD(DNSDistTest):
 
@@ -192,8 +192,8 @@ class TestAdvancedAddCD(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = expectedQuery.id
-            self.assertEquals(expectedQuery, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(expectedQuery, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testAdvancedSetCDViaAction(self):
         """
@@ -221,8 +221,8 @@ class TestAdvancedAddCD(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = expectedQuery.id
-            self.assertEquals(expectedQuery, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(expectedQuery, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testAdvancedKeepNoCD(self):
         """
@@ -248,8 +248,8 @@ class TestAdvancedAddCD(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 class TestAdvancedClearRD(DNSDistTest):
 
@@ -285,8 +285,8 @@ class TestAdvancedClearRD(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = expectedQuery.id
-            self.assertEquals(expectedQuery, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(expectedQuery, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testAdvancedClearRDViaAction(self):
         """
@@ -314,8 +314,8 @@ class TestAdvancedClearRD(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = expectedQuery.id
-            self.assertEquals(expectedQuery, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(expectedQuery, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testAdvancedKeepRD(self):
         """
@@ -341,8 +341,8 @@ class TestAdvancedClearRD(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 
 class TestAdvancedACL(DNSDistTest):
@@ -366,7 +366,7 @@ class TestAdvancedACL(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
 class TestAdvancedDelay(DNSDistTest):
 
@@ -397,16 +397,16 @@ class TestAdvancedDelay(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         end = datetime.now()
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertTrue((end - begin) > timedelta(0, 1))
 
         begin = datetime.now()
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         end = datetime.now()
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertTrue((end - begin) < timedelta(0, 1))
 
 
@@ -443,14 +443,14 @@ class TestAdvancedTruncateAnyAndTCP(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         expectedResponse = dns.message.make_response(query)
         expectedResponse.flags |= dns.flags.TC
 
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
 class TestAdvancedAndNot(DNSDistTest):
 
@@ -483,8 +483,8 @@ class TestAdvancedAndNot(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
     def testAOverUDPReturnsNotImplemented(self):
         """
@@ -504,7 +504,7 @@ class TestAdvancedAndNot(DNSDistTest):
         expectedResponse.set_rcode(dns.rcode.NOTIMP)
 
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         response = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name,
@@ -518,8 +518,8 @@ class TestAdvancedAndNot(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
 class TestAdvancedOr(DNSDistTest):
 
@@ -551,14 +551,14 @@ class TestAdvancedOr(DNSDistTest):
         expectedResponse.set_rcode(dns.rcode.NOTIMP)
 
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
     def testAOverUDPReturnsNotImplemented(self):
         """
@@ -579,7 +579,7 @@ class TestAdvancedOr(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 
 class TestAdvancedLogAction(DNSDistTest):
@@ -609,8 +609,8 @@ class TestAdvancedLogAction(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         self.assertTrue(os.path.isfile('dnsdist.log'))
         self.assertTrue(os.stat('dnsdist.log').st_size > 0)
@@ -643,13 +643,13 @@ class TestAdvancedDNSSEC(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(doquery, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
 class TestAdvancedQClass(DNSDistTest):
 
@@ -668,7 +668,7 @@ class TestAdvancedQClass(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
     def testAdvancedQClassINAllow(self):
         """
@@ -691,8 +691,8 @@ class TestAdvancedQClass(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 class TestAdvancedOpcode(DNSDistTest):
 
@@ -712,7 +712,7 @@ class TestAdvancedOpcode(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
     def testAdvancedOpcodeUpdateINAllow(self):
         """
@@ -736,8 +736,8 @@ class TestAdvancedOpcode(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 class TestAdvancedNonTerminalRule(DNSDistTest):
 
@@ -773,8 +773,8 @@ class TestAdvancedNonTerminalRule(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = expectedQuery.id
-            self.assertEquals(expectedQuery, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(expectedQuery, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 class TestAdvancedStringOnlyServer(DNSDistTest):
 
@@ -802,8 +802,8 @@ class TestAdvancedStringOnlyServer(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 class TestAdvancedRestoreFlagsOnSelfResponse(DNSDistTest):
 
@@ -838,7 +838,7 @@ class TestAdvancedRestoreFlagsOnSelfResponse(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(response, receivedResponse)
 
 class TestAdvancedQPS(DNSDistTest):
 
@@ -868,12 +868,12 @@ class TestAdvancedQPS(DNSDistTest):
         for _ in range(maxQPS):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # we should now be dropped
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         time.sleep(1)
 
@@ -881,12 +881,12 @@ class TestAdvancedQPS(DNSDistTest):
         for _ in range(maxQPS):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
 class TestAdvancedQPSNone(DNSDistTest):
 
@@ -913,7 +913,7 @@ class TestAdvancedQPSNone(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestAdvancedNMGRule(DNSDistTest):
 
@@ -940,7 +940,7 @@ class TestAdvancedNMGRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestDSTPortRule(DNSDistTest):
 
@@ -967,7 +967,7 @@ class TestDSTPortRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestAdvancedLabelsCountRule(DNSDistTest):
 
@@ -997,8 +997,8 @@ class TestAdvancedLabelsCountRule(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # more than 6 labels, the query should be refused
         name = 'not.ok.labelscount.advanced.tests.powerdns.com.'
@@ -1010,7 +1010,7 @@ class TestAdvancedLabelsCountRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
         # less than 5 labels, the query should be refused
         name = 'labelscountadvanced.tests.powerdns.com.'
@@ -1022,7 +1022,7 @@ class TestAdvancedLabelsCountRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestAdvancedWireLengthRule(DNSDistTest):
 
@@ -1051,8 +1051,8 @@ class TestAdvancedWireLengthRule(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # too short, the query should be refused
         name = 'short.qnamewirelength.advanced.tests.powerdns.com.'
@@ -1064,7 +1064,7 @@ class TestAdvancedWireLengthRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
         # too long, the query should be refused
         name = 'toolongtobevalid.qnamewirelength.advanced.tests.powerdns.com.'
@@ -1076,7 +1076,7 @@ class TestAdvancedWireLengthRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestAdvancedIncludeDir(DNSDistTest):
 
@@ -1106,8 +1106,8 @@ class TestAdvancedIncludeDir(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # this one should be refused
         name = 'notincludedir.advanced.tests.powerdns.com.'
@@ -1119,7 +1119,7 @@ class TestAdvancedIncludeDir(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestAdvancedLuaDO(DNSDistTest):
 
@@ -1158,8 +1158,8 @@ class TestAdvancedLuaDO(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
         # with DO
         for method in ("sendUDPQuery", "sendTCPQuery"):
@@ -1167,7 +1167,7 @@ class TestAdvancedLuaDO(DNSDistTest):
             (_, receivedResponse) = sender(queryWithDO, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
             doResponse.id = receivedResponse.id
-            self.assertEquals(receivedResponse, doResponse)
+            self.assertEqual(receivedResponse, doResponse)
 
 class TestAdvancedLuaRefused(DNSDistTest):
 
@@ -1200,7 +1200,7 @@ class TestAdvancedLuaRefused(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
             refusedResponse.id = receivedResponse.id
-            self.assertEquals(receivedResponse, refusedResponse)
+            self.assertEqual(receivedResponse, refusedResponse)
 
 class TestAdvancedLuaActionReturnSyntax(DNSDistTest):
 
@@ -1233,7 +1233,7 @@ class TestAdvancedLuaActionReturnSyntax(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
             refusedResponse.id = receivedResponse.id
-            self.assertEquals(receivedResponse, refusedResponse)
+            self.assertEqual(receivedResponse, refusedResponse)
 
 class TestAdvancedLuaTruncated(DNSDistTest):
 
@@ -1270,15 +1270,15 @@ class TestAdvancedLuaTruncated(DNSDistTest):
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
         self.assertTrue(receivedResponse)
         truncatedResponse.id = receivedResponse.id
-        self.assertEquals(receivedResponse, truncatedResponse)
+        self.assertEqual(receivedResponse, truncatedResponse)
 
         # no truncation over TCP
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
 class TestStatNodeRespRingSince(DNSDistTest):
 
@@ -1314,14 +1314,14 @@ class TestStatNodeRespRingSince(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         self.sendConsoleCommand("nodesSeen = {}")
         self.sendConsoleCommand("statNodeRespRing(visitor)")
         nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
         nodes = nodes.strip("\n")
-        self.assertEquals(nodes, """statnodesince.advanced.tests.powerdns.com.
+        self.assertEqual(nodes, """statnodesince.advanced.tests.powerdns.com.
 advanced.tests.powerdns.com.
 tests.powerdns.com.
 powerdns.com.
@@ -1331,7 +1331,7 @@ com.""")
         self.sendConsoleCommand("statNodeRespRing(visitor, 0)")
         nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
         nodes = nodes.strip("\n")
-        self.assertEquals(nodes, """statnodesince.advanced.tests.powerdns.com.
+        self.assertEqual(nodes, """statnodesince.advanced.tests.powerdns.com.
 advanced.tests.powerdns.com.
 tests.powerdns.com.
 powerdns.com.
@@ -1343,7 +1343,7 @@ com.""")
         self.sendConsoleCommand("statNodeRespRing(visitor)")
         nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
         nodes = nodes.strip("\n")
-        self.assertEquals(nodes, """statnodesince.advanced.tests.powerdns.com.
+        self.assertEqual(nodes, """statnodesince.advanced.tests.powerdns.com.
 advanced.tests.powerdns.com.
 tests.powerdns.com.
 powerdns.com.
@@ -1353,13 +1353,13 @@ com.""")
         self.sendConsoleCommand("statNodeRespRing(visitor, 5)")
         nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
         nodes = nodes.strip("\n")
-        self.assertEquals(nodes, """""")
+        self.assertEqual(nodes, """""")
 
         self.sendConsoleCommand("nodesSeen = {}")
         self.sendConsoleCommand("statNodeRespRing(visitor, 10)")
         nodes = self.sendConsoleCommand("str = '' for key,value in pairs(nodesSeen) do str = str..value..\"\\n\" end return str")
         nodes = nodes.strip("\n")
-        self.assertEquals(nodes, """statnodesince.advanced.tests.powerdns.com.
+        self.assertEqual(nodes, """statnodesince.advanced.tests.powerdns.com.
 advanced.tests.powerdns.com.
 tests.powerdns.com.
 powerdns.com.
@@ -1385,7 +1385,7 @@ class TestAdvancedRD(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testAdvancedNoRDAllowed(self):
         """
@@ -1400,8 +1400,8 @@ class TestAdvancedRD(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
 class TestAdvancedGetLocalPort(DNSDistTest):
 
@@ -1434,7 +1434,7 @@ class TestAdvancedGetLocalPort(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
 class TestAdvancedGetLocalPortOnAnyBind(DNSDistTest):
 
@@ -1468,7 +1468,7 @@ class TestAdvancedGetLocalPortOnAnyBind(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
 class TestAdvancedGetLocalAddressOnAnyBind(DNSDistTest):
 
@@ -1505,7 +1505,7 @@ class TestAdvancedGetLocalAddressOnAnyBind(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
 class TestAdvancedLuaTempFailureTTL(DNSDistTest):
 
@@ -1548,8 +1548,8 @@ class TestAdvancedLuaTempFailureTTL(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
 class TestAdvancedEDNSOptionRule(DNSDistTest):
 
@@ -1571,7 +1571,7 @@ class TestAdvancedEDNSOptionRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
     def testReplied(self):
         """
@@ -1591,8 +1591,8 @@ class TestAdvancedEDNSOptionRule(DNSDistTest):
             self.assertTrue(receivedResponse)
 
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
         # and with no EDNS at all
         query = dns.message.make_query(name, 'A', 'IN', use_edns=False)
@@ -1605,8 +1605,8 @@ class TestAdvancedEDNSOptionRule(DNSDistTest):
             self.assertTrue(receivedResponse)
 
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
 class TestAdvancedAllowHeaderOnly(DNSDistTest):
 
@@ -1630,8 +1630,8 @@ class TestAdvancedAllowHeaderOnly(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
     def testHeaderOnlyNoErrorResponse(self):
         """
@@ -1647,8 +1647,8 @@ class TestAdvancedAllowHeaderOnly(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
     def testHeaderOnlyNXDResponse(self):
         """
@@ -1665,8 +1665,8 @@ class TestAdvancedAllowHeaderOnly(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
 class TestAdvancedEDNSVersionRule(DNSDistTest):
 
@@ -1690,7 +1690,7 @@ class TestAdvancedEDNSVersionRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testNoEDNS0Pass(self):
         """
@@ -1706,8 +1706,8 @@ class TestAdvancedEDNSVersionRule(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
     def testReplied(self):
         """
@@ -1723,8 +1723,8 @@ class TestAdvancedEDNSVersionRule(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
 class TestSetRules(DNSDistTest):
 
@@ -1760,7 +1760,7 @@ class TestSetRules(DNSDistTest):
 
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
         # clear all the rules, we should not be spoofing and get a SERVFAIL from the responder instead
         self.sendConsoleCommand("clearRules()")
@@ -1773,7 +1773,7 @@ class TestSetRules(DNSDistTest):
 
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
         # insert a new spoofing rule
         self.sendConsoleCommand("setRules({ newRuleAction(AllRule(), SpoofAction(\"192.0.2.2\")) })")
@@ -1791,7 +1791,7 @@ class TestSetRules(DNSDistTest):
 
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
 class TestAdvancedContinueAction(DNSDistTest):
 
@@ -1818,8 +1818,8 @@ class TestAdvancedContinueAction(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
-            self.assertEquals(receivedQuery, expectedQuery)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedQuery, expectedQuery)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testNoContinue(self):
         """
@@ -1839,8 +1839,8 @@ class TestAdvancedContinueAction(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             expectedQuery.id = receivedQuery.id
-            self.assertEquals(receivedQuery, expectedQuery)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedQuery, expectedQuery)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestAdvancedNegativeAndSOA(DNSDistTest):
 
@@ -1970,7 +1970,7 @@ class TestAdvancedLuaRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, notimplResponse)
+            self.assertEqual(receivedResponse, notimplResponse)
 
         name = 'not-lua-rule.advanced.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
@@ -1982,7 +1982,7 @@ class TestAdvancedLuaRule(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, refusedResponse)
+            self.assertEqual(receivedResponse, refusedResponse)
 
 class TestAdvancedLuaFFI(DNSDistTest):
 
@@ -2110,7 +2110,7 @@ class TestAdvancedLuaFFI(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
     def testAdvancedLuaFFIUpdate(self):
         """
@@ -2128,7 +2128,7 @@ class TestAdvancedLuaFFI(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
 class TestAdvancedDropEmptyQueries(DNSDistTest):
 
@@ -2147,4 +2147,4 @@ class TestAdvancedDropEmptyQueries(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)

--- a/regression-tests.dnsdist/test_Basics.py
+++ b/regression-tests.dnsdist/test_Basics.py
@@ -32,7 +32,7 @@ class TestBasics(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
     def testAWithECS(self):
         """
@@ -54,8 +54,8 @@ class TestBasics(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testSimpleA(self):
         """
@@ -77,8 +77,8 @@ class TestBasics(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testAnyIsTruncated(self):
         """
@@ -96,7 +96,7 @@ class TestBasics(DNSDistTest):
         expectedResponse.flags |= dns.flags.TC
 
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         response = dns.message.make_response(query)
         rrset = dns.rrset.from_text(name,
@@ -111,8 +111,8 @@ class TestBasics(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
     def testTruncateTC(self):
         """
@@ -139,13 +139,13 @@ class TestBasics(DNSDistTest):
 
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(expectedResponse.flags, receivedResponse.flags)
-        self.assertEquals(expectedResponse.question, receivedResponse.question)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(expectedResponse.flags, receivedResponse.flags)
+        self.assertEqual(expectedResponse.question, receivedResponse.question)
         self.assertFalse(response.answer == receivedResponse.answer)
-        self.assertEquals(len(receivedResponse.answer), 0)
-        self.assertEquals(len(receivedResponse.authority), 0)
-        self.assertEquals(len(receivedResponse.additional), 0)
+        self.assertEqual(len(receivedResponse.answer), 0)
+        self.assertEqual(len(receivedResponse.authority), 0)
+        self.assertEqual(len(receivedResponse.additional), 0)
         self.checkMessageNoEDNS(expectedResponse, receivedResponse)
 
     def testTruncateTCEDNS(self):
@@ -177,18 +177,18 @@ class TestBasics(DNSDistTest):
 
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response.flags, receivedResponse.flags)
-        self.assertEquals(response.question, receivedResponse.question)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response.flags, receivedResponse.flags)
+        self.assertEqual(response.question, receivedResponse.question)
         self.assertFalse(response.answer == receivedResponse.answer)
-        self.assertEquals(len(receivedResponse.answer), 0)
-        self.assertEquals(len(receivedResponse.authority), 0)
-        self.assertEquals(len(receivedResponse.additional), 0)
+        self.assertEqual(len(receivedResponse.answer), 0)
+        self.assertEqual(len(receivedResponse.authority), 0)
+        self.assertEqual(len(receivedResponse.additional), 0)
         print(expectedResponse)
         print(receivedResponse)
         self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
         self.assertFalse(receivedResponse.ednsflags & dns.flags.DO)
-        self.assertEquals(receivedResponse.payload, 4242)
+        self.assertEqual(receivedResponse.payload, 4242)
 
     def testRegexReturnsRefused(self):
         """
@@ -208,7 +208,7 @@ class TestBasics(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testQNameReturnsSpoofed(self):
         """
@@ -231,7 +231,7 @@ class TestBasics(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testDomainAndQTypeReturnsNotImplemented(self):
         """
@@ -251,7 +251,7 @@ class TestBasics(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testDomainWithoutQTypeIsNotAffected(self):
         """
@@ -278,8 +278,8 @@ class TestBasics(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testOtherDomainANDQTypeIsNotAffected(self):
         """
@@ -306,8 +306,8 @@ class TestBasics(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testWrongResponse(self):
         """
@@ -335,9 +335,9 @@ class TestBasics(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, unrelatedResponse)
             self.assertTrue(receivedQuery)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
+            self.assertEqual(query, receivedQuery)
 
     def testHeaderOnlyRefused(self):
         """
@@ -354,8 +354,8 @@ class TestBasics(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
     def testHeaderOnlyNoErrorResponse(self):
         """
@@ -371,8 +371,8 @@ class TestBasics(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, None)
 
     def testHeaderOnlyNXDResponse(self):
         """
@@ -389,8 +389,8 @@ class TestBasics(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response)
             self.assertTrue(receivedQuery)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, None)
 
     def testAddActionDNSName(self):
         """
@@ -405,7 +405,7 @@ class TestBasics(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testAddActionDNSNames(self):
         """
@@ -420,7 +420,7 @@ class TestBasics(DNSDistTest):
             for method in ("sendUDPQuery", "sendTCPQuery"):
                 sender = getattr(self, method)
                 (_, receivedResponse) = sender(query, response=None, useQueue=False)
-                self.assertEquals(receivedResponse, expectedResponse)
+                self.assertEqual(receivedResponse, expectedResponse)
 
     def testEmptyQueries(self):
         """
@@ -435,4 +435,4 @@ class TestBasics(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)

--- a/regression-tests.dnsdist/test_CDB.py
+++ b/regression-tests.dnsdist/test_CDB.py
@@ -86,7 +86,7 @@ class TestCDBSimple(CDBTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testCDBQNamePlusTagLookup(self):
         """
@@ -109,7 +109,7 @@ class TestCDBSimple(CDBTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testCDBSuffixLookup(self):
         """
@@ -132,7 +132,7 @@ class TestCDBSimple(CDBTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
 class TestCDBReload(CDBTest):
 
@@ -172,7 +172,7 @@ class TestCDBReload(CDBTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
         # switch to the second DB which has no entry for 127.0.0.1
         shutil.copyfile('kvs.cdb.2', self._cdbFileName)
@@ -193,4 +193,4 @@ class TestCDBReload(CDBTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)

--- a/regression-tests.dnsdist/test_CacheHitResponses.py
+++ b/regression-tests.dnsdist/test_CacheHitResponses.py
@@ -33,13 +33,13 @@ class TestCacheHitResponses(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         # now the result should be cached, and so dropped
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
         print(receivedResponse)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         time.sleep(ttl + 1)
 
@@ -48,15 +48,15 @@ class TestCacheHitResponses(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCacheHitResponses._responsesCounter[key] = 0
 
-        self.assertEquals(total, 2)
+        self.assertEqual(total, 2)
 
         # TCP should not be cached
         # first query to fill the cache
@@ -64,12 +64,12 @@ class TestCacheHitResponses(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         # now the result should be cached, and so dropped
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         time.sleep(ttl + 1)
 
@@ -78,12 +78,12 @@ class TestCacheHitResponses(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCacheHitResponses._responsesCounter[key] = 0
 
-        self.assertEquals(total, 2)
+        self.assertEqual(total, 2)

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -45,19 +45,19 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEquals(total, 1)
+        self.assertEqual(total, 1)
 
         # TCP should not be cached
         # first query to fill the cache
@@ -65,19 +65,19 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEquals(total, 1)
+        self.assertEqual(total, 1)
 
     def testDOCached(self):
         """
@@ -103,19 +103,19 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEquals(total, 1)
+        self.assertEqual(total, 1)
 
         # TCP should not be cached
         # first query to fill the cache
@@ -123,19 +123,19 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEquals(total, 1)
+        self.assertEqual(total, 1)
 
     def testSkipCache(self):
         """
@@ -162,12 +162,12 @@ class TestCaching(DNSDistTest):
                 self.assertTrue(receivedQuery)
                 self.assertTrue(receivedResponse)
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(receivedResponse, response)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(receivedResponse, response)
 
         for key in self._responsesCounter:
             value = self._responsesCounter[key]
-            self.assertEquals(value, numberOfQueries)
+            self.assertEqual(value, numberOfQueries)
 
     def testSkipCacheViaLua(self):
         """
@@ -194,12 +194,12 @@ class TestCaching(DNSDistTest):
                 self.assertTrue(receivedQuery)
                 self.assertTrue(receivedResponse)
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(receivedResponse, response)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(receivedResponse, response)
 
         for key in self._responsesCounter:
             value = self._responsesCounter[key]
-            self.assertEquals(value, numberOfQueries)
+            self.assertEqual(value, numberOfQueries)
 
     def testSkipCacheResponse(self):
         """
@@ -226,12 +226,12 @@ class TestCaching(DNSDistTest):
                 self.assertTrue(receivedQuery)
                 self.assertTrue(receivedResponse)
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(receivedResponse, response)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(receivedResponse, response)
 
         for key in self._responsesCounter:
             value = self._responsesCounter[key]
-            self.assertEquals(value, numberOfQueries)
+            self.assertEqual(value, numberOfQueries)
 
     def testCacheExpiration(self):
         """
@@ -259,13 +259,13 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # now we wait a bit for the cache entry to expire
         time.sleep(ttl + 1)
@@ -275,19 +275,19 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
         misses += 1
 
         # following queries should hit the cache again
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheExpirationDifferentSets(self):
         """
@@ -322,13 +322,13 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # now we wait a bit for the cache entry to expire
         time.sleep(ttl + 1)
@@ -338,19 +338,19 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
         misses += 1
 
         # following queries should hit the cache again
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheDecreaseTTL(self):
         """
@@ -376,13 +376,13 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
         for an in receivedResponse.answer:
             self.assertTrue(an.ttl <= ttl)
 
@@ -391,7 +391,7 @@ class TestCaching(DNSDistTest):
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
         for an in receivedResponse.answer:
             self.assertTrue(an.ttl < ttl)
 
@@ -399,7 +399,7 @@ class TestCaching(DNSDistTest):
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheDifferentCase(self):
         """
@@ -429,12 +429,12 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         # different case query should still hit the cache
         (_, receivedResponse) = self.sendUDPQuery(differentCaseQuery, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, differentCaseResponse)
+        self.assertEqual(receivedResponse, differentCaseResponse)
 
     def testLargeAnswer(self):
         """
@@ -461,26 +461,26 @@ class TestCaching(DNSDistTest):
                                     dns.rdatatype.TXT,
                                     content)
         response.answer.append(rrset)
-        self.assertEquals(len(response.to_wire()), 4096)
+        self.assertEqual(len(response.to_wire()), 4096)
 
         # first query to fill the cache
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEquals(total, 1)
+        self.assertEqual(total, 1)
 
         # TCP should not be cached
         # first query to fill the cache
@@ -488,19 +488,19 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEquals(total, 1)
+        self.assertEqual(total, 1)
 
     def testCacheDifferentCookies(self):
         """
@@ -523,15 +523,15 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         eco = cookiesoption.CookiesOption(b'badc0fee', b'badc0fee')
         query = dns.message.make_query(name, 'AAAA', 'IN', use_edns=True, payload=4096, options=[eco])
         # second query should be served from the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
         receivedResponse.id = response.id
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
     def testCacheCookies(self):
         """
@@ -554,8 +554,8 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[])
         response = dns.message.make_response(query)
@@ -570,8 +570,8 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
     def testCacheSameCookieDifferentECS(self):
         """
@@ -594,8 +594,8 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         eco = cookiesoption.CookiesOption(b'deadbeef', b'deadbeef')
         ecso = clientsubnetoption.ClientSubnetOption('192.0.2.2', 32)
@@ -612,8 +612,8 @@ class TestCaching(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
 class TestCachingHashingCookies(DNSDistTest):
 
@@ -647,19 +647,19 @@ class TestCachingHashingCookies(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEquals(total, 1)
+        self.assertEqual(total, 1)
 
         # TCP should not be cached
         # first query to fill the cache
@@ -667,19 +667,19 @@ class TestCachingHashingCookies(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
             TestCaching._responsesCounter[key] = 0
 
-        self.assertEquals(total, 1)
+        self.assertEqual(total, 1)
 
 
     def testCacheDifferentCookies(self):
@@ -703,8 +703,8 @@ class TestCachingHashingCookies(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         eco = cookiesoption.CookiesOption(b'badc0fee', b'badc0fee')
         query = dns.message.make_query(name, 'AAAA', 'IN', use_edns=True, payload=4096, options=[eco])
@@ -720,9 +720,9 @@ class TestCachingHashingCookies(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, differentResponse)
-        self.assertNotEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, differentResponse)
+        self.assertNotEqual(receivedResponse, response)
 
     def testCacheCookies(self):
         """
@@ -745,8 +745,8 @@ class TestCachingHashingCookies(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, options=[])
         response = dns.message.make_response(query)
@@ -761,8 +761,8 @@ class TestCachingHashingCookies(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
     def testCacheSameCookieDifferentECS(self):
         """
@@ -785,8 +785,8 @@ class TestCachingHashingCookies(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         eco = cookiesoption.CookiesOption(b'deadbeef', b'deadbeef')
         ecso = clientsubnetoption.ClientSubnetOption('192.0.2.2', 32)
@@ -803,8 +803,8 @@ class TestCachingHashingCookies(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
 class TestTempFailureCacheTTLAction(DNSDistTest):
 
@@ -833,14 +833,14 @@ class TestTempFailureCacheTTLAction(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         # next query should hit the cache
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
         self.assertFalse(receivedQuery)
         self.assertTrue(receivedResponse)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # now we wait a bit for the Failure-Cache TTL to expire
         time.sleep(2)
@@ -849,7 +849,7 @@ class TestTempFailureCacheTTLAction(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
 
 class TestCachingWithExistingEDNS(DNSDistTest):
@@ -882,8 +882,8 @@ class TestCachingWithExistingEDNS(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096)
@@ -899,15 +899,15 @@ class TestCachingWithExistingEDNS(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingCacheFull(DNSDistTest):
 
@@ -937,13 +937,13 @@ class TestCachingCacheFull(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # ok, now the cache is full, send another query
         name = 'cachefull.cache.tests.powerdns.com.'
@@ -961,8 +961,8 @@ class TestCachingCacheFull(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should NOT hit the cache
@@ -970,15 +970,15 @@ class TestCachingCacheFull(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingNoStale(DNSDistTest):
 
@@ -1013,12 +1013,12 @@ class TestCachingNoStale(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # ok, we mark the backend as down
         self.sendConsoleCommand("getServer(0):setDown()")
@@ -1027,7 +1027,7 @@ class TestCachingNoStale(DNSDistTest):
 
         # we should NOT get a cached, stale, entry
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
 
 class TestCachingStale(DNSDistTest):
@@ -1066,13 +1066,13 @@ class TestCachingStale(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # ok, we mark the backend as down
         self.sendConsoleCommand("getServer(0):setDown()")
@@ -1081,15 +1081,15 @@ class TestCachingStale(DNSDistTest):
 
         # we should get a cached, stale, entry
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
         for an in receivedResponse.answer:
-            self.assertEquals(an.ttl, self._staleCacheTTL)
+            self.assertEqual(an.ttl, self._staleCacheTTL)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingStaleExpunged(DNSDistTest):
 
@@ -1131,17 +1131,17 @@ class TestCachingStaleExpunged(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"misses\"]").strip("\n")), misses + drops)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"misses\"]").strip("\n")), misses + drops)
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
         # the cache should have one entry
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"entries\"]").strip("\n")), 1)
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"hits\"]").strip("\n")), 1)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"entries\"]").strip("\n")), 1)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"hits\"]").strip("\n")), 1)
 
         # ok, we mark the backend as down
         self.sendConsoleCommand("getServer(0):setDown()")
@@ -1150,21 +1150,21 @@ class TestCachingStaleExpunged(DNSDistTest):
         # wait a bit more to be sure that the cache cleaning algo has been run
         time.sleep(1)
         # the cache should be empty now
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"entries\"]").strip("\n")), 0)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"entries\"]").strip("\n")), 0)
 
         # we should get a DROP (backend is down, nothing in the cache anymore)
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
         drops += 1
 
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"misses\"]").strip("\n")), misses + drops)
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"hits\"]").strip("\n")), 1)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"misses\"]").strip("\n")), misses + drops)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"hits\"]").strip("\n")), 1)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingStaleExpungePrevented(DNSDistTest):
 
@@ -1204,17 +1204,17 @@ class TestCachingStaleExpungePrevented(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"misses\"]").strip("\n")), 1)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"misses\"]").strip("\n")), 1)
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
         # the cache should have one entry
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"entries\"]").strip("\n")), 1)
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"hits\"]").strip("\n")), 1)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"entries\"]").strip("\n")), 1)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"hits\"]").strip("\n")), 1)
 
         # ok, we mark the backend as down
         self.sendConsoleCommand("getServer(0):setDown()")
@@ -1224,20 +1224,20 @@ class TestCachingStaleExpungePrevented(DNSDistTest):
         time.sleep(1)
         # the cache should NOT be empty because the removal of the expired entry should have been prevented
         # since all backends for this pool are down
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"entries\"]").strip("\n")), 1)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"entries\"]").strip("\n")), 1)
 
         # we should get a HIT
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"misses\"]").strip("\n")), 1)
-        self.assertEquals(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"hits\"]").strip("\n")), 2)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"misses\"]").strip("\n")), 1)
+        self.assertEqual(int(self.sendConsoleCommand("getPool(\"\"):getCache():getStats()[\"hits\"]").strip("\n")), 2)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCacheManagement(DNSDistTest):
 
@@ -1273,13 +1273,13 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # remove cached entries
         self.sendConsoleCommand("getPool(\"\"):getCache():expunge(0)")
@@ -1289,19 +1289,19 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache again
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheExpungeByName(self):
         """
@@ -1335,29 +1335,29 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # cache another entry
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query2.id
-        self.assertEquals(query2, receivedQuery)
-        self.assertEquals(response2, receivedResponse)
+        self.assertEqual(query2, receivedQuery)
+        self.assertEqual(response2, receivedResponse)
         misses += 1
 
         # queries for name and name 2 should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response2)
+        self.assertEqual(receivedResponse, response2)
 
         # remove cached entries from name
         self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"" + name + "\"))")
@@ -1367,23 +1367,23 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries for name should hit the cache again
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # queries for name2 should still hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response2)
+        self.assertEqual(receivedResponse, response2)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheExpungeByNameAndType(self):
         """
@@ -1416,29 +1416,29 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # cache another entry
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query2.id
-        self.assertEquals(query2, receivedQuery)
-        self.assertEquals(response2, receivedResponse)
+        self.assertEqual(query2, receivedQuery)
+        self.assertEqual(response2, receivedResponse)
         misses += 1
 
         # queries for name A and AAAA should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response2)
+        self.assertEqual(receivedResponse, response2)
 
         # remove cached entries from name A
         self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"" + name + "\"), DNSQType.A)")
@@ -1448,22 +1448,22 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries for name A should hit the cache again
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # queries for name AAAA should still hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response2)
+        self.assertEqual(receivedResponse, response2)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheExpungeByNameAndSuffix(self):
         """
@@ -1497,29 +1497,29 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # cache another entry
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query2.id
-        self.assertEquals(query2, receivedQuery)
-        self.assertEquals(response2, receivedResponse)
+        self.assertEqual(query2, receivedQuery)
+        self.assertEqual(response2, receivedResponse)
         misses += 1
 
         # queries for name and name 2 should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response2)
+        self.assertEqual(receivedResponse, response2)
 
         # remove cached entries from name
         self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"suffix.cache.tests.powerdns.com.\"), DNSQType.ANY, true)")
@@ -1529,23 +1529,23 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries for name should hit the cache again
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # queries for name2 should still hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response2)
+        self.assertEqual(receivedResponse, response2)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheExpungeByNameAndTypeAndSuffix(self):
         """
@@ -1578,29 +1578,29 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # cache another entry
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query2.id
-        self.assertEquals(query2, receivedQuery)
-        self.assertEquals(response2, receivedResponse)
+        self.assertEqual(query2, receivedQuery)
+        self.assertEqual(response2, receivedResponse)
         misses += 1
 
         # queries for name A and AAAA should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response2)
+        self.assertEqual(receivedResponse, response2)
 
         # remove cached entries from name A
         self.sendConsoleCommand("getPool(\"\"):getCache():expungeByName(newDNSName(\"suffixtype.cache.tests.powerdns.com.\"), DNSQType.A, true)")
@@ -1610,22 +1610,22 @@ class TestCacheManagement(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries for name A should hit the cache again
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # queries for name AAAA should still hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response2)
+        self.assertEqual(receivedResponse, response2)
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingTTL(DNSDistTest):
 
@@ -1659,10 +1659,10 @@ class TestCachingTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         for an in receivedResponse.answer:
-            self.assertEquals(an.ttl, ttl)
+            self.assertEqual(an.ttl, ttl)
         misses += 1
 
         # We should not have been cached
@@ -1670,17 +1670,17 @@ class TestCachingTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         for an in receivedResponse.answer:
-            self.assertEquals(an.ttl, ttl)
+            self.assertEqual(an.ttl, ttl)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheNXWithNoRR(self):
         """
@@ -1698,8 +1698,8 @@ class TestCachingTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # We should not have been cached
@@ -1707,15 +1707,15 @@ class TestCachingTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingLongTTL(DNSDistTest):
 
@@ -1748,15 +1748,15 @@ class TestCachingLongTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         for an in receivedResponse.answer:
-            self.assertEquals(an.ttl, ttl)
+            self.assertEqual(an.ttl, ttl)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
         for an in receivedResponse.answer:
             self.assertTrue(an.ttl <= ttl)
 
@@ -1768,17 +1768,17 @@ class TestCachingLongTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         for an in receivedResponse.answer:
-            self.assertEquals(an.ttl, ttl)
+            self.assertEqual(an.ttl, ttl)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingFailureTTL(DNSDistTest):
 
@@ -1805,13 +1805,13 @@ class TestCachingFailureTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         time.sleep(self._failureCacheTTL + 1)
 
@@ -1821,15 +1821,15 @@ class TestCachingFailureTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheRefusedTTL(self):
         """
@@ -1847,13 +1847,13 @@ class TestCachingFailureTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         time.sleep(self._failureCacheTTL + 1)
 
@@ -1863,15 +1863,15 @@ class TestCachingFailureTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheHeaderOnlyRefusedTTL(self):
         """
@@ -1890,13 +1890,13 @@ class TestCachingFailureTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         time.sleep(self._failureCacheTTL + 1)
 
@@ -1906,15 +1906,15 @@ class TestCachingFailureTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingNegativeTTL(DNSDistTest):
 
@@ -1948,13 +1948,13 @@ class TestCachingNegativeTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         time.sleep(self._negCacheTTL + 1)
 
@@ -1964,15 +1964,15 @@ class TestCachingNegativeTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
     def testCacheNegativeTTLNoData(self):
         """
@@ -1996,13 +1996,13 @@ class TestCachingNegativeTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         time.sleep(self._negCacheTTL + 1)
 
@@ -2012,15 +2012,15 @@ class TestCachingNegativeTTL(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingDontAge(DNSDistTest):
 
@@ -2054,13 +2054,13 @@ class TestCachingDontAge(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
         misses += 1
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
         for an in receivedResponse.answer:
             self.assertTrue(an.ttl == ttl)
 
@@ -2069,7 +2069,7 @@ class TestCachingDontAge(DNSDistTest):
 
         # next queries should hit the cache
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
         for an in receivedResponse.answer:
             self.assertTrue(an.ttl == ttl)
 
@@ -2077,7 +2077,7 @@ class TestCachingDontAge(DNSDistTest):
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
 
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestCachingECSWithoutPoolECS(DNSDistTest):
 
@@ -2114,14 +2114,14 @@ class TestCachingECSWithoutPoolECS(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
         # next queries should hit the cache
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         # we mark the backend as down
         self.sendConsoleCommand("getServer(0):setDown()")
@@ -2131,7 +2131,7 @@ class TestCachingECSWithoutPoolECS(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
 class TestCachingECSWithPoolECS(DNSDistTest):
 
@@ -2169,14 +2169,14 @@ class TestCachingECSWithPoolECS(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
 
         # next queries should hit the cache
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
         # we mark the backend as down
         self.sendConsoleCommand("getServer(0):setDown()")
@@ -2186,7 +2186,7 @@ class TestCachingECSWithPoolECS(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
 class TestCachingCollisionNoECSParsing(DNSDistTest):
 
@@ -2217,8 +2217,8 @@ class TestCachingCollisionNoECSParsing(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         # second query will hash to the same key, triggering a collision which
         # will not be detected because the qname, qtype, qclass and flags will
@@ -2228,7 +2228,7 @@ class TestCachingCollisionNoECSParsing(DNSDistTest):
         query2.flags = dns.flags.RD
         (_, receivedResponse) = self.sendUDPQuery(query2, response=None, useQueue=False)
         receivedResponse.id = response.id
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
 class TestCachingCollisionWithECSParsing(DNSDistTest):
 
@@ -2259,8 +2259,8 @@ class TestCachingCollisionWithECSParsing(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         # second query will hash to the same key, triggering a collision which
         # _will_ be detected this time because the qname, qtype, qclass and flags will
@@ -2276,7 +2276,7 @@ class TestCachingCollisionWithECSParsing(DNSDistTest):
                                     '2001:DB8::1')
         response2.answer.append(rrset)
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query2, response2)
-        self.assertEquals(receivedResponse, response2)
+        self.assertEqual(receivedResponse, response2)
 
 class TestCachingScopeZero(DNSDistTest):
 

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -92,7 +92,7 @@ class TestCarbon(DNSDistTest):
         for line in data1.splitlines():
             self.assertTrue(line.startswith(expectedStart))
             parts = line.split(b' ')
-            self.assertEquals(len(parts), 3)
+            self.assertEqual(len(parts), 3)
             self.assertTrue(parts[1].isdigit())
             self.assertTrue(parts[2].isdigit())
             self.assertTrue(int(parts[2]) <= int(after))
@@ -103,7 +103,7 @@ class TestCarbon(DNSDistTest):
         for line in data2.splitlines():
             self.assertTrue(line.startswith(expectedStart))
             parts = line.split(b' ')
-            self.assertEquals(len(parts), 3)
+            self.assertEqual(len(parts), 3)
             self.assertTrue(parts[1].isdigit())
             self.assertTrue(parts[2].isdigit())
             self.assertTrue(int(parts[2]) <= int(after))
@@ -138,15 +138,15 @@ class TestCarbon(DNSDistTest):
             if expectedStart in line:
                 parts = line.split(b' ')
                 if b'servers-up' in line:
-                    self.assertEquals(len(parts), 3)
+                    self.assertEqual(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
-                    self.assertEquals(int(parts[1]), 2)
+                    self.assertEqual(int(parts[1]), 2)
                     self.assertTrue(parts[2].isdigit())
                     self.assertTrue(int(parts[2]) <= int(after))
                 else:
-                    self.assertEquals(len(parts), 3)
+                    self.assertEqual(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
-                    self.assertEquals(int(parts[1]), 3)
+                    self.assertEqual(int(parts[1]), 3)
                     self.assertTrue(parts[2].isdigit())
                     self.assertTrue(int(parts[2]) <= int(after))
 
@@ -161,14 +161,14 @@ class TestCarbon(DNSDistTest):
             if expectedStart in line:
                 parts = line.split(b' ')
                 if b'servers-up' in line:
-                    self.assertEquals(len(parts), 3)
+                    self.assertEqual(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
-                    self.assertEquals(int(parts[1]), 2)
+                    self.assertEqual(int(parts[1]), 2)
                     self.assertTrue(parts[2].isdigit())
                     self.assertTrue(int(parts[2]) <= int(after))
                 else:
-                    self.assertEquals(len(parts), 3)
+                    self.assertEqual(len(parts), 3)
                     self.assertTrue(parts[1].isdigit())
-                    self.assertEquals(int(parts[1]), 3)
+                    self.assertEqual(int(parts[1]), 3)
                     self.assertTrue(parts[2].isdigit())
                     self.assertTrue(int(parts[2]) <= int(after))

--- a/regression-tests.dnsdist/test_CheckConfig.py
+++ b/regression-tests.dnsdist/test_CheckConfig.py
@@ -22,7 +22,7 @@ class TestCheckConfig(unittest.TestCase):
             self.assertNotEqual(dnsdist.poll(), None)
 
         if shouldBeSuccessful:
-            self.assertEquals(dnsdist.returncode, 0)
+            self.assertEqual(dnsdist.returncode, 0)
         else:
             self.assertNotEqual(dnsdist.returncode, 0)
 

--- a/regression-tests.dnsdist/test_DNSCrypt.py
+++ b/regression-tests.dnsdist/test_DNSCrypt.py
@@ -42,8 +42,8 @@ class DNSCryptTest(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
 
 class TestDNSCrypt(DNSCryptTest):
@@ -104,8 +104,8 @@ class TestDNSCrypt(DNSCryptTest):
 
         self.assertTrue(receivedQuery)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse.question, response.question)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse.question, response.question)
         self.assertTrue(receivedResponse.flags & ~dns.flags.TC)
         self.assertTrue(len(receivedResponse.answer) == 0)
         self.assertTrue(len(receivedResponse.authority) == 0)
@@ -120,7 +120,7 @@ class TestDNSCrypt(DNSCryptTest):
 
         cert = client.getResolverCertificate()
         self.assertTrue(cert)
-        self.assertEquals(cert.serial, self._resolverCertificateSerial)
+        self.assertEqual(cert.serial, self._resolverCertificateSerial)
 
         name = 'rotation.dnscrypt.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
@@ -141,31 +141,31 @@ class TestDNSCrypt(DNSCryptTest):
         self.sendConsoleCommand("getDNSCryptBind(0):loadNewCertificate('DNSCryptResolver.cert.2', 'DNSCryptResolver.key.2')")
 
         oldSerial = self.sendConsoleCommand("getDNSCryptBind(0):getCertificate(0):getSerial()")
-        self.assertEquals(int(oldSerial), self._resolverCertificateSerial)
+        self.assertEqual(int(oldSerial), self._resolverCertificateSerial)
         effectiveSerial = self.sendConsoleCommand("getDNSCryptBind(0):getCertificate(1):getSerial()")
-        self.assertEquals(int(effectiveSerial), self._resolverCertificateSerial + 1)
+        self.assertEqual(int(effectiveSerial), self._resolverCertificateSerial + 1)
         tsStart = self.sendConsoleCommand("getDNSCryptBind(0):getCertificate(1):getTSStart()")
-        self.assertEquals(int(tsStart), self._resolverCertificateValidFrom)
+        self.assertEqual(int(tsStart), self._resolverCertificateValidFrom)
         tsEnd = self.sendConsoleCommand("getDNSCryptBind(0):getCertificate(1):getTSEnd()")
-        self.assertEquals(int(tsEnd), self._resolverCertificateValidUntil)
+        self.assertEqual(int(tsEnd), self._resolverCertificateValidUntil)
 
         # we should still be able to send queries with the previous certificate
         self.doDNSCryptQuery(client, query, response, False)
         self.doDNSCryptQuery(client, query, response, True)
         cert = client.getResolverCertificate()
         self.assertTrue(cert)
-        self.assertEquals(cert.serial, self._resolverCertificateSerial)
+        self.assertEqual(cert.serial, self._resolverCertificateSerial)
 
         # but refreshing should get us the new one
         client.refreshResolverCertificates()
         cert = client.getResolverCertificate()
         self.assertTrue(cert)
-        self.assertEquals(cert.serial, self._resolverCertificateSerial + 1)
+        self.assertEqual(cert.serial, self._resolverCertificateSerial + 1)
         # we should still get the old ones
         certs = client.getAllResolverCertificates(True)
-        self.assertEquals(len(certs), 2)
-        self.assertEquals(certs[0].serial, self._resolverCertificateSerial)
-        self.assertEquals(certs[1].serial, self._resolverCertificateSerial + 1)
+        self.assertEqual(len(certs), 2)
+        self.assertEqual(certs[0].serial, self._resolverCertificateSerial)
+        self.assertEqual(certs[1].serial, self._resolverCertificateSerial + 1)
 
         # generate a third certificate, this time in memory
         self.sendConsoleCommand("getDNSCryptBind(0):generateAndLoadInMemoryCertificate('DNSCryptProviderPrivate.key', {!s}, {:.0f}, {:.0f})".format(self._resolverCertificateSerial + 2, self._resolverCertificateValidFrom, self._resolverCertificateValidUntil))
@@ -175,19 +175,19 @@ class TestDNSCrypt(DNSCryptTest):
         self.doDNSCryptQuery(client, query, response, True)
         cert = client.getResolverCertificate()
         self.assertTrue(cert)
-        self.assertEquals(cert.serial, self._resolverCertificateSerial + 1)
+        self.assertEqual(cert.serial, self._resolverCertificateSerial + 1)
 
         # but refreshing should get us the new one
         client.refreshResolverCertificates()
         cert = client.getResolverCertificate()
         self.assertTrue(cert)
-        self.assertEquals(cert.serial, self._resolverCertificateSerial + 2)
+        self.assertEqual(cert.serial, self._resolverCertificateSerial + 2)
         # we should still get the old ones
         certs = client.getAllResolverCertificates(True)
-        self.assertEquals(len(certs), 3)
-        self.assertEquals(certs[0].serial, self._resolverCertificateSerial)
-        self.assertEquals(certs[1].serial, self._resolverCertificateSerial + 1)
-        self.assertEquals(certs[2].serial, self._resolverCertificateSerial + 2)
+        self.assertEqual(len(certs), 3)
+        self.assertEqual(certs[0].serial, self._resolverCertificateSerial)
+        self.assertEqual(certs[1].serial, self._resolverCertificateSerial + 1)
+        self.assertEqual(certs[2].serial, self._resolverCertificateSerial + 2)
 
         # generate a fourth certificate, still in memory
         self.sendConsoleCommand("getDNSCryptBind(0):generateAndLoadInMemoryCertificate('DNSCryptProviderPrivate.key', {!s}, {:.0f}, {:.0f})".format(self._resolverCertificateSerial + 3, self._resolverCertificateValidFrom, self._resolverCertificateValidUntil))
@@ -201,7 +201,7 @@ class TestDNSCrypt(DNSCryptTest):
         self.doDNSCryptQuery(client, query, response, True)
         cert = client.getResolverCertificate()
         self.assertTrue(cert)
-        self.assertEquals(cert.serial, self._resolverCertificateSerial + 2)
+        self.assertEqual(cert.serial, self._resolverCertificateSerial + 2)
         # now remove them
         self.sendConsoleCommand("getDNSCryptBind(0):removeInactiveCertificate({!s})".format(self._resolverCertificateSerial))
         self.sendConsoleCommand("getDNSCryptBind(0):removeInactiveCertificate({!s})".format(self._resolverCertificateSerial + 1))
@@ -212,22 +212,22 @@ class TestDNSCrypt(DNSCryptTest):
             data = client.query(query.to_wire())
         except socket.timeout:
             data = None
-        self.assertEquals(data, None)
+        self.assertEqual(data, None)
 
         # refreshing should get us the fourth one
         client.refreshResolverCertificates()
         cert = client.getResolverCertificate()
         self.assertTrue(cert)
-        self.assertEquals(cert.serial, self._resolverCertificateSerial + 3)
+        self.assertEqual(cert.serial, self._resolverCertificateSerial + 3)
         # and only that one
         certs = client.getAllResolverCertificates(True)
-        self.assertEquals(len(certs), 1)
+        self.assertEqual(len(certs), 1)
         # and we should be able to query with it
         self.doDNSCryptQuery(client, query, response, False)
         self.doDNSCryptQuery(client, query, response, True)
         cert = client.getResolverCertificate()
         self.assertTrue(cert)
-        self.assertEquals(cert.serial, self._resolverCertificateSerial + 3)
+        self.assertEqual(cert.serial, self._resolverCertificateSerial + 3)
 
 class TestDNSCryptWithCache(DNSCryptTest):
 
@@ -267,8 +267,8 @@ class TestDNSCryptWithCache(DNSCryptTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         misses += 1
 
         # second query should get a cached response
@@ -278,13 +278,13 @@ class TestDNSCryptWithCache(DNSCryptTest):
         if not self._fromResponderQueue.empty():
             receivedQuery = self._fromResponderQueue.get(query)
 
-        self.assertEquals(receivedQuery, None)
+        self.assertEqual(receivedQuery, None)
         self.assertTrue(receivedResponse)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
         total = 0
         for key in self._responsesCounter:
             total += self._responsesCounter[key]
-        self.assertEquals(total, misses)
+        self.assertEqual(total, misses)
 
 class TestDNSCryptAutomaticRotation(DNSCryptTest):
     _config_template = """

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -120,7 +120,7 @@ class DNSDistDOHTest(DNSDistTest):
 
     def checkHasHeader(self, name, value):
         got = self.getHeaderValue(name)
-        self.assertEquals(got, value)
+        self.assertEqual(got, value)
 
     def checkNoHeader(self, name):
         self.checkHasHeader(name, None)
@@ -206,14 +206,14 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.assertTrue((self._customResponseHeader1) in self._response_headers.decode())
         self.assertTrue((self._customResponseHeader2) in self._response_headers.decode())
         self.assertFalse(('UPPERCASE: VaLuE' in self._response_headers.decode()))
         self.assertTrue(('uppercase: VaLuE' in self._response_headers.decode()))
         self.assertTrue(('cache-control: max-age=3600' in self._response_headers.decode()))
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
         self.checkHasHeader('cache-control', 'max-age=3600')
 
     def testDOHTransactionID(self):
@@ -237,11 +237,11 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
         # just to be sure the ID _is_ checked
-        self.assertEquals(response.id, receivedResponse.id)
+        self.assertEqual(response.id, receivedResponse.id)
 
     def testDOHSimplePOST(self):
         """
@@ -264,9 +264,9 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
     def testDOHExistingEDNS(self):
         """
@@ -287,8 +287,8 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.checkQueryEDNSWithoutECS(query, receivedQuery)
         self.checkResponseEDNSWithoutECS(response, receivedResponse)
 
@@ -314,8 +314,8 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.checkQueryEDNSWithECS(query, receivedQuery)
         self.checkResponseEDNSWithECS(response, receivedResponse)
 
@@ -326,7 +326,7 @@ class TestDOH(DNSDistDOHTest):
         name = 'drop.doh.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN')
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, caFile=self._caCert, query=query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
     def testRefused(self):
         """
@@ -340,7 +340,7 @@ class TestDOH(DNSDistDOHTest):
         expectedResponse.set_rcode(dns.rcode.REFUSED)
 
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, caFile=self._caCert, query=query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
     def testSpoof(self):
         """
@@ -359,7 +359,7 @@ class TestDOH(DNSDistDOHTest):
         expectedResponse.answer.append(rrset)
 
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, caFile=self._caCert, query=query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
     def testDOHInvalid(self):
         """
@@ -372,7 +372,7 @@ class TestDOH(DNSDistDOHTest):
         invalidQuery = invalidQuery.to_wire()
         invalidQuery = invalidQuery[:-5]
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, caFile=self._caCert, query=invalidQuery, response=None, useQueue=False, rawQuery=True)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         # and now a valid one
         query = dns.message.make_query(name, 'A', 'IN', use_edns=False)
@@ -390,9 +390,9 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
     def testDOHWithoutQuery(self):
         """
@@ -408,7 +408,7 @@ class TestDOH(DNSDistDOHTest):
         conn.setopt(pycurl.CAINFO, self._caCert)
         data = conn.perform_rb()
         rcode = conn.getinfo(pycurl.RESPONSE_CODE)
-        self.assertEquals(rcode, 400)
+        self.assertEqual(rcode, 400)
 
     def testDOHEmptyPOST(self):
         """
@@ -417,7 +417,7 @@ class TestDOH(DNSDistDOHTest):
         name = 'empty-post.doh.tests.powerdns.com.'
 
         (_, receivedResponse) = self.sendDOHPostQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query="", rawQuery=True, response=None, caFile=self._caCert)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         # and now a valid one
         query = dns.message.make_query(name, 'A', 'IN', use_edns=False)
@@ -435,9 +435,9 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
     def testHeaderRule(self):
         """
@@ -457,7 +457,7 @@ class TestDOH(DNSDistDOHTest):
 
         # this header should match
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, caFile=self._caCert, query=query, response=None, useQueue=False, customHeaders=['x-powerdnS: aaaaa'])
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096)
         expectedQuery.flags &= ~dns.flags.RD
@@ -475,9 +475,9 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
     def testHTTPPath(self):
         """
@@ -497,7 +497,7 @@ class TestDOH(DNSDistDOHTest):
 
         # this path should match
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL + 'PowerDNS', caFile=self._caCert, query=query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096)
         expectedQuery.id = 0
@@ -515,15 +515,15 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
         # this path is not in the URLs map and should lead to a 404
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL + "PowerDNS/something", query, caFile=self._caCert, useQueue=False, rawResponse=True)
         self.assertTrue(receivedResponse)
-        self.assertEquals(receivedResponse, b'there is no endpoint configured for this path')
-        self.assertEquals(self._rcode, 404)
+        self.assertEqual(receivedResponse, b'there is no endpoint configured for this path')
+        self.assertEqual(self._rcode, 404)
 
     def testHTTPPathRegex(self):
         """
@@ -543,7 +543,7 @@ class TestDOH(DNSDistDOHTest):
 
         # this path should match
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL + 'PowerDNS-999', caFile=self._caCert, query=query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096)
         expectedQuery.id = 0
@@ -561,9 +561,9 @@ class TestDOH(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
     def testHTTPStatusAction200(self):
         """
@@ -575,8 +575,8 @@ class TestDOH(DNSDistDOHTest):
 
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, caFile=self._caCert, useQueue=False, rawResponse=True)
         self.assertTrue(receivedResponse)
-        self.assertEquals(receivedResponse, b'Plaintext answer')
-        self.assertEquals(self._rcode, 200)
+        self.assertEqual(receivedResponse, b'Plaintext answer')
+        self.assertEqual(self._rcode, 200)
         self.assertTrue('content-type: text/plain' in self._response_headers.decode())
 
     def testHTTPStatusAction307(self):
@@ -589,7 +589,7 @@ class TestDOH(DNSDistDOHTest):
 
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, caFile=self._caCert, useQueue=False, rawResponse=True)
         self.assertTrue(receivedResponse)
-        self.assertEquals(self._rcode, 307)
+        self.assertEqual(self._rcode, 307)
         self.assertTrue('location: https://doh.powerdns.org' in self._response_headers.decode())
 
     def testHTTPLuaResponse(self):
@@ -602,8 +602,8 @@ class TestDOH(DNSDistDOHTest):
 
         (_, receivedResponse) = self.sendDOHPostQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, caFile=self._caCert, useQueue=False, rawResponse=True)
         self.assertTrue(receivedResponse)
-        self.assertEquals(receivedResponse, b'It works!')
-        self.assertEquals(self._rcode, 200)
+        self.assertEqual(receivedResponse, b'It works!')
+        self.assertEqual(self._rcode, 200)
         self.assertTrue('content-type: text/plain' in self._response_headers.decode())
 
     def testHTTPEarlyResponse(self):
@@ -623,8 +623,8 @@ class TestDOH(DNSDistDOHTest):
         rcode = conn.getinfo(pycurl.RESPONSE_CODE)
         headers = response_headers.getvalue().decode()
 
-        self.assertEquals(rcode, 418)
-        self.assertEquals(data, b'C0FFEE')
+        self.assertEqual(rcode, 418)
+        self.assertEqual(data, b'C0FFEE')
         self.assertIn('foo: bar', headers)
         self.assertNotIn(self._customResponseHeader2, headers)
 
@@ -643,8 +643,8 @@ class TestDOH(DNSDistDOHTest):
         data = conn.perform_rb()
         rcode = conn.getinfo(pycurl.RESPONSE_CODE)
         headers = response_headers.getvalue().decode()
-        self.assertEquals(rcode, 418)
-        self.assertEquals(data, b'C0FFEE')
+        self.assertEqual(rcode, 418)
+        self.assertEqual(data, b'C0FFEE')
         self.assertIn('foo: bar', headers)
         self.assertNotIn(self._customResponseHeader2, headers)
 
@@ -683,7 +683,7 @@ class TestDOHSubPaths(DNSDistDOHTest):
 
         # this path should match
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL + 'PowerDNS', caFile=self._caCert, query=query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         expectedQuery = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096)
         expectedQuery.id = 0
@@ -699,12 +699,12 @@ class TestDOHSubPaths(DNSDistDOHTest):
         # this path is not in the URLs map and should lead to a 404
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL + "NotPowerDNS", query, caFile=self._caCert, useQueue=False, rawResponse=True)
         self.assertTrue(receivedResponse)
-        self.assertEquals(receivedResponse, b'not found')
-        self.assertEquals(self._rcode, 404)
+        self.assertEqual(receivedResponse, b'not found')
+        self.assertEqual(self._rcode, 404)
 
         # this path is below one in the URLs map and exactPathMatching is false, so we should be good
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL + 'PowerDNS/something', caFile=self._caCert, query=query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
 class TestDOHAddingECS(DNSDistDOHTest):
 
@@ -742,9 +742,9 @@ class TestDOHAddingECS(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         expectedQuery.id = receivedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
         self.checkResponseNoEDNS(response, receivedResponse)
 
     def testDOHExistingEDNS(self):
@@ -768,8 +768,8 @@ class TestDOHAddingECS(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(expectedQuery, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.checkQueryEDNSWithECS(expectedQuery, receivedQuery)
         self.checkResponseEDNSWithoutECS(response, receivedResponse)
 
@@ -796,8 +796,8 @@ class TestDOHAddingECS(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(expectedQuery, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.checkQueryEDNSWithECS(expectedQuery, receivedQuery)
         self.checkResponseEDNSWithECS(response, receivedResponse)
 
@@ -835,9 +835,9 @@ Configuration 'configs/dnsdist_TestDOHOverHTTP.conf' OK!
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         expectedQuery.id = receivedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
         self.checkResponseNoEDNS(response, receivedResponse)
 
     def testDOHSimplePOST(self):
@@ -861,9 +861,9 @@ Configuration 'configs/dnsdist_TestDOHOverHTTP.conf' OK!
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
         self.checkResponseNoEDNS(response, receivedResponse)
 
 class TestDOHWithCache(DNSDistDOHTest):
@@ -910,27 +910,27 @@ class TestDOHWithCache(DNSDistDOHTest):
                                     dns.rdatatype.TXT,
                                     content)
         response.answer.append(rrset)
-        self.assertEquals(len(response.to_wire()), 4096)
+        self.assertEqual(len(response.to_wire()), 4096)
 
         # first query to fill the cache
         (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
         self.checkHasHeader('cache-control', 'max-age=3600')
 
         for _ in range(numberOfQueries):
             (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, caFile=self._caCert, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
             self.checkHasHeader('cache-control', 'max-age=' + str(receivedResponse.answer[0].ttl))
 
         time.sleep(1)
 
         (_, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, caFile=self._caCert, useQueue=False)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
         self.checkHasHeader('cache-control', 'max-age=' + str(receivedResponse.answer[0].ttl))
 
 class TestDOHWithoutCacheControl(DNSDistDOHTest):
@@ -969,10 +969,10 @@ class TestDOHWithoutCacheControl(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkNoHeader('cache-control')
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
 class TestDOHFFI(DNSDistDOHTest):
 
@@ -1032,8 +1032,8 @@ class TestDOHFFI(DNSDistDOHTest):
 
         (_, receivedResponse) = self.sendDOHPostQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, caFile=self._caCert, useQueue=False, rawResponse=True)
         self.assertTrue(receivedResponse)
-        self.assertEquals(receivedResponse, b'It works!')
-        self.assertEquals(self._rcode, 200)
+        self.assertEqual(receivedResponse, b'It works!')
+        self.assertEqual(self._rcode, 200)
         self.assertTrue('content-type: text/plain' in self._response_headers.decode())
 
 class TestDOHForwardedFor(DNSDistDOHTest):
@@ -1073,9 +1073,9 @@ class TestDOHForwardedFor(DNSDistDOHTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryEDNSWithoutECS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
     def testDOHDeniedForwarded(self):
         """
@@ -1096,8 +1096,8 @@ class TestDOHForwardedFor(DNSDistDOHTest):
 
         (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert, useQueue=False, rawResponse=True, customHeaders=['x-forwarded-for: 127.0.0.1:42, 127.0.0.1'])
 
-        self.assertEquals(self._rcode, 403)
-        self.assertEquals(receivedResponse, b'dns query not allowed because of ACL')
+        self.assertEqual(self._rcode, 403)
+        self.assertEqual(receivedResponse, b'dns query not allowed because of ACL')
 
 class TestDOHForwardedForNoTrusted(DNSDistDOHTest):
 
@@ -1134,8 +1134,8 @@ class TestDOHForwardedForNoTrusted(DNSDistDOHTest):
 
         (receivedQuery, receivedResponse) = self.sendDOHQuery(self._dohServerPort, self._serverName, self._dohBaseURL, query, response=response, caFile=self._caCert, useQueue=False, rawResponse=True, customHeaders=['x-forwarded-for: 192.0.2.1:4200'])
 
-        self.assertEquals(self._rcode, 403)
-        self.assertEquals(receivedResponse, b'dns query not allowed because of ACL')
+        self.assertEqual(self._rcode, 403)
+        self.assertEqual(receivedResponse, b'dns query not allowed because of ACL')
 
 class TestDOHFrontendLimits(DNSDistDOHTest):
 

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -29,17 +29,17 @@ def checkDnstapBase(testinstance, dnstap, protocol, initiator):
     testinstance.assertTrue(dnstap.message.HasField('socket_protocol'))
     testinstance.assertEqual(dnstap.message.socket_protocol, protocol)
     testinstance.assertTrue(dnstap.message.HasField('socket_family'))
-    testinstance.assertEquals(dnstap.message.socket_family, dnstap_pb2.INET)
+    testinstance.assertEqual(dnstap.message.socket_family, dnstap_pb2.INET)
     testinstance.assertTrue(dnstap.message.HasField('query_address'))
-    testinstance.assertEquals(socket.inet_ntop(socket.AF_INET, dnstap.message.query_address), initiator)
+    testinstance.assertEqual(socket.inet_ntop(socket.AF_INET, dnstap.message.query_address), initiator)
     testinstance.assertTrue(dnstap.message.HasField('response_address'))
-    testinstance.assertEquals(socket.inet_ntop(socket.AF_INET, dnstap.message.response_address), initiator)
+    testinstance.assertEqual(socket.inet_ntop(socket.AF_INET, dnstap.message.response_address), initiator)
     testinstance.assertTrue(dnstap.message.HasField('response_port'))
-    testinstance.assertEquals(dnstap.message.response_port, testinstance._dnsDistPort)
+    testinstance.assertEqual(dnstap.message.response_port, testinstance._dnsDistPort)
   
 
 def checkDnstapQuery(testinstance, dnstap, protocol, query, initiator='127.0.0.1'):
-    testinstance.assertEquals(dnstap.message.type, dnstap_pb2.Message.CLIENT_QUERY)
+    testinstance.assertEqual(dnstap.message.type, dnstap_pb2.Message.CLIENT_QUERY)
     checkDnstapBase(testinstance, dnstap, protocol, initiator)
 
     testinstance.assertTrue(dnstap.message.HasField('query_time_sec'))
@@ -60,7 +60,7 @@ def checkDnstapNoExtra(testinstance, dnstap):
 
 
 def checkDnstapResponse(testinstance, dnstap, protocol, response, initiator='127.0.0.1'):
-    testinstance.assertEquals(dnstap.message.type, dnstap_pb2.Message.CLIENT_RESPONSE)
+    testinstance.assertEqual(dnstap.message.type, dnstap_pb2.Message.CLIENT_RESPONSE)
     checkDnstapBase(testinstance, dnstap, protocol, initiator)
 
     testinstance.assertTrue(dnstap.message.HasField('query_time_sec'))
@@ -190,8 +190,8 @@ class TestDnstapOverRemoteLogger(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # give the dnstap messages time to get here
         time.sleep(1)
@@ -211,8 +211,8 @@ class TestDnstapOverRemoteLogger(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # give the dnstap messages time to get here
         time.sleep(1)
@@ -256,8 +256,8 @@ class TestDnstapOverRemoteLogger(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # give the dnstap messages time to get here
         time.sleep(1)
@@ -276,8 +276,8 @@ class TestDnstapOverRemoteLogger(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # give the dnstap messages time to get here
         time.sleep(1)
@@ -422,8 +422,8 @@ class TestDnstapOverFrameStreamUnixLogger(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # check the dnstap message corresponding to the UDP query
         dnstap = self.getFirstDnstap()
@@ -504,8 +504,8 @@ class TestDnstapOverFrameStreamTcpLogger(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # check the dnstap message corresponding to the UDP query
         dnstap = self.getFirstDnstap()

--- a/regression-tests.dnsdist/test_DynBlocks.py
+++ b/regression-tests.dnsdist/test_DynBlocks.py
@@ -22,7 +22,7 @@ class DynBlocksTest(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/jsonstat?command=dynblocklist'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
         content = r.json()
         self.assertIsNotNone(content)
@@ -55,8 +55,8 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -73,7 +73,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         if testViaAPI:
             self.doTestDynBlockViaAPI('127.0.0.1/32', 'Exceeded query rate', self._dynBlockDuration - 4, self._dynBlockDuration, (sent-allowed)+1, (sent-allowed)+1)
@@ -84,8 +84,8 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # again, over TCP this time
         allowed = 0
@@ -95,8 +95,8 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -113,7 +113,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)
@@ -121,8 +121,8 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
     def doTestQRateRCode(self, name, rcode):
         query = dns.message.make_query(name, 'A', 'IN')
@@ -143,11 +143,11 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(receivedResponse, response)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(receivedResponse, response)
                 allowed = allowed + 1
             else:
-                self.assertEquals(receivedResponse, expectedResponse)
+                self.assertEqual(receivedResponse, expectedResponse)
                 # the query has not reached the responder,
                 # let's clear the response queue
                 self.clearToResponderQueue()
@@ -162,7 +162,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be 'rcode' for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)
@@ -170,8 +170,8 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         allowed = 0
         sent = 0
@@ -181,11 +181,11 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(receivedResponse, response)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(receivedResponse, response)
                 allowed = allowed + 1
             else:
-                self.assertEquals(receivedResponse, expectedResponse)
+                self.assertEqual(receivedResponse, expectedResponse)
                 # the query has not reached the responder,
                 # let's clear the response queue
                 self.clearToResponderQueue()
@@ -200,7 +200,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be 'rcode' for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)
@@ -208,8 +208,8 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
     def doTestResponseByteRate(self, name):
         query = dns.message.make_query(name, 'A', 'IN')
@@ -235,8 +235,8 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + len(response.to_wire())
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
                 allowed = allowed + len(response.to_wire())
             else:
                 # the query has not reached the responder,
@@ -269,7 +269,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         print(self.sendConsoleCommand("showDynBlocks()"))
         print(self.sendConsoleCommand("grepq(\"\")"))
@@ -285,8 +285,8 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # again, over TCP this time
         allowed = 0
@@ -296,8 +296,8 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + len(response.to_wire())
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
                 allowed = allowed + len(response.to_wire())
             else:
                 # the query has not reached the responder,
@@ -318,7 +318,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)
@@ -326,8 +326,8 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
     def doTestRCodeRate(self, name, rcode):
         query = dns.message.make_query(name, 'A', 'IN')
@@ -345,15 +345,15 @@ class DynBlocksTest(DNSDistTest):
         for _ in range((self._dynBlockQPS * self._dynBlockPeriod) + 1):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # wait for the maintenance function to run
         time.sleep(2)
 
         # we should NOT be dropped!
         (_, receivedResponse) = self.sendUDPQuery(query, response)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # now with rcode!
         sent = 0
@@ -363,8 +363,8 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(expectedResponse, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(expectedResponse, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -381,7 +381,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)
@@ -389,23 +389,23 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # again, over TCP this time
         # start with normal responses
         for _ in range((self._dynBlockQPS * self._dynBlockPeriod) + 1):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # wait for the maintenance function to run
         time.sleep(2)
 
         # we should NOT be dropped!
         (_, receivedResponse) = self.sendUDPQuery(query, response)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # now with rcode!
         sent = 0
@@ -415,8 +415,8 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(expectedResponse, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(expectedResponse, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -433,7 +433,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)
@@ -441,8 +441,8 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
     def doTestRCodeRatio(self, name, rcode, noerrorcount, rcodecount):
         query = dns.message.make_query(name, 'A', 'IN')
@@ -460,15 +460,15 @@ class DynBlocksTest(DNSDistTest):
         for _ in range(noerrorcount-1):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # wait for the maintenance function to run
         time.sleep(2)
 
         # we should NOT be dropped!
         (_, receivedResponse) = self.sendUDPQuery(query, response)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # now with rcode!
         sent = 0
@@ -478,8 +478,8 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(expectedResponse, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(expectedResponse, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -494,7 +494,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)
@@ -502,23 +502,23 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # again, over TCP this time
         # start with normal responses
         for _ in range(noerrorcount-1):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # wait for the maintenance function to run
         time.sleep(2)
 
         # we should NOT be dropped!
         (_, receivedResponse) = self.sendUDPQuery(query, response)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # now with rcode!
         sent = 0
@@ -528,8 +528,8 @@ class DynBlocksTest(DNSDistTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(expectedResponse, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(expectedResponse, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -544,7 +544,7 @@ class DynBlocksTest(DNSDistTest):
 
         # we should now be dropped for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)
@@ -552,8 +552,8 @@ class DynBlocksTest(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
 class TestDynBlockQPS(DynBlocksTest):
 
@@ -753,11 +753,11 @@ class TestDynBlockQPSActionTruncated(DNSDistTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(receivedResponse, response)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(receivedResponse, response)
                 allowed = allowed + 1
             else:
-                self.assertEquals(receivedResponse, truncatedResponse)
+                self.assertEqual(receivedResponse, truncatedResponse)
                 # the query has not reached the responder,
                 # let's clear the response queue
                 self.clearToResponderQueue()
@@ -772,13 +772,13 @@ class TestDynBlockQPSActionTruncated(DNSDistTest):
 
         # we should now be 'truncated' for up to self._dynBlockDuration + self._dynBlockPeriod
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, truncatedResponse)
+        self.assertEqual(receivedResponse, truncatedResponse)
 
         # check over TCP, which should not be truncated
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
 
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         # wait until we are not blocked anymore
         time.sleep(self._dynBlockDuration + self._dynBlockPeriod)
@@ -786,8 +786,8 @@ class TestDynBlockQPSActionTruncated(DNSDistTest):
         # this one should succeed
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         allowed = 0
         sent = 0
@@ -795,12 +795,12 @@ class TestDynBlockQPSActionTruncated(DNSDistTest):
         for _ in range((self._dynBlockQPS * self._dynBlockPeriod) + 1):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
             sent = sent + 1
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, response)
             receivedQuery.id = query.id
             allowed = allowed + 1
 
-        self.assertEquals(allowed, sent)
+        self.assertEqual(allowed, sent)
 
 class TestDynBlockServFails(DynBlocksTest):
 
@@ -875,8 +875,8 @@ class TestDynBlockAllowlist(DynBlocksTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -892,8 +892,8 @@ class TestDynBlockAllowlist(DynBlocksTest):
         # we should still not be blocked
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, receivedResponse)
 
         # check that we would have been blocked without the allowlisting
         name = 'allowlisted-test.dynblocks.tests.powerdns.com.'
@@ -908,7 +908,7 @@ class TestDynBlockAllowlist(DynBlocksTest):
                                     '192.0.2.42')
         expectedResponse.answer.append(rrset)
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(receivedResponse, expectedResponse)
 
 class TestDynBlockGroupServFails(DynBlocksTest):
 
@@ -1050,8 +1050,8 @@ class TestDynBlockGroupExcluded(DynBlocksTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -1067,8 +1067,8 @@ class TestDynBlockGroupExcluded(DynBlocksTest):
         # we should still not be blocked
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, receivedResponse)
 
 class TestDynBlockGroupExcludedViaNMG(DynBlocksTest):
 
@@ -1112,8 +1112,8 @@ class TestDynBlockGroupExcludedViaNMG(DynBlocksTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -1129,8 +1129,8 @@ class TestDynBlockGroupExcludedViaNMG(DynBlocksTest):
         # we should still not be blocked
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, receivedResponse)
 
 class TestDynBlockGroupNoOp(DynBlocksTest):
 
@@ -1172,8 +1172,8 @@ class TestDynBlockGroupNoOp(DynBlocksTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -1189,8 +1189,8 @@ class TestDynBlockGroupNoOp(DynBlocksTest):
         # the rule should still be present, but the queries pass through anyway
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, receivedResponse)
 
         # check that the rule has been inserted
         self.doTestDynBlockViaAPI('127.0.0.1/32', 'Exceeded query rate', self._dynBlockDuration - 4, self._dynBlockDuration, 0, sent)
@@ -1236,8 +1236,8 @@ class TestDynBlockGroupWarning(DynBlocksTest):
             sent = sent + 1
             if receivedQuery:
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
                 allowed = allowed + 1
             else:
                 # the query has not reached the responder,
@@ -1254,8 +1254,8 @@ class TestDynBlockGroupWarning(DynBlocksTest):
         # the rule should still be present, but the queries pass through anyway
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, receivedResponse)
 
         # check that the rule has been inserted
         self.doTestDynBlockViaAPI('127.0.0.1/32', 'Exceeded query rate', self._dynBlockDuration - 4, self._dynBlockDuration, 0, sent)

--- a/regression-tests.dnsdist/test_EDNSOptions.py
+++ b/regression-tests.dnsdist/test_EDNSOptions.py
@@ -92,8 +92,8 @@ class TestEDNSOptions(EDNSOptionsBase):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testCookie(self):
         """
@@ -116,8 +116,8 @@ class TestEDNSOptions(EDNSOptionsBase):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testECS4(self):
         """
@@ -140,8 +140,8 @@ class TestEDNSOptions(EDNSOptionsBase):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testECS6(self):
         """
@@ -164,8 +164,8 @@ class TestEDNSOptions(EDNSOptionsBase):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testECS6Cookie(self):
         """
@@ -189,8 +189,8 @@ class TestEDNSOptions(EDNSOptionsBase):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testMultiCookiesECS6(self):
         """
@@ -215,8 +215,8 @@ class TestEDNSOptions(EDNSOptionsBase):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
 class TestEDNSOptionsAddingECS(EDNSOptionsBase):
 
@@ -382,8 +382,8 @@ class TestEDNSOptionsAddingECS(EDNSOptionsBase):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
 class TestEDNSOptionsLuaFFI(DNSDistTest):
 
@@ -544,8 +544,8 @@ class TestEDNSOptionsLuaFFI(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testCookieFFI(self):
         """
@@ -568,8 +568,8 @@ class TestEDNSOptionsLuaFFI(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testECS4FFI(self):
         """
@@ -592,8 +592,8 @@ class TestEDNSOptionsLuaFFI(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testECS6FFI(self):
         """
@@ -616,8 +616,8 @@ class TestEDNSOptionsLuaFFI(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testECS6CookieFFI(self):
         """
@@ -641,8 +641,8 @@ class TestEDNSOptionsLuaFFI(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testMultiCookiesECS6FFI(self):
         """
@@ -667,5 +667,5 @@ class TestEDNSOptionsLuaFFI(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)

--- a/regression-tests.dnsdist/test_EDNSSelfGenerated.py
+++ b/regression-tests.dnsdist/test_EDNSSelfGenerated.py
@@ -95,7 +95,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertFalse(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
         name = 'edns-no-do.tc.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, want_dnssec=False)
@@ -109,7 +109,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertFalse(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
         name = 'edns-no-do.lua.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, want_dnssec=False)
@@ -121,7 +121,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertFalse(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
         name = 'edns-no-do.spoof.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, want_dnssec=False)
@@ -139,7 +139,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertFalse(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
     def testWithEDNSWithDO(self):
         """
@@ -156,7 +156,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertTrue(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
         name = 'edns-do.tc.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, want_dnssec=True)
@@ -170,7 +170,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertTrue(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
         name = 'edns-do.lua.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, want_dnssec=True)
@@ -182,7 +182,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertTrue(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
         name = 'edns-do.spoof.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, payload=4096, want_dnssec=True)
@@ -200,7 +200,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertTrue(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
     def testWithEDNSNoOptions(self):
         """
@@ -218,7 +218,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertTrue(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
         name = 'edns-options.tc.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, options=[ecso], payload=512, want_dnssec=True)
@@ -232,7 +232,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertTrue(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
         name = 'edns-options.lua.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, options=[ecso], payload=512, want_dnssec=True)
@@ -244,7 +244,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertTrue(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
         name = 'edns-options.spoof.edns-self.tests.powerdns.com.'
         query = dns.message.make_query(name, 'A', 'IN', use_edns=True, options=[ecso], payload=512, want_dnssec=True)
@@ -262,7 +262,7 @@ class TestEDNSSelfGenerated(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertTrue(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1042)
+            self.assertEqual(receivedResponse.payload, 1042)
 
 
 class TestEDNSSelfGeneratedDisabled(DNSDistTest):

--- a/regression-tests.dnsdist/test_HealthChecks.py
+++ b/regression-tests.dnsdist/test_HealthChecks.py
@@ -29,39 +29,39 @@ class TestDefaultHealthCheck(HealthCheckTest):
         before = TestDefaultHealthCheck._healthCheckCounter
         time.sleep(1.5)
         self.assertGreater(TestDefaultHealthCheck._healthCheckCounter, before)
-        self.assertEquals(self.getBackendStatus(), 'up')
+        self.assertEqual(self.getBackendStatus(), 'up')
 
         self.sendConsoleCommand("getServer(0):setUp()")
-        self.assertEquals(self.getBackendStatus(), 'up')
+        self.assertEqual(self.getBackendStatus(), 'up')
 
         before = TestDefaultHealthCheck._healthCheckCounter
         time.sleep(1.5)
-        self.assertEquals(TestDefaultHealthCheck._healthCheckCounter, before)
+        self.assertEqual(TestDefaultHealthCheck._healthCheckCounter, before)
 
         self.sendConsoleCommand("getServer(0):setDown()")
-        self.assertEquals(self.getBackendStatus(), 'down')
+        self.assertEqual(self.getBackendStatus(), 'down')
 
         before = TestDefaultHealthCheck._healthCheckCounter
         time.sleep(1.5)
-        self.assertEquals(TestDefaultHealthCheck._healthCheckCounter, before)
+        self.assertEqual(TestDefaultHealthCheck._healthCheckCounter, before)
 
         self.sendConsoleCommand("getServer(0):setAuto()")
         # we get back the previous state, which was up
-        self.assertEquals(self.getBackendStatus(), 'up')
+        self.assertEqual(self.getBackendStatus(), 'up')
 
         before = TestDefaultHealthCheck._healthCheckCounter
         time.sleep(1.5)
         self.assertGreater(TestDefaultHealthCheck._healthCheckCounter, before)
-        self.assertEquals(self.getBackendStatus(), 'up')
+        self.assertEqual(self.getBackendStatus(), 'up')
 
         self.sendConsoleCommand("getServer(0):setDown()")
-        self.assertEquals(self.getBackendStatus(), 'down')
+        self.assertEqual(self.getBackendStatus(), 'down')
         self.sendConsoleCommand("getServer(0):setAuto(false)")
 
         before = TestDefaultHealthCheck._healthCheckCounter
         time.sleep(1.5)
         self.assertGreater(TestDefaultHealthCheck._healthCheckCounter, before)
-        self.assertEquals(self.getBackendStatus(), 'up')
+        self.assertEqual(self.getBackendStatus(), 'up')
 
 class TestHealthCheckForcedUP(HealthCheckTest):
     # this test suite uses a different responder port
@@ -81,8 +81,8 @@ class TestHealthCheckForcedUP(HealthCheckTest):
         """
         before = TestHealthCheckForcedUP._healthCheckCounter
         time.sleep(1.5)
-        self.assertEquals(TestHealthCheckForcedUP._healthCheckCounter, before)
-        self.assertEquals(self.getBackendStatus(), 'up')
+        self.assertEqual(TestHealthCheckForcedUP._healthCheckCounter, before)
+        self.assertEqual(self.getBackendStatus(), 'up')
 
 class TestHealthCheckForcedDown(HealthCheckTest):
     # this test suite uses a different responder port
@@ -102,7 +102,7 @@ class TestHealthCheckForcedDown(HealthCheckTest):
         """
         before = TestHealthCheckForcedDown._healthCheckCounter
         time.sleep(1.5)
-        self.assertEquals(TestHealthCheckForcedDown._healthCheckCounter, before)
+        self.assertEqual(TestHealthCheckForcedDown._healthCheckCounter, before)
 
 class TestHealthCheckCustomName(HealthCheckTest):
     # this test suite uses a different responder port
@@ -124,7 +124,7 @@ class TestHealthCheckCustomName(HealthCheckTest):
         before = TestHealthCheckCustomName._healthCheckCounter
         time.sleep(1.5)
         self.assertGreater(TestHealthCheckCustomName._healthCheckCounter, before)
-        self.assertEquals(self.getBackendStatus(), 'up')
+        self.assertEqual(self.getBackendStatus(), 'up')
 
 class TestHealthCheckCustomNameNoAnswer(HealthCheckTest):
     # this test suite uses a different responder port
@@ -144,8 +144,8 @@ class TestHealthCheckCustomNameNoAnswer(HealthCheckTest):
         """
         before = TestHealthCheckCustomNameNoAnswer._healthCheckCounter
         time.sleep(1.5)
-        self.assertEquals(TestHealthCheckCustomNameNoAnswer._healthCheckCounter, before)
-        self.assertEquals(self.getBackendStatus(), 'down')
+        self.assertEqual(TestHealthCheckCustomNameNoAnswer._healthCheckCounter, before)
+        self.assertEqual(self.getBackendStatus(), 'down')
 
 class TestHealthCheckCustomFunction(HealthCheckTest):
     # this test suite uses a different responder port
@@ -174,4 +174,4 @@ class TestHealthCheckCustomFunction(HealthCheckTest):
         before = TestHealthCheckCustomFunction._healthCheckCounter
         time.sleep(1.5)
         self.assertGreater(TestHealthCheckCustomFunction._healthCheckCounter, before)
-        self.assertEquals(self.getBackendStatus(), 'up')
+        self.assertEqual(self.getBackendStatus(), 'up')

--- a/regression-tests.dnsdist/test_LMDB.py
+++ b/regression-tests.dnsdist/test_LMDB.py
@@ -99,7 +99,7 @@ class TestLMDB(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLMDBQNamePlusTagLookup(self):
         """
@@ -122,7 +122,7 @@ class TestLMDB(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLMDBSuffixLookup(self):
         """
@@ -145,7 +145,7 @@ class TestLMDB(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLMDBQNamePlainText(self):
         """
@@ -168,7 +168,7 @@ class TestLMDB(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLMDBKeyValueStoreLookupRule(self):
         """
@@ -191,4 +191,4 @@ class TestLMDB(DNSDistTest):
             (receivedQuery, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertFalse(receivedQuery)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)

--- a/regression-tests.dnsdist/test_OCSP.py
+++ b/regression-tests.dnsdist/test_OCSP.py
@@ -86,7 +86,7 @@ class TestOCSPStaplingDOH(DNSDistOCSPStaplingTest):
         self.assertIn('OCSP Response Status: successful (0x0)', output)
         serialNumber2 = self.getOCSPSerial(output)
         self.assertTrue(serialNumber2)
-        self.assertNotEquals(serialNumber, serialNumber2)
+        self.assertNotEqual(serialNumber, serialNumber2)
 
 class TestOCSPStaplingTLSGnuTLS(DNSDistOCSPStaplingTest):
 
@@ -128,7 +128,7 @@ class TestOCSPStaplingTLSGnuTLS(DNSDistOCSPStaplingTest):
         self.assertIn('OCSP Response Status: successful (0x0)', output)
         serialNumber2 = self.getOCSPSerial(output)
         self.assertTrue(serialNumber2)
-        self.assertNotEquals(serialNumber, serialNumber2)
+        self.assertNotEqual(serialNumber, serialNumber2)
 
 class TestOCSPStaplingTLSOpenSSL(DNSDistOCSPStaplingTest):
 
@@ -170,4 +170,4 @@ class TestOCSPStaplingTLSOpenSSL(DNSDistOCSPStaplingTest):
         self.assertIn('OCSP Response Status: successful (0x0)', output)
         serialNumber2 = self.getOCSPSerial(output)
         self.assertTrue(serialNumber2)
-        self.assertNotEquals(serialNumber, serialNumber2)
+        self.assertNotEqual(serialNumber, serialNumber2)

--- a/regression-tests.dnsdist/test_OOOR.py
+++ b/regression-tests.dnsdist/test_OOOR.py
@@ -195,7 +195,7 @@ class TestOOORWithClientNotBackend(DNSDistTest):
             self.assertTrue(receivedResponse)
             receivedResponses[str(receivedResponse.question[0].name)] = (receivedResponse)
 
-        self.assertEquals(len(receivedResponses), 5)
+        self.assertEqual(len(receivedResponses), 5)
         for idx in range(5):
             self.assertIn('%d.simple.ooor.tests.powerdns.com.' % (idx), receivedResponses)
 
@@ -230,7 +230,7 @@ class TestOOORWithClientNotBackend(DNSDistTest):
             self.assertTrue(receivedResponse)
             receivedResponses[str(receivedResponse.question[0].name)] = (receivedResponse)
 
-        self.assertEquals(len(receivedResponses), 100)
+        self.assertEqual(len(receivedResponses), 100)
         for idx in range(5):
             self.assertIn('%d.more-queries.ooor.tests.powerdns.com.' % (idx), receivedResponses)
 
@@ -284,11 +284,11 @@ class TestOOORWithClientAndBackend(DNSDistTest):
             self.assertTrue(receivedResponse)
             receivedResponses[str(receivedResponse.question[0].name)] = (receivedResponse)
 
-        self.assertEquals(len(receivedResponses), 5)
+        self.assertEqual(len(receivedResponses), 5)
         for idx in range(5):
             self.assertIn('%d.simple.reverse-ooor.tests.powerdns.com.' % (idx), receivedResponses)
 
-        self.assertEquals(ReverseOOORTCPResponder.numberOfConnections, 1)
+        self.assertEqual(ReverseOOORTCPResponder.numberOfConnections, 1)
 
     def testMoreQueriesThanAllowedInFlight(self):
         """
@@ -318,10 +318,10 @@ class TestOOORWithClientAndBackend(DNSDistTest):
             receivedResponses[str(receivedResponse.question[0].name)] = (receivedResponse)
             #print("Received a response for %s" % (receivedResponse.question[0].name))
 
-        self.assertEquals(len(receivedResponses), 100)
+        self.assertEqual(len(receivedResponses), 100)
         for idx in range(5):
             self.assertIn('%d.more-queries.reverse-ooor.tests.powerdns.com.' % (idx), receivedResponses)
 
         # in theory they could all be handled by the same backend if we get the responses
         # fast enough, but over 100 queries that's very, very unlikely
-        self.assertEquals(ReverseOOORTCPResponder.numberOfConnections, 2)
+        self.assertEqual(ReverseOOORTCPResponder.numberOfConnections, 2)

--- a/regression-tests.dnsdist/test_Prometheus.py
+++ b/regression-tests.dnsdist/test_Prometheus.py
@@ -26,11 +26,11 @@ class TestPrometheus(DNSDistTest):
                 self.assertGreaterEqual(len(tokens), 4)
             elif line.startswith('# TYPE'):
                 tokens = line.split(' ')
-                self.assertEquals(len(tokens), 4)
+                self.assertEqual(len(tokens), 4)
                 self.assertIn(tokens[3], ['counter', 'gauge', 'histogram'])
             elif not line.startswith('#'):
                 tokens = line.split(' ')
-                self.assertEquals(len(tokens), 2)
+                self.assertEqual(len(tokens), 2)
                 if not line.startswith('dnsdist_'):
                     raise AssertionError('Expecting prometheus metric to be prefixed by \'dnsdist_\', got: "%s"' % (line))
 
@@ -59,6 +59,6 @@ class TestPrometheus(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/metrics'
         r = requests.get(url, auth=('whatever', self._webServerBasicAuthPassword), timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.checkPrometheusContentBasic(r.text)
         self.checkPrometheusContentPromtool(r.content)

--- a/regression-tests.dnsdist/test_Protobuf.py
+++ b/regression-tests.dnsdist/test_Protobuf.py
@@ -69,42 +69,42 @@ class DNSDistProtobufTest(DNSDistTest):
         self.assertTrue(msg)
         self.assertTrue(msg.HasField('timeSec'))
         self.assertTrue(msg.HasField('socketFamily'))
-        self.assertEquals(msg.socketFamily, dnsmessage_pb2.PBDNSMessage.INET)
+        self.assertEqual(msg.socketFamily, dnsmessage_pb2.PBDNSMessage.INET)
         self.assertTrue(msg.HasField('from'))
         fromvalue = getattr(msg, 'from')
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, fromvalue), initiator)
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, fromvalue), initiator)
         self.assertTrue(msg.HasField('socketProtocol'))
-        self.assertEquals(msg.socketProtocol, protocol)
+        self.assertEqual(msg.socketProtocol, protocol)
         self.assertTrue(msg.HasField('messageId'))
         self.assertTrue(msg.HasField('id'))
-        self.assertEquals(msg.id, query.id)
+        self.assertEqual(msg.id, query.id)
         self.assertTrue(msg.HasField('inBytes'))
         self.assertTrue(msg.HasField('serverIdentity'))
-        self.assertEquals(msg.serverIdentity, self._protobufServerID.encode('utf-8'))
+        self.assertEqual(msg.serverIdentity, self._protobufServerID.encode('utf-8'))
 
         if normalQueryResponse:
           # compare inBytes with length of query/response
-          self.assertEquals(msg.inBytes, len(query.to_wire()))
+          self.assertEqual(msg.inBytes, len(query.to_wire()))
         # dnsdist doesn't set the existing EDNS Subnet for now,
         # although it might be set from Lua
         # self.assertTrue(msg.HasField('originalRequestorSubnet'))
-        # self.assertEquals(len(msg.originalRequestorSubnet), 4)
-        # self.assertEquals(socket.inet_ntop(socket.AF_INET, msg.originalRequestorSubnet), '127.0.0.1')
+        # self.assertEqual(len(msg.originalRequestorSubnet), 4)
+        # self.assertEqual(socket.inet_ntop(socket.AF_INET, msg.originalRequestorSubnet), '127.0.0.1')
 
     def checkProtobufQuery(self, msg, protocol, query, qclass, qtype, qname, initiator='127.0.0.1'):
-        self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSQueryType)
+        self.assertEqual(msg.type, dnsmessage_pb2.PBDNSMessage.DNSQueryType)
         self.checkProtobufBase(msg, protocol, query, initiator)
         # dnsdist doesn't fill the responder field for responses
         # because it doesn't keep the information around.
         self.assertTrue(msg.HasField('to'))
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, msg.to), '127.0.0.1')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, msg.to), '127.0.0.1')
         self.assertTrue(msg.HasField('question'))
         self.assertTrue(msg.question.HasField('qClass'))
-        self.assertEquals(msg.question.qClass, qclass)
+        self.assertEqual(msg.question.qClass, qclass)
         self.assertTrue(msg.question.HasField('qType'))
-        self.assertEquals(msg.question.qClass, qtype)
+        self.assertEqual(msg.question.qClass, qtype)
         self.assertTrue(msg.question.HasField('qName'))
-        self.assertEquals(msg.question.qName, qname)
+        self.assertEqual(msg.question.qName, qname)
 
     def checkProtobufTags(self, tags, expectedTags):
         # only differences will be in new list
@@ -113,27 +113,27 @@ class DNSDistProtobufTest(DNSDistTest):
         self.assertEqual(len(listx), 0, "Protobuf tags don't match")
 
     def checkProtobufQueryConvertedToResponse(self, msg, protocol, response, initiator='127.0.0.0'):
-        self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
+        self.assertEqual(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
         # skip comparing inBytes (size of the query) with the length of the generated response
         self.checkProtobufBase(msg, protocol, response, initiator, False)
         self.assertTrue(msg.HasField('response'))
         self.assertTrue(msg.response.HasField('queryTimeSec'))
 
     def checkProtobufResponse(self, msg, protocol, response, initiator='127.0.0.1'):
-        self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
+        self.assertEqual(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
         self.checkProtobufBase(msg, protocol, response, initiator)
         self.assertTrue(msg.HasField('response'))
         self.assertTrue(msg.response.HasField('queryTimeSec'))
 
     def checkProtobufResponseRecord(self, record, rclass, rtype, rname, rttl):
         self.assertTrue(record.HasField('class'))
-        self.assertEquals(getattr(record, 'class'), rclass)
+        self.assertEqual(getattr(record, 'class'), rclass)
         self.assertTrue(record.HasField('type'))
-        self.assertEquals(record.type, rtype)
+        self.assertEqual(record.type, rtype)
         self.assertTrue(record.HasField('name'))
-        self.assertEquals(record.name, rname)
+        self.assertEqual(record.name, rname)
         self.assertTrue(record.HasField('ttl'))
-        self.assertEquals(record.ttl, rttl)
+        self.assertEqual(record.ttl, rttl)
         self.assertTrue(record.HasField('rdata'))
 
 class TestProtobuf(DNSDistProtobufTest):
@@ -273,8 +273,8 @@ class TestProtobuf(DNSDistProtobufTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # let the protobuf messages the time to get there
         time.sleep(1)
@@ -289,20 +289,20 @@ class TestProtobuf(DNSDistProtobufTest):
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response)
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Response,456"])
-        self.assertEquals(len(msg.response.rrs), 2)
+        self.assertEqual(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.CNAME, name, 3600)
-        self.assertEquals(rr.rdata.decode('utf-8'), target)
+        self.assertEqual(rr.rdata.decode('utf-8'), target)
         rr = msg.response.rrs[1]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, target, 3600)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
 
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # let the protobuf messages the time to get there
         time.sleep(1)
@@ -317,13 +317,13 @@ class TestProtobuf(DNSDistProtobufTest):
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, response)
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Response,456"])
-        self.assertEquals(len(msg.response.rrs), 2)
+        self.assertEqual(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.CNAME, name, 3600)
-        self.assertEquals(rr.rdata.decode('utf-8'), target)
+        self.assertEqual(rr.rdata.decode('utf-8'), target)
         rr = msg.response.rrs[1]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, target, 3600)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
 
     def testLuaProtobuf(self):
 
@@ -346,8 +346,8 @@ class TestProtobuf(DNSDistProtobufTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
 
         # let the protobuf messages the time to get there
@@ -363,17 +363,17 @@ class TestProtobuf(DNSDistProtobufTest):
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response, '127.0.0.0')
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Response,456"])
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         for rr in msg.response.rrs:
             self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 3600)
-            self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
+            self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
 
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # let the protobuf messages the time to get there
         time.sleep(1)
@@ -387,10 +387,10 @@ class TestProtobuf(DNSDistProtobufTest):
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, response, '127.0.0.0')
         self.checkProtobufTags(msg.response.tags, [ u"TestLabel1,TestData1", u"TestLabel2,TestData2", u"TestLabel3,TestData3", u"Response,456"])
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         for rr in msg.response.rrs:
             self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 3600)
-            self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
+            self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
 
 class TestProtobufIPCipher(DNSDistProtobufTest):
     _config_params = ['_testServerPort', '_protobufServerPort', '_protobufServerID', '_protobufServerID']
@@ -431,8 +431,8 @@ class TestProtobufIPCipher(DNSDistProtobufTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # let the protobuf messages the time to get there
         time.sleep(1)
@@ -447,20 +447,20 @@ class TestProtobufIPCipher(DNSDistProtobufTest):
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, response, '108.41.239.98')
 
-        self.assertEquals(len(msg.response.rrs), 2)
+        self.assertEqual(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.CNAME, name, 3600)
-        self.assertEquals(rr.rdata.decode('ascii'), target)
+        self.assertEqual(rr.rdata.decode('ascii'), target)
         rr = msg.response.rrs[1]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, target, 3600)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
 
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # let the protobuf messages the time to get there
         time.sleep(1)
@@ -473,10 +473,10 @@ class TestProtobufIPCipher(DNSDistProtobufTest):
         # check the protobuf message corresponding to the TCP response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.TCP, response, '108.41.239.98')
-        self.assertEquals(len(msg.response.rrs), 2)
+        self.assertEqual(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.CNAME, name, 3600)
-        self.assertEquals(rr.rdata.decode('ascii'), target)
+        self.assertEqual(rr.rdata.decode('ascii'), target)
         rr = msg.response.rrs[1]
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, target, 3600)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '127.0.0.1')

--- a/regression-tests.dnsdist/test_ProxyProtocol.py
+++ b/regression-tests.dnsdist/test_ProxyProtocol.py
@@ -145,32 +145,32 @@ class ProxyProtocolTest(DNSDistTest):
     def checkMessageProxyProtocol(self, receivedProxyPayload, source, destination, isTCP, values=[], v6=False, sourcePort=None, destinationPort=None):
       proxy = ProxyProtocol()
       self.assertTrue(proxy.parseHeader(receivedProxyPayload))
-      self.assertEquals(proxy.version, 0x02)
-      self.assertEquals(proxy.command, 0x01)
+      self.assertEqual(proxy.version, 0x02)
+      self.assertEqual(proxy.command, 0x01)
       if v6:
-        self.assertEquals(proxy.family, 0x02)
+        self.assertEqual(proxy.family, 0x02)
       else:
-        self.assertEquals(proxy.family, 0x01)
+        self.assertEqual(proxy.family, 0x01)
       if not isTCP:
-        self.assertEquals(proxy.protocol, 0x02)
+        self.assertEqual(proxy.protocol, 0x02)
       else:
-        self.assertEquals(proxy.protocol, 0x01)
+        self.assertEqual(proxy.protocol, 0x01)
       self.assertGreater(proxy.contentLen, 0)
 
       self.assertTrue(proxy.parseAddressesAndPorts(receivedProxyPayload))
-      self.assertEquals(proxy.source, source)
-      self.assertEquals(proxy.destination, destination)
+      self.assertEqual(proxy.source, source)
+      self.assertEqual(proxy.destination, destination)
       if sourcePort:
-        self.assertEquals(proxy.sourcePort, sourcePort)
+        self.assertEqual(proxy.sourcePort, sourcePort)
       if destinationPort:
-        self.assertEquals(proxy.destinationPort, destinationPort)
+        self.assertEqual(proxy.destinationPort, destinationPort)
       else:
-        self.assertEquals(proxy.destinationPort, self._dnsDistPort)
+        self.assertEqual(proxy.destinationPort, self._dnsDistPort)
 
       self.assertTrue(proxy.parseAdditionalValues(receivedProxyPayload))
       proxy.values.sort()
       values.sort()
-      self.assertEquals(proxy.values, values)
+      self.assertEqual(proxy.values, values)
 
 class TestProxyProtocol(ProxyProtocolTest):
     """
@@ -221,8 +221,8 @@ class TestProxyProtocol(ProxyProtocolTest):
         receivedQuery = dns.message.from_wire(receivedDNSData)
         receivedQuery.id = query.id
         receivedResponse.id = response.id
-        self.assertEquals(receivedQuery, query)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
         self.checkMessageProxyProtocol(receivedProxyPayload, '127.0.0.1', '127.0.0.1', False)
 
     def testProxyTCP(self):
@@ -252,8 +252,8 @@ class TestProxyProtocol(ProxyProtocolTest):
       receivedQuery = dns.message.from_wire(receivedDNSData)
       receivedQuery.id = query.id
       receivedResponse.id = response.id
-      self.assertEquals(receivedQuery, query)
-      self.assertEquals(receivedResponse, response)
+      self.assertEqual(receivedQuery, query)
+      self.assertEqual(receivedResponse, response)
       self.checkMessageProxyProtocol(receivedProxyPayload, '127.0.0.1', '127.0.0.1', True)
 
     def testProxyUDPWithValuesFromLua(self):
@@ -286,8 +286,8 @@ class TestProxyProtocol(ProxyProtocolTest):
         receivedQuery = dns.message.from_wire(receivedDNSData)
         receivedQuery.id = query.id
         receivedResponse.id = response.id
-        self.assertEquals(receivedQuery, query)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
         self.checkMessageProxyProtocol(receivedProxyPayload, '127.0.0.1', '127.0.0.1', False, [ [0, b'foo'] , [ 42, b'bar'] ])
 
     def testProxyTCPWithValuesFromLua(self):
@@ -317,8 +317,8 @@ class TestProxyProtocol(ProxyProtocolTest):
       receivedQuery = dns.message.from_wire(receivedDNSData)
       receivedQuery.id = query.id
       receivedResponse.id = response.id
-      self.assertEquals(receivedQuery, query)
-      self.assertEquals(receivedResponse, response)
+      self.assertEqual(receivedQuery, query)
+      self.assertEqual(receivedResponse, response)
       self.checkMessageProxyProtocol(receivedProxyPayload, '127.0.0.1', '127.0.0.1', True, [ [0, b'foo'] , [ 42, b'bar'] ])
 
     def testProxyUDPWithValuesFromAction(self):
@@ -351,8 +351,8 @@ class TestProxyProtocol(ProxyProtocolTest):
         receivedQuery = dns.message.from_wire(receivedDNSData)
         receivedQuery.id = query.id
         receivedResponse.id = response.id
-        self.assertEquals(receivedQuery, query)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
         self.checkMessageProxyProtocol(receivedProxyPayload, '127.0.0.1', '127.0.0.1', False, [ [1, b'dnsdist'] , [ 255, b'proxy-protocol'] ])
 
     def testProxyTCPWithValuesFromAction(self):
@@ -382,8 +382,8 @@ class TestProxyProtocol(ProxyProtocolTest):
       receivedQuery = dns.message.from_wire(receivedDNSData)
       receivedQuery.id = query.id
       receivedResponse.id = response.id
-      self.assertEquals(receivedQuery, query)
-      self.assertEquals(receivedResponse, response)
+      self.assertEqual(receivedQuery, query)
+      self.assertEqual(receivedResponse, response)
       self.checkMessageProxyProtocol(receivedProxyPayload, '127.0.0.1', '127.0.0.1', True, [ [1, b'dnsdist'] , [ 255, b'proxy-protocol'] ])
 
     def testProxyTCPSeveralQueriesOnSameConnection(self):
@@ -414,8 +414,8 @@ class TestProxyProtocol(ProxyProtocolTest):
         receivedQuery = dns.message.from_wire(receivedDNSData)
         receivedQuery.id = query.id
         receivedResponse.id = response.id
-        self.assertEquals(receivedQuery, query)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
         self.checkMessageProxyProtocol(receivedProxyPayload, '127.0.0.1', '127.0.0.1', True, [])
 
 class TestProxyProtocolIncoming(ProxyProtocolTest):
@@ -474,7 +474,7 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
           sender = getattr(self, method)
           (_, receivedResponse) = sender(query, response=None)
-          self.assertEquals(receivedResponse, None)
+          self.assertEqual(receivedResponse, None)
 
     def testIncomingProxyDest(self):
         """
@@ -499,7 +499,7 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
 
         udpPayload = ProxyProtocol.getPayload(False, False, True, srcAddr, destAddr, srcPort, destPort, [ [ 2, b'foo'], [ 3, b'proxy'] ])
         (_, receivedResponse) = self.sendUDPQuery(udpPayload + query.to_wire(), response=None, useQueue=False, rawQuery=True)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         tcpPayload = ProxyProtocol.getPayload(False, True, True, srcAddr, destAddr, srcPort, destPort, [ [ 2, b'foo'], [ 3, b'proxy'] ])
         wire = query.to_wire()
@@ -513,7 +513,7 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
           receivedResponse = self.recvTCPResponseOverConnection(conn)
         except socket.timeout:
           print('timeout')
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
     def testProxyUDPWithValuesFromLua(self):
         """
@@ -541,8 +541,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
         receivedQuery = dns.message.from_wire(receivedDNSData)
         receivedQuery.id = query.id
         receivedResponse.id = response.id
-        self.assertEquals(receivedQuery, query)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
         self.checkMessageProxyProtocol(receivedProxyPayload, srcAddr, destAddr, False, [ [0, b'foo'], [1, b'dnsdist'], [ 2, b'foo'], [3, b'proxy'], [ 42, b'bar'], [255, b'proxy-protocol'] ], True, srcPort, destPort)
 
     def testProxyTCPWithValuesFromLua(self):
@@ -574,7 +574,7 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
           receivedResponse = self.recvTCPResponseOverConnection(conn)
         except socket.timeout:
           print('timeout')
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         (receivedProxyPayload, receivedDNSData) = fromProxyQueue.get(True, 2.0)
         self.assertTrue(receivedProxyPayload)
@@ -584,8 +584,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
         receivedQuery = dns.message.from_wire(receivedDNSData)
         receivedQuery.id = query.id
         receivedResponse.id = response.id
-        self.assertEquals(receivedQuery, query)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
         self.checkMessageProxyProtocol(receivedProxyPayload, srcAddr, destAddr, True, [ [0, b'foo'], [1, b'dnsdist'], [ 2, b'foo'], [3, b'proxy'], [ 42, b'bar'], [255, b'proxy-protocol'] ], True, srcPort, destPort)
 
     def testProxyUDPWithValueOverride(self):
@@ -614,8 +614,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
         receivedQuery = dns.message.from_wire(receivedDNSData)
         receivedQuery.id = query.id
         receivedResponse.id = response.id
-        self.assertEquals(receivedQuery, query)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
         self.checkMessageProxyProtocol(receivedProxyPayload, srcAddr, destAddr, False, [ [50, b'overridden'] ], True, srcPort, destPort)
 
     def testProxyTCPSeveralQueriesOverConnection(self):
@@ -647,7 +647,7 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
           receivedResponse = self.recvTCPResponseOverConnection(conn)
         except socket.timeout:
           print('timeout')
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         (receivedProxyPayload, receivedDNSData) = fromProxyQueue.get(True, 2.0)
         self.assertTrue(receivedProxyPayload)
@@ -657,8 +657,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
         receivedQuery = dns.message.from_wire(receivedDNSData)
         receivedQuery.id = query.id
         receivedResponse.id = response.id
-        self.assertEquals(receivedQuery, query)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedQuery, query)
+        self.assertEqual(receivedResponse, response)
         self.checkMessageProxyProtocol(receivedProxyPayload, srcAddr, destAddr, True, [ [0, b'foo'], [1, b'dnsdist'], [ 2, b'foo'], [3, b'proxy'], [ 42, b'bar'], [255, b'proxy-protocol'] ], True, srcPort, destPort)
 
         for idx in range(5):
@@ -671,7 +671,7 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
           except socket.timeout:
             print('timeout')
 
-          self.assertEquals(receivedResponse, response)
+          self.assertEqual(receivedResponse, response)
 
           (receivedProxyPayload, receivedDNSData) = fromProxyQueue.get(True, 2.0)
           self.assertTrue(receivedProxyPayload)
@@ -681,8 +681,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
           receivedQuery = dns.message.from_wire(receivedDNSData)
           receivedQuery.id = query.id
           receivedResponse.id = response.id
-          self.assertEquals(receivedQuery, query)
-          self.assertEquals(receivedResponse, response)
+          self.assertEqual(receivedQuery, query)
+          self.assertEqual(receivedResponse, response)
           self.checkMessageProxyProtocol(receivedProxyPayload, srcAddr, destAddr, True, [ [0, b'foo'], [1, b'dnsdist'], [ 2, b'foo'], [3, b'proxy'], [ 42, b'bar'], [255, b'proxy-protocol'] ], True, srcPort, destPort)
 
 class TestProxyProtocolNotExpected(DNSDistTest):
@@ -718,8 +718,8 @@ class TestProxyProtocolNotExpected(DNSDistTest):
           sender = getattr(self, method)
           (receivedQuery, receivedResponse) = sender(query, response)
           receivedQuery.id = query.id
-          self.assertEquals(query, receivedQuery)
-          self.assertEquals(response, receivedResponse)
+          self.assertEqual(query, receivedQuery)
+          self.assertEqual(response, receivedResponse)
 
     def testIncomingProxyDest(self):
         """
@@ -736,7 +736,7 @@ class TestProxyProtocolNotExpected(DNSDistTest):
 
         udpPayload = ProxyProtocol.getPayload(False, False, True, srcAddr, destAddr, srcPort, destPort, [ [ 2, b'foo'], [ 3, b'proxy'] ])
         (_, receivedResponse) = self.sendUDPQuery(udpPayload + query.to_wire(), response=None, useQueue=False, rawQuery=True)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         tcpPayload = ProxyProtocol.getPayload(False, True, True, srcAddr, destAddr, srcPort, destPort, [ [ 2, b'foo'], [ 3, b'proxy'] ])
         wire = query.to_wire()
@@ -750,4 +750,4 @@ class TestProxyProtocolNotExpected(DNSDistTest):
           receivedResponse = self.recvTCPResponseOverConnection(conn)
         except socket.timeout:
           print('timeout')
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)

--- a/regression-tests.dnsdist/test_RecordsCount.py
+++ b/regression-tests.dnsdist/test_RecordsCount.py
@@ -27,7 +27,7 @@ class TestRecordsCountOnlyOneAR(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testRecordsCountAllowOneAR(self):
         """
@@ -51,8 +51,8 @@ class TestRecordsCountOnlyOneAR(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testRecordsCountRefuseTwoAR(self):
         """
@@ -81,7 +81,7 @@ class TestRecordsCountOnlyOneAR(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestRecordsCountMoreThanOneLessThanFour(DNSDistTest):
 
@@ -107,7 +107,7 @@ class TestRecordsCountMoreThanOneLessThanFour(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testRecordsCountAllowTwoAN(self):
         """
@@ -133,8 +133,8 @@ class TestRecordsCountMoreThanOneLessThanFour(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testRecordsCountRefuseFourAN(self):
         """
@@ -160,7 +160,7 @@ class TestRecordsCountMoreThanOneLessThanFour(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestRecordsCountNothingInNS(DNSDistTest):
 
@@ -193,7 +193,7 @@ class TestRecordsCountNothingInNS(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 
     def testRecordsCountAllowEmptyNS(self):
@@ -218,8 +218,8 @@ class TestRecordsCountNothingInNS(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 class TestRecordsCountNoOPTInAR(DNSDistTest):
 
@@ -244,7 +244,7 @@ class TestRecordsCountNoOPTInAR(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testRecordsCountAllowNoOPTInAR(self):
         """
@@ -268,8 +268,8 @@ class TestRecordsCountNoOPTInAR(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testRecordsCountAllowTwoARButNoOPT(self):
         """
@@ -304,5 +304,5 @@ class TestRecordsCountNoOPTInAR(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)

--- a/regression-tests.dnsdist/test_Responses.py
+++ b/regression-tests.dnsdist/test_Responses.py
@@ -29,8 +29,8 @@ class TestResponseRuleNXDelayed(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         end = datetime.now()
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertTrue((end - begin) > timedelta(0, 1))
 
         # NoError over UDP
@@ -39,8 +39,8 @@ class TestResponseRuleNXDelayed(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         end = datetime.now()
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertTrue((end - begin) < timedelta(0, 1))
 
         # NX over TCP
@@ -49,8 +49,8 @@ class TestResponseRuleNXDelayed(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         end = datetime.now()
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertTrue((end - begin) < timedelta(0, 1))
 
 class TestResponseRuleERCode(DNSDistTest):
@@ -80,8 +80,8 @@ class TestResponseRuleERCode(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         end = datetime.now()
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertTrue((end - begin) > timedelta(0, 1))
 
         # BADKEY (17, an ERCode) over UDP
@@ -90,8 +90,8 @@ class TestResponseRuleERCode(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         end = datetime.now()
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertTrue((end - begin) < timedelta(0, 1))
 
         # NoError (non-ERcode, basic RCode bits match BADVERS) over UDP
@@ -100,8 +100,8 @@ class TestResponseRuleERCode(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         end = datetime.now()
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertTrue((end - begin) < timedelta(0, 1))
 
 class TestResponseRuleQNameDropped(DNSDistTest):
@@ -126,8 +126,8 @@ class TestResponseRuleQNameDropped(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, None)
 
     def testNotDropped(self):
         """
@@ -144,8 +144,8 @@ class TestResponseRuleQNameDropped(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 class TestResponseRuleQNameAllowed(DNSDistTest):
 
@@ -170,8 +170,8 @@ class TestResponseRuleQNameAllowed(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testNotAllowed(self):
         """
@@ -188,8 +188,8 @@ class TestResponseRuleQNameAllowed(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, None)
 
 class TestResponseRuleEditTTL(DNSDistTest):
 
@@ -228,10 +228,10 @@ class TestResponseRuleEditTTL(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
-            self.assertNotEquals(response.answer[0].ttl, receivedResponse.answer[0].ttl)
-            self.assertEquals(receivedResponse.answer[0].ttl, self._ttl)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
+            self.assertNotEqual(response.answer[0].ttl, receivedResponse.answer[0].ttl)
+            self.assertEqual(receivedResponse.answer[0].ttl, self._ttl)
 
 class TestResponseLuaActionReturnSyntax(DNSDistTest):
 
@@ -265,8 +265,8 @@ class TestResponseLuaActionReturnSyntax(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
         end = datetime.now()
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertTrue((end - begin) > timedelta(0, 1))
 
     def testDropped(self):
@@ -284,5 +284,5 @@ class TestResponseLuaActionReturnSyntax(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(receivedResponse, None)

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -33,8 +33,8 @@ class TestRoutingPoolRouting(DNSDistTest):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testDefaultPool(self):
         """
@@ -50,7 +50,7 @@ class TestRoutingPoolRouting(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
 class TestRoutingQPSPoolRouting(DNSDistTest):
     _config_template = """
@@ -80,13 +80,13 @@ class TestRoutingQPSPoolRouting(DNSDistTest):
         for _ in range(maxQPS):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # we should now be sent to the "abuse" pool which is empty,
         # so the queries should be dropped
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
         time.sleep(1)
 
@@ -94,12 +94,12 @@ class TestRoutingQPSPoolRouting(DNSDistTest):
         for _ in range(maxQPS):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
 
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
-        self.assertEquals(receivedResponse, None)
+        self.assertEqual(receivedResponse, None)
 
 
 class TestRoutingRoundRobinLB(DNSDistTest):
@@ -155,18 +155,18 @@ class TestRoutingRoundRobinLB(DNSDistTest):
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         for key in self._responsesCounter:
             value = self._responsesCounter[key]
-            self.assertEquals(value, numberOfQueries / 2)
+            self.assertEqual(value, numberOfQueries / 2)
 
 class TestRoutingRoundRobinLBOneDown(DNSDistTest):
 
@@ -203,14 +203,14 @@ class TestRoutingRoundRobinLBOneDown(DNSDistTest):
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         total = 0
         for key in self._responsesCounter:
@@ -218,7 +218,7 @@ class TestRoutingRoundRobinLBOneDown(DNSDistTest):
             self.assertTrue(value == numberOfQueries or value == 0)
             total += value
 
-        self.assertEquals(total, numberOfQueries * 2)
+        self.assertEqual(total, numberOfQueries * 2)
 
 class TestRoutingRoundRobinLBAllDown(DNSDistTest):
 
@@ -251,7 +251,7 @@ class TestRoutingRoundRobinLBAllDown(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
 class TestRoutingLuaFFIPerThreadRoundRobinLB(DNSDistTest):
 
@@ -319,18 +319,18 @@ class TestRoutingLuaFFIPerThreadRoundRobinLB(DNSDistTest):
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         for key in self._responsesCounter:
             value = self._responsesCounter[key]
-            self.assertEquals(value, numberOfQueries / 2)
+            self.assertEqual(value, numberOfQueries / 2)
 
 class TestRoutingOrder(DNSDistTest):
 
@@ -386,16 +386,16 @@ class TestRoutingOrder(DNSDistTest):
                 sender = getattr(self, method)
                 (receivedQuery, receivedResponse) = sender(query, response)
                 receivedQuery.id = query.id
-                self.assertEquals(query, receivedQuery)
-                self.assertEquals(response, receivedResponse)
+                self.assertEqual(query, receivedQuery)
+                self.assertEqual(response, receivedResponse)
 
         total = 0
         if 'UDP Responder' in self._responsesCounter:
-            self.assertEquals(self._responsesCounter['UDP Responder'], 0)
-        self.assertEquals(self._responsesCounter['UDP Responder 2'], numberOfQueries)
+            self.assertEqual(self._responsesCounter['UDP Responder'], 0)
+        self.assertEqual(self._responsesCounter['UDP Responder 2'], numberOfQueries)
         if 'TCP Responder' in self._responsesCounter:
-            self.assertEquals(self._responsesCounter['TCP Responder'], 0)
-        self.assertEquals(self._responsesCounter['TCP Responder 2'], numberOfQueries)
+            self.assertEqual(self._responsesCounter['TCP Responder'], 0)
+        self.assertEqual(self._responsesCounter['TCP Responder 2'], numberOfQueries)
 
 class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
 
@@ -455,20 +455,20 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             for method in ("sendUDPQuery", "sendTCPQuery"):
                 sender = getattr(self, method)
                 (_, receivedResponse) = sender(query, response=None, useQueue=False)
-                self.assertEquals(receivedResponse, response)
+                self.assertEqual(receivedResponse, response)
 
         numberOfQueries = 10
         name = 'order-qps-cache-2.routing.tests.powerdns.com.'
@@ -486,20 +486,20 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, response)
 
         for _ in range(numberOfQueries):
             for method in ("sendUDPQuery", "sendTCPQuery"):
                 sender = getattr(self, method)
                 (_, receivedResponse) = sender(query, response=None, useQueue=False)
-                self.assertEquals(receivedResponse, response)
+                self.assertEqual(receivedResponse, response)
 
         # 4 queries should made it through, 2 UDP and 2 TCP
         for k,v in self._responsesCounter.items():
@@ -507,11 +507,11 @@ class TestFirstAvailableQPSPacketCacheHits(DNSDistTest):
             print(v)
 
         if 'UDP Responder' in self._responsesCounter:
-            self.assertEquals(self._responsesCounter['UDP Responder'], 0)
-        self.assertEquals(self._responsesCounter['UDP Responder 2'], 2)
+            self.assertEqual(self._responsesCounter['UDP Responder'], 0)
+        self.assertEqual(self._responsesCounter['UDP Responder 2'], 2)
         if 'TCP Responder' in self._responsesCounter:
-            self.assertEquals(self._responsesCounter['TCP Responder'], 0)
-        self.assertEquals(self._responsesCounter['TCP Responder 2'], 2)
+            self.assertEqual(self._responsesCounter['TCP Responder'], 0)
+        self.assertEqual(self._responsesCounter['TCP Responder 2'], 2)
 
 class TestRoutingNoServer(DNSDistTest):
 
@@ -545,7 +545,7 @@ class TestRoutingNoServer(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.checkMessageEDNSWithoutOptions(expectedResponse, receivedResponse)
             self.assertFalse(receivedResponse.ednsflags & dns.flags.DO)
-            self.assertEquals(receivedResponse.payload, 1232)
+            self.assertEqual(receivedResponse.payload, 1232)
 
 class TestRoutingWRandom(DNSDistTest):
 
@@ -600,14 +600,14 @@ class TestRoutingWRandom(DNSDistTest):
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         # The lower weight downstream should receive less than half the queries
         self.assertLess(self._responsesCounter['UDP Responder'], numberOfQueries * 0.50)
@@ -676,14 +676,14 @@ class TestRoutingHighValueWRandom(DNSDistTest):
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendUDPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         for _ in range(numberOfQueries):
             (receivedQuery, receivedResponse) = self.sendTCPQuery(query, response)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
         stats = self.sendConsoleCommand("dumpStats()").split()
         stats_dict = {}
@@ -694,7 +694,7 @@ class TestRoutingHighValueWRandom(DNSDistTest):
                 stats_dict[x] = stats[i+1]
 
         # There should be no queries getting "no-policy" responses
-        self.assertEquals(stats_dict['no-policy'], '0')
+        self.assertEqual(stats_dict['no-policy'], '0')
 
         # Each downstream should receive some queries, but it will be unbalanced
         # because the sum of the weights is higher than INT_MAX.
@@ -704,9 +704,9 @@ class TestRoutingHighValueWRandom(DNSDistTest):
 
         # The second downstream will receive the remainder of the queries, but it might very well be 0
         if 'UDP Responder 2' in self._responsesCounter:
-            self.assertEquals(self._responsesCounter['UDP Responder 2'], numberOfQueries - self._responsesCounter['UDP Responder'])
+            self.assertEqual(self._responsesCounter['UDP Responder 2'], numberOfQueries - self._responsesCounter['UDP Responder'])
         if 'TCP Responder 2' in self._responsesCounter:
-            self.assertEquals(self._responsesCounter['TCP Responder 2'], numberOfQueries - self._responsesCounter['TCP Responder'])
+            self.assertEqual(self._responsesCounter['TCP Responder 2'], numberOfQueries - self._responsesCounter['TCP Responder'])
 
 class TestRoutingBadWeightWRandom(DNSDistTest):
 

--- a/regression-tests.dnsdist/test_SNMP.py
+++ b/regression-tests.dnsdist/test_SNMP.py
@@ -39,12 +39,12 @@ class TestSNMP(DNSDistTest):
         # check that the queries, responses and rdQueries counters are now at queriesCountersValue
         for i in [1, 2, 28]:
             oid = self._snmpOID + '.1.' + str(i) + '.0'
-            self.assertEquals(results[oid], queriesCountersValue)
+            self.assertEqual(results[oid], queriesCountersValue)
 
         # the others counters (except for latency ones) should still be at 0
         for i in [3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 26, 27, 29, 30, 31, 35, 36]:
             oid = self._snmpOID + '.1.' + str(i) + '.0'
-            self.assertEquals(results[oid], 0)
+            self.assertEqual(results[oid], 0)
 
         # check the backend stats
         print(results)
@@ -58,25 +58,25 @@ class TestSNMP(DNSDistTest):
             self.assertTrue(isinstance(results[oid], OctetString))
 
         ## name
-        self.assertEquals(str(results['1.3.6.1.4.1.43315.3.2.1.2.0']), "servername")
+        self.assertEqual(str(results['1.3.6.1.4.1.43315.3.2.1.2.0']), "servername")
         ## weight
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.4.0'], 1)
+        self.assertEqual(results['1.3.6.1.4.1.43315.3.2.1.4.0'], 1)
         ## outstanding
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.5.0'], 0)
+        self.assertEqual(results['1.3.6.1.4.1.43315.3.2.1.5.0'], 0)
         ## qpslimit
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.6.0'], 0)
+        self.assertEqual(results['1.3.6.1.4.1.43315.3.2.1.6.0'], 0)
         ## reused
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.7.0'], 0)
+        self.assertEqual(results['1.3.6.1.4.1.43315.3.2.1.7.0'], 0)
         ## state
-        self.assertEquals(str(results['1.3.6.1.4.1.43315.3.2.1.8.0']), "up")
+        self.assertEqual(str(results['1.3.6.1.4.1.43315.3.2.1.8.0']), "up")
         ## address
-        self.assertEquals(str(results['1.3.6.1.4.1.43315.3.2.1.9.0']), ("127.0.0.1:%s" % (self._testServerPort)))
+        self.assertEqual(str(results['1.3.6.1.4.1.43315.3.2.1.9.0']), ("127.0.0.1:%s" % (self._testServerPort)))
         ## pools
-        self.assertEquals(str(results['1.3.6.1.4.1.43315.3.2.1.10.0']), "")
+        self.assertEqual(str(results['1.3.6.1.4.1.43315.3.2.1.10.0']), "")
         ## queries
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.12.0'], queriesCountersValue)
+        self.assertEqual(results['1.3.6.1.4.1.43315.3.2.1.12.0'], queriesCountersValue)
         ## order
-        self.assertEquals(results['1.3.6.1.4.1.43315.3.2.1.13.0'], 1)
+        self.assertEqual(results['1.3.6.1.4.1.43315.3.2.1.13.0'], 1)
 
     def _getSNMPStats(self, auth):
         results = {}
@@ -118,8 +118,8 @@ class TestSNMP(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.__class__._queriesSent = self.__class__._queriesSent + 1
 
         results = self._getSNMPStats(auth)

--- a/regression-tests.dnsdist/test_SelfAnsweredResponses.py
+++ b/regression-tests.dnsdist/test_SelfAnsweredResponses.py
@@ -32,7 +32,7 @@ class TestSelfAnsweredResponses(DNSDistTest):
         # self-answered, but no SelfAnswered rule matches.
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
         self.assertTrue(receivedResponse)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # self-answered, AND SelfAnswered rule matches. Should not see a reply.
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
@@ -57,7 +57,7 @@ class TestSelfAnsweredResponses(DNSDistTest):
         # self-answered, but no SelfAnswered rule matches.
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)
         self.assertTrue(receivedResponse)
-        self.assertEquals(receivedResponse, response)
+        self.assertEqual(receivedResponse, response)
 
         # self-answered, AND SelfAnswered rule matches. Should not see a reply.
         (_, receivedResponse) = self.sendTCPQuery(query, response=None, useQueue=False)

--- a/regression-tests.dnsdist/test_Spoofing.py
+++ b/regression-tests.dnsdist/test_Spoofing.py
@@ -44,7 +44,7 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testSpoofActionAAAA(self):
         """
@@ -69,7 +69,7 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testSpoofActionCNAME(self):
         """
@@ -94,7 +94,7 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testSpoofActionMultiA(self):
         """
@@ -119,7 +119,7 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testSpoofActionMultiAAAA(self):
         """
@@ -144,7 +144,7 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testSpoofActionMultiANY(self):
         """
@@ -177,7 +177,7 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testSpoofActionSetAA(self):
         """
@@ -200,8 +200,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
     def testSpoofActionSetAD(self):
         """
@@ -224,8 +224,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
     def testSpoofActionSetRA(self):
         """
@@ -248,8 +248,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
     def testSpoofActionSetNoRA(self):
         """
@@ -270,8 +270,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
     def testSpoofActionSetTTL(self):
         """
@@ -292,8 +292,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 1500)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 1500)
 
     def testSpoofRawAction(self):
         """
@@ -317,8 +317,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
         # TXT
         query = dns.message.make_query(name, 'TXT', 'IN')
@@ -336,8 +336,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
         # SRV
         query = dns.message.make_query(name, 'SRV', 'IN')
@@ -356,8 +356,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 3600)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 3600)
 
     def testSpoofRawActionMulti(self):
         """
@@ -381,8 +381,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
         # TXT
         query = dns.message.make_query(name, 'TXT', 'IN')
@@ -400,8 +400,8 @@ class TestSpoofingSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
 class TestSpoofingLuaSpoof(DNSDistTest):
 
@@ -466,7 +466,7 @@ class TestSpoofingLuaSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLuaSpoofAAAA(self):
         """
@@ -491,7 +491,7 @@ class TestSpoofingLuaSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLuaSpoofAWithCNAME(self):
         """
@@ -516,7 +516,7 @@ class TestSpoofingLuaSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLuaSpoofAAAAWithCNAME(self):
         """
@@ -541,7 +541,7 @@ class TestSpoofingLuaSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLuaSpoofRawAction(self):
         """
@@ -565,8 +565,8 @@ class TestSpoofingLuaSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
         # TXT
         query = dns.message.make_query(name, 'TXT', 'IN')
@@ -584,8 +584,8 @@ class TestSpoofingLuaSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
         # SRV
         query = dns.message.make_query(name, 'SRV', 'IN')
@@ -604,9 +604,9 @@ class TestSpoofingLuaSpoof(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
             # sorry, we can't set the TTL from the Lua API right now
-            #self.assertEquals(receivedResponse.answer[0].ttl, 3600)
+            #self.assertEqual(receivedResponse.answer[0].ttl, 3600)
 
 class TestSpoofingLuaSpoofMulti(DNSDistTest):
 
@@ -668,7 +668,7 @@ class TestSpoofingLuaSpoofMulti(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLuaSpoofMultiAAAA(self):
         """
@@ -693,7 +693,7 @@ class TestSpoofingLuaSpoofMulti(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testLuaSpoofMultiRawAction(self):
         """
@@ -717,8 +717,8 @@ class TestSpoofingLuaSpoofMulti(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
         # TXT
         query = dns.message.make_query(name, 'TXT', 'IN')
@@ -736,8 +736,8 @@ class TestSpoofingLuaSpoofMulti(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
-            self.assertEquals(receivedResponse.answer[0].ttl, 60)
+            self.assertEqual(expectedResponse, receivedResponse)
+            self.assertEqual(receivedResponse.answer[0].ttl, 60)
 
         # SRV
         query = dns.message.make_query(name, 'SRV', 'IN')
@@ -756,9 +756,9 @@ class TestSpoofingLuaSpoofMulti(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
             # sorry, we can't set the TTL from the Lua API right now
-            #self.assertEquals(receivedResponse.answer[0].ttl, 3600)
+            #self.assertEqual(receivedResponse.answer[0].ttl, 3600)
 
 class TestSpoofingLuaWithStatistics(DNSDistTest):
 
@@ -810,14 +810,14 @@ class TestSpoofingLuaWithStatistics(DNSDistTest):
 
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
         self.assertTrue(receivedResponse)
-        self.assertEquals(expectedResponse1, receivedResponse)
+        self.assertEqual(expectedResponse1, receivedResponse)
 
         (_, receivedResponse) = self.sendUDPQuery(query, response=None, useQueue=False)
         self.assertTrue(receivedResponse)
-        self.assertEquals(expectedResponse2, receivedResponse)
+        self.assertEqual(expectedResponse2, receivedResponse)
 
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponseAfterwards, receivedResponse)
+            self.assertEqual(expectedResponseAfterwards, receivedResponse)

--- a/regression-tests.dnsdist/test_TCPFastOpen.py
+++ b/regression-tests.dnsdist/test_TCPFastOpen.py
@@ -82,10 +82,10 @@ class TestBrokenTCPFastOpen(DNSDistTest):
         url = 'http://127.0.0.1:' + str(self._webServerPort) + '/api/v1/servers/localhost'
         r = requests.get(url, headers=headers, timeout=self._webTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         self.assertTrue(len(content['servers']), 1)
         server = content['servers'][0]
         self.assertIn('tcpDiedReadingResponse', server)
-        self.assertEquals(server['tcpDiedReadingResponse'], self._testServerRetries)
+        self.assertEqual(server['tcpDiedReadingResponse'], self._testServerRetries)

--- a/regression-tests.dnsdist/test_TCPKeepAlive.py
+++ b/regression-tests.dnsdist/test_TCPKeepAlive.py
@@ -58,7 +58,7 @@ class TestTCPKeepAlive(DNSDistTest):
                 response = self.recvTCPResponseOverConnection(conn)
                 if response is None:
                     break
-                self.assertEquals(expectedResponse, response)
+                self.assertEqual(expectedResponse, response)
                 count = count + 1
             except:
                 pass
@@ -85,8 +85,8 @@ class TestTCPKeepAlive(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, expectedResponse)
 
         conn = self.openTCPConnection()
 
@@ -97,7 +97,7 @@ class TestTCPKeepAlive(DNSDistTest):
                 response = self.recvTCPResponseOverConnection(conn)
                 if response is None:
                     break
-                self.assertEquals(expectedResponse, response)
+                self.assertEqual(expectedResponse, response)
                 count = count + 1
             except:
                 pass
@@ -127,7 +127,7 @@ class TestTCPKeepAlive(DNSDistTest):
                 response = self.recvTCPResponseOverConnection(conn)
                 if response is None:
                     break
-                self.assertEquals(expectedResponse, response)
+                self.assertEqual(expectedResponse, response)
                 count = count + 1
             except:
                 pass
@@ -239,7 +239,7 @@ class TestTCPKeepAlive(DNSDistTest):
                 response = self.recvTCPResponseOverConnection(conn)
                 if response is None:
                     break
-                self.assertEquals(expectedResponse, response)
+                self.assertEqual(expectedResponse, response)
                 count = count + 1
             except:
                 pass

--- a/regression-tests.dnsdist/test_TCPLimits.py
+++ b/regression-tests.dnsdist/test_TCPLimits.py
@@ -125,8 +125,8 @@ class TestTCPLimits(DNSDistTest):
 
         end = time.time()
 
-        self.assertAlmostEquals(count / 10, self._maxTCPConnDuration, delta=2)
-        self.assertAlmostEquals(end - start, self._maxTCPConnDuration, delta=2)
+        self.assertAlmostEqual(count / 10, self._maxTCPConnDuration, delta=2)
+        self.assertAlmostEqual(end - start, self._maxTCPConnDuration, delta=2)
 
         conn.close()
 

--- a/regression-tests.dnsdist/test_TCPShort.py
+++ b/regression-tests.dnsdist/test_TCPShort.py
@@ -80,8 +80,8 @@ class TestTCPShort(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, expectedResponse)
 
     def testTCPTLSShortRead(self):
         """
@@ -121,8 +121,8 @@ class TestTCPShort(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponse, expectedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponse, expectedResponse)
 
     def testTCPShortWrite(self):
         """
@@ -210,8 +210,8 @@ class TestTCPShort(DNSDistTest):
         # and check that everything is good
         self.assertTrue(receivedQuery)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(receivedResponses, responses)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(receivedResponses, responses)
 
     def testTCPTLSShortWrite(self):
         """
@@ -292,6 +292,6 @@ class TestTCPShort(DNSDistTest):
 
         self.assertTrue(receivedQuery)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(len(receivedResponses), len(responses))
-        self.assertEquals(receivedResponses, responses)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(len(receivedResponses), len(responses))
+        self.assertEqual(receivedResponses, responses)

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -35,8 +35,8 @@ class TLSTests(object):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # check the certificate
         cert = self.getServerCertificate()
@@ -45,12 +45,12 @@ class TLSTests(object):
         self.assertIn('subjectAltName', cert)
         subject = cert['subject']
         altNames = cert['subjectAltName']
-        self.assertEquals(dict(subject[0])['commonName'], 'tls.tests.dnsdist.org')
-        self.assertEquals(dict(subject[1])['organizationalUnitName'], 'PowerDNS.com BV')
+        self.assertEqual(dict(subject[0])['commonName'], 'tls.tests.dnsdist.org')
+        self.assertEqual(dict(subject[1])['organizationalUnitName'], 'PowerDNS.com BV')
         names = []
         for entry in altNames:
             names.append(entry[1])
-        self.assertEquals(names, ['tls.tests.dnsdist.org', 'powerdns.com'])
+        self.assertEqual(names, ['tls.tests.dnsdist.org', 'powerdns.com'])
         serialNumber = cert['serialNumber']
 
         self.generateNewCertificateAndKey()
@@ -64,8 +64,8 @@ class TLSTests(object):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
         # check that the certificate is OK
         cert = self.getServerCertificate()
@@ -74,15 +74,15 @@ class TLSTests(object):
         self.assertIn('subjectAltName', cert)
         subject = cert['subject']
         altNames = cert['subjectAltName']
-        self.assertEquals(dict(subject[0])['commonName'], 'tls.tests.dnsdist.org')
-        self.assertEquals(dict(subject[1])['organizationalUnitName'], 'PowerDNS.com BV')
+        self.assertEqual(dict(subject[0])['commonName'], 'tls.tests.dnsdist.org')
+        self.assertEqual(dict(subject[1])['organizationalUnitName'], 'PowerDNS.com BV')
         names = []
         for entry in altNames:
             names.append(entry[1])
-        self.assertEquals(names, ['tls.tests.dnsdist.org', 'powerdns.com'])
+        self.assertEqual(names, ['tls.tests.dnsdist.org', 'powerdns.com'])
 
         # and that the serial is different
-        self.assertNotEquals(serialNumber, cert['serialNumber'])
+        self.assertNotEqual(serialNumber, cert['serialNumber'])
 
     def testTLKA(self):
         """
@@ -106,8 +106,8 @@ class TLSTests(object):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testTLSPipelining(self):
         """
@@ -133,8 +133,8 @@ class TLSTests(object):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testTLSSNIRouting(self):
         """
@@ -164,7 +164,7 @@ class TLSTests(object):
         self.sendTCPQueryOverConnection(conn, query, response=None)
         receivedResponse = self.recvTCPResponseOverConnection(conn, useQueue=False)
         self.assertTrue(receivedResponse)
-        self.assertEquals(expectedResponse, receivedResponse)
+        self.assertEqual(expectedResponse, receivedResponse)
 
         # this one should not
         conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
@@ -174,8 +174,8 @@ class TLSTests(object):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
 
     def testTLSSNIRoutingAfterResumption(self):
         # we have more complicated tests about session resumption itself,
@@ -216,7 +216,7 @@ class TLSTests(object):
         self.sendTCPQueryOverConnection(sslsock, query, response=None)
         receivedResponse = self.recvTCPResponseOverConnection(sslsock, useQueue=False)
         self.assertTrue(receivedResponse)
-        self.assertEquals(expectedResponse, receivedResponse)
+        self.assertEqual(expectedResponse, receivedResponse)
         self.assertFalse(sslsock.session_reused)
         session = sslsock.session
 
@@ -232,8 +232,8 @@ class TLSTests(object):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = query.id
-        self.assertEquals(query, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(response, receivedResponse)
         self.assertFalse(sslsock.session_reused)
 
         # and now we should be able to resume the session
@@ -247,7 +247,7 @@ class TLSTests(object):
         self.sendTCPQueryOverConnection(sslsock, query, response=None)
         receivedResponse = self.recvTCPResponseOverConnection(sslsock, useQueue=False)
         self.assertTrue(receivedResponse)
-        self.assertEquals(expectedResponse, receivedResponse)
+        self.assertEqual(expectedResponse, receivedResponse)
         self.assertTrue(sslsock.session_reused)
 
 class TestOpenSSL(DNSDistTest, TLSTests):
@@ -330,7 +330,7 @@ class TestDOTWithCache(DNSDistTest):
                                     dns.rdatatype.TXT,
                                     content)
         response.answer.append(rrset)
-        self.assertEquals(len(response.to_wire()), 4096)
+        self.assertEqual(len(response.to_wire()), 4096)
 
         # first query to fill the cache
         conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
@@ -340,15 +340,15 @@ class TestDOTWithCache(DNSDistTest):
         self.assertTrue(receivedQuery)
         self.assertTrue(receivedResponse)
         receivedQuery.id = expectedQuery.id
-        self.assertEquals(expectedQuery, receivedQuery)
+        self.assertEqual(expectedQuery, receivedQuery)
         self.checkQueryNoEDNS(expectedQuery, receivedQuery)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
         for _ in range(numberOfQueries):
             conn = self.openTLSConnection(self._tlsServerPort, self._serverName, self._caCert)
             self.sendTCPQueryOverConnection(conn, query, response=None)
             receivedResponse = self.recvTCPResponseOverConnection(conn, useQueue=False)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedResponse, response)
 
 class TestTLSFrontendLimits(DNSDistTest):
 

--- a/regression-tests.dnsdist/test_Tags.py
+++ b/regression-tests.dnsdist/test_Tags.py
@@ -60,8 +60,8 @@ class TestTags(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testQuestionMatchTagAndValue(self):
         """
@@ -83,7 +83,7 @@ class TestTags(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testQuestionMatchTagOnly(self):
         """
@@ -105,7 +105,7 @@ class TestTags(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testResponseNoMatch(self):
         """
@@ -127,8 +127,8 @@ class TestTags(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
     def testResponseMatchTagAndValue(self):
         """
@@ -156,8 +156,8 @@ class TestTags(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(expectedResponse, receivedResponse)
 
     def testResponseMatchResponseTagMatches(self):
         """
@@ -185,5 +185,5 @@ class TestTags(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(expectedResponse, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(expectedResponse, receivedResponse)

--- a/regression-tests.dnsdist/test_TeeAction.py
+++ b/regression-tests.dnsdist/test_TeeAction.py
@@ -60,8 +60,8 @@ class TestTeeAction(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
             # retrieve the query from the Tee server
             teedQuery = self._fromTeeQueue.get(True, 2.0)
@@ -72,7 +72,7 @@ class TestTeeAction(DNSDistTest):
 
         # check the TeeAction stats
         stats = self.sendConsoleCommand("getAction(0):printStats()")
-        self.assertEquals(stats, """noerrors\t%d
+        self.assertEqual(stats, """noerrors\t%d
 nxdomains\t0
 other-rcode\t0
 queries\t%d
@@ -108,8 +108,8 @@ tcp-drops\t0
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
             # retrieve the query from the Tee server
             teedQuery = self._fromTeeQueue.get(True, 2.0)
@@ -120,7 +120,7 @@ tcp-drops\t0
 
         # check the TeeAction stats
         stats = self.sendConsoleCommand("getAction(0):printStats()")
-        self.assertEquals(stats, """noerrors\t%d
+        self.assertEqual(stats, """noerrors\t%d
 nxdomains\t0
 other-rcode\t0
 queries\t%d

--- a/regression-tests.dnsdist/test_Trailing.py
+++ b/regression-tests.dnsdist/test_Trailing.py
@@ -91,8 +91,8 @@ class TestTrailingDataToBackend(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testTrailingCapacity(self):
         """
@@ -117,8 +117,8 @@ class TestTrailingDataToBackend(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testTrailingLimited(self):
         """
@@ -141,7 +141,7 @@ class TestTrailingDataToBackend(DNSDistTest):
             sender = getattr(self, method)
             (_, receivedResponse) = sender(query, response, useQueue=False)
             self.assertTrue(receivedResponse)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testTrailingAdded(self):
         """
@@ -166,8 +166,8 @@ class TestTrailingDataToBackend(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, expectedResponse)
 
 class TestTrailingDataToDnsdist(DNSDistTest):
     _verboseMode = True
@@ -248,12 +248,12 @@ class TestTrailingDataToDnsdist(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(query, receivedQuery)
-            self.assertEquals(response, receivedResponse)
+            self.assertEqual(query, receivedQuery)
+            self.assertEqual(response, receivedResponse)
 
             # Verify that queries with trailing data don't make it through.
             (_, receivedResponse) = sender(raw, response, rawQuery=True, useQueue=False)
-            self.assertEquals(receivedResponse, None)
+            self.assertEqual(receivedResponse, None)
 
     def testTrailingRemoved(self):
         """
@@ -279,8 +279,8 @@ class TestTrailingDataToDnsdist(DNSDistTest):
             self.assertTrue(receivedQuery)
             self.assertTrue(receivedResponse)
             receivedQuery.id = query.id
-            self.assertEquals(receivedQuery, query)
-            self.assertEquals(receivedResponse, response)
+            self.assertEqual(receivedQuery, query)
+            self.assertEqual(receivedResponse, response)
 
     def testTrailingRead(self):
         """
@@ -307,7 +307,7 @@ class TestTrailingDataToDnsdist(DNSDistTest):
             (_, receivedResponse) = sender(raw, response=None, rawQuery=True, useQueue=False)
             self.assertTrue(receivedResponse)
             expectedResponse.flags = receivedResponse.flags
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testTrailingReplaced(self):
         """
@@ -334,7 +334,7 @@ class TestTrailingDataToDnsdist(DNSDistTest):
             (_, receivedResponse) = sender(raw, response=None, rawQuery=True, useQueue=False)
             self.assertTrue(receivedResponse)
             expectedResponse.flags = receivedResponse.flags
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testTrailingReadUnsafe(self):
         """
@@ -361,7 +361,7 @@ class TestTrailingDataToDnsdist(DNSDistTest):
             (_, receivedResponse) = sender(raw, response=None, rawQuery=True, useQueue=False)
             self.assertTrue(receivedResponse)
             expectedResponse.flags = receivedResponse.flags
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)
 
     def testTrailingReplacedUnsafe(self):
         """
@@ -388,4 +388,4 @@ class TestTrailingDataToDnsdist(DNSDistTest):
             (_, receivedResponse) = sender(raw, response=None, rawQuery=True, useQueue=False)
             self.assertTrue(receivedResponse)
             expectedResponse.flags = receivedResponse.flags
-            self.assertEquals(receivedResponse, expectedResponse)
+            self.assertEqual(receivedResponse, expectedResponse)

--- a/regression-tests.dnsdist/test_XPF.py
+++ b/regression-tests.dnsdist/test_XPF.py
@@ -21,11 +21,11 @@ class XPFTest(DNSDistTest):
         for add in msg.additional:
             if add.rdtype == self._xpfCode:
                 found = True
-                self.assertEquals(add.rdclass, dns.rdataclass.IN)
-                self.assertEquals(add.ttl, 0)
+                self.assertEqual(add.rdclass, dns.rdataclass.IN)
+                self.assertEqual(add.ttl, 0)
                 xpfData = add.to_rdataset()[0].to_text()
                 # skip the ports
-                self.assertEquals(xpfData[:26], expectedValue[:26])
+                self.assertEqual(xpfData[:26], expectedValue[:26])
 
         self.assertTrue(found)
 
@@ -53,7 +53,7 @@ class XPFTest(DNSDistTest):
         receivedResponse.id = response.id
 
         self.checkMessageHasXPF(receivedQuery, xpfData)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)
 
         expectedQuery = dns.message.make_query(name, 'A', 'IN')
         # 0x04 is IPv4, 0x06 (6) is TCP then 127.0.0.1 as source and destination
@@ -72,4 +72,4 @@ class XPFTest(DNSDistTest):
         receivedResponse.id = response.id
 
         self.checkMessageHasXPF(receivedQuery, xpfData)
-        self.assertEquals(response, receivedResponse)
+        self.assertEqual(response, receivedResponse)

--- a/regression-tests.ixfrdist/test_IXFR.py
+++ b/regression-tests.ixfrdist/test_IXFR.py
@@ -111,7 +111,7 @@ class IXFRDistBasicTest(IXFRDistTest):
         for expectedAnswer in expected:
             pos = 0
             for rec in expectedAnswer:
-                self.assertEquals(rec.ttl, answers[answerPos][pos].ttl)
+                self.assertEqual(rec.ttl, answers[answerPos][pos].ttl)
                 pos = pos + 1
             answerPos = answerPos + 1
 
@@ -131,11 +131,11 @@ class IXFRDistBasicTest(IXFRDistTest):
         expected.answer.append(xfrServer._getSOAForSerial(2))
 
         response = self.sendUDPQuery(query)
-        self.assertEquals(expected, response)
+        self.assertEqual(expected, response)
         # check the TTLs
         pos = 0
         for rec in expected.answer:
-            self.assertEquals(rec.ttl, response.answer[pos].ttl)
+            self.assertEqual(rec.ttl, response.answer[pos].ttl)
             pos = pos + 1
 
     def test_b_UDP_SOA_not_loaded(self):
@@ -144,7 +144,7 @@ class IXFRDistBasicTest(IXFRDistTest):
         expected.set_rcode(dns.rcode.REFUSED)
 
         response = self.sendUDPQuery(query)
-        self.assertEquals(expected, response)
+        self.assertEqual(expected, response)
 
     def test_b_UDP_SOA_not_configured(self):
         query = dns.message.make_query('example3.', 'SOA')
@@ -152,4 +152,4 @@ class IXFRDistBasicTest(IXFRDistTest):
         expected.set_rcode(dns.rcode.REFUSED)
 
         response = self.sendUDPQuery(query)
-        self.assertEquals(expected, response)
+        self.assertEqual(expected, response)

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -954,7 +954,7 @@ distributor-threads={threads}""".format(confdir=confdir,
         expectedResponse.answer = expectedRRs
         print(expectedResponse)
         print(response)
-        self.assertEquals(response, expectedResponse)
+        self.assertEqual(response, expectedResponse)
 
     @classmethod
     def sendQuery(cls, name, rdtype, useTCP=False):

--- a/regression-tests.recursor-dnssec/test_API.py
+++ b/regression-tests.recursor-dnssec/test_API.py
@@ -43,7 +43,7 @@ api-key=%s
         url = 'http://127.0.0.1:' + str(self._wsPort) + '/api/v1/servers/localhost/statistics'
         r = requests.get(url, headers=headers, timeout=self._wsTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
 
 class APIDeniedRecursorTest(APIRecursorTest):

--- a/regression-tests.recursor-dnssec/test_AggressiveNSECCache.py
+++ b/regression-tests.recursor-dnssec/test_AggressiveNSECCache.py
@@ -30,7 +30,7 @@ class AggressiveNSECCacheBase(RecursorTest):
         url = 'http://127.0.0.1:' + str(self._wsPort) + '/api/v1/servers/localhost/statistics'
         r = requests.get(url, headers=headers, timeout=self._wsTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
 
@@ -60,8 +60,8 @@ class AggressiveNSECCacheBase(RecursorTest):
         self.assertAnswerEmpty(res)
         self.assertAuthorityHasSOA(res)
         self.assertMessageIsAuthenticated(res)
-        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
-        self.assertEquals(self.getMetric('aggressive-nsec-cache-entries'), entries)
+        self.assertEqual(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEqual(self.getMetric('aggressive-nsec-cache-entries'), entries)
 
 class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
     _confdir = 'AggressiveNSECCacheNSEC'
@@ -80,7 +80,7 @@ class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
         self.assertAuthorityHasSOA(res)
         self.assertMessageIsAuthenticated(res)
         self.assertGreater(self.getMetric('aggressive-nsec-cache-entries'), entries)
-        self.assertEquals(self.getMetric('aggressive-nsec-cache-nsec-hits'), hits)
+        self.assertEqual(self.getMetric('aggressive-nsec-cache-nsec-hits'), hits)
 
         # now we ask for a different name that is covered by the NSEC,
         # we should generate the answer from the NSEC and no outgoing query should be made
@@ -92,8 +92,8 @@ class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
         self.assertAnswerEmpty(res)
         self.assertAuthorityHasSOA(res)
         self.assertMessageIsAuthenticated(res)
-        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
-        self.assertEquals(self.getMetric('aggressive-nsec-cache-entries'), entries)
+        self.assertEqual(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEqual(self.getMetric('aggressive-nsec-cache-entries'), entries)
         self.assertGreater(self.getMetric('aggressive-nsec-cache-nsec-hits'), hits)
 
     def testWildcard(self):
@@ -115,7 +115,7 @@ class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
         self.assertMatchingRRSIGInAnswer(res, expected)
         self.assertMessageIsAuthenticated(res)
-        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEqual(nbQueries, self.getMetric('all-outqueries'))
         self.assertGreater(self.getMetric('aggressive-nsec-cache-nsec-wc-hits'), hits)
 
         # now we ask for a type that does not exist at the wildcard
@@ -126,7 +126,7 @@ class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
         self.assertAnswerEmpty(res)
         self.assertAuthorityHasSOA(res)
         self.assertMessageIsAuthenticated(res)
-        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEqual(nbQueries, self.getMetric('all-outqueries'))
         self.assertGreater(self.getMetric('aggressive-nsec-cache-nsec-hits'), hits)
 
         # we can also ask a different type, for a different name that is covered
@@ -138,7 +138,7 @@ class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
         self.assertAnswerEmpty(res)
         self.assertAuthorityHasSOA(res)
         self.assertMessageIsAuthenticated(res)
-        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEqual(nbQueries, self.getMetric('all-outqueries'))
         self.assertGreater(self.getMetric('aggressive-nsec-cache-nsec-hits'), hits)
 
     def test_Bogus(self):
@@ -168,7 +168,7 @@ class AggressiveNSECCacheNSEC(AggressiveNSECCacheBase):
         self.assertAuthorityHasSOA(res)
         self.assertGreater(self.getMetric('all-outqueries'), nbQueries)
         # we will accept a NSEC for root, which is secure..
-        self.assertEquals(entries + 1, self.getMetric('aggressive-nsec-cache-entries'))
+        self.assertEqual(entries + 1, self.getMetric('aggressive-nsec-cache-entries'))
 
 class AggressiveNSECCacheNSEC3(AggressiveNSECCacheBase):
     _confdir = 'AggressiveNSECCacheNSEC3'
@@ -235,7 +235,7 @@ class AggressiveNSECCacheNSEC3(AggressiveNSECCacheBase):
         self.assertAnswerEmpty(res)
         self.assertAuthorityHasSOA(res)
         self.assertMessageIsAuthenticated(res)
-        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEqual(nbQueries, self.getMetric('all-outqueries'))
 
     def testWildcard(self):
 
@@ -263,7 +263,7 @@ class AggressiveNSECCacheNSEC3(AggressiveNSECCacheBase):
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
         self.assertMatchingRRSIGInAnswer(res, expected)
         self.assertMessageIsAuthenticated(res)
-        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEqual(nbQueries, self.getMetric('all-outqueries'))
 
         # now we ask for a type that does not exist at the wildcard
         nbQueries = self.getMetric('all-outqueries')
@@ -272,7 +272,7 @@ class AggressiveNSECCacheNSEC3(AggressiveNSECCacheBase):
         self.assertAnswerEmpty(res)
         self.assertAuthorityHasSOA(res)
         self.assertMessageIsAuthenticated(res)
-        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEqual(nbQueries, self.getMetric('all-outqueries'))
 
         # we can also ask a different type, for a different name that is covered
         # by the NSEC3s and matches the wildcard (but the type does not exist)
@@ -282,7 +282,7 @@ class AggressiveNSECCacheNSEC3(AggressiveNSECCacheBase):
         self.assertAnswerEmpty(res)
         self.assertAuthorityHasSOA(res)
         self.assertMessageIsAuthenticated(res)
-        self.assertEquals(nbQueries, self.getMetric('all-outqueries'))
+        self.assertEqual(nbQueries, self.getMetric('all-outqueries'))
 
     def test_OptOut(self):
         # query a name in an opt-out zone

--- a/regression-tests.recursor-dnssec/test_DNS64.py
+++ b/regression-tests.recursor-dnssec/test_DNS64.py
@@ -69,7 +69,7 @@ cname2 3600 IN CNAME www.example.dns64.
             sender = getattr(self, method)
             res = sender(query)
             self.assertRcodeEqual(res, dns.rcode.NOERROR)
-            self.assertEquals(len(res.answer), 0)
+            self.assertEqual(len(res.answer), 0)
 
     # this type (AAAA) does not exist for this name but there is an A record, we should get a DNS64-wrapped AAAA
     def testNonExistingAAAA(self):

--- a/regression-tests.recursor-dnssec/test_ECS.py
+++ b/regression-tests.recursor-dnssec/test_ECS.py
@@ -42,7 +42,7 @@ disable-syslog=yes
             self.assertEqual(res.answer[0].ttl, expectedFirstTTL)
         else:
             expectedFirstTTL = res.answer[0].ttl
-        self.assertEquals(res.edns, query.edns)
+        self.assertEqual(res.edns, query.edns)
 
         if scopeZeroResponse is not None:
             self.assertEqual(res.edns, 0)
@@ -64,7 +64,7 @@ disable-syslog=yes
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
         self.assertRRsetInAnswer(res, expected)
         self.assertLess(res.answer[0].ttl, expectedFirstTTL)
-        self.assertEquals(res.edns, query.edns)
+        self.assertEqual(res.edns, query.edns)
 
     def checkECSQueryHit(self, query, expected):
         res = self.sendUDPQuery(query)
@@ -571,13 +571,13 @@ log-common-errors=yes
         # should not have an ECS Option since the packet is too large already
         res = self.sendUDPQuery(query, timeout=5.0)
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertEquals(len(res.answer), 1)
+        self.assertEqual(len(res.answer), 1)
         self.assertEqual(res.edns, 0)
         self.assertEqual(len(res.options), 0)
 
         res = self.sendTCPQuery(query, timeout=5.0)
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertEquals(len(res.answer), 1)
+        self.assertEqual(len(res.answer), 1)
         self.assertEqual(res.edns, 0)
         self.assertEqual(len(res.options), 1)
         self.assertEqual(res.options[0].otype, 8)

--- a/regression-tests.recursor-dnssec/test_EDNSBufferSize.py
+++ b/regression-tests.recursor-dnssec/test_EDNSBufferSize.py
@@ -84,13 +84,13 @@ edns-outgoing-bufsize=%d
         """
         response = dns.message.from_wire(rawResponse)
 
-        self.assertEquals(len(rawResponse), size)
+        self.assertEqual(len(rawResponse), size)
         self.assertRcodeEqual(response, dns.rcode.NOERROR)
 
         self.assertMessageHasFlags(response, ['QR', 'RD', 'RA'])
 
         for record in response.answer:
-            self.assertEquals(record.rdtype, dns.rdatatype.TXT)
+            self.assertEqual(record.rdtype, dns.rdatatype.TXT)
             for part in record:
                 for string in part.strings:
                     self.assertTrue(len(string) == 255 or

--- a/regression-tests.recursor-dnssec/test_EDNSPadding.py
+++ b/regression-tests.recursor-dnssec/test_EDNSPadding.py
@@ -33,15 +33,15 @@ class RecursorEDNSPaddingTest(RecursorTest):
 
     def checkPadding(self, message, numberOfBytes=None):
         self.assertEqual(message.edns, 0)
-        self.assertEquals(len(message.options), 1)
+        self.assertEqual(len(message.options), 1)
         for option in message.options:
-            self.assertEquals(option.otype, 12)
+            self.assertEqual(option.otype, 12)
             if numberOfBytes:
-                self.assertEquals(option.olen, numberOfBytes)
+                self.assertEqual(option.olen, numberOfBytes)
 
     def checkNoPadding(self, message):
         self.assertEqual(message.edns, 0)
-        self.assertEquals(len(message.options), 0)
+        self.assertEqual(len(message.options), 0)
 
     def checkNoEDNS(self, message):
         self.assertEqual(message.edns, -1)

--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -191,13 +191,13 @@ log-common-errors=yes
         # should not have the Extended Option since the packet is too large already
         res = self.sendUDPQuery(query, timeout=5.0)
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertEquals(len(res.answer), 1)
+        self.assertEqual(len(res.answer), 1)
         self.assertEqual(res.edns, 0)
         self.assertEqual(len(res.options), 0)
 
         res = self.sendTCPQuery(query, timeout=5.0)
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertEquals(len(res.answer), 1)
+        self.assertEqual(len(res.answer), 1)
         self.assertEqual(res.edns, 0)
         self.assertEqual(len(res.options), 1)
         self.assertEqual(res.options[0].otype, 15)

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -579,8 +579,8 @@ class PDNSGeneratingAnswerFromGettagTest(RecursorTest):
         self.assertEqual(len(res.answer), 1)
         self.assertEqual(len(res.authority), 0)
         self.assertEqual(len(res.additional), 1)
-        self.assertEquals(res.answer, expectedAnswerRecords)
-        self.assertEquals(res.additional, expectedAdditionalRecords)
+        self.assertEqual(res.answer, expectedAnswerRecords)
+        self.assertEqual(res.additional, expectedAdditionalRecords)
 
 class PDNSValidationStatesTest(RecursorTest):
     """Tests that we have access to the validation states from Lua"""

--- a/regression-tests.recursor-dnssec/test_PacketCache.py
+++ b/regression-tests.recursor-dnssec/test_PacketCache.py
@@ -47,7 +47,7 @@ e 3600 IN A 192.0.2.42
         url = 'http://127.0.0.1:' + str(self._wsPort) + '/api/v1/servers/localhost/statistics'
         r = requests.get(url, headers=headers, timeout=self._wsTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         foundHits = False
@@ -55,10 +55,10 @@ e 3600 IN A 192.0.2.42
         for entry in content:
             if entry['name'] == 'packetcache-hits':
                 foundHits = True
-                self.assertEquals(int(entry['value']), expectedHits)
+                self.assertEqual(int(entry['value']), expectedHits)
             elif entry['name'] == 'packetcache-misses':
                 foundMisses = True
-                self.assertEquals(int(entry['value']), expectedMisses)
+                self.assertEqual(int(entry['value']), expectedMisses)
 
         self.assertTrue(foundHits)
         self.assertTrue(foundMisses)

--- a/regression-tests.recursor-dnssec/test_Protobuf.py
+++ b/regression-tests.recursor-dnssec/test_Protobuf.py
@@ -115,7 +115,7 @@ class TestRecursorProtobuf(RecursorTest):
           msg = dnsmessage_pb2.PBDNSMessage()
           msg.ParseFromString(data)
           if oldmsg is not None:
-            self.assertEquals(msg, oldmsg)
+            self.assertEqual(msg, oldmsg)
 
         print(msg)
         return msg
@@ -128,16 +128,16 @@ class TestRecursorProtobuf(RecursorTest):
         self.assertTrue(msg)
         self.assertTrue(msg.HasField('timeSec'))
         self.assertTrue(msg.HasField('socketFamily'))
-        self.assertEquals(msg.socketFamily, dnsmessage_pb2.PBDNSMessage.INET)
+        self.assertEqual(msg.socketFamily, dnsmessage_pb2.PBDNSMessage.INET)
         self.assertTrue(msg.HasField('from'))
         fromvalue = getattr(msg, 'from')
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, fromvalue), initiator)
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, fromvalue), initiator)
         self.assertTrue(msg.HasField('socketProtocol'))
-        self.assertEquals(msg.socketProtocol, protocol)
+        self.assertEqual(msg.socketProtocol, protocol)
         self.assertTrue(msg.HasField('messageId'))
         self.assertTrue(msg.HasField('serverIdentity'))
         self.assertTrue(msg.HasField('id'))
-        self.assertEquals(msg.id, query.id)
+        self.assertEqual(msg.id, query.id)
         self.assertTrue(msg.HasField('inBytes'))
         if normalQueryResponse:
             # compare inBytes with length of query/response
@@ -145,103 +145,103 @@ class TestRecursorProtobuf(RecursorTest):
             # because dnspython might compress labels differently from
             # the recursor
             if receivedSize:
-                self.assertEquals(msg.inBytes, receivedSize)
+                self.assertEqual(msg.inBytes, receivedSize)
             else:
-                self.assertEquals(msg.inBytes, len(query.to_wire()))
+                self.assertEqual(msg.inBytes, len(query.to_wire()))
         if expectedECS is not None:
             self.assertTrue(msg.HasField('originalRequestorSubnet'))
             # v4 only for now
-            self.assertEquals(len(msg.originalRequestorSubnet), 4)
-            self.assertEquals(socket.inet_ntop(socket.AF_INET, msg.originalRequestorSubnet), '127.0.0.1')
+            self.assertEqual(len(msg.originalRequestorSubnet), 4)
+            self.assertEqual(socket.inet_ntop(socket.AF_INET, msg.originalRequestorSubnet), '127.0.0.1')
 
     def checkOutgoingProtobufBase(self, msg, protocol, query, initiator, length=None):
         self.assertTrue(msg)
         self.assertTrue(msg.HasField('timeSec'))
         self.assertTrue(msg.HasField('socketFamily'))
-        self.assertEquals(msg.socketFamily, dnsmessage_pb2.PBDNSMessage.INET)
+        self.assertEqual(msg.socketFamily, dnsmessage_pb2.PBDNSMessage.INET)
         self.assertTrue(msg.HasField('socketProtocol'))
-        self.assertEquals(msg.socketProtocol, protocol)
+        self.assertEqual(msg.socketProtocol, protocol)
         self.assertTrue(msg.HasField('messageId'))
         self.assertTrue(msg.HasField('serverIdentity'))
         self.assertTrue(msg.HasField('id'))
-        self.assertNotEquals(msg.id, query.id)
+        self.assertNotEqual(msg.id, query.id)
         self.assertTrue(msg.HasField('inBytes'))
         if length is not None:
-          self.assertEquals(msg.inBytes, length)
+          self.assertEqual(msg.inBytes, length)
         else:
           # compare inBytes with length of query/response
-          self.assertEquals(msg.inBytes, len(query.to_wire()))
+          self.assertEqual(msg.inBytes, len(query.to_wire()))
 
     def checkProtobufQuery(self, msg, protocol, query, qclass, qtype, qname, initiator='127.0.0.1'):
-        self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSQueryType)
+        self.assertEqual(msg.type, dnsmessage_pb2.PBDNSMessage.DNSQueryType)
         self.checkProtobufBase(msg, protocol, query, initiator)
         # dnsdist doesn't fill the responder field for responses
         # because it doesn't keep the information around.
         self.assertTrue(msg.HasField('to'))
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, msg.to), '127.0.0.1')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, msg.to), '127.0.0.1')
         self.assertTrue(msg.HasField('question'))
         self.assertTrue(msg.question.HasField('qClass'))
-        self.assertEquals(msg.question.qClass, qclass)
+        self.assertEqual(msg.question.qClass, qclass)
         self.assertTrue(msg.question.HasField('qType'))
-        self.assertEquals(msg.question.qClass, qtype)
+        self.assertEqual(msg.question.qClass, qtype)
         self.assertTrue(msg.question.HasField('qName'))
-        self.assertEquals(msg.question.qName, qname)
+        self.assertEqual(msg.question.qName, qname)
 
     def checkProtobufResponse(self, msg, protocol, response, initiator='127.0.0.1', receivedSize=None, vstate=dnsmessage_pb2.PBDNSMessage.VState.Indeterminate):
-        self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
+        self.assertEqual(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
         self.checkProtobufBase(msg, protocol, response, initiator, receivedSize=receivedSize)
         self.assertTrue(msg.HasField('response'))
         self.assertTrue(msg.response.HasField('queryTimeSec'))
         self.assertTrue(msg.response.HasField('validationState'))
-        self.assertEquals(msg.response.validationState, vstate)
+        self.assertEqual(msg.response.validationState, vstate)
 
     def checkProtobufResponseRecord(self, record, rclass, rtype, rname, rttl, checkTTL=True):
         self.assertTrue(record.HasField('class'))
-        self.assertEquals(getattr(record, 'class'), rclass)
+        self.assertEqual(getattr(record, 'class'), rclass)
         self.assertTrue(record.HasField('type'))
-        self.assertEquals(record.type, rtype)
+        self.assertEqual(record.type, rtype)
         self.assertTrue(record.HasField('name'))
-        self.assertEquals(record.name, rname)
+        self.assertEqual(record.name, rname)
         self.assertTrue(record.HasField('ttl'))
         if checkTTL:
-            self.assertEquals(record.ttl, rttl)
+            self.assertEqual(record.ttl, rttl)
         self.assertTrue(record.HasField('rdata'))
 
     def checkProtobufPolicy(self, msg, policyType, reason, trigger, hit, kind):
-        self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
+        self.assertEqual(msg.type, dnsmessage_pb2.PBDNSMessage.DNSResponseType)
         self.assertTrue(msg.response.HasField('appliedPolicyType'))
         self.assertTrue(msg.response.HasField('appliedPolicy'))
         self.assertTrue(msg.response.HasField('appliedPolicyTrigger'))
         self.assertTrue(msg.response.HasField('appliedPolicyHit'))
         self.assertTrue(msg.response.HasField('appliedPolicyKind'))
-        self.assertEquals(msg.response.appliedPolicy, reason)
-        self.assertEquals(msg.response.appliedPolicyType, policyType)
-        self.assertEquals(msg.response.appliedPolicyTrigger, trigger)
-        self.assertEquals(msg.response.appliedPolicyHit, hit)
-        self.assertEquals(msg.response.appliedPolicyKind, kind)
+        self.assertEqual(msg.response.appliedPolicy, reason)
+        self.assertEqual(msg.response.appliedPolicyType, policyType)
+        self.assertEqual(msg.response.appliedPolicyTrigger, trigger)
+        self.assertEqual(msg.response.appliedPolicyHit, hit)
+        self.assertEqual(msg.response.appliedPolicyKind, kind)
 
     def checkProtobufTags(self, msg, tags):
         print(tags)
         print('---')
         print(msg.response.tags)
-        self.assertEquals(len(msg.response.tags), len(tags))
+        self.assertEqual(len(msg.response.tags), len(tags))
         for tag in msg.response.tags:
             self.assertTrue(tag in tags)
 
     def checkProtobufOutgoingQuery(self, msg, protocol, query, qclass, qtype, qname, initiator='127.0.0.1', length=None):
-        self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSOutgoingQueryType)
+        self.assertEqual(msg.type, dnsmessage_pb2.PBDNSMessage.DNSOutgoingQueryType)
         self.checkOutgoingProtobufBase(msg, protocol, query, initiator, length=length)
         self.assertTrue(msg.HasField('to'))
         self.assertTrue(msg.HasField('question'))
         self.assertTrue(msg.question.HasField('qClass'))
-        self.assertEquals(msg.question.qClass, qclass)
+        self.assertEqual(msg.question.qClass, qclass)
         self.assertTrue(msg.question.HasField('qType'))
-        self.assertEquals(msg.question.qType, qtype)
+        self.assertEqual(msg.question.qType, qtype)
         self.assertTrue(msg.question.HasField('qName'))
-        self.assertEquals(msg.question.qName, qname)
+        self.assertEqual(msg.question.qName, qname)
 
     def checkProtobufIncomingResponse(self, msg, protocol, response, initiator='127.0.0.1', length=None):
-        self.assertEquals(msg.type, dnsmessage_pb2.PBDNSMessage.DNSIncomingResponseType)
+        self.assertEqual(msg.type, dnsmessage_pb2.PBDNSMessage.DNSIncomingResponseType)
         self.checkOutgoingProtobufBase(msg, protocol, response, initiator, length=length)
         self.assertTrue(msg.HasField('response'))
         self.assertTrue(msg.response.HasField('rcode'))
@@ -249,16 +249,16 @@ class TestRecursorProtobuf(RecursorTest):
 
     def checkProtobufIncomingNetworkErrorResponse(self, msg, protocol, response, initiator='127.0.0.1'):
         self.checkProtobufIncomingResponse(msg, protocol, response, initiator, length=0)
-        self.assertEquals(msg.response.rcode, 65536)
+        self.assertEqual(msg.response.rcode, 65536)
 
     def checkProtobufIdentity(self, msg, requestorId, deviceId, deviceName):
         print(msg)
         self.assertTrue((requestorId == '') == (not msg.HasField('requestorId')))
         self.assertTrue((deviceId == b'') == (not msg.HasField('deviceId')))
         self.assertTrue((deviceName == '') == (not msg.HasField('deviceName')))
-        self.assertEquals(msg.requestorId, requestorId)
-        self.assertEquals(msg.deviceId, deviceId)
-        self.assertEquals(msg.deviceName, deviceName)
+        self.assertEqual(msg.requestorId, requestorId)
+        self.assertEqual(msg.deviceId, deviceId)
+        self.assertEqual(msg.deviceName, deviceName)
 
     def setUp(self):
         super(TestRecursorProtobuf, self).setUp()
@@ -317,11 +317,11 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res, '127.0.0.1')
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
         self.checkNoRemainingMessage()
 
     def testCNAME(self):
@@ -342,15 +342,15 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res, '127.0.0.1', receivedSize=len(raw))
-        self.assertEquals(len(msg.response.rrs), 2)
+        self.assertEqual(len(msg.response.rrs), 2)
         rr = msg.response.rrs[0]
         # we don't want to check the TTL for the A record, it has been cached by the previous test
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.CNAME, name, 15)
-        self.assertEquals(rr.rdata, b'a.example.')
+        self.assertEqual(rr.rdata, b'a.example.')
         rr = msg.response.rrs[1]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, 'a.example.', 15, checkTTL=False)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
         self.checkNoRemainingMessage()
 
 class OutgoingProtobufDefaultTest(TestRecursorProtobuf):
@@ -493,11 +493,11 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res, '112.0.0.0')
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
         self.checkNoRemainingMessage()
 
 class ProtobufQueriesOnlyTest(TestRecursorProtobuf):
@@ -549,11 +549,11 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # check the protobuf message corresponding to the UDP response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
         # nothing else in the queue
         self.checkNoRemainingMessage()
 
@@ -614,11 +614,11 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.84')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.84')
         tags = [ self._tag_from_gettag ] + self._tags
         self.checkProtobufTags(msg, tags)
         self.checkNoRemainingMessage()
@@ -697,11 +697,11 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # check the protobuf messages corresponding to the UDP response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.84')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.84')
         self.checkNoRemainingMessage()
 
 class ProtobufExportTypesTest(TestRecursorProtobuf):
@@ -739,25 +739,25 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res, '127.0.0.1', receivedSize=len(raw))
-        self.assertEquals(len(msg.response.rrs), 5)
+        self.assertEqual(len(msg.response.rrs), 5)
         for rr in msg.response.rrs:
             self.assertTrue(rr.type in [dns.rdatatype.AAAA, dns.rdatatype.TXT, dns.rdatatype.MX, dns.rdatatype.SPF, dns.rdatatype.SRV])
 
             if rr.type == dns.rdatatype.AAAA:
                 self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.AAAA, name, 15)
-                self.assertEquals(socket.inet_ntop(socket.AF_INET6, rr.rdata), '2001:db8::1')
+                self.assertEqual(socket.inet_ntop(socket.AF_INET6, rr.rdata), '2001:db8::1')
             elif rr.type == dns.rdatatype.TXT:
                 self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.TXT, name, 15)
-                self.assertEquals(rr.rdata, b'"Lorem ipsum dolor sit amet"')
+                self.assertEqual(rr.rdata, b'"Lorem ipsum dolor sit amet"')
             elif rr.type == dns.rdatatype.MX:
                 self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.MX, name, 15)
-                self.assertEquals(rr.rdata, b'a.example.')
+                self.assertEqual(rr.rdata, b'a.example.')
             elif rr.type == dns.rdatatype.SPF:
                 self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.SPF, name, 15)
-                self.assertEquals(rr.rdata, b'"v=spf1 -all"')
+                self.assertEqual(rr.rdata, b'"v=spf1 -all"')
             elif rr.type == dns.rdatatype.SRV:
                 self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.SRV, name, 15)
-                self.assertEquals(rr.rdata, b'a.example.')
+                self.assertEqual(rr.rdata, b'a.example.')
 
         self.checkNoRemainingMessage()
 
@@ -803,11 +803,11 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res, '127.0.0.1')
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
         self.checkProtobufIdentity(msg, '', b'', '')
         self.checkNoRemainingMessage()
 
@@ -827,11 +827,11 @@ auth-zones=example=configs/%s/example.zone""" % _confdir
         # then the response
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.84')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.84')
         self.checkProtobufIdentity(msg, self._requestorId, self._deviceId.encode('ascii'), self._deviceName)
         self.checkNoRemainingMessage()
 
@@ -917,11 +917,11 @@ sub.test 3600 IN A 192.0.2.42
         msg = self.getFirstProtobufMessage()
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
         self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.', '*.test.example.', 'sub.test.example', dnsmessage_pb2.PBDNSMessage.PolicyKind.NoAction)
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
         self.checkNoRemainingMessage()
 
 class ProtobufRPZTagsTest(TestRecursorProtobuf):
@@ -985,9 +985,9 @@ sub.test 3600 IN A 192.0.2.42
         self.checkProtobufResponse(msg, dnsmessage_pb2.PBDNSMessage.UDP, res)
         self.checkProtobufPolicy(msg, dnsmessage_pb2.PBDNSMessage.PolicyType.QNAME, 'zone.rpz.', '*.test.example.', 'sub.test.example', dnsmessage_pb2.PBDNSMessage.PolicyKind.NoAction)
         self.checkProtobufTags(msg, self._tags + self._tags_from_gettag + self._tags_from_rpz)
-        self.assertEquals(len(msg.response.rrs), 1)
+        self.assertEqual(len(msg.response.rrs), 1)
         rr = msg.response.rrs[0]
         # we have max-cache-ttl set to 15
         self.checkProtobufResponseRecord(rr, dns.rdataclass.IN, dns.rdatatype.A, name, 15)
-        self.assertEquals(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
+        self.assertEqual(socket.inet_ntop(socket.AF_INET, rr.rdata), '192.0.2.42')
         self.checkNoRemainingMessage()

--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -328,7 +328,7 @@ log-rpz-changes=yes
         url = 'http://127.0.0.1:' + str(self._wsPort) + '/api/v1/servers/localhost/rpzstatistics'
         r = requests.get(url, headers=headers, timeout=self._wsTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         self.assertIn('zone.rpz.', content)
@@ -336,10 +336,10 @@ log-rpz-changes=yes
         for key in ['last_update', 'records', 'serial', 'transfers_failed', 'transfers_full', 'transfers_success']:
             self.assertIn(key, zone)
 
-        self.assertEquals(zone['serial'], serial)
-        self.assertEquals(zone['records'], recordsCount)
-        self.assertEquals(zone['transfers_full'], fullXFRCount)
-        self.assertEquals(zone['transfers_success'], totalXFRCount)
+        self.assertEqual(zone['serial'], serial)
+        self.assertEqual(zone['records'], recordsCount)
+        self.assertEqual(zone['transfers_full'], fullXFRCount)
+        self.assertEqual(zone['transfers_success'], totalXFRCount)
 
 rpzServerPort = 4250
 rpzServer = RPZServer(rpzServerPort)
@@ -953,7 +953,7 @@ class RPZCNameChainCustomTest(RPZRecursorTest):
                 sender = getattr(self, method)
                 res = sender(query)
                 self.assertRcodeEqual(res, dns.rcode.NXDOMAIN)
-                self.assertEquals(len(res.answer), 0)
+                self.assertEqual(len(res.answer), 0)
 
     def testRPZChainNODATA(self):
         # we should match the A at the end of the CNAME chain and
@@ -967,7 +967,7 @@ class RPZCNameChainCustomTest(RPZRecursorTest):
                 sender = getattr(self, method)
                 res = sender(query)
                 self.assertRcodeEqual(res, dns.rcode.NOERROR)
-                self.assertEquals(len(res.answer), 0)
+                self.assertEqual(len(res.answer), 0)
 
     def testRPZChainCustom(self):
         # we should match the A at the end of the CNAME chain and
@@ -982,6 +982,6 @@ class RPZCNameChainCustomTest(RPZRecursorTest):
                 res = sender(query)
                 self.assertRcodeEqual(res, dns.rcode.NOERROR)
                 # the original CNAME record is signed
-                self.assertEquals(len(res.answer), 3)
+                self.assertEqual(len(res.answer), 3)
                 self.assertRRsetInAnswer(res, dns.rrset.from_text('cname-custom-a.example.', 0, dns.rdataclass.IN, 'CNAME', 'cname-custom-a-target.example.'))
                 self.assertRRsetInAnswer(res, dns.rrset.from_text('cname-custom-a-target.example.', 0, dns.rdataclass.IN, 'A', '192.0.2.103'))

--- a/regression-tests.recursor-dnssec/test_RecDnstap.py
+++ b/regression-tests.recursor-dnssec/test_RecDnstap.py
@@ -38,20 +38,20 @@ def checkDnstapBase(testinstance, dnstap, protocol, initiator):
     testinstance.assertTrue(dnstap.message.HasField('socket_protocol'))
     testinstance.assertEqual(dnstap.message.socket_protocol, protocol)
     testinstance.assertTrue(dnstap.message.HasField('socket_family'))
-    testinstance.assertEquals(dnstap.message.socket_family, dnstap_pb2.INET)
+    testinstance.assertEqual(dnstap.message.socket_family, dnstap_pb2.INET)
     #
     # We cannot check the query address and port since we only log outgoing queries via dnstap
     #
     #testinstance.assertTrue(dnstap.message.HasField('query_address'))
-    #testinstance.assertEquals(socket.inet_ntop(socket.AF_INET, dnstap.message.query_address), initiator)
+    #testinstance.assertEqual(socket.inet_ntop(socket.AF_INET, dnstap.message.query_address), initiator)
     testinstance.assertTrue(dnstap.message.HasField('response_address'))
-    testinstance.assertEquals(socket.inet_ntop(socket.AF_INET, dnstap.message.response_address), initiator)
+    testinstance.assertEqual(socket.inet_ntop(socket.AF_INET, dnstap.message.response_address), initiator)
     testinstance.assertTrue(dnstap.message.HasField('response_port'))
-    testinstance.assertEquals(dnstap.message.response_port, 53)
+    testinstance.assertEqual(dnstap.message.response_port, 53)
 
 
 def checkDnstapQuery(testinstance, dnstap, protocol, initiator='127.0.0.1'):
-    testinstance.assertEquals(dnstap.message.type, dnstap_pb2.Message.RESOLVER_QUERY)
+    testinstance.assertEqual(dnstap.message.type, dnstap_pb2.Message.RESOLVER_QUERY)
     checkDnstapBase(testinstance, dnstap, protocol, initiator)
 
     testinstance.assertTrue(dnstap.message.HasField('query_time_sec'))
@@ -76,7 +76,7 @@ def checkDnstapNoExtra(testinstance, dnstap):
 
 
 def checkDnstapResponse(testinstance, dnstap, protocol, response, initiator='127.0.0.1'):
-    testinstance.assertEquals(dnstap.message.type, dnstap_pb2.Message.RESOLVER_RESPONSE)
+    testinstance.assertEqual(dnstap.message.type, dnstap_pb2.Message.RESOLVER_RESPONSE)
     checkDnstapBase(testinstance, dnstap, protocol, initiator)
 
     testinstance.assertTrue(dnstap.message.HasField('query_time_sec'))
@@ -280,7 +280,7 @@ dnstapFrameStreamServer({"%s"})
         query = dns.message.make_query(name, 'A', want_dnssec=True)
         query.flags |= dns.flags.RD
         res = self.sendUDPQuery(query)
-        self.assertNotEquals(res, None)
+        self.assertNotEqual(res, None)
         
         # check the dnstap message corresponding to the UDP query
         dnstap = self.getFirstDnstap()
@@ -308,7 +308,7 @@ dnstapFrameStreamServer({"%s"}, {logQueries=false})
         query = dns.message.make_query(name, 'A', want_dnssec=True)
         query.flags |= dns.flags.RD
         res = self.sendUDPQuery(query)
-        self.assertNotEquals(res, None)
+        self.assertNotEqual(res, None)
 
         # We don't expect anything
         self.assertTrue(DNSTapServerParameters.queue.empty())

--- a/regression-tests.recursor-dnssec/test_RootNXTrust.py
+++ b/regression-tests.recursor-dnssec/test_RootNXTrust.py
@@ -10,7 +10,7 @@ class RootNXTrustRecursorTest(RecursorTest):
         url = 'http://127.0.0.1:' + str(self._wsPort) + '/api/v1/servers/localhost/statistics'
         r = requests.get(url, headers=headers, timeout=self._wsTimeout)
         self.assertTrue(r)
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json())
         content = r.json()
         for entry in content:

--- a/regression-tests.recursor-dnssec/test_TTL.py
+++ b/regression-tests.recursor-dnssec/test_TTL.py
@@ -25,6 +25,6 @@ max-cache-bogus-ttl=5"""
         res = self.sendUDPQuery(query)
         self.assertMessageHasFlags(res, ['CD', 'QR', 'RA', 'RD'], ['DO'])
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
-        self.assertEquals(len(res.answer), 2)
+        self.assertEqual(len(res.answer), 2)
         for ans in res.answer:
             self.assertLessEqual(ans.ttl, 5)


### PR DESCRIPTION
### Short description
Stop using the deprecated aliases for `assertXyz` functions, those are deprecated since Python 3.2.

Note this is a treewide change and done with a simple search/replace.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
