### PR TITLE
dnsdist: Fix a double-free when a DoH cross-protocol response is dropped

### DIFF
--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -241,7 +241,7 @@ struct IDState
   std::unique_ptr<QTag> qTag{nullptr}; // 8
   boost::optional<uint32_t> tempFailureTTL; // 8
   const ClientState* cs{nullptr}; // 8
-  DOHUnit* du{nullptr}; // 8
+  DOHUnit* du{nullptr}; // 8 (not a unique_ptr because we currently need to be able to peek at it without knowing taking ownership until later)
   std::atomic<int64_t> usageIndicator{unusedIndicator}; // set to unusedIndicator to indicate this state is empty   // 8
   std::atomic<uint32_t> generation{0}; // increased every time a state is used, to be able to detect an ABA issue    // 4
   uint32_t cacheKey{0}; // 4

--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -241,7 +241,7 @@ struct IDState
   std::unique_ptr<QTag> qTag{nullptr}; // 8
   boost::optional<uint32_t> tempFailureTTL; // 8
   const ClientState* cs{nullptr}; // 8
-  DOHUnit* du{nullptr}; // 8 (not a unique_ptr because we currently need to be able to peek at it without knowing taking ownership until later)
+  DOHUnit* du{nullptr}; // 8 (not a unique_ptr because we currently need to be able to peek at it without taking ownership until later)
   std::atomic<int64_t> usageIndicator{unusedIndicator}; // set to unusedIndicator to indicate this state is empty   // 8
   std::atomic<uint32_t> generation{0}; // increased every time a state is used, to be able to detect an ABA issue    // 4
   uint32_t cacheKey{0}; // 4

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -630,7 +630,7 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
 
         /* read the potential DOHUnit state as soon as possible, but don't use it
            until we have confirmed that we own this state by updating usageIndicator */
-        auto du = std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>(ids->du, DOHUnit::release);
+        auto du = DOHUnitUniquePtr(ids->du, DOHUnit::release);
         /* setting age to 0 to prevent the maintainer thread from
            cleaning this IDS while we process the response.
         */
@@ -1524,13 +1524,13 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     unsigned int idOffset = (ss->idOffset++) % ss->idStates.size();
     IDState* ids = &ss->idStates[idOffset];
     ids->age = 0;
-    std::unique_ptr<DOHUnit, void(*)(DOHUnit*)> du(nullptr, DOHUnit::release);
+    DOHUnitUniquePtr du(nullptr, DOHUnit::release);
 
     /* that means that the state was in use, possibly with an allocated
        DOHUnit that we will need to handle, but we can't touch it before
        confirming that we now own this state */
     if (ids->isInUse()) {
-      du = std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>(ids->du, DOHUnit::release);
+      du = DOHUnitUniquePtr(ids->du, DOHUnit::release);
     }
 
     /* we atomically replace the value, we now own this state */
@@ -1886,7 +1886,7 @@ static void healthChecksThread()
             continue;
           }
           ids.du = nullptr;
-          handleDOHTimeout(std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>(oldDU, DOHUnit::release));
+          handleDOHTimeout(DOHUnitUniquePtr(oldDU, DOHUnit::release));
           oldDU = nullptr;
           ids.age = 0;
           dss->reuseds++;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -630,7 +630,7 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
 
         /* read the potential DOHUnit state as soon as possible, but don't use it
            until we have confirmed that we own this state by updating usageIndicator */
-        auto du = ids->du;
+        auto du = std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>(ids->du, DOHUnit::release);
         /* setting age to 0 to prevent the maintainer thread from
            cleaning this IDS while we process the response.
         */
@@ -656,7 +656,7 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
           --dss->outstanding;  // you'd think an attacker could game this, but we're using connected socket
         } else {
           /* someone updated the state in the meantime, we can't touch the existing pointer */
-          du = nullptr;
+          du.release();
           /* since the state has been updated, we can't safely access it so let's just drop
              this response */
           continue;
@@ -669,8 +669,7 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
         if (du) {
 #ifdef HAVE_DNS_OVER_HTTPS
           // DoH query, we cannot touch du after that
-          du->handleUDPResponse(std::move(response), std::move(*ids));
-          du = nullptr;
+          handleUDPResponseForDoH(std::move(du), std::move(response), std::move(*ids));
 #endif
           continue;
         }
@@ -1525,20 +1524,20 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
     unsigned int idOffset = (ss->idOffset++) % ss->idStates.size();
     IDState* ids = &ss->idStates[idOffset];
     ids->age = 0;
-    DOHUnit* du = nullptr;
+    std::unique_ptr<DOHUnit, void(*)(DOHUnit*)> du(nullptr, DOHUnit::release);
 
     /* that means that the state was in use, possibly with an allocated
        DOHUnit that we will need to handle, but we can't touch it before
        confirming that we now own this state */
     if (ids->isInUse()) {
-      du = ids->du;
+      du = std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>(ids->du, DOHUnit::release);
     }
 
     /* we atomically replace the value, we now own this state */
     if (!ids->markAsUsed()) {
       /* the state was not in use.
          we reset 'du' because it might have still been in use when we read it. */
-      du = nullptr;
+      du.release();
       ++ss->outstanding;
     }
     else {
@@ -1547,8 +1546,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
       ids->du = nullptr;
       ++ss->reuseds;
       ++g_stats.downstreamTimeouts;
-      handleDOHTimeout(du);
-      du = nullptr;
+      handleDOHTimeout(std::move(du));
     }
 
     ids->cs = &cs;
@@ -1888,7 +1886,7 @@ static void healthChecksThread()
             continue;
           }
           ids.du = nullptr;
