### PR TITLE
dnsdist: Add missing getEDNSOptions and getDO bindings for DNSResponse

### DIFF
--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -193,6 +193,16 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
   luaCtx.registerFunction<void(DNSResponse::*)(std::function<uint32_t(uint8_t section, uint16_t qclass, uint16_t qtype, uint32_t ttl)> editFunc)>("editTTLs", [](DNSResponse& dr, std::function<uint32_t(uint8_t section, uint16_t qclass, uint16_t qtype, uint32_t ttl)> editFunc) {
     editDNSPacketTTL(reinterpret_cast<char *>(dr.getMutableData().data()), dr.getData().size(), editFunc);
       });
+  luaCtx.registerFunction<bool(DNSResponse::*)()const>("getDO", [](const DNSResponse& dq) {
+      return getEDNSZ(dq) & EDNS_HEADER_FLAG_DO;
+    });
+  luaCtx.registerFunction<std::map<uint16_t, EDNSOptionView>(DNSResponse::*)()const>("getEDNSOptions", [](const DNSResponse& dq) {
+      if (dq.ednsOptions == nullptr) {
+        parseEDNSOptions(dq);
+      }
+
+      return *dq.ednsOptions;
+    });
   luaCtx.registerFunction<std::string(DNSResponse::*)(void)const>("getTrailingData", [](const DNSResponse& dq) {
       return dq.getTrailingData();
     });

--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -259,7 +259,27 @@ DNSResponse object
 
 .. class:: DNSResponse
 
-  This object has all the functions and members of a :ref:`DNSQuestion <DNSQuestion>` and some more
+  This object has almost all the functions and members of a :ref:`DNSQuestion <DNSQuestion>`, except for the following ones which are not available on a response:
+
+  - ``addProxyProtocolValue``
+  - ``ecsOverride``
+  - ``ecsPrefixLength``
+  - ``getProxyProtocolValues``
+  - ``getHTTPHeaders``
+  - ``getHTTPHost``
+  - ``getHTTPPath``
+  - ``getHTTPQueryString``
+  - ``setHTTPResponse``
+  - ``getHTTPScheme``
+  - ``getServerNameIndication``
+  - ``setNegativeAndAdditionalSOA``
+  - ``setProxyProtocolValues``
+  - ``spoof``
+  - ``tempFailureTTL``
+  - ``useECS``
+
+  If the value is really needed while the response is being processed, it is possible to set a tag while the query is processed, as tags will be passed to the response object.
+  It also has one additional method:
 
   .. method:: DNSResponse:editTTLs(func)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Also document that some methods and attributes are not present on the DNSResponse object.

Fixes #10262.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
