### PR TITLE
auth: make sure we recheck failed SOA lookups for notifies

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -184,13 +184,23 @@ void Bind2Backend::setNotified(uint32_t id, uint32_t serial)
   safePutBBDomainInfo(bbd);
 }
 
-void Bind2Backend::setFresh(uint32_t domain_id)
+void Bind2Backend::setLastCheck(uint32_t domain_id, time_t lastcheck)
 {
   BB2DomainInfo bbd;
   if (safeGetBBDomainInfo(domain_id, &bbd)) {
-    bbd.d_lastcheck = time(nullptr);
+    bbd.d_lastcheck = lastcheck;
     safePutBBDomainInfo(bbd);
   }
+}
+
+void Bind2Backend::setStale(uint32_t domain_id)
+{
+  setLastCheck(domain_id, 0);
+}
+
+void Bind2Backend::setFresh(uint32_t domain_id)
+{
+  setLastCheck(domain_id, time(nullptr));
 }
 
 bool Bind2Backend::startTransaction(const DNSName& qname, int id)

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -199,6 +199,7 @@ public:
   static DNSBackend* maker();
   static std::mutex s_startup_lock;
 
+  void setStale(uint32_t domain_id) override;
   void setFresh(uint32_t domain_id) override;
   void setNotified(uint32_t id, uint32_t serial) override;
   bool startTransaction(const DNSName& qname, int id) override;
@@ -251,6 +252,7 @@ private:
   static bool safeRemoveBBDomainInfo(const DNSName& name);
   shared_ptr<SSQLite3> d_dnssecdb;
   bool getNSEC3PARAM(const DNSName& name, NSEC3PARAMRecordContent* ns3p);
+  void setLastCheck(uint32_t domain_id, time_t lastcheck);
   class handle
   {
   public:

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -932,6 +932,13 @@ bool LMDBBackend::setAccount(const DNSName& domain, const std::string& account)
   });
 }
 
+void LMDBBackend::setStale(uint32_t domain_id)
+{
+  genChangeDomain(domain_id, [](DomainInfo& di) {
+    di.last_check = 0;
+  });
+}
+
 void LMDBBackend::setFresh(uint32_t domain_id)
 {
   genChangeDomain(domain_id, [](DomainInfo& di) {

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -97,6 +97,7 @@ public:
   }
 
   bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta) override;
+  void setStale(uint32_t domain_id) override;
   void setFresh(uint32_t domain_id) override;
   void setNotified(uint32_t id, uint32_t serial) override;
   bool setAccount(const DNSName& domain, const std::string& account) override;

--- a/modules/remotebackend/httpconnector.cc
+++ b/modules/remotebackend/httpconnector.cc
@@ -260,6 +260,10 @@ void HTTPConnector::restful_requestbuilder(const std::string& method, const Json
     req.preparePost();
     verb = "PATCH";
   }
+  else if (method == "setStale") {
+    req.preparePost();
+    verb = "PATCH";
+  }
   else if (method == "setFresh") {
     req.preparePost();
     verb = "PATCH";

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -927,6 +927,18 @@ void RemoteBackend::getUnfreshSlaveInfos(vector<DomainInfo>* domains)
   }
 }
 
+void RemoteBackend::setStale(uint32_t domain_id)
+{
+  Json query = Json::object{
+    {"method", "setStale"},
+    {"parameters", Json::object{{"id", static_cast<double>(domain_id)}}}};
+
+  Json answer;
+  if (this->send(query) == false || this->recv(answer) == false) {
+    g_log << Logger::Error << kBackendId << " Failed to execute RPC for RemoteBackend::setStale(" << domain_id << ")" << endl;
+  }
+}
+
 void RemoteBackend::setFresh(uint32_t domain_id)
 {
   Json query = Json::object{

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -202,6 +202,7 @@ public:
   void getUpdatedMasters(vector<DomainInfo>* domains) override;
   void alsoNotifies(const DNSName& domain, set<string>* ips) override;
   void getUnfreshSlaveInfos(vector<DomainInfo>* domains) override;
+  void setStale(uint32_t domain_id) override;
   void setFresh(uint32_t domain_id) override;
 
   static DNSBackend* maker();

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -207,20 +207,26 @@ void GSQLBackend::setNotified(uint32_t domain_id, uint32_t serial)
   }
 }
 
