### PR TITLE
dnsdist: Fix const-correctness of dnsdist_ffi_raw_value_t's value

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
+++ b/pdns/dnsdistdist/dnsdist-lua-ffi-interface.h
@@ -44,7 +44,7 @@ typedef struct dnsdist_ffi_tag {
 } dnsdist_ffi_tag_t;
 
 typedef struct dnsdist_ffi_raw_value {
-  char* value;
+  const char* value;
   uint16_t size;
 } dnsdist_ffi_raw_value_t;
 

--- a/regression-tests.dnsdist/test_Spoofing.py
+++ b/regression-tests.dnsdist/test_Spoofing.py
@@ -773,12 +773,10 @@ class TestSpoofingLuaFFISpoofMulti(DNSDistTest):
 
             local str = "\\192\\000\\002\\001"
             records[0].size = #str
-            records[0].value = ffi.new("char[?]", #str)
-            ffi.copy(records[0].value, str, #str)
+            records[0].value = str
 
             local str = "\\192\\000\\002\\255"
-            records[1].value = ffi.new("char[?]", #str)
-            ffi.copy(records[1].value, str, #str)
+            records[1].value = str
             records[1].size = #str
 
             ffi.C.dnsdist_ffi_dnsquestion_spoof_raw(dq, records, 2)
@@ -788,13 +786,11 @@ class TestSpoofingLuaFFISpoofMulti(DNSDistTest):
 
             local str = "\\033this text has a comma at the end,"
             records[0].size = #str
-            records[0].value = ffi.new("char[?]", #str)
-            ffi.copy(records[0].value, str, #str)
+            records[0].value = str
 
             local str = "\\003aaa\\004bbbb"
             records[1].size = #str
-            records[1].value = ffi.new("char[?]", #str)
-            ffi.copy(records[1].value, str, #str)
+            records[1].value = str
 
             ffi.C.dnsdist_ffi_dnsquestion_spoof_raw(dq, records, 2)
             return DNSAction.HeaderModify


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This prevent an allocation and a copy since we can now directly pass a Lua string.
Many thanks to @wojas for the suggestion!

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
