### PR TITLE
get rid of make_pair

### DIFF
--- a/pdns/bindparserclasses.hh
+++ b/pdns/bindparserclasses.hh
@@ -57,7 +57,7 @@ public:
 
   bool operator<(const BindDomainInfo& b) const
   {
-    return make_pair(d_dev, d_ino) < make_pair(b.d_dev, b.d_ino);
+    return pair(d_dev, d_ino) < pair(b.d_dev, b.d_ino);
   }
 };
 

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -156,8 +156,8 @@ bool DNSSECKeeper::addKey(const DNSName& name, const DNSSECPrivateKey& dpk, int6
 
 static bool keyCompareByKindAndID(const DNSSECKeeper::keyset_t::value_type& a, const DNSSECKeeper::keyset_t::value_type& b)
 {
-  return make_pair(!a.second.keyType, a.second.id) <
-         make_pair(!b.second.keyType, b.second.id);
+  return pair(!a.second.keyType, a.second.id) <
+         pair(!b.second.keyType, b.second.id);
 }
 
 DNSSECPrivateKey DNSSECKeeper::getKeyById(const DNSName& zname, unsigned int id)

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2311,8 +2311,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
       if (vars->count("customResponseHeaders")) {
         for (auto const& headerMap : boost::get<std::map<std::string,std::string>>((*vars)["customResponseHeaders"])) {
-          auto headerResponse = std::make_pair(boost::to_lower_copy(headerMap.first), headerMap.second);
-          frontend->d_customResponseHeaders.push_back(std::move(headerResponse));
+          frontend->d_customResponseHeaders.emplace_back(boost::to_lower_copy(headerMap.first), headerMap.second);
         }
       }
 

--- a/pdns/dnsdist-protobuf.cc
+++ b/pdns/dnsdist-protobuf.cc
@@ -78,12 +78,12 @@ void DNSDistProtoBufMessage::setBytes(size_t bytes)
 
 void DNSDistProtoBufMessage::setTime(time_t sec, uint32_t usec)
 {
-  d_time = std::make_pair(sec, usec);
+  d_time = std::pair(sec, usec);
 }
 
 void DNSDistProtoBufMessage::setQueryTime(time_t sec, uint32_t usec)
 {
-  d_queryTime = std::make_pair(sec, usec);
+  d_queryTime = std::pair(sec, usec);
 }
 
 void DNSDistProtoBufMessage::setQuestion(const DNSName& name, uint16_t qtype, uint16_t qclass)

--- a/pdns/dnsdistdist/dnsdist-dynblocks.cc
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.cc
@@ -458,7 +458,7 @@ std::map<std::string, std::list<std::pair<Netmask, unsigned int>>> DynBlockMaint
     }
 
     if (topsForReason.size() < topN || topsForReason.front().second < value) {
-      auto newEntry = std::make_pair(entry.first, value);
+      auto newEntry = std::pair(entry.first, value);
 
       if (topsForReason.size() >= topN) {
         topsForReason.pop_front();
@@ -485,7 +485,7 @@ std::map<std::string, std::list<std::pair<DNSName, unsigned int>>> DynBlockMaint
   blocks->visit([&results, topN](const SuffixMatchTree<DynBlock>& node) {
     auto& topsForReason = results[node.d_value.reason];
     if (topsForReason.size() < topN || topsForReason.front().second < node.d_value.blocks) {
-      auto newEntry = std::make_pair(node.d_value.domain, node.d_value.blocks.load());
+      auto newEntry = std::pair(node.d_value.domain, node.d_value.blocks.load());
 
       if (topsForReason.size() >= topN) {
         topsForReason.pop_front();

--- a/pdns/dnsgram.cc
+++ b/pdns/dnsgram.cc
@@ -169,7 +169,7 @@ try
             g_lastquestionTime=pr.d_pheader.ts;
             g_clientQuestions++;
             totalQueries++;
-            counts[make_pair(mdp.d_qname, mdp.d_qtype)]++;
+            counts[pair(mdp.d_qname, mdp.d_qtype)]++;
             questions.emplace(mdp.d_qname, mdp.d_qtype);
           }
           else if(mdp.d_header.rd && mdp.d_header.qr) {
@@ -181,7 +181,7 @@ try
           else if(!mdp.d_header.rd && !mdp.d_header.qr) {
             g_lastquestionTime=pr.d_pheader.ts;
             g_serverQuestions++;
-            counts[make_pair(mdp.d_qname, mdp.d_qtype)]++;
+            counts[pair(mdp.d_qname, mdp.d_qtype)]++;
             questions.emplace(mdp.d_qname, mdp.d_qtype);
             totalQueries++;
           }
@@ -233,7 +233,7 @@ try
     ofstream failed("failed");
     failed<<"name\ttype\tnumber\n";
     for(diff_t::const_iterator i = diff.begin(); i != diff.end() ; ++i) {
-      failed << i->first << "\t" << DNSRecordContent::NumberToType(i->second) << "\t"<< counts[make_pair(i->first, i->second)]<<"\n";
+      failed << i->first << "\t" << DNSRecordContent::NumberToType(i->second) << "\t"<< counts[pair(i->first, i->second)]<<"\n";
     }
 
     diff.clear();
@@ -245,7 +245,7 @@ try
     ofstream succeeded("succeeded");
     succeeded<<"name\ttype\tnumber\n";
     for(queries_t::const_iterator i = answers.begin(); i != answers.end() ; ++i) {
-      succeeded << i->first << "\t" <<DNSRecordContent::NumberToType(i->second) << "\t" << counts[make_pair(i->first, i->second)]<<"\n";
+      succeeded << i->first << "\t" <<DNSRecordContent::NumberToType(i->second) << "\t" << counts[pair(i->first, i->second)]<<"\n";
     }
   }
 }

--- a/pdns/dnsparser.cc
+++ b/pdns/dnsparser.cc
@@ -124,7 +124,7 @@ std::shared_ptr<DNSRecordContent> DNSRecordContent::mastermake(const DNSRecord &
 {
   uint16_t searchclass = (dr.d_type == QType::OPT) ? 1 : dr.d_class; // class is invalid for OPT
 
-  auto i = getTypemap().find(make_pair(searchclass, dr.d_type));
+  auto i = getTypemap().find(pair(searchclass, dr.d_type));
   if(i==getTypemap().end() || !i->second) {
     return std::make_shared<UnknownRecordContent>(dr, pr);
   }
@@ -135,7 +135,7 @@ std::shared_ptr<DNSRecordContent> DNSRecordContent::mastermake(const DNSRecord &
 std::shared_ptr<DNSRecordContent> DNSRecordContent::mastermake(uint16_t qtype, uint16_t qclass,
                                                const string& content)
 {
-  auto i = getZmakermap().find(make_pair(qclass, qtype));
+  auto i = getZmakermap().find(pair(qclass, qtype));
   if(i==getZmakermap().end()) {
     return std::make_shared<UnknownRecordContent>(content);
   }
@@ -152,7 +152,7 @@ std::shared_ptr<DNSRecordContent> DNSRecordContent::mastermake(const DNSRecord &
 
   uint16_t searchclass = (dr.d_type == QType::OPT) ? 1 : dr.d_class; // class is invalid for OPT
 
-  auto i = getTypemap().find(make_pair(searchclass, dr.d_type));
+  auto i = getTypemap().find(pair(searchclass, dr.d_type));
   if(i==getTypemap().end() || !i->second) {
     return std::make_shared<UnknownRecordContent>(dr, pr);
   }

--- a/pdns/dnsparser.hh
+++ b/pdns/dnsparser.hh
@@ -233,17 +233,17 @@ public:
   static void regist(uint16_t cl, uint16_t ty, makerfunc_t* f, zmakerfunc_t* z, const char* name)
   {
     if(f)
-      getTypemap()[make_pair(cl,ty)]=f;
+      getTypemap()[pair(cl,ty)]=f;
     if(z)
-      getZmakermap()[make_pair(cl,ty)]=z;
+      getZmakermap()[pair(cl,ty)]=z;
 
-    getT2Namemap().emplace(make_pair(cl, ty), name);
-    getN2Typemap().emplace(name, make_pair(cl, ty));
+    getT2Namemap().emplace(pair(cl, ty), name);
+    getN2Typemap().emplace(name, pair(cl, ty));
   }
 
   static void unregist(uint16_t cl, uint16_t ty) 
   {
-    auto key = make_pair(cl, ty);
+    auto key = pair(cl, ty);
     getTypemap().erase(key);
     getZmakermap().erase(key);
   }
@@ -267,7 +267,7 @@ public:
 
   static const string NumberToType(uint16_t num, uint16_t classnum=1)
   {
-    auto iter = getT2Namemap().find(make_pair(classnum, num));
+    auto iter = getT2Namemap().find(pair(classnum, num));
     if(iter == getT2Namemap().end()) 
       return "TYPE" + std::to_string(num);
       //      throw runtime_error("Unknown DNS type with numerical id "+std::to_string(num));

--- a/pdns/mastercommunicator.cc
+++ b/pdns/mastercommunicator.cc
@@ -281,13 +281,13 @@ void CommunicatorClass::sendNotification(int sock, const DNSName& domain, const 
 
 void CommunicatorClass::drillHole(const DNSName &domain, const string &ip)
 {
-  (*d_holes.lock())[make_pair(domain,ip)]=time(nullptr);
+  (*d_holes.lock())[pair(domain,ip)]=time(nullptr);
 }
 
 bool CommunicatorClass::justNotified(const DNSName &domain, const string &ip)
 {
   auto holes = d_holes.lock();
-  auto it = holes->find(make_pair(domain,ip));
+  auto it = holes->find(pair(domain,ip));
   if (it == holes->end()) {
     // no hole
     return false;

--- a/pdns/namespaces.hh
+++ b/pdns/namespaces.hh
@@ -42,7 +42,6 @@ using std::clog;
 using std::cout;
 using std::endl;
 using std::ifstream;
-using std::make_pair;
 using std::make_unique;
 using std::map;
 using std::max;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1669,7 +1669,7 @@ static string doGenericTopQueries(pleasequeryfunc_t func, boost::function<DNSNam
   unsigned int total=0;
   for(const query_t& q :  queries) {
     total++;
-    counts[make_pair(filter(q.first),q.second)]++;
+    counts[pair(filter(q.first),q.second)]++;
   }
 
   typedef std::multimap<int, query_t> rcounts_t;

--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -83,7 +83,7 @@ bool ZoneData::isRRSetAuth(const DNSName& qname, QType qtype) const
 
 void ZoneData::parseDRForCache(DNSRecord& dr)
 {
-  const auto key = make_pair(dr.d_name, dr.d_type);
+  const auto key = pair(dr.d_name, dr.d_type);
 
   dr.d_ttl += d_now;
 
@@ -93,7 +93,7 @@ void ZoneData::parseDRForCache(DNSRecord& dr)
     break;
   case QType::RRSIG: {
     const auto& rr = getRR<RRSIGRecordContent>(dr);
-    const auto sigkey = make_pair(key.first, rr->d_type);
+    const auto sigkey = pair(key.first, rr->d_type);
     auto found = d_sigs.find(sigkey);
     if (found != d_sigs.end()) {
       found->second.push_back(rr);

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_denial_nowrap)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a.example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a.example.org."), QType::NSEC)] = pair;
 
   /* add wildcard denial */
   recordContents.clear();
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_denial_nowrap)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(DNSName("example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("example.org."), QType::NSEC)] = pair;
 
   dState denialState = getDenial(denialMap, DNSName("b.example.org."), QType::A, false, false);
   BOOST_CHECK_EQUAL(denialState, dState::NXDOMAIN);
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_denial_wrap_case_1)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("z.example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("z.example.org."), QType::NSEC)] = pair;
 
   dState denialState = getDenial(denialMap, DNSName("a.example.org."), QType::A, false, false);
   BOOST_CHECK_EQUAL(denialState, dState::NXDOMAIN);
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_denial_wrap_case_2)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("y.example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("y.example.org."), QType::NSEC)] = pair;
 
   dState denialState = getDenial(denialMap, DNSName("z.example.org."), QType::A, false, false);
   BOOST_CHECK_EQUAL(denialState, dState::NXDOMAIN);
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_denial_only_one_nsec)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a.example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a.example.org."), QType::NSEC)] = pair;
 
   dState denialState = getDenial(denialMap, DNSName("b.example.org."), QType::A, false, false);
   BOOST_CHECK_EQUAL(denialState, dState::NXDOMAIN);
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_root_nxd_denial)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a."), QType::NSEC)] = pair;
 
   /* add wildcard denial */
   recordContents.clear();
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_root_nxd_denial)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(DNSName("."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("."), QType::NSEC)] = pair;
 
   dState denialState = getDenial(denialMap, DNSName("b."), QType::A, false, false);
   BOOST_CHECK_EQUAL(denialState, dState::NXDOMAIN);
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_ancestor_nxqtype_denial)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a."), QType::NSEC)] = pair;
 
   /* RFC 6840 section 4.1 "Clarifications on Nonexistence Proofs":
      Ancestor delegation NSEC or NSEC3 RRs MUST NOT be used to assume
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_ds_denial_from_child)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("example.org."), QType::NSEC)] = pair;
 
   /* check that this NSEC from the child zone can deny a AAAA at the apex */
   BOOST_CHECK_EQUAL(getDenial(denialMap, DNSName("example.org."), QType::AAAA, false, true, true), dState::NXQTYPE);
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_insecure_delegation_denial)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a."), QType::NSEC)] = pair;
 
   /* Insecure because the NS is not set, so while it does
      denies the DS, it can't prove an insecure delegation */
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_nxqtype_cname)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a.powerdns.com."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a.powerdns.com."), QType::NSEC)] = pair;
 
   /* this NSEC is not valid to deny a.powerdns.com|A since it states that a CNAME exists */
   dState denialState = getDenial(denialMap, DNSName("a.powerdns.com."), QType::A, true, true);
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_nxqtype_ds)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
   records.clear();
 
   /* this NSEC3 is not valid to deny the DS since it is from the child zone */
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_nxqtype_cname)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
   records.clear();
 
   /* this NSEC3 is not valid to deny a.powerdns.com|A since it states that a CNAME exists */
@@ -442,7 +442,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_nxdomain_denial_missing_wildcard)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a.powerdns.com."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a.powerdns.com."), QType::NSEC)] = pair;
 
   dState denialState = getDenial(denialMap, DNSName("b.powerdns.com."), QType::A, false, false);
   BOOST_CHECK_EQUAL(denialState, dState::NODENIAL);
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_nxdomain_denial_missing_wildcard)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   /* Add NSEC3 for the closest encloser */
   recordContents.clear();
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_nxdomain_denial_missing_wildcard)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   dState denialState = getDenial(denialMap, DNSName("a.powerdns.com."), QType::A, false, false);
   BOOST_CHECK_EQUAL(denialState, dState::NODENIAL);
