### PR TITLE
auth-4.6.x: Stop using the now deprecated and useless std::binary_function

### DIFF
--- a/pdns/dnsname.hh
+++ b/pdns/dnsname.hh
@@ -237,7 +237,7 @@ inline bool DNSName::canonCompare(const DNSName& rhs) const
 }
 
 
-struct CanonDNSNameCompare: public std::binary_function<DNSName, DNSName, bool>
+struct CanonDNSNameCompare
 {
   bool operator()(const DNSName&a, const DNSName& b) const
   {

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -137,7 +137,7 @@ private:
 
 
 
-struct CanonicalCompare: public std::binary_function<string, string, bool>  
+struct CanonicalCompare
 {
   bool operator()(const std::string& a, const std::string& b) {
     std::vector<std::string> avect, bvect;

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -143,7 +143,7 @@ union ComboAddress {
     }
   };
 
-  struct addressOnlyLessThan: public std::binary_function<ComboAddress, ComboAddress, bool>
+  struct addressOnlyLessThan
   {
     bool operator()(const ComboAddress& a, const ComboAddress& b) const
     {
@@ -158,7 +158,7 @@ union ComboAddress {
     }
   };
 
-  struct addressOnlyEqual: public std::binary_function<ComboAddress, ComboAddress, bool>
+  struct addressOnlyEqual
   {
     bool operator()(const ComboAddress& a, const ComboAddress& b) const
     {

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -381,7 +381,7 @@ typedef unsigned long AtomicCounterInner;
 typedef std::atomic<AtomicCounterInner> AtomicCounter ;
 
 // FIXME400 this should probably go? 
-struct CIStringCompare: public std::binary_function<string, string, bool>
+struct CIStringCompare
 {
   bool operator()(const string& a, const string& b) const
   {
@@ -405,7 +405,7 @@ struct CIStringComparePOSIX
    }
 };
 
-struct CIStringPairCompare: public std::binary_function<pair<string, uint16_t>, pair<string,uint16_t>, bool>
+struct CIStringPairCompare
 {
   bool operator()(const pair<string, uint16_t>& a, const pair<string, uint16_t>& b) const
   {


### PR DESCRIPTION
### Short description

It is no longer needed since the types can now be automatically
deduced, has been deprecated in C++11 and removed in C++17.

backport of #11197


<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master