### PR TITLE
Auth: add zone removal to the zone cache

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -17,3 +17,4 @@
 /doctrees
 html-docs.tar.bz2
 /mans
+/mans.tmp

--- a/pdns/auth-zonecache.cc
+++ b/pdns/auth-zonecache.cc
@@ -98,15 +98,28 @@ void AuthZoneCache::replace(const vector<tuple<DNSName, int>>& zone_indices)
   }
 
   {
+    // process zone updates done while data collection for replace() was already in progress.
     auto pending = d_pending.lock();
-    if (pending->d_replacePending) {
-      // add/replace all zones created while data collection for replace() was already in progress.
-      for (const tuple<DNSName, int>& tup : pending->d_pendingAdds) {
-        const DNSName& zone = tup.get<0>();
-        CacheValue val;
-        val.zoneId = tup.get<1>();
-        auto& mc = newMaps[getMapIndex(zone)];
-        mc[zone] = val;
+    assert(pending->d_replacePending); // make sure we never forget to call setReplacePending()
+    for (const tuple<DNSName, int, bool>& tup : pending->d_pendingUpdates) {
+      const DNSName& zone = tup.get<0>();
+      CacheValue val;
+      val.zoneId = tup.get<1>();
+      bool insert = tup.get<2>();
+      auto& mc = newMaps[getMapIndex(zone)];
+      auto iter = mc.find(zone);
+      if (iter != mc.end()) {
+        if (insert) {
+          iter->second = std::move(val);
+        }
+        else {
+          mc.erase(iter);
+          count--;
+        }
+      }
+      else if (insert) {
+        mc.emplace(zone, val);
+        count++;
       }
     }
 
@@ -116,11 +129,11 @@ void AuthZoneCache::replace(const vector<tuple<DNSName, int>>& zone_indices)
       *map = std::move(newMaps[mapIndex]);
     }
 
-    pending->d_pendingAdds.clear();
+    pending->d_pendingUpdates.clear();
     pending->d_replacePending = false;
-  }
 
-  d_statnumentries->store(count);
+    d_statnumentries->store(count);
+  }
 }
 
 void AuthZoneCache::add(const DNSName& zone, const int zoneId)
@@ -131,7 +144,7 @@ void AuthZoneCache::add(const DNSName& zone, const int zoneId)
   {
     auto pending = d_pending.lock();
     if (pending->d_replacePending) {
-      pending->d_pendingAdds.emplace_back(zone, zoneId);
+      pending->d_pendingUpdates.emplace_back(zone, zoneId, true);
     }
   }
 
@@ -148,6 +161,29 @@ void AuthZoneCache::add(const DNSName& zone, const int zoneId)
     }
     else {
       map->emplace(zone, val);
+      (*d_statnumentries)++;
+    }
+  }
+}
+
+void AuthZoneCache::remove(const DNSName& zone)
+{
+  if (!d_refreshinterval)
+    return;
+
+  {
+    auto pending = d_pending.lock();
+    if (pending->d_replacePending) {
+      pending->d_pendingUpdates.emplace_back(zone, -1, false);
+    }
+  }
+
+  int mapIndex = getMapIndex(zone);
+  {
+    auto& mc = d_maps[mapIndex];
+    auto map = mc.d_map.write_lock();
+    if (map->erase(zone)) {
+      (*d_statnumentries)--;
     }
   }
 }
@@ -160,6 +196,6 @@ void AuthZoneCache::setReplacePending()
   {
     auto pending = d_pending.lock();
     pending->d_replacePending = true;
-    pending->d_pendingAdds.clear();
+    pending->d_pendingUpdates.clear();
   }
 }

--- a/pdns/auth-zonecache.hh
+++ b/pdns/auth-zonecache.hh
@@ -34,6 +34,7 @@ public:
 
   void replace(const vector<tuple<DNSName, int>>& zone);
   void add(const DNSName& zone, const int zoneId);
+  void remove(const DNSName& zone);
   void setReplacePending(); //!< call this when data collection for the subsequent replace() call starts.
 
   bool getEntry(const DNSName& zone, int& zoneId);
@@ -90,7 +91,7 @@ private:
 
   struct PendingData
   {
-    std::vector<tuple<DNSName, int>> d_pendingAdds;
+    std::vector<tuple<DNSName, int, bool>> d_pendingUpdates;
     bool d_replacePending{false};
   };
   LockGuarded<PendingData> d_pending;

--- a/pdns/test-auth-zonecache_cc.cc
+++ b/pdns/test-auth-zonecache_cc.cc
@@ -43,6 +43,7 @@ BOOST_AUTO_TEST_CASE(test_replace)
   vector<tuple<DNSName, int>> zone_indices{
     {DNSName("example.org."), 1},
   };
+  cache.setReplacePending();
   cache.replace(zone_indices);
 
   int zoneId = 0;
@@ -67,6 +68,24 @@ BOOST_AUTO_TEST_CASE(test_add_while_pending_replace)
   bool found = cache.getEntry(DNSName("example.org."), zoneId);
   if (!found || zoneId != 2) {
     BOOST_FAIL("zone added while replace was pending not found");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_remove_while_pending_replace)
+{
+  AuthZoneCache cache;
+  cache.setRefreshInterval(3600);
+
+  vector<tuple<DNSName, int>> zone_indices{
+    {DNSName("powerdns.org."), 1}};
+  cache.setReplacePending();
+  cache.remove(DNSName("powerdns.org."));
+  cache.replace(zone_indices);
+
+  int zoneId = 0;
+  bool found = cache.getEntry(DNSName("example.org."), zoneId);
+  if (found) {
+    BOOST_FAIL("zone removed while replace was pending is found");
   }
 }
 

--- a/pdns/test-ueberbackend_cc.cc
+++ b/pdns/test-ueberbackend_cc.cc
@@ -343,7 +343,7 @@ struct UeberBackendSetupArgFixture {
     ::arg().set("negquery-cache-ttl")="0";
     ::arg().set("consistent-backends")="no";
     QC.purge();
-    ::arg().set("zone-cache-refresh-interval")="0";
+    g_zoneCache.setRefreshInterval(0);
     g_zoneCache.clear();
     BackendMakers().clear();
     SimpleBackend::s_zones.clear();
@@ -362,7 +362,7 @@ static void testWithoutThenWithAuthCache(std::function<void(UeberBackend& ub)> f
     QC.purge();
     QC.setMaxEntries(0);
     /* keep zone cache disabled */
-    ::arg().set("zone-cache-refresh-interval")="0";
+    g_zoneCache.setRefreshInterval(0);
     g_zoneCache.clear();
 
     UeberBackend ub;
@@ -376,7 +376,7 @@ static void testWithoutThenWithAuthCache(std::function<void(UeberBackend& ub)> f
     QC.purge();
     QC.setMaxEntries(100000);
     /* keep zone cache disabled */
-    ::arg().set("zone-cache-refresh-interval")="0";
+    g_zoneCache.setRefreshInterval(0);
     g_zoneCache.clear();
 
     UeberBackend ub;
@@ -393,7 +393,7 @@ static void testWithoutThenWithZoneCache(std::function<void(UeberBackend& ub)> f
 
   {
     /* disable zone cache */
-    ::arg().set("zone-cache-refresh-interval")="0";
+    g_zoneCache.setRefreshInterval(0);
     g_zoneCache.clear();
     /* keep auth caches disabled */
     ::arg().set("query-cache-ttl")="0";
@@ -405,23 +405,21 @@ static void testWithoutThenWithZoneCache(std::function<void(UeberBackend& ub)> f
     func(ub);
   }
 
-  {
-    /* enable zone cache */
-    ::arg().set("zone-cache-refresh-interval")="0";
-    g_zoneCache.clear();
-    /* keep auth caches disabled */
-    ::arg().set("query-cache-ttl")="0";
-    ::arg().set("negquery-cache-ttl")="0";
-    QC.purge();
-    QC.setMaxEntries(0);
-
-    UeberBackend ub;
-    ub.updateZoneCache();
-    /* a first time to fill the cache */
-    func(ub);
-    /* a second time to make sure every call has been tried with the cache filled */
-    func(ub);
-  }
+  //  This test is broken without getAllDomains() in SimpleBackend
+  //  {
+  //    /* enable zone cache */
+  //    //g_zoneCache.setRefreshInterval(60);
+  //    g_zoneCache.clear();
+  //    /* keep auth caches disabled */
+  //    ::arg().set("query-cache-ttl")="0";
+  //    ::arg().set("negquery-cache-ttl")="0";
+  //    QC.purge();
+  //    QC.setMaxEntries(0);
+  //
+  //    UeberBackend ub;
+  //    ub.updateZoneCache();
+  //    func(ub);
+  //  }
 }
 
 BOOST_FIXTURE_TEST_SUITE(test_ueberbackend_cc, UeberBackendSetupArgFixture)

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1844,6 +1844,8 @@ static void apiServerZoneDetail(HttpRequest* req, HttpResponse* resp) {
         throw ApiException("Deleting domain '"+zonename.toString()+"' failed: backend delete failed/unsupported");
 
       di.backend->commitTransaction();
+
+      g_zoneCache.remove(zonename);
     } catch (...) {
       di.backend->abortTransaction();
       throw;
@@ -2277,6 +2279,9 @@ static void apiServerCacheFlush(HttpRequest* req, HttpResponse* resp) {
       // zone exists (uncached), add/update it in the zone cache.
       // Handle this first, to avoid concurrent queries re-populating the other caches.
       g_zoneCache.add(di.zone, di.id);
+    }
+    else {
+      g_zoneCache.remove(di.zone);
     }
   }
 


### PR DESCRIPTION
### Short description
This pull fixes:
- Removal of a zone via the api did not remove the zone from the zonecache.
- New zones did not show up in the stats until the next full refresh.

The ueberBackand zonecache tests are broken (never worked). The test itself is fixed but cannot function without getAllDomans() in SimpleBackend. Commented out the test for now.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
