### PR TITLE
SVCB: Accept known SVCParams in generic format

### DIFF
--- a/pdns/svc-records.cc
+++ b/pdns/svc-records.cc
@@ -34,12 +34,19 @@ const std::map<std::string, SvcParam::SvcParamKey> SvcParam::SvcParams = {
 };
 
 SvcParam::SvcParamKey SvcParam::keyFromString(const std::string& k) {
+  bool ignored;
+  return SvcParam::keyFromString(k, ignored);
+}
+
+SvcParam::SvcParamKey SvcParam::keyFromString(const std::string& k, bool &generic) {
   auto it = SvcParams.find(k);
   if (it != SvcParams.end()) {
+    generic = false;
     return it->second;
   }
   if (k.substr(0, 3) == "key") {
     try {
+      generic = true;
       return SvcParam::SvcParamKey(pdns_stou(k.substr(3)));
     }
     catch (...) {
@@ -104,7 +111,7 @@ SvcParam::SvcParam(const SvcParamKey &key, std::set<std::string> &&value) {
 SvcParam::SvcParam(const SvcParamKey &key, std::set<SvcParam::SvcParamKey> &&value) {
   d_key = key;
   if (d_key != SvcParamKey::mandatory) {
-    throw std::invalid_argument("can not create SvcParam for " + keyToString(key) + " with a string-set value");
+    throw std::invalid_argument("can not create SvcParam for " + keyToString(key) + " with a SvcParamKey-set value");
   }
   d_mandatory = std::move(value);
 }

--- a/pdns/svc-records.hh
+++ b/pdns/svc-records.hh
@@ -68,6 +68,9 @@ class SvcParam {
   //! Returns the SvcParamKey based on the input
   static SvcParamKey keyFromString(const std::string &k);
 
+  //! Returns the SvcParamKey based on the input, generic is true when the format was 'keyNNNN'
+  static SvcParamKey keyFromString(const std::string &k, bool &generic);
+
   //! Returns the string value of the SvcParamKey
   static std::string keyToString(const SvcParamKey &k);
 


### PR DESCRIPTION
### Short description
This allows PowerDNS to accept SVC Params like `key4=\192\000\002\222` or `key4=abcd`. I've included tests, but am not truly happy with the implementation and would like some comments.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)