### PR TITLE
Handle waiting for a descriptor to become readable OR writable

### DIFF
--- a/.not-formatted
+++ b/.not-formatted
@@ -39,7 +39,6 @@
 ./pdns/decafsigners.cc
 ./pdns/delaypipe.cc
 ./pdns/delaypipe.hh
-./pdns/devpollmplexer.cc
 ./pdns/digests.hh
 ./pdns/distributor.hh
 ./pdns/dns.cc
@@ -162,7 +161,6 @@
 ./pdns/ednspadding.cc
 ./pdns/ednssubnet.cc
 ./pdns/ednssubnet.hh
-./pdns/epollmplexer.cc
 ./pdns/filterpo.cc
 ./pdns/filterpo.hh
 ./pdns/fstrm_logger.cc
@@ -191,7 +189,6 @@
 ./pdns/ixplore.cc
 ./pdns/json.cc
 ./pdns/json.hh
-./pdns/kqueuemplexer.cc
 ./pdns/kvresp.cc
 ./pdns/lazy_allocator.hh
 ./pdns/libssl.cc
@@ -211,7 +208,6 @@
 ./pdns/minicurl.hh
 ./pdns/misc.cc
 ./pdns/misc.hh
-./pdns/mplexer.hh
 ./pdns/mtasker.cc
 ./pdns/mtasker.hh
 ./pdns/mtasker_context.hh
@@ -237,8 +233,6 @@
 ./pdns/pdnsutil.cc
 ./pdns/pkcs11signers.cc
 ./pdns/pkcs11signers.hh
-./pdns/pollmplexer.cc
-./pdns/portsmplexer.cc
 ./pdns/protozero.cc
 ./pdns/protozero.hh
 ./pdns/proxy-protocol.cc
@@ -335,7 +329,6 @@
 ./pdns/test-lock_hh.cc
 ./pdns/test-lua_auth4_cc.cc
 ./pdns/test-misc_hh.cc
-./pdns/test-mplexer.cc
 ./pdns/test-nameserver_cc.cc
 ./pdns/test-packetcache_cc.cc
 ./pdns/test-packetcache_hh.cc

--- a/pdns/devpollmplexer.cc
+++ b/pdns/devpollmplexer.cc
@@ -71,7 +71,7 @@ static struct DevPollRegisterOurselves
 {
   DevPollRegisterOurselves()
   {
-    FDMultiplexer::getMultiplexerMap().insert(make_pair(0, &makeDevPoll)); // priority 0!
+    FDMultiplexer::getMultiplexerMap().emplace(1, &makeDevPoll); // priority 1, so that /dev/poll is preferred over poll, but not over completion ports!
   }
 } doItDevPoll;
 

--- a/pdns/devpollmplexer.cc
+++ b/pdns/devpollmplexer.cc
@@ -161,11 +161,13 @@ int DevPollFDMultiplexer::run(struct timeval* now, int timeout)
   }
 
   d_inrun = true;
+  int count = 0;
   for (int n = 0; n < ret; ++n) {
     if ((fds.at(n).revents & POLLIN) || (fds.at(n).revents & POLLERR) || (fds.at(n).revents & POLLHUP)) {
       const auto& iter = d_readCallbacks.find(fds.at(n).fd);
       if (iter != d_readCallbacks.end()) {
         iter->d_callback(iter->d_fd, iter->d_parameter);
+        count++;
       }
     }
 
@@ -173,12 +175,13 @@ int DevPollFDMultiplexer::run(struct timeval* now, int timeout)
       const auto& iter = d_writeCallbacks.find(fds.at(n).fd);
       if (iter != d_writeCallbacks.end()) {
         iter->d_callback(iter->d_fd, iter->d_parameter);
+        count++;
       }
     }
   }
 
   d_inrun = false;
-  return ret;
+  return count;
 }
 
 #if 0

--- a/pdns/devpollmplexer.cc
+++ b/pdns/devpollmplexer.cc
@@ -93,6 +93,7 @@ static int convertEventKind(FDMultiplexer::EventKind kind)
   case FDMultiplexer::EventKind::Both:
     return POLLIN | POLLOUT;
   }
+  throw std::runtime_error("Unhandled event kind in the /dev/poll multiplexer");
 }
 
 void DevPollFDMultiplexer::addFD(int fd, FDMultiplexer::EventKind kind)

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -349,10 +349,6 @@ public:
   {
   }
 
-  void alterFD(int fd, FDMultiplexer::EventKind kind) override
-  {
-  }
-
   string getName() const override
   {
     return "mockup";

--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -341,20 +341,16 @@ public:
   {
   }
 
-  void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const funcparam_t& parameter, const struct timeval* ttd=nullptr) override
+  void addFD(int fd, FDMultiplexer::EventKind kind) override
   {
-    accountingAddFD(cbmap, fd, toDo, parameter, ttd);
   }
 
-  void removeFD(callbackmap_t& cbmap, int fd) override
+  void removeFD(int fd, FDMultiplexer::EventKind) override
   {
-    accountingRemoveFD(cbmap, fd);
   }
 
-  void alterFD(callbackmap_t& from, callbackmap_t& to, int fd, callbackfunc_t toDo, const funcparam_t& parameter, const struct timeval* ttd) override
+  void alterFD(int fd, FDMultiplexer::EventKind kind) override
   {
-    accountingRemoveFD(from, fd);
-    accountingAddFD(to, fd, toDo, parameter, ttd);
   }
 
   string getName() const override

--- a/pdns/epollmplexer.cc
+++ b/pdns/epollmplexer.cc
@@ -113,6 +113,8 @@ static uint32_t convertEventKind(FDMultiplexer::EventKind kind)
   case FDMultiplexer::EventKind::Both:
     return EPOLLIN | EPOLLOUT;
   }
+
+  throw std::runtime_error("Unhandled event kind in the epoll multiplexer");
 }
 
 void EpollFDMultiplexer::addFD(int fd, FDMultiplexer::EventKind kind)

--- a/pdns/epollmplexer.cc
+++ b/pdns/epollmplexer.cc
@@ -71,7 +71,7 @@ static struct EpollRegisterOurselves
 {
   EpollRegisterOurselves()
   {
-    FDMultiplexer::getMultiplexerMap().insert(make_pair(0, &makeEpoll)); // priority 0!
+    FDMultiplexer::getMultiplexerMap().emplace(0, &makeEpoll); // priority 0!
   }
 } doItEpoll;
 

--- a/pdns/epollmplexer.cc
+++ b/pdns/epollmplexer.cc
@@ -185,11 +185,13 @@ int EpollFDMultiplexer::run(struct timeval* now, int timeout)
   }
 
   d_inrun = true;