@@ -511,7 +511,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_expanded_wildcard_proof)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a.example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a.example.org."), QType::NSEC)] = pair;
 
   /* This is an expanded wildcard proof, meaning that it does prove that the exact name
      does not exist so the wildcard can apply */
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_wildcard_with_cname)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a.example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a.example.org."), QType::NSEC)] = pair;
 
   /* add a NSEC proving that a wildcard exists, without a CNAME type */
   recordContents.clear();
@@ -555,7 +555,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_wildcard_with_cname)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(DNSName("*.example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("*.example.org."), QType::NSEC)] = pair;
 
   /* A does exist at the wildcard, AAAA does not */
   dState denialState = getDenial(denialMap, DNSName("b.example.org."), QType::A, false, true);
@@ -575,7 +575,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_wildcard_with_cname)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(DNSName("*.example.org."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("*.example.org."), QType::NSEC)] = pair;
 
   /* A and AAAA do not exist but we have a CNAME so at the wildcard */
   denialState = getDenial(denialMap, DNSName("b.example.org."), QType::A, false, true);
@@ -607,7 +607,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_wildcard_with_cname)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   /* Add NSEC3 for the closest encloser */
   recordContents.clear();
@@ -620,7 +620,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_wildcard_with_cname)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   /* add wildcard, without a CNAME type */
   recordContents.clear();
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_wildcard_with_cname)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   /* A does exist at the wildcard, AAAA does not */
   dState denialState = getDenial(denialMap, DNSName("b.example.org."), QType::A, false, true);
@@ -653,7 +653,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_wildcard_with_cname)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   /* A and AAAA do not exist but we have a CNAME so at the wildcard */
   denialState = getDenial(denialMap, DNSName("b.example.org."), QType::A, false, true);
@@ -685,7 +685,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_ent_denial)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(DNSName("a.powerdns.com."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName("a.powerdns.com."), QType::NSEC)] = pair;
 
   /* this NSEC is valid to prove a NXQTYPE at c.powerdns.com because it proves that
      it is an ENT */
@@ -711,7 +711,7 @@ BOOST_AUTO_TEST_CASE(test_nsec_ent_denial)
   records.clear();
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(DNSName(").powerdns.com."), QType::NSEC)] = pair;
+  denialMap[std::pair(DNSName(").powerdns.com."), QType::NSEC)] = pair;
 
   denialState = getDenial(denialMap, DNSName("b.powerdns.com."), QType::A, true, false);
   BOOST_CHECK_EQUAL(denialState, dState::NXDOMAIN);
@@ -749,7 +749,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_ancestor_nxqtype_denial)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
   records.clear();
 
   /* RFC 6840 section 4.1 "Clarifications on Nonexistence Proofs":
@@ -779,7 +779,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_ancestor_nxqtype_denial)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   /* add wildcard denial */
   recordContents.clear();
