### PR TITLE
service files: Add more sandboxing options

### DIFF
--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -193,6 +193,9 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
               if test $_systemd_version -ge 245; then
                  systemd_protect_clock=y
               fi
+              if test $_systemd_version -ge 247; then
+                 systemd_protect_proc=y
+              fi
           ])
         ])
         AM_CONDITIONAL([HAVE_SYSTEMD_DYNAMIC_USER], [ test x"$systemd_dynamic_user" = "xy" ])
@@ -210,6 +213,7 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
         AM_CONDITIONAL([HAVE_SYSTEMD_PROTECT_KERNEL_LOGS], [ test x"$systemd_protect_kernel_logs" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PROTECT_KERNEL_MODULES], [ test x"$systemd_protect_kernel_modules" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PROTECT_KERNEL_TUNABLES], [ test x"$systemd_protect_kernel_tunables" = "xy" ])
+        AM_CONDITIONAL([HAVE_SYSTEMD_PROTECT_PROC], [ test x"$systemd_protect_proc" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PROTECT_SYSTEM], [ test x"$systemd_protect_system" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PROTECT_SYSTEM_STRICT], [ test x"$systemd_protect_system_strict" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_REMOVE_IPC], [ test x"$systemd_remove_ipc" = "xy" ])

--- a/m4/systemd.m4
+++ b/m4/systemd.m4
@@ -196,6 +196,9 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
               if test $_systemd_version -ge 247; then
                  systemd_protect_proc=y
               fi
+              if test $_systemd_version -ge 248; then
+                 systemd_private_ipc=y
+              fi
           ])
         ])
         AM_CONDITIONAL([HAVE_SYSTEMD_DYNAMIC_USER], [ test x"$systemd_dynamic_user" = "xy" ])
