### PR TITLE
NetmaskTree: Drop the 'noexcept' qualifier on the TreeNode ctor

### DIFF
--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -705,7 +705,7 @@ private:
     explicit TreeNode() noexcept :
       parent(nullptr), node(), assigned(false), d_bits(0) {
     }
-    explicit TreeNode(const key_type& key) noexcept :
+    explicit TreeNode(const key_type& key) :
       parent(nullptr), node({key.getNormalized(), value_type()}),
       assigned(false), d_bits(key.getFullBits()) {
     }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Coverity reports that it was already too restrictive with the existing Netmask key (see CID 1465032) and clearly is now for the AddressAndPort one (CID 373668).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
