### PR TITLE
dnsdist: Make DNSDist XFR aware when transfer is finished

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -370,7 +370,7 @@ static IOState sendQueuedResponses(std::shared_ptr<IncomingTCPConnectionState>& 
 
 static void handleResponseSent(std::shared_ptr<IncomingTCPConnectionState>& state, const TCPResponse& currentResponse)
 {
-  if (state->d_isXFR) {
+  if (state->d_isXFR || currentResponse.d_idstate.qtype == QType::AXFR || currentResponse.d_idstate.qtype == QType::IXFR) {
     return;
   }
 

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -435,6 +435,9 @@ void IncomingTCPConnectionState::resetForNewQuery()
   d_buffer.resize(sizeof(uint16_t));
   d_currentPos = 0;
   d_querySize = 0;
+  d_xfrMasterSerial = 0;
+  d_xfrSerialCount = 0;
+  d_xfrMasterSerialCount = 0;
   d_state = State::waitingForQuery;
 }
 

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -483,13 +483,16 @@ IOState TCPConnectionToBackend::handleResponse(std::shared_ptr<TCPConnectionToBa
     TCPResponse response;
     response.d_buffer = std::move(d_responseBuffer);
     response.d_connection = conn;
+    /* could be a IXFR but that does not matter,
+       we only need to know that this is a AXFR or IXFR response */
+    response.d_idstate.qtype = QType::AXFR;
 
     done = isXFRFinished(response, clientConn);
 
     clientConn->handleXFRResponse(clientConn, now, std::move(response));
     if (done) {
       conn->d_usedForXFR = false;
-      d_clientConn->d_isXFR = false;
+      clientConn->d_isXFR = false;
       d_state = State::idle;
       d_clientConn.reset();
       return IOState::Done;

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -191,6 +191,7 @@ private:
   static void handleIOCallback(int fd, FDMultiplexer::funcparam_t& param);
   static IOState queueNextQuery(std::shared_ptr<TCPConnectionToBackend>& conn);
   static IOState sendQuery(std::shared_ptr<TCPConnectionToBackend>& conn, const struct timeval& now);
+  static bool isXFRFinished(const TCPResponse& response, const shared_ptr<IncomingTCPConnectionState>& clientConn);
 
   IOState handleResponse(std::shared_ptr<TCPConnectionToBackend>& conn, const struct timeval& now);
   uint16_t getQueryIdFromResponse();

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -209,4 +209,7 @@ public:
   bool d_proxyProtocolPayloadHasTLV{false};
   bool d_lastIOBlocked{false};
   bool d_hadErrors{false};
+  uint32_t d_xfrMasterSerial{0};
+  uint32_t d_xfrSerialCount{0};
+  uint8_t d_xfrMasterSerialCount{0};
 };

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -203,13 +203,13 @@ public:
   size_t d_proxyProtocolNeed{0};
   size_t d_queriesCount{0};
   size_t d_currentQueriesCount{0};
+  uint32_t d_xfrMasterSerial{0};
+  uint32_t d_xfrSerialCount{0};
+  uint8_t d_xfrMasterSerialCount{0};
   uint16_t d_querySize{0};
   State d_state{State::doingHandshake};
   bool d_isXFR{false};
   bool d_proxyProtocolPayloadHasTLV{false};
   bool d_lastIOBlocked{false};
   bool d_hadErrors{false};
-  uint32_t d_xfrMasterSerial{0};
-  uint32_t d_xfrSerialCount{0};
-  uint8_t d_xfrMasterSerialCount{0};
 };

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -382,6 +382,11 @@ public:
     return d_dr.d_type;
   }
 
+  const vector<uint8_t>& getRawContent() const
+  {
+    return d_record;
+  }
+
 private:
   DNSRecord d_dr;
   vector<uint8_t> d_record;

--- a/regression-tests.dnsdist/test_AXFR.py
+++ b/regression-tests.dnsdist/test_AXFR.py
@@ -165,6 +165,156 @@ class TestAXFR(DNSDistTest):
         self.assertEqual(query, receivedQuery)
         self.assertEqual(len(receivedResponses), len(responses))
 
+    def testThreePlusTrailingAXFR(self):
+        """
+        AXFR: Three messages including the final SOA, plus a trailing one
+        """
+        name = 'threeplustrailing.axfr.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AXFR', 'IN')
+        responses = []
+        soa = dns.rrset.from_text(name,
+                                  60,
+                                  dns.rdataclass.IN,
+                                  dns.rdatatype.SOA,
+                                  'ns.' + name + ' hostmaster.' + name + ' 1 3600 3600 3600 60')
+
+        # the SOA starts the AXFR
+        response = dns.message.make_response(query)
+        response.answer.append(soa)
+        responses.append(response)
+
+        # one A
+        response = dns.message.make_response(query)
+        response.answer.append(dns.rrset.from_text(name,
+                                                   60,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.A,
+                                                   '192.0.2.1'))
+        responses.append(response)
+
+        # one AAAA
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.AAAA,
+                                    '2001:DB8::1')
+        response.answer.append(rrset)
+        responses.append(response)
+
+        # one TXT then the SOA that ends the AXFR
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.TXT,
+                                    "Some text")
+        response.answer.append(rrset)
+        response.answer.append(soa)
+        responses.append(response)
+
+        # and we add a final, dummy TXT message that will
+        # be sent by the backend but that dnsdist should not
+        # pass along to the client
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.TXT,
+                                    'dummy')
+        response.answer.append(rrset)
+        responses.append(response)
+
+        (receivedQuery, receivedResponses) = self.sendTCPQueryWithMultipleResponses(query, responses)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(len(receivedResponses), len(responses) - 1)
+
+    def testThreePlusTrailingIXFR(self):
+        """
+        IXFR: Three messages including the final SOA, plus a trailing one
+        """
+        name = 'threeplustrailing.ixfr.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'AXFR', 'IN')
+        responses = []
+
+        finalSoa = dns.rrset.from_text(name,
+                                       60,
+                                       dns.rdataclass.IN,
+                                       dns.rdatatype.SOA,
+                                       'ns.' + name + ' hostmaster.' + name + ' 3 3600 3600 3600 60')
+
+        # the final SOA starts the AXFR, with first an update from 1 to 2 (one removal, two additions)
+        response = dns.message.make_response(query)
+        response.answer.append(finalSoa)
+        # update from 1 to 2
+        response.answer.append(dns.rrset.from_text(name,
+                                                   60,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.SOA,
+                                                   'ns.' + name + ' hostmaster.' + name + ' 1 3600 3600 3600 60'))
+        # one removal
+        response.answer.append(dns.rrset.from_text(name,
+                                                   60,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.A,
+                                                   '192.0.2.1'))
+        # then additions
+        response.answer.append(dns.rrset.from_text(name,
+                                                   60,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.SOA,
+                                                   'ns.' + name + ' hostmaster.' + name + ' 2 3600 3600 3600 60'))
+        # new message in the middle of the additions
+        responses.append(response)
+        response = dns.message.make_response(query)
+
+        response.answer.append(dns.rrset.from_text_list(name,
+                                                        60,
+                                                        dns.rdataclass.IN,
+                                                        dns.rdatatype.A,
+                                                        ['192.0.2.2', '192.0.2.3']))
+        # done with 1 -> 2
+        response.answer.append(dns.rrset.from_text(name,
+                                                   60,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.SOA,
+                                                   'ns.' + name + ' hostmaster.' + name + ' 2 3600 3600 3600 60'))
+        # new message
+        responses.append(response)
+        response = dns.message.make_response(query)
+
+        # then upgrade to 3
+        # no removals
+        response.answer.append(finalSoa)
+
+        # and one addition
+        response.answer.append(dns.rrset.from_text(name,
+                                                   60,
+                                                   dns.rdataclass.IN,
+                                                   dns.rdatatype.A,
+                                                   '192.0.2.4'))
+        # and the final SOA
+        response.answer.append(finalSoa)
+        responses.append(response)
+
+        # and we add a final, dummy TXT message that will
+        # be sent by the backend but that dnsdist should not
+        # pass along to the client
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.TXT,
+                                    'dummy')
+        response.answer.append(rrset)
+        responses.append(response)
+
+        (receivedQuery, receivedResponses) = self.sendTCPQueryWithMultipleResponses(query, responses)
+        receivedQuery.id = query.id
+        self.assertEqual(query, receivedQuery)
+        self.assertEqual(len(receivedResponses), len(responses) - 1)
+
     # def testFourNoFirstSOAAXFR(self):
     #     """
     #     AXFR: Four messages, no SOA in the first one


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Added logic to parse SOA records for XFR transfers and figure out if the XFR transfer is finished.

Resolves #10436

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
