### PR TITLE
rec: backport 10982 to rec-4.x.6: Condition to HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV is reversed

### DIFF
--- a/builder-support/specs/pdns-recursor.spec
+++ b/builder-support/specs/pdns-recursor.spec
@@ -73,6 +73,14 @@ sed -i \
     -e 's/# setgid=/setgid=pdns-recursor/' \
     %{buildroot}%{_sysconfdir}/%{name}/recursor.conf
 
+# The EL7 and 8 systemd actually supports %t, but its version number is older than that, so we do use seperate runtime dirs, but don't rely on RUNTIME_DIRECTORY
+%if 0%{?rhel} < 9
+sed -e 's!/pdns_recursor!& --socket-dir=%t/pdns-recursor!' -i %{buildroot}/%{_unitdir}/pdns-recursor.service
+%if 0%{?rhel} < 8
+sed -e 's!/pdns_recursor!& --socket-dir=%t/pdns-recursor-%i!' -e 's!RuntimeDirectory=pdns-recursor!&-%i!' -i %{buildroot}/%{_unitdir}/pdns-recursor@.service
+%endif
+%endif
+
 %pre
 getent group pdns-recursor > /dev/null || groupadd -r pdns-recursor
 getent passwd pdns-recursor > /dev/null || \

--- a/builder-support/specs/pdns.spec
+++ b/builder-support/specs/pdns.spec
@@ -225,6 +225,14 @@ chmod 600 %{buildroot}%{_sysconfdir}/%{name}/pdns.conf
 %{__mv} %{buildroot}/%{_bindir}/zone2ldap %{buildroot}/%{_bindir}/pdns-zone2ldap
 %{__mv} %{buildroot}/%{_mandir}/man1/zone2ldap.1 %{buildroot}/%{_mandir}/man1/pdns-zone2ldap.1
 
+# The EL7 and 8 systemd actually supports %t, but its version number is older than that, so we do use seperate runtime dirs, but don't rely on RUNTIME_DIRECTORY
+%if 0%{?rhel} < 9
+sed -e 's!/pdns_server!& --socket-dir=%t/pdns!' -i %{buildroot}/%{_unitdir}/pdns.service
+%if 0%{?rhel} < 8
+sed -e 's!/pdns_server!& --socket-dir=%t/pdns-%i!' -e 's!RuntimeDirectory=pdns!&-%i!' -i %{buildroot}/%{_unitdir}/pdns@.service
+%endif
+%endif
+
 %check
 PDNS_TEST_NO_IPV6=1 make %{?_smp_mflags} -C pdns check || (cat pdns/test-suite.log && false)
 

--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -174,6 +174,9 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
                  # @aio, @sync, @chown, @setuid, @memlock, @signal and @timer in 235
                  systemd_system_call_filter=y
               fi
+              if test $_systemd_version -ge 236; then
+                 systemd_percent_t=y
+              fi
               if test $_systemd_version -ge 239; then
                  systemd_private_mounts=y
               fi
@@ -195,6 +198,7 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
         AM_CONDITIONAL([HAVE_SYSTEMD_DYNAMIC_USER], [ test x"$systemd_dynamic_user" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_LOCK_PERSONALITY], [ test x"$systemd_lock_personality" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE], [ test x"$systemd_memory_deny_write_execute" = "xy" ])
+        AM_CONDITIONAL([HAVE_SYSTEMD_PERCENT_T], [ test x"$systemd_percent_t" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PRIVATE_DEVICES], [ test x"$systemd_private_devices" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PRIVATE_MOUNTS], [ test x"$systemd_private_mounts" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PRIVATE_TMP], [ test x"$systemd_private_tmp" = "xy" ])

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1664,7 +1664,9 @@ if HAVE_SYSTEMD
 pdns.service: pdns.service.in
 	$(AM_V_GEN)sed -e 's![@]sbindir[@]!$(sbindir)!' -e 's![@]service_user[@]!$(service_user)!' -e 's![@]service_group[@]!$(service_group)!' < $< > $@
 if !HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV
+if HAVE_SYSTEMD_PERCENT_T
 	$(AM_V_GEN)sed -e 's!/pdns_server!& --socket-dir=%t/pdns!' -i $@
+endif
 endif
 if !HAVE_SYSTEMD_LOCK_PERSONALITY
 	$(AM_V_GEN)perl -ni -e 'print unless /^LockPersonality/' $@
@@ -1724,11 +1726,13 @@ endif
 pdns@.service: pdns.service
 	$(AM_V_GEN)sed -e 's!/pdns_server!& --config-name=%i!' \
 	  -e 's!Authoritative Server!& %i!' \
-	  -e 's!RuntimeDirectory=.*!&-%i!' \
 	  -e 's!SyslogIdentifier=.*!&-%i!' \
 	  < $< > $@
+if HAVE_SYSTEMD_PERCENT_T
+	$(AM_V_GEN)sed -e 's!RuntimeDirectory=.*!&-%i!' -i $@
 if !HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV
 	$(AM_V_GEN)sed -e 's!--socket-dir=[^ ]\+!&-%i !' -i $@
+endif
 endif
 
 systemdsystemunitdir = $(SYSTEMD_DIR)

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -545,7 +545,9 @@ if HAVE_SYSTEMD
 pdns-recursor.service: pdns-recursor.service.in
 	$(AM_V_GEN)sed -e 's![@]sbindir[@]!$(sbindir)!' -e 's![@]service_user[@]!$(service_user)!' -e 's![@]service_group[@]!$(service_group)!' < $< > $@
 if !HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV
+if HAVE_SYSTEMD_PERCENT_T
 	$(AM_V_GEN)sed -e 's!/pdns_recursor!& --socket-dir=%t/pdns-recursor!' -i $@
+endif
 endif
 if !HAVE_SYSTEMD_LOCK_PERSONALITY
 	$(AM_V_GEN)perl -ni -e 'print unless /^LockPersonality/' $@
@@ -605,11 +607,13 @@ endif
 pdns-recursor@.service: pdns-recursor.service
 	$(AM_V_GEN)sed -e 's!/pdns_recursor!& --config-name=%i!' \
 	  -e 's!Recursor!& %i!' \
-	  -e 's!RuntimeDirectory=.*!&-%i!' \
 	  -e 's!SyslogIdentifier=.*!&-%i!' \
 	  < $< > $@
+if HAVE_SYSTEMD_PERCENT_T
+	$(AM_V_GEN)sed -e 's!RuntimeDirectory=.*!&-%i!' -i $@
 if !HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV
 	$(AM_V_GEN)sed -e 's!--socket-dir=[^ ]\+!&-%i !' -i $@
+endif
 endif
 
 systemdsystemunitdir = $(SYSTEMD_DIR)


### PR DESCRIPTION
(cherry picked from commit fc1f6fb803e3ab7346f327b6113fc79eaa40abf2)

Backport of #10982 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
