### PR TITLE
Auth: add zone to zonecache on flush API endpoint

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2270,7 +2270,8 @@ static void apiServerCacheFlush(HttpRequest* req, HttpResponse* resp) {
 
   DNSName canon = apiNameToDNSName(req->getvars["domain"]);
 
-  uint64_t count = purgeAuthCachesExact(canon);
+  // purge entire zone from cache, not just zone-level records.
+  uint64_t count = purgeAuthCaches(canon.toString() + "$");
   resp->setJsonBody(Json::object {
       { "count", (int) count },
       { "result", "Flushed cache." }


### PR DESCRIPTION
### Short description
Some people want to add domains to the zonecache as soon as possible. This is currently automatic when the zone is created using the API or autoprimary. For database-based provisioning systems this allows the provisioning system to add the zone by calling the /cache/flush endpoint.

This is #10617 without any cleanup, and adding the zone works only on the HTTP APIs cache flush endpoint. Nothing happens on the command line, etc.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
