### PR TITLE
dnsdist: Add Lua bindings to get the list of network interfaces, addresses

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -599,6 +599,7 @@ getdomaininfo
 getdomainkeys
 getdomainmetadata
 gethostname
+getifaddrs
 getlocaladdress
 getn
 getrandom

--- a/m4/pdns_check_network_libs.m4
+++ b/m4/pdns_check_network_libs.m4
@@ -4,4 +4,5 @@ AC_DEFUN([PDNS_CHECK_NETWORK_LIBS],[
   AC_SEARCH_LIBS([socket], [socket])
   AC_SEARCH_LIBS([gethostent], [nsl])
   AC_CHECK_FUNCS([recvmmsg sendmmsg accept4])
+  AC_CHECK_DECL(getifaddrs, [AC_DEFINE([HAVE_GETIFADDRS], [1], [Define to 1 if you have getifaddrs])], [], [#include <ifaddrs.h>])
 ])

--- a/pdns/dnsdist-console.cc
+++ b/pdns/dnsdist-console.cc
@@ -457,6 +457,8 @@ const std::vector<ConsoleKeyword> g_consoleKeywords{
   { "getDNSCryptBindCount", true, "", "returns the number of DNSCrypt listeners" },
   { "getDOHFrontend", true, "n", "returns the DOH frontend with index n" },
   { "getDOHFrontendCount", true, "", "returns the number of DoH listeners" },
+  { "getListOfAddressesOfNetworkInterface", true, "itf", "returns the list of addresses configured on a given network interface, as strings" },
+  { "getListOfNetworkInterfaces", true, "", "returns the list of network interfaces present on the system, as strings" },
   { "getOutgoingTLSSessionCacheSize", true, "", "returns the number of TLS sessions (for outgoing connections) currently cached" },
   { "getPool", true, "name", "return the pool named `name`, or \"\" for the default pool" },
   { "getPoolServers", true, "pool", "return servers part of this pool" },

--- a/pdns/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdist-lua-bindings.cc
@@ -616,4 +616,24 @@ void setupLuaBindings(LuaContext& luaCtx, bool client)
 
     return parameters;
   });
+
+  luaCtx.writeFunction("getListOfNetworkInterfaces", []() {
+    std::vector<std::pair<int, std::string>> result;
+    auto itfs = getListOfNetworkInterfaces();
+    int counter = 1;
+    for (const auto& itf : itfs) {
+      result.push_back({counter++, itf});
+    }
+    return result;
+  });
+
+  luaCtx.writeFunction("getListOfAddressesOfNetworkInterface", [](const std::string& itf) {
+    std::vector<std::pair<int, std::string>> result;
+    auto addrs = getListOfAddressesOfNetworkInterface(itf);
+    int counter = 1;
+    for (const auto& addr : addrs) {
+      result.push_back({counter++, addr.toString()});
+    }
+    return result;
+  });
 }

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -950,6 +950,22 @@ Status, Statistics and More
 
   Return the number of DOHFrontend binds.
 
+.. function:: getListOfAddressesOfNetworkInterface(itf)
+
+  .. versionadded:: 1.8.0
+
+  Return the list of addresses configured on a given network interface, as strings.
+  This function requires support for ``getifaddrs``, which is known to be present on FreeBSD, Linux, and OpenBSD at least.
+
+  :param str itf: The name of the network interface
+
+.. function:: getListOfNetworkInterfaces()
+
+  .. versionadded:: 1.8.0
+
+  Return the list of network interfaces configured on the system, as strings
+  This function requires support for ``getifaddrs``, which is known to be present on FreeBSD, Linux, and OpenBSD at least.
+
 .. function:: getOutgoingTLSSessionCacheSize()
 
   .. versionadded:: 1.7.0

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -1650,6 +1650,9 @@ bool isTCPSocketUsable(int sock);
 extern template class NetmaskTree<bool>;
 ComboAddress parseIPAndPort(const std::string& input, uint16_t port);
 
+std::set<std::string> getListOfNetworkInterfaces();
+std::vector<ComboAddress> getListOfAddressesOfNetworkInterface(const std::string& itf);
+
 /* These functions throw if the value was already set to a higher value,
    or on error */
 void setSocketBuffer(int fd, int optname, uint32_t size);


### PR DESCRIPTION
### Short description
This PR adds Lua bindings to retrieve the list of network interfaces and associated addresses, provided that `getifaddrs` is supported.
I tested this code on Linux, the documentation suggests that it should work on FreeBSD and OpenBSD as well but I did not test that.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
