### PR TITLE
Fix 'temporary used in loop' warnings reported by g++ 11.1.0

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -614,7 +614,7 @@ void mainthread()
     // Some sanity checking on default key settings
     bool hadKeyError = false;
     int kskAlgo{0}, zskAlgo{0};
-    for (const string& algotype : {"ksk", "zsk"}) {
+    for (const string algotype : {"ksk", "zsk"}) {
       int algo, size;
       if (::arg()["default-"+algotype+"-algorithm"].empty())
         continue;

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -681,7 +681,7 @@ BOOST_AUTO_TEST_CASE(test_compare_canonical) {
   BOOST_CHECK(!a(DNSName("www.powerdns.net"), g_rootdnsname));
 
   vector<DNSName> vec;
-  for(const std::string& b : {"bert.com.", "alpha.nl.", "articles.xxx.",
+  for(const char* b : {"bert.com.", "alpha.nl.", "articles.xxx.",
 	"Aleph1.powerdns.com.", "ZOMG.powerdns.com.", "aaa.XXX.", "yyy.XXX.", 
 	"test.powerdns.com.", "\\128.com"}) {
     vec.push_back(DNSName(b));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
No real issue:
```
test-dnsname_cc.cc: In member function ‘void test_dnsname_cc::test_compare_canonical::test_method()’:
test-dnsname_cc.cc:684:26: warning: loop variable ‘b’ of type ‘const string&’ {aka ‘const std::__cxx11::basic_string<char>&’} binds to a temporary constructed from type ‘const char* const’ [-Wrange-loop-construct]
  684 |   for(const std::string& b : {"bert.com.", "alpha.nl.", "articles.xxx.",
      |                          ^
test-dnsname_cc.cc:684:26: note: use non-reference type ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} to make the copy explicit or ‘const char* const&’ to prevent copying
```
and 
```
common_startup.cc: In function ‘void mainthread()’:
common_startup.cc:617:24: warning: loop variable ‘algotype’ of type ‘const string&’ {aka ‘const std::__cxx11::basic_string<char>&’} binds to a temporary constructed from type ‘const char* const’ [-Wrange-loop-construct]
  617 |     for (const string& algotype : {"ksk", "zsk"}) {
      |                        ^~~~~~~~
common_startup.cc:617:24: note: use non-reference type ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} to make the copy explicit or ‘const char* const&’ to prevent copying
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
