### PR TITLE
auth: change default timeout to 2s for lua records

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -36,6 +36,11 @@ Their old names still work in 4.5.x, but will be removed in the release after it
 * :ref:`setting-slave` is now :ref:`setting-secondary`
 * :ref:`setting-superslave` is now :ref:`setting-autosecondary`
 
+Changed defaults
+~~~~~~~~~~~~~~~~
+
+- The default value of the ``timeout`` option for :ref:`ifportup` and :ref:`ifurlup` functions has been changed from ``1`` to ``2`` seconds.
+
 4.3.x to 4.4.0
 --------------
 

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -89,7 +89,7 @@ private:
   void checkURL(const CheckDesc& cd, const bool status, const bool first = false)
   {
     try {
-      int timeout = 1;
+      int timeout = 2;
       if (cd.opts.count("timeout")) {
         timeout = std::atoi(cd.opts.at("timeout").c_str());
       }
@@ -123,7 +123,7 @@ private:
   }
   void checkTCP(const CheckDesc& cd, const bool status, const bool first = false) {
     try {
-      int timeout = 1;
+      int timeout = 2;
       if (cd.opts.count("timeout")) {
         timeout = std::atoi(cd.opts.at("timeout").c_str());
       }


### PR DESCRIPTION
### Short description

Bumping default timeout  to 2s  for ifportup and ifurlup lua functions like described in the related documentation.

Fixes #10357.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
