### PR TITLE
dnsdist: Add support for Lua per-thread FFI rules and actions

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -489,6 +489,8 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "LogResponseAction", true, "[filename], [append], [buffered]", "Log a line for each response, to the specified file if any, to the console (require verbose) otherwise. The `append` optional parameter specifies whether we open the file for appending or truncate each time (default), and the `buffered` optional parameter specifies whether writes to the file are buffered (default) or not." },
   { "LuaAction", true, "function", "Invoke a Lua function that accepts a DNSQuestion" },
   { "LuaFFIAction", true, "function", "Invoke a Lua FFI function that accepts a DNSQuestion" },
+  { "LuaFFIPerThreadAction", true, "function", "Invoke a Lua FFI function that accepts a DNSQuestion, with a per-thread Lua context" },
+  { "LuaFFIPerThreadResponseAction", true, "function", "Invoke a Lua FFI function that accepts a DNSResponse, with a per-thread Lua context" },
   { "LuaFFIResponseAction", true, "function", "Invoke a Lua FFI function that accepts a DNSResponse" },
   { "LuaFFIRule", true, "function", "Invoke a Lua FFI function that filters DNS questions" },
   { "LuaResponseAction", true, "function", "Invoke a Lua function that accepts a DNSResponse" },

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -549,13 +549,13 @@ private:
     func_t d_func;
     bool d_initialized{false};
   };
-  static uint64_t s_functionsCounter;
+  static std::atomic<uint64_t> s_functionsCounter;
   static thread_local std::map<uint64_t, PerThreadState> t_perThreadStates;
   std::string d_functionCode;
   uint64_t d_functionID;
 };
 
-uint64_t LuaFFIPerThreadAction::s_functionsCounter = 0;
+std::atomic<uint64_t> LuaFFIPerThreadAction::s_functionsCounter = 0;
 thread_local std::map<uint64_t, LuaFFIPerThreadAction::PerThreadState> LuaFFIPerThreadAction::t_perThreadStates;
 
 class LuaFFIResponseAction: public DNSResponseAction
@@ -671,13 +671,13 @@ private:
     bool d_initialized{false};
   };
 
-  static uint64_t s_functionsCounter;
+  static std::atomic<uint64_t> s_functionsCounter;
   static thread_local std::map<uint64_t, PerThreadState> t_perThreadStates;
   std::string d_functionCode;
   uint64_t d_functionID;
 };
 
-uint64_t LuaFFIPerThreadResponseAction::s_functionsCounter = 0;
+std::atomic<uint64_t> LuaFFIPerThreadResponseAction::s_functionsCounter = 0;
 thread_local std::map<uint64_t, LuaFFIPerThreadResponseAction::PerThreadState> LuaFFIPerThreadResponseAction::t_perThreadStates;
 
 thread_local std::default_random_engine SpoofAction::t_randomEngine;

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -504,8 +504,15 @@ public:
       auto& state = t_perThreadStates[d_functionID];
       if (!state.d_initialized) {
         setupLuaFFIPerThreadContext(state.d_luaContext);
-        state.d_func = state.d_luaContext.executeCode<func_t>(d_functionCode);
+        /* mark the state as initialized first so if there is a syntax error
+           we only try to execute the code once */
         state.d_initialized = true;
+        state.d_func = state.d_luaContext.executeCode<func_t>(d_functionCode);
+      }
+
+      if (!state.d_func) {
+        /* the function was not properly initialized */
+        return DNSAction::Action::None;
       }
 
       dnsdist_ffi_dnsquestion_t dqffi(dq);
@@ -520,9 +527,11 @@ public:
         }
       }
       return static_cast<DNSAction::Action>(ret);
-    } catch (const std::exception &e) {
+    }
+    catch (const std::exception &e) {
       warnlog("LuaFFIPerThreadAction failed inside Lua, returning ServFail: %s", e.what());
-    } catch (...) {
+    }
+    catch (...) {
       warnlog("LuaFFIPerthreadAction failed inside Lua, returning ServFail: [unknown exception]");
     }
     return DNSAction::Action::ServFail;
