### PR TITLE
auth: use primary and secondary for pdnsutil and pdns_control commands 

### DIFF
--- a/docs/manpages/pdns_control.1.rst
+++ b/docs/manpages/pdns_control.1.rst
@@ -27,36 +27,36 @@ Options
 Commands
 --------
 
-bind-add-zone *DOMAIN* *FILENAME*
+bind-add-zone *ZONE* *FILENAME*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When using the BIND backend, add a zone. This zone is added in-memory
 and served immediately. Note that this does not add the zone to the
 bind-config file. *FILENAME* must be an absolute path.
 
-bind-domain-extended-status [*DOMAIN*...]
+bind-domain-extended-status [*ZONE*...]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Output an extended status of all domains, containing much more information than
-the simple domain status, like the number of records currently loaded, whether pdns
-is master or slave for the domain, the list of masters, various timers, etc
-Optionally, append *DOMAIN*\ s to get the status of specific zones.
+Output an extended status of all zones, containing much more information than
+the simple zone status, like the number of records currently loaded, whether pdns
+is primary or secondary for the zone, the list of primaries, various timers, etc
+Optionally, append *ZONE*\ s to get the status of specific zones.
 
-bind-domain-status [*DOMAIN*...]
+bind-domain-status [*ZONE*...]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When using the BIND backend, list status of all domains. Optionally,
-append *DOMAIN*\ s to get the status of specific zones.
+When using the BIND backend, list status of all zones. Optionally,
+append *ZONE*\ s to get the status of specific zones.
 
 bind-list-rejects
 ^^^^^^^^^^^^^^^^^
 
-When using the BIND backend, get a list of all rejected domains.
+When using the BIND backend, get a list of all rejected zones.
 
-bind-reload-now *DOMAIN* [*DOMAIN*...]
+bind-reload-now *ZONE* [*ZONE*...]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When using the BIND backend, immediately reload *DOMAIN* from disk.
+When using the BIND backend, immediately reload *ZONE* from disk.
 
 ccounts
 ^^^^^^^
@@ -80,22 +80,22 @@ list
 Dump all statistics and their values in a comma separated list,
 equivalent to ``show *``.
 
-list-zones [master,slave,native]
+list-zones [primary,secondary,native]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Show a list of zones, optionally filter on the type of zones to
 show.
 
-notify *DOMAIN*
+notify *ZONE*
 ^^^^^^^^^^^^^^^
 
-Adds *DOMAIN* to the notification list, causing PowerDNS to send out
-notifications to the nameservers of a domain. Can be used if a slave
+Adds *ZONE* to the notification list, causing PowerDNS to send out
+notifications to the nameservers of a zone. Can be used if a secondary
 missed previous notifications or is generally hard of hearing. Use
-\* to notify for all domains. (Note that you may need to escape the
+\* to notify for all zones. (Note that you may need to escape the
 \* sign in your shell.)
 
-notify-host *DOMAIN* *ADDRESS*
+notify-host *ZONE* *ADDRESS*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Same as above but with operator specified IP *ADDRESS* as
@@ -128,7 +128,7 @@ Tell a running pdns\_server to quit.
 rediscover
 ^^^^^^^^^^
 
-Instructs backends that new domains may have appeared in the
+Instructs backends that new zones may have appeared in the
 database, or, in the case of the BIND backend, in named.conf.
 
 reload
@@ -147,10 +147,10 @@ respsizes
 
 Get a histogram of the response sizes.
 
-retrieve *DOMAIN* [IP]
+retrieve *ZONE* [IP]
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Retrieve slave *DOMAIN* from its master. Done nearly immediately.
+Retrieve secondary *ZONE* from its primary. Done nearly immediately.
 If IP is specified, then retrieval is forced from the specified IP.
 Port may be specified in AFI specific manner.
 

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -139,11 +139,11 @@ commands require an *ALGORITHM*, the following are available:
 -  hmac-sha384
 -  hmac-sha512
 
-activate-tsig-key *ZONE* *NAME* {**master**,\ **slave**}
+activate-tsig-key *ZONE* *NAME* {**primary**,\ **secondary**}
     Enable TSIG authenticated AXFR using the key *NAME* for zone *ZONE*.
-    This sets the ``TSIG-ALLOW-AXFR`` (master) or ``AXFR-MASTER-TSIG``
-    (slave) zone metadata.
-deactivate-tsig-key *ZONE* *NAME* {**master**,\ **slave**}
+    This sets the ``TSIG-ALLOW-AXFR`` (primary) or ``AXFR-MASTER-TSIG``
+    (secondary) zone metadata.
+deactivate-tsig-key *ZONE* *NAME* {**primary**,\ **secondary**}
     Disable TSIG authenticated AXFR using the key *NAME* for zone
     *ZONE*.
 delete-tsig-key *NAME*
@@ -162,22 +162,22 @@ ZONE MANIPULATION COMMANDS
 add-record *ZONE* *NAME* *TYPE* [*TTL*] *CONTENT*
     Add one or more records of *NAME* and *TYPE* to *ZONE* with *CONTENT* 
     and optional *TTL*. If *TTL* is not set, default will be used. 
-add-supermaster *IP* *NAMESERVER* [*ACCOUNT*]
-    Add a supermaster entry into the backend. This enables receiving zone updates from other servers.
+add-autoprimary *IP* *NAMESERVER* [*ACCOUNT*]
+    Add a autoprimary entry into the backend. This enables receiving zone updates from other servers.
 create-zone *ZONE*
     Create an empty zone named *ZONE*.
-create-slave-zone *ZONE* *MASTER* [*MASTER*]..
-    Create a new slave zone *ZONE* with masters *MASTER*. All *MASTER*\ s
+create-secondary-zone *ZONE* *PRIMARY* [*PRIMARY*]..
+    Create a new secondary zone *ZONE* with primaries *PRIMARY*. All *PRIMARY*\ s
     need to to be space-separated IP addresses with an optional port.
-change-slave-zone-master *ZONE* *MASTER* [*MASTER*]..
-    Change the masters for slave zone *ZONE* to new masters *MASTER*. All
-    *MASTER*\ s need to to be space-separated IP addresses with an optional port.
+change-secondary-zone-primary *ZONE* *PRIMARY* [*PRIMARY*]..
+    Change the primaries for secondary zone *ZONE* to new primaries *PRIMARY*. All
+    *PRIMARY*\ s need to to be space-separated IP addresses with an optional port.
 check-all-zones
     Check all zones for correctness.
 check-zone *ZONE*
     Check zone *ZONE* for correctness.
 clear-zone *ZONE*
-    Clear the records in zone *ZONE*, but leave actual domain and
+    Clear the records in zone *ZONE*, but leave actual zone and
     settings unchanged
 delete-rrset *ZONE* *NAME* *TYPE*
     Delete named RRSET from zone.
@@ -226,7 +226,7 @@ secure-all-zones [**increase-serial**]
     serial of those zones too. You should manually run 'pdnsutil
     rectify-all-zones' afterwards.
 set-kind *ZONE* *KIND*
-    Change the kind of *ZONE* to *KIND* (master, slave, native).
+    Change the kind of *ZONE* to *KIND* (primary, secondary, native).
 set-account *ZONE* *ACCOUNT*
     Change the account (owner) of *ZONE* to *ACCOUNT*.
 add-meta *ZONE* *ATTRIBUTE* *VALUE* [*VALUE*]...
@@ -234,7 +234,7 @@ add-meta *ZONE* *ATTRIBUTE* *VALUE* [*VALUE*]...
     Will return an error if *ATTRIBUTE* does not support multiple values, use
     **set-meta** for these values.
 set-meta *ZONE* *ATTRIBUTE* [*VALUE*]...
-    Set domainmetadata *ATTRIBUTE* for *ZONE* to *VALUE*. An empty value
+    Set zonemetadata *ATTRIBUTE* for *ZONE* to *VALUE*. An empty value
     clears it.
 set-presigned *ZONE*
     Switches *ZONE* to presigned operation, utilizing in-zone RRSIGs.
@@ -256,7 +256,7 @@ backend-cmd *BACKEND* *CMD* [*CMD..*]
     careful!
 bench-db [*FILE*]
     Perform a benchmark of the backend-database.
-    *FILE* can be a file with a list, one per line, of domain names to use for this.
+    *FILE* can be a file with a list, one per line, of zone names to use for this.
     If *FILE* is not specified, powerdns.com is used.
 
 OTHER TOOLS

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -80,9 +80,9 @@ struct DomainInfo
 
   static DomainKind stringToKind(const string& kind)
   {
-    if(pdns_iequals(kind,"SLAVE"))
+    if (pdns_iequals(kind, "SECONDARY") || pdns_iequals(kind, "SLAVE"))
       return DomainInfo::Slave;
-    else if(pdns_iequals(kind,"MASTER"))
+    else if (pdns_iequals(kind, "PRIMARY") || pdns_iequals(kind, "MASTER"))
       return DomainInfo::Master;
     else
       return DomainInfo::Native;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -256,7 +256,7 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const DNSName& zone, con
     }
   } catch(const PDNSException &e) {
     if (di.kind == DomainInfo::Slave) {
-      cout<<"[Error] non-IP address for masters: "<<e.reason<<endl;
+      cout << "[Error] non-IP address for primaries: " << e.reason << endl;
       numerrors++;
     }
   }
