### PR TITLE
rec: backport to rec-4.4.x: CI: dnspython 2.2.0 breaks auth and ixfrdist testing, pin to 2.1.0

### DIFF
--- a/regression-tests.auth-py/requirements.txt
+++ b/regression-tests.auth-py/requirements.txt
@@ -1,4 +1,4 @@
-dnspython>=1.11
+dnspython==2.1.0
 nose>=1.3.7
 Twisted>0.15.0
 requests>=2.18.4

--- a/regression-tests.ixfrdist/requirements.txt
+++ b/regression-tests.ixfrdist/requirements.txt
@@ -1,4 +1,4 @@
-dnspython
+dnspython==2.1.0
 nose>=1.3.7
 git+https://github.com/PowerDNS/xfrserver.git@0.1
 requests


### PR DESCRIPTION
(cherry picked from commit 46a40ed033d64f58aa30013d7e68daa5b5e8d615)

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