+  int count = 0;
   for (int n = 0; n < ret; ++n) {
     if ((d_eevents[n].events & EPOLLIN) || (d_eevents[n].events & EPOLLERR) || (d_eevents[n].events & EPOLLHUP)) {
       const auto& iter = d_readCallbacks.find(d_eevents[n].data.fd);
       if (iter != d_readCallbacks.end()) {
         iter->d_callback(iter->d_fd, iter->d_parameter);
+        count++;
       }
     }
 
@@ -197,12 +199,13 @@ int EpollFDMultiplexer::run(struct timeval* now, int timeout)
       const auto& iter = d_writeCallbacks.find(d_eevents[n].data.fd);
       if (iter != d_writeCallbacks.end()) {
         iter->d_callback(iter->d_fd, iter->d_parameter);
+        count++;
       }
     }
   }
 
   d_inrun = false;
-  return ret;
+  return count;
 }
 
 #if 0

--- a/pdns/epollmplexer.cc
+++ b/pdns/epollmplexer.cc
@@ -49,7 +49,7 @@ public:
 
   void addFD(int fd, FDMultiplexer::EventKind kind) override;
   void removeFD(int fd, FDMultiplexer::EventKind kind) override;
-  void alterFD(int fd, FDMultiplexer::EventKind kind) override;
+  void alterFD(int fd, FDMultiplexer::EventKind from, FDMultiplexer::EventKind to) override;
 
   string getName() const override
   {
@@ -140,10 +140,10 @@ void EpollFDMultiplexer::removeFD(int fd, FDMultiplexer::EventKind)
   }
 }
 
-void EpollFDMultiplexer::alterFD(int fd, FDMultiplexer::EventKind kind)
+void EpollFDMultiplexer::alterFD(int fd, FDMultiplexer::EventKind, FDMultiplexer::EventKind to)
 {
   struct epoll_event eevent;
-  eevent.events = convertEventKind(kind);
+  eevent.events = convertEventKind(to);
   eevent.data.u64 = 0; // placate valgrind (I love it so much)
   eevent.data.fd = fd;
 

--- a/pdns/epollmplexer.cc
+++ b/pdns/epollmplexer.cc
@@ -37,28 +37,30 @@ class EpollFDMultiplexer : public FDMultiplexer
 {
 public:
   EpollFDMultiplexer();
-  virtual ~EpollFDMultiplexer()
+  ~EpollFDMultiplexer()
   {
-    close(d_epollfd);
+    if (d_epollfd >= 0) {
+      close(d_epollfd);
+    }
   }
 
-  virtual int run(struct timeval* tv, int timeout=500) override;
-  virtual void getAvailableFDs(std::vector<int>& fds, int timeout) override;
+  int run(struct timeval* tv, int timeout = 500) override;
+  void getAvailableFDs(std::vector<int>& fds, int timeout) override;
 
-  virtual void addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const funcparam_t& parameter, const struct timeval* ttd=nullptr) override;
-  virtual void removeFD(callbackmap_t& cbmap, int fd) override;
-  virtual void alterFD(callbackmap_t& from, callbackmap_t& to, int fd, callbackfunc_t toDo, const funcparam_t& parameter, const struct timeval* ttd) override;
+  void addFD(int fd, FDMultiplexer::EventKind kind) override;
+  void removeFD(int fd, FDMultiplexer::EventKind kind) override;
+  void alterFD(int fd, FDMultiplexer::EventKind kind) override;
 
   string getName() const override
   {
     return "epoll";
   }
+
 private:
   int d_epollfd;
   boost::shared_array<epoll_event> d_eevents;
   static int s_maxevents; // not a hard maximum
 };
