### PR TITLE
Update protozero to 1.7.1

### DIFF
--- a/ext/protozero/CHANGELOG.md
+++ b/ext/protozero/CHANGELOG.md
@@ -2,8 +2,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-This project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [unreleased] -
 
@@ -12,6 +12,24 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Fixed
+
+
+## [1.7.1] - 2022-01-10
+
+### Changed
+
+- Don't build tests if the standard CMake `BUILD_TESTING` variable is set to
+  off.
+- Now needs CMake 3.5.0 or greater.
+- Update included catch2 framework to current version v2.13.8.
+- Only enable clang-tidy make target if protobuf was found.
+- Allow setting C++ version to compile with in CMake config.
+
+### Fixed
+
+- Fixes undefined behaviour in `float` and `double` byteswap.
+- Add missing includes of "config.hpp".
+- Avoid narrowing conversion by doing an explicit `static_cast`.
 
 
 ## [1.7.0] - 2020-06-08
@@ -381,7 +399,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Make pbf reader and writer code endianess-aware.
 
 
-[unreleased]: https://github.com/osmcode/libosmium/compare/v1.7.0...HEAD
+[unreleased]: https://github.com/osmcode/libosmium/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/osmcode/libosmium/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/osmcode/libosmium/compare/v1.6.8...v1.7.0
 [1.6.8]: https://github.com/osmcode/libosmium/compare/v1.6.7...v1.6.8
 [1.6.7]: https://github.com/osmcode/libosmium/compare/v1.6.6...v1.6.7

--- a/ext/protozero/include/protozero/buffer_string.hpp
+++ b/ext/protozero/include/protozero/buffer_string.hpp
@@ -18,6 +18,7 @@ documentation.
  */
 
 #include "buffer_tmpl.hpp"
+#include "config.hpp"
 
 #include <cstddef>
 #include <iterator>
@@ -56,7 +57,8 @@ struct buffer_customization<std::string> {
         protozero_assert(from <= buffer->size());
         protozero_assert(to <= buffer->size());
         protozero_assert(from <= to);
-        buffer->erase(std::next(buffer->begin(), from), std::next(buffer->begin(), to));
+        buffer->erase(std::next(buffer->begin(), static_cast<std::string::iterator::difference_type>(from)),
+                      std::next(buffer->begin(), static_cast<std::string::iterator::difference_type>(to)));
     }
 
     static char* at_pos(std::string* buffer, std::size_t pos) {

--- a/ext/protozero/include/protozero/buffer_vector.hpp
+++ b/ext/protozero/include/protozero/buffer_vector.hpp
@@ -18,6 +18,7 @@ documentation.
  */
 
 #include "buffer_tmpl.hpp"
+#include "config.hpp"
 
 #include <cstddef>
 #include <iterator>
@@ -56,7 +57,8 @@ struct buffer_customization<std::vector<char>> {
         protozero_assert(from <= buffer->size());
         protozero_assert(to <= buffer->size());
         protozero_assert(from <= to);
-        buffer->erase(std::next(buffer->begin(), from), std::next(buffer->begin(), to));
+        buffer->erase(std::next(buffer->begin(), static_cast<std::string::iterator::difference_type>(from)),
+                      std::next(buffer->begin(), static_cast<std::string::iterator::difference_type>(to)));
     }
 
     static char* at_pos(std::vector<char>* buffer, std::size_t pos) {

--- a/ext/protozero/include/protozero/byteswap.hpp
+++ b/ext/protozero/include/protozero/byteswap.hpp
@@ -19,6 +19,7 @@ documentation.
 #include "config.hpp"
 
 #include <cstdint>
+#include <cstring>
 
 namespace protozero {
 namespace detail {
@@ -75,14 +76,22 @@ inline void byteswap_inplace(int64_t* ptr) noexcept {
 
 /// byteswap the data pointed to by ptr in-place.
 inline void byteswap_inplace(float* ptr) noexcept {
-    auto* bptr = reinterpret_cast<uint32_t*>(ptr);
-    *bptr = detail::byteswap_impl(*bptr);
+    static_assert(sizeof(float) == 4, "Expecting four byte float");
+
+    uint32_t tmp = 0;
+    std::memcpy(&tmp, ptr, 4);
+    tmp = detail::byteswap_impl(tmp); // uint32 overload
+    std::memcpy(ptr, &tmp, 4);
 }
 
 /// byteswap the data pointed to by ptr in-place.
 inline void byteswap_inplace(double* ptr) noexcept {
-    auto* bptr = reinterpret_cast<uint64_t*>(ptr);
-    *bptr = detail::byteswap_impl(*bptr);
+    static_assert(sizeof(double) == 8, "Expecting eight byte double");
+
+    uint64_t tmp = 0;
+    std::memcpy(&tmp, ptr, 8);
+    tmp = detail::byteswap_impl(tmp); // uint64 overload
+    std::memcpy(ptr, &tmp, 8);
 }
 
 namespace detail {

--- a/ext/protozero/include/protozero/version.hpp
+++ b/ext/protozero/include/protozero/version.hpp
@@ -23,12 +23,12 @@ documentation.
 #define PROTOZERO_VERSION_MINOR 7
 
 /// The patch number
-#define PROTOZERO_VERSION_PATCH 0
+#define PROTOZERO_VERSION_PATCH 1
 
 /// The complete version number
 #define PROTOZERO_VERSION_CODE (PROTOZERO_VERSION_MAJOR * 10000 + PROTOZERO_VERSION_MINOR * 100 + PROTOZERO_VERSION_PATCH)
 
 /// Version number as string
-#define PROTOZERO_VERSION_STRING "1.7.0"
+#define PROTOZERO_VERSION_STRING "1.7.1"
 
 #endif // PROTOZERO_VERSION_HPP


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Changes:
- Fixes undefined behaviour in `float` and `double` byteswap.
- Add missing includes of "config.hpp".
- Avoid narrowing conversion by doing an explicit `static_cast`.

As far as I can tell these changes do not need to be backported.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
