### PR TITLE
dnsdist: Better handling of outgoing DoH workers

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -536,7 +536,12 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
           if (ret->d_tlsCtx) {
             setupDoHClientProtocolNegotiation(ret->d_tlsCtx);
           }
-          if (g_outgoingDoHWorkerThreads == 0) {
+
+          if (g_configurationDone && g_outgoingDoHWorkerThreads && *g_outgoingDoHWorkerThreads == 0) {
+            throw std::runtime_error("Error: setOutgoingDoHWorkerThreads() is set to 0 so no outgoing DoH worker thread is available to serve queries");
+          }
+
+          if (!g_outgoingDoHWorkerThreads || *g_outgoingDoHWorkerThreads == 0) {
             g_outgoingDoHWorkerThreads = 1;
           }
 

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -40,7 +40,7 @@
 
 std::atomic<uint64_t> g_dohStatesDumpRequested{0};
 std::unique_ptr<DoHClientCollection> g_dohClientThreads{nullptr};
-uint16_t g_outgoingDoHWorkerThreads{0};
+std::optional<uint16_t> g_outgoingDoHWorkerThreads{std::nullopt};
 
 #ifdef HAVE_NGHTTP2
 class DoHConnectionToBackend : public TCPConnectionToBackend
@@ -1229,9 +1229,15 @@ void DoHClientCollection::addThread()
 bool initDoHWorkers()
 {
 #ifdef HAVE_NGHTTP2
-  if (g_outgoingDoHWorkerThreads > 0) {
-    g_dohClientThreads = std::make_unique<DoHClientCollection>(g_outgoingDoHWorkerThreads);
-    for (size_t idx = 0; idx < g_outgoingDoHWorkerThreads; idx++) {
+  if (!g_outgoingDoHWorkerThreads) {
+    /* Unless the value has been set to 0 explicitly, always start at least one outgoing DoH worker thread, in case a DoH backend
+       is added at a later time. */
+    g_outgoingDoHWorkerThreads = 1;
+  }
+
+  if (g_outgoingDoHWorkerThreads && *g_outgoingDoHWorkerThreads > 0) {
+    g_dohClientThreads = std::make_unique<DoHClientCollection>(*g_outgoingDoHWorkerThreads);
+    for (size_t idx = 0; idx < *g_outgoingDoHWorkerThreads; idx++) {
       g_dohClientThreads->addThread();
     }
   }

--- a/pdns/dnsdistdist/dnsdist-nghttp2.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.hh
@@ -57,7 +57,7 @@ private:
 
 extern std::unique_ptr<DoHClientCollection> g_dohClientThreads;
 extern std::atomic<uint64_t> g_dohStatesDumpRequested;
-extern uint16_t g_outgoingDoHWorkerThreads;
+extern std::optional<uint16_t> g_outgoingDoHWorkerThreads;
 
 class TLSCtx;
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This commit raises the number of DoH workers to be at least 1, always, unless told otherwise via `setOutgoingDoHWorkerThreads(0)`.
In that last case it raises an exception if the console is used to declare a new DoH backend later on.

Fixes #10771.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
