### PR TITLE
auth dnsupdate: add option which aborts transaction on error

### DIFF
--- a/docs/dnsupdate.rst
+++ b/docs/dnsupdate.rst
@@ -69,6 +69,15 @@ authorization methods, and you are expected to take care of everything
 yourself. See :ref:`dnsupdate-update-policy` for details and
 examples.
 
+.. _dnsupdate-lua-dnsupdate-policy-script-strict-mode:
+
+``lua-dnsupdate-policy-script-strict-mode``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When turning this setting on, PowerDNS will handle DNS updates as atomic,
+rolling back an update when a single record in an update causes the
+configured lua script to return false, and returning `REFUSED` to the client.
+
 The semantics are that first a dynamic update has to be allowed either
 by the global :ref:`setting-allow-dnsupdate-from` setting, or by a per-zone
 ``ALLOW-DNSUPDATE-FROM`` metadata setting.

--- a/pdns/common_startup.cc
+++ b/pdns/common_startup.cc
@@ -222,6 +222,7 @@ void declareArguments()
 
   ::arg().set("lua-prequery-script", "Lua script with prequery handler (DO NOT USE)")="";
   ::arg().set("lua-dnsupdate-policy-script", "Lua script with DNS update policy handler")="";
+  ::arg().setSwitch("lua-dnsupdate-policy-script-strict-mode", "Enables strict adherence to RFC2136 Section 3.7 by failing the entire transaction when a single record does not pass the policy script")="no";
 
   ::arg().setSwitch("traceback-handler","Enable the traceback handler (Linux only)")="yes";
   ::arg().setSwitch("direct-dnskey","Fetch DNSKEY, CDS and CDNSKEY RRs from backend during DNSKEY or CDS/CDNSKEY synthesis")="no";

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -869,9 +869,15 @@ int PacketHandler::processUpdate(DNSPacket& p) {
       if (rr->d_place == DNSResourceRecord::AUTHORITY) {
         /* see if it's permitted by policy */
         if (this->d_update_policy_lua != nullptr) {
+          const bool rfc2136_strict_mode = ::arg().mustDo("lua-dnsupdate-policy-script-strict-mode");
           if (this->d_update_policy_lua->updatePolicy(rr->d_name, QType(rr->d_type), di.zone, p) == false) {
             g_log<<Logger::Warning<<msgPrefix<<"Refusing update for " << rr->d_name << "/" << QType(rr->d_type).toString() << ": Not permitted by policy"<<endl;
-            continue;
+            if (rfc2136_strict_mode) {
+              di.backend->abortTransaction();
+              return RCode::Refused;
+            } else {
+              continue;
+            }
           } else {
             g_log<<Logger::Debug<<msgPrefix<<"Accepting update for " << rr->d_name << "/" << QType(rr->d_type).toString() << ": Permitted by policy"<<endl;
           }


### PR DESCRIPTION
### Short description
This PR adds a config option `lua-dnsupdate-policy-script-strict-mode`, which, when set to `yes`, makes PowerDNS abort a DNSUPDATE transaction, which in turn can resolve #8422 when turned on.

The PR is based on #8422 and aims to be a more configurable option, as changing the existing behaviour is not desirable

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] compiled this code
- [ ] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
