### PR TITLE
rec: Backport 10426 to rec-4.5.x: Be less aggressive forcing refresh of almost-expired NS and their A/AAAA records

### DIFF
--- a/pdns/recursordist/taskqueue.cc
+++ b/pdns/recursordist/taskqueue.cc
@@ -69,7 +69,8 @@ bool TaskQueue::runOnce(bool logErrors)
     sr.setRefreshAlmostExpired(task.d_refreshMode);
     try {
       g_log << Logger::Debug << "TaskQueue: resolving " << task.d_qname.toString() << '|' << QType(task.d_qtype).getName() << endl;
-      sr.beginResolve(task.d_qname, QType(task.d_qtype), QClass::IN, ret);
+      int res = sr.beginResolve(task.d_qname, QType(task.d_qtype), QClass::IN, ret);
+      g_log << Logger::Debug << "TaskQueue: DONE resolving " << task.d_qname.toString() << '|' << QType(task.d_qtype).getName() << ": " << res << endl;
     }
     catch (const std::exception& e) {
       g_log << Logger::Error << "Exception while running the background task queue: " << e.what() << endl;


### PR DESCRIPTION

Backport of #10426

Slightly different approach, since 4.5.x does not do explicit cache calls in `getAddr()`.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
