### PR TITLE
auth: remove dead return statements

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -221,7 +221,6 @@ bool Bind2Backend::startTransaction(const DNSName& qname, int id)
     int fd = mkstemp(&d_transaction_tmpname.at(0));
     if (fd == -1) {
       throw DBException("Unable to create a unique temporary zonefile '" + d_transaction_tmpname + "': " + stringerror());
-      return false;
     }
 
     d_of = std::make_unique<ofstream>(d_transaction_tmpname);

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -382,8 +382,6 @@ bool Bind2Backend::addDomainKey(const DNSName& name, const KeyData& key, int64_t
     id = -2;
     return true;
   }
-
-  return false;
 }
 
 bool Bind2Backend::activateDomainKey(const DNSName& name, unsigned int id)

--- a/modules/godbcbackend/sodbc.cc
+++ b/modules/godbcbackend/sodbc.cc
@@ -395,7 +395,6 @@ SSqlStatement* SODBCStatement::nextRow(row_t& row)
 
   SQLFreeStmt(d_statement, SQL_CLOSE);
   throw SSqlException("Should not get here.");
-  return this;
 }
 
 // Constructor.

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -572,7 +572,6 @@ bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& inse
     }
     catch (SSqlException &e) {
       throw PDNSException("GSQLBackend unable to delete empty non-terminal records from domain_id "+itoa(domain_id)+": "+e.txtReason());
-      return false;
     }
   }
   else
@@ -589,7 +588,6 @@ bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& inse
       }
       catch (SSqlException &e) {
         throw PDNSException("GSQLBackend unable to delete empty non-terminal rr '"+qname.toLogString()+"' from domain_id "+itoa(domain_id)+": "+e.txtReason());
-        return false;
       }
     }
   }
@@ -608,7 +606,6 @@ bool GSQLBackend::updateEmptyNonTerminals(uint32_t domain_id, set<DNSName>& inse
     }
     catch (SSqlException &e) {
       throw PDNSException("GSQLBackend unable to insert empty non-terminal rr '"+qname.toLogString()+"' in domain_id "+itoa(domain_id)+": "+e.txtReason());
-      return false;
     }
   }
 
@@ -775,8 +772,6 @@ bool GSQLBackend::addDomainKey(const DNSName& name, const KeyData& key, int64_t&
     id = -2;
     return true;
   }
-
-  return false;
 }
 
 bool GSQLBackend::activateDomainKey(const DNSName& name, unsigned int id)
@@ -1849,8 +1844,6 @@ bool GSQLBackend::searchRecords(const string &pattern, int maxResults, vector<DN
   catch (SSqlException &e) {
     throw PDNSException("GSQLBackend unable to search for records with pattern '" + pattern + "' (escaped pattern '" + escaped_pattern + "'): "+e.txtReason());
   }
-
-  return false;
 }
 
 bool GSQLBackend::searchComments(const string &pattern, int maxResults, vector<Comment>& result)
@@ -1882,8 +1875,6 @@ bool GSQLBackend::searchComments(const string &pattern, int maxResults, vector<C
   catch (SSqlException &e) {
     throw PDNSException("GSQLBackend unable to search for comments with pattern '" + pattern + "' (escaped pattern '" + escaped_pattern + "'): "+e.txtReason());
   }
-
-  return false;
 }
 
 void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)

--- a/pdns/resolver.cc
+++ b/pdns/resolver.cc
@@ -336,7 +336,6 @@ int Resolver::resolve(const ComboAddress& to, const DNSName &domain, int type, R
   catch(ResolverException &re) {
     throw ResolverException(re.reason+" from "+to.toLogString());
   }
-  return -1;
 }
 
 int Resolver::resolve(const ComboAddress& ipport, const DNSName &domain, int type, Resolver::res_t* res) {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Removes never reachable `return <something>;` statements.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
