### PR TITLE
dnsdist: Add a parameter to PoolAction to keep processing rules

### DIFF
--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -833,7 +833,9 @@ bool processRulesResult(const DNSAction::Action& action, DNSQuestion& dq, std::s
     return true;
     break;
   case DNSAction::Action::Pool:
-    dq.poolname=ruleresult;
+    /* we need to keep this because a custom Lua action can return
+       DNSAction.Spoof, 'poolname' */
+    dq.poolname = ruleresult;
     return true;
     break;
   case DNSAction::Action::NoRecurse:

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1204,11 +1204,15 @@ The following actions exist.
   Strip RD bit from the question, let it go through.
   Subsequent rules are processed after this action.
 
-.. function:: PoolAction(poolname)
+.. function:: PoolAction(poolname [, stop])
 
-  Send the packet into the specified pool.
+  .. versionchanged:: 1.8.0
+    Added the ``stop`` optional parameter.
+
+  Send the packet into the specified pool. If ``stop`` is set to false, subsequent rules will be processed after this action.
 
   :param string poolname: The name of the pool
+  :param bool stop: Whether to stop processing rules after this action. Default is true, meaning the remaining rules will not be processed.
 
 .. function:: QPSAction(maxqps)
 

--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1223,11 +1223,15 @@ The following actions exist.
 
 .. function:: QPSPoolAction(maxqps, poolname)
 
-  Send the packet into the specified pool only if it does not exceed the ``maxqps`` queries per second limits.
+  .. versionchanged:: 1.8.0
+    Added the ``stop`` optional parameter.
+
+  Send the packet into the specified pool only if it does not exceed the ``maxqps`` queries per second limits. If ``stop`` is set to false, subsequent rules will be processed after this action.
   Letting the subsequent rules apply otherwise.
 
   :param int maxqps: The QPS limit for that pool
   :param string poolname: The name of the pool
+  :param bool stop: Whether to stop processing rules after this action. Default is true, meaning the remaining rules will not be processed.
 
 .. function:: RCodeAction(rcode [, options])
 

--- a/regression-tests.dnsdist/test_RulesActions.py
+++ b/regression-tests.dnsdist/test_RulesActions.py
@@ -1334,10 +1334,11 @@ class TestAdvancedContinueAction(DNSDistTest):
         for method in ("sendUDPQuery", "sendTCPQuery"):
             sender = getattr(self, method)
             (receivedQuery, receivedResponse) = sender(query, response)
+            expectedQuery.id = receivedQuery.id
             self.assertEqual(receivedQuery, expectedQuery)
             self.assertEqual(receivedResponse, expectedResponse)
 
-    def testNoContinue(self):
+    def testContinue(self):
         """
         Advanced: Query routed to pool, ContinueAction() should not stop the processing
         """


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It seems silly not being able to apply other rules after that one.

Could use a regression test.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
