### PR TITLE
docs: query-local-address6 has been removed in #10251 as well

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -53,7 +53,7 @@ Changed defaults
 Removed options
 ~~~~~~~~~~~~~~~
 - :ref:`setting-local-ipv6` has been removed. IPv4 and IPv6 listen addresses should now be set with :ref:`setting-local-address`.
-- :ref:`setting-query-local-address6` has been removed. IPv4 and IPv6 addresses used for sending queries should now be set with :ref:`query-local-address`.
+- :ref:`setting-query-local-address6` has been removed. IPv4 and IPv6 addresses used for sending queries should now be set with :ref:`setting-query-local-address`.
 
 Starting with auth-4.5.0-beta1:
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -53,6 +53,7 @@ Changed defaults
 Removed options
 ~~~~~~~~~~~~~~~
 - :ref:`setting-local-ipv6` has been removed. IPv4 and IPv6 listen addresses should now be set with :ref:`setting-local-address`.
+- :ref:`setting-query-local-address6` has been removed. IPv4 and IPv6 addresses used for sending queries should now be set with :ref:`query-local-address`.
 
 Starting with auth-4.5.0-beta1:
 


### PR DESCRIPTION
### Short description
Upgrade Notes should say farewell to query-local-address6 as well.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
