### PR TITLE
undef cert from libssl, as it conflicts with the one from qtype.hh

### DIFF
--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -21,6 +21,7 @@
 #include <sodium.h>
 #endif /* HAVE_LIBSODIUM */
 
+#undef CERT
 #include "misc.hh"
 
 #if (OPENSSL_VERSION_NUMBER < 0x1010000fL || (defined LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2090100fL)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
https://github.com/PowerDNS/pdns/runs/3739441924?check_suite_focus=true:
```
In file included from /usr/include/openssl/ssl.h:1652,
                 from libssl.hh:56,
                 from libssl.cc:3:
qtype.hh:84:5: error: expected identifier before 'char'
     CERT = 37,
     ^~~~
qtype.hh:84:5: error: expected '}' before 'char'
In file included from dns.hh:28,
                 from misc.hh:38,
                 from libssl.cc:24:
qtype.hh:61:28: note: to match this '{'
   enum typeenum : uint16_t {
```
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
