### PR TITLE
Rec: eventtrace

### DIFF
--- a/contrib/ProtobufLogger.py
+++ b/contrib/ProtobufLogger.py
@@ -98,7 +98,33 @@ class PDNSPBConnHandler(object):
         elif polType == dnsmessage_pb2.PBDNSMessage.NSIP:
             return 'NS IP'
 
+    @staticmethod
+    def getEventAsString(event):
+        descr =  dnsmessage_pb2.PBDNSMessage.DESCRIPTOR
+        return descr.EnumValueName('EventType', event);
+
     def printResponse(self, message):
+        if message.trace:
+            print("- Event Trace:")
+            for event in message.trace:
+                ev = self.getEventAsString(event.event) + '(' + str(event.ts)
+                valstr = ''
+                if event.HasField('boolVal'):
+                      valstr = str(event.boolVal)
+                elif event.HasField('intVal'):
+                      valstr = str(event.intVal)
+                elif event.HasField('stringVal'):
+                      valstr = event.stringVal
+                elif event.HasField('bytesVal'):
+                      valstr = binascii.hexlify(event.bytesVal)
+                if len(valstr) > 0:
+                    valstr = ',' + valstr
+                if not event.start:
+                    startstr = ',done'
+                else:
+                    startstr = ''
+                print("\t- %s%s%s)" % (ev, valstr, startstr))
+
         if message.HasField('response'):
             response = message.response
 

--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -126,6 +126,34 @@ message PBDNSMessage {
     required MetaValue value = 2;
   }
   repeated Meta meta = 22;                      // Arbitrary meta-data - to be used in future rather than adding new fields all the time
+
+  enum EventType {
+    RecRecv = 1;
+    DistPipe = 2;
+    PCacheCheck = 3;
+    SyncRes = 4;
+    AnswerSent = 5;
+    LuaGetTag = 100;
+    LuaGetTagFFI = 101;
+    LuaIPFilter = 102;
+    LuaPreRPZ = 103;
+    LuaPreResolve = 104;
+    LuaPreOutQuery = 105;
+    LuaPostResolve = 106;
+    LuaNoData = 107;
+    LuaNXDomain = 108;
+  }
+  
+  message Event {
+    required uint64 ts = 1;
+    required EventType event = 2;
+    required bool start = 3;
+    optional bool boolVal = 4;
+    optional int64 intVal = 5;
+    optional string stringVal = 6;
+    optional bytes bytesVal = 7;
+  }
+  repeated Event trace = 23;
 }
 
 message PBDNSMessageList {

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -502,32 +502,47 @@ void RecursorLua4::maintenance() const
   }
 }
 
-bool RecursorLua4::prerpz(DNSQuestion& dq, int& ret) const
+bool RecursorLua4::prerpz(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
-  return genhook(d_prerpz, dq, ret);
+  et.add(RecEventTrace::LuaPreRPZ);
+  bool ok = genhook(d_prerpz, dq, ret);
+  et.add(RecEventTrace::LuaPreRPZ, ok, false);
+  return ok;
 }
 
-bool RecursorLua4::preresolve(DNSQuestion& dq, int& ret) const
+bool RecursorLua4::preresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
-  return genhook(d_preresolve, dq, ret);
+  et.add(RecEventTrace::LuaPreResolve);
+  bool ok = genhook(d_preresolve, dq, ret);
+  et.add(RecEventTrace::LuaPreResolve, ok, false);
+  return ok;
 }
 
-bool RecursorLua4::nxdomain(DNSQuestion& dq, int& ret) const
+bool RecursorLua4::nxdomain(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
-  return genhook(d_nxdomain, dq, ret);
+  et.add(RecEventTrace::LuaNXDomain);
+  bool ok = genhook(d_nxdomain, dq, ret);
+  et.add(RecEventTrace::LuaNXDomain, ok, false);
+  return ok;
 }
 
-bool RecursorLua4::nodata(DNSQuestion& dq, int& ret) const
+bool RecursorLua4::nodata(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
-  return genhook(d_nodata, dq, ret);
+  et.add(RecEventTrace::LuaNoData);
+  bool ok = genhook(d_nodata, dq, ret);
+  et.add(RecEventTrace::LuaNoData, ok, false);
+  return ok;
 }
 
-bool RecursorLua4::postresolve(DNSQuestion& dq, int& ret) const
+bool RecursorLua4::postresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
-  return genhook(d_postresolve, dq, ret);
+  et.add(RecEventTrace::LuaPostResolve);
+  bool ok = genhook(d_postresolve, dq, ret);
+  et.add(RecEventTrace::LuaPostResolve, ok, false);
+  return ok;
 }
 
-bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret) const
+bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, RecEventTrace& et) const
 {
   bool variableAnswer = false;
   bool wantsRPZ = false;
@@ -535,8 +550,10 @@ bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& reque
   bool addPaddingToResponse = false;
   RecursorLua4::DNSQuestion dq(ns, requestor, query, qtype.getCode(), isTcp, variableAnswer, wantsRPZ, logQuery, addPaddingToResponse);
   dq.currentRecords = &res;
-
-  return genhook(d_preoutquery, dq, ret);
+  et.add(RecEventTrace::LuaPreOutQuery);
+  bool ok = genhook(d_preoutquery, dq, ret);
+  et.add(RecEventTrace::LuaPreOutQuery, ok, false);
+  return ok;
 }
 
 bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader& dh) const

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -35,6 +35,7 @@
 #include "lua-base4.hh"
 #include "proxy-protocol.hh"
 #include "noinitvector.hh"
+#include "rec-eventtrace.hh"
 
 #include <unordered_map>
 
@@ -185,13 +186,13 @@ public:
   unsigned int gettag_ffi(FFIParams&) const;
 
   void maintenance() const;
-  bool prerpz(DNSQuestion& dq, int& ret) const;
-  bool preresolve(DNSQuestion& dq, int& ret) const;
-  bool nxdomain(DNSQuestion& dq, int& ret) const;
-  bool nodata(DNSQuestion& dq, int& ret) const;
-  bool postresolve(DNSQuestion& dq, int& ret) const;
+  bool prerpz(DNSQuestion& dq, int& ret, RecEventTrace&) const;
+  bool preresolve(DNSQuestion& dq, int& ret, RecEventTrace&) const;
+  bool nxdomain(DNSQuestion& dq, int& ret, RecEventTrace&) const;
+  bool nodata(DNSQuestion& dq, int& ret, RecEventTrace&) const;
+  bool postresolve(DNSQuestion& dq, int& ret, RecEventTrace&) const;
 
-  bool preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret) const;
+  bool preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, RecEventTrace& et) const;
   bool ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader&) const;
 
   bool policyHitEventFilter(const ComboAddress& remote, const DNSName& qname, const QType& qtype, bool tcp, DNSFilterEngine::Policy& policy, std::unordered_set<std::string>& tags, std::unordered_map<std::string, bool>& discardedPolicies) const;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -114,6 +114,7 @@
 #include "rec-protozero.hh"
 
 #include "xpf.hh"
+#include "rec-eventtrace.hh"
 
 typedef map<ComboAddress, uint32_t, ComboAddress::addressOnlyLessThan> tcpClientCounts_t;
 
@@ -336,6 +337,7 @@ struct DNSComboWriter {
      d_local holds our own. */
   ComboAddress d_local;
   ComboAddress d_destination;
+  RecEventTrace d_eventTrace;
   boost::uuids::uuid d_uuid;
   string d_requestorId;
   string d_deviceId;
@@ -1682,6 +1684,7 @@ static void startDoResolve(void *p)
     uint32_t minTTL = dc->d_ttlCap;
 
     SyncRes sr(dc->d_now);
+    sr.d_eventTrace = std::move(dc->d_eventTrace);
     sr.setId(MT->getTid());
 
     bool DNSSECOK=false;
@@ -1780,7 +1783,7 @@ static void startDoResolve(void *p)
     }
 
     if (t_pdl) {
-      t_pdl->prerpz(dq, res);
+      t_pdl->prerpz(dq, res, sr.d_eventTrace);
     }
 
     // Check if the client has a policy attached to it
@@ -1827,7 +1830,7 @@ static void startDoResolve(void *p)
     }
 
     // if there is a RecursorLua active, and it 'took' the query in preResolve, we don't launch beginResolve