@@ -616,8 +625,15 @@ public:
       auto& state = t_perThreadStates[d_functionID];
       if (!state.d_initialized) {
         setupLuaFFIPerThreadContext(state.d_luaContext);
-        state.d_func = state.d_luaContext.executeCode<func_t>(d_functionCode);
+        /* mark the state as initialized first so if there is a syntax error
+           we only try to execute the code once */
         state.d_initialized = true;
+        state.d_func = state.d_luaContext.executeCode<func_t>(d_functionCode);
+      }
+
+      if (!state.d_func) {
+        /* the function was not properly initialized */
+        return DNSResponseAction::Action::None;
       }
 
       dnsdist_ffi_dnsquestion_t dqffi(dq);
@@ -632,9 +648,11 @@ public:
         }
       }
       return static_cast<DNSResponseAction::Action>(ret);
-    } catch (const std::exception &e) {
+    }
+    catch (const std::exception &e) {
       warnlog("LuaFFIPerThreadResponseAction failed inside Lua, returning ServFail: %s", e.what());
-    } catch (...) {
+    }
+    catch (...) {
       warnlog("LuaFFIPerthreadResponseAction failed inside Lua, returning ServFail: [unknown exception]");
     }
     return DNSResponseAction::Action::ServFail;

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -551,8 +551,8 @@ private:
   };
   static std::atomic<uint64_t> s_functionsCounter;
   static thread_local std::map<uint64_t, PerThreadState> t_perThreadStates;
-  std::string d_functionCode;
-  uint64_t d_functionID;
+  const std::string d_functionCode;
+  const uint64_t d_functionID;
 };
 
 std::atomic<uint64_t> LuaFFIPerThreadAction::s_functionsCounter = 0;
@@ -673,8 +673,8 @@ private:
 
   static std::atomic<uint64_t> s_functionsCounter;
   static thread_local std::map<uint64_t, PerThreadState> t_perThreadStates;
-  std::string d_functionCode;
-  uint64_t d_functionID;
+  const std::string d_functionCode;
+  const uint64_t d_functionID;
 };
 
 std::atomic<uint64_t> LuaFFIPerThreadResponseAction::s_functionsCounter = 0;

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -489,6 +489,65 @@ private:
   func_t d_func;
 };
 
+class LuaFFIPerThreadAction: public DNSAction
+{
+public:
+  typedef std::function<int(dnsdist_ffi_dnsquestion_t* dq)> func_t;
+
+  LuaFFIPerThreadAction(const std::string& code): d_functionCode(code), d_functionID(s_functionsCounter++)
+  {
+  }
+
+  DNSAction::Action operator()(DNSQuestion* dq, std::string* ruleresult) const override
+  {
+    try {
+      auto& state = t_perThreadStates[d_functionID];
+      if (!state.d_initialized) {
+        setupLuaFFIPerThreadContext(state.d_luaContext);
+        state.d_func = state.d_luaContext.executeCode<func_t>(d_functionCode);
+        state.d_initialized = true;
+      }
+
+      dnsdist_ffi_dnsquestion_t dqffi(dq);
+      auto ret = state.d_func(&dqffi);
+      if (ruleresult) {
+        if (dqffi.result) {
+          *ruleresult = *dqffi.result;
+        }
+        else {
+          // default to empty string
+          ruleresult->clear();
+        }
+      }
+      return static_cast<DNSAction::Action>(ret);
+    } catch (const std::exception &e) {
+      warnlog("LuaFFIPerThreadAction failed inside Lua, returning ServFail: %s", e.what());
+    } catch (...) {
+      warnlog("LuaFFIPerthreadAction failed inside Lua, returning ServFail: [unknown exception]");
+    }
+    return DNSAction::Action::ServFail;
+  }
+
+  string toString() const override
+  {
+    return "Lua FFI per-thread script";
+  }
+
+private:
+  struct PerThreadState
+  {
+    LuaContext d_luaContext;
+    func_t d_func;
+    bool d_initialized{false};
+  };
+  static uint64_t s_functionsCounter;
+  static thread_local std::map<uint64_t, PerThreadState> t_perThreadStates;
+  std::string d_functionCode;
+  uint64_t d_functionID;
+};
+
+uint64_t LuaFFIPerThreadAction::s_functionsCounter = 0;
+thread_local std::map<uint64_t, LuaFFIPerThreadAction::PerThreadState> LuaFFIPerThreadAction::t_perThreadStates;
 
 class LuaFFIResponseAction: public DNSResponseAction
 {
@@ -536,6 +595,72 @@ public:
 private:
   func_t d_func;
 };