@@ -1439,7 +1439,7 @@ static int createSlaveZone(const vector<string>& cmds) {
   for (unsigned i=2; i < cmds.size(); i++) {
     masters.emplace_back(cmds.at(i), 53);
   }
-  cerr<<"Creating slave zone '"<<zone<<"', with master(s) '"<<comboAddressVecToString(masters)<<"'"<<endl;
+  cerr << "Creating secondary zone '" << zone << "', with primaries '" << comboAddressVecToString(masters) << "'" << endl;
   B.createDomain(zone, DomainInfo::Slave, masters, "");
   if(!B.getDomainInfo(zone, di)) {
     cerr << "Zone '" << zone << "' was not created!" << endl;
@@ -1460,13 +1460,13 @@ static int changeSlaveZoneMaster(const vector<string>& cmds) {
   for (unsigned i=2; i < cmds.size(); i++) {
     masters.emplace_back(cmds.at(i), 53);
   }
-  cerr<<"Updating slave zone '"<<zone<<"', master(s) to '"<<comboAddressVecToString(masters)<<"'"<<endl;
+  cerr << "Updating secondary zone '" << zone << "', primaries to '" << comboAddressVecToString(masters) << "'" << endl;
   try {
     di.backend->setMasters(zone, masters);
     return EXIT_SUCCESS;
   }
   catch (PDNSException& e) {
-    cerr<<"Setting master for zone '"<<zone<<"' failed: "<<e.reason<<endl;
+    cerr << "Setting primary for zone '" << zone << "' failed: " << e.reason << endl;
     return EXIT_FAILURE;
   }
 }
@@ -1564,7 +1564,7 @@ static int addOrReplaceRecord(bool addOrReplace, const vector<string>& cmds) {
   return EXIT_SUCCESS;
 }
 
-// addSuperMaster add anew super master
+// addSuperMaster add anew super primary
 static int addSuperMaster(const std::string &IP, const std::string &nameserver, const std::string &account)
 {
   UeberBackend B("default");
@@ -1603,14 +1603,14 @@ static int listAllZones(const string &type="") {
 
   int kindFilter = -1;
   if (type.size()) {
-    if (toUpper(type) == "MASTER")
+    if (toUpper(type) == "PRIMARY" || toUpper(type) == "MASTER")
       kindFilter = 0;
-    else if (toUpper(type) == "SLAVE")
+    else if (toUpper(type) == "SECONDARY" || toUpper(type) == "SLAVE")
       kindFilter = 1;
     else if (toUpper(type) == "NATIVE")
       kindFilter = 2;
     else {
-      cerr<<"Syntax: pdnsutil list-all-zones [master|slave|native]"<<endl;
+      cerr << "Syntax: pdnsutil list-all-zones [primary|secondary|native]" << endl;
       return 1;
     }
   }
@@ -1810,7 +1810,7 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
       }
     }
     else if(di.kind == DomainInfo::Slave) {
-      cout<<"Master"<<addS(di.masters)<<": ";
+      cout << "Primary" << addS(di.masters) << ": ";
       for(const auto& m : di.masters)
         cout<<m.toStringWithPort()<<" ";
       cout<<endl;
@@ -1822,7 +1822,7 @@ static bool showZone(DNSSECKeeper& dk, const DNSName& zone, bool exportDS = fals
       else
         strncpy(buf, "Never", sizeof(buf)-1);
       buf[sizeof(buf)-1] = '\0';
-      cout<<"Last time we got update from master: "<<buf<<endl;
+      cout << "Last time we got update from primary: " << buf << endl;
       SOAData sd;
       if(B.getSOAUncached(zone, sd)) {
         cout<<"SOA serial in database: "<<sd.serial<<endl;
@@ -2032,7 +2032,7 @@ static bool secureZone(DNSSECKeeper& dk, const DNSName& zone)
 
   if(di.kind == DomainInfo::Slave)
   {
-    cerr << "Warning! This is a slave zone! If this was a mistake, please run" << endl;
+    cerr << "Warning! This is a secondary zone! If this was a mistake, please run" << endl;
     cerr<<"pdnsutil disable-dnssec "<<zone<<" right now!"<<endl;
   }
 
@@ -2094,9 +2094,9 @@ static int testSchema(DNSSECKeeper& dk, const DNSName& zone)
   UeberBackend B("default");
   cout<<"Picking first backend - if this is not what you want, edit launch line!"<<endl;
   DNSBackend *db = B.backends[0];
-  cout << "Creating slave zone " << zone << endl;
+  cout << "Creating secondary zone " << zone << endl;
   db->createSlaveDomain("127.0.0.1", zone, "", "_testschema");
-  cout << "Slave zone created" << endl;
+  cout << "Secondary zone created" << endl;
 
   DomainInfo di;
   if(!B.getDomainInfo(zone, di) || !di.backend) { // di.backend and B are mostly identical
@@ -2269,13 +2269,13 @@ try
   if (cmds.empty() || g_vm.count("help") || cmds.at(0) == "help") {
     cout<<"Usage: \npdnsutil [options] <command> [params ..]\n"<<endl;
     cout<<"Commands:"<<endl;
-    cout<<"activate-tsig-key ZONE NAME {master|slave}"<<endl;
+    cout << "activate-tsig-key ZONE NAME {primary|secondary}" << endl;
     cout<<"                                   Enable TSIG authenticated AXFR using the key NAME for ZONE"<<endl;
     cout<<"activate-zone-key ZONE KEY-ID      Activate the key with key id KEY-ID in ZONE"<<endl;
     cout<<"add-record ZONE NAME TYPE [ttl] content"<<endl;
     cout<<"             [content..]           Add one or more records to ZONE"<<endl;
-    cout<<"add-supermaster IP NAMESERVER [account]"<<endl;
-    cout<<"                                   Add a new super-master "<<endl;
+    cout << "add-autoprimary IP NAMESERVER [account]" << endl;
+    cout << "                                   Add a new autoprimary " << endl;
     cout<<"add-zone-key ZONE {zsk|ksk} [BITS] [active|inactive] [published|unpublished]"<<endl;
     cout<<"             [rsasha1|rsasha1-nsec3-sha1|rsasha256|rsasha512|ecdsa256|ecdsa384";
 #if defined(HAVE_LIBSODIUM) || defined(HAVE_LIBDECAF) || defined(HAVE_LIBCRYPTO_ED25519)
@@ -2294,12 +2294,12 @@ try
     cout<<"                                   after finding an error in a zone."<<endl;
     cout<<"clear-zone ZONE                    Clear all records of a zone, but keep everything else"<<endl;
     cout<<"create-bind-db FNAME               Create DNSSEC db for BIND backend (bind-dnssec-db)"<<endl;
-    cout<<"create-slave-zone ZONE master-ip [master-ip..]"<<endl;
-    cout<<"                                   Create slave zone ZONE with master IP address master-ip"<<endl;
-    cout<<"change-slave-zone-master ZONE master-ip [master-ip..]"<<endl;
-    cout<<"                                   Change slave zone ZONE master IP address to master-ip"<<endl;
+    cout << "create-secondary-zone ZONE primary-ip [primary-ip..]" << endl;
+    cout << "                                   Create secondary zone ZONE with primary IP address primary-ip" << endl;
+    cout << "change-secondary-zone-primary ZONE primary-ip [primary-ip..]" << endl;
+    cout << "                                   Change secondary zone ZONE primary IP address to primary-ip" << endl;
     cout<<"create-zone ZONE [nsname]          Create empty zone ZONE"<<endl;
-    cout<<"deactivate-tsig-key ZONE NAME {master|slave}"<<endl;
+    cout << "deactivate-tsig-key ZONE NAME {primary|secondary}" << endl;
     cout<<"                                   Disable TSIG authenticated AXFR using the key NAME for ZONE"<<endl;
     cout<<"deactivate-zone-key ZONE KEY-ID    Deactivate the key with key id KEY-ID in ZONE"<<endl;
     cout<<"delete-rrset ZONE NAME TYPE        Delete named RRSET from zone"<<endl;
@@ -2332,7 +2332,7 @@ try
     cout<<"list-algorithms [with-backend]     List all DNSSEC algorithms supported, optionally also listing the crypto library used"<<endl;
     cout<<"list-keys [ZONE]                   List DNSSEC keys for ZONE. When ZONE is unset or \"all\", display all keys for all zones"<<endl;
     cout<<"list-zone ZONE                     List zone contents"<<endl;
-    cout<<"list-all-zones [master|slave|native]"<<endl;
+    cout << "list-all-zones [primary|secondary|native]" << endl;
     cout<<"                                   List all zone names"<<endl;;
     cout<<"list-tsig-keys                     List all TSIG keys"<<endl;
     cout<<"publish-zone-key ZONE KEY-ID       Publish the zone key with key id KEY-ID in ZONE"<<endl;
@@ -2343,7 +2343,7 @@ try
     cout<<"       content [content..]"<<endl;
     cout<<"secure-all-zones [increase-serial] Secure all zones without keys"<<endl;
     cout<<"secure-zone ZONE [ZONE ..]         Add DNSSEC to zone ZONE"<<endl;
-    cout<<"set-kind ZONE KIND                 Change the kind of ZONE to KIND (master, slave, native)"<<endl;
+    cout << "set-kind ZONE KIND                 Change the kind of ZONE to KIND (primary, secondary, native)" << endl;
     cout<<"set-account ZONE ACCOUNT           Change the account (owner) of ZONE to ACCOUNT"<<endl;
     cout<<"set-nsec3 ZONE ['PARAMS' [narrow]] Enable NSEC3 with PARAMS. Optionally narrow"<<endl;
     cout<<"set-presigned ZONE                 Use presigned RRSIGs from storage"<<endl;
@@ -2506,7 +2506,7 @@ try
   }
   else if (cmds.at(0) == "list-all-zones") {
     if (cmds.size() > 2) {
-      cerr << "Syntax: pdnsutil list-all-zones [master|slave|native]"<<endl;
+      cerr << "Syntax: pdnsutil list-all-zones [primary|secondary|native]" << endl;
       return 0;
     }
     if (cmds.size() == 2)
@@ -2526,7 +2526,7 @@ try
   {
     signingServer();
   }
-  else if(cmds.at(0) == "signing-slave")
+  else if(cmds.at(0) == "signing-secondary")
   {
     launchSigningService(0);
   }
@@ -2770,16 +2770,16 @@ try
     }
     return createZone(DNSName(cmds.at(1)), cmds.size() > 2 ? DNSName(cmds.at(2)) : DNSName());
   }
-  else if (cmds.at(0) == "create-slave-zone") {
+  else if (cmds.at(0) == "create-secondary-zone" || cmds.at(0) == "create-slave-zone") {
     if(cmds.size() < 3 ) {
-      cerr<<"Syntax: pdnsutil create-slave-zone ZONE master-ip [master-ip..]"<<endl;
+      cerr << "Syntax: pdnsutil create-secondary-zone ZONE primary-ip [primary-ip..]" << endl;
       return 0;
     }
     return createSlaveZone(cmds);
   }
-  else if (cmds.at(0) == "change-slave-zone-master") {
+  else if (cmds.at(0) == "change-secondary-zone-primary" || cmds.at(0) == "change-slave-zone-master") {
     if(cmds.size() < 3 ) {
-      cerr<<"Syntax: pdnsutil change-slave-zone-master ZONE master-ip [master-ip..]"<<endl;
+      cerr << "Syntax: pdnsutil change-secondary-zone-primary ZONE primary-ip [primary-ip..]" << endl;
       return 0;
     }
     return changeSlaveZoneMaster(cmds);
@@ -2791,9 +2791,9 @@ try
     }
     return addOrReplaceRecord(true, cmds);
   }
-  else if (cmds.at(0) == "add-supermaster") {
+  else if (cmds.at(0) == "add-autoprimary" || cmds.at(0) == "add-supermaster") {
     if(cmds.size() < 3) {
-      cerr<<"Syntax: pdnsutil add-supermaster IP NAMESERVER [account]"<<endl;
+      cerr << "Syntax: pdnsutil add-autoprimary IP NAMESERVER [account]" << endl;
       return 0;
     }
     exit(addSuperMaster(cmds.at(1), cmds.at(2), cmds.size() > 3 ? cmds.at(3) : ""));
@@ -3351,17 +3351,17 @@ try
   else if (cmds.at(0) == "activate-tsig-key") {
     string metaKey;
     if (cmds.size() < 4) {
-      cerr << "Syntax: " << cmds.at(0) << " ZONE NAME {primary|secondary|master|slave}" << endl;
+      cerr << "Syntax: " << cmds.at(0) << " ZONE NAME {primary|secondary}" << endl;
       return 0;
     }
     DNSName zname(cmds.at(1));
     string name = cmds.at(2);
-    if (cmds.at(3) == "master" || cmds.at(3) == "primary")
+    if (cmds.at(3) == "primary" || cmds.at(3) == "master")
       metaKey = "TSIG-ALLOW-AXFR";
-    else if (cmds.at(3) == "slave" || cmds.at(3) == "secondary")
+    else if (cmds.at(3) == "secondary" || cmds.at(3) == "slave")
       metaKey = "AXFR-MASTER-TSIG";
     else {
-      cerr << "Invalid parameter '" << cmds.at(3) << "', expected master or slave" << endl;
+      cerr << "Invalid parameter '" << cmds.at(3) << "', expected primary or secondary" << endl;
       return 1;
     }
     UeberBackend B("default");
@@ -3396,17 +3396,17 @@ try
   else if (cmds.at(0) == "deactivate-tsig-key") {
     string metaKey;
     if (cmds.size() < 4) {
-      cerr << "Syntax: " << cmds.at(0) << " ZONE NAME {master|slave}" << endl;
+      cerr << "Syntax: " << cmds.at(0) << " ZONE NAME {primary|secondary}" << endl;
       return 0;
     }
     DNSName zname(cmds.at(1));
     string name = cmds.at(2);
-    if (cmds.at(3) == "master" || cmds.at(3) == "primary")
+    if (cmds.at(3) == "primary" || cmds.at(3) == "master")
       metaKey = "TSIG-ALLOW-AXFR";
-    else if (cmds.at(3) == "slave" || cmds.at(3) == "secondary")
+    else if (cmds.at(3) == "secondary" || cmds.at(3) == "slave")
       metaKey = "AXFR-MASTER-TSIG";
     else {
-      cerr << "Invalid parameter '" << cmds.at(3) << "', expected master or slave" << endl;
+      cerr << "Invalid parameter '" << cmds.at(3) << "', expected primary or secondary" << endl;
       return 1;
     }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2330,10 +2330,12 @@ try
     cout<<"load-zone ZONE FILE                Load ZONE from FILE, possibly creating zone or atomically"<<endl;
     cout<<"                                   replacing contents"<<endl;
     cout<<"list-algorithms [with-backend]     List all DNSSEC algorithms supported, optionally also listing the crypto library used"<<endl;
-    cout<<"list-keys [ZONE]                   List DNSSEC keys for ZONE. When ZONE is unset or \"all\", display all keys for all zones"<<endl;
+    cout << "list-keys [ZONE]                   List DNSSEC keys for ZONE. When ZONE is unset, display all keys for all active zones" << endl;
+    cout << "                                   --verbose or -v will also include the keys for disabled or empty zones" << endl;
     cout<<"list-zone ZONE                     List zone contents"<<endl;
     cout << "list-all-zones [primary|secondary|native]" << endl;
-    cout<<"                                   List all zone names"<<endl;;
+    cout << "                                   List all active zone names. --verbose or -v will also include disabled or empty zones" << endl;
+    ;
     cout<<"list-tsig-keys                     List all TSIG keys"<<endl;
     cout<<"publish-zone-key ZONE KEY-ID       Publish the zone key with key id KEY-ID in ZONE"<<endl;
     cout<<"rectify-zone ZONE [ZONE ..]        Fix up DNSSEC fields (order, auth)"<<endl;

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -592,8 +592,8 @@ int main(int argc, char **argv)
     DynListener::registerFunc("RPING",&DLPingHandler, "ping instance");
     DynListener::registerFunc("QUIT",&DLRQuitHandler, "quit daemon");
     DynListener::registerFunc("UPTIME",&DLUptimeHandler, "get instance uptime");
-    DynListener::registerFunc("NOTIFY-HOST",&DLNotifyHostHandler, "notify host for specific domain", "<domain> <host>");
-    DynListener::registerFunc("NOTIFY",&DLNotifyHandler, "queue a notification", "<domain>");
+    DynListener::registerFunc("NOTIFY-HOST", &DLNotifyHostHandler, "notify host for specific zone", "<zone> <host>");
+    DynListener::registerFunc("NOTIFY", &DLNotifyHandler, "queue a notification", "<zone>");
     DynListener::registerFunc("RELOAD",&DLReloadHandler, "reload all zones");
     DynListener::registerFunc("REDISCOVER",&DLRediscoverHandler, "discover any new zones");
     DynListener::registerFunc("VERSION",&DLVersionHandler, "get instance version");
@@ -603,9 +603,9 @@ int main(int argc, char **argv)
     DynListener::registerFunc("RESPSIZES", &DLRSizesHandler, "get histogram of response sizes");
     DynListener::registerFunc("REMOTES", &DLRemotesHandler, "get top remotes");
     DynListener::registerFunc("SET",&DLSettingsHandler, "set config variables", "<var> <value>");
-    DynListener::registerFunc("RETRIEVE",&DLNotifyRetrieveHandler, "retrieve slave domain", "<domain> [<ip>]");
+    DynListener::registerFunc("RETRIEVE", &DLNotifyRetrieveHandler, "retrieve slave zone", "<zone> [<ip>]");
     DynListener::registerFunc("CURRENT-CONFIG",&DLCurrentConfigHandler, "retrieve the current configuration", "[diff]");
-    DynListener::registerFunc("LIST-ZONES",&DLListZones, "show list of zones", "[master|slave|native]");
+    DynListener::registerFunc("LIST-ZONES", &DLListZones, "show list of zones", "[primary|secondary|native]");
     DynListener::registerFunc("TOKEN-LOGIN", &DLTokenLogin, "Login to a PKCS#11 token", "<module> <slot> <pin>");
     DynListener::registerFunc("XFR-QUEUE", &DLSuckRequests, "Get all requests for XFR in queue");
 


### PR DESCRIPTION
### Short description
The old versions of the commands are still available for compatibility reasons. The tests are not modified and still use the old version of the commands, to make sure they still work as expected. We should change this at a later date.

Both tools now consistently use 'zone'. Before this  pull it was a mix of 'domain' and 'zone'.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
