### PR TITLE
dnsdist: Catch FDMultiplexerException in IOStateHandler's destructor

### DIFF
--- a/pdns/dnsdistdist/tcpiohandler-mplexer.hh
+++ b/pdns/dnsdistdist/tcpiohandler-mplexer.hh
@@ -27,7 +27,13 @@ public:
     /* be careful that this won't save us if the callback is still registered to the multiplexer,
        because in that case the shared pointer count will never reach zero so this destructor won't
        be called */
-    reset();
+    try {
+      reset();
+    }
+    catch (const FDMultiplexerException& e) {
+      /* that should not happen, but an exception raised from a destructor would be bad so better
+         safe than sorry */
+    }
   }
 
   IOState getState() const


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported by Coverity (CID 372512).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