-          handleDOHTimeout(oldDU);
+          handleDOHTimeout(std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>(oldDU, DOHUnit::release));
           oldDU = nullptr;
           ids.age = 0;
           dss->reuseds++;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -668,8 +668,9 @@ void responderThread(std::shared_ptr<DownstreamState> dss)
         /* don't call processResponse for DOH */
         if (du) {
 #ifdef HAVE_DNS_OVER_HTTPS
-          // DoH query
+          // DoH query, we cannot touch du after that
           du->handleUDPResponse(std::move(response), std::move(*ids));
+          du = nullptr;
 #endif
           continue;
         }
@@ -1547,6 +1548,7 @@ static void processUDPQuery(ClientState& cs, LocalHolders& holders, const struct
       ++ss->reuseds;
       ++g_stats.downstreamTimeouts;
       handleDOHTimeout(du);
+      du = nullptr;
     }
 
     ids->cs = &cs;
@@ -1887,6 +1889,7 @@ static void healthChecksThread()
           }
           ids.du = nullptr;
           handleDOHTimeout(oldDU);
+          oldDU = nullptr;
           ids.age = 0;
           dss->reuseds++;
           --dss->outstanding;

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -459,6 +459,7 @@ public:
 
     if (!processResponse(du->response, localRespRuleActions, dr, false, false)) {
       du->release();
+      du = nullptr;
       return;
     }
 

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1327,8 +1327,6 @@ static void on_dnsdist(h2o_socket_t *listener, const char *err)
       queryDH->id = du->ids.origID;
 
       auto cpq = std::make_unique<DoHCrossProtocolQuery>(du);
-
-      du->get();
       du->tcp = true;
       du->truncated = false;
 

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -228,6 +228,7 @@ struct DOHServerConfig
 static void sendDoHUnitToTheMainThread(std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>&& du, const char* description)
 {
   auto ptr = du.release();
+  ptr->get();
   static_assert(sizeof(ptr) <= PIPE_BUF, "Writes up to PIPE_BUF are guaranteed not to be interleaved and to either fully succeed or fail");
 
   ssize_t sent = write(ptr->rsock, &ptr, sizeof(ptr));
@@ -242,6 +243,7 @@ static void sendDoHUnitToTheMainThread(std::unique_ptr<DOHUnit, void(*)(DOHUnit*
 
     ptr->release();
   }
+  ptr->release();
 }
 
 /* This function is called from other threads than the main DoH one,

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -726,7 +726,8 @@ static void processDOHQuery(DOHUnitUniquePtr&& du)
 
     int fd = pickBackendSocketForSending(du->downstream);
     try {
-      /* you can't touch du after this line, because it might already have been freed */
+      /* you can't touch du after this line, unless the call returned a non-negative value,
+         because it might already have been freed */
       ssize_t ret = udpClientSendRequestToBackend(du->downstream, fd, du->query);
 
       if (ret < 0) {

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -260,4 +260,6 @@ void handleUDPResponseForDoH(std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>&&, Pack
 
 #endif /* HAVE_DNS_OVER_HTTPS  */
 
-void handleDOHTimeout(std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>&& oldDU);
+using DOHUnitUniquePtr = std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>;
+
+void handleDOHTimeout(DOHUnitUniquePtr&& oldDU);

--- a/pdns/doh.hh
+++ b/pdns/doh.hh
@@ -173,6 +173,9 @@ struct DOHFrontend
 #ifndef HAVE_DNS_OVER_HTTPS
 struct DOHUnit
 {
+  static void release(DOHUnit* ptr)
+  {
+  }
 };
 
 #else /* HAVE_DNS_OVER_HTTPS */
@@ -208,7 +211,12 @@ struct DOHUnit
     }
   }
 
-  void handleUDPResponse(PacketBuffer&& response, IDState&& state);
+  static void release(DOHUnit* ptr)
+  {
+    if (ptr) {
+      ptr->release();
+    }
+  }
 
   IDState ids;
   std::string sni;
@@ -248,6 +256,8 @@ struct DOHUnit
   void setHTTPResponse(uint16_t statusCode, PacketBuffer&& body, const std::string& contentType="");
 };
 
+void handleUDPResponseForDoH(std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>&&, PacketBuffer&& response, IDState&& state);
+
 #endif /* HAVE_DNS_OVER_HTTPS  */
 
-void handleDOHTimeout(DOHUnit* oldDU);
+void handleDOHTimeout(std::unique_ptr<DOHUnit, void(*)(DOHUnit*)>&& oldDU);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Introduced in 1.7.0, and only when a cross-protocol response to a DoH query is dropped by a rule.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
