### PR TITLE
rec: Use the correct RPZ policy name when loading via XFR

### DIFF
--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -383,7 +383,7 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& primaries, const boost::opt
   // If oldZone failed to load its getRefresh() returns 0, protect against that
   uint32_t refresh = std::max(refreshFromConf ? refreshFromConf : oldZone->getRefresh(), 10U);
   DNSName zoneName = oldZone->getDomain();
-  std::string polName = oldZone->getName().empty() ? oldZone->getName() : zoneName.toString();
+  std::string polName = !oldZone->getName().empty() ? oldZone->getName() : zoneName.toStringNoDot();
 
   // Now that we know the name, set it in the logger
   logger = logger->withValues("zone", Logging::Loggable(zoneName));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This commit fixes two issues:
- if the existing zone name is not empty we should use it, instead of the zone domain
- if the zone domain has to be used, it should not include a final dot

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
