### PR TITLE
rec: postresolve ffi

### DIFF
--- a/pdns/dnsmessage.proto
+++ b/pdns/dnsmessage.proto
@@ -163,6 +163,7 @@ message PBDNSMessage {
     LuaPostResolve = 107;
     LuaNoData = 108;
     LuaNXDomain = 109;
+    LuaPostResolveFFI = 110;
   }
 
   message Event {

--- a/pdns/lua-recursor4-ffi.hh
+++ b/pdns/lua-recursor4-ffi.hh
@@ -59,6 +59,7 @@ extern "C"
   typedef struct pdns_ffi_record
   {
     const char* name;
+    size_t name_len;
     const char* content;
     size_t content_len;
     uint32_t ttl;
@@ -114,8 +115,10 @@ extern "C"
   typedef struct pdns_postresolve_ffi_handle pdns_postresolve_ffi_handle_t;
 
   const char* pdns_postresolve_ffi_handle_get_qname(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
+  void pdns_postresolve_ffi_handle_get_qname_raw(pdns_postresolve_ffi_handle_t* ref, const char** qname, size_t* qnameSize) __attribute__((visibility("default")));
   uint16_t pdns_postresolve_ffi_handle_get_qtype(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
   uint16_t pdns_postresolve_ffi_handle_get_rcode(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
+  void pdns_postresolve_ffi_handle_set_rcode(const pdns_postresolve_ffi_handle_t* ref, uint16_t rcode) __attribute__((visibility("default")));
   pdns_policy_kind_t pdns_postresolve_ffi_handle_get_appliedpolicy_kind(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
   void pdns_postresolve_ffi_handle_set_appliedpolicy_kind(pdns_postresolve_ffi_handle_t* ref, pdns_policy_kind_t kind) __attribute__((visibility("default")));
   bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, pdns_ffi_record_t* record, bool raw) __attribute__((visibility("default")));
@@ -125,3 +128,5 @@ extern "C"
   const char* pdns_postresolve_ffi_handle_get_authip(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
   void pdns_postresolve_ffi_handle_get_authip_raw(pdns_postresolve_ffi_handle_t* ref, const void** addr, size_t* addrSize) __attribute__((visibility("default")));
 }
+
+#undef PDNS_VISIBILITY

--- a/pdns/lua-recursor4-ffi.hh
+++ b/pdns/lua-recursor4-ffi.hh
@@ -128,5 +128,3 @@ extern "C"
   const char* pdns_postresolve_ffi_handle_get_authip(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
   void pdns_postresolve_ffi_handle_get_authip_raw(pdns_postresolve_ffi_handle_t* ref, const void** addr, size_t* addrSize) __attribute__((visibility("default")));
 }
-
-#undef PDNS_VISIBILITY

--- a/pdns/lua-recursor4-ffi.hh
+++ b/pdns/lua-recursor4-ffi.hh
@@ -56,7 +56,8 @@ extern "C"
     pdns_policy_kind_custom = 5
   } pdns_policy_kind_t;
 
-  typedef struct pdns_ffi_record {
+  typedef struct pdns_ffi_record
+  {
     const char* name;
     const char* content;
     size_t content_len;
@@ -117,7 +118,7 @@ extern "C"
   uint16_t pdns_postresolve_ffi_handle_get_rcode(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
   pdns_policy_kind_t pdns_postresolve_ffi_handle_get_appliedpolicy_kind(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
   void pdns_postresolve_ffi_handle_set_appliedpolicy_kind(pdns_postresolve_ffi_handle_t* ref, pdns_policy_kind_t kind) __attribute__((visibility("default")));
-  bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, pdns_ffi_record_t *record, bool raw) __attribute__((visibility("default")));
+  bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, pdns_ffi_record_t* record, bool raw) __attribute__((visibility("default")));
   bool pdns_postresolve_ffi_handle_set_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, const char* content, size_t contentLen, bool raw) __attribute__((visibility("default")));
   void pdns_postresolve_ffi_handle_clear_records(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
   bool pdns_postresolve_ffi_handle_add_record(pdns_postresolve_ffi_handle_t* ref, const char* name, uint16_t type, uint32_t ttl, const char* content, size_t contentLen, pdns_record_place_t place, bool raw) __attribute__((visibility("default")));

--- a/pdns/lua-recursor4-ffi.hh
+++ b/pdns/lua-recursor4-ffi.hh
@@ -121,4 +121,6 @@ extern "C"
   bool pdns_postresolve_ffi_handle_set_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, const char* content, size_t contentLen, bool raw) __attribute__((visibility("default")));
   void pdns_postresolve_ffi_handle_clear_records(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
   bool pdns_postresolve_ffi_handle_add_record(pdns_postresolve_ffi_handle_t* ref, const char* name, uint16_t type, uint32_t ttl, const char* content, size_t contentLen, pdns_record_place_t place, bool raw) __attribute__((visibility("default")));
+  const char* pdns_postresolve_ffi_handle_get_authip(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
+  void pdns_postresolve_ffi_handle_get_authip_raw(pdns_postresolve_ffi_handle_t* ref, const void** addr, size_t* addrSize) __attribute__((visibility("default")));
 }

--- a/pdns/lua-recursor4-ffi.hh
+++ b/pdns/lua-recursor4-ffi.hh
@@ -40,10 +40,30 @@ extern "C"
 
   typedef enum
   {
-    answer = 1,
-    authority = 2,
-    additional = 3
+    pdns_record_place_answer = 1,
+    pdns_record_place_authority = 2,
+    pdns_record_place_additional = 3
   } pdns_record_place_t;
+
+  // Must match DNSFilterEngine::PolicyKind
+  typedef enum
+  {
+    pdns_policy_kind_noaction = 0,
+    pdns_policy_kind_drop = 1,
+    pdns_policy_kind_nxdomain = 2,
+    pdns_policy_kind_nodata = 3,
+    pdns_policy_kind_truncate = 4,
+    pdns_policy_kind_custom = 5
+  } pdns_policy_kind_t;
+
+  typedef struct pdns_ffi_record {
+    const char* name;
+    const char* content;
+    size_t content_len;
+    uint32_t ttl;
+    pdns_record_place_t place;
+    uint16_t type;
+  } pdns_ffi_record_t;
 
   const char* pdns_ffi_param_get_qname(pdns_ffi_param_t* ref) __attribute__((visibility("default")));
   void pdns_ffi_param_get_qname_raw(pdns_ffi_param_t* ref, const char** qname, size_t* qnameSize) __attribute__((visibility("default")));
@@ -89,4 +109,16 @@ extern "C"
   void pdns_ffi_param_set_padding_disabled(pdns_ffi_param_t* ref, bool disabled) __attribute__((visibility("default")));
   void pdns_ffi_param_add_meta_single_string_kv(pdns_ffi_param_t* ref, const char* key, const char* val) __attribute__((visibility("default")));
   void pdns_ffi_param_add_meta_single_int64_kv(pdns_ffi_param_t* ref, const char* key, int64_t val) __attribute__((visibility("default")));
+
+  typedef struct pdns_postresolve_ffi_handle pdns_postresolve_ffi_handle_t;
+
+  const char* pdns_postresolve_ffi_handle_get_qname(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
+  uint16_t pdns_postresolve_ffi_handle_get_qtype(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
+  uint16_t pdns_postresolve_ffi_handle_get_rcode(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
+  pdns_policy_kind_t pdns_postresolve_ffi_handle_get_appliedpolicy_kind(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
+  void pdns_postresolve_ffi_handle_set_appliedpolicy_kind(pdns_postresolve_ffi_handle_t* ref, pdns_policy_kind_t kind) __attribute__((visibility("default")));
+  bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, pdns_ffi_record_t *record, bool raw) __attribute__((visibility("default")));
+  bool pdns_postresolve_ffi_handle_set_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, const char* content, size_t contentLen, bool raw) __attribute__((visibility("default")));
+  void pdns_postresolve_ffi_handle_clear_records(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
+  bool pdns_postresolve_ffi_handle_add_record(pdns_postresolve_ffi_handle_t* ref, const char* name, uint16_t type, uint32_t ttl, const char* content, size_t contentLen, pdns_record_place_t place, bool raw) __attribute__((visibility("default")));
 }

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -1134,7 +1134,7 @@ bool pdns_postresolve_ffi_handle_set_record(pdns_postresolve_ffi_handle_t* ref, 
     return true;
   }
   catch (const std::exception& e) {
-    g_log << Logger::Error << "Error attempting to add a record from Lua via pdns_postresolve_ffi_handle_set_record(): " << e.what() << endl;
+    g_log << Logger::Error << "Error attempting to set record content from Lua via pdns_postresolve_ffi_handle_set_record(): " << e.what() << endl;
     return false;
   }
 }

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -1042,15 +1042,11 @@ public:
     handle(h)
   {
   }
-  ~pdns_postresolve_ffi_handle()
-  {
-    cerr << "~pdns_postresolve_ffi_handle: " << pool.size() << endl;
-  }
   RecursorLua4::PostResolveFFIHandle& handle;
   std::unordered_set<std::string> pool;
-  auto insert(const std::string& str)
+  auto insert(std::string&& str)
   {
-    auto [it, inserted] = pool.insert(str);
+    auto [it, inserted] = pool.insert(std::move(str));
     return it;
   }
 };

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -1043,12 +1043,13 @@ public:
   {
   }
   RecursorLua4::PostResolveFFIHandle& handle;
-  std::unordered_set<std::string> pool;
   auto insert(std::string&& str)
   {
-    auto [it, inserted] = pool.insert(std::move(str));
+    const auto it = pool.insert(std::move(str)).first;
     return it;
   }
+private:
+  std::unordered_set<std::string> pool;
 };
 
 bool RecursorLua4::postresolve_ffi(RecursorLua4::PostResolveFFIHandle& h) const

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -1048,6 +1048,7 @@ public:
     const auto it = pool.insert(std::move(str)).first;
     return it;
   }
+
 private:
   std::unordered_set<std::string> pool;
 };
@@ -1089,7 +1090,7 @@ void pdns_postresolve_ffi_handle_set_appliedpolicy_kind(pdns_postresolve_ffi_han
   ref->handle.d_dq.appliedPolicy->d_kind = static_cast<DNSFilterEngine::PolicyKind>(kind);
 }
 
-bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, pdns_ffi_record_t *record, bool raw)
+bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, pdns_ffi_record_t* record, bool raw)
 {
   if (i >= ref->handle.d_dq.currentRecords->size()) {
     return false;
@@ -1101,7 +1102,8 @@ bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, 
       auto content = ref->insert(r.d_content->serialize(r.d_name, true));
       record->content = content->data();
       record->content_len = content->size();
-    } else {
+    }
+    else {
       auto content = ref->insert(r.d_content->getZoneRepresentation());
       record->content = content->data();
       record->content_len = content->size();
@@ -1127,7 +1129,8 @@ bool pdns_postresolve_ffi_handle_set_record(pdns_postresolve_ffi_handle_t* ref, 
     DNSRecord& r = ref->handle.d_dq.currentRecords->at(i);
     if (raw) {
       r.d_content = DNSRecordContent::deserialize(r.d_name, r.d_type, string(content, contentLen));
-    } else {
+    }
+    else {
       r.d_content = DNSRecordContent::mastermake(r.d_type, QClass::IN, string(content, contentLen));
     }
 
@@ -1155,7 +1158,8 @@ bool pdns_postresolve_ffi_handle_add_record(pdns_postresolve_ffi_handle_t* ref, 
     dr.d_place = DNSResourceRecord::Place(place);
     if (raw) {
       dr.d_content = DNSRecordContent::deserialize(dr.d_name, dr.d_type, string(content, contentLen));
-    } else {
+    }
+    else {
       dr.d_content = DNSRecordContent::mastermake(type, QClass::IN, string(content, contentLen));
     }
     ref->handle.d_dq.currentRecords->push_back(std::move(dr));

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -1113,7 +1113,8 @@ bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, 
       const auto& storage = r.d_name.getStorage();
       record->name = storage.data();
       record->name_len = storage.size();
-    } else {
+    }
+    else {
       std::string name = r.d_name.toStringNoDot();
       record->name_len = name.size();
       record->name = ref->insert(std::move(name))->c_str();

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -1167,3 +1167,12 @@ bool pdns_postresolve_ffi_handle_add_record(pdns_postresolve_ffi_handle_t* ref, 
   }
 }
 
+const char* pdns_postresolve_ffi_handle_get_authip(pdns_postresolve_ffi_handle_t* ref)
+{
+  return ref->insert(ref->handle.d_dq.fromAuthIP->toString())->c_str();
+}
+
+void pdns_postresolve_ffi_handle_get_authip_raw(pdns_postresolve_ffi_handle_t* ref, const void** addr, size_t* addrSize)
+{
+  return pdns_ffi_comboaddress_to_raw(*ref->handle.d_dq.fromAuthIP, addr, addrSize);
+}

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -94,6 +94,7 @@ public:
     const uint16_t qtype;
     const ComboAddress& local;
     const ComboAddress& remote;
+    const ComboAddress* fromAuthIP{nullptr};
     const struct dnsheader* dh{nullptr};
     const bool isTcp;
     const std::vector<pair<uint16_t, string>>* ednsOptions{nullptr};

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -72,7 +72,6 @@ struct LuaContext::Pusher<pdns_postresolve_ffi_handle*>
   }
 };
 
-
 class RecursorLua4 : public BaseLua4
 {
 public:
@@ -224,10 +223,10 @@ public:
   typedef std::function<boost::optional<LuaContext::LuaObject>(pdns_ffi_param_t*)> gettag_ffi_t;
   gettag_ffi_t d_gettag_ffi;
 
-
   struct PostResolveFFIHandle
   {
-    PostResolveFFIHandle(DNSQuestion& dq) : d_dq(dq)
+    PostResolveFFIHandle(DNSQuestion& dq) :
+      d_dq(dq)
     {
     }
     DNSQuestion& d_dq;

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -58,7 +58,7 @@ struct LuaContext::Pusher<pdns_ffi_param*>
   }
 };
 
-// pdns_postresolve_ffi_param_t is a lightuserdata
+// pdns_postresolve_ffi_handle is a lightuserdata
 template <>
 struct LuaContext::Pusher<pdns_postresolve_ffi_handle*>
 {

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -58,6 +58,21 @@ struct LuaContext::Pusher<pdns_ffi_param*>
   }
 };
 
+// pdns_postresolve_ffi_param_t is a lightuserdata
+template <>
+struct LuaContext::Pusher<pdns_postresolve_ffi_handle*>
+{
+  static const int minSize = 1;
+  static const int maxSize = 1;
+
+  static PushedObject push(lua_State* state, pdns_postresolve_ffi_handle* ptr) noexcept
+  {
+    lua_pushlightuserdata(state, ptr);
+    return PushedObject{state, 1};
+  }
+};
+
+
 class RecursorLua4 : public BaseLua4
 {
 public:
@@ -204,8 +219,22 @@ public:
 
   typedef std::function<std::tuple<unsigned int, boost::optional<std::unordered_map<int, string>>, boost::optional<LuaContext::LuaObject>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<std::string>, boost::optional<string>>(ComboAddress, Netmask, ComboAddress, DNSName, uint16_t, const EDNSOptionViewMap&, bool, const std::vector<std::pair<int, const ProxyProtocolValue*>>&)> gettag_t;
   gettag_t d_gettag; // public so you can query if we have this hooked
+
   typedef std::function<boost::optional<LuaContext::LuaObject>(pdns_ffi_param_t*)> gettag_ffi_t;
   gettag_ffi_t d_gettag_ffi;
+
+
+  struct PostResolveFFIHandle
+  {
+    PostResolveFFIHandle(DNSQuestion& dq) : d_dq(dq)
+    {
+    }
+    DNSQuestion& d_dq;
+    bool d_ret{false};
+  };
+  bool postresolve_ffi(PostResolveFFIHandle&) const;
+  typedef std::function<bool(pdns_postresolve_ffi_handle_t*)> postresolve_ffi_t;
+  postresolve_ffi_t d_postresolve_ffi;
 
 protected:
   virtual void postPrepareContext() override;

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2002,12 +2002,28 @@ static void startDoResolve(void *p)
           }
         }
 
