### PR TITLE
auth: incoming PROXY support

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1158,6 +1158,7 @@ openssl
 opensuse
 openwall
 Opmeer
+OPNUM
 optcode
 Opteron
 optmem

--- a/docs/manpages/sdig.1.rst
+++ b/docs/manpages/sdig.1.rst
@@ -57,6 +57,8 @@ tlsProvider *name*
     when using DoT, use TLS provider *name*. Currently supported (if compiled in): `openssl` and `gnutls`. Default is `openssl` if available.
 xpf *XPFCODE* *XPFVERSION* *XPFPROTO* *XPFSRC* *XPFDST*
 	Send an *XPF* additional with these parameters.
+opcode *OPNUM*
+    Use opcode *OPNUM* instead of 0 (Query). For example, ``sdig 192.0.2.1 53 example.com SOA opcode 4`` sends a ``NOTIFY``.
 
 Examples
 --------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1253,7 +1253,7 @@ prevent-self-notification to "no".
 
 Turn on operating as a primary. See :ref:`primary-operation`.
 
-.. _setting-proxy-protocol-from
+.. _setting-proxy-protocol-from:
 
 ``proxy-protocol-from``
 -----------------------
@@ -1266,6 +1266,7 @@ Ranges that are required to send a Proxy Protocol version 2 header in front of U
 Queries that are not prefixed with such a header will not be accepted from clients in these ranges. Queries prefixed by headers from clients that are not listed in these ranges will be dropped.
 
 Note that once a Proxy Protocol header has been received, the source address from the proxy header instead of the address of the proxy will be checked against primary addresses sending NOTIFYs, and the ACLs for any client requesting AXFRs.
+When using this setting combined with :ref:`setting-trusted-notification-proxy`, please be aware that the trusted address will also be checked against the source address in the PROXY header.
 
 .. _setting-proxy-protocol-maximum-size:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1253,6 +1253,31 @@ prevent-self-notification to "no".
 
 Turn on operating as a primary. See :ref:`primary-operation`.
 
+.. _setting-proxy-protocol-from
+
+``proxy-protocol-from``
+-----------------------
+.. versionadded:: 4.6.0
+
+-  IP addresses or netmasks, separated by commas
+-  Default: empty
+
+Ranges that are required to send a Proxy Protocol version 2 header in front of UDP and TCP queries, to pass the original source and destination addresses and ports to the Authoritative.
+Queries that are not prefixed with such a header will not be accepted from clients in these ranges. Queries prefixed by headers from clients that are not listed in these ranges will be dropped.
+
+Note that once a Proxy Protocol header has been received, the source address from the proxy header instead of the address of the proxy will be checked against primary addresses sending NOTIFYs, and the ACLs for any client requesting AXFRs.
+
+.. _setting-proxy-protocol-maximum-size:
+
+``proxy-protocol-maximum-size``
+-------------------------------
+.. versionadded:: 4.6.0
+
+-  Integer
+-  Default: 512
+
+The maximum size, in bytes, of a Proxy Protocol payload (header, addresses and ports, and TLV values). Queries with a larger payload will be dropped.
+
 .. _setting-query-cache-ttl:
 
 ``query-cache-ttl``

