### PR TITLE
Properly handle ipcipher support when libcrypto is not available

### DIFF
--- a/m4/pdns_enable_ipcipher.m4
+++ b/m4/pdns_enable_ipcipher.m4
@@ -1,17 +1,25 @@
 AC_DEFUN([PDNS_ENABLE_IPCIPHER], [
   AC_MSG_CHECKING([whether to enable ipcipher support])
+  HAVE_IPCIPHER=0
   AC_ARG_ENABLE([ipcipher],
-    AS_HELP_STRING([--enable-ipcipher], [enable ipcipher support (requires libcrypto) @<:@default=yes@:>@]),
+    AS_HELP_STRING([--enable-ipcipher], [enable ipcipher support (requires libcrypto) @<:@default=auto@:>@]),
     [enable_ipcipher=$enableval],
-    [enable_ipcipher=yes]
+    [enable_ipcipher=auto]
   )
   AC_MSG_RESULT([$enable_ipcipher])
-  AM_CONDITIONAL([IPCIPHER], [test "x$enable_ipcipher" != "xno"])
 
-  AM_COND_IF([IPCIPHER], [
-    AM_COND_IF([HAVE_LIBCRYPTO], [
-      AC_DEFINE([HAVE_IPCIPHER], [1], [Define to 1 if you enable ipcipher support])
-    ],[
+  AS_IF([test "x$enable_ipcipher" != "xno"], [
+    AS_IF([test "x$enable_ipcipher" = "xyes" -o "x$enable_ipcipher" = "xauto"], [
+      AM_COND_IF([HAVE_LIBCRYPTO], [
+        AC_DEFINE([HAVE_IPCIPHER], [1], [Define to 1 if you enable ipcipher support])
+        [HAVE_IPCIPHER=1]
+      ])
+    ])
+  ])
+  AM_CONDITIONAL([IPCIPHER], [test "x$HAVE_IPCIPHER" != "x0"])
+
+  AS_IF([test "x$enable_ipcipher" = "xyes"], [
+    AS_IF([test x"$HAVE_IPCIPHER" = "x0"], [
       AC_MSG_ERROR([ipcipher support requested but libcrypto is not available])
     ])
   ])

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -183,7 +183,7 @@ AS_IF([test "x$systemd" != "xn"],
   [AC_MSG_NOTICE([systemd: yes])],
   [AC_MSG_NOTICE([systemd: no])]
 )
-AS_IF([test "x$enable_ipcipher" != "xno"],
+AS_IF([test "x$HAVE_IPCIPHER" = "x1"],
   [AC_MSG_NOTICE([ipcipher: yes])],
   [AC_MSG_NOTICE([ipcipher: no])]
 )


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
`ipcipher` support now defaults to `auto` instead of `yes`, so that we can build (or just run `make dist`) even if `libcrypto` is not available.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