-	if (t_pdl && t_pdl->postresolve(dq, res, sr.d_eventTrace)) {
-          shouldNotValidate = true;
-          auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw, tcpGuard);
-          // haveAnswer case redundant
-          if (policyResult == PolicyResult::Drop) {
-            return;
+        if (t_pdl) {
+          if (t_pdl->d_postresolve_ffi) {
+            RecursorLua4::PostResolveFFIHandle handle(dq);
+            sr.d_eventTrace.add(RecEventTrace::LuaPostResolveFFI);
+            bool pr = t_pdl->postresolve_ffi(handle);
+            sr.d_eventTrace.add(RecEventTrace::LuaPostResolveFFI, pr, false);
+            if (pr) {
+              shouldNotValidate = true;
+              auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw, tcpGuard);
+              // haveAnswer case redundant
+              if (policyResult == PolicyResult::Drop) {
+                return;
+              }
+            }
+          }
+          else if (t_pdl->postresolve(dq, res, sr.d_eventTrace)) {
+            shouldNotValidate = true;
+            auto policyResult = handlePolicyHit(appliedPolicy, dc, sr, res, ret, pw, tcpGuard);
+            // haveAnswer case redundant
+            if (policyResult == PolicyResult::Drop) {
+              return;
+            }
           }
         }
       }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1806,6 +1806,7 @@ static void startDoResolve(void *p)
     dq.extendedErrorCode = &dc->d_extendedErrorCode;
     dq.extendedErrorExtra = &dc->d_extendedErrorExtra;
     dq.meta = std::move(dc->d_meta);