@@ -792,7 +792,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_ancestor_nxqtype_denial)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   denialState = getDenial(denialMap, DNSName("sub.a."), QType::A, false, true);
   BOOST_CHECK_EQUAL(denialState, dState::NODENIAL);
@@ -824,7 +824,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_denial_too_many_iterations)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
   records.clear();
 
   dState denialState = getDenial(denialMap, DNSName("a."), QType::A, false, true);
@@ -865,7 +865,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_insecure_delegation_denial)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
   records.clear();
 
   /* Insecure because the NS is not set, so while it does
@@ -907,7 +907,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_ent_opt_out)
   pair.records = recordContents;
   pair.signatures = signatureContents;
   cspmap_t denialMap;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   /* it can not be used to deny any RRs below that owner name either */
   /* Add NSEC3 for the next closer */
@@ -921,7 +921,7 @@ BOOST_AUTO_TEST_CASE(test_nsec3_ent_opt_out)
 
   pair.records = recordContents;
   pair.signatures = signatureContents;
-  denialMap[std::make_pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
 
   /* Insecure because the opt-out bit is set */
   dState denialState = getDenial(denialMap, DNSName("ent.was.here."), QType::A, false, true);

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -345,7 +345,7 @@ bool UeberBackend::getAuth(const DNSName &target, const QType& qtype, SOAData* s
   bool found = false;
   int cstat;
   DNSName shorter(target);
-  vector<pair<size_t, SOAData> > bestmatch (backends.size(), make_pair(target.wirelength()+1, SOAData()));
+  vector<pair<size_t, SOAData> > bestmatch (backends.size(), pair(target.wirelength()+1, SOAData()));
   do {
     int zoneId{-1};
     if(cachedOk && g_zoneCache.isEnabled()) {

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -1333,9 +1333,9 @@ vState getKeysFor(DNSRecordOracle& dro, const DNSName& zone, skeyset_t& keyset)
     cspmap_t validrrsets;
     validateWithKeySet(cspmap, validrrsets, validkeys);
 
-    LOG("got "<<cspmap.count(make_pair(*(zoneCutIter+1),QType::DS))<<" records for DS query of which "<<validrrsets.count(make_pair(*(zoneCutIter+1),QType::DS))<<" valid "<<endl);
+    LOG("got "<<cspmap.count(pair(*(zoneCutIter+1),QType::DS))<<" records for DS query of which "<<validrrsets.count(pair(*(zoneCutIter+1),QType::DS))<<" valid "<<endl);
 
-    auto r = validrrsets.equal_range(make_pair(*(zoneCutIter+1), QType::DS));
+    auto r = validrrsets.equal_range(pair(*(zoneCutIter+1), QType::DS));
     if(r.first == r.second) {
       LOG("No DS for "<<*(zoneCutIter+1)<<", now look for a secure denial"<<endl);
       dState res = getDenial(validrrsets, *(zoneCutIter+1), QType::DS, true, true);

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -1188,9 +1188,9 @@ void RecursorWebServer::jsonstat(HttpRequest* req, HttpResponse *resp)
     for(const query_t& q :  queries) {
       total++;
       if(filter)
-	counts[make_pair(getRegisteredName(q.first), q.second)]++;
+	counts[pair(getRegisteredName(q.first), q.second)]++;
       else
-	counts[make_pair(q.first, q.second)]++;
+	counts[pair(q.first, q.second)]++;
     }
 
     typedef std::multimap<int, query_t> rcounts_t;


### PR DESCRIPTION
With C++17, std::pair can completely replace make_pair

Signed-off-by: Rosen Penev <rosenp@gmail.com>