### PR TITLE
rec: backport 11168 to rec-4.6.x: servfail.nl changed their setup.

### DIFF
--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -130,7 +130,7 @@ log-common-errors=yes
             self.assertEqual(res.edns, 0)
             self.assertEqual(len(res.options), 1)
             self.assertEqual(res.options[0].otype, 15)
-            self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(7, b''))
+            self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(6, b''))
 
     def testBogus(self):
         qname = 'bogussig.ok.bad-dnssec.wb.sidnlabs.nl.'


### PR DESCRIPTION
I think in an ideal world we should return 9 (DNSSEC key missing) but I don't see a
easy way to do that at the moment.

(cherry picked from commit 2cd34ba5c565ee6bad368f577e34fa6d9519ab7d)

Backport of #11168

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
