### PR TITLE
rec-4.5.x: Pin docutils to < 0.18 for now

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ git+https://github.com/pieterlexis/sphinx-jsondomain@no-type-links
 git+https://github.com/pieterlexis/sphinx-changelog@render-tags
 sphinxcontrib-fulltoc
 guzzle_sphinx_theme
-docutils!=0.15
+docutils!=0.15,<0.18

--- a/pdns/dnsdistdist/docs/requirements.txt
+++ b/pdns/dnsdistdist/docs/requirements.txt
@@ -4,4 +4,4 @@ git+https://github.com/pieterlexis/sphinx-jsondomain@no-type-links
 git+https://github.com/pieterlexis/sphinx-changelog@render-tags
 sphinxcontrib-httpdomain
 sphinxcontrib-fulltoc
-docutils!=0.15
+docutils!=0.15,<0.18

--- a/pdns/recursordist/docs/requirements.txt
+++ b/pdns/recursordist/docs/requirements.txt
@@ -5,4 +5,4 @@ git+https://github.com/pieterlexis/sphinx-changelog@render-tags
 guzzle_sphinx_theme
 sphinxcontrib.httpdomain
 sphinxcontrib-fulltoc
-docutils!=0.15
+docutils!=0.15,<0.18


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We will have to deal with that pain later, but let's unbreak our CI first.

Backport of #10902 to rel/rec-4.5.x.

(cherry picked from commit 2503af018b72112a2422ce895d9e7418155cbc9f)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
