### PR TITLE
dnsdist: Reorganize the IDState and Rings fields

### DIFF
--- a/pdns/dnsdist-rings.hh
+++ b/pdns/dnsdist-rings.hh
@@ -36,23 +36,23 @@
 struct Rings {
   struct Query
   {
-    struct timespec when;
     ComboAddress requestor;
     DNSName name;
+    struct timespec when;
+    struct dnsheader dh;
     uint16_t size;
     uint16_t qtype;
-    struct dnsheader dh;
   };
   struct Response
   {
-    struct timespec when;
     ComboAddress requestor;
+    ComboAddress ds; // who handled it
     DNSName name;
-    uint16_t qtype;
+    struct timespec when;
+    struct dnsheader dh;
     unsigned int usec;
     unsigned int size;
-    struct dnsheader dh;
-    ComboAddress ds; // who handled it
+    uint16_t qtype;
   };
 
   struct Shard
@@ -216,7 +216,7 @@ private:
     if (!shard->queryRing.full()) {
       d_nbQueryEntries++;
     }
-    shard->queryRing.push_back({when, requestor, name, size, qtype, dh});
+    shard->queryRing.push_back({requestor, name, when, dh, size, qtype});
   }
 
   void insertResponseLocked(std::unique_ptr<Shard>& shard, const struct timespec& when, const ComboAddress& requestor, const DNSName& name, uint16_t qtype, unsigned int usec, unsigned int size, const struct dnsheader& dh, const ComboAddress& backend)
@@ -224,7 +224,7 @@ private:
     if (!shard->respRing.full()) {
       d_nbResponseEntries++;
     }
-    shard->respRing.push_back({when, requestor, name, qtype, usec, size, dh, backend});
+    shard->respRing.push_back({requestor, backend, name, when, dh, usec, size, qtype});
   }
 
   std::atomic<size_t> d_nbQueryEntries;

--- a/pdns/dnsdistdist/docs/advanced/tuning.rst
+++ b/pdns/dnsdistdist/docs/advanced/tuning.rst
@@ -130,23 +130,34 @@ For other components, like the packet cache and the in-memory ring buffers, it i
 
 Sharding was disabled by default before 1.6.0 and could be enabled via the `numberOfShards` option to :func:`newPacketCache` and :func:`setRingBuffersSize`. It might still make sense to increment the number of shards when dealing with a lot of threads.
 
-Memory usage for TCP, DoH and DoT
----------------------------------
+Memory usage
+------------
 
-+--------------------------------+-----------------------------+
-| Protocol                       | Memory usage per connection |
-+================================+=============================+
-| TCP                            | 6 kB                        |
-+--------------------------------+-----------------------------+
-| DoT (GnuTLS)                   | 16 kB                       |
-+--------------------------------+-----------------------------+
-| DoT (OpenSSL)                  | 52 kB                       |
-+--------------------------------+-----------------------------+
-| DoT (OpenSSL w/ releaseBuffers | 19 kB                       |
-+--------------------------------+-----------------------------+
-| DoH (http)                     | 2 kB                        |
-+--------------------------------+-----------------------------+
-| DoH                            | 48 kB                       |
-+--------------------------------+-----------------------------+
-| DoH (w/ releaseBuffers)        | 15 kB                       |
-+--------------------------------+-----------------------------+
+The main sources of memory usage in DNSDist are:
+
+ * packet caches, when enabled
+ * the number of outstanding UDP queries per backend, configured with :func:`setMaxUDPOutstanding` (see above)
+ * the number of entries in the ring-buffers, configured with :func:`setRingBuffersSize`
+ * the number of short-lived dynamic block entries
+ * the number of user-defined rules and actions
+ * the number of TCP, DoT and DoH connections
+
+Memory usage per connection for connected protocols:
+
++---------------------------------+-----------------------------+
+| Protocol                        | Memory usage per connection |
++=================================+=============================+
+| TCP                             | 6 kB                        |
++---------------------------------+-----------------------------+
+| DoT (GnuTLS)                    | 16 kB                       |
++---------------------------------+-----------------------------+
+| DoT (OpenSSL)                   | 52 kB                       |
++---------------------------------+-----------------------------+
+| DoT (OpenSSL w/ releaseBuffers) | 19 kB                       |
++---------------------------------+-----------------------------+
+| DoH (http)                      | 2 kB                        |
++---------------------------------+-----------------------------+
+| DoH                             | 48 kB                       |
++---------------------------------+-----------------------------+
+| DoH (w/ releaseBuffers)         | 15 kB                       |
++---------------------------------+-----------------------------+

--- a/pdns/dnsdistdist/test-dnsdistrings_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrings_cc.cc
@@ -197,8 +197,8 @@ BOOST_AUTO_TEST_CASE(test_Rings_Threaded) {
   uint16_t size = 42;
 
   Rings rings(numberOfEntries, numberOfShards, lockAttempts, true);
-  Rings::Query query({now, requestor, qname, size, qtype, dh});
-  Rings::Response response({now, requestor, qname, qtype, latency, size, dh, server});
+  Rings::Query query({requestor, qname, now, dh, size, qtype});
+  Rings::Response response({requestor, server, qname, now, dh, latency, size, qtype});
 
   std::atomic<bool> done(false);
   std::vector<std::thread> writerThreads;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reducing the space lost to padding and thus the memory usage. This change saves 1 MB of memory per downstream server in the default configuration, and around 8 bytes per entry in the ring buffer. It also adds a few words about memory consumption in the documentation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