+    dq.fromAuthIP = &sr.d_fromAuthIP;
 
     RunningResolveGuard tcpGuard(dc);
 

--- a/pdns/recursor_cache.hh
+++ b/pdns/recursor_cache.hh
@@ -57,7 +57,7 @@ public:
 
   typedef boost::optional<std::string> OptTag;
 
-  time_t get(time_t, const DNSName& qname, const QType qt, bool requireAuth, vector<DNSRecord>* res, const ComboAddress& who, bool refresh = false, const OptTag& routingTag = boost::none, vector<std::shared_ptr<RRSIGRecordContent>>* signatures = nullptr, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr);
+  time_t get(time_t, const DNSName& qname, const QType qt, bool requireAuth, vector<DNSRecord>* res, const ComboAddress& who, bool refresh = false, const OptTag& routingTag = boost::none, vector<std::shared_ptr<RRSIGRecordContent>>* signatures = nullptr, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs = nullptr, bool* variable = nullptr, vState* state = nullptr, bool* wasAuth = nullptr, DNSName* fromAuthZone = nullptr, ComboAddress* fromAuthIP = nullptr);
 
   void replace(time_t, const DNSName& qname, const QType qt, const vector<DNSRecord>& content, const vector<shared_ptr<RRSIGRecordContent>>& signatures, const std::vector<std::shared_ptr<DNSRecord>>& authorityRecs, bool auth, const DNSName& authZone, boost::optional<Netmask> ednsmask = boost::none, const OptTag& routingTag = boost::none, vState state = vState::Indeterminate, boost::optional<ComboAddress> from = boost::none);
 
