### PR TITLE
auth: make UeberBackend::addCache pick the correct ttl

### DIFF
--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -588,15 +588,12 @@ void UeberBackend::addCache(const Question &q, vector<DNSZoneRecord> &&rrs)
   if(!d_cache_ttl)
     return;
 
-  unsigned int store_ttl = d_cache_ttl;
   for(const auto& rr : rrs) {
-   if (rr.dr.d_ttl < store_ttl)
-     store_ttl = rr.dr.d_ttl;
    if (rr.scopeMask)
      return;
   }
 
-  QC.insert(q.qname, q.qtype, std::move(rrs), store_ttl, q.zoneId);
+  QC.insert(q.qname, q.qtype, std::move(rrs), d_cache_ttl, q.zoneId);
 }
 
 void UeberBackend::alsoNotifies(const DNSName &domain, set<string> *ips)

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -590,7 +590,7 @@ void UeberBackend::addCache(const Question &q, vector<DNSZoneRecord> &&rrs)
 
   unsigned int store_ttl = d_cache_ttl;
   for(const auto& rr : rrs) {
-   if (rr.dr.d_ttl < d_cache_ttl)
+   if (rr.dr.d_ttl < store_ttl)
      store_ttl = rr.dr.d_ttl;
    if (rr.scopeMask)
      return;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This fixes that UeberBackend::addCache always uses d_cache_ttl, rather than the last TTL lower than d_cache_ttl. The old behavior leads to potentially undesirable results in case of ANY lookups.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
