### PR TITLE
Rec: Minimal Backport of 10632: match ordering of PacketID using the Birtdah vs non-Birtday comparator

### DIFF
--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -974,7 +974,7 @@ struct PacketID
     if( tie(remote, ourSock, type) > tie(b.remote, bSock, b.type))
       return false;
 
-    return tie(fd, id, domain) < tie(b.fd, b.id, b.domain);
+    return tie(domain, fd, id) < tie(b.domain, b.fd, b.id);
   }
 };
 


### PR DESCRIPTION

MInimal backport of #10632

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
