### PR TITLE
dnsdist: Add a lot more of build-time options to select features

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -394,6 +394,7 @@ dnsdistdoc
 dnsdomain
 dnsext
 dnsgram
+dnsheader
 dnskey
 dnsmessage
 dnsname

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -99,6 +99,10 @@ jobs:
     strategy:
       matrix:
         sanitizers: [ubsan+asan, tsan]
+        features: [least, full]
+        exclude:
+          - sanitizers: tsan
+            features: least
     env:
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp"
       ASAN_OPTIONS: detect_leaks=0
@@ -120,14 +124,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: dnsdist-${{ matrix.sanitizers }}-ccache-${{ steps.get-stamp.outputs.stamp }}
-          restore-keys: dnsdist-${{ matrix.sanitizers }}-ccache-
+          key: dnsdist-${{ matrix.features }}-${{ matrix.sanitizers }}-ccache-${{ steps.get-stamp.outputs.stamp }}
+          restore-keys: dnsdist-${{ matrix.features }}-${{ matrix.sanitizers }}-ccache-
       - run: ../../build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
       - run: inv apt-fresh
       - run: inv install-clang
       - run: inv install-dnsdist-build-deps
       - run: inv ci-autoconf
-      - run: inv ci-dnsdist-configure
+      - run: inv ci-dnsdist-configure ${{ matrix.features }}
       - run: inv ci-dnsdist-make
       - run: inv ci-dnsdist-run-unit-tests
       - run: inv ci-make-install
@@ -135,7 +139,7 @@ jobs:
       - name: Store the binaries
         uses: actions/upload-artifact@v2 # this takes 30 seconds, maybe we want to tar
         with:
-          name: dnsdist-${{ matrix.sanitizers }}
+          name: dnsdist-${{ matrix.features }}-${{ matrix.sanitizers }}
           path: /opt/dnsdist
           retention-days: 1
 
@@ -373,7 +377,7 @@ jobs:
       - name: Fetch the binaries
         uses: actions/download-artifact@v2
         with:
-          name: dnsdist-${{ matrix.sanitizers }}
+          name: dnsdist-full-${{ matrix.sanitizers }}
           path: /opt/dnsdist
       - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
       - run: inv install-clang-runtime

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,8 @@ AS_IF([test "x$enable_dns_over_tls" != "xno"], [
   ])
 ])
 
+PDNS_ENABLE_IPCIPHER
+
 PDNS_CHECK_RAGEL([pdns/dnslabeltext.cc], [www.powerdns.com])
 PDNS_CHECK_CLOCK_GETTIME
 

--- a/m4/pdns_enable_ipcipher.m4
+++ b/m4/pdns_enable_ipcipher.m4
@@ -1,0 +1,18 @@
+AC_DEFUN([PDNS_ENABLE_IPCIPHER], [
+  AC_MSG_CHECKING([whether to enable ipcipher support])
+  AC_ARG_ENABLE([ipcipher],
+    AS_HELP_STRING([--enable-ipcipher], [enable ipcipher support (requires libcrypto) @<:@default=yes@:>@]),
+    [enable_ipcipher=$enableval],
+    [enable_ipcipher=yes]
+  )
+  AC_MSG_RESULT([$enable_ipcipher])
+  AM_CONDITIONAL([IPCIPHER], [test "x$enable_ipcipher" != "xno"])
+
+  AM_COND_IF([IPCIPHER], [
+    AM_COND_IF([HAVE_LIBCRYPTO], [
+      AC_DEFINE([HAVE_IPCIPHER], [1], [Define to 1 if you enable ipcipher support])
+    ],[
+      AC_MSG_ERROR([ipcipher support requested but libcrypto is not available])
+    ])
+  ])
+])

--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -22,12 +22,12 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "iputils.hh"
+
+#include "dnsdist-carbon.hh"
+#include "dnsdist.hh"
+#include "dnsdist-carbon.hh"
 #include "dolog.hh"
 #include "sstuff.hh"
-
-#include "namespaces.hh"
-#include "dnsdist.hh"
 #include "threadname.hh"
 
 GlobalStateHolder<vector<CarbonConfig> > g_carbon;

--- a/pdns/dnsdist-carbon.cc
+++ b/pdns/dnsdist-carbon.cc
@@ -25,18 +25,13 @@
 
 #include "dnsdist-carbon.hh"
 #include "dnsdist.hh"
-#include "dnsdist-carbon.hh"
+
+#ifndef DISABLE_CARBON
 #include "dolog.hh"
 #include "sstuff.hh"
 #include "threadname.hh"
 
 GlobalStateHolder<vector<CarbonConfig> > g_carbon;
-static time_t s_start = time(nullptr);
-
-uint64_t uptimeOfProcess(const std::string& str)
-{
-  return time(nullptr) - s_start;
-}
 
 void carbonDumpThread()
 {
@@ -277,4 +272,12 @@ void carbonDumpThread()
   {
     errlog("Carbon thread died");
   }
+}
+#endif /* DISABLE_CARBON */
+
+static time_t s_start = time(nullptr);
+
+uint64_t uptimeOfProcess(const std::string& str)
+{
+  return time(nullptr) - s_start;
 }

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -397,6 +397,8 @@ void doConsole()
     }
   }
 }
+
+#ifndef DISABLE_COMPLETION
 /**** CARGO CULT CODE AHEAD ****/
 const std::vector<ConsoleKeyword> g_consoleKeywords{
   /* keyword, function, parameters, description */
@@ -755,6 +757,7 @@ char** my_completion( const char * text , int start,  int end)
   return matches;
 }
 }
+#endif /* DISABLE_COMPLETION */
 
 static void controlClientThread(ConsoleConnection&& conn)
 {

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -505,7 +505,9 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "LuaFFIRule", true, "function", "Invoke a Lua FFI function that filters DNS questions" },
   { "LuaResponseAction", true, "function", "Invoke a Lua function that accepts a DNSResponse" },
   { "LuaRule", true, "function", "Invoke a Lua function that filters DNS questions" },
+#ifdef HAVE_IPCIPHER
   { "makeIPCipherKey", true, "password", "generates a 16-byte key that can be used to pseudonymize IP addresses with IP cipher" },
+#endif /* HAVE_IPCIPHER */
   { "makeKey", true, "", "generate a new server access key, emit configuration line ready for pasting" },
   { "makeRule", true, "rule", "Make a NetmaskGroupRule() or a SuffixMatchNodeRule(), depending on how it is called" }  ,
   { "MaxQPSIPRule", true, "qps, [v4Mask=32 [, v6Mask=64 [, burst=qps [, expiration=300 [, cleanupDelay=60]]]]]", "matches traffic exceeding the qps limit per subnet" },

--- a/pdns/dnsdist-console.hh
+++ b/pdns/dnsdist-console.hh
@@ -21,6 +21,9 @@
  */
 #pragma once
 
+#include "config.h"
+
+#ifndef DISABLE_COMPLETION
 struct ConsoleKeyword {
   std::string name;
   bool function;
@@ -37,9 +40,14 @@ struct ConsoleKeyword {
     return res;
   }
 };
+extern const std::vector<ConsoleKeyword> g_consoleKeywords;
+extern "C" {
+char** my_completion( const char * text , int start,  int end);
+}
+
+#endif /* DISABLE_COMPLETION */
 
 extern GlobalStateHolder<NetmaskGroup> g_consoleACL;
-extern const std::vector<ConsoleKeyword> g_consoleKeywords;
 extern std::string g_consoleKey; // in theory needs locking
 extern bool g_logConsoleConnections;
 extern bool g_consoleEnabled;
@@ -47,9 +55,6 @@ extern uint32_t g_consoleOutputMsgMaxSize;
 
 void doClient(ComboAddress server, const std::string& command);
 void doConsole();
-extern "C" {
-char** my_completion( const char * text , int start,  int end);
-}
 void controlThread(int fd, ComboAddress local);
 void clearConsoleHistory();
 

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -2129,22 +2129,12 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new SetNoRecurseAction);
     });
 
-  luaCtx.writeFunction("NoRecurseAction", []() {
-      warnlog("access to NoRecurseAction is deprecated and will be removed in a future version, please use SetNoRecurseAction instead");
-      return std::shared_ptr<DNSAction>(new SetNoRecurseAction);
-    });
-
   luaCtx.writeFunction("SetMacAddrAction", [](int code) {
       return std::shared_ptr<DNSAction>(new SetMacAddrAction(code));
     });
 
   luaCtx.writeFunction("SetEDNSOptionAction", [](int code, const std::string& data) {
       return std::shared_ptr<DNSAction>(new SetEDNSOptionAction(code, data));
-    });
-
-  luaCtx.writeFunction("MacAddrAction", [](int code) {
-      warnlog("access to MacAddrAction is deprecated and will be removed in a future version, please use SetMacAddrAction instead");
-      return std::shared_ptr<DNSAction>(new SetMacAddrAction(code));
     });
 
   luaCtx.writeFunction("PoolAction", [](const std::string& a) {
@@ -2239,11 +2229,6 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new SetDisableValidationAction);
     });
 
-  luaCtx.writeFunction("DisableValidationAction", []() {
-      warnlog("access to DisableValidationAction is deprecated and will be removed in a future version, please use SetDisableValidationAction instead");
-      return std::shared_ptr<DNSAction>(new SetDisableValidationAction);
-  });
-
   luaCtx.writeFunction("LogAction", [](boost::optional<std::string> fname, boost::optional<bool> binary, boost::optional<bool> append, boost::optional<bool> buffered, boost::optional<bool> verboseOnly, boost::optional<bool> includeTimestamp) {
       return std::shared_ptr<DNSAction>(new LogAction(fname ? *fname : "", binary ? *binary : true, append ? *append : false, buffered ? *buffered : false, verboseOnly ? *verboseOnly : true, includeTimestamp ? *includeTimestamp : false));
     });
@@ -2295,21 +2280,11 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new SetSkipCacheAction);
     });
 
-  luaCtx.writeFunction("SkipCacheAction", []() {
-      warnlog("access to SkipCacheAction is deprecated and will be removed in a future version, please use SetSkipCacheAction instead");
-      return std::shared_ptr<DNSAction>(new SetSkipCacheAction);
-    });
-
   luaCtx.writeFunction("SetSkipCacheResponseAction", []() {
       return std::shared_ptr<DNSResponseAction>(new SetSkipCacheResponseAction);
     });
 
   luaCtx.writeFunction("SetTempFailureCacheTTLAction", [](int maxTTL) {
-      return std::shared_ptr<DNSAction>(new SetTempFailureCacheTTLAction(maxTTL));
-    });
-
-  luaCtx.writeFunction("TempFailureCacheTTLAction", [](int maxTTL) {
-      warnlog("access to TempFailureCacheTTLAction is deprecated and will be removed in a future version, please use SetTempFailureCacheTTLAction instead");
       return std::shared_ptr<DNSAction>(new SetTempFailureCacheTTLAction(maxTTL));
     });
 
@@ -2406,26 +2381,11 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new SetECSPrefixLengthAction(v4PrefixLength, v6PrefixLength));
     });
 
-  luaCtx.writeFunction("ECSPrefixLengthAction", [](uint16_t v4PrefixLength, uint16_t v6PrefixLength) {
-      warnlog("access to ECSPrefixLengthAction is deprecated and will be removed in a future version, please use SetECSPrefixLengthAction instead");
-      return std::shared_ptr<DNSAction>(new SetECSPrefixLengthAction(v4PrefixLength, v6PrefixLength));
-    });
-
   luaCtx.writeFunction("SetECSOverrideAction", [](bool ecsOverride) {
       return std::shared_ptr<DNSAction>(new SetECSOverrideAction(ecsOverride));
     });
 
-  luaCtx.writeFunction("ECSOverrideAction", [](bool ecsOverride) {
-      warnlog("access to ECSOverrideAction is deprecated and will be removed in a future version, please use SetECSOverrideAction instead");
-      return std::shared_ptr<DNSAction>(new SetECSOverrideAction(ecsOverride));
-    });
-
   luaCtx.writeFunction("SetDisableECSAction", []() {
-      return std::shared_ptr<DNSAction>(new SetDisableECSAction());
-    });
-
-  luaCtx.writeFunction("DisableECSAction", []() {
-      warnlog("access to DisableECSAction is deprecated and will be removed in a future version, please use SetDisableECSAction instead");
       return std::shared_ptr<DNSAction>(new SetDisableECSAction());
     });
 
@@ -2456,17 +2416,7 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSAction>(new SetTagAction(tag, value));
     });
 
-  luaCtx.writeFunction("TagAction", [](std::string tag, std::string value) {
-      warnlog("access to TagAction is deprecated and will be removed in a future version, please use SetTagAction instead");
-      return std::shared_ptr<DNSAction>(new SetTagAction(tag, value));
-    });
-
   luaCtx.writeFunction("SetTagResponseAction", [](std::string tag, std::string value) {
-      return std::shared_ptr<DNSResponseAction>(new SetTagResponseAction(tag, value));
-    });
-
-  luaCtx.writeFunction("TagResponseAction", [](std::string tag, std::string value) {
-      warnlog("access to TagResponseAction is deprecated and will be removed in a future version, please use SetTagResponseAction instead");
       return std::shared_ptr<DNSResponseAction>(new SetTagResponseAction(tag, value));
     });
 
@@ -2492,14 +2442,6 @@ void setupLuaActions(LuaContext& luaCtx)
     });
 
   luaCtx.writeFunction("NegativeAndSOAAction", [](bool nxd, const std::string& zone, uint32_t ttl, const std::string& mname, const std::string& rname, uint32_t serial, uint32_t refresh, uint32_t retry, uint32_t expire, uint32_t minimum, boost::optional<responseParams_t> vars) {
-      auto ret = std::shared_ptr<DNSAction>(new NegativeAndSOAAction(nxd, DNSName(zone), ttl, DNSName(mname), DNSName(rname), serial, refresh, retry, expire, minimum));
-      auto action = std::dynamic_pointer_cast<NegativeAndSOAAction>(ret);
-      parseResponseConfig(vars, action->d_responseConfig);
-      return ret;
-    });
-
-  luaCtx.writeFunction("SetNegativeAndSOAAction", [](bool nxd, const std::string& zone, uint32_t ttl, const std::string& mname, const std::string& rname, uint32_t serial, uint32_t refresh, uint32_t retry, uint32_t expire, uint32_t minimum, boost::optional<responseParams_t> vars) {
-      warnlog("access to SetNegativeAndSOAAction is deprecated and will be removed in a future version, please use NegativeAndSOAAction instead");
       auto ret = std::shared_ptr<DNSAction>(new NegativeAndSOAAction(nxd, DNSName(zone), ttl, DNSName(mname), DNSName(rname), serial, refresh, retry, expire, minimum));
       auto action = std::dynamic_pointer_cast<NegativeAndSOAAction>(ret);
       parseResponseConfig(vars, action->d_responseConfig);

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -39,9 +39,7 @@
 
 #include <boost/optional/optional_io.hpp>
 
-#ifdef HAVE_LIBCRYPTO
 #include "ipcipher.hh"
-#endif /* HAVE_LIBCRYPTO */
 
 class DropAction : public DNSAction
 {
@@ -1469,12 +1467,12 @@ public:
       message.setServerIdentity(d_serverID);
     }
 
-#if HAVE_LIBCRYPTO
+#if HAVE_IPCIPHER
     if (!d_ipEncryptKey.empty())
     {
       message.setRequestor(encryptCA(*dq->remote, d_ipEncryptKey));
     }
-#endif /* HAVE_LIBCRYPTO */
+#endif /* HAVE_IPCIPHER */
 
     if (d_alterFunc) {
       auto lock = g_lua.lock();
@@ -1599,12 +1597,12 @@ public:
       message.setServerIdentity(d_serverID);
     }
 
-#if HAVE_LIBCRYPTO
+#if HAVE_IPCIPHER
     if (!d_ipEncryptKey.empty())
     {
       message.setRequestor(encryptCA(*dr->remote, d_ipEncryptKey));
     }
-#endif /* HAVE_LIBCRYPTO */
+#endif /* HAVE_IPCIPHER */
 
     if (d_alterFunc) {
       auto lock = g_lua.lock();

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -1391,6 +1391,7 @@ private:
   bool d_hasV6;
 };
 
+#ifndef DISABLE_PROTOBUF
 static DnstapMessage::ProtocolType ProtocolToDNSTap(dnsdist::Protocol protocol)
 {
   if (protocol == dnsdist::Protocol::DoUDP) {
@@ -1497,6 +1498,8 @@ private:
   std::string d_ipEncryptKey;
 };
 
+#endif /* DISABLE_PROTOBUF */
+
 class SNMPTrapAction : public DNSAction
 {
 public:
@@ -1542,6 +1545,7 @@ private:
   std::string d_value;
 };
 
+#ifndef DISABLE_PROTOBUF
 class DnstapLogResponseAction : public DNSResponseAction, public boost::noncopyable
 {
 public:
@@ -1627,6 +1631,8 @@ private:
   std::string d_ipEncryptKey;
   bool d_includeCNAME;
 };
+
+#endif /* DISABLE_PROTOBUF */
 
 class DropResponseAction : public DNSResponseAction
 {
@@ -2334,6 +2340,7 @@ void setupLuaActions(LuaContext& luaCtx)
       return std::shared_ptr<DNSResponseAction>(new LuaFFIPerThreadResponseAction(code));
     });
 
+#ifndef DISABLE_PROTOBUF
   luaCtx.writeFunction("RemoteLogAction", [](std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(DNSQuestion*, DNSDistProtoBufMessage*)> > alterFunc, boost::optional<std::unordered_map<std::string, std::string>> vars) {
       if (logger) {
         // avoids potentially-evaluated-expression warning with clang.
@@ -2389,6 +2396,7 @@ void setupLuaActions(LuaContext& luaCtx)
   luaCtx.writeFunction("DnstapLogResponseAction", [](const std::string& identity, std::shared_ptr<RemoteLoggerInterface> logger, boost::optional<std::function<void(DNSResponse*, DnstapMessage*)> > alterFunc) {
       return std::shared_ptr<DNSResponseAction>(new DnstapLogResponseAction(identity, logger, alterFunc));
     });
+#endif /* DISABLE_PROTOBUF */
 
   luaCtx.writeFunction("TeeAction", [](const std::string& remote, boost::optional<bool> addECS) {
       return std::shared_ptr<DNSAction>(new TeeAction(ComboAddress(remote, 53), addECS ? *addECS : false));

--- a/pdns/dnsdist-lua-bindings-dnsquestion.cc
+++ b/pdns/dnsdist-lua-bindings-dnsquestion.cc
@@ -26,6 +26,7 @@
 
 void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
 {
+#ifndef DISABLE_NON_FFI_DQ_BINDINGS
   /* DNSQuestion */
   /* PowerDNS DNSQuestion compat */
   luaCtx.registerMember<const ComboAddress (DNSQuestion::*)>("localaddr", [](const DNSQuestion& dq) -> const ComboAddress { return *dq.local; }, [](DNSQuestion& dq, const ComboAddress newLocal) { (void) newLocal; });
@@ -306,4 +307,5 @@ void setupLuaBindingsDNSQuestion(LuaContext& luaCtx)
       checkParameterBound("setNegativeAndAdditionalSOA", minimum, std::numeric_limits<uint32_t>::max());
       return setNegativeAndAdditionalSOA(dq, nxd, DNSName(zone), ttl, DNSName(mname), DNSName(rname), serial, refresh, retry, expire, minimum);
     });
+#endif /* DISABLE_NON_FFI_DQ_BINDINGS */
 }

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -594,7 +594,8 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
     return values;
   });
 
-  luaCtx.writeFunction("newDOHResponseMapEntry", [](const std::string& regex, uint16_t status, const std::string& content, boost::optional<std::map<std::string, std::string>> customHeaders) {
+  luaCtx.writeFunction("newDOHResponseMapEntry", [](const std::string& regex, uint64_t status, const std::string& content, boost::optional<std::map<std::string, std::string>> customHeaders) {
+    checkParameterBound("newDOHResponseMapEntry", status, std::numeric_limits<uint16_t>::max());
     boost::optional<std::vector<std::pair<std::string, std::string>>> headers{boost::none};
     if (customHeaders) {
       headers = std::vector<std::pair<std::string, std::string>>();
@@ -605,8 +606,9 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
     return std::make_shared<DOHResponseMapEntry>(regex, status, PacketBuffer(content.begin(), content.end()), headers);
   });
 
-  luaCtx.writeFunction("newSVCRecordParameters", [](uint16_t priority, const std::string& target, boost::optional<svcParamsLua_t> additionalParameters)
+  luaCtx.writeFunction("newSVCRecordParameters", [](uint64_t priority, const std::string& target, boost::optional<svcParamsLua_t> additionalParameters)
   {
+    checkParameterBound("newSVCRecordParameters", priority, std::numeric_limits<uint16_t>::max());
     SVCRecordParameters parameters;
     if (additionalParameters) {
       parameters = parseSVCParameters(*additionalParameters);

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -28,6 +28,7 @@
 
 #include "statnode.hh"
 
+#ifndef DISABLE_TOP_N_BINDINGS
 static std::vector<std::pair<int, vector<boost::variant<string,double>>>> getGenResponses(uint64_t top, boost::optional<int> labels, std::function<bool(const Rings::Response&)> pred)
 {
   setLuaNoSideEffect();
@@ -89,6 +90,7 @@ static std::vector<std::pair<int, vector<boost::variant<string,double>>>> getGen
 
   return ret;
 }
+#endif /* DISABLE_TOP_N_BINDINGS */
 
 #ifndef DISABLE_DEPRECATED_DYNBLOCK
 
@@ -240,6 +242,7 @@ static counts_t exceedRespByterate(unsigned int rate, int seconds)
 
 void setupLuaInspection(LuaContext& luaCtx)
 {
+#ifndef DISABLE_TOP_N_BINDINGS
   luaCtx.writeFunction("topClients", [](boost::optional<uint64_t> top_) {
       setLuaNoSideEffect();
       auto top = top_.get_value_or(10);
@@ -378,6 +381,7 @@ void setupLuaInspection(LuaContext& luaCtx)
     });
 
   luaCtx.executeCode(R"(function topBandwidth(top) top = top or 10; for k,v in ipairs(getTopBandwidth(top)) do show(string.format("%4d  %-40s %4d %4.1f%%",k,v[1],v[2],v[3])) end end)");
+#endif /* DISABLE_TOP_N_BINDINGS */
 
   luaCtx.writeFunction("delta", []() {
       setLuaNoSideEffect();

--- a/pdns/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdist-lua-inspection.cc
@@ -70,7 +70,7 @@ static std::vector<std::pair<int, vector<boost::variant<string,double>>>> getGen
        });
 
   std::vector<std::pair<int, vector<boost::variant<string,double>>>> ret;
-  ret.reserve(std::min(rcounts.size(), top + 1U));
+  ret.reserve(std::min(rcounts.size(), static_cast<size_t>(top + 1U)));
   uint64_t count = 1;
   unsigned int rest = 0;
   for(const auto& rc : rcounts) {

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -75,10 +75,10 @@ void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid
 
   if (params) {
     if (params->count("uuid")) {
-      uuidStr = boost::get<std::string>((*params)["uuid"]);
+      uuidStr = params->at("uuid");
     }
     if (params->count("name")) {
-      name = boost::get<std::string>((*params)["name"]);
+      name = params->at("name");
     }
   }
 

--- a/pdns/dnsdist-lua-rules.cc
+++ b/pdns/dnsdist-lua-rules.cc
@@ -369,11 +369,11 @@ void setupLuaRules(LuaContext& luaCtx)
     return rulesToString(getTopRules(*rules, top.get_value_or(10)), vars);
   });
 
-  luaCtx.writeFunction("MaxQPSIPRule", [](unsigned int qps, boost::optional<int> ipv4trunc, boost::optional<int> ipv6trunc, boost::optional<int> burst, boost::optional<unsigned int> expiration, boost::optional<unsigned int> cleanupDelay, boost::optional<unsigned int> scanFraction) {
+  luaCtx.writeFunction("MaxQPSIPRule", [](unsigned int qps, boost::optional<unsigned int> ipv4trunc, boost::optional<unsigned int> ipv6trunc, boost::optional<unsigned int> burst, boost::optional<unsigned int> expiration, boost::optional<unsigned int> cleanupDelay, boost::optional<unsigned int> scanFraction) {
       return std::shared_ptr<DNSRule>(new MaxQPSIPRule(qps, burst.get_value_or(qps), ipv4trunc.get_value_or(32), ipv6trunc.get_value_or(64), expiration.get_value_or(300), cleanupDelay.get_value_or(60), scanFraction.get_value_or(10)));
     });
 
-  luaCtx.writeFunction("MaxQPSRule", [](unsigned int qps, boost::optional<int> burst) {
+  luaCtx.writeFunction("MaxQPSRule", [](unsigned int qps, boost::optional<unsigned int> burst) {
       if(!burst)
         return std::shared_ptr<DNSRule>(new MaxQPSRule(qps));
       else
@@ -414,9 +414,9 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new NetmaskGroupRule(nmg, src ? *src : true, quiet ? *quiet : false));
     });
 
-  luaCtx.writeFunction("benchRule", [](std::shared_ptr<DNSRule> rule, boost::optional<int> times_, boost::optional<string> suffix_)  {
+  luaCtx.writeFunction("benchRule", [](std::shared_ptr<DNSRule> rule, boost::optional<unsigned int> times_, boost::optional<string> suffix_)  {
       setLuaNoSideEffect();
-      int times = times_.get_value_or(100000);
+      unsigned int times = times_.get_value_or(100000);
       DNSName suffix(suffix_.get_value_or("powerdns.com"));
       struct item {
         PacketBuffer packet;
@@ -442,7 +442,7 @@ void setupLuaRules(LuaContext& luaCtx)
       ComboAddress dummy("127.0.0.1");
       StopWatch sw;
       sw.start();
-      for(int n=0; n < times; ++n) {
+      for(unsigned int n=0; n < times; ++n) {
         item& i = items[n % items.size()];
         DNSQuestion dq(&i.qname, i.qtype, i.qclass, &i.rem, &i.rem, i.packet, dnsdist::Protocol::DoUDP, &sw.d_start);
         if (rule->matches(&dq)) {
@@ -466,25 +466,28 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new QNameRule(DNSName(qname)));
     });
 
-  luaCtx.writeFunction("QTypeRule", [](boost::variant<int, std::string> str) {
+  luaCtx.writeFunction("QTypeRule", [](boost::variant<unsigned int, std::string> str) {
       uint16_t qtype;
-      if(auto dir = boost::get<int>(&str)) {
+      if (auto dir = boost::get<unsigned int>(&str)) {
         qtype = *dir;
       }
       else {
-        string val=boost::get<string>(str);
+        string val = boost::get<string>(str);
         qtype = QType::chartocode(val.c_str());
-        if(!qtype)
+        if (!qtype) {
           throw std::runtime_error("Unable to convert '"+val+"' to a DNS type");
+        }
       }
       return std::shared_ptr<DNSRule>(new QTypeRule(qtype));
     });
 
-  luaCtx.writeFunction("QClassRule", [](int c) {
+  luaCtx.writeFunction("QClassRule", [](uint64_t c) {
+      checkParameterBound("QClassRule", c, std::numeric_limits<uint16_t>::max());
       return std::shared_ptr<DNSRule>(new QClassRule(c));
     });
 
-  luaCtx.writeFunction("OpcodeRule", [](uint8_t code) {
+  luaCtx.writeFunction("OpcodeRule", [](uint64_t code) {
+      checkParameterBound("OpcodeRule", code, std::numeric_limits<uint8_t>::max());
       return std::shared_ptr<DNSRule>(new OpcodeRule(code));
     });
 
@@ -496,7 +499,8 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new OrRule(a));
     });
 
-  luaCtx.writeFunction("DSTPortRule", [](uint16_t port) {
+  luaCtx.writeFunction("DSTPortRule", [](uint64_t port) {
+      checkParameterBound("DSTPortRule", port, std::numeric_limits<uint16_t>::max());
       return std::shared_ptr<DNSRule>(new DSTPortRule(port));
     });
 
@@ -512,11 +516,18 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new NotRule(rule));
     });
 
-  luaCtx.writeFunction("RecordsCountRule", [](uint8_t section, uint16_t minCount, uint16_t maxCount) {
+  luaCtx.writeFunction("RecordsCountRule", [](uint64_t section, uint64_t minCount, uint64_t maxCount) {
+      checkParameterBound("RecordsCountRule", section, std::numeric_limits<uint8_t>::max());
+      checkParameterBound("RecordsCountRule", minCount, std::numeric_limits<uint16_t>::max());
+      checkParameterBound("RecordsCountRule", maxCount, std::numeric_limits<uint16_t>::max());
       return std::shared_ptr<DNSRule>(new RecordsCountRule(section, minCount, maxCount));
     });
 
-  luaCtx.writeFunction("RecordsTypeCountRule", [](uint8_t section, uint16_t type, uint16_t minCount, uint16_t maxCount) {
+  luaCtx.writeFunction("RecordsTypeCountRule", [](uint64_t section, uint64_t type, uint64_t minCount, uint64_t maxCount) {
+      checkParameterBound("RecordsTypeCountRule", section, std::numeric_limits<uint8_t>::max());
+      checkParameterBound("RecordsTypeCountRule", type, std::numeric_limits<uint16_t>::max());
+      checkParameterBound("RecordsTypeCountRule", minCount, std::numeric_limits<uint16_t>::max());
+      checkParameterBound("RecordsTypeCountRule", maxCount, std::numeric_limits<uint16_t>::max());
       return std::shared_ptr<DNSRule>(new RecordsTypeCountRule(section, type, minCount, maxCount));
     });
 
@@ -524,27 +535,33 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new TrailingDataRule());
     });
 
-  luaCtx.writeFunction("QNameLabelsCountRule", [](unsigned int minLabelsCount, unsigned int maxLabelsCount) {
+  luaCtx.writeFunction("QNameLabelsCountRule", [](uint64_t minLabelsCount, uint64_t maxLabelsCount) {
+      checkParameterBound("QNameLabelsCountRule", minLabelsCount, std::numeric_limits<unsigned int>::max());
+      checkParameterBound("QNameLabelsCountRule", maxLabelsCount, std::numeric_limits<unsigned int>::max());
       return std::shared_ptr<DNSRule>(new QNameLabelsCountRule(minLabelsCount, maxLabelsCount));
     });
 
-  luaCtx.writeFunction("QNameWireLengthRule", [](size_t min, size_t max) {
+  luaCtx.writeFunction("QNameWireLengthRule", [](uint64_t min, uint64_t max) {
       return std::shared_ptr<DNSRule>(new QNameWireLengthRule(min, max));
     });
 
-  luaCtx.writeFunction("RCodeRule", [](uint8_t rcode) {
+  luaCtx.writeFunction("RCodeRule", [](uint64_t rcode) {
+      checkParameterBound("RCodeRule", rcode, std::numeric_limits<uint8_t>::max());
       return std::shared_ptr<DNSRule>(new RCodeRule(rcode));
     });
 
-  luaCtx.writeFunction("ERCodeRule", [](uint8_t rcode) {
+  luaCtx.writeFunction("ERCodeRule", [](uint64_t rcode) {
+      checkParameterBound("ERCodeRule", rcode, std::numeric_limits<uint8_t>::max());
       return std::shared_ptr<DNSRule>(new ERCodeRule(rcode));
     });
 
-  luaCtx.writeFunction("EDNSVersionRule", [](uint8_t version) {
+  luaCtx.writeFunction("EDNSVersionRule", [](uint64_t version) {
+      checkParameterBound("EDNSVersionRule", version, std::numeric_limits<uint8_t>::max());
       return std::shared_ptr<DNSRule>(new EDNSVersionRule(version));
     });
 
-  luaCtx.writeFunction("EDNSOptionRule", [](uint16_t optcode) {
+  luaCtx.writeFunction("EDNSOptionRule", [](uint64_t optcode) {
+      checkParameterBound("EDNSOptionRule", optcode, std::numeric_limits<uint16_t>::max());
       return std::shared_ptr<DNSRule>(new EDNSOptionRule(optcode));
     });
 
@@ -568,7 +585,7 @@ void setupLuaRules(LuaContext& luaCtx)
     return std::shared_ptr<DNSRule>(new PoolAvailableRule(poolname));
   });
 
-  luaCtx.writeFunction("PoolOutstandingRule", [](std::string poolname, size_t limit) {
+  luaCtx.writeFunction("PoolOutstandingRule", [](std::string poolname, uint64_t limit) {
     return std::shared_ptr<DNSRule>(new PoolOutstandingRule(poolname, limit));
   });
 
@@ -595,6 +612,7 @@ void setupLuaRules(LuaContext& luaCtx)
       return std::shared_ptr<DNSRule>(new QNameSetRule(names));
     });
 
+#if defined(HAVE_LMDB) || defined(HAVE_CDB)
   luaCtx.writeFunction("KeyValueStoreLookupRule", [](std::shared_ptr<KeyValueStore>& kvs, std::shared_ptr<KeyValueLookupKey>& lookupKey) {
       return std::shared_ptr<DNSRule>(new KeyValueStoreLookupRule(kvs, lookupKey));
     });
@@ -602,6 +620,7 @@ void setupLuaRules(LuaContext& luaCtx)
   luaCtx.writeFunction("KeyValueStoreRangeLookupRule", [](std::shared_ptr<KeyValueStore>& kvs, std::shared_ptr<KeyValueLookupKey>& lookupKey) {
       return std::shared_ptr<DNSRule>(new KeyValueStoreRangeLookupRule(kvs, lookupKey));
     });
+#endif /* defined(HAVE_LMDB) || defined(HAVE_CDB) */
 
   luaCtx.writeFunction("LuaRule", [](LuaRule::func_t func) {
       return std::shared_ptr<DNSRule>(new LuaRule(func));

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -941,6 +941,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     return std::shared_ptr<DownstreamState>(nullptr);
   });
 
+#ifndef DISABLE_CARBON
   luaCtx.writeFunction("carbonServer", [](const std::string& address, boost::optional<string> ourName, boost::optional<unsigned int> interval, boost::optional<string> namespace_name, boost::optional<string> instance_name) {
     setLuaSideEffect();
     auto ours = g_carbon.getCopy();
@@ -951,6 +952,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
                     interval ? *interval : 30});
     g_carbon.setState(ours);
   });
+#endif /* DISABLE_CARBON */
 
   luaCtx.writeFunction("webserver", [client, configCheck](const std::string& address, boost::optional<std::string> password, boost::optional<std::string> apiKey, const boost::optional<std::map<std::string, std::string>> customHeaders, const boost::optional<std::string> acl) {
     setLuaSideEffect();

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1811,6 +1811,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.writeFunction("help", [](boost::optional<std::string> command) {
     setLuaNoSideEffect();
     g_outputBuffer = "";
+#ifndef DISABLE_COMPLETION
     for (const auto& keyword : g_consoleKeywords) {
       if (!command) {
         g_outputBuffer += keyword.toString() + "\n";
@@ -1820,6 +1821,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
         return;
       }
     }
+#endif /* DISABLE_COMPLETION */
     if (command) {
       g_outputBuffer = "Nothing found for " + *command + "\n";
     }

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2254,6 +2254,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     g_PayloadSizeSelfGenAnswers = payloadSize;
   });
 
+#ifndef DISABLE_SECPOLL
   luaCtx.writeFunction("setSecurityPollSuffix", [](const std::string& suffix) {
     if (g_configurationDone) {
       g_outputBuffer = "setSecurityPollSuffix() cannot be used at runtime!\n";
@@ -2271,6 +2272,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
     g_secPollInterval = newInterval;
   });
+#endif /* DISABLE_SECPOLL */
 
   luaCtx.writeFunction("setSyslogFacility", [](boost::variant<int, std::string> facility) {
     setLuaSideEffect();

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -949,7 +949,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
                     (namespace_name && !namespace_name->empty()) ? *namespace_name : "dnsdist",
                     ourName ? *ourName : "",
                     (instance_name && !instance_name->empty()) ? *instance_name : "main",
-                    (interval && *interval < std::numeric_limits<unsigned int>::max())  ? static_cast<unsigned int>(*interval) : 30});
+                    (interval && *interval < std::numeric_limits<unsigned int>::max()) ? static_cast<unsigned int>(*interval) : 30});
     g_carbon.setState(ours);
   });
 #endif /* DISABLE_CARBON */

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1404,6 +1404,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     g_dynblockSMT.setState(smt);
   });
 
+#ifndef DISABLE_DEPRECATED_DYNBLOCK
   luaCtx.writeFunction("addDynBlocks",
                        [](const std::unordered_map<ComboAddress, unsigned int, ComboAddress::addressOnlyHash, ComboAddress::addressOnlyEqual>& m, const std::string& msg, boost::optional<int> seconds, boost::optional<DNSAction::Action> action) {
                          if (m.empty()) {
@@ -1496,6 +1497,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       g_outputBuffer = "Dynamic blocks action cannot be altered at runtime!\n";
     }
   });
+#endif /* DISABLE_DEPRECATED_DYNBLOCK */
 
   luaCtx.writeFunction("setDynBlocksPurgeInterval", [](uint64_t interval) {
     DynBlockMaintenance::s_expiredDynBlocksPurgeInterval = interval;
@@ -1751,6 +1753,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
+#ifndef DISABLE_DEPRECATED_DYNBLOCK
   luaCtx.writeFunction("addBPFFilterDynBlocks", [](const std::unordered_map<ComboAddress, unsigned int, ComboAddress::addressOnlyHash, ComboAddress::addressOnlyEqual>& m, std::shared_ptr<DynBPFFilter> dynbpf, boost::optional<int> seconds, boost::optional<std::string> msg) {
     if (!dynbpf) {
       return;
@@ -1767,6 +1770,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       }
     }
   });
+#endif /* DISABLE_DEPRECATED_DYNBLOCK */
 
 #endif /* HAVE_EBPF */
 

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1951,10 +1951,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
   luaCtx.writeFunction("setTCPInternalPipeBufferSize", [](uint64_t size) { g_tcpInternalPipeBufferSize = size; });
 
+#ifdef HAVE_NET_SNMP
   luaCtx.writeFunction("snmpAgent", [client, configCheck](bool enableTraps, boost::optional<std::string> daemonSocket) {
     if (client || configCheck)
       return;
-#ifdef HAVE_NET_SNMP
     if (g_configurationDone) {
       errlog("snmpAgent() cannot be used at runtime!");
       g_outputBuffer = "snmpAgent() cannot be used at runtime!\n";
@@ -1970,10 +1970,6 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     g_snmpEnabled = true;
     g_snmpTrapsEnabled = enableTraps;
     g_snmpAgent = new DNSDistSNMPAgent("dnsdist", daemonSocket ? *daemonSocket : std::string());
-#else
-      errlog("NET SNMP support is required to use snmpAgent()");
-      g_outputBuffer = "NET SNMP support is required to use snmpAgent()\n";
-#endif /* HAVE_NET_SNMP */
   });
 
   luaCtx.writeFunction("sendCustomTrap", [](const std::string& str) {
@@ -1981,6 +1977,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       g_snmpAgent->sendCustomTrap(str);
     }
   });
+#endif /* HAVE_NET_SNMP */
 
   luaCtx.writeFunction("setServerPolicy", [](const ServerPolicy& policy) {
     setLuaSideEffect();

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -32,6 +32,7 @@
 #include <thread>
 
 #include "dnsdist.hh"
+#include "dnsdist-carbon.hh"
 #include "dnsdist-console.hh"
 #include "dnsdist-dynblocks.hh"
 #include "dnsdist-ecs.hh"

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -131,8 +131,9 @@ private:
 
 typedef boost::variant<string, vector<pair<int, string>>, std::shared_ptr<DNSRule>, DNSName, vector<pair<int, DNSName> > > luadnsrule_t;
 std::shared_ptr<DNSRule> makeRule(const luadnsrule_t& var);
-typedef std::unordered_map<std::string, boost::variant<std::string> > luaruleparams_t;
+typedef std::unordered_map<std::string, std::string> luaruleparams_t;
 void parseRuleParams(boost::optional<luaruleparams_t> params, boost::uuids::uuid& uuid, std::string& name, uint64_t& creationOrder);
+void checkParameterBound(const std::string& parameter, uint64_t value, size_t max = std::numeric_limits<uint16_t>::max());
 
 typedef NetmaskTree<DynBlock, AddressAndPortRange> nmts_t;
 

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -139,7 +139,7 @@ typedef NetmaskTree<DynBlock, AddressAndPortRange> nmts_t;
 vector<std::function<void(void)>> setupLua(LuaContext& luaCtx, bool client, bool configCheck, const std::string& config);
 void setupLuaActions(LuaContext& luaCtx);
 void setupLuaBindings(LuaContext& luaCtx, bool client);
-void setupLuaBindingsDNSCrypt(LuaContext& luaCtx);
+void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client);
 void setupLuaBindingsDNSQuestion(LuaContext& luaCtx);
 void setupLuaBindingsKVS(LuaContext& luaCtx, bool client);
 void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client);

--- a/pdns/dnsdist-protobuf.cc
+++ b/pdns/dnsdist-protobuf.cc
@@ -20,6 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "config.h"
+
+#ifndef DISABLE_PROTOBUF
 #include "dnsdist.hh"
 #include "dnsdist-protobuf.hh"
 #include "protozero.hh"
@@ -184,3 +186,5 @@ void DNSDistProtoBufMessage::serialize(std::string& data) const
 
   m.commitResponse();
 }
+
+#endif /* DISABLE_PROTOBUF */

--- a/pdns/dnsdist-protobuf.hh
+++ b/pdns/dnsdist-protobuf.hh
@@ -23,6 +23,8 @@
 
 #include "dnsdist.hh"
 #include "dnsname.hh"
+
+#ifndef DISABLE_PROTOBUF
 #include "protozero.hh"
 
 class DNSDistProtoBufMessage
@@ -91,3 +93,5 @@ private:
   pdns::ProtoZero::Message::MessageType d_type{pdns::ProtoZero::Message::MessageType::DNSQueryType};
   bool d_includeCNAME{false};
 };
+
+#endif /* DISABLE_PROTOBUF */

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -52,7 +52,7 @@ struct WebserverConfig
   NetmaskGroup acl;
   std::unique_ptr<CredentialsHolder> password;
   std::unique_ptr<CredentialsHolder> apiKey;
-  boost::optional<std::map<std::string, std::string> > customHeaders;
+  boost::optional<std::unordered_map<std::string, std::string> > customHeaders;
   bool statsRequireAuthentication{true};
 };
 
@@ -354,7 +354,7 @@ static void handleCORS(const YaHTTP::Request& req, YaHTTP::Response& resp)
   }
 }
 
-static void addSecurityHeaders(YaHTTP::Response& resp, const boost::optional<std::map<std::string, std::string> >& customHeaders)
+static void addSecurityHeaders(YaHTTP::Response& resp, const boost::optional<std::unordered_map<std::string, std::string> >& customHeaders)
 {
   static const std::vector<std::pair<std::string, std::string> > headers = {
     { "X-Content-Type-Options", "nosniff" },
@@ -375,7 +375,7 @@ static void addSecurityHeaders(YaHTTP::Response& resp, const boost::optional<std
   }
 }
 
-static void addCustomHeaders(YaHTTP::Response& resp, const boost::optional<std::map<std::string, std::string> >& customHeaders)
+static void addCustomHeaders(YaHTTP::Response& resp, const boost::optional<std::unordered_map<std::string, std::string> >& customHeaders)
 {
   if (!customHeaders)
     return;
@@ -1537,7 +1537,7 @@ void setWebserverACL(const std::string& acl)
   g_webserverConfig.lock()->acl = std::move(newACL);
 }
 
-void setWebserverCustomHeaders(const boost::optional<std::map<std::string, std::string> > customHeaders)
+void setWebserverCustomHeaders(const boost::optional<std::unordered_map<std::string, std::string> > customHeaders)
 {
   g_webserverConfig.lock()->customHeaders = customHeaders;
 }

--- a/pdns/dnsdist-web.cc
+++ b/pdns/dnsdist-web.cc
@@ -38,7 +38,6 @@
 #include "dnsdist-web.hh"
 #include "dolog.hh"
 #include "gettime.hh"
-#include "htmlfiles.h"
 #include "threadname.hh"
 #include "sodcrypto.hh"
 #include "sstuff.hh"
@@ -1369,6 +1368,9 @@ void clearWebHandlers()
   s_webHandlers.clear();
 }
 
+#ifndef DISABLE_BUILTIN_HTML
+#include "htmlfiles.h"
+
 static void redirectToIndex(const YaHTTP::Request& req, YaHTTP::Response& resp)
 {
   const string charset = "; charset=utf-8";
@@ -1403,6 +1405,7 @@ static void handleBuiltInFiles(const YaHTTP::Request& req, YaHTTP::Response& res
 
   resp.status = 200;
 }
+#endif /* DISABLE_BUILTIN_HTML */
 
 void registerBuiltInWebHandlers()
 {
@@ -1415,11 +1418,13 @@ void registerBuiltInWebHandlers()
   registerWebHandler("/api/v1/servers/localhost/statistics", handleStatsOnly);
   registerWebHandler("/api/v1/servers/localhost/config", handleConfigDump);
   registerWebHandler("/api/v1/servers/localhost/config/allow-from", handleAllowFrom);
+#ifndef DISABLE_BUILTIN_HTML
   registerWebHandler("/", redirectToIndex);
 
   for (const auto& path : s_urlmap) {
     registerWebHandler("/" + path.first, handleBuiltInFiles);
   }
+#endif /* DISABLE_BUILTIN_HTML */
 }
 
 static void connectionThread(WebClientConnection&& conn)

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2240,10 +2240,12 @@ int main(int argc, char** argv)
   try {
     size_t udpBindsCount = 0;
     size_t tcpBindsCount = 0;
+#ifdef HAVE_LIBEDIT
 #ifndef DISABLE_COMPLETION
     rl_attempted_completion_function = my_completion;
     rl_completion_append_character = 0;
 #endif /* DISABLE_COMPLETION */
+#endif /* HAVE_LIBEDIT */
 
     signal(SIGPIPE, SIG_IGN);
     signal(SIGCHLD, SIG_IGN);
@@ -2383,6 +2385,9 @@ int main(int argc, char** argv)
 #endif
 #ifdef HAVE_IPCIPHER
         cout<<"ipcipher ";
+#endif
+#ifdef HAVE_LIBEDIT
+        cout<<"libeditr ";
 #endif
 #ifdef HAVE_LIBSODIUM
         cout<<"libsodium ";

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2390,7 +2390,9 @@ int main(int argc, char** argv)
 #ifdef HAVE_NGHTTP2
         cout<<"outgoing-dns-over-https(nghttp2) ";
 #endif
+#ifndef DISABLE_PROTOBUF
         cout<<"protobuf ";
+#endif
 #ifdef HAVE_RE2
         cout<<"re2 ";
 #endif

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2237,8 +2237,10 @@ int main(int argc, char** argv)
   try {
     size_t udpBindsCount = 0;
     size_t tcpBindsCount = 0;
+#ifndef DISABLE_COMPLETION
     rl_attempted_completion_function = my_completion;
     rl_completion_append_character = 0;
+#endif /* DISABLE_COMPLETION */
 
     signal(SIGPIPE, SIG_IGN);
     signal(SIGCHLD, SIG_IGN);

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -46,6 +46,7 @@
 
 #include "dnsdist.hh"
 #include "dnsdist-cache.hh"
+#include "dnsdist-carbon.hh"
 #include "dnsdist-console.hh"
 #include "dnsdist-dynblocks.hh"
 #include "dnsdist-ecs.hh"

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2378,7 +2378,7 @@ int main(int argc, char** argv)
 #ifdef HAVE_FSTRM
         cout<<"fstrm ";
 #endif
-#ifdef HAVE_LIBCRYPTO
+#ifdef HAVE_IPCIPHER
         cout<<"ipcipher ";
 #endif
 #ifdef HAVE_LIBSODIUM

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2691,8 +2691,10 @@ int main(int argc, char** argv)
       }
     }
 
+#ifndef DISABLE_CARBON
     thread carbonthread(carbonDumpThread);
     carbonthread.detach();
+#endif /* DISABLE_CARBON */
 
     thread stattid(maintThread);
     stattid.detach();

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -1840,6 +1840,7 @@ static void dynBlockMaintenanceThread()
   DynBlockMaintenance::run();
 }
 
+#ifndef DISABLE_SECPOLL
 static void secPollThread()
 {
   setThreadName("dnsdist/secpoll");
@@ -1853,6 +1854,7 @@ static void secPollThread()
     sleep(g_secPollInterval);
   }
 }
+#endif /* DISABLE_SECPOLL */
 
 static void healthChecksThread()
 {
@@ -2704,10 +2706,12 @@ int main(int argc, char** argv)
     thread dynBlockMaintThread(dynBlockMaintenanceThread);
     dynBlockMaintThread.detach();
 
+#ifndef DISABLE_SECPOLL
     if (!g_secPollSuffix.empty()) {
       thread secpollthread(secPollThread);
       secpollthread.detach();
     }
+#endif /* DISABLE_SECPOLL */
 
     if(g_cmdLine.beSupervised) {
 #ifdef HAVE_SYSTEMD

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -947,15 +947,6 @@ private:
   bool d_useECS{false};
 };
 
-struct CarbonConfig
-{
-  ComboAddress server;
-  std::string namespace_name;
-  std::string ourname;
-  std::string instance_name;
-  unsigned int interval;
-};
-
 enum ednsHeaderFlags {
   EDNS_HEADER_FLAG_NONE = 0,
   EDNS_HEADER_FLAG_DO = 32768
@@ -982,7 +973,6 @@ struct DNSDistResponseRuleAction
 extern GlobalStateHolder<SuffixMatchTree<DynBlock>> g_dynblockSMT;
 extern DNSAction::Action g_dynBlockAction;
 
-extern GlobalStateHolder<vector<CarbonConfig> > g_carbon;
 extern GlobalStateHolder<ServerPolicy> g_policy;
 extern GlobalStateHolder<servers_t> g_dstates;
 extern GlobalStateHolder<pools_t> g_pools;
@@ -1087,4 +1077,3 @@ int pickBackendSocketForSending(std::shared_ptr<DownstreamState>& state);
 ssize_t udpClientSendRequestToBackend(const std::shared_ptr<DownstreamState>& ss, const int sd, const PacketBuffer& request, bool healthCheck = false);
 void handleResponseSent(const IDState& ids, double udiff, const ComboAddress& client, const ComboAddress& backend, unsigned int size, const dnsheader& cleartextDH, dnsdist::Protocol protocol);
 
-void carbonDumpThread();

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -135,7 +135,7 @@ dnsdist_SOURCES = \
 	dnscrypt.cc dnscrypt.hh \
 	dnsdist-backend.cc \
 	dnsdist-cache.cc dnsdist-cache.hh \
-	dnsdist-carbon.cc \
+	dnsdist-carbon.cc dnsdist-carbon.hh \
 	dnsdist-console.cc dnsdist-console.hh \
 	dnsdist-dnscrypt.cc \
 	dnsdist-dynblocks.cc dnsdist-dynblocks.hh \

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -98,7 +98,7 @@ AS_IF([test "x$enable_dns_over_https" != "xno"], [
 
 PDNS_WITH_NGHTTP2
 
-PDNS_CHECK_CDB
+DNSDIST_WITH_CDB
 PDNS_CHECK_LMDB
 PDNS_ENABLE_IPCIPHER
 

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -24,7 +24,7 @@ CXXFLAGS="-g -O3 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wmissing-declarat
 PDNS_WITH_LIBSODIUM
 PDNS_CHECK_DNSTAP([auto])
 PDNS_CHECK_RAGEL([dnslabeltext.cc], [www.dnsdist.org])
-PDNS_CHECK_LIBEDIT
+PDNS_WITH_LIBEDIT
 PDNS_CHECK_CLOCK_GETTIME
 
 PDNS_CHECK_OS
@@ -186,6 +186,10 @@ AS_IF([test "x$systemd" != "xn"],
 AS_IF([test "x$enable_ipcipher" != "xno"],
   [AC_MSG_NOTICE([ipcipher: yes])],
   [AC_MSG_NOTICE([ipcipher: no])]
+)
+AS_IF([test "x$LIBEDIT_LIBS" != "x"],
+  [AC_MSG_NOTICE([libedit: yes])],
+  [AC_MSG_NOTICE([libedit: no])]
 )
 AS_IF([test "x$LIBSODIUM_LIBS" != "x"],
   [AC_MSG_NOTICE([libsodium: yes])],

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -57,7 +57,7 @@ AC_SUBST([IPCRYPT_LIBS], ['$(top_builddir)/ext/ipcrypt/libipcrypt.la'])
 
 PDNS_WITH_LUA([mandatory])
 AS_IF([test "x$LUAPC" = "xluajit"], [
-  # export all symbols to be able to use the Lua FFI interface
+  # export all symbols with default visibility, to be able to use the Lua FFI interface
   AC_MSG_NOTICE([Adding -rdynamic to export all symbols for the Lua FFI interface])
   LDFLAGS="$LDFLAGS -rdynamic"
 ])

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -100,6 +100,7 @@ PDNS_WITH_NGHTTP2
 
 PDNS_CHECK_CDB
 PDNS_CHECK_LMDB
+PDNS_ENABLE_IPCIPHER
 
 AX_CXX_COMPILE_STDCXX_17([noext], [mandatory])
 
@@ -182,7 +183,7 @@ AS_IF([test "x$systemd" != "xn"],
   [AC_MSG_NOTICE([systemd: yes])],
   [AC_MSG_NOTICE([systemd: no])]
 )
-AS_IF([test "x$LIBCRYPTO_LIBS" != "x"],
+AS_IF([test "x$enable_ipcipher" != "xno"],
   [AC_MSG_NOTICE([ipcipher: yes])],
   [AC_MSG_NOTICE([ipcipher: no])]
 )

--- a/pdns/dnsdistdist/dnsdist-carbon.hh
+++ b/pdns/dnsdistdist/dnsdist-carbon.hh
@@ -21,6 +21,9 @@
  */
 #pragma once
 
+#include "config.h"
+
+#ifndef DISABLE_CARBON
 #include "sholder.hh"
 #include "iputils.hh"
 
@@ -35,3 +38,4 @@ struct CarbonConfig
 
 extern GlobalStateHolder<std::vector<CarbonConfig> > g_carbon;
 void carbonDumpThread();
+#endif /* DISABLE_CARBON */

--- a/pdns/dnsdistdist/dnsdist-carbon.hh
+++ b/pdns/dnsdistdist/dnsdist-carbon.hh
@@ -1,0 +1,37 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "sholder.hh"
+#include "iputils.hh"
+
+struct CarbonConfig
+{
+  ComboAddress server;
+  std::string namespace_name;
+  std::string ourname;
+  std::string instance_name;
+  unsigned int interval;
+};
+
+extern GlobalStateHolder<std::vector<CarbonConfig> > g_carbon;
+void carbonDumpThread();

--- a/pdns/dnsdistdist/dnsdist-carbon.hh
+++ b/pdns/dnsdistdist/dnsdist-carbon.hh
@@ -36,6 +36,6 @@ struct CarbonConfig
   unsigned int interval;
 };
 
-extern GlobalStateHolder<std::vector<CarbonConfig> > g_carbon;
+extern GlobalStateHolder<std::vector<CarbonConfig>> g_carbon;
 void carbonDumpThread();
 #endif /* DISABLE_CARBON */

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-dnscrypt.cc
@@ -171,11 +171,9 @@ void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client)
         g_outputBuffer = "Error: " + string(e.what()) + "\n";
       }
     });
-#endif
 
     luaCtx.writeFunction("generateDNSCryptProviderKeys", [client](const std::string& publicKeyFile, const std::string privateKeyFile) {
       setLuaNoSideEffect();
-#ifdef HAVE_DNSCRYPT
       if (client) {
         return;
       }
@@ -203,14 +201,10 @@ void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client)
 
       sodium_memzero(privateKey, sizeof(privateKey));
       sodium_munlock(privateKey, sizeof(privateKey));
-#else
-      g_outputBuffer = "Error: DNSCrypt support is not enabled.\n";
-#endif
     });
 
     luaCtx.writeFunction("printDNSCryptProviderFingerprint", [](const std::string& publicKeyFile) {
       setLuaNoSideEffect();
-#ifdef HAVE_DNSCRYPT
       unsigned char publicKey[DNSCRYPT_PROVIDER_PUBLIC_KEY_SIZE];
 
       try {
@@ -228,8 +222,6 @@ void setupLuaBindingsDNSCrypt(LuaContext& luaCtx, bool client)
         errlog(e.what());
         g_outputBuffer = "Error: " + string(e.what()) + "\n";
       }
-#else
-      g_outputBuffer = "Error: DNSCrypt support is not enabled.\n";
-#endif
     });
+#endif
 }

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-packetcache.cc
@@ -119,6 +119,8 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
 
       return res;
     });
+
+#ifndef DISABLE_PACKETCACHE_BINDINGS
   luaCtx.registerFunction<std::string(std::shared_ptr<DNSDistPacketCache>::*)()const>("toString", [](const std::shared_ptr<DNSDistPacketCache>& cache) {
       if (cache) {
         return cache->toString();
@@ -211,4 +213,5 @@ void setupLuaBindingsPacketCache(LuaContext& luaCtx, bool client)
         g_outputBuffer += "Dumped " + std::to_string(records) + " records\n";
       }
     });
+#endif /* DISABLE_PACKETCACHE_BINDINGS */
 }

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -26,11 +26,8 @@
 #include "dnsdist-protobuf.hh"
 #include "dnstap.hh"
 #include "fstrm_logger.hh"
-#include "remote_logger.hh"
-
-#ifdef HAVE_LIBCRYPTO
 #include "ipcipher.hh"
-#endif /* HAVE_LIBCRYPTO */
+#include "remote_logger.hh"
 
 #ifdef HAVE_FSTRM
 static void parseFSTRMOptions(const boost::optional<std::unordered_map<std::string, unsigned int>>& params, std::unordered_map<string, unsigned int>& options)
@@ -51,7 +48,7 @@ static void parseFSTRMOptions(const boost::optional<std::unordered_map<std::stri
 
 void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
 {
-#ifdef HAVE_LIBCRYPTO
+#ifdef HAVE_IPCIPHER
   luaCtx.registerFunction<ComboAddress(ComboAddress::*)(const std::string& key)const>("ipencrypt", [](const ComboAddress& ca, const std::string& key) {
       return encryptCA(ca, key);
     });
@@ -62,7 +59,7 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.writeFunction("makeIPCipherKey", [](const std::string& password) {
       return makeIPCipherKey(password);
     });
-#endif /* HAVE_LIBCRYPTO */
+#endif /* HAVE_IPCIPHER */
 
   /* ProtobufMessage */
   luaCtx.registerFunction<void(DNSDistProtoBufMessage::*)(std::string)>("setTag", [](DNSDistProtoBufMessage& message, const std::string& strValue) {

--- a/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings-protobuf.cc
@@ -20,9 +20,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "config.h"
+
 #include "dnsdist.hh"
 #include "dnsdist-lua.hh"
 
+#ifndef DISABLE_PROTOBUF
 #include "dnsdist-protobuf.hh"
 #include "dnstap.hh"
 #include "fstrm_logger.hh"
@@ -163,3 +165,8 @@ void setupLuaBindingsProtoBuf(LuaContext& luaCtx, bool client, bool configCheck)
       return std::string();
   });
 }
+#else /* DISABLE_PROTOBUF */
+void setupLuaBindingsProtoBuf(LuaContext&, bool, bool)
+{
+}
+#endif /* DISABLE_PROTOBUF */

--- a/pdns/dnsdistdist/dnsdist-lua-web.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-web.cc
@@ -29,6 +29,7 @@ void registerWebHandler(const std::string& endpoint, std::function<void(const Ya
 
 void setupLuaWeb(LuaContext& luaCtx)
 {
+#ifndef DISABLE_LUA_WEB_HANDLERS
   luaCtx.writeFunction("registerWebHandler", [](const std::string& path, std::function<void(const YaHTTP::Request*, YaHTTP::Response*)> handler) {
     /* LuaWrapper does a copy for objects passed by reference, so we pass a pointer */
     registerWebHandler(path, [handler](const YaHTTP::Request& req, YaHTTP::Response& resp) { handler(&req, &resp); });
@@ -75,5 +76,6 @@ void setupLuaWeb(LuaContext& luaCtx)
       resp.headers.insert({entry.first, entry.second});
     }
   });
+#endif /* DISABLE_LUA_WEB_HANDLERS */
 }
 

--- a/pdns/dnsdistdist/dnsdist-prometheus.hh
+++ b/pdns/dnsdistdist/dnsdist-prometheus.hh
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#ifndef DISABLE_PROMETHEUS
 // Metric types for Prometheus
 enum class PrometheusMetricType: int {
     counter = 1,
@@ -70,3 +71,4 @@ struct MetricDefinitionStorage {
 
   static const std::map<std::string, MetricDefinition> metrics;
 };
+#endif /* DISABLE_PROMETHEUS */

--- a/pdns/dnsdistdist/dnsdist-secpoll.cc
+++ b/pdns/dnsdistdist/dnsdist-secpoll.cc
@@ -20,9 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "config.h"
+#include "dnsdist-secpoll.hh"
+#ifndef DISABLE_SECPOLL
 
-#include <string>
 #include <vector>
 
 #ifdef HAVE_LIBSODIUM
@@ -36,7 +36,6 @@
 #include "sstuff.hh"
 
 #include "dnsdist.hh"
-#include "dnsdist-secpoll.hh"
 
 #ifndef PACKAGEVERSION
 #define PACKAGEVERSION PACKAGE_VERSION
@@ -244,3 +243,5 @@ void doSecPoll(const std::string& suffix)
     g_secPollDone = true;
   }
 }
+
+#endif /* DISABLE_SECPOLL */

--- a/pdns/dnsdistdist/dnsdist-secpoll.hh
+++ b/pdns/dnsdistdist/dnsdist-secpoll.hh
@@ -21,7 +21,13 @@
  */
 #pragma once
 
+#include "config.h"
+
+#ifndef DISABLE_SECPOLL
+#include <string>
+
 extern std::string g_secPollSuffix;
 extern time_t g_secPollInterval;
 
 void doSecPoll(const std::string& suffix);
+#endif /* DISABLE_SECPOLL */

--- a/pdns/dnsdistdist/dnsdist-web.hh
+++ b/pdns/dnsdistdist/dnsdist-web.hh
@@ -5,7 +5,7 @@
 void setWebserverAPIKey(std::unique_ptr<CredentialsHolder>&& apiKey);
 void setWebserverPassword(std::unique_ptr<CredentialsHolder>&& password);
 void setWebserverACL(const std::string& acl);
-void setWebserverCustomHeaders(const boost::optional<std::map<std::string, std::string> > customHeaders);
+void setWebserverCustomHeaders(const boost::optional<std::unordered_map<std::string, std::string> > customHeaders);
 void setWebserverStatsRequireAuthentication(bool);
 void setWebserverMaxConcurrentConnections(size_t);
 

--- a/pdns/dnsdistdist/docs/install.rst
+++ b/pdns/dnsdistdist/docs/install.rst
@@ -107,3 +107,36 @@ OS Specific Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 None, really.
+
+Build options
+~~~~~~~~~~~~~
+
+Our ``configure`` script provides a fair number of options with regard to which features should be enabled, as well as which libraries should be used. In addition to these options, more features can be disabled at compile-time by defining the following symbols:
+
+* ``DISABLE_BUILTIN_HTML`` removes the built-in web pages
+* ``DISABLE_CARBON`` for carbon support
+* ``DISABLE_COMPLETION`` for completion support in the console
+* ``DISABLE_DEPRECATED_DYNBLOCK`` for legacy dynamic blocks not using the new ``DynBlockRulesGroup`` interface
+* ``DISABLE_ECS_ACTIONS`` to disable actions altering EDNS Client Subnet
+* ``DISABLE_LUA_WEB_HANDLERS`` for custom Lua web handlers support
+* ``DISABLE_PROMETHEUS`` for prometheus
+* ``DISABLE_PROTOBUF`` for protocol-buffer support, including dnstap
+* ``DISABLE_RECVMMSG`` for ``recvmmsg`` support
+* ``DISABLE_RULES_ALTERING_QUERIES`` to remove rules altering the content of queries
+* ``DISABLE_SECPOLL`` for security polling
+* ``DISABLE_WEB_CONFIG`` to disable accessing the configuration via the web interface
+
+Additionally several Lua bindings can be removed when they are not needed, as they increase the memory required during compilation and the size of the final binary:
+
+* ``DDISABLE_CLIENT_STATE_BINDINGS``
+* ``DISABLE_COMBO_ADDR_BINDINGS``
+* ``DISABLE_DNSHEADER_BINDINGS``
+* ``DISABLE_DNSNAME_BINDINGS``
+* ``DISABLE_DOWNSTREAM_BINDINGS``
+* ``DISABLE_NETMASK_BINDINGS``
+* ``DISABLE_NON_FFI_DQ_BINDINGS``
+* ``DISABLE_PACKETCACHE_BINDINGS``
+* ``DISABLE_POLICIES_BINDINGS``
+* ``DISABLE_QPS_LIMITER_BINDINGS``
+* ``DISABLE_SUFFIX_MATCH_BINDINGS``
+* ``DISABLE_TOP_N_BINDINGS``

--- a/pdns/dnsdistdist/docs/install.rst
+++ b/pdns/dnsdistdist/docs/install.rst
@@ -128,7 +128,7 @@ Our ``configure`` script provides a fair number of options with regard to which 
 
 Additionally several Lua bindings can be removed when they are not needed, as they increase the memory required during compilation and the size of the final binary:
 
-* ``DDISABLE_CLIENT_STATE_BINDINGS``
+* ``DISABLE_CLIENT_STATE_BINDINGS``
 * ``DISABLE_COMBO_ADDR_BINDINGS``
 * ``DISABLE_DNSHEADER_BINDINGS``
 * ``DISABLE_DNSNAME_BINDINGS``

--- a/pdns/dnsdistdist/m4/dnsdist_with_cdb.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_with_cdb.m4
@@ -1,0 +1,39 @@
+AC_DEFUN([DNSDIST_WITH_CDB], [
+  AC_MSG_CHECKING([whether we will we liniking with libcdb])
+  HAVE_CDB=0
+  AC_ARG_WITH([cdb],
+    AS_HELP_STRING([--with-cdb], [use CDB @<:@default=auto@:>@]),
+    [with_cdb=$withval],
+    [with_cdb=auto]
+  )
+  AC_MSG_RESULT([$with_cdb])
+
+  AS_IF([test "x$with_cdb" != "xno"], [
+    AS_IF([test "x$with_cdb" = "xyes" -o "x$with_cdb" = "xauto"], [
+      PKG_CHECK_MODULES([CDB], [libcdb], [
+        [HAVE_CDB=1]
+        AC_DEFINE([HAVE_CDB], [1], [Define to 1 if you have CDB])
+        ],
+        [AC_CHECK_HEADERS([cdb.h],
+          [AC_CHECK_LIB([cdb], [cdb_find],
+            [
+              CDB_LIBS="-lcdb"
+              AC_DEFINE([HAVE_CDB], [1], [Define to 1 if you have CDB])
+              [HAVE_CDB=1]
+            ],
+            [:]
+          )],
+          [:]
+        )]
+      )
+    ])
+  ])
+  AC_SUBST(CDB_LIBS)
+  AC_SUBST(CDB_CFLAGS)
+  AM_CONDITIONAL([HAVE_CDB], [test "x$CDB_LIBS" != "x"])
+  AS_IF([test "x$with_cdb" = "xyes"], [
+    AS_IF([test x"$CDB_LIBS" = "x"], [
+      AC_MSG_ERROR([CDB requested but libraries were not found])
+    ])
+  ])
+])

--- a/pdns/dnsdistdist/m4/pdns_check_cdb.m4
+++ b/pdns/dnsdistdist/m4/pdns_check_cdb.m4
@@ -1,1 +1,0 @@
-../../../m4/pdns_check_cdb.m4

--- a/pdns/dnsdistdist/m4/pdns_check_libedit.m4
+++ b/pdns/dnsdistdist/m4/pdns_check_libedit.m4
@@ -12,13 +12,6 @@ AC_DEFUN([PDNS_WITH_LIBEDIT], [
       PKG_CHECK_MODULES([LIBEDIT], [libedit], [
         [HAVE_LIBEDIT=1]
         AC_DEFINE([HAVE_LIBEDIT], [1], [Define to 1 if you have libedit])
-        save_CFLAGS=$CFLAGS
-        save_LIBS=$LIBS
-        CFLAGS="$LIBEDIT_CFLAGS $CFLAGS"
-        LIBS="$LIBEDIT_LIBS $LIBS"
-        CFLAGS=$save_CFLAGS
-        LIBS=$save_LIBS
-
       ], [ : ])
     ])
   ])

--- a/pdns/dnsdistdist/m4/pdns_check_libedit.m4
+++ b/pdns/dnsdistdist/m4/pdns_check_libedit.m4
@@ -1,3 +1,31 @@
-AC_DEFUN([PDNS_CHECK_LIBEDIT], [
-  PKG_CHECK_MODULES([LIBEDIT], [libedit])
+AC_DEFUN([PDNS_WITH_LIBEDIT], [
+  AC_MSG_CHECKING([whether to link in libedit])
+  AC_ARG_WITH([libedit],
+    AS_HELP_STRING([--with-libedit], [enable libedit support @<:@default=yes@:>@]),
+    [with_libedit=$enableval],
+    [with_libedit=yes]
+  )
+  AC_MSG_RESULT([$with_libedit])
+
+  AS_IF([test "x$with_libedit" != "xno"], [
+    AS_IF([test "x$with_libedit" = "xyes" -o "x$with_libedit" = "xauto"], [
+      PKG_CHECK_MODULES([LIBEDIT], [libedit], [
+        [HAVE_LIBEDIT=1]
+        AC_DEFINE([HAVE_LIBEDIT], [1], [Define to 1 if you have libedit])
+        save_CFLAGS=$CFLAGS
+        save_LIBS=$LIBS
+        CFLAGS="$LIBEDIT_CFLAGS $CFLAGS"
+        LIBS="$LIBEDIT_LIBS $LIBS"
+        CFLAGS=$save_CFLAGS
+        LIBS=$save_LIBS
+
+      ], [ : ])
+    ])
+  ])
+  AM_CONDITIONAL([HAVE_LIBEDIT], [test "x$LIBEDIT_LIBS" != "x"])
+  AS_IF([test "x$with_libedit" = "xyes"], [
+    AS_IF([test x"$LIBEDIT_LIBS" = "x"], [
+      AC_MSG_ERROR([libedit support requested but library not found])
+    ])
+  ])
 ])

--- a/pdns/dnsdistdist/m4/pdns_enable_ipcipher.m4
+++ b/pdns/dnsdistdist/m4/pdns_enable_ipcipher.m4
@@ -1,0 +1,1 @@
+../../../m4/pdns_enable_ipcipher.m4

--- a/pdns/dnsdistdist/m4/pdns_with_nghttp2.m4
+++ b/pdns/dnsdistdist/m4/pdns_with_nghttp2.m4
@@ -13,13 +13,6 @@ AC_DEFUN([PDNS_WITH_NGHTTP2], [
       PKG_CHECK_MODULES([NGHTTP2], [libnghttp2], [
         [HAVE_NGHTTP2=1]
         AC_DEFINE([HAVE_NGHTTP2], [1], [Define to 1 if you have nghttp2])
-        save_CFLAGS=$CFLAGS
-        save_LIBS=$LIBS
-        CFLAGS="$NGHTTP2_CFLAGS $CFLAGS"
-        LIBS="$NGHTTP2_LIBS $LIBS"
-        CFLAGS=$save_CFLAGS
-        LIBS=$save_LIBS
-
       ], [ : ])
     ])
   ])

--- a/pdns/dnsdistdist/test-dnsdistrules_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrules_cc.cc
@@ -7,6 +7,14 @@
 
 #include "dnsdist-rules.hh"
 
+void checkParameterBound(const std::string& parameter, uint64_t value, size_t max);
+void checkParameterBound(const std::string& parameter, uint64_t value, size_t max)
+{
+  if (value > std::numeric_limits<uint16_t>::max()) {
+    throw std::runtime_error("The value passed to " + parameter + " is too large, the maximum is " + std::to_string(max));
+  }
+}
+
 static DNSQuestion getDQ(const DNSName* providedName = nullptr)
 {
   static const DNSName qname("powerdns.com.");

--- a/pdns/dnsdistdist/test-dnsdistrules_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrules_cc.cc
@@ -10,7 +10,7 @@
 void checkParameterBound(const std::string& parameter, uint64_t value, size_t max);
 void checkParameterBound(const std::string& parameter, uint64_t value, size_t max)
 {
-  if (value > std::numeric_limits<uint16_t>::max()) {
+  if (value > max) {
     throw std::runtime_error("The value passed to " + parameter + " is too large, the maximum is " + std::to_string(max));
   }
 }

--- a/pdns/dnstap.cc
+++ b/pdns/dnstap.cc
@@ -3,6 +3,8 @@
 #include "gettime.hh"
 #include "dnstap.hh"
 
+#ifndef DISABLE_PROTOBUF
+
 #include <protozero/pbf_writer.hpp>
 
 namespace DnstapBaseFields {
@@ -90,3 +92,5 @@ void DnstapMessage::setExtra(const std::string& extra)
   protozero::pbf_writer pbf{d_buffer};
   pbf.add_bytes(DnstapBaseFields::extra, extra);
 }
+
+#endif /* DISABLE_PROTOBUF */

--- a/pdns/dnstap.hh
+++ b/pdns/dnstap.hh
@@ -28,6 +28,8 @@
 
 #include "dnsname.hh"
 #include "iputils.hh"
+
+#ifndef DISABLE_PROTOBUF
 #include "protozero.hh"
 
 class DnstapMessage
@@ -43,3 +45,5 @@ public:
 protected:
   std::string& d_buffer;
 };
+
+#endif /* DISABLE_PROTOBUF */

--- a/pdns/dnswasher.cc
+++ b/pdns/dnswasher.cc
@@ -37,6 +37,8 @@ otherwise, obfuscate the response IP address
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#ifdef HAVE_IPCIPHER
 #include "statbag.hh"
 #include "dnspcap.hh"
 #include "iputils.hh"
@@ -272,3 +274,11 @@ catch(std::exception& e)
 {
   cerr<<"Fatal: "<<e.what()<<endl;
 }
+
+#else
+int main()
+{
+  cerr<<"dnswasher requires ipcipher support, which is not available"<<endl;
+  exit(1);
+}
+#endif /* HAVE_IPCIPHER */

--- a/pdns/ipcipher.cc
+++ b/pdns/ipcipher.cc
@@ -3,6 +3,7 @@
 #include <openssl/aes.h>
 #include <openssl/evp.h>
 
+#ifdef HAVE_IPCIPHER
 /*
 int PKCS5_PBKDF2_HMAC_SHA1(const char *pass, int passlen,
                            const unsigned char *salt, int saltlen, int iter,
@@ -97,3 +98,5 @@ ComboAddress decryptCA(const ComboAddress& ca, const std::string& key)
     throw std::runtime_error("ipcrypt can't decrypt non-IP addresses");
 
 }
+
+#endif /* HAVE_IPCIPHER */

--- a/pdns/ipcipher.hh
+++ b/pdns/ipcipher.hh
@@ -1,9 +1,13 @@
 #pragma once
+#include "config.h"
+
 #include "iputils.hh"
 #include <string>
 
 // see https://powerdns.org/ipcipher
 
+#ifdef HAVE_IPCIPHER
 ComboAddress encryptCA(const ComboAddress& ca, const std::string& key);
 ComboAddress decryptCA(const ComboAddress& ca, const std::string& key);
 std::string makeIPCipherKey(const std::string& password);
+#endif /* HAVE_IPCIPHER */

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1344,6 +1344,7 @@ static int editZone(const DNSName &zone) {
   return EXIT_SUCCESS;
 }
 
+#ifdef HAVE_IPCIPHER
 static int xcryptIP(const std::string& cmd, const std::string& ip, const std::string& rkey)
 {
 
@@ -1357,7 +1358,7 @@ static int xcryptIP(const std::string& cmd, const std::string& ip, const std::st
   cout<<ret.toString()<<endl;
   return EXIT_SUCCESS;
 }
-
+#endif /* HAVE_IPCIPHER */
 
 static int loadZone(const DNSName& zone, const string& fname) {
   UeberBackend B;
@@ -2434,6 +2435,7 @@ try
       cerr<<"Syntax: pdnsutil [ipencrypt|ipdecrypt] IP passphrase [key]"<<endl;
       return 0;
     }
+#ifdef HAVE_IPCIPHER
     string key;
     if(cmds.size()==4) {
       if (B64Decode(cmds.at(2), key) < 0) {
@@ -2445,6 +2447,10 @@ try
       key = makeIPCipherKey(cmds.at(2));
     }
     exit(xcryptIP(cmds.at(0), cmds.at(1), key));
+#else
+    cerr<<cmds.at(0)<<" requires ipcipher support which is not available"<<endl;
+    return 0;
+#endif /* HAVE_IPCIPHER */
   }
 
   if (cmds.at(0) == "test-algorithms") {

--- a/pdns/protozero.cc
+++ b/pdns/protozero.cc
@@ -21,6 +21,8 @@
  */
 
 #include "protozero.hh"
+
+#ifndef DISABLE_PROTOBUF
 #include "dnsparser.hh"
 
 void pdns::ProtoZero::Message::encodeComboAddress(const protozero::pbf_tag_type type, const ComboAddress& ca)
@@ -157,3 +159,5 @@ void pdns::ProtoZero::Message::addRR(const DNSName& name, uint16_t uType, uint16
   pbf_rr.add_uint32(static_cast<protozero::pbf_tag_type>(pdns::ProtoZero::Message::RRField::ttl), uTTL);
   pbf_rr.add_string(static_cast<protozero::pbf_tag_type>(pdns::ProtoZero::Message::RRField::rdata), blob);
 }
+
+#endif /* DISABLE_PROTOBUF */

--- a/pdns/protozero.hh
+++ b/pdns/protozero.hh
@@ -21,12 +21,15 @@
  */
 #pragma once
 
-#include <protozero/pbf_writer.hpp>
-
 #include "config.h"
+
 #include "iputils.hh"
 #include "gettime.hh"
 #include "uuid-utils.hh"
+
+#ifndef DISABLE_PROTOBUF
+
+#include <protozero/pbf_writer.hpp>
 
 namespace pdns {
   namespace ProtoZero {
@@ -270,3 +273,5 @@ namespace pdns {
     };
   };
 };
+
+#endif /* DISABLE_PROTOBUF */

--- a/pdns/test-ipcrypt_cc.cc
+++ b/pdns/test-ipcrypt_cc.cc
@@ -3,6 +3,9 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#ifdef HAVE_IPCIPHER
+
 #include <boost/test/unit_test.hpp>
 #include "ipcipher.hh"
 #include "misc.hh"
@@ -66,5 +69,6 @@ BOOST_AUTO_TEST_CASE(test_ipcrypt6)
   BOOST_CHECK_EQUAL(ca.toString(), decrypted.toString());
 }
 
-
 BOOST_AUTO_TEST_SUITE_END()
+
+#endif /* HAVE_IPCIPHER */

--- a/tasks.py
+++ b/tasks.py
@@ -339,7 +339,7 @@ def ci_dnsdist_configure(c, features):
                      CXX='clang++-12' \
                      --enable-option-checking=fatal \
                      --enable-unit-tests \
-                     --prefix=/opt/dnsdist %s %s %s''' % (cflags, cxxflags, features_set, sanitizers), warn=True)
+                     --prefix=/opt/dnsdist %s %s''' % (cflags, cxxflags, features_set, sanitizers), warn=True)
     if res.exited != 0:
         c.run('cat config.log')
         raise UnexpectedExit(res)

--- a/tasks.py
+++ b/tasks.py
@@ -304,6 +304,7 @@ def ci_dnsdist_configure(c, features):
                       --without-libsodium \
                       --without-lmdb \
                       --without-net-snmp \
+                      --without-nghttp2 \
                       --without-re2 '
       additional_flags = '-DDISABLE_COMPLETION \
                           -DDISABLE_PROMETHEUS \


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PR adds a lot of build-time options to select which features are built into dnsdist, to reduce the attack surface, memory usage and disk usage.

These features can now be disabled via a configure option, thus not linking against the corresponding libraries:
- cdb
- ipcipher
- libedit

For that last one, the console will still work if not disabled (see below) but no completion, history or line editing will be available.

These features can now be disabled by defining a value in `CXXFLAGS`:
- carbon (`DISABLE_CARBON`)
- completion (`DISABLE_COMPLETION`)
- protobuf (`DISABLE_PROTOBUF`)
- legacy dynamic blocks not using the new `DynBlockRulesGroup` interface (`DISABLE_DEPRECATED_DYNBLOCK`)
- recvmmsg (`DISABLE_RECVMMSG`)
- security polling (`DISABLE_SECPOLL`)
- prometheus (`DISABLE_PROMETHEUS`)
- accessing the configuration via the web interface (`DISABLE_WEB_CONFIG`)
- built-in web page (`DISABLE_BUILTIN_HTML`)
- custom Lua web handlers (`DISABLE_LUA_WEB_HANDLERS`)

Additionally several Lua bindings can be removed when they are not needed:
- `DISABLE_NON_FFI_DQ_BINDINGS`
- `DISABLE_POLICIES_BINDINGS`
- `DISABLE_DOWNSTREAM_BINDINGS`
- `DISABLE_DNSHEADER_BINDINGS`
- `DISABLE_COMBO_ADDR_BINDINGS`
- `DISABLE_DNSNAME_BINDINGS`
- `DISABLE_SUFFIX_MATCH_BINDINGS`
- `DISABLE_NETMASK_BINDINGS`
- `DISABLE_QPS_LIMITER_BINDINGS`
- `DISABLE_PACKETCACHE_BINDINGS`

It also cleans up the usage of various integer types in our Lua bindings, to prevent silent overflow from happening. Cleaning the integer types used reduces the number of template instantiations and thus the final binary size.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
