### PR TITLE
rec: Backpoprt of 10908 to rec-4.5.x: A SHA-384 DS should not trump a SHA-256 one, so only potentially zap SHA-1

### DIFF
--- a/pdns/recursordist/test-syncres_cc9.cc
+++ b/pdns/recursordist/test-syncres_cc9.cc
@@ -819,9 +819,9 @@ BOOST_AUTO_TEST_CASE(test_getDSRecords_multialgo_all_sha)
   dsmap_t ds;
   auto state = sr->getDSRecords(target, ds, false, 0, false);
   BOOST_CHECK_EQUAL(state, vState::Secure);
-  BOOST_REQUIRE_EQUAL(ds.size(), 1U);
+  BOOST_REQUIRE_EQUAL(ds.size(), 2U);
   for (const auto& i : ds) {
-    BOOST_CHECK_EQUAL(i.d_digesttype, DNSSECKeeper::DIGEST_SHA384);
+    BOOST_CHECK(i.d_digesttype == DNSSECKeeper::DIGEST_SHA384 || i.d_digesttype == DNSSECKeeper::DIGEST_SHA256);
   }
 }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -2562,10 +2562,10 @@ vState SyncRes::getDSRecords(const DNSName& zone, dsmap_t& ds, bool taOnly, unsi
 
     /* RFC 4509 section 3: "Validator implementations SHOULD ignore DS RRs containing SHA-1
      * digests if DS RRs with SHA-256 digests are present in the DS RRset."
-     * As SHA348 is specified as well, the spirit of the this line is "use the best algorithm".
+     * We interpret that as: do not use SHA-1 if SHA-256 or SHA-384 is available
      */
     for (auto dsrec = ds.begin(); dsrec != ds.end(); ) {
-      if (dsrec->d_digesttype != bestDigestType) {
+      if (dsrec->d_digesttype == DNSSECKeeper::DIGEST_SHA1 && dsrec->d_digesttype != bestDigestType) {
         dsrec = ds.erase(dsrec);
       }
       else {


### PR DESCRIPTION

(cherry picked from commit a660ce6dbfc4182922eea8e548eb504af31b6cc1)

Backport of #10908 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
