### PR TITLE
rec: Backport of 10905 to rec-4.5.x: wipe-cache-typed  should check if a qtype arg is present and valid

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1855,7 +1855,13 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int s, const str
     return {0, doWipeCache(begin, end, 0xffff)};
   }
   if (cmd == "wipe-cache-typed") {
+    if (begin == end) {
+      return {1, "Need a qtype\n"};
+    }
     uint16_t qtype = QType::chartocode(begin->c_str());
+    if (qtype == 0) {
+      return {1, "Unknown qtype " + *begin + "\n"};
+    }
     ++begin;
     return {0, doWipeCache(begin, end, qtype)};
   }


### PR DESCRIPTION
(cherry picked from commit a721f7b21a75cefaa189bf84b14979facde7d3ab)

Backport of #10905 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
