### PR TITLE
auth 4.5 upgrade notes and settings: more words on the zone cache

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1898,7 +1898,7 @@ means no restriction.
 
 Seconds to cache a list of all known zones. A value of 0 will disable the cache.
 
-If your backends do not respond to unknown or dynamically generated zones, it is suggested to enable :ref:`setting-consistent-backends` and set this option to `60`.
+If your backends do not respond to unknown or dynamically generated zones, it is suggested to enable :ref:`setting-consistent-backends` (default since 4.5) and leave this option at its default of `300`.
 
 .. _setting-zone-metadata-cache-ttl:
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -49,15 +49,22 @@ Changed defaults
 - The default value of the :ref:`setting-consistent-backends` option has been changed from ``no`` to ``yes``.
 - The default value of the :ref:`setting-max-nsec3-iterations` option has been changed from ``500`` to ``100``.
 - The default value of the ``timeout`` parameter for :func:`ifportup` and :func:`ifurlup` functions has been changed from ``1`` to ``2`` seconds.
+- The default value of the new :ref:`setting-zone-cache-refresh-interval` option is ``300``.
+
+Zone cache
+~~~~~~~~~~
+
+Version 4.5 introduces the zone cache.
+The default refresh interval (:ref:`setting-zone-cache-refresh-interval`) is 300, meaning that zones newly added to your backend may need a few minutes to appear.
+However, zones added using the API should not notice a delay.
+
+If your backend is dynamic in what zones it does or does not offer, and thus cannot easily provide a complete list of zones every few minutes, set the interval to 0 to disable the feature.
 
 Removed options
 ~~~~~~~~~~~~~~~
 - :ref:`setting-local-ipv6` has been removed. IPv4 and IPv6 listen addresses should now be set with :ref:`setting-local-address`.
 - :ref:`setting-query-local-address6` has been removed. IPv4 and IPv6 addresses used for sending queries should now be set with :ref:`setting-query-local-address`.
 
-Starting with auth-4.5.0-beta1:
-
-- The default value of the ``zone-cache-refresh-interval`` option has been changed from ``0`` to ``300``.
 
 4.3.x to 4.4.0
 --------------


### PR DESCRIPTION
### Short description
A comment on https://blog.powerdns.com/2021/07/13/powerdns-authoritative-server-4-5-0/ rightfully said that the upgrade notes lack these words.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master