### PR TITLE
rec: enable recursor regression tests using tsan

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        sanitizers: [ubsan+asan]
+        sanitizers: [ubsan+asan, tsan]
     env:
       UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:suppressions=${{ github.workspace }}/build-scripts/UBSan.supp'
       ASAN_OPTIONS: detect_leaks=0

--- a/pdns/recursordist/recursor-tsan.supp
+++ b/pdns/recursordist/recursor-tsan.supp
@@ -1,3 +1,2 @@
 # We don't care about stats for now
-race:doStats
 race:g_stats

--- a/pdns/recursordist/recursor-tsan.supp
+++ b/pdns/recursordist/recursor-tsan.supp
@@ -1,2 +1,3 @@
 # We don't care about stats for now
+race:doStats
 race:g_stats

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -104,6 +104,19 @@ int SyncRes::s_event_trace_enabled;
 
 #define LOG(x) if(d_lm == Log) { g_log <<Logger::Warning << x; } else if(d_lm == Store) { d_trace << x; }
 
+// A helper function to print a double with specific precsision
+// Not using boost::format since it is not thread safe while calling into locale handling code according to tsan
+// This allocates a string, but that's nothing compared to what boost::format is doing
+static inline std::string fmtfloat(const char* fmt, double f)
+{
+  char buf[20];
+  int ret = snprintf(buf, sizeof(buf), fmt, f);
+  if (ret < 0 || ret >= static_cast<int>(sizeof(buf))) {
+    return "?";
+  }
+  return std::string(buf, strlen(buf));
+}
+
 static inline void accountAuthLatency(uint64_t usec, int family)
 {
   if (family == AF_INET) {
@@ -1224,7 +1237,7 @@ vector<ComboAddress> SyncRes::getAddrs(const DNSName &qname, unsigned int depth,
       else {
         LOG(", ");
       }
-      LOG((addr.toString())<<"(" << (boost::format("%0.2f") % (speeds[addr]/1000.0)).str() <<"ms)");
+      LOG((addr.toString())<<"(" << fmtfloat("%0.2f", speeds[addr]/1000.0) <<"ms)");
     }
     LOG(endl);
   }
@@ -2023,7 +2036,7 @@ inline std::vector<std::pair<DNSName, float>> SyncRes::shuffleInSpeedOrder(NsSet
           LOG(endl<<prefix<<"             ");
         }
       }
-      LOG(i->first.toLogString()<<"(" << (boost::format("%0.2f") % (i->second/1000.0)).str() <<"ms)");
+      LOG(i->first.toLogString()<<"(" << fmtfloat("%0.2f", i->second/1000.0) <<"ms)");
     }
     LOG(endl);
   }
@@ -2054,7 +2067,7 @@ inline vector<ComboAddress> SyncRes::shuffleForwardSpeed(const vector<ComboAddre
           LOG(endl<<prefix<<"             ");
         }
       }
-      LOG((wasRd ? string("+") : string("-")) << i->toStringWithPort() <<"(" << (boost::format("%0.2f") % (speeds[*i]/1000.0)).str() <<"ms)");
+      LOG((wasRd ? string("+") : string("-")) << i->toStringWithPort() <<"(" << fmtfloat("%0.2f", speeds[*i]/1000.0) <<"ms)");
     }
     LOG(endl);
   }

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -116,7 +116,7 @@ static inline std::string fmtfloat(const char* fmt, double f)
   if (ret < 0 || ret >= static_cast<int>(sizeof(buf))) {
     return "?";
   }
-  return std::string(buf, strlen(buf));
+  return std::string(buf, ret);
 }
 
 static inline void accountAuthLatency(uint64_t usec, int family)

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -104,9 +104,11 @@ int SyncRes::s_event_trace_enabled;
 
 #define LOG(x) if(d_lm == Log) { g_log <<Logger::Warning << x; } else if(d_lm == Store) { d_trace << x; }
 
