### PR TITLE
rec: servfail.nl changed setup

### DIFF
--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -119,7 +119,7 @@ extended-resolution-errors=yes
             self.assertEqual(res.edns, 0)
             self.assertEqual(len(res.options), 1)
             self.assertEqual(res.options[0].otype, 15)
-            self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(7, b''))
+            self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(6, b''))
 
     def testBogus(self):
         qname = 'bogussig.ok.bad-dnssec.wb.sidnlabs.nl.'


### PR DESCRIPTION
This was prompted by a change in one of the external tests we do.
servfail.nl/AAAA should maybe return edns error code 9 (DNSKEY Missing), but it is not clear 1) if that is correct and 2) how to do that in the current code

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [X] added or modified unit test(s)
