### PR TITLE
auth postgres: escape identifiers

### DIFF
--- a/modules/gpgsqlbackend/spgsql.cc
+++ b/modules/gpgsqlbackend/spgsql.cc
@@ -126,16 +126,11 @@ public:
     // by stored procedures. you can return more than one
     // if you return SETOF refcursor.
     if (PQftype(d_res_set, 0) == 1790) { // REFCURSOR
-#if PG_VERSION_NUM > 90000
       // PQescapeIdentifier was added to libpq in postgresql 9.0
       char* val = PQgetvalue(d_res_set, d_cur_set++, 0);
       char* portal = PQescapeIdentifier(d_db(), val, strlen(val));
       string cmd = string("FETCH ALL FROM \"") + string(portal) + string("\"");
       PQfreemem(portal);
-#else
-      string portal = string(PQgetvalue(d_res_set, d_cur_set++, 0));
-      string cmd = string("FETCH ALL FROM \"") + portal + string("\"");
-#endif
       // execute FETCH
       if (d_dolog) {
         g_log << Logger::Warning << "Query: " << cmd << endl;


### PR DESCRIPTION
### Short description
In #3477 we stopped escaping identifiers on all distributions (not just on CentOS 6) because PG_VERSION_NUM was not set by the include we use. Now that we dropped support for CentOS 6, we can get rid of the #ifdef altogether.


(spotted by @mind04, thanks)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master