### PR TITLE
rec: Keep a count of per rpz (or filter) hits

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1161,7 +1161,7 @@ static PolicyResult handlePolicyHit(const DNSFilterEngine::Policy& appliedPolicy
   /* don't account truncate actions for TCP queries, since they are not applied */
   if (appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::Truncate || !dc->d_tcp) {
     ++g_stats.policyResults[appliedPolicy.d_kind];
-    ++g_stats.policyHits[appliedPolicy.getName()];
+    ++(g_stats.policyHits.lock()->operator[](appliedPolicy.getName()));
   }
 
   if (sr.doLog() &&  appliedPolicy.d_type != DNSFilterEngine::PolicyType::None) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1161,6 +1161,7 @@ static PolicyResult handlePolicyHit(const DNSFilterEngine::Policy& appliedPolicy
   /* don't account truncate actions for TCP queries, since they are not applied */
   if (appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::Truncate || !dc->d_tcp) {
     ++g_stats.policyResults[appliedPolicy.d_kind];
+    ++g_stats.policyHits[appliedPolicy.getName()];
   }
 
   if (sr.doLog() &&  appliedPolicy.d_type != DNSFilterEngine::PolicyType::None) {
@@ -5860,7 +5861,7 @@ int main(int argc, char **argv)
     for (size_t idx = 0; idx < 128; idx++) {
       defaultAPIDisabledStats += ", ecs-v6-response-bits-" + std::to_string(idx + 1);
     }
-    std::string defaultDisabledStats = defaultAPIDisabledStats + ", cumul-answers, cumul-auth4answers, cumul-auth6answers";
+    std::string defaultDisabledStats = defaultAPIDisabledStats + ", cumul-answers, cumul-auth4answers, cumul-auth6answers, policy-hits";
 
     ::arg().set("stats-api-blacklist", "List of statistics that are disabled when retrieving the complete list of statistics via the API (deprecated)")=defaultAPIDisabledStats;
     ::arg().set("stats-carbon-blacklist", "List of statistics that are prevented from being exported via Carbon (deprecated)")=defaultDisabledStats;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1158,6 +1158,7 @@ static StatsMap toRPZStatsMap(const string& name, const std::unordered_map<std::
   const string pbasename = getPrometheusName(name);
   StatsMap entries;
 
+  uint64_t total = 0;
   for (const auto& entry: map) {
     auto &key = entry.first;
     auto count = entry.second.load();
@@ -1167,10 +1168,12 @@ static StatsMap toRPZStatsMap(const string& name, const std::unordered_map<std::
       pname = pbasename + "{type=\"filter\"}";
     } else {
       sname = name + "-rpz-" + key;
-      pname = pbasename + "{type=\"rpz\",zone=\"" + entry.first + "\"}";
+      pname = pbasename + "{type=\"rpz\",policyname=\"" + entry.first + "\"}";
     }
-    entries.emplace(make_pair(sname, StatsMapEntry{pname, std::to_string(count)}));
+    entries.emplace(sname, StatsMapEntry{pname, std::to_string(count)});
+    total += count;
   }
+  entries.emplace(name, StatsMapEntry{pbasename, std::to_string(total)});
   return entries;
 }
 

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1153,13 +1153,13 @@ static StatsMap toCPUStatsMap(const string& name)
   return entries;
 }
 
-static StatsMap toRPZStatsMap(const string& name, const std::unordered_map<std::string, std::atomic<uint64_t>>& map)
+static StatsMap toRPZStatsMap(const string& name, LockGuarded<std::unordered_map<std::string, std::atomic<uint64_t>>>& map)
 {
   const string pbasename = getPrometheusName(name);
   StatsMap entries;
 
   uint64_t total = 0;
-  for (const auto& entry: map) {
+  for (const auto& entry: *map.lock()) {
     auto &key = entry.first;
     auto count = entry.second.load();
     std::string sname, pname;
@@ -1168,7 +1168,7 @@ static StatsMap toRPZStatsMap(const string& name, const std::unordered_map<std::
       pname = pbasename + "{type=\"filter\"}";
     } else {
       sname = name + "-rpz-" + key;
-      pname = pbasename + "{type=\"rpz\",policyname=\"" + entry.first + "\"}";
+      pname = pbasename + "{type=\"rpz\",policyname=\"" + key + "\"}";
     }
     entries.emplace(sname, StatsMapEntry{pname, std::to_string(count)});
     total += count;

--- a/pdns/recursordist/docs/lua-config/rpz.rst
+++ b/pdns/recursordist/docs/lua-config/rpz.rst
@@ -141,6 +141,7 @@ The maximum TTL value of the synthesized records, overriding a higher value from
 policyName
 ^^^^^^^^^^
 The name logged as 'appliedPolicy' in :doc:`protobuf <protobuf>` messages when this policy is applied.
+Defaults to ``rpzFile`` for RPZs loaded by :func:`rpzFile` or the name of the zone for RPZs loaded by :func:`rpzPrimary`.
 
 tags
 ^^^^

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -594,6 +594,11 @@ policy-drops
 ^^^^^^^^^^^^
 packets dropped because of (Lua) policy decision
 
+policy-hits
+^^^^^^^^^^^
+Number of policy decisions based on Lua (``type = "filter"``), or RPZ (``type = "rpz"``). RPZ hits include the :ref:`rpz-policyName`.
+These metrics are useful for Prometheus and not listed other outputs by default.
+
 policy-result-noaction
 ^^^^^^^^^^^^^^^^^^^^^^
 packets that were not acted upon by   the RPZ/filter engine

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -597,7 +597,7 @@ packets dropped because of (Lua) policy decision
 policy-hits
 ^^^^^^^^^^^
 Number of policy decisions based on Lua (``type = "filter"``), or RPZ (``type = "rpz"``). RPZ hits include the :ref:`rpz-policyName`.
-These metrics are useful for Prometheus and not listed other outputs by default.
+These metrics are useful for Prometheus and not listed in other outputs by default.
 
 policy-result-noaction
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/rec_metrics.hh
+++ b/pdns/recursordist/rec_metrics.hh
@@ -23,36 +23,31 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
-#include <vector>
-#include <inttypes.h>
-#include <unistd.h>
-#include <atomic>
+#include <map>
 
 // Metric types for Prometheus
-enum class PrometheusMetricType : int
+enum class PrometheusMetricType
 {
-  counter = 1,
-  gauge = 2,
-  histogram = 3,
-  multicounter = 4
+  counter,
+  gauge,
+  histogram,
+  multicounter
 };
 
 // Keeps additional information about metrics
 struct MetricDefinition
 {
-  MetricDefinition(const PrometheusMetricType& prometheusType_, const std::string& description_)
+  MetricDefinition(const PrometheusMetricType prometheusType, const std::string& description) :
+    d_description(description), d_prometheusType(prometheusType)
   {
-    prometheusType = prometheusType_;
-    description = description_;
   }
 
   MetricDefinition() = default;
 
   // Metric description
-  std::string description;
+  std::string d_description;
   // Metric type for Prometheus
-  PrometheusMetricType prometheusType;
+  PrometheusMetricType d_prometheusType;
 };
 
 class MetricDefinitionStorage
@@ -61,9 +56,9 @@ public:
   // Return metric definition by name
   bool getMetricDetails(const std::string& metricName, MetricDefinition& metric)
   {
-    auto metricDetailsIter = metrics.find(metricName);
+    auto metricDetailsIter = d_metrics.find(metricName);
 
-    if (metricDetailsIter == metrics.end()) {
+    if (metricDetailsIter == d_metrics.end()) {
       return false;
     }
 
@@ -72,7 +67,7 @@ public:
   };
 
   // Return string representation of Prometheus metric type
-  std::string getPrometheusStringMetricType(const PrometheusMetricType& metricType)
+  static std::string getPrometheusStringMetricType(const PrometheusMetricType metricType)
   {
     switch (metricType) {
     case PrometheusMetricType::counter:
@@ -85,7 +80,8 @@ public:
       return "histogram";
       break;
     case PrometheusMetricType::multicounter:
-      return "multicounter";
+      // A multicounter produces multiple values of type "counter"
+      return "counter";
       break;
     default:
       return "";
@@ -95,7 +91,5 @@ public:
 
 private:
   // Description and types for prometheus output of stats
-  static const std::map<std::string, MetricDefinition> metrics;
+  static const std::map<std::string, MetricDefinition> d_metrics;
 };
-
-extern MetricDefinitionStorage g_metricDefinitions;

--- a/pdns/recursordist/rec_metrics.hh
+++ b/pdns/recursordist/rec_metrics.hh
@@ -26,7 +26,7 @@
 #include <map>
 
 // Metric types for Prometheus
-enum class PrometheusMetricType
+enum class PrometheusMetricType : uint8_t
 {
   counter,
   gauge,

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2184,6 +2184,7 @@ void SyncRes::handlePolicyHit(const std::string& prefix, const DNSName& qname, c
   /* don't account truncate actions for TCP queries, since they are not applied */
   if (d_appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::Truncate || !d_queryReceivedOverTCP) {
     ++g_stats.policyResults[d_appliedPolicy.d_kind];
+    ++g_stats.policyHits[d_appliedPolicy.getName()];
   }
 
   if (d_appliedPolicy.d_type != DNSFilterEngine::PolicyType::None) {

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2184,7 +2184,7 @@ void SyncRes::handlePolicyHit(const std::string& prefix, const DNSName& qname, c
   /* don't account truncate actions for TCP queries, since they are not applied */
   if (d_appliedPolicy.d_kind != DNSFilterEngine::PolicyKind::Truncate || !d_queryReceivedOverTCP) {
     ++g_stats.policyResults[d_appliedPolicy.d_kind];
-    ++g_stats.policyHits[d_appliedPolicy.getName()];
+    ++(g_stats.policyHits.lock()->operator[](d_appliedPolicy.getName()));
   }
 
   if (d_appliedPolicy.d_type != DNSFilterEngine::PolicyType::None) {

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1072,6 +1072,7 @@ struct RecursorStats
   std::map<vState, std::atomic<uint64_t> > dnssecResults;
   std::map<vState, std::atomic<uint64_t> > xdnssecResults;
   std::map<DNSFilterEngine::PolicyKind, std::atomic<uint64_t> > policyResults;
+  std::unordered_map<std::string, std::atomic<uint64_t>> policyHits;
   std::atomic<uint64_t> rebalancedQueries{0};
   std::atomic<uint64_t> proxyProtocolInvalidCount{0};
   std::atomic<uint64_t> nodLookupsDroppedOversize{0};

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1072,7 +1072,7 @@ struct RecursorStats
   std::map<vState, std::atomic<uint64_t> > dnssecResults;
   std::map<vState, std::atomic<uint64_t> > xdnssecResults;
   std::map<DNSFilterEngine::PolicyKind, std::atomic<uint64_t> > policyResults;
-  std::unordered_map<std::string, std::atomic<uint64_t>> policyHits;
+  LockGuarded<std::unordered_map<std::string, std::atomic<uint64_t>>> policyHits;
   std::atomic<uint64_t> rebalancedQueries{0};
   std::atomic<uint64_t> proxyProtocolInvalidCount{0};
   std::atomic<uint64_t> nodLookupsDroppedOversize{0};


### PR DESCRIPTION
By default only exported via Prometheus.

This is not finished yet, after #10554 is merged the Prometheus help info should be added
to this branch. The current Prometheus HELP code does not handle multicounter stuff and that PR adds is.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
