### PR TITLE
dnsdist: Add a function to set the UDP recv/snd buffer sizes

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1413,6 +1413,7 @@ rightsidebar
 Rijsdijk
 ringbuffer
 rkey
+rmem
 rname
 rng
 rocommunity
@@ -1905,6 +1906,7 @@ yubikey
 YYYYMMD
 YYYYMMDD
 YYYYMMDDSS
+wmem
 Zealey
 zeha
 Zengers

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -633,6 +633,7 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "setTCPRecvTimeout", true, "n", "set the read timeout on TCP connections from the client, in seconds" },
   { "setTCPSendTimeout", true, "n", "set the write timeout on TCP connections from the client, in seconds" },
   { "setUDPMultipleMessagesVectorSize", true, "n", "set the size of the vector passed to recvmmsg() to receive UDP messages. Default to 1 which means that the feature is disabled and recvmsg() is used instead" },
+  { "setUDPSocketBufferSizes", true, "recv, send", "Set the size of the receive (SO_RCVBUF) and send (SO_SNDBUF) buffers for incoming UDP sockets" },
   { "setUDPTimeout", true, "n", "set the maximum time dnsdist will wait for a response from a backend over UDP, in seconds" },
   { "setVerboseHealthChecks", true, "bool", "set whether health check errors will be logged" },
   { "setWebserverConfig", true, "[{password=string, apiKey=string, customHeaders, statsRequireAuthentication}]", "Updates webserver configuration" },

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2780,6 +2780,23 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
       }
     }
   });
+
+  luaCtx.writeFunction("setUDPSocketBufferSizes", [client](uint64_t recv, uint64_t snd) {
+    if (client) {
+      return;
+    }
+    checkParameterBound("setUDPSocketBufferSizes", recv, std::numeric_limits<uint32_t>::max());
+    checkParameterBound("setUDPSocketBufferSizes", snd, std::numeric_limits<uint32_t>::max());
+    setLuaSideEffect();
+
+    if (g_configurationDone) {
+      g_outputBuffer = "setUDPSocketBufferSizes cannot be used at runtime!\n";
+      return;
+    }
+
+    g_socketUDPSendBuffer = snd;
+    g_socketUDPRecvBuffer = recv;
+  });
 }
 
 vector<std::function<void(void)>> setupLua(LuaContext& luaCtx, bool client, bool configCheck, const std::string& config)

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -141,6 +141,8 @@ bool g_servFailOnNoPolicy{false};
 bool g_truncateTC{false};
 bool g_fixupCase{false};
 bool g_dropEmptyQueries{false};
+uint32_t g_socketUDPSendBuffer{16777216};
+uint32_t g_socketUDPRecvBuffer{16777216};
 
 std::set<std::string> g_capabilitiesToRetain;
 
@@ -2070,6 +2072,26 @@ static void setUpLocalBind(std::unique_ptr<ClientState>& cs)
     }
     catch(const std::exception& e) {
       warnlog("Failed to set IP_MTU_DISCOVER on UDP server socket for local address '%s': %s", cs->local.toStringWithPort(), e.what());
+    }
+  }
+
+  if (!cs->tcp) {
+    if (g_socketUDPSendBuffer > 0) {
+      try {
+        setSocketSendBuffer(cs->udpFD, g_socketUDPSendBuffer);
+      }
+      catch (const std::exception& e) {
+        warnlog(e.what());
+      }
+    }
+
+    if (g_socketUDPRecvBuffer > 0) {
+      try {
+        setSocketReceiveBuffer(cs->udpFD, g_socketUDPRecvBuffer);
+      }
+      catch (const std::exception& e) {
+        warnlog(e.what());
+      }
     }
   }
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -141,8 +141,8 @@ bool g_servFailOnNoPolicy{false};
 bool g_truncateTC{false};
 bool g_fixupCase{false};
 bool g_dropEmptyQueries{false};
-uint32_t g_socketUDPSendBuffer{16777216};
-uint32_t g_socketUDPRecvBuffer{16777216};
+uint32_t g_socketUDPSendBuffer{0};
+uint32_t g_socketUDPRecvBuffer{0};
 
 std::set<std::string> g_capabilitiesToRetain;
 

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -1016,6 +1016,8 @@ extern std::string g_apiConfigDirectory;
 extern bool g_servFailOnNoPolicy;
 extern size_t g_udpVectorSize;
 extern bool g_allowEmptyResponse;
+extern uint32_t g_socketUDPSendBuffer;
+extern uint32_t g_socketUDPRecvBuffer;
 
 extern shared_ptr<BPFFilter> g_defaultBPFFilter;
 extern std::vector<std::shared_ptr<DynBPFFilter> > g_dynBPFFilters;

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -160,6 +160,15 @@ Tuning related functions
 
   :param int num: maximum number of UDP queries to accept
 
+.. function:: setUDPSocketBufferSize(recv, send)
+
+  .. versionadded:: 1.7.0
+
+  Set the size of the receive (SO_RCVBUF) and send (SO_SNDBUF) buffers for incoming UDP sockets.
+
+  :param int recv: SO_RCVBUF value. Default is 16777216. 0 means the system value will be kept.
+  :param int send: SO_SNDBUF value. Default is 16777216. 0 means the system value will be kept.
+
 .. function:: setUDPTimeout(num)
 
   Set the maximum time dnsdist will wait for a response from a backend over UDP, in seconds. Defaults to 2

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -164,10 +164,12 @@ Tuning related functions
 
   .. versionadded:: 1.7.0
 
