### PR TITLE
Add our various random implementations to speedtest

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -916,11 +916,11 @@ tsig_tests_LDADD += $(P11KIT1_LIBS)
 endif
 
 speedtest_SOURCES = \
-        arguments.cc arguments.hh \
+	arguments.cc arguments.hh \
 	base32.cc \
 	base64.cc base64.hh \
 	credentials.cc credentials.hh \
-        dns_random.cc dns_random.hh \
+	dns_random.cc dns_random.hh \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dnsparser.cc dnsparser.hh \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -916,9 +916,11 @@ tsig_tests_LDADD += $(P11KIT1_LIBS)
 endif
 
 speedtest_SOURCES = \
+        arguments.cc arguments.hh \
 	base32.cc \
 	base64.cc base64.hh \
 	credentials.cc credentials.hh \
+        dns_random.cc dns_random.hh \
 	dnslabeltext.cc \
 	dnsname.cc dnsname.hh \
 	dnsparser.cc dnsparser.hh \

--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -1063,10 +1063,10 @@ struct RndSpeedTest
 
   void operator()() const
   {
-    dns_random(0x10000);
+    dns_random_uint16();
   }
 
-  std::string name;
+  const std::string name;
 };
 
 struct CredentialsVerifyTest
@@ -1196,17 +1196,17 @@ try
 
   doRun(UUIDGenTest());
 
-#if defined(HAVE_RANDOMBYTES_STIR)
-  doRun(RndSpeedTest("sodium"));
-#endif
-#if defined(HAVE_RAND_BYTES)
-  doRun(RndSpeedTest("openssl"));
-#endif
 #if defined(HAVE_GETRANDOM)
   doRun(RndSpeedTest("getrandom"));
 #endif
 #if defined(HAVE_ARC4RANDOM)
   doRun(RndSpeedTest("arc4random"));
+#endif
+#if defined(HAVE_RANDOMBYTES_STIR)
+  doRun(RndSpeedTest("sodium"));
+#endif
+#if defined(HAVE_RAND_BYTES)
+  doRun(RndSpeedTest("openssl"));
 #endif
   doRun(RndSpeedTest("urandom"));
 
@@ -1222,7 +1222,7 @@ try
   doRun(NSEC3HashTest(150, "ABCDABCDABCDABCDABCDABCDABCDABCD"));
   doRun(NSEC3HashTest(500, "ABCDABCDABCDABCDABCDABCDABCDABCD"));
 
-#ifdef HAVE_LIBSODIUM
+#if defined(HAVE_LIBSODIUM) && defined(HAVE_EVP_PKEY_CTX_SET1_SCRYPT_SALT)
   doRun(CredentialsHashTest());
   doRun(CredentialsVerifyTest());
 #endif
@@ -1236,7 +1236,6 @@ try
   S.declareDNSNameQTypeRing("testringdnsname", "Just some ring where we'll account things");
   doRun(StatRingDNSNameQTypeTest(DNSName("example.com"), QType(1)));
 #endif
-
 
   cerr<<"Total runs: " << g_totalRuns<<endl;
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Fixes #6492 (or at least gives us some data).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)

On old bullseye laptop:
```
'Random test sodium' 0.38 seconds: 1847879.0 runs/s, 0.54 usec/run
'Random test openssl' 0.12 seconds: 580113.7 runs/s, 1.72 usec/run
'Random test getrandom' 0.34 seconds: 1883117.4 runs/s, 0.53 usec/run
'Random test urandom' 0.51 seconds: 1649074.8 runs/s, 0.61 usec/run
```
Random buster VM:
```
'Random test sodium' 0.48 seconds: 1252499.3 runs/s, 0.80 usec/run
'Random test openssl' 0.12 seconds: 332932.7 runs/s, 3.00 usec/run
'Random test getrandom' 0.54 seconds: 1280666.6 runs/s, 0.78 usec/run
'Random test urandom' 0.45 seconds: 1115434.9 runs/s, 0.90 usec/run
```

on OpenBSD (pretty beefy AMD):
```
'Random test sodium' 0.10 seconds: 35829910.5 runs/s, 0.03 usec/run
'Random test openssl' 0.10 seconds: 30367527.4 runs/s, 0.03 usec/run
'Random test arc4random' 0.10 seconds: 60572491.4 runs/s, 0.02 usec/run
'Random test urandom' 1.26 seconds: 1781943.5 runs/s, 0.56 usec/run
```

All in all I think the current auto order of getrandom, arc4random, libsodium, openssl, urandom is ok.
