### PR TITLE
rec: followup to Prometheus-friendly histograms (#10122)

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -77,6 +77,7 @@ Atomia
 aton
 attr
 atype
+authanswers
 AUTHIP
 Authoritativedoc
 auths
@@ -233,6 +234,7 @@ chroot
 chrooting
 CIDR
 classmethod
+clientanswers
 Cloos
 closesocket
 clusions

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5861,7 +5861,7 @@ int main(int argc, char **argv)
     for (size_t idx = 0; idx < 128; idx++) {
       defaultAPIDisabledStats += ", ecs-v6-response-bits-" + std::to_string(idx + 1);
     }
-    std::string defaultDisabledStats = defaultAPIDisabledStats + ", cumul-answers, cumul-auth4answers, cumul-auth6answers, policy-hits";
+    std::string defaultDisabledStats = defaultAPIDisabledStats + ", cumul-clientanswers, cumul-authanswers, policy-hits";
 
     ::arg().set("stats-api-blacklist", "List of statistics that are disabled when retrieving the complete list of statistics via the API (deprecated)")=defaultAPIDisabledStats;
     ::arg().set("stats-carbon-blacklist", "List of statistics that are prevented from being exported via Carbon (deprecated)")=defaultDisabledStats;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1153,7 +1153,7 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
     snprintf(buf, sizeof(buf), "%g", bucket.d_boundary / 1e6);
     pname = pbasename + "seconds_bucket{ipversion=\"v4\",le=\"" +
       (bucket.d_boundary == std::numeric_limits<uint64_t>::max() ? "+Inf" : buf) + "\"}";
-    entries.emplace(bucket.d_name + "-4", StatsMapEntry{pname, std::to_string(bucket.d_count)});
+    entries.emplace(bucket.d_name + "4", StatsMapEntry{pname, std::to_string(bucket.d_count)});
   }
 
   const auto& data6 = histogram6.getCumulativeBuckets();
@@ -1161,7 +1161,7 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
     snprintf(buf, sizeof(buf), "%g", bucket.d_boundary / 1e6);
     pname = pbasename + "seconds_bucket{ipversion=\"v6\",le=\"" +
       (bucket.d_boundary == std::numeric_limits<uint64_t>::max() ? "+Inf" : buf) + "\"}";
-    entries.emplace(bucket.d_name + "-6", StatsMapEntry{pname, std::to_string(bucket.d_count)});
+    entries.emplace(bucket.d_name + "6", StatsMapEntry{pname, std::to_string(bucket.d_count)});
   }
 
   snprintf(buf, sizeof(buf), "%g", (histogram4.getSum() +  histogram6.getSum()) / 1e6);

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1156,7 +1156,7 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
     entries.emplace(bucket.d_name + "4", StatsMapEntry{pname, std::to_string(bucket.d_count)});
   }
   snprintf(buf, sizeof(buf), "%g", histogram4.getSum() / 1e6);
-  entries.emplace(name + "sum4", StatsMapEntry{pbasename + "seconds_count{ipversion=\"v4\"}", buf});
+  entries.emplace(name + "sum4", StatsMapEntry{pbasename + "seconds_sum{ipversion=\"v4\"}", buf});
   entries.emplace(name + "count4", StatsMapEntry{pbasename + "seconds_count{ipversion=\"v4\"}", std::to_string(data4.back().d_count)});
 
   const auto& data6 = histogram6.getCumulativeBuckets();
@@ -1167,7 +1167,7 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
     entries.emplace(bucket.d_name + "6", StatsMapEntry{pname, std::to_string(bucket.d_count)});
   }
   snprintf(buf, sizeof(buf), "%g", histogram6.getSum() / 1e6);
-  entries.emplace(name + "sum6", StatsMapEntry{pbasename + "seconds_count{ipversion=\"v6\"}", buf});
+  entries.emplace(name + "sum6", StatsMapEntry{pbasename + "seconds_sum{ipversion=\"v6\"}", buf});
   entries.emplace(name + "count6", StatsMapEntry{pbasename + "seconds_count{ipversion=\"v6\"}", std::to_string(data6.back().d_count)});
 
   return entries;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1155,6 +1155,9 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
       (bucket.d_boundary == std::numeric_limits<uint64_t>::max() ? "+Inf" : buf) + "\"}";
     entries.emplace(bucket.d_name + "4", StatsMapEntry{pname, std::to_string(bucket.d_count)});
   }
+  snprintf(buf, sizeof(buf), "%g", histogram4.getSum() / 1e6);
+  entries.emplace(name + "sum4", StatsMapEntry{pbasename + "seconds_count{ipversion=\"v4\"}", buf});
+  entries.emplace(name + "count4", StatsMapEntry{pbasename + "seconds_count{ipversion=\"v4\"}", std::to_string(data4.back().d_count)});
 
   const auto& data6 = histogram6.getCumulativeBuckets();
   for (const auto& bucket : data6) {
@@ -1163,10 +1166,9 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
       (bucket.d_boundary == std::numeric_limits<uint64_t>::max() ? "+Inf" : buf) + "\"}";
     entries.emplace(bucket.d_name + "6", StatsMapEntry{pname, std::to_string(bucket.d_count)});
   }
-
-  snprintf(buf, sizeof(buf), "%g", (histogram4.getSum() +  histogram6.getSum()) / 1e6);
-  entries.emplace(name + "sum", StatsMapEntry{pbasename + "seconds_sum", buf});
-  entries.emplace(name + "count", StatsMapEntry{pbasename + "seconds_count", std::to_string(data4.back().d_count + data6.back().d_count)});
+  snprintf(buf, sizeof(buf), "%g", histogram6.getSum() / 1e6);
+  entries.emplace(name + "sum6", StatsMapEntry{pbasename + "seconds_count{ipversion=\"v6\"}", buf});
+  entries.emplace(name + "count6", StatsMapEntry{pbasename + "seconds_count{ipversion=\"v6\"}", std::to_string(data6.back().d_count)});
 
   return entries;
 }

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1131,12 +1131,42 @@ static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& hist
     snprintf(buf, sizeof(buf), "%g", bucket.d_boundary / 1e6);
     std::string pname = pbasename + "seconds_bucket{" + "le=\"" +
       (bucket.d_boundary == std::numeric_limits<uint64_t>::max() ? "+Inf" : buf) + "\"}";
-    entries.emplace(make_pair(bucket.d_name, StatsMapEntry{pname, std::to_string(bucket.d_count)}));
+    entries.emplace(bucket.d_name, StatsMapEntry{pname, std::to_string(bucket.d_count)});
   }
 
   snprintf(buf, sizeof(buf), "%g", histogram.getSum() / 1e6);
-  entries.emplace(make_pair(name + "sum", StatsMapEntry{pbasename + "seconds_sum", buf}));
-  entries.emplace(make_pair(name + "count", StatsMapEntry{pbasename + "seconds_count", std::to_string(data.back().d_count)}));
+  entries.emplace(name + "sum", StatsMapEntry{pbasename + "seconds_sum", buf});
+  entries.emplace(name + "count", StatsMapEntry{pbasename + "seconds_count", std::to_string(data.back().d_count)});
+
+  return entries;
+}
+
+static StatsMap toStatsMap(const string& name, const pdns::AtomicHistogram& histogram4,  const pdns::AtomicHistogram& histogram6)
+{
+  const string pbasename = getPrometheusName(name);
+  StatsMap entries;
+  char buf[32];
+  std::string pname;
+
+  const auto& data4 = histogram4.getCumulativeBuckets();
+  for (const auto& bucket : data4) {
+    snprintf(buf, sizeof(buf), "%g", bucket.d_boundary / 1e6);
+    pname = pbasename + "seconds_bucket{ipversion=\"v4\",le=\"" +
+      (bucket.d_boundary == std::numeric_limits<uint64_t>::max() ? "+Inf" : buf) + "\"}";
+    entries.emplace(bucket.d_name + "-4", StatsMapEntry{pname, std::to_string(bucket.d_count)});
+  }
+
+  const auto& data6 = histogram6.getCumulativeBuckets();
+  for (const auto& bucket : data6) {
+    snprintf(buf, sizeof(buf), "%g", bucket.d_boundary / 1e6);
+    pname = pbasename + "seconds_bucket{ipversion=\"v6\",le=\"" +
+      (bucket.d_boundary == std::numeric_limits<uint64_t>::max() ? "+Inf" : buf) + "\"}";
+    entries.emplace(bucket.d_name + "-6", StatsMapEntry{pname, std::to_string(bucket.d_count)});
+  }
+
+  snprintf(buf, sizeof(buf), "%g", (histogram4.getSum() +  histogram6.getSum()) / 1e6);
+  entries.emplace(name + "sum", StatsMapEntry{pbasename + "seconds_sum", buf});
+  entries.emplace(name + "count", StatsMapEntry{pbasename + "seconds_count", std::to_string(data4.back().d_count + data6.back().d_count)});
 
   return entries;
 }
@@ -1424,14 +1454,11 @@ static void registerAllStats1()
     addGetStat(name, &(SyncRes::s_ecsResponsesBySubnetSize6.at(idx)));
   }
 
-  addGetStat("cumul-answers", []() {
+  addGetStat("cumul-clientanswers", []() {
     return toStatsMap(g_stats.cumulativeAnswers.getName(), g_stats.cumulativeAnswers);
   });
-  addGetStat("cumul-auth4answers", []() {
-    return toStatsMap(g_stats.cumulativeAuth4Answers.getName(), g_stats.cumulativeAuth4Answers);
-  });
-  addGetStat("cumul-auth6answers", []() {
-    return toStatsMap(g_stats.cumulativeAuth6Answers.getName(), g_stats.cumulativeAuth6Answers);
+  addGetStat("cumul-authanswers", []() {
+    return toStatsMap(g_stats.cumulativeAuth4Answers.getName(), g_stats.cumulativeAuth4Answers, g_stats.cumulativeAuth6Answers);
   });
   addGetStat("policy-hits", []() {
     return toRPZStatsMap("policy-hits", g_stats.policyHits);

--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -284,28 +284,21 @@ cpu-steal
 
 Stolen time, which is the time spent by the whole system in other operating systems when running in a virtualized environment, in units of USER_HZ.
 
-cumul-answers-x
+
+cumul-authanswers-x
+^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 4.6
+
+Cumulative counts of answer times of authoritative servers in buckets less than x microseconds.
+These metrics are useful for Prometheus and not listed in other outputs by default.
+
+cumul-clientanswers-x
 ^^^^^^^^^^^^^^^^^^
 .. versionadded:: 4.6
 
-Cumulative counts of answer times in buckets less or equal than x microseconds.
+Cumulative counts of our answer times to clients in buckets less or equal than x microseconds.
 These metrics include packet cache hits.
-These metrics are useful for Prometheus and not listed other outputs by default.
-
-
-cumul-auth4-answers-x
-^^^^^^^^^^^^^^^^^^^^^
-.. versionadded:: 4.6
-
-Cumulative counts of answer times of authoritative servers over IPv4 in buckets less than x microseconds.
-These metrics are useful for Prometheus and not listed other outputs by default.
-
-cumul-auth6-answers-x
-^^^^^^^^^^^^^^^^^^^^^
-.. versionadded:: 4.6
-
-Cumulative counts of answer times of authoritative servers over IPv6 in buckets less than x microseconds.
-These metrics are useful for Prometheus and not listed other outputs by default.
+These metrics are useful for Prometheus and not listed in other outputs by default.
 
 dns64-prefix-answers
 ^^^^^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/test-histogram_hh.cc
+++ b/pdns/recursordist/test-histogram_hh.cc
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(test_simple)
   h(4);
   h(100);
   h(101);
-  h(-1);
+  h(-1); // actually a very large value, but for sum it will boil down to be -1 */
 
   auto data = h.getRawData();
   BOOST_CHECK_EQUAL(data.size(), 6U);
@@ -60,6 +60,7 @@ BOOST_AUTO_TEST_CASE(test_simple)
   for (auto e : cexpected) {
     BOOST_CHECK_EQUAL(c[i++], e);
   }
+  BOOST_CHECK_EQUAL(h.getSum(), 209U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1083,9 +1083,10 @@ struct RecursorStats
     auth4Answers("auth4answers", { 1000, 10000, 100000, 1000000 }),
     auth6Answers("auth6answers", { 1000, 10000, 100000, 1000000 }),
     ourtime("ourtime", { 1000, 2000, 4000, 8000, 16000, 32000 }),
-    cumulativeAnswers("cumul-answers-", 10, 19),
-    cumulativeAuth4Answers("cumul-auth4answers-", 1000, 13),
-    cumulativeAuth6Answers("cumul-auth6answers-", 1000, 13)
+    cumulativeAnswers("cumul-clientanswers-", 10, 19),
+    // These two will be merged when outputting
+    cumulativeAuth4Answers("cumul-authanswers-", 1000, 13),
+    cumulativeAuth6Answers("cumul-authanswers-", 1000, 13)
   {
   }
 };

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -460,8 +460,9 @@ static void prometheusMetrics(HttpRequest *req, HttpResponse *resp) {
             helpname = prometheusMetricName.substr(0, prometheusMetricName.find('{'));
           }
           else if (metricDetails.d_prometheusType == PrometheusMetricType::histogram) {
+            helpname = prometheusMetricName.substr(0, prometheusMetricName.find('{'));
             // name is XXX_count, strip the _count part
-            helpname = prometheusMetricName.substr(0, prometheusMetricName.length() - 6);
+            helpname = helpname.substr(0, helpname.length() - 6);
           }
           output << "# TYPE " << helpname << " " << prometheusTypeName << "\n";
           output << "# HELP " << helpname << " " << metricDetails.d_description << "\n";
@@ -1065,7 +1066,7 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::d_metrics
     MetricDefinition(PrometheusMetricType::histogram,
                      "histogram of our answer times to clients")},
   // For cumulative histogram, state the xxx_count name where xxx matches the name in rec_channel_rec
-  { "cumul-authanswers-count",
+  { "cumul-authanswers-count4",
     MetricDefinition(PrometheusMetricType::histogram,
                      "histogram of answer times of authoritative servers")},
   { "almost-expired-pushed",

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -1061,18 +1061,13 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::d_metrics
                      "Number of answers synthesized from the NSEC3 aggressive cache")},
 
   // For cumulative histogram, state the xxx_count name where xxx matches the name in rec_channel_rec
-  { "cumul-answers-count",
+  { "cumul-clientanswers-count",
     MetricDefinition(PrometheusMetricType::histogram,
-                     "histogram of our answer times")},
+                     "histogram of our answer times to clients")},
   // For cumulative histogram, state the xxx_count name where xxx matches the name in rec_channel_rec
-  { "cumul-auth4answers-count",
+  { "cumul-authanswers-count",
     MetricDefinition(PrometheusMetricType::histogram,
-                     "histogram of authoritative answer times over IPv4")},
-  // For cumulative histogram, state the xxx_count name where xxx matches the name in rec_channel_rec
-  { "cumul-auth6answers-count",
-    MetricDefinition(PrometheusMetricType::histogram,
-                     "histogram of authoritative answer times over IPV6")},
-
+                     "histogram of answer times of authoritative servers")},
   { "almost-expired-pushed",
     MetricDefinition(PrometheusMetricType::counter,
                      "number of almost-expired tasks pushed")},


### PR DESCRIPTION
Process feedback from @johnhtodd and @wojas : better names and HELP and use a tag to distinguish
ipv4 and ipv6 for the new Prometheus-friendly histograms.

Followup to #10122 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

Example output:
```
# TYPE pdns_recursor_cumul_authanswers_seconds histogram
# HELP pdns_recursor_cumul_authanswers_seconds histogram of answer times of authoritative servers
pdns_recursor_cumul_authanswers_seconds_count 5
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="0.001"} 0
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="0.001"} 0
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="0.002"} 0
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="0.002"} 0
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="0.005"} 0
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="0.005"} 0
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="0.01"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="0.01"} 0
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="0.02"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="0.02"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="0.05"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="0.05"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="0.1"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="0.1"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="0.2"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="0.2"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="0.5"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="0.5"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="1"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="1"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="2"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="2"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="5"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="5"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="10"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="10"} 1
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v4",le="+Inf"} 4
pdns_recursor_cumul_authanswers_seconds_bucket{ipversion="v6",le="+Inf"} 1
pdns_recursor_cumul_authanswers_seconds_sum 0.068424
# TYPE pdns_recursor_cumul_clientanswers_seconds histogram
# HELP pdns_recursor_cumul_clientanswers_seconds histogram of our answer times to clients
pdns_recursor_cumul_clientanswers_seconds_count 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="1e-05"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="2e-05"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="5e-05"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.0001"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.0002"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.0005"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.001"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.002"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.005"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.01"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.02"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.05"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.1"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.2"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="0.5"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="1"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="2"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="5"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="10"} 0
pdns_recursor_cumul_clientanswers_seconds_bucket{le="+Inf"} 0
pdns_recursor_cumul_clientanswers_seconds_sum 0
```