### PR TITLE
rec: backport 10291 to rec-4.4.x: Exception loading the RPZ seedfile is not fatal.

### DIFF
--- a/pdns/rec-lua-conf.cc
+++ b/pdns/rec-lua-conf.cc
@@ -370,8 +370,13 @@ void loadRecursorLuaConfig(const std::string& fname, luaConfigDelayedThreads& de
               throw PDNSException("The RPZ zone " + zoneName + " loaded from the seed file (" + zone->getDomain().toString() + ") has no SOA record");
             }
           }
-          catch(const std::exception& e) {
+          catch(const PDNSException& e) {
+            g_log<<Logger::Warning<<"Unable to pre-load RPZ zone "<<zoneName<<" from seed file '"<<seedFile<<"': "<<e.reason<<endl;
+            zone->clear();
+          }
+         catch(const std::exception& e) {
             g_log<<Logger::Warning<<"Unable to pre-load RPZ zone "<<zoneName<<" from seed file '"<<seedFile<<"': "<<e.what()<<endl;
+            zone->clear();
           }
         }
       }


### PR DESCRIPTION
Catch PDNSException and clear on failure.

(cherry picked from commit a47cc75dfa7519bcf7b31cee511852ae954a50f8)

Backport of #10291 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
