### PR TITLE
rec: Fix TSAN complaints: max stacksize and response stats size counters

### DIFF
--- a/.not-formatted
+++ b/.not-formatted
@@ -275,8 +275,6 @@
 ./pdns/resolver.cc
 ./pdns/resolver.hh
 ./pdns/responsestats-auth.cc
-./pdns/responsestats.cc
-./pdns/responsestats.hh
 ./pdns/rfc2136handler.cc
 ./pdns/root-addresses.hh
 ./pdns/root-dnssec.hh

--- a/.not-formatted
+++ b/.not-formatted
@@ -175,7 +175,6 @@
 ./pdns/gettime.cc
 ./pdns/gettime.hh
 ./pdns/histog.hh
-./pdns/histogram.hh
 ./pdns/inflighter.cc
 ./pdns/ipcipher.cc
 ./pdns/iputils.cc

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -220,6 +220,7 @@ pdns_server_SOURCES = \
 	dynmessenger.hh \
 	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc ednssubnet.hh \
+	histogram.hh \
 	iputils.cc iputils.hh \
 	ixfr.cc ixfr.hh \
 	json.cc json.hh \
@@ -1326,6 +1327,7 @@ testrunner_SOURCES = \
 	ednsoptions.cc ednsoptions.hh \
 	ednssubnet.cc \
 	gettime.cc gettime.hh \
+	histogram.hh \
 	ipcipher.cc ipcipher.hh \
 	iputils.cc \
 	ixfr.cc ixfr.hh \

--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <string>
 #include <vector>
 
 namespace pdns {

--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -27,7 +27,8 @@
 #include <string>
 #include <vector>
 
-namespace pdns {
+namespace pdns
+{
 
 // By convention, we are using microsecond units
 struct Bucket
@@ -41,15 +42,17 @@ struct AtomicBucket
 {
   // We need the constructors in this case, since atomics have a disabled copy constructor.
   AtomicBucket() {}
-  AtomicBucket(std::string name, uint64_t boundary, uint64_t val) : d_name(std::move(name)), d_boundary(boundary), d_count(val) {}
-  AtomicBucket(const AtomicBucket& rhs) : d_name(rhs.d_name), d_boundary(rhs.d_boundary), d_count(rhs.d_count.load()) {}
+  AtomicBucket(std::string name, uint64_t boundary, uint64_t val) :
+    d_name(std::move(name)), d_boundary(boundary), d_count(val) {}
+  AtomicBucket(const AtomicBucket& rhs) :
+    d_name(rhs.d_name), d_boundary(rhs.d_boundary), d_count(rhs.d_count.load()) {}
 
   std::string d_name;
   uint64_t d_boundary{0};
   std::atomic<uint64_t> d_count{0};
 };
 
-template<class B>
+template <class B>
 class BaseHistogram
 {
 public:
@@ -66,7 +69,7 @@ public:
     }
     d_buckets.reserve(boundaries.size() + 1);
     uint64_t prev = 0;
-    for (auto b: boundaries) {
+    for (auto b : boundaries) {
       if (prev == b) {
         throw std::invalid_argument("boundary array's elements should be distinct");
       }
@@ -120,7 +123,7 @@ public:
   inline void operator()(uint64_t d)
   {
     auto index = std::upper_bound(d_buckets.begin(), d_buckets.end(), d, lessOrEqual);
-    // out index is always valid
+    // our index is always valid
     ++index->d_count;
   }
 
@@ -128,10 +131,10 @@ private:
   std::vector<B> d_buckets;
 };
 
-template<class T>
+template <class T>
 using Histogram = BaseHistogram<Bucket>;
 
-template<class T>
+template <class T>
 using AtomicHistogram = BaseHistogram<AtomicBucket>;
 
 } // namespace pdns

--- a/pdns/mtasker.cc
+++ b/pdns/mtasker.cc
@@ -399,7 +399,7 @@ template<class Key, class Val>int MTasker<Key,Val>::getTid() const
 }
 
 //! Returns the maximum stack usage so far of this MThread
-template<class Key, class Val>unsigned int MTasker<Key,Val>::getMaxStackUsage()
+template<class Key, class Val>uint64_t MTasker<Key,Val>::getMaxStackUsage()
 {
   return d_threads[d_tid].startOfStack - d_threads[d_tid].highestStackSeen;
 }

--- a/pdns/mtasker.hh
+++ b/pdns/mtasker.hh
@@ -136,7 +136,7 @@ public:
   bool noProcesses() const;
   unsigned int numProcesses() const;
   int getTid() const;
-  unsigned int getMaxStackUsage();
+  uint64_t getMaxStackUsage();
   unsigned int getUsec();
 
 private:

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2096,7 +2096,7 @@ static void startDoResolve(void *p)
       pw.commit();
     }
 
-    g_rs.submitResponse(dc->d_mdp.d_qtype, packet.size(), !dc->d_tcp);
+    g_rs.submitResponse(dc->d_mdp.d_qtype, packet.size(), pw.getHeader()->rcode, !dc->d_tcp);
     updateResponseStats(res, dc->d_source, packet.size(), &dc->d_mdp.d_qname, dc->d_mdp.d_qtype);
 #ifdef NOD_ENABLED
     bool nod = false;
@@ -2272,7 +2272,7 @@ static void startDoResolve(void *p)
 
   runTaskOnce(g_logCommonErrors);
 
-  g_stats.maxMThreadStackUsage = max(MT->getMaxStackUsage(), g_stats.maxMThreadStackUsage);
+  g_stats.maxMThreadStackUsage = max(MT->getMaxStackUsage(), g_stats.maxMThreadStackUsage.load());
 }
 
 static void makeControlChannelSocket(int processNum=-1)

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1140,7 +1140,6 @@ static void registerAllStats1()
   addGetStat("over-capacity-drops", &g_stats.overCapacityDrops);
   addGetStat("policy-drops", &g_stats.policyDrops);
   addGetStat("no-packet-error", &g_stats.noPacketError);
