### PR TITLE
auth: actually use the QueryCache for the UeberBackend unit tests

### DIFF
--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -137,8 +137,13 @@ public:
     findZone(qdomain, zoneId, d_records, d_currentZone);
 
     if (d_records) {
-      if (qdomain == DNSName("geo.powerdns.com.") && pkt_p != nullptr && pkt_p->getRealRemote() == Netmask("192.0.2.1")) {
-        d_currentScopeMask = 32;
+      if (qdomain == DNSName("geo.powerdns.com.") && pkt_p != nullptr) {
+        if (pkt_p->getRealRemote() == Netmask("192.0.2.1")) {
+          d_currentScopeMask = 32;
+        }
+        else if (pkt_p->getRealRemote() == Netmask("198.51.100.1")) {
+          d_currentScopeMask = 24;
+        }
       }
 
       auto& idx = d_records->get<OrderedNameTypeTag>();
@@ -337,7 +342,7 @@ struct UeberBackendSetupArgFixture {
     ::arg().set("query-cache-ttl")="0";
     ::arg().set("negquery-cache-ttl")="0";
     ::arg().set("consistent-backends")="no";
-    QC.cleanup();
+    QC.purge();
     ::arg().set("zone-cache-refresh-interval")="0";
     g_zoneCache.clear();
     BackendMakers().clear();
@@ -354,7 +359,7 @@ static void testWithoutThenWithAuthCache(std::function<void(UeberBackend& ub)> f
     /* disable the cache */
     ::arg().set("query-cache-ttl")="0";
     ::arg().set("negquery-cache-ttl")="0";
-    QC.cleanup();
+    QC.purge();
     QC.setMaxEntries(0);
     /* keep zone cache disabled */
     ::arg().set("zone-cache-refresh-interval")="0";
@@ -368,7 +373,7 @@ static void testWithoutThenWithAuthCache(std::function<void(UeberBackend& ub)> f
     /* enable the cache */
     ::arg().set("query-cache-ttl")="20";
     ::arg().set("negquery-cache-ttl")="60";
-    QC.cleanup();
+    QC.purge();
     QC.setMaxEntries(100000);
     /* keep zone cache disabled */
     ::arg().set("zone-cache-refresh-interval")="0";
@@ -393,7 +398,7 @@ static void testWithoutThenWithZoneCache(std::function<void(UeberBackend& ub)> f
     /* keep auth caches disabled */
     ::arg().set("query-cache-ttl")="0";
     ::arg().set("negquery-cache-ttl")="0";
-    QC.cleanup();
+    QC.purge();
     QC.setMaxEntries(0);
 
     UeberBackend ub;
@@ -407,7 +412,7 @@ static void testWithoutThenWithZoneCache(std::function<void(UeberBackend& ub)> f
     /* keep auth caches disabled */
     ::arg().set("query-cache-ttl")="0";
     ::arg().set("negquery-cache-ttl")="0";
-    QC.cleanup();
+    QC.purge();
     QC.setMaxEntries(0);
 
     UeberBackend ub;
@@ -530,11 +535,11 @@ BOOST_AUTO_TEST_CASE(test_simple) {
       BOOST_REQUIRE_EQUAL(records.size(), 1U);
       checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 32, true);
       // and that we don't get the same result for a different client
-      remote = ComboAddress("192.0.2.2");
+      remote = ComboAddress("198.51.100.1");
       pkt.setRemote(&remote);
       records = getRecords(ub, DNSName("geo.powerdns.com."), QType::ANY, 1, &pkt);
       BOOST_REQUIRE_EQUAL(records.size(), 1U);
-      checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 0, true);
+      checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 24, true);
     }
 
     };
@@ -677,11 +682,11 @@ BOOST_AUTO_TEST_CASE(test_multi_backends_separate_zones) {
       BOOST_REQUIRE_EQUAL(records.size(), 1U);
       checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 32, true);
       // and that we don't get the same result for a different client
-      remote = ComboAddress("192.0.2.2");
+      remote = ComboAddress("198.51.100.1");
       pkt.setRemote(&remote);
       records = getRecords(ub, DNSName("geo.powerdns.com."), QType::ANY, 1, &pkt);
       BOOST_REQUIRE_EQUAL(records.size(), 1U);
-      checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 0, true);
+      checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 24, true);
     }
 
     };