-
 
 static FDMultiplexer* makeEpoll()
 {
@@ -67,122 +69,137 @@ static FDMultiplexer* makeEpoll()
 
 static struct EpollRegisterOurselves
 {
-  EpollRegisterOurselves() {
+  EpollRegisterOurselves()
+  {
     FDMultiplexer::getMultiplexerMap().insert(make_pair(0, &makeEpoll)); // priority 0!
   }
 } doItEpoll;
 
-int EpollFDMultiplexer::s_maxevents=1024;
+int EpollFDMultiplexer::s_maxevents = 1024;
 
-EpollFDMultiplexer::EpollFDMultiplexer() : d_eevents(new epoll_event[s_maxevents])
+EpollFDMultiplexer::EpollFDMultiplexer() :
+  d_eevents(new epoll_event[s_maxevents])
 {
-  d_epollfd=epoll_create(s_maxevents); // not hard max
-  if(d_epollfd < 0)
-    throw FDMultiplexerException("Setting up epoll: "+stringerror());
-  int fd=socket(AF_INET, SOCK_DGRAM, 0); // for self-test
-  if(fd < 0)
+  d_epollfd = epoll_create(s_maxevents); // not hard max
+  if (d_epollfd < 0) {
+    throw FDMultiplexerException("Setting up epoll: " + stringerror());
+  }
+  int fd = socket(AF_INET, SOCK_DGRAM, 0); // for self-test
+
+  if (fd < 0) {
     return;
+  }
+
   try {
     addReadFD(fd, 0);
     removeReadFD(fd);
     close(fd);
     return;
   }
-  catch(FDMultiplexerException &fe) {
+  catch (const FDMultiplexerException& fe) {
     close(fd);
     close(d_epollfd);
-    throw FDMultiplexerException("epoll multiplexer failed self-test: "+string(fe.what()));
+    throw FDMultiplexerException("epoll multiplexer failed self-test: " + string(fe.what()));
   }
-
 }
 
-void EpollFDMultiplexer::addFD(callbackmap_t& cbmap, int fd, callbackfunc_t toDo, const funcparam_t& parameter, const struct timeval* ttd)
+static uint32_t convertEventKind(FDMultiplexer::EventKind kind)
 {
-  accountingAddFD(cbmap, fd, toDo, parameter, ttd);
+  switch (kind) {
+  case FDMultiplexer::EventKind::Read:
+    return EPOLLIN;
+  case FDMultiplexer::EventKind::Write:
+    return EPOLLOUT;
+  case FDMultiplexer::EventKind::Both:
+    return EPOLLIN | EPOLLOUT;
+  }
+}
 
+void EpollFDMultiplexer::addFD(int fd, FDMultiplexer::EventKind kind)
+{
   struct epoll_event eevent;
 
-  eevent.events = (&cbmap == &d_readCallbacks) ? EPOLLIN : EPOLLOUT;
+  eevent.events = convertEventKind(kind);
 
-  eevent.data.u64=0; // placate valgrind (I love it so much)
-  eevent.data.fd=fd;
+  eevent.data.u64 = 0; // placate valgrind (I love it so much)
+  eevent.data.fd = fd;
 
   if (epoll_ctl(d_epollfd, EPOLL_CTL_ADD, fd, &eevent) < 0) {
-    cbmap.erase(fd);
-    throw FDMultiplexerException("Adding fd to epoll set: "+stringerror());
+    throw FDMultiplexerException("Adding fd to epoll set: " + stringerror());
   }
 }
 
-void EpollFDMultiplexer::removeFD(callbackmap_t& cbmap, int fd)
+void EpollFDMultiplexer::removeFD(int fd, FDMultiplexer::EventKind)
 {
-  accountingRemoveFD(cbmap, fd);
-
   struct epoll_event dummy;
   dummy.events = 0;
   dummy.data.u64 = 0;
 
-  if(epoll_ctl(d_epollfd, EPOLL_CTL_DEL, fd, &dummy) < 0)
-    throw FDMultiplexerException("Removing fd from epoll set: "+stringerror());
+  if (epoll_ctl(d_epollfd, EPOLL_CTL_DEL, fd, &dummy) < 0) {
+    throw FDMultiplexerException("Removing fd from epoll set: " + stringerror());
+  }
 }
 
-void EpollFDMultiplexer::alterFD(callbackmap_t& from, callbackmap_t& to, int fd, callbackfunc_t toDo, const funcparam_t& parameter, const struct timeval* ttd)
+void EpollFDMultiplexer::alterFD(int fd, FDMultiplexer::EventKind kind)
 {
-  accountingRemoveFD(from, fd);
-  accountingAddFD(to, fd, toDo, parameter, ttd);
-
   struct epoll_event eevent;
-  eevent.events = (&to == &d_readCallbacks) ? EPOLLIN : EPOLLOUT;
+  eevent.events = convertEventKind(kind);
   eevent.data.u64 = 0; // placate valgrind (I love it so much)
   eevent.data.fd = fd;
 
   if (epoll_ctl(d_epollfd, EPOLL_CTL_MOD, fd, &eevent) < 0) {
-    to.erase(fd);
-    throw FDMultiplexerException("Altering fd in epoll set: "+stringerror());
+    throw FDMultiplexerException("Altering fd in epoll set: " + stringerror());
   }
 }
 
 void EpollFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
 {
-  int ret=epoll_wait(d_epollfd, d_eevents.get(), s_maxevents, timeout);
+  int ret = epoll_wait(d_epollfd, d_eevents.get(), s_maxevents, timeout);
 
-  if(ret < 0 && errno!=EINTR)
-    throw FDMultiplexerException("epoll returned error: "+stringerror());
+  if (ret < 0 && errno != EINTR) {
+    throw FDMultiplexerException("epoll returned error: " + stringerror());
+  }
 
-  for(int n=0; n < ret; ++n) {
+  for (int n = 0; n < ret; ++n) {
     fds.push_back(d_eevents[n].data.fd);
   }
 }
 
 int EpollFDMultiplexer::run(struct timeval* now, int timeout)
 {
-  if(d_inrun) {
+  if (d_inrun) {
     throw FDMultiplexerException("FDMultiplexer::run() is not reentrant!\n");
   }
 
-  int ret=epoll_wait(d_epollfd, d_eevents.get(), s_maxevents, timeout);
-  gettimeofday(now,0); // MANDATORY
+  int ret = epoll_wait(d_epollfd, d_eevents.get(), s_maxevents, timeout);
+  gettimeofday(now, nullptr); // MANDATORY
 
-  if(ret < 0 && errno!=EINTR)
-    throw FDMultiplexerException("epoll returned error: "+stringerror());
+  if (ret < 0 && errno != EINTR) {
+    throw FDMultiplexerException("epoll returned error: " + stringerror());
+  }
 
-  if(ret < 1) // thanks AB!
+  if (ret < 1) { // thanks AB!
     return 0;
+  }
 
-  d_inrun=true;
-  for(int n=0; n < ret; ++n) {
-    d_iter=d_readCallbacks.find(d_eevents[n].data.fd);
-
-    if(d_iter != d_readCallbacks.end()) {
-      d_iter->d_callback(d_iter->d_fd, d_iter->d_parameter);
-      continue; // so we don't refind ourselves as writable!
+  d_inrun = true;
+  for (int n = 0; n < ret; ++n) {
+    if ((d_eevents[n].events & EPOLLIN) || (d_eevents[n].events & EPOLLERR) || (d_eevents[n].events & EPOLLHUP)) {
+      const auto& iter = d_readCallbacks.find(d_eevents[n].data.fd);
+      if (iter != d_readCallbacks.end()) {
+        iter->d_callback(iter->d_fd, iter->d_parameter);
+      }
     }
-    d_iter=d_writeCallbacks.find(d_eevents[n].data.fd);
 
-    if(d_iter != d_writeCallbacks.end()) {
-      d_iter->d_callback(d_iter->d_fd, d_iter->d_parameter);
+    if ((d_eevents[n].events & EPOLLOUT) || (d_eevents[n].events & EPOLLERR) || (d_eevents[n].events & EPOLLHUP)) {
+      const auto& iter = d_writeCallbacks.find(d_eevents[n].data.fd);
+      if (iter != d_writeCallbacks.end()) {
+        iter->d_callback(iter->d_fd, iter->d_parameter);
+      }
     }
   }
-  d_inrun=false;
+
+  d_inrun = false;
   return ret;
 }
 

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -97,6 +97,8 @@ static uint32_t convertEventKind(FDMultiplexer::EventKind kind)
   case FDMultiplexer::EventKind::Both:
     throw std::runtime_error("Read and write events cannot be combined in one go with kqueue");
   }
+
+  throw std::runtime_error("Unhandled event kind in the kqueue multiplexer");
 }
 
 void KqueueFDMultiplexer::addFD(int fd, FDMultiplexer::EventKind kind)

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -116,7 +116,7 @@ void KqueueFDMultiplexer::addFD(int fd, FDMultiplexer::EventKind kind)
     nevents++;
   }
 
-  if (kevent(d_kqueuefd, &kqevents, nevents, 0, 0, 0) < 0) {
+  if (kevent(d_kqueuefd, kqevents, nevents, 0, 0, 0) < 0) {
     throw FDMultiplexerException("Adding fd to kqueue set: " + stringerror());
   }
 }
@@ -136,7 +136,7 @@ void KqueueFDMultiplexer::removeFD(int fd, FDMultiplexer::EventKind kind)
     nevents++;
   }
 
-  if (kevent(d_kqueuefd, &kqevents, nevents, 0, 0, 0) < 0) {
+  if (kevent(d_kqueuefd, kqevents, nevents, 0, 0, 0) < 0) {
     // ponder putting Callback back on the map..
     throw FDMultiplexerException("Removing fd from kqueue set: " + stringerror());
   }
@@ -157,7 +157,7 @@ void KqueueFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
   // we de-duplicate here, since if a descriptor is readable AND writable
   // we will get two events
   std::unordered_set<int> fdSet;
-  fdSet.reserve(n);
+  fdSet.reserve(ret);
   for (int n = 0; n < ret; ++n) {
     fdSet.insert(d_kevents[n].ident);
   }

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -74,7 +74,7 @@ static struct KqueueRegisterOurselves
 {
   KqueueRegisterOurselves()
   {
-    FDMultiplexer::getMultiplexerMap().insert(make_pair(0, &make)); // priority 0!
+    FDMultiplexer::getMultiplexerMap().emplace(0, &make); // priority 0!
   }
 } kQueueDoIt;
 

--- a/pdns/kqueuemplexer.cc
+++ b/pdns/kqueuemplexer.cc
@@ -50,7 +50,7 @@ public:
   void getAvailableFDs(std::vector<int>& fds, int timeout) override;
 
   void addFD(int fd, FDMultiplexer::EventKind kind) override;
-  void removeFD(int fd) override;
+  void removeFD(int fd, FDMultiplexer::EventKind kind) override;
 
   string getName() const override
   {

--- a/pdns/mplexer.hh
+++ b/pdns/mplexer.hh
@@ -85,7 +85,8 @@ public:
   /* tv will be updated to 'now' before run returns */
   /* timeout is in ms */
   /* returns 0 on timeout, -1 in case of error (but all implementations
-     actually throw in that case) and the number of ready events otherwise */
+     actually throw in that case) and the number of ready events otherwise.
+     Note that We might have two events (read AND write) for the same descriptor */
   virtual int run(struct timeval* tv, int timeout = 500) = 0;
 
   /* timeout is in ms, 0 will return immediately, -1 will block until at least one FD is ready */

--- a/pdns/pollmplexer.cc
+++ b/pdns/pollmplexer.cc
@@ -5,6 +5,7 @@
 #include "sstuff.hh"
 #include <iostream>
 #include <poll.h>
+#include <unordered_map>
 #include "misc.hh"
 #include "namespaces.hh"
 

--- a/pdns/pollmplexer.cc
+++ b/pdns/pollmplexer.cc
@@ -59,7 +59,7 @@ static struct RegisterOurselves
 {
   RegisterOurselves()
   {
-    FDMultiplexer::getMultiplexerMap().insert(make_pair(1, &make));
+    FDMultiplexer::getMultiplexerMap().emplace(2, &make);
   }
 } doIt;
 

--- a/pdns/pollmplexer.cc
+++ b/pdns/pollmplexer.cc
@@ -144,13 +144,13 @@ int PollFDMultiplexer::run(struct timeval* now, int timeout)
   }
 
   d_inrun = true;
-
+  int count = 0;
   for (const auto& pollfd : pollfds) {
-
     if (pollfd.revents & POLLIN || pollfd.revents & POLLERR || pollfd.revents & POLLHUP) {
       const auto& iter = d_readCallbacks.find(pollfd.fd);
       if (iter != d_readCallbacks.end()) {
         iter->d_callback(iter->d_fd, iter->d_parameter);
+        count++;
       }
     }
 
@@ -158,12 +158,13 @@ int PollFDMultiplexer::run(struct timeval* now, int timeout)
       const auto& iter = d_writeCallbacks.find(pollfd.fd);
       if (iter != d_writeCallbacks.end()) {
         iter->d_callback(iter->d_fd, iter->d_parameter);
+        count++;
       }
     }
   }
 
   d_inrun = false;
-  return ret;
+  return count;
 }
 
 #if 0

--- a/pdns/portsmplexer.cc
+++ b/pdns/portsmplexer.cc
@@ -49,7 +49,7 @@ static struct PortsRegisterOurselves
 {
   PortsRegisterOurselves()
   {
-    FDMultiplexer::getMultiplexerMap().insert(make_pair(0, &makePorts)); // priority 0!
+    FDMultiplexer::getMultiplexerMap().emplace(0, &makePorts); // priority 0!
   }
 } doItPorts;
 

--- a/pdns/portsmplexer.cc
+++ b/pdns/portsmplexer.cc
@@ -28,7 +28,6 @@ public:
 
   void addFD(int fd, FDMultiplexer::EventKind kind) override;
   void removeFD(int fd, FDMultiplexer::EventKind kind) override;
-  void alterFD(int fd, FDMultiplexer::EventKind kind) override;
 
   string getName() const override
   {

--- a/pdns/test-mplexer.cc
+++ b/pdns/test-mplexer.cc
@@ -10,277 +10,295 @@
 
 BOOST_AUTO_TEST_SUITE(mplexer)
 
-BOOST_AUTO_TEST_CASE(test_MPlexer)
+BOOST_AUTO_TEST_CASE(test_getMultiplexerSilent)
 {
   auto mplexer = std::unique_ptr<FDMultiplexer>(FDMultiplexer::getMultiplexerSilent());
   BOOST_REQUIRE(mplexer != nullptr);
 
-  struct timeval now;
+  struct timeval now{0,0};
   int ready = mplexer->run(&now, 100);
   BOOST_CHECK_EQUAL(ready, 0);
+  BOOST_CHECK(now.tv_sec != 0);
+}
 
-  std::vector<int> readyFDs;
-  mplexer->getAvailableFDs(readyFDs, 0);
-  BOOST_CHECK_EQUAL(readyFDs.size(), 0U);
+BOOST_AUTO_TEST_CASE(test_MPlexer)
+{
+  for (const auto& entry : FDMultiplexer::getMultiplexerMap()) {
+    auto mplexer = std::unique_ptr<FDMultiplexer>(entry.second());
+    BOOST_REQUIRE(mplexer != nullptr);
+    //cerr<<"Testing multiplexer "<<mplexer->getName()<<endl;
 
-  auto timeouts = mplexer->getTimeouts(now);
-  BOOST_CHECK_EQUAL(timeouts.size(), 0U);
+    struct timeval now{0,0};
+    int ready = mplexer->run(&now, 100);
+    BOOST_CHECK_EQUAL(ready, 0);
+    BOOST_CHECK(now.tv_sec != 0);
 
-  int pipes[2];
-  int res = pipe(pipes);
-  BOOST_REQUIRE_EQUAL(res, 0);
-  BOOST_REQUIRE_EQUAL(setNonBlocking(pipes[0]), true);
-  BOOST_REQUIRE_EQUAL(setNonBlocking(pipes[1]), true);
+    std::vector<int> readyFDs;
+    mplexer->getAvailableFDs(readyFDs, 0);
+    BOOST_CHECK_EQUAL(readyFDs.size(), 0U);
 
-  /* let's declare a TTD that expired 5s ago */
-  struct timeval ttd = now;
-  ttd.tv_sec -= 5;
+    auto timeouts = mplexer->getTimeouts(now);
+    BOOST_CHECK_EQUAL(timeouts.size(), 0U);
 
-  bool writeCBCalled = false;
-  auto writeCB = [](int fd, FDMultiplexer::funcparam_t param) {
-    auto calledPtr = boost::any_cast<bool*>(param);
-    BOOST_REQUIRE(calledPtr != nullptr);
-    *calledPtr = true;
-  };
-  mplexer->addWriteFD(pipes[1],
-                      writeCB,
-                      &writeCBCalled,
-                      &ttd);
-  /* we can't add it twice */
-  BOOST_CHECK_THROW(mplexer->addWriteFD(pipes[1],
-                                        writeCB,
-                                        &writeCBCalled,
-                                        &ttd),
-                    FDMultiplexerException);
+    int pipes[2];
+    int res = pipe(pipes);
+    BOOST_REQUIRE_EQUAL(res, 0);
+    BOOST_REQUIRE_EQUAL(setNonBlocking(pipes[0]), true);
+    BOOST_REQUIRE_EQUAL(setNonBlocking(pipes[1]), true);
 
-  readyFDs.clear();
-  mplexer->getAvailableFDs(readyFDs, 0);
-  BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
-  BOOST_CHECK_EQUAL(readyFDs.at(0), pipes[1]);
+    /* let's declare a TTD that expired 5s ago */
+    struct timeval ttd = now;
+    ttd.tv_sec -= 5;
 
-  ready = mplexer->run(&now, 100);
-  BOOST_CHECK_EQUAL(ready, 1);
-  BOOST_CHECK_EQUAL(writeCBCalled, true);
+    bool writeCBCalled = false;
+    auto writeCB = [](int fd, FDMultiplexer::funcparam_t param) {
+      auto calledPtr = boost::any_cast<bool*>(param);
+      BOOST_REQUIRE(calledPtr != nullptr);
+      *calledPtr = true;
+    };
+    mplexer->addWriteFD(pipes[1],
+                        writeCB,
+                        &writeCBCalled,
+                        &ttd);
+    /* we can't add it twice */
+    BOOST_CHECK_THROW(mplexer->addWriteFD(pipes[1],
+                                          writeCB,
+                                          &writeCBCalled,
+                                          &ttd),
+                      FDMultiplexerException);
 
-  /* no read timeouts */
-  timeouts = mplexer->getTimeouts(now, false);
-  BOOST_CHECK_EQUAL(timeouts.size(), 0U);
-  /* but we should have a write one */
-  timeouts = mplexer->getTimeouts(now, true);
-  BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
-  BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[1]);
+    readyFDs.clear();
+    mplexer->getAvailableFDs(readyFDs, 0);
+    BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
+    BOOST_CHECK_EQUAL(readyFDs.at(0), pipes[1]);
 
-  /* can't remove from the wrong type of FD */
-  BOOST_CHECK_THROW(mplexer->removeReadFD(pipes[1]), FDMultiplexerException);
-  mplexer->removeWriteFD(pipes[1]);
-  /* can't remove a non-existing FD */
-  BOOST_CHECK_THROW(mplexer->removeWriteFD(pipes[0]), FDMultiplexerException);
-  BOOST_CHECK_THROW(mplexer->removeWriteFD(pipes[1]), FDMultiplexerException);
-
-  readyFDs.clear();
-  mplexer->getAvailableFDs(readyFDs, 0);
-  BOOST_REQUIRE_EQUAL(readyFDs.size(), 0U);
-
-  ready = mplexer->run(&now, 100);
-  BOOST_CHECK_EQUAL(ready, 0);
-
-  bool readCBCalled = false;
-  auto readCB = [](int fd, FDMultiplexer::funcparam_t param) {
-    auto calledPtr = boost::any_cast<bool*>(param);
-    BOOST_REQUIRE(calledPtr != nullptr);
-    *calledPtr = true;
-  };
-  mplexer->addReadFD(pipes[0],
-                     readCB,
-                     &readCBCalled,
-                     &ttd);
-
-  /* not ready for reading yet */
-  readyFDs.clear();
-  mplexer->getAvailableFDs(readyFDs, 0);
-  BOOST_REQUIRE_EQUAL(readyFDs.size(), 0U);
-
-  ready = mplexer->run(&now, 100);
-  BOOST_CHECK_EQUAL(ready, 0);
-  BOOST_CHECK_EQUAL(readCBCalled, false);
-
-  /* let's make the pipe readable */
-  BOOST_REQUIRE_EQUAL(write(pipes[1], "0", 1), 1);
-
-  readyFDs.clear();
-  mplexer->getAvailableFDs(readyFDs, 0);
-  BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
-  BOOST_CHECK_EQUAL(readyFDs.at(0), pipes[0]);
-
-  ready = mplexer->run(&now, 100);
-  BOOST_CHECK_EQUAL(ready, 1);
-  BOOST_CHECK_EQUAL(readCBCalled, true);
-
-  /* add back the write FD */
-  mplexer->addWriteFD(pipes[1],
-                      writeCB,
-                      &writeCBCalled,
-                      &ttd);
-
-  /* both should be available */
-  readCBCalled = false;
-  writeCBCalled = false;
-  readyFDs.clear();
-
-  mplexer->getAvailableFDs(readyFDs, 0);
-  BOOST_REQUIRE_GT(readyFDs.size(), 0U);
-  if (readyFDs.size() == 2) {
     ready = mplexer->run(&now, 100);
-    BOOST_CHECK_EQUAL(ready, 2);
-  }
-  else if (readyFDs.size() == 1) {
-    /* under high pressure (lots of existing pipes on the system, for example,
-       the pipe might only have room for one 'buffer' and will not be writable
-       after our write of 1 byte, we need to read it so that the pipe becomes
-       writable again */
-    /* make sure the pipe is readable, otherwise something is off */
-    BOOST_REQUIRE_EQUAL(readyFDs.at(0), pipes[0]);
+    BOOST_CHECK_EQUAL(ready, 1);
+    BOOST_CHECK_EQUAL(writeCBCalled, true);
+
+    /* no read timeouts */
+    timeouts = mplexer->getTimeouts(now, false);
+    BOOST_CHECK_EQUAL(timeouts.size(), 0U);
+    /* but we should have a write one */
+    timeouts = mplexer->getTimeouts(now, true);
+    BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
+    BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[1]);
+
+    /* can't remove from the wrong type of FD */
+    BOOST_CHECK_THROW(mplexer->removeReadFD(pipes[1]), FDMultiplexerException);
+    mplexer->removeWriteFD(pipes[1]);
+    /* can't remove a non-existing FD */
+    BOOST_CHECK_THROW(mplexer->removeWriteFD(pipes[0]), FDMultiplexerException);
+    BOOST_CHECK_THROW(mplexer->removeWriteFD(pipes[1]), FDMultiplexerException);
+
+    readyFDs.clear();
+    mplexer->getAvailableFDs(readyFDs, 0);
+    BOOST_REQUIRE_EQUAL(readyFDs.size(), 0U);
+
+    ready = mplexer->run(&now, 100);
+    BOOST_CHECK_EQUAL(ready, 0);
+
+    bool readCBCalled = false;
+    auto readCB = [](int fd, FDMultiplexer::funcparam_t param) {
+      auto calledPtr = boost::any_cast<bool*>(param);
+      BOOST_REQUIRE(calledPtr != nullptr);
+      *calledPtr = true;
+    };
+    mplexer->addReadFD(pipes[0],
+                       readCB,
+                       &readCBCalled,
+                       &ttd);
+
+    /* not ready for reading yet */
+    readyFDs.clear();
+    mplexer->getAvailableFDs(readyFDs, 0);
+    BOOST_REQUIRE_EQUAL(readyFDs.size(), 0U);
+
+    ready = mplexer->run(&now, 100);
+    BOOST_CHECK_EQUAL(ready, 0);
+    BOOST_CHECK_EQUAL(readCBCalled, false);
+
+    /* let's make the pipe readable */
+    BOOST_REQUIRE_EQUAL(write(pipes[1], "0", 1), 1);
+
+    readyFDs.clear();
+    mplexer->getAvailableFDs(readyFDs, 0);
+    BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
+    BOOST_CHECK_EQUAL(readyFDs.at(0), pipes[0]);
+
     ready = mplexer->run(&now, 100);
     BOOST_CHECK_EQUAL(ready, 1);
     BOOST_CHECK_EQUAL(readCBCalled, true);
-    BOOST_CHECK_EQUAL(writeCBCalled, false);
-    char buffer[1];
-    ssize_t got = read(pipes[0], &buffer[0], sizeof(buffer));
-    BOOST_CHECK_EQUAL(got, 1U);
 
-    /* ok, the pipe should be writable now, but not readable */
+    /* add back the write FD */
+    mplexer->addWriteFD(pipes[1],
+                        writeCB,
+                        &writeCBCalled,
+                        &ttd);
+
+    /* both should be available */
+    readCBCalled = false;
+    writeCBCalled = false;
     readyFDs.clear();
+
     mplexer->getAvailableFDs(readyFDs, 0);
-    BOOST_CHECK_EQUAL(readyFDs.size(), 1U);
-    BOOST_REQUIRE_EQUAL(readyFDs.at(0), pipes[1]);
+    BOOST_REQUIRE_GT(readyFDs.size(), 0U);
+    if (readyFDs.size() == 2) {
+      ready = mplexer->run(&now, 100);
+      BOOST_CHECK_EQUAL(ready, 2);
+    }
+    else if (readyFDs.size() == 1) {
+      /* under high pressure (lots of existing pipes on the system, for example,
+         the pipe might only have room for one 'buffer' and will not be writable
+         after our write of 1 byte, we need to read it so that the pipe becomes
+         writable again */
+      /* make sure the pipe is readable, otherwise something is off */
+      BOOST_REQUIRE_EQUAL(readyFDs.at(0), pipes[0]);
+      ready = mplexer->run(&now, 100);
+      BOOST_CHECK_EQUAL(ready, 1);
+      BOOST_CHECK_EQUAL(readCBCalled, true);
+      BOOST_CHECK_EQUAL(writeCBCalled, false);
+      char buffer[1];
+      ssize_t got = read(pipes[0], &buffer[0], sizeof(buffer));
+      BOOST_CHECK_EQUAL(got, 1U);
 
-    ready = mplexer->run(&now, 100);
-    BOOST_CHECK_EQUAL(ready, 1);
+      /* ok, the pipe should be writable now, but not readable */
+      readyFDs.clear();
+      mplexer->getAvailableFDs(readyFDs, 0);
+      BOOST_CHECK_EQUAL(readyFDs.size(), 1U);
+      BOOST_REQUIRE_EQUAL(readyFDs.at(0), pipes[1]);
+
+      ready = mplexer->run(&now, 100);
+      BOOST_CHECK_EQUAL(ready, 1);
+    }
+
+    BOOST_CHECK_EQUAL(readCBCalled, true);
+    BOOST_CHECK_EQUAL(writeCBCalled, true);
+
+    /* both the read and write FD should be reported */
+    timeouts = mplexer->getTimeouts(now, false);
+    BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
+    BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[0]);
+    timeouts = mplexer->getTimeouts(now, true);
+    BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
+    BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[1]);
+
+    struct timeval past = ttd;
+    /* so five seconds before the actual TTD */
+    past.tv_sec -= 5;
+
+    /* no read timeouts */
+    timeouts = mplexer->getTimeouts(past, false);
+    BOOST_CHECK_EQUAL(timeouts.size(), 0U);
+    /* and we should not have a write one either */
+    timeouts = mplexer->getTimeouts(past, true);
+    BOOST_CHECK_EQUAL(timeouts.size(), 0U);
+
+    /* update the timeouts to now, they should not be reported anymore */
+    mplexer->setReadTTD(pipes[0], now, 0);
+    mplexer->setWriteTTD(pipes[1], now, 0);
+    timeouts = mplexer->getTimeouts(now, false);
+    BOOST_REQUIRE_EQUAL(timeouts.size(), 0U);
+    timeouts = mplexer->getTimeouts(now, true);
+    BOOST_REQUIRE_EQUAL(timeouts.size(), 0U);
+
+    /* put it back into the past */
+    mplexer->setReadTTD(pipes[0], now, -5);
+    mplexer->setWriteTTD(pipes[1], now, -5);
+    timeouts = mplexer->getTimeouts(now, false);
+    BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
+    BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[0]);
+    timeouts = mplexer->getTimeouts(now, true);
+    BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
+    BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[1]);
+
+    mplexer->removeReadFD(pipes[0]);
+    mplexer->removeWriteFD(pipes[1]);
+
+    /* clean up */
+    close(pipes[0]);
+    close(pipes[1]);
   }
