### PR TITLE
 dnsdist: add support to spoof a full self-generated response from lua

### DIFF
--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -784,7 +784,7 @@ DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, std::string* ruleresu
 
   if (d_raw.size() >= sizeof(dnsheader)) {
     auto id = dq->getHeader()->id;
-    dq->getMutableData() = std::move(d_raw);
+    dq->getMutableData() = d_raw;
     dq->getHeader()->id = id;
     return Action::HeaderModify;
   }

--- a/pdns/dnsdist-lua-actions.cc
+++ b/pdns/dnsdist-lua-actions.cc
@@ -776,10 +776,18 @@ DNSAction::Action SpoofAction::operator()(DNSQuestion* dq, std::string* ruleresu
   // do we even have a response?
   if (d_cname.empty() &&
       d_rawResponses.empty() &&
+      // make sure pre-forged response is greater than sizeof(dnsheader)
+      (d_raw.size() < sizeof(dnsheader)) &&
       d_types.count(qtype) == 0) {
     return Action::None;
   }
 
+  if (d_raw.size() >= sizeof(dnsheader)) {
+    auto id = dq->getHeader()->id;
+    dq->getMutableData() = std::move(d_raw);
+    dq->getHeader()->id = id;
+    return Action::HeaderModify;
+  }
   vector<ComboAddress> addrs;
   vector<std::string> rawResponses;
   unsigned int totrdatalen = 0;
@@ -2178,6 +2186,14 @@ void setupLuaActions(LuaContext& luaCtx)
       auto sa = std::dynamic_pointer_cast<SpoofAction>(ret);
       parseResponseConfig(vars, sa->d_responseConfig);
       return ret;
+    });
+
+  luaCtx.writeFunction("SpoofPacketAction", [](const std::string& response, size_t len) {
+    if (len < sizeof(dnsheader)) {
+      throw std::runtime_error(std::string("SpoofPacketAction: given packet len is too small"));
+    }
+    auto ret = std::shared_ptr<DNSAction>(new SpoofAction(response.c_str(), len));
+    return ret;
     });
 
   luaCtx.writeFunction("DropAction", []() {

--- a/pdns/dnsdist-lua-vars.cc
+++ b/pdns/dnsdist-lua-vars.cc
@@ -32,6 +32,7 @@ void setupLuaVars(LuaContext& luaCtx)
       {"Nxdomain", (int)DNSAction::Action::Nxdomain},
       {"Refused", (int)DNSAction::Action::Refused},
       {"Spoof", (int)DNSAction::Action::Spoof},
+      {"SpoofPacket", (int)DNSAction::Action::SpoofPacket},
       {"SpoofRaw", (int)DNSAction::Action::SpoofRaw},
       {"Allow", (int)DNSAction::Action::Allow},
       {"HeaderModify", (int)DNSAction::Action::HeaderModify},

--- a/pdns/dnsdist-lua.hh
+++ b/pdns/dnsdist-lua.hh
@@ -55,6 +55,10 @@ public:
   {
   }
 
+  SpoofAction(const char* rawresponse, size_t len): d_raw(rawresponse, rawresponse + len)
+  {
+  }
+
   SpoofAction(const vector<std::string>& raws): d_rawResponses(raws)
   {
   }
@@ -84,6 +88,7 @@ private:
   std::vector<ComboAddress> d_addrs;
   std::set<uint16_t> d_types;
   std::vector<std::string> d_rawResponses;
+  PacketBuffer d_raw;
   DNSName d_cname;
 };
 

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -768,6 +768,14 @@ static void spoofResponseFromString(DNSQuestion& dq, const string& spoofContent,
   }
 }
 
