### PR TITLE
dnsdist: Fix the wrong RD and CD flags being cached, causing misses

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -294,7 +294,7 @@ static void restoreFlags(struct dnsheader* dh, uint16_t origFlags)
 
 static uint16_t getRDAndCDFlagsFromDNSHeader(const struct dnsheader* dh)
 {
-  return static_cast<uint16_t>((dh->rd << FLAGS_RD_OFFSET) + (dh->cd << FLAGS_CD_OFFSET));
+  return static_cast<uint16_t>(dh->rd) << FLAGS_RD_OFFSET | static_cast<uint16_t>(dh->cd) << FLAGS_CD_OFFSET;
 }
 
 static bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags)

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -292,6 +292,11 @@ static void restoreFlags(struct dnsheader* dh, uint16_t origFlags)
   *flags |= origFlags;
 }
 
+static uint16_t getRDAndCDFlagsFromDNSHeader(const struct dnsheader* dh)
+{
+  return static_cast<uint16_t>((dh->rd << FLAGS_RD_OFFSET) + (dh->cd << FLAGS_CD_OFFSET));
+}
+
 static bool fixUpQueryTurnedResponse(DNSQuestion& dq, const uint16_t origFlags)
 {
   restoreFlags(dq.getHeader(), origFlags);
@@ -445,6 +450,9 @@ bool processResponse(PacketBuffer& response, LocalStateHolder<vector<DNSDistResp
     return false;
   }
 
+  /* We need to get the flags for the packet cache before restoring the original ones, otherwise it might not match later queries */
+  const auto cacheFlags = getRDAndCDFlagsFromDNSHeader(dr.getHeader());
+
   bool zeroScope = false;
   if (!fixUpResponse(response, *dr.qname, dr.origFlags, dr.ednsAdded, dr.ecsAdded, dr.useZeroScope ? &zeroScope : nullptr)) {
     return false;
@@ -463,7 +471,7 @@ bool processResponse(PacketBuffer& response, LocalStateHolder<vector<DNSDistResp
       zeroScope = false;
     }
     // if zeroScope, pass the pre-ECS hash-key and do not pass the subnet to the cache
-    dr.packetCache->insert(zeroScope ? dr.cacheKeyNoECS : dr.cacheKey, zeroScope ? boost::none : dr.subnet, dr.origFlags, dr.dnssecOK, *dr.qname, dr.qtype, dr.qclass, response, receivedOverUDP, dr.getHeader()->rcode, dr.tempFailureTTL);
+    dr.packetCache->insert(zeroScope ? dr.cacheKeyNoECS : dr.cacheKey, zeroScope ? boost::none : dr.subnet, cacheFlags, dr.dnssecOK, *dr.qname, dr.qtype, dr.qclass, response, receivedOverUDP, dr.getHeader()->rcode, dr.tempFailureTTL);
   }
 
 #ifdef HAVE_DNSCRYPT
@@ -1237,6 +1245,8 @@ ProcessQueryResult processQuery(DNSQuestion& dq, ClientState& cs, LocalHolders& 
 
     if (dq.packetCache && !dq.skipCache) {
       if (dq.packetCache->get(dq, dq.getHeader()->id, &dq.cacheKey, dq.subnet, dq.dnssecOK, !dq.overTCP() || dq.getProtocol() == DNSQuestion::Protocol::DoH, allowExpired)) {
+
+        restoreFlags(dq.getHeader(), dq.origFlags);
 
         if (!prepareOutgoingResponse(holders, cs, dq, true)) {
           return ProcessQueryResult::Drop;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to restore the RD and CD flags from the initial query before inserting the response into the cache. That would cause an issue if the flags had been altered, for example via `SetNoRecurseAction`, as the cache lookup is done _after_ the actions have been applied and thus after the flags altered.
If the initial query had the RD bit set, and thus was cleared by the rule, the response would have been inserted with the RD bit restored, and no lookup would then succeed because it would be done with the bit cleared.
This commit fixes the insertion to use the RD and CD bits as set in the response before restoring them, and restores the RD and CD bits after a cache hit as well, to ensure that:
- cache lookups are done after the rules are applied
- cache insertions are done before the flags are restored

This issue was reported by Adam Bishop (many thanks!).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