-// A helper function to print a double with specific precsision
-// Not using boost::format since it is not thread safe while calling into locale handling code according to tsan
-// This allocates a string, but that's nothing compared to what boost::format is doing
+// A helper function to print a double with specific printf format.
+// Not using boost::format since it is not thread safe while calling
+// into locale handling code according to tsan.
+// This allocates a string, but that's nothing compared to what
+// boost::format is doing and maybe even gets optimized away anyway.
 static inline std::string fmtfloat(const char* fmt, double f)
 {
   char buf[20];

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -108,7 +108,7 @@ int SyncRes::s_event_trace_enabled;
 // Not using boost::format since it is not thread safe while calling
 // into locale handling code according to tsan.
 // This allocates a string, but that's nothing compared to what
-// boost::format is doing and maybe even gets optimized away anyway.
+// boost::format is doing and may even be optimized away anyway.
 static inline std::string fmtfloat(const char* fmt, double f)
 {
   char buf[20];

--- a/regression-tests.recursor-dnssec/recursortests.py
+++ b/regression-tests.recursor-dnssec/recursortests.py
@@ -58,6 +58,7 @@ threads=1
 loglevel=9
 disable-syslog=yes
 log-common-errors=yes
+statistics-interval=0
 """
     _config_template = """
 """

--- a/regression-tests.recursor-dnssec/test_ECS.py
+++ b/regression-tests.recursor-dnssec/test_ECS.py
@@ -22,7 +22,6 @@ class ECSTest(RecursorTest):
 daemon=no
 trace=yes
 dont-query=
-ecs-add-for=0.0.0.0/0
 local-address=127.0.0.1
 packetcache-ttl=0
 packetcache-servfail-ttl=0
@@ -30,6 +29,9 @@ max-cache-ttl=600
 threads=1
 loglevel=9
 disable-syslog=yes
+log-common-errors=yes
+statistics-interval=0
+ecs-add-for=0.0.0.0/0
 """
 
     def sendECSQuery(self, query, expected, expectedFirstTTL=None, scopeZeroResponse=None):
@@ -536,21 +538,10 @@ class testECSWithProxyProtocoldRecursorTest(ECSTest):
 class testTooLargeToAddZeroScope(RecursorTest):
 
     _confdir = 'TooLargeToAddZeroScope'
-    _config_template_default = """
+    _config_template = """
 use-incoming-edns-subnet=yes
 dnssec=validate
-daemon=no
-trace=yes
-packetcache-ttl=0
-packetcache-servfail-ttl=0
-max-cache-ttl=15
-threads=1
-loglevel=9
-disable-syslog=yes
-log-common-errors=yes
 """
-    _config_template = """
-    """
     _lua_dns_script_file = """
     function preresolve(dq)
       if dq.qname == newDN('toolarge.ecs.') then

--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -7,21 +7,10 @@ from recursortests import RecursorTest
 class ExtendedErrorsRecursorTest(RecursorTest):
 
     _confdir = 'ExtendedErrors'
-    _config_template_default = """
-dnssec=validate
-daemon=no
-trace=yes
-packetcache-ttl=0
-packetcache-servfail-ttl=0
-max-cache-ttl=15
-threads=1
-loglevel=9
-disable-syslog=yes
-log-common-errors=yes
-"""
     _config_template = """
-    extended-resolution-errors=yes
-    """
+dnssec=validate
+extended-resolution-errors=yes
+"""
     _lua_config_file = """
     rpzFile('configs/%s/zone.rpz', { policyName="zone.rpz.", extendedErrorCode=15, extendedErrorExtra='Blocked by RPZ!'})
     """ % (_confdir)
@@ -219,20 +208,9 @@ log-common-errors=yes
 class NoExtendedErrorsRecursorTest(RecursorTest):
 
     _confdir = 'ExtendedErrorsDisabled'
-    _config_template_default = """
-dnssec=validate
-daemon=no
-trace=yes
-packetcache-ttl=0
-packetcache-servfail-ttl=0
-max-cache-ttl=15
-threads=1
-loglevel=9
-disable-syslog=yes
-log-common-errors=yes
-"""
     _config_template = """
-    extended-resolution-errors=no
+dnssec=validate
+extended-resolution-errors=no
     """
     _roothints = None
 

--- a/regression-tests.recursor-dnssec/test_Lua.py
+++ b/regression-tests.recursor-dnssec/test_Lua.py
@@ -642,23 +642,13 @@ class PDNSValidationStatesTest(RecursorTest):
     """Tests that we have access to the validation states from Lua"""
 
     _confdir = 'validation-states-from-lua'
-    _config_template_default = """
+    _config_template = """
 dnssec=validate
-daemon=no
-trace=yes
-packetcache-ttl=0
-packetcache-servfail-ttl=0
-max-cache-ttl=15
-threads=1
-loglevel=9
-disable-syslog=yes
-log-common-errors=yes
 """
     _roothints = None
     _lua_config_file = """
     """
-    _config_template = """
-    """
+
     _lua_dns_script_file = """
     function postresolve (dq)
       if pdns.validationstates.Indeterminate == nil or

--- a/regression-tests.recursor-dnssec/test_Prometheus.py
+++ b/regression-tests.recursor-dnssec/test_Prometheus.py
@@ -74,6 +74,7 @@ api-key=%s
 """ % (_wsPort, _wsPassword, _apiKey)
 
     def testPrometheus(self):
+        self.waitForTCPSocket("127.0.0.1", self._wsPort)
         url = 'http://user:' + self._wsPassword + '@127.0.0.1:' + str(self._wsPort) + '/metrics'
         r = requests.get(url, timeout=self._wsTimeout)
         self.assertTrue(r)

--- a/regression-tests.recursor-dnssec/test_RoutingTag.py
+++ b/regression-tests.recursor-dnssec/test_RoutingTag.py
@@ -21,7 +21,6 @@ class RoutingTagTest(RecursorTest):
 daemon=no
 trace=yes
 dont-query=
-ecs-add-for=0.0.0.0/0
 local-address=127.0.0.1
 packetcache-ttl=0
 packetcache-servfail-ttl=0
@@ -29,6 +28,9 @@ max-cache-ttl=600
 threads=1
 loglevel=9
 disable-syslog=yes
+log-common-errors=yes
+statistics-interval=0
+ecs-add-for=0.0.0.0/0
 """
 
     def sendECSQuery(self, query, expected, expectedFirstTTL=None):
@@ -107,9 +109,8 @@ class testRoutingTag(RoutingTagTest):
     _confdir = 'RoutingTag'
 
     _config_template = """
-log-common-errors=yes
 use-incoming-edns-subnet=yes
-edns-subnet-whitelist=ecs-echo.example.
+edns-subnet-allow-list=ecs-echo.example.
 forward-zones=ecs-echo.example=%s.24
     """ % (os.environ['PREFIX'])
     _lua_dns_script_file = """
@@ -182,9 +183,8 @@ class testRoutingTagFFI(RoutingTagTest):
     _confdir = 'RoutingTagFFI'
 
     _config_template = """
-log-common-errors=yes
 use-incoming-edns-subnet=yes
-edns-subnet-whitelist=ecs-echo.example.
+edns-subnet-allow-list=ecs-echo.example.
 forward-zones=ecs-echo.example=%s.24
     """ % (os.environ['PREFIX'])
     _lua_dns_script_file = """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Some modifications were needed to make tsan work for rec regression test:
- Update `numberOfDistributedQueries` only from the thread itself
- Do not `use boost::format` (it calls into locale handling code that does not seem to be thread-safe)
- Stop printing periodic stats (they are racey, but we do not care)

Survived a couple of test runs here.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
