### PR TITLE
rec: NS from the cache could be a forwarder

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2373,9 +2373,17 @@ bool SyncRes::throttledOrBlocked(const std::string& prefix, const ComboAddress& 
     return true;
   }
   else if(!pierceDontQuery && s_dontQuery && s_dontQuery->match(&remoteIP)) {
-    LOG(prefix<<qname<<": not sending query to " << remoteIP.toString() << ", blocked by 'dont-query' setting" << endl);
-    s_dontqueries++;
-    return true;
+    // We could have retrieved an NS from the cache in a forwarding domain
+    // Even in the case of !pierceDontQuery we still want to allow that NS
+    DNSName forwardCandidate(qname);
+    auto it = getBestAuthZone(&forwardCandidate);
+    if (it == t_sstorage.domainmap->end()) {
+      LOG(prefix<<qname<<": not sending query to " << remoteIP.toString() << ", blocked by 'dont-query' setting" << endl);
+      s_dontqueries++;
+      return true;
+    } else {
+      LOG(prefix<<qname<<": sending query to " << remoteIP.toString() << ", blocked by 'dont-query' but a forwarding/auth case" << endl);
+    }
   }
   return false;
 }


### PR DESCRIPTION
Take that into acount when determining `dont-query` status. Should fix #10638.
Only if it;s coming from the auth domain map `pierceDontQuery` wil lbe set.

A workarounf is to add `!<forwarder-ip>` to `dont-query`

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
