### PR TITLE
rec: Improve the rec bulk test script

### DIFF
--- a/regression-tests/recursor-test
+++ b/regression-tests/recursor-test
@@ -33,31 +33,42 @@ rm -f recursor.pid pdns_recursor.pid
 <measurement><name>%% CPU used</name><value>%P</value></measurement>
 '         ${RECURSOR} --daemon=no --local-port=$port --socket-dir=./ --trace=$TRACE --config-dir=. --max-mthreads=$mthreads --query-local-address="0.0.0.0${QLA6}" --threads=$threads --record-cache-shards=$shards --disable-packetcache --refresh-on-ttl-perc=10 --dnssec=validate > recursor.log 2>&1 &
 sleep 3
+if [ ! -e pdns_recursor.pid ]; then
+	echo Recursor did not start or did not write pdns_recursor.pid, exiting
+	exit 1
+fi
+
 
 # warm up the cache
 echo
 echo === First run with limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
 echo
-kill -USR1 $(cat pdns_recursor.pid)
-${RECCONTROL} --socket-dir=. --config-dir=. get-all
+kill -USR1 $(cat pdns_recursor.pid) || true
+${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. get-all || true
+
 # rerun 1 with hot cache
 echo
 echo === Second run with limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
-kill -USR1 $(cat pdns_recursor.pid)
-${RECCONTROL} --socket-dir=. --config-dir=. get-all
+kill -USR1 $(cat pdns_recursor.pid) || true
+${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. get-all || true
+
 # rerun 2 with hot cache
 echo
 echo === Third run with limit=$limit threads=$threads mthreads=$mthreads shards=$shards ===
 ${DNSBULKTEST} --www=false -qe 127.0.0.1 $port $limit < ${CSV} > bulktest.results
+kill -USR1 $(cat pdns_recursor.pid) || true
+${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. get-all || true
+
+# give it a chance to write the log requested by the kill
+sleep 1
 echo
 echo "=== RECURSOR LOG ==="
 cat recursor.log
 echo "=== END RECURSOR LOG ==="
-kill -USR1 $(cat pdns_recursor.pid)
-${RECCONTROL} --socket-dir=. --config-dir=. get-all
 sleep 1
+${RECCONTROL} --timeout=20 --socket-dir=. --config-dir=. ping
 kill $(cat pdns_recursor.pid) 
 sleep 5
 


### PR DESCRIPTION
We see the occasional bulk test failures on buildbot (but not locally or on CirlceCI). So improve the script a bit to help diagnosis:

- Exit if rec did not start up
- Status requesting commands (rec_control and kill -USR1) failures are non-fatal
  except for the last 'ping' so the dump of the recursor log is reached.
- Increase timeout of rec_control command (to help investigating issues on buildbot)

The script is run with -e, so failure will lead to exit without killing
the running recursor atm.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
