### PR TITLE
rec: print the covering NSEC

### DIFF
--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -577,7 +577,7 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
 
         /* check if the whole NAME is denied existing */
         if (isCoveredByNSEC(qname, owner, nsec->d_next)) {
-          LOG(name<<" is covered by ("<<owner<<" to "<<nsec->d_next<<") ");
+          LOG(qname<<" is covered by ("<<owner<<" to "<<nsec->d_next<<") ");
 
           if (nsecProvesENT(qname, owner, nsec->d_next)) {
             if (wantsNoDataProof) {

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -452,7 +452,7 @@ dState matchesNSEC(const DNSName& name, uint16_t qtype, const DNSName& nsecOwner
   }
 
   if (isCoveredByNSEC(name, owner, nsec->d_next)) {
-    LOG(name<<" is covered ");
+    LOG(name<<" is covered by ("<<owner<<" to "<<nsec->d_next<<") ");
 
     if (nsecProvesENT(name, owner, nsec->d_next)) {
       LOG("Denies existence of type "<<name<<"/"<<QType(qtype).getName()<<" by proving that "<<name<<" is an ENT"<<endl);
@@ -577,7 +577,7 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
 
         /* check if the whole NAME is denied existing */
         if (isCoveredByNSEC(qname, owner, nsec->d_next)) {
-          LOG(qname<<" is covered ");
+          LOG(name<<" is covered by ("<<owner<<" to "<<nsec->d_next<<") ");
 
           if (nsecProvesENT(qname, owner, nsec->d_next)) {
             if (wantsNoDataProof) {


### PR DESCRIPTION

### Short description
It would be nice to log not only that a name is covered, but what entry actually covers it. This is useful in debugging crazy setups.

"works for me" but not sure how correct this is or if it's the correct place to be logging. 

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
