### PR TITLE
dnsdist-1.7.x: Test correct member in DynBlockRatioRule::warningRatioExceeded

### DIFF
--- a/pdns/dnsdist-dynblocks.hh
+++ b/pdns/dnsdist-dynblocks.hh
@@ -108,6 +108,10 @@ private:
 
     bool warningRateExceeded(unsigned int count, const struct timespec& now) const
     {
+      if (!d_enabled) {
+        return false;
+      }
+
       if (d_warningRate == 0) {
         return false;
       }
@@ -177,7 +181,11 @@ private:
 
     bool warningRatioExceeded(unsigned int total, unsigned int count) const
     {
-      if (d_warningRate == 0) {
+      if (!d_enabled) {
+        return false;
+      }
+
+      if (d_warningRatio == 0.0) {
         return false;
       }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #11132 to rel/dnsdist-1.7.x.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
