### PR TITLE
auth: zone-cache improvements

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1378,7 +1378,7 @@ BB2DomainInfo Bind2Backend::createDomainEntry(const DNSName& domain, const strin
   return bbd;
 }
 
-bool Bind2Backend::createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account)
+bool Bind2Backend::createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account, int* zoneId)
 {
   string filename = getArg("supermaster-destdir") + '/' + domain.toStringNoDot();
 
@@ -1410,6 +1410,13 @@ bool Bind2Backend::createSlaveDomain(const string& ip, const DNSName& domain, co
   bbd.d_masters.push_back(ComboAddress(ip, 53));
   bbd.setCtime();
   safePutBBDomainInfo(bbd);
+
+  if (zoneId) {
+    if (!safeGetBBDomainInfo(domain, &bbd))
+      return false;
+    *zoneId = bbd.d_id;
+  }
+
   return true;
 }
 

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -239,7 +239,7 @@ public:
   // for supermaster support
   bool superMasterBackend(const string& ip, const DNSName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** db) override;
   static std::mutex s_supermaster_config_lock;
-  bool createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account) override;
+  bool createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account, int* zoneId = nullptr) override;
 
 private:
   void setupDNSSEC();

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -664,7 +664,7 @@ bool RemoteBackend::superMasterBackend(const string& ip, const DNSName& domain, 
   return true;
 }
 
-bool RemoteBackend::createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account)
+bool RemoteBackend::createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account, int* zoneId)
 {
   Json query = Json::object{
     {"method", "createSlaveDomain"},

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -184,7 +184,7 @@ public:
   void setNotified(uint32_t id, uint32_t serial) override;
   bool doesDNSSEC() override;
   bool superMasterBackend(const string& ip, const DNSName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** ddb) override;
-  bool createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account) override;
+  bool createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account, int* zoneId = nullptr) override;
   bool replaceRRSet(uint32_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
   bool feedRecord(const DNSResourceRecord& r, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
   bool feedEnts(int domain_id, map<DNSName, bool>& nonterm) override;

--- a/pdns/auth-zonecache.cc
+++ b/pdns/auth-zonecache.cc
@@ -101,7 +101,13 @@ void AuthZoneCache::replace(const vector<tuple<DNSName, int>>& zone_indices)
     CacheValue val;
     val.zoneId = tup.get<1>();
     auto& mc = newMaps[getMapIndex(zone)];
-    mc.d_map.emplace(zone, val);
+    auto iter = mc.d_map.find(zone);
+    if (iter != mc.d_map.end()) {
+      iter->second = std::move(val);
+    }
+    else {
+      mc.d_map.emplace(zone, val);
+    }
   }
 
   {
@@ -149,7 +155,13 @@ void AuthZoneCache::add(const DNSName& zone, const int zoneId)
   {
     auto& mc = d_maps[mapIndex];
     WriteLock mcLock(mc.d_mut);
-    mc.d_map.emplace(zone, val);
+    auto iter = mc.d_map.find(zone);
+    if (iter != mc.d_map.end()) {
+      iter->second = std::move(val);
+    }
+    else {
+      mc.d_map.emplace(zone, val);
+    }
   }
 }
 

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1341,7 +1341,7 @@ bool GSQLBackend::createDomain(const DNSName &domain, const DomainInfo::DomainKi
   return true;
 }
 
-bool GSQLBackend::createSlaveDomain(const string &ip, const DNSName &domain, const string &nameserver, const string &account)
+bool GSQLBackend::createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account, int* zoneId)
 {
   string name;
   vector<ComboAddress> masters({ComboAddress(ip, 53)});
@@ -1367,7 +1367,7 @@ bool GSQLBackend::createSlaveDomain(const string &ip, const DNSName &domain, con
         masters = tmp;
       }
     }
-    createDomain(domain, DomainInfo::Slave, masters, account, nullptr);
+    createDomain(domain, DomainInfo::Slave, masters, account, zoneId);
   }
   catch(SSqlException &e) {
     throw PDNSException("Database error trying to insert new slave domain '"+domain.toLogString()+"': "+ e.txtReason());

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -194,7 +194,7 @@ public:
   bool feedEnts(int domain_id, map<DNSName,bool>& nonterm) override;
   bool feedEnts3(int domain_id, const DNSName &domain, map<DNSName,bool> &nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
   bool createDomain(const DNSName &domain, const DomainInfo::DomainKind kind, const vector<ComboAddress> &masters, const string &account, int* zoneId=nullptr) override;
-  bool createSlaveDomain(const string &ip, const DNSName &domain, const string &nameserver, const string &account) override;
+  bool createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account, int* zoneId = nullptr) override;
   bool deleteDomain(const DNSName &domain) override;
   bool superMasterAdd(const string &ip, const string &nameserver, const string &account) override; 
   bool superMasterBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db) override;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -362,7 +362,7 @@ public:
   }
 
   //! called by PowerDNS to create a slave record for a superMaster
-  virtual bool createSlaveDomain(const string &ip, const DNSName &domain, const string &nameserver, const string &account)
+  virtual bool createSlaveDomain(const string& ip, const DNSName& domain, const string& nameserver, const string& account, int* zoneId = nullptr)
   {
     return false;
   }

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -964,7 +964,9 @@ int PacketHandler::trySuperMasterSynchronous(const DNSPacket& p, const DNSName& 
     return RCode::Refused;
   }
   try {
-    db->createSlaveDomain(remote.toString(), p.qdomain, nameserver, account);
+    int zoneId{-1};
+    db->createSlaveDomain(remote.toString(), p.qdomain, nameserver, account, &zoneId);
+    g_zoneCache.add(p.qdomain, zoneId);
     if (tsigkeyname.empty() == false) {
       vector<string> meta;
       meta.push_back(tsigkeyname.toStringNoDot());

--- a/regression-tests.nobackend/supermaster-unsigned/command
+++ b/regression-tests.nobackend/supermaster-unsigned/command
@@ -50,6 +50,7 @@ module-dir=../regression-tests/modules
 launch=gsqlite3
 gsqlite3-dnssec=yes
 gsqlite3-database=slave.db
+zone-cache-refresh-interval=900
 EOF
 	rm -f master.db slave.db
 	sqlite3 master.db < ../modules/gsqlite3backend/schema.sqlite3.sql


### PR DESCRIPTION
### Short description
- New auto-secondary zones were not added to the zone-cache
- Delete and recreate a zone within one refresh cycle could result in the cache returning the old zoneid for this zone

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