+
+class LuaFFIPerThreadResponseAction: public DNSResponseAction
+{
+public:
+  typedef std::function<int(dnsdist_ffi_dnsquestion_t* dq)> func_t;
+
+  LuaFFIPerThreadResponseAction(const std::string& code): d_functionCode(code), d_functionID(s_functionsCounter++)
+  {
+  }
+
+  DNSResponseAction::Action operator()(DNSResponse* dr, std::string* ruleresult) const override
+  {
+    DNSQuestion* dq = dynamic_cast<DNSQuestion*>(dr);
+    if (dq == nullptr) {
+      return DNSResponseAction::Action::ServFail;
+    }
+
+    try {
+      auto& state = t_perThreadStates[d_functionID];
+      if (!state.d_initialized) {
+        setupLuaFFIPerThreadContext(state.d_luaContext);
+        state.d_func = state.d_luaContext.executeCode<func_t>(d_functionCode);
+        state.d_initialized = true;
+      }
+
+      dnsdist_ffi_dnsquestion_t dqffi(dq);
+      auto ret = state.d_func(&dqffi);
+      if (ruleresult) {
+        if (dqffi.result) {
+          *ruleresult = *dqffi.result;
+        }
+        else {
+          // default to empty string
+          ruleresult->clear();
+        }
+      }
+      return static_cast<DNSResponseAction::Action>(ret);
+    } catch (const std::exception &e) {
+      warnlog("LuaFFIPerThreadResponseAction failed inside Lua, returning ServFail: %s", e.what());
+    } catch (...) {
+      warnlog("LuaFFIPerthreadResponseAction failed inside Lua, returning ServFail: [unknown exception]");
+    }
+    return DNSResponseAction::Action::ServFail;
+  }
+
+  string toString() const override
+  {
+    return "Lua FFI per-thread script";
+  }
+
+private:
+  struct PerThreadState
+  {
+    LuaContext d_luaContext;
+    func_t d_func;
+    bool d_initialized{false};
+  };
+
+  static uint64_t s_functionsCounter;
+  static thread_local std::map<uint64_t, PerThreadState> t_perThreadStates;
+  std::string d_functionCode;
+  uint64_t d_functionID;
+};
+
+uint64_t LuaFFIPerThreadResponseAction::s_functionsCounter = 0;
+thread_local std::map<uint64_t, LuaFFIPerThreadResponseAction::PerThreadState> LuaFFIPerThreadResponseAction::t_perThreadStates;
 
 thread_local std::default_random_engine SpoofAction::t_randomEngine;
 
@@ -1692,6 +1817,11 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new LuaFFIAction(func));
     });
 
+  luaCtx.writeFunction("LuaFFIPerThreadAction", [](std::string code) {
+      setLuaSideEffect();
+      return std::shared_ptr<DNSAction>(new LuaFFIPerThreadAction(code));
+    });
+
   luaCtx.writeFunction("SetNoRecurseAction", []() {
       return std::shared_ptr<DNSAction>(new SetNoRecurseAction);
     });
@@ -1856,6 +1986,11 @@ void setupLuaActions(LuaContext& luaCtx)
   luaCtx.writeFunction("LuaFFIResponseAction", [](LuaFFIResponseAction::func_t func) {
       setLuaSideEffect();
       return std::shared_ptr<DNSResponseAction>(new LuaFFIResponseAction(func));
+    });
+
+  luaCtx.writeFunction("LuaFFIPerThreadResponseAction", [](std::string code) {
+      setLuaSideEffect();
+      return std::shared_ptr<DNSResponseAction>(new LuaFFIPerThreadResponseAction(code));
     });
 
   luaCtx.writeFunction("RemoteLogAction", [](std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(DNSQuestion*, DNSDistProtoBufMessage*)> > alterFunc, boost::optional<std::unordered_map<std::string, std::string>> vars) {

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -603,6 +603,10 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new LuaFFIRule(func));
     });
 
