### PR TITLE
dnsdist: Fix missing locks in DNSCrypt certificates management

### DIFF
--- a/pdns/dnscrypt.hh
+++ b/pdns/dnscrypt.hh
@@ -278,7 +278,7 @@ public:
   void markActive(uint32_t serial);
   void markInactive(uint32_t serial);
   void removeInactiveCertificate(uint32_t serial);
-  std::vector<std::shared_ptr<DNSCryptCertificatePair>> getCertificates() { return d_certs; };
+  std::vector<std::shared_ptr<DNSCryptCertificatePair>> getCertificates();
   const DNSName& getProviderName() const { return providerName; }
 
   int encryptQuery(PacketBuffer& query, size_t maximumSize, const unsigned char clientPublicKey[DNSCRYPT_PUBLIC_KEY_SIZE], const DNSCryptPrivateKey& clientPrivateKey, const unsigned char clientNonce[DNSCRYPT_NONCE_SIZE / 2], bool tcp, const std::shared_ptr<DNSCryptCert>& cert) const;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In theory these functions should already be protected by the Lua lock but better safe than sorry.
Found while working on the migration to LockGuarded.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
