### PR TITLE
auth: Update zone cache after initialization

### DIFF
--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -704,6 +704,17 @@ void mainthread()
 
   pdns::parseTrustedNotificationProxy(::arg()["trusted-notification-proxy"]);
 
+  try {
+    UeberBackend B;
+    B.updateZoneCache();
+  }
+  catch(PDNSException &e) {
+    g_log<<Logger::Error<<"PDNSException while updating zone cache: "<<e.reason<<endl;
+  }
+  catch(std::exception &e) {
+    g_log<<Logger::Error<<"STL Exception while updating zone cache: "<<e.what()<<endl;
+  }
+
   // NOW SAFE TO CREATE THREADS!
   dl->go();
 

--- a/pdns/receiver.cc
+++ b/pdns/receiver.cc
@@ -627,14 +627,9 @@ int main(int argc, char **argv)
       }
     }
 
-    UeberBackend::go();
-
     g_zoneCache.setRefreshInterval(::arg().asNum("zone-cache-refresh-interval"));
-    {
-      UeberBackend B;
-      B.updateZoneCache();
-    }
 
+    UeberBackend::go();
     N=std::make_shared<UDPNameserver>(); // this fails when we are not root, throws exception
     g_udpReceivers.push_back(N);
 


### PR DESCRIPTION
The code in `receiver.cc` creates backends before complete initialization with chroot() is done, causing startup failures for backends that require files from inside of the chroot.

Closes: https://github.com/PowerDNS/pdns/issues/10829

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