@@ -803,11 +808,11 @@ BOOST_AUTO_TEST_CASE(test_multi_backends_overlay) {
       BOOST_REQUIRE_EQUAL(records.size(), 1U);
       checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 32, true);
       // and that we don't get the same result for a different client
-      remote = ComboAddress("192.0.2.2");
+      remote = ComboAddress("198.51.100.1");
       pkt.setRemote(&remote);
       records = getRecords(ub, DNSName("geo.powerdns.com."), QType::ANY, 1, &pkt);
       BOOST_REQUIRE_EQUAL(records.size(), 1U);
-      checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 0, true);
+      checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 24, true);
     }
 
     };
@@ -926,11 +931,11 @@ BOOST_AUTO_TEST_CASE(test_multi_backends_overlay_name) {
       BOOST_REQUIRE_EQUAL(records.size(), 1U);
       checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 32, true);
       // and that we don't get the same result for a different client
-      remote = ComboAddress("192.0.2.2");
+      remote = ComboAddress("198.51.100.1");
       pkt.setRemote(&remote);
       records = getRecords(ub, DNSName("geo.powerdns.com."), QType::ANY, 1, &pkt);
       BOOST_REQUIRE_EQUAL(records.size(), 1U);
-      checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 0, true);
+      checkRecordExists(records, DNSName("geo.powerdns.com."), QType::A, 1, 24, true);
     }
 
     };
@@ -1059,8 +1064,9 @@ BOOST_AUTO_TEST_CASE(test_multi_backends_best_soa) {
       BOOST_REQUIRE(ub.getAuth(DNSName("2.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."), QType::PTR, &sd));
       BOOST_CHECK_EQUAL(sd.qname.toString(), "d.0.1.0.0.2.ip6.arpa.");
       BOOST_CHECK_EQUAL(sd.domain_id, 1);
-      // check that only one auth lookup occurred to this backend
-      BOOST_CHECK_EQUAL(sbba->d_authLookupCount, 1U);
+
+      // check that at most one auth lookup occurred to this backend (O with caching enabled)
+      BOOST_CHECK_LE(sbba->d_authLookupCount, 1U);
     }
 
     };

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -355,6 +355,7 @@ static void testWithoutThenWithAuthCache(std::function<void(UeberBackend& ub)> f
     ::arg().set("query-cache-ttl")="0";
     ::arg().set("negquery-cache-ttl")="0";
     QC.cleanup();
+    QC.setMaxEntries(0);
     /* keep zone cache disabled */
     ::arg().set("zone-cache-refresh-interval")="0";
     g_zoneCache.clear();
@@ -368,6 +369,7 @@ static void testWithoutThenWithAuthCache(std::function<void(UeberBackend& ub)> f
     ::arg().set("query-cache-ttl")="20";
     ::arg().set("negquery-cache-ttl")="60";
     QC.cleanup();
+    QC.setMaxEntries(100000);
     /* keep zone cache disabled */
     ::arg().set("zone-cache-refresh-interval")="0";
     g_zoneCache.clear();
@@ -392,6 +394,7 @@ static void testWithoutThenWithZoneCache(std::function<void(UeberBackend& ub)> f
     ::arg().set("query-cache-ttl")="0";
     ::arg().set("negquery-cache-ttl")="0";
     QC.cleanup();
+    QC.setMaxEntries(0);
 
     UeberBackend ub;
     func(ub);
@@ -405,6 +408,7 @@ static void testWithoutThenWithZoneCache(std::function<void(UeberBackend& ub)> f
     ::arg().set("query-cache-ttl")="0";
     ::arg().set("negquery-cache-ttl")="0";
     QC.cleanup();
+    QC.setMaxEntries(0);
 
     UeberBackend ub;
     ub.updateZoneCache();


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Due to an oversight the QueryCache wasn't actually enabled for the UeberBackend unit tests cases where it should.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] added or modified unit test(s)