+  luaCtx.writeFunction("LuaFFIPerThreadRule", [](std::string code) {
+    return std::shared_ptr<DNSRule>(new LuaFFIPerThreadRule(code));
+  });
+
   luaCtx.writeFunction("ProxyProtocolValueRule", [](uint8_t type, boost::optional<std::string> value) {
       return std::shared_ptr<DNSRule>(new ProxyProtocolValueRule(type, value));
     });

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -162,7 +162,7 @@ dnsdist_SOURCES = \
 	dnsdist-protobuf.cc dnsdist-protobuf.hh \
 	dnsdist-proxy-protocol.cc dnsdist-proxy-protocol.hh \
 	dnsdist-rings.cc dnsdist-rings.hh \
-	dnsdist-rules.hh \
+	dnsdist-rules.cc dnsdist-rules.hh \
 	dnsdist-secpoll.cc dnsdist-secpoll.hh \
 	dnsdist-snmp.cc dnsdist-snmp.hh \
 	dnsdist-systemd.cc dnsdist-systemd.hh \
@@ -240,6 +240,7 @@ testrunner_SOURCES = \
 	dnsdist-lua-vars.cc \
 	dnsdist-proxy-protocol.cc dnsdist-proxy-protocol.hh \
 	dnsdist-rings.cc dnsdist-rings.hh \
+	dnsdist-rules.cc dnsdist-rules.hh \
 	dnsdist-tcp-downstream.cc \
 	dnsdist-tcp.cc \
 	dnsdist-xpf.cc dnsdist-xpf.hh \

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -533,3 +533,12 @@ void setupLuaLoadBalancingContext(LuaContext& luaCtx)
   luaCtx.executeCode(getLuaFFIWrappers());
 #endif
 }
+
+void setupLuaFFIPerThreadContext(LuaContext& luaCtx)
+{
+  setupLuaVars(luaCtx);
+
+#ifdef LUAJIT_VERSION
+  luaCtx.executeCode(getLuaFFIWrappers());
+#endif
+}

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.hh
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.hh
@@ -107,3 +107,4 @@ struct dnsdist_ffi_servers_list_t
 };
 
 const std::string& getLuaFFIWrappers();
+void setupLuaFFIPerThreadContext(LuaContext& luaCtx);

--- a/pdns/dnsdistdist/dnsdist-rules.cc
+++ b/pdns/dnsdistdist/dnsdist-rules.cc
@@ -22,5 +22,5 @@
 
 #include "dnsdist-rules.hh"
 
-uint64_t LuaFFIPerThreadRule::s_functionsCounter = 0;
+std::atomic<uint64_t> LuaFFIPerThreadRule::s_functionsCounter = 0;
 thread_local std::map<uint64_t, LuaFFIPerThreadRule::PerThreadState> LuaFFIPerThreadRule::t_perThreadStates;

--- a/pdns/dnsdistdist/dnsdist-rules.cc
+++ b/pdns/dnsdistdist/dnsdist-rules.cc
@@ -1,0 +1,26 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "dnsdist-rules.hh"
+
+uint64_t LuaFFIPerThreadRule::s_functionsCounter = 0;
+thread_local std::map<uint64_t, LuaFFIPerThreadRule::PerThreadState> LuaFFIPerThreadRule::t_perThreadStates;

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -1228,7 +1228,7 @@ private:
     bool d_initialized{false};
   };
 
-  static uint64_t s_functionsCounter;
+  static std::atomic<uint64_t> s_functionsCounter;
   static thread_local std::map<uint64_t, PerThreadState> t_perThreadStates;
   std::string d_functionCode;
   uint64_t d_functionID;

--- a/pdns/dnsdistdist/dnsdist-rules.hh
+++ b/pdns/dnsdistdist/dnsdist-rules.hh
@@ -1230,8 +1230,8 @@ private:
 
   static std::atomic<uint64_t> s_functionsCounter;
   static thread_local std::map<uint64_t, PerThreadState> t_perThreadStates;
