### PR TITLE
auth: add/fix getAllDomains()

### DIFF
--- a/docs/backends/bind.rst
+++ b/docs/backends/bind.rst
@@ -10,6 +10,7 @@ BIND zone file backend
 * Disabled data: No
 * Comments: No
 * API: Read-only
+* Zone caching: Yes (except in hybrid mode)
 * Module name: bind
 * Launch: ``bind``
 

--- a/docs/backends/generic-mysql.rst
+++ b/docs/backends/generic-mysql.rst
@@ -10,6 +10,7 @@ Generic MySQL backend
 * DNSSEC: Yes (set ``gmysql-dnssec``)
 * Disabled data: Yes
 * Comments: Yes
+* Zone caching: Yes
 * Module name: gmysql
 * Launch name: ``gmysql``
 

--- a/docs/backends/generic-odbc.rst
+++ b/docs/backends/generic-odbc.rst
@@ -10,6 +10,7 @@ Generic ODBC Backend
 * DNSSEC: Yes
 * Disabled data: Yes
 * Comments: Yes
+* Zone caching: Yes
 * Module name: godbc
 * Launch name: ``godbc``
 

--- a/docs/backends/generic-postgresql.rst
+++ b/docs/backends/generic-postgresql.rst
@@ -10,6 +10,7 @@ Generic PostgreSQL backend
 * DNSSEC: Yes (set ``gpgsql-dnssec``)
 * Disabled data: Yes
 * Comments: Yes
+* Zone caching: Yes
 * Module name: gpgsql
 * Launch name: ``gpgsql``
 

--- a/docs/backends/generic-sqlite3.rst
+++ b/docs/backends/generic-sqlite3.rst
@@ -8,6 +8,7 @@ Generic SQLite 3 backend
 * DNSSEC: Yes
 * Disabled data: Yes
 * Comments: Yes
+* Zone caching: Yes
 * Module name: gsqlite3
 * Launch name: ``gsqlite3``
 

--- a/docs/backends/geoip.rst
+++ b/docs/backends/geoip.rst
@@ -8,6 +8,7 @@ GeoIP backend
 * DNSSEC: Yes
 * Disabled data: No
 * Comments: No
+* Zone caching: Yes
 * Module name: geoip
 * Launch name: ``geoip``
 

--- a/docs/backends/ldap.rst
+++ b/docs/backends/ldap.rst
@@ -9,6 +9,7 @@ LDAP backend
 * DNSSEC: No
 * Disabled data: No
 * Comments: No
+* Zone caching: No
 * Module name: ldap
 * Launch name: ``ldap``
 

--- a/docs/backends/lmdb.rst
+++ b/docs/backends/lmdb.rst
@@ -10,6 +10,7 @@ LMDB backend
 * Disabled data: No
 * Comments: No
 * Multiple instances: No
+* Zone caching: Yes
 * Module name: lmdb
 * Launch name: ``lmdb``
 

--- a/docs/backends/lua2.rst
+++ b/docs/backends/lua2.rst
@@ -9,6 +9,7 @@ Lua2 Backend
 * DNSSEC: Yes
 * Disabled data: No
 * Comments: No
+* Zone caching: Yes
 * Module name: lua2
 * Launch name: ``lua2``
 

--- a/docs/backends/pipe.rst
+++ b/docs/backends/pipe.rst
@@ -10,6 +10,7 @@ Pipe Backend
 * DNSSEC: Partial, no delegation, no key storage
 * Disabled data: No
 * Comments: No
+* Zone caching: No
 * Module name: pipe
 * Launch name: ``pipe``
 

--- a/docs/backends/random.rst
+++ b/docs/backends/random.rst
@@ -10,6 +10,7 @@ Random Backend
 - DNSSEC: Yes, no key storage
 - Disabled data: No
 - Comments: No
+- Zone caching: No
 - Module name: built in
 - Launch: ``random``
 

--- a/docs/backends/remote.rst
+++ b/docs/backends/remote.rst
@@ -7,6 +7,7 @@ Remote Backend
 * Superslave: Yes\*
 * Autoserial: Yes\*
 * DNSSEC: Yes\*
+* Zone caching: Yes\*
 * Multiple instances: Yes
 
 \* If provided by the responder (your script).

--- a/docs/backends/tinydns.rst
+++ b/docs/backends/tinydns.rst
@@ -7,6 +7,7 @@ TinyDNS Backend
 - Superslave: No
 - Autoserial: No
 - DNSSEC: No
+* Zone caching: Yes
 - Multiple Instances: Yes
 - Module name: tinydns
 - Launch: ``tinydns``

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -54,6 +54,10 @@ Removed options
 ~~~~~~~~~~~~~~~
 - :ref:`setting-local-ipv6` has been removed. IPv4 and IPv6 listen addresses should now be set with :ref:`setting-local-address`.
 
+Starting with auth-4.5.0-alpha2:
+
+- The default value of the ``zone-cache-refresh-interval`` option has been changed from ``0`` to ``300``.
+
 4.3.x to 4.4.0
 --------------
 

