### PR TITLE
Fix docs: refresh-on-ttl-perc was added in 4.5.0

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1520,7 +1520,7 @@ enlarge this value or run with fewer threads.
 
 ``refresh-on-ttl-perc``
 -----------------------
-.. versionadded: 4.5.0
+.. versionadded:: 4.5.0
 
 -  Integer
 -  Default: 0


### PR DESCRIPTION
### Short description
Properly document that _refresh-on-ttl-perc_ was introduced in 4.5.0 - guess the colon went missing.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
