### PR TITLE
Recursor: clean up kv-example-script.lua

### DIFF
--- a/pdns/recursordist/contrib/kv-example-script.lua
+++ b/pdns/recursordist/contrib/kv-example-script.lua
@@ -1,58 +1,58 @@
 
---[[ 
+--[[
 This implements a two-step domain filtering solution where the status of an IP address
 and a domain name need to be looked up.
 To do so, we use the udpQuestionResponse answers which generically allows us to do asynchronous
 lookups via UDP.
 Such lookups can be slow, but they won't block PowerDNS while we wait for them.
 
-To benefit from this hook, 
+To benefit from this hook,
 ..
 
 To test, use the 'kvresp' example program provided.
 --]]
 
 function preresolve (dq)
-	pdnslog("preresolve handler called for: "..dq.remoteaddr:toString()..", local: "..dq.localaddr:toString()..", "..dq.qname:toString()..", "..dq.qtype)
-	dq.followupFunction="udpQueryResponse"
-	dq.udpCallback="gotdomaindetails"
-	dq.udpQueryDest=newCA("127.0.0.1:5555")
-	dq.udpQuery = "DOMAIN "..dq.qname:toString()
-	return true;
+    pdnslog("preresolve handler called for: "..dq.remoteaddr:toString()..", local: "..dq.localaddr:toString()..", "..dq.qname:toString()..", "..dq.qtype)
+    dq.followupFunction="udpQueryResponse"
+    dq.udpCallback="gotdomaindetails"
+    dq.udpQueryDest=newCA("127.0.0.1:5555")
+    dq.udpQuery = "DOMAIN "..dq.qname:toString()
+    return true;
 end
 
 function gotdomaindetails(dq)
-	pdnslog("gotdomaindetails called, got: "..dq.udpAnswer)
-        if(dq.udpAnswer == "0") 
-        then
-			pdnslog("This domain needs no filtering, not looking up this domain")
-                dq.followupFunction=""   
-                return false
-        end
-        pdnslog("Domain might need filtering for some users")
-        dq.variable = true -- disable packet cache
-	local data={}
-	data["domaindetails"]= dq.udpAnswer
-	dq.data=data 
-	dq.udpQuery="IP "..dq.remoteaddr:toString()
-	dq.udpCallback="gotipdetails"
-	pdnslog("returning true in gotipdetails")
-	return true
+    pdnslog("gotdomaindetails called, got: "..dq.udpAnswer)
+
+    if(dq.udpAnswer == "0")
+    then
+        pdnslog("This domain needs no filtering, not looking up this domain")
+        dq.followupFunction=""
+        return false
+    end
+    pdnslog("Domain might need filtering for some users")
+    dq.variable = true -- disable packet cache
+
+    local data={}
+    data["domaindetails"]= dq.udpAnswer
+    dq.data=data
+    dq.udpQuery="IP "..dq.remoteaddr:toString()
+    dq.udpCallback="gotipdetails"
+    pdnslog("returning true in gotipdetails")
+    return true
 end
 
 function gotipdetails(dq)
-        dq.followupFunction=""
-		pdnslog("So status of IP is "..dq.udpAnswer.." and status of domain is "..dq.data.domaindetails)
-	if(dq.data.domaindetails=="1" and dq.udpAnswer=="1")
-	then
-		pdnslog("IP wants filtering and domain is of the filtered kind")
-		dq:addAnswer(pdns.CNAME, "blocked.powerdns.com")
-		return true
-	else
-                pdnslog("Returning false (normal resolution should proceed, for this user)")
-		return false
-	end
+    dq.followupFunction=""
+    pdnslog("So status of IP is "..dq.udpAnswer.." and status of domain is "..dq.data.domaindetails)
+
+    if(dq.data.domaindetails=="1" and dq.udpAnswer=="1")
+    then
+        pdnslog("IP wants filtering and domain is of the filtered kind")
+        dq:addAnswer(pdns.CNAME, "blocked.powerdns.com")
+        return true
+    else
+        pdnslog("Returning false (normal resolution should proceed, for this user)")
+        return false
+    end
 end
-
-
-


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In addition to https://github.com/PowerDNS/pdns/pull/10798 clean up remained kv-example-script.lua and use pdnslog() instead of print()

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)