### PR TITLE
auth: enable zone cache by default

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -44,6 +44,10 @@ Changed defaults
 - The default value of the ``max-nsec3-iterations`` option has been changed from ``500`` to ``100``.
 - The default value of the ``timeout`` option for :ref:`ifportup` and :ref:`ifurlup` functions has been changed from ``1`` to ``2`` seconds.
 
+Starting with auth-4.5.0-alpha2:
+
+- The default value of the ``zone-cache-refresh-interval`` option has been changed from ``0`` to ``300``.
+
 4.3.x to 4.4.0
 --------------
 

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -181,7 +181,7 @@ void declareArguments()
   ::arg().set("cache-ttl","Seconds to store packets in the PacketCache")="20";
   ::arg().set("negquery-cache-ttl","Seconds to store negative query results in the QueryCache")="60";
   ::arg().set("query-cache-ttl","Seconds to store query results in the QueryCache")="20";
-  ::arg().set("zone-cache-refresh-interval", "Seconds to cache list of known zones") = "0";
+  ::arg().set("zone-cache-refresh-interval", "Seconds to cache list of known zones") = "300";
   ::arg().set("server-id", "Returned when queried for 'id.server' TXT or NSID, defaults to hostname - disabled or custom")="";
   ::arg().set("default-soa-content","Default SOA content")="a.misconfigured.dns.server.invalid hostmaster.@ 0 10800 3600 604800 3600";
   ::arg().set("default-soa-edit","Default SOA-EDIT value")="";


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master