### PR TITLE
dnsdist: Enable GnuTLS support in GitHub actions

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -54,6 +54,7 @@ dnsdist_build_deps = [
     'libcdb-dev',
     'libedit-dev',
     'libfstrm-dev',
+    'libgnutls28-dev',
     'libh2o-evloop-dev',
     'liblmdb-dev',
     'libre2-dev',
@@ -171,6 +172,7 @@ def install_dnsdist_test_deps(c): # FIXME: rename this, we do way more than apt-
               libcdb1 \
               libcurl4-openssl-dev \
               libfstrm0 \
+              libgnutls30 \
               libh2o-evloop0.13 \
               liblmdb0 \
               libre2-5 \
@@ -260,6 +262,7 @@ def ci_dnsdist_configure(c):
                      --enable-dns-over-https \
                      --enable-systemd \
                      --prefix=/opt/dnsdist \
+                     --with-gnutls \
                      --with-libsodium \
                      --with-lua=luajit \
                      --with-libcap \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It looks like it was not enabled in CircleCI, meaning that some of our regression tests were done with OpenSSL twice since we fallback gracefully when the requested provider is not available.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
