### PR TITLE
speedtest: Fix QType::getName() renamed to QType::toString()

### DIFF
--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -801,7 +801,7 @@ struct StatRingDNSNameQTypeToStringTest
   string getName() const { return "StatRing test with DNSName and QType to string"; }
 
   void operator()() const {
-    S.ringAccount("testring", d_name.toLogString()+"/"+d_type.getName());
+    S.ringAccount("testring", d_name.toLogString()+"/"+d_type.toString());
   };
 
   DNSName d_name;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
