### PR TITLE
builder: migrate EL8 builds to oraclelinux, rename centos8 to el8 where possible

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -16,7 +16,7 @@ jobs:
         os:
           - centos-7
           - ubuntu-bionic
-          - oraclelinux-8
+          - el-8
           - centos-8-stream
           - debian-bullseye
           - ubuntu-jammy

--- a/builder-support/dockerfiles/Dockerfile.target.centos-7
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-7
@@ -3,10 +3,10 @@
 
 # This defines the distribution base layer
 # Put only the bare minimum of common commands here, without dev tools
-@IF [ ${BUILDER_TARGET} = centos-7 ]
+@IF [ ${BUILDER_TARGET} = centos-7 -o ${BUILDER_TARGET} = el-7 ]
 FROM centos:7 as dist-base
 @ENDIF
-@IF [ ${BUILDER_TARGET} = centos-7-amd64 ]
+@IF [ ${BUILDER_TARGET} = centos-7-amd64 -o ${BUILDER_TARGET} = el-7-amd64]
 FROM amd64/centos:7 as dist-base
 @ENDIF
 

--- a/builder-support/dockerfiles/Dockerfile.target.centos-8
+++ b/builder-support/dockerfiles/Dockerfile.target.centos-8
@@ -3,8 +3,11 @@
 
 # This defines the distribution base layer
 # Put only the bare minimum of common commands here, without dev tools
-@IF [ ${BUILDER_TARGET} = centos-8 -o ${BUILDER_TARGET} = centos-8-stream ]
+@IF [ ${BUILDER_TARGET} = centos-8 ]
 FROM centos:8 as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = centos-8-stream ]
+FROM quay.io/centos/centos:stream8 as dist-base
 @ENDIF
 @IF [ ${BUILDER_TARGET} = centos-8-amd64 ]
 FROM amd64/centos:8 as dist-base

--- a/builder-support/dockerfiles/Dockerfile.target.el-7
+++ b/builder-support/dockerfiles/Dockerfile.target.el-7
@@ -1,0 +1,1 @@
+Dockerfile.target.centos-7

--- a/builder-support/dockerfiles/Dockerfile.target.el-7-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.el-7-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.centos-7-amd64

--- a/builder-support/dockerfiles/Dockerfile.target.el-8
+++ b/builder-support/dockerfiles/Dockerfile.target.el-8
@@ -1,0 +1,1 @@
+Dockerfile.target.oraclelinux-8

--- a/builder-support/dockerfiles/Dockerfile.target.el-8-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.el-8-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.oraclelinux-8-amd64

--- a/builder-support/dockerfiles/Dockerfile.target.el-8-arm64
+++ b/builder-support/dockerfiles/Dockerfile.target.el-8-arm64
@@ -1,0 +1,1 @@
+Dockerfile.target.oraclelinux-8-arm64

--- a/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8
+++ b/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8
@@ -3,7 +3,16 @@
 
 # This defines the distribution base layer
 # Put only the bare minimum of common commands here, without dev tools
+@IF [ ${BUILDER_TARGET} = oraclelinux-8 -o ${BUILDER_TARGET} = el-8 ]
 FROM oraclelinux:8 as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = oraclelinux-8-amd64 -o ${BUILDER_TARGET} = el-8-amd64 ]
+FROM amd64/oraclelinux:8 as dist-base
+@ENDIF
+@IF [ ${BUILDER_TARGET} = oraclelinux-8-arm64 -o ${BUILDER_TARGET} = el-8-arm64 ]
+FROM arm64v8/oraclelinux:8 as dist-base
+@ENDIF
+
 ARG BUILDER_CACHE_BUSTER=
 RUN touch /var/lib/rpm/* && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf install -y 'dnf-command(config-manager)' yum && \

--- a/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8-amd64
+++ b/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8-amd64
@@ -1,0 +1,1 @@
+Dockerfile.target.oraclelinux-8

--- a/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8-arm64
+++ b/builder-support/dockerfiles/Dockerfile.target.oraclelinux-8-arm64
@@ -1,0 +1,1 @@
+Dockerfile.target.oraclelinux-8


### PR DESCRIPTION
### Short description

TODO:

- [ ] update `generate-repo-files.py`
- [ ] fix structure & text on https://repo.powerdns.com/
- [ ] update builder config
- [ ] backport to supported branches

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master