### PR TITLE
rec: Rename static, global and thread_local vars to follow naming conventions

### DIFF
--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1160,8 +1160,6 @@ static StatsMap toRPZStatsMap(const string& name, LockGuarded<std::unordered_map
   return entries;
 }
 
-extern ResponseStats g_rs;
-
 static void registerAllStats1()
 {
   addGetStat("questions", &g_stats.qcounter);
@@ -1445,12 +1443,10 @@ void registerAllStats()
 void doExitGeneric(bool nicely)
 {
   g_log << Logger::Error << "Exiting on user request" << endl;
-  extern RecursorControlChannel s_rcc;
-  s_rcc.~RecursorControlChannel();
+  g_rcc.~RecursorControlChannel();
 
-  extern string s_pidfname;
-  if (!s_pidfname.empty())
-    unlink(s_pidfname.c_str()); // we can at least try..
+  if (!g_pidfname.empty())
+    unlink(g_pidfname.c_str()); // we can at least try..
   if (nicely) {
     RecursorControlChannel::stop = true;
   }

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -33,9 +33,7 @@ int g_tcpTimeout;
 bool g_anyToTcp;
 
 uint16_t TCPConnection::s_maxInFlight;
-std::atomic<uint32_t> TCPConnection::s_currentConnections;
 
-typedef map<ComboAddress, uint32_t, ComboAddress::addressOnlyLessThan> tcpClientCounts_t;
 thread_local std::unique_ptr<tcpClientCounts_t> t_tcpClientCounts;
 
 static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var);
@@ -48,6 +46,8 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var);
 #else
 #define TCPLOG(pid, x)
 #endif
+
+std::atomic<uint32_t> TCPConnection::s_currentConnections;
 
 TCPConnection::TCPConnection(int fd, const ComboAddress& addr) :
   data(2, 0), d_remote(addr), d_fd(fd)


### PR DESCRIPTION
The `thread_local` vars in `houseKeeping()` should be reviewed, as some of them are only relevant for the handler thread, so they do not need to be `thread_local`.

This PR only does mechanical renaming.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
