### PR TITLE
auth: Prevent dereferencing std::string::end() in SimpleMatch

### DIFF
--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -498,7 +498,7 @@ public:
         if (vi == vend) return false;
         ++vi;
       } else if (*mi == '*') {
-        while(*mi == '*') ++mi;
+        while(mi != mend && *mi == '*') ++mi;
         if (mi == d_mask.end()) return true;
         while(vi != vend) {
           if (match(mi,mend,vi,vend)) return true;

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -489,7 +489,7 @@ public:
   {
   }
  
-  bool match(string::const_iterator mi, string::const_iterator mend, string::const_iterator vi, string::const_iterator vend)
+  bool match(string::const_iterator mi, string::const_iterator mend, string::const_iterator vi, string::const_iterator vend) const
   {
     for(;;++mi) {
       if (mi == mend) {
@@ -499,7 +499,7 @@ public:
         ++vi;
       } else if (*mi == '*') {
         while(mi != mend && *mi == '*') ++mi;
-        if (mi == d_mask.end()) return true;
+        if (mi == mend) return true;
         while(vi != vend) {
           if (match(mi,mend,vi,vend)) return true;
           ++vi;
@@ -518,17 +518,17 @@ public:
     }
   }
 
-  bool match(const string& value) {
+  bool match(const string& value) const {
     return match(d_mask.begin(), d_mask.end(), value.begin(), value.end());
   }
 
-  bool match(const DNSName& name) {
+  bool match(const DNSName& name) const {
     return match(name.toStringNoDot());
   }
 
 private:
-  string d_mask;
-  bool d_fold;
+  const string d_mask;
+  const bool d_fold;
 };
 
 union ComboAddress;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
SimpleMatch is called with user-supplied strings in the API and the bind backend. We might get away with it in most cases because std::strings are null-terminated, but it's still undefined behaviour as there is no guarantee that end() will point to the terminator.

Reported by cppcheck 2.4.1:
```
misc.hh:501:16: warning: Either the condition 'mi==d_mask.end()' is redundant or there is possible dereference of an invalid iterator: mi. [derefInvalidIteratorRedundantCheck]
        while(*mi == '*') ++mi;
               ^
misc.hh:502:16: note: Assuming that condition 'mi==d_mask.end()' is not redundant
        if (mi == d_mask.end()) return true;
               ^
misc.hh:501:16: note: Dereference of an invalid iterator
        while(*mi == '*') ++mi;
```

Only the first commit is relevant for backports.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
