### PR TITLE
Add speedtest for burtle and siphash

### DIFF
--- a/pdns/speedtest.cc
+++ b/pdns/speedtest.cc
@@ -1287,10 +1287,11 @@ try
 #endif
 
   doRun(BurtleHashTest("a string of chars"));
+#ifdef HAVE_LIBSODIUM
   doRun(SipHashTest("a string of chars"));
+#endif
 
   cerr<<"Total runs: " << g_totalRuns<<endl;
-
 }
 catch(std::exception &e)
 {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master

Note that siphash produced 64 bits and burtle 32, so it's not a completely fair compare.

Some runs
amd64/OpenBSD:
```
'BurtleHash' 0.10 seconds: 120395610.1 runs/s, 0.01 usec/run
'SipHash' 0.10 seconds: 52376399.7 runs/s, 0.02 usec/run
```
arm64/OpenSBD
```
'BurtleHash' 0.10 seconds: 23157242.6 runs/s, 0.04 usec/run
'SipHash' 0.10 seconds: 10380769.7 runs/s, 0.10 usec/run
```
Random old laptop running bullseye:
```
'BurtleHash' 0.10 seconds: 55192526.9 runs/s, 0.02 usec/run
'SipHash' 0.10 seconds: 46346859.5 runs/s, 0.02 usec/run
```

Random VM running buster:
```
'BurtleHash' 0.11 seconds: 42800549.3 runs/s, 0.02 usec/run
'SipHash' 0.10 seconds: 35943916.8 runs/s, 0.03 usec/run
```

So siphash is slower in all these cases, up to about 2.3x as slow. Difference on OpenBSD seems bigger than on Linux.