### PR TITLE
Add `rec-45` for Debian Bullseye to repo test script.

### DIFF
--- a/build-scripts/docker/repo-test/generate-repo-files.py
+++ b/build-scripts/docker/repo-test/generate-repo-files.py
@@ -167,7 +167,7 @@ def write_release_files (release):
         write_list_file('ubuntu', 'focal', release)
 
     if release in ['auth-46', 'auth-master',
-                   'rec-46', 'rec-master',
+                   'rec-45', 'rec-46', 'rec-master',
                    'dnsdist-16', 'dnsdist-17', 'dnsdist-master']:
         write_dockerfile('debian', 'bullseye', release)
         write_list_file('debian', 'bullseye', release)


### PR DESCRIPTION
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
