### PR TITLE
First part of ZONEMD support

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1916,6 +1916,7 @@ zilopbg
 Zmd
 zonecryptokey
 zonefile
+zonemd
 zonemetadata
 zonename
 zoneparser

--- a/docs/manpages/pdnsutil.1.rst
+++ b/docs/manpages/pdnsutil.1.rst
@@ -251,6 +251,8 @@ unset-presigned *ZONE*
     Disables presigned operation for *ZONE*.
 raw-lua-from-content *TYPE* *CONTENT*  
     Display record contents in a form suitable for dnsdist's `SpoofRawAction`.
+zonemd-verify-file *ZONE* *FILE*  
+    Validate ZONEMD for *ZONE* read from *FILE*.
 
 DEBUGGING TOOLS
 ---------------

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -378,6 +378,7 @@ pdnsutil_SOURCES = \
 	tsigutils.hh tsigutils.cc \
 	ueberbackend.cc \
 	unix_utility.cc \
+	zonemd.hh zonemd.cc \
 	zoneparser-tng.cc
 
 pdnsutil_LDFLAGS = \

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1406,6 +1406,7 @@ testrunner_SOURCES = \
 	test-trusted-notification-proxy_cc.cc \
 	test-tsig.cc \
 	test-ueberbackend_cc.cc \
+	test-zonemd_cc.cc \
 	test-zoneparser_tng_cc.cc \
 	testrunner.cc \
 	threadname.hh threadname.cc \
@@ -1413,6 +1414,7 @@ testrunner_SOURCES = \
 	tsigverifier.cc tsigverifier.hh \
 	ueberbackend.cc ueberbackend.hh \
 	unix_utility.cc \
+	zonemd.cc zonemd.hh \
 	zoneparser-tng.cc zoneparser-tng.hh
 
 testrunner_LDFLAGS = \

--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -305,6 +305,13 @@ boilerplate_conv(KEY,
                  conv.xfrBlob(d_certificate);
                  );
 
+boilerplate_conv(ZONEMD,
+                 conv.xfr32BitInt(d_serial);
+                 conv.xfr8BitInt(d_scheme);
+                 conv.xfr8BitInt(d_hashalgo);
+                 conv.xfrHexBlob(d_digest, true); // keep reading across spaces
+                 );
+
 boilerplate_conv(CERT,
                  conv.xfr16BitInt(d_type); 
                  if (d_type == 0) throw MOADNSException("CERT type 0 is reserved");
@@ -963,6 +970,7 @@ void reportOtherTypes()
    L32RecordContent::report();
    L64RecordContent::report();
    LPRecordContent::report();
+   ZONEMDRecordContent::report();
 }
 
 void reportAllTypes()

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -586,6 +586,19 @@ public:
   struct soatimes d_st;
 };
 
+class ZONEMDRecordContent : public DNSRecordContent
+{
+public:
+  includeboilerplate(ZONEMD)
+  //ZONEMDRecordContent(uint32_t serial, uint8_t scheme, uint8_t hashalgo, string digest);
+
+private:
+  uint32_t d_serial;
+  uint8_t d_scheme;
+  uint8_t d_hashalgo;
+  string d_digest;
+};
+
 class NSECBitmap
 {
 public:

--- a/pdns/dnsrecords.hh
+++ b/pdns/dnsrecords.hh
@@ -592,7 +592,6 @@ public:
   includeboilerplate(ZONEMD)
   //ZONEMDRecordContent(uint32_t serial, uint8_t scheme, uint8_t hashalgo, string digest);
 
-private:
   uint32_t d_serial;
   uint8_t d_scheme;
   uint8_t d_hashalgo;

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -160,7 +160,7 @@ struct sharedDNSSECRecordCompare {
 
 typedef std::set<std::shared_ptr<DNSRecordContent>, sharedDNSSECRecordCompare> sortedRecords_t;
 
-string getMessageForRRSET(const DNSName& qname, const RRSIGRecordContent& rrc, const sortedRecords_t& signRecords, bool processRRSIGLabels = false);
+string getMessageForRRSET(const DNSName& qname, const RRSIGRecordContent& rrc, const sortedRecords_t& signRecords, bool processRRSIGLabels = false, bool includeRRSIG_RDATA = true);
 
 DSRecordContent makeDSFromDNSKey(const DNSName& qname, const DNSKEYRecordContent& drc, uint8_t digest);
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3200,7 +3200,7 @@ try
   }
   else if (cmds.at(0) == "unset-nsec3") {
     if(cmds.size() < 2) {
-      cerr<<"Syntax: pdnsutil unset-nsec3 ZON"<<endl;
+      cerr<<"Syntax: pdnsutil unset-nsec3 ZONE"<<endl;
       return 0;
     }
     if (!dk.unsetNSEC3PARAM(DNSName(cmds.at(1)))) {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1375,14 +1375,15 @@ static int zonemdVerifyFile(const DNSName& zone, const string& fname) {
   }
   catch (const std::exception& ex) {
     cerr << "zonemd-verify-file: " << ex.what() << endl;
+    return EXIT_FAILURE;
   }
 
   if (validationDone) {
     if (validationOK) {
-      cout << "zonemd-verify-file: Validation of ZONEMD record succeeded" << endl;
+      cout << "zonemd-verify-file: Verification of ZONEMD record succeeded" << endl;
       return EXIT_SUCCESS;
     } else {
-      cerr << "zonemd-verify-file: Validation of ZONEMD record(s) failed" << endl;
+      cerr << "zonemd-verify-file: Verification of ZONEMD record(s) failed" << endl;
     }
   }
   else {
@@ -2445,6 +2446,7 @@ try
     cout<<"unset-publish-cds ZONE             Disable sending CDS responses for ZONE"<<endl;
     cout<<"test-schema ZONE                   Test DB schema - will create ZONE"<<endl;
     cout<<"raw-lua-from-content TYPE CONTENT  Display record contents in a form suitable for dnsdist's `SpoofRawAction`"<<endl;
+    cout<<"zonemd-verify-file ZONE FILE       Validate ZONEMD for ZONE"<<endl;
     cout<<desc<<endl;
     return 0;
   }
@@ -2571,14 +2573,13 @@ try
   if(cmds[0] == "zonemd-verify-file") {
     if(cmds.size() < 3) {
       cerr<<"Syntax: pdnsutil zonemd-verify-file ZONE FILENAME"<<endl;
-      return 0;
+      return 1;
     }
     if(cmds[1]==".")
       cmds[1].clear();
 
     auto ret = zonemdVerifyFile(DNSName(cmds[1]), cmds[2]);
-    if (ret) exit(ret);
-    return 0;
+    return ret;
   }
 
   DNSSECKeeper dk;

--- a/pdns/qtype.cc
+++ b/pdns/qtype.cc
@@ -73,6 +73,7 @@ const map<const string, uint16_t> QType::names = {
   {"CDNSKEY", 60},
   {"OPENPGPKEY", 61},
   {"CSYNC", 62},
+  {"ZONEMD", 63},
   {"SVCB", 64},
   {"HTTPS", 65},
   {"SPF", 99},

--- a/pdns/qtype.hh
+++ b/pdns/qtype.hh
@@ -102,6 +102,7 @@ public:
     CDNSKEY = 60,
     OPENPGPKEY = 61,
     CSYNC = 62,
+    ZONEMD = 63,
     SVCB = 64,
     HTTPS = 65,
     SPF = 99,

--- a/pdns/sha.hh
+++ b/pdns/sha.hh
@@ -59,7 +59,7 @@ class SHADigest
 {
 public:
   SHADigest(unsigned int bits) :
-    mdctx(std::unique_ptr<EVP_MD_CTX, void (*)(EVP_MD_CTX*)>(EVP_MD_CTX_new(), EVP_MD_CTX_free))
+    mdctx(std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>(EVP_MD_CTX_new(), EVP_MD_CTX_free))
   {
     if (mdctx == nullptr) {
       throw std::runtime_error("SHADigest: EVP_MD_CTX_new failed");
@@ -109,7 +109,7 @@ public:
   }
 
 private:
-  std::unique_ptr<EVP_MD_CTX, void (*)(EVP_MD_CTX*)> mdctx;
+  std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> mdctx;
   const EVP_MD* md;
 };
 }

--- a/pdns/sha.hh
+++ b/pdns/sha.hh
@@ -20,9 +20,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
+
 #include <string>
-#include <stdint.h>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 
 inline std::string pdns_sha1sum(const std::string& input)
 {
@@ -50,4 +51,67 @@ inline std::string pdns_sha512sum(const std::string& input)
   unsigned char result[64] = {0};
   SHA512(reinterpret_cast<const unsigned char*>(input.c_str()), input.length(), result);
   return std::string(result, result + sizeof result);
+}
+
+namespace pdns
+{
+  class SHADigest
+  {
+  public:
+    SHADigest(int bits)
+    {
+      mdctx = EVP_MD_CTX_new();
+      if (mdctx == nullptr) {
+        throw std::runtime_error("VSHADigest: P_MD_CTX_new failed");
+      }
+      switch (bits) {
+      case 256:
+        md = EVP_sha256();
+        break;
+      case 384:
+        md = EVP_sha384();
+        break;
+      case 512:
+        md = EVP_sha512();
+        break;
+      default:
+        throw std::runtime_error("SHADigest: unsupported size");
+      }
+      if (EVP_DigestInit_ex(mdctx, md, NULL) == 0) {
+        throw std::runtime_error("SHADigest: init error");
+      }
+    }
+
+    ~SHADigest()
+    {
+      // No free of md needed afaik
+      if (mdctx != nullptr) {
+        EVP_MD_CTX_free(mdctx);
+      }
+    }
+
+    void process(const std::string& msg, size_t sz)
+    {
+      if (EVP_DigestUpdate(mdctx, msg.data(), msg.size()) == 0) {
+        throw std::runtime_error("SHADigest: update error");
+      }
+    }
+
+    std::string digest()
+    {
+      std::string md_value;
+      md_value.resize(EVP_MD_size(md));
+      unsigned int md_len;
+      if (EVP_DigestFinal_ex(mdctx, reinterpret_cast<unsigned char*>(md_value.data()), &md_len) == 0) {
+        throw std::runtime_error("SHADigest: finalize error");
+      }
+      if (md_len != md_value.size()) {
+        throw std::runtime_error("SHADigest: inconsisten size");
+      }
+      return md_value;
+    }
+  private:
+    EVP_MD_CTX *mdctx{nullptr};
+    const EVP_MD *md;
+  };
 }

--- a/pdns/sha.hh
+++ b/pdns/sha.hh
@@ -75,7 +75,7 @@ public:
       md = EVP_sha512();
       break;
     default:
-      throw std::runtime_error("SHADigest: unsupported size");
+      throw std::invalid_argument("SHADigest: unsupported size");
     }
     if (EVP_DigestInit_ex(mdctx.get(), md, NULL) == 0) {
       throw std::runtime_error("SHADigest: init error");

--- a/pdns/sha.hh
+++ b/pdns/sha.hh
@@ -55,63 +55,64 @@ inline std::string pdns_sha512sum(const std::string& input)
 
 namespace pdns
 {
-  class SHADigest
+class SHADigest
+{
+public:
+  SHADigest(int bits)
   {
-  public:
-    SHADigest(int bits)
-    {
-      mdctx = EVP_MD_CTX_new();
-      if (mdctx == nullptr) {
-        throw std::runtime_error("VSHADigest: P_MD_CTX_new failed");
-      }
-      switch (bits) {
-      case 256:
-        md = EVP_sha256();
-        break;
-      case 384:
-        md = EVP_sha384();
-        break;
-      case 512:
-        md = EVP_sha512();
-        break;
-      default:
-        throw std::runtime_error("SHADigest: unsupported size");
-      }
-      if (EVP_DigestInit_ex(mdctx, md, NULL) == 0) {
-        throw std::runtime_error("SHADigest: init error");
-      }
+    mdctx = EVP_MD_CTX_new();
+    if (mdctx == nullptr) {
+      throw std::runtime_error("VSHADigest: P_MD_CTX_new failed");
     }
+    switch (bits) {
+    case 256:
+      md = EVP_sha256();
+      break;
+    case 384:
+      md = EVP_sha384();
+      break;
+    case 512:
+      md = EVP_sha512();
+      break;
+    default:
+      throw std::runtime_error("SHADigest: unsupported size");
+    }
+    if (EVP_DigestInit_ex(mdctx, md, NULL) == 0) {
+      throw std::runtime_error("SHADigest: init error");
+    }
+  }
 
-    ~SHADigest()
-    {
-      // No free of md needed afaik
-      if (mdctx != nullptr) {
-        EVP_MD_CTX_free(mdctx);
-      }
+  ~SHADigest()
+  {
+    // No free of md needed afaik
+    if (mdctx != nullptr) {
+      EVP_MD_CTX_free(mdctx);
     }
+  }
 
-    void process(const std::string& msg, size_t sz)
-    {
-      if (EVP_DigestUpdate(mdctx, msg.data(), msg.size()) == 0) {
-        throw std::runtime_error("SHADigest: update error");
-      }
+  void process(const std::string& msg, size_t sz)
+  {
+    if (EVP_DigestUpdate(mdctx, msg.data(), msg.size()) == 0) {
+      throw std::runtime_error("SHADigest: update error");
     }
+  }
 
-    std::string digest()
-    {
-      std::string md_value;
-      md_value.resize(EVP_MD_size(md));
-      unsigned int md_len;
-      if (EVP_DigestFinal_ex(mdctx, reinterpret_cast<unsigned char*>(md_value.data()), &md_len) == 0) {
-        throw std::runtime_error("SHADigest: finalize error");
-      }
-      if (md_len != md_value.size()) {
-        throw std::runtime_error("SHADigest: inconsisten size");
-      }
-      return md_value;
+  std::string digest()
+  {
+    std::string md_value;
+    md_value.resize(EVP_MD_size(md));
+    unsigned int md_len;
+    if (EVP_DigestFinal_ex(mdctx, reinterpret_cast<unsigned char*>(md_value.data()), &md_len) == 0) {
+      throw std::runtime_error("SHADigest: finalize error");
     }
-  private:
-    EVP_MD_CTX *mdctx{nullptr};
-    const EVP_MD *md;
-  };
+    if (md_len != md_value.size()) {
+      throw std::runtime_error("SHADigest: inconsisten size");
+    }
+    return md_value;
+  }
+
+private:
+  EVP_MD_CTX* mdctx{nullptr};
+  const EVP_MD* md;
+};
 }

--- a/pdns/sha.hh
+++ b/pdns/sha.hh
@@ -58,11 +58,11 @@ namespace pdns
 class SHADigest
 {
 public:
-  SHADigest(int bits)
+  SHADigest(unsigned int bits)
   {
     mdctx = EVP_MD_CTX_new();
     if (mdctx == nullptr) {
-      throw std::runtime_error("VSHADigest: P_MD_CTX_new failed");
+      throw std::runtime_error("SHADigest: EVP_MD_CTX_new failed");
     }
     switch (bits) {
     case 256:
@@ -90,7 +90,7 @@ public:
     }
   }
 
-  void process(const std::string& msg, size_t sz)
+  void process(const std::string& msg)
   {
     if (EVP_DigestUpdate(mdctx, msg.data(), msg.size()) == 0) {
       throw std::runtime_error("SHADigest: update error");
@@ -106,7 +106,7 @@ public:
       throw std::runtime_error("SHADigest: finalize error");
     }
     if (md_len != md_value.size()) {
-      throw std::runtime_error("SHADigest: inconsisten size");
+      throw std::runtime_error("SHADigest: inconsistent size");
     }
     return md_value;
   }

--- a/pdns/sha.hh
+++ b/pdns/sha.hh
@@ -84,7 +84,7 @@ public:
 
   ~SHADigest()
   {
-    // No free of md needed afaik
+    // No free of md needed and mdctx is cleaned up by unique_ptr
   }
 
   void process(const std::string& msg)

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -206,6 +206,10 @@ BOOST_AUTO_TEST_CASE(test_record_types) {
 
      (CASE_S(QType::CSYNC, "66 3 A NS AAAA", "\x00\x00\x00\x42\x00\x03\x00\x04\x60\x00\x00\x08"))
 
+     // ZONEMD
+     (CASE_S(QType::ZONEMD, "2018031900 1 1 a3b69bad980a3504e1cffcb0fd6397f93848071c93151f552ae2f6b1711d4bd2d8b39808226d7b9db71e34b72077f8fe", "\x78\x48\xb9\x1c\x01\x01\xa3\xb6\x9b\xad\x98\x0a\x35\x04\xe1\xcf\xfc\xb0\xfd\x63\x97\xf9\x38\x48\x07\x1c\x93\x15\x1f\x55\x2a\xe2\xf6\xb1\x71\x1d\x4b\xd2\xd8\xb3\x98\x08\x22\x6d\x7b\x9d\xb7\x1e\x34\xb7\x20\x77\xf8\xfe"))
+     (CASE_L(QType::ZONEMD, " 2018031900  1  1 ( 616c6c6f77656420 6275742069676e6f \n 7265642e20616c6c \n6f77656420627574\n 2069676e6f726564 \n2e20616c6c6f7765 \n)", "2018031900 1 1 616c6c6f776564206275742069676e6f7265642e20616c6c6f776564206275742069676e6f7265642e20616c6c6f7765", "\x78\x48\xb9\x1c\x01\x01\x61\x6c\x6c\x6f\x77\x65\x64\x20\x62\x75\x74\x20\x69\x67\x6e\x6f\x72\x65\x64\x2e\x20\x61\x6c\x6c\x6f\x77\x65\x64\x20\x62\x75\x74\x20\x69\x67\x6e\x6f\x72\x65\x64\x2e\x20\x61\x6c\x6c\x6f\x77\x65"))
+
      // Alias mode
      (CASE_S(QType::SVCB, "0 foo.powerdns.org.", "\0\0\3foo\x08powerdns\x03org\x00"))
      (CASE_L(QType::SVCB, "0 foo.powerdns.org", "0 foo.powerdns.org.", "\0\0\3foo\x08powerdns\x03org\x00"))

--- a/pdns/test-zonemd_cc.cc
+++ b/pdns/test-zonemd_cc.cc
@@ -25,11 +25,9 @@ static void testZoneMD(const std::string& zone, const std::string& file, bool ex
     pdns::zonemdVerify(z, zpt, validationDone, validationOK);
   }
   catch (const PDNSException& e) {
-    cerr << e.reason << endl;
     BOOST_CHECK(ex);
   }
   catch (const std::exception& e) {
-    cerr << e.what() << endl;
     BOOST_CHECK(ex);
   }
 

--- a/pdns/test-zonemd_cc.cc
+++ b/pdns/test-zonemd_cc.cc
@@ -1,0 +1,92 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include "zonemd.hh"
+#include "dnsrecords.hh"
+#include "zoneparser-tng.hh"
+
+BOOST_AUTO_TEST_SUITE(test_zonemd_cc)
+
+static void testZoneMD(const std::string& zone, const std::string& file, bool ex, bool done, bool ok) {
+  const char* p = std::getenv("SRCDIR");
+  if (!p) {
+    p = ".";
+  }
+  DNSName z(zone);
+  std::ostringstream pathbuf;
+  pathbuf << p << "/../regression-tests/zones/" + file;
+  ZoneParserTNG zpt(pathbuf.str(), z);
+
+  bool validationDone, validationOK;
+
+  try {
+    pdns::zonemdVerify(z, zpt, validationDone, validationOK);
+  }
+  catch (const PDNSException& e) {
+    cerr << e.reason << endl;
+    BOOST_CHECK(ex);
+  }
+  catch (const std::exception& e) {
+    cerr << e.what() << endl;
+    BOOST_CHECK(ex);
+  }
+
+  BOOST_CHECK(validationDone == done);
+  BOOST_CHECK(validationOK == ok);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_zonemd1) {
+  testZoneMD("example", "zonemd1.zone", false, true, true);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd2) {
+  testZoneMD("example", "zonemd2.zone", false, true, true);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd3) {
+  testZoneMD("example", "zonemd3.zone", false, true, true);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd4) {
+  testZoneMD("uri.arpa", "zonemd4.zone", false, true, true);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd5) {
+  testZoneMD("root-servers.net", "zonemd5.zone", false, true, true);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd6) {
+  testZoneMD("example", "zonemd-invalid.zone", false, true, false);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd7) {
+  testZoneMD("example", "zonemd-nozonemd.zone", false, false, false);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd8) {
+  testZoneMD("example", "zonemd-allunsup.zone", false, false, false);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd9) {
+  testZoneMD("example", "zonemd-sha512.zone", false, true, true);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd10) {
+  testZoneMD("example", "zonemd-serialmismatch.zone", false, false, false);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd11) {
+  testZoneMD("example", "zonemd-duplicate.zone", false, false, false);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd12) {
+  testZoneMD("root-servers.net", "zonemd-syntax.zone", true, false, false);
+}
+
+BOOST_AUTO_TEST_CASE(test_zonemd13) {
+  testZoneMD("xxx", "zonemd1.zone", false, false, false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/test-zonemd_cc.cc
+++ b/pdns/test-zonemd_cc.cc
@@ -8,7 +8,8 @@
 
 BOOST_AUTO_TEST_SUITE(test_zonemd_cc)
 
-static void testZoneMD(const std::string& zone, const std::string& file, bool ex, bool done, bool ok) {
+static void testZoneMD(const std::string& zone, const std::string& file, bool ex, bool done, bool ok)
+{
   const char* p = std::getenv("SRCDIR");
   if (!p) {
     p = ".";
@@ -36,56 +37,68 @@ static void testZoneMD(const std::string& zone, const std::string& file, bool ex
   BOOST_CHECK(validationOK == ok);
 }
 
-
-BOOST_AUTO_TEST_CASE(test_zonemd1) {
+BOOST_AUTO_TEST_CASE(test_zonemd1)
+{
   testZoneMD("example", "zonemd1.zone", false, true, true);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd2) {
+BOOST_AUTO_TEST_CASE(test_zonemd2)
+{
   testZoneMD("example", "zonemd2.zone", false, true, true);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd3) {
+BOOST_AUTO_TEST_CASE(test_zonemd3)
+{
   testZoneMD("example", "zonemd3.zone", false, true, true);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd4) {
+BOOST_AUTO_TEST_CASE(test_zonemd4)
+{
   testZoneMD("uri.arpa", "zonemd4.zone", false, true, true);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd5) {
+BOOST_AUTO_TEST_CASE(test_zonemd5)
+{
   testZoneMD("root-servers.net", "zonemd5.zone", false, true, true);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd6) {
+BOOST_AUTO_TEST_CASE(test_zonemd6)
+{
   testZoneMD("example", "zonemd-invalid.zone", false, true, false);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd7) {
+BOOST_AUTO_TEST_CASE(test_zonemd7)
+{
   testZoneMD("example", "zonemd-nozonemd.zone", false, false, false);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd8) {
+BOOST_AUTO_TEST_CASE(test_zonemd8)
+{
   testZoneMD("example", "zonemd-allunsup.zone", false, false, false);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd9) {
+BOOST_AUTO_TEST_CASE(test_zonemd9)
+{
   testZoneMD("example", "zonemd-sha512.zone", false, true, true);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd10) {
+BOOST_AUTO_TEST_CASE(test_zonemd10)
+{
   testZoneMD("example", "zonemd-serialmismatch.zone", false, false, false);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd11) {
+BOOST_AUTO_TEST_CASE(test_zonemd11)
+{
   testZoneMD("example", "zonemd-duplicate.zone", false, false, false);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd12) {
+BOOST_AUTO_TEST_CASE(test_zonemd12)
+{
   testZoneMD("root-servers.net", "zonemd-syntax.zone", true, false, false);
 }
 
-BOOST_AUTO_TEST_CASE(test_zonemd13) {
+BOOST_AUTO_TEST_CASE(test_zonemd13)
+{
   testZoneMD("xxx", "zonemd1.zone", false, false, false);
 }
 

--- a/pdns/zonemd.cc
+++ b/pdns/zonemd.cc
@@ -30,7 +30,7 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG& zpt, bool& validatio
   validationDone = false;
   validationOK = false;
 
-  // scheme,hasalgo -> duplicate,zonemdrecord
+  // scheme,hashalgo -> duplicate,zonemdrecord
   struct ZoneMDAndDuplicateFlag
   {
     std::shared_ptr<ZONEMDRecordContent> record;
@@ -117,10 +117,10 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG& zpt, bool& validatio
   // A little helper
   auto hash = [&sha384digest, &sha512digest](const std::string& msg) {
     if (sha384digest) {
-      sha384digest->process(msg, msg.size());
+      sha384digest->process(msg);
     }
     if (sha512digest) {
-      sha512digest->process(msg, msg.size());
+      sha512digest->process(msg);
     }
   };
 

--- a/pdns/zonemd.cc
+++ b/pdns/zonemd.cc
@@ -1,0 +1,184 @@
+#include "zonemd.hh"
+
+#include "dnsrecords.hh"
+#include "dnssecinfra.hh"
+#include "sha.hh"
+#include "zoneparser-tng.hh"
+
+typedef std::pair<DNSName, QType> rrSetKey_t;
+typedef std::vector<std::shared_ptr<DNSRecordContent>> rrVector_t;
+
+struct CanonrrSetKeyCompare: public std::binary_function<rrSetKey_t, rrSetKey_t, bool>
+{
+  bool operator()(const rrSetKey_t&a, const rrSetKey_t& b) const
+  {
+    // FIXME surely we can be smarter here
+    if(a.first.canonCompare(b.first)) {
+      return true;
+    }
+    if (b.first.canonCompare(a.first)) {
+      return false;
+    }
+    return a.second < b.second;
+  }
+};
+
+typedef std::map<rrSetKey_t, rrVector_t, CanonrrSetKeyCompare> RRsetMap_t;
+
+RRsetMap_t RRsets;
+std::map<rrSetKey_t, uint32_t> RRsetTTLs;
+
+void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validationDone, bool& validationOK)
+{
+  validationDone = false;
+  validationOK = false;
+
+  DNSResourceRecord dnsrr;
+  std::map<std::pair<uint8_t, uint8_t>, std::shared_ptr<ZONEMDRecordContent>> zonemdRecords;
+  std::shared_ptr<SOARecordContent> soarc;
+
+  // Get all records and remember RRSets and TTLs
+  while (zpt.get(dnsrr)) {
+    if (!dnsrr.qname.isPartOf(zone) && dnsrr.qname != zone) {
+      continue;
+    }
+    if (dnsrr.qtype == QType::SOA && soarc) {
+      // XXX skip extra SOA?
+      continue;
+    }
+    std::shared_ptr<DNSRecordContent> drc;
+    try {
+      drc = DNSRecordContent::mastermake(dnsrr.qtype, QClass::IN, dnsrr.content);
+    }
+    catch (const PDNSException& pe) {
+      std::string err = "Bad record content in record for '" + dnsrr.qname.toStringNoDot() + "'|" + dnsrr.qtype.toString() + ": "+ pe.reason;
+      throw PDNSException(err);
+    }
+    catch (const std::exception& e) {
+      std::string err = "Bad record content in record for '" + dnsrr.qname.toStringNoDot() + "|" + dnsrr.qtype.toString() + "': " + e.what();
+      throw PDNSException(err);
+    }
+    if (dnsrr.qtype == QType::SOA && dnsrr.qname == zone) {
+      soarc = std::dynamic_pointer_cast<SOARecordContent>(drc);
+    }
+    if (dnsrr.qtype == QType::ZONEMD && dnsrr.qname == zone) {
+      auto zonemd = std::dynamic_pointer_cast<ZONEMDRecordContent>(drc);
+      auto inserted = zonemdRecords.insert(pair(pair(zonemd->d_scheme, zonemd->d_hashalgo), zonemd)).second;
+      if (!inserted) {
+        throw PDNSException("Duplicate ZONEMD record");
+      }
+    }
+    rrSetKey_t key = std::pair(dnsrr.qname, dnsrr.qtype);
+    RRsets[key].push_back(drc);
+    RRsetTTLs[key] = dnsrr.ttl;
+  }
+
+  // Determine which digests to compute based on accepted zonemd records present
+  unique_ptr<pdns::SHADigest> sha384digest{nullptr}, sha512digest{nullptr};
+
+  for (const auto& [k, zonemd] : zonemdRecords) {
+    if (zonemd->d_serial != soarc->d_st.serial) {
+      // The SOA Serial field MUST exactly match the ZONEMD Serial
+      // field. If the fields do not match, digest verification MUST
+      // NOT be considered successful with this ZONEMD RR.
+      continue;
+    }
+    if (zonemd->d_scheme != 1) {
+      // The Scheme field MUST be checked. If the verifier does not
+      // support the given scheme, verification MUST NOT be considered
+      // successful with this ZONEMD RR.
+      continue;
+    }
+    // The Hash Algorithm field MUST be checked. If the verifier does
+    // not support the given hash algorithm, verification MUST NOT be
+    // considered successful with this ZONEMD RR.
+    if (zonemd->d_hashalgo == 1) {
+      sha384digest = make_unique<pdns::SHADigest>(384);
+    }
+    else if (zonemd->d_hashalgo == 2) {
+      sha512digest = make_unique<pdns::SHADigest>(512);
+    }
+  }
+
+  // A little helper
+  auto hash = [&sha384digest, &sha512digest](const std::string& msg) {
+    if (sha384digest) {
+      sha384digest->process(msg, msg.size());
+    }
+    if (sha512digest) {
+      sha512digest->process(msg, msg.size());
+    }
+  };
+
+  // Compute requested digests
+  for (auto& rrset: RRsets) {
+    const auto& qname = rrset.first.first;
+    const auto& qtype = rrset.first.second;
+    if (qtype == QType::ZONEMD && qname == zone) {
+      continue; // the apex ZONEMD is not digested
+    }
+
+    sortedRecords_t sorted;
+    for (auto& rr: rrset.second) {
+      if (qtype == QType::RRSIG) {
+        const auto rrsig = std::dynamic_pointer_cast<RRSIGRecordContent>(rr);
+        if (rrsig->d_type == QType::ZONEMD && qname == zone) {
+          continue;
+        }
+      }
+      sorted.insert(rr);
+    }
+
+    if (qtype != QType::RRSIG) {
+      RRSIGRecordContent rrc;
+      rrc.d_originalttl = RRsetTTLs[rrset.first];
+      rrc.d_type = qtype;
+      auto msg = getMessageForRRSET(qname, rrc, sorted, false, false);
+      hash(msg);
+    } else {
+      // RRSIG is special, since  original TTL depends on qtype covered by RRSIG
+      // which can be different per record
+      for (const auto& rrsig : sorted) {
+        auto rrsigc = std::dynamic_pointer_cast<RRSIGRecordContent>(rrsig);
+        RRSIGRecordContent rrc;
+        rrc.d_originalttl = RRsetTTLs[pair(rrset.first.first, rrsigc->d_type)];
+        rrc.d_type = qtype;
+        auto msg = getMessageForRRSET(qname, rrc, { rrsigc }, false, false);
+        hash(msg);
+      }
+    }
+  }
+
+  // Final verify
+  for (const auto& [k, zonemd] : zonemdRecords) {
+    if (zonemd->d_serial != soarc->d_st.serial) {
+      // The SOA Serial field MUST exactly match the ZONEMD Serial
+      // field. If the fields do not match, digest verification MUST
+      // NOT be considered successful with this ZONEMD RR.
+      continue;
+    }
+    if (zonemd->d_scheme != 1) {
+      // The Scheme field MUST be checked. If the verifier does not
+      // support the given scheme, verification MUST NOT be considered
+      // successful with this ZONEMD RR.
+      continue;
+    }
+    // The Hash Algorithm field MUST be checked. If the verifier does
+    // not support the given hash algorithm, verification MUST NOT be
+    // considered successful with this ZONEMD RR.
+    if (zonemd->d_hashalgo == 1) {
+      validationDone = true;
+      if (constantTimeStringEquals(zonemd->d_digest, sha384digest->digest())) {
+        validationOK = true;
+        break; // Per RFC: a single succeeding validation is enough
+      }
+    }
+    else if (zonemd->d_hashalgo == 2) {
+      validationDone = true;
+      if (constantTimeStringEquals(zonemd->d_digest, sha512digest->digest())) {
+        validationOK = true;
+        break; // Per RFC: a single succeeding validation is enough
+      }
+    }
+  }
+}

--- a/pdns/zonemd.cc
+++ b/pdns/zonemd.cc
@@ -8,12 +8,12 @@
 typedef std::pair<DNSName, QType> rrSetKey_t;
 typedef std::vector<std::shared_ptr<DNSRecordContent>> rrVector_t;
 
-struct CanonrrSetKeyCompare: public std::binary_function<rrSetKey_t, rrSetKey_t, bool>
+struct CanonrrSetKeyCompare : public std::binary_function<rrSetKey_t, rrSetKey_t, bool>
 {
-  bool operator()(const rrSetKey_t&a, const rrSetKey_t& b) const
+  bool operator()(const rrSetKey_t& a, const rrSetKey_t& b) const
   {
     // FIXME surely we can be smarter here
-    if(a.first.canonCompare(b.first)) {
+    if (a.first.canonCompare(b.first)) {
       return true;
     }
     if (b.first.canonCompare(a.first)) {
@@ -25,7 +25,7 @@ struct CanonrrSetKeyCompare: public std::binary_function<rrSetKey_t, rrSetKey_t,
 
 typedef std::map<rrSetKey_t, rrVector_t, CanonrrSetKeyCompare> RRsetMap_t;
 
-void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validationDone, bool& validationOK)
+void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG& zpt, bool& validationDone, bool& validationOK)
 {
   validationDone = false;
   validationOK = false;
@@ -59,7 +59,7 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validatio
       drc = DNSRecordContent::mastermake(dnsrr.qtype, QClass::IN, dnsrr.content);
     }
     catch (const PDNSException& pe) {
-      std::string err = "Bad record content in record for '" + dnsrr.qname.toStringNoDot() + "'|" + dnsrr.qtype.toString() + ": "+ pe.reason;
+      std::string err = "Bad record content in record for '" + dnsrr.qname.toStringNoDot() + "'|" + dnsrr.qtype.toString() + ": " + pe.reason;
       throw PDNSException(err);
     }
     catch (const std::exception& e) {
@@ -85,7 +85,7 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validatio
   // Determine which digests to compute based on accepted zonemd records present
   unique_ptr<pdns::SHADigest> sha384digest{nullptr}, sha512digest{nullptr};
 
-  for (auto it = zonemdRecords.begin(); it != zonemdRecords.end(); ) {
+  for (auto it = zonemdRecords.begin(); it != zonemdRecords.end();) {
     // The SOA Serial field MUST exactly match the ZONEMD Serial
     // field. If the fields do not match, digest verification MUST
     // NOT be considered successful with this ZONEMD RR.
@@ -99,9 +99,7 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validatio
     // considered successful with this ZONEMD RR.
     const auto duplicate = it->second.duplicate;
     const auto& r = it->second.record;
-    if (!duplicate && r->d_serial == soarc->d_st.serial &&
-        r->d_scheme == 1 &&
-        (r->d_hashalgo == 1 || r->d_hashalgo == 2)) {
+    if (!duplicate && r->d_serial == soarc->d_st.serial && r->d_scheme == 1 && (r->d_hashalgo == 1 || r->d_hashalgo == 2)) {
       // A supported ZONEMD record
       if (r->d_hashalgo == 1) {
         sha384digest = make_unique<pdns::SHADigest>(384);
@@ -110,7 +108,8 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validatio
         sha512digest = make_unique<pdns::SHADigest>(512);
       }
       ++it;
-    } else {
+    }
+    else {
       it = zonemdRecords.erase(it);
     }
   }
@@ -126,7 +125,7 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validatio
   };
 
   // Compute requested digests
-  for (auto& rrset: RRsets) {
+  for (auto& rrset : RRsets) {
     const auto& qname = rrset.first.first;
     const auto& qtype = rrset.first.second;
     if (qtype == QType::ZONEMD && qname == zone) {
@@ -134,7 +133,7 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validatio
     }
 
     sortedRecords_t sorted;
-    for (auto& rr: rrset.second) {
+    for (auto& rr : rrset.second) {
       if (qtype == QType::RRSIG) {
         const auto rrsig = std::dynamic_pointer_cast<RRSIGRecordContent>(rr);
         if (rrsig->d_type == QType::ZONEMD && qname == zone) {
@@ -150,7 +149,8 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validatio
       rrc.d_type = qtype;
       auto msg = getMessageForRRSET(qname, rrc, sorted, false, false);
       hash(msg);
-    } else {
+    }
+    else {
       // RRSIG is special, since  original TTL depends on qtype covered by RRSIG
       // which can be different per record
       for (const auto& rrsig : sorted) {
@@ -158,7 +158,7 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validatio
         RRSIGRecordContent rrc;
         rrc.d_originalttl = RRsetTTLs[pair(rrset.first.first, rrsigc->d_type)];
         rrc.d_type = qtype;
-        auto msg = getMessageForRRSET(qname, rrc, { rrsigc }, false, false);
+        auto msg = getMessageForRRSET(qname, rrc, {rrsigc}, false, false);
         hash(msg);
       }
     }

--- a/pdns/zonemd.cc
+++ b/pdns/zonemd.cc
@@ -51,7 +51,6 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG& zpt, bool& validatio
       continue;
     }
     if (dnsResourceRecord.qtype == QType::SOA && soaRecordContent) {
-      // XXX skip extra SOA?
       continue;
     }
     std::shared_ptr<DNSRecordContent> drc;
@@ -73,7 +72,7 @@ void pdns::zonemdVerify(const DNSName& zone, ZoneParserTNG& zpt, bool& validatio
       auto zonemd = std::dynamic_pointer_cast<ZONEMDRecordContent>(drc);
       auto inserted = zonemdRecords.insert({pair(zonemd->d_scheme, zonemd->d_hashalgo), {zonemd, false}});
       if (!inserted.second) {
-        // Mark as duplicate;
+        // Mark as duplicate
         inserted.first->second.duplicate = true;
       }
     }

--- a/pdns/zonemd.hh
+++ b/pdns/zonemd.hh
@@ -28,6 +28,6 @@ class ZoneParserTNG;
 
 namespace pdns
 {
-  void zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validationDone, bool& validationOK);
+void zonemdVerify(const DNSName& zone, ZoneParserTNG& zpt, bool& validationDone, bool& validationOK);
 
 }

--- a/pdns/zonemd.hh
+++ b/pdns/zonemd.hh
@@ -1,0 +1,33 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include "config.h"
+
+class DNSName;
+class ZoneParserTNG;
+
+namespace pdns
+{
+  void zonemdVerify(const DNSName& zone, ZoneParserTNG &zpt, bool& validationDone, bool& validationOK);
+
+}

--- a/regression-tests/zones/zonemd-allunsup.zone
+++ b/regression-tests/zones/zonemd-allunsup.zone
@@ -1,0 +1,14 @@
+example.      86400  IN  SOA     ns1 admin 2018031900 (
+                                 1800 900 604800 86400 )
+example.      86400  IN  NS      ns1.example.
+example.      86400  IN  NS      ns2.example.
+example.      86400  IN  ZONEMD  2018031900 1 240 (
+                                 e2d523f654b9422a
+                                 96c5a8f44607bbee )
+example.      86400  IN  ZONEMD  2018031900 241 1 (
+                                 e1846540e33a9e41
+                                 89792d18d5d131f6
+                                 05fc283e )
+ns1.example.  3600   IN  A       203.0.113.63
+ns2.example.  86400  IN  TXT     "This example has multiple digests"
+NS2.EXAMPLE.  3600   IN  AAAA    2001:db8::63

--- a/regression-tests/zones/zonemd-duplicate.zone
+++ b/regression-tests/zones/zonemd-duplicate.zone
@@ -1,0 +1,41 @@
+example.      86400  IN  SOA     ns1 admin 2018031900 (
+                                 1800 900 604800 86400 )
+              86400  IN  NS      ns1
+              86400  IN  NS      ns2
+              86400  IN  ZONEMD  2018031900 1 1 (
+                                 a3b69bad980a3504
+                                 e1cffcb0fd6397f9
+                                 3848071c93151f55
+                                 2ae2f6b1711d4bd2
+                                 d8b39808226d7b9d
+                                 b71e34b72077f8fe )
+              86400  IN  ZONEMD  2018031900 1 1 (
+                                 a3b69bad980a3504
+                                 e1cffcb0fd6397f9
+                                 3848071c93151f55
+                                 2ae2f6b1711d4bd2
+                                 d8b39808226d7b9d
+                                 b71e34b72077f8fe )
+ns1           3600   IN  A       203.0.113.63
+NS2           3600   IN  AAAA    2001:db8::63
+occluded.sub  7200   IN  TXT     "I'm occluded but must be digested"
+sub           7200   IN  NS      ns1
+duplicate     300    IN  TXT     "I must be digested just once"
+duplicate     300    IN  TXT     "I must be digested just once"
+foo.test.     555    IN  TXT     "out-of-zone data must be excluded"
+UPPERCASE     3600   IN  TXT     "canonicalize uppercase owner names"
+*             777    IN  PTR     dont-forget-about-wildcards
+mail          3600   IN  MX      20 MAIL1
+mail          3600   IN  MX      10 Mail2.Example.
+sortme        3600   IN  AAAA    2001:db8::5:61
+sortme        3600   IN  AAAA    2001:db8::3:62
+sortme        3600   IN  AAAA    2001:db8::4:63
+sortme        3600   IN  AAAA    2001:db8::1:65
+sortme        3600   IN  AAAA    2001:db8::2:64
+non-apex      900    IN  ZONEMD  2018031900 1 1 (
+                                 616c6c6f77656420
+                                 6275742069676e6f
+                                 7265642e20616c6c
+                                 6f77656420627574
+                                 2069676e6f726564
+                                 2e20616c6c6f7765 )

--- a/regression-tests/zones/zonemd-invalid.zone
+++ b/regression-tests/zones/zonemd-invalid.zone
@@ -1,0 +1,13 @@
+example.      86400  IN  SOA     ns1 admin 2018031900 (
+                                 1800 900 604800 86400 )
+              86400  IN  NS      ns1
+              86400  IN  NS      ns2
+              86400  IN  ZONEMD  2018031900 1 1 (
+                                 d68090d90a7aed71
+                                 6bc459f9340e3d7c
+                                 1370d4d24b7e2fc3
+                                 a1ddc0b9a87153b9
+                                 a9713b3c9ae5cc27
+                                 777f98b8e730044c )
+ns1           3600   IN  A       203.0.113.63
+ns2           3600   IN  AAAA    2001:db8::63

--- a/regression-tests/zones/zonemd-nozonemd.zone
+++ b/regression-tests/zones/zonemd-nozonemd.zone
@@ -1,0 +1,6 @@
+example.      86400  IN  SOA     ns1 admin 2018031900 (
+                                 1800 900 604800 86400 )
+              86400  IN  NS      ns1
+              86400  IN  NS      ns2
+ns1           3600   IN  A       203.0.113.63
+ns2           3600   IN  AAAA    2001:db8::63

--- a/regression-tests/zones/zonemd-serialmismatch.zone
+++ b/regression-tests/zones/zonemd-serialmismatch.zone
@@ -1,0 +1,129 @@
+uri.arpa.       3600    IN      SOA     sns.dns.icann.org. (
+   noc.dns.icann.org. 2018100702 10800 3600 1209600 3600 )
+uri.arpa.       3600    IN      RRSIG   SOA 8 2 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    GzQw+QzwLDJr13REPGVmpEChjD1D2XlX0ie1DnWHpgaEw1E/dhs3lCN3+B
+    mHd4Kx3tffTRgiyq65HxR6feQ5v7VmAifjyXUYB1DZur1eP5q0Ms2ygCB3
+    byoeMgCNsFS1oKZ2LdzNBRpy3oace8xQn1SpmHGfyrsgg+WbHKCT1dY= )
+uri.arpa.       86400   IN      NS      a.iana-servers.net.
+uri.arpa.       86400   IN      NS      b.iana-servers.net.
+uri.arpa.       86400   IN      NS      c.iana-servers.net.
+uri.arpa.       86400   IN      NS      ns2.lacnic.net.
+uri.arpa.       86400   IN      NS      sec3.apnic.net.
+uri.arpa.       86400   IN      RRSIG   NS 8 2 86400 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    M+Iei2lcewWGaMtkPlrhM9FpUAHXFkCHTVpeyrjxjEONeNgKtHZor5e4V4
+    qJBOzNqo8go/qJpWlFBm+T5Hn3asaBZVstFIYky38/C8UeRLPKq1hTTHAR
+    YUlFrexr5fMtSUAVOgOQPSBfH3xBq/BgSccTdRb9clD+HE7djpqrLS4= )
+uri.arpa.       600     IN      MX      10 pechora.icann.org.
+uri.arpa.       600     IN      RRSIG   MX 8 2 600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    kQAJQivmv6A5hqYBK8h6Z13ESY69gmosXwKI6WE09I8RFetfrxr24ecdnY
+    d0lpnDtgNNSoHkYRSOoB+C4+zuJsoyAAzGo9uoWMWj97/2xeGhf3PTC9me
+    Q9Ohi6hul9By7OR76XYmGhdWX8PBi60RUmZ1guslFBfQ8izwPqzuphs= )
+uri.arpa.       3600    IN      DNSKEY  256 3 8 (
+    AwEAAbMxuFuLeVDuOwIMzYOTD/bTREjLflo7wOi6ieIJhqltEzgjNzmWJf
+    9kGwwDmzxU7kbthMEhBNBZNn84zmcyRSCMzuStWveL7xmqqUlE3swL8kLO
+    vdZvc75XnmpHrk3ndTyEb6eZM7slh2C63Oh6K8VR5VkiZAkEGg0uZIT3Nj
+    sF )
+uri.arpa.       3600    IN      DNSKEY  257 3 8 (
+    AwEAAdkTaWkZtZuRh7/OobBUFxM+ytTst+bCu0r9w+rEwXD7GbDs0pIMhM
+    enrZzoAvmv1fQxw2MGs6Ri6yPKfNULcFOSt9l8i6BVBLI+SKTY6XXeDUQp
+    SEmSaxohHeRPMQFzpysfjxINp/L2rGtZ7yPmxY/XRiFPSO0myqwGJa9r06
+    Zw9CHM5UDHKWV/E+zxPFq/I7CfPbrrzbUotBX7Z6Vh3Sarllbe8cGUB2UF
+    NaTRgwB0TwDBPRD5ER3w2Dzbry9NhbElTr7vVfhaGWeOGuqAUXwlXEg6Cr
+    NkmJXJ2F1Rzr9WHUzhp7uWxhAbmJREGfi2dEyPAbUAyCjBqhFaqglknvc= )
+uri.arpa.       3600    IN      DNSKEY  257 3 8 (
+    AwEAAenQaBoFmDmvRT+/H5oNbm0Tr5FmNRNDEun0Jpj/ELkzeUrTWhNpQm
+    ZeIMC8I0kZ185tEvOnRvn8OvV39B17QIdrvvKGIh2HlgeDRCLolhaojfn2
+    QM0DStjF/WWHpxJOmE6CIuvhqYEU37yoJscGAPpPVPzNvnL1HhYTaao1VR
+    YWQ/maMrJ+bfHg+YX1N6M/8MnRjIKBif1FWjbCKvsn6dnuGGL9oCWYUFJ3
+    DwofXuhgPyZMkzPc88YkJj5EMvbMH4wtelbCwC+ivx732l0w/rXJn0ciQS
+    OgoeVvDio8dIJmWQITWQAuP+q/ZHFEFHPlrP3gvQh5mcVS48eLX71Bq7c= )
+uri.arpa.       3600    IN      RRSIG   DNSKEY 8 2 3600 (
+    20210217232440 20210120232440 12670 uri.arpa.
+    DBE2gkKAoxJCfz47KKxzoImN/0AKArhIVHE7TyTwy0DdRPo44V5R+vL6th
+    UxlQ1CJi2Rw0jwAXymx5Y3Q873pOEllH+4bJoIT4dmoBmPXfYWW7Clvw9U
+    PKHRP0igKHmCVwIeBYDTU3gfLcMTbR4nEWPDN0GxlL1Mf7ITaC2Ioabo79
+    Ip3M/MR8I3Vx/xZ4ZKKPHtLn3xUuJluPNanqJrED2gTslL2xWZ1tqjsAjJ
+    v7JnJo2HJ8XVRB5zBto0IaJ2oBlqcjdcQ/0VlyoM8uOy1pDwHQ2BJl7322
+    gNMHBP9HSiUPIOaIDNUCwW8eUcW6DIUk+s9u3GN1uTqwWzsYB/rA== )
+uri.arpa.       3600    IN      RRSIG   DNSKEY 8 2 3600 (
+    20210217232440 20210120232440 30577 uri.arpa.
+    Kx6HwP4UlkGc1UZ7SERXtQjPajOF4iUvkwDj7MEG1xbQFB1KoJiEb/eiW0
+    qmSWdIhMDv8myhgauejRLyJxwxz8HDRV4xOeHWnRGfWBk4XGYwkejVzOHz
+    oIArVdUVRbr2JKigcTOoyFN+uu52cNB7hRYu7dH5y1hlc6UbOnzRpMtGxc
+    gVyKQ+/ARbIqGG3pegdEOvV49wTPWEiyY65P2urqhvnRg5ok/jzwAdMx4X
+    Gshiib7Ojq0sRVl2ZIzj4rFgY/qsSO8SEXEhMo2VuSkoJNiofVzYoqpxEe
+    GnANkIT7Tx2xJL1BWyJxyc7E8Wr2QSgCcc+rYL6IkHDtJGHy7TaQ== )
+uri.arpa.       3600    IN      ZONEMD  3018100702 1 1 (
+    0dbc3c4dbfd75777c12ca19c337854b1577799901307c482e9d91d5d15
+    cd934d16319d98e30c4201cf25a1d5a0254960 )
+uri.arpa.       3600    IN      RRSIG   ZONEMD 8 2 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    QDo4XZcL3HMyn8aAHyCUsu/Tqj4Gkth8xY1EqByOb8XOTwVtA4ZNQORE1s
+    iqNqjtJUbeJPtJSbLNqCL7rCq0CzNNnBscv6IIf4gnqJZjlGtHO30ohXtK
+    vEc4z7SU3IASsi6bB3nLmEAyERdYSeU6UBfx8vatQDIRhkgEnnWUTh4= )
+uri.arpa.       3600    IN      NSEC    ftp.uri.arpa. (
+    NS SOA MX RRSIG NSEC DNSKEY ZONEMD )
+uri.arpa.       3600    IN      RRSIG   NSEC 8 2 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    dU/rXLM/naWd1+1PiWiYVaNJyCkiuyZJSccr91pJI673T8r3685B4ODMYF
+    afZRboVgwnl3ZrXddY6xOhZL3n9V9nxXZwjLJ2HJUojFoKcXTlpnUyYUYv
+    VQ2kj4GHAo6fcGCEp5QFJ2KbCpeJoS+PhKGRRx28icCiNT4/uXQvO2E= )
+ftp.uri.arpa.   604800  IN      NAPTR   0 0 "" "" (
+    "!^ftp://([^:/?#]*).*$!\\1!i" . )
+ftp.uri.arpa.   604800  IN      RRSIG   NAPTR 8 3 604800 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    EygekDgl+Lyyq4NMSEpPyOrOywYf9Y3FAB4v1DT44J3R5QGidaH8l7ZFjH
+    oYFI8sY64iYOCV4sBnX/dh6C1L5NgpY+8l5065Xu3vvjyzbtuJ2k6YYwJr
+    rCbvl5DDn53zAhhO2hL9uLgyLraZGi9i7TFGd0sm3zNyUF/EVL0CcxU= )
+ftp.uri.arpa.   3600    IN      NSEC    http.uri.arpa. (
+    NAPTR RRSIG NSEC )
+ftp.uri.arpa.   3600    IN      RRSIG   NSEC 8 3 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    pbP4KxevPXCu/bDqcvXiuBppXyFEmtHyiy0eAN5gS7mi6mp9Z9bWFjx/Ld
+    H9+6oFGYa5vGmJ5itu/4EDMe8iQeZbI8yrpM4TquB7RR/MGfBnTd8S+sjy
+    QtlRYG7yqEu77Vd78Fme22BKPJ+MVqjS0JHMUE/YUGomPkAjLJJwwGw= )
+http.uri.arpa.  604800  IN      NAPTR   0 0 "" "" (
+    "!^http://([^:/?#]*).*$!\\1!i" . )
+http.uri.arpa.  604800  IN      RRSIG   NAPTR 8 3 604800 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    eTqbWvt1GvTeXozuvm4ebaAfkXFQKrtdu0cEiExto80sHIiCbO0WL8UDa/
+    J3cDivtQca7LgUbOb6c17NESsrsVkc6zNPx5RK2tG7ZQYmhYmtqtfg1oU5
+    BRdHZ5TyqIXcHlw9Blo2pir1Y9IQgshhD7UOGkbkEmvB1Lrd0aHhAAg= )
+http.uri.arpa.  3600    IN      NSEC    mailto.uri.arpa. (
+    NAPTR RRSIG NSEC )
+http.uri.arpa.  3600    IN      RRSIG   NSEC 8 3 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    R9rlNzw1CVz2N08q6DhULzcsuUm0UKcPaGAWEU40tr81jEDHsFHNM+khCd
+    OI8nDstzA42aee4rwCEgijxJpRCcY9hrO1Ysrrr2fdqNz60JikMdarvU5O
+    0p0VXeaaJDfJQT44+o+YXaBwI7Qod3FTMx7aRib8i7istvPm1Rr7ixA= )
+mailto.uri.arpa.        604800  IN      NAPTR   0 0 "" "" (
+    "!^mailto:(.*)@(.*)$!\\2!i" . )
+mailto.uri.arpa.        604800  IN      RRSIG   NAPTR 8 3 604800 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    Ch2zTG2F1plEvQPyIH4Yd80XXLjXOPvMbiqDjpJBcnCJsV8QF7kr0wTLnU
+    T3dB+asQudOjPyzaHGwFlMzmrrAsszN4XAMJ6htDtFJdsgTMP/NkHhYRSm
+    Vv6rLeAhd+mVfObY12M//b/GGVTjeUI/gJaLW0fLVZxr1Fp5U5CRjyw= )
+mailto.uri.arpa.        3600    IN      NSEC    urn.uri.arpa. (
+    NAPTR RRSIG NSEC )
+mailto.uri.arpa.        3600    IN      RRSIG   NSEC 8 3 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    fQUbSIE6E7JDi2rosah4SpCOTrKufeszFyj5YEavbQuYlQ5cNFvtm8KuE2
+    xXMRgRI4RGvM2leVqcoDw5hS3m2pOJLxH8l2WE72YjYvWhvnwc5Rofe/8y
+    B/vaSK9WCnqN8y2q6Vmy73AGP0fuiwmuBra7LlkOiqmyx3amSFizwms= )
+urn.uri.arpa.   604800  IN      NAPTR   0 0 "" "" (
+    "/urn:([^:]+)/\\1/i" . )
+urn.uri.arpa.   604800  IN      RRSIG   NAPTR 8 3 604800 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    CVt2Tgz0e5ZmaSXqRfNys/8OtVCk9nfP0zhezhN8Bo6MDt6yyKZ2kEEWJP
+    jkN7PCYHjO8fGjnUn0AHZI2qBNv7PKHcpR42VY03q927q85a65weOO1YE0
+    vPYMzACpua9TOtfNnynM2Ws0uN9URxUyvYkXBdqOC81N3sx1dVELcwc= )
+urn.uri.arpa.   3600    IN      NSEC    uri.arpa. NAPTR RRSIG NSEC
+urn.uri.arpa.   3600    IN      RRSIG   NSEC 8 3 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    JuKkMiC3/j9iM3V8/izcouXWAVGnSZjkOgEgFPhutMqoylQNRcSkbEZQzF
+    K8B/PIVdzZF0Y5xkO6zaKQjOzz6OkSaNPIo1a7Vyyl3wDY/uLCRRAHRJfp
+    knuY7O+AUNXvVVIEYJqZggd4kl/Rjh1GTzPYZTRrVi5eQidI1LqCOeg= )
+

--- a/regression-tests/zones/zonemd-sha512.zone
+++ b/regression-tests/zones/zonemd-sha512.zone
@@ -1,0 +1,30 @@
+example.      86400  IN  SOA     ns1 admin 2018031900 (
+                                 1800 900 604800 86400 )
+example.      86400  IN  NS      ns1.example.
+example.      86400  IN  NS      ns2.example.
+example.      86400  IN  ZONEMD  2018031900 1 1 (
+                                 62e6cf51b02e54b9
+                                 b5f967d547ce4313
+                                 6792901f9f88e637
+                                 493daaf401c92c27
+                                 9dd10f0edb1c56f8
+                                 080211f8480ee306 )
+example.      86400  IN  ZONEMD  2018031900 1 2 (
+                                 08cfa1115c7b948c
+                                 4163a901270395ea
+                                 226a930cd2cbcf2f
+                                 a9a5e6eb85f37c8a
+                                 4e114d884e66f176
+                                 eab121cb02db7d65
+                                 2e0cc4827e7a3204
+                                 f166b47e5613fd27 )
+example.      86400  IN  ZONEMD  2018031900 1 240 (
+                                 e2d523f654b9422a
+                                 96c5a8f44607bbee )
+example.      86400  IN  ZONEMD  2018031900 241 1 (
+                                 e1846540e33a9e41
+                                 89792d18d5d131f6
+                                 05fc283e )
+ns1.example.  3600   IN  A       203.0.113.63
+ns2.example.  86400  IN  TXT     "This example has multiple digests"
+NS2.EXAMPLE.  3600   IN  AAAA    2001:db8::63

--- a/regression-tests/zones/zonemd-syntax.zone
+++ b/regression-tests/zones/zonemd-syntax.zone
@@ -1,0 +1,48 @@
+root-servers.net.     3600000 IN  SOA     a.root-servers.net. (
+    nstld.verisign-grs.com. 2018091100 14400 7200 1209600 3600000 )
+root-servers.net.     3600000 IN  NS      a.root-servers.net.
+root-servers.net.     3600000 IN  NS      b.root-servers.net.
+root-servers.net.     3600000 IN  NS      c.root-servers.net.
+root-servers.net.     3600000 IN  NS      d.root-servers.net.
+root-servers.net.     3600000 IN  NS      e.root-servers.net.
+root-servers.net.     3600000 IN  NS      f.root-servers.net.
+root-servers.net.     3600000 IN  NS      g.root-servers.net.
+root-servers.net.     3600000 IN  NS      h.root-servers.net.
+root-servers.net.     3600000 IN  NS      i.root-servers.net.
+root-servers.net.     3600000 IN  NS      j.root-servers.net.
+root-servers.net.     3600000 IN  NS      k.root-servers.net.
+root-servers.net.     3600000 IN  NS      l.root-servers.net.
+root-servers.net.     3600000 IN  NS      m.root-servers.net.
+a.root-servers.net.   3600000 IN  AAAA    2001:503:ba3e::2:30
+a.root-servers.net.   3600000 IN  A       198.41.0.4
+b.root-servers.net.   3600000 IN  MX      20 mail.isi.edu.
+b.root-servers.net.   3600000 IN  AAAA    2001:500:200::b
+b.root-servers.net.   3600000 IN  A       199.9.14.201
+c.root-servers.net.   3600000 IN  AAAA    2001:500:2::c
+c.root-servers.net.   3600000 IN  A       192.33.4.12
+d.root-servers.net.   3600000 IN  AAAA    2001:500:2d::d
+d.root-servers.net.   3600000 IN  A       199.7.91.13
+e.root-servers.net.   3600000 IN  AAAA    2001:500:a8::e
+e.root-servers.net.   3600000 IN  A       192.203.230.10
+f.root-servers.net.   3600000 IN  AAAA    2001:500:2f::f
+f.root-servers.net.   3600000 IN  A       192.5.5.241
+g.root-servers.net.   3600000 IN  AAAA    2001:500:12::d0d
+g.root-servers.net.   3600000 IN  A       192.112.36.4
+h.root-servers.net.   3600000 IN  AAAA    2001:500:1::53
+h.root-servers.net.   3600000 IN  A       198.97.190.53
+i.root-servers.net.   3600000 IN  MX      10 mx.i.root-servers.org.
+i.root-servers.net.   3600000 IN  AAAA    2001:7fe::53
+i.root-servers.net.   3600000 IN  A       192.36.148.17
+j.root-servers.net.   3600000 IN  AAAA    2001:503:c27::2:30
+j.root-servers.net.   3600000 IN  A       192.58.128.30
+k.root-servers.net.   3600000 IN  AAAA    2001:7fd::1
+k.root-servers.net.   3600000 IN  A       193.0.14.129
+l.root-servers.net.   3600000 IN  AAAA    2001:500:9f::42
+l.root-servers.net.   3600000 IN  A       199.7.83.42
+m.root-servers.net.   3600000 IN  AAAA    2001:dc3::35
+m.root-servers.net.   3600000 IN  A       
+root-servers.net.     3600000 IN  SOA     a.root-servers.net. (
+    nstld.verisign-grs.com. 2018091100 14400 7200 1209600 3600000 )
+root-servers.net.     3600000 IN  ZONEMD  2018091100 1 1 (
+    f1ca0ccd91bd5573d9f431c00ee0101b2545c97602be0a97
+    8a3b11dbfc1c776d5b3e86ae3d973d6b5349ba7f04340f79 )

--- a/regression-tests/zones/zonemd1.zone
+++ b/regression-tests/zones/zonemd1.zone
@@ -1,0 +1,13 @@
+example.      86400  IN  SOA     ns1 admin 2018031900 (
+                                 1800 900 604800 86400 )
+              86400  IN  NS      ns1
+              86400  IN  NS      ns2
+              86400  IN  ZONEMD  2018031900 1 1 (
+                                 c68090d90a7aed71
+                                 6bc459f9340e3d7c
+                                 1370d4d24b7e2fc3
+                                 a1ddc0b9a87153b9
+                                 a9713b3c9ae5cc27
+                                 777f98b8e730044c )
+ns1           3600   IN  A       203.0.113.63
+ns2           3600   IN  AAAA    2001:db8::63

--- a/regression-tests/zones/zonemd2.zone
+++ b/regression-tests/zones/zonemd2.zone
@@ -1,0 +1,34 @@
+example.      86400  IN  SOA     ns1 admin 2018031900 (
+                                 1800 900 604800 86400 )
+              86400  IN  NS      ns1
+              86400  IN  NS      ns2
+              86400  IN  ZONEMD  2018031900 1 1 (
+                                 a3b69bad980a3504
+                                 e1cffcb0fd6397f9
+                                 3848071c93151f55
+                                 2ae2f6b1711d4bd2
+                                 d8b39808226d7b9d
+                                 b71e34b72077f8fe )
+ns1           3600   IN  A       203.0.113.63
+NS2           3600   IN  AAAA    2001:db8::63
+occluded.sub  7200   IN  TXT     "I'm occluded but must be digested"
+sub           7200   IN  NS      ns1
+duplicate     300    IN  TXT     "I must be digested just once"
+duplicate     300    IN  TXT     "I must be digested just once"
+foo.test.     555    IN  TXT     "out-of-zone data must be excluded"
+UPPERCASE     3600   IN  TXT     "canonicalize uppercase owner names"
+*             777    IN  PTR     dont-forget-about-wildcards
+mail          3600   IN  MX      20 MAIL1
+mail          3600   IN  MX      10 Mail2.Example.
+sortme        3600   IN  AAAA    2001:db8::5:61
+sortme        3600   IN  AAAA    2001:db8::3:62
+sortme        3600   IN  AAAA    2001:db8::4:63
+sortme        3600   IN  AAAA    2001:db8::1:65
+sortme        3600   IN  AAAA    2001:db8::2:64
+non-apex      900    IN  ZONEMD  2018031900 1 1 (
+                                 616c6c6f77656420
+                                 6275742069676e6f
+                                 7265642e20616c6c
+                                 6f77656420627574
+                                 2069676e6f726564
+                                 2e20616c6c6f7765 )

--- a/regression-tests/zones/zonemd3.zone
+++ b/regression-tests/zones/zonemd3.zone
@@ -1,0 +1,23 @@
+example.      86400  IN  SOA     ns1 admin 2018031900 (
+                                 1800 900 604800 86400 )
+example.      86400  IN  NS      ns1.example.
+example.      86400  IN  NS      ns2.example.
+example.      86400  IN  ZONEMD  2018031900 1 2 (
+                                 08cfa1115c7b948c
+                                 4163a901270395ea
+                                 226a930cd2cbcf2f
+                                 a9a5e6eb85f37c8a
+                                 4e114d884e66f176
+                                 eab121cb02db7d65
+                                 2e0cc4827e7a3204
+                                 f166b47e5613fd27 )
+example.      86400  IN  ZONEMD  2018031900 1 240 (
+                                 e2d523f654b9422a
+                                 96c5a8f44607bbee )
+example.      86400  IN  ZONEMD  2018031900 241 1 (
+                                 e1846540e33a9e41
+                                 89792d18d5d131f6
+                                 05fc283e )
+ns1.example.  3600   IN  A       203.0.113.63
+ns2.example.  86400  IN  TXT     "This example has multiple digests"
+NS2.EXAMPLE.  3600   IN  AAAA    2001:db8::63

--- a/regression-tests/zones/zonemd4.zone
+++ b/regression-tests/zones/zonemd4.zone
@@ -1,0 +1,129 @@
+uri.arpa.       3600    IN      SOA     sns.dns.icann.org. (
+   noc.dns.icann.org. 2018100702 10800 3600 1209600 3600 )
+uri.arpa.       3600    IN      RRSIG   SOA 8 2 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    GzQw+QzwLDJr13REPGVmpEChjD1D2XlX0ie1DnWHpgaEw1E/dhs3lCN3+B
+    mHd4Kx3tffTRgiyq65HxR6feQ5v7VmAifjyXUYB1DZur1eP5q0Ms2ygCB3
+    byoeMgCNsFS1oKZ2LdzNBRpy3oace8xQn1SpmHGfyrsgg+WbHKCT1dY= )
+uri.arpa.       86400   IN      NS      a.iana-servers.net.
+uri.arpa.       86400   IN      NS      b.iana-servers.net.
+uri.arpa.       86400   IN      NS      c.iana-servers.net.
+uri.arpa.       86400   IN      NS      ns2.lacnic.net.
+uri.arpa.       86400   IN      NS      sec3.apnic.net.
+uri.arpa.       86400   IN      RRSIG   NS 8 2 86400 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    M+Iei2lcewWGaMtkPlrhM9FpUAHXFkCHTVpeyrjxjEONeNgKtHZor5e4V4
+    qJBOzNqo8go/qJpWlFBm+T5Hn3asaBZVstFIYky38/C8UeRLPKq1hTTHAR
+    YUlFrexr5fMtSUAVOgOQPSBfH3xBq/BgSccTdRb9clD+HE7djpqrLS4= )
+uri.arpa.       600     IN      MX      10 pechora.icann.org.
+uri.arpa.       600     IN      RRSIG   MX 8 2 600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    kQAJQivmv6A5hqYBK8h6Z13ESY69gmosXwKI6WE09I8RFetfrxr24ecdnY
+    d0lpnDtgNNSoHkYRSOoB+C4+zuJsoyAAzGo9uoWMWj97/2xeGhf3PTC9me
+    Q9Ohi6hul9By7OR76XYmGhdWX8PBi60RUmZ1guslFBfQ8izwPqzuphs= )
+uri.arpa.       3600    IN      DNSKEY  256 3 8 (
+    AwEAAbMxuFuLeVDuOwIMzYOTD/bTREjLflo7wOi6ieIJhqltEzgjNzmWJf
+    9kGwwDmzxU7kbthMEhBNBZNn84zmcyRSCMzuStWveL7xmqqUlE3swL8kLO
+    vdZvc75XnmpHrk3ndTyEb6eZM7slh2C63Oh6K8VR5VkiZAkEGg0uZIT3Nj
+    sF )
+uri.arpa.       3600    IN      DNSKEY  257 3 8 (
+    AwEAAdkTaWkZtZuRh7/OobBUFxM+ytTst+bCu0r9w+rEwXD7GbDs0pIMhM
+    enrZzoAvmv1fQxw2MGs6Ri6yPKfNULcFOSt9l8i6BVBLI+SKTY6XXeDUQp
+    SEmSaxohHeRPMQFzpysfjxINp/L2rGtZ7yPmxY/XRiFPSO0myqwGJa9r06
+    Zw9CHM5UDHKWV/E+zxPFq/I7CfPbrrzbUotBX7Z6Vh3Sarllbe8cGUB2UF
+    NaTRgwB0TwDBPRD5ER3w2Dzbry9NhbElTr7vVfhaGWeOGuqAUXwlXEg6Cr
+    NkmJXJ2F1Rzr9WHUzhp7uWxhAbmJREGfi2dEyPAbUAyCjBqhFaqglknvc= )
+uri.arpa.       3600    IN      DNSKEY  257 3 8 (
+    AwEAAenQaBoFmDmvRT+/H5oNbm0Tr5FmNRNDEun0Jpj/ELkzeUrTWhNpQm
+    ZeIMC8I0kZ185tEvOnRvn8OvV39B17QIdrvvKGIh2HlgeDRCLolhaojfn2
+    QM0DStjF/WWHpxJOmE6CIuvhqYEU37yoJscGAPpPVPzNvnL1HhYTaao1VR
+    YWQ/maMrJ+bfHg+YX1N6M/8MnRjIKBif1FWjbCKvsn6dnuGGL9oCWYUFJ3
+    DwofXuhgPyZMkzPc88YkJj5EMvbMH4wtelbCwC+ivx732l0w/rXJn0ciQS
+    OgoeVvDio8dIJmWQITWQAuP+q/ZHFEFHPlrP3gvQh5mcVS48eLX71Bq7c= )
+uri.arpa.       3600    IN      RRSIG   DNSKEY 8 2 3600 (
+    20210217232440 20210120232440 12670 uri.arpa.
+    DBE2gkKAoxJCfz47KKxzoImN/0AKArhIVHE7TyTwy0DdRPo44V5R+vL6th
+    UxlQ1CJi2Rw0jwAXymx5Y3Q873pOEllH+4bJoIT4dmoBmPXfYWW7Clvw9U
+    PKHRP0igKHmCVwIeBYDTU3gfLcMTbR4nEWPDN0GxlL1Mf7ITaC2Ioabo79
+    Ip3M/MR8I3Vx/xZ4ZKKPHtLn3xUuJluPNanqJrED2gTslL2xWZ1tqjsAjJ
+    v7JnJo2HJ8XVRB5zBto0IaJ2oBlqcjdcQ/0VlyoM8uOy1pDwHQ2BJl7322
+    gNMHBP9HSiUPIOaIDNUCwW8eUcW6DIUk+s9u3GN1uTqwWzsYB/rA== )
+uri.arpa.       3600    IN      RRSIG   DNSKEY 8 2 3600 (
+    20210217232440 20210120232440 30577 uri.arpa.
+    Kx6HwP4UlkGc1UZ7SERXtQjPajOF4iUvkwDj7MEG1xbQFB1KoJiEb/eiW0
+    qmSWdIhMDv8myhgauejRLyJxwxz8HDRV4xOeHWnRGfWBk4XGYwkejVzOHz
+    oIArVdUVRbr2JKigcTOoyFN+uu52cNB7hRYu7dH5y1hlc6UbOnzRpMtGxc
+    gVyKQ+/ARbIqGG3pegdEOvV49wTPWEiyY65P2urqhvnRg5ok/jzwAdMx4X
+    Gshiib7Ojq0sRVl2ZIzj4rFgY/qsSO8SEXEhMo2VuSkoJNiofVzYoqpxEe
+    GnANkIT7Tx2xJL1BWyJxyc7E8Wr2QSgCcc+rYL6IkHDtJGHy7TaQ== )
+uri.arpa.       3600    IN      ZONEMD  2018100702 1 1 (
+    0dbc3c4dbfd75777c12ca19c337854b1577799901307c482e9d91d5d15
+    cd934d16319d98e30c4201cf25a1d5a0254960 )
+uri.arpa.       3600    IN      RRSIG   ZONEMD 8 2 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    QDo4XZcL3HMyn8aAHyCUsu/Tqj4Gkth8xY1EqByOb8XOTwVtA4ZNQORE1s
+    iqNqjtJUbeJPtJSbLNqCL7rCq0CzNNnBscv6IIf4gnqJZjlGtHO30ohXtK
+    vEc4z7SU3IASsi6bB3nLmEAyERdYSeU6UBfx8vatQDIRhkgEnnWUTh4= )
+uri.arpa.       3600    IN      NSEC    ftp.uri.arpa. (
+    NS SOA MX RRSIG NSEC DNSKEY ZONEMD )
+uri.arpa.       3600    IN      RRSIG   NSEC 8 2 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    dU/rXLM/naWd1+1PiWiYVaNJyCkiuyZJSccr91pJI673T8r3685B4ODMYF
+    afZRboVgwnl3ZrXddY6xOhZL3n9V9nxXZwjLJ2HJUojFoKcXTlpnUyYUYv
+    VQ2kj4GHAo6fcGCEp5QFJ2KbCpeJoS+PhKGRRx28icCiNT4/uXQvO2E= )
+ftp.uri.arpa.   604800  IN      NAPTR   0 0 "" "" (
+    "!^ftp://([^:/?#]*).*$!\\1!i" . )
+ftp.uri.arpa.   604800  IN      RRSIG   NAPTR 8 3 604800 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    EygekDgl+Lyyq4NMSEpPyOrOywYf9Y3FAB4v1DT44J3R5QGidaH8l7ZFjH
+    oYFI8sY64iYOCV4sBnX/dh6C1L5NgpY+8l5065Xu3vvjyzbtuJ2k6YYwJr
+    rCbvl5DDn53zAhhO2hL9uLgyLraZGi9i7TFGd0sm3zNyUF/EVL0CcxU= )
+ftp.uri.arpa.   3600    IN      NSEC    http.uri.arpa. (
+    NAPTR RRSIG NSEC )
+ftp.uri.arpa.   3600    IN      RRSIG   NSEC 8 3 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    pbP4KxevPXCu/bDqcvXiuBppXyFEmtHyiy0eAN5gS7mi6mp9Z9bWFjx/Ld
+    H9+6oFGYa5vGmJ5itu/4EDMe8iQeZbI8yrpM4TquB7RR/MGfBnTd8S+sjy
+    QtlRYG7yqEu77Vd78Fme22BKPJ+MVqjS0JHMUE/YUGomPkAjLJJwwGw= )
+http.uri.arpa.  604800  IN      NAPTR   0 0 "" "" (
+    "!^http://([^:/?#]*).*$!\\1!i" . )
+http.uri.arpa.  604800  IN      RRSIG   NAPTR 8 3 604800 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    eTqbWvt1GvTeXozuvm4ebaAfkXFQKrtdu0cEiExto80sHIiCbO0WL8UDa/
+    J3cDivtQca7LgUbOb6c17NESsrsVkc6zNPx5RK2tG7ZQYmhYmtqtfg1oU5
+    BRdHZ5TyqIXcHlw9Blo2pir1Y9IQgshhD7UOGkbkEmvB1Lrd0aHhAAg= )
+http.uri.arpa.  3600    IN      NSEC    mailto.uri.arpa. (
+    NAPTR RRSIG NSEC )
+http.uri.arpa.  3600    IN      RRSIG   NSEC 8 3 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    R9rlNzw1CVz2N08q6DhULzcsuUm0UKcPaGAWEU40tr81jEDHsFHNM+khCd
+    OI8nDstzA42aee4rwCEgijxJpRCcY9hrO1Ysrrr2fdqNz60JikMdarvU5O
+    0p0VXeaaJDfJQT44+o+YXaBwI7Qod3FTMx7aRib8i7istvPm1Rr7ixA= )
+mailto.uri.arpa.        604800  IN      NAPTR   0 0 "" "" (
+    "!^mailto:(.*)@(.*)$!\\2!i" . )
+mailto.uri.arpa.        604800  IN      RRSIG   NAPTR 8 3 604800 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    Ch2zTG2F1plEvQPyIH4Yd80XXLjXOPvMbiqDjpJBcnCJsV8QF7kr0wTLnU
+    T3dB+asQudOjPyzaHGwFlMzmrrAsszN4XAMJ6htDtFJdsgTMP/NkHhYRSm
+    Vv6rLeAhd+mVfObY12M//b/GGVTjeUI/gJaLW0fLVZxr1Fp5U5CRjyw= )
+mailto.uri.arpa.        3600    IN      NSEC    urn.uri.arpa. (
+    NAPTR RRSIG NSEC )
+mailto.uri.arpa.        3600    IN      RRSIG   NSEC 8 3 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    fQUbSIE6E7JDi2rosah4SpCOTrKufeszFyj5YEavbQuYlQ5cNFvtm8KuE2
+    xXMRgRI4RGvM2leVqcoDw5hS3m2pOJLxH8l2WE72YjYvWhvnwc5Rofe/8y
+    B/vaSK9WCnqN8y2q6Vmy73AGP0fuiwmuBra7LlkOiqmyx3amSFizwms= )
+urn.uri.arpa.   604800  IN      NAPTR   0 0 "" "" (
+    "/urn:([^:]+)/\\1/i" . )
+urn.uri.arpa.   604800  IN      RRSIG   NAPTR 8 3 604800 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    CVt2Tgz0e5ZmaSXqRfNys/8OtVCk9nfP0zhezhN8Bo6MDt6yyKZ2kEEWJP
+    jkN7PCYHjO8fGjnUn0AHZI2qBNv7PKHcpR42VY03q927q85a65weOO1YE0
+    vPYMzACpua9TOtfNnynM2Ws0uN9URxUyvYkXBdqOC81N3sx1dVELcwc= )
+urn.uri.arpa.   3600    IN      NSEC    uri.arpa. NAPTR RRSIG NSEC
+urn.uri.arpa.   3600    IN      RRSIG   NSEC 8 3 3600 (
+    20210217232440 20210120232440 37444 uri.arpa.
+    JuKkMiC3/j9iM3V8/izcouXWAVGnSZjkOgEgFPhutMqoylQNRcSkbEZQzF
+    K8B/PIVdzZF0Y5xkO6zaKQjOzz6OkSaNPIo1a7Vyyl3wDY/uLCRRAHRJfp
+    knuY7O+AUNXvVVIEYJqZggd4kl/Rjh1GTzPYZTRrVi5eQidI1LqCOeg= )
+

--- a/regression-tests/zones/zonemd5.zone
+++ b/regression-tests/zones/zonemd5.zone
@@ -1,0 +1,48 @@
+root-servers.net.     3600000 IN  SOA     a.root-servers.net. (
+    nstld.verisign-grs.com. 2018091100 14400 7200 1209600 3600000 )
+root-servers.net.     3600000 IN  NS      a.root-servers.net.
+root-servers.net.     3600000 IN  NS      b.root-servers.net.
+root-servers.net.     3600000 IN  NS      c.root-servers.net.
+root-servers.net.     3600000 IN  NS      d.root-servers.net.
+root-servers.net.     3600000 IN  NS      e.root-servers.net.
+root-servers.net.     3600000 IN  NS      f.root-servers.net.
+root-servers.net.     3600000 IN  NS      g.root-servers.net.
+root-servers.net.     3600000 IN  NS      h.root-servers.net.
+root-servers.net.     3600000 IN  NS      i.root-servers.net.
+root-servers.net.     3600000 IN  NS      j.root-servers.net.
+root-servers.net.     3600000 IN  NS      k.root-servers.net.
+root-servers.net.     3600000 IN  NS      l.root-servers.net.
+root-servers.net.     3600000 IN  NS      m.root-servers.net.
+a.root-servers.net.   3600000 IN  AAAA    2001:503:ba3e::2:30
+a.root-servers.net.   3600000 IN  A       198.41.0.4
+b.root-servers.net.   3600000 IN  MX      20 mail.isi.edu.
+b.root-servers.net.   3600000 IN  AAAA    2001:500:200::b
+b.root-servers.net.   3600000 IN  A       199.9.14.201
+c.root-servers.net.   3600000 IN  AAAA    2001:500:2::c
+c.root-servers.net.   3600000 IN  A       192.33.4.12
+d.root-servers.net.   3600000 IN  AAAA    2001:500:2d::d
+d.root-servers.net.   3600000 IN  A       199.7.91.13
+e.root-servers.net.   3600000 IN  AAAA    2001:500:a8::e
+e.root-servers.net.   3600000 IN  A       192.203.230.10
+f.root-servers.net.   3600000 IN  AAAA    2001:500:2f::f
+f.root-servers.net.   3600000 IN  A       192.5.5.241
+g.root-servers.net.   3600000 IN  AAAA    2001:500:12::d0d
+g.root-servers.net.   3600000 IN  A       192.112.36.4
+h.root-servers.net.   3600000 IN  AAAA    2001:500:1::53
+h.root-servers.net.   3600000 IN  A       198.97.190.53
+i.root-servers.net.   3600000 IN  MX      10 mx.i.root-servers.org.
+i.root-servers.net.   3600000 IN  AAAA    2001:7fe::53
+i.root-servers.net.   3600000 IN  A       192.36.148.17
+j.root-servers.net.   3600000 IN  AAAA    2001:503:c27::2:30
+j.root-servers.net.   3600000 IN  A       192.58.128.30
+k.root-servers.net.   3600000 IN  AAAA    2001:7fd::1
+k.root-servers.net.   3600000 IN  A       193.0.14.129
+l.root-servers.net.   3600000 IN  AAAA    2001:500:9f::42
+l.root-servers.net.   3600000 IN  A       199.7.83.42
+m.root-servers.net.   3600000 IN  AAAA    2001:dc3::35
+m.root-servers.net.   3600000 IN  A       202.12.27.33
+root-servers.net.     3600000 IN  SOA     a.root-servers.net. (
+    nstld.verisign-grs.com. 2018091100 14400 7200 1209600 3600000 )
+root-servers.net.     3600000 IN  ZONEMD  2018091100 1 1 (
+    f1ca0ccd91bd5573d9f431c00ee0101b2545c97602be0a97
+    8a3b11dbfc1c776d5b3e86ae3d973d6b5349ba7f04340f79 )


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

1) Define record type
2) Verification according to RFC, including many failure cases and RSIG handling. Support sha384 and sha512
3) Unit tests, including all examples from RFC and a few failure cases.
4) Command line for pdnsutil: zonemd-verify-file

Based on POC from @Habbie, with many changes.

Things to be done I can think of (details to be decided):
 
For the Recursor: 
- validation of incoming zones (potentially Zone to Cache, RPZ, Auth-Zones). Those cases need to consider DNSSEC validation of ZONEMD records as well per RFC. Also config of zone should indicate if ZONEMD verification is required. For Zone to Cache and RPZ we can do that from Lua, for Auth Zones it is not immediately clear how.

For the Authoritative Server:
- verify/insert/update/remove ZONEMD in DB 
- send ZONEMD out on AXFR. 
- verify incoming AXFR ZONEMD. 

Both should be handled in separate PRs imo.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
