### PR TITLE
auth bindbackend: NSEC(3) setting consistency, reload improvements

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -54,6 +54,7 @@
 #include "pdns/dynlistener.hh"
 #include "pdns/lock.hh"
 #include "pdns/auth-zonecache.hh"
+#include "pdns/auth-caches.hh"
 
 /* 
    All instances of this backend share one s_state, which is indexed by zone name and zone id.
@@ -576,6 +577,8 @@ string Bind2Backend::DLReloadNowHandler(const vector<string>& parts, Utility::pi
         ret << *i << ": [missing]\n";
       else
         ret << *i << ": " << (bbd.d_wasRejectedLastReload ? "[rejected]" : "") << "\t" << bbd.d_status << "\n";
+      purgeAuthCaches(zone.toString() + "$");
+      DNSSECKeeper::clearMetaCache(zone);
     }
     else
       ret << *i << " no such domain\n";

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -498,7 +498,7 @@ void Bind2Backend::parseZoneFile(BB2DomainInfo* bbd)
     nsec3zone = dk.getNSEC3PARAM(bbd->d_name, &ns3pr);
   }
   else
-    nsec3zone = getNSEC3PARAM(bbd->d_name, &ns3pr);
+    nsec3zone = getNSEC3PARAMuncached(bbd->d_name, &ns3pr);
 
   auto records = std::make_shared<recordstorage_t>();
   ZoneParserTNG zpt(bbd->d_filename, bbd->d_name, s_binddirectory, d_upgradeContent);
@@ -518,6 +518,8 @@ void Bind2Backend::parseZoneFile(BB2DomainInfo* bbd)
   bbd->d_checknow = false;
   bbd->d_status = "parsed into memory at " + nowTime();
   bbd->d_records = LookButDontTouch<recordstorage_t>(records);
+  bbd->d_nsec3zone = nsec3zone;
+  bbd->d_nsec3param = ns3pr;
 }
 
 /** THIS IS AN INTERNAL FUNCTION! It does moadnsparser prio impedance matching
@@ -1102,18 +1104,8 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(uint32_t id, const DNSName& qn
   if (!safeGetBBDomainInfo(id, &bbd))
     return false;
 
-  NSEC3PARAMRecordContent ns3pr;
-
-  bool nsec3zone;
-  if (d_hybrid) {
-    DNSSECKeeper dk;
-    nsec3zone = dk.getNSEC3PARAM(bbd.d_name, &ns3pr);
-  }
-  else
-    nsec3zone = getNSEC3PARAM(bbd.d_name, &ns3pr);
-
   shared_ptr<const recordstorage_t> records = bbd.d_records.get();
-  if (!nsec3zone) {
+  if (!bbd.d_nsec3zone) {
     return findBeforeAndAfterUnhashed(records, qname, unhashed, before, after);
   }
   else {

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -167,6 +167,8 @@ public:
   mutable bool d_checknow; //!< if this domain has been flagged for a check
   bool d_loaded; //!< if a domain is loaded
   bool d_wasRejectedLastReload{false}; //!< if the domain was rejected during Bind2Backend::queueReloadAndStore
+  bool d_nsec3zone{false};
+  NSEC3PARAMRecordContent d_nsec3param;
 
 private:
   time_t getCtime();
@@ -253,6 +255,7 @@ private:
   shared_ptr<SSQLite3> d_dnssecdb;
   bool getNSEC3PARAM(const DNSName& name, NSEC3PARAMRecordContent* ns3p);
   void setLastCheck(uint32_t domain_id, time_t lastcheck);
+  bool getNSEC3PARAMuncached(const DNSName& name, NSEC3PARAMRecordContent* ns3p);
   class handle
   {
   public:

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -200,6 +200,19 @@ bool Bind2Backend::doesDNSSEC()
 
 bool Bind2Backend::getNSEC3PARAM(const DNSName& name, NSEC3PARAMRecordContent* ns3p)
 {
+  BB2DomainInfo bbd;
+  if (!safeGetBBDomainInfo(name, &bbd))
+    return false;
+
+  if (ns3p) {
+    *ns3p = bbd.d_nsec3param;
+  }
+
+  return bbd.d_nsec3zone;
+}
+
+bool Bind2Backend::getNSEC3PARAMuncached(const DNSName& name, NSEC3PARAMRecordContent* ns3p)
+{
   if (!d_dnssecdb || d_hybrid)
     return false;
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2994,9 +2994,9 @@ try
       cerr<<"NSEC3 (opt-out) set, ";
 
     if(dk.isSecuredZone(zone))
-      cerr<<"please rectify your zone if your backend needs it"<<endl;
+      cerr<<"Done, please rectify your zone if your backend needs it (or reload it if you are using the bindbackend)"<<endl;
     else
-      cerr<<"please secure and rectify your zone."<<endl;
+      cerr<<"Done, please secure and rectify your zone (or reload it if you are using the bindbackend)"<<endl;
 
     return 0;
   }
@@ -3099,6 +3099,8 @@ try
       cerr << "Cannot unset NSEC3 param for " << cmds.at(1) << endl;
       return 1;
     }
+    cerr<<"Done, please rectify your zone if your backend needs it (or reload it if you are using the bindbackend)"<<endl;
+
     return 0;
   }
   else if (cmds.at(0) == "export-zone-key") {


### PR DESCRIPTION
### Short description

* keep, inside the bindbackend, the nsec(3) settings consistent with the 'rectification' applied on zone load. This avoids crashes when nsec3 is enabled or disabled without reloading the zone in the bindbackend.
* purge auth caches on bindbackend zone reload


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master