### PR TITLE
Test correct member in DynBlockRatioRule::warningRatioExceeded

### DIFF
--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -108,6 +108,10 @@ private:
 
     bool warningRateExceeded(unsigned int count, const struct timespec& now) const
     {
+      if (!d_enabled) {
+        return false;
+      }
+
       if (d_warningRate == 0) {
         return false;
       }
@@ -177,7 +181,11 @@ private:
 
     bool warningRatioExceeded(unsigned int total, unsigned int count) const
     {
-      if (d_warningRate == 0) {
+      if (!d_enabled) {
+        return false;
+      }
+
+      if (d_warningRatio == 0.0) {
         return false;
       }
 


### PR DESCRIPTION
### Short description

`d_warningRate` in this function will always be 0, as that's how it's initialized and it's never updated, so we need to check `d_warningRatio` instead to see if warnings are enabled.

This also adds some more tests of `d_enabled` as the correct short-circuit for when these are initialized with their zero-argument constructor.

Fixes #11131

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
