### PR TITLE
rec: Backport 10286 to rec 4.5.x: rpz dumper: stop generating double zz labels on networks that start with zeroes

### DIFF
--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -701,7 +701,7 @@ DNSName DNSFilterEngine::Zone::maskToRPZ(const Netmask& nm)
     auto src = reinterpret_cast<const uint16_t*>(&addr.sin6.sin6_addr.s6_addr);
     std::array<uint16_t,8> elems;
 
-    // this routine was adopted from glibc's inet_ntop6, written by Paul Vixie
+    // this routine was adopted from libc's inet_ntop6, written by Paul Vixie
     // because the RPZ spec (https://datatracker.ietf.org/doc/html/draft-vixie-dnsop-dns-rpz-00#section-4.1.1) says:
     //
     //    If there exists more than one sequence of zero-valued fields of

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -698,7 +698,7 @@ DNSName DNSFilterEngine::Zone::maskToRPZ(const Netmask& nm)
   else {
     DNSName temp;
     static_assert(sizeof(addr.sin6.sin6_addr.s6_addr) == sizeof(uint16_t) * 8);
-    uint16_t *src = (uint16_t*) &addr.sin6.sin6_addr.s6_addr;
+    auto src = reinterpret_cast<const uint16_t*>(&addr.sin6.sin6_addr.s6_addr);
     std::array<uint16_t,8> elems;
 
     // this routine was adopted from glibc's inet_ntop6, written by Paul Vixie

--- a/pdns/filterpo.cc
+++ b/pdns/filterpo.cc
@@ -715,8 +715,7 @@ DNSName DNSFilterEngine::Zone::maskToRPZ(const Netmask& nm)
     struct { int base, len; } best = {-1, 0}, cur = {-1, 0};
 
     for (int i = 0; i < (int)elems.size(); i++) {
-      auto elem = ntohs(src[i]);
-      elems[i] = elem;
+      elems[i] = ntohs(src[i]);
       if (elems[i] == 0) {
         if (cur.base == -1) {  // start of a run of zeroes
           cur = { i, 1 };
@@ -743,7 +742,7 @@ DNSName DNSFilterEngine::Zone::maskToRPZ(const Netmask& nm)
       best.base = -1;
     }
     for (int i=0; i < (int)elems.size(); i++) {
-      if (i==best.base) {
+      if (i == best.base) {
         temp = DNSName("zz") + temp;
         i = i + best.len - 1;
       } else {

--- a/pdns/recursordist/test-filterpo_cc.cc
+++ b/pdns/recursordist/test-filterpo_cc.cc
@@ -814,3 +814,14 @@ BOOST_AUTO_TEST_CASE(test_multiple_filter_policies_order)
     BOOST_CHECK(matchingPolicy.d_kind == DNSFilterEngine::PolicyKind::NoAction);
   }
 }
+
+BOOST_AUTO_TEST_CASE(test_mask_to_rpz)
+{
+  BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("::2/127")).toString(), "127.2.zz.");
+  BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1::2/127")).toString(), "127.2.zz.1.");
+  BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("2::/127")).toString(), "127.zz.2.");
+  BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1abc:2::/127")).toString(), "127.zz.2.1abc.");
+  BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1:2:3:4:5:6:7::/127")).toString(), "127.0.7.6.5.4.3.2.1.");
+  BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1:2:3:4:5:6::/127")).toString(), "127.zz.6.5.4.3.2.1.");
+  BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1:0:0:0:2:0:0:0/127")).toString(), "127.zz.2.0.0.0.1.");
+}

--- a/pdns/recursordist/test-filterpo_cc.cc
+++ b/pdns/recursordist/test-filterpo_cc.cc
@@ -824,4 +824,6 @@ BOOST_AUTO_TEST_CASE(test_mask_to_rpz)
   BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1:2:3:4:5:6:7::/127")).toString(), "127.0.7.6.5.4.3.2.1.");
   BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1:2:3:4:5:6::/127")).toString(), "127.zz.6.5.4.3.2.1.");
   BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1:0:0:0:2:0:0:0/127")).toString(), "127.zz.2.0.0.0.1.");
+  BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1:0:0:2:0:0:0:0/127")).toString(), "127.zz.2.0.0.1.");
+  BOOST_CHECK_EQUAL(DNSFilterEngine::Zone::maskToRPZ(Netmask("1:0:0:0:0:2:0:0/127")).toString(), "127.0.0.2.zz.1.");
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #10286 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