@@ -203,6 +206,7 @@ AC_DEFUN([AX_CHECK_SYSTEMD_FEATURES], [
         AM_CONDITIONAL([HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE], [ test x"$systemd_memory_deny_write_execute" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PERCENT_T], [ test x"$systemd_percent_t" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PRIVATE_DEVICES], [ test x"$systemd_private_devices" = "xy" ])
+        AM_CONDITIONAL([HAVE_SYSTEMD_PRIVATE_IPC], [ test x"$systemd_private_ipc" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PRIVATE_MOUNTS], [ test x"$systemd_private_mounts" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PRIVATE_TMP], [ test x"$systemd_private_tmp" = "xy" ])
         AM_CONDITIONAL([HAVE_SYSTEMD_PRIVATE_USERS], [ test x"$systemd_private_users" = "xy" ])

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1793,6 +1793,9 @@ endif
 if !HAVE_SYSTEMD_SYSTEM_CALL_FILTER
 	$(AM_V_GEN)perl -ni -e 'print unless /^SystemCallFilter/' $@
 endif
+if !HAVE_SYSTEMD_PROTECT_PROC
+	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
+endif
 
 pdns@.service: pdns.service
 	$(AM_V_GEN)sed -e 's!/pdns_server!& --config-name=%i!' \
@@ -1872,6 +1875,9 @@ if !HAVE_SYSTEMD_SYSTEM_CALL_ARCHITECTURES
 endif
 if !HAVE_SYSTEMD_SYSTEM_CALL_FILTER
 	$(AM_V_GEN)perl -ni -e 'print unless /^SystemCallFilter/' $@
+endif
+if !HAVE_SYSTEMD_PROTECT_PROC
+	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
 endif
 
 ixfrdist@.service: ixfrdist.service

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1793,6 +1793,9 @@ endif
 if !HAVE_SYSTEMD_SYSTEM_CALL_FILTER
 	$(AM_V_GEN)perl -ni -e 'print unless /^SystemCallFilter/' $@
 endif
+if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
+	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
+endif
 if !HAVE_SYSTEMD_PROTECT_PROC
 	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
 endif
@@ -1878,6 +1881,9 @@ if !HAVE_SYSTEMD_SYSTEM_CALL_FILTER
 endif
 if !HAVE_SYSTEMD_PROTECT_PROC
 	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
+endif
+if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
+	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
 endif
 
 ixfrdist@.service: ixfrdist.service

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1799,6 +1799,12 @@ endif
 if !HAVE_SYSTEMD_PROTECT_PROC
 	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
 endif
+if !HAVE_SYSTEMD_PRIVATE_IPC
+	$(AM_V_GEN)perl -ni -e 'print unless /^PrivateIPC/' $@
+endif
+if !HAVE_SYSTEMD_REMOVE_IPC
+	$(AM_V_GEN)perl -ni -e 'print unless /^RemoveIPC/' $@
+endif
 
 pdns@.service: pdns.service
 	$(AM_V_GEN)sed -e 's!/pdns_server!& --config-name=%i!' \
@@ -1884,6 +1890,12 @@ if !HAVE_SYSTEMD_PROTECT_PROC
 endif
 if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
 	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
+endif
+if !HAVE_SYSTEMD_PRIVATE_IPC
+	$(AM_V_GEN)perl -ni -e 'print unless /^PrivateIPC/' $@
+endif
+if !HAVE_SYSTEMD_REMOVE_IPC
+	$(AM_V_GEN)perl -ni -e 'print unless /^RemoveIPC/' $@
 endif
 
 ixfrdist@.service: ixfrdist.service

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1793,9 +1793,6 @@ endif
 if !HAVE_SYSTEMD_SYSTEM_CALL_FILTER
 	$(AM_V_GEN)perl -ni -e 'print unless /^SystemCallFilter/' $@
 endif
-if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
-	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
-endif
 if !HAVE_SYSTEMD_PROTECT_PROC
 	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
 endif

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -539,6 +539,9 @@ endif
 if !HAVE_SYSTEMD_SYSTEM_CALL_FILTER
 	$(AM_V_GEN)perl -ni -e 'print unless /^SystemCallFilter/' $@
 endif
+if !HAVE_SYSTEMD_PROTECT_PROC
+	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
+endif
 
 dnsdist@.service: dnsdist.service
 	$(AM_V_GEN)sed -e 's!/dnsdist !&--config $(sysconfdir)/dnsdist-%i.conf !' \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -545,6 +545,12 @@ endif
 if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
 	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
 endif
+if !HAVE_SYSTEMD_PRIVATE_IPC
+	$(AM_V_GEN)perl -ni -e 'print unless /^PrivateIPC/' $@
+endif
+if !HAVE_SYSTEMD_REMOVE_IPC
+	$(AM_V_GEN)perl -ni -e 'print unless /^RemoveIPC/' $@
+endif
 
 dnsdist@.service: dnsdist.service
 	$(AM_V_GEN)sed -e 's!/dnsdist !&--config $(sysconfdir)/dnsdist-%i.conf !' \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -542,6 +542,9 @@ endif
 if !HAVE_SYSTEMD_PROTECT_PROC
 	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
 endif
+if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
+	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
+endif
 
 dnsdist@.service: dnsdist.service
 	$(AM_V_GEN)sed -e 's!/dnsdist !&--config $(sysconfdir)/dnsdist-%i.conf !' \

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -542,9 +542,6 @@ endif
 if !HAVE_SYSTEMD_PROTECT_PROC
 	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
 endif
-if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
-	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
-endif
 if !HAVE_SYSTEMD_PRIVATE_IPC
 	$(AM_V_GEN)perl -ni -e 'print unless /^PrivateIPC/' $@
 endif

--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -50,6 +50,7 @@ RestrictRealtime=true
 RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
+ProtectProc=invisible
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -54,6 +54,7 @@ ProtectProc=invisible
 MemoryDenyWriteExecute=true
 PrivateIPC=true
 RemoveIPC=true
+DevicePolicy=closed
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -52,6 +52,8 @@ SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
 MemoryDenyWriteExecute=true
+PrivateIPC=true
+RemoveIPC=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -51,6 +51,7 @@ RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/dnsdistdist/dnsdist.service.in
+++ b/pdns/dnsdistdist/dnsdist.service.in
@@ -51,10 +51,11 @@ RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
-MemoryDenyWriteExecute=true
 PrivateIPC=true
 RemoveIPC=true
 DevicePolicy=closed
+# Not enabled by default because it does not play well with LuaJIT
+# MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/ixfrdist.service.in
+++ b/pdns/ixfrdist.service.in
@@ -34,6 +34,7 @@ RestrictRealtime=true
 RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
+ProtectProc=invisible
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/ixfrdist.service.in
+++ b/pdns/ixfrdist.service.in
@@ -35,6 +35,7 @@ RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/ixfrdist.service.in
+++ b/pdns/ixfrdist.service.in
@@ -35,10 +35,10 @@ RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
-MemoryDenyWriteExecute=true
 PrivateIPC=true
 RemoveIPC=true
 DevicePolicy=closed
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/ixfrdist.service.in
+++ b/pdns/ixfrdist.service.in
@@ -36,6 +36,8 @@ SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
 MemoryDenyWriteExecute=true
+PrivateIPC=true
+RemoveIPC=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/ixfrdist.service.in
+++ b/pdns/ixfrdist.service.in
@@ -38,6 +38,7 @@ ProtectProc=invisible
 MemoryDenyWriteExecute=true
 PrivateIPC=true
 RemoveIPC=true
+DevicePolicy=closed
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -42,6 +42,8 @@ SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
 MemoryDenyWriteExecute=true
+PrivateIPC=true
+RemoveIPC=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -41,10 +41,11 @@ RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
-MemoryDenyWriteExecute=true
 PrivateIPC=true
 RemoveIPC=true
 DevicePolicy=closed
+# Not enabled by default because it does not play well with LuaJIT
+# MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -40,6 +40,7 @@ RestrictRealtime=true
 RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
+ProtectProc=invisible
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -41,6 +41,7 @@ RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/pdns.service.in
+++ b/pdns/pdns.service.in
@@ -44,6 +44,7 @@ ProtectProc=invisible
 MemoryDenyWriteExecute=true
 PrivateIPC=true
 RemoveIPC=true
+DevicePolicy=closed
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -624,9 +624,6 @@ endif
 if !HAVE_SYSTEMD_PROTECT_PROC
 	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
 endif
-if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
-	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
-endif
 if !HAVE_SYSTEMD_PRIVATE_IPC
 	$(AM_V_GEN)perl -ni -e 'print unless /^PrivateIPC/' $@
 endif

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -624,6 +624,9 @@ endif
 if !HAVE_SYSTEMD_PROTECT_PROC
 	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
 endif
+if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
+	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
+endif
 
 pdns-recursor@.service: pdns-recursor.service
 	$(AM_V_GEN)sed -e 's!/pdns_recursor!& --config-name=%i!' \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -627,6 +627,12 @@ endif
 if !HAVE_SYSTEMD_MEMORY_DENY_WRITE_EXECUTE
 	$(AM_V_GEN)perl -ni -e 'print unless /^MemoryDenyWriteExecute/' $@
 endif
+if !HAVE_SYSTEMD_PRIVATE_IPC
+	$(AM_V_GEN)perl -ni -e 'print unless /^PrivateIPC/' $@
+endif
+if !HAVE_SYSTEMD_REMOVE_IPC
+	$(AM_V_GEN)perl -ni -e 'print unless /^RemoveIPC/' $@
+endif
 
 pdns-recursor@.service: pdns-recursor.service
 	$(AM_V_GEN)sed -e 's!/pdns_recursor!& --config-name=%i!' \

--- a/pdns/recursordist/Makefile.am
+++ b/pdns/recursordist/Makefile.am
@@ -621,6 +621,9 @@ endif
 if !HAVE_SYSTEMD_SYSTEM_CALL_FILTER
 	$(AM_V_GEN)perl -ni -e 'print unless /^SystemCallFilter/' $@
 endif
+if !HAVE_SYSTEMD_PROTECT_PROC
+	$(AM_V_GEN)perl -ni -e 'print unless /^ProtectProc/' $@
+endif
 
 pdns-recursor@.service: pdns-recursor.service
 	$(AM_V_GEN)sed -e 's!/pdns_recursor!& --config-name=%i!' \

--- a/pdns/recursordist/pdns-recursor.service.in
+++ b/pdns/recursordist/pdns-recursor.service.in
@@ -41,6 +41,7 @@ RestrictRealtime=true
 RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
+ProtectProc=invisible
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/recursordist/pdns-recursor.service.in
+++ b/pdns/recursordist/pdns-recursor.service.in
@@ -42,10 +42,11 @@ RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
-MemoryDenyWriteExecute=true
 PrivateIPC=true
 RemoveIPC=true
 DevicePolicy=closed
+# Not enabled by default because it does not play well with LuaJIT
+# MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/recursordist/pdns-recursor.service.in
+++ b/pdns/recursordist/pdns-recursor.service.in
@@ -45,6 +45,7 @@ ProtectProc=invisible
 MemoryDenyWriteExecute=true
 PrivateIPC=true
 RemoveIPC=true
+DevicePolicy=closed
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/recursordist/pdns-recursor.service.in
+++ b/pdns/recursordist/pdns-recursor.service.in
@@ -43,6 +43,8 @@ SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
 MemoryDenyWriteExecute=true
+PrivateIPC=true
+RemoveIPC=true
 
 [Install]
 WantedBy=multi-user.target

--- a/pdns/recursordist/pdns-recursor.service.in
+++ b/pdns/recursordist/pdns-recursor.service.in
@@ -42,6 +42,7 @@ RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=~ @clock @debug @module @mount @raw-io @reboot @swap @cpu-emulation @obsolete
 ProtectProc=invisible
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Short description
Another sandboxing option, [ProtectProc](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ProtectProc=) hides all /proc/<pid> that are not owned by the service user and hides some kernel things from /proc as well.

Also adds `MemoryDenyWriteExecute`

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)