### PR TITLE
auth lmdb: add a UUID to newly created databases

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -34,11 +34,13 @@
 #include "pdns/version.hh"
 #include "pdns/arguments.hh"
 #include "pdns/lock.hh"
+#include "pdns/uuid-utils.hh"
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/string.hpp>
 #include <boost/serialization/utility.hpp>
+#include <boost/uuid/uuid_serialize.hpp>
 
 #include <boost/iostreams/device/back_inserter.hpp>
 
@@ -113,6 +115,13 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
       else {
         s_shards = atoi(getArg("shards").c_str());
         txn->put(pdnsdbi, "shards", s_shards);
+      }
+
+      MDBOutVal gotuuid;
+      if (txn->get(pdnsdbi, "uuid", gotuuid)) {
+        const auto uuid = getUniqueID();
+        const string uuids(uuid.begin(), uuid.end());
+        txn->put(pdnsdbi, "uuid", uuids);
       }
 
       txn->commit();

--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -378,6 +378,7 @@ pdnsutil_SOURCES = \
 	tsigutils.hh tsigutils.cc \
 	ueberbackend.cc \
 	unix_utility.cc \
+	uuid-utils.hh uuid-utils.cc \
 	zonemd.hh zonemd.cc \
 	zoneparser-tng.cc
 


### PR DESCRIPTION
### Short description
This allows external software to detect when a database has been fully replaced.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master