### PR TITLE
dnsdist: Defer the actual allocation of the ring buffer entries

### DIFF
--- a/pdns/dnsdist-rings.cc
+++ b/pdns/dnsdist-rings.cc
@@ -24,6 +24,49 @@
 
 #include "dnsdist-rings.hh"
 
+void Rings::setCapacity(size_t newCapacity, size_t numberOfShards)
+{
+  if (d_initialized) {
+    throw std::runtime_error("Rings::setCapacity() should not be called once the rings have been initialized");
+  }
+  d_capacity = newCapacity;
+  d_numberOfShards = numberOfShards;
+}
+
+void Rings::init()
+{
+  if (d_initialized) {
+    throw std::runtime_error("Rings::init() should only be called once");
+  }
+  d_initialized = true;
+
+  if (d_numberOfShards <= 1) {
+    d_nbLockTries = 0;
+  }
+
+  d_shards.resize(d_numberOfShards);
+
+  /* resize all the rings */
+  for (auto& shard : d_shards) {
+    shard = std::make_unique<Shard>();
+    shard->queryRing.lock()->set_capacity(d_capacity / d_numberOfShards);
+    shard->respRing.lock()->set_capacity(d_capacity / d_numberOfShards);
+  }
+
+  /* we just recreated the shards so they are now empty */
+  d_nbQueryEntries = 0;
+  d_nbResponseEntries = 0;
+}
+
+void Rings::setNumberOfLockRetries(size_t retries)
+{
+  if (d_numberOfShards <= 1) {
+    d_nbLockTries = 0;
+  } else {
+    d_nbLockTries = retries;
+  }
+}
+
 size_t Rings::numDistinctRequestors()
 {
   std::set<ComboAddress, ComboAddress::addressOnlyLessThan> s;

--- a/pdns/dnsdist-rings.cc
+++ b/pdns/dnsdist-rings.cc
@@ -35,10 +35,9 @@ void Rings::setCapacity(size_t newCapacity, size_t numberOfShards)
 
 void Rings::init()
 {
-  if (d_initialized) {
+  if (d_initialized.exchange(true)) {
     throw std::runtime_error("Rings::init() should only be called once");
   }
-  d_initialized = true;
 
   if (d_numberOfShards <= 1) {
     d_nbLockTries = 0;

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -2543,6 +2543,8 @@ int main(int argc, char** argv)
 
     g_configurationDone = true;
 
+    g_rings.init();
+
     for(auto& frontend : g_frontends) {
       setUpLocalBind(frontend);
 

--- a/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
+++ b/pdns/dnsdistdist/test-dnsdistdynblocks_hh.cc
@@ -36,6 +36,9 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_QueryRate) {
   const auto action = DNSAction::Action::Drop;
   const std::string reason = "Exceeded query rate";
 
+  g_rings.reset();
+  g_rings.init();
+
   DynBlockRulesGroup dbrg;
   dbrg.setQuiet(true);
 
@@ -177,6 +180,9 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_QueryRate_RangeV6) {
   dbrg.setQuiet(true);
   dbrg.setMasks(32, 64, 0);
 
+  g_rings.reset();
+  g_rings.init();
+
   /* block above 50 qps for numberOfSeconds seconds, no warning */
   dbrg.setQueryRate(50, 0, numberOfSeconds, reason, blockDuration, action);
 
@@ -276,6 +282,9 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_QueryRate_V4Ports) {
   dbrg.setQuiet(true);
   /* split v4 by ports using a  /2 (0 - 16383, 16384 - 32767, 32768 - 49151, 49152 - 65535) */
   dbrg.setMasks(32, 128, 2);
+
+  g_rings.reset();
+  g_rings.init();
 
   /* block above 50 qps for numberOfSeconds seconds, no warning */
   dbrg.setQueryRate(50, 0, numberOfSeconds, reason, blockDuration, action);
@@ -401,15 +410,14 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_QueryRate_responses) {
   NetmaskTree<DynBlock, AddressAndPortRange> emptyNMG;
 
   /* 100k entries, one shard */
+  g_rings.reset();
   g_rings.setCapacity(1000000, 1);
+  g_rings.init();
 
   size_t numberOfSeconds = 10;
   size_t blockDuration = 60;
   const auto action = DNSAction::Action::Drop;
   const std::string reason = "Exceeded query rate";
-
-  /* 100k entries, one shard */
-  g_rings.setCapacity(1000000, 1);
 
   DynBlockRulesGroup dbrg;
   dbrg.setQuiet(true);
@@ -465,6 +473,8 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_QTypeRate) {
 
   DynBlockRulesGroup dbrg;
   dbrg.setQuiet(true);
+  g_rings.reset();
+  g_rings.init();
 
   /* block above 50 qps for numberOfSeconds seconds, no warning */
   dbrg.setQTypeRate(QType::AAAA, 50, 0, numberOfSeconds, reason, blockDuration, action);
@@ -650,6 +660,9 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_RCodeRatio) {
   DynBlockRulesGroup dbrg;
   dbrg.setQuiet(true);
 
+  g_rings.reset();
+  g_rings.init();
+
   /* block above 0.2 ServFail/Total ratio over numberOfSeconds seconds, no warning, minimum number of queries should be at least 51 */
   dbrg.setRCodeRatio(rcode, 0.2, 0, numberOfSeconds, reason, blockDuration, action, 51);
 
@@ -769,6 +782,9 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_ResponseByteRate) {
   DynBlockRulesGroup dbrg;
   dbrg.setQuiet(true);
 
+  g_rings.reset();
+  g_rings.init();
+
   /* block above 10kB/s for numberOfSeconds seconds, no warning */
   dbrg.setResponseByteRate(10000, 0, numberOfSeconds, reason, blockDuration, action);
 
@@ -839,6 +855,9 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_Warning) {
 
   DynBlockRulesGroup dbrg;
   dbrg.setQuiet(true);
+
+  g_rings.reset();
+  g_rings.init();
 
   /* warn above 20 qps for numberOfSeconds seconds, block above 50 qps */
   dbrg.setQueryRate(50, 20, numberOfSeconds, reason, blockDuration, action);
@@ -1007,6 +1026,9 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesGroup_Ranges) {
   /* block above 50 qps for numberOfSeconds seconds, no warning */
   dbrg.setQueryRate(50, 0, numberOfSeconds, reason, blockDuration, action);
 
+  g_rings.reset();
+  g_rings.init();
+
   {
     /* insert just above 50 qps from the two clients in the last 10s
        this should trigger the rule for the first one but not the second one */
@@ -1054,8 +1076,10 @@ BOOST_AUTO_TEST_CASE(test_DynBlockRulesMetricsCache_GetTopN) {
   const auto action = DNSAction::Action::Drop;
   const std::string reason = "Exceeded query rate";
 
+  g_rings.reset();
   /* 10M entries, only one shard */
   g_rings.setCapacity(10000000, 1);
+  g_rings.init();
 
   {
     DynBlockRulesGroup dbrg;

--- a/pdns/dnsdistdist/test-dnsdistrings_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrings_cc.cc
@@ -13,6 +13,7 @@ BOOST_AUTO_TEST_SUITE(dnsdistrings_cc)
 static void test_ring(size_t maxEntries, size_t numberOfShards, size_t nbLockTries)
 {
   Rings rings(maxEntries, numberOfShards, nbLockTries);
+  rings.init();
   size_t entriesPerShard = maxEntries / numberOfShards;
 
   BOOST_CHECK_EQUAL(rings.getNumberOfShards(), numberOfShards);
@@ -205,6 +206,7 @@ BOOST_AUTO_TEST_CASE(test_Rings_Threaded) {
   dnsdist::Protocol outgoingProtocol = dnsdist::Protocol::DoUDP;
 
   Rings rings(numberOfEntries, numberOfShards, lockAttempts, true);
+  rings.init();
 #if defined(DNSDIST_RINGS_WITH_MACADDRESS)
   Rings::Query query({requestor, qname, now, dh, size, qtype, protocol, "", false});
 #else


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It is a bit cumbersome to have to call `Rings::init()` when we are ready, but it prevents allocating the default number of entries, 10k, which is quite a lot for small setups. Of course the memory was released once the configuration had been parsed, but it might be too late in some cases, and we would end up with a bigger reported memory usage than our actual one since heap shrinkage seldom happens.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
