### PR TITLE
rec: Fire and forget mode for directResolve()

### DIFF
--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -407,9 +407,10 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
       g_stats.ipv6queries++;
     }
 
-    ret = asendto((const char*)&*vpacket.begin(), vpacket.size(), 0, ip, qid, domain, type, &queryfd);
+    const bool faf = context && context->d_fire_and_forget;
+    ret = asendto((const char*)&*vpacket.begin(), vpacket.size(), 0, ip, qid, domain, type, &queryfd, faf);
 
-    if (ret != LWResult::Result::Success || (context && context->d_fire_and_forget)) {
+    if (ret != LWResult::Result::Success || faf) {
       return ret;
     }
 

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -283,8 +283,7 @@ static bool tcpconnect(const struct timeval& now, const ComboAddress& ip, TCPOut
 }
 
 static LWResult::Result tcpsendrecv(const ComboAddress& ip, TCPOutConnectionManager::Connection& connection,
-                                    ComboAddress& localip, const vector<uint8_t>& vpacket, size_t& len, PacketBuffer& buf,
-                                    bool faf = false)
+                                    ComboAddress& localip, const vector<uint8_t>& vpacket, size_t& len, PacketBuffer& buf)
 {
   socklen_t slen = ip.getSocklen();
   uint16_t tlen = htons(vpacket.size());
@@ -299,9 +298,10 @@ static LWResult::Result tcpsendrecv(const ComboAddress& ip, TCPOutConnectionMana
   packet.insert(packet.end(), vpacket.begin(), vpacket.end());
 
   LWResult::Result ret = asendtcp(packet, connection.d_handler);
-  if (ret != LWResult::Result::Success || faf) {
+  if (ret != LWResult::Result::Success) {
     return ret;
   }
+
   ret = arecvtcp(packet, 2, connection.d_handler, false);
   if (ret != LWResult::Result::Success) {
     return ret;

--- a/pdns/lwres.cc
+++ b/pdns/lwres.cc
@@ -408,7 +408,7 @@ static LWResult::Result asyncresolve(const ComboAddress& ip, const DNSName& doma
     }
 
     const bool faf = context && context->d_fire_and_forget;
-    ret = asendto((const char*)&*vpacket.begin(), vpacket.size(), 0, ip, qid, domain, type, &queryfd, faf);
+    ret = asendto((const char*)&*vpacket.begin(), vpacket.size(), 0, ip, qid, domain, type, &queryfd, faf, now->tv_sec);
 
     if (ret != LWResult::Result::Success || faf) {
       return ret;

--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -67,7 +67,7 @@ public:
 };
 
 LWResult::Result asendto(const char *data, size_t len, int flags, const ComboAddress& ip, uint16_t id,
-                         const DNSName& domain, uint16_t qtype, int* fd, bool faf);
+                         const DNSName& domain, uint16_t qtype, int* fd, bool faf, time_t);
 LWResult::Result arecvfrom(PacketBuffer& packet, int flags, const ComboAddress& ip, size_t *d_len, uint16_t id,
                            const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now);
 

--- a/pdns/lwres.hh
+++ b/pdns/lwres.hh
@@ -67,7 +67,7 @@ public:
 };
 
 LWResult::Result asendto(const char *data, size_t len, int flags, const ComboAddress& ip, uint16_t id,
-                         const DNSName& domain, uint16_t qtype,  int* fd);
+                         const DNSName& domain, uint16_t qtype, int* fd, bool faf);
 LWResult::Result arecvfrom(PacketBuffer& packet, int flags, const ComboAddress& ip, size_t *d_len, uint16_t id,
                            const DNSName& domain, uint16_t qtype, int fd, const struct timeval* now);
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1428,7 +1428,7 @@ static void sendNODLookup(const shared_ptr<Logr::Logger>& nodlogger, const DNSNa
     }
     nodlogger->v(10)->info(Logr::Debug, "Sending NOD lookup", "nodqname", Logging::Loggable(qname));
     vector<DNSRecord> dummy;
-    directResolve(qname, QType::A, QClass::IN, dummy, nullptr, false);
+    directResolve(qname, QType::A, QClass::IN, dummy, nullptr, false, true);
   }
 }
 

--- a/pdns/resolve-context.hh
+++ b/pdns/resolve-context.hh
@@ -12,9 +12,10 @@ struct ResolveContext {
 
   ResolveContext(const ResolveContext& ctx) = delete;
   ResolveContext & operator=(const ResolveContext&) = delete;
-  
+
   boost::optional<const boost::uuids::uuid&> d_initialRequestId;
 #ifdef HAVE_FSTRM
   boost::optional<const DNSName&> d_auth;
 #endif
+  bool d_fire_and_forget{false};
 };

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -598,7 +598,7 @@ public:
 
   explicit SyncRes(const struct timeval& now);
 
