### PR TITLE
add fd-usage metric to Recursor documentation

### DIFF
--- a/pdns/recursordist/docs/metrics.rst
+++ b/pdns/recursordist/docs/metrics.rst
@@ -490,7 +490,7 @@ number of servers that failed to resolve
 fd-usage
 ^^^^^^^^
 Number of currently used file descriptors.
-This metric is available on Linux only.
+Currently, this metric is available on Linux and OpenBSD only.
 
 ignored-packets
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Short description

I was about do file a feature request to get fd-usage metrics in Recursor, but
then I realized it is already available but it is not in the docs.

This PR adds it to the docs.

This PR is missing the version when this feature was added to Recursor.

description is copied from dnsdist 
(I simply assumed it has the same meaning)
https://dnsdist.org/statistics.html#fd-usage





