### PR TITLE
Fix a warning about catching a polymorphic exception type by value

### DIFF
--- a/pdns/decafsigners.cc
+++ b/pdns/decafsigners.cc
@@ -137,7 +137,7 @@ bool DecafED25519DNSCryptoKeyEngine::verify(const std::string& msg, const std::s
 
   try {
     pub.verify(sig, message);
-  } catch(CryptoException) {
+  } catch(const CryptoException& e) {
     return false;
   }
 
@@ -273,7 +273,7 @@ bool DecafED448DNSCryptoKeyEngine::verify(const std::string& msg, const std::str
 
   try {
     pub.verify(sig, message);
-  } catch(CryptoException) {
+  } catch(const CryptoException& e) {
     return false;
   }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
```
decafsigners.cc: In member function ‘virtual bool DecafED25519DNSCryptoKeyEngine::verify(const string&, const string&) const’:
decafsigners.cc:140:11: warning: catching polymorphic type ‘class decaf::CryptoException’ by value [-Wcatch-value=]
  140 |   } catch(CryptoException) {
      |           ^~~~~~~~~~~~~~~
decafsigners.cc: In member function ‘virtual bool DecafED448DNSCryptoKeyEngine::verify(const string&, const string&) const’:
decafsigners.cc:276:11: warning: catching polymorphic type ‘class decaf::CryptoException’ by value [-Wcatch-value=]
  276 |   } catch(CryptoException) {
      |           ^~~~~~~~~~~~~~~
```

On the other hand, I wonder if we should not drop the decaf code altogether since:
- 15 is provided by `libsodium` and recent versions of `OpenSSL`
- 16 is provided by recent versions of `OpenSSL`
- but more importantly it looks like we don't really test that code..

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
