### PR TITLE
doc: remove auth-can-lower-ttl

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -192,19 +192,6 @@ Disallow data modification through the REST API when set.
 
 Location of the server logfile (used by the REST API).
 
-.. _setting-auth-can-lower-ttl:
-
-``auth-can-lower-ttl``
-----------------------
--  Boolean
--  Default: no
-
-Authoritative zones can transmit a TTL value that is lower than that specified in the parent zone.
-This is called a 'delegation inconsistency'.
-To follow :rfc:`RFC 2181 section 5.2<2181#section-5.2>` and :rfc:`5.4 <2181#section-5.4>` to the letter, enable this feature.
-This will mean a slight deterioration of performance, and it will not solve any problems, but does make the recursor more standards compliant.
-Not recommended unless you have to tick an 'RFC 2181 compliant' box.
-
 .. _setting-auth-zones:
 
 ``auth-zones``


### PR DESCRIPTION
### Short description
This wasn't around as of 4.0 - it landed in this file in 223bb49ef87feee34af9d1076b55bee81a38b8bc
but the removal notice was already included at that time.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