-
-  BOOST_CHECK_EQUAL(readCBCalled, true);
-  BOOST_CHECK_EQUAL(writeCBCalled, true);
-
-  /* both the read and write FD should be reported */
-  timeouts = mplexer->getTimeouts(now, false);
-  BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
-  BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[0]);
-  timeouts = mplexer->getTimeouts(now, true);
-  BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
-  BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[1]);
-
-  struct timeval past = ttd;
-  /* so five seconds before the actual TTD */
-  past.tv_sec -= 5;
-
-  /* no read timeouts */
-  timeouts = mplexer->getTimeouts(past, false);
-  BOOST_CHECK_EQUAL(timeouts.size(), 0U);
-  /* and we should not have a write one either */
-  timeouts = mplexer->getTimeouts(past, true);
-  BOOST_CHECK_EQUAL(timeouts.size(), 0U);
-
-  /* update the timeouts to now, they should not be reported anymore */
-  mplexer->setReadTTD(pipes[0], now, 0);
-  mplexer->setWriteTTD(pipes[1], now, 0);
-  timeouts = mplexer->getTimeouts(now, false);
-  BOOST_REQUIRE_EQUAL(timeouts.size(), 0U);
-  timeouts = mplexer->getTimeouts(now, true);
-  BOOST_REQUIRE_EQUAL(timeouts.size(), 0U);
-
-  /* put it back into the past */
-  mplexer->setReadTTD(pipes[0], now, -5);
-  mplexer->setWriteTTD(pipes[1], now, -5);
-  timeouts = mplexer->getTimeouts(now, false);
-  BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
-  BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[0]);
-  timeouts = mplexer->getTimeouts(now, true);
-  BOOST_REQUIRE_EQUAL(timeouts.size(), 1U);
-  BOOST_CHECK_EQUAL(timeouts.at(0).first, pipes[1]);
-
-  mplexer->removeReadFD(pipes[0]);
-  mplexer->removeWriteFD(pipes[1]);
-
-  /* clean up */
-  close(pipes[0]);
-  close(pipes[1]);
 }
 
 BOOST_AUTO_TEST_CASE(test_MPlexer_ReadAndWrite)
 {
-  auto mplexer = std::unique_ptr<FDMultiplexer>(FDMultiplexer::getMultiplexerSilent());
-  BOOST_REQUIRE(mplexer != nullptr);
+  for (const auto& entry : FDMultiplexer::getMultiplexerMap()) {
+    auto mplexer = std::unique_ptr<FDMultiplexer>(entry.second());
+    BOOST_REQUIRE(mplexer != nullptr);
+    //cerr<<"Testing multiplexer "<<mplexer->getName()<<" for read AND write"<<endl;
 
-  int sockets[2];
-  int res = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
-  BOOST_REQUIRE_EQUAL(res, 0);
-  BOOST_REQUIRE_EQUAL(setNonBlocking(sockets[0]), true);
-  BOOST_REQUIRE_EQUAL(setNonBlocking(sockets[1]), true);
+    int sockets[2];
+    int res = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+    BOOST_REQUIRE_EQUAL(res, 0);
+    BOOST_REQUIRE_EQUAL(setNonBlocking(sockets[0]), true);
+    BOOST_REQUIRE_EQUAL(setNonBlocking(sockets[1]), true);
 
-  struct timeval now;
-  std::vector<int> readyFDs;
-  struct timeval ttd = now;
-  ttd.tv_sec += 5;
+    struct timeval now;
+    std::vector<int> readyFDs;
+    struct timeval ttd = now;
+    ttd.tv_sec += 5;
 
-  bool readCBCalled = false;
-  bool writeCBCalled = false;
-  auto readCB = [](int fd, FDMultiplexer::funcparam_t param) {
-    auto calledPtr = boost::any_cast<bool*>(param);
-    BOOST_REQUIRE(calledPtr != nullptr);
-    *calledPtr = true;
-  };
-  auto writeCB = [](int fd, FDMultiplexer::funcparam_t param) {
-    auto calledPtr = boost::any_cast<bool*>(param);
-    BOOST_REQUIRE(calledPtr != nullptr);
-    *calledPtr = true;
-  };
-  mplexer->addReadFD(sockets[0],
-                     readCB,
-                     &readCBCalled,
-                     &ttd);
-  mplexer->addWriteFD(sockets[0],
-                      writeCB,
-                      &writeCBCalled,
-                      &ttd);
+    bool readCBCalled = false;
+    bool writeCBCalled = false;
+    auto readCB = [](int fd, FDMultiplexer::funcparam_t param) {
+      auto calledPtr = boost::any_cast<bool*>(param);
+      BOOST_REQUIRE(calledPtr != nullptr);
+      *calledPtr = true;
+    };
+    auto writeCB = [](int fd, FDMultiplexer::funcparam_t param) {
+      auto calledPtr = boost::any_cast<bool*>(param);
+      BOOST_REQUIRE(calledPtr != nullptr);
+      *calledPtr = true;
+    };
+    mplexer->addReadFD(sockets[0],
+                       readCB,
+                       &readCBCalled,
+                       &ttd);
+    mplexer->addWriteFD(sockets[0],
+                        writeCB,
+                        &writeCBCalled,
+                        &ttd);
 
-  /* not ready for reading yet, but should be writable */
-  readyFDs.clear();
-  mplexer->getAvailableFDs(readyFDs, 0);
-  BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
-  BOOST_CHECK_EQUAL(readyFDs.at(0), sockets[0]);
+    /* not ready for reading yet, but should be writable */
+    readyFDs.clear();
+    mplexer->getAvailableFDs(readyFDs, 0);
+    BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
+    BOOST_CHECK_EQUAL(readyFDs.at(0), sockets[0]);
 
-  /* let's make the socket readable */
-  BOOST_REQUIRE_EQUAL(write(sockets[1], "0", 1), 1);
+    /* let's make the socket readable */
+    BOOST_REQUIRE_EQUAL(write(sockets[1], "0", 1), 1);
 
-  readyFDs.clear();
-  mplexer->getAvailableFDs(readyFDs, 0);
-  BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
-  BOOST_CHECK_EQUAL(readyFDs.at(0), sockets[0]);
+    readyFDs.clear();
+    mplexer->getAvailableFDs(readyFDs, 0);
+    BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
+    BOOST_CHECK_EQUAL(readyFDs.at(0), sockets[0]);
 
-  auto ready = mplexer->run(&now, 100);
-  BOOST_CHECK_EQUAL(ready, 2);
-  BOOST_CHECK_EQUAL(readCBCalled, true);
-  BOOST_CHECK_EQUAL(writeCBCalled, true);
+    auto ready = mplexer->run(&now, 100);
+    BOOST_CHECK_EQUAL(ready, 2);
+    BOOST_CHECK_EQUAL(readCBCalled, true);
+    BOOST_CHECK_EQUAL(writeCBCalled, true);
 
-  /* check that the write cb remains when we remove the read one */
-  mplexer->removeReadFD(sockets[0]);
+    /* check that the write cb remains when we remove the read one */
+    mplexer->removeReadFD(sockets[0]);
 
-  readCBCalled = false;
-  writeCBCalled = false;
-  readyFDs.clear();
-  mplexer->getAvailableFDs(readyFDs, 0);
-  BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
-  BOOST_CHECK_EQUAL(readyFDs.at(0), sockets[0]);
-  ready = mplexer->run(&now, 100);
-  BOOST_CHECK_EQUAL(ready, 1);
-  BOOST_CHECK_EQUAL(readCBCalled, false);
-  BOOST_CHECK_EQUAL(writeCBCalled, true);
+    readCBCalled = false;
+    writeCBCalled = false;
+    readyFDs.clear();
+    mplexer->getAvailableFDs(readyFDs, 0);
+    BOOST_REQUIRE_EQUAL(readyFDs.size(), 1U);
+    BOOST_CHECK_EQUAL(readyFDs.at(0), sockets[0]);
+    ready = mplexer->run(&now, 100);
+    BOOST_CHECK_EQUAL(ready, 1);
+    BOOST_CHECK_EQUAL(readCBCalled, false);
+    BOOST_CHECK_EQUAL(writeCBCalled, true);
 
-  mplexer->removeWriteFD(sockets[0]);
+    mplexer->removeWriteFD(sockets[0]);
 
-  /* clean up */
-  close(sockets[0]);
-  close(sockets[1]);
+    /* clean up */
+    close(sockets[0]);
+    close(sockets[1]);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-mplexer.cc
+++ b/pdns/test-mplexer.cc
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(test_MPlexer_ReadAndWrite)
   BOOST_CHECK_EQUAL(readyFDs.at(0), sockets[0]);
 
   auto ready = mplexer->run(&now, 100);
-  BOOST_CHECK_EQUAL(ready, 1);
+  BOOST_CHECK_EQUAL(ready, 2);
   BOOST_CHECK_EQUAL(readCBCalled, true);
   BOOST_CHECK_EQUAL(writeCBCalled, true);
 

--- a/pdns/test-mplexer.cc
+++ b/pdns/test-mplexer.cc
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(test_MPlexer)
     ttd.tv_sec -= 5;
 
     bool writeCBCalled = false;
-    auto writeCB = [](int fd, FDMultiplexer::funcparam_t param) {
+    auto writeCB = [](int fd, FDMultiplexer::funcparam_t& param) {
       auto calledPtr = boost::any_cast<bool*>(param);
       BOOST_REQUIRE(calledPtr != nullptr);
       *calledPtr = true;
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(test_MPlexer)
     BOOST_CHECK_EQUAL(ready, 0);
 
     bool readCBCalled = false;
-    auto readCB = [](int fd, FDMultiplexer::funcparam_t param) {
+    auto readCB = [](int fd, FDMultiplexer::funcparam_t& param) {
       auto calledPtr = boost::any_cast<bool*>(param);
       BOOST_REQUIRE(calledPtr != nullptr);
       *calledPtr = true;
@@ -235,18 +235,19 @@ BOOST_AUTO_TEST_CASE(test_MPlexer_ReadAndWrite)
     BOOST_REQUIRE_EQUAL(setNonBlocking(sockets[1]), true);
 
     struct timeval now;
+    gettimeofday(&now, nullptr);
     std::vector<int> readyFDs;
     struct timeval ttd = now;
     ttd.tv_sec += 5;
 
     bool readCBCalled = false;
     bool writeCBCalled = false;
-    auto readCB = [](int fd, FDMultiplexer::funcparam_t param) {
+    auto readCB = [](int fd, FDMultiplexer::funcparam_t& param) {
       auto calledPtr = boost::any_cast<bool*>(param);
       BOOST_REQUIRE(calledPtr != nullptr);
       *calledPtr = true;
     };
-    auto writeCB = [](int fd, FDMultiplexer::funcparam_t param) {
+    auto writeCB = [](int fd, FDMultiplexer::funcparam_t& param) {
       auto calledPtr = boost::any_cast<bool*>(param);
       BOOST_REQUIRE(calledPtr != nullptr);
       *calledPtr = true;

--- a/pdns/test-mplexer.cc
+++ b/pdns/test-mplexer.cc
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(test_getMultiplexerSilent)
   auto mplexer = std::unique_ptr<FDMultiplexer>(FDMultiplexer::getMultiplexerSilent());
   BOOST_REQUIRE(mplexer != nullptr);
 
-  struct timeval now{0,0};
+  struct timeval now = {0, 0};
   int ready = mplexer->run(&now, 100);
   BOOST_CHECK_EQUAL(ready, 0);
   BOOST_CHECK(now.tv_sec != 0);
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(test_MPlexer)
     BOOST_REQUIRE(mplexer != nullptr);
     //cerr<<"Testing multiplexer "<<mplexer->getName()<<endl;
 
-    struct timeval now{0,0};
+    struct timeval now = {0, 0};
     int ready = mplexer->run(&now, 100);
     BOOST_CHECK_EQUAL(ready, 0);
     BOOST_CHECK(now.tv_sec != 0);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This commit refactors our multiplexers to be able to wait for a descriptor to become readable OR writable at the same time.

I kept the two separate maps for an easier handling of the separate TTD and to limit the amount of changes, but we might want to mergethem into a single map in the future.
The accounting is moved into the parent class instead of being dealt with by the multiplexers themselves.

I noticed that the poll multiplexer allocates and fills a vector of pollfd for every call to run(), which seems wasteful, but I did not
want to touch that in this commit.

I did not compile or test the kqueue, ports and /dev/poll multiplexers yet, so don't merge this without testing them first.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
