### PR TITLE
auth gpgsql: add stored procedure test, drop refcursor support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -881,6 +881,8 @@ jobs:
           context: gpgsql-nsec3-optout-both
       - auth-regress:
           context: gpgsql-nsec3-narrow
+      - auth-regress:
+          context: gpgsql_sp-both
 
   test-auth-regress-ldap:
     resource_class: small

--- a/regression-tests/backends/gpgsql-master
+++ b/regression-tests/backends/gpgsql-master
@@ -1,7 +1,7 @@
 source ./backends/gsql-common
 
 case $context in
-	gpgsql-nodnssec | gpgsql | gpgsql-nsec3 | gpgsql-nsec3-optout | gpgsql-nsec3-narrow)
+	gpgsql-nodnssec | gpgsql | gpgsql-nsec3 | gpgsql-nsec3-optout | gpgsql-nsec3-narrow | gpgsql_sp)
 		[ -z "$GPGSQLDB" ] && GPGSQLDB=pdnstest
 		[ -z "$GPGSQLUSER" ] && GPGSQLUSER=$(whoami)
 
@@ -24,3 +24,26 @@ __EOF__
 	*)
 		nocontext=yes
 esac
+
+if [[ "$context" = "gpgsql_sp" ]]; then
+    cat >> pdns-gpgsql.conf << '__EOF__'
+gpgsql-basic-query=SELECT * FROM basic_query($1, $2)
+__EOF__
+    psql --user="$GPGSQLUSER" "$GPGSQLDB" << '__EOF__'
+CREATE FUNCTION basic_query(incoming_type varchar(10), incoming_name varchar(255))
+RETURNS TABLE
+(
+  content               VARCHAR(65535),
+  ttl                   INT,
+  prio                  INT,
+  type                  VARCHAR(10),
+  domain_id             INT,
+  disabled              BOOL,
+  name                  VARCHAR(255),
+  auth                  BOOL
+)
+AS $$
+SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=false and type=incoming_type and name=incoming_name;
+$$ LANGUAGE SQL;
+__EOF__
+fi

--- a/regression-tests/start-test-stop
+++ b/regression-tests/start-test-stop
@@ -47,7 +47,7 @@ geoip geoip-nsec3-narrow
 gmysql-nodnssec gmysql gmysql-nsec3 gmysql-nsec3-optout gmysql-nsec3-narrow gmysql_sp
 godbc_mssql-nodnssec godbc_mssql godbc_mssql-nsec3 godbc_mssql-nsec3-optout godbc_mssql-nsec3-narrow
 godbc_sqlite3-nodnssec godbc_sqlite3 godbc_sqlite3-nsec3 godbc_sqlite3-nsec3-optout godbc_sqlite3-narrow
-gpgsql-nodnssec gpgsql gpgsql-nsec3 gpgsql-nsec3-optout gpgsql-nsec3-narrow
+gpgsql-nodnssec gpgsql gpgsql-nsec3 gpgsql-nsec3-optout gpgsql-nsec3-narrow gpgsql_sp
 gsqlite3-nodnssec gsqlite3 gsqlite3-nsec3 gsqlite3-nsec3-optout gsqlite3-nsec3-narrow
 lmdb-nodnssec lmdb
 remotebackend-pipe remotebackend-unix remotebackend-http remotebackend-zeromq


### PR DESCRIPTION
### Short description
#2743 introduced support for 'multiple result sets' from Postgres (and MySQL). For Postgres, this needed the wrapping of even simple `SELECT` queries in transactions so that the 'refcursor' result sets would not get freed before we could get to them. That PR did not contain tests for the functionality.

(For reference, that would make the test in -this- PR work if the function looked more like:
```
CREATE FUNCTION basic_query(incoming_type varchar(10), incoming_name varchar(255))
RETURNS REFCURSOR AS $$
DECLARE
  ref refcursor;
BEGIN
  OPEN ref FOR SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=false and type=incoming_type and name=incoming_name;
  RETURN ref;
END;
$$ LANGUAGE plpgsql;
```
)

Later, #3477 added an `#ifdef` because the code in #2743 relied on Postgres 9 functionality, while CentOS 6 was on a lower version.

Later, #5233 removed the transaction around all those `SELECT` queries because it was not obvious why they were there, and they added a bunch of roundtrips to each backend query, hurting performance.

Recently, @mind04 pointed out to me that the `#ifdef` in #3477 did nothing because `PG_VERSION_NUM` was not actually defined.

Today, I filed #10255 to undo #3477, because we no longer support CentOS 6. Then @zeha pointed out 'this code cannot work' (see reasons (quoting) in #10255). I added a test (part of this PR right here) and noticed that REFCURSOR support was broken for reasons other than quoting.

So, it turns out REFCURSOR support has been broken since Auth 4.0, and as far as I can tell, nobody complained.

This PR:
* adds a test (which can also serve as an example) for doing simple (non-refcursor) stored procedures with Postgres
* removes the broken REFCURSOR support
* serves as a reference to be used in an error message stating we do not support REFCURSORs

Dear user, if you made it through all that, and feel that we've done you wrong by not supporting REFCURSORs, please speak up so that we can figure out how to serve your usecase best.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