-  std::string d_functionCode;
-  uint64_t d_functionID;
+  const std::string d_functionCode;
+  const uint64_t d_functionID;
 };
 
 class ProxyProtocolValueRule : public DNSRule

--- a/pdns/dnsdistdist/docs/advanced/tuning.rst
+++ b/pdns/dnsdistdist/docs/advanced/tuning.rst
@@ -111,6 +111,8 @@ When Lua inspection is needed, the best course of action is to restrict the quer
 +------------------------------+-------------+-----------------+
 | Lua FFI rule                 | fast        | global Lua lock |
 +------------------------------+-------------+-----------------+
+| Lua per-thread FFI rule      | fast        | none            |
++------------------------------+-------------+-----------------+
 | C++ LB policy                | fast        | none            |
 +------------------------------+-------------+-----------------+
 | Lua LB policy                | slow        | global Lua lock |

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -506,7 +506,9 @@ These ``DNSRule``\ s be one of the following items:
 
   The ``function`` should return true if the query matches, or false otherwise. If the Lua code fails, false is returned.
 
-  The function will be invoked in a per-thread Lua state, without access to the global Lua state.
+  The function will be invoked in a per-thread Lua state, without access to the global Lua state. All constants (:ref:`DNSQType`, :ref:`DNSRCode`, ...) are available in that per-thread context,
+  as well as all FFI functions. Objects and their bindings that are not usable in a FFI context (:class:`DNSQuestion`, :class:`DNSDistProtoBufMessage`, :class:`PacketCache`, ...)
+  are not available.
 
   :param string function: a Lua string returning a Lua function
 
@@ -1018,7 +1020,9 @@ The following actions exist.
 
   The ``function`` should return a :ref:`DNSAction`. If the Lua code fails, ServFail is returned.
 
-  The function will be invoked in a per-thread Lua state, without access to the global Lua state.
+  The function will be invoked in a per-thread Lua state, without access to the global Lua state. All constants (:ref:`DNSQType`, :ref:`DNSRCode`, ...) are available in that per-thread context,
+  as well as all FFI functions. Objects and their bindings that are not usable in a FFI context (:class:`DNSQuestion`, :class:`DNSDistProtoBufMessage`, :class:`PacketCache`, ...)
+  are not available.
 
   :param string function: a Lua string returning a Lua function
 
@@ -1030,7 +1034,9 @@ The following actions exist.
 
   The ``function`` should return a :ref:`DNSResponseAction`. If the Lua code fails, ServFail is returned.
 
-  The function will be invoked in a per-thread Lua state, without access to the global Lua state.
+  The function will be invoked in a per-thread Lua state, without access to the global Lua state. All constants (:ref:`DNSQType`, :ref:`DNSRCode`, ...) are available in that per-thread context,
+  as well as all FFI functions. Objects and their bindings that are not usable in a FFI context (:class:`DNSQuestion`, :class:`DNSDistProtoBufMessage`, :class:`PacketCache`, ...)
+  are not available.
 
   :param string function: a Lua string returning a Lua function
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -498,6 +498,18 @@ These ``DNSRule``\ s be one of the following items:
   :param KeyValueStore kvs: The key value store to query
   :param KeyValueLookupKey lookupKey: The key to use for the lookup
 
+.. function:: LuaFFIPerThreadRule(function)
+
+  .. versionadded:: 1.7.0
+
+  Invoke a Lua FFI function that accepts a pointer to a ``dnsdist_ffi_dnsquestion_t`` object, whose bindings are defined in ``dnsdist-lua-ffi.hh``.
+
+  The ``function`` should return true if the query matches, or false otherwise. If the Lua code fails, false is returned.
+
+  The function will be invoked in a per-thread Lua state, without access to the global Lua state.
+
+  :param string function: the name of a Lua function
+
 .. function:: LuaFFIRule(function)
 
   .. versionadded:: 1.5.0
