### PR TITLE
Document setTag(Response)Action behaviour

### DIFF
--- a/pdns/dnsdistdist/docs/reference/dq.rst
+++ b/pdns/dnsdistdist/docs/reference/dq.rst
@@ -222,14 +222,16 @@ This state can be modified from the various hooks.
   .. method:: DNSQuestion:setTag(key, value)
 
     Set a tag into the DNSQuestion object.
-
+    This function will not overwrite an existing tag. If the tag already exists it will keep its original value.
+  
     :param string key: The tag's key
     :param string value: The tag's value
 
   .. method:: DNSQuestion:setTagArray(tags)
 
     Set an array of tags into the DNSQuestion object.
-
+    This function will not overwrite an existing tag. If the tag already exists it will keep its original value.
+  
     :param table tags: A table of tags, using strings as keys and values
 
   .. method:: DNSQuestion:setTrailingData(tail) -> bool

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1334,6 +1334,7 @@ The following actions exist.
   .. versionadded:: 1.6.0
 
   Associate a tag named ``name`` with a value of ``value`` to this query, that will be passed on to the response.
+  This function will not overwrite an existing tag. If the tag already exists it will keep its original value.
   Subsequent rules are processed after this action.
   Note that this function was called :func:`TagAction` before 1.6.0.
 
@@ -1345,6 +1346,7 @@ The following actions exist.
   .. versionadded:: 1.6.0
 
   Associate a tag named ``name`` with a value of ``value`` to this response.
+  This function will not overwrite an existing tag. If the tag already exists it will keep its original value.
   Subsequent rules are processed after this action.
   Note that this function was called :func:`TagResponseAction` before 1.6.0.
 


### PR DESCRIPTION
### Short description
It surprised me that setTagAction and setTagResponseAction didn't overwrite existing tag values. This adds a line to the docs so that future users aren't surprised by this.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