--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -850,6 +850,23 @@ bool GeoIPBackend::getDomainInfo(const DNSName& domain, DomainInfo& di, bool get
   return false;
 }
 
+void GeoIPBackend::getAllDomains(vector<DomainInfo>* domains, bool include_disabled)
+{
+  ReadLock rl(&s_state_lock);
+
+  DomainInfo di;
+  for (const auto& dom : s_domains) {
+    SOAData sd;
+    this->getSOA(dom.domain, sd);
+    di.id = dom.id;
+    di.zone = dom.domain;
+    di.serial = sd.serial;
+    di.kind = DomainInfo::Native;
+    di.backend = this;
+    domains->emplace_back(di);
+  }
+}
+
 bool GeoIPBackend::getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string>>& meta)
 {
   if (!d_dnssec)

--- a/modules/geoipbackend/geoipbackend.hh
+++ b/modules/geoipbackend/geoipbackend.hh
@@ -55,6 +55,7 @@ public:
   void reload() override;
   void rediscover(string* status = 0) override;
   bool getDomainInfo(const DNSName& domain, DomainInfo& di, bool getSerial = true) override;
+  void getAllDomains(vector<DomainInfo>* domains, bool include_disabled = false) override;
 
   // dnssec support
   bool doesDNSSEC() override { return d_dnssec; };

--- a/modules/lua2backend/regression-tests/lua2-dnssec.lua
+++ b/modules/lua2backend/regression-tests/lua2-dnssec.lua
@@ -123,6 +123,10 @@ function dns_get_domaininfo(dom)
   return false
 end
 
+function dns_get_all_domains()
+  return { [newDN("test.invalid")] = { id=1, serial=20180115 }, [newDN("test.unit")] = { id=2, serial=20180115 } }
+end
+
 function dns_get_domain_metadata(dom)
   return false
 end

--- a/modules/tinydnsbackend/tinydnsbackend.hh
+++ b/modules/tinydnsbackend/tinydnsbackend.hh
@@ -104,6 +104,7 @@ private:
   DNSPacket* d_dnspacket; // used for location and edns-client support.
   bool d_isWildcardQuery; // Indicate if the query received was a wildcard query.
   bool d_isAxfr; // Indicate if we received a list() and not a lookup().
+  bool d_isGetDomains{false};
   bool d_locations;
   bool d_ignorebogus;
   string d_suffix;

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -181,7 +181,7 @@ void declareArguments()
   ::arg().set("cache-ttl","Seconds to store packets in the PacketCache")="20";
   ::arg().set("negquery-cache-ttl","Seconds to store negative query results in the QueryCache")="60";
   ::arg().set("query-cache-ttl","Seconds to store query results in the QueryCache")="20";
-  ::arg().set("zone-cache-refresh-interval", "Seconds to cache list of known zones") = "0";
+  ::arg().set("zone-cache-refresh-interval", "Seconds to cache list of known zones") = "300";
   ::arg().set("server-id", "Returned when queried for 'id.server' TXT or NSID, defaults to hostname - disabled or custom")="";
   ::arg().set("default-soa-content","Default SOA content")="a.misconfigured.dns.server.invalid hostmaster.@ 0 10800 3600 604800 3600";
   ::arg().set("default-soa-edit","Default SOA-EDIT value")="";

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -29,7 +29,8 @@
 #include "logger.hh"
 
 #include <sys/types.h>
-#include "pdns/packetcache.hh"
+#include "packetcache.hh"
+#include "auth-zonecache.hh"
 #include "dnspacket.hh"
 #include "dns.hh"
 #include "statbag.hh"
@@ -295,6 +296,14 @@ bool DNSBackend::getBeforeAndAfterNames(uint32_t id, const DNSName& zonename, co
   before += lczonename;
   after += lczonename;
   return ret;
+}
+
+void DNSBackend::getAllDomains(vector<DomainInfo>* domains, bool include_disabled)
+{
+  if (g_zoneCache.isEnabled()) {
+    g_log << Logger::Error << "One of the backends does not support zone caching. Put zone-cache-refresh-interval=0 in the config file to disable this cache." << endl;
+    exit(1);
+  }
 }
 
 void fillSOAData(const DNSZoneRecord& in, SOAData& sd)

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -173,8 +173,7 @@ public:
     return setDomainMetadata(name, kind, meta);
   }
 
-
-  virtual void getAllDomains(vector<DomainInfo> *domains, bool include_disabled=false) { }
+  virtual void getAllDomains(vector<DomainInfo>* domains, bool include_disabled = false);
 
   /** Determines if we are authoritative for a zone, and at what level */
   virtual bool getAuth(const DNSName &target, SOAData *sd);

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -628,13 +628,14 @@ int main(int argc, char **argv)
       }
     }
 
+    UeberBackend::go();
+
     g_zoneCache.setRefreshInterval(::arg().asNum("zone-cache-refresh-interval"));
     {
       UeberBackend B;
       B.updateZoneCache();
     }
 
-    UeberBackend::go();
     N=std::make_shared<UDPNameserver>(); // this fails when we are not root, throws exception
     g_udpReceivers.push_back(N);
 

--- a/regression-tests/backends/bind-master
+++ b/regression-tests/backends/bind-master
@@ -44,6 +44,7 @@ gmysql-user=$GMYSQLUSER
 gmysql-host=$GMYSQLHOST
 gmysql-password=$GMYSQLPASSWD
 gmysql-dnssec
+zone-cache-refresh-interval=0
 __EOF__
         else
             echo "bind-dnssec-db=./dnssec.sqlite3" >> pdns-bind.conf

--- a/regression-tests/backends/gmysql-master
+++ b/regression-tests/backends/gmysql-master
@@ -25,6 +25,7 @@ gmysql-host=$GMYSQLHOST
 gmysql-password=$GMYSQLPASSWD
 
 any-to-tcp=no
+zone-cache-refresh-interval=0
 __EOF__
 
 		gsql_master gmysql dyndns

--- a/regression-tests/backends/gmysql-slave
+++ b/regression-tests/backends/gmysql-slave
@@ -18,6 +18,8 @@ gmysql-dbname=$GMYSQL2DB
 gmysql-user=$GMYSQL2USER
 gmysql-host=$GMYSQL2HOST
 gmysql-password=$GMYSQL2PASSWD
+
+zone-cache-refresh-interval=0
 __EOF__
 
 	if [[ $context != *nodnssec* ]]

--- a/regression-tests/backends/gpgsql-master
+++ b/regression-tests/backends/gpgsql-master
@@ -16,6 +16,8 @@ module-dir=./modules
 launch=gpgsql
 gpgsql-dbname=$GPGSQLDB
 gpgsql-user=$GPGSQLUSER
+
+zone-cache-refresh-interval=120
 __EOF__
 
 		gsql_master gpgsql nodyndns

--- a/regression-tests/backends/gpgsql-slave
+++ b/regression-tests/backends/gpgsql-slave
@@ -11,6 +11,8 @@ module-dir=./modules
 launch=gpgsql
 gpgsql-dbname=$GPGSQL2DB
 gpgsql-user=$GPGSQL2USER
+
+zone-cache-refresh-interval=120
 __EOF__
 
 	if [[ $context != *nodnssec* ]]

--- a/regression-tests/backends/ldap-master
+++ b/regression-tests/backends/ldap-master
@@ -29,9 +29,9 @@ __EOF__
 		$RUNWRAPPER $PDNS --daemon=no --local-address=$address --local-port=$port --config-dir=. \
 			--config-name=ldap --socket-dir=./ --no-shuffle \
 			--query-logging --dnsupdate=yes \
-      --expand-alias=yes --outgoing-axfr-expand-alias=yes \
-      --resolver=$RESOLVERIP \
-      --zone-cache-refresh-interval=0 \
+			--expand-alias=yes --outgoing-axfr-expand-alias=yes \
+			--resolver=$RESOLVERIP \
+			--zone-cache-refresh-interval=0 \
 			--cache-ttl=$cachettl --dname-processing $lua_prequery &
 
 		skipreasons="nodnssec noent nodyndns nometa noaxfr"

--- a/regression-tests/backends/lua2-master
+++ b/regression-tests/backends/lua2-master
@@ -10,12 +10,15 @@ case $context in
 
 		luascript="lua2.lua"
 
+		interval=0
+
 		if [ "$lua2sec" = "dnssec" ]
 		then
 			lua2dosec="yes"
 			extracontexts="dnssec"
 			skipreasons="nonsec3 nonarrow nodyndns"
 			luascript="lua2-dnssec.lua"
+			interval=60
 		fi
 
 		# generate pdns.conf for pdnsutil
@@ -30,7 +33,7 @@ EOF
 		$RUNWRAPPER $PDNS --daemon=no --local-address=$address --local-port=$port --socket-dir=./ \
 			--no-shuffle --launch=lua2 \
 			--cache-ttl=$cachettl --dname-processing --no-config \
-			--distributor-threads=1 \
+			--distributor-threads=1 --zone-cache-refresh-interval=$interval \
 			--allow-axfr-ips=0.0.0.0/0,::/0 \
 			--lua2-filename=$testsdir/$luascript --lua2-api=2 --module-dir=./modules &
 		;;

--- a/regression-tests/backends/remote-master
+++ b/regression-tests/backends/remote-master
@@ -113,7 +113,7 @@ EOF
 			--no-shuffle --launch=remote \
 			--cache-ttl=$cachettl --dname-processing --no-config \
 			--distributor-threads=1 \
-			--dnsupdate=yes \
+			--dnsupdate=yes --zone-cache-refresh-interval=0 \
 			--remote-connection-string="$connstr" $remote_add_param --module-dir=./modules &
 		;;
 


### PR DESCRIPTION
### Short description
getAllDomains() was missing in some backend and was broken in others.

Closes #10449 (commit included in this pull)

After this pull the following backends are still incompatible with the zone cache:
- bindbackend (hybrid mode)
- ldapbackend
- randombackend

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