@@ -252,7 +252,7 @@ private:
   Entries getEntries(MapCombo::LockedContent& content, const DNSName& qname, const QType qt, const OptTag& rtag);
   cache_t::const_iterator getEntryUsingECSIndex(MapCombo::LockedContent& content, time_t now, const DNSName& qname, QType qtype, bool requireAuth, const ComboAddress& who);
 
-  time_t handleHit(MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, vector<std::shared_ptr<RRSIGRecordContent>>* signatures, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone);
+  time_t handleHit(MapCombo::LockedContent& content, OrderedTagIterator_t& entry, const DNSName& qname, uint32_t& origTTL, vector<DNSRecord>* res, vector<std::shared_ptr<RRSIGRecordContent>>* signatures, std::vector<std::shared_ptr<DNSRecord>>* authorityRecs, bool* variable, boost::optional<vState>& state, bool* wasAuth, DNSName* authZone, ComboAddress* fromAuthIP);
 
 public:
   void preRemoval(MapCombo::LockedContent& map, const CacheEntry& entry)

--- a/pdns/recursordist/rec-eventtrace.cc
+++ b/pdns/recursordist/rec-eventtrace.cc
@@ -40,4 +40,5 @@ const std::unordered_map<RecEventTrace::EventType, std::string> RecEventTrace::s
   NameEntry(LuaPreOutQuery),
   NameEntry(LuaPostResolve),
   NameEntry(LuaNoData),
