### PR TITLE
Numeric sort for numeric DNS name fields

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -214,6 +214,17 @@ inline bool DNSName::canonCompare(const DNSName& rhs) const
     uint8_t ourlen = *(ourstr - 1), rhslen = *(rhsstr - 1);
     bool res;
 
+    // If both names are integers of different lengths: longer name is greater
+    if (ourlen != rhslen) {
+      res = true;
+      for (int i = 0; res && i < ourlen; i++)
+        res = isdigit(ourstr[i]);
+      for (int i = 0; res && i < rhslen; i++)
+        res = isdigit(rhsstr[i]);
+      if (res)
+        return ourlen < rhslen;
+    }
+
     res = std::lexicographical_compare(ourstr, ourstr + ourlen,
                                        rhsstr, rhsstr + rhslen,
                                        [](const unsigned char& a, const unsigned char& b) {

--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -209,26 +209,25 @@ inline bool DNSName::canonCompare(const DNSName& rhs) const
     ourcount--;
     rhscount--;
 
-    bool res=std::lexicographical_compare(
-					  d_storage.c_str() + ourpos[ourcount] + 1, 
-					  d_storage.c_str() + ourpos[ourcount] + 1 + *(d_storage.c_str() + ourpos[ourcount]),
-					  rhs.d_storage.c_str() + rhspos[rhscount] + 1, 
-					  rhs.d_storage.c_str() + rhspos[rhscount] + 1 + *(rhs.d_storage.c_str() + rhspos[rhscount]),
-					  [](const unsigned char& a, const unsigned char& b) {
-					    return dns_tolower(a) < dns_tolower(b);
-					  });
-    
+    const char* ourstr = d_storage.c_str() + ourpos[ourcount] + 1;
+    const char* rhsstr = rhs.d_storage.c_str() + rhspos[rhscount] + 1;
+    uint8_t ourlen = *(ourstr - 1), rhslen = *(rhsstr - 1);
+    bool res;
+
+    res = std::lexicographical_compare(ourstr, ourstr + ourlen,
+                                       rhsstr, rhsstr + rhslen,
+                                       [](const unsigned char& a, const unsigned char& b) {
+                                         return dns_tolower(a) < dns_tolower(b);
+                                       });
     //    cout<<"Forward: "<<res<<endl;
     if(res)
       return true;
 
-    res=std::lexicographical_compare(	  rhs.d_storage.c_str() + rhspos[rhscount] + 1, 
-					  rhs.d_storage.c_str() + rhspos[rhscount] + 1 + *(rhs.d_storage.c_str() + rhspos[rhscount]),
-					  d_storage.c_str() + ourpos[ourcount] + 1, 
-					  d_storage.c_str() + ourpos[ourcount] + 1 + *(d_storage.c_str() + ourpos[ourcount]),
-					  [](const unsigned char& a, const unsigned char& b) {
-					    return dns_tolower(a) < dns_tolower(b);
-					  });
+    res = std::lexicographical_compare(rhsstr, rhsstr + rhslen,
+                                       ourstr, ourstr + ourlen,
+                                       [](const unsigned char& a, const unsigned char& b) {
+                                         return dns_tolower(a) < dns_tolower(b);
+                                       });
     //    cout<<"Reverse: "<<res<<endl;
     if(res)
       return false;

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -695,6 +695,13 @@ BOOST_AUTO_TEST_CASE(test_compare_canonical) {
   BOOST_CHECK(DNSName("BeRt.com").canonCompare(DNSName("WWW.berT.com")));
   BOOST_CHECK(!DNSName("www.BeRt.com").canonCompare(DNSName("WWW.berT.com")));
 
+  BOOST_CHECK(DNSName("99.2.1.10.in-addr.arpa").canonCompare(DNSName("101.2.1.10.in-addr.arpa")));
+  BOOST_CHECK(!DNSName("101.2.1.10.in-addr.arpa").canonCompare(DNSName("99.2.1.10.in-addr.arpa")));
+  BOOST_CHECK(DNSName("ns12.example.com").canonCompare(DNSName("ns8.example.com")));
+  BOOST_CHECK(!DNSName("ns8.example.com").canonCompare(DNSName("ns12.example.com")));
+  BOOST_CHECK(DNSName("135.org").canonCompare(DNSName("2x.org")));
+  BOOST_CHECK(!DNSName("2x.org").canonCompare(DNSName("135.org")));
+
   CanonDNSNameCompare a;
   BOOST_CHECK(a(g_rootdnsname, DNSName("www.powerdns.com")));
   BOOST_CHECK(a(g_rootdnsname, DNSName("www.powerdns.net")));


### PR DESCRIPTION
### Short description
Sort numeric DNS fields numerically. This is particularly noticeable in the `pdnsutil edit-zone` use case for IPv4 reverse zones, where many DNS name components are small integers. For example,

`99.1.168.192.in-addr.arpa`
`101.1.168.192.in-addr.arpa`

now sorts correctly. The previous lexical sort is retained for mixed alphanumeric fields, as it is not clear what users would expect in all cases. So, for example, `ns12` still sorts above `ns8`.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)