### PR TITLE
dnsdist: Fix the health-check timeout for outgoing DoH connections

### DIFF
--- a/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-downstream.hh
@@ -151,7 +151,8 @@ protected:
     }
 
     struct timeval res = now;
-    res.tv_sec += d_ds->checkTimeout;
+    res.tv_sec += d_ds->checkTimeout / 1000; /* ms to s */
+    res.tv_usec += (d_ds->checkTimeout % 1000) / 1000; /* remaining ms to µs */
 
     return res;
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The health-check timeout is in milliseconds, contrary to the other ones that are in seconds.

Fixes #11250.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