-  addGetStat("dlg-only-drops", &SyncRes::s_nodelegated);
   addGetStat("ignored-packets", &g_stats.ignoredCount);
   addGetStat("empty-queries", &g_stats.emptyQueriesCount);
   addGetStat("max-mthread-stack", &g_stats.maxMThreadStackUsage);

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -21,7 +21,8 @@
  */
 #pragma once
 
-#include <boost/scoped_array.hpp>
+#include <array>
+#include "histogram.hh"
 
 #include "dnspacket.hh"
 
@@ -30,7 +31,7 @@ class ResponseStats
 public:
   ResponseStats();
 
-  void submitResponse(DNSPacket &p, bool udpOrTCP, bool last=true);
+  void submitResponse(DNSPacket& p, bool udpOrTCP, bool last = true);
   void submitResponse(uint16_t qtype, uint16_t respsize, bool udpOrTCP);
   void submitResponse(uint16_t qtype, uint16_t respsize, uint8_t rcode, bool udpOrTCP);
   map<uint16_t, uint64_t> getQTypeResponseCounts();
@@ -39,10 +40,9 @@ public:
   string getQTypeReport();
 
 private:
-  boost::scoped_array<std::atomic<unsigned long>> d_qtypecounters;
-  boost::scoped_array<std::atomic<unsigned long>> d_rcodecounters;
-  typedef vector<pair<uint16_t, uint64_t> > sizecounters_t;
-  sizecounters_t d_sizecounters;
+  std::array<std::atomic<uint64_t>, 65535> d_qtypecounters;
+  std::array<std::atomic<uint64_t>, 256> d_rcodecounters;
+  pdns::AtomicHistogram<uint64_t> d_sizecounters;
 };
 
 extern ResponseStats g_rs;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1033,7 +1033,7 @@ struct RecursorStats
   std::atomic<uint64_t> dnssecAuthenticDataQueries;
   std::atomic<uint64_t> dnssecCheckDisabledQueries;
   std::atomic<uint64_t> variableResponses;
-  unsigned int maxMThreadStackUsage;
+  std::atomic<uint64_t> maxMThreadStackUsage;
   std::atomic<uint64_t> dnssecValidations; // should be the sum of all dnssecResult* stats
   std::map<vState, std::atomic<uint64_t> > dnssecResults;
   std::map<vState, std::atomic<uint64_t> > xdnssecResults;

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 #include <boost/algorithm/string.hpp>
+#include <boost/scoped_array.hpp>
 #include "auth-packetcache.hh"
 #include "utility.hh"
 #include "threadname.hh"

