### PR TITLE
Rec incoming tcp bookkeeping

### DIFF
--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1154,6 +1154,9 @@ static bool addRecordToPacket(DNSPacketWriter& pw, const DNSRecord& rec, uint32_
 class RunningResolveGuard {
 public:
   RunningResolveGuard(std::unique_ptr<DNSComboWriter>& dc) : d_dc(dc) {
+    if (d_dc->d_tcp && !d_dc->d_tcpConnection) {
+      throw std::runtime_error("incoming TCP case without TCP connection");
+    }
   }
   ~RunningResolveGuard() {
     if (!d_handled && d_dc->d_tcp) {
@@ -1164,7 +1167,9 @@ public:
     d_handled = true;
   }
   void setDropOnIdle() {
-    d_dc->d_tcpConnection->setDropOnIdle();
+    if (d_dc->d_tcp) {
+      d_dc->d_tcpConnection->setDropOnIdle();
+    }
   }
 private:
   std::unique_ptr<DNSComboWriter>& d_dc;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2649,7 +2649,7 @@ static void requestWipeCaches(const DNSName& canon)
 
 /*
  * A helper class that by default closes the incoming TCP connection on destruct
- * If you want to keep the connection aliave, call keep() on the guard object
+ * If you want to keep the connection alive, call keep() on the guard object
  */
 class RunningTCPQuestionGuard {
 public:

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1111,7 +1111,14 @@ public:
   {
     return d_fd;
   }
-
+  void setDropOnIdle()
+  {
+    d_dropOnIdle = true;
+  }
+  bool isDropOnIdle() const
+  {
+    return d_dropOnIdle;
+  }
   std::vector<ProxyProtocolValue> proxyProtocolValues;
   std::string data;
   const ComboAddress d_remote;
@@ -1130,6 +1137,7 @@ public:
 private:
   const int d_fd;
   static std::atomic<uint32_t> s_currentConnections; //!< total number of current TCP connections
+  bool d_dropOnIdle{false};
 };
 
 class ImmediateServFailException

--- a/regression-tests.recursor-dnssec/test_KeepOpenTCP.py
+++ b/regression-tests.recursor-dnssec/test_KeepOpenTCP.py
@@ -1,0 +1,83 @@
+import dns
+import os
+import socket
+import struct
+
+from recursortests import RecursorTest
+
+class testKeepOpenTCP(RecursorTest):
+    _confdir = 'KeepOpenTCP'
+
+    _config_template = """dnssec=validate
+packetcache-ttl=10
+packetcache-servfail-ttl=10
+auth-zones=authzone.example=configs/%s/authzone.zone""" % _confdir
+
+    @classmethod
+    def generateRecursorConfig(cls, confdir):
+        authzonepath = os.path.join(confdir, 'authzone.zone')
+        with open(authzonepath, 'w') as authzone:
+            authzone.write("""$ORIGIN authzone.example.
+@ 3600 IN SOA {soa}
+@ 3600 IN A 192.0.2.88
+""".format(soa=cls._SOA))
+        super(testKeepOpenTCP, cls).generateRecursorConfig(confdir)
+
+    def sendTCPQueryKeepOpen(cls, sock, query, timeout=2.0):
+        try:
+            wire = query.to_wire()
+            sock.send(struct.pack("!H", len(wire)))
+            sock.send(wire)
+            data = sock.recv(2)
+            if data:
+                (datalen,) = struct.unpack("!H", data)
+                data = sock.recv(datalen)
+        except socket.timeout as e:
+            print("Timeout: %s" % (str(e)))
+            data = None
+        except socket.error as e:
+            print("Network error: %s" % (str(e)))
+            data = None
+
+        message = None
+        if data:
+            message = dns.message.from_wire(data)
+        return message
+
+    def testNoTrailingData(self):
+        count = 10
+        sock = [None] * count
+        expected = dns.rrset.from_text('ns.secure.example.', 0, dns.rdataclass.IN, 'A', '{prefix}.9'.format(prefix=self._PREFIX))
+        query = dns.message.make_query('ns.secure.example', 'A', want_dnssec=True)
+        query.flags |= dns.flags.AD
+        for i in range(count):
+            sock[i] = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock[i].settimeout(2.0)
+            sock[i].connect(("127.0.0.1", self._recursorPort))
+
+            res = self.sendTCPQueryKeepOpen(sock[i], query)
+            self.assertMessageIsAuthenticated(res)
+            self.assertRRsetInAnswer(res, expected)
+            self.assertMatchingRRSIGInAnswer(res, expected)
+            sock[i].settimeout(0.1)
+            try:
+                data = sock[i].recv(1)
+                self.assertTrue(False)
+            except socket.timeout as e:
+                print("ok")
+
+        for i in range(count):
+            sock[i].settimeout(2.0)
+            res = self.sendTCPQueryKeepOpen(sock[i], query)
+            self.assertMessageIsAuthenticated(res)
+            self.assertRRsetInAnswer(res, expected)
+            self.assertMatchingRRSIGInAnswer(res, expected)
+            sock[i].settimeout(0.1)
+            try:
+                data = sock[i].recv(1)
+                self.assertTrue(False)
+            except socket.timeout as e:
+                print("ok")
+        for i in range(count):
+            sock[i].close()
+


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Use guard objects to do the TCP connection bookkeeping and cleanup if needed.

If a policy drop is to be handled for a TCP connection, do not answer that query, but do handle already in-flight queries and then close.

Fixes #11021 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
