### PR TITLE
rec: Always wait() on a killed process, even if poll() returns `not None`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -868,7 +868,7 @@ jobs:
           ASAN_OPTIONS: detect_leaks=0
     steps:
       - add-auth-repo
-      - run: apt-get --no-install-recommends install -qq -y pdns-server pdns-backend-bind pdns-tools daemontools authbind jq libfaketime lua-posix lua-socket moreutils bc python3-venv protobuf-compiler prometheus
+      - run: apt-get --no-install-recommends install -qq -y pdns-server pdns-backend-bind pdns-tools daemontools authbind jq libfaketime lua-posix lua-socket moreutils bc python3-venv protobuf-compiler prometheus lsof
       - install-recursor-deps
       - run:
           name: Set up authbind

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -299,7 +299,9 @@ jobs:
       - run: inv test-api recursor
 
   test-recursor-regression:
-    needs: build-recursor
+    needs:
+      - build-recursor
+      - build-auth
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -318,10 +320,16 @@ jobs:
         with:
           name: pdns-recursor-${{ matrix.sanitizers }}
           path: /opt/pdns-recursor
+      - name: Fetch the built auth binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: pdns-auth
+          path: /opt/pdns-auth
       - run: build-scripts/gh-actions-setup-inv  # this runs apt update+upgrade
       - run: inv add-auth-repo
       - run: inv install-clang-runtime
       - run: inv install-rec-test-deps
+      - run: inv install-auth-test-deps
       - run: inv test-regression-recursor
 
   test-recursor-bulk:

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -45,6 +45,8 @@
 
 #include "namespaces.hh"
 
+#include <cstdlib>
+
 extern StatBag S;
 
 /** \mainpage 
@@ -156,6 +158,12 @@ void UDPNameserver::bindAddresses()
         g_log<<Logger::Error<<"Address " << locala << " does not exist on this server - skipping UDP bind" << endl;
         continue;
       } else {
+        char t[100] = "/tmp/lsofXXXXXXXXX";
+        string tmp = string(mktemp(t));
+        std::system((string("lsof -nPi :53 > ") + tmp).c_str()); 
+        auto stream = std::ifstream(tmp);
+        for (string line; std::getline(stream, line); )
+          g_log << Logger::Error<< "lsof " << line << endl;
         g_log<<Logger::Error<<"Unable to bind UDP socket to '"+locala.toStringWithPort()+"': "<<stringerror(err)<<endl;
         throw PDNSException("Unable to bind to UDP socket");
       }

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -160,10 +160,13 @@ void UDPNameserver::bindAddresses()
       } else {
         char t[100] = "/tmp/lsofXXXXXXXXX";
         string tmp = string(mktemp(t));
-        std::system((string("lsof -nPi :53 > ") + tmp).c_str()); 
+        std::system((string("sudo lsof -nPi :53 > ") + tmp).c_str());
+        g_log << Logger::Error << "UID: " << getuid() << ' ' << geteuid() << endl;
+        g_log << Logger::Error<< "sudo lsof  -nPi :53" << endl;
         auto stream = std::ifstream(tmp);
         for (string line; std::getline(stream, line); )
           g_log << Logger::Error<< "lsof " << line << endl;
+        g_log << Logger::Error<< "End sudo lsof  -nPi :53" << endl;
         g_log<<Logger::Error<<"Unable to bind UDP socket to '"+locala.toStringWithPort()+"': "<<stringerror(err)<<endl;
         throw PDNSException("Unable to bind to UDP socket");
       }

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -151,6 +151,16 @@ void UDPNameserver::bindAddresses()
     if( !d_additional_socket )
         g_localaddresses.push_back(locala);
 
+    {
+      char t[100] = "/tmp/lsofXXXXXXXXX";
+      string tmp = string(mktemp(t));
+      std::system((string("sudo lsof -nPi :53 > ") + tmp).c_str());
+      g_log << Logger::Error<< "Before sudo lsof -nPi :53" << endl;
+      auto stream = std::ifstream(tmp);
+      for (string line; std::getline(stream, line); )
+        g_log << Logger::Error<< "lsof " << line << endl;
+      g_log << Logger::Error<< "End before sudo lsof -nPi :53" << endl;
+    }
     if(::bind(s, (sockaddr*)&locala, locala.getSocklen()) < 0) {
       int err = errno;
       close(s);
@@ -161,12 +171,11 @@ void UDPNameserver::bindAddresses()
         char t[100] = "/tmp/lsofXXXXXXXXX";
         string tmp = string(mktemp(t));
         std::system((string("sudo lsof -nPi :53 > ") + tmp).c_str());
-        g_log << Logger::Error << "UID: " << getuid() << ' ' << geteuid() << endl;
-        g_log << Logger::Error<< "sudo lsof  -nPi :53" << endl;
+        g_log << Logger::Error<< "sudo lsof -nPi :53" << endl;
         auto stream = std::ifstream(tmp);
         for (string line; std::getline(stream, line); )
           g_log << Logger::Error<< "lsof " << line << endl;
-        g_log << Logger::Error<< "End sudo lsof  -nPi :53" << endl;
+        g_log << Logger::Error<< "End sudo lsof -nPi :53" << endl;
         g_log<<Logger::Error<<"Unable to bind UDP socket to '"+locala.toStringWithPort()+"': "<<stringerror(err)<<endl;
         throw PDNSException("Unable to bind to UDP socket");
       }

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -154,12 +154,12 @@ void UDPNameserver::bindAddresses()
     {
       char t[100] = "/tmp/lsofXXXXXXXXX";
       string tmp = string(mktemp(t));
-      std::system((string("sudo lsof -nPi :53 > ") + tmp).c_str());
-      g_log << Logger::Error<< "Before sudo lsof -nPi :53" << endl;
+      std::system((string("sudo ss -aun > ") + tmp).c_str());
+      g_log << Logger::Error<< "Before sudo ss -aun" << endl;
       auto stream = std::ifstream(tmp);
       for (string line; std::getline(stream, line); )
-        g_log << Logger::Error<< "lsof " << line << endl;
-      g_log << Logger::Error<< "End before sudo lsof -nPi :53" << endl;
+        g_log << Logger::Error<< "ss " << line << endl;
+      g_log << Logger::Error<< "End before ss -aun" << endl;
     }
     if(::bind(s, (sockaddr*)&locala, locala.getSocklen()) < 0) {
       int err = errno;
@@ -170,12 +170,12 @@ void UDPNameserver::bindAddresses()
       } else {
         char t[100] = "/tmp/lsofXXXXXXXXX";
         string tmp = string(mktemp(t));
-        std::system((string("sudo lsof -nPi :53 > ") + tmp).c_str());
-        g_log << Logger::Error<< "sudo lsof -nPi :53" << endl;
+        std::system((string("sudo ss -aun > ") + tmp).c_str());
+        g_log << Logger::Error<< "sudo ss -aun" << endl;
         auto stream = std::ifstream(tmp);
         for (string line; std::getline(stream, line); )
-          g_log << Logger::Error<< "lsof " << line << endl;
-        g_log << Logger::Error<< "End sudo lsof -nPi :53" << endl;
+          g_log << Logger::Error<< "ss " << line << endl;
+        g_log << Logger::Error<< "End sudo ss -aun" << endl;
         g_log<<Logger::Error<<"Unable to bind UDP socket to '"+locala.toStringWithPort()+"': "<<stringerror(err)<<endl;
         throw PDNSException("Unable to bind to UDP socket");
       }

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -154,12 +154,12 @@ void UDPNameserver::bindAddresses()
     {
       char t[100] = "/tmp/lsofXXXXXXXXX";
       string tmp = string(mktemp(t));
-      std::system((string("sudo ss -aun > ") + tmp).c_str());
-      g_log << Logger::Error<< "Before sudo ss -aun" << endl;
+      std::system((string("sudo ss -aunp > ") + tmp).c_str());
+      g_log << Logger::Error<< "Before sudo ss -aunp" << endl;
       auto stream = std::ifstream(tmp);
       for (string line; std::getline(stream, line); )
         g_log << Logger::Error<< "ss " << line << endl;
-      g_log << Logger::Error<< "End before ss -aun" << endl;
+      g_log << Logger::Error<< "End before ss -aunp" << endl;
     }
     if(::bind(s, (sockaddr*)&locala, locala.getSocklen()) < 0) {
       int err = errno;
@@ -170,12 +170,12 @@ void UDPNameserver::bindAddresses()
       } else {
         char t[100] = "/tmp/lsofXXXXXXXXX";
         string tmp = string(mktemp(t));
-        std::system((string("sudo ss -aun > ") + tmp).c_str());
-        g_log << Logger::Error<< "sudo ss -aun" << endl;
+        std::system((string("sudo ss -aunp > ") + tmp).c_str());
+        g_log << Logger::Error<< "sudo ss -aunp" << endl;
         auto stream = std::ifstream(tmp);
         for (string line; std::getline(stream, line); )
           g_log << Logger::Error<< "ss " << line << endl;
-        g_log << Logger::Error<< "End sudo ss -aun" << endl;
+        g_log << Logger::Error<< "End sudo ss -aunp" << endl;
         g_log<<Logger::Error<<"Unable to bind UDP socket to '"+locala.toStringWithPort()+"': "<<stringerror(err)<<endl;
         throw PDNSException("Unable to bind to UDP socket");
       }

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -681,7 +681,7 @@ distributor-threads={threads}""".format(confdir=confdir,
             if x is None:
                 print("kill...", p, file=sys.stderr)
                 p.kill()
-                p.wait()
+            p.wait()
         except OSError as e:
             # There is a race-condition with the poll() and
             # kill() statements, when the process is dead on the

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -538,8 +538,8 @@ distributor-threads={threads}""".format(confdir=confdir,
     @classmethod
     def startAuth(cls, confdir, ipaddress):
         print("Launching pdns_server..")
-        print("But first an lsof -nPi :53 run")
-        lsof = subprocess.run(["sudo", "lsof", "-nPi", ":53"], capture_output=True, text=True )
+        print("But first an ss -uan run")
+        lsof = subprocess.run(["sudo", "ss", "-uan"], capture_output=True, text=True )
         print(lsof.stdout)
         authcmd = list(cls._auth_cmd)
         authcmd.append('--config-dir=%s' % confdir)
@@ -559,8 +559,8 @@ distributor-threads={threads}""".format(confdir=confdir,
         cls.waitForTCPSocket(ipaddress, 53)
 
         if cls._auths[ipaddress].poll() is not None:
-            print("Start auth failed, second lsof -nPi :43 run:");
-            lsof = subprocess.run(["sudo", "lsof", "-nPi", ":53"], capture_output=True, text=True )
+            print("Start auth failed, second ss -uan run:");
+            lsof = subprocess.run(["sudo", "ss", "-uan", ":53"], capture_output=True, text=True )
             print(lsof.stdout)
             print(f"\n*** startAuth log for {logFile} ***")
             with open(logFile, 'r') as fdLog:

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -539,7 +539,7 @@ distributor-threads={threads}""".format(confdir=confdir,
     def startAuth(cls, confdir, ipaddress):
         print("Launching pdns_server..")
         print("But first an lsof -nPi :53 run")
-        lsof = subprocess.run(["lsof", "-nPi", ":53"], capture_output=True, text=True )
+        lsof = subprocess.run(["sudo", "lsof", "-nPi", ":53"], capture_output=True, text=True )
         print(lsof.stdout)
         authcmd = list(cls._auth_cmd)
         authcmd.append('--config-dir=%s' % confdir)
@@ -560,7 +560,7 @@ distributor-threads={threads}""".format(confdir=confdir,
 
         if cls._auths[ipaddress].poll() is not None:
             print("Start auth failed, second lsof -nPi :43 run:");
-            lsof = subprocess.run(["lsof", "-nPi", ":53"], capture_output=True, text=True )
+            lsof = subprocess.run(["sudo", "lsof", "-nPi", ":53"], capture_output=True, text=True )
             print(lsof.stdout)
             print(f"\n*** startAuth log for {logFile} ***")
             with open(logFile, 'r') as fdLog:

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -559,6 +559,9 @@ distributor-threads={threads}""".format(confdir=confdir,
         cls.waitForTCPSocket(ipaddress, 53)
 
         if cls._auths[ipaddress].poll() is not None:
+            print("Start auth failed, second lsof -nPi :43 run:");
+            lsof = subprocess.run(["lsof", "-nPi", ":53"], capture_output=True, text=True )
+            print(lsof.stdout)
             print(f"\n*** startAuth log for {logFile} ***")
             with open(logFile, 'r') as fdLog:
                 print(fdLog.read())

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -538,8 +538,8 @@ distributor-threads={threads}""".format(confdir=confdir,
     @classmethod
     def startAuth(cls, confdir, ipaddress):
         print("Launching pdns_server..")
-        print("But first an ss -uan run")
-        lsof = subprocess.run(["sudo", "ss", "-uan"], capture_output=True, text=True )
+        print("But first an ss -uanp run")
+        lsof = subprocess.run(["sudo", "ss", "-uanp"], capture_output=True, text=True )
         print(lsof.stdout)
         authcmd = list(cls._auth_cmd)
         authcmd.append('--config-dir=%s' % confdir)
@@ -559,8 +559,8 @@ distributor-threads={threads}""".format(confdir=confdir,
         cls.waitForTCPSocket(ipaddress, 53)
 
         if cls._auths[ipaddress].poll() is not None:
-            print("Start auth failed, second ss -uan run:");
-            lsof = subprocess.run(["sudo", "ss", "-uan", ":53"], capture_output=True, text=True )
+            print("Start auth failed, second ss -uanp run:");
+            lsof = subprocess.run(["sudo", "ss", "-uanp", ":53"], capture_output=True, text=True )
             print(lsof.stdout)
             print(f"\n*** startAuth log for {logFile} ***")
             with open(logFile, 'r') as fdLog:

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -538,6 +538,9 @@ distributor-threads={threads}""".format(confdir=confdir,
     @classmethod
     def startAuth(cls, confdir, ipaddress):
         print("Launching pdns_server..")
+        print("But first an lsof -nPi :53 run")
+        lsof = subprocess.run(["lsof", "-nPi", ":53"], capture_output=True, text=True )
+        print(lsof.stdout)
         authcmd = list(cls._auth_cmd)
         authcmd.append('--config-dir=%s' % confdir)
         ipconfig = ipaddress

--- a/tasks.py
+++ b/tasks.py
@@ -456,6 +456,7 @@ def test_dnsdist(c):
 @task
 def test_regression_recursor(c):
     c.run('sudo systemctl stop systemd-resolved')
+    c.run('sudo systemctl stop pdns.service')
     c.run('chmod +x /opt/pdns-auth/bin/* /opt/pdns-auth/sbin/*')
     c.run('/opt/pdns-recursor/sbin/pdns_recursor --version')
     c.run('PDNSRECURSOR=/opt/pdns-recursor/sbin/pdns_recursor RECCONTROL=/opt/pdns-recursor/bin/rec_control PDNS=/opt/pdns-auth/sbin/pdns_server PDNSUTIL=/opt/pdns-auth/bin/pdnsutil SKIP_IPV6_TESTS=y ./build-scripts/test-recursor')

--- a/tasks.py
+++ b/tasks.py
@@ -181,7 +181,7 @@ def install_rec_test_deps(c): # FIXME: rename this, we do way more than apt-get
               pdns-server pdns-backend-bind daemontools \
               jq libfaketime lua-posix lua-socket bc authbind \
               python3-venv python3-dev default-libmysqlclient-dev libpq-dev \
-              protobuf-compiler snmpd prometheus')
+              protobuf-compiler snmpd prometheus lsof')
 
     c.run('chmod +x /opt/pdns-recursor/bin/* /opt/pdns-recursor/sbin/*')
 

--- a/tasks.py
+++ b/tasks.py
@@ -181,7 +181,7 @@ def install_rec_test_deps(c): # FIXME: rename this, we do way more than apt-get
               pdns-server pdns-backend-bind daemontools \
               jq libfaketime lua-posix lua-socket bc authbind \
               python3-venv python3-dev default-libmysqlclient-dev libpq-dev \
-              protobuf-compiler snmpd prometheus lsof')
+              protobuf-compiler snmpd prometheus iproute2')
 
     c.run('chmod +x /opt/pdns-recursor/bin/* /opt/pdns-recursor/sbin/*')
 

--- a/tasks.py
+++ b/tasks.py
@@ -457,7 +457,7 @@ def test_dnsdist(c):
 def test_regression_recursor(c):
     c.run('chmod +x /opt/pdns-auth/bin/* /opt/pdns-auth/sbin/*')
     c.run('/opt/pdns-recursor/sbin/pdns_recursor --version')
-    c.run('PDNSRECURSOR=/opt/pdns-recursor/sbin/pdns_recursor RECCONTROL=/opt/pdns-recursor/bin/rec_control AUTH=/opt/pdns-auth/sbin/pdns_server PDNSUTIL=/opt/pdns-auth/bin/pdnsutil SKIP_IPV6_TESTS=y ./build-scripts/test-recursor')
+    c.run('PDNSRECURSOR=/opt/pdns-recursor/sbin/pdns_recursor RECCONTROL=/opt/pdns-recursor/bin/rec_control PDNS=/opt/pdns-auth/sbin/pdns_server PDNSUTIL=/opt/pdns-auth/bin/pdnsutil SKIP_IPV6_TESTS=y ./build-scripts/test-recursor')
 
 @task
 def test_bulk_recursor(c, threads, mthreads, shards):

--- a/tasks.py
+++ b/tasks.py
@@ -455,8 +455,9 @@ def test_dnsdist(c):
 
 @task
 def test_regression_recursor(c):
+    c.run('chmod +x /opt/pdns-auth/bin/* /opt/pdns-auth/sbin/*')
     c.run('/opt/pdns-recursor/sbin/pdns_recursor --version')
-    c.run('PDNSRECURSOR=/opt/pdns-recursor/sbin/pdns_recursor RECCONTROL=/opt/pdns-recursor/bin/rec_control SKIP_IPV6_TESTS=y ./build-scripts/test-recursor')
+    c.run('PDNSRECURSOR=/opt/pdns-recursor/sbin/pdns_recursor RECCONTROL=/opt/pdns-recursor/bin/rec_control AUTH=/opt/pdns-auth/sbin/pdns_server PDNSUTIL=/opt/pdns-auth/bin/pdnsutil SKIP_IPV6_TESTS=y ./build-scripts/test-recursor')
 
 @task
 def test_bulk_recursor(c, threads, mthreads, shards):

--- a/tasks.py
+++ b/tasks.py
@@ -457,6 +457,7 @@ def test_dnsdist(c):
 def test_regression_recursor(c):
     c.run('sudo systemctl stop systemd-resolved')
     c.run('sudo systemctl stop pdns.service')
+    c.run('sudo sh -c "echo nameserver 9.9.9.9 >> /etc/resolv.conf"')
     c.run('chmod +x /opt/pdns-auth/bin/* /opt/pdns-auth/sbin/*')
     c.run('/opt/pdns-recursor/sbin/pdns_recursor --version')
     c.run('PDNSRECURSOR=/opt/pdns-recursor/sbin/pdns_recursor RECCONTROL=/opt/pdns-recursor/bin/rec_control PDNS=/opt/pdns-auth/sbin/pdns_server PDNSUTIL=/opt/pdns-auth/bin/pdnsutil SKIP_IPV6_TESTS=y ./build-scripts/test-recursor')

--- a/tasks.py
+++ b/tasks.py
@@ -455,6 +455,7 @@ def test_dnsdist(c):
 
 @task
 def test_regression_recursor(c):
+    c.run('sudo systemctl stop systemd-resolved')
     c.run('chmod +x /opt/pdns-auth/bin/* /opt/pdns-auth/sbin/*')
     c.run('/opt/pdns-recursor/sbin/pdns_recursor --version')
     c.run('PDNSRECURSOR=/opt/pdns-recursor/sbin/pdns_recursor RECCONTROL=/opt/pdns-recursor/bin/rec_control PDNS=/opt/pdns-auth/sbin/pdns_server PDNSUTIL=/opt/pdns-auth/bin/pdnsutil SKIP_IPV6_TESTS=y ./build-scripts/test-recursor')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is an attempt to fix:

`Dec 08 13:28:02 Unable to bind UDP socket to '127.0.0.18:53': Address already in use`

This only seems to happen on GH actions, local test are fine with and without this.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
