### PR TITLE
Implement fd-usage metric for OpenBSD

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1301,6 +1301,9 @@ uint64_t getOpenFileDescriptors(const std::string&)
   closedir(dirhdl);
   return ret;
 
+#elif defined(__OpenBSD__)
+  // FreeBSD also has this in libopenbsd, but I don't know if that's available always
+  return getdtablecount();
 #else
   return 0;
 #endif


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

FreeBSD has the same `getdtablecount()` (undocumented) function in libopenbsd, but to me it's unclear if it is something that needs to be linked in specifically. Pull request to do that on FreeBSD welcome.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
