### PR TITLE
ZoneParserTNG: Stricter checks when loading a zone file

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -12,7 +12,7 @@ jobs:
     name: build auth
     runs-on: ubuntu-20.04
     env:
-      UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/build-scripts/UBSan.supp'
+      UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       ASAN_OPTIONS: detect_leaks=0
     steps:
       - uses: actions/checkout@v2.3.4
@@ -51,7 +51,7 @@ jobs:
     name: build recursor
     runs-on: ubuntu-20.04
     env:
-      UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/build-scripts/UBSan.supp'
+      UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       ASAN_OPTIONS: detect_leaks=0
     defaults:
       run:
@@ -96,7 +96,7 @@ jobs:
       matrix:
         sanitizers: [ubsan+asan, tsan]
     env:
-      UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/build-scripts/UBSan.supp'
+      UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       ASAN_OPTIONS: detect_leaks=0
       SANITIZERS: ${{ matrix.sanitizers }}
     defaults:
@@ -139,9 +139,9 @@ jobs:
     needs: build-auth
     runs-on: ubuntu-20.04
     env:
-      UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/build-scripts/UBSan.supp'
+      UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       ASAN_OPTIONS: detect_leaks=0
-      TSAN_OPTIONS: 'halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/pdns/dnsdistdist/dnsdist-tsan.supp'
+      TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ github.workspace }}/pdns/dnsdistdist/dnsdist-tsan.supp"
     strategy:
       matrix:
         include:
@@ -188,7 +188,7 @@ jobs:
     needs: build-auth
     runs-on: ubuntu-20.04
     env:
-      UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/build-scripts/UBSan.supp'
+      UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       ASAN_OPTIONS: detect_leaks=0
     strategy:
       matrix:
@@ -251,7 +251,7 @@ jobs:
     needs: build-auth
     runs-on: ubuntu-20.04
     env:
-      UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/build-scripts/UBSan.supp'
+      UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       ASAN_OPTIONS: detect_leaks=0
     steps:
       - uses: actions/checkout@v2.3.4
@@ -272,7 +272,7 @@ jobs:
     needs: build-recursor
     runs-on: ubuntu-20.04
     env:
-      UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/build-scripts/UBSan.supp'
+      UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       ASAN_OPTIONS: detect_leaks=0
     steps:
       - uses: actions/checkout@v2.3.4
@@ -297,9 +297,9 @@ jobs:
       matrix:
         sanitizers: [ubsan+asan, tsan]
     env:
-      UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/build-scripts/UBSan.supp'
+      UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       ASAN_OPTIONS: detect_leaks=0
-      TSAN_OPTIONS: 'halt_on_error=1:suppressions=/home/runner/work/pdns/pdns/pdns/dnsdistdist/dnsdist-tsan.supp'
+      TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ github.workspace }}/pdns/dnsdistdist/dnsdist-tsan.supp"
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1011,6 +1011,17 @@ will generally suffice for most installations.
 Maximum number of empty non-terminals to add to a zone. This is a
 protection measure to avoid database explosion due to long names.
 
