### PR TITLE
rec: Prep for rec-4.6.0-rc1

### DIFF
--- a/docs/secpoll.zone
+++ b/docs/secpoll.zone
@@ -1,4 +1,4 @@
-@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2021112901 10800 3600 604800 10800
+@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2021120301 10800 3600 604800 10800
 @       3600    IN  NS  pdns-public-ns1.powerdns.com.
 @       3600    IN  NS  pdns-public-ns2.powerdns.com.
 
@@ -283,6 +283,7 @@ recursor-4.6.0-alpha1.security-status                   60 IN TXT "1 Unsupported
 recursor-4.6.0-alpha2.security-status                   60 IN TXT "1 Unsupported pre-release"
 recursor-4.6.0-beta1.security-status                    60 IN TXT "1 Unsupported pre-release"
 recursor-4.6.0-beta2.security-status                    60 IN TXT "1 Unsupported pre-release"
+recursor-4.6.0-rc1.security-status                      60 IN TXT "1 Unsupported pre-release"
 
 ; Recursor Debian
 recursor-3.6.2-2.debian.security-status                 60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/3/security/powerdns-advisory-2015-01/ and https://doc.powerdns.com/3/security/powerdns-advisory-2016-02/"

--- a/pdns/recursordist/docs/changelog/4.6.rst
+++ b/pdns/recursordist/docs/changelog/4.6.rst
@@ -2,6 +2,39 @@ Changelogs for 4.6.X
 ====================
 
 .. changelog::
+  :version: 4.6.0-rc1
+  :released: 3rd of December 2021
+
+  .. change::
+    :tags: Bug Fixes
+    :pullreq: 11055
+    :tickets: 10982
+
+    Condition to HAVE_SYSTEMD_WITH_RUNTIME_DIR_ENV is reversed.
+    During build, the runtime directory in the service files for virtual-hosting are now correctly generated.
+
+  .. change::
+    :tags: Bug Fixes
+    :pullreq: 11025
+    :tickets: 10994, 11010
+
+    Do cache negcache results, even when wasVariable() is true.
+
+  .. change::
+    :tags: Bug Fixes
+    :pullreq: 11022
+    :tickets: 11018
+
+    Fix logic botch in TCP code introduced by notify handling in 4.6.0-beta2.
+
+  .. change::
+    :tags: Bug Fixes
+    :pullreq: 11016
+    :tickets: 11005
+
+    Include sys/time.h; needed on musl.
+
+.. changelog::
   :version: 4.6.0-beta2
   :released: 17th of November 2021
 

--- a/pdns/recursordist/docs/changelog/4.6.rst
+++ b/pdns/recursordist/docs/changelog/4.6.rst
@@ -18,7 +18,7 @@ Changelogs for 4.6.X
     :pullreq: 11025
     :tickets: 10994, 11010
 
-    Do cache negcache results, even when wasVariable() is true.
+    Do cache negative answers, even when the response was ECS-scoped.
 
   .. change::
     :tags: Bug Fixes


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Prep for rec-4.6.0-rc1.

I wish we could say in the secpoll: superseded release, i.e. a status between 1 and 2: 

`X: recommended to upgrade` (but no security issue).

Or should we redefine status 2 to be: "Recommended upgrade for security or other reasons?

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
