### PR TITLE
dnsdist: Document webserver and actions removals in 1.7.0

### DIFF
--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -1,11 +1,12 @@
 Built-in webserver
 ==================
 
-To visually interact with dnsdist, try add :func:`webserver` to the configuration:
+To visually interact with dnsdist, try adding :func:`webserver` and :func:`setWebserverConfig` directives to the configuration:
 
 .. code-block:: lua
 
-  webserver("127.0.0.1:8083", "supersecretpassword", "supersecretAPIkey")
+  webserver("127.0.0.1:8083")
+  setWebserverConfig({password="supersecretpassword", apiKey="supersecretAPIkey"})
 
 Now point your browser at http://127.0.0.1:8083 and log in with any username, and that password. Enjoy!
 
@@ -13,7 +14,7 @@ Since 1.5.0, only connections from 127.0.0.1 and ::1 are allowed by default. To 
 
 .. code-block:: lua
 
-  webserver("127.0.0.1:8083", "supersecretpassword", "supersecretAPIkey", {}, "192.0.2.0/24, !192.0.2.1")
+  setWebserverConfig({password="supersecretpassword", apiKey="supersecretAPIkey", acl="192.0.2.0/24, !192.0.2.1"})
 
 
 Security of the Webserver
@@ -34,9 +35,9 @@ For example, to remove the X-Frame-Options header and add a X-Custom one:
 
 .. code-block:: lua
 
-  webserver("127.0.0.1:8080", "supersecret", "apikey", {["X-Frame-Options"]= "", ["X-Custom"]="custom"})
+  setWebserverConfig({password="supersecretpassword", apiKey="supersecretAPIkey", customHeaders={["X-Frame-Options"]= "", ["X-Custom"]="custom"} })
 
-Credentials can be changed over time using the :func:`setWebserverConfig` function.
+Credentials can be changed at run time using the :func:`setWebserverConfig` function.
 
 dnsdist API
 -----------

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -325,8 +325,11 @@ Webserver configuration
     The ``password`` parameter is now optional.
     The use of optional parameters is now deprecated. Please use :func:`setWebserverConfig` instead.
 
-  Launch the :doc:`../guides/webserver` with statistics and the API. Note that the parameters are global, so the parameter from the last ``webserver`` will override any existing ones. For this reason
-  the use of :func:`setWebserverConfig` is advised instead of specifying optional parameters here.
+  .. versionchanged:: 1.7.0
+    The ``password``, ``apikey``, ``customHeaders`` and ``acl`` parameters is no longer supported.
+    Please use :func:`setWebserverConfig` instead.
+
+  Launch the :doc:`../guides/webserver` with statistics and the API. Note that the parameters are global, so the parameter from the last ``webserver`` will override any existing ones. For this reason :func:`setWebserverConfig` should be used instead of specifying optional parameters here.
 
   :param str listen_address: The IP address and Port to listen on
   :param str password: The password required to access the webserver

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -893,7 +893,7 @@ The following actions exist.
 
   .. deprecated:: 1.6.0
 
-  This function has been deprecated in 1.6.0, please use :func:`SetDisableECSAction` instead.
+  This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetDisableECSAction` instead.
 
   Disable the sending of ECS to the backend.
   Subsequent rules are processed after this action.
@@ -902,7 +902,7 @@ The following actions exist.
 
   .. deprecated:: 1.6.0
 
-  This function has been deprecated in 1.6.0, please use :func:`SetDisableValidationAction` instead.
+  This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetDisableValidationAction` instead.
 
   Set the CD bit in the query and let it go through.
   Subsequent rules are processed after this action.
@@ -939,7 +939,7 @@ The following actions exist.
 
   .. deprecated:: 1.6.0
 
-  This function has been deprecated in 1.6.0, please use :func:`SetECSOverrideAction` instead.
+  This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetECSOverrideAction` instead.
 
   Whether an existing EDNS Client Subnet value should be overridden (true) or not (false).
   Subsequent rules are processed after this action.
@@ -950,7 +950,7 @@ The following actions exist.
 
   .. deprecated:: 1.6.0
 
-  This function has been deprecated in 1.6.0, please use :func:`SetECSPrefixLengthAction` instead.
+  This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetECSPrefixLengthAction` instead.
 
   Set the ECS prefix length.
   Subsequent rules are processed after this action.
@@ -1157,7 +1157,7 @@ The following actions exist.
 
   .. deprecated:: 1.6.0
 
-  This function has been deprecated in 1.6.0, please use :func:`SetMacAddrAction` instead.
+  This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetMacAddrAction` instead.
 
   Add the source MAC address to the query as EDNS0 option ``option``.
   This action is currently only supported on Linux.
@@ -1199,7 +1199,7 @@ The following actions exist.
 
   .. deprecated:: 1.6.0
 
-  This function has been deprecated in 1.6.0, please use :func:`SetNoRecurseAction` instead.
+  This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetNoRecurseAction` instead.
 
   Strip RD bit from the question, let it go through.
   Subsequent rules are processed after this action.
@@ -1394,7 +1394,7 @@ The following actions exist.
 
   .. deprecated:: 1.6.0
 
-  This function has been deprecated in 1.6.0, please use :func:`NegativeAndSOAAction` instead.
+  This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`NegativeAndSOAAction` instead.
 
   Turn a question into a response, either a NXDOMAIN or a NODATA one based on ''nxd'', setting the QR bit to 1 and adding a SOA record in the additional section.
 
@@ -1484,7 +1484,7 @@ The following actions exist.
 
   .. deprecated:: 1.6.0
 
-  This function has been deprecated in 1.6.0, please use :func:`SetSkipAction` instead.
+  This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetSkipAction` instead.
 
   Don't lookup the cache for this query, don't store the answer.
   Subsequent rules are processed after this action.
@@ -1618,7 +1618,7 @@ The following actions exist.
 .. function:: TagAction(name, value)
 
   .. deprecated:: 1.6.0
-    This function has been deprecated in 1.6.0, please use :func:`SetTagAction` instead.
+    This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetTagAction` instead.
 
   Associate a tag named ``name`` with a value of ``value`` to this query, that will be passed on to the response.
   Subsequent rules are processed after this action.
@@ -1629,7 +1629,7 @@ The following actions exist.
 .. function:: TagResponseAction(name, value)
 
   .. deprecated:: 1.6.0
-    This function has been deprecated in 1.6.0, please use :func:`SetTagResponseAction` instead.
+    This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetTagResponseAction` instead.
 
   Associate a tag named ``name`` with a value of ``value`` to this response.
   Subsequent rules are processed after this action.
@@ -1659,7 +1659,7 @@ The following actions exist.
 
   .. deprecated:: 1.6.0
 
-  This function has been deprecated in 1.6.0, please use :func:`SetTempFailureCacheTTLAction` instead.
+  This function has been deprecated in 1.6.0 and removed in 1.7.0, please use :func:`SetTempFailureCacheTTLAction` instead.
 
   Set the cache TTL to use for ServFail and Refused replies. TTL is not applied for successful replies.
   Subsequent rules are processed after this action.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Several deprecated actions have been removed in e22209274a48fde28ab7cb256939ee65e5283bfa, along with the deprecated additional parameters to the `webserver` directive.
Closes #11149.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
