### PR TITLE
Fix documentation around get*DomainMetadata

### DIFF
--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -330,9 +330,9 @@ Response:
 
 Returns the value(s) for variable kind for zone name. You **must**
 always return something, if there are no values, you shall return empty
-set or false.
+set.
 
-*  Mandatory: No
+*  Mandatory: yes
 *  Parameters: name
 *  Reply: hash of key to array of strings
 
@@ -375,7 +375,7 @@ Response:
 Returns the value(s) for variable kind for zone name. Most commonly it's
 one of NSEC3PARAM, PRESIGNED, SOA-EDIT. Can be others, too. You **must**
 always return something, if there are no values, you shall return empty
-array or false.
+array.
 
 -  Mandatory: No
 -  Parameters: name, kind


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

* Somewhere between PowerDNS 4.2 and 4.4, `GetAllDomainMetadata` became mandatory: a backend returning 404 (+ html error page) will result in PowerDNS responding with `SERVFAIL`:
```
Mar 25 21:57:32 ip-10-80-68-222 pdns_server[2795931]: Cannot parse JSON reply: expected value, got '<' (60)
Mar 25 21:57:32 ip-10-80-68-222 pdns_server[2795931]: Backend reported condition which prevented lookup (Exception caught when receiving: Unknown error while receiving data) sending out servfail
````

* `GetDomainMetadata` and `GetAllDomainMetadata` state `false` can be returned, but doing this results in an error (sorry, I did not capture the exact log message)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- 

- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] ~~compiled this code~~
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
