### PR TITLE
dnsdist: Disable TLS renegotiation, release buffers for outgoing TLS

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -524,6 +524,14 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         if (vars.count("validateCertificates")) {
           tlsParams.d_validateCertificates = boost::get<bool>(vars.at("validateCertificates"));
         }
+        if (vars.count("releaseBuffers")) {
+          tlsParams.d_releaseBuffers = boost::get<bool>(vars.at("releaseBuffers"));
+        }
+        if (vars.count("enableRenegotiation")) {
+          tlsParams.d_enableRenegotiation = boost::get<bool>(vars.at("enableRenegotiation"));
+        }
+
+
         if (vars.count("subjectName")) {
           ret->d_tlsSubjectName = boost::get<string>(vars.at("subjectName"));
         }

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -503,7 +503,7 @@ Servers
     Added ``maxInFlight`` to server_table.
 
   .. versionchanged:: 1.7.0
-    Added ``caStore``, ``checkTCP``, ``ciphers``, ``ciphers13``, ``dohPath``, ``subjectName``, ``tcpOnly``, ``tls`` and ``validateCertificates`` to server_table.
+    Added ``caStore``, ``checkTCP``, ``ciphers``, ``ciphers13``, ``dohPath``, ``enableRenegotiation``, ``releaseBuffers``, ``subjectName``, ``tcpOnly``, ``tls`` and ``validateCertificates`` to server_table.
 
   Add a new backend server. Call this function with either a string::
 
@@ -559,7 +559,9 @@ Servers
       ciphersTLS13=STRING,      -- The ciphers to use for TLS 1.3, when the OpenSSL provider is used. When the GnuTLS provider is used, ``ciphers`` applies regardless of the TLS protocol and this setting is not used.
       subjectName=STRING,       -- The subject name passed in the SNI value of the TLS handshake, and against which to validate the certificate presented by the backend. Default is empty.
       validateCertificates=BOOL,-- Whether the certificate presented by the backend should be validated against the CA store (see ``caStore``). Default is true.
-      dohPath=STRING            -- Enable DNS over HTTPS communication for this backend, using POST queries to the HTTP host supplied as ``subjectName`` and the HTTP path supplied in this parameter.
+      dohPath=STRING,           -- Enable DNS over HTTPS communication for this backend, using POST queries to the HTTP host supplied as ``subjectName`` and the HTTP path supplied in this parameter.
+      releaseBuffers=BOOL,      -- Whether OpenSSL should release its I/O buffers when a connection goes idle, saving roughly 35 kB of memory per connection. Default to true.
+      enableRenegotiation=BOOL  -- Whether secure TLS renegotiation should be enabled. Disabled by default since it increases the attack surface and is seldom used for DNS.
     })
 
   :param str server_string: A simple IP:PORT string.

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -545,6 +545,13 @@ public:
       SSL_OP_SINGLE_DH_USE |
       SSL_OP_SINGLE_ECDH_USE |
       SSL_OP_CIPHER_SERVER_PREFERENCE;
+    if (!params.d_enableRenegotiation) {
+#ifdef SSL_OP_NO_RENEGOTIATION
+      sslOptions |= SSL_OP_NO_RENEGOTIATION;
+#elif defined(SSL_OP_NO_CLIENT_RENEGOTIATION)
+      sslOptions |= SSL_OP_NO_CLIENT_RENEGOTIATION;
+#endif
+    }
 
     registerOpenSSLUser();
 
@@ -599,6 +606,12 @@ public:
        but we don't want OpenSSL to cache the session itself so we set SSL_SESS_CACHE_NO_INTERNAL_STORE as well */
     SSL_CTX_set_session_cache_mode(d_tlsCtx.get(), SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL_STORE);
     SSL_CTX_sess_set_new_cb(d_tlsCtx.get(), &OpenSSLTLSIOCtx::newTicketFromServerCb);
+
+#ifdef SSL_MODE_RELEASE_BUFFERS
+    if (params.d_releaseBuffers) {
+      SSL_CTX_set_mode(d_tlsCtx.get(), SSL_MODE_RELEASE_BUFFERS);
+    }
+#endif
   }
 
   ~OpenSSLTLSIOCtx() override

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -546,6 +546,8 @@ struct TLSContextParameters
   std::string d_ciphers13;
   std::string d_caStore;
   bool d_validateCertificates{true};
+  bool d_releaseBuffers{true};
+  bool d_enableRenegotiation{false};
 };
 
 std::shared_ptr<TLSCtx> getTLSContext(const TLSContextParameters& params);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We already do that for incoming TLS connections, do it for outgoing ones as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
