### PR TITLE
dnsdist: Fix the unit tests to handle v4-only or v6-only connectivity

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp.hh
@@ -31,6 +31,10 @@ struct ConnectionInfo
     cs(cs_), fd(-1)
   {
   }
+  ConnectionInfo(ClientState* cs_, const ComboAddress remote_) :
+    remote(remote_), cs(cs_), fd(-1)
+  {
+  }
   ConnectionInfo(ConnectionInfo&& rhs) :
     remote(rhs.remote), cs(rhs.cs), fd(rhs.fd)
   {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In the load-balancing policies tests, we simply do not try to open a connection to the backend. In the TCP and HTTP/2 tests, we detect which protocol is available by trying to connect a socket, and use v6 if it is available and v4 otherwise.

Closes #10403.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