--- a/modules/lua2backend/lua2api2.hh
+++ b/modules/lua2backend/lua2api2.hh
@@ -204,7 +204,7 @@ public:
 
     lookup_context_t ctx;
     if (p != NULL) {
-      ctx.emplace_back(lookup_context_t::value_type{"source_address", p->getRemote().toString()});
+      ctx.emplace_back(lookup_context_t::value_type{"source_address", p->getInnerRemote().toString()});
       ctx.emplace_back(lookup_context_t::value_type{"real_source_address", p->getRealRemote().toString()});
     }
 

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -172,7 +172,7 @@ void PipeBackend::lookup(const QType& qtype, const DNSName& qname, int zoneId, D
       if (pkt_p) {
         localIP = pkt_p->getLocal().toString();
         realRemote = pkt_p->getRealRemote();
-        remoteIP = pkt_p->getRemote().toString();
+        remoteIP = pkt_p->getInnerRemote().toString();
       }
       // abi-version = 1
       // type    qname           qclass  qtype   id      remote-ip-address

--- a/modules/remotebackend/Makefile.am
+++ b/modules/remotebackend/Makefile.am
@@ -4,6 +4,10 @@ AM_CPPFLAGS += \
 	$(LIBCRYPTO_CFLAGS) \
 	$(LIBZMQ_CFLAGS)
 
+if LUA
+AM_CPPFLAGS +=$(LUA_CFLAGS)
+endif
+
 AM_LDFLAGS = $(THREADFLAGS)
 
 JSON11_LIBS = $(top_builddir)/ext/json11/libjson11.la

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -203,7 +203,7 @@ void RemoteBackend::lookup(const QType& qtype, const DNSName& qdomain, int zoneI
   if (pkt_p) {
     localIP = pkt_p->getLocal().toString();
     realRemote = pkt_p->getRealRemote().toString();
-    remoteIP = pkt_p->getRemote().toString();
+    remoteIP = pkt_p->getInnerRemote().toString();
   }
 
   Json query = Json::object{

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -239,6 +239,7 @@ pdns_server_SOURCES = \
 	packetcache.hh \
 	packethandler.cc packethandler.hh \
 	pdnsexception.hh \
+	proxy-protocol.cc proxy-protocol.hh \
 	qtype.cc qtype.hh \
 	query-local-address.hh query-local-address.cc \
 	rcpgenerator.cc \

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -479,7 +479,7 @@ try
     S.ringAccount("queries", question.qdomain, question.qtype);
     S.ringAccount("remotes", question.d_remote);
     if(logDNSQueries) {
-      g_log << Logger::Notice<<"Remote "<< question.getRemoteString() <<" wants '" << question.qdomain<<"|"<<question.qtype.toString() <<
+      g_log << Logger::Notice<<"Remote "<< question.getRemoteString() <<" wants '" << question.qdomain<<"|"<<question.qtype <<
         "', do = " <<question.d_dnssecOk <<", bufsize = "<< question.getMaxReplyLen();
       if(question.d_ednsRawPacketSizeLimit > 0 && question.getMaxReplyLen() != (unsigned int)question.d_ednsRawPacketSizeLimit)
         g_log<<" ("<<question.d_ednsRawPacketSizeLimit<<")";

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -95,7 +95,7 @@ void declareArguments()
   ::arg().setSwitch("dnsupdate","Enable/Disable DNS update (RFC2136) support. Default is no.")="no";
   ::arg().setSwitch("write-pid","Write a PID file")="yes";
   ::arg().set("allow-dnsupdate-from","A global setting to allow DNS updates from these IP ranges.")="127.0.0.0/8,::1";
-  ::arg().set("proxy-protocol-from","A Proxy Protocol header is only allowed from these subnets, and is mandatory then too.")="";
+  ::arg().set("proxy-protocol-from", "A Proxy Protocol header is only allowed from these subnets, and is mandatory then too.")="";
   ::arg().set("proxy-protocol-maximum-size", "The maximum size of a proxy protocol payload, including the TLV values")="512";
   ::arg().setSwitch("send-signed-notify", "Send TSIG secured NOTIFY if TSIG key is configured for a zone") = "yes";
   ::arg().set("allow-unsigned-notify", "Allow unsigned notifications for TSIG secured zones") = "yes"; //FIXME: change to 'no' later

--- a/pdns/common_startup.hh
+++ b/pdns/common_startup.hh
@@ -53,6 +53,8 @@ extern int isGuarded( char ** );
 void carbonDumpThread();
 extern bool g_anyToTcp;
 extern bool g_8bitDNS;
+extern NetmaskGroup g_proxyProtocolACL;
+extern size_t g_proxyProtocolMaximumSize;
 #ifdef HAVE_LUA_RECORDS
 extern bool g_doLuaRecord;
 extern bool g_LuaRecordSharedState;

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -553,7 +553,7 @@ try
   d_wrapped=true;
   if(length < 12) { 
     g_log << Logger::Debug << "Ignoring packet: too short from "
-      << getRemote() << endl;
+      << getRemoteString() << endl;
     return -1;
   }
 
@@ -608,7 +608,7 @@ try
 
   if(!ntohs(d.qdcount)) {
     if(!d_tcp) {
-      g_log << Logger::Debug << "No question section in packet from " << getRemote() <<", RCode="<<RCode::to_s(d.rcode)<<endl;
+      g_log << Logger::Debug << "No question section in packet from " << getRemoteString() <<", RCode="<<RCode::to_s(d.rcode)<<endl;
       return -1;
     }
   }

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -61,8 +61,9 @@ public:
   const string& getString(); //!< for serialization - just passes the whole packet
 
   // address & socket manipulation
-  void setRemote(const ComboAddress*);
+  void setRemote(const ComboAddress*, std::optional<ComboAddress> = std::nullopt);
   ComboAddress getRemote() const;
+  ComboAddress getInnerRemote() const; // for proxy protocol
   Netmask getRealRemote() const;
   ComboAddress getLocal() const
   {
@@ -73,6 +74,9 @@ public:
   }
   uint16_t getRemotePort() const;
 
+  string getRemoteString() const;
+  string getRemoteStringWithPort() const;
+
   boost::optional<ComboAddress> d_anyLocal;
 
   Utility::sock_t getSocket() const
@@ -80,7 +84,6 @@ public:
     return d_socket;
   }
   void setSocket(Utility::sock_t sock);
-
 
   // these manipulate 'd'
   void setA(bool); //!< make this packet authoritative - manipulates 'd'
@@ -144,6 +147,7 @@ public:
   TSIGRecordContent d_trc; //72
 
   ComboAddress d_remote; //28
+  std::optional<ComboAddress> d_inner_remote; // for proxy protocol
   TSIGHashEnum d_tsig_algo{TSIG_MD5}; //4
 
   int d_ednsRawPacketSizeLimit{-1}; // only used for Lua record

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -147,7 +147,7 @@ public:
   TSIGRecordContent d_trc; //72
 
   ComboAddress d_remote; //28
-  std::optional<ComboAddress> d_inner_remote; // for proxy protocol
+  std::optional<ComboAddress> d_inner_remote; // the 'outer' remote is the IP on the physical packet header. The 'inner' remote lives one layer deeper, in the PROXY header.
   TSIGHashEnum d_tsig_algo{TSIG_MD5}; //4
 
   int d_ednsRawPacketSizeLimit{-1}; // only used for Lua record

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -41,10 +41,10 @@ void AuthLua4::postPrepareContext() {
   d_lw->registerFunction<DNSPacket, int(const char *, size_t)>("parse", [](DNSPacket &p, const char *mesg, size_t len){ return p.parse(mesg, len); });
   d_lw->registerFunction<DNSPacket, const std::string()>("getString", [](DNSPacket &p) { return p.getString(); });
   d_lw->registerFunction<DNSPacket, void(const ComboAddress&)>("setRemote", [](DNSPacket &p, const ComboAddress &ca) { p.setRemote(&ca); });
-  d_lw->registerFunction<DNSPacket, ComboAddress()>("getRemote", [](DNSPacket &p) { return p.getRemote(); });
+  d_lw->registerFunction<DNSPacket, ComboAddress()>("getRemote", [](DNSPacket &p) { return p.getInnerRemote(); });
   d_lw->registerFunction<DNSPacket, Netmask()>("getRealRemote", [](DNSPacket &p) { return p.getRealRemote(); });
   d_lw->registerFunction<DNSPacket, ComboAddress()>("getLocal", [](DNSPacket &p) { return p.getLocal(); });
-  d_lw->registerFunction<DNSPacket, unsigned int()>("getRemotePort", [](DNSPacket &p) { return p.getRemotePort(); });
+  d_lw->registerFunction<DNSPacket, unsigned int()>("getRemotePort", [](DNSPacket &p) { return p.getInnerRemote().getPort(); });
   d_lw->registerFunction<DNSPacket, std::tuple<const std::string, unsigned int>()>("getQuestion", [](DNSPacket &p) { return std::make_tuple(p.qdomain.toString(), static_cast<unsigned int>(p.qtype.getCode())); });
   d_lw->registerFunction<DNSPacket, void(bool)>("setA", [](DNSPacket &p, bool a) { return p.setA(a); });
   d_lw->registerFunction<DNSPacket, void(unsigned int)>("setID", [](DNSPacket &p, unsigned int id) { return p.setID(static_cast<uint16_t>(id)); });
@@ -153,7 +153,7 @@ bool AuthLua4::updatePolicy(const DNSName &qname, const QType& qtype, const DNSN
   upq.qtype = qtype.getCode();
   upq.zonename = zonename;
   upq.local = packet.getLocal();
-  upq.remote = packet.getRemote();
+  upq.remote = packet.getInnerRemote();
   upq.realRemote = packet.getRealRemote();
   upq.tsigName = packet.getTSIGKeyname();
   upq.peerPrincipal = packet.d_peer_principal;

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -978,7 +978,7 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
   lua.writeVariable("qname", query);
   lua.writeVariable("zone", zone);
   lua.writeVariable("zoneid", zoneid);
-  lua.writeVariable("who", dnsp.getRemote());
+  lua.writeVariable("who", dnsp.getInnerRemote());
   lua.writeVariable("dh", (dnsheader*)&dnsp.d);
   lua.writeVariable("dnssecOK", dnsp.d_dnssecOk);
   lua.writeVariable("tcp", dnsp.d_tcp);
@@ -989,7 +989,7 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(const std::string& code, cons
   }
   else {
     lua.writeVariable("ecswho", nullptr);
-    s_lua_record_ctx->bestwho = dnsp.getRemote();
+    s_lua_record_ctx->bestwho = dnsp.getInnerRemote();
   }
   lua.writeVariable("bestwho", s_lua_record_ctx->bestwho);
 

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -327,7 +327,7 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
 
   if(packet.parse(&buffer.at(0), (size_t) len)<0) {
     S.inc("corrupt-packets");
-    S.ringAccount("remotes-corrupt", packet.d_remote);
+    S.ringAccount("remotes-corrupt", packet.getInnerRemote());
 
     return false; // unable to parse
   }

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include "responsestats.hh"
 
+#include "common_startup.hh"
 #include "dns.hh"
 #include "dnsbackend.hh"
 #include "dnspacket.hh"
@@ -40,6 +41,7 @@
 #include "logger.hh"
 #include "arguments.hh"
 #include "statbag.hh"
+#include "proxy-protocol.hh"
 
 #include "namespaces.hh"
 
@@ -301,7 +303,27 @@ bool UDPNameserver::receive(DNSPacket& packet, std::string& buffer)
     packet.d_dt.setTimeval(recvtv);
   }
   else
-    packet.d_dt.set(); // timing    
+    packet.d_dt.set(); // timing
+
+  if (g_proxyProtocolACL.match(remote)) {
+    ComboAddress psource, pdestination;
+    bool proxyProto, tcp;
+    std::vector<ProxyProtocolValue> ppvalues;
+
+    buffer.resize(len);
+    ssize_t used = parseProxyHeader(buffer, proxyProto, psource, pdestination, tcp, ppvalues);
+    if (used <= 0 || (size_t) used > g_proxyProtocolMaximumSize || (len - used) > DNSPacket::s_udpTruncationThreshold) {
+      S.inc("corrupt-packets");
+      S.ringAccount("remotes-corrupt", packet.d_remote);
+      return false;
+    }
+    buffer.erase(0, used);
+    packet.d_inner_remote = psource;
+    packet.d_tcp = tcp;
+  }
+  else {
+    packet.d_inner_remote.reset();
+  }
 
   if(packet.parse(&buffer.at(0), (size_t) len)<0) {
     S.inc("corrupt-packets");

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1278,7 +1278,7 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
     if(d_logDNSDetails)
       g_log<<Logger::Error<<"Received an answer (non-query) packet from "<<p.getRemoteString()<<", dropping"<<endl;
     S.inc("corrupt-packets");
-    S.ringAccount("remotes-corrupt", p.d_remote);
+    S.ringAccount("remotes-corrupt", p.getInnerRemote());
     return nullptr;
   }
 
@@ -1286,7 +1286,7 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
     if(d_logDNSDetails)
       g_log<<Logger::Error<<"Received truncated query packet from "<<p.getRemoteString()<<", dropping"<<endl;
     S.inc("corrupt-packets");
-    S.ringAccount("remotes-corrupt", p.d_remote);
+    S.ringAccount("remotes-corrupt", p.getInnerRemote());
     return nullptr;
   }
 
@@ -1334,7 +1334,7 @@ std::unique_ptr<DNSPacket> PacketHandler::doQuestion(DNSPacket& p)
       if(d_logDNSDetails)
         g_log<<Logger::Error<<"Received a malformed qdomain from "<<p.getRemoteString()<<", '"<<p.qdomain<<"': sending servfail"<<endl;
       S.inc("corrupt-packets");
-      S.ringAccount("remotes-corrupt", p.d_remote);
+      S.ringAccount("remotes-corrupt", p.getInnerRemote());
       S.inc("servfail-packets");
       r->setRcode(RCode::ServFail);
       return r;

--- a/pdns/proxy-protocol.hh
+++ b/pdns/proxy-protocol.hh
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <iputils.hh>
+#include "iputils.hh"
 
 struct ProxyProtocolValue
 {

--- a/pdns/responsestats-auth.cc
+++ b/pdns/responsestats-auth.cc
@@ -22,7 +22,7 @@ void ResponseStats::submitResponse(DNSPacket &p, bool udpOrTCP, bool last) const
   static AtomicCounter &tcpbytesanswered4=*S.getPointer("tcp4-answers-bytes");
   static AtomicCounter &tcpbytesanswered6=*S.getPointer("tcp6-answers-bytes");
 
-  ComboAddress& accountremote = p.d_remote;
+  ComboAddress accountremote = p.d_remote;
   if (p.d_inner_remote) accountremote = *p.d_inner_remote;
 
   if(p.d.aa) {

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -644,7 +644,7 @@ int PacketHandler::processUpdate(DNSPacket& p) {
   if (! ::arg().mustDo("dnsupdate"))
     return RCode::Refused;
 
-  string msgPrefix="UPDATE (" + itoa(p.d.id) + ") from " + p.getRemote().toString() + " for " + p.qdomain.toLogString() + ": ";
+  string msgPrefix="UPDATE (" + itoa(p.d.id) + ") from " + p.getRemoteString() + " for " + p.qdomain.toLogString() + ": ";
   g_log<<Logger::Info<<msgPrefix<<"Processing started."<<endl;
 
   // if there is policy, we delegate all checks to it
@@ -661,7 +661,7 @@ int PacketHandler::processUpdate(DNSPacket& p) {
       ng.addMask(i);
     }
 
-    if ( ! ng.match(&p.d_remote)) {
+    if ( ! ng.match(p.getInnerRemote())) {
       g_log<<Logger::Error<<msgPrefix<<"Remote not listed in allow-dnsupdate-from or domainmetadata. Sending REFUSED"<<endl;
       return RCode::Refused;
     }

--- a/pdns/sdig.cc
+++ b/pdns/sdig.cc
@@ -41,8 +41,8 @@ static void usage()
           "[dnssec] [ednssubnet SUBNET/MASK] [hidesoadetails] [hidettl] [recurse] [showflags] "
           "[tcp] [dot] [insecure] [fastOpen] [subjectName name] [caStore file] [tlsProvider openssl|gnutls] "
           "[xpf XPFDATA] [class CLASSNUM] "
-          "[proxy UDP(0)/TCP(1) SOURCE-IP-ADDRESS-AND-PORT DESTINATION-IP-ADDRESS-AND-PORT]"
-          "dumpluaraw"
+          "[proxy UDP(0)/TCP(1) SOURCE-IP-ADDRESS-AND-PORT DESTINATION-IP-ADDRESS-AND-PORT] "
+          "[dumpluaraw]"
        << endl;
 }
 

--- a/pdns/tcpreceiver.hh
+++ b/pdns/tcpreceiver.hh
@@ -49,7 +49,6 @@ public:
 private:
 
   static void sendPacket(std::unique_ptr<DNSPacket>& p, int outsock, bool last=true);
-  static int readLength(int fd, ComboAddress *remote);
   static void getQuestion(int fd, char *mesg, int pktlen, const ComboAddress& remote, unsigned int totalTime);
   static int doAXFR(const DNSName &target, std::unique_ptr<DNSPacket>& q, int outsock);
   static int doIXFR(std::unique_ptr<DNSPacket>& q, int outsock);

--- a/pdns/test-nameserver_cc.cc
+++ b/pdns/test-nameserver_cc.cc
@@ -11,6 +11,8 @@
 #include <utility>
 
 extern vector<ComboAddress> g_localaddresses;
+NetmaskGroup g_proxyProtocolACL;
+size_t g_proxyProtocolMaximumSize = 512;
 
 BOOST_AUTO_TEST_SUITE(test_nameserver_cc)
 

--- a/regression-tests.auth-py/proxyprotocol.py
+++ b/regression-tests.auth-py/proxyprotocol.py
@@ -1,0 +1,1 @@
+../regression-tests.common/proxyprotocol.py

--- a/regression-tests.auth-py/test_ProxyProtocol.py
+++ b/regression-tests.auth-py/test_ProxyProtocol.py
@@ -1,0 +1,227 @@
+import dns
+import os
+import socket
+import struct
+import threading
+import time
+import unittest
+
+from authtests import AuthTest
+from proxyprotocol import ProxyProtocol
+
+class TestProxyProtocolLuaRecords(AuthTest):
+    _config_template = """
+launch=bind
+any-to-tcp=no
+proxy-protocol-from=127.0.0.1
+"""
+
+    _zones = {
+        'example.org': """
+example.org.                 3600 IN SOA  {soa}
+example.org.                 3600 IN NS   ns1.example.org.
+example.org.                 3600 IN NS   ns2.example.org.
+ns1.example.org.             3600 IN A    {prefix}.10
+ns2.example.org.             3600 IN A    {prefix}.11
+
+myip.example.org.            3600 IN LUA  A     "who:toString()"
+        """
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestProxyProtocolLuaRecords, cls).setUpClass()
+
+    def testWhoAmI(self):
+        """
+        See if LUA who picks up the inner address from the PROXY protocol
+        """
+        
+        # first test with an unproxied query - should get ignored
+        query = dns.message.make_query('myip.example.org', 'A')
+
+        res = self.sendUDPQuery(query)
+
+        self.assertEqual(res, None)     # query was ignored correctly
+
+
+        # now send a proxied query
+        queryPayload = query.to_wire()
+        ppPayload = ProxyProtocol.getPayload(False, False, False, "192.0.2.1", "10.1.2.3", 12345, 53, [])
+        payload = ppPayload + queryPayload
+
+        # UDP
+        self._sock.settimeout(2.0)
+
+        try:
+            self._sock.send(payload)
+            data = self._sock.recv(4096)
+        except socket.timeout:
+            data = None
+        finally:
+            self._sock.settimeout(None)
+
+        res = None
+        if data:
+            res = dns.message.from_wire(data)
+
+        expected = [dns.rrset.from_text('myip.example.org.', 0, dns.rdataclass.IN, 'A', '192.0.2.1')]
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertEqual(res.answer, expected)
+
+        # TCP
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(2.0)
+        sock.connect(("127.0.0.1", self._authPort))
+
+        try:
+            sock.send(ppPayload)
+            sock.send(struct.pack("!H", len(queryPayload)))
+            sock.send(queryPayload)
+            data = sock.recv(2)
+            if data:
+                (datalen,) = struct.unpack("!H", data)
+                data = sock.recv(datalen)
+        except socket.timeout as e:
+            print("Timeout: %s" % (str(e)))
+            data = None
+        except socket.error as e:
+            print("Network error: %s" % (str(e)))
+            data = None
+        finally:
+            sock.close()
+
+        res = None
+        if data:
+            res = dns.message.from_wire(data)
+
+        self.assertRcodeEqual(res, dns.rcode.NOERROR)
+        self.assertEqual(res.answer, expected)
+
+class TestProxyProtocolNOTIFY(AuthTest):
+    _config_template = """
+launch=bind
+any-to-tcp=no
+proxy-protocol-from=127.0.0.1
+secondary
+"""
+
+    _zones = { 'example.org': '192.0.2.1',
+               'example.com': '192.0.2.2'
+    }
+
+    @classmethod
+    def generateAuthZone(cls, confdir, zonename, zonecontent):
+        try:
+            os.unlink(os.path.join(confdir, '%s.zone' % zonename))
+        except:
+            pass
+
+    @classmethod
+    def generateAuthNamedConf(cls, confdir, zones):
+        with open(os.path.join(confdir, 'named.conf'), 'w') as namedconf:
+            namedconf.write("""
+options {
+    directory "%s";
+};""" % confdir)
+            for zonename in zones:
+                zone = '.' if zonename == 'ROOT' else zonename
+
+                namedconf.write("""
+        zone "%s" {
+            type slave;
+            file "%s.zone";
+            masters { %s; };
+        };""" % (zone, zonename, cls._zones[zone]))
+
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestProxyProtocolNOTIFY, cls).setUpClass()
+
+    def testNOTIFY(self):
+        """
+        Check that NOTIFY is properly accepted/rejected based on the PROXY header inner address
+        """
+
+        query = dns.message.make_query('example.org', 'SOA')
+        query.set_opcode(dns.opcode.NOTIFY)
+
+        queryPayload = query.to_wire()
+
+        for task in ('192.0.2.1', dns.rcode.NOERROR), ('192.0.2.2', dns.rcode.REFUSED):
+            ip, expectedrcode = task
+
+            ppPayload = ProxyProtocol.getPayload(False, False, False, ip, "10.1.2.3", 12345, 53, [])
+            payload = ppPayload + queryPayload
+
+            self._sock.settimeout(2.0)
+
+            try:
+                self._sock.send(payload)
+                data = self._sock.recv(4096)
+            except socket.timeout:
+                data = None
+            finally:
+                self._sock.settimeout(None)
+
+            res = None
+            if data:
+                res = dns.message.from_wire(data)
+
+            self.assertRcodeEqual(res, expectedrcode)
+
+
+class TestProxyProtocolAXFRACL(AuthTest):
+    _config_template = """
+launch=bind
+any-to-tcp=no
+proxy-protocol-from=127.0.0.1
+allow-axfr-ips=192.0.2.53
+"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestProxyProtocolAXFRACL, cls).setUpClass()
+
+    def testAXFR(self):
+        """
+        Check that AXFR is properly accepted/rejected based on the PROXY header inner address
+        """
+
+        query = dns.message.make_query('example.org', 'AXFR')
+
+        queryPayload = query.to_wire()
+
+        for task in ('192.0.2.1', dns.rcode.NOTAUTH), ('127.0.0.1', dns.rcode.NOTAUTH), ('192.0.2.53', dns.rcode.NOERROR):
+            ip, expectedrcode = task
+
+            ppPayload = ProxyProtocol.getPayload(False, True, False, ip, "10.1.2.3", 12345, 53, [])
+
+            # TCP
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(2.0)
+            sock.connect(("127.0.0.1", self._authPort))
+
+            try:
+                sock.send(ppPayload)
+                sock.send(struct.pack("!H", len(queryPayload)))
+                sock.send(queryPayload)
+                data = sock.recv(2)
+                if data:
+                    (datalen,) = struct.unpack("!H", data)
+                    data = sock.recv(datalen)
+            except socket.timeout as e:
+                print("Timeout: %s" % (str(e)))
+                data = None
+            except socket.error as e:
+                print("Network error: %s" % (str(e)))
+                data = None
+            finally:
+                sock.close()
+
+            res = None
+            if data:
+                res = dns.message.from_wire(data)
+
+            self.assertRcodeEqual(res, expectedrcode)


### PR DESCRIPTION
### Short description
incoming PROXY support for:

* AXFR ACLs
* NOTIFY sources
* getting the remote address in LUA records
* 2136 ACLs
* query/response accounting
* log output
* the remote used by backends to take geo-style decisions

Fixes #8403.

Needs:
* [x] tests
* [x] docs

Check that backends use the right IP:
* [x] lua2backend
* [x] geoipbackend
* [x] remotebackend
* [x] tinydnsbackend
* [x] pipebackend

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master