### PR TITLE
dnsdist: Reuse and save the TLS session tickets in DoT healthchecks

### DIFF
--- a/pdns/dnsdistdist/dnsdist-healthchecks.cc
+++ b/pdns/dnsdistdist/dnsdist-healthchecks.cc
@@ -292,9 +292,7 @@ static void healthCheckTCPCallback(int fd, FDMultiplexer::funcparam_t& param)
         try {
           auto sessions = data->d_tcpHandler->getTLSSessions();
           if (!sessions.empty()) {
-            struct timeval now;
-            gettimeofday(&now, nullptr);
-            g_sessionCache.putSessions(data->d_ds->getID(), now.tv_sec, std::move(sessions));
+            g_sessionCache.putSessions(data->d_ds->getID(), time(nullptr), std::move(sessions));
           }
         }
         catch (const std::exception& e) {

--- a/regression-tests.dnsdist/test_OutgoingTLS.py
+++ b/regression-tests.dnsdist/test_OutgoingTLS.py
@@ -65,8 +65,10 @@ class OutgoingTLSTests(object):
         # we tried to reuse the connection (and then it failed but hey)
         self.assertEqual(self.getServerStat('tcpReusedConnections'), numberOfQueries - 1)
         # we resumed the TLS session, though, but since we only learn about that
-        # when the connection is closed, we are off by one
-        self.assertEqual(self.getServerStat('tlsResumptions'), numberOfUDPQueries - 1)
+        # when the connection is closed, we might be off by one, except if a health check
+        # allowed the first TCP connection to be resumed as well
+        self.assertGreaterEqual(self.getServerStat('tlsResumptions'), numberOfUDPQueries - 1)
+        self.assertLessEqual(self.getServerStat('tlsResumptions'), numberOfUDPQueries)
 
     def testTCP(self):
         """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This reduces the cost of the healthchecks themselves while saving the TLS session reduces the cost of opening of a DoT connection for actual queries later on.
In the future a refactoring of the TCP/DoT healthcheck code to be more like the "black box" approach used for DoH would be nice to have.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
