### PR TITLE
libssl: fix compilation issues on older openssl versions

### DIFF
--- a/m4/pdns_with_libssl.m4
+++ b/m4/pdns_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_set_min_proto_version SSL_set_hostflags SSL_CTX_set_alpn_protos SSL_CTX_set_next_proto_select_cb SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_set_min_proto_version SSL_set_hostflags SSL_CTX_set_alpn_protos SSL_CTX_set_next_proto_select_cb SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -787,7 +787,7 @@ std::unique_ptr<SSL_CTX, void(*)(SSL_CTX*)> libssl_init_server_context(const TLS
   /* load certificate and private key */
   for (const auto& pair : config.d_certKeyPairs) {
     if (!pair.d_key) {
-#if defined(HAVE_SSL_CTX_USE_CERT_AND_KEY) && HAVE_SSL_CTX_USE_CERT_AND_KEY == 1 && defined(sk_X509_free)
+#if defined(HAVE_SSL_CTX_USE_CERT_AND_KEY) && HAVE_SSL_CTX_USE_CERT_AND_KEY == 1
       // If no separate key is given, treat it as a pkcs12 file
       auto fp = std::unique_ptr<FILE, int(*)(FILE*)>(fopen(pair.d_cert.c_str(), "r"), fclose);
       if (!fp) {


### PR DESCRIPTION
Fix `missing SSL_CTX_use_cert_and_key` function on openssl version < 1.1.1 by disabling pkcs12 support

Introduced in https://github.com/PowerDNS/pdns/pull/11027

```
libssl.cc: In function 'std::unique_ptr<ssl_ctx_st, void (*)(ssl_ctx_st*)> libssl_init_server_context(const TLSConfig&, std::map<int, std::basic_string<char> >&)':
libssl.cc:809:82: error: 'sk_X509_free' was not declared in this scope
       auto ca = std::unique_ptr<STACK_OF(X509), void(*)(STACK_OF(X509)*)>(captr, sk_X509_free);
                                                                                  ^~~~~~~~~~~~
libssl.cc:811:11: error: 'SSL_CTX_use_cert_and_key' was not declared in this scope
       if (SSL_CTX_use_cert_and_key(ctx.get(), cert.get(), key.get(), ca.get(), 1) != 1) {
           ^~~~~~~~~~~~~~~~~~~~~~~~
libssl.cc:811:11: note: suggested alternative: 'SSL_CTX_use_certificate'
       if (SSL_CTX_use_cert_and_key(ctx.get(), cert.get(), key.get(), ca.get(), 1) != 1) {
           ^~~~~~~~~~~~~~~~~~~~~~~~
           SSL_CTX_use_certificate
```

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
