### PR TITLE
dnsdist: dont try to set IPV6_RECVPKTINFO on an ipv4 any bind?

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2044,7 +2044,7 @@ static void setUpLocalBind(std::unique_ptr<ClientState>& cs)
     int one=1;
     (void)setsockopt(fd, IPPROTO_IP, GEN_IP_PKTINFO, &one, sizeof(one)); // linux supports this, so why not - might fail on other systems
 #ifdef IPV6_RECVPKTINFO
-    if (cs->local.sin4.sin_family == AF_INET6 && setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &one, sizeof(one)) < 0 &&
+    if (cs->local.isIPv6() && setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &one, sizeof(one)) < 0 &&
         !g_warned_ipv6_recvpktinfo) {
         warnlog("Warning: IPV6_RECVPKTINFO setsockopt failed: %s", stringerror());
         g_warned_ipv6_recvpktinfo = true;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2044,7 +2044,7 @@ static void setUpLocalBind(std::unique_ptr<ClientState>& cs)
     int one=1;
     (void)setsockopt(fd, IPPROTO_IP, GEN_IP_PKTINFO, &one, sizeof(one)); // linux supports this, so why not - might fail on other systems
 #ifdef IPV6_RECVPKTINFO
-    if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &one, sizeof(one)) < 0 &&
+    if (cs->local.sin4.sin_family == AF_INET6 && setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &one, sizeof(one)) < 0 &&
         !g_warned_ipv6_recvpktinfo) {
         warnlog("Warning: IPV6_RECVPKTINFO setsockopt failed: %s", stringerror());
         g_warned_ipv6_recvpktinfo = true;


### PR DESCRIPTION
### Short description
`addLocal("0.0.0.0:9999")` gives `Warning: IPV6_RECVPKTINFO setsockopt failed: Protocol not available` otherwise.

No idea how correct this is other than "works for me"

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