+static void spoofPacketFromString(DNSQuestion& dq, const string& spoofContent)
+{
+  string result;
+
+  SpoofAction sa(spoofContent.c_str(), spoofContent.size());
+  sa(&dq, &result);
+}
+
 bool processRulesResult(const DNSAction::Action& action, DNSQuestion& dq, std::string& ruleresult, bool& drop)
 {
   switch(action) {
@@ -799,6 +807,10 @@ bool processRulesResult(const DNSAction::Action& action, DNSQuestion& dq, std::s
     break;
   case DNSAction::Action::Spoof:
     spoofResponseFromString(dq, ruleresult, false);
+    return true;
+    break;
+  case DNSAction::Action::SpoofPacket:
+    spoofPacketFromString(dq, ruleresult);
     return true;
     break;
   case DNSAction::Action::SpoofRaw:

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -204,7 +204,7 @@ struct DNSResponse : DNSQuestion
 class DNSAction
 {
 public:
-  enum class Action : uint8_t { Drop, Nxdomain, Refused, Spoof, Allow, HeaderModify, Pool, Delay, Truncate, ServFail, None, NoOp, NoRecurse, SpoofRaw };
+  enum class Action : uint8_t { Drop, Nxdomain, Refused, Spoof, Allow, HeaderModify, Pool, Delay, Truncate, ServFail, None, NoOp, NoRecurse, SpoofRaw, SpoofPacket };
   static std::string typeToString(const Action& action)
   {
     switch(action) {
@@ -216,6 +216,8 @@ public:
       return "Send Refused";
     case Action::Spoof:
       return "Spoof an answer";
+    case Action::SpoofPacket:
+      return "Spoof a raw answer from bytes";
     case Action::SpoofRaw:
       return "Spoof an answer from raw bytes";
     case Action::Allow:

--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -107,6 +107,8 @@ void dnsdist_ffi_dnsquestion_send_trap(dnsdist_ffi_dnsquestion_t* dq, const char
 void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_raw_value_t* values, size_t valuesCount) __attribute__ ((visibility ("default")));
 // the content of values should contain raw IPv4 or IPv6 addresses in network byte-order
 void dnsdist_ffi_dnsquestion_spoof_addrs(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_raw_value_t* values, size_t valuesCount) __attribute__ ((visibility ("default")));
+// spoof raw response. will just replace qid to match question
+void dnsdist_ffi_dnsquestion_spoof_packet(dnsdist_ffi_dnsquestion_t* dq, const char* rawresponse, size_t len) __attribute__ ((visibility ("default")));
 
 typedef struct dnsdist_ffi_servers_list_t dnsdist_ffi_servers_list_t;
 typedef struct dnsdist_ffi_server_t dnsdist_ffi_server_t;

--- a/pdns/dnsdistdist/dnsdist-lua-ffi.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi.cc
@@ -434,6 +434,13 @@ void dnsdist_ffi_dnsquestion_send_trap(dnsdist_ffi_dnsquestion_t* dq, const char
   }
 }
 
+void dnsdist_ffi_dnsquestion_spoof_packet(dnsdist_ffi_dnsquestion_t* dq, const char* raw, size_t len)
+{
+  std::string result;
+  SpoofAction sa(raw, len);
+  sa(dq->dq, &result);
+}
+
 void dnsdist_ffi_dnsquestion_spoof_raw(dnsdist_ffi_dnsquestion_t* dq, const dnsdist_ffi_raw_value_t* values, size_t valuesCount)
 {
   std::vector<std::string> data;

--- a/pdns/dnsdistdist/docs/reference/constants.rst
+++ b/pdns/dnsdistdist/docs/reference/constants.rst
@@ -108,6 +108,9 @@ DNSAction
 .. versionchanged:: 1.5.0
   ``DNSAction.SpoofRaw`` has been added.
 
+.. versionchanged:: 1.8.0
+  ``DNSAction.SpoofPacket`` has been added.
+
 These constants represent an Action that can be returned from :func:`LuaAction` functions.
 
  * ``DNSAction.Allow``: let the query pass, skipping other rules
@@ -121,6 +124,7 @@ These constants represent an Action that can be returned from :func:`LuaAction` 
  * ``DNSAction.Refused``: return a response with a Refused rcode
  * ``DNSAction.ServFail``: return a response with a ServFail rcode
  * ``DNSAction.Spoof``: spoof the response using the supplied IPv4 (A), IPv6 (AAAA) or string (CNAME) value. TTL will be 60 seconds.
+ * ``DNSAction.SpoofPacket``: spoof the response using the supplied raw packet
  * ``DNSAction.SpoofRaw``: spoof the response using the supplied raw value as record data (see also :meth:`DNSQuestion:spoof` and :func:`dnsdist_ffi_dnsquestion_spoof_raw` to spoof multiple values)
  * ``DNSAction.Truncate``: truncate the response
  * ``DNSAction.NoRecurse``: set rd=0 on the query

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1561,7 +1561,7 @@ The following actions exist.
   Spoof a raw self-generated answer
 
   :param string rawPacket: The raw wire-ready DNS answer
-  :param int len: The len of the packet
+  :param int len: The length of the packet
 
 .. function:: TagAction(name, value)
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1554,6 +1554,15 @@ The following actions exist.
   * ``ra``: bool - Set the RA bit to this value (true means the bit is set, false means it's cleared). Default is to copy the value of the RD bit from the incoming query.
   * ``ttl``: int - The TTL of the record.
 
+.. function:: SpoofPacketAction(rawPacket, len)
+
+  .. versionadded:: 1.8.0
+
+  Spoof a raw self-generated answer
+
+  :param string rawPacket: The raw wire-ready DNS answer
+  :param int len: The len of the packet
+
 .. function:: TagAction(name, value)
 
   .. deprecated:: 1.6.0

--- a/regression-tests.dnsdist/test_Spoofing.py
+++ b/regression-tests.dnsdist/test_Spoofing.py
@@ -917,46 +917,59 @@ class TestSpoofingLuaWithStatistics(DNSDistTest):
 class TestSpoofingLuaSpoofPacket(DNSDistTest):
 
     _config_template = """
-    local ffi = require("ffi")
 
     function spoofpacket(dq)
-        -- REFUSED answer
-        local rawResponse="\\000\\000\\129\\133\\000\\001\\000\\000\\000\\000\\000\\000\\014lua\\045raw\\045packet\\012ffi\\045spoofing\\005tests\\008powerdns\\003com\\000\\000\\001\\000\\001"
-        local qtype = ffi.C.dnsdist_ffi_dnsquestion_get_qtype(dq)
-        ffi.C.dnsdist_ffi_dnsquestion_spoof_packet(dq, rawResponse, string.len(rawResponse))
-        return DNSAction.HeaderModify
+        if dq.qtype == DNSQType.A then
+             return DNSAction.SpoofPacket, "\\000\\000\\129\\133\\000\\001\\000\\000\\000\\000\\000\\000\\014lua\\045raw\\045packet\\008spoofing\\005tests\\008powerdns\\003com\\000\\000\\001\\000\\001"
+        end
+        return DNSAction.None, ""
     end
 
-    addAction("lua-raw-packet.ffi-spoofing.tests.powerdns.com.", LuaFFIAction(spoofpacket))
-    local otherResponse="\\000\\000\\129\\133\\000\\001\\000\\000\\000\\000\\000\\000\\014lua\\045raw\\045packet\\008spoofing\\005tests\\008powerdns\\003com\\000\\000\\001\\000\\001"
-    addAction("lua-raw-packet.spoofing.tests.powerdns.com.", SpoofPacketAction(otherResponse, string.len(otherResponse)))
+    addAction("lua-raw-packet.spoofing.tests.powerdns.com.", LuaAction(spoofpacket))
+    local rawResponse="\\000\\000\\129\\133\\000\\001\\000\\000\\000\\000\\000\\000\\019rule\\045lua\\045raw\\045packet\\008spoofing\\005tests\\008powerdns\\003com\\000\\000\\001\\000\\001"
+    addAction(AndRule{QTypeRule(DNSQType.A), makeRule("rule-lua-raw-packet.spoofing.tests.powerdns.com.")}, SpoofPacketAction(rawResponse, string.len(rawResponse)))
+
+    local ffi = require("ffi")
+
+    function spoofpacketffi(dq)
+        local qtype = ffi.C.dnsdist_ffi_dnsquestion_get_qtype(dq)
+        if qtype == DNSQType.A then
+            -- REFUSED answer
+            local refusedResponse="\\000\\000\\129\\133\\000\\001\\000\\000\\000\\000\\000\\000\\014lua\\045raw\\045packet\\012ffi\\045spoofing\\005tests\\008powerdns\\003com\\000\\000\\001\\000\\001"
+
+            ffi.C.dnsdist_ffi_dnsquestion_spoof_packet(dq, refusedResponse, string.len(refusedResponse))
+            return DNSAction.HeaderModify
+        end
+        return DNSAction.None, ""
+    end
+
+    addAction("lua-raw-packet.ffi-spoofing.tests.powerdns.com.", LuaFFIAction(spoofpacketffi))
     newServer{address="127.0.0.1:%s"}
     """
     _verboseMode = True
+
+    def testLuaSpoofPacket(self):
+        """
+        Spoofing via Lua FFI: Spoof raw response via Lua FFI
+        """
+        for name in ('lua-raw-packet.spoofing.tests.powerdns.com.', 'rule-lua-raw-packet.spoofing.tests.powerdns.com.'):
+
+            query = dns.message.make_query(name, 'A', 'IN')
+            expectedResponse = dns.message.make_response(query)
+            expectedResponse.flags |= dns.flags.RA
+            expectedResponse.set_rcode(dns.rcode.REFUSED)
+
+            for method in ("sendUDPQuery", "sendTCPQuery"):
+                sender = getattr(self, method)
+                (_, receivedResponse) = sender(query, response=None, useQueue=False)
+                self.assertTrue(receivedResponse)
+                self.assertEqual(expectedResponse, receivedResponse)
 
     def testLuaFFISpoofPacket(self):
         """
         Spoofing via Lua FFI: Spoof raw response via Lua FFI
         """
         name = 'lua-raw-packet.ffi-spoofing.tests.powerdns.com.'
-
-        #
-        query = dns.message.make_query(name, 'A', 'IN')
-        expectedResponse = dns.message.make_response(query)
-        expectedResponse.flags |= dns.flags.RA
-        expectedResponse.set_rcode(dns.rcode.REFUSED)
-
-        for method in ("sendUDPQuery", "sendTCPQuery"):
-            sender = getattr(self, method)
-            (_, receivedResponse) = sender(query, response=None, useQueue=False)
-            self.assertTrue(receivedResponse)
-            self.assertEqual(expectedResponse, receivedResponse)
-
-    def testLuaSpoofPacket(self):
-        """
-        Spoofing via Lua : Spoof raw response via Lua
-        """
-        name = 'lua-raw-packet.spoofing.tests.powerdns.com.'
 
         #
         query = dns.message.make_query(name, 'A', 'IN')


### PR DESCRIPTION
### Short description
This adds the ability to set a completely self-generated raw answer from Lua

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
