### PR TITLE
rec: Backport 10768 to rec-4.5.x: Use the correct RPZ policy name when loading via XFR

### DIFF
--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -366,7 +366,7 @@ void RPZIXFRTracker(const std::vector<ComboAddress>& masters, boost::optional<DN
   // If oldZone failed to load its getRefresh() returns 0, protect against that
   uint32_t refresh = std::max(refreshFromConf ? refreshFromConf : oldZone->getRefresh(), 10U);
   DNSName zoneName = oldZone->getDomain();
-  std::string polName = oldZone->getName().empty() ? oldZone->getName() : zoneName.toString();
+  std::string polName = !oldZone->getName().empty() ? oldZone->getName() : zoneName.toStringNoDot();
 
   while (!sr) {
     /* if we received an empty sr, the zone was not really preloaded */


### PR DESCRIPTION
This commit fixes two issues:
- if the existing zone name is not empty we should use it, instead of
  the zone domain
- if the zone domain has to be used, it should not include a final dot

(cherry picked from commit 3e86a970828dda814a140c9613311a8507c3c458)

Backport of #10768 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