-  int beginResolve(const DNSName &qname, QType qtype, QClass qclass, vector<DNSRecord>&ret, unsigned int depth = 0);
+  int beginResolve(const DNSName &qname, QType qtype, QClass qclass, vector<DNSRecord>&ret, unsigned int depth = 0, bool faf = false);
 
   void setId(int id)
   {
@@ -839,12 +839,12 @@ private:
 
   bool doDoTtoAuth(const DNSName& ns) const;
   int doResolveAt(NsSet &nameservers, DNSName auth, bool flawedNSSet, const DNSName &qname, QType qtype, vector<DNSRecord>&ret,
-                  unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation);
-  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool doDoT, bool& truncated, bool& spoofed);
+                  unsigned int depth, set<GetBestNSAnswer>&beenthere, vState& state, StopAtDelegation* stopAtDelegation, bool faf);
+  bool doResolveAtThisIP(const std::string& prefix, const DNSName& qname, const QType qtype, LWResult& lwr, boost::optional<Netmask>& ednsmask, const DNSName& auth, bool const sendRDQuery, const bool wasForwarded, const DNSName& nsName, const ComboAddress& remoteIP, bool doTCP, bool doDoT, bool& truncated, bool& spoofed, bool faf);
   bool processAnswer(unsigned int depth, LWResult& lwr, const DNSName& qname, const QType qtype, DNSName& auth, bool wasForwarded, const boost::optional<Netmask> ednsmask, bool sendRDQuery, NsSet &nameservers, std::vector<DNSRecord>& ret, const DNSFilterEngine& dfe, bool* gotNewServers, int* rcode, vState& state, const ComboAddress& remoteIP);
 
-  int doResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state);
-  int doResolveNoQNameMinimization(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool* fromCache = NULL, StopAtDelegation* stopAtDelegation = NULL, bool considerforwards = true);
+  int doResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool faf = false);
+  int doResolveNoQNameMinimization(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, set<GetBestNSAnswer>& beenthere, vState& state, bool faf = false, bool* fromCache = NULL, StopAtDelegation* stopAtDelegation = NULL, bool considerforwards = true);
   bool doOOBResolve(const AuthDomain& domain, const DNSName &qname, QType qtype, vector<DNSRecord>&ret, int& res);
   bool doOOBResolve(const DNSName &qname, QType qtype, vector<DNSRecord>&ret, unsigned int depth, int &res);
   bool isRecursiveForwardOrAuth(const DNSName &qname) const;
@@ -875,7 +875,7 @@ private:
 
   bool doSpecialNamesResolve(const DNSName &qname, QType qtype, const QClass qclass, vector<DNSRecord> &ret);
 
-  LWResult::Result asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, const DNSName& auth, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res, bool* chained) const;
+  LWResult::Result asyncresolveWrapper(const ComboAddress& ip, bool ednsMANDATORY, const DNSName& domain, const DNSName& auth, int type, bool doTCP, bool sendRDQuery, struct timeval* now, boost::optional<Netmask>& srcmask, LWResult* res, bool* chained, bool faf) const;
 
   boost::optional<Netmask> getEDNSSubnetMask(const DNSName&dn, const ComboAddress& rem);
 
@@ -1171,7 +1171,7 @@ void broadcastFunction(const pipefunc_t& func);
 void distributeAsyncFunction(const std::string& question, const pipefunc_t& func);
 
 int directResolve(const DNSName& qname, const QType qtype, const QClass qclass, vector<DNSRecord>& ret, shared_ptr<RecursorLua4> pdl);
-int directResolve(const DNSName& qname, const QType qtype, const QClass qclass, vector<DNSRecord>& ret, shared_ptr<RecursorLua4> pdl, bool qm);
+int directResolve(const DNSName& qname, const QType qtype, const QClass qclass, vector<DNSRecord>& ret, shared_ptr<RecursorLua4> pdl, bool qm, bool faf = false);
 int followCNAMERecords(std::vector<DNSRecord>& ret, const QType qtype, int oldret);
 int getFakeAAAARecords(const DNSName& qname, ComboAddress prefix, vector<DNSRecord>& ret);
 int getFakePTRRecords(const DNSName& qname, vector<DNSRecord>& ret);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

An (experimental) approach to fix #10425. Not too happy about it as it adds an extra argument (and logic) in way too many functions.

As I never really understood why a  full DNS lookup would be needed to signal an NOD...

It might be better to just change the way NOD lookup works:

- a config that supplies an IP. 
- on NOD, we sent a query for the domain (with suffix) to that IP and done. 

As I understood a typical config includes a forwarder for the NOD suffix domain anyway.

Or can somebody explain why a full DNS lookup is good for a NOD?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
