### PR TITLE
boost 1.76 containers: use standard exceptions

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -7,7 +7,8 @@ AM_CPPFLAGS += \
 	$(LIBCRYPTO_INCLUDES) \
 	$(SYSTEMD_CFLAGS) \
 	$(YAML_CFLAGS) \
-	-I$(top_srcdir)/ext/protozero/include
+	-I$(top_srcdir)/ext/protozero/include \
+	-DBOOST_CONTAINER_USE_STD_EXCEPTIONS
 
 AM_CXXFLAGS = \
 	-DSYSCONFDIR=\"$(sysconfdir)\" \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -7,7 +7,8 @@ AM_CPPFLAGS += $(SYSTEMD_CFLAGS) \
 	$(NET_SNMP_CFLAGS) \
 	$(LIBCAP_CFLAGS) \
 	-I$(top_srcdir)/ext/protozero/include \
-	-DSYSCONFDIR=\"${sysconfdir}\"
+	-DSYSCONFDIR=\"${sysconfdir}\" \
+	-DBOOST_CONTAINER_USE_STD_EXCEPTIONS
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -7,7 +7,8 @@ AM_CPPFLAGS += \
 	-I$(top_srcdir)/ext/json11 \
 	-I$(top_srcdir)/ext/protozero/include \
 	$(YAHTTP_CFLAGS) \
-	$(LIBCRYPTO_INCLUDES)
+	$(LIBCRYPTO_INCLUDES) \
+	-DBOOST_CONTAINER_USE_STD_EXCEPTIONS
 
 AM_CXXFLAGS = \
 	-DSYSCONFDIR=\"$(sysconfdir)\" \


### PR DESCRIPTION
### Short description

https://www.boost.org/users/history/version_1_76_0.html

> Replaced default standard exception classes with Boost.Container own classes, reducing considerably the included files overhead. Example: in MSVC 19 boost/container/vector.hpp preprocessed file size reduces from 1,5MB to 930KB. If you still want to use standard exception classes, you can define BOOST_CONTAINER_USE_STD_EXCEPTIONS before using any Boost.Container class.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master