### PR TITLE
Docker images: Remove capability requirements

### DIFF
--- a/Docker-README.md
+++ b/Docker-README.md
@@ -53,3 +53,5 @@ There are multiple ways of dealing with these restrictions if you encounter them
 * Use custom configuration files to bind to alternate ports outside of the privileged range. This can be done via the following configuration settings:
     * dnsdist: `setLocal()`
     * Auth & Recursor: `local-address` and/or `local-port`
+
+Note: Docker Engine 20.10.0 (released december 2020) removed the need to set the `NET_BIND_SERVICE` capability when attempting to bind to a privileged port. 

--- a/Docker-README.md
+++ b/Docker-README.md
@@ -42,3 +42,14 @@ In a plain Docker or Compose setup, this can be done by using the host PID names
 We have a Docker Compose example at https://github.com/PowerDNS/pdns/blob/master/docker-compose.yml .
 It brings up all three services, and exposes them to eachother by name (using Docker's internal DNS).
 In the dockerdata dir, you can find an example dnsdist Lua config (with Python helper to make DNS lookups non-blocking for dnsdist) for managing your auth/rec backends by name.
+
+# Privileged ports
+
+The default configurations included for dnsdist, Auth and Recursor attempt to bind to port 53, which may not be permitted by the platform on which you intend to use these images. Kubernetes clusters, for example, might have a restriction on binding to privileged ports unless the `NET_BIND_SERVICE` capability is explicitly added to the container's security context.
+
+There are multiple ways of dealing with these restrictions if you encounter them:
+
+* Grant the `NET_BIND_SERVICE` capability to the containers which utilize these images
+* Use custom configuration files to bind to alternate ports outside of the privileged range. This can be done via the following configuration settings:
+    * dnsdist: `setLocal()`
+    * Auth & Recursor: `local-address` and/or `local-port`

--- a/Dockerfile-auth
+++ b/Dockerfile-auth
@@ -78,7 +78,6 @@ RUN apt-get install -y python3 python3-jinja2 sqlite3 tini libcap2-bin vim-tiny 
 # Output from builder
 COPY --from=builder /build /
 RUN chmod 1777 /tmp # FIXME: better not use /build/tmp for equivs at all
-RUN setcap 'cap_net_bind_service=+eip' /usr/local/sbin/pdns_server
 
 # Ensure dependencies are present
 RUN apt-get install -y /tmp/equivs-dummy_1.0_all.deb && apt-get clean
@@ -97,10 +96,10 @@ USER pdns
 # Set up database - this needs to be smarter
 RUN sqlite3 /var/lib/powerdns/pdns.sqlite3 < /usr/local/share/doc/pdns/schema.sqlite3.sql
 
-# DNS ports
+# Default DNS ports
 EXPOSE 53/udp
 EXPOSE 53/tcp
-# webserver port
+# Default webserver port
 EXPOSE 8081/tcp
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/sbin/pdns_server-startup"]

--- a/Dockerfile-dnsdist
+++ b/Dockerfile-dnsdist
@@ -74,7 +74,6 @@ RUN apt-get install -y python3 python3-jinja2 python3-atomicwrites tini libcap2-
 # Output from builder
 COPY --from=builder /build /
 RUN chmod 1777 /tmp # FIXME: better not use /build/tmp for equivs at all
-RUN setcap 'cap_net_bind_service=+eip' /usr/local/bin/dnsdist
 
 # Ensure dependencies are present
 RUN apt-get install -y /tmp/equivs-dummy_1.0_all.deb && apt-get clean
@@ -91,12 +90,12 @@ RUN adduser --system --disabled-password --disabled-login --no-create-home --gro
 RUN chown pdns:pdns /etc/dnsdist/conf.d /etc/dnsdist/templates.d
 USER pdns
 
-# DNS ports
+# Default DNS ports
 EXPOSE 53/udp
 EXPOSE 53/tcp
-# console port
+# Default console port
 EXPOSE 5199/tcp
-# webserver port
+# Default webserver port
 EXPOSE 8083/tcp
 
 WORKDIR /etc/dnsdist

--- a/Dockerfile-recursor
+++ b/Dockerfile-recursor
@@ -77,7 +77,6 @@ RUN apt-get install -y python3 python3-jinja2 tini libcap2-bin && apt-get clean
 # Executables from builder
 COPY --from=builder /build /
 RUN chmod 1777 /tmp # FIXME: better not use /build/tmp for equivs at all
-RUN setcap 'cap_net_bind_service=+eip' /usr/local/sbin/pdns_recursor
 
 # Ensure dependencies are present
 RUN apt-get install -y /tmp/equivs-dummy_1.0_all.deb && apt-get clean
@@ -96,11 +95,11 @@ RUN adduser --system --disabled-password --disabled-login --no-create-home --gro
 RUN chown pdns:pdns /var/run/pdns-recursor /etc/powerdns/recursor.d /etc/powerdns/templates.d
 USER pdns
 
-# DNS ports
+# Default DNS ports
 EXPOSE 53/udp
 EXPOSE 53/tcp
 
-# webserver port
+# Default webserver port
 EXPOSE 8082/tcp
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/sbin/pdns_recursor-startup"]


### PR DESCRIPTION
### Short description
The current Docker images are built with a dependency on the NET_BIND_SERVICE capability which used to be required for binding to a privileged port. This capability included in the image causes problems when trying to deploy the image on a Kubernetes platform with restrictive security policies in place (which is becoming the norm).

This pull request removes those dependencies and adds instructions to:
- Avoid these privileged ports (by binding to non-privileged ports)
- Add the NET_BIND_SERVICE capability to containers

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
