### PR TITLE
builder rpmbuild: run yum upgrade first

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -1,5 +1,6 @@
 FROM dist-base as package-builder
 RUN touch /var/lib/rpm/* && \
+    yum upgrade -y && \
     yum install -y rpm-build rpmdevtools python3 "@Development Tools"
 
 RUN mkdir /dist /pdns


### PR DESCRIPTION
### Short description
This unbreaks the oraclelinux-8 build and prevents future problems. It also means our deps and headers are newer.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master