### PR TITLE
rec: Add xref between allow-notify-for-file and forward-zones-file

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -83,6 +83,8 @@ Like `allow-notify-for`_, except reading from file. To use this
 feature, supply one domain name per line, with optional comments
 preceded by a "#".
 
+NOTIFY-allowed zones can also be specified using `forward-zones-file`_.
+
 .. _setting-allow-notify-from:
 
 ``allow-notify-from``


### PR DESCRIPTION
### Short description
Provide a cross-reference so users will know that `forward-zones-file` can be used to specify NOTIFY-allowed zones.
