### PR TITLE
rec: Fix zone-to-cache test by properly initing trust anchors and dnssec mode

### DIFF
--- a/pdns/recursordist/test-rec-zonetocache.cc
+++ b/pdns/recursordist/test-rec-zonetocache.cc
@@ -5,6 +5,7 @@
 
 #include "rec-zonetocache.hh"
 #include "recursor_cache.hh"
+#include "test-syncres_cc.hh"
 
 extern unique_ptr<MemRecursorCache> g_recCache;
 
@@ -96,6 +97,10 @@ static void zonemdTest(const std::string& lines, pdns::ZoneMD::Config mode, pdns
 
 BOOST_AUTO_TEST_CASE(test_zonetocache)
 {
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true);
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
   zonemdTest(zone, pdns::ZoneMD::Config::Ignore, pdns::ZoneMD::Config::Ignore, 17U);
   zonemdTest(zone, pdns::ZoneMD::Config::Validate, pdns::ZoneMD::Config::Ignore, 17U);
   zonemdTest(zone, pdns::ZoneMD::Config::Require, pdns::ZoneMD::Config::Ignore, 0U);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
