### PR TITLE
auth 2136: allow placing DNSKEY/CDS/CDNSKEY regardless of direct-dnskey setting

### DIFF
--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -627,6 +627,9 @@ void PacketHandler::emitNSEC(std::unique_ptr<DNSPacket>& r, const DNSName& name,
       nrc.set(QType::A);
       nrc.set(QType::AAAA);
     }
+    else if((rr.dr.d_type == QType::DNSKEY || rr.dr.d_type == QType::CDS || rr.dr.d_type == QType::CDNSKEY) && !d_dk.isPresigned(d_sd.qname) && !::arg().mustDo("direct-dnskey")) {
+      continue;
+    }
     else if(rr.dr.d_type == QType::NS || rr.auth) {
       nrc.set(rr.dr.d_type);
     }
@@ -690,6 +693,9 @@ void PacketHandler::emitNSEC3(std::unique_ptr<DNSPacket>& r, const NSEC3PARAMRec
         // be requested.
         n3rc.set(QType::A);
         n3rc.set(QType::AAAA);
+      }
+      else if((rr.dr.d_type == QType::DNSKEY || rr.dr.d_type == QType::CDS || rr.dr.d_type == QType::CDNSKEY) && !d_dk.isPresigned(d_sd.qname) && !::arg().mustDo("direct-dnskey")) {
+        continue;
       }
       else if(rr.dr.d_type && (rr.dr.d_type == QType::NS || rr.auth)) {
           // skip empty non-terminals

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -99,7 +99,7 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
     return 0;
   }
 
-  if (!isPresigned && ((!::arg().mustDo("direct-dnskey") && rrType == QType::DNSKEY) || rrType == QType::RRSIG)) {
+  if (!isPresigned && rrType == QType::RRSIG) {
     g_log<<Logger::Warning<<msgPrefix<<"Trying to add/update/delete "<<rr->d_name<<"|"<<rrType.toString()<<" in non-presigned zone, ignoring!"<<endl;
     return 0;
   }


### PR DESCRIPTION
### Short description
Fixes #10321.
Fixes #10516.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master