### PR TITLE
auth: lower max-nsec3-iterations to 100

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1012,10 +1012,13 @@ means unlimited.
 ------------------------
 
 -  Integer
--  Default: 500
+-  Default: 100
 
 Limit the number of NSEC3 hash iterations for zone configurations.
 For more information see :ref:`dnssec-operational-nsec-modes-params`.
+
+.. note::
+  Pre 4.5.0 the default was 500.
 
 .. _setting-max-packet-cache-entries:
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -41,6 +41,7 @@ Changed defaults
 ~~~~~~~~~~~~~~~~
 
 - The default value of the ``consistent-backends`` option has been changed from ``no`` to ``yes``.
+- The default value of the ``max-nsec3-iterations`` option has been changed from ``500`` to ``100``.
 - The default value of the ``timeout`` option for :ref:`ifportup` and :ref:`ifurlup` functions has been changed from ``1`` to ``2`` seconds.
 
 4.3.x to 4.4.0

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -222,7 +222,7 @@ void declareArguments()
   ::arg().set("default-ksk-size","Default KSK size (0 means default)")="0";
   ::arg().set("default-zsk-algorithm","Default ZSK algorithm")="";
   ::arg().set("default-zsk-size","Default ZSK size (0 means default)")="0";
-  ::arg().set("max-nsec3-iterations","Limit the number of NSEC3 hash iterations")="500"; // RFC5155 10.3
+  ::arg().set("max-nsec3-iterations", "Limit the number of NSEC3 hash iterations") = "100";
   ::arg().set("default-publish-cdnskey","Default value for PUBLISH-CDNSKEY")="";
   ::arg().set("default-publish-cds","Default value for PUBLISH-CDS")="";
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -347,7 +347,7 @@ bool DNSSECKeeper::getNSEC3PARAM(const DNSName& zname, NSEC3PARAMRecordContent* 
   static int maxNSEC3Iterations=::arg().asNum("max-nsec3-iterations");
   if(ns3p) {
     *ns3p = NSEC3PARAMRecordContent(value);
-    if (ns3p->d_iterations > maxNSEC3Iterations) {
+    if (ns3p->d_iterations > maxNSEC3Iterations && !isPresigned(zname, useCache)) {
       ns3p->d_iterations = maxNSEC3Iterations;
       g_log<<Logger::Error<<"Number of NSEC3 iterations for zone '"<<zname<<"' is above 'max-nsec3-iterations'. Value adjusted to: "<<maxNSEC3Iterations<<endl;
     }

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -496,7 +496,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         Create a zone with "nsec3param" set and see if the metadata was added.
         """
         name = unique_zone_name()
-        nsec3param = '1 0 500 aabbccddeeff'
+        nsec3param = '1 0 100 aabbccddeeff'
         name, payload, data = self.create_zone(dnssec=True, nsec3param=nsec3param)
 
         r = self.session.get(self.url("/api/v1/servers/localhost/zones/" + name))
@@ -522,7 +522,7 @@ class AuthZones(ApiTestCase, AuthZonesHelperMixin):
         Create a zone with "nsec3narrow" set and see if the metadata was added.
         """
         name = unique_zone_name()
-        nsec3param = '1 0 500 aabbccddeeff'
+        nsec3param = '1 0 100 aabbccddeeff'
         name, payload, data = self.create_zone(dnssec=True, nsec3param=nsec3param,
                                                nsec3narrow=True)
 


### PR DESCRIPTION
### Short description
A high number of iterations is a waste of resources and is not future proof .

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
