### PR TITLE
dnsdist: Warn that GnuTLS 3.7.x leaks memory when validating certs

### DIFF
--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -1539,6 +1539,9 @@ public:
 
     if (params.d_validateCertificates) {
       if (params.d_caStore.empty()) {
+#if GNUTLS_VERSION_NUMBER >= 0x030700
+        std::cerr<<"Warning: GnuTLS >= 3.7.0 has a known memory leak when validating server certificates in some configurations (PKCS11 support enabled, and a default PKCS11 trust store), please consider using the OpenSSL provider for outgoing connections instead, or explicitely setting a CA store"<<std::endl;
+#endif /* GNUTLS_VERSION_NUMBER >= 0x030700 */
         rc = gnutls_certificate_set_x509_system_trust(d_creds.get());
         if (rc < 0) {
           throw std::runtime_error("Error adding the system's default trusted CAs: " + std::string(gnutls_strerror(rc)));


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
In some configurations that we can't detect (PKCS11 support enabled, with a default PKCS11 trust store), GnuTLS from 3.7.0 to at least 3.7.2 leaks memory when validating a server certificate. The issue has been reported to GnuTLS and acknowledged, but there is no available fix yet.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