-void GSQLBackend::setFresh(uint32_t domain_id)
+void GSQLBackend::setLastCheck(uint32_t domain_id, time_t lastcheck)
 {
   try {
     reconnectIfNeeded();
 
-    d_UpdateLastCheckOfZoneQuery_stmt->
-      bind("last_check", time(nullptr))->
-      bind("domain_id", domain_id)->
-      execute()->
-      reset();
+    d_UpdateLastCheckOfZoneQuery_stmt->bind("last_check", lastcheck)->bind("domain_id", domain_id)->execute()->reset();
   }
   catch (SSqlException &e) {
-    throw PDNSException("GSQLBackend unable to refresh domain_id "+itoa(domain_id)+": "+e.txtReason());
+    throw PDNSException("GSQLBackend unable to update last_check for domain_id " + itoa(domain_id) + ": " + e.txtReason());
   }
+}
+
+void GSQLBackend::setStale(uint32_t domain_id)
+{
+  setLastCheck(domain_id, 0);
+}
+
+void GSQLBackend::setFresh(uint32_t domain_id)
+{
+  setLastCheck(domain_id, time(nullptr));
 }
 
 bool GSQLBackend::setMasters(const DNSName &domain, const vector<ComboAddress> &masters)

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -198,6 +198,7 @@ public:
   bool deleteDomain(const DNSName &domain) override;
   bool superMasterAdd(const string &ip, const string &nameserver, const string &account) override; 
   bool superMasterBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db) override;
+  void setStale(uint32_t domain_id) override;
   void setFresh(uint32_t domain_id) override;
   void getUnfreshSlaveInfos(vector<DomainInfo> *domains) override;
   void getUpdatedMasters(vector<DomainInfo> *updatedDomains) override;
@@ -244,6 +245,7 @@ protected:
   string pattern2SQLPattern(const string& pattern);
   void extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& rr);
   void extractComment(SSqlStatement::row_t& row, Comment& c);
+  void setLastCheck(uint32_t domain_id, time_t lastcheck);
   bool isConnectionUsable() {
     if (d_db) {
       return d_db->isConnectionUsable();

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -311,12 +311,17 @@ public:
   virtual void getUpdatedMasters(vector<DomainInfo>* domains)
   {
   }
-  
+
+  //! Called by PowerDNS to inform a backend that a domain need to be checked for freshness
+  virtual void setStale(uint32_t domain_id)
+  {
+  }
+
   //! Called by PowerDNS to inform a backend that a domain has been checked for freshness
   virtual void setFresh(uint32_t domain_id)
   {
-
   }
+
   //! Called by PowerDNS to inform a backend that the changes in the domain have been reported to slaves
   virtual void setNotified(uint32_t id, uint32_t serial)
   {

--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -951,6 +951,10 @@ void CommunicatorClass::slaveRefresh(PacketHandler *P)
       } else if (newCount % 10 == 0) {
         g_log<<Logger::Notice<<"Unable to retrieve SOA for "<<di.zone<<", this was the "<<std::to_string(newCount)<<"th time. Skipping SOA checks until "<<nextCheck<<endl;
       }
+      // Make sure we recheck SOA for notifies
+      if (di.receivedNotify) {
+        di.backend->setStale(di.id);
+      }
       continue;
     }
 


### PR DESCRIPTION
### Short description
A failed SOA lookup triggered by a notify was not retried. The log message told that a recheck was scheduled, but this was a lie.
This pull will improve the reliability of notifies, especially on servers with a large number of zones.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
