### PR TITLE
dnsdist: Do not execute 'newThread' in client or config check modes

### DIFF
--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -2794,7 +2794,10 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
   });
 #endif /* HAVE_LIBSSL */
 
-  luaCtx.writeFunction("newThread", [](const std::string& code) {
+  luaCtx.writeFunction("newThread", [client, configCheck](const std::string& code) {
+    if (client || configCheck) {
+      return;
+    }
     std::thread newThread(LuaThread, code);
     newThread.detach();
   });

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -1608,6 +1608,7 @@ Other functions
 
   Spawns a separate thread running the supplied code.
   Code is supplied as a string, not as a function object.
+  Note that this function does nothing in 'client' or 'config-check' modes.
 
 .. function:: submitToMainThread(cmd, dict)
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
New Lua threads will no longer get started in 'client' and 'config check' modes, where they make little sense.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
