### PR TITLE
auth: correct upper bounds on d_qtypecounters

### DIFF
--- a/docs/changelog/4.5.rst
+++ b/docs/changelog/4.5.rst
@@ -10,7 +10,7 @@ Changelogs for 4.5.x
 
   .. change::
     :tags: Bug Fixes
-    :pullreq: X
+    :pullreq: 10611
 
     auth: correct upper bounds on d_qtypecounters
 

--- a/pdns/responsestats.cc
+++ b/pdns/responsestats.cc
@@ -27,11 +27,11 @@ static auto sizeBounds()
 ResponseStats::ResponseStats() :
   d_sizecounters("SizeCounters", sizeBounds())
 {
-  for (unsigned int n = 0; n < 65535; ++n) {
-    d_qtypecounters[n].value = 0;
+  for (auto& entry : d_qtypecounters) {
+    entry.value = 0;
   }
-  for (unsigned int n = 0; n < 256; ++n) {
-    d_rcodecounters[n].value = 0;
+  for (auto& entry : d_rcodecounters) {
+    entry.value = 0;
   }
 }
 
@@ -53,7 +53,7 @@ map<uint16_t, uint64_t> ResponseStats::getQTypeResponseCounts() const
 {
   map<uint16_t, uint64_t> ret;
   uint64_t count;
-  for (unsigned int i = 0; i < 65535; ++i) {
+  for (unsigned int i = 0; i < d_qtypecounters.size(); ++i) {
     count = d_qtypecounters.at(i).value;
     if (count) {
       ret[i] = count;
@@ -77,7 +77,7 @@ map<uint8_t, uint64_t> ResponseStats::getRCodeResponseCounts() const
 {
   map<uint8_t, uint64_t> ret;
   uint64_t count;
-  for (unsigned int i = 0; i < 256; ++i) {
+  for (unsigned int i = 0; i < d_rcodecounters.size(); ++i) {
     count = d_rcodecounters.at(i).value;
     if (count) {
       ret[i] = count;

--- a/pdns/responsestats.hh
+++ b/pdns/responsestats.hh
@@ -45,7 +45,7 @@ private:
     mutable std::atomic<uint64_t> value;
   };
 
-  std::array<Counter, 65535> d_qtypecounters;
+  std::array<Counter, 65536> d_qtypecounters;
   std::array<Counter, 256> d_rcodecounters;
   pdns::AtomicHistogram d_sizecounters;
 };

--- a/regression-tests/tests/type65535-query/command
+++ b/regression-tests/tests/type65535-query/command
@@ -1,0 +1,3 @@
+#!/bin/sh
+cleandig outpost.example.com TYPE65535
+

--- a/regression-tests/tests/type65535-query/description
+++ b/regression-tests/tests/type65535-query/description
@@ -1,0 +1,1 @@
+TYPE65535 queries crashed Auth 4.5.0.

--- a/regression-tests/tests/type65535-query/expected_result
+++ b/regression-tests/tests/type65535-query/expected_result
@@ -1,0 +1,3 @@
+1	example.com.	IN	SOA	86400	ns1.example.com. ahu.example.com. 2847484148 28800 7200 604800 86400
+Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
+Reply to question for qname='outpost.example.com.', qtype=TYPE65535


### PR DESCRIPTION
### Short description
This fixes security advisory 2021-01.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master