### PR TITLE
dnsdist: Initialize the cacheFlags member of DNSQuestion to 0

### DIFF
--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -161,7 +161,7 @@ public:
   const uint16_t qclass;
   uint16_t ecsPrefixLength;
   uint16_t origFlags;
-  uint16_t cacheFlags; /* DNS flags as sent to the backend */
+  uint16_t cacheFlags{0}; /* DNS flags as sent to the backend */
   const Protocol protocol;
   uint8_t ednsRCode{0};
   bool skipCache{false};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It should always be set in `processQuery()`, passed via the `IDState` and set again before being read in `processResponse()`, but better safe than sorry.

Reported by Coverity in CID 372808.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
