### PR TITLE
fix: dnsdist docs quickstart typo

### DIFF
--- a/pdns/dnsdistdist/docs/quickstart.rst
+++ b/pdns/dnsdistdist/docs/quickstart.rst
@@ -8,9 +8,9 @@ Running in the Foreground
 
 After :doc:`installing <install>` dnsdist, the quickest way to start experimenting is launching it on the foreground with::
 
-   dnsdist -l 127.0.0.1:5300 9.9.9.9 2620:fe::fe2620:fe::9
+   dnsdist -l 127.0.0.1:5300 9.9.9.9 2620:fe::fe 2620:fe::9
 
-This will make dnsdist listen on IP address 127.0.0.1, port 5300 and forward all queries to the two listed IP addresses, with a sensible balancing policy.
+This will make dnsdist listen on IP address 127.0.0.1, port 5300 and forward all queries to the three listed IP addresses, with a sensible balancing policy.
 
 ``dnsdist`` Console and Configuration
 -------------------------------------


### PR DESCRIPTION
### Short description
This PR fixes two small typos in the dnsdist docs. Very minor but figured I'd correct them nonetheless.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

