### PR TITLE
dnsdist: Fix a memory leak when reusing TLS tickets for outgoing connections

### DIFF
--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -498,7 +498,7 @@ public:
     if (ret != 1) {
       throw std::runtime_error("Error setting up session: " + libssl_get_error_string());
     }
-    native.release();
+    session.reset();
   }
 
   void addNewTicket(SSL_SESSION* session)
@@ -916,12 +916,9 @@ public:
     d_sess.data = nullptr;
   }
 
-  gnutls_datum_t getNative()
+  const gnutls_datum_t& getNative()
   {
-    auto ret = d_sess;
-    d_sess.data = nullptr;
-    d_sess.size = 0;
-    return ret;
+    return d_sess;
   }
 
 private:
@@ -1424,8 +1421,7 @@ public:
     if (ret != GNUTLS_E_SUCCESS) {
       throw std::runtime_error("Error setting up GnuTLS session: " + std::string(gnutls_strerror(ret)));
     }
-
-    session.release();
+    session.reset();
   }
 
   void close() override


### PR DESCRIPTION
### Short description

We were not properly freeing the memory of TLS session tickets reused for outgoing TLS (DoT / DoH) connections.

Reported by Stéphane Bortzmeyer (many thanks!)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
