### PR TITLE
Rename the 'queued' metric of the Remote Logger to 'processed'

### DIFF
--- a/pdns/remote_logger.cc
+++ b/pdns/remote_logger.cc
@@ -170,7 +170,7 @@ void RemoteLogger::queueData(const std::string& data)
   }
 
   runtime->d_writer.write(data);
-  ++d_queued;
+  ++d_processed;
 }
 
 void RemoteLogger::maintenanceThread() 

--- a/pdns/remote_logger.hh
+++ b/pdns/remote_logger.hh
@@ -90,7 +90,7 @@ public:
   void queueData(const std::string& data) override;
   std::string toString() const override
   {
-    return d_remote.toStringWithPort() + " (" + std::to_string(d_queued) + " queued, " + std::to_string(d_drops) + " dropped)";
+    return d_remote.toStringWithPort() + " (" + std::to_string(d_processed) + " processed, " + std::to_string(d_drops) + " dropped)";
   }
   void stop()
   {
@@ -109,7 +109,7 @@ private:
 
   ComboAddress d_remote;
   std::atomic<uint64_t> d_drops{0};
-  std::atomic<uint64_t> d_queued{0};
+  std::atomic<uint64_t> d_processed{0};
   uint16_t d_timeout;
   uint8_t d_reconnectWaitTime;
   std::atomic<bool> d_exiting{false};


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Since it was not clear at all whether 'queued' meant 'has been put in the queue at some point, might have been sent or not' or 'actually still in the queue' (it was the former).

Closes #10405.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
