### PR TITLE
dnsdist: Increase the TTL of test answers to prevent spurious failures

### DIFF
--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -1918,7 +1918,7 @@ class TestCachingFailureTTL(DNSDistTest):
 
 class TestCachingNegativeTTL(DNSDistTest):
 
-    _negCacheTTL = 1
+    _negCacheTTL = 2
     _config_params = ['_negCacheTTL', '_testServerPort']
     _config_template = """
     pc = newPacketCache(1000, {maxTTL=86400, minTTL=0, temporaryFailureTTL=60, staleTTL=60, dontAge=false, numberOfShards=1, deferrableInsertLock=true, maxNegativeTTL=%d})


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The value of the TTL for negative answers was capped to 1s, which means that the answer will only be present in the cache for the current second. If the test starts at the end of a second in unix time, there is a real risk that the entry is no longer usable when we try to fetch it from the cache.
Increase the TTL to 2s instead to reduce that risk.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
