### PR TITLE
auth: change the consistent-backends default to 'yes'

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -291,7 +291,7 @@ Name of this virtual configuration - will rename the binary image. See
 -----------------------
 
 -  Boolean
--  Default: no
+-  Default: yes
 
 .. versionadded:: 4.4.0
 
@@ -299,7 +299,9 @@ When this is set, PowerDNS assumes that any single domain lives in only one back
 This allows PowerDNS to send ANY lookups to its backends, instead of sometimes requesting the exact needed type.
 This reduces the load on backends by retrieving all the types for a given name at once, adding all of them to the cache.
 It improves performance significantly for latency-sensitive backends, like SQL ones, where a round-trip takes serious time.
-This behaviour will be enabled by default in a future release.
+
+.. note::
+  Pre 4.5.0 the default was no.
 
 .. _setting-control-console:
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -39,6 +39,7 @@ Their old names still work in 4.5.x, but will be removed in the release after it
 Changed defaults
 ~~~~~~~~~~~~~~~~
 
+- The default value of the ``consistent-backends`` option has been changed from ``no`` to ``yes``.
 - The default value of the ``timeout`` option for :ref:`ifportup` and :ref:`ifurlup` functions has been changed from ``1`` to ``2`` seconds.
 
 4.3.x to 4.4.0

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -247,7 +247,7 @@ void declareArguments()
   ::arg().setSwitch("upgrade-unknown-types","Transparently upgrade known TYPExxx records. Recommended to keep off, except for PowerDNS upgrades until data sources are cleaned up")="no";
   ::arg().setSwitch("svc-autohints", "Transparently fill ipv6hint=auto ipv4hint=auto SVC params with AAAA/A records for the target name of the record (if within the same zone)")="no";
 
-  ::arg().setSwitch("consistent-backends", "Assume individual domains are not divided over backends. Send only ANY lookup operations to the backend to reduce the number of lookups")="no";
+  ::arg().setSwitch("consistent-backends", "Assume individual domains are not divided over backends. Send only ANY lookup operations to the backend to reduce the number of lookups")="yes";
 
   ::arg().set("rng", "Specify the random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
   ::arg().setDefaults();


### PR DESCRIPTION
### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
