### PR TITLE
dnsdist: Disable the actual connect() in the test_dnsdisttcp_cc_c unit tests.

### DIFF
--- a/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdisttcp_cc.cc
@@ -41,6 +41,8 @@ GlobalStateHolder<servers_t> g_dstates;
 
 QueryCount g_qcount;
 
+const bool TCPIOHandler::s_disableConnectForUnitTests = true;
+
 bool checkDNSCryptQuery(const ClientState& cs, PacketBuffer& query, std::unique_ptr<DNSCryptQuery>& dnsCryptQuery, time_t now, bool tcp)
 {
   return false;

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -5,6 +5,8 @@
 #include "lock.hh"
 #include "tcpiohandler.hh"
 
+const bool TCPIOHandler::s_disableConnectForUnitTests = false;
+
 #ifdef HAVE_LIBSODIUM
 #include <sodium.h>
 #endif /* HAVE_LIBSODIUM */
@@ -19,6 +21,7 @@
 #include <openssl/x509v3.h>
 
 #include "libssl.hh"
+
 
 class OpenSSLFrontendContext
 {

--- a/pdns/tcpiohandler.hh
+++ b/pdns/tcpiohandler.hh
@@ -288,10 +288,14 @@ public:
       d_fastOpen = true;
     }
     else {
-      SConnectWithTimeout(d_socket, remote, /* no timeout, we will handle it ourselves */ timeval{0,0});
+      if (!s_disableConnectForUnitTests) {
+        SConnectWithTimeout(d_socket, remote, /* no timeout, we will handle it ourselves */ timeval{0,0});
+      }
     }
 #else
-    SConnectWithTimeout(d_socket, remote, /* no timeout, we will handle it ourselves */ timeval{0,0});
+    if (!s_disableConnectForUnitTests) {
+      SConnectWithTimeout(d_socket, remote, /* no timeout, we will handle it ourselves */ timeval{0,0});
+    }
 #endif /* MSG_FASTOPEN */
 
     if (d_conn) {
@@ -320,10 +324,14 @@ public:
       d_fastOpen = true;
     }
     else {
-      SConnectWithTimeout(d_socket, remote, timeout);
+      if (!s_disableConnectForUnitTests) {
+        SConnectWithTimeout(d_socket, remote, timeout);
+      }
     }
 #else
-    SConnectWithTimeout(d_socket, remote, timeout);
+    if (!s_disableConnectForUnitTests) {
+      SConnectWithTimeout(d_socket, remote, timeout);
+    }
 #endif /* MSG_FASTOPEN */
 
     if (d_conn) {
@@ -538,6 +546,8 @@ public:
     }
     return d_conn->isUsable();
   }
+
+  const static bool s_disableConnectForUnitTests;
 
 private:
   std::unique_ptr<TLSConnection> d_conn{nullptr};


### PR DESCRIPTION
They are not needed and cause (at least on OpenBSD) firewall state table
clashes: they remain in a embryotic state because no actual activity
occurs on them due to the rest of the tests using mockup code.

tcpiohandler.cc is not linked into the tests, so define it locally in
test-dnsdisttcp_cc.cc as well.

Followup on the diagnosis made in #10976.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
