### PR TITLE
rec: Use the correct ECS address when proxy-protocol is enabled

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1620,7 +1620,7 @@ static void startDoResolve(void *p)
 #ifdef HAVE_FSTRM
     sr.setFrameStreamServers(t_frameStreamServers);
 #endif
-    sr.setQuerySource(dc->d_remote, g_useIncomingECS && !dc->d_ednssubnet.source.empty() ? boost::optional<const EDNSSubnetOpts&>(dc->d_ednssubnet) : boost::none);
+    sr.setQuerySource(dc->d_source, g_useIncomingECS && !dc->d_ednssubnet.source.empty() ? boost::optional<const EDNSSubnetOpts&>(dc->d_ednssubnet) : boost::none);
     sr.setQueryReceivedOverTCP(dc->d_tcp);
 
     bool tracedQuery=false; // we could consider letting Lua know about this too
@@ -1735,7 +1735,7 @@ static void startDoResolve(void *p)
 
       if (wantsRPZ && appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::NoAction) {
 
-        if (t_pdl && t_pdl->policyHitEventFilter(dc->d_remote, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, appliedPolicy, dc->d_policyTags, sr.d_discardedPolicies)) {
+        if (t_pdl && t_pdl->policyHitEventFilter(dc->d_source, dc->d_mdp.d_qname, QType(dc->d_mdp.d_qtype), dc->d_tcp, appliedPolicy, dc->d_policyTags, sr.d_discardedPolicies)) {
           /* reset to no match */
           appliedPolicy = DNSFilterEngine::Policy();
         }

--- a/regression-tests.recursor-dnssec/test_ECS.py
+++ b/regression-tests.recursor-dnssec/test_ECS.py
@@ -117,7 +117,7 @@ disable-syslog=yes
 class testNoECS(ECSTest):
     _confdir = 'NoECS'
 
-    _config_template = """edns-subnet-whitelist=
+    _config_template = """edns-subnet-allow-list=
 forward-zones=ecs-echo.example=%s.21
     """ % (os.environ['PREFIX'])
 
@@ -142,7 +142,7 @@ forward-zones=ecs-echo.example=%s.21
 class testIncomingNoECS(ECSTest):
     _confdir = 'IncomingNoECS'
 
-    _config_template = """edns-subnet-whitelist=
+    _config_template = """edns-subnet-allow-list=
 use-incoming-edns-subnet=yes
 forward-zones=ecs-echo.example=%s.21
     """ % (os.environ['PREFIX'])
@@ -170,7 +170,7 @@ forward-zones=ecs-echo.example=%s.21
 class testECSByName(ECSTest):
     _confdir = 'ECSByName'
 
-    _config_template = """edns-subnet-whitelist=ecs-echo.example.
+    _config_template = """edns-subnet-allow-list=ecs-echo.example.
 forward-zones=ecs-echo.example=%s.21
     """ % (os.environ['PREFIX'])
 
@@ -201,7 +201,7 @@ forward-zones=ecs-echo.example=%s.21
 class testECSByNameLarger(ECSTest):
     _confdir = 'ECSByNameLarger'
 
-    _config_template = """edns-subnet-whitelist=ecs-echo.example.
+    _config_template = """edns-subnet-allow-list=ecs-echo.example.
 ecs-ipv4-bits=32
 forward-zones=ecs-echo.example=%s.21
 ecs-ipv4-cache-bits=32
@@ -235,7 +235,7 @@ ecs-ipv6-cache-bits=128
 class testECSByNameSmaller(ECSTest):
     _confdir = 'ECSByNameLarger'
 
-    _config_template = """edns-subnet-whitelist=ecs-echo.example.
+    _config_template = """edns-subnet-allow-list=ecs-echo.example.
 ecs-ipv4-bits=16
 forward-zones=ecs-echo.example=%s.21
     """ % (os.environ['PREFIX'])
@@ -262,7 +262,7 @@ forward-zones=ecs-echo.example=%s.21
 class testIncomingECSByName(ECSTest):
     _confdir = 'ECSIncomingByName'
 
-    _config_template = """edns-subnet-whitelist=ecs-echo.example.
+    _config_template = """edns-subnet-allow-list=ecs-echo.example.
 use-incoming-edns-subnet=yes
 forward-zones=ecs-echo.example=%s.21
 ecs-scope-zero-address=2001:db8::42
@@ -302,7 +302,7 @@ ecs-ipv6-cache-bits=128
 class testIncomingECSByNameLarger(ECSTest):
     _confdir = 'ECSIncomingByNameLarger'
 
-    _config_template = """edns-subnet-whitelist=ecs-echo.example.
+    _config_template = """edns-subnet-allow-list=ecs-echo.example.
 use-incoming-edns-subnet=yes
 ecs-ipv4-bits=32
 forward-zones=ecs-echo.example=%s.21
@@ -334,7 +334,7 @@ ecs-ipv6-cache-bits=128
 class testIncomingECSByNameSmaller(ECSTest):
     _confdir = 'ECSIncomingByNameSmaller'
 
-    _config_template = """edns-subnet-whitelist=ecs-echo.example.
+    _config_template = """edns-subnet-allow-list=ecs-echo.example.
 use-incoming-edns-subnet=yes
 ecs-ipv4-bits=16
 forward-zones=ecs-echo.example=%s.21
@@ -365,7 +365,7 @@ ecs-ipv6-cache-bits=128
 class testIncomingECSByNameV6(ECSTest):
     _confdir = 'ECSIncomingByNameV6'
 
-    _config_template = """edns-subnet-whitelist=ecs-echo.example.
+    _config_template = """edns-subnet-allow-list=ecs-echo.example.
 use-incoming-edns-subnet=yes
 ecs-ipv6-bits=128
 ecs-ipv4-cache-bits=32
@@ -398,7 +398,7 @@ forward-zones=ecs-echo.example=[::1]:53000
 class testECSNameMismatch(ECSTest):
     _confdir = 'ECSNameMismatch'
 
-    _config_template = """edns-subnet-whitelist=not-the-right-name.example.
+    _config_template = """edns-subnet-allow-list=not-the-right-name.example.
 forward-zones=ecs-echo.example=%s.21
     """ % (os.environ['PREFIX'])
 
@@ -423,7 +423,7 @@ forward-zones=ecs-echo.example=%s.21
 class testECSByIP(ECSTest):
     _confdir = 'ECSByIP'
 
-    _config_template = """edns-subnet-whitelist=%s.21
+    _config_template = """edns-subnet-allow-list=%s.21
 forward-zones=ecs-echo.example=%s.21
     """ % (os.environ['PREFIX'], os.environ['PREFIX'])
 
@@ -449,7 +449,7 @@ forward-zones=ecs-echo.example=%s.21
 class testIncomingECSByIP(ECSTest):
     _confdir = 'ECSIncomingByIP'
 
-    _config_template = """edns-subnet-whitelist=%s.21
+    _config_template = """edns-subnet-allow-list=%s.21
 use-incoming-edns-subnet=yes
 forward-zones=ecs-echo.example=%s.21
 ecs-scope-zero-address=::1
@@ -489,7 +489,7 @@ ecs-ipv6-cache-bits=128
 class testECSIPMismatch(ECSTest):
     _confdir = 'ECSIPMismatch'
 
-    _config_template = """edns-subnet-whitelist=192.0.2.1
+    _config_template = """edns-subnet-allow-list=192.0.2.1
 forward-zones=ecs-echo.example=%s.21
     """ % (os.environ['PREFIX'])
 

--- a/regression-tests.recursor-dnssec/test_ECS.py
+++ b/regression-tests.recursor-dnssec/test_ECS.py
@@ -512,6 +512,27 @@ forward-zones=ecs-echo.example=%s.21
         query = dns.message.make_query(nameECS, 'TXT', 'IN', use_edns=True, options=[ecso], payload=512)
         self.sendECSQuery(query, expected)
 
+class testECSWithProxyProtocoldRecursorTest(ECSTest):
+    _confdir = 'ECSWithProxyProtocol'
+    _config_template = """
+    ecs-add-for=2001:db8::1/128
+    edns-subnet-allow-list=ecs-echo.example.
+    forward-zones=ecs-echo.example=%s.21
+    proxy-protocol-from=127.0.0.1/32
+    allow-from=2001:db8::1/128
+""" % (os.environ['PREFIX'])
+
+    def testProxyProtocolPlusECS(self):
+        qname = nameECS
+        expected = dns.rrset.from_text(qname, 0, dns.rdataclass.IN, 'TXT', '2001:db8::/56')
+
+        query = dns.message.make_query(qname, 'TXT', use_edns=True)
+        for method in ("sendUDPQueryWithProxyProtocol", "sendTCPQueryWithProxyProtocol"):
+            sender = getattr(self, method)
+            res = sender(query, True, '2001:db8::1', '2001:db8::2', 0, 65535)
+            self.assertRcodeEqual(res, dns.rcode.NOERROR)
+            self.assertRRsetInAnswer(res, expected)
+
 class testTooLargeToAddZeroScope(RecursorTest):
 
     _confdir = 'TooLargeToAddZeroScope'

--- a/regression-tests.recursor-dnssec/test_ProxyProtocol.py
+++ b/regression-tests.recursor-dnssec/test_ProxyProtocol.py
@@ -11,6 +11,7 @@ except NameError:
     pass
 
 from recursortests import RecursorTest
+from proxyprotocol import ProxyProtocol
 
 class ProxyProtocolRecursorTest(RecursorTest):
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The recursor was using the address of the proxy instead of the one of the proxied client to generate the EDNS Client Subnet value to send to authoritative servers.
Reported on the mailing-list: https://mailman.powerdns.com/pipermail/pdns-users/2021-April/027168.html

I reproduced the issue locally and tested the fix, but this PR could use a regression test.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
