### PR TITLE
fix read alignment in dnspcap

### DIFF
--- a/pdns/dnspcap.cc
+++ b/pdns/dnspcap.cc
@@ -94,7 +94,7 @@ try
 
     if(d_pheader.caplen > d_bufsize) {
       d_oversized++;
-      throw runtime_error((boost::format("Can't handle a %d byte packet, have space for %d")  % d_pheader.caplen % d_bufsize).str());
+      throw runtime_error((boost::format("Can't handle a %d byte packet, have space for %zu")  % d_pheader.caplen % d_bufsize).str());
     }
 
     checkedFreadSize(d_buffer, d_pheader.caplen);

--- a/pdns/dnspcap.hh
+++ b/pdns/dnspcap.hh
@@ -115,7 +115,9 @@ public:
 
   pdns_pcap_file_header d_pfh;
   unsigned int d_runts, d_oversized, d_correctpackets, d_nonetheripudp;
-  char d_buffer[32768];
+  alignas (struct ip) char d_readbuffer[32768];
+  char *d_buffer;
+  size_t d_bufsize;
 private:
   std::unique_ptr<FILE, int(*)(FILE*)> d_fp{nullptr, fclose};
   string d_fname;

--- a/pdns/dnsreplay.cc
+++ b/pdns/dnsreplay.cc
@@ -627,7 +627,7 @@ static bool sendPacketFromPR(PcapPacketReader& pr, const ComboAddress& remote, i
       uint16_t dlen = pr.d_len;
 
       if (stamp >= 0) {
-        static_assert(sizeof(pr.d_buffer) >= 1500, "The size of the underlying buffer should be at least 1500 bytes");
+        static_assert(sizeof(pr.d_readbuffer) >= 1500, "The size of the underlying buffer should be at least 1500 bytes");
         if (dlen > 1500) {
           /* the existing packet is larger than the maximum size we are willing to send, and it won't get better by adding ECS */
           return false;


### PR DESCRIPTION
### Short description
This avoids:
```
dnspcap.cc:146:98: runtime error: member access within misaligned address 0x7ffc47a138d2 for type 'struct ip', which requires 4 byte alignment
0x7ffc47a138d2: note: pointer points here
 00 00  08 00 45 00 00 54 06 83  00 00 40 11 76 14 7f 00  00 01 7f 00 00 01 89 f3  14 b4 00 40 fe 53
              ^ 
    #0 0x564956a3f534 in PcapPacketReader::getUDPPacket() /home/peter/projects/powerdns/pdns/pdns/dnspcap.cc:146
    #1 0x564956c4ed99 in main /home/peter/projects/powerdns/pdns/pdns/dnsscope.cc:230
    #2 0x7f2f7c6bb09a in __libc_start_main ../csu/libc-start.c:308
    #3 0x5649569182d9 in _start (/home/peter/projects/powerdns/pdns/pdns/dnsscope+0xd3f2d9)

```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master