### PR TITLE
rec: Fix compile error on Ubuntu 18

### DIFF
--- a/pdns/recursordist/test-rec-zonetocache.cc
+++ b/pdns/recursordist/test-rec-zonetocache.cc
@@ -69,12 +69,8 @@ BOOST_AUTO_TEST_CASE(test_zonetocache)
   BOOST_REQUIRE(written == zone.length());
   BOOST_REQUIRE(fclose(fp) == 0);
 
-  RecZoneToCache::Config config
-    = {
-      .d_zone = ".",
-      .d_method = "file",
-      .d_sources = {temp},
-      .d_refreshPeriod = 0};
+  RecZoneToCache::Config config{".", "file", {temp}, ComboAddress(), TSIGTriplet()};
+  config.d_refreshPeriod = 0;
 
   // Start with a new, empty cache
   g_recCache = std::unique_ptr<MemRecursorCache>(new MemRecursorCache());


### PR DESCRIPTION
Fixes #10799
```
test-rec-zonetocache.cc: In member function 'void rec_zonetocache::test_zonetocache::test_method()':
test-rec-zonetocache.cc:77:27: sorry, unimplemented: non-trivial designated initializers not supported
       .d_refreshPeriod = 0};
       ^
test-rec-zonetocache.cc:77:27: warning: missing initializer for member 'RecZoneToCache::Config::d_tt' [-Wmissing-field-initializers]
```
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