-    if (!t_pdl || !t_pdl->preresolve(dq, res)) {
+    if (!t_pdl || !t_pdl->preresolve(dq, res, sr.d_eventTrace)) {
 
       if (!g_dns64PrefixReverse.empty() && dq.qtype == QType::PTR && dq.qname.isPartOf(g_dns64PrefixReverse)) {
         res = getFakePTRRecords(dq.qname, ret);
@@ -1916,7 +1919,7 @@ static void startDoResolve(void *p)
       if (t_pdl || (g_dns64Prefix && dq.qtype == QType::AAAA && !vStateIsBogus(dq.validationState))) {
         if (res == RCode::NoError) {
           if (answerIsNOData(dc->d_mdp.d_qtype, res, ret)) {
-            if (t_pdl && t_pdl->nodata(dq, res)) {
+            if (t_pdl && t_pdl->nodata(dq, res, sr.d_eventTrace)) {
               shouldNotValidate = true;
             }
             else if (g_dns64Prefix && dq.qtype == QType::AAAA && !vStateIsBogus(dq.validationState)) {
@@ -1925,11 +1928,11 @@ static void startDoResolve(void *p)
             }
           }
 	}
-	else if (res == RCode::NXDomain && t_pdl && t_pdl->nxdomain(dq, res)) {
+	else if (res == RCode::NXDomain && t_pdl && t_pdl->nxdomain(dq, res, sr.d_eventTrace)) {
           shouldNotValidate = true;
         }
 
-	if (t_pdl && t_pdl->postresolve(dq, res)) {
+	if (t_pdl && t_pdl->postresolve(dq, res, sr.d_eventTrace)) {
           shouldNotValidate = true;
           auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw);
           // haveAnswer case redundant
@@ -2305,6 +2308,11 @@ static void startDoResolve(void *p)
     else {
       bool hadError = sendResponseOverTCP(dc, packet);
       finishTCPReply(dc, hadError, true);
+    }
+    // Protobuf sending should be here...
+    sr.d_eventTrace.add(RecEventTrace::AnswerSent);
+    if (sr.d_eventTrace.enabled()) {
+      g_log << Logger::Info << sr.d_eventTrace.toString() << endl;
     }
 
     // Originally this code used a mix of floats, doubles, uint64_t with different units.
@@ -2708,6 +2716,8 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       bool logQuery = false;
       bool qnameParsed = false;
 
+      dc->d_eventTrace.setEnabled(true);
+      dc->d_eventTrace.add(RecEventTrace::RecRecv);
       auto luaconfsLocal = g_luaconfs.getLocal();
       if (checkProtobufExport(luaconfsLocal)) {
         needECS = true;
@@ -2736,9 +2746,12 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
               if (t_pdl->d_gettag_ffi) {
                 RecursorLua4::FFIParams params(qname, qtype, dc->d_destination, dc->d_source, dc->d_ednssubnet.source, dc->d_data, dc->d_policyTags, dc->d_records, ednsOptions, dc->d_proxyProtocolValues, requestorId, deviceId, deviceName, dc->d_routingTag, dc->d_rcode, dc->d_ttlCap, dc->d_variable, true, logQuery, dc->d_logResponse, dc->d_followCNAMERecords, dc->d_extendedErrorCode, dc->d_extendedErrorExtra, dc->d_responsePaddingDisabled, dc->d_meta);
                 dc->d_tag = t_pdl->gettag_ffi(params);
+                dc->d_eventTrace.add(RecEventTrace::LuaGetTagFFI, dc->d_tag, false);
               }
               else if (t_pdl->d_gettag) {
+                dc->d_eventTrace.add(RecEventTrace::LuaGetTag);
                 dc->d_tag = t_pdl->gettag(dc->d_source, dc->d_ednssubnet.source, dc->d_destination, qname, qtype, &dc->d_policyTags, dc->d_data, ednsOptions, true, requestorId, deviceId, deviceName, dc->d_routingTag, dc->d_proxyProtocolValues);
+                dc->d_eventTrace.add(RecEventTrace::LuaGetTag, dc->d_tag, false);
               }
             }
             catch(const std::exception& e)  {
@@ -2784,7 +2797,10 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       }
 
       if (t_pdl) {
-        if (t_pdl->ipfilter(dc->d_source, dc->d_destination, *dh)) {
+        dc->d_eventTrace.add(RecEventTrace::LuaIPFilter);
+        bool ipf = t_pdl->ipfilter(dc->d_source, dc->d_destination, *dh);
+        dc->d_eventTrace.add(RecEventTrace::LuaIPFilter, ipf, false);
+        if (ipf) {
           if (!g_quiet) {
             g_log<<Logger::Notice<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] DROPPED TCP question from "<<dc->d_source.toStringWithPort()<<(dc->d_source != dc->d_remote ? " (via "+dc->d_remote.toStringWithPort()+")" : "")<<" based on policy"<<endl;
           }
@@ -2829,7 +2845,9 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
         /* It might seem like a good idea to skip the packet cache lookup if we know that the answer is not cacheable,
            but it means that the hash would not be computed. If some script decides at a later time to mark back the answer
            as cacheable we would cache it with a wrong tag, so better safe than sorry. */
+        dc->d_eventTrace.add(RecEventTrace::PCacheCheck);
         bool cacheHit = checkForCacheHit(qnameParsed, dc->d_tag, conn->data, qname, qtype, qclass, g_now, response, dc->d_qhash, pbData, true, dc->d_source);
+        dc->d_eventTrace.add(RecEventTrace::PCacheCheck, cacheHit, false);
 
         if (cacheHit) {
           if (t_protobufServers && dc->d_logResponse && !(luaconfsLocal->protobufExportConfig.taggedOnly && pbData && !pbData->d_tagged)) {
@@ -2847,6 +2865,10 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
           Utility::gettimeofday(&now, nullptr);
           uint64_t spentUsec = uSec(now - start);
           g_stats.cumulativeAnswers(spentUsec);
+          dc->d_eventTrace.add(RecEventTrace::AnswerSent);
+          if (dc->d_eventTrace.enabled()) {
+            g_log << Logger::Info << dc->d_eventTrace.toString() << endl;
+          }
         } else {
           // No cache hit, setup for startDoResolve() in an mthread
           ++conn->d_requestsInFlight;
@@ -2942,7 +2964,7 @@ static void handleNewTCPQuestion(int fd, FDMultiplexer::funcparam_t& )
   }
 }
 
-static string* doProcessUDPQuestion(const std::string& question, const ComboAddress& fromaddr, const ComboAddress& destaddr, ComboAddress source, ComboAddress destination, struct timeval tv, int fd, std::vector<ProxyProtocolValue>& proxyProtocolValues)
+static string* doProcessUDPQuestion(const std::string& question, const ComboAddress& fromaddr, const ComboAddress& destaddr, ComboAddress source, ComboAddress destination, struct timeval tv, int fd, std::vector<ProxyProtocolValue>& proxyProtocolValues, RecEventTrace& eventTrace)
 {
   gettimeofday(&g_now, nullptr);
   if (tv.tv_sec) {
@@ -3035,9 +3057,12 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
               RecursorLua4::FFIParams params(qname, qtype, destination, source, ednssubnet.source, data, policyTags, records, ednsOptions, proxyProtocolValues, requestorId, deviceId, deviceName, routingTag, rcode, ttlCap, variable, false, logQuery, logResponse, followCNAMEs, extendedErrorCode, extendedErrorExtra, responsePaddingDisabled, meta);
 
               ctag = t_pdl->gettag_ffi(params);
+              eventTrace.add(RecEventTrace::LuaGetTagFFI, ctag, false);
             }
             else if (t_pdl->d_gettag) {
+              eventTrace.add(RecEventTrace::LuaGetTag);
               ctag = t_pdl->gettag(source, ednssubnet.source, destination, qname, qtype, &policyTags, data, ednsOptions, false, requestorId, deviceId, deviceName, routingTag, proxyProtocolValues);
+              eventTrace.add(RecEventTrace::LuaGetTag, ctag, false);
             }
           }
           catch (const std::exception& e)  {
@@ -3068,7 +3093,9 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
     /* It might seem like a good idea to skip the packet cache lookup if we know that the answer is not cacheable,
        but it means that the hash would not be computed. If some script decides at a later time to mark back the answer
        as cacheable we would cache it with a wrong tag, so better safe than sorry. */
+    eventTrace.add(RecEventTrace::PCacheCheck);
     bool cacheHit = checkForCacheHit(qnameParsed, ctag, question, qname, qtype, qclass, g_now, response, qhash, pbData, false, source);
+    eventTrace.add(RecEventTrace::PCacheCheck, cacheHit, false);
     if (cacheHit) {
       if (t_protobufServers && logResponse && !(luaconfsLocal->protobufExportConfig.taggedOnly && pbData && !pbData->d_tagged)) {
         protobufLogResponse(dh, luaconfsLocal, pbData, tv, false, source, destination, ednssubnet, uniqueId, requestorId, deviceId, deviceName, meta);
@@ -3087,6 +3114,10 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
         addCMsgSrcAddr(&msgh, &cbuf, &destaddr, 0);
       }
       int sendErr = sendOnNBSocket(fd, &msgh);
+      eventTrace.add(RecEventTrace::AnswerSent);
+      if (eventTrace.enabled()) {
+        g_log << Logger::Info << eventTrace.toString() << endl;
+      }
       if (sendErr && g_logCommonErrors) {
         g_log << Logger::Warning << "Sending UDP reply to client " << source.toStringWithPort()
               << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << " failed with: "
@@ -3107,7 +3138,10 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
   }
 
   if (t_pdl) {
-    if (t_pdl->ipfilter(source, destination, *dh)) {
+    eventTrace.add(RecEventTrace::LuaIPFilter);
+    bool ipf = t_pdl->ipfilter(source, destination, *dh);
+    eventTrace.add(RecEventTrace::LuaIPFilter, ipf, false);
+    if (ipf) {
       if (!g_quiet) {
 	g_log<<Logger::Notice<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] DROPPED question from "<<source.toStringWithPort()<<(source != fromaddr ? " (via "+fromaddr.toStringWithPort()+")" : "")<<" based on policy"<<endl;
       }
@@ -3155,7 +3189,9 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
   dc->d_responsePaddingDisabled = responsePaddingDisabled;
   dc->d_meta = std::move(meta);
 
+  dc->d_eventTrace = std::move(eventTrace);
   MT->makeThread(startDoResolve, (void*) dc.release()); // deletes dc
+
   return 0;
 }
 
@@ -3173,6 +3209,7 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
   cmsgbuf_aligned cbuf;
   bool firstQuery = true;
   std::vector<ProxyProtocolValue> proxyProtocolValues;
+  RecEventTrace eventTrace;
 
   for(size_t queriesCounter = 0; queriesCounter < s_maxUDPQueriesPerRound; queriesCounter++) {
     bool proxyProto = false;
@@ -3182,6 +3219,9 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
     fillMSGHdr(&msgh, &iov, &cbuf, sizeof(cbuf), &data[0], data.size(), &fromaddr);
 
     if((len=recvmsg(fd, &msgh, 0)) >= 0) {
+      eventTrace.clear();
+      eventTrace.setEnabled(true);
+      eventTrace.add(RecEventTrace::RecRecv);
 
       firstQuery = false;
 
@@ -3307,12 +3347,13 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
 
           if(g_weDistributeQueries) {
             std::string localdata = data;
-            distributeAsyncFunction(data, [localdata, fromaddr, dest, source, destination, tv, fd, proxyProtocolValues]() mutable
-              { return doProcessUDPQuestion(localdata, fromaddr, dest, source, destination, tv, fd, proxyProtocolValues); });
+            distributeAsyncFunction(data, [localdata, fromaddr, dest, source, destination, tv, fd, proxyProtocolValues, eventTrace]() mutable {
+              return doProcessUDPQuestion(localdata, fromaddr, dest, source, destination, tv, fd, proxyProtocolValues, eventTrace);
+            });
           }
           else {
             ++s_threadInfos[t_id].numberOfDistributedQueries;
-            doProcessUDPQuestion(data, fromaddr, dest, source, destination, tv, fd, proxyProtocolValues);
+            doProcessUDPQuestion(data, fromaddr, dest, source, destination, tv, fd, proxyProtocolValues, eventTrace);
           }
         }
       }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1068,7 +1068,8 @@ static void protobufLogResponse(const struct dnsheader* dh, LocalStateHolder<Lua
                                 bool tcp, const ComboAddress& source, const ComboAddress& destination,
                                 const EDNSSubnetOpts& ednssubnet,
                                 const boost::uuids::uuid& uniqueId, const string& requestorId, const string& deviceId,
-                                const string& deviceName, const std::map<std::string, RecursorLua4::MetaValue>& meta)
+                                const string& deviceName, const std::map<std::string, RecursorLua4::MetaValue>& meta,
+                                const RecEventTrace& eventTrace)
 {
   pdns::ProtoZero::RecMessage pbMessage(pbData ? pbData->d_message : "", pbData ? pbData->d_response : "", 64, 10); // The extra bytes we are going to add
   // Normally we take the immutable string from the cache and append a few values, but if it's not there (can this happen?)
@@ -1110,6 +1111,9 @@ static void protobufLogResponse(const struct dnsheader* dh, LocalStateHolder<Lua
     pbMessage.setNewlyObservedDomain(false);
   }
 #endif
+  if (eventTrace.enabled()) {
+    pbMessage.addEvents(eventTrace);
+  }
   protobufLogResponse(pbMessage);
 }
 
@@ -2269,6 +2273,9 @@ static void startDoResolve(void *p)
         }
       }
 #endif /* NOD_ENABLED */
+      if (sr.d_eventTrace.enabled()) {
+        pbMessage.addEvents(sr.d_eventTrace);
+      }
       if (dc->d_logResponse) {
         protobufLogResponse(pbMessage);
       }
@@ -2852,7 +2859,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
         if (cacheHit) {
           if (t_protobufServers && dc->d_logResponse && !(luaconfsLocal->protobufExportConfig.taggedOnly && pbData && !pbData->d_tagged)) {
             struct timeval tv{0, 0};
-            protobufLogResponse(dh, luaconfsLocal, pbData, tv, true, dc->d_source, dc->d_destination, dc->d_ednssubnet, dc->d_uuid, dc->d_requestorId, dc->d_deviceId, dc->d_deviceName, dc->d_meta);
+            protobufLogResponse(dh, luaconfsLocal, pbData, tv, true, dc->d_source, dc->d_destination, dc->d_ednssubnet, dc->d_uuid, dc->d_requestorId, dc->d_deviceId, dc->d_deviceName, dc->d_meta, dc->d_eventTrace);
           }
 
           if (!g_quiet) {
@@ -2866,6 +2873,9 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
           uint64_t spentUsec = uSec(now - start);
           g_stats.cumulativeAnswers(spentUsec);
           dc->d_eventTrace.add(RecEventTrace::AnswerSent);
+
+          // Protobuf sending shoudl be here...
+
           if (dc->d_eventTrace.enabled()) {
             g_log << Logger::Info << dc->d_eventTrace.toString() << endl;
           }
@@ -3098,7 +3108,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
     eventTrace.add(RecEventTrace::PCacheCheck, cacheHit, false);
     if (cacheHit) {
       if (t_protobufServers && logResponse && !(luaconfsLocal->protobufExportConfig.taggedOnly && pbData && !pbData->d_tagged)) {
-        protobufLogResponse(dh, luaconfsLocal, pbData, tv, false, source, destination, ednssubnet, uniqueId, requestorId, deviceId, deviceName, meta);
+        protobufLogResponse(dh, luaconfsLocal, pbData, tv, false, source, destination, ednssubnet, uniqueId, requestorId, deviceId, deviceName, meta, eventTrace);
       }
 
       if (!g_quiet) {
@@ -3115,6 +3125,9 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
       }
       int sendErr = sendOnNBSocket(fd, &msgh);
       eventTrace.add(RecEventTrace::AnswerSent);
+
+      // Protobuf sending should be here...
+ 
       if (eventTrace.enabled()) {
         g_log << Logger::Info << eventTrace.toString() << endl;
       }

--- a/pdns/protozero.hh
+++ b/pdns/protozero.hh
@@ -35,8 +35,9 @@ namespace pdns {
 
       enum class MetaValueField : protozero::pbf_tag_type { stringVal = 1, intVal = 2 };
       enum class MetaField : protozero::pbf_tag_type { key = 1, value = 2 };
+      enum class Event : protozero::pbf_tag_type { ts = 1, event = 2, start = 3, boolVal = 4, intVal = 5, stringVal = 6, bytesVal = 7 };
       enum class MessageType : int32_t { DNSQueryType = 1, DNSResponseType = 2, DNSOutgoingQueryType = 3, DNSIncomingResponseType = 4 };
-      enum class Field : protozero::pbf_tag_type { type = 1, messageId = 2, serverIdentity = 3, socketFamily = 4, socketProtocol = 5, from = 6, to = 7, inBytes = 8, timeSec = 9, timeUsec = 10, id = 11, question = 12, response = 13, originalRequestorSubnet = 14, requestorId = 15, initialRequestId = 16, deviceId = 17, newlyObservedDomain = 18, deviceName = 19, fromPort = 20, toPort = 21, meta = 22 };
+      enum class Field : protozero::pbf_tag_type { type = 1, messageId = 2, serverIdentity = 3, socketFamily = 4, socketProtocol = 5, from = 6, to = 7, inBytes = 8, timeSec = 9, timeUsec = 10, id = 11, question = 12, response = 13, originalRequestorSubnet = 14, requestorId = 15, initialRequestId = 16, deviceId = 17, newlyObservedDomain = 18, deviceName = 19, fromPort = 20, toPort = 21, meta = 22, trace = 23 };
       enum class QuestionField : protozero::pbf_tag_type { qName = 1, qType = 2, qClass = 3 };
       enum class ResponseField : protozero::pbf_tag_type { rcode = 1, rrs = 2, appliedPolicy = 3, tags = 4, queryTimeSec = 5, queryTimeUsec = 6, appliedPolicyType = 7, appliedPolicyTrigger = 8, appliedPolicyHit = 9, appliedPolicyKind = 10, validationState = 11 };
       enum class RRField : protozero::pbf_tag_type { name = 1, type = 2, class_ = 3, ttl = 4, rdata = 5, udr = 6 };

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -158,6 +158,7 @@ pdns_recursor_SOURCES = \
 	query-local-address.hh query-local-address.cc \
 	rcpgenerator.cc rcpgenerator.hh \
 	rec-carbon.cc \
+	rec-eventtrace.cc rec-eventtrace.hh \
 	rec-lua-conf.hh rec-lua-conf.cc \
 	rec-protozero.cc rec-protozero.hh \
 	rec-snmp.hh rec-snmp.cc \
@@ -270,6 +271,7 @@ testrunner_SOURCES = \
 	qtype.cc qtype.hh \
 	query-local-address.hh query-local-address.cc \
 	rcpgenerator.cc \
+	rec-eventtrace.cc rec-eventtrace.hh \
 	recpacketcache.cc recpacketcache.hh \
 	recursor_cache.cc recursor_cache.hh \
 	resolver.hh resolver.cc \

--- a/pdns/recursordist/rec-eventtrace.cc
+++ b/pdns/recursordist/rec-eventtrace.cc
@@ -1,0 +1,44 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "rec-eventtrace.hh"
+
+#define NameEntry(M) \
+  {                  \
+    M, #M            \
+  }
+
+const std::map<RecEventTrace::EventType, std::string> RecEventTrace::s_eventNames = {
+  NameEntry(Processing),
+  NameEntry(RecRecv),
+  NameEntry(DistPipe),
+  NameEntry(PCacheCheck),
+  NameEntry(SyncRes),
+  NameEntry(AnswerSent),
+  NameEntry(LuaGetTag),
+  NameEntry(LuaGetTagFFI),
+  NameEntry(LuaIPFilter),
+  NameEntry(LuaPreRPZ),
+  NameEntry(LuaPreResolve),
+  NameEntry(LuaPreOutQuery),
+  NameEntry(LuaPostResolve),
+  NameEntry(LuaNoData),
+  NameEntry(LuaNXDomain)};

--- a/pdns/recursordist/rec-eventtrace.cc
+++ b/pdns/recursordist/rec-eventtrace.cc
@@ -26,8 +26,7 @@
     M, #M            \
   }
 
-const std::map<RecEventTrace::EventType, std::string> RecEventTrace::s_eventNames = {
-  NameEntry(Processing),
+const std::unordered_map<RecEventTrace::EventType, std::string> RecEventTrace::s_eventNames = {
   NameEntry(RecRecv),
   NameEntry(DistPipe),
   NameEntry(PCacheCheck),
@@ -41,4 +40,6 @@ const std::map<RecEventTrace::EventType, std::string> RecEventTrace::s_eventName
   NameEntry(LuaPreOutQuery),
   NameEntry(LuaPostResolve),
   NameEntry(LuaNoData),
-  NameEntry(LuaNXDomain)};
+  NameEntry(LuaNXDomain)
+};
+

--- a/pdns/recursordist/rec-eventtrace.hh
+++ b/pdns/recursordist/rec-eventtrace.hh
@@ -1,0 +1,210 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "namespaces.hh"
+#include <optional>
+#include <time.h>
+#include <variant>
+
+class RecEventTrace
+{
+public:
+  enum EventType : uint8_t
+  {
+    // Don't forget to add a new entry to the table in the .cc file!
+    Processing = 1,
+    RecRecv = 2,
+    DistPipe = 3,
+    PCacheCheck = 4,
+    SyncRes = 5,
+    AnswerSent = 6,
+    LuaGetTag = 50,
+    LuaGetTagFFI = 51,
+    LuaIPFilter = 52,
+    LuaPreRPZ = 53,
+    LuaPreResolve = 54,
+    LuaPreOutQuery = 55,
+    LuaPostResolve = 56,
+    LuaNoData = 57,
+    LuaNXDomain = 58
+  };
+
+  static const std::map<EventType, std::string> s_eventNames;
+
+  RecEventTrace()
+  {
+    reset();
+  }
+
+  RecEventTrace(const RecEventTrace& old) :
+    d_events(std::move(old.d_events)),
+    d_base(old.d_base),
+    d_status(old.d_status)
+  {
+    old.d_status = Invalid;
+  }
+  RecEventTrace(RecEventTrace&& old) :
+    d_events(std::move(old.d_events)),
+    d_base(old.d_base),
+    d_status(old.d_status)
+  {
+    old.d_status = Invalid;
+  }
+  RecEventTrace& operator=(const RecEventTrace& old) = delete;
+  RecEventTrace& operator=(RecEventTrace&& old)
+  {
+    d_events = std::move(old.d_events);
+    d_base = old.d_base;
+    d_status = old.d_status;
+    old.d_status = Invalid;
+    return *this;
+  }
+
+  typedef std::variant<std::nullopt_t, bool, int32_t, uint32_t, std::string> Value_t;
+
+  static std::string toString(const EventType v)
+  {
+    return s_eventNames.at(v);
+  }
+
+  static std::string toString(const Value_t& v)
+  {
+    if (std::holds_alternative<std::nullopt_t>(v)) {
+      return "";
+    }
+    else if (std::holds_alternative<bool>(v)) {
+      return std::to_string(std::get<bool>(v));
+    }
+    else if (std::holds_alternative<int32_t>(v)) {
+      return std::to_string(std::get<int32_t>(v));
+    }
+    else if (std::holds_alternative<uint32_t>(v)) {
+      return std::to_string(std::get<uint32_t>(v));
+    }
+    else if (std::holds_alternative<std::string>(v)) {
+      return std::get<std::string>(v);
+    }
+    return "?";
+  }
+
+  struct Entry
+  {
+    Entry(Value_t& v, EventType e, bool start, uint32_t ts) :
+      d_value(v), d_ts(ts), d_event(e), d_start(start)
+    {
+    }
+    Value_t d_value;
+    uint64_t d_ts;
+    EventType d_event;
+    bool d_start;
+
+    std::string toString() const
+    {
+      std::string v = RecEventTrace::toString(d_value);
+      if (!v.empty()) {
+        v = "," + v;
+      }
+      return RecEventTrace::toString(d_event) + "(" + std::to_string(d_ts) + v + (d_start ? ")" : ",done)");
+    }
+  };
+
+  void setEnabled(bool flag)
+  {
+    assert(d_status != Invalid);
+    d_status = flag ? Enabled : Disabled;
+  }
+
+  bool enabled() const
+  {
+    return d_status == Enabled;
+  }
+
+  void add(EventType e, Value_t v, bool start)
+  {
+    assert(d_status != Invalid);
+    if (d_status == Disabled) {
+      return;
+    }
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint64_t stamp = ts.tv_nsec + ts.tv_sec * 1000000000;
+    stamp -= d_base;
+    d_events.emplace_back(v, e, start, stamp);
+  }
+
+  void add(EventType e)
+  {
+    add(e, Value_t(std::nullopt), true);
+  }
+
+  template <class T>
+  void add(EventType e, T v, bool start)
+  {
+    add(e, Value_t(v), start);
+  }
+
+  void clear()
+  {
+    d_events.clear();
+    reset();
+  }
+  void reset()
+  {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    d_base = ts.tv_nsec + ts.tv_sec * 1000000000;
+    d_status = Disabled;
+  }
+
+  std::string toString() const
+  {
+    assert(d_status != Invalid);
+    if (d_status == Disabled) {
+      return "Disabled\n";
+    }
+    std::string ret = "eventTrace [";
+    bool first = true;
+    for (const auto& e : d_events) {
+      if (first) {
+        first = false;
+      }
+      else {
+        ret += "; ";
+      }
+      ret += e.toString();
+    }
+    ret += ']';
+    return ret;
+  }
+
+private:
+  std::vector<Entry> d_events;
+  uint64_t d_base;
+  enum Status
+  {
+    Disabled,
+    Invalid,
+    Enabled
+  };
+  mutable Status d_status{Disabled};
+};

--- a/pdns/recursordist/rec-protozero.hh
+++ b/pdns/recursordist/rec-protozero.hh
@@ -24,6 +24,7 @@
 #include "protozero.hh"
 
 #include "filterpo.hh"
+#include "rec-eventtrace.hh"
 #include "validate.hh"
 
 namespace pdns
@@ -98,6 +99,8 @@ namespace ProtoZero
       }
       return std::move(d_msgbuf);
     }
+
+    void addEvents(const RecEventTrace& trace);
 
     // DNSResponse related fields below
 

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -39,7 +39,7 @@ void BaseLua4::getFeatures(Features&)
 {
 }
 
-bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret) const
+bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, RecEventTrace& et) const
 {
   return false;
 }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -125,6 +125,7 @@ SyncRes::SyncRes(const struct timeval& now) :  d_authzonequeries(0), d_outquerie
 /** everything begins here - this is the entry point just after receiving a packet */
 int SyncRes::beginResolve(const DNSName &qname, const QType qtype, QClass qclass, vector<DNSRecord>&ret, unsigned int depth)
 {
+  d_eventTrace.add(RecEventTrace::SyncRes);
   vState state = vState::Indeterminate;
   s_queries++;
   d_wasVariable=false;
@@ -170,6 +171,7 @@ int SyncRes::beginResolve(const DNSName &qname, const QType qtype, QClass qclass
     }
   }
 
+  d_eventTrace.add(RecEventTrace::SyncRes, res, false);
   return res;
 }
 
@@ -3828,7 +3830,7 @@ bool SyncRes::doResolveAtThisIP(const std::string& prefix, const DNSName& qname,
   }
 
   int preOutQueryRet = RCode::NoError;
-  if(d_pdl && d_pdl->preoutquery(remoteIP, d_requestor, qname, qtype, doTCP, lwr.d_records, preOutQueryRet)) {
+  if(d_pdl && d_pdl->preoutquery(remoteIP, d_requestor, qname, qtype, doTCP, lwr.d_records, preOutQueryRet, d_eventTrace)) {
     LOG(prefix<<qname<<": query handled by Lua"<<endl);
   }
   else {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -53,6 +53,7 @@
 #include "sholder.hh"
 #include "histogram.hh"
 #include "tcpiohandler.hh"
+#include "rec-eventtrace.hh"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -793,6 +794,7 @@ public:
   DNSFilterEngine::Policy d_appliedPolicy;
   std::unordered_set<std::string> d_policyTags;
   boost::optional<string> d_routingTag;
+  RecEventTrace d_eventTrace;
 
   unsigned int d_authzonequeries;
   unsigned int d_outqueries;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is a stab at event traces, as suggested in #7558

Quite some rough edges: 
- always on, needs a (runtime configurable!) setting
- lots of more event types to be created and added to the code
- protobuf mesages are created too early, so the trace in the protobuf does not contains all info.
- types of timestamps and values have to be validated. ts are now ns and 64-bit to avoid having to think about wrapping. We might want to squeeze out a few bits. OTOH, I seem to remember protobuf uses variable length coding anyway, so leading zero bytes do not hurt really.
- docs
- tests

Example output (no PC hit):
```
        - RecRecv(241)
        - PCacheCheck(35979)
        - PCacheCheck(40177,False,done)
        - SyncRes(82968)
        - SyncRes(3803710778,0,done)
```

With a PC hit:
```
- Event Trace:
        - RecRecv(321)
        - PCacheCheck(47110)
        - PCacheCheck(64343,True,done)
```
Note that the `AnswerSent` events are missing, see the bullet point above

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
