### PR TITLE
dnsdist: Allow randomly selecting a backend UDP socket and query ID

### DIFF
--- a/pdns/dns_random.cc
+++ b/pdns/dns_random.cc
@@ -209,32 +209,14 @@ void dns_random_init(const string& data __attribute__((unused)), bool force) {
 #endif
 }
 
-/* Parts of this code come from arc4random_uniform */
 uint32_t dns_random(uint32_t upper_bound) {
   if (chosen_rng == RNG_UNINITIALIZED)
     dns_random_setup();
 
-  unsigned int min;
   if (upper_bound < 2)
     return 0;
-  /* To avoid "modulo bias" for some methods, calculate
-     minimum acceptable value for random number to improve
-     uniformity.
 
-     On applicable rngs, we loop until the rng spews out
-     value larger than min, and then take modulo out of that.
-  */
-#if (ULONG_MAX > 0xffffffffUL)
-  min = 0x100000000UL % upper_bound;
-#else
-  /* Calculate (2**32 % upper_bound) avoiding 64-bit math */
-  if (upper_bound > 0x80000000)
-    min = 1 + ~upper_bound; /* 2**32 - upper_bound */
-  else {
-    /* (2**32 - (x * 2)) % x == 2**32 % x when x <= 2**31 */
-    min = ((0xffffffff - (upper_bound * 2)) + 1) % upper_bound;
-  }
-#endif
+  unsigned int min = pdns::random_minimum_acceptable_value(upper_bound);
 
   switch(chosen_rng) {
   case RNG_UNINITIALIZED:

--- a/pdns/dns_random.hh
+++ b/pdns/dns_random.hh
@@ -22,6 +22,7 @@
 #pragma once
 #include <cstdint>
 #include <limits>
+#include <string>
 
 void dns_random_init(const std::string& data = "", bool force_reinit = false);
 uint32_t dns_random(uint32_t n);
@@ -47,4 +48,30 @@ namespace pdns {
       return dns_random(std::numeric_limits<result_type>::max());
     }
   };
+
+  /* minimum value that a PRNG should return for this upper bound to avoid a modulo bias */
+  inline unsigned int random_minimum_acceptable_value(uint32_t upper_bound)
+  {
+    /* Parts of this code come from arc4random_uniform */
+    /* To avoid "modulo bias" for some methods, calculate
+       minimum acceptable value for random number to improve
+       uniformity.
+
+       On applicable rngs, we loop until the rng spews out
+       value larger than min, and then take modulo out of that.
+    */
+    unsigned int min;
+#if (ULONG_MAX > 0xffffffffUL)
+    min = 0x100000000UL % upper_bound;
+#else
+    /* Calculate (2**32 % upper_bound) avoiding 64-bit math */
+    if (upper_bound > 0x80000000)
+      min = 1 + ~upper_bound; /* 2**32 - upper_bound */
+    else {
+      /* (2**32 - (x * 2)) % x == 2**32 % x when x <= 2**31 */
+      min = ((0xffffffff - (upper_bound * 2)) + 1) % upper_bound;
+    }
+#endif
+    return min;
+  }
 }

--- a/pdns/dnsdist-idstate.hh
+++ b/pdns/dnsdist-idstate.hh
@@ -99,7 +99,7 @@ struct IDState
     sentTime(true), tempFailureTTL(boost::none) { origDest.sin4.sin_family = 0; }
   IDState(const IDState& orig) = delete;
   IDState(IDState&& rhs) :
-    subnet(rhs.subnet), origRemote(rhs.origRemote), origDest(rhs.origDest), hopRemote(rhs.hopRemote), hopLocal(rhs.hopLocal), qname(std::move(rhs.qname)), sentTime(rhs.sentTime), packetCache(std::move(rhs.packetCache)), dnsCryptQuery(std::move(rhs.dnsCryptQuery)), qTag(std::move(rhs.qTag)), tempFailureTTL(rhs.tempFailureTTL), cs(rhs.cs), du(std::move(rhs.du)), cacheKey(rhs.cacheKey), cacheKeyNoECS(rhs.cacheKeyNoECS), cacheKeyUDP(rhs.cacheKeyUDP), origFD(rhs.origFD), delayMsec(rhs.delayMsec), qtype(rhs.qtype), qclass(rhs.qclass), origID(rhs.origID), origFlags(rhs.origFlags), cacheFlags(rhs.cacheFlags), protocol(rhs.protocol), ednsAdded(rhs.ednsAdded), ecsAdded(rhs.ecsAdded), skipCache(rhs.skipCache), destHarvested(rhs.destHarvested), dnssecOK(rhs.dnssecOK), useZeroScope(rhs.useZeroScope)
+    subnet(rhs.subnet), origRemote(rhs.origRemote), origDest(rhs.origDest), hopRemote(rhs.hopRemote), hopLocal(rhs.hopLocal), qname(std::move(rhs.qname)), sentTime(rhs.sentTime), packetCache(std::move(rhs.packetCache)), dnsCryptQuery(std::move(rhs.dnsCryptQuery)), qTag(std::move(rhs.qTag)), tempFailureTTL(rhs.tempFailureTTL), cs(rhs.cs), du(std::move(rhs.du)), cacheKey(rhs.cacheKey), cacheKeyNoECS(rhs.cacheKeyNoECS), cacheKeyUDP(rhs.cacheKeyUDP), origFD(rhs.origFD), backendFD(rhs.backendFD), delayMsec(rhs.delayMsec), qtype(rhs.qtype), qclass(rhs.qclass), origID(rhs.origID), origFlags(rhs.origFlags), cacheFlags(rhs.cacheFlags), protocol(rhs.protocol), ednsAdded(rhs.ednsAdded), ecsAdded(rhs.ecsAdded), skipCache(rhs.skipCache), destHarvested(rhs.destHarvested), dnssecOK(rhs.dnssecOK), useZeroScope(rhs.useZeroScope)
   {
     if (rhs.isInUse()) {
       throw std::runtime_error("Trying to move an in-use IDState");
@@ -140,6 +140,7 @@ struct IDState
     cacheKeyNoECS = rhs.cacheKeyNoECS;
     cacheKeyUDP = rhs.cacheKeyUDP;
     origFD = rhs.origFD;
+    backendFD = rhs.backendFD;
     delayMsec = rhs.delayMsec;
 #ifdef __SANITIZE_THREAD__
     age.store(rhs.age.load());
@@ -249,6 +250,7 @@ struct IDState
   // DoH-only */
   uint32_t cacheKeyUDP{0}; // 4
   int origFD{-1}; // 4
+  int backendFD{-1}; // 4
   int delayMsec{0};
 #ifdef __SANITIZE_THREAD__
   std::atomic<uint16_t> age{0};

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2783,6 +2783,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     DownstreamState::s_randomizeSockets = randomized;
   });
 
+  luaCtx.writeFunction("setRandomizedIdsOverUDP", [](bool randomized) {
+    DownstreamState::s_randomizeIDs = randomized;
+  });
+
 #if defined(HAVE_LIBSSL)
   luaCtx.writeFunction("loadTLSEngine", [client](const std::string& engineName, boost::optional<std::string> defaultString) {
     if (client) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -1279,7 +1279,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
   luaCtx.writeFunction("setTCPSendTimeout", [](int timeout) { g_tcpSendTimeout = timeout; });
 
-  luaCtx.writeFunction("setUDPTimeout", [](int timeout) { g_udpTimeout = timeout; });
+  luaCtx.writeFunction("setUDPTimeout", [](int timeout) { DownstreamState::s_udpTimeout = timeout; });
 
   luaCtx.writeFunction("setMaxUDPOutstanding", [](uint64_t max) {
     if (!g_configurationDone) {

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2779,6 +2779,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     g_socketUDPRecvBuffer = recv;
   });
 
+  luaCtx.writeFunction("setRandomizedOutgoingSockets", [](bool randomized) {
+    DownstreamState::s_randomizeSockets = randomized;
+  });
+
 #if defined(HAVE_LIBSSL)
   luaCtx.writeFunction("loadTLSEngine", [client](const std::string& engineName, boost::optional<std::string> defaultString) {
     if (client) {

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -882,6 +882,7 @@ public:
   bool passCrossProtocolQuery(std::unique_ptr<CrossProtocolQuery>&& cpq);
   int pickSocketForSending();
   void pickSocketsReadyForReceiving(std::vector<int>& ready);
+  IDState* getIDState(unsigned int& id, int64_t& generation);
 
   dnsdist::Protocol getProtocol() const
   {
@@ -898,6 +899,7 @@ public:
   }
 
   static bool s_randomizeSockets;
+  static bool s_randomizeIDs;
 };
 using servers_t =vector<std::shared_ptr<DownstreamState>>;
 

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -132,6 +132,7 @@ dnsdist_SOURCES = \
 	connection-management.hh \
 	credentials.cc credentials.hh \
 	dns.cc dns.hh \
+	dns_random.hh \
 	dnscrypt.cc dnscrypt.hh \
 	dnsdist-backend.cc \
 	dnsdist-cache.cc dnsdist-cache.hh \
@@ -165,6 +166,7 @@ dnsdist_SOURCES = \
 	dnsdist-protobuf.cc dnsdist-protobuf.hh \
 	dnsdist-protocols.cc dnsdist-protocols.hh \
 	dnsdist-proxy-protocol.cc dnsdist-proxy-protocol.hh \
+	dnsdist-random.cc dnsdist-random.hh \
 	dnsdist-rings.cc dnsdist-rings.hh \
 	dnsdist-rules.cc dnsdist-rules.hh \
 	dnsdist-secpoll.cc dnsdist-secpoll.hh \
@@ -248,6 +250,7 @@ testrunner_SOURCES = \
 	dnsdist-nghttp2.cc dnsdist-nghttp2.hh \
 	dnsdist-protocols.cc dnsdist-protocols.hh \
 	dnsdist-proxy-protocol.cc dnsdist-proxy-protocol.hh \
+	dnsdist-random.cc dnsdist-random.hh \
 	dnsdist-rings.cc dnsdist-rings.hh \
 	dnsdist-rules.cc dnsdist-rules.hh \
 	dnsdist-session-cache.cc dnsdist-session-cache.hh \

--- a/pdns/dnsdistdist/dns_random.hh
+++ b/pdns/dnsdistdist/dns_random.hh
@@ -1,0 +1,1 @@
+../dns_random.hh

--- a/pdns/dnsdistdist/dnsdist-healthchecks.cc
+++ b/pdns/dnsdistdist/dnsdist-healthchecks.cc
@@ -24,6 +24,7 @@
 #include "tcpiohandler-mplexer.hh"
 #include "dnswriter.hh"
 #include "dolog.hh"
+#include "dnsdist-random.hh"
 #include "dnsdist-tcp.hh"
 #include "dnsdist-nghttp2.hh"
 #include "dnsdist-session-cache.hh"
@@ -325,7 +326,7 @@ bool queueHealthCheck(std::unique_ptr<FDMultiplexer>& mplexer, const std::shared
 {
   try
   {
-    uint16_t queryID = getRandomDNSID();
+    uint16_t queryID = dnsdist::getRandomDNSID();
     DNSName checkName = ds->checkName;
     uint16_t checkType = ds->checkType.getCode();
     uint16_t checkClass = ds->checkClass;

--- a/pdns/dnsdistdist/dnsdist-random.cc
+++ b/pdns/dnsdistdist/dnsdist-random.cc
@@ -39,7 +39,7 @@ namespace dnsdist
 void initRandom()
 {
 #ifdef HAVE_LIBSODIUM
-  srandom(randombytes_uniform(0xffffffff));
+  srandom(randombytes_random());
 #else
   {
     auto getSeed = []() {

--- a/pdns/dnsdistdist/dnsdist-random.cc
+++ b/pdns/dnsdistdist/dnsdist-random.cc
@@ -1,0 +1,90 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "config.h"
+
+#include <stdexcept>
+#include <sys/time.h>
+#include <unistd.h>
+#ifdef HAVE_LIBSODIUM
+#include <sodium.h>
+#endif /* HAVE_LIBSODIUM */
+#ifdef HAVE_RAND_BYTES
+#include <openssl/rand.h>
+#endif /* HAVE_RAND_BYTES */
+
+#include "dnsdist-random.hh"
+#include "dns_random.hh"
+
+namespace dnsdist
+{
+void initRandom()
+{
+#ifdef HAVE_LIBSODIUM
+  srandom(randombytes_uniform(0xffffffff));
+#else
+  {
+    auto getSeed = []() {
+#ifdef HAVE_RAND_BYTES
+      unsigned int seed;
+      if (RAND_bytes(reinterpret_cast<unsigned char*>(&seed), sizeof(seed)) == 1) {
+        return seed;
+      }
+#endif /* HAVE_RAND_BYTES */
+      struct timeval tv;
+      gettimeofday(&tv, 0);
+      return static_cast<unsigned int>(tv.tv_sec ^ tv.tv_usec ^ getpid());
+    };
+
+    srandom(getSeed());
+  }
+#endif
+}
+
+uint32_t getRandomValue(uint32_t upperBound)
+{
+#ifdef HAVE_LIBSODIUM
+  return randombytes_uniform(upperBound);
+#else /* HAVE_LIBSODIUM */
+  uint32_t result;
+  unsigned int min = pdns::random_minimum_acceptable_value(upperBound);
+#ifdef HAVE_RAND_BYTES
+  do {
+    if (RAND_bytes(reinterpret_cast<unsigned char*>(&result), sizeof(result)) != 1) {
+      throw std::runtime_error("Error getting a random value via RAND_bytes");
+    }
+  } while (result < min);
+
+  return result % upperBound;
+#endif /* HAVE_RAND_BYTES */
+  do {
+    result = random();
+  } while (result < min);
+
+  return result % upperBound;
+#endif /* HAVE_LIBSODIUM */
+}
+
+uint16_t getRandomDNSID()
+{
+  return getRandomValue(65536);
+}
+}

--- a/pdns/dnsdistdist/dnsdist-random.hh
+++ b/pdns/dnsdistdist/dnsdist-random.hh
@@ -1,0 +1,31 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace dnsdist
+{
+void initRandom();
+uint32_t getRandomValue(uint32_t upperBound);
+uint16_t getRandomDNSID();
+}

--- a/pdns/dnsdistdist/dnsdist-secpoll.cc
+++ b/pdns/dnsdistdist/dnsdist-secpoll.cc
@@ -36,6 +36,7 @@
 #include "sstuff.hh"
 
 #include "dnsdist.hh"
+#include "dnsdist-random.hh"
 
 #ifndef PACKAGEVERSION
 #define PACKAGEVERSION PACKAGE_VERSION
@@ -92,7 +93,7 @@ static std::string getSecPollStatus(const std::string& queriedName, int timeout=
   const DNSName& sentName = DNSName(queriedName);
   std::vector<uint8_t> packet;
   DNSPacketWriter pw(packet, sentName, QType::TXT);
-  pw.getHeader()->id = getRandomDNSID();
+  pw.getHeader()->id = dnsdist::getRandomDNSID();
   pw.getHeader()->rd = 1;
 
   const auto& resolversForStub = getResolvers("/etc/resolv.conf");

--- a/pdns/dnsdistdist/docs/quickstart.rst
+++ b/pdns/dnsdistdist/docs/quickstart.rst
@@ -118,6 +118,18 @@ Adding network ranges to the :term:`ACL` is done with the :func:`setACL` and :fu
   setACL({'192.0.2.0/28', '2001:db8:1::/56'}) -- Set the ACL to only allow these subnets
   addACL('2001:db8:2::/56')                   -- Add this subnet to the existing ACL
 
+Securing the path to the backend
+--------------------------------
+
+dnsdist has always been designed as a load-balancer placed in front of authoritative or recursive servers,
+assuming that the network path between dnsdist and these servers is trusted.
+
+If dnsdist is instead intended to be deployed in such a way that the path to its backend is not secure, the
+UDP protocol should not be used, and 'TCP-only', DNS over TLS and DNS over HTTPS protocols used instead, as
+supported since 1.7.0.
+
+For more details, please look at the :doc:`../guides/downstreams` guide.
+
 More Information
 ----------------
 

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -131,12 +131,14 @@ Tuning related functions
   Setting this parameter to true (default is false) will randomize the IDs in outgoing UDP queries, at a small performance cost, ignoring the :func:`setMaxUDPOutstanding`
   value. This is only useful if the path between dnsdist and the backend is not trusted and the 'TCP-only', DNS over TLS or DNS over HTTPS transports cannot be used.
   See also :func:`setRandomizedOutgoingSockets`.
+  The default is to use a linearly increasing counter from 0 to 65535, wrapping back to 0 when necessary.
 
 .. function:: setRandomizedOutgoingSockets(val):
 
   .. versionadded:: 1.8.0
 
   Setting this parameter to true (default is false) will randomize the outgoing socket used when forwarding a query to a backend.
+  The default is to use a round-robin mechanism to select the outgoing socket.
   This requires configuring the backend to use more than one outgoing socket via the ``sockets`` parameter of :func:`newServer`
   to be of any use, and only makes sense if the path between dnsdist and the backend is not trusted and the 'TCP-only', DNS over
   TLS or DNS over HTTPS transports cannot be used.

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -128,9 +128,8 @@ Tuning related functions
 
   .. versionadded:: 1.8.0
 
-  Setting this parameter to true (default is false) will randomize the IDs in outgoing UDP queries, at a small performance cost. :func:`setMaxUDPOutstanding`
-  should be set at its highest possible value (default since 1.4.0) to make that setting fully efficient. This is only useful if the path between dnsdist
-  and the backend is not trusted and the 'TCP-only', DNS over TLS or DNS over HTTPS transports cannot be used.
+  Setting this parameter to true (default is false) will randomize the IDs in outgoing UDP queries, at a small performance cost, ignoring the :func:`setMaxUDPOutstanding`
+  value. This is only useful if the path between dnsdist and the backend is not trusted and the 'TCP-only', DNS over TLS or DNS over HTTPS transports cannot be used.
   See also :func:`setRandomizedOutgoingSockets`.
 
 .. function:: setRandomizedOutgoingSockets(val):

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -124,6 +124,25 @@ Tuning related functions
   :param int max: The maximum time in seconds.
 
 
+.. function:: setRandomizedIdsOverUDP(val)
+
+  .. versionadded:: 1.8.0
+
+  Setting this parameter to true (default is false) will randomize the IDs in outgoing UDPqueries, at a small performance cost. :func:`setMaxUDPOutstanding`
+  should be set at its highest possible value (default since 1.4.0) to make that setting fully efficient. This is only useful if the path between dnsdist
+  and the backend is not trusted and the 'TCP-only', DNS over TLS or DNS over HTTPS transports cannot be used.
+  See also :func:`setRandomizedOutgoingSockets`.
+
+.. function:: setRandomizedOutgoingSockets(val):
+
+  .. versionadded:: 1.8.0
+
+  Setting this parameter to true (default is false) will randomize the outgoing socket used when forwarding a query to a backend.
+  This requires configuring the backend to use more than one outgoing socket via the ``sockets`` parameter of :func:`newServer`
+  to be of any use, and only makes sense if the path between dnsdist and the backend is not trusted and the 'TCP-only', DNS over
+  TLS or DNS over HTTPS transports cannot be used.
+  See also :func:`setRandomizedIdsOverUDP`.
+
 .. function:: setTCPInternalPipeBufferSize(size)
 
   .. versionadded:: 1.6.0

--- a/pdns/dnsdistdist/docs/reference/tuning.rst
+++ b/pdns/dnsdistdist/docs/reference/tuning.rst
@@ -128,7 +128,7 @@ Tuning related functions
 
   .. versionadded:: 1.8.0
 
-  Setting this parameter to true (default is false) will randomize the IDs in outgoing UDPqueries, at a small performance cost. :func:`setMaxUDPOutstanding`
+  Setting this parameter to true (default is false) will randomize the IDs in outgoing UDP queries, at a small performance cost. :func:`setMaxUDPOutstanding`
   should be set at its highest possible value (default since 1.4.0) to make that setting fully efficient. This is only useful if the path between dnsdist
   and the backend is not trusted and the 'TCP-only', DNS over TLS or DNS over HTTPS transports cannot be used.
   See also :func:`setRandomizedOutgoingSockets`.

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -724,7 +724,8 @@ static void processDOHQuery(DOHUnitUniquePtr&& du)
       }
     }
 
-    int fd = pickBackendSocketForSending(du->downstream);
+    int fd = du->downstream->pickSocketForSending();
+    ids->backendFD = fd;
     try {
       /* you can't touch du after this line, unless the call returned a non-negative value,
          because it might already have been freed */

--- a/pdns/dnsdistdist/doh.cc
+++ b/pdns/dnsdistdist/doh.cc
@@ -661,33 +661,9 @@ static void processDOHQuery(DOHUnitUniquePtr&& du)
     }
 
     ComboAddress dest = du->ids.origDest;
-    unsigned int idOffset = (du->downstream->idOffset++) % du->downstream->idStates.size();
-    IDState* ids = &du->downstream->idStates[idOffset];
-    ids->age = 0;
-    DOHUnit* oldDU = nullptr;
-    if (ids->isInUse()) {
-      /* that means that the state was in use, possibly with an allocated
-         DOHUnit that we will need to handle, but we can't touch it before
-         confirming that we now own this state */
-      oldDU = ids->du;
-    }
-
-    /* we atomically replace the value, we now own this state */
-    int64_t generation = ids->generation++;
-    if (!ids->markAsUsed(generation)) {
-      /* the state was not in use.
-         we reset 'oldDU' because it might have still been in use when we read it. */
-      oldDU = nullptr;
-      ++du->downstream->outstanding;
-    }
-    else {
-      ids->du = nullptr;
-      /* we are reusing a state, no change in outstanding but if there was an existing DOHUnit we need
-         to handle it because it's about to be overwritten. */
-      ++du->downstream->reuseds;
-      ++g_stats.downstreamTimeouts;
-      handleDOHTimeout(DOHUnitUniquePtr(oldDU, DOHUnit::release));
-    }
+    unsigned int idOffset = 0;
+    int64_t generation;
+    IDState* ids = du->downstream->getIDState(idOffset, generation);
 
     ids->origFD = 0;
     /* increase the ref count since we are about to store the pointer */

--- a/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistlbpolicies_cc.cc
@@ -64,6 +64,10 @@ void DOHUnit::setHTTPResponse(uint16_t statusCode, PacketBuffer&& body_, const s
 }
 #endif /* HAVE_DNS_OVER_HTTPS */
 
+void handleDOHTimeout(DOHUnitUniquePtr&& oldDU)
+{
+}
+
 std::string DNSQuestion::getTrailingData() const
 {
   return "";


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This PRs add two options that can be used to reduce the risk of UDP exchanges when the path between dnsdist and its backend is not trusted:
- `setRandomizedIdsOverUDP()` allows picking up a random ID
- `setRandomizedOutgoingSockets()` allows selecting a random outgoing socket if several are available, effectively improving the entropy of the source port.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
