### PR TITLE
RFC6742 types: use correct size

### DIFF
--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -386,7 +386,7 @@ void PacketReader::xfrNodeOrLocatorID(NodeOrLocatorID& ret)
   if (d_pos + sizeof(ret) > d_content.size()) {
     throw std::out_of_range("Attempt to read 64 bit value outside of packet");
   }
-  memcpy(&ret, &d_content.at(d_pos), sizeof(ret));
+  memcpy(&ret.content, &d_content.at(d_pos), sizeof(ret.content));
   d_pos += sizeof(ret);
 }
 

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -140,7 +140,7 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfr48BitIn
   d_content.insert(d_content.end(), bytes, bytes + sizeof(bytes));
 }
 
-template <typename Container> void GenericDNSPacketWriter<Container>::xfrNodeOrLocatorID(NodeOrLocatorID val)
+template <typename Container> void GenericDNSPacketWriter<Container>::xfrNodeOrLocatorID(const NodeOrLocatorID& val)
 {
   d_content.insert(d_content.end(), val.content, val.content + sizeof(val.content));
 }

--- a/pdns/dnswriter.cc
+++ b/pdns/dnswriter.cc
@@ -142,7 +142,7 @@ template <typename Container> void GenericDNSPacketWriter<Container>::xfr48BitIn
 
 template <typename Container> void GenericDNSPacketWriter<Container>::xfrNodeOrLocatorID(NodeOrLocatorID val)
 {
-  d_content.insert(d_content.end(), val, val + sizeof(val));
+  d_content.insert(d_content.end(), val.content, val.content + sizeof(val.content));
 }
 
 template <typename Container> void GenericDNSPacketWriter<Container>::xfr32BitInt(uint32_t val)

--- a/pdns/dnswriter.hh
+++ b/pdns/dnswriter.hh
@@ -86,7 +86,7 @@ public:
   void truncate();
 
   void xfr48BitInt(uint64_t val);
-  void xfrNodeOrLocatorID(NodeOrLocatorID val);
+  void xfrNodeOrLocatorID(const NodeOrLocatorID& val);
   void xfr32BitInt(uint32_t val);
   void xfr16BitInt(uint16_t val);
   void xfrType(uint16_t val)

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -630,4 +630,4 @@ size_t parseSVCBValueList(const std::string &in, vector<std::string> &val);
 std::string makeLuaString(const std::string& in);
 
 // Used in NID and L64 records
-typedef uint8_t NodeOrLocatorID[8];
+struct NodeOrLocatorID { uint8_t content[8]; };

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -66,7 +66,7 @@ void RecordTextReader::xfrNodeOrLocatorID(NodeOrLocatorID& val) {
     throw RecordTextException("while parsing colon-delimited 64-bit field: '" + d_string.substr(d_pos, len) + "' is invalid");
   }
 
-  std::memcpy(&val, tmpbuf.s6_addr, sizeof(val));
+  std::memcpy(&val.content, tmpbuf.s6_addr, sizeof(val.content));
   d_pos += len;
 }
 

--- a/pdns/rcpgenerator.cc
+++ b/pdns/rcpgenerator.cc
@@ -601,7 +601,7 @@ void RecordTextWriter::xfrNodeOrLocatorID(const NodeOrLocatorID& val)
 
   size_t ctr = 0;
   char tmp[5];
-  for (auto const &c : val) {
+  for (auto const &c : val.content) {
     snprintf(tmp, sizeof(tmp), "%02X", c);
     d_string+=tmp;
     ctr++;

--- a/pdns/test-rcpgenerator_cc.cc
+++ b/pdns/test-rcpgenerator_cc.cc
@@ -385,14 +385,14 @@ BOOST_AUTO_TEST_CASE(test_xfrNodeOrLocatorID) {
   RecordTextReader rtr(source);
   NodeOrLocatorID v;
   rtr.xfrNodeOrLocatorID(v);
-  BOOST_CHECK_EQUAL(v[0], 0);
-  BOOST_CHECK_EQUAL(v[1], 0);
-  BOOST_CHECK_EQUAL(v[2], 0);
-  BOOST_CHECK_EQUAL(v[3], 0);
-  BOOST_CHECK_EQUAL(v[4], 0);
-  BOOST_CHECK_EQUAL(v[5], 0);
-  BOOST_CHECK_EQUAL(v[6], 0);
-  BOOST_CHECK_EQUAL(v[7], 1);
+  BOOST_CHECK_EQUAL(v.content[0], 0);
+  BOOST_CHECK_EQUAL(v.content[1], 0);
+  BOOST_CHECK_EQUAL(v.content[2], 0);
+  BOOST_CHECK_EQUAL(v.content[3], 0);
+  BOOST_CHECK_EQUAL(v.content[4], 0);
+  BOOST_CHECK_EQUAL(v.content[5], 0);
+  BOOST_CHECK_EQUAL(v.content[6], 0);
+  BOOST_CHECK_EQUAL(v.content[7], 1);
 
   string target;
   RecordTextWriter rtw(target);


### PR DESCRIPTION
### Short description
The implementation in #10121 threw compiler warnings. After investigation, I found that that code only works by accident, because pointers are 64 bits on the systems we compile for.

In this PR, the first and third(!) commits are two alternative fixes for this problem. Please review and let me know what you like.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
