### PR TITLE
Remove debug print line flooding logs

### DIFF
--- a/dockerdata/dnsdist-resolver.py
+++ b/dockerdata/dnsdist-resolver.py
@@ -40,5 +40,4 @@ if __name__ == '__main__':
     lt.fname = '/tmp/dnsdist-resolver.out'
     lt.start()
     for line in sys.stdin:
-        print(line.split())
         lt.targets=line.split()


### PR DESCRIPTION
### Short description
Remove debug log line printing a statement into stdout all the time.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

