### PR TITLE
dnsdist: Add some leeway for the carbon data to reach the test receiver

### DIFF
--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -78,12 +78,13 @@ class TestCarbon(DNSDistTest):
         # wait for the carbon data to be sent
         time.sleep(self._carbonInterval + 1)
 
+        # check if the servers have received our data
+        # we will block for a short while if the data is not already there,
+        # and an exception will be raised after the timeout
         # first server
-        self.assertFalse(self._carbonQueue1.empty())
-        data1 = self._carbonQueue1.get(False)
+        data1 = self._carbonQueue1.get(block=True, timeout=2.0)
         # second server
-        self.assertFalse(self._carbonQueue2.empty())
-        data2 = self._carbonQueue2.get(False)
+        data2 = self._carbonQueue2.get(block=True, timeout=2.0)
         after = time.time()
 
         self.assertTrue(data1)
@@ -120,12 +121,13 @@ class TestCarbon(DNSDistTest):
         # wait for the carbon data to be sent
         time.sleep(self._carbonInterval + 1)
 
+        # check if the servers have received our data
+        # we will block for a short while if the data is not already there,
+        # and an exception will be raised after the timeout
         # first server
-        self.assertFalse(self._carbonQueue1.empty())
-        data1 = self._carbonQueue1.get(False)
+        data1 = self._carbonQueue1.get(block=True, timeout=2.0)
         # second server
-        self.assertFalse(self._carbonQueue2.empty())
-        data2 = self._carbonQueue2.get(False)
+        data2 = self._carbonQueue2.get(block=True, timeout=2.0)
         after = time.time()
 
         # check the first carbon server got both servers and


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It seems to fail quite frequently these days, and that gives us two whole more seconds before timing out, which hopefully should be enough in most cases.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
