### PR TITLE
dnsdist: Add a function to know how many TLS sessions are currently cached

### DIFF
--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -457,6 +457,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "getDNSCryptBindCount", true, "", "returns the number of DNSCrypt listeners" },
   { "getDOHFrontend", true, "n", "returns the DOH frontend with index n" },
   { "getDOHFrontendCount", true, "", "returns the number of DoH listeners" },
+  { "getOutgoingTLSSessionCacheSize", true, "", "returns the number of TLS sessions (for outgoing connections) currently cached" },
   { "getPool", true, "name", "return the pool named `name`, or \"\" for the default pool" },
   { "getPoolServers", true, "pool", "return servers part of this pool" },
   { "getQueryCounters", true, "[max=10]", "show current buffer of query counters, limited by 'max' if provided" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1346,6 +1346,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     TLSSessionCache::setSessionValidity(validity);
   });
 
+  luaCtx.writeFunction("getOutgoingTLSSessionCacheSize", []() {
+    setLuaNoSideEffect();
+    return g_sessionCache.getSize();
+  });
+
   luaCtx.writeFunction("setCacheCleaningDelay", [](uint64_t delay) {
     checkParameterBound("setCacheCleaningDelay", delay, std::numeric_limits<uint32_t>::max());
     g_cacheCleaningDelay = delay;

--- a/pdns/dnsdist-tcp.cc
+++ b/pdns/dnsdist-tcp.cc
@@ -1277,6 +1277,7 @@ static void tcpClientThread(int pipefd, int crossProtocolQueriesPipeFD, int cros
                   errlog(" - Worker thread pipe");
                 }
               });
+              errlog("The TCP/DoT client cache has %d active and %d idle outgoing connections cached", t_downstreamTCPConnectionsManager.getActiveCount(), t_downstreamTCPConnectionsManager.getIdleCount());
             }
           }
         }

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -924,6 +924,7 @@ static void dohClientThread(int crossProtocolPipeFD)
                   errlog(" - Worker thread pipe");
                 }
               });
+              errlog("The DoH client cache has %d active and %d idle outgoing connections cached", t_downstreamDoHConnectionsManager.getActiveCount(), t_downstreamDoHConnectionsManager.getIdleCount());
             }
           }
         }

--- a/pdns/dnsdistdist/dnsdist-session-cache.cc
+++ b/pdns/dnsdistdist/dnsdist-session-cache.cc
@@ -78,3 +78,13 @@ std::unique_ptr<TLSSession> TLSSessionCache::getSession(const boost::uuids::uuid
 
   return value;
 }
+
+size_t TLSSessionCache::getSize()
+{
+  size_t count = 0;
+  auto data = d_data.lock();
+  for (const auto& backend : data->d_sessions) {
+    count += backend.second.d_sessions.size();
+  }
+  return count;
+}

--- a/pdns/dnsdistdist/dnsdist-session-cache.hh
+++ b/pdns/dnsdistdist/dnsdist-session-cache.hh
@@ -53,6 +53,8 @@ public:
     s_maxSessionsPerBackend = max;
   }
 
+  size_t getSize();
+
 private:
   static time_t s_cleanupDelay;
   static time_t s_sessionValidity;

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -943,6 +943,12 @@ Status, Statistics and More
 
   Return the number of DOHFrontend binds.
 
+.. function:: getOutgoingTLSSessionCacheSize()
+
+  .. versionadded:: 1.7.0
+
+  Return the number of TLS sessions (for outgoing connections) currently cached.
+
 .. function:: getTLSContext(idx)
 
   Return the TLSContext object for the context of index ``idx``.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Also dump the number of cached (active and idle) outgoing connections when a TCP or DoH state dump is requested.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
