### PR TITLE
dnsdist: add support to store mac address in query rings

### DIFF
--- a/pdns/dnsdistdist/test-dnsdistrings_cc.cc
+++ b/pdns/dnsdistdist/test-dnsdistrings_cc.cc
@@ -205,7 +205,11 @@ BOOST_AUTO_TEST_CASE(test_Rings_Threaded) {
   dnsdist::Protocol outgoingProtocol = dnsdist::Protocol::DoUDP;
 
   Rings rings(numberOfEntries, numberOfShards, lockAttempts, true);
+#if defined(DNSDIST_RINGS_WITH_MACADDRESS)
+  Rings::Query query({requestor, qname, now, dh, size, qtype, protocol, "", false});
+#else
   Rings::Query query({requestor, qname, now, dh, size, qtype, protocol});
+#endif
   Rings::Response response({requestor, server, qname, now, dh, latency, size, qtype, outgoingProtocol});
 
   std::atomic<bool> done(false);

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -577,6 +577,7 @@ uint64_t getCPUTimeSystem(const std::string&);
 uint64_t getCPUIOWait(const std::string&);
 uint64_t getCPUSteal(const std::string&);
 std::string getMACAddress(const ComboAddress& ca);
+int getMACAddress(const ComboAddress& ca, char* dest, size_t len);
 
 template<typename T>
 const T& defTer(const T& a, const T& b)


### PR DESCRIPTION
### Short description
This PR adds support for storing mac address of the requestor in query rings (only when compiled with `-DDNSDIST_RINGS_WITH_MACADDRESS`).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
