### PR TITLE
auth-4.5.x: apply new TTL to whole RRset, not only to the added record

### DIFF
--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -156,7 +156,7 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
           di->backend->replaceRRSet(di->id, oldRec->qname, oldRec->qtype, rrset);
           *updatedSerial = true;
           changedRecords++;
-          g_log<<Logger::Notice<<msgPrefix<<"Replacing record "<<rr->d_name<<"|"<<rrType.toString()<<endl;
+          g_log<<Logger::Notice<<msgPrefix<<"Replacing SOA record "<<rr->d_name<<"|"<<rrType.toString()<<endl;
         } else {
           g_log<<Logger::Notice<<msgPrefix<<"Provided serial ("<<sdUpdate.serial<<") is older than the current serial ("<<sdOld.serial<<"), ignoring SOA update."<<endl;
         }
@@ -173,10 +173,10 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
         }
         if (changedCNames > 0) {
           di->backend->replaceRRSet(di->id, rr->d_name, rrType, rrset);
-          g_log<<Logger::Notice<<msgPrefix<<"Replacing record "<<rr->d_name<<"|"<<rrType.toString()<<endl;
+          g_log<<Logger::Notice<<msgPrefix<<"Replacing CNAME record "<<rr->d_name<<"|"<<rrType.toString()<<endl;
           changedRecords += changedCNames;
         } else {
-          g_log<<Logger::Notice<<msgPrefix<<"Replace for record "<<rr->d_name<<"|"<<rrType.toString()<<" requested, but no changes made."<<endl;
+          g_log<<Logger::Notice<<msgPrefix<<"Replace for CNAME record "<<rr->d_name<<"|"<<rrType.toString()<<" requested, but no changes made."<<endl;
         }
 
       // In any other case, we must check if the TYPE and RDATA match to provide an update (which effectively means a update of TTL)

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -194,8 +194,10 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
         for (auto& i : rrset) {
           string icontent = i.getZoneRepresentation();
           if (lowerCase) icontent = toLower(icontent);
-          if (rrType == i.qtype.getCode() && icontent == content) {
-            foundRecord=true;
+          if (rrType == i.qtype.getCode()) {
+            if (icontent == content) {
+              foundRecord=true;
+            }
             if (i.ttl != rr->d_ttl)  {
               i.ttl = rr->d_ttl;
               updateTTL++;
@@ -204,10 +206,10 @@ uint PacketHandler::performUpdate(const string &msgPrefix, const DNSRecord *rr, 
         }
         if (updateTTL > 0) {
           di->backend->replaceRRSet(di->id, rr->d_name, rrType, rrset);
-          g_log<<Logger::Notice<<msgPrefix<<"Replacing record "<<rr->d_name<<"|"<<rrType.toString()<<endl;
+          g_log<<Logger::Notice<<msgPrefix<<"Updating TTLs for "<<rr->d_name<<"|"<<rrType.toString()<<endl;
           changedRecords += updateTTL;
         } else {
-          g_log<<Logger::Notice<<msgPrefix<<"Replace for record "<<rr->d_name<<"|"<<rrType.toString()<<" requested, but no changes made."<<endl;
+          g_log<<Logger::Notice<<msgPrefix<<"Replace for recordset "<<rr->d_name<<"|"<<rrType.toString()<<" requested, but no changes made."<<endl;
         }
       }
 

--- a/regression-tests/tests/1dyndns-update-add-delete-mx/expected_result
+++ b/regression-tests/tests/1dyndns-update-add-delete-mx/expected_result
@@ -10,9 +10,9 @@ Answer:
 ;; ZONE SECTION:
 ;test.dyndns.			IN	SOA
 
+0	test.dyndns.	IN	MX	3000	10 host-1.test.dyndns.
+0	test.dyndns.	IN	MX	3000	20 host-2.test.dyndns.
 0	test.dyndns.	IN	MX	3000	30 host-3.test.dyndns.
-0	test.dyndns.	IN	MX	3600	10 host-1.test.dyndns.
-0	test.dyndns.	IN	MX	3600	20 host-2.test.dyndns.
 2	host-1.test.dyndns.	IN	A	3600	127.0.0.101
 2	host-2.test.dyndns.	IN	A	3600	127.0.0.102
 2	host-3.test.dyndns.	IN	A	3600	127.0.0.103
@@ -24,8 +24,8 @@ Answer:
 ;; ZONE SECTION:
 ;test.dyndns.			IN	SOA
 
-0	test.dyndns.	IN	MX	3600	10 host-1.test.dyndns.
-0	test.dyndns.	IN	MX	3600	20 host-2.test.dyndns.
+0	test.dyndns.	IN	MX	3000	10 host-1.test.dyndns.
+0	test.dyndns.	IN	MX	3000	20 host-2.test.dyndns.
 2	host-1.test.dyndns.	IN	A	3600	127.0.0.101
 2	host-2.test.dyndns.	IN	A	3600	127.0.0.102
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0

--- a/regression-tests/tests/1dyndns-update-delete-mx-prio/expected_result
+++ b/regression-tests/tests/1dyndns-update-delete-mx-prio/expected_result
@@ -1,5 +1,5 @@
-0	test.dyndns.	IN	MX	3600	10 host-1.test.dyndns.
-0	test.dyndns.	IN	MX	3600	20 host-2.test.dyndns.
+0	test.dyndns.	IN	MX	3000	10 host-1.test.dyndns.
+0	test.dyndns.	IN	MX	3000	20 host-2.test.dyndns.
 2	host-1.test.dyndns.	IN	A	3600	127.0.0.101
 2	host-2.test.dyndns.	IN	A	3600	127.0.0.102
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0

--- a/regression-tests/tests/1dyndns-update-replace-mx/expected_result
+++ b/regression-tests/tests/1dyndns-update-replace-mx/expected_result
@@ -11,7 +11,7 @@ Answer:
 ;test.dyndns.			IN	SOA
 
 0	test.dyndns.	IN	MX	3000	10 host-1.test.dyndns.
-0	test.dyndns.	IN	MX	3600	20 host-2.test.dyndns.
+0	test.dyndns.	IN	MX	3000	20 host-2.test.dyndns.
 2	host-1.test.dyndns.	IN	A	3600	127.0.0.101
 2	host-2.test.dyndns.	IN	A	3600	127.0.0.102
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0

--- a/regression-tests/tests/1dyndns-update-srv/expected_result
+++ b/regression-tests/tests/1dyndns-update-srv/expected_result
@@ -16,8 +16,8 @@ Answer:
 ;; ZONE SECTION:
 ;test.dyndns.			IN	SOA
 
-0	srv.test.dyndns.	IN	SRV	3600	1 100 389 server2.
 0	srv.test.dyndns.	IN	SRV	3601	0 100 389 server1.
+0	srv.test.dyndns.	IN	SRV	3601	1 100 389 server2.
 Rcode: 0 (No Error), RD: 0, QR: 1, TC: 0, AA: 1, opcode: 0
 Reply to question for qname='srv.test.dyndns.', qtype=SRV
 1	test.dyndns.	IN	SOA	3600	ns1.test.dyndns. ahu.example.dyndns. [serial] 28800 7200 604800 86400


### PR DESCRIPTION
### Short description
backport of #10981

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master