@@ -995,6 +1007,30 @@ The following actions exist.
   Invoke a Lua FFI function that accepts a pointer to a ``dnsdist_ffi_dnsquestion_t`` object, whose bindings are defined in ``dnsdist-lua-ffi.hh``.
 
   The ``function`` should return a :ref:`DNSAction`. If the Lua code fails, ServFail is returned.
+
+  :param string function: the name of a Lua function
+
+.. function:: LuaFFIPerThreadAction(function)
+
+  .. versionadded:: 1.7.0
+
+  Invoke a Lua FFI function that accepts a pointer to a ``dnsdist_ffi_dnsquestion_t`` object, whose bindings are defined in ``dnsdist-lua-ffi.hh``.
+
+  The ``function`` should return a :ref:`DNSAction`. If the Lua code fails, ServFail is returned.
+
+  The function will be invoked in a per-thread Lua state, without access to the global Lua state.
+
+  :param string function: the name of a Lua function
+
+.. function:: LuaFFIPerThreadResponseAction(function)
+
+  .. versionadded:: 1.7.0
+
+  Invoke a Lua FFI function that accepts a pointer to a ``dnsdist_ffi_dnsquestion_t`` object, whose bindings are defined in ``dnsdist-lua-ffi.hh``.
+
+  The ``function`` should return a :ref:`DNSResponseAction`. If the Lua code fails, ServFail is returned.
+
+  The function will be invoked in a per-thread Lua state, without access to the global Lua state.
 
   :param string function: the name of a Lua function
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -508,7 +508,7 @@ These ``DNSRule``\ s be one of the following items:
 
   The function will be invoked in a per-thread Lua state, without access to the global Lua state.
 
-  :param string function: the name of a Lua function
+  :param string function: a Lua string returning a Lua function
 
 .. function:: LuaFFIRule(function)
 
@@ -1020,7 +1020,7 @@ The following actions exist.
 
   The function will be invoked in a per-thread Lua state, without access to the global Lua state.
 
-  :param string function: the name of a Lua function
+  :param string function: a Lua string returning a Lua function
 
 .. function:: LuaFFIPerThreadResponseAction(function)
 
@@ -1032,7 +1032,7 @@ The following actions exist.
 
   The function will be invoked in a per-thread Lua state, without access to the global Lua state.
 
-  :param string function: the name of a Lua function
+  :param string function: a Lua string returning a Lua function
 
 .. function:: LuaFFIResponseAction(function)
 

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -2130,6 +2130,155 @@ class TestAdvancedLuaFFI(DNSDistTest):
             (_, receivedResponse) = sender(query, response=None, useQueue=False)
             self.assertEqual(receivedResponse, response)
 
