### PR TITLE
rec: Apply dns64 on RPZ hits generated after a gettag_ffi hit

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1476,6 +1476,24 @@ int getFakePTRRecords(const DNSName& qname, vector<DNSRecord>& ret)
   return rcode;
 }
 
+static bool answerIsNOData(uint16_t requestedType, int rcode, const std::vector<DNSRecord>& records)
+{
+  if (rcode != RCode::NoError) {
+    return false;
+  }
+  for (const auto& rec : records) {
+    if (rec.d_place != DNSResourceRecord::ANSWER) {
+      /* no records in the answer section */
+      return true;
+    }
+    if (rec.d_type == requestedType) {
+      /* we have a record, of the right type, in the right section */
+      return false;
+    }
+  }
+  return true;
+}
+
 static void startDoResolve(void *p)
 {
   auto dc=std::unique_ptr<DNSComboWriter>(reinterpret_cast<DNSComboWriter*>(p));
@@ -1742,6 +1760,10 @@ static void startDoResolve(void *p)
         else {
           auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw);
           if (policyResult == PolicyResult::HaveAnswer) {
+            if (dq.qtype == QType::AAAA && answerIsNOData(dc->d_mdp.d_qtype, res, ret) && g_dns64Prefix) {
+              res = getFakeAAAARecords(dq.qname, *g_dns64Prefix, ret);
+              shouldNotValidate = true;
+            }
             goto haveAnswer;
           }
           else if (policyResult == PolicyResult::Drop) {
@@ -1807,15 +1829,7 @@ static void startDoResolve(void *p)
 
       if (t_pdl || (g_dns64Prefix && dq.qtype == QType::AAAA && !vStateIsBogus(dq.validationState))) {
         if (res == RCode::NoError) {
-          auto i = ret.cbegin();
-          for(; i!= ret.cend(); ++i) {
-            if (i->d_type == dc->d_mdp.d_qtype && i->d_place == DNSResourceRecord::ANSWER) {
-              break;
-            }
-          }
-
-          if (i == ret.cend()) {
-            /* no record in the answer section, NODATA */
+          if (answerIsNOData(dc->d_mdp.d_qtype, res, ret)) {
             if (t_pdl && t_pdl->nodata(dq, res)) {
               shouldNotValidate = true;
             }
@@ -1824,9 +1838,8 @@ static void startDoResolve(void *p)
               shouldNotValidate = true;
             }
           }
-
 	}
-	else if(res == RCode::NXDomain && t_pdl && t_pdl->nxdomain(dq, res)) {
+	else if (res == RCode::NXDomain && t_pdl && t_pdl->nxdomain(dq, res)) {
           shouldNotValidate = true;
         }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1760,7 +1760,7 @@ static void startDoResolve(void *p)
         else {
           auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw);
           if (policyResult == PolicyResult::HaveAnswer) {
-            if (dq.qtype == QType::AAAA && answerIsNOData(dc->d_mdp.d_qtype, res, ret) && g_dns64Prefix) {
+            if (g_dns64Prefix && dq.qtype == QType::AAAA && answerIsNOData(dc->d_mdp.d_qtype, res, ret)) {
               res = getFakeAAAARecords(dq.qname, *g_dns64Prefix, ret);
               shouldNotValidate = true;
             }

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -412,10 +412,10 @@ threads=2
 quiet=no
     """ % (os.environ['PREFIX'])
 
-class DNS64Test(RecursorTest):
+class LuaDNS64Test(RecursorTest):
     """Tests the dq.followupAction("getFakeAAAARecords")"""
 
-    _confdir = 'dns64'
+    _confdir = 'lua-dns64'
     _config_template = """
     """
     _lua_dns_script_file = """
@@ -469,6 +469,62 @@ class DNS64Test(RecursorTest):
             self.assertEqual(len(res.authority), 0)
             self.assertResponseMatches(query, expected, res)
 
+class GettagFFIDNS64Test(RecursorTest):
+    """Tests the interaction between gettag_ffi, RPZ and DNS64:
+       - gettag_ffi will intercept the query and return a NODATA
+       - the RPZ zone will match the name, but the only type is A
+       - DNS64 should kick in, generating an AAAA
+    """
+
+    _confdir = 'gettagffi-rpz-dns64'
+    _config_template = """
+    dns64-prefix=64:ff9b::/96
+    """
+    _lua_config_file = """
+    rpzFile('configs/%s/zone.rpz', { policyName="zone.rpz." })
+    """ % (_confdir)
+
+    _lua_dns_script_file = """
+    local ffi = require("ffi")
+
+    ffi.cdef[[
+      typedef struct pdns_ffi_param pdns_ffi_param_t;
+
+      void pdns_ffi_param_set_rcode(pdns_ffi_param_t* ref, int rcode);
+    ]]
+
+    function gettag_ffi(obj)
+      -- fake a NODATA (without SOA) no matter the query
+      ffi.C.pdns_ffi_param_set_rcode(obj, 0)
+      return {}
+    end
+    """
+    _auth_zones = []
+
+    @classmethod
+    def generateRecursorConfig(cls, confdir):
+        rpzFilePath = os.path.join(confdir, 'zone.rpz')
+        with open(rpzFilePath, 'w') as rpzZone:
+            rpzZone.write("""$ORIGIN zone.rpz.
+@ 3600 IN SOA {soa}
+dns64.test.powerdns.com.zone.rpz. 60 IN A 192.0.2.42
+""".format(soa=cls._SOA))
+        super(GettagFFIDNS64Test, cls).generateRecursorConfig(confdir)
+
+    def testAtoAAAA(self):
+        expected = [
+            dns.rrset.from_text('dns64.test.powerdns.com.', 15, dns.rdataclass.IN, 'AAAA', '64:ff9b::c000:22a')
+        ]
+        query = dns.message.make_query('dns64.test.powerdns.com.', 'AAAA')
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            res = sender(query)
+
+            self.assertRcodeEqual(res, dns.rcode.NOERROR)
+            self.assertEqual(len(res.answer), 1)
+            self.assertEqual(len(res.authority), 0)
+            self.assertResponseMatches(query, expected, res)
 
 class PDNSRandomTest(RecursorTest):
     """Tests if pdnsrandom works"""


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We do special case the `qname RPZ` processing after a `gettag_ffi` hit, leading to `dns64` to not be applied in that case. This commit adds `dns64` handling to the special case.

<strike>Needs regression tests.</strike>

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
