### PR TITLE
rec: assorted improvements

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5599,7 +5599,7 @@ catch(...) {
 //static std::string s_timestampFormat = "%m-%dT%H:%M:%S";
 static std::string s_timestampFormat = "%s";
 
-const char* toTimestampStringMilli(const struct timeval& tv, char *buf, size_t sz)
+static const char* toTimestampStringMilli(const struct timeval& tv, char *buf, size_t sz)
 {
   struct tm tm;
   size_t len = strftime(buf, sz, s_timestampFormat.c_str(), localtime_r(&tv.tv_sec, &tm));

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4883,9 +4883,7 @@ static int serviceMain(int argc, char*argv[])
   SyncRes::s_tcp_fast_open = ::arg().asNum("tcp-fast-open");
   SyncRes::s_tcp_fast_open_connect = ::arg().mustDo("tcp-fast-open-connect");
 
-#ifdef HAVE_DNS_OVER_TLS
   SyncRes::s_dot_to_port_853 = ::arg().mustDo("dot-to-port-853");
-#endif
 
   if (SyncRes::s_tcp_fast_open_connect) {
     checkFastOpenSysctl(true);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5074,6 +5074,11 @@ static int serviceMain(int argc, char*argv[])
     SuffixMatchNode dotauthNames;
     vector<string> parts;
     stringtok(parts, ::arg()["dot-to-auth-names"], " ,");
+#ifndef HAVE_DNS_OVER_TLS
+    if (parts.size()) {
+      g_log << Logger::Error << "dot-to-auth-names setting contains names, but Recursor was built without DNS over TLS support. Setting will be ignored."<<endl;
+    }
+#endif
     for (const auto &p : parts) {
       dotauthNames.add(DNSName(p));
     }

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -389,7 +389,7 @@ ratio.
 .. _settings-dot-to-auth-names:
 
 ``dot-to-auth-names``
--------------------
+---------------------
 .. versionadded:: 4.6.0
 
 - Comma separated list of domain-names or suffixes
@@ -1809,7 +1809,7 @@ These statistics can still be retrieved individually by specifically asking for 
 .. versionadded:: 4.5.0
 
 -  String
--  Default: "cache-bytes, packetcache-bytes, special-memory-usage, ecs-v4-response-bits-*, ecs-v6-response-bits-*, cumul-answers-*, cumul-auth4answers-*, cumul-auth6answers-*"
+-  Default: "cache-bytes, packetcache-bytes, special-memory-usage, ecs-v4-response-bits-\*, ecs-v6-response-bits-\*, cumul-answers-\*, cumul-auth4answers-\*, cumul-auth6answers-\*"
 
 A list of comma-separated statistic names, that are prevented from being exported via carbon for performance reasons.
 
@@ -1828,7 +1828,7 @@ A list of comma-separated statistic names, that are prevented from being exporte
 .. versionadded:: 4.5.0
 
 -  String
--  Default: "cache-bytes, packetcache-bytes, special-memory-usage, ecs-v4-response-bits-*, ecs-v6-response-bits-*, cumul-answers-*, cumul-auth4answers-*, cumul-auth6answers-*"
+-  Default: "cache-bytes, packetcache-bytes, special-memory-usage, ecs-v4-response-bits-\*, ecs-v6-response-bits-\*, cumul-answers-\*, cumul-auth4answers-\*, cumul-auth6answers-\*"
 
 A list of comma-separated statistic names, that are disabled when retrieving the complete list of statistics via `rec_control get-all`, for performance reasons.
 These statistics can still be retrieved individually.


### PR DESCRIPTION
### Short description
a05df8bd4
   remove DNS_OVER_TLS guard around applying the dot-to-port-853 setting

   before this commit: pointing a forward at port 853, without DoT support,
   causes Recursor to attempt to do UDP over port 853 to the upstream. This
   rarely works.

   after this commit: much swifter failure with an error log message saying
   `45.55.10.200:853 requested but not available`

b42f9eb31
   emit error when dot-to-auth-names is set without DoT support

3f2abbbe0
   toTimestampStringMilli is only called from inside this file, make it static

e1cab5663153c17eca8f40574e6029be7bfb7dc9
    rec docs: fix warnings


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master