+.. _setting-max-include-depth:
+
+``max-include-depth``
+----------------------
+
+-  Integer
+-  Default: 20
+
+Maximum number of nested ``$INCLUDE`` directives while processing a zone file.
+Zero mean no ``$INCLUDE`` directives will be accepted.
+
 .. _setting-max-generate-steps:
 
 ``max-generate-steps``

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -503,6 +503,7 @@ void Bind2Backend::parseZoneFile(BB2DomainInfo* bbd)
   auto records = std::make_shared<recordstorage_t>();
   ZoneParserTNG zpt(bbd->d_filename, bbd->d_name, s_binddirectory, d_upgradeContent);
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
   DNSResourceRecord rr;
   string hashed;
   while (zpt.get(rr)) {

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -254,6 +254,7 @@ void declareArguments()
   ::arg().set("tcp-fast-open", "Enable TCP Fast Open support on the listening sockets, using the supplied numerical value as the queue size")="0";
 
   ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
+  ::arg().set("max-include-depth", "Maximum number of nested $INCLUDE directives while processing a zone file")="20";
   ::arg().setSwitch("upgrade-unknown-types","Transparently upgrade known TYPExxx records. Recommended to keep off, except for PowerDNS upgrades until data sources are cleaned up")="no";
   ::arg().setSwitch("svc-autohints", "Transparently fill ipv6hint=auto ipv4hint=auto SVC params with AAAA/A records for the target name of the record (if within the same zone)")="no";
 

--- a/pdns/fuzz_zoneparsertng.cc
+++ b/pdns/fuzz_zoneparsertng.cc
@@ -51,6 +51,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     ZoneParserTNG zpt(lines, g_rootdnsname);
     /* limit the number of steps for '$GENERATE' entries */
     zpt.setMaxGenerateSteps(10000);
+    zpt.setMaxIncludes(20);
     DNSResourceRecord drr;
     while (zpt.get(drr)) {
     }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -5992,6 +5992,7 @@ int main(int argc, char **argv)
     ::arg().setSwitch("qname-minimization", "Use Query Name Minimization")="yes";
     ::arg().setSwitch("nothing-below-nxdomain", "When an NXDOMAIN exists in cache for a name with fewer labels than the qname, send NXDOMAIN without doing a lookup (see RFC 8020)")="dnssec";
     ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
+    ::arg().set("max-include-depth", "Maximum nested $INCLUDE depth when loading a zone from a file")="20";
     ::arg().set("record-cache-shards", "Number of shards in the record cache")="1024";
     ::arg().set("refresh-on-ttl-perc", "If a record is requested from the cache and only this % of original TTL remains, refetch") = "0";
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -108,6 +108,7 @@ static void loadMainConfig(const std::string& configdir)
   ::arg().set("max-signature-cache-entries", "Maximum number of signatures cache entries")="";
   ::arg().set("rng", "Specify random number generator to use. Valid values are auto,sodium,openssl,getrandom,arc4random,urandom.")="auto";
   ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
+  ::arg().set("max-include-depth", "Maximum nested $INCLUDE depth when loading a zone from a file")="20";
   ::arg().setSwitch("upgrade-unknown-types","Transparently upgrade known TYPExxx records. Recommended to keep off, except for PowerDNS upgrades until data sources are cleaned up")="no";
   ::arg().laxFile(configname.c_str());
 
@@ -1190,6 +1191,7 @@ static int editZone(const DNSName &zone) {
   cmdline.clear();
   ZoneParserTNG zpt(tmpnam, g_rootdnsname);
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
   DNSResourceRecord zrr;
   map<pair<DNSName,uint16_t>, vector<DNSRecord> > grouped;
   try {

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1044,6 +1044,17 @@ Maximum number of incoming requests handled concurrently per tcp
 connection. This number must be larger than 0 and smaller than 65536
 and also smaller than `max-mthreads`.
 
+.. _setting-max-include-depth:
+
+``max-include-depth``
+----------------------
+
+-  Integer
+-  Default: 20
+
+Maximum number of nested ``$INCLUDE`` directives while processing a zone file.
+Zero mean no ``$INCLUDE`` directives will be accepted.
+
 .. _setting-max-generate-steps:
 
 ``max-generate-steps``

--- a/pdns/recursordist/rec-zonetocache.cc
+++ b/pdns/recursordist/rec-zonetocache.cc
@@ -218,6 +218,7 @@ void ZoneData::ZoneToCache(const RecZoneToCache::Config& config, uint64_t config
     DNSResourceRecord drr;
     ZoneParserTNG zpt(lines, d_zone);
     zpt.setMaxGenerateSteps(1);
+    zpt.setMaxIncludes(0);
 
     while (zpt.get(drr)) {
       DNSRecord dr(drr);

--- a/pdns/reczones.cc
+++ b/pdns/reczones.cc
@@ -99,6 +99,7 @@ bool primeHints(time_t ignored)
   else {
     ZoneParserTNG zpt(::arg()["hint-file"]);
     zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+    zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
     DNSResourceRecord rr;
     set<DNSName> seenNS;
     set<DNSName> seenA;
@@ -399,6 +400,7 @@ std::shared_ptr<SyncRes::domainmap_t> parseAuthAndForwards()
         g_log << Logger::Error << "Parsing authoritative data for zone '" << headers.first << "' from file '" << headers.second << "'" << endl;
         ZoneParserTNG zpt(headers.second, DNSName(headers.first));
         zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+        zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
         DNSResourceRecord rr;
         DNSRecord dr;
         while (zpt.get(rr)) {

--- a/pdns/rpzloader.cc
+++ b/pdns/rpzloader.cc
@@ -286,6 +286,7 @@ std::shared_ptr<SOARecordContent> loadRPZFromFile(const std::string& fname, std:
   shared_ptr<SOARecordContent> sr = nullptr;
   ZoneParserTNG zpt(fname);
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
   DNSResourceRecord drr;
   DNSName domain;
   while(zpt.get(drr)) {

--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -166,16 +166,29 @@ BOOST_AUTO_TEST_CASE(test_tng_record_generate) {
     BOOST_CHECK_THROW(zp.get(rr), std::exception);
   }
 
-   {
+  {
     /* test invalid generate parameters: negative counter */
     ZoneParserTNG zp(std::vector<std::string>({"$GENERATE -1-4/1 $.${1,2,o}.${3,4,d}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("test"));
     DNSResourceRecord rr;
     BOOST_CHECK_THROW(zp.get(rr), std::exception);
   }
+  {
+    /* test invalid generate parameters: counter out of bounds */
+    ZoneParserTNG zp(std::vector<std::string>({"$GENERATE 4294967296-4/1 $.${1,2,o}.${3,4,d}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("test"));
+    DNSResourceRecord rr;
+    BOOST_CHECK_THROW(zp.get(rr), std::exception);
+  }
 
-   {
+  {
     /* test invalid generate parameters: negative stop */
     ZoneParserTNG zp(std::vector<std::string>({"$GENERATE 0--4/1 $.${1,2,o}.${3,4,d}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("test"));
+    DNSResourceRecord rr;
+    BOOST_CHECK_THROW(zp.get(rr), std::exception);
+  }
+
+  {
+    /* test invalid generate parameters: stop out of bounds */
+    ZoneParserTNG zp(std::vector<std::string>({"$GENERATE 0-4294967296/1 $.${1,2,o}.${3,4,d}.${5,6,X}.${7,8,x}	86400	IN	A 1.2.3.4"}), DNSName("test"));
     DNSResourceRecord rr;
     BOOST_CHECK_THROW(zp.get(rr), std::exception);
   }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1385,6 +1385,7 @@ static void gatherRecordsFromZone(const std::string& zonestring, vector<DNSResou
 
   ZoneParserTNG zpt(zonedata, zonename);
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
 
   bool seenSOA=false;
 

--- a/pdns/zone2json.cc
+++ b/pdns/zone2json.cc
@@ -104,6 +104,7 @@ try
     ::arg().set("zone-name","Specify an $ORIGIN in case it is not present")="";
     ::arg().set("named-conf","Bind 8/9 named.conf to parse")="";
     ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
+    ::arg().set("max-include-depth", "Maximum level of nested $INCLUDE depth when loading a zone from a file")="20";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print the version");
@@ -171,6 +172,7 @@ try
             Json::array recs;
             ZoneParserTNG zpt(i->filename, i->name, BP.getDirectory());
             zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+            zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
             DNSResourceRecord rr;
             obj["name"] = i->name.toString();
 

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -249,6 +249,7 @@ int main( int argc, char* argv[] )
                 args.set( "domainid", "Domain ID of the first domain found (incremented afterwards)" ) = "1";
                 args.set( "metadata-dn", "DN under which to store the domain metadata" ) = "";
                 args.set( "max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
+                args.set( "max-include-depth", "Maximum nested $INCLUDE depth when loading a zone from a file")="20";
 
                 args.parse( argc, argv );
 
@@ -318,6 +319,7 @@ int main( int argc, char* argv[] )
                                                 g_zonename = i.name;
                                                 ZoneParserTNG zpt(i.filename, i.name, BP.getDirectory());
                                                 zpt.setMaxGenerateSteps(args.asNum("max-generate-steps"));
+                                                zpt.setMaxIncludes(args.asNum("max-include-depth"));
                                                 DNSResourceRecord rr;
                                                 while(zpt.get(rr)) {
                                                         callback(g_domainid, rr.qname, rr.qtype.toString(), encode_non_ascii(rr.content), rr.ttl);

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -213,6 +213,7 @@ try
     ::arg().set("named-conf","Bind 8/9 named.conf to parse")="";
 
     ::arg().set("max-generate-steps", "Maximum number of $GENERATE steps when loading a zone from a file")="0";
+    ::arg().set("max-include-depth", "Maximum nested $INCLUDE depth when loading a zone from a file")="20";
 
     ::arg().setCmd("help","Provide a helpful message");
     ::arg().setCmd("version","Print the version");
@@ -295,6 +296,7 @@ try
             
             ZoneParserTNG zpt(domain.filename, domain.name, BP.getDirectory());
             zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+            zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
             DNSResourceRecord rr;
             bool seenSOA=false;
             string comment;

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -198,6 +198,11 @@ bool ZoneParserTNG::getTemplateLine()
         if (extracted < 1) {
           throw PDNSException("Unable to parse offset, width and radix for $GENERATE's lhs from '"+spec+"' "+getLineOfFile());
         }
+        if (width < 0) {
+          throw PDNSException("Invalid width ("+std::to_string(width)+") for $GENERATE's lhs from '"+spec+"' "+getLineOfFile());
+        }
+        /* a width larger than the output buffer does not make any sense */
+        width = std::min(width, 80);
 
         char tmp[80];
         switch (radix) {

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -201,10 +201,12 @@ bool ZoneParserTNG::getTemplateLine()
         if (width < 0) {
           throw PDNSException("Invalid width ("+std::to_string(width)+") for $GENERATE's lhs from '"+spec+"' "+getLineOfFile());
         }
-        /* a width larger than the output buffer does not make any sense */
-        width = std::min(width, 80);
 
         char tmp[80];
+
+        /* a width larger than the output buffer does not make any sense */
+        width = std::min(width, static_cast<int>(sizeof(tmp)));
+
         switch (radix) {
         case 'o':
           snprintf(tmp, sizeof(tmp), "%0*o", width, d_templatecounter + offset);

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -49,6 +49,10 @@ public:
   {
     d_maxGenerateSteps = max;
   }
+  void setMaxIncludes(size_t max)
+  {
+    d_maxIncludes = max;
+  }
 private:
   bool getLine();
   bool getTemplateLine();
@@ -73,6 +77,7 @@ private:
   std::stack<filestate> d_filestates;
   parts_t d_templateparts;
   size_t d_maxGenerateSteps{0};
+  size_t d_maxIncludes{20};
   int d_defaultttl;
   uint32_t d_templatecounter, d_templatestop, d_templatestep;
   bool d_havedollarttl;

--- a/pdns/zoneparser-tng.hh
+++ b/pdns/zoneparser-tng.hh
@@ -79,4 +79,5 @@ private:
   bool d_fromfile;
   bool d_generateEnabled{true};
   bool d_upgradeContent;
+  bool d_templateCounterWrapped{false};
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- Stricter parsing of `$GENERATE` parameters
- Limit the number of nested `$INCLUDE` directives

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
