### PR TITLE
dnsdist: Check the size of the query when re-sending a DoH query

### DIFF
--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1320,7 +1320,10 @@ static void on_dnsdist(h2o_socket_t *listener, const char *err)
       continue;
     }
 
-    if (!du->tcp && du->truncated && du->query.size() > sizeof(dnsheader)) {
+    if (!du->tcp &&
+        du->truncated &&
+        du->query.size() > du->proxyProtocolPayloadSize &&
+        (du->query.size() - du->proxyProtocolPayloadSize) > sizeof(dnsheader)) {
       /* restoring the original ID */
       dnsheader* queryDH = reinterpret_cast<struct dnsheader*>(du->query.data() + du->proxyProtocolPayloadSize);
       queryDH->id = du->ids.origID;

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -1320,7 +1320,7 @@ static void on_dnsdist(h2o_socket_t *listener, const char *err)
       continue;
     }
 
-    if (!du->tcp && du->truncated && du->response.size() > sizeof(dnsheader)) {
+    if (!du->tcp && du->truncated && du->query.size() > sizeof(dnsheader)) {
       /* restoring the original ID */
       dnsheader* queryDH = reinterpret_cast<struct dnsheader*>(du->query.data() + du->proxyProtocolPayloadSize);
       queryDH->id = du->ids.origID;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
When the UDP response to a DoH query was truncated, we re-send the query via TCP, passing it to a TCP worker. We need to edit the ID to its original value before that, and while there is no reason that the query is smaller than a dnsheader, we need to check its size, not the size of the response.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
