### PR TITLE
rec: Backport 11069 to rec-4.6.x: Do not generate eventtrace records if no Lua hook is defined

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -504,6 +504,9 @@ void RecursorLua4::maintenance() const
 
 bool RecursorLua4::prerpz(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
+  if (!d_prerpz) {
+    return false;
+  }
   et.add(RecEventTrace::LuaPreRPZ);
   bool ok = genhook(d_prerpz, dq, ret);
   et.add(RecEventTrace::LuaPreRPZ, ok, false);
@@ -512,6 +515,9 @@ bool RecursorLua4::prerpz(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 
 bool RecursorLua4::preresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
+  if (!d_preresolve) {
+    return false;
+  }
   et.add(RecEventTrace::LuaPreResolve);
   bool ok = genhook(d_preresolve, dq, ret);
   et.add(RecEventTrace::LuaPreResolve, ok, false);
@@ -520,6 +526,9 @@ bool RecursorLua4::preresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) cons
 
 bool RecursorLua4::nxdomain(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
+  if (!d_nxdomain) {
+    return false;
+  }
   et.add(RecEventTrace::LuaNXDomain);
   bool ok = genhook(d_nxdomain, dq, ret);
   et.add(RecEventTrace::LuaNXDomain, ok, false);
@@ -528,6 +537,9 @@ bool RecursorLua4::nxdomain(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 
 bool RecursorLua4::nodata(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
+  if (!d_nodata) {
+    return false;
+  }
   et.add(RecEventTrace::LuaNoData);
   bool ok = genhook(d_nodata, dq, ret);
   et.add(RecEventTrace::LuaNoData, ok, false);
@@ -536,6 +548,9 @@ bool RecursorLua4::nodata(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 
 bool RecursorLua4::postresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) const
 {
+  if (!d_postresolve) {
+    return false;
+  }
   et.add(RecEventTrace::LuaPostResolve);
   bool ok = genhook(d_postresolve, dq, ret);
   et.add(RecEventTrace::LuaPostResolve, ok, false);
@@ -544,6 +559,9 @@ bool RecursorLua4::postresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) con
 
 bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, RecEventTrace& et) const
 {
+  if (!d_preoutquery) {
+    return false;
+  }
   bool variableAnswer = false;
   bool wantsRPZ = false;
   bool logQuery = false;
@@ -556,11 +574,15 @@ bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& reque
   return ok;
 }
 
-bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader& dh) const
+bool RecursorLua4::ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader& dh, RecEventTrace& et) const
 {
-  if (d_ipfilter)
-    return d_ipfilter(remote, local, dh);
-  return false; // don't block
+  if (!d_ipfilter) {
+    return false; // Do not block
+  }
+  et.add(RecEventTrace::LuaIPFilter);
+  bool ok = d_ipfilter(remote, local, dh);
+  et.add(RecEventTrace::LuaIPFilter, ok, false);
+  return ok;
 }
 
 bool RecursorLua4::policyHitEventFilter(const ComboAddress& remote, const DNSName& qname, const QType& qtype, bool tcp, DNSFilterEngine::Policy& policy, std::unordered_set<std::string>& tags, std::unordered_map<std::string, bool>& discardedPolicies) const

--- a/pdns/lua-recursor4.hh
+++ b/pdns/lua-recursor4.hh
@@ -193,7 +193,7 @@ public:
   bool postresolve(DNSQuestion& dq, int& ret, RecEventTrace&) const;
 
   bool preoutquery(const ComboAddress& ns, const ComboAddress& requestor, const DNSName& query, const QType& qtype, bool isTcp, vector<DNSRecord>& res, int& ret, RecEventTrace& et) const;
-  bool ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader&) const;
+  bool ipfilter(const ComboAddress& remote, const ComboAddress& local, const struct dnsheader&, RecEventTrace&) const;
 
   bool policyHitEventFilter(const ComboAddress& remote, const DNSName& qname, const QType& qtype, bool tcp, DNSFilterEngine::Policy& policy, std::unordered_set<std::string>& tags, std::unordered_map<std::string, bool>& discardedPolicies) const;
 

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -2903,9 +2903,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       }
 
       if (t_pdl) {
-        dc->d_eventTrace.add(RecEventTrace::LuaIPFilter);
-        bool ipf = t_pdl->ipfilter(dc->d_source, dc->d_destination, *dh);
-        dc->d_eventTrace.add(RecEventTrace::LuaIPFilter, ipf, false);
+        bool ipf = t_pdl->ipfilter(dc->d_source, dc->d_destination, *dh, dc->d_eventTrace);
         if (ipf) {
           if (!g_quiet) {
             g_log<<Logger::Notice<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] DROPPED TCP question from "<<dc->d_source.toStringWithPort()<<(dc->d_source != dc->d_remote ? " (via "+dc->d_remote.toStringWithPort()+")" : "")<<" based on policy"<<endl;
@@ -3289,9 +3287,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
   }
 
   if (t_pdl) {
-    eventTrace.add(RecEventTrace::LuaIPFilter);
-    bool ipf = t_pdl->ipfilter(source, destination, *dh);
-    eventTrace.add(RecEventTrace::LuaIPFilter, ipf, false);
+    bool ipf = t_pdl->ipfilter(source, destination, *dh, eventTrace);
     if (ipf) {
       if (!g_quiet) {
         g_log<<Logger::Notice<<t_id<<" ["<<MT->getTid()<<"/"<<MT->numProcesses()<<"] DROPPED question from "<<source.toStringWithPort()<<(source != fromaddr ? " (via "+fromaddr.toStringWithPort()+")" : "")<<" based on policy"<<endl;


### PR DESCRIPTION
(cherry picked from commit 6a948130b2406d0e3b295ec68f56b3b8ed302960)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
