### PR TITLE
gsqlbackend: throw when lookup of newly created zone fails

### DIFF
--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1329,7 +1329,7 @@ bool GSQLBackend::createDomain(const DNSName &domain, const DomainInfo::DomainKi
         execute();
       if (!d_InfoOfDomainsZoneQuery_stmt->hasNextRow()) {
         d_InfoOfDomainsZoneQuery_stmt->reset();
-        return false;
+        throw PDNSException("Zone lookup failed for newly created zone '" + domain.toLogString() + "'");
       }
       SSqlStatement::row_t row;
       d_InfoOfDomainsZoneQuery_stmt->nextRow(row);


### PR DESCRIPTION
### Short description
gsqlbackend returns false instead of throwing when a zone has been inserted, but the id lookup for it fails. That seems inconsistent with surrounding code.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
