### PR TITLE
rec: Backport 10396 to rec-4.5.x: Take into account q_quiet when determing loglevel and change a few loglevels.

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4004,7 +4004,7 @@ static void handleRCC(int fd, FDMultiplexer::funcparam_t& var)
     RecursorControlParser rcp;
     RecursorControlParser::func_t* command;
 
-    g_log << Logger::Notice << "Received rec_control command '" << msg << "' from control socket" << endl;
+    g_log << Logger::Info << "Received rec_control command '" << msg << "' from control socket" << endl;
     auto answer = rcp.getAnswer(fd, msg, &command);
 
     // If we are inside a chroot, we need to strip
@@ -4665,8 +4665,6 @@ static int serviceMain(int argc, char*argv[])
     }
     g_log<<Logger::Warning<<endl;
   }
-
-  g_quiet=::arg().mustDo("quiet");
 
   /* this needs to be done before parseACLs(), which call broadcastFunction() */
   g_weDistributeQueries = ::arg().mustDo("pdns-distributes-queries");
@@ -5745,6 +5743,7 @@ int main(int argc, char **argv)
     g_recCache = std::unique_ptr<MemRecursorCache>(new MemRecursorCache(::arg().asNum("record-cache-shards")));
     g_negCache = std::unique_ptr<NegCache>(new NegCache(::arg().asNum("record-cache-shards")));
 
+    g_quiet=::arg().mustDo("quiet");
     Logger::Urgency logUrgency = (Logger::Urgency)::arg().asNum("loglevel");
 
     if (logUrgency < Logger::Error)

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -4421,7 +4421,7 @@ int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigne
     g_log<<Logger::Notice<<"Refreshed . records"<<endl;
   }
   else
-    g_log<<Logger::Error<<"Failed to update . records, RCODE="<<res<<endl;
+    g_log<<Logger::Warning<<"Failed to update . records, RCODE="<<res<<endl;
 
   return res;
 }


### PR DESCRIPTION

(cherry picked from commit cf02f990a7fb9398aa4b13373c7ae35f7d2d47e3)

Backport of #10396 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
