### PR TITLE
dnsdist docs: switch RA and RD

### DIFF
--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1441,7 +1441,7 @@ The following actions exist.
 
 .. function:: TCAction()
 
-  Create answer to query with the TC bit set, and the RD bit set to the value of RA in the query, to force the client to TCP.
+  Create answer to query with the TC bit set, and the RA bit set to the value of RD in the query, to force the client to TCP.
 
 .. function:: TeeAction(remote[, addECS])
 


### PR DESCRIPTION
### Short description
This sentence had RA and RD backwards.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)