### PR TITLE
rec: Don't follow referral from the parent to the child for DS queries

### DIFF
--- a/pdns/recursordist/test-syncres_cc9.cc
+++ b/pdns/recursordist/test-syncres_cc9.cc
@@ -1216,7 +1216,7 @@ BOOST_AUTO_TEST_CASE(test_records_sanitization_scrubs_ns_nxd)
   BOOST_CHECK_LT(g_recCache->get(now, DNSName("spoofed.ns."), QType(QType::AAAA), false, &cached, who), 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_dnssec_validation_referral_on_ds_query)
+BOOST_AUTO_TEST_CASE(test_dnssec_validation_referral_on_ds_query_insecure)
 {
   /*
     The server at ds-ignorant.com sends a referral to the child zone
@@ -1251,7 +1251,6 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_referral_on_ds_query)
     }
     else if (type == QType::DNSKEY || (type == QType::DS && domain != target)) {
       DNSName auth(domain);
-      /* no DS for com, auth will be . */
       auth.chopOff();
       return genericDSAndDNSKEYHandler(res, domain, auth, type, keys, false);
     }
@@ -1276,7 +1275,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_referral_on_ds_query)
           setLWResult(res, 0, true, false, true);
           addRecordToLW(res, domain, QType::SOA, "signed.ds-ignorant.com. admin\\.signed.ds-ignorant.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
           addRRSIG(keys, res->d_records, domain, 300);
-          addNSECRecordToLW(domain, DNSName("z.signed.ds-ignorant.com."), {QType::A,QType::SOA,QType::NSEC}, 600, res->d_records);
+          addNSECRecordToLW(domain, DNSName("z.signed.ds-ignorant.com."), {QType::A, QType::SOA, QType::NSEC}, 600, res->d_records);
           addRRSIG(keys, res->d_records, domain, 300);
           return LWResult::Result::Success;
         }
@@ -1299,6 +1298,94 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_referral_on_ds_query)
   res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
   BOOST_CHECK_EQUAL(res, RCode::NoError);
   BOOST_CHECK_EQUAL(sr->getValidationState(), vState::Insecure);
+  BOOST_CHECK_EQUAL(ret.size(), 2U);
+  BOOST_CHECK(ret.at(0).d_type == QType::A);
+  BOOST_CHECK(ret.at(1).d_type == QType::RRSIG);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+}
+
+BOOST_AUTO_TEST_CASE(test_dnssec_validation_referral_on_ds_query_secure)
+{
+  /*
+    The server at ds-ignorant.com sends a referral to the child zone
+    on a ds-ignorant.com DS query. ds-ignorant.com is signed,
+    signed.ds-ignorant.com as well.
+  */
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target("signed.ds-ignorant.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("ds-ignorant.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+  generateKeyMaterial(DNSName("signed.ds-ignorant.com."), DNSSECKeeper::ECDSA256, DNSSECKeeper::DIGEST_SHA256, keys);
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([target, &queriesCount, keys](const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, LWResult* res, bool* chained) {
+    queriesCount++;
+
+    if (domain.isPartOf(DNSName("signed.ds-ignorant.com.")) && ip == ComboAddress("192.0.2.1:53")) {
+      setLWResult(res, 0, false, false, true);
+      addRecordToLW(res, "signed.ds-ignorant.com.", QType::NS, "ns.signed.ds-ignorant.com.", DNSResourceRecord::AUTHORITY, 3600);
+      addRecordToLW(res, "ns.signed.ds-ignorant.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
+      return LWResult::Result::Success;
+    }
+    else if (type == QType::DNSKEY || (type == QType::DS && domain != target)) {
+      DNSName auth(domain);
+      auth.chopOff();
+      return genericDSAndDNSKEYHandler(res, domain, auth, type, keys, false);
+    }
+    else {
+      if (domain.isPartOf(DNSName("ds-ignorant.com.")) && isRootServer(ip)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "ds-ignorant.com.", QType::NS, "ns.ds-ignorant.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("ds-ignorant.com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "ns.ds-ignorant.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      else if (domain == target) {
+        if (type == QType::A) {
+          setLWResult(res, 0, true, false, true);
+          addRecordToLW(res, target, QType::A, "192.0.2.200");
+          addRRSIG(keys, res->d_records, domain, 300);
+          return LWResult::Result::Success;
+        }
+        else if (type == QType::DS) {
+          setLWResult(res, 0, true, false, true);
+          addRecordToLW(res, domain, QType::SOA, "signed.ds-ignorant.com. admin\\.signed.ds-ignorant.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+          addRRSIG(keys, res->d_records, domain, 300);
+          addNSECRecordToLW(domain, DNSName("z.signed.ds-ignorant.com."), {QType::A, QType::SOA, QType::NSEC}, 600, res->d_records);
+          addRRSIG(keys, res->d_records, domain, 300);
+          return LWResult::Result::Success;
+        }
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusMissingNegativeIndication);
+  BOOST_REQUIRE_EQUAL(ret.size(), 2U);
+  BOOST_CHECK(ret.at(0).d_type == QType::A);
+  BOOST_CHECK(ret.at(1).d_type == QType::RRSIG);
+  BOOST_CHECK_EQUAL(queriesCount, 7U);
+
+  ret.clear();
+  res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusMissingNegativeIndication);
   BOOST_CHECK_EQUAL(ret.size(), 2U);
   BOOST_CHECK(ret.at(0).d_type == QType::A);
   BOOST_CHECK(ret.at(1).d_type == QType::RRSIG);

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -3396,6 +3396,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
   bool done = false;
   DNSName dnameTarget, dnameOwner;
   uint32_t dnameTTL = 0;
+  bool referralOnDS = false;
 
   for (auto& rec : lwr.d_records) {
     if (rec.d_type != QType::OPT && rec.d_class != QClass::IN) {
@@ -3591,21 +3592,20 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
         newauth = rec.d_name;
         LOG(prefix<<qname<<": got NS record '"<<rec.d_name<<"' -> '"<<rec.d_content->getZoneRepresentation()<<"'"<<endl);
 
-        if (!negindic && qtype == QType::DS && qname == newauth) {
+        /* check if we have a referral from the parent zone to a child zone for a DS query, which is not right */
+        if (qtype == QType::DS && (newauth.isPartOf(qname) || qname == newauth)) {
           /* just got a referral from the parent zone when asking for a DS, looks like this server did not get the DNSSEC memo.. */
-          LOG(prefix<<qname<<": got (implicit) negative indication of DS record for '"<<qname<<"'"<<endl);
-          negindic = true;
-          negIndicHasSignatures = false;
-          nsset.clear();
+          referralOnDS = true;
         }
         else {
           realreferral = true;
+          if (auto content = getRR<NSRecordContent>(rec)) {
+            nsset.insert(content->getNS());
+          }
         }
       }
       else {
         LOG(prefix<<qname<<": got upwards/level NS record '"<<rec.d_name<<"' -> '"<<rec.d_content->getZoneRepresentation()<<"', had '"<<auth<<"'"<<endl);
-      }
-      if (!negindic) {
         if (auto content = getRR<NSRecordContent>(rec)) {
           nsset.insert(content->getNS());
         }
@@ -3712,6 +3712,23 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
     cnamerec.d_content = std::make_shared<CNAMERecordContent>(CNAMERecordContent(newtarget));
     ret.push_back(std::move(cnamerec));
   }
+
+  /* If we have seen a proper denial, let's forget that we also had a referral for a DS query.
+     Otherwise we need to deal with it. */
+  if (referralOnDS && !negindic) {
+    LOG(prefix<<qname<<": got a referral to the child zone for a DS query without a negative indication (missing SOA in authority), treating that as a NODATA"<<endl);
+    if (!vStateIsBogus(state)) {
+      auto recordState = getValidationStatus(qname, false, true, depth);
+      if (recordState == vState::Secure) {
+        /* we are in a secure zone, got a referral to the child zone on a DS query, no denial, that's wrong */
+        LOG(prefix<<qname<<": NODATA without a negative indication (missing SOA in authority) in a DNSSEC secure zone, going Bogus"<<endl);
+        updateValidationState(state, vState::BogusMissingNegativeIndication);
+      }
+    }
+    negindic = true;
+    negIndicHasSignatures = false;
+  }
+
   return done;
 }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -3592,7 +3592,7 @@ bool SyncRes::processRecords(const std::string& prefix, const DNSName& qname, co
         LOG(prefix<<qname<<": got NS record '"<<rec.d_name<<"' -> '"<<rec.d_content->getZoneRepresentation()<<"'"<<endl);
 
         if (!negindic && qtype == QType::DS && qname == newauth) {
-          /* just got a referral from the parent zone when asking for a DS, looks like this server did not get the DNSSE memo.. */
+          /* just got a referral from the parent zone when asking for a DS, looks like this server did not get the DNSSEC memo.. */
           LOG(prefix<<qname<<": got (implicit) negative indication of DS record for '"<<qname<<"'"<<endl);
           negindic = true;
           negIndicHasSignatures = false;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It happens if the server does not know about the DS special case.
Treat the delegation as a unsigned NODATA answer in that case.

For example for sthc.nordlo.cloud we go from the existing:

```
[1]   sthc.nordlo.cloud: Resolved 'nordlo.cloud' NS ns2.zetup.se to: 159.253.27.75
[1]   sthc.nordlo.cloud: Trying IP 159.253.27.75:53, asking 'sthc.nordlo.cloud|DS'
[1]   sthc.nordlo.cloud: Got 3 answers from ns2.zetup.se (159.253.27.75), rcode=0 (No Error), aa=0, in 35ms
[1]   sthc.nordlo.cloud: accept answer 'sthc.nordlo.cloud|NS|ns2.loopia.se.' from 'nordlo.cloud' nameservers? ttl=3600, place=2 YES!
[1]   sthc.nordlo.cloud: accept answer 'sthc.nordlo.cloud|NS|ns1.loopia.se.' from 'nordlo.cloud' nameservers? ttl=3600, place=2 YES!
[1]   sthc.nordlo.cloud: OPT answer '.' from 'nordlo.cloud' nameservers
[1]   sthc.nordlo.cloud: determining status after receiving this packet
[1]   sthc.nordlo.cloud: got NS record 'sthc.nordlo.cloud' -> 'ns2.loopia.se.'
[1]   sthc.nordlo.cloud: got NS record 'sthc.nordlo.cloud' -> 'ns1.loopia.se.'
[1]   sthc.nordlo.cloud: status=did not resolve, got 2 NS, looping to them
[1]   sthc.nordlo.cloud.: Nameservers: ns1.loopia.se(37.85ms), ns2.loopia.se(38.26ms)
[1]   sthc.nordlo.cloud: Trying to resolve NS 'ns1.loopia.se' (1/2)
[1]   Nameserver ns1.loopia.se IPs: 93.188.0.20(37.85ms)
[1]   sthc.nordlo.cloud: Resolved 'sthc.nordlo.cloud' NS ns1.loopia.se to: 93.188.0.20
[1]   sthc.nordlo.cloud: Trying IP 93.188.0.20:53, asking 'sthc.nordlo.cloud|DS'
```

to:

```
[1]   sthc.nordlo.cloud: Resolved 'nordlo.cloud' NS ns2.zetup.se to: 159.253.27.75
[1]   sthc.nordlo.cloud: Trying IP 159.253.27.75:53, asking 'sthc.nordlo.cloud|DS'
[1]   sthc.nordlo.cloud: Got 3 answers from ns2.zetup.se (159.253.27.75), rcode=0 (No Error), aa=0, in 35ms
[1]   sthc.nordlo.cloud: accept answer 'sthc.nordlo.cloud|NS|ns2.loopia.se.' from 'nordlo.cloud' nameservers? ttl=3600, place=2 YES!
[1]   sthc.nordlo.cloud: accept answer 'sthc.nordlo.cloud|NS|ns1.loopia.se.' from 'nordlo.cloud' nameservers? ttl=3600, place=2 YES!
[1]   sthc.nordlo.cloud: OPT answer '.' from 'nordlo.cloud' nameservers
[1]   sthc.nordlo.cloud: determining status after receiving this packet
[1]   sthc.nordlo.cloud: got NS record 'sthc.nordlo.cloud' -> 'ns2.loopia.se.'
[1]   sthc.nordlo.cloud: got (implicit) negative indication of DS record for 'sthc.nordlo.cloud'
[1]   sthc.nordlo.cloud: got NS record 'sthc.nordlo.cloud' -> 'ns1.loopia.se.'
[1]   sthc.nordlo.cloud: status=noerror, other types may exist, but we are done (have negative SOA)
[1] : no signatures for sthc.nordlo.cloud, we likely missed a cut between cloud and nordlo.cloud, looking for it
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
