### PR TITLE
github actions: Set policy to not start/enable services by default

### DIFF
--- a/build-scripts/gh-actions-setup-inv
+++ b/build-scripts/gh-actions-setup-inv
@@ -1,4 +1,10 @@
 #!/bin/bash -x
+sudo sh -c "cat > /usr/sbin/policy-rc.d << EOF
+#!/bin/sh
+exit 101
+EOF
+"
+sudo chmod 755 /usr/sbin/policy-rc.d
 sudo apt-get update
 sudo apt-get -qq -y dist-upgrade
 sudo apt-get -qq -y --no-install-recommends install python3-pip


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

After a long search documented in #11080 it turns out that the periodic (failing) starting of `pdns_server` by `systemd` interferes with starting the authoritative servers used in the recursor regression tests.

If you need a service running in a test, start it explicitly. At the moment only the SNMP daemon is needed, which was already (re)started in the test scripts.

Tested many times in my own repo without seeing any failure to start auths in the recursor regression tests. The failure was quite common without this.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
