### PR TITLE
require nose >= 1.3.7 everywhere

### DIFF
--- a/regression-tests.api/requirements.txt
+++ b/regression-tests.api/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.20.0
-nose==1.3.0
+nose>=1.3.7
 parameterized
 mysql-connector
 psycopg2

--- a/regression-tests.ixfrdist/requirements.txt
+++ b/regression-tests.ixfrdist/requirements.txt
@@ -1,4 +1,4 @@
 dnspython
-nose
+nose>=1.3.7
 git+https://github.com/PowerDNS/xfrserver.git@0.1
 requests


### PR DESCRIPTION
### Short description
Breakage noticed on a rel/rec-4.4.x build. I am unsure why our master builds are not suffering.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master