### PR TITLE
Replace apt-key with curl -o

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,9 +328,9 @@ commands:
           name: "Install apt-keys"
           command: |
             if [ "<< parameters.version >>" = "master" ]; then
-              curl https://repo.powerdns.com/CBC8B383-pub.asc | apt-key add -
+              curl https://repo.powerdns.com/CBC8B383-pub.asc -o /etc/apt/trusted.gpg.d/CBC8B383-pub.asc
             else
-              curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add -
+              curl https://repo.powerdns.com/FD380FBB-pub.asc -o /etc/apt/trusted.gpg.d/FD380FBB-pub.asc
             fi
       - run:
           name: "Add repository"

--- a/.github/workflows/secpoll.yml
+++ b/.github/workflows/secpoll.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
       - run: echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu focal-auth-master main' | sudo tee /etc/apt/sources.list.d/pdns.list
       - run: "echo -ne 'Package: pdns-*\nPin: origin repo.powerdns.com\nPin-Priority: 600\n' | sudo tee /etc/apt/preferences.d/pdns"
-      - run: curl https://repo.powerdns.com/CBC8B383-pub.asc | sudo apt-key add -
+      - run: sudo curl https://repo.powerdns.com/CBC8B383-pub.asc -o /etc/apt/trusted.gpg.d/CBC8B383-pub.asc
       - run: sudo apt-get update
       - run: sudo systemctl mask pdns
       - run: sudo apt-get install -y pdns-server pdns-backend-sqlite3

--- a/build-scripts/docker/repo-test/templates/Dockerfile-debian.jinja2
+++ b/build-scripts/docker/repo-test/templates/Dockerfile-debian.jinja2
@@ -1,7 +1,6 @@
 FROM {{ os_image }}:{{ os_version }}
 
-RUN apt-get update
-RUN apt-get install -y curl gnupg dnsutils apt-transport-https
+RUN apt-get update && apt-get install -y curl gnupg dnsutils apt-transport-https
 
 {% if release.startswith('dnsdist-') %}
 COPY pkg-pin /etc/apt/preferences.d/dnsdist
@@ -13,8 +12,7 @@ COPY pdns.list.{{ release }}.{{ os }}-{{ os_version }} /etc/apt/sources.list.d/p
 
 RUN curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add -
 RUN curl https://repo.powerdns.com/CBC8B383-pub.asc | apt-key add -
-RUN apt-get update
-RUN apt-get install -y {{ pkg }}
+RUN apt-get update && apt-get install -y {{ pkg }}
 
 {# in the old script this was just for rec-43, -44 and -45 #}
 {% if release.startswith('rec-') %}

--- a/build-scripts/docker/repo-test/templates/Dockerfile-debian.jinja2
+++ b/build-scripts/docker/repo-test/templates/Dockerfile-debian.jinja2
@@ -10,8 +10,8 @@ COPY pkg-pin /etc/apt/preferences.d/pdns
 
 COPY pdns.list.{{ release }}.{{ os }}-{{ os_version }} /etc/apt/sources.list.d/pdns.list
 
-RUN curl https://repo.powerdns.com/FD380FBB-pub.asc | apt-key add -
-RUN curl https://repo.powerdns.com/CBC8B383-pub.asc | apt-key add -
+RUN curl https://repo.powerdns.com/CBC8B383-pub.asc -o /etc/apt/trusted.gpg.d/CBC8B383-pub.asc \
+         https://repo.powerdns.com/FD380FBB-pub.asc -o /etc/apt/trusted.gpg.d/FD380FBB-pub.asc
 RUN apt-get update && apt-get install -y {{ pkg }}
 
 {# in the old script this was just for rec-43, -44 and -45 #}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Replace `apt-key` with `curl -o`

(Also merge some `apt-get update` / `apt-get install` docker stages as it's dangerous to have them split)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
