### PR TITLE
dnsdist: add support for password protected PCKS12 files for TLS configuration

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -132,13 +132,13 @@ static void parseLocalBindVars(boost::optional<localbind_t> vars, bool& reusePor
 }
 
 #if defined(HAVE_DNS_OVER_TLS) || defined(HAVE_DNS_OVER_HTTPS)
-static bool loadTLSCertificateAndKeys(const std::string& context, std::vector<TLSCertKeyPair>& pairs, boost::variant<std::string, std::shared_ptr<TLSCertKeyPair>, std::vector<std::pair<int, std::string>>, std::vector<std::pair<int, std::shared_ptr<TLSCertKeyPair>>>> certFiles, boost::variant<std::string, std::vector<std::pair<int, std::string>>> keyFiles, std::optional<std::string> password = std::nullopt)
+static bool loadTLSCertificateAndKeys(const std::string& context, std::vector<TLSCertKeyPair>& pairs, boost::variant<std::string, std::shared_ptr<TLSCertKeyPair>, std::vector<std::pair<int, std::string>>, std::vector<std::pair<int, std::shared_ptr<TLSCertKeyPair>>>> certFiles, boost::variant<std::string, std::vector<std::pair<int, std::string>>> keyFiles)
 {
   if (certFiles.type() == typeid(std::string) && keyFiles.type() == typeid(std::string)) {
     auto certFile = boost::get<std::string>(certFiles);
     auto keyFile = boost::get<std::string>(keyFiles);
     pairs.clear();
-    pairs.emplace_back(certFile, keyFile, password);
+    pairs.emplace_back(certFile, keyFile);
   }
   else if (certFiles.type() == typeid(std::shared_ptr<TLSCertKeyPair>)) {
     auto cert = boost::get<std::shared_ptr<TLSCertKeyPair>>(certFiles);
@@ -158,7 +158,7 @@ static bool loadTLSCertificateAndKeys(const std::string& context, std::vector<TL
     if (certFilesVect.size() == keyFilesVect.size()) {
       pairs.clear();
       for (size_t idx = 0; idx < certFilesVect.size(); idx++) {
-        pairs.emplace_back(certFilesVect.at(idx).second, keyFilesVect.at(idx).second, password);
+        pairs.emplace_back(certFilesVect.at(idx).second, keyFilesVect.at(idx).second);
       }
     }
     else {

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -118,7 +118,7 @@ Listen Sockets
     ``enableRenegotiation``, ``exactPathMatching``, ``maxConcurrentTCPConnections`` and ``releaseBuffers`` options added.
     ``internalPipeBufferSize`` now defaults to 1048576 on Linux.
 
-  .. versionchanged:: 1.x.0
+  .. versionchanged:: 1.8.0
      ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`)
 
   Listen on the specified address and TCP port for incoming DNS over HTTPS connections, presenting the specified X.509 certificate.
@@ -1650,9 +1650,11 @@ Other functions
 
   .. versionadded:: 1.8.0
 
-  Creates a TLSCertificate object suited to be used with functions like :func:`addDOHLocal` and :func:`addTLSLocal` for TLS certificate configuration
+  Creates a TLSCertificate object suited to be used with functions like :func:`addDOHLocal` and :func:`addTLSLocal` for TLS certificate configuration.
 
-  :param string pathToCert: Path to a file containing the certificate or a PCKS12 file containing both certificate and the key
+  PKCS12 files are only supported by the ``openssl`` provider, password-protected or not.
+
+  :param string pathToCert: Path to a file containing the certificate or a PCKS12 file containing both a certificate and a key.
   :param table options: A table with key: value pairs with additional options.
 
   Options:
@@ -1662,7 +1664,7 @@ Other functions
 
   .. code-block:: lua
 
-    newTLSCertificate("path/to/pub.crt", {key="pat/to/private.pem"})
+    newTLSCertificate("path/to/pub.crt", {key="path/to/private.pem"})
     newTLSCertificate("path/to/domain.p12", {password="passphrase"}) -- use a password protected PCKS12 file
 
 DOHFrontend
@@ -1678,7 +1680,7 @@ DOHFrontend
 
      .. versionadded:: 1.6.1
 
-     .. versionchanged:: 1.x.0
+     .. versionchanged:: 1.8.0
         ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`)
 
      :param str certFile(s): The path to a X.509 certificate file in PEM format, a list of paths to such files, or a TLSCertificate object.

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -118,13 +118,16 @@ Listen Sockets
     ``enableRenegotiation``, ``exactPathMatching``, ``maxConcurrentTCPConnections`` and ``releaseBuffers`` options added.
     ``internalPipeBufferSize`` now defaults to 1048576 on Linux.
 
+  .. versionchanged:: 1.x.0
+     ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`)
+
   Listen on the specified address and TCP port for incoming DNS over HTTPS connections, presenting the specified X.509 certificate.
   If no certificate (or key) files are specified, listen for incoming DNS over HTTP connections instead.
 
   :param str address: The IP Address with an optional port to listen on.
                       The default port is 443.
-  :param str certFile(s): The path to a X.509 certificate file in PEM format, or a list of paths to such files.
-  :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones.
+  :param str certFile(s): The path to a X.509 certificate file in PEM format, a list of paths to such files, or a TLSCertificate object.
+  :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones. Ignored if ``certFile`` contains TLSCertificate objects.
   :param str-or-list urls: The path part of a URL, or a list of paths, to accept queries on. Any query with a path matching exactly one of these will be treated as a DoH query (sub-paths can be accepted by setting the ``exactPathMatching`` to false). The default is /dns-query.
   :param table options: A table with key: value pairs with listen options.
 
@@ -168,13 +171,15 @@ Listen Sockets
     ``enableRenegotiation``, ``maxConcurrentTCPConnections``, ``maxInFlight`` and ``releaseBuffers`` options added.
   .. versionchanged:: 1.8.0
     ``tlsAsyncMode`` option added.
+  .. versionchanged:: 1.8.0
+     ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`)
 
   Listen on the specified address and TCP port for incoming DNS over TLS connections, presenting the specified X.509 certificate.
 
   :param str address: The IP Address with an optional port to listen on.
                       The default port is 853.
-  :param str certFile(s): The path to a X.509 certificate file in PEM format, or a list of paths to such files.
-  :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones.
+  :param str certFile(s): The path to a X.509 certificate file in PEM format, a list of paths to such files, or a TLSCertificate object.
+  :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones. Ignored if ``certFile`` contains TLSCertificate objects.
   :param table options: A table with key: value pairs with listen options.
 
   Options:
@@ -1641,6 +1646,25 @@ Other functions
   :param string engineName: The name of the engine to load.
   :param string defaultString: The default string to pass to the engine. The exact value depends on the engine but represents the algorithms to register with the engine, as a list of  comma-separated keywords. For example "RSA,EC,DSA,DH,PKEY,PKEY_CRYPTO,PKEY_ASN1".
 
+.. function:: newTLSCertificate(pathToCert[, options])
+
+  .. versionadded:: 1.8.0
+
+  Creates a TLSCertificate object suited to be used with functions like :func:`addDOHLocal` and :func:`addTLSLocal` for TLS certificate configuration
+
+  :param string pathToCert: Path to a file containing the certificate or a PCKS12 file containing both certificate and the key
+  :param table options: A table with key: value pairs with additional options.
+
+  Options:
+
+  * ``key="path/to/key"``: string - Path to a file containing the key corresponding to the certificate.
+  * ``password="pass"``: string - Password protecting the PCKS12 file if appropriate.
+
+  .. code-block:: lua
+
+    newTLSCertificate("path/to/pub.crt", {key="pat/to/private.pem"})
+    newTLSCertificate("path/to/domain.p12", {password="passphrase"}) -- use a password protected PCKS12 file
+
 DOHFrontend
 ~~~~~~~~~~~
 
@@ -1654,10 +1678,11 @@ DOHFrontend
 
      .. versionadded:: 1.6.1
 
-     Create and switch to a new TLS context using the same options than were passed to the corresponding `addDOHLocal()` directive, but loading new certificates and keys from the selected files, replacing the existing ones.
+     .. versionchanged:: 1.x.0
+        ``certFile`` now accepts a TLSCertificate object or a list of such objects (see :func:`newTLSCertificate`)
 
-     :param str certFile(s): The path to a X.509 certificate file in PEM format, or a list of paths to such files.
-     :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones.
+     :param str certFile(s): The path to a X.509 certificate file in PEM format, a list of paths to such files, or a TLSCertificate object.
+     :param str keyFile(s): The path to the private key file corresponding to the certificate, or a list of paths to such files, whose order should match the certFile(s) ones. Ignored if ``certFile`` contains TLSCertificate objects.
 
   .. method:: DOHFrontend:loadTicketsKeys(ticketsKeysFile)
 

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <optional>
 
 #include "config.h"
 #include "circular_buffer.hh"
@@ -14,10 +15,20 @@
 
 enum class LibsslTLSVersion : uint8_t { Unknown, TLS10, TLS11, TLS12, TLS13 };
 
+struct TLSCertKeyPair
+{
+  std::string d_cert;
+  std::optional<std::string> d_key;
+  std::optional<std::string> d_password;
+  explicit TLSCertKeyPair(const std::string& cert, std::optional<std::string> key = std::nullopt, std::optional<std::string> password = std::nullopt):
+    d_cert(cert), d_key(key), d_password(password) {
+  }
+};
+
 class TLSConfig
 {
 public:
-  std::vector<std::pair<std::string, std::string>> d_certKeyPairs;
+  std::vector<TLSCertKeyPair> d_certKeyPairs;
   std::vector<std::string> d_ocspFiles;
 
   std::string d_ciphers;

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -1513,9 +1513,9 @@ public:
     creds = nullptr;
 
     for (const auto& pair : fe.d_tlsConfig.d_certKeyPairs) {
-      rc = gnutls_certificate_set_x509_key_file(d_creds.get(), pair.first.c_str(), pair.second.c_str(), GNUTLS_X509_FMT_PEM);
+      rc = gnutls_certificate_set_x509_key_file(d_creds.get(), pair.d_cert.c_str(), pair.d_key->c_str(), GNUTLS_X509_FMT_PEM);
       if (rc != GNUTLS_E_SUCCESS) {
-        throw std::runtime_error("Error loading certificate ('" + pair.first + "') and key ('" + pair.second + "') for TLS context on " + fe.d_addr.toStringWithPort() + ": " + gnutls_strerror(rc));
+        throw std::runtime_error("Error loading certificate ('" + pair.d_cert + "') and key ('" + pair.d_key.value() + "') for TLS context on " + fe.d_addr.toStringWithPort() + ": " + gnutls_strerror(rc));
       }
     }
 
@@ -1523,7 +1523,7 @@ public:
     for (const auto& file : fe.d_tlsConfig.d_ocspFiles) {
       rc = gnutls_certificate_set_ocsp_status_request_file(d_creds.get(), file.c_str(), count);
       if (rc != GNUTLS_E_SUCCESS) {
-        throw std::runtime_error("Error loading OCSP response from file '" + file + "' for certificate ('" + fe.d_tlsConfig.d_certKeyPairs.at(count).first + "') and key ('" + fe.d_tlsConfig.d_certKeyPairs.at(count).second + "') for TLS context on " + fe.d_addr.toStringWithPort() + ": " + gnutls_strerror(rc));
+        throw std::runtime_error("Error loading OCSP response from file '" + file + "' for certificate ('" + fe.d_tlsConfig.d_certKeyPairs.at(count).d_cert + "') and key ('" + fe.d_tlsConfig.d_certKeyPairs.at(count).d_key.value() + "') for TLS context on " + fe.d_addr.toStringWithPort() + ": " + gnutls_strerror(rc));
       }
       ++count;
     }

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -801,6 +801,14 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                 with open(inFileName) as inFile:
                     outFile.write(inFile.read())
 
+        cmd = ['openssl', 'pkcs12', '-export', '-passout', 'pass:passw0rd', '-clcerts', '-in', 'server.pem', '-CAfile', 'ca.pem', '-inkey', 'server.key', '-out', 'server.p12']
+        output = None
+        try:
+            process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
+            output = process.communicate(input='')
+        except subprocess.CalledProcessError as exc:
+            raise AssertionError('openssl pkcs12 failed (%d): %s' % (exc.returncode, exc.output))
+
     def checkMessageProxyProtocol(self, receivedProxyPayload, source, destination, isTCP, values=[], v6=False, sourcePort=None, destinationPort=None):
         proxy = ProxyProtocol()
         self.assertTrue(proxy.parseHeader(receivedProxyPayload))

--- a/regression-tests.dnsdist/runtests
+++ b/regression-tests.dnsdist/runtests
@@ -48,6 +48,8 @@ openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr -con
 openssl x509 -req -days 1 -CA ca.pem -CAkey ca.key -CAcreateserial -in server.csr -out server.pem -extfile configServer.conf -extensions v3_req
 # Generate a chain
 cat server.pem ca.pem > server.chain
+# Generate a password-protected PKCS12 file
+openssl pkcs12 -export -passout pass:passw0rd -clcerts -in server.pem -CAfile ca.pem -inkey server.key -out server.p12
 
 out=$(mktemp)
 set -o pipefail

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -461,3 +461,21 @@ class TestProtocols(DNSDistTest):
         receivedQuery.id = query.id
         self.assertEqual(query, receivedQuery)
         self.assertEqual(response, receivedResponse)
+
+class TestPKCSTLSCertificate(DNSDistTest, TLSTests):
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode('ascii')
+    _serverCert = 'server.p12'
+    _pkcsPassphrase = 'passw0rd'
+    _serverName = 'tls.tests.dnsdist.org'
+    _caCert = 'ca.pem'
+    _tlsServerPort = 8453
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%s")
+    newServer{address="127.0.0.1:%s"}
+    cert=newTLSCertificate("%s", {password="%s"})
+    addTLSLocal("127.0.0.1:%s", cert, "", { provider="openssl" })
+    addAction(SNIRule("powerdns.com"), SpoofAction("1.2.3.4"))
+    """
+    _config_params = ['_consoleKeyB64', '_consolePort', '_testServerPort', '_serverCert', '_pkcsPassphrase', '_tlsServerPort']


### PR DESCRIPTION
### Short description
This adds support for password protected PCKS12 files. `addDOHLocal` and `addTLSLocal` now accept either a single `cert` parameter (without any `key`) and thus try to open it as a PCKS12 file or directly a `TLSCertificate` object initialized via `newTLSCertificate`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
