### PR TITLE
builder-support: add Debian bullseye dockerfiles

### DIFF
--- a/builder-support/debian/recursor/debian-buster/control
+++ b/builder-support/debian/recursor/debian-buster/control
@@ -5,7 +5,6 @@ Standards-Version: 4.1.2
 Maintainer: PowerDNS.COM BV <powerdns.support@powerdns.com>
 Build-Depends: debhelper (>= 10),
                dh-autoreconf,
-               dh-systemd [linux-any],
                libboost-all-dev,
                libcap-dev,
                libluajit-5.1-dev [!arm64 !s390x],

--- a/builder-support/dockerfiles/Dockerfile.target.debian-bullseye
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-bullseye
@@ -1,0 +1,36 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+@IF [ ${BUILDER_TARGET} = debian-bullseye ]
+FROM debian:bullseye as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = debian-bullseye-amd64 ]
+FROM amd64/debian:bullseye as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = debian-bullseye-arm64 ]
+FROM arm64v8/debian:bullseye as dist-base
+@ENDIF
+
+ARG BUILDER_CACHE_BUSTER=
+ARG APT_URL
+RUN apt-get update && apt-get -y dist-upgrade
+
+@INCLUDE Dockerfile.debbuild-prepare
+
+@IF [ -n "$M_authoritative$M_all" ]
+ADD builder-support/debian/authoritative/debian-buster/ pdns-${BUILDER_VERSION}/debian/
+@ENDIF
+
+@IF [ -n "$M_recursor$M_all" ]
+ADD builder-support/debian/recursor/debian-buster/ pdns-recursor-${BUILDER_VERSION}/debian/
+@ENDIF
+
+@IF [ -n "$M_dnsdist$M_all" ]
+ADD builder-support/debian/dnsdist/debian-buster/ dnsdist-${BUILDER_VERSION}/debian/
+@ENDIF
+
+@INCLUDE Dockerfile.debbuild
+
+# Do a test install and verify
+# Can be skipped with skiptests=1 in the environment
+# @EXEC [ "$skiptests" = "" ] && include Dockerfile.debtest

--- a/builder-support/dockerfiles/Dockerfile.target.debian-bullseye-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-bullseye-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.debian-bullseye

--- a/builder-support/dockerfiles/Dockerfile.target.debian-bullseye-arm64
+++ b/builder-support/dockerfiles/Dockerfile.target.debian-bullseye-arm64
@@ -1,0 +1,1 @@
+Dockerfile.target.debian-bullseye


### PR DESCRIPTION
### Short description
Add Debian bullseye Dockerfiles.
Related to #10406.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