--- a/regression-tests.api/test_Servers.py
+++ b/regression-tests.api/test_Servers.py
@@ -43,8 +43,8 @@ class Servers(ApiTestCase):
         self.assert_success_json(r)
         data = r.json()
         self.assertIn('uptime', [e['name'] for e in data])
+        print(data)
         if is_auth():
-            print(data)
             qtype_stats, respsize_stats, queries_stats, rcode_stats = None, None, None, None
             for elem in data:
                 if elem['type'] == 'MapStatisticItem' and elem['name'] == 'response-by-qtype':
@@ -59,6 +59,19 @@ class Servers(ApiTestCase):
             self.assertIn('60', [e['name'] for e in respsize_stats])
             self.assertIn('example.com/A', [e['name'] for e in queries_stats])
             self.assertIn('No Error', [e['name'] for e in rcode_stats])
+        else:
+            qtype_stats, respsize_stats, rcode_stats = None, None, None
+            for elem in data:
+                if elem['type'] == 'MapStatisticItem' and elem['name'] == 'response-by-qtype':
+                    qtype_stats = elem['value']
+                elif elem['type'] == 'MapStatisticItem' and elem['name'] == 'response-sizes':
+                    respsize_stats = elem['value']
+                elif elem['type'] == 'MapStatisticItem' and elem['name'] == 'response-by-rcode':
+                    rcode_stats = elem['value']
+            self.assertIn('A', [e['name'] for e in qtype_stats])
+            self.assertIn('60', [e['name'] for e in respsize_stats])
+            self.assertIn('No Error', [e['name'] for e in rcode_stats])
+           
 
     def test_read_one_statistic(self):
         r = self.session.get(self.url("/api/v1/servers/localhost/statistics?statistic=uptime"))

--- a/regression-tests.api/test_Servers.py
+++ b/regression-tests.api/test_Servers.py
@@ -56,7 +56,7 @@ class Servers(ApiTestCase):
                 elif elem['type'] == 'MapStatisticItem' and elem['name'] == 'response-by-rcode':
                     rcode_stats = elem['value']
             self.assertIn('A', [e['name'] for e in qtype_stats])
-            self.assertIn('60', [e['name'] for e in respsize_stats])
+            self.assertIn('80', [e['name'] for e in respsize_stats])
             self.assertIn('example.com/A', [e['name'] for e in queries_stats])
             self.assertIn('No Error', [e['name'] for e in rcode_stats])
         else:
@@ -70,8 +70,8 @@ class Servers(ApiTestCase):
                     rcode_stats = elem['value']
             self.assertIn('A', [e['name'] for e in qtype_stats])
             self.assertIn('60', [e['name'] for e in respsize_stats])
+            self.assertIn('80', [e['name'] for e in respsize_stats])
             self.assertIn('No Error', [e['name'] for e in rcode_stats])
-           
 
     def test_read_one_statistic(self):
         r = self.session.get(self.url("/api/v1/servers/localhost/statistics?statistic=uptime"))
@@ -96,7 +96,7 @@ class Servers(ApiTestCase):
                 if line.split(" ")[0] == "pdns_recursor_uptime":
                     found = True
             self.assertTrue(found,"pdns_recursor_uptime is missing")
-            
+
     @unittest.skipIf(is_auth(), "Not applicable")
     def test_read_statistics_using_password(self):
         r = requests.get(self.url("/api/v1/servers/localhost/statistics"), auth=('admin', self.server_web_password))


### PR DESCRIPTION
Start using new generic (atomic) histogram code and while there, fix a bug
concerning the rcode stats (which was not passed in by the caller by rec).

Note that this changes the histogram: instead of lumping all large counts into the last 2^16-1 bucket., there is an explicit bucket with bound MAX_UINT64

So the existing code has buckets
```
... 64800 65000 65535
``` 
with all values > 6500 end up in the last, we now have
```
... 64800 65000 MAX_UINT64
```

Draft since I have not tested auth yet.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
