### PR TITLE
speedtest: Count the system time as well as the user time

### DIFF
--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -36,8 +36,8 @@ template<typename C> void doRun(const C& cmd, int mseconds=100)
   it.it_interval.tv_sec=0;
   it.it_interval.tv_usec=0;
 
-  signal(SIGVTALRM, alarmHandler);
-  setitimer(ITIMER_VIRTUAL, &it, 0);
+  signal(SIGPROF, alarmHandler);
+  setitimer(ITIMER_PROF, &it, 0);
 
   unsigned int runs=0;
   g_stop=false;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Our tests are designed to run for 100 ms of CPU time, but this is currently measured with `ITIMER_VIRTUAL` which means only when the process is executing in userspace. Switching to `ITIMER_PROF` would also account for the time spent
when the system is running on behalf of the process, which seems closer to what we want.

It fixes the reported time often exceeding 100ms in the numbers reported for `sodium`, `getrandom` and `urandom` in #10753, as they spend most of their time in kernel space.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
