### PR TITLE
Update AX_CHECK_SIGN for autoconf 2.71

### DIFF
--- a/m4/ax_check_sign.m4
+++ b/m4/ax_check_sign.m4
@@ -35,16 +35,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([VL_CHECK_SIGN], [AX_CHECK_SIGN])
 AC_DEFUN([AX_CHECK_SIGN], [
  typename=`echo $1 | sed "s/@<:@^a-zA-Z0-9_@:>@/_/g"`
  AC_CACHE_CHECK([whether $1 is signed], ax_cv_decl_${typename}_signed, [
-   AC_TRY_COMPILE([$4],
-     [ int foo @<:@ 1 - 2 * !((($1) -1) < 0) @:>@ ],
+   AC_COMPILE_IFELSE(
+     [AC_LANG_PROGRAM([[$4]],
+       [[ int foo @<:@ 1 - 2 * !((($1) -1) < 0) @:>@ ]])],
      [ eval "ax_cv_decl_${typename}_signed=\"yes\"" ],
-     [ eval "ax_cv_decl_${typename}_signed=\"no\"" ])])
+     [ eval "ax_cv_decl_${typename}_signed=\"no\"" ])
+ ])
  symbolname=`echo $1 | sed "s/@<:@^a-zA-Z0-9_@:>@/_/g" | tr "a-z" "A-Z"`
  if eval "test \"\${ax_cv_decl_${typename}_signed}\" = \"yes\""; then
    $2


### PR DESCRIPTION
### Short description
When running autoreconf with ax_check_sign.m4, autoconf 2.71 complains
about the use of `AX_TRY_COMPILE`:

```
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:29: warning: The macro `AC_TRY_COMPILE' is obsolete.
configure.ac:29: You should run autoupdate.
./lib/autoconf/general.m4:2847: AC_TRY_COMPILE is expanded from...
lib/m4sugar/m4sh.m4:692: _AS_IF_ELSE is expanded from...
lib/m4sugar/m4sh.m4:699: AS_IF is expanded from...
./lib/autoconf/general.m4:2249: AC_CACHE_VAL is expanded from...
./lib/autoconf/general.m4:2270: AC_CACHE_CHECK is expanded from...
m4/ax_check_sign.m4:41: AX_CHECK_SIGN is expanded from...
m4/pdns_check_time_t.m4:1: PDNS_CHECK_TIME_T is expanded from...
configure.ac:29: the top level
```

This updates the macro to use `AC_COMPILE_IFELSE`, which has been present in
autoconf since at least version 2.60, released in 26 Jun 2006 (I did not
check any older releases).

This patch has been [submitted](http://savannah.gnu.org/patch/index.php?10071) [upstream](https://github.com/autoconf-archive/autoconf-archive/pull/225).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)