### PR TITLE
Stop using the deprecated boost::shared_array

### DIFF
--- a/pdns/axfr-retriever.hh
+++ b/pdns/axfr-retriever.hh
@@ -21,7 +21,6 @@
  */
 #pragma once
 #include <boost/utility.hpp>
-#include <boost/shared_array.hpp>
 
 #include "iputils.hh"
 #include "dnsname.hh"
@@ -44,7 +43,7 @@ class AXFRRetriever : public boost::noncopyable
     int getLength(uint16_t timeout);
     void timeoutReadn(uint16_t bytes, uint16_t timeoutsec=10);
 
-    boost::shared_array<char> d_buf;
+    std::vector<char> d_buf;
     string d_domain;
     int d_sock;
     int d_soacount;

--- a/pdns/mplexer.hh
+++ b/pdns/mplexer.hh
@@ -22,7 +22,6 @@
 #pragma once
 #include <boost/function.hpp>
 #include <boost/any.hpp>
-#include <boost/shared_array.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
 #include <boost/multi_index_container.hpp>

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -61,7 +61,6 @@
 #include <boost/any.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
-#include <boost/shared_array.hpp>
 #include <boost/function.hpp>
 #include <boost/algorithm/string.hpp>
 #ifdef MALLOC_TRACE

--- a/pdns/portsmplexer.cc
+++ b/pdns/portsmplexer.cc
@@ -36,7 +36,7 @@ public:
 
 private:
   int d_portfd;
-  boost::shared_array<port_event_t> d_pevents;
+  std::vector<port_event_t> d_pevents;
   static int s_maxevents; // not a hard maximum
 };
 
@@ -56,7 +56,7 @@ static struct PortsRegisterOurselves
 int PortsFDMultiplexer::s_maxevents = 1024;
 
 PortsFDMultiplexer::PortsFDMultiplexer() :
-  d_pevents(new port_event_t[s_maxevents])
+  d_pevents(s_maxevents)
 {
   d_portfd = port_create(); // not hard max
   if (d_portfd < 0) {
@@ -97,7 +97,7 @@ void PortsFDMultiplexer::getAvailableFDs(std::vector<int>& fds, int timeout)
   timeoutspec.tv_sec = timeout / 1000;
   timeoutspec.tv_nsec = (timeout % 1000) * 1000000;
   unsigned int numevents = 1;
-  int ret = port_getn(d_portfd, d_pevents.get(), min(PORT_MAX_LIST, s_maxevents), &numevents, &timeoutspec);
+  int ret = port_getn(d_portfd, d_pevents.data(), min(PORT_MAX_LIST, s_maxevents), &numevents, &timeoutspec);
 
   /* port_getn has an unusual API - (ret == -1, errno == ETIME) can
      mean partial success; you must check (*numevents) in this case
@@ -158,7 +158,7 @@ int PortsFDMultiplexer::run(struct timeval* now, int timeout)
   timeoutspec.tv_sec = timeout / 1000;
   timeoutspec.tv_nsec = (timeout % 1000) * 1000000;
   unsigned int numevents = 1;
-  int ret = port_getn(d_portfd, d_pevents.get(), min(PORT_MAX_LIST, s_maxevents), &numevents, &timeoutspec);
+  int ret = port_getn(d_portfd, d_pevents.data(), min(PORT_MAX_LIST, s_maxevents), &numevents, &timeoutspec);
 
   /* port_getn has an unusual API - (ret == -1, errno == ETIME) can
      mean partial success; you must check (*numevents) in this case


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It was deprecated in 1.65.0: `This facility is deprecated because a shared_ptr to T[] or T[N] is now available, and is superior in every regard`.

As far as I can tell we never actually used the reference counting 'shared' feature anyway.

I have only partially tested this change, in particular I did not test the `ports` and `kqueue` multiplexers.
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
