### PR TITLE
auth: lmdb, check if the lookup name is part of the zone

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -736,6 +736,9 @@ void LMDBBackend::lookup(const QType& type, const DNSName& qdomain, int zoneId, 
   }
 
   DNSName relqname = qdomain.makeRelative(hunt);
+  if (relqname.empty()) {
+    return;
+  }
   // cout<<"get will look for "<<relqname<< " in zone "<<hunt<<" with id "<<zoneId<<" and type "<<type.toString()<<endl;
   d_rotxn = getRecordsROTransaction(zoneId, d_rwtxn);
 

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -32,8 +32,14 @@ std::string keyConv(const T& t)
      nl -> nl0
      
   */
-  if (t.isRoot())
+  if (t.empty()) {
+    throw std::out_of_range(std::string(__PRETTY_FUNCTION__) + " Attempt to serialize an unset dnsname");
+  }
+
+  if (t.isRoot()) {
     return std::string(1, (char)0);
+  }
+
   std::string in = t.labelReverse().toDNSStringLC(); // www.ds9a.nl is now 2nl4ds9a3www0
   std::string ret;
   ret.reserve(in.size());


### PR DESCRIPTION
### Short description
Duplicate domain-id's in the zone cache could trick imdb backend into serving records from the wrong zone.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

