### PR TITLE
dnsdist: Remove unreachable code in HTTP/2 connections cleanup

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1306,11 +1306,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
   luaCtx.writeFunction("setMaxCachedTCPConnectionsPerDownstream", [](size_t max) {
-    DownstreamTCPConnectionsManager::setMaxCachedConnectionsPerDownstream(max);
+    DownstreamTCPConnectionsManager::setMaxIdleConnectionsPerDownstream(max);
   });
 
-  luaCtx.writeFunction("setMaxCachedDoHConnectionsPerDownstream", [](size_t max) {
-    setDoHDownstreamMaxConnectionsPerBackend(max);
+  luaCtx.writeFunction("setMaxIdleDoHConnectionsPerDownstream", [](size_t max) {
+    setDoHDownstreamMaxIdleConnectionsPerBackend(max);
   });
 
   luaCtx.writeFunction("setOutgoingDoHWorkerThreads", [](uint64_t workers) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1306,7 +1306,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   });
 
   luaCtx.writeFunction("setMaxCachedTCPConnectionsPerDownstream", [](size_t max) {
-    DownstreamConnectionsManager::setMaxCachedConnectionsPerDownstream(max);
+    DownstreamTCPConnectionsManager::setMaxCachedConnectionsPerDownstream(max);
   });
 
   luaCtx.writeFunction("setMaxCachedDoHConnectionsPerDownstream", [](size_t max) {
@@ -2121,7 +2121,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.writeFunction("setTCPDownstreamCleanupInterval", [](uint64_t interval) {
     setLuaSideEffect();
     checkParameterBound("setTCPDownstreamCleanupInterval", interval);
-    DownstreamConnectionsManager::setCleanupInterval(interval);
+    DownstreamTCPConnectionsManager::setCleanupInterval(interval);
   });
 
   luaCtx.writeFunction("setDoHDownstreamCleanupInterval", [](uint64_t interval) {
@@ -2133,7 +2133,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.writeFunction("setTCPDownstreamMaxIdleTime", [](uint64_t max) {
     setLuaSideEffect();
     checkParameterBound("setTCPDownstreamMaxIdleTime", max);
-    DownstreamConnectionsManager::setMaxIdleTime(max);
+    DownstreamTCPConnectionsManager::setMaxIdleTime(max);
   });
 
   luaCtx.writeFunction("setDoHDownstreamMaxIdleTime", [](uint64_t max) {

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -285,6 +285,7 @@ testrunner_SOURCES = \
 	test-credentials_cc.cc \
 	test-delaypipe_hh.cc \
 	test-dnscrypt_cc.cc \
+	test-dnsdist-connections-cache.cc \
 	test-dnsdist_cc.cc \
 	test-dnsdistdynblocks_hh.cc \
 	test-dnsdistkvs_cc.cc \

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -46,7 +46,7 @@ std::optional<uint16_t> g_outgoingDoHWorkerThreads{std::nullopt};
 class DoHConnectionToBackend : public ConnectionToBackend
 {
 public:
-  DoHConnectionToBackend(std::shared_ptr<DownstreamState> ds, std::unique_ptr<FDMultiplexer>& mplexer, const struct timeval& now, std::string&& proxyProtocolPayload);
+  DoHConnectionToBackend(const std::shared_ptr<DownstreamState>& ds, std::unique_ptr<FDMultiplexer>& mplexer, const struct timeval& now, std::string&& proxyProtocolPayload);
 
   void handleTimeout(const struct timeval& now, bool write) override;
   void queueQuery(std::shared_ptr<TCPQuerySender>& sender, TCPQuery&& query) override;
@@ -63,7 +63,7 @@ public:
     d_healthCheckQuery = h;
   }
 
-  void stopIO();
+  void stopIO() override;
   bool reachedMaxConcurrentQueries() const override;
   bool reachedMaxStreamID() const override;
   bool isIdle() const override;
@@ -121,37 +121,8 @@ private:
   bool d_firstWrite{true};
 };
 
-class DownstreamDoHConnectionsManager
-{
-public:
-  static std::shared_ptr<DoHConnectionToBackend> getConnectionToDownstream(std::unique_ptr<FDMultiplexer>& mplexer, const std::shared_ptr<DownstreamState>& ds, const struct timeval& now, std::string&& proxyProtocolPayload);
-  static void releaseDownstreamConnection(std::shared_ptr<DoHConnectionToBackend>&& conn);
-  static bool removeDownstreamConnection(std::shared_ptr<DoHConnectionToBackend>& conn);
-  static void cleanupClosedConnections(struct timeval now);
-  static size_t clear();
-
-  static void setMaxCachedConnectionsPerDownstream(size_t max)
-  {
-    s_maxCachedConnectionsPerDownstream = max;
-  }
-
-  static void setCleanupInterval(uint16_t interval)
-  {
-    s_cleanupInterval = interval;
-  }
-
-  static void setMaxIdleTime(uint16_t max)
-  {
-    s_maxIdleTime = max;
-  }
-
-private:
-  static thread_local map<boost::uuids::uuid, std::deque<std::shared_ptr<DoHConnectionToBackend>>> t_downstreamConnections;
-  static thread_local time_t t_nextCleanup;
-  static size_t s_maxCachedConnectionsPerDownstream;
-  static uint16_t s_cleanupInterval;
-  static uint16_t s_maxIdleTime;
-};
+using DownstreamDoHConnectionsManager = DownstreamConnectionsManager<DoHConnectionToBackend>;
+thread_local DownstreamDoHConnectionsManager t_downstreamDoHConnectionsManager;
 
 uint32_t DoHConnectionToBackend::getConcurrentStreamsCount() const
 {
@@ -493,7 +464,7 @@ void DoHConnectionToBackend::stopIO()
     /* remove ourselves from the connection cache, this might mean that our
        reference count drops to zero after that, so we need to be careful */
     auto shared = std::dynamic_pointer_cast<DoHConnectionToBackend>(shared_from_this());
-    DownstreamDoHConnectionsManager::removeDownstreamConnection(shared);
+    t_downstreamDoHConnectionsManager.removeDownstreamConnection(shared);
   }
 }
 
@@ -745,7 +716,7 @@ int DoHConnectionToBackend::on_stream_close_callback(nghttp2_session* session, i
   if (request.d_query.d_downstreamFailures < conn->d_ds->d_retries) {
     // cerr<<"in "<<__PRETTY_FUNCTION__<<", looking for a connection to send a query of size "<<request.d_query.d_buffer.size()<<endl;
     ++request.d_query.d_downstreamFailures;
-    auto downstream = DownstreamDoHConnectionsManager::getConnectionToDownstream(conn->d_mplexer, conn->d_ds, now, std::string(conn->d_proxyProtocolPayload));
+    auto downstream = t_downstreamDoHConnectionsManager.getConnectionToDownstream(conn->d_mplexer, conn->d_ds, now, std::string(conn->d_proxyProtocolPayload));
     downstream->queueQuery(request.d_sender, std::move(request.d_query));
   }
   else {
@@ -803,7 +774,7 @@ int DoHConnectionToBackend::on_error_callback(nghttp2_session* session, int lib_
   return 0;
 }
 
-DoHConnectionToBackend::DoHConnectionToBackend(std::shared_ptr<DownstreamState> ds, std::unique_ptr<FDMultiplexer>& mplexer, const struct timeval& now, std::string&& proxyProtocolPayload) :
+DoHConnectionToBackend::DoHConnectionToBackend(const std::shared_ptr<DownstreamState>& ds, std::unique_ptr<FDMultiplexer>& mplexer, const struct timeval& now, std::string&& proxyProtocolPayload) :
   ConnectionToBackend(ds, mplexer, now), d_proxyProtocolPayload(std::move(proxyProtocolPayload))
 {
   // inherit most of the stuff from the ConnectionToBackend()
@@ -859,147 +830,6 @@ DoHConnectionToBackend::DoHConnectionToBackend(std::shared_ptr<DownstreamState> 
   }
 }
 
-thread_local map<boost::uuids::uuid, std::deque<std::shared_ptr<DoHConnectionToBackend>>> DownstreamDoHConnectionsManager::t_downstreamConnections;
-thread_local time_t DownstreamDoHConnectionsManager::t_nextCleanup{0};
-size_t DownstreamDoHConnectionsManager::s_maxCachedConnectionsPerDownstream{10};
-uint16_t DownstreamDoHConnectionsManager::s_cleanupInterval{60};
-uint16_t DownstreamDoHConnectionsManager::s_maxIdleTime{300};
-
-size_t DownstreamDoHConnectionsManager::clear()
-{
-  size_t result = 0;
-  for (const auto& backend : t_downstreamConnections) {
-    result += backend.second.size();
-    for (auto& conn : backend.second) {
-      conn->stopIO();
-    }
-  }
-  t_downstreamConnections.clear();
-  return result;
-}
-
-bool DownstreamDoHConnectionsManager::removeDownstreamConnection(std::shared_ptr<DoHConnectionToBackend>& conn)
-{
-  bool found = false;
-  auto backendIt = t_downstreamConnections.find(conn->getDS()->getID());
-  if (backendIt == t_downstreamConnections.end()) {
-    return found;
-  }
-
-  for (auto connIt = backendIt->second.begin(); connIt != backendIt->second.end(); ++connIt) {
-    if (*connIt == conn) {
-      backendIt->second.erase(connIt);
-      found = true;
-      break;
-    }
-  }
-
-  return found;
-}
-
-void DownstreamDoHConnectionsManager::cleanupClosedConnections(struct timeval now)
-{
-  //cerr<<"cleanup interval is "<<s_cleanupInterval<<", next cleanup is "<<t_nextCleanup<<", now is "<<now.tv_sec<<endl;
-  if (s_cleanupInterval <= 0 || (t_nextCleanup > 0 && t_nextCleanup > now.tv_sec)) {
-    return;
-  }
-
-  t_nextCleanup = now.tv_sec + s_cleanupInterval;
-
-  struct timeval freshCutOff = now;
-  freshCutOff.tv_sec -= 1;
-  struct timeval idleCutOff = now;
-  idleCutOff.tv_sec -= s_maxIdleTime;
-
-  for (auto dsIt = t_downstreamConnections.begin(); dsIt != t_downstreamConnections.end();) {
-    for (auto connIt = dsIt->second.begin(); connIt != dsIt->second.end();) {
-      if (!(*connIt)) {
-        connIt = dsIt->second.erase(connIt);
-        continue;
-      }
-
-      /* don't bother checking freshly used connections */
-      if (freshCutOff < (*connIt)->getLastDataReceivedTime()) {
-        ++connIt;
-        continue;
-      }
-
-      if ((*connIt)->isIdle() && (*connIt)->getLastDataReceivedTime() < idleCutOff) {
-        /* idle for too long */
-        connIt = dsIt->second.erase(connIt);
-        continue;
-      }
-
-      if ((*connIt)->isUsable()) {
-        ++connIt;
-        continue;
-      }
-
-      connIt = dsIt->second.erase(connIt);
-    }
-
-    if (!dsIt->second.empty()) {
-      ++dsIt;
-    }
-    else {
-      dsIt = t_downstreamConnections.erase(dsIt);
-    }
-  }
-}
-
-std::shared_ptr<DoHConnectionToBackend> DownstreamDoHConnectionsManager::getConnectionToDownstream(std::unique_ptr<FDMultiplexer>& mplexer, const std::shared_ptr<DownstreamState>& ds, const struct timeval& now, std::string&& proxyProtocolPayload)
-{
-  std::shared_ptr<DoHConnectionToBackend> result;
-  struct timeval freshCutOff = now;
-  freshCutOff.tv_sec -= 1;
-
-  auto backendId = ds->getID();
-
-  cleanupClosedConnections(now);
-
-  const bool haveProxyProtocol = !proxyProtocolPayload.empty();
-  if (!haveProxyProtocol) {
-    //cerr<<"looking for existing connection"<<endl;
-    const auto& it = t_downstreamConnections.find(backendId);
-    if (it != t_downstreamConnections.end()) {
-      auto& list = it->second;
-      for (auto listIt = list.begin(); listIt != list.end();) {
-        auto& entry = *listIt;
-        if (!entry->canBeReused()) {
-          if (!entry->willBeReusable(false)) {
-            listIt = list.erase(listIt);
-          }
-          else {
-            ++listIt;
-          }
-          continue;
-        }
-        entry->setReused();
-        /* for connections that have not been used very recently,
-           check whether they have been closed in the meantime */
-        if (freshCutOff < entry->getLastDataReceivedTime()) {
-          /* used recently enough, skip the check */
-          ++ds->tcpReusedConnections;
-          return entry;
-        }
-
-        if (isTCPSocketUsable(entry->getHandle())) {
-          ++ds->tcpReusedConnections;
-          return entry;
-        }
-
-        listIt = list.erase(listIt);
-      }
-    }
-  }
-
-  auto newConnection = std::make_shared<DoHConnectionToBackend>(ds, mplexer, now, std::move(proxyProtocolPayload));
-  if (!haveProxyProtocol) {
-    t_downstreamConnections[backendId].push_front(newConnection);
-  }
-  return newConnection;
-}
-
 static void handleCrossProtocolQuery(int pipefd, FDMultiplexer::funcparam_t& param)
 {
   auto threadData = boost::any_cast<DoHClientThreadData*>(param);
@@ -1030,7 +860,7 @@ static void handleCrossProtocolQuery(int pipefd, FDMultiplexer::funcparam_t& par
     tmp = nullptr;
 
     try {
-      auto downstream = DownstreamDoHConnectionsManager::getConnectionToDownstream(threadData->mplexer, downstreamServer, now, std::move(query.d_proxyProtocolPayload));
+      auto downstream = t_downstreamDoHConnectionsManager.getConnectionToDownstream(threadData->mplexer, downstreamServer, now, std::move(query.d_proxyProtocolPayload));
       downstream->queueQuery(tqs, std::move(query));
     }
     catch (...) {
@@ -1062,7 +892,7 @@ static void dohClientThread(int crossProtocolPipeFD)
         lastTimeoutScan = now.tv_sec;
 
         try {
-          DownstreamDoHConnectionsManager::cleanupClosedConnections(now);
+          t_downstreamDoHConnectionsManager.cleanupClosedConnections(now);
           handleH2Timeouts(*data.mplexer, now);
 
           if (g_dohStatesDumpRequested > 0) {
@@ -1304,7 +1134,7 @@ bool sendH2Query(const std::shared_ptr<DownstreamState>& ds, std::unique_ptr<FDM
     newConnection->queueQuery(sender, std::move(query));
   }
   else {
-    auto connection = DownstreamDoHConnectionsManager::getConnectionToDownstream(mplexer, ds, now, std::move(query.d_proxyProtocolPayload));
+    auto connection = t_downstreamDoHConnectionsManager.getConnectionToDownstream(mplexer, ds, now, std::move(query.d_proxyProtocolPayload));
     connection->queueQuery(sender, std::move(query));
   }
 
@@ -1318,7 +1148,7 @@ size_t clearH2Connections()
 {
   size_t cleared = 0;
 #ifdef HAVE_NGHTTP2
-  cleared = DownstreamDoHConnectionsManager::clear();
+  cleared = t_downstreamDoHConnectionsManager.clear();
 #endif /* HAVE_NGHTTP2 */
   return cleared;
 }

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -932,6 +932,7 @@ void DownstreamDoHConnectionsManager::cleanupClosedConnections(struct timeval no
 
       if ((*connIt)->isUsable()) {
         ++connIt;
+        continue;
       }
 
       connIt = dsIt->second.erase(connIt);

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -933,9 +933,8 @@ void DownstreamDoHConnectionsManager::cleanupClosedConnections(struct timeval no
       if ((*connIt)->isUsable()) {
         ++connIt;
       }
-      else {
-        connIt = dsIt->second.erase(connIt);
-      }
+
+      connIt = dsIt->second.erase(connIt);
     }
 
     if (!dsIt->second.empty()) {
@@ -988,8 +987,7 @@ std::shared_ptr<DoHConnectionToBackend> DownstreamDoHConnectionsManager::getConn
           return entry;
         }
 
-        /* otherwise let's try the next one, if any */
-        ++listIt;
+        listIt = list.erase(listIt);
       }
     }
   }

--- a/pdns/dnsdistdist/dnsdist-nghttp2.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.hh
@@ -72,4 +72,4 @@ size_t clearH2Connections();
 
 void setDoHDownstreamCleanupInterval(uint16_t max);
 void setDoHDownstreamMaxIdleTime(uint16_t max);
-void setDoHDownstreamMaxConnectionsPerBackend(size_t max);
+void setDoHDownstreamMaxIdleConnectionsPerBackend(size_t max);

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -805,13 +805,8 @@ std::shared_ptr<TCPConnectionToBackend> DownstreamConnectionsManager::getConnect
           ++ds->tcpReusedConnections;
           return entry;
         }
-        else {
-          listIt = list.erase(listIt);
-          continue;
-        }
 
-        /* otherwise let's try the next one, if any */
-        ++listIt;
+        listIt = list.erase(listIt);
       }
     }
   }
@@ -858,9 +853,8 @@ void DownstreamConnectionsManager::cleanupClosedTCPConnections(struct timeval no
       if ((*connIt)->isUsable()) {
         ++connIt;
       }
-      else {
-        connIt = dsIt->second.erase(connIt);
-      }
+
+      connIt = dsIt->second.erase(connIt);
     }
 
     if (!dsIt->second.empty()) {

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -633,12 +633,14 @@ IOState TCPConnectionToBackend::handleResponse(std::shared_ptr<TCPConnectionToBa
       --conn->d_ds->outstanding;
       /* marking as idle for now, so we can accept new queries if our queues are empty */
       if (d_pendingQueries.empty() && d_pendingResponses.empty()) {
+        t_downstreamTCPConnectionsManager.moveToIdle(conn);
         d_state = State::idle;
       }
     }
 
     sender->handleXFRResponse(now, std::move(response));
     if (done) {
+      t_downstreamTCPConnectionsManager.moveToIdle(conn);
       d_state = State::idle;
       return IOState::Done;
     }
@@ -655,6 +657,7 @@ IOState TCPConnectionToBackend::handleResponse(std::shared_ptr<TCPConnectionToBa
   d_pendingResponses.erase(it);
   /* marking as idle for now, so we can accept new queries if our queues are empty */
   if (d_pendingQueries.empty() && d_pendingResponses.empty()) {
+    t_downstreamTCPConnectionsManager.moveToIdle(conn);
     d_state = State::idle;
   }
 
@@ -678,6 +681,7 @@ IOState TCPConnectionToBackend::handleResponse(std::shared_ptr<TCPConnectionToBa
   }
   else {
     DEBUGLOG("nothing to do, waiting for a new query");
+    t_downstreamTCPConnectionsManager.moveToIdle(conn);
     d_state = State::idle;
     return IOState::Done;
   }

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.cc
@@ -852,6 +852,7 @@ void DownstreamConnectionsManager::cleanupClosedTCPConnections(struct timeval no
 
       if ((*connIt)->isUsable()) {
         ++connIt;
+        continue;
       }
 
       connIt = dsIt->second.erase(connIt);

--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -374,7 +374,7 @@ public:
     return newConnection;
   }
 
-  void cleanupClosedConnections(struct timeval now)
+  void cleanupClosedConnections(const struct timeval& now)
   {
     if (s_cleanupInterval == 0 || (d_nextCleanup != 0 && d_nextCleanup > now.tv_sec)) {
       return;
@@ -524,7 +524,7 @@ protected:
     }
   }
 
-  std::shared_ptr<T> findUsableConnectionInList(const struct timeval& now, struct timeval& freshCutOff, list_t& list, bool removeIfFound)
+  std::shared_ptr<T> findUsableConnectionInList(const struct timeval& now, const struct timeval& freshCutOff, list_t& list, bool removeIfFound)
   {
     auto& sidx = list.template get<SequencedTag>();
     for (auto listIt = sidx.begin(); listIt != sidx.end(); ) {
@@ -536,6 +536,7 @@ protected:
       auto& entry = *listIt;
       if (isConnectionUsable(entry, now, freshCutOff)) {
         entry->setReused();
+        // make a copy since the iterator will be invalidated after erasing
         auto result = entry;
         if (removeIfFound) {
           sidx.erase(listIt);
@@ -568,11 +569,7 @@ protected:
       return true;
     }
 
-    if (conn->isUsable()) {
-      return true;
-    }
-
-    return false;
+    return conn->isUsable();
   }
 
   static size_t s_maxIdleConnectionsPerDownstream;

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -16,7 +16,7 @@ Tuning related functions
 
   :param int max: The maximum time in seconds.
 
-.. function:: setMaxCachedDoHConnectionsPerDownstream(max)
+.. function:: setMaxIdleDoHConnectionsPerDownstream(max)
 
   .. versionadded:: 1.7.0
 

--- a/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
+++ b/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
@@ -29,7 +29,8 @@
 class MockupConnection
 {
 public:
-  MockupConnection(const std::shared_ptr<DownstreamState>& ds, std::unique_ptr<FDMultiplexer>&, const struct timeval&, std::string&&): d_ds(ds)
+  MockupConnection(const std::shared_ptr<DownstreamState>& ds, std::unique_ptr<FDMultiplexer>&, const struct timeval&, std::string&&) :
+    d_ds(ds)
   {
   }
 

--- a/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
+++ b/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
@@ -1,0 +1,186 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include "dnsdist-tcp-downstream.hh"
+
+class MockupConnection
+{
+public:
+  MockupConnection(const std::shared_ptr<DownstreamState>&, std::unique_ptr<FDMultiplexer>&, const struct timeval&, std::string&&)
+  {
+  }
+
+  bool canBeReused() const
+  {
+    return d_reusable;
+  }
+
+  bool isUsable() const
+  {
+    return d_usable;
+  }
+
+  bool willBeReusable(bool) const
+  {
+    return d_reusable;
+  }
+
+  void setReused()
+  {
+  }
+
+  struct timeval getLastDataReceivedTime() const
+  {
+    return d_lastDataReceivedTime;
+  }
+
+  bool isIdle() const
+  {
+    return d_idle;
+  }
+
+  void stopIO()
+  {
+  }
+
+  struct timeval d_lastDataReceivedTime{0, 0};
+  bool d_reusable{true};
+  bool d_usable{true};
+  bool d_idle{false};
+};
+
+BOOST_AUTO_TEST_SUITE(test_dnsdist_connections_cache)
+
+BOOST_AUTO_TEST_CASE(test_ConnectionsCache)
+{
+  DownstreamConnectionsManager<MockupConnection> manager;
+  const size_t maxConnPerDownstream = 5;
+  const uint16_t cleanupInterval = 1;
+  const uint16_t maxIdleTime = 5;
+  manager.setMaxCachedConnectionsPerDownstream(maxConnPerDownstream);
+  manager.setCleanupInterval(cleanupInterval);
+  manager.setMaxIdleTime(maxIdleTime);
+
+  auto mplexer = std::unique_ptr<FDMultiplexer>(FDMultiplexer::getMultiplexerSilent());
+  auto downstream1 = std::make_shared<DownstreamState>(ComboAddress("192.0.2.1"));
+  auto downstream2 = std::make_shared<DownstreamState>(ComboAddress("192.0.2.2"));
+  struct timeval now;
+  gettimeofday(&now, nullptr);
+
+  auto conn = manager.getConnectionToDownstream(mplexer, downstream1, now, std::string());
+  BOOST_REQUIRE(conn != nullptr);
+  BOOST_CHECK_EQUAL(manager.count(), 1U);
+
+  /* since the connection can be reused, we should get the same one */
+  {
+    auto conn1 = manager.getConnectionToDownstream(mplexer, downstream1, now, std::string());
+    BOOST_CHECK(conn.get() == conn1.get());
+    BOOST_CHECK_EQUAL(manager.count(), 1U);
+  }
+
+  /* if we mark it non-usable, we should get a new one */
+  conn->d_usable = false;
+  auto conn2 = manager.getConnectionToDownstream(mplexer, downstream1, now, std::string());
+  BOOST_CHECK(conn.get() != conn2.get());
+  BOOST_CHECK_EQUAL(manager.count(), 2U);
+
+  /* since the second connection can be reused, we should get it */
+  {
+    auto conn3 = manager.getConnectionToDownstream(mplexer, downstream1, now, std::string());
+    BOOST_CHECK(conn3.get() == conn2.get());
+    BOOST_CHECK_EQUAL(manager.count(), 2U);
+  }
+
+  /* different downstream so different connection */
+  auto differentConn = manager.getConnectionToDownstream(mplexer, downstream2, now, std::string());
+  BOOST_REQUIRE(differentConn != nullptr);
+  BOOST_CHECK(differentConn.get() != conn.get());
+  BOOST_CHECK(differentConn.get() != conn2.get());
+  BOOST_CHECK_EQUAL(manager.count(), 3U);
+  {
+    /* but we should be able to reuse it */
+    auto sameConn = manager.getConnectionToDownstream(mplexer, downstream2, now, std::string());
+    BOOST_CHECK(sameConn.get() == differentConn.get());
+    BOOST_CHECK_EQUAL(manager.count(), 3U);
+  }
+
+  struct timeval later = now;
+  later.tv_sec += cleanupInterval + 1;
+
+  /* mark the second connection as no longer usable */
+  conn2->d_usable = false;
+  /* first one as well but still fresh so it will not get checked */
+  conn->d_usable = true;
+  conn->d_lastDataReceivedTime = later;
+  /* third one is usable but idle for too long */
+  differentConn->d_idle = true;
+  differentConn->d_lastDataReceivedTime = later;
+  differentConn->d_lastDataReceivedTime.tv_sec -= (maxIdleTime + 1);
+
+  /* we should not do an actual cleanup attempt since the last cleanup was done recently */
+  manager.cleanupClosedConnections(now);
+  BOOST_CHECK_EQUAL(manager.count(), 3U);
+
+  manager.cleanupClosedConnections(later);
+  BOOST_CHECK_EQUAL(manager.count(), 1U);
+
+  /* mark the remaining conn as non-usable, to get new ones */
+  conn->d_usable = false;
+  conn->d_lastDataReceivedTime.tv_sec = 0;
+
+  std::vector<std::shared_ptr<MockupConnection>> conns = { conn };
+  while (conns.size() < maxConnPerDownstream) {
+    auto newConn = manager.getConnectionToDownstream(mplexer, downstream1, now, std::string());
+    newConn->d_usable = false;
+    conns.push_back(newConn);
+    BOOST_CHECK_EQUAL(manager.count(), conns.size());
+  }
+
+  /* if we add a new one, the oldest should get expunged */
+  auto newConn = manager.getConnectionToDownstream(mplexer, downstream1, now, std::string());
+  BOOST_CHECK_EQUAL(manager.count(), maxConnPerDownstream);
+
+  {
+    /* mark all connections as not usable anymore */
+    for (auto& c : conns) {
+      c->d_usable = false;
+    }
+
+    /* except the last one */
+    newConn->d_usable = true;
+
+    BOOST_CHECK_EQUAL(manager.count(), maxConnPerDownstream);
+    later.tv_sec += cleanupInterval + 1;
+    manager.cleanupClosedConnections(later);
+    BOOST_CHECK_EQUAL(manager.count(), 1U);
+  }
+
+  conns.clear();
+  auto cleared = manager.clear();
+  BOOST_CHECK_EQUAL(cleared, 1U);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
+++ b/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
@@ -66,7 +66,10 @@ public:
   {
   }
 
-  struct timeval d_lastDataReceivedTime{0, 0};
+  struct timeval d_lastDataReceivedTime
+  {
+    0, 0
+  };
   bool d_reusable{true};
   bool d_usable{true};
   bool d_idle{false};
@@ -151,7 +154,7 @@ BOOST_AUTO_TEST_CASE(test_ConnectionsCache)
   conn->d_usable = false;
   conn->d_lastDataReceivedTime.tv_sec = 0;
 
-  std::vector<std::shared_ptr<MockupConnection>> conns = { conn };
+  std::vector<std::shared_ptr<MockupConnection>> conns = {conn};
   while (conns.size() < maxConnPerDownstream) {
     auto newConn = manager.getConnectionToDownstream(mplexer, downstream1, now, std::string());
     newConn->d_usable = false;

--- a/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
+++ b/pdns/dnsdistdist/test-dnsdist-connections-cache.cc
@@ -216,6 +216,18 @@ BOOST_AUTO_TEST_CASE(test_ConnectionsCache)
   BOOST_CHECK_EQUAL(manager.count(), maxIdleConnPerDownstream);
   BOOST_CHECK_EQUAL(manager.getActiveCount(), 0U);
   BOOST_CHECK_EQUAL(manager.getIdleCount(), maxIdleConnPerDownstream);
+
+  {
+    /* if we ask for a connection, one of these should become active and no longer idle */
+    /* but first we need to mark them as usable again */
+    for (const auto& c : conns) {
+      c->d_usable = true;
+    }
+    auto got = manager.getConnectionToDownstream(mplexer, downstream1, now, std::string());
+    BOOST_CHECK_EQUAL(manager.count(), maxIdleConnPerDownstream);
+    BOOST_CHECK_EQUAL(manager.getActiveCount(), 1U);
+    BOOST_CHECK_EQUAL(manager.getIdleCount(), maxIdleConnPerDownstream - 1U);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/regression-tests.dnsdist/test_AXFR.py
+++ b/regression-tests.dnsdist/test_AXFR.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import threading
+import time
 import dns
 from dnsdisttests import DNSDistTest
 
@@ -13,6 +14,7 @@ class TestAXFR(DNSDistTest):
     _config_template = """
     newServer{address="127.0.0.1:%s"}
     """
+    _verboseMode = True
 
     @classmethod
     def startResponders(cls):
@@ -24,6 +26,13 @@ class TestAXFR(DNSDistTest):
         cls._TCPResponder = threading.Thread(name='TCP Responder', target=cls.TCPResponder, args=[cls._testServerPort, cls._toResponderQueue, cls._fromResponderQueue, False, True, None, None, True])
         cls._TCPResponder.setDaemon(True)
         cls._TCPResponder.start()
+
+    def setUp(self):
+        # This function is called before every test
+        super(TestAXFR, self).setUp()
+        # make sure the TCP connection handlers from the previous test
+        # are not going to read our queue
+        time.sleep(1)
 
     def testOneMessageAXFR(self):
         """
@@ -245,7 +254,7 @@ class TestAXFR(DNSDistTest):
                                        dns.rdatatype.SOA,
                                        'ns.' + name + ' hostmaster.' + name + ' 3 3600 3600 3600 60')
 
-        # the final SOA starts the AXFR, with first an update from 1 to 2 (one removal, two additions)
+        # the final SOA starts the IXFR, with first an update from 1 to 2 (one removal, two additions)
         response = dns.message.make_response(query)
         response.answer.append(finalSoa)
         # update from 1 to 2


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported by Coverity (CID 373724).

It also immediately removes a HTTP/2 connection from the list if it is no longer usable (TCP socket is dead).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
