### PR TITLE
add missing includes (Fedora 34, gcc 11.1 / clang 12)

### DIFF
--- a/pdns/histogram.hh
+++ b/pdns/histogram.hh
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/pdns/lock.hh
+++ b/pdns/lock.hh
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
+#include <mutex>
 #include <shared_mutex>
 
 class ReadWriteLock


### PR DESCRIPTION
### Short description
Pdns did not compile on fedora 34

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
