### PR TITLE
Backport 10622 to rec 4.5.x: Detect a loop when the denial of the DS comes from the child zone 

### DIFF
--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2837,6 +2837,13 @@ vState SyncRes::validateRecordsWithSigs(unsigned int depth, const DNSName& qname
         state = vState::BogusSelfSignedDS;
         dsFailed = true;
       }
+      else if (qtype == QType::DS && signer == qname && !signer.isRoot() && (type == QType::SOA || type == QType::NSEC || type == QType::NSEC3)) {
+        /* if we are trying to validate the DS or more likely NSEC(3)s proving that it does not exist, we have a problem.
+           In that case let's go Bogus (we will check later if we missed a cut)
+        */
+        state = vState::BogusSelfSignedDS;
+        dsFailed = true;
+      }
       else if (qtype == QType::DNSKEY && signer == qname) {
         /* that actually does happen when a server returns NS records in authority
            along with the DNSKEY, leading us to trying to validate the RRSIGs for


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #10622 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