-  NameEntry(LuaNXDomain)};
+  NameEntry(LuaNXDomain),
+  NameEntry(LuaPostResolveFFI)};

--- a/pdns/recursordist/rec-eventtrace.hh
+++ b/pdns/recursordist/rec-eventtrace.hh
@@ -54,6 +54,7 @@ public:
     LuaPostResolve = 107,
     LuaNoData = 108,
     LuaNXDomain = 109,
+    LuaPostResolveFFI = 110,
   };
 
   static const std::unordered_map<EventType, std::string> s_eventNames;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -799,6 +799,7 @@ public:
   DNSFilterEngine::Policy d_appliedPolicy;
   std::unordered_set<std::string> d_policyTags;
   boost::optional<string> d_routingTag;
+  ComboAddress d_fromAuthIP;
   RecEventTrace d_eventTrace;
 
   unsigned int d_authzonequeries;

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -121,6 +121,11 @@ optout.example.          3600 IN NS   ns1.optout.example.
 optout.example.          3600 IN DS   59332 13 1 e664f886ae1b5df03d918bc1217d22afc29925b9
 ns1.optout.example.      3600 IN A    {prefix}.14
 
+postresolve_ffi.example.  3600 IN A    1.2.3.4
+postresolve_ffi.example.  3600 IN A    1.2.3.5
+postresolve_ffi.example.  3600 IN AAAA ::1
+postresolve_ffi.example.  3600 IN AAAA ::2
+
 insecure-formerr.example. 3600 IN NS   ns1.insecure-formerr.example.
 ns1.insecure-formerr.example. 3600 IN A    {prefix}.2
 

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -889,6 +889,7 @@ function postresolve_ffi(ref)
      if record.type == pdns.A and content == "1.2.3.4"
      then
        ffi.C.pdns_postresolve_ffi_handle_set_record(ref, i, "0.1.2.3", 7, false);
