### PR TITLE
rec: Fix a few cases discoverd by tsan:

### DIFF
--- a/pdns/rec_channel.cc
+++ b/pdns/rec_channel.cc
@@ -17,7 +17,7 @@
 
 #include "namespaces.hh"
 
-volatile sig_atomic_t RecursorControlChannel::stop = 0;
+std::atomic<bool> RecursorControlChannel::stop = false;
 
 RecursorControlChannel::RecursorControlChannel()
 {

--- a/pdns/rec_channel.hh
+++ b/pdns/rec_channel.hh
@@ -69,7 +69,7 @@ public:
   RecursorControlChannel::Answer recv(std::string* remote = nullptr, unsigned int timeout = 5);
 
   int d_fd;
-  static volatile sig_atomic_t stop;
+  static std::atomic<bool> stop;
 
 private:
   struct sockaddr_un d_local;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1325,7 +1325,7 @@ void doExitGeneric(bool nicely)
   if(!s_pidfname.empty())
     unlink(s_pidfname.c_str()); // we can at least try..
   if(nicely) {
-    RecursorControlChannel::stop = 1;
+    RecursorControlChannel::stop = true;
   } else {
     _exit(1);
   }

--- a/pdns/recursor_cache.cc
+++ b/pdns/recursor_cache.cc
@@ -19,19 +19,6 @@ MemRecursorCache::MemRecursorCache(size_t mapsCount) : d_maps(mapsCount)
 {
 }
 
-MemRecursorCache::~MemRecursorCache()
-{
-  try {
-    typedef std::unique_ptr<lock> lock_t;
-    vector<lock_t> locks;
-    for (auto& map : d_maps) {
-      locks.push_back(lock_t(new lock(map)));
-    }
-  }
-  catch(...) {
-  }
-}
-
 size_t MemRecursorCache::size()
 {
   size_t count = 0;

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -48,7 +48,6 @@ class MemRecursorCache : public boost::noncopyable //  : public RecursorCache
 {
 public:
   MemRecursorCache(size_t mapsCount = 1024);
-  ~MemRecursorCache();
 
   size_t size();
   size_t bytes();

--- a/pdns/recursordist/negcache.cc
+++ b/pdns/recursordist/negcache.cc
@@ -31,19 +31,6 @@ NegCache::NegCache(size_t mapsCount) :
 {
 }
 
-NegCache::~NegCache()
-{
-  try {
-    typedef std::unique_ptr<lock> lock_t;
-    vector<lock_t> locks;
-    for (auto& map : d_maps) {
-      locks.push_back(lock_t(new lock(map)));
-    }
-  }
-  catch (...) {
-  }
-}
-
 size_t NegCache::size() const
 {
   size_t count = 0;

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -51,7 +51,6 @@ class NegCache : public boost::noncopyable
 {
 public:
   NegCache(size_t mapsCount = 1024);
-  ~NegCache();
 
   struct NegCacheEntry
   {


### PR DESCRIPTION
- The NegCache and MemRecursorCache destructors were not deadlock free
  when running from testrunner. The purpose of the code in the dts
  is also unclear, so delete them.
- quit-nicely uses a volatile sig_atomic_t, which is not thread-safe
  according to tsan. Replace by atomic<bool>.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)


Errors reported:

```
FATAL: ThreadSanitizer CHECK failed: ../../../../src/libsanitizer/sanitizer_common/sanitizer_deadlock_detector.h:67 "((n_all_locks_)) < (((sizeof(all_locks_with_contexts_)/sizeof((all_locks_with_contexts_)[0]))))" (0x40, 0x40)
    #0 __tsan::TsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) ../../../../src/libsanitizer/tsan/tsan_rtl_report.cpp:47 (libtsan.so.0+0x972d2)
    #1 __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) ../../../../src/libsanitizer/sanitizer_common/sanitizer_termination.cpp:78 (libtsan.so.0+0xb513a)
    #2 __sanitizer::DeadlockDetectorTLS<__sanitizer::TwoLevelBitVector<1ul, __sanitizer::BasicBitVector<unsigned long> > >::addLock(unsigned long, unsigned long, unsigned int) ../../../../src/libsanitizer/sanitizer_common/sanitizer_deadlock_detector.h:67 (libtsan.so.0+0xa17d6)
    #3 __sanitizer::DeadlockDetectorTLS<__sanitizer::TwoLevelBitVector<1ul, __sanitizer::BasicBitVector<unsigned long> > >::addLock(unsigned long, unsigned long, unsigned int) ../../../../src/libsanitizer/sanitizer_common/sanitizer_deadlock_detector.h:59 (libtsan.so.0+0xa17d6)
    #4 __sanitizer::DeadlockDetector<__sanitizer::TwoLevelBitVector<1ul, __sanitizer::BasicBitVector<unsigned long> > >::onLockAfter(__sanitizer::DeadlockDetectorTLS<__sanitizer::TwoLevelBitVector<1ul, __sanitizer::BasicBitVector<unsigned long> > >*, unsigned long, unsigned int) ../../../../src/libsanitizer/sanitizer_common/sanitizer_deadlock_detector.h:216 (libtsan.so.0+0xa17d6)
    #5 __sanitizer::DD::MutexAfterLock(__sanitizer::DDCallback*, __sanitizer::DDMutex*, bool, bool) ../../../../src/libsanitizer/sanitizer_common/sanitizer_deadlock_detector1.cpp:169 (libtsan.so.0+0xa17d6)
    #6 __tsan::MutexPostLock(__tsan::ThreadState*, unsigned long, unsigned long, unsigned int, int) ../../../../src/libsanitizer/tsan/tsan_rtl_mutex.cpp:199 (libtsan.so.0+0x9587f)
    #7 pthread_mutex_trylock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1251 (libtsan.so.0+0x4117c)
    #8 __gthread_mutex_trylock /usr/include/x86_64-linux-gnu/c++/10/bits/gthr-default.h:758 (testrunner+0x257f15)
    #9 std::mutex::try_lock() /usr/include/c++/10/bits/std_mutex.h:111 (testrunner+0x257f15)
    #10 NegCache::lock::lock(NegCache::MapCombo const&) /home/otto/pdns/pdns/recursordist/negcache.hh:139 (testrunner+0x257f15)
    #11 NegCache::~NegCache() /home/otto/pdns/pdns/recursordist/negcache.cc:40 (testrunner+0x251abe)
```
and
```
WARNING: ThreadSanitizer: data race (pid=30641)
  Read of size 4 at 0x557490379ebc by thread T2:
    #0 recursorThread /home/otto/pdns/pdns/recursordist/pdns_recursor.cc:5321 (pdns_recursor+0x47276e)
...
 Previous write of size 4 at 0x557490379ebc by thread T4:
    #0 doExitGeneric(bool) /home/otto/pdns/pdns/recursordist/rec_channel_rec.cc:1328 (pdns_recursor+0x519bd3)

```