### PR TITLE
pdns: Document that SVCB and HTTPS RRs are supported

### DIFF
--- a/docs/appendices/types.rst
+++ b/docs/appendices/types.rst
@@ -300,6 +300,20 @@ priority. For example,
 be encoded with ``0`` in the priority field and
 ``100 389 mars.conaxis.ch`` in the content field.
 
+SVCB, HTTPS
+-----------
+
+Since 4.4. SVCB records, defined in
+(`draft-ietf-dnsop-svcb-https-07.html
+<https://www.ietf.org/archive/id/draft-ietf-dnsop-svcb-https-07.html>`__)
+are used to facilitate the lookup of information needed to make
+connections to network services. SVCB records allow a service to be
+provided from multiple alternative endpoints, each with associated
+parameters (such as transport protocol configuration and keys for
+encrypting the TLS ClientHello). They also enable aliasing of apex
+domains, which is not possible with CNAME. The HTTPS RR is a variation
+of SVCB for HTTPS and HTTP origins.
+
 TKEY, TSIG
 ----------
 


### PR DESCRIPTION
### Short description
These two record types (not yet standardized) have been supported since the 4.4.0 release, but were not listed in the 'Supported
Record Types' appendix in the documentation.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