+       ffi.C.pdns_postresolve_ffi_handle_add_record(ref, "add."..name, pdns.A, record.ttl, '4.5.6.7', 7, "pdns_record_place_additional", false);
      elseif record.type == pdns.AAAA and content == "::1"
      then
        ffi.C.pdns_postresolve_ffi_handle_set_record(ref, i, "\\0\\1\\2\\3\\4\\5\\6\\7\\8\\9\\10\\11\\12\\13\\14\\15", 16, true);
@@ -940,13 +941,18 @@ end
         expectedAnswerRecords = [
             dns.rrset.from_text('postresolve_ffi.example.', 60, dns.rdataclass.IN, 'A', '0.1.2.3', '1.2.3.5'),
         ]
+        expectedAdditionalRecords = [
+            dns.rrset.from_text('add.postresolve_ffi.example.', 60, dns.rdataclass.IN, 'A', '4.5.6.7'),
+        ]
+
         query = dns.message.make_query('postresolve_ffi.example', 'A')
         res = self.sendUDPQuery(query)
         self.assertRcodeEqual(res, dns.rcode.NOERROR)
         self.assertEqual(len(res.answer), 1)
         self.assertEqual(len(res.authority), 0)
-        self.assertEqual(len(res.additional), 0)
+        self.assertEqual(len(res.additional), 1)
         self.assertEqual(res.answer, expectedAnswerRecords)
