### PR TITLE
Rec: tcp/dot connection pooling

### DIFF
--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -457,6 +457,10 @@ private:
 };
 
 
+#ifdef CERT
+#error likely openssl/ssl2.h is included, defining CERT, avoid that or undef CERT before including dnsrecords.hh
+#endif
+
 class CERTRecordContent : public DNSRecordContent
 {
 public:

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -558,7 +558,7 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
       ret = asyncresolve(ip, domain, type,doTCP, sendRDQuery, EDNS0Level, now, srcmask, context, outgoingLoggers, fstrmLoggers, exportTypes, lwr, chained, connection);
     } 
     if (connection.d_handler && lwr->d_validpacket) {
-      t_tcp_manager.store(ip, connection);
+      t_tcp_manager.store(*now, ip, std::move(connection));
     }
   }
   return ret;

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -57,6 +57,9 @@
 #include "dnstap.hh"
 #include "fstrm_logger.hh"
 
+#include "rec-tcpout.hh"
+
+thread_local TCPOutConnectionManager t_tcp_manager;
 
 bool g_syslog;
 
@@ -232,7 +235,7 @@ static void logIncomingResponse(const std::shared_ptr<std::vector<std::unique_pt
 /** lwr is only filled out in case 1 was returned, and even when returning 1 for 'success', lwr might contain DNS errors
     Never throws! 
  */
-LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstrmLoggers, const std::set<uint16_t>& exportTypes, LWResult *lwr, bool* chained)
+static LWResult::Result asyncresolve1(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstrmLoggers, const std::set<uint16_t>& exportTypes, LWResult *lwr, bool* chained, TCPOutConnectionManager::Connection& connection)
 {
   size_t len;
   size_t bufsize=g_outgoingEDNSBufsize;
@@ -343,70 +346,88 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
   }
   else {
     try {
-      const struct timeval timeout{ g_networkTimeoutMsec / 1000, static_cast<suseconds_t>(g_networkTimeoutMsec) % 1000 * 1000};
+      while (true) {
+        bool isNew = false;
+        connection = t_tcp_manager.get(ip);
+        if (!connection.d_handler) {
+          isNew = true;
+          const struct timeval timeout{ g_networkTimeoutMsec / 1000, static_cast<suseconds_t>(g_networkTimeoutMsec) % 1000 * 1000};
+          Socket s(ip.sin4.sin_family, SOCK_STREAM);
+          s.setNonBlocking();
+          localip = pdns::getQueryLocalAddress(ip.sin4.sin_family, 0);
+          s.bind(localip);
 
-      Socket s(ip.sin4.sin_family, SOCK_STREAM);
-      s.setNonBlocking();
-      localip = pdns::getQueryLocalAddress(ip.sin4.sin_family, 0);
-      s.bind(localip);
-
-      std::shared_ptr<TLSCtx> tlsCtx{nullptr};
-      if (SyncRes::s_dot_to_port_853 && ip.getPort() == 853) {
-        TLSContextParameters tlsParams;
-        tlsParams.d_provider = "openssl";
-        tlsParams.d_validateCertificates = false;
-        //tlsParams.d_caStore = caaStore;
-        tlsCtx = getTLSContext(tlsParams);
-        if (tlsCtx == nullptr) {
-          g_log << Logger::Error << "DoT to " << ip << " requested but not available" << endl;
+          std::shared_ptr<TLSCtx> tlsCtx{nullptr};
+          if (SyncRes::s_dot_to_port_853 && ip.getPort() == 853) {
+            TLSContextParameters tlsParams;
+            tlsParams.d_provider = "openssl";
+            tlsParams.d_validateCertificates = false;
+            //tlsParams.d_caStore = caaStore;
+            tlsCtx = getTLSContext(tlsParams);
+            if (tlsCtx == nullptr) {
+              g_log << Logger::Error << "DoT to " << ip << " requested but not available" << endl;
+          }
+            else {
+              dnsOverTLS = true;
+            }
+          }
+          connection.d_handler = std::make_shared<TCPIOHandler>("", s.releaseHandle(), timeout, tlsCtx, now->tv_sec);
+          // Returned state ignored
+          connection.d_handler->tryConnect(SyncRes::s_tcp_fast_open_connect, ip);
         }
-        else {
-          dnsOverTLS = true;
+        localip.sin4.sin_family = ip.sin4.sin_family;
+        socklen_t slen = ip.getSocklen();
+        getsockname(connection.d_handler->getDescriptor(), reinterpret_cast<sockaddr*>(&localip), &slen);
+        uint16_t tlen = htons(vpacket.size());
+        char *lenP = (char*)&tlen;
+        const char *msgP=(const char*)&*vpacket.begin();
+        PacketBuffer packet;
+        packet.reserve(2 + vpacket.size());
+        packet.insert(packet.end(), lenP, lenP+2);
+        packet.insert(packet.end(), msgP, msgP+vpacket.size());
+        ret = asendtcp(packet, connection.d_handler);
+        if (ret != LWResult::Result::Success) {
+          if (isNew) {
+            connection.d_handler->close();
+            return ret;
+          } else {
+            continue;
+          }
         }
-      }
-      auto handler = std::make_shared<TCPIOHandler>("", s.releaseHandle(), timeout, tlsCtx, now->tv_sec);
-      // Returned state ignored
-      handler->tryConnect(SyncRes::s_tcp_fast_open_connect, ip);
-
-      uint16_t tlen=htons(vpacket.size());
-      char *lenP=(char*)&tlen;
-      const char *msgP=(const char*)&*vpacket.begin();
-      PacketBuffer packet;
-      packet.reserve(2 + vpacket.size());
-      packet.insert(packet.end(), lenP, lenP+2);
-      packet.insert(packet.end(), msgP, msgP+vpacket.size());
-      ret = asendtcp(packet, handler);
-      if (ret != LWResult::Result::Success) {
-        handler->close();
-        return ret;
-      }
-
 #ifdef HAVE_FSTRM
-      if (fstrmQEnabled) {
-        logFstreamQuery(fstrmLoggers, queryTime, localip, ip, !dnsOverTLS ? DnstapMessage::ProtocolType::DoTCP : DnstapMessage::ProtocolType::DoT, context ? context->d_auth : boost::none, vpacket);
-      }
+        if (fstrmQEnabled) {
+          logFstreamQuery(fstrmLoggers, queryTime, localip, ip, !dnsOverTLS ? DnstapMessage::ProtocolType::DoTCP : DnstapMessage::ProtocolType::DoT, context ? context->d_auth : boost::none, vpacket);
+        }
 #endif /* HAVE_FSTRM */
 
-      ret = arecvtcp(packet, 2, handler, false);
-      if (ret != LWResult::Result::Success) {
-        return ret;
+        ret = arecvtcp(packet, 2, connection.d_handler, false);
+        if (ret != LWResult::Result::Success) {
+          if (isNew) {
+            return ret;
+          } else {
+            continue;
+          }
+        }
+
+        memcpy(&tlen, packet.data(), sizeof(tlen));
+        len = ntohs(tlen); // switch to the 'len' shared with the rest of the function
+
+        // XXX receive into buf directly?
+        packet.resize(len);
+        ret = arecvtcp(packet, len, connection.d_handler, false);
+        if (ret != LWResult::Result::Success) {
+          if (isNew) {
+            return ret;
+          } else {
+            continue;
+          }
+        }
+        buf.resize(len);
+        memcpy(buf.data(), packet.data(), len);
+        //handler->close();
+        ret = LWResult::Result::Success;
+        break;
       }
-
-      memcpy(&tlen, packet.data(), sizeof(tlen));
-      len=ntohs(tlen); // switch to the 'len' shared with the rest of the function
-
-      // XXX receive into buf directly?
-      packet.resize(len);
-      ret = arecvtcp(packet, len, handler, false);
-      if (ret != LWResult::Result::Success) {
-        return ret;
-      }
-
-      buf.resize(len);
-      memcpy(buf.data(), packet.data(), len);
-
-      handler->close();
-      ret = LWResult::Result::Success;
     }
     catch (const NetworkError& ne) {
       ret = LWResult::Result::OSLimitError; // OS limits error
@@ -491,7 +512,7 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
     if(outgoingLoggers) {
       logIncomingResponse(outgoingLoggers, context ? context->d_initialRequestId : boost::none, uuid, ip, domain, type, qid, doTCP, srcmask, len, lwr->d_rcode, lwr->d_records, queryTime, exportTypes);
     }
-
+    
     lwr->d_validpacket = true;
     return LWResult::Result::Success;
   }
@@ -522,5 +543,21 @@ LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int
   }
 
   return LWResult::Result::PermanentError;
+}
+
+LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& domain, int type, bool doTCP, bool sendRDQuery, int EDNS0Level, struct timeval* now, boost::optional<Netmask>& srcmask, boost::optional<const ResolveContext&> context, const std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>>& outgoingLoggers, const std::shared_ptr<std::vector<std::unique_ptr<FrameStreamLogger>>>& fstrmLoggers, const std::set<uint16_t>& exportTypes, LWResult *lwr, bool* chained)
+{
+  TCPOutConnectionManager::Connection connection;
+  auto ret = asyncresolve1(ip, domain, type,doTCP, sendRDQuery, EDNS0Level, now, srcmask, context, outgoingLoggers, fstrmLoggers, exportTypes, lwr, chained, connection);
+
+  if (doTCP) {
+    if (!lwr->d_validpacket) {
+      ret = asyncresolve1(ip, domain, type,doTCP, sendRDQuery, EDNS0Level, now, srcmask, context, outgoingLoggers, fstrmLoggers, exportTypes, lwr, chained, connection);
+    } 
+    if (connection.d_handler && lwr->d_validpacket) {
+      t_tcp_manager.store(ip, connection);
+    }
+  }
+  return ret;
 }
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -100,6 +100,7 @@
 #include "nod.hh"
 #endif /* NOD_ENABLED */
 #include "query-local-address.hh"
+#include "rec-tcpout.hh"
 
 #include "rec-snmp.hh"
 #include "rec-taskqueue.hh"
@@ -3662,8 +3663,8 @@ static void doStats(void)
       <<broadcastAccFunction<uint64_t>(pleaseGetEDNSStatusesSize)<<endl;
     g_log<<Logger::Notice<<"stats: outpacket/query ratio "<<ratePercentage(SyncRes::s_outqueries, SyncRes::s_queries)<<"%";
     g_log<<Logger::Notice<<", "<<ratePercentage(SyncRes::s_throttledqueries, SyncRes::s_outqueries+SyncRes::s_throttledqueries)<<"% throttled"<<endl;
-    g_log<<Logger::Notice<<"stats: "<<SyncRes::s_tcpoutqueries<<"/"<<SyncRes::s_dotoutqueries << " outgoing tcp/dot connections, "<<
-      broadcastAccFunction<uint64_t>(pleaseGetConcurrentQueries)<<" queries running, "<<SyncRes::s_outgoingtimeouts<<" outgoing timeouts"<<endl;
+    g_log<<Logger::Notice<<"stats: "<<SyncRes::s_tcpoutqueries<<"/"<<SyncRes::s_dotoutqueries << "/" << getCurrentIdleTCPConnections() << " outgoing tcp/dot/idle connections, "<<
+      broadcastAccFunction<uint64_t>(pleaseGetConcurrentQueries)<<" queries running, "<<SyncRes::s_outgoingtimeouts<<" outgoing timeouts "<<endl;
 
     uint64_t pcSize = broadcastAccFunction<uint64_t>(pleaseGetPacketCacheSize);
     uint64_t pcHits = broadcastAccFunction<uint64_t>(pleaseGetPacketCacheHits);
@@ -3734,6 +3735,7 @@ static void houseKeeping(void *)
       SyncRes::pruneThrottledServers();
       SyncRes::pruneNonResolving(now.tv_sec - SyncRes::s_nonresolvingnsthrottletime);
       Utility::gettimeofday(&last_prune, nullptr);
+      t_tcp_manager.cleanup();
     }
 
     if(isHandlerThread()) {
@@ -4504,6 +4506,7 @@ static void checkOrFixFDS()
 {
   unsigned int availFDs=getFilenumLimit(); 
   unsigned int wantFDs = g_maxMThreads * g_numWorkerThreads +25; // even healthier margin then before
+  wantFDs += g_numWorkerThreads * TCPOutConnectionManager::maxIdlePerThread;
 
   if(wantFDs > availFDs) {
     unsigned int hardlimit= getFilenumLimit(true);
@@ -4512,7 +4515,7 @@ static void checkOrFixFDS()
       g_log<<Logger::Warning<<"Raised soft limit on number of filedescriptors to "<<wantFDs<<" to match max-mthreads and threads settings"<<endl;
     }
     else {
-      int newval = (hardlimit - 25) / g_numWorkerThreads;
+      int newval = (hardlimit - 25 - TCPOutConnectionManager::maxIdlePerThread) / g_numWorkerThreads;
       g_log<<Logger::Warning<<"Insufficient number of filedescriptors available for max-mthreads*threads setting! ("<<hardlimit<<" < "<<wantFDs<<"), reducing max-mthreads to "<<newval<<endl;
       g_maxMThreads = newval;
       setFilenumLimit(hardlimit);
@@ -5061,6 +5064,12 @@ static int serviceMain(int argc, char*argv[])
   } else {
     TCPConnection::s_maxInFlight = maxInFlight;
   }
+
+  int64_t millis = ::arg().asNum("tcpout-maxidle-ms");
+  TCPOutConnectionManager::maxIdleTime = timeval{millis / 1000, (millis % 1000) * 1000 };
+  TCPOutConnectionManager::maxIdlePerAuth = ::arg().asNum("tcpout-maxidle-per-auth");
+  TCPOutConnectionManager::maxQueries = ::arg().asNum("tcpout-max-queries");
+  TCPOutConnectionManager::maxIdlePerThread = ::arg().asNum("tcpout-maxidle-per-thread");
 
   g_gettagNeedsEDNSOptions = ::arg().mustDo("gettag-needs-edns-options");
 
@@ -5932,6 +5941,11 @@ int main(int argc, char **argv)
 
     ::arg().setSwitch("dot-to-port-853", "Force DoT connection to target port 853 if DoT compiled in")="yes";
     ::arg().set("dot-to-auth-names", "Use DoT to authoritative servers with these names or suffixes")="";
+
+    ::arg().set("tcpout-maxidle-ms", "Maximum time TCP connections are left idle in milliseconds or 0 if no limit") = "10000";
+    ::arg().set("tcpout-maxidle-per-auth", "Maximum number of idle TCP connections to a specific IP per thread, 0 means do not keep idle connections open") = "10";
+    ::arg().set("tcpout-max-queries", "Maximum total number of queries per connection, 0 means no limit") = "0";
+    ::arg().set("tcpout-maxidle-per-thread", "Maximum number of idle TCP connections per thread") = "100";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print version string");

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5942,10 +5942,10 @@ int main(int argc, char **argv)
     ::arg().setSwitch("dot-to-port-853", "Force DoT connection to target port 853 if DoT compiled in")="yes";
     ::arg().set("dot-to-auth-names", "Use DoT to authoritative servers with these names or suffixes")="";
 
-    ::arg().set("tcpout-maxidle-ms", "Maximum time TCP connections are left idle in milliseconds or 0 if no limit") = "10000";
-    ::arg().set("tcpout-maxidle-per-auth", "Maximum number of idle TCP connections to a specific IP per thread, 0 means do not keep idle connections open") = "10";
-    ::arg().set("tcpout-max-queries", "Maximum total number of queries per connection, 0 means no limit") = "0";
-    ::arg().set("tcpout-maxidle-per-thread", "Maximum number of idle TCP connections per thread") = "100";
+    ::arg().set("tcpout-maxidle-ms", "Time TCP/DoT connections are left idle in milliseconds or 0 if no limit") = "10000";
+    ::arg().set("tcpout-maxidle-per-auth", "Maximum number of idle TCP/DoT connections to a specific IP per thread, 0 means do not keep idle connections open") = "10";
+    ::arg().set("tcpout-max-queries", "Maximum total number of queries per TCP/DoT connection, 0 means no limit") = "0";
+    ::arg().set("tcpout-maxidle-per-thread", "Maximum number of idle TCP/DoT connections per thread") = "100";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print version string");

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5065,11 +5065,11 @@ static int serviceMain(int argc, char*argv[])
     TCPConnection::s_maxInFlight = maxInFlight;
   }
 
-  int64_t millis = ::arg().asNum("tcpout-maxidle-ms");
+  int64_t millis = ::arg().asNum("tcp-out-max-idle-ms");
   TCPOutConnectionManager::maxIdleTime = timeval{millis / 1000, (millis % 1000) * 1000 };
-  TCPOutConnectionManager::maxIdlePerAuth = ::arg().asNum("tcpout-maxidle-per-auth");
-  TCPOutConnectionManager::maxQueries = ::arg().asNum("tcpout-max-queries");
-  TCPOutConnectionManager::maxIdlePerThread = ::arg().asNum("tcpout-maxidle-per-thread");
+  TCPOutConnectionManager::maxIdlePerAuth = ::arg().asNum("tcp-out-max-idle-per-auth");
+  TCPOutConnectionManager::maxQueries = ::arg().asNum("tcp-out-max-queries");
+  TCPOutConnectionManager::maxIdlePerThread = ::arg().asNum("tcp-out-max-idle-per-thread");
 
   g_gettagNeedsEDNSOptions = ::arg().mustDo("gettag-needs-edns-options");
 
@@ -5942,10 +5942,10 @@ int main(int argc, char **argv)
     ::arg().setSwitch("dot-to-port-853", "Force DoT connection to target port 853 if DoT compiled in")="yes";
     ::arg().set("dot-to-auth-names", "Use DoT to authoritative servers with these names or suffixes")="";
 
-    ::arg().set("tcpout-maxidle-ms", "Time TCP/DoT connections are left idle in milliseconds or 0 if no limit") = "10000";
-    ::arg().set("tcpout-maxidle-per-auth", "Maximum number of idle TCP/DoT connections to a specific IP per thread, 0 means do not keep idle connections open") = "10";
-    ::arg().set("tcpout-max-queries", "Maximum total number of queries per TCP/DoT connection, 0 means no limit") = "0";
-    ::arg().set("tcpout-maxidle-per-thread", "Maximum number of idle TCP/DoT connections per thread") = "100";
+    ::arg().set("tcp-out-max-idle-ms", "Time TCP/DoT connections are left idle in milliseconds or 0 if no limit") = "10000";
+    ::arg().set("tcp-out-max-idle-per-auth", "Maximum number of idle TCP/DoT connections to a specific IP per thread, 0 means do not keep idle connections open") = "10";
+    ::arg().set("tcp-out-max-queries", "Maximum total number of queries per TCP/DoT connection, 0 means no limit") = "0";
+    ::arg().set("tcp-out-max-idle-per-thread", "Maximum number of idle TCP/DoT connections per thread") = "100";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print version string");

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3735,7 +3735,7 @@ static void houseKeeping(void *)
       SyncRes::pruneThrottledServers();
       SyncRes::pruneNonResolving(now.tv_sec - SyncRes::s_nonresolvingnsthrottletime);
       Utility::gettimeofday(&last_prune, nullptr);
-      t_tcp_manager.cleanup();
+      t_tcp_manager.cleanup(now);
     }
 
     if(isHandlerThread()) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -4506,7 +4506,7 @@ static void checkOrFixFDS()
 {
   unsigned int availFDs=getFilenumLimit(); 
   unsigned int wantFDs = g_maxMThreads * g_numWorkerThreads +25; // even healthier margin then before
-  wantFDs += g_numWorkerThreads * TCPOutConnectionManager::maxIdlePerThread;
+  wantFDs += g_numWorkerThreads * TCPOutConnectionManager::s_maxIdlePerThread;
 
   if(wantFDs > availFDs) {
     unsigned int hardlimit= getFilenumLimit(true);
@@ -4515,7 +4515,7 @@ static void checkOrFixFDS()
       g_log<<Logger::Warning<<"Raised soft limit on number of filedescriptors to "<<wantFDs<<" to match max-mthreads and threads settings"<<endl;
     }
     else {
-      int newval = (hardlimit - 25 - TCPOutConnectionManager::maxIdlePerThread) / g_numWorkerThreads;
+      int newval = (hardlimit - 25 - TCPOutConnectionManager::s_maxIdlePerThread) / g_numWorkerThreads;
       g_log<<Logger::Warning<<"Insufficient number of filedescriptors available for max-mthreads*threads setting! ("<<hardlimit<<" < "<<wantFDs<<"), reducing max-mthreads to "<<newval<<endl;
       g_maxMThreads = newval;
       setFilenumLimit(hardlimit);
@@ -5066,10 +5066,10 @@ static int serviceMain(int argc, char*argv[])
   }
 
   int64_t millis = ::arg().asNum("tcp-out-max-idle-ms");
-  TCPOutConnectionManager::maxIdleTime = timeval{millis / 1000, (millis % 1000) * 1000 };
-  TCPOutConnectionManager::maxIdlePerAuth = ::arg().asNum("tcp-out-max-idle-per-auth");
-  TCPOutConnectionManager::maxQueries = ::arg().asNum("tcp-out-max-queries");
-  TCPOutConnectionManager::maxIdlePerThread = ::arg().asNum("tcp-out-max-idle-per-thread");
+  TCPOutConnectionManager::s_maxIdleTime = timeval{millis / 1000, (millis % 1000) * 1000 };
+  TCPOutConnectionManager::s_maxIdlePerAuth = ::arg().asNum("tcp-out-max-idle-per-auth");
+  TCPOutConnectionManager::s_maxQueries = ::arg().asNum("tcp-out-max-queries");
+  TCPOutConnectionManager::s_maxIdlePerThread = ::arg().asNum("tcp-out-max-idle-per-thread");
 
   g_gettagNeedsEDNSOptions = ::arg().mustDo("gettag-needs-edns-options");
 

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -39,6 +39,7 @@
 #include "pubsuffix.hh"
 #include "namespaces.hh"
 #include "rec-taskqueue.hh"
+#include "rec-tcpout.hh"
 
 std::pair<std::string, std::string> PrefixDashNumberCompare::prefixAndTrailingNum(const std::string& a)
 {
@@ -1422,6 +1423,8 @@ static void registerAllStats1()
   addGetStat("almost-expired-pushed",  []() { return getAlmostExpiredTasksPushed(); });
   addGetStat("almost-expired-run",  []() { return getAlmostExpiredTasksRun(); });
   addGetStat("almost-expired-exceptions",  []() { return getAlmostExpiredTaskExceptions(); });
+
+  addGetStat("idle-tcpout-connections",  getCurrentIdleTCPConnections);
 
   /* make sure that the ECS stats are properly initialized */
   SyncRes::clearECSStats();

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -163,7 +163,7 @@ pdns_recursor_SOURCES = \
 	rec-protozero.cc rec-protozero.hh \
 	rec-snmp.hh rec-snmp.cc \
 	rec-taskqueue.cc rec-taskqueue.hh \
-        rec-tcpout.cc rec_tcpout.hh \
+        rec-tcpout.cc rec-tcpout.hh \
 	rec_channel.cc rec_channel.hh rec_metrics.hh \
 	rec_channel_rec.cc \
 	recpacketcache.cc recpacketcache.hh \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -163,6 +163,7 @@ pdns_recursor_SOURCES = \
 	rec-protozero.cc rec-protozero.hh \
 	rec-snmp.hh rec-snmp.cc \
 	rec-taskqueue.cc rec-taskqueue.hh \
+        rec-tcpout.cc rec_tcpout.hh \
 	rec_channel.cc rec_channel.hh rec_metrics.hh \
 	rec_channel_rec.cc \
 	recpacketcache.cc recpacketcache.hh \

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1887,6 +1887,8 @@ The numerical value supplied is used as the queue size, 0 meaning disabled. See 
 
 Enable TCP Fast Open Connect support, if available, on the outgoing connections to authoritative servers. See :ref:`tcp-fast-open-support`.
 
+.. _setting-tcp-out-max-idle-ms:
+
 ``tcp-out-max-idle-ms``
 -----------------------
 .. versionadded:: 4.6.0
@@ -1895,6 +1897,8 @@ Enable TCP Fast Open Connect support, if available, on the outgoing connections 
 -  Default : 10000
 
 Time outgoing TCP/DoT connections are left idle in milliseconds or 0 if no limit. After having been idle for this time, the connection is eligible for closing.
+
+.. _setting-tcp-out-max-per-auth:
 
 ``tcp-out-max-idle-per-auth``
 -----------------------------
@@ -1905,6 +1909,8 @@ Time outgoing TCP/DoT connections are left idle in milliseconds or 0 if no limit
 
 Maximum number of idle outgoing TCP/DoT connections to a specific IP per thread, 0 means do not keep idle connections open.
 
+.. _setting-tcp-out-max-queries:
+
 ``tcp-out-max-queries``
 -----------------------
 -  Integer
@@ -1914,6 +1920,8 @@ Maximum total number of queries per outgoing TCP/DoT connection, 0 means no limi
 closed and a new one will be created if needed.
 
 .. versionadded:: 4.6.0
+
+.. _setting-tcp-out-max-idle-per-thread:
 
 ``tcp-out-max-idle-per-thread``
 -------------------------------

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1888,7 +1888,7 @@ The numerical value supplied is used as the queue size, 0 meaning disabled. See 
 Enable TCP Fast Open Connect support, if available, on the outgoing connections to authoritative servers. See :ref:`tcp-fast-open-support`.
 
 ``tcp-out-max-idle-ms``
----------------------
+-----------------------
 .. versionadded:: 4.6.0
 
 -  Integer
@@ -1897,7 +1897,7 @@ Enable TCP Fast Open Connect support, if available, on the outgoing connections 
 Time outgoing TCP/DoT connections are left idle in milliseconds or 0 if no limit. After having been idle for this time, the connection is eligible for closing.
 
 ``tcp-out-max-idle-per-auth``
----------------------------
+-----------------------------
 .. versionadded:: 4.6.0
 
 -  Integer
@@ -1906,7 +1906,7 @@ Time outgoing TCP/DoT connections are left idle in milliseconds or 0 if no limit
 Maximum number of idle outgoing TCP/DoT connections to a specific IP per thread, 0 means do not keep idle connections open.
 
 ``tcp-out-max-queries``
-----------------------
+-----------------------
 -  Integer
 -  Default : 0
 
@@ -1916,7 +1916,7 @@ closed and a new one will be created if needed.
 .. versionadded:: 4.6.0
 
 ``tcp-out-max-idle-per-thread``
------------------------------
+-------------------------------
 .. versionadded:: 4.6.0
 
 -  Integer

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1887,6 +1887,43 @@ The numerical value supplied is used as the queue size, 0 meaning disabled. See 
 
 Enable TCP Fast Open Connect support, if available, on the outgoing connections to authoritative servers. See :ref:`tcp-fast-open-support`.
 
+``tcpout-maxidle-ms``
+---------------------
+.. versionadded:: 4.6.0
+
+-  Integer
+-  Default : 10000
+
+Time outgoing TCP/DoT connections are left idle in milliseconds or 0 if no limit. After having been idle for this time, the connection is elegible for closing.
+
+``tcpout-maxidle-per-auth``
+---------------------------
+.. versionadded:: 4.6.0
+
+-  Integer
+-  Default : 10
+
+Maximum number of idle outgoing TCP/DoT connections to a specific IP per thread, 0 means do not keep idle connections open.
+
+``tcpout-max-queries``
+----------------------
+-  Integer
+-  Default : 0
+
+Maximum total number of queries per outgoing TCP/DoT connection, 0 means no limit. After this number of queries, the concection is
+closed and a new one will be created if needed.
+
+.. versionadded:: 4.6.0
+
+``tcpout-maxidle-per-thread``
+-----------------------------
+.. versionadded:: 4.6.0
+
+-  Integer
+-  Default : 0
+
+Maximum number of idle outgoing TCP/DoT connections per thread, 0 means do not keep idle connections open.
+
 .. _setting-threads:
 
 ``threads``

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1887,16 +1887,16 @@ The numerical value supplied is used as the queue size, 0 meaning disabled. See 
 
 Enable TCP Fast Open Connect support, if available, on the outgoing connections to authoritative servers. See :ref:`tcp-fast-open-support`.
 
-``tcpout-maxidle-ms``
+``tcp-out-max-idle-ms``
 ---------------------
 .. versionadded:: 4.6.0
 
 -  Integer
 -  Default : 10000
 
-Time outgoing TCP/DoT connections are left idle in milliseconds or 0 if no limit. After having been idle for this time, the connection is elegible for closing.
+Time outgoing TCP/DoT connections are left idle in milliseconds or 0 if no limit. After having been idle for this time, the connection is eligible for closing.
 
-``tcpout-maxidle-per-auth``
+``tcp-out-max-idle-per-auth``
 ---------------------------
 .. versionadded:: 4.6.0
 
@@ -1905,17 +1905,17 @@ Time outgoing TCP/DoT connections are left idle in milliseconds or 0 if no limit
 
 Maximum number of idle outgoing TCP/DoT connections to a specific IP per thread, 0 means do not keep idle connections open.
 
-``tcpout-max-queries``
+``tcp-out-max-queries``
 ----------------------
 -  Integer
 -  Default : 0
 
-Maximum total number of queries per outgoing TCP/DoT connection, 0 means no limit. After this number of queries, the concection is
+Maximum total number of queries per outgoing TCP/DoT connection, 0 means no limit. After this number of queries, the connection is
 closed and a new one will be created if needed.
 
 .. versionadded:: 4.6.0
 
-``tcpout-maxidle-per-thread``
+``tcp-out-max-idle-per-thread``
 -----------------------------
 .. versionadded:: 4.6.0
 

--- a/pdns/recursordist/rec-tcpout.cc
+++ b/pdns/recursordist/rec-tcpout.cc
@@ -1,0 +1,80 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "rec-tcpout.hh"
+
+timeval TCPOutConnectionManager::maxIdleTime;
+size_t TCPOutConnectionManager::maxQueries;
+size_t TCPOutConnectionManager::maxIdlePerAuth;
+size_t TCPOutConnectionManager::maxIdlePerThread;
+
+void TCPOutConnectionManager::cleanup()
+{
+  if (maxIdleTime.tv_sec == 0 && maxIdleTime.tv_usec == 0) {
+    // no maximum idle time
+    return;
+  }
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
+  for (auto it = d_idle_connections.begin(); it != d_idle_connections.end();) {
+    timeval idle = now - it->second.d_last_used;
+    if (maxIdleTime < idle) {
+      it = d_idle_connections.erase(it);
+    }
+    else {
+      ++it;
+    }
+  }
+}
+
+void TCPOutConnectionManager::store(const ComboAddress& ip, Connection& connection)
+{
+  cleanup();
+  if (d_idle_connections.size() >= maxIdlePerThread) {
+    return;
+  }
+  if (d_idle_connections.count(ip) >= maxIdlePerAuth) {
+    return;
+  }
+
+  ++connection.d_numqueries;
+  if (maxQueries > 0 && connection.d_numqueries > maxQueries) {
+    return;
+  }
+  gettimeofday(&connection.d_last_used, nullptr);
+  d_idle_connections.emplace(ip, connection);
+}
+
+TCPOutConnectionManager::Connection TCPOutConnectionManager::get(const ComboAddress& ip)
+{
+  if (d_idle_connections.count(ip) > 0) {
+    auto h = d_idle_connections.extract(ip);
+    return h.mapped();
+  }
+  return Connection{};
+}
+
+uint64_t getCurrentIdleTCPConnections()
+{
+  return broadcastAccFunction<uint64_t>([] { return t_tcp_manager.getSize(); });
+}

--- a/pdns/recursordist/rec-tcpout.cc
+++ b/pdns/recursordist/rec-tcpout.cc
@@ -49,7 +49,10 @@ void TCPOutConnectionManager::cleanup()
 
 void TCPOutConnectionManager::store(const ComboAddress& ip, Connection& connection)
 {
-  cleanup();
+  if (d_idle_connections.size() >= maxIdlePerThread || d_idle_connections.count(ip) >= maxIdlePerAuth) {
+    cleanup();
+  }
+
   if (d_idle_connections.size() >= maxIdlePerThread) {
     return;
   }

--- a/pdns/recursordist/rec-tcpout.cc
+++ b/pdns/recursordist/rec-tcpout.cc
@@ -33,14 +33,12 @@ size_t TCPOutConnectionManager::maxQueries;
 size_t TCPOutConnectionManager::maxIdlePerAuth;
 size_t TCPOutConnectionManager::maxIdlePerThread;
 
-void TCPOutConnectionManager::cleanup()
+void TCPOutConnectionManager::cleanup(const struct timeval& now)
 {
   if (maxIdleTime.tv_sec == 0 && maxIdleTime.tv_usec == 0) {
     // no maximum idle time
     return;
   }
-  struct timeval now;
-  gettimeofday(&now, nullptr);
 
   for (auto it = d_idle_connections.begin(); it != d_idle_connections.end();) {
     timeval idle = now - it->second.d_last_used;
@@ -53,10 +51,10 @@ void TCPOutConnectionManager::cleanup()
   }
 }
 
-void TCPOutConnectionManager::store(const ComboAddress& ip, Connection& connection)
+void TCPOutConnectionManager::store(const struct timeval& now, const ComboAddress& ip, Connection&& connection)
 {
   if (d_idle_connections.size() >= maxIdlePerThread || d_idle_connections.count(ip) >= maxIdlePerAuth) {
-    cleanup();
+    cleanup(now);
   }
 
   if (d_idle_connections.size() >= maxIdlePerThread) {

--- a/pdns/recursordist/rec-tcpout.cc
+++ b/pdns/recursordist/rec-tcpout.cc
@@ -22,6 +22,12 @@
 
 #include "rec-tcpout.hh"
 
+// This line from /usr/include/openssl/ssl2.h: # define CERT char
+// throws dnsrecords.hh off the rails.
+#undef CERT
+
+#include "syncres.hh"
+
 timeval TCPOutConnectionManager::maxIdleTime;
 size_t TCPOutConnectionManager::maxQueries;
 size_t TCPOutConnectionManager::maxIdlePerAuth;

--- a/pdns/recursordist/rec-tcpout.hh
+++ b/pdns/recursordist/rec-tcpout.hh
@@ -67,10 +67,8 @@ public:
   }
 
 private:
-
   std::multimap<ComboAddress, Connection> d_idle_connections;
 };
 
 extern thread_local TCPOutConnectionManager t_tcp_manager;
 uint64_t getCurrentIdleTCPConnections();
-

--- a/pdns/recursordist/rec-tcpout.hh
+++ b/pdns/recursordist/rec-tcpout.hh
@@ -1,0 +1,76 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include "iputils.hh"
+#include "tcpiohandler.hh"
+#include "syncres.hh"
+
+class TCPOutConnectionManager
+{
+public:
+  // Max idle time for a connection, 0 is no timeout
+  static struct timeval maxIdleTime;
+  // Per thread maximum of idle connections for a specific destination, 0 means no idle connections will be kept open
+  static size_t maxIdlePerAuth;
+  // Max total number of queries to handle per connection, 0 is no max
+  static size_t maxQueries;
+  // Per thread max # of idle connections, here 0 means a real limit
+  static size_t maxIdlePerThread;
+
+  struct Connection
+  {
+    std::string toString() const
+    {
+      if (d_handler) {
+        return std::to_string(d_handler->getDescriptor()) + ' ' + std::to_string(d_handler.use_count());
+      }
+      return "";
+    }
+
+    std::shared_ptr<TCPIOHandler> d_handler;
+    timeval d_last_used{0, 0};
+    size_t d_numqueries{0};
+  };
+
+  void store(const ComboAddress& ip, Connection& connection);
+  Connection get(const ComboAddress& ip);
+  void cleanup();
+
+  size_t size() const
+  {
+    return d_idle_connections.size();
+  }
+  uint64_t* getSize() const
+  {
+    return new uint64_t(size());
+  }
+
+private:
+
+  std::multimap<ComboAddress, Connection> d_idle_connections;
+};
+
+extern thread_local TCPOutConnectionManager t_tcp_manager;
+uint64_t getCurrentIdleTCPConnections();
+

--- a/pdns/recursordist/rec-tcpout.hh
+++ b/pdns/recursordist/rec-tcpout.hh
@@ -24,7 +24,6 @@
 
 #include "iputils.hh"
 #include "tcpiohandler.hh"
-#include "syncres.hh"
 
 class TCPOutConnectionManager
 {

--- a/pdns/recursordist/rec-tcpout.hh
+++ b/pdns/recursordist/rec-tcpout.hh
@@ -66,6 +66,8 @@ public:
   }
 
 private:
+  // This does not take into account that we can have multiple connections with different hosts (via SNI) to the same IP.
+  // That is OK, since we are connecting by IP only at the moment.
   std::multimap<ComboAddress, Connection> d_idle_connections;
 };
 

--- a/pdns/recursordist/rec-tcpout.hh
+++ b/pdns/recursordist/rec-tcpout.hh
@@ -52,7 +52,7 @@ public:
     size_t d_numqueries{0};
   };
 
-  void store(const struct timeval &now, const ComboAddress& ip, Connection&& connection);
+  void store(const struct timeval& now, const ComboAddress& ip, Connection&& connection);
   Connection get(const ComboAddress& ip);
   void cleanup(const struct timeval& now);
 

--- a/pdns/recursordist/rec-tcpout.hh
+++ b/pdns/recursordist/rec-tcpout.hh
@@ -35,7 +35,7 @@ public:
   static size_t maxIdlePerAuth;
   // Max total number of queries to handle per connection, 0 is no max
   static size_t maxQueries;
-  // Per thread max # of idle connections, here 0 means a real limit
+  // Per thread max # of idle connections, 0 means no idle connections will be kept open
   static size_t maxIdlePerThread;
 
   struct Connection

--- a/pdns/recursordist/rec-tcpout.hh
+++ b/pdns/recursordist/rec-tcpout.hh
@@ -29,13 +29,13 @@ class TCPOutConnectionManager
 {
 public:
   // Max idle time for a connection, 0 is no timeout
-  static struct timeval maxIdleTime;
+  static struct timeval s_maxIdleTime;
   // Per thread maximum of idle connections for a specific destination, 0 means no idle connections will be kept open
-  static size_t maxIdlePerAuth;
+  static size_t s_maxIdlePerAuth;
   // Max total number of queries to handle per connection, 0 is no max
-  static size_t maxQueries;
+  static size_t s_maxQueries;
   // Per thread max # of idle connections, 0 means no idle connections will be kept open
-  static size_t maxIdlePerThread;
+  static size_t s_maxIdlePerThread;
 
   struct Connection
   {

--- a/pdns/recursordist/rec-tcpout.hh
+++ b/pdns/recursordist/rec-tcpout.hh
@@ -52,9 +52,9 @@ public:
     size_t d_numqueries{0};
   };
 
-  void store(const ComboAddress& ip, Connection& connection);
+  void store(const struct timeval &now, const ComboAddress& ip, Connection&& connection);
   Connection get(const ComboAddress& ip);
-  void cleanup();
+  void cleanup(const struct timeval& now);
 
   size_t size() const
   {

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -1085,6 +1085,11 @@ const std::map<std::string, MetricDefinition> MetricDefinitionStorage::d_metrics
   { "policy-hits",
     MetricDefinition(PrometheusMetricType::multicounter,
                      "Number of filter or RPZ policy hits")},
+
+  { "idle-tcpout-connections",
+    MetricDefinition(PrometheusMetricType::gauge,
+                     "Number of connections in the TCP idle outgoing connections pool")},
+
 };
 
 #define CHECK_PROMETHEUS_METRICS 0


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This maintains open TCP/DoT connections to auth or forwarders.  If a new connection is needed to a specific IP, one from the idle set is used if available. Connections are put in the idle set after a query is done with some basic success. If a connection comes from the idle set, it might be closed by the peer, so the code has to be prepared that it may not work and a new one has to be requested from the set (and if not available, created).

There might be some overlap with (upcoming) dnsdist code, we should look into merging at some point.
But for now I want to publish this so people can review and test.

ATM this mechanism is enabled with `tcp-out-max-idle-ms=10000`, `tcp-out-max-idle-per-auth=10`, `tcp-out-max-queries=0` (no maximum) and `"tcp-out-max-idle-per-thread=100`. See the docs for the semantics.

We might want to disable this by defaulting to `"tcp-out-max-idle-per-thread=0` on the final release.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
