### PR TITLE
dnsdist: Only set recursion protection once we know we do not return

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1847,7 +1847,6 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         return;
       }
 
-      g_included = true;
       struct stat st;
       if (stat(dirname.c_str(), &st)) {
         errlog("The included directory %s does not exist!", dirname.c_str());
@@ -1890,6 +1889,8 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       closedir(dirp);
       files.sort();
 
+      g_included = true;
+
       for (auto file = files.begin(); file != files.end(); ++file) {
         std::ifstream ifs(*file);
         if (!ifs) {
@@ -1898,7 +1899,13 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
           vinfolog("Read configuration from '%s'", *file);
         }
 
-        luaCtx.executeCode(ifs);
+        try {
+          luaCtx.executeCode(ifs);
+        }
+        catch (...) {
+          g_included = false;
+          throw;
+        }
       }
 
       g_included = false;


### PR DESCRIPTION
This is not a fix for the tsan errors we're seeing, but worthwhile to fix anyway.

Also catch exception thrown by executeCode. (I'm assuming it can throw an exception).

Note that the function is not thread-safe both due to the use of a global and `opendir` and `readdir` calls. Now as far as I understand the dnsdist startup seqeunce, this *should* not be a problem as dnssdist is still single threaded at the point of call. But if by accident `includeDir` is called from several threads simultaneously, things can go wrong.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
