### PR TITLE
rec: Allow disabling of processing the root hints

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -879,8 +879,11 @@ If set, EDNS options in incoming queries are extracted and passed to the :func:`
 ``hint-file``
 -------------
 -  Path
+-  Default: empty
 
-If set, the root-hints are read from this file. If unset, default root hints are used.
+If set, the root-hints are read from this file. If empty, the default built-in root hints are used.
+In some special cases, processing the root hints is not needed, for example when forwarding all queries to another recursor.
+For these special cases, it is possible to disable the processing of root hints by setting the value to ``no``.
 
 .. _setting-ignore-unknown-settings:
 

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -881,7 +881,12 @@ If set, EDNS options in incoming queries are extracted and passed to the :func:`
 -  Path
 -  Default: empty
 
+.. versionchanged:: 4.7.0
+
+  Introduced the value ``no`` to disable root-hints processing.
+
 If set, the root-hints are read from this file. If empty, the default built-in root hints are used.
+
 In some special cases, processing the root hints is not needed, for example when forwarding all queries to another recursor.
 For these special cases, it is possible to disable the processing of root hints by setting the value to ``no``.
 

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -4,8 +4,15 @@ Upgrade Guide
 Before upgrading, it is advised to read the :doc:`changelog/index`.
 When upgrading several versions, please read **all** notes applying to the upgrade.
 
-4.5.x to 4.6.0 or master
-------------------------
+4.6.x to master
+---------------
+
+Deprecated and changed settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-  The :ref:`setting-hint-file` gained a special value ``no`` to indicate that no hint file should not processed.
+
+4.5.x to 4.6.0
+--------------
 
 Offensive language
 ^^^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -1828,10 +1828,10 @@ static void houseKeeping(void*)
       // Divide by 12 to get the original 2 hour cycle if s_maxcachettl is default (1 day)
       if (now.tv_sec - t_last_rootupdate > max(SyncRes::s_maxcachettl / 12, 10U)) {
         int res = SyncRes::getRootNS(g_now, nullptr, 0);
-        if (!res) {
+        if (res == 0) {
           t_last_rootupdate = now.tv_sec;
           try {
-            primeRootNSZones(g_dnssecmode != DNSSECMode::Off, 0);
+            primeRootNSZones(g_dnssecmode, 0);
           }
           catch (const std::exception& e) {
             g_log << Logger::Error << "Exception while priming the root NS zones: " << e.what() << endl;
@@ -1925,7 +1925,7 @@ try {
       g_log << Logger::Critical << "Priming cache failed, stopping" << endl;
       return nullptr;
     }
-    g_log << Logger::Warning << "Done priming cache with root hints" << endl;
+    g_log << Logger::Debug << "Done priming cache with root hints" << endl;
   }
 
   t_packetCache = std::make_unique<RecursorPacketCache>();

--- a/pdns/recursordist/test-syncres_cc.cc
+++ b/pdns/recursordist/test-syncres_cc.cc
@@ -27,7 +27,7 @@ ArgvMap& arg()
   return theArg;
 }
 
-void primeRootNSZones(bool, unsigned int)
+void primeRootNSZones(DNSSECMode, unsigned int)
 {
 }
 

--- a/pdns/syncres.cc
+++ b/pdns/syncres.cc
@@ -1336,7 +1336,7 @@ void SyncRes::getBestNSFromCache(const DNSName &qname, const QType qtype, vector
       LOG(prefix<<qname<<": reprimed the root"<<endl);
       /* let's prevent an infinite loop */
       if (!d_updatingRootNS) {
-        primeRootNSZones(g_dnssecmode != DNSSECMode::Off, depth);
+        primeRootNSZones(g_dnssecmode, depth);
         getRootNS(d_now, d_asyncResolve, depth);
       }
     }
@@ -4666,9 +4666,9 @@ int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigne
   sr.setAsyncCallback(asyncCallback);
 
   vector<DNSRecord> ret;
-  int res=-1;
+  int res = -1;
   try {
-    res=sr.beginResolve(g_rootdnsname, QType::NS, 1, ret, depth + 1);
+    res = sr.beginResolve(g_rootdnsname, QType::NS, 1, ret, depth + 1);
     if (g_dnssecmode != DNSSECMode::Off && g_dnssecmode != DNSSECMode::ProcessNoValidate) {
       auto state = sr.getValidationState();
       if (vStateIsBogus(state)) {
@@ -4693,11 +4693,11 @@ int SyncRes::getRootNS(struct timeval now, asyncresolve_t asyncCallback, unsigne
     g_log<<Logger::Error<<"Failed to update . records, got an exception"<<endl;
   }
 
-  if(!res) {
-    g_log<<Logger::Notice<<"Refreshed . records"<<endl;
+  if (res == 0) {
+    g_log<<Logger::Debug<<"Refreshed . records"<<endl;
   }
-  else
-    g_log<<Logger::Warning<<"Failed to update . records, RCODE="<<res<<endl;
-
+  else {
+    g_log<<Logger::Warning<<"Failed to update root NS records, RCODE="<<res<<endl;
+  }
   return res;
 }

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -45,7 +45,7 @@
 #include <boost/tuple/tuple_comparison.hpp>
 #include "mtasker.hh"
 #include "iputils.hh"
-#include "validate.hh"
+#include "validate-recursor.hh"
 #include "ednssubnet.hh"
 #include "filterpo.hh"
 #include "negcache.hh"
@@ -1201,7 +1201,7 @@ uint64_t* pleaseGetPacketCacheHits();
 uint64_t* pleaseGetPacketCacheSize();
 void doCarbonDump(void*);
 bool primeHints(time_t now = time(nullptr));
-void primeRootNSZones(bool, unsigned int depth);
+void primeRootNSZones(DNSSECMode, unsigned int depth);
 
 struct WipeCacheResult
 {


### PR DESCRIPTION
Disabling can be useful in special setups, e.g. if the root servers cannot be reached and you're forwarding all queries to another recursor. This PR then allows you to not have  to setup a fake root by setting `hint-file=no`.

This also make sure we use the right dnssec mode for processing hints
and changes a few log levels to Debug to be less verbose.

I do worry that people will disable root-hints processing when they should not and then come complaining that their recursor is broken... hence the draft status

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
