### PR TITLE
dnsdist: Add a suppression for a race in TCP stats reported by TSAN

### DIFF
--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1033,6 +1033,8 @@ struct DownstreamState
     qps.addHit();
   }
 
+  void incCurrentConnectionsCount();
+
 private:
   std::string name;
   std::string nameWithAddr;

--- a/pdns/dnsdistdist/dnsdist-backend.cc
+++ b/pdns/dnsdistdist/dnsdist-backend.cc
@@ -186,3 +186,11 @@ DownstreamState::~DownstreamState()
     tid.detach();
   }
 }
+
+void DownstreamState::incCurrentConnectionsCount()
+{
+  auto currentConnectionsCount = ++tcpCurrentConnections;
+  if (currentConnectionsCount > tcpMaxConcurrentConnections) {
+    tcpMaxConcurrentConnections.store(currentConnectionsCount);
+  }
+}

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -351,10 +351,7 @@ bool TCPConnectionToBackend::reconnect()
       d_queries = 0;
 
       d_handler = std::move(handler);
-      ++d_ds->tcpCurrentConnections;
-      if (d_ds->tcpCurrentConnections > d_ds->tcpMaxConcurrentConnections) {
-        d_ds->tcpMaxConcurrentConnections = d_ds->tcpCurrentConnections;
-      }
+      d_ds->incCurrentConnectionsCount();
       return true;
     }
     catch (const std::runtime_error& e) {

--- a/pdns/dnsdistdist/tsan.supp
+++ b/pdns/dnsdistdist/tsan.supp
@@ -4,6 +4,7 @@ race:doLatencyStats
 race:handleStats
 race:ClientState::updateTCPMetrics
 race:DownstreamState::updateTCPMetrics
+race:DownstreamState::incCurrentConnectionsCount
 # There is a race when we update the status of a backend,
 # but eventual consistency is fine there
 race:DownstreamState::setDown


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We might indeed be off by a few connections in the "maximum connections seen" counter, but we don't care that much.
TSAN report was:
```
WARNING: ThreadSanitizer: data race (pid=10555)
  Atomic write of size 8 at 0x7b74000023c0 by thread T5:
    #0 __tsan_atomic64_fetch_sub <null> (dnsdist+0x7a9ea9)
    #1 std::__atomic_base<unsigned long>::operator--() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/atomic_base.h:304:16 (dnsdist+0x82537f)
    #2 pdns::stat_t_trait<unsigned long>::operator--() /opt/project/pdns/dnsdistdist/./stat_t.hh:52:14 (dnsdist+0xed91a5)
    #3 TCPConnectionToBackend::~TCPConnectionToBackend() /opt/project/pdns/dnsdistdist/./dnsdist-tcp-downstream.hh:58:7 (dnsdist+0xeed22c)
    #4 void __gnu_cxx::new_allocator<TCPConnectionToBackend>::destroy<TCPConnectionToBackend>(TCPConnectionToBackend*) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/ext/new_allocator.h:140:28 (dnsdist+0xeed1c5)
    #5 void std::allocator_traits<std::allocator<TCPConnectionToBackend> >::destroy<TCPConnectionToBackend>(std::allocator<TCPConnectionToBackend>&, TCPConnectionToBackend*) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/alloc_traits.h:487:8 (dnsdist+0xeed16e)
    #6 std::_Sp_counted_ptr_inplace<TCPConnectionToBackend, std::allocator<TCPConnectionToBackend>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:554:2 (dnsdist+0xeec54f)
    #7 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:155:6 (dnsdist+0x804bdc)
    #8 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:728:11 (dnsdist+0x804ba2)
    #9 std::__shared_ptr<TCPConnectionToBackend, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:1167:31 (dnsdist+0xed9d09)
    #10 TCPResponse::~TCPResponse() /opt/project/pdns/dnsdistdist/./dnsdist-tcp-downstream.hh:27:8 (dnsdist+0xeda6e9)
    #11 IncomingTCPConnectionState::~IncomingTCPConnectionState() /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:230:1 (dnsdist+0xee199c)
    #12 void __gnu_cxx::new_allocator<IncomingTCPConnectionState>::destroy<IncomingTCPConnectionState>(IncomingTCPConnectionState*) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/ext/new_allocator.h:140:28 (dnsdist+0xef1d05)
    #13 void std::allocator_traits<std::allocator<IncomingTCPConnectionState> >::destroy<IncomingTCPConnectionState>(std::allocator<IncomingTCPConnectionState>&, IncomingTCPConnectionState*) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/alloc_traits.h:487:8 (dnsdist+0xef1cae)
    #14 std::_Sp_counted_ptr_inplace<IncomingTCPConnectionState, std::allocator<IncomingTCPConnectionState>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:554:2 (dnsdist+0xef0d2f)
    #15 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:155:6 (dnsdist+0x804bdc)
    #16 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:728:11 (dnsdist+0x804ba2)
    #17 std::__shared_ptr<IncomingTCPConnectionState, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:1167:31 (dnsdist+0xedaf39)
    #18 IncomingTCPConnectionState::handleIOCallback(int, boost::any&) /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:778:1 (dnsdist+0xee3a3d)
    #19 boost::detail::function::void_function_invoker2<void (*)(int, boost::any&), void, int, boost::any&>::invoke(boost::detail::function::function_buffer&, int, boost::any&) /usr/include/boost/function/function_template.hpp:118:11 (dnsdist+0x895698)
    #20 boost::function2<void, int, boost::any&>::operator()(int, boost::any&) const /usr/include/boost/function/function_template.hpp:768:14 (dnsdist+0xf9efbc)
    #21 EpollFDMultiplexer::run(timeval*, int) /opt/project/pdns/dnsdistdist/epollmplexer.cc:176:7 (dnsdist+0xfd1e6b)
    #22 tcpClientThread(int) /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:1140:19 (dnsdist+0xee275a)
    #23 void std::__invoke_impl<void, void (*)(int), int>(std::__invoke_other, void (*&&)(int), int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/invoke.h:60:14 (dnsdist+0xef7842)
    #24 std::__invoke_result<void (*)(int), int>::type std::__invoke<void (*)(int), int>(void (*&&)(int), int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/invoke.h:95:14 (dnsdist+0xef7761)
    #25 decltype(std::__invoke(_S_declval<0ul>(), _S_declval<1ul>())) std::thread::_Invoker<std::tuple<void (*)(int), int> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/thread:244:13 (dnsdist+0xef770e)
    #26 std::thread::_Invoker<std::tuple<void (*)(int), int> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/thread:253:11 (dnsdist+0xef76b5)
    #27 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(int), int> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/thread:196:13 (dnsdist+0xef7479)
    #28 <null> <null> (libstdc++.so.6+0xbbb2e)

  Previous read of size 8 at 0x7b74000023c0 by thread T6:
    #0 memcpy <null> (dnsdist+0x7690fd)
    #1 TCPConnectionToBackend::reconnect() /opt/project/pdns/dnsdistdist/dnsdist-tcp-downstream.cc:356:43 (dnsdist+0xed7018)
    #2 TCPConnectionToBackend::TCPConnectionToBackend(std::shared_ptr<DownstreamState>&, timeval const&) /opt/project/pdns/dnsdistdist/./dnsdist-tcp-downstream.hh:52:5 (dnsdist+0xeec853)
    #3 void __gnu_cxx::new_allocator<TCPConnectionToBackend>::construct<TCPConnectionToBackend, std::shared_ptr<DownstreamState>&, timeval const&>(TCPConnectionToBackend*, std::shared_ptr<DownstreamState>&, timeval const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/ext/new_allocator.h:136:23 (dnsdist+0xeec698)
    #4 void std::allocator_traits<std::allocator<TCPConnectionToBackend> >::construct<TCPConnectionToBackend, std::shared_ptr<DownstreamState>&, timeval const&>(std::allocator<TCPConnectionToBackend>&, TCPConnectionToBackend*, std::shared_ptr<DownstreamState>&, timeval const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/alloc_traits.h:475:8 (dnsdist+0xeec471)
    #5 std::_Sp_counted_ptr_inplace<TCPConnectionToBackend, std::allocator<TCPConnectionToBackend>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::shared_ptr<DownstreamState>&, timeval const&>(std::allocator<TCPConnectionToBackend>, std::shared_ptr<DownstreamState>&, timeval const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:545:4 (dnsdist+0xeec15a)
    #6 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<TCPConnectionToBackend, std::allocator<TCPConnectionToBackend>, std::shared_ptr<DownstreamState>&, timeval const&>(TCPConnectionToBackend*&, std::_Sp_alloc_shared_tag<std::allocator<TCPConnectionToBackend> >, std::shared_ptr<DownstreamState>&, timeval const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:678:6 (dnsdist+0xeebf34)
    #7 std::__shared_ptr<TCPConnectionToBackend, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<TCPConnectionToBackend>, std::shared_ptr<DownstreamState>&, timeval const&>(std::_Sp_alloc_shared_tag<std::allocator<TCPConnectionToBackend> >, std::shared_ptr<DownstreamState>&, timeval const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:1342:14 (dnsdist+0xeebe78)
    #8 std::shared_ptr<TCPConnectionToBackend>::shared_ptr<std::allocator<TCPConnectionToBackend>, std::shared_ptr<DownstreamState>&, timeval const&>(std::_Sp_alloc_shared_tag<std::allocator<TCPConnectionToBackend> >, std::shared_ptr<DownstreamState>&, timeval const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr.h:359:4 (dnsdist+0xeebdf1)
    #9 std::shared_ptr<TCPConnectionToBackend> std::allocate_shared<TCPConnectionToBackend, std::allocator<TCPConnectionToBackend>, std::shared_ptr<DownstreamState>&, timeval const&>(std::allocator<TCPConnectionToBackend> const&, std::shared_ptr<DownstreamState>&, timeval const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr.h:705:14 (dnsdist+0xeebd41)
    #10 std::shared_ptr<TCPConnectionToBackend> std::make_shared<TCPConnectionToBackend, std::shared_ptr<DownstreamState>&, timeval const&>(std::shared_ptr<DownstreamState>&, timeval const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr.h:721:14 (dnsdist+0xeeb979)
    #11 DownstreamConnectionsManager::getConnectionToDownstream(std::unique_ptr<FDMultiplexer, std::default_delete<FDMultiplexer> >&, std::shared_ptr<DownstreamState>&, timeval const&) /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:114:12 (dnsdist+0xee8155)
    #12 IncomingTCPConnectionState::getDownstreamConnection(std::shared_ptr<DownstreamState>&, std::unique_ptr<std::vector<ProxyProtocolValue, std::allocator<ProxyProtocolValue> >, std::default_delete<std::vector<ProxyProtocolValue, std::allocator<ProxyProtocolValue> > > > const&, timeval const&) /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:245:18 (dnsdist+0xee1bcf)
    #13 handleQuery(std::shared_ptr<IncomingTCPConnectionState>&, timeval const&) /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:731:38 (dnsdist+0xee5e70)
    #14 IncomingTCPConnectionState::handleIO(std::shared_ptr<IncomingTCPConnectionState>&, timeval const&) /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:919:11 (dnsdist+0xee501f)
    #15 handleIncomingTCPQuery(int, boost::any&) /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:1115:5 (dnsdist+0xee73bd)
    #16 boost::detail::function::void_function_invoker2<void (*)(int, boost::any&), void, int, boost::any&>::invoke(boost::detail::function::function_buffer&, int, boost::any&) /usr/include/boost/function/function_template.hpp:118:11 (dnsdist+0x895698)
    #17 boost::function2<void, int, boost::any&>::operator()(int, boost::any&) const /usr/include/boost/function/function_template.hpp:768:14 (dnsdist+0xf9efbc)
    #18 EpollFDMultiplexer::run(timeval*, int) /opt/project/pdns/dnsdistdist/epollmplexer.cc:176:7 (dnsdist+0xfd1e6b)
    #19 tcpClientThread(int) /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:1140:19 (dnsdist+0xee275a)
    #20 void std::__invoke_impl<void, void (*)(int), int>(std::__invoke_other, void (*&&)(int), int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/invoke.h:60:14 (dnsdist+0xef7842)
    #21 std::__invoke_result<void (*)(int), int>::type std::__invoke<void (*)(int), int>(void (*&&)(int), int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/invoke.h:95:14 (dnsdist+0xef7761)
    #22 decltype(std::__invoke(_S_declval<0ul>(), _S_declval<1ul>())) std::thread::_Invoker<std::tuple<void (*)(int), int> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/thread:244:13 (dnsdist+0xef770e)
    #23 std::thread::_Invoker<std::tuple<void (*)(int), int> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/thread:253:11 (dnsdist+0xef76b5)
    #24 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(int), int> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/thread:196:13 (dnsdist+0xef7479)
    #25 <null> <null> (libstdc++.so.6+0xbbb2e)

  Location is heap block of size 2304 at 0x7b7400001e00 allocated by main thread:
    #0 operator new(unsigned long, std::align_val_t) <null> (dnsdist+0x7e8c57)
    #1 __gnu_cxx::new_allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/ext/new_allocator.h:108:31 (dnsdist+0xe6b3e2)
    #2 std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> >&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/alloc_traits.h:436:20 (dnsdist+0xe6b330)
    #3 std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<DownstreamState, std::allocator<DownstreamState>, (__gnu_cxx::_Lock_policy)2> >&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/allocated_ptr.h:97:21 (dnsdist+0xe6b0d0)
    #4 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<DownstreamState, std::allocator<DownstreamState>, ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool>(DownstreamState*&, std::_Sp_alloc_shared_tag<std::allocator<DownstreamState> >, ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:675:19 (dnsdist+0xe6fa0a)
    #5 std::__shared_ptr<DownstreamState, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<DownstreamState>, ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool>(std::_Sp_alloc_shared_tag<std::allocator<DownstreamState> >, ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr_base.h:1342:14 (dnsdist+0xe6f97a)
    #6 std::shared_ptr<DownstreamState>::shared_ptr<std::allocator<DownstreamState>, ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool>(std::_Sp_alloc_shared_tag<std::allocator<DownstreamState> >, ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr.h:359:4 (dnsdist+0xe6f89d)
    #7 std::shared_ptr<DownstreamState> std::allocate_shared<DownstreamState, std::allocator<DownstreamState>, ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool>(std::allocator<DownstreamState> const&, ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr.h:705:14 (dnsdist+0xe6f7e0)
    #8 std::shared_ptr<DownstreamState> std::make_shared<DownstreamState, ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool>(ComboAddress&, ComboAddress&, unsigned int&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned long&, bool&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/shared_ptr.h:721:14 (dnsdist+0xe6a626)
    #9 setupLuaConfig(LuaContext&, bool, bool)::$_2::operator()(boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>) const /opt/project/pdns/dnsdistdist/dnsdist-lua.cc:356:11 (dnsdist+0xdf9066)
    #10 _ZN10LuaContext6BinderIRZL14setupLuaConfigRS_bbE3$_2RKN5boost7variantINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJSt13unordered_mapISB_NS5_IbJSB_St6vectorISt4pairIiSB_ESaISF_EESt8functionIFSt5tupleIJ7DNSNamettEERKSK_ttP9dnsheaderEEEEESt4hashISB_ESt8equal_toISB_ESaISE_IKSB_SS_EEEEEEEclIJRKNS4_8optionalIiEEEEEDTcldtdefpT8functiondtdefpT5paramspclsr3stdE7forwardIT_Efp_EEEDpOS1A_ /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:1846:20 (dnsdist+0xdf88af)
    #11 _ZN10LuaContext6BinderIRNS0_IRZL14setupLuaConfigRS_bbE3$_2RKN5boost7variantINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEJSt13unordered_mapISB_NS5_IbJSB_St6vectorISt4pairIiSB_ESaISF_EESt8functionIFSt5tupleIJ7DNSNamettEERKSK_ttP9dnsheaderEEEEESt4hashISB_ESt8equal_toISB_ESaISE_IKSB_SS_EEEEEEEERKNS4_8optionalIiEEEclIJEEEDTcldtdefpT8functiondtdefpT5paramspclsr3stdE7forwardIT_Efp_EEEDpOS1C_ /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:1846:20 (dnsdist+0xdf8817)
    #12 std::shared_ptr<DownstreamState> LuaContext::readIntoFunction<std::shared_ptr<DownstreamState>, LuaContext::Binder<LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_2&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > > const&>&, boost::optional<int> const&>&>(lua_State*, LuaContext::tag<std::shared_ptr<DownstreamState> >, LuaContext::Binder<LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_2&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > > const&>&, boost::optional<int> const&>&, int) /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:1766:16 (dnsdist+0xdf87be)
    #13 std::enable_if<IsOptional<boost::optional<int> >::value, std::shared_ptr<DownstreamState> >::type LuaContext::readIntoFunction<std::shared_ptr<DownstreamState>, LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_2&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > > const&>&, boost::optional<int> >(lua_State*, LuaContext::tag<std::shared_ptr<DownstreamState> >, LuaContext::Binder<setupLuaConfig(LuaContext&, bool, bool)::$_2&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > > const&>&, int, LuaContext::tag<boost::optional<int> >) /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:1774:20 (dnsdist+0xdf8524)
    #14 std::enable_if<!(IsOptional<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > > >::value), std::shared_ptr<DownstreamState> >::type LuaContext::readIntoFunction<std::shared_ptr<DownstreamState>, setupLuaConfig(LuaContext&, bool, bool)::$_2&, boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int> >(lua_State*, LuaContext::tag<std::shared_ptr<DownstreamState> >, setupLuaConfig(LuaContext&, bool, bool)::$_2&, int, LuaContext::tag<boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > > >, LuaContext::tag<boost::optional<int> >) /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:1796:16 (dnsdist+0xdf838d)
    #15 std::enable_if<(!(std::integral_constant<bool, false>::value)) && (!(std::is_void<bool>::value)), LuaContext::PushedObject>::type LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>), void>::callback2<setupLuaConfig(LuaContext&, bool, bool)::$_2&>(lua_State*, bool&&, int) /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2429:31 (dnsdist+0xdf82c2)
    #16 LuaContext::PushedObject LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>), void>::callback<setupLuaConfig(LuaContext&, bool, bool)::$_2>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_2*, int) /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2398:20 (dnsdist+0xdf8069)
    #17 std::enable_if<boost::has_trivial_destructor<setupLuaConfig(LuaContext&, bool, bool)::$_2>::value, LuaContext::PushedObject>::type LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>), void>::push<setupLuaConfig(LuaContext&, bool, bool)::$_2>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_2)::'lambda'(lua_State*)::operator()(lua_State*) const /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2327:20 (dnsdist+0xdf7fc9)
    #18 std::enable_if<boost::has_trivial_destructor<setupLuaConfig(LuaContext&, bool, bool)::$_2>::value, LuaContext::PushedObject>::type LuaContext::Pusher<std::shared_ptr<DownstreamState> (boost::variant<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::variant<bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::function<std::tuple<DNSName, unsigned short, unsigned short> (DNSName const&, unsigned short, unsigned short, dnsheader*)> > > > > >, boost::optional<int>), void>::push<setupLuaConfig(LuaContext&, bool, bool)::$_2>(lua_State*, setupLuaConfig(LuaContext&, bool, bool)::$_2)::'lambda'(lua_State*)::__invoke(lua_State*) /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:2323:31 (dnsdist+0xdf7f55)
    #19 _init <null> (libluajit-5.1.so.2+0x9dd6)
    #20 std::tuple<> LuaContext::call<std::tuple<> >(lua_State*, LuaContext::PushedObject) /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:1413:29 (dnsdist+0xc9add7)
    #21 LuaContext::executeCode(std::istream&) /opt/project/pdns/dnsdistdist/./ext/luawrapper/include/LuaContext.hpp:267:9 (dnsdist+0xe6067a)
    #22 setupLua(LuaContext&, bool, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /opt/project/pdns/dnsdistdist/dnsdist-lua.cc:2599:10 (dnsdist+0xdf4ef3)
    #23 main /opt/project/pdns/dnsdistdist/dnsdist.cc:2235:17 (dnsdist+0xf2818a)

  Thread T5 'dnsdist/tcpClie' (tid=10561, running) created by main thread at:
    #0 pthread_create <null> (dnsdist+0x75f2d5)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xbbdb4)
    #2 TCPClientCollection::addTCPClientThread() /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:332:19 (dnsdist+0xee22c4)
    #3 main /opt/project/pdns/dnsdistdist/dnsdist.cc:2427:27 (dnsdist+0xf29393)

  Thread T6 'dnsdist/tcpClie' (tid=10562, running) created by main thread at:
    #0 pthread_create <null> (dnsdist+0x75f2d5)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xbbdb4)
    #2 TCPClientCollection::addTCPClientThread() /opt/project/pdns/dnsdistdist/dnsdist-tcp.cc:332:19 (dnsdist+0xee22c4)
    #3 main /opt/project/pdns/dnsdistdist/dnsdist.cc:2427:27 (dnsdist+0xf29393)

SUMMARY: ThreadSanitizer: data race (/opt/dnsdist-with-tsan/bin/dnsdist+0x7a9ea9) in __tsan_atomic64_fetch_sub
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
