### PR TITLE
dnsdist: Fix secpoll for 1.7.0-alpha1

### DIFF
--- a/docs/secpoll.zone
+++ b/docs/secpoll.zone
@@ -1,4 +1,4 @@
-@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2021092301 10800 3600 604800 10800
+@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2021092302 10800 3600 604800 10800
 @       3600    IN  NS  pdns-public-ns1.powerdns.com.
 @       3600    IN  NS  pdns-public-ns2.powerdns.com.
 
@@ -414,4 +414,4 @@ dnsdist-1.6.0-rc1.security-status                          60 IN TXT "3 Unsuppor
 dnsdist-1.6.0-rc2.security-status                          60 IN TXT "3 Unsupported pre-release"
 dnsdist-1.6.0.security-status                              60 IN TXT "1 OK"
 dnsdist-1.6.1.security-status                              60 IN TXT "1 OK"
-dnsdist-1.7.0-alpha1.security-status                       60 IN TXT "3 Unsupported pre-release"
+dnsdist-1.7.0-alpha1.security-status                       60 IN TXT "1 Unsupported pre-release"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It should be '1', not '3' as there is currently nothing to update to.
Currently dnsdist complains with:
```
PowerDNS DNSDist Security Update Mandatory: Unsupported pre-release
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
