### PR TITLE
rec: Regression tests: smarter and faster startup and teardown of auth and rec

### DIFF
--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -526,6 +526,7 @@ distributor-threads={threads}""".format(confdir=confdir,
         for try_number in range(0, 100):
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(1.0)
                 sock.connect((ipaddress, port))
                 sock.close()
                 return

--- a/regression-tests.recursor-dnssec/test_RPZ.py
+++ b/regression-tests.recursor-dnssec/test_RPZ.py
@@ -403,6 +403,7 @@ e 3600 IN A 192.0.2.42
         raise AssertionError("Waited %d seconds for the serial to be updated to %d but the serial is still %d" % (timeout, serial, currentSerial))
 
     def testRPZ(self):
+        self.waitForTCPSocket("127.0.0.1", self._wsPort)
         # first zone, only a should be blocked
         self.waitUntilCorrectSerialIsLoaded(1)
         self.checkRPZStats(1, 1, 1, self._xfrDone)

--- a/regression-tests.recursor-dnssec/test_RootNXTrust.py
+++ b/regression-tests.recursor-dnssec/test_RootNXTrust.py
@@ -54,6 +54,7 @@ api-key=%s
         after receiving a NXD from "." for nx-example. as an answer for www.nx-example.
         """
 
+        self.waitForTCPSocket("127.0.0.1", self._wsPort)
         self.waitForOutgoingToStabilize()
         # First query nx.example.
         before = self.getOutgoingQueriesCount()
@@ -101,6 +102,7 @@ api-key=%s
         after receiving a NXD from "." for nx-example. as an answer for www.nx-example.
         """
 
+        self.waitForTCPSocket("127.0.0.1", self._wsPort)
         self.waitForOutgoingToStabilize()
         # first query nx.example.
         before = self.getOutgoingQueriesCount()


### PR DESCRIPTION
Instead of having a fixed 1 or 2s delay, poll the TCP port to see
if rec or auth has started up in a semi-tight loop: a loop with a
small sleep.  For teardown we poll the wait status using poll() in
a similar loop.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