+        self.assertEqual(res.additional, expectedAdditionalRecords)
 
     def testModifyAAAA(self):
         """postresolve_ffi: test that we can modify AAAA answers"""

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -795,16 +795,19 @@ ffi.cdef[[
 
   typedef struct pdns_ffi_record {
     const char* name;
+    size_t name_len;
     const char* content;
-    const size_t content_len;
+    size_t content_len;
     uint32_t ttl;
     pdns_record_place_t place;
     uint16_t type;
   } pdns_ffi_record_t;
 
   const char* pdns_postresolve_ffi_handle_get_qname(pdns_postresolve_ffi_handle_t* ref);
+  const char* pdns_postresolve_ffi_handle_get_qname_raw(pdns_postresolve_ffi_handle_t* ref, const char** name, size_t* len);
   uint16_t pdns_postresolve_ffi_handle_get_qtype(const pdns_postresolve_ffi_handle_t* ref);
   uint16_t pdns_postresolve_ffi_handle_get_rcode(const pdns_postresolve_ffi_handle_t* ref);
+  void pdns_postresolve_ffi_handle_set_rcode(const pdns_postresolve_ffi_handle_t* ref, uint16_t rcode);
   void pdns_postresolve_ffi_handle_set_appliedpolicy_kind(pdns_postresolve_ffi_handle_t* ref, pdns_policy_kind_t kind);
   bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, pdns_ffi_record_t *record, bool raw);
   bool pdns_postresolve_ffi_handle_set_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, const char* content, size_t contentLen, bool raw);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Initial stab at providing an ffi interface for postresolve.

Although I think this is already useful, this PR is mainly to solicit feedback.
The API likely need some extra tweaks and methods.

Many simple cases can be handled by `pdns_postresolve_ffi_handle_set_appliedpolicy_kind()` (custom is not available for that case, since it is really RPZ oriented)
It is also possible to modify existing records (content only), remove all records and add records.
Current methods:
```
  typedef struct pdns_postresolve_ffi_handle pdns_postresolve_ffi_handle_t;

  const char* pdns_postresolve_ffi_handle_get_qname(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
  void pdns_postresolve_ffi_handle_get_qname_raw(pdns_postresolve_ffi_handle_t* ref, const char** qname, size_t* qnameSize) __attribute__((visibility("default")));
  uint16_t pdns_postresolve_ffi_handle_get_qtype(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
  uint16_t pdns_postresolve_ffi_handle_get_rcode(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
  void pdns_postresolve_ffi_handle_set_rcode(const pdns_postresolve_ffi_handle_t* ref, uint16_t rcode) __attribute__((visibility("default")));
  pdns_policy_kind_t pdns_postresolve_ffi_handle_get_appliedpolicy_kind(const pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
  void pdns_postresolve_ffi_handle_set_appliedpolicy_kind(pdns_postresolve_ffi_handle_t* ref, pdns_policy_kind_t kind) __attribute__((visibility("default")));
  bool pdns_postresolve_ffi_handle_get_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, pdns_ffi_record_t* record, bool raw) __attribute__((visibility("default")));
  bool pdns_postresolve_ffi_handle_set_record(pdns_postresolve_ffi_handle_t* ref, unsigned int i, const char* content, size_t contentLen, bool raw) __attribute__((visibility("default")));
  void pdns_postresolve_ffi_handle_clear_records(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
  bool pdns_postresolve_ffi_handle_add_record(pdns_postresolve_ffi_handle_t* ref, const char* name, uint16_t type, uint32_t ttl, const char* content, size_t contentLen, pdns_record_place_t place, bool raw) __attribute__((visibility("default")));
  const char* pdns_postresolve_ffi_handle_get_authip(pdns_postresolve_ffi_handle_t* ref) __attribute__((visibility("default")));
  void pdns_postresolve_ffi_handle_get_authip_raw(pdns_postresolve_ffi_handle_t* ref, const void** addr, size_t* addrSize) __attribute__((visibility("default")));
```

Refer to the regression test for some example use.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
