### PR TITLE
Try shorter thread names

### DIFF
--- a/pdns/threadname.cc
+++ b/pdns/threadname.cc
@@ -39,7 +39,7 @@
 
 #include "threadname.hh"
 
-void setThreadName(const std::string& threadName) {
+int trySetThreadName(const std::string& threadName) {
   int retval = 0;
 
 #ifdef HAVE_PTHREAD_SETNAME_NP_2
@@ -57,6 +57,16 @@ void setThreadName(const std::string& threadName) {
 #ifdef HAVE_PTHREAD_SETNAME_NP_3
   retval = pthread_setname_np(pthread_self(), threadName.c_str(), nullptr);
 #endif
+
+  return retval;
+}
+
+void setThreadName(const std::string& threadName) {
+  int retval = trySetThreadName(threadName);
+  if (retval == ERANGE) {
+    const std::string shortThreadName(threadName.substr(0, 15));
+    retval = trySetThreadName(shortThreadName);
+  }
 
   if (retval != 0) {
 #ifdef DNSDIST

--- a/pdns/threadname.cc
+++ b/pdns/threadname.cc
@@ -39,7 +39,7 @@
 
 #include "threadname.hh"
 
-int trySetThreadName(const std::string& threadName) {
+static int trySetThreadName(const std::string& threadName) {
   int retval = 0;
 
 #ifdef HAVE_PTHREAD_SETNAME_NP_2


### PR DESCRIPTION
https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html

       ... The thread name is a
       meaningful C language string, whose length is restricted to 16
       characters, including the terminating null byte ('\0').

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

User reports:
> Could not set thread name pdns-r/ztc/rpz.urlhaus.abuse.ch. for thread: Numerical result out of range

the `pdns-r/ztc` is a really expensive prefix for a 15 char threadname, I'd personally suggest using `ztc:` instead, that'd give 6 chars to the thread name that are currently wasted.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
