### PR TITLE
Rec: thread refactoring

### DIFF
--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -422,8 +422,8 @@ void RecursorLua4::postPrepareContext()
     });
 
   d_lw->writeFunction("getRecursorThreadId", []() {
-      return getRecursorThreadId();
-    });
+    return RecThreadInfo::id();
+  });
 
   d_lw->writeFunction("sendCustomSNMPTrap", [](const std::string& str) {
       if (g_snmpAgent) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -1756,7 +1756,7 @@ void requestWipeCaches(const DNSName& canon)
   ThreadMSG* tmsg = new ThreadMSG();
   tmsg->func = [=] { return pleaseWipeCaches(canon, true, 0xffff); };
   tmsg->wantAnswer = false;
-  if (write(g_threadInfos[0].pipes.writeToThread, &tmsg, sizeof(tmsg)) != sizeof(tmsg)) {
+  if (write(RecThreadInfo::info(0).pipes.writeToThread, &tmsg, sizeof(tmsg)) != sizeof(tmsg)) {
     delete tmsg;
 
     unixDie("write to thread pipe returned wrong size or error");
@@ -2322,7 +2322,7 @@ void makeUDPServerSockets(deferredAdd_t& deferredAdds)
 
 static bool trySendingQueryToWorker(unsigned int target, ThreadMSG* tmsg)
 {
-  auto& targetInfo = g_threadInfos[target];
+  auto& targetInfo = RecThreadInfo::info(target);
   if (!targetInfo.isWorker()) {
     g_log << Logger::Error << "distributeAsyncFunction() tried to assign a query to a non-worker thread" << endl;
     _exit(1);
@@ -2353,7 +2353,7 @@ static bool trySendingQueryToWorker(unsigned int target, ThreadMSG* tmsg)
 
 static unsigned int getWorkerLoad(size_t workerIdx)
 {
-  const auto mt = g_threadInfos[/* skip handler */ 1 + RecThreadInfo::s_numDistributorThreads + workerIdx].mt;
+  const auto mt = RecThreadInfo::info(/* skip handler */ 1 + RecThreadInfo::s_numDistributorThreads + workerIdx).mt;
   if (mt != nullptr) {
     return mt->numProcesses();
   }

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -43,7 +43,6 @@
 #endif /* NOD_ENABLED */
 
 thread_local std::shared_ptr<RecursorLua4> t_pdl;
-thread_local unsigned int t_id = 0;
 thread_local std::shared_ptr<Regex> t_traceRegex;
 thread_local std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>> t_protobufServers{nullptr};
 thread_local std::shared_ptr<std::vector<std::unique_ptr<RemoteLogger>>> t_outgoingProtobufServers{nullptr};
@@ -964,7 +963,7 @@ void startDoResolve(void* p)
     }
 
     if (!g_quiet || tracedQuery) {
-      g_log << Logger::Warning << t_id << " [" << MT->getTid() << "/" << MT->numProcesses() << "] " << (dc->d_tcp ? "TCP " : "") << "question for '" << dc->d_mdp.d_qname << "|"
+      g_log << Logger::Warning << RecThreadInfo::id() << " [" << MT->getTid() << "/" << MT->numProcesses() << "] " << (dc->d_tcp ? "TCP " : "") << "question for '" << dc->d_mdp.d_qname << "|"
             << QType(dc->d_mdp.d_qtype) << "' from " << dc->getRemote();
       if (!dc->d_ednssubnet.source.empty()) {
         g_log << " (ecs " << dc->d_ednssubnet.source.toString() << ")";
@@ -1555,7 +1554,7 @@ void startDoResolve(void* p)
     // Now it always uses an integral number of microseconds, except for averages, which use doubles
     uint64_t spentUsec = uSec(sr.getNow() - dc->d_now);
     if (!g_quiet) {
-      g_log << Logger::Error << t_id << " [" << MT->getTid() << "/" << MT->numProcesses() << "] answer to " << (dc->d_mdp.d_header.rd ? "" : "non-rd ") << "question '" << dc->d_mdp.d_qname << "|" << DNSRecordContent::NumberToType(dc->d_mdp.d_qtype);
+      g_log << Logger::Error << RecThreadInfo::id() << " [" << MT->getTid() << "/" << MT->numProcesses() << "] answer to " << (dc->d_mdp.d_header.rd ? "" : "non-rd ") << "question '" << dc->d_mdp.d_qname << "|" << DNSRecordContent::NumberToType(dc->d_mdp.d_qtype);
       g_log << "': " << ntohs(pw.getHeader()->ancount) << " answers, " << ntohs(pw.getHeader()->arcount) << " additional, took " << sr.d_outqueries << " packets, " << sr.d_totUsec / 1000.0 << " netw ms, " << spentUsec / 1000.0 << " tot ms, " << sr.d_throttledqueries << " throttled, " << sr.d_timeouts << " timeouts, " << sr.d_tcpoutqueries << "/" << sr.d_dotoutqueries << " tcp/dot connections, rcode=" << res;
 
       if (!shouldNotValidate && sr.isDNSSECValidationRequested()) {
@@ -1771,7 +1770,7 @@ bool expectProxyProtocol(const ComboAddress& from)
 
 static string* doProcessUDPQuestion(const std::string& question, const ComboAddress& fromaddr, const ComboAddress& destaddr, ComboAddress source, ComboAddress destination, struct timeval tv, int fd, std::vector<ProxyProtocolValue>& proxyProtocolValues, RecEventTrace& eventTrace)
 {
-  ++g_threadInfos[t_id].numberOfDistributedQueries;
+  ++(RecThreadInfo::self().numberOfDistributedQueries);
   gettimeofday(&g_now, nullptr);
   if (tv.tv_sec) {
     struct timeval diff = g_now - tv;
@@ -1907,7 +1906,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
       eventTrace.add(RecEventTrace::PCacheCheck, cacheHit, false);
       if (cacheHit) {
         if (!g_quiet) {
-          g_log << Logger::Notice << t_id << " question answered from packet cache tag=" << ctag << " from " << source.toStringWithPort() << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << endl;
+          g_log << Logger::Notice << RecThreadInfo::id() << " question answered from packet cache tag=" << ctag << " from " << source.toStringWithPort() << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << endl;
         }
         struct msghdr msgh;
         struct iovec iov;
@@ -1952,7 +1951,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
     bool ipf = t_pdl->ipfilter(source, destination, *dh, eventTrace);
     if (ipf) {
       if (!g_quiet) {
-        g_log << Logger::Notice << t_id << " [" << MT->getTid() << "/" << MT->numProcesses() << "] DROPPED question from " << source.toStringWithPort() << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << " based on policy" << endl;
+        g_log << Logger::Notice << RecThreadInfo::id() << " [" << MT->getTid() << "/" << MT->numProcesses() << "] DROPPED question from " << source.toStringWithPort() << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << " based on policy" << endl;
       }
       g_stats.policyDrops++;
       return 0;
@@ -1970,7 +1969,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
     }
 
     if (!g_quiet) {
-      g_log << Logger::Notice << t_id << " got NOTIFY for " << qname.toLogString() << " from " << source.toStringWithPort() << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << endl;
+      g_log << Logger::Notice << RecThreadInfo::id() << " got NOTIFY for " << qname.toLogString() << " from " << source.toStringWithPort() << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << endl;
     }
 
     requestWipeCaches(qname);
@@ -1984,7 +1983,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
 
   if (MT->numProcesses() > g_maxMThreads) {
     if (!g_quiet)
-      g_log << Logger::Notice << t_id << " [" << MT->getTid() << "/" << MT->numProcesses() << "] DROPPED question from " << source.toStringWithPort() << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << ", over capacity" << endl;
+      g_log << Logger::Notice << RecThreadInfo::id() << " [" << MT->getTid() << "/" << MT->numProcesses() << "] DROPPED question from " << source.toStringWithPort() << (source != fromaddr ? " (via " + fromaddr.toStringWithPort() + ")" : "") << ", over capacity" << endl;
 
     g_stats.overCapacityDrops++;
     return 0;
@@ -2188,7 +2187,7 @@ static void handleNewUDPQuestion(int fd, FDMultiplexer::funcparam_t& var)
             destination = dest;
           }
 
-          if (g_weDistributeQueries) {
+          if (RecThreadInfo::s_weDistributeQueries) {
             std::string localdata = data;
             distributeAsyncFunction(data, [localdata, fromaddr, dest, source, destination, tv, fd, proxyProtocolValues, eventTrace]() mutable {
               return doProcessUDPQuestion(localdata, fromaddr, dest, source, destination, tv, fd, proxyProtocolValues, eventTrace);
@@ -2324,7 +2323,7 @@ void makeUDPServerSockets(deferredAdd_t& deferredAdds)
 static bool trySendingQueryToWorker(unsigned int target, ThreadMSG* tmsg)
 {
   auto& targetInfo = g_threadInfos[target];
-  if (!targetInfo.isWorker) {
+  if (!targetInfo.isWorker()) {
     g_log << Logger::Error << "distributeAsyncFunction() tried to assign a query to a non-worker thread" << endl;
     _exit(1);
   }
@@ -2354,7 +2353,7 @@ static bool trySendingQueryToWorker(unsigned int target, ThreadMSG* tmsg)
 
 static unsigned int getWorkerLoad(size_t workerIdx)
 {
-  const auto mt = g_threadInfos[/* skip handler */ 1 + g_numDistributorThreads + workerIdx].mt;
+  const auto mt = g_threadInfos[/* skip handler */ 1 + RecThreadInfo::s_numDistributorThreads + workerIdx].mt;
   if (mt != nullptr) {
     return mt->numProcesses();
   }
@@ -2364,39 +2363,39 @@ static unsigned int getWorkerLoad(size_t workerIdx)
 static unsigned int selectWorker(unsigned int hash)
 {
   if (g_balancingFactor == 0) {
-    return /* skip handler */ 1 + g_numDistributorThreads + (hash % g_numWorkerThreads);
+    return /* skip handler */ 1 + RecThreadInfo::s_numDistributorThreads + (hash % RecThreadInfo::s_numWorkerThreads);
   }
 
   /* we start with one, representing the query we are currently handling */
   double currentLoad = 1;
-  std::vector<unsigned int> load(g_numWorkerThreads);
-  for (size_t idx = 0; idx < g_numWorkerThreads; idx++) {
+  std::vector<unsigned int> load(RecThreadInfo::s_numWorkerThreads);
+  for (size_t idx = 0; idx < RecThreadInfo::s_numWorkerThreads; idx++) {
     load[idx] = getWorkerLoad(idx);
     currentLoad += load[idx];
     // cerr<<"load for worker "<<idx<<" is "<<load[idx]<<endl;
   }
 
-  double targetLoad = (currentLoad / g_numWorkerThreads) * g_balancingFactor;
+  double targetLoad = (currentLoad / RecThreadInfo::s_numWorkerThreads) * g_balancingFactor;
   // cerr<<"total load is "<<currentLoad<<", number of workers is "<<g_numWorkerThreads<<", target load is "<<targetLoad<<endl;
 
-  unsigned int worker = hash % g_numWorkerThreads;
+  unsigned int worker = hash % RecThreadInfo::s_numWorkerThreads;
   /* at least one server has to be at or below the average load */
   if (load[worker] > targetLoad) {
     ++g_stats.rebalancedQueries;
     do {
       // cerr<<"worker "<<worker<<" is above the target load, selecting another one"<<endl;
-      worker = (worker + 1) % g_numWorkerThreads;
+      worker = (worker + 1) % RecThreadInfo::s_numWorkerThreads;
     } while (load[worker] > targetLoad);
   }
 
-  return /* skip handler */ 1 + g_numDistributorThreads + worker;
+  return /* skip handler */ 1 + RecThreadInfo::s_numDistributorThreads + worker;
 }
 
 // This function is only called by the distributor threads, when pdns-distributes-queries is set
 void distributeAsyncFunction(const string& packet, const pipefunc_t& func)
 {
-  if (!isDistributorThread()) {
-    g_log << Logger::Error << "distributeAsyncFunction() has been called by a worker (" << t_id << ")" << endl;
+  if (!RecThreadInfo::self().isDistributor()) {
+    g_log << Logger::Error << "distributeAsyncFunction() has been called by a worker (" << RecThreadInfo::id() << ")" << endl;
     _exit(1);
   }
 
@@ -2412,7 +2411,7 @@ void distributeAsyncFunction(const string& packet, const pipefunc_t& func)
        was full, let's try another one */
     unsigned int newTarget = 0;
     do {
-      newTarget = /* skip handler */ 1 + g_numDistributorThreads + dns_random(g_numWorkerThreads);
+      newTarget = /* skip handler */ 1 + RecThreadInfo::s_numDistributorThreads + dns_random(RecThreadInfo::s_numWorkerThreads);
     } while (newTarget == target);
 
     if (!trySendingQueryToWorker(newTarget, tmsg)) {

--- a/pdns/pdns_recursor.cc
+++ b/pdns/pdns_recursor.cc
@@ -52,7 +52,7 @@ std::unique_ptr<MemRecursorCache> g_recCache;
 std::unique_ptr<NegCache> g_negCache;
 
 thread_local std::unique_ptr<RecursorPacketCache> t_packetCache;
-thread_local FDMultiplexer* t_fdm{nullptr};
+thread_local std::unique_ptr<FDMultiplexer> t_fdm;
 thread_local std::unique_ptr<addrringbuf_t> t_remotes, t_servfailremotes, t_largeanswerremotes, t_bogusremotes;
 thread_local std::unique_ptr<boost::circular_buffer<pair<DNSName, uint16_t>>> t_queryring, t_servfailqueryring, t_bogusqueryring;
 thread_local std::shared_ptr<NetmaskGroup> t_allowFrom;

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1118,7 +1118,7 @@ static StatsMap toCPUStatsMap(const string& name)
 {
   const string pbasename = getPrometheusName(name);
   StatsMap entries;
-  for (unsigned int n = 0; n < RecThreadInfo::numThreads(); ++n) {
+  for (unsigned int n = 0; n < RecThreadInfo::numRecursorThreads(); ++n) {
     uint64_t tm = doGetThreadCPUMsec(n);
     std::string pname = pbasename + "{thread=\"" + std::to_string(n) + "\"}";
     entries.emplace(name + "-thread-" + std::to_string(n), StatsMapEntry{pname, std::to_string(tm)});

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1669,7 +1669,7 @@ static string doGenericTopQueries(pleasequeryfunc_t func, boost::function<DNSNam
 
 static string* nopFunction()
 {
-  return new string("pong " + RecThreadInfo::self().getname() + '\n');
+  return new string("pong " + RecThreadInfo::self().getName() + '\n');
 }
 
 static string getDontThrottleNames()

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1118,7 +1118,9 @@ static StatsMap toCPUStatsMap(const string& name)
 {
   const string pbasename = getPrometheusName(name);
   StatsMap entries;
-  for (unsigned int n = 0; n < RecThreadInfo::numRecursorThreads(); ++n) {
+  // Only distr and worker threads, I think we should revisit this as we now not only have the handler thread but also
+  // taskThread(s).
+  for (unsigned int n = 0; n < RecThreadInfo::numDistributors() + RecThreadInfo::numWorkers(); ++n) {
     uint64_t tm = doGetThreadCPUMsec(n);
     std::string pname = pbasename + "{thread=\"" + std::to_string(n) + "\"}";
     entries.emplace(name + "-thread-" + std::to_string(n), StatsMapEntry{pname, std::to_string(tm)});

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1669,7 +1669,7 @@ static string doGenericTopQueries(pleasequeryfunc_t func, boost::function<DNSNam
 
 static string* nopFunction()
 {
-  return new string("pong\n");
+  return new string("pong " + RecThreadInfo::self().getname() + '\n');
 }
 
 static string getDontThrottleNames()

--- a/pdns/rec_channel_rec.cc
+++ b/pdns/rec_channel_rec.cc
@@ -1118,7 +1118,7 @@ static StatsMap toCPUStatsMap(const string& name)
 {
   const string pbasename = getPrometheusName(name);
   StatsMap entries;
-  for (unsigned int n = 0; n < g_numThreads; ++n) {
+  for (unsigned int n = 0; n < RecThreadInfo::numThreads(); ++n) {
     uint64_t tm = doGetThreadCPUMsec(n);
     std::string pname = pbasename + "{thread=\"" + std::to_string(n) + "\"}";
     entries.emplace(name + "-thread-" + std::to_string(n), StatsMapEntry{pname, std::to_string(tm)});

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -306,26 +306,25 @@ When running multiple recursors on the same server, read settings from :file:`re
 
 ``cpu-map``
 -----------
-.. versionadded:: 4.1.0
 
 - String
 - Default: unset
 
-Set CPU affinity for worker threads, asking the scheduler to run those threads on a single CPU, or a set of CPUs.
+Set CPU affinity for threads, asking the scheduler to run those threads on a single CPU, or a set of CPUs.
 This parameter accepts a space separated list of thread-id=cpu-id, or thread-id=cpu-id-1,cpu-id-2,...,cpu-id-N.
 For example, to make the worker thread 0 run on CPU id 0 and the worker thread 1 on CPUs 1 and 2::
 
   cpu-map=0=0 1=1,2
 
-The number of worker threads is determined by the :ref:`setting-threads` setting.
-If :ref:`setting-pdns-distributes-queries` is set, an additional thread is started, assigned the id 0,
-and is the only one listening on client sockets and accepting queries, distributing them to the other worker threads afterwards.
+The thread handling the control channel, the webserver and other internal stuff has been assigned id 0, the distributor
+threads if any are assigned id 1 and counting, and the worker threads follow behind.
+The number of distributor threads is determined by :ref:`setting-distributor-threads`, the number of worker threads is determined by the :ref:`setting-threads` setting.
 
-Starting with version 4.2.0, the thread handling the control channel, the webserver and other internal stuff has been assigned
-id 0 and more than one distributor thread can be started using the :ref:`setting-distributor-threads` setting, so the distributor
-threads if any are assigned id 1 and counting, and the other threads follow behind.
+This parameter is only available if the OS provides the ``pthread_setaffinity_np()`` function.
 
-This parameter is only available on OS that provides the `pthread_setaffinity_np()` function.
+Note that depending on the configuration the Recursor can start more threads.
+Typically these threads will sleep most of the time.
+These threads cannot be specified in this setting as their thread-ids are left unspecified.
 
 .. _setting-daemon:
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -847,7 +847,6 @@ static void loggerBackend(const Logging::Entry& entry)
   g_log << u << buf.str() << endl;
 }
 
-
 static int ratePercentage(uint64_t nom, uint64_t denom)
 {
   if (denom == 0) {
@@ -1054,7 +1053,7 @@ void broadcastFunction(const pipefunc_t& func)
 
   unsigned int n = 0;
   for (const auto& threadInfo : RecThreadInfo::infos()) {
-    if (n++ ==  RecThreadInfo::id()) {
+    if (n++ == RecThreadInfo::id()) {
       func(); // don't write to ourselves!
       continue;
     }
@@ -1535,7 +1534,7 @@ static int serviceMain(int argc, char* argv[])
     if (RecThreadInfo::weDistributeQueries()) {
       /* first thread is the handler, then distributors */
       for (unsigned int threadId = 1; threadId <= RecThreadInfo::numDistributors(); threadId++) {
-        auto& info =  RecThreadInfo::info(threadId);
+        auto& info = RecThreadInfo::info(threadId);
         auto& deferredAdds = info.deferredAdds;
         auto& tcpSockets = info.tcpSockets;
         makeUDPServerSockets(deferredAdds);
@@ -1545,7 +1544,7 @@ static int serviceMain(int argc, char* argv[])
     else {
       /* first thread is the handler, there is no distributor here and workers are accepting queries */
       for (unsigned int threadId = 1; threadId <= RecThreadInfo::numWorkers(); threadId++) {
-        auto& info =  RecThreadInfo::info(threadId);
+        auto& info = RecThreadInfo::info(threadId);
         auto& deferredAdds = info.deferredAdds;
         auto& tcpSockets = info.tcpSockets;
         makeUDPServerSockets(deferredAdds);

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -290,8 +290,6 @@ static bool sendResponseOverTCP(const std::unique_ptr<DNSComboWriter>& dc, const
   return hadError;
 }
 
-void* recursorThread();
-
 // For communicating with our threads effectively readonly after
 // startup.
 // First we have the handler thread, t_id == 0 (some other helper

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -384,6 +384,11 @@ public:
     t_id = id;
   }
 
+  std::string getname() const
+  {
+    return name;
+  }
+
   static unsigned int numHandlers()
   {
     return 1;
@@ -466,6 +471,7 @@ private:
   bool taskThread{false};
 
   static thread_local unsigned int t_id;
+  std::string name;
   static std::vector<RecThreadInfo> s_threadInfos;
   static bool s_weDistributeQueries; // if true, 1 or more threads listen on the incoming query sockets and distribute them to workers
   static unsigned int s_numDistributorThreads;

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -139,7 +139,7 @@ struct DNSComboWriter
   std::map<std::string, RecursorLua4::MetaValue> d_meta;
 };
 
-extern thread_local FDMultiplexer* t_fdm;
+extern thread_local unique_ptr<FDMultiplexer> t_fdm;
 extern uint16_t g_minUdpSourcePort;
 extern uint16_t g_maxUdpSourcePort;
 

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -480,8 +480,6 @@ struct ThreadMSG
   bool wantAnswer;
 };
 
-
-
 PacketBuffer GenUDPQueryResponse(const ComboAddress& dest, const string& query);
 bool checkProtobufExport(LocalStateHolder<LuaConfigItems>& luaconfsLocal);
 bool checkOutgoingProtobufExport(LocalStateHolder<LuaConfigItems>& luaconfsLocal);

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -376,16 +376,6 @@ public:
     taskThread = true;
   }
 
-  void start(unsigned int id, const string& name)
-  {
-    thread = std::thread([id, name] {
-      t_id = id;
-      const string threadPrefix = "rec/";
-      setThreadName(threadPrefix + name);
-      recursorThread();
-    });
-  }
-
   static unsigned int id()
   {
     return t_id;
@@ -441,6 +431,14 @@ public:
     return numHandlers() + numDistributors() + numWorkers() + numTaskThreads();
   }
 
+  static int runThreads();
+  static void makeThreadPipes();
+
+  void setExitCode(int e)
+  {
+    exitCode = e;
+  }
+
   // FD corresponding to TCP sockets this thread is listening on.
   // These FDs are also in deferredAdds when we have one socket per
   // listener, and in g_deferredAdds instead.
@@ -451,12 +449,15 @@ public:
   deferredAdd_t deferredAdds;
 
   struct ThreadPipeSet pipes;
-  std::thread thread;
   MT_t* mt{nullptr};
   uint64_t numberOfDistributedQueries{0};
-  int exitCode{0};
 
 private:
+  void start(unsigned int id, const string& name, const std::map<unsigned int, std::set<int>>& cpusMap);
+
+  std::thread thread;
+  int exitCode{0};
+
   // handle the web server, carbon, statistics and the control channel
   bool handler{false};
   // accept incoming queries (and distributes them to the workers if pdns-distributes-queries is set)

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -384,7 +384,7 @@ public:
     t_id = id;
   }
 
-  std::string getname() const
+  std::string getName() const
   {
     return name;
   }
@@ -458,6 +458,7 @@ public:
 private:
   void start(unsigned int id, const string& name, const std::map<unsigned int, std::set<int>>& cpusMap);
 
+  std::string name;
   std::thread thread;
   int exitCode{0};
 
@@ -471,7 +472,6 @@ private:
   bool taskThread{false};
 
   static thread_local unsigned int t_id;
-  std::string name;
   static std::vector<RecThreadInfo> s_threadInfos;
   static bool s_weDistributeQueries; // if true, 1 or more threads listen on the incoming query sockets and distribute them to workers
   static unsigned int s_numDistributorThreads;

--- a/pdns/recursordist/rec-taskqueue.cc
+++ b/pdns/recursordist/rec-taskqueue.cc
@@ -21,11 +21,12 @@
  */
 #include "rec-taskqueue.hh"
 #include "taskqueue.hh"
+#include "lock.hh"
 #include "logger.hh"
 #include "stat_t.hh"
 #include "syncres.hh"
 
-static thread_local pdns::TaskQueue t_taskQueue;
+static LockGuarded<pdns::TaskQueue> s_taskQueue;
 static pdns::stat_t s_almost_expired_tasks_pushed;
 static pdns::stat_t s_almost_expired_tasks_run;
 static pdns::stat_t s_almost_expired_tasks_exceptions;
@@ -70,29 +71,29 @@ static void resolve(const struct timeval& now, bool logErrors, const pdns::Resol
 
 void runTaskOnce(bool logErrors)
 {
-  t_taskQueue.runOnce(logErrors);
+  s_taskQueue.lock()->runOnce(logErrors);
 }
 
 void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline)
 {
   ++s_almost_expired_tasks_pushed;
   pdns::ResolveTask task{qname, qtype, deadline, true, resolve};
-  t_taskQueue.push(std::move(task));
+  s_taskQueue.lock()->push(std::move(task));
 }
 
 uint64_t getTaskPushes()
 {
-  return broadcastAccFunction<uint64_t>([] { return t_taskQueue.getPushes(); });
+  return s_taskQueue.lock()->getPushes();
 }
 
 uint64_t getTaskExpired()
 {
-  return broadcastAccFunction<uint64_t>([] { return t_taskQueue.getExpired(); });
+  return s_taskQueue.lock()->getExpired();
 }
 
 uint64_t getTaskSize()
 {
-  return broadcastAccFunction<uint64_t>([] { return t_taskQueue.getSize(); });
+  return s_taskQueue.lock()->size();
 }
 
 uint64_t getAlmostExpiredTasksPushed()

--- a/pdns/recursordist/rec-taskqueue.hh
+++ b/pdns/recursordist/rec-taskqueue.hh
@@ -25,6 +25,7 @@
 
 void runTaskOnce(bool logErrors);
 void pushAlmostExpiredTask(const DNSName& qname, uint16_t qtype, time_t deadline);
+
 // General task stats
 uint64_t getTaskPushes();
 uint64_t getTaskExpired();

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -452,7 +452,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
         bool ipf = t_pdl->ipfilter(dc->d_source, dc->d_destination, *dh, dc->d_eventTrace);
         if (ipf) {
           if (!g_quiet) {
-            g_log << Logger::Notice << t_id << " [" << MT->getTid() << "/" << MT->numProcesses() << "] DROPPED TCP question from " << dc->d_source.toStringWithPort() << (dc->d_source != dc->d_remote ? " (via " + dc->d_remote.toStringWithPort() + ")" : "") << " based on policy" << endl;
+            g_log << Logger::Notice << RecThreadInfo::id() << " [" << MT->getTid() << "/" << MT->numProcesses() << "] DROPPED TCP question from " << dc->d_source.toStringWithPort() << (dc->d_source != dc->d_remote ? " (via " + dc->d_remote.toStringWithPort() + ")" : "") << " based on policy" << endl;
           }
           g_stats.policyDrops++;
           return;
@@ -522,7 +522,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
 
           if (cacheHit) {
             if (!g_quiet) {
-              g_log << Logger::Notice << t_id << " TCP question answered from packet cache tag=" << dc->d_tag << " from " << dc->d_source.toStringWithPort() << (dc->d_source != dc->d_remote ? " (via " + dc->d_remote.toStringWithPort() + ")" : "") << endl;
+              g_log << Logger::Notice << RecThreadInfo::id() << " TCP question answered from packet cache tag=" << dc->d_tag << " from " << dc->d_source.toStringWithPort() << (dc->d_source != dc->d_remote ? " (via " + dc->d_remote.toStringWithPort() + ")" : "") << endl;
             }
 
             bool hadError = sendResponseOverTCP(dc, response);
@@ -551,7 +551,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
 
         if (dc->d_mdp.d_header.opcode == Opcode::Notify) {
           if (!g_quiet) {
-            g_log << Logger::Notice << t_id << " got NOTIFY for " << qname.toLogString() << " from " << dc->d_source.toStringWithPort() << (dc->d_source != dc->d_remote ? " (via " + dc->d_remote.toStringWithPort() + ")" : "") << endl;
+            g_log << Logger::Notice << RecThreadInfo::id() << " got NOTIFY for " << qname.toLogString() << " from " << dc->d_source.toStringWithPort() << (dc->d_source != dc->d_remote ? " (via " + dc->d_remote.toStringWithPort() + ")" : "") << endl;
           }
 
           requestWipeCaches(qname);

--- a/pdns/recursordist/taskqueue.cc
+++ b/pdns/recursordist/taskqueue.cc
@@ -85,19 +85,4 @@ void TaskQueue::runAll(bool logErrors)
   }
 }
 
-uint64_t* TaskQueue::getPushes() const
-{
-  return new uint64_t(d_pushes);
-}
-
-uint64_t* TaskQueue::getExpired() const
-{
-  return new uint64_t(d_expired);
-}
-
-uint64_t* TaskQueue::getSize() const
-{
-  return new uint64_t(size());
-}
-
 } /* namespace pdns */

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -47,36 +47,26 @@ struct ResolveTask
   uint16_t d_qtype;
   time_t d_deadline;
   bool d_refreshMode; // Whether to run this task in regular mode (false) or in the mode that refreshes almost expired tasks
-  void (*func)(const struct timeval&, bool logErrors, const ResolveTask&);
-};
+  std::function<void(const struct timeval& now, bool logErrors, const ResolveTask& task)> d_func;
 
-struct HashTag
-{
+  bool run(bool logErrors);
 };
-struct SequencedTag
-{
-};
-
-typedef multi_index_container<
-  ResolveTask,
-  indexed_by<
-    hashed_unique<tag<HashTag>,
-                  composite_key<ResolveTask,
-                                member<ResolveTask, DNSName, &ResolveTask::d_qname>,
-                                member<ResolveTask, uint16_t, &ResolveTask::d_qtype>,
-                                member<ResolveTask, bool, &ResolveTask::d_refreshMode>>>,
-    sequenced<tag<SequencedTag>>>>
-  queue_t;
 
 class TaskQueue
 {
 public:
-  bool empty() const;
-  size_t size() const;
+  bool empty() const
+  {
+    return d_queue.empty();
+  }
+
+  size_t size() const
+  {
+    return d_queue.size();
+  }
+
   void push(ResolveTask&& task);
   ResolveTask pop();
-  bool runOnce(bool logErrors); // Run one task if the queue is not empty
-  void runAll(bool logErrors);
 
   uint64_t getPushes()
   {
@@ -88,7 +78,29 @@ public:
     return d_expired;
   }
 
+  void incExpired()
+  {
+    d_expired++;
+  }
+
 private:
+  struct HashTag
+  {
+  };
+  struct SequencedTag
+  {
+  };
+  typedef multi_index_container<
+    ResolveTask,
+    indexed_by<
+      hashed_unique<tag<HashTag>,
+                    composite_key<ResolveTask,
+                                  member<ResolveTask, DNSName, &ResolveTask::d_qname>,
+                                  member<ResolveTask, uint16_t, &ResolveTask::d_qtype>,
+                                  member<ResolveTask, bool, &ResolveTask::d_refreshMode>>>,
+      sequenced<tag<SequencedTag>>>>
+    queue_t;
+
   queue_t d_queue;
   uint64_t d_pushes{0};
   uint64_t d_expired{0};

--- a/pdns/recursordist/taskqueue.hh
+++ b/pdns/recursordist/taskqueue.hh
@@ -77,9 +77,16 @@ public:
   ResolveTask pop();
   bool runOnce(bool logErrors); // Run one task if the queue is not empty
   void runAll(bool logErrors);
-  uint64_t* getPushes() const;
-  uint64_t* getExpired() const;
-  uint64_t* getSize() const;
+
+  uint64_t getPushes()
+  {
+    return d_pushes;
+  }
+
+  uint64_t getExpired()
+  {
+    return d_expired;
+  }
 
 private:
   queue_t d_queue;

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -16,7 +16,6 @@ GlobalStateHolder<NetmaskGroup> g_dontThrottleNetmasks;
 GlobalStateHolder<SuffixMatchNode> g_DoTToAuthNames;
 std::unique_ptr<MemRecursorCache> g_recCache;
 std::unique_ptr<NegCache> g_negCache;
-unsigned int g_numThreads = 1;
 bool g_lowercaseOutgoing = false;
 
 /* Fake some required functions we didn't want the trouble to

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -1171,7 +1171,6 @@ string doTraceRegex(vector<string>::const_iterator begin, vector<string>::const_
 void parseACLs();
 extern RecursorStats g_stats;
 extern unsigned int g_networkTimeoutMsec;
-extern unsigned int g_numThreads;
 extern uint16_t g_outgoingEDNSBufsize;
 extern std::atomic<uint32_t> g_maxCacheEntries, g_maxPacketCacheEntries;
 extern bool g_lowercaseOutgoing;

--- a/pdns/ws-recursor.cc
+++ b/pdns/ws-recursor.cc
@@ -45,8 +45,6 @@
 #include "tcpiohandler.hh"
 #include "rec-main.hh"
 
-extern thread_local FDMultiplexer* t_fdm;
-
 using json11::Json;
 
 void productServerStatisticsFetch(map<string, string>& out)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

1. Refactor recursor thread code, `RecThreadInfo` becomes a proper class with methods.
2. Introduce a new thread: `taskThead`. This is a `recursorThread` that can be used for async task execution. Currently one, but in theory there could be more.
3. Use the new `taskThread` to execute the `Zone to Cache`code and the `taskQueue`. The `taskQueue` now has become shared data instead of a thread local one.

The `broadcastAccFucntion` does call the distributor, worker and the new `taskThread`, but skips the handler. This needs to be revisited. One of the questions is; should all the `recursorThreads` be included in stats gathering? ATM, handler is skipped, but it is not clear to me why, as the handler thread also does resolving work, e.g. to prime the root info so constributes to stat counts. I did not change this right now, as there is a complication wit the Lua context, so changing this is better done in a separate PR.

This PR does have the consequence that e.g.`rec_channel ping` now reports one more `pong`, as we have gained an extra `recursorThread`. As the exact response is not documented, I took the liberty to reply with the thread name. Note that atm this function also skips the handler.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
