### PR TITLE
rec: Fix the acquired/contended cache counters not being updated

### DIFF
--- a/pdns/cachecleaner.hh
+++ b/pdns/cachecleaner.hh
@@ -144,7 +144,7 @@ template <typename S, typename C, typename T> uint64_t pruneMutexCollectionsVect
   }
 
   for (auto& content : maps) {
-    auto mc = content.d_content.lock();
+    auto mc = content.lock();
     mc->invalidate();
     auto& sidx = boost::multi_index::get<S>(mc->d_map);
     uint64_t erased = 0, lookedAt = 0;
@@ -178,7 +178,7 @@ template <typename S, typename C, typename T> uint64_t pruneMutexCollectionsVect
   while (true) {
     size_t pershard = toTrim / maps_size + 1;
     for (auto& content : maps) {
-      auto mc = content.d_content.lock();
+      auto mc = content.lock();
       mc->invalidate();
       auto& sidx = boost::multi_index::get<S>(mc->d_map);
       size_t removed = 0;

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -224,7 +224,6 @@ private:
       }
     };
 
-    LockGuarded<LockedContent> d_content;
     std::atomic<uint64_t> d_entriesCount{0};
 
     LockGuardedTryHolder<LockedContent> lock()
@@ -237,6 +236,9 @@ private:
       ++locked->d_acquired_count;
       return locked;
     }
+
+  private:
+    LockGuarded<LockedContent> d_content;
   };
 
   vector<MapCombo> d_maps;

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -113,7 +113,6 @@ private:
       uint64_t d_acquired_count{0};
       void invalidate() {}
     };
-    LockGuarded<LockedContent> d_content;
     std::atomic<uint64_t> d_entriesCount{0};
 
     LockGuardedTryHolder<MapCombo::LockedContent> lock()
@@ -126,6 +125,10 @@ private:
       ++locked->d_acquired_count;
       return locked;
     }
+
+  private:
+
+    LockGuarded<LockedContent> d_content;
   };
 
   vector<MapCombo> d_maps;

--- a/pdns/recursordist/negcache.hh
+++ b/pdns/recursordist/negcache.hh
@@ -127,7 +127,6 @@ private:
     }
 
   private:
-
     LockGuarded<LockedContent> d_content;
   };
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since the migration to LockGuarded, the code keeping track of the contention of record and negative cache shard locks was bypassed and the lock directly acquired. This does not cause any other issue than the `record-cache-acquired` and `record-cache-contended` metrics not being updated.
This PR fixes that, and make the content private so we no longer can bypass that code in the future.

Note that it looks like we don't do anything about these metrics for the negative cache, even though we dutifully record them.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