-  Set the size of the receive (SO_RCVBUF) and send (SO_SNDBUF) buffers for incoming UDP sockets.
+  Set the size of the receive (``SO_RCVBUF``) and send (``SO_SNDBUF``) buffers for incoming UDP sockets. On Linux the default
+  values correspond to ``net.core.rmem_default`` and ``net.core.wmem_default`` , and the maximum values are restricted
+  by ``net.core.rmem_max`` and ``net.core.wmem_max``.
 
-  :param int recv: SO_RCVBUF value. Default is 16777216. 0 means the system value will be kept.
-  :param int send: SO_SNDBUF value. Default is 16777216. 0 means the system value will be kept.
+  :param int recv: ``SO_RCVBUF`` value. Default is 0, meaning the system value will be kept.
+  :param int send: ``SO_SNDBUF`` value. Default is 0, meaning the system value will be kept.
 
 .. function:: setUDPTimeout(num)
 

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -519,3 +519,27 @@ ComboAddress parseIPAndPort(const std::string& input, uint16_t port)
     return ComboAddress(input, port);
   }
 }
+
+void setSocketBuffer(int fd, int optname, uint32_t size)
+{
+  uint32_t psize = 0;
+  socklen_t len = sizeof(psize);
+
+  if (!getsockopt(fd, SOL_SOCKET, optname, &psize, &len) && psize > size) {
+    throw std::runtime_error("Not decreasing socket buffer size from " + std::to_string(psize) + " to " + std::to_string(size));
+  }
+
+  if (setsockopt(fd, SOL_SOCKET, optname, &size, sizeof(size)) < 0) {
+    throw std::runtime_error("Unable to raise socket buffer size to " + std::to_string(size) + ": " + stringerror());
+  }
+}
+
+void setSocketReceiveBuffer(int fd, uint32_t size)
+{
+  setSocketBuffer(fd, SO_RCVBUF, size);
+}
+
+void setSocketSendBuffer(int fd, uint32_t size)
+{
+  setSocketBuffer(fd, SO_SNDBUF, size);
+}

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1649,3 +1649,9 @@ bool isTCPSocketUsable(int sock);
 
 extern template class NetmaskTree<bool>;
 ComboAddress parseIPAndPort(const std::string& input, uint16_t port);
+
+/* These functions throw if the value was already set to a higher value,
+   or on error */
+void setSocketBuffer(int fd, int optname, uint32_t size);
+void setSocketReceiveBuffer(int fd, uint32_t size);
+void setSocketSendBuffer(int fd, uint32_t size);

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -597,34 +597,6 @@ PacketBuffer GenUDPQueryResponse(const ComboAddress& dest, const string& query)
 
 static void handleUDPServerResponse(int fd, FDMultiplexer::funcparam_t&);
 
-static void setSocketBuffer(int fd, int optname, uint32_t size)
-{
-  uint32_t psize=0;
-  socklen_t len=sizeof(psize);
-
-  if(!getsockopt(fd, SOL_SOCKET, optname, (char*)&psize, &len) && psize > size) {
-    g_log<<Logger::Error<<"Not decreasing socket buffer size from "<<psize<<" to "<<size<<endl;
-    return;
-  }
-
-  if (setsockopt(fd, SOL_SOCKET, optname, (char*)&size, sizeof(size)) < 0) {
-    int err = errno;
-    g_log << Logger::Error << "Unable to raise socket buffer size to " << size << ": " << stringerror(err) << endl;
-  }
-}
-
-
-static void setSocketReceiveBuffer(int fd, uint32_t size)
-{
-  setSocketBuffer(fd, SO_RCVBUF, size);
-}
-
-static void setSocketSendBuffer(int fd, uint32_t size)
-{
-  setSocketBuffer(fd, SO_SNDBUF, size);
-}
-
-
 // you can ask this class for a UDP socket to send a query from
 // this socket is not yours, don't even think about deleting it
 // but after you call 'returnSocket' on it, don't assume anything anymore
@@ -3680,7 +3652,13 @@ static void makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tcp
       throw PDNSException("Binding TCP server socket for "+ st.host +": "+stringerror());
 
     setNonBlocking(fd);
-    setSocketSendBuffer(fd, 65000);
+    try {
+      setSocketSendBuffer(fd, 65000);
+    }
+    catch (const std::exception& e) {
+      g_log<<Logger::Error<<e.what()<<endl;
+    }
+
     listen(fd, 128);
     deferredAdds.emplace_back(fd, handleNewTCPQuestion);
     tcpSockets.insert(fd);
@@ -3744,7 +3722,12 @@ static void makeUDPServerSockets(deferredAdd_t& deferredAdds)
 
     setCloseOnExec(fd);
 
-    setSocketReceiveBuffer(fd, 250000);
+    try {
+      setSocketReceiveBuffer(fd, 25000);
+    }
+    catch (const std::exception& e) {
+      g_log<<Logger::Error<<e.what()<<endl;
+    }
     sin.sin4.sin_port = htons(st.port);
 
   

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -3723,7 +3723,7 @@ static void makeUDPServerSockets(deferredAdd_t& deferredAdds)
     setCloseOnExec(fd);
 
     try {
-      setSocketReceiveBuffer(fd, 25000);
+      setSocketReceiveBuffer(fd, 250000);
     }
     catch (const std::exception& e) {
       g_log<<Logger::Error<<e.what()<<endl;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
And raise them to 16777216 by default. Although perhaps we should only do that on Linux?

This PR also refactors the functions duplicated in the recursor, calidns and dnsreplay and therefore impacts the auth and the rec.

Closes #10898.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
