### PR TITLE
dnsdist: Add the ability to retain select capabilities at runtime

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -403,6 +403,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "addACL", true, "netmask", "add to the ACL set who can use this server" },
   { "addAction", true, "DNS rule, DNS action [, {uuid=\"UUID\", name=\"name\"}]", "add a rule" },
   { "addBPFFilterDynBlocks", true, "addresses, dynbpf[[, seconds=10], msg]", "This is the eBPF equivalent of addDynBlocks(), blocking a set of addresses for (optionally) a number of seconds, using an eBPF dynamic filter" },
+  { "addCapabilitiesToRetain", true, "capability or list of capabilities", "Linux capabilities to retain after startup, like CAP_BPF" },
   { "addConsoleACL", true, "netmask", "add a netmask to the console ACL" },
   { "addDNSCryptBind", true, "\"127.0.0.1:8443\", \"provider name\", \"/path/to/resolver.cert\", \"/path/to/resolver.key\", {reusePort=false, tcpFastOpenQueueSize=0, interface=\"\", cpus={}}", "listen to incoming DNSCrypt queries on 127.0.0.1 port 8443, with a provider name of `provider name`, using a resolver certificate and associated key stored respectively in the `resolver.cert` and `resolver.key` files. The fifth optional parameter is a table of parameters" },
   { "addDOHLocal", true, "addr, certFile, keyFile [, urls [, vars]]", "listen to incoming DNS over HTTPS queries on the specified address using the specified certificate and key. The last two parameters are tables" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2764,6 +2764,22 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     libssl_generate_ocsp_response(certFile, caCert, caKey, outFile, ndays, nmin);
   });
 #endif /* HAVE_LIBSSL && HAVE_OCSP_BASIC_SIGN*/
+
+  luaCtx.writeFunction("addCapabilitiesToRetain", [](boost::variant<std::string, std::map<int, std::string>> caps) {
+    setLuaSideEffect();
+    if (g_configurationDone) {
+      g_outputBuffer = "addCapabilitiesToRetain cannot be used at runtime!\n";
+      return;
+    }
+    if (caps.type() == typeid(std::string)) {
+      g_capabilitiesToRetain.insert(boost::get<std::string>(caps));
+    }
+    else if (caps.type() == typeid(std::map<int, std::string>)) {
+      for (const auto& cap : boost::get<std::map<int, std::string>>(caps)) {
+        g_capabilitiesToRetain.insert(cap.second);
+      }
+    }
+  });
 }
 
 vector<std::function<void(void)>> setupLua(LuaContext& luaCtx, bool client, bool configCheck, const std::string& config)

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -37,6 +37,15 @@ The ``.`` means ``order`` is a data member, while the ``:`` means ``addPool`` is
 Global configuration
 --------------------
 
+.. function:: addCapabilitiesToRetain(capabilities)
+
+  .. versionadded:: 1.7.0
+
+  Accept a Linux capability as a string, or a list of these, to retain after startup so that privileged operations can still be performed at runtime.
+  Keeping ``CAP_BPF`` on kernel 5.8+ for example allows loading eBPF programs and altering eBPF maps at runtime even if the ``kernel.unprivileged_bpf_disabled`` sysctl is set.
+  Note that this does not grant the capabilities to the process, doing so might be done by running it as root which we don't advise, or by adding capabilities via the systemd unit file, for example.
+  Please also be aware that switching to a different user via ``--uid`` will still drop all capabilities.
+
 .. function:: includeDirectory(path)
 
   Include configuration files from ``path``.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This allows retaining the ability to create and use eBPF programs and maps at runtime, even if `kernel.unprivileged_bpf_disabled` is set, by keeping the `CAP_BPF` capability. It can be useful to prevent unprivileged programs on the system from loading eBPF while still allowing dnsdist to do so.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
