### PR TITLE
secpoll: for pre-releases, use status 2 when supserseded.

### DIFF
--- a/docs/common/secpoll.rst
+++ b/docs/common/secpoll.rst
@@ -38,6 +38,7 @@ The data returned is in one of the following forms:
 -  "3 Upgrade mandatory for security reasons, see ..." -> 3
 
 In cases 2 or 3, periodic logging commences.
+Case 2 can also be issued for non-security related upgrade recommendations for pre-releases.
 The metric security-status is set to 2 or 3 respectively.
 If at a later date, resolution fails, the security-status is not reset to 1.
 It could be lowered however if we discover the security status is less urgent than we thought.

--- a/docs/secpoll.zone
+++ b/docs/secpoll.zone
@@ -1,6 +1,18 @@
-@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2021120301 10800 3600 604800 10800
+@       86400   IN  SOA pdns-public-ns1.powerdns.com. pieter\.lexis.powerdns.com. 2021120304 10800 3600 604800 10800
 @       3600    IN  NS  pdns-public-ns1.powerdns.com.
 @       3600    IN  NS  pdns-public-ns2.powerdns.com.
+
+; Policy to mark releases
+; =======================
+; Status 1: OK
+; Status 2: Upgrade recommended for security or other reasons
+; Status 3: Upgrade mandatory for security reasons
+
+; Pre-releases (alpha, beta, rc) get initial status: "1 Unsupported pre-release"
+; Superseded pre-releases get "2 Superseded pre-release", or "3 ..." if a security issue was found.
+
+; Official releases get status 2 or 3 on security issues or on end-of-life of the version only.
+;
 
 ; Auth
 auth-3.3.2.security-status                              60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/3/security/powerdns-advisory-2015-01/"
@@ -224,7 +236,7 @@ recursor-4.1.14.security-status                         60 IN TXT "3 Upgrade now
 recursor-4.1.15.security-status                         60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2020-01.html https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2020-02.html https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2020-03.html"
 recursor-4.1.16.security-status                         60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2020-04.html"
 recursor-4.1.17.security-status                         60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2020-07.html"
-recursor-4.1.18.security-status                         60 IN TXT "1 OK"
+recursor-4.1.18.security-status                         60 IN TXT "2 Unsupported release (EOL)"
 
 recursor-4.2.0-alpha1.security-status                   60 IN TXT "3 Unsupported pre-release (known vulnerabilities)"
 recursor-4.2.0-beta1.security-status                    60 IN TXT "3 Unsupported pre-release (known vulnerabilities)"
@@ -235,7 +247,7 @@ recursor-4.2.1.security-status                          60 IN TXT "3 Upgrade now
 recursor-4.2.2.security-status                          60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2020-04.html"
 recursor-4.2.3.security-status                          60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2020-07.html"
 recursor-4.2.4.security-status                          60 IN TXT "3 Upgrade now, see https://doc.powerdns.com/recursor/security-advisories/powerdns-advisory-2020-07.html"
-recursor-4.2.5.security-status                          60 IN TXT "1 OK"
+recursor-4.2.5.security-status                          60 IN TXT "2 Unsupported release (EOL)"
 
 recursor-4.3.0-alpha1.security-status                   60 IN TXT "3 Unsupported pre-release (known vulnerabilities)"
 recursor-4.3.0-alpha2.security-status                   60 IN TXT "3 Unsupported pre-release (known vulnerabilities)"
@@ -279,10 +291,10 @@ recursor-4.5.4.security-status                          60 IN TXT "1 OK"
 recursor-4.5.5.security-status                          60 IN TXT "1 OK"
 recursor-4.5.6.security-status                          60 IN TXT "1 OK"
 recursor-4.5.7.security-status                          60 IN TXT "1 OK"
-recursor-4.6.0-alpha1.security-status                   60 IN TXT "1 Unsupported pre-release"
-recursor-4.6.0-alpha2.security-status                   60 IN TXT "1 Unsupported pre-release"
-recursor-4.6.0-beta1.security-status                    60 IN TXT "1 Unsupported pre-release"
-recursor-4.6.0-beta2.security-status                    60 IN TXT "1 Unsupported pre-release"
+recursor-4.6.0-alpha1.security-status                   60 IN TXT "2 Unsupported pre-release"
+recursor-4.6.0-alpha2.security-status                   60 IN TXT "2 Unsupported pre-release"
+recursor-4.6.0-beta1.security-status                    60 IN TXT "2 Unsupported pre-release"
+recursor-4.6.0-beta2.security-status                    60 IN TXT "2 Unsupported pre-release"
 recursor-4.6.0-rc1.security-status                      60 IN TXT "1 Unsupported pre-release"
 
 ; Recursor Debian
@@ -426,7 +438,7 @@ dnsdist-1.6.0-rc1.security-status                          60 IN TXT "3 Unsuppor
 dnsdist-1.6.0-rc2.security-status                          60 IN TXT "3 Unsupported pre-release"
 dnsdist-1.6.0.security-status                              60 IN TXT "1 OK"
 dnsdist-1.6.1.security-status                              60 IN TXT "1 OK"
-dnsdist-1.7.0-alpha1.security-status                       60 IN TXT "1 Unsupported pre-release"
-dnsdist-1.7.0-alpha2.security-status                       60 IN TXT "1 Unsupported pre-release"
-dnsdist-1.7.0-beta1.security-status                        60 IN TXT "1 Unsupported pre-release"
+dnsdist-1.7.0-alpha1.security-status                       60 IN TXT "2 Unsupported pre-release"
+dnsdist-1.7.0-alpha2.security-status                       60 IN TXT "2 Unsupported pre-release"
+dnsdist-1.7.0-beta1.security-status                        60 IN TXT "2 Unsupported pre-release"
 dnsdist-1.7.0-beta2.security-status                        60 IN TXT "1 Unsupported pre-release"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

A proposal:

Slight change in the secpoll policy: status 2 is also issued for non-security related upgrade recommendations, but for pre-releases only. This is to nudge people into not running a pre-release version if a newer one is available.

Also add the policy to `secpoll.zone` itself.

If this is deemed a good thing, I'll update the secpoll records of pre-releases as well.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
