### PR TITLE
rec: Prevent a race in the aggressive NSEC cache

### DIFF
--- a/pdns/recursordist/aggressive_nsec.hh
+++ b/pdns/recursordist/aggressive_nsec.hh
@@ -79,7 +79,8 @@ public:
 private:
   struct ZoneEntry
   {
-    ZoneEntry()
+    ZoneEntry(const DNSName& zone) :
+      d_zone(zone)
     {
     }
 
@@ -120,7 +121,7 @@ private:
       cache_t;
 
     cache_t d_entries;
-    DNSName d_zone;
+    const DNSName d_zone;
     std::string d_salt;
     std::mutex d_lock;
     uint16_t d_iterations{0};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When a new NSEC3 record has a different salt than the one we know, we update the zone entry with the new salt. Unfortunately, that salt was read without holding the lock in `AggressiveNSECCache::getNSEC3Denial`, leading to a possible data race.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
