### PR TITLE
rec: Improve packet cache sizing.

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3577,7 +3577,7 @@ static void houseKeeping(void *)
     past = now;
     past.tv_sec -= 5;
     if (last_prune < past) {
-      t_packetCache->doPruneTo(g_maxPacketCacheEntries / g_numWorkerThreads);
+      t_packetCache->doPruneTo(g_maxPacketCacheEntries / (g_numWorkerThreads + g_numDistributorThreads));
 
       time_t limit;
       if(!((cleanCounter++)%40)) {  // this is a full scan!

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1038,7 +1038,7 @@ Maximum number of simultaneous MTasker threads.
 -  Integer
 -  Default: 500000
 
-Maximum number of Packet Cache entries. Each worker and each distributor thread has a packets cache instance.
+Maximum number of Packet Cache entries. Each worker and each distributor thread has a packet cache instance.
 This number will be divided by the number of worker plus the number of distributor threads to compute the maximum number of entries per cache instance.
 
 .. _setting-max-qperq:

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1038,8 +1038,8 @@ Maximum number of simultaneous MTasker threads.
 -  Integer
 -  Default: 500000
 
-Maximum number of Packet Cache entries.
-This number will be divided by the number of worker threads to compute the number of entries per thread.
+Maximum number of Packet Cache entries. Each worker and each distributor thread has a packets cache instance.
+This number will be divided by the number of worker plus the number of distributor threads to compute the maximum number of entries per cache instance.
 
 .. _setting-max-qperq:
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -53,6 +53,9 @@ Deprecated and changed settings
 - The :ref:`setting-minimum-ttl-override` and :ref:`setting-ecs-minimum-ttl-override` defaults have ben changed from 0 to 1.
 - The :ref:`setting-spoof-nearmiss-max` default has been changed from 20 to 1.
 - The :ref:`setting-dnssec` default has changed from ``process-no-validate`` to ``process``.
+- The meaning of the :ref:`setting-max-packetcache-entries` has changed: previously there was one packet cache instance per worker thread.
+  Since queries incoming over TCP are now also using the packet cache, there is now also one packet cache instance per distributor thread.
+  Each cache instance has a size of :ref:`setting-max-packetcache-entries` divided by (:ref:`setting-threads` + :ref:`setting-distributor-threads`).
 
 Removed settings
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Since queries incoming over TCP are now also using the packet
cache, there is now also one packet cache instance per distributor
thread. Each cache instance has a size of max-packetcache-entries
divided by (threads + distributor-threads).

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