+class TestAdvancedLuaFFIPerThread(DNSDistTest):
+
+    _config_template = """
+
+    local rulefunction = [[
+      local ffi = require("ffi")
+
+      return function(dq)
+        local qtype = ffi.C.dnsdist_ffi_dnsquestion_get_qtype(dq)
+        if qtype ~= DNSQType.A and qtype ~= DNSQType.SOA then
+          print('invalid qtype')
+          return false
+        end
+
+        local qclass = ffi.C.dnsdist_ffi_dnsquestion_get_qclass(dq)
+        if qclass ~= DNSClass.IN then
+          print('invalid qclass')
+          return false
+        end
+
+        local ret_ptr = ffi.new("char *[1]")
+        local ret_ptr_param = ffi.cast("const char **", ret_ptr)
+        local ret_size = ffi.new("size_t[1]")
+        local ret_size_param = ffi.cast("size_t*", ret_size)
+        ffi.C.dnsdist_ffi_dnsquestion_get_qname_raw(dq, ret_ptr_param, ret_size_param)
+        if ret_size[0] ~= 45 then
+          print('invalid length for the qname ')
+          print(ret_size[0])
+          return false
+        end
+
+        local expectedQname = string.char(15)..'luaffiperthread'..string.char(8)..'advanced'..string.char(5)..'tests'..string.char(8)..'powerdns'..string.char(3)..'com'
+        if ffi.string(ret_ptr[0]) ~= expectedQname then
+          print('invalid qname')
+          print(ffi.string(ret_ptr[0]))
+          return false
+        end
+
+        local rcode = ffi.C.dnsdist_ffi_dnsquestion_get_rcode(dq)
+        if rcode ~= 0 then
+          print('invalid rcode')
+          return false
+        end
+
+        local opcode = ffi.C.dnsdist_ffi_dnsquestion_get_opcode(dq)
+        if qtype == DNSQType.A and opcode ~= DNSOpcode.Query then
+          print('invalid opcode')
+          return false
+        elseif qtype == DNSQType.SOA and opcode ~= DNSOpcode.Update then
+          print('invalid opcode')
+          return false
+        end
+
+        local dnssecok = ffi.C.dnsdist_ffi_dnsquestion_get_do(dq)
+        if dnssecok ~= false then
+          print('invalid DNSSEC OK')
+          return false
+        end
+
+        local len = ffi.C.dnsdist_ffi_dnsquestion_get_len(dq)
+        if len ~= 61 then
+          print('invalid length')
+          print(len)
+          return false
+        end
+
+        local tag = ffi.C.dnsdist_ffi_dnsquestion_get_tag(dq, 'a-tag')
+        if ffi.string(tag) ~= 'a-value' then
+          print('invalid tag value')
+          print(ffi.string(tag))
+          return false
+        end
+
+        return true
+      end
+    ]]
+
+    local actionfunction = [[
+      local ffi = require("ffi")
+
+      return function(dq)
+        local qtype = ffi.C.dnsdist_ffi_dnsquestion_get_qtype(dq)
+        if qtype == DNSQType.A then
+          local str = "192.0.2.1"
+          local buf = ffi.new("char[?]", #str + 1)
+          ffi.copy(buf, str)
+          ffi.C.dnsdist_ffi_dnsquestion_set_result(dq, buf, #str)
+          return DNSAction.Spoof
+        elseif qtype == DNSQType.SOA then
+          ffi.C.dnsdist_ffi_dnsquestion_set_rcode(dq, DNSRCode.REFUSED)
+          return DNSAction.Refused
+        end
+      end
+    ]]
+
+    local settagfunction = [[
+      local ffi = require("ffi")
+
+      return function(dq)
+        ffi.C.dnsdist_ffi_dnsquestion_set_tag(dq, 'a-tag', 'a-value')
+        return DNSAction.None
+      end
+    ]]
+
+    addAction(AllRule(), LuaFFIPerThreadAction(settagfunction))
+    addAction(LuaFFIPerThreadRule(rulefunction), LuaFFIPerThreadAction(actionfunction))
+    -- newServer{address="127.0.0.1:%s"}
+    """
+
+    def testAdvancedLuaPerthreadFFI(self):
+        """
+        Advanced: Test the Lua FFI per-thread interface
+        """
+        name = 'luaffiperthread.advanced.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'A', 'IN')
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+
+        response = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name,
+                                    60,
+                                    dns.rdataclass.IN,
+                                    dns.rdatatype.A,
+                                    '192.0.2.1')
+        response.answer.append(rrset)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (_, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertEqual(receivedResponse, response)
+
+    def testAdvancedLuaFFIPerThreadUpdate(self):
+        """
+        Advanced: Test the Lua FFI per-thread interface via an update
+        """
+        name = 'luaffiperthread.advanced.tests.powerdns.com.'
+        query = dns.message.make_query(name, 'SOA', 'IN')
+        query.set_opcode(dns.opcode.UPDATE)
+        # dnsdist set RA = RD for spoofed responses
+        query.flags &= ~dns.flags.RD
+
+        response = dns.message.make_response(query)
+        response.set_rcode(dns.rcode.REFUSED)
+
+        for method in ("sendUDPQuery", "sendTCPQuery"):
+            sender = getattr(self, method)
+            (_, receivedResponse) = sender(query, response=None, useQueue=False)
+            self.assertEqual(receivedResponse, response)
+
 class TestAdvancedDropEmptyQueries(DNSDistTest):
 
     _config_template = """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This allows Lua FFI rules and actions that don't need access to the global, shared Lua state to be lock-less, avoiding lock contention.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
