### PR TITLE
dnsdist: Properly cache UDP queries passed to a TCP/DoT/DoH backend

### DIFF
--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -1323,8 +1323,8 @@ void tcpAcceptorThread(ClientState* cs)
         continue;
       }
 
-      if (concurrentConnections > cs->tcpMaxConcurrentConnections) {
-        cs->tcpMaxConcurrentConnections = concurrentConnections;
+      if (concurrentConnections > cs->tcpMaxConcurrentConnections.load()) {
+        cs->tcpMaxConcurrentConnections.store(concurrentConnections);
       }
 
       if (ci->fd < 0) {

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1336,7 +1336,7 @@ public:
     dnsheader cleartextDH;
     memcpy(&cleartextDH, dr.getHeader(), sizeof(cleartextDH));
 
-    if (!processResponse(response.d_buffer, localRespRuleActions, dr, false, false)) {
+    if (!processResponse(response.d_buffer, localRespRuleActions, dr, false, true)) {
       return;
     }
 

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1369,8 +1369,8 @@ static void on_accept(h2o_socket_t *listener, const char *err)
     return;
   }
 
-  if (concurrentConnections > dsc->cs->tcpMaxConcurrentConnections) {
-    dsc->cs->tcpMaxConcurrentConnections = concurrentConnections;
+  if (concurrentConnections > dsc->cs->tcpMaxConcurrentConnections.load()) {
+    dsc->cs->tcpMaxConcurrentConnections.store(concurrentConnections);
   }
 
   auto& conn = t_conns[descriptor];


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to tell the cache that the queries was received over TCP when inserting the response into the packet cache, which is obviously not true.

Reported by Denis Machard on the mailing-list [1].

[1]: https://mailman.powerdns.com/pipermail/dnsdist/2021-October/001122.html

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
