### PR TITLE
Rec: document changes to policy.DROP better and warn on using the now unsupported way

### DIFF
--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -244,7 +244,8 @@ void BaseLua4::prepareContext() {
                                        {"YXRRSET",  RCode::YXRRSet  },
                                        {"NXRRSET",  RCode::NXRRSet  },
                                        {"NOTAUTH",  RCode::NotAuth  },
-                                       {"NOTZONE",  RCode::NotZone  }};
+                                       {"NOTZONE",  RCode::NotZone  },
+                                       {"DROP",    -2               }}; // To give backport-incompatibilityy warning
   for(const auto& rcode : rcodes)
     d_pd.push_back({rcode.first, rcode.second});
 

--- a/pdns/lua-base4.cc
+++ b/pdns/lua-base4.cc
@@ -245,7 +245,7 @@ void BaseLua4::prepareContext() {
                                        {"NXRRSET",  RCode::NXRRSet  },
                                        {"NOTAUTH",  RCode::NotAuth  },
                                        {"NOTZONE",  RCode::NotZone  },
-                                       {"DROP",    -2               }}; // To give backport-incompatibilityy warning
+                                       {"DROP",    -2               }}; // To give backport-incompatibility warning
   for(const auto& rcode : rcodes)
     d_pd.push_back({rcode.first, rcode.second});
 

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -500,7 +500,7 @@ void RecursorLua4::getFeatures(Features& features)
 static void warnDrop(const RecursorLua4::DNSQuestion& dq)
 {
   if (dq.rcode == -2) {
-    g_log << Logger::Error << "Returing -2 (pdns.DROP) is not supported anymore, see https://docs.powerdns.com/recursor/lua-scripting/hooks.html#hooksemantics" << endl;
+    g_log << Logger::Error << "Returning -2 (pdns.DROP) is not supported anymore, see https://docs.powerdns.com/recursor/lua-scripting/hooks.html#hooksemantics" << endl;
     // We *could* set policy here, but that would also mean interfering with rcode and the return code of the hook.
     // So leave it at the error message.
   }

--- a/pdns/lua-recursor4.cc
+++ b/pdns/lua-recursor4.cc
@@ -497,6 +497,15 @@ void RecursorLua4::getFeatures(Features& features)
   features.emplace_back("PR8001_devicename", true);
 }
 
+static void warnDrop(const RecursorLua4::DNSQuestion& dq)
+{
+  if (dq.rcode == -2) {
+    g_log << Logger::Error << "Returing -2 (pdns.DROP) is not supported anymore, see https://docs.powerdns.com/recursor/lua-scripting/hooks.html#hooksemantics" << endl;
+    // We *could* set policy here, but that would also mean interfering with rcode and the return code of the hook.
+    // So leave it at the error message.
+  }
+}
+
 void RecursorLua4::maintenance() const
 {
   if (d_maintenance) {
@@ -512,6 +521,7 @@ bool RecursorLua4::prerpz(DNSQuestion& dq, int& ret, RecEventTrace& et) const
   et.add(RecEventTrace::LuaPreRPZ);
   bool ok = genhook(d_prerpz, dq, ret);
   et.add(RecEventTrace::LuaPreRPZ, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -523,6 +533,7 @@ bool RecursorLua4::preresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) cons
   et.add(RecEventTrace::LuaPreResolve);
   bool ok = genhook(d_preresolve, dq, ret);
   et.add(RecEventTrace::LuaPreResolve, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -534,6 +545,7 @@ bool RecursorLua4::nxdomain(DNSQuestion& dq, int& ret, RecEventTrace& et) const
   et.add(RecEventTrace::LuaNXDomain);
   bool ok = genhook(d_nxdomain, dq, ret);
   et.add(RecEventTrace::LuaNXDomain, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -545,6 +557,7 @@ bool RecursorLua4::nodata(DNSQuestion& dq, int& ret, RecEventTrace& et) const
   et.add(RecEventTrace::LuaNoData);
   bool ok = genhook(d_nodata, dq, ret);
   et.add(RecEventTrace::LuaNoData, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -556,6 +569,7 @@ bool RecursorLua4::postresolve(DNSQuestion& dq, int& ret, RecEventTrace& et) con
   et.add(RecEventTrace::LuaPostResolve);
   bool ok = genhook(d_postresolve, dq, ret);
   et.add(RecEventTrace::LuaPostResolve, ok, false);
+  warnDrop(dq);
   return ok;
 }
 
@@ -573,6 +587,7 @@ bool RecursorLua4::preoutquery(const ComboAddress& ns, const ComboAddress& reque
   et.add(RecEventTrace::LuaPreOutQuery);
   bool ok = genhook(d_preoutquery, dq, ret);
   et.add(RecEventTrace::LuaPreOutQuery, ok, false);
+  warnDrop(dq);
   return ok;
 }
 

--- a/pdns/recursordist/contrib/powerdns-example-script.lua
+++ b/pdns/recursordist/contrib/powerdns-example-script.lua
@@ -18,9 +18,9 @@ badips:addMask("127.1.0.0/16")
 
 -- this check is applied before any packet parsing is done
 function ipfilter(rem, loc, dh)
-  pdnslog("ipfilter called, rem: "..rem:toStringWithPort().."loc: "..loc:toStringWithPort().."match:"..badips:match(rem))
-  pdnslog("id: "..dh:getID().."aa: "..dh:getAA().."ad: "..dh:getAD().."arcount: "..dh:getARCOUNT())
-  pdnslog("ports: "..rem:getPort()..loc:getPort())
+  pdnslog("ipfilter called, rem: "..rem:toStringWithPort().."loc: "..loc:toStringWithPort().." match:"..tostring(badips:match(rem)))
+  pdnslog("id: "..dh:getID().."aa: "..tostring(dh:getAA()).."ad: "..tostring(dh:getAD()).." arcount: "..dh:getARCOUNT())
+  pdnslog("ports: "..rem:getPort().." "..loc:getPort())
   return badips:match(rem)
 end
 
@@ -35,7 +35,6 @@ function preresolve(dq)
   then
     pdnslog("Packet EDNS subnet source: "..ednssubnet:toString()..", "..ednssubnet:getNetwork():toString())
   end
-
 
   local a = dq:getEDNSOption(3)
   if a
@@ -57,10 +56,10 @@ function preresolve(dq)
     pdnslog("not magic..")
   end
 
-  if dq.qname:__eq(magic2)  -- we hope to improve this syntax
+  if dq.qname == magic2
   then
     pdnslog("Faster magic") -- compares against existing DNSName
-  end                       -- sadly, dq.qname == magic2 won't work yet
+  end
 
   if blockset:check(dq.qname)
   then
@@ -85,10 +84,9 @@ function preresolve(dq)
     dq.followupFunction = "followCNAMERecords"    -- this makes PowerDNS lookup your CNAME
     return true;
   end
-  
+
   return false;
 end
-
 
 -- this implements DNS64
 
@@ -117,7 +115,7 @@ function postresolve(dq)
   pdnslog("postresolve called for "..dq.qname:toString())
   local records = dq:getRecords()
   for k,v in pairs(records) do
-    pdnslog(k, v.name:toString()..v:getContent())
+    pdnslog(k.." "..v.name:toString().." "..v:getContent())
     if v.type == pdns.A and v:getContent() == "185.31.17.73"
     then
       pdnslog("Changing content!")

--- a/pdns/recursordist/contrib/powerdns-example-script.lua
+++ b/pdns/recursordist/contrib/powerdns-example-script.lua
@@ -11,132 +11,134 @@ malwareset:add("nl")
 
 magic2 = newDN("www.magic2.com")
 
-
 magicMetric = getMetric("magic")
-
--- shows the various ways of blocking, dropping, changing questions
--- return false to say you did not take over the question, but we'll still listen to 'variable'
--- to selectively disable the cache
-function preresolve(dq)
-	pdnslog("Got question for "..dq.qname:toString().." from "..dq.remoteaddr:toString().." to "..dq.localaddr:toString())
-
-        local ednssubnet=dq:getEDNSSubnet()
-	if(ednssubnet) then
-			pdnslog("Packet EDNS subnet source: "..ednssubnet:toString()..", "..ednssubnet:getNetwork():toString())
-        end
-
-
-	local a=dq:getEDNSOption(3)
-	if(a) then
-		pdnslog("There is an EDNS option 3 present: "..a)
-	end
-
-	loc = newCA("127.0.0.1")
-	if(dq.remoteaddr:equal(loc))
-	then
-		pdnslog("Query from loopback")
-	end
-
-	-- note that the comparisons below are CaSe InSensiTivE and you don't have to worry about trailing dots
-	if(dq.qname:equal("magic.com"))
-	then
-		magicMetric:inc()
-		pdnslog("Magic!")
-	else
-		pdnslog("not magic..")
-	end
-
-	if(dq.qname:__eq(magic2)) -- we hope to improve this syntax
-	then
-		pdnslog("Faster magic") -- compares against existing DNSName
-	end                           -- sadly, dq.qname == magic2 won't work yet
-
-        if blockset:check(dq.qname) then
-                dq.variable = true  -- disable packet cache in any case
-                if dq.qtype == pdns.A then
-	        	dq:addAnswer(pdns.A, "1.2.3.4")
-        		dq:addAnswer(pdns.TXT, "\"Hello!\"", 3601) -- ttl
-        		return true;
-        	end
-        end
-
-        if dropset:check(dq.qname) then
-        	dq.rcode = pdns.DROP
-        	return true;
-        end
-
-
-
-        if malwareset:check(dq.qname) then
-		dq:addAnswer(pdns.CNAME, "xs.powerdns.com.")
-        	dq.rcode = 0
-        	dq.followupFunction="followCNAMERecords"    -- this makes PowerDNS lookup your CNAME
-        	return true;
-        end
-
-	return false;
-end
-
-
--- this implements DNS64
-
-function nodata(dq)
-        if dq.qtype == pdns.AAAA then
-        	dq.followupFunction="getFakeAAAARecords"
-        	dq.followupName=dq.qname
-        	dq.followupPrefix="fe80::"
-        	return true
-        end
-
-        if dq.qtype == pdns.PTR then
-        	dq.followupFunction="getFakePTRRecords"
-        	dq.followupName=dq.qname
-        	dq.followupPrefix="fe80::"
-        	return true
-        end
-	return false
-end
-
 
 badips = newNMG()
 badips:addMask("127.1.0.0/16")
 
 -- this check is applied before any packet parsing is done
 function ipfilter(rem, loc, dh)
-	pdnslog("ipfilter called, rem: "..rem:toStringWithPort().."loc: "..loc:toStringWithPort().."match:"..badips:match(rem))
-	pdnslog("id: "..dh:getID().."aa: "..dh:getAA().."ad: "..dh:getAD().."arcount: "..dh:getARCOUNT())
-	pdnslog("ports: "..rem:getPort()..loc:getPort())
-	return badips:match(rem)
+  pdnslog("ipfilter called, rem: "..rem:toStringWithPort().."loc: "..loc:toStringWithPort().."match:"..badips:match(rem))
+  pdnslog("id: "..dh:getID().."aa: "..dh:getAA().."ad: "..dh:getAD().."arcount: "..dh:getARCOUNT())
+  pdnslog("ports: "..rem:getPort()..loc:getPort())
+  return badips:match(rem)
+end
+
+-- shows the various ways of blocking, dropping, changing questions
+-- return false to say you did not take over the question, but we'll still listen to 'variable'
+-- to selectively disable the cache
+function preresolve(dq)
+  pdnslog("Got question for "..dq.qname:toString().." from "..dq.remoteaddr:toString().." to "..dq.localaddr:toString())
+
+  local ednssubnet = dq:getEDNSSubnet()
+  if ednssubnet
+  then
+    pdnslog("Packet EDNS subnet source: "..ednssubnet:toString()..", "..ednssubnet:getNetwork():toString())
+  end
+
+
+  local a = dq:getEDNSOption(3)
+  if a
+  then
+    pdnslog("There is an EDNS option 3 present: "..a)
+  end
+
+  loc = newCA("127.0.0.1")
+  if dq.remoteaddr:equal(loc) then
+    pdnslog("Query from loopback")
+  end
+
+  -- note that the comparisons below are CaSe InSensiTivE and you don't have to worry about trailing dots
+  if dq.qname:equal("magic.com")
+  then
+    magicMetric:inc()
+    pdnslog("Magic!")
+  else
+    pdnslog("not magic..")
+  end
+
+  if dq.qname:__eq(magic2)  -- we hope to improve this syntax
+  then
+    pdnslog("Faster magic") -- compares against existing DNSName
+  end                       -- sadly, dq.qname == magic2 won't work yet
+
+  if blockset:check(dq.qname)
+  then
+    dq.variable = true      -- disable packet cache in any case
+    if dq.qtype == pdns.A then
+      dq:addAnswer(pdns.A, "1.2.3.4")
+      dq:addAnswer(pdns.TXT, "\"Hello!\"", 3601) -- ttl
+      return true;
+    end
+  end
+
+  if dropset:check(dq.qname)
+  then
+    dq.rcode = pdns.DROP
+   return true;
+  end
+
+  if malwareset:check(dq.qname)
+  then
+    dq:addAnswer(pdns.CNAME, "xs.powerdns.com.")
+    dq.rcode = 0
+    dq.followupFunction = "followCNAMERecords"    -- this makes PowerDNS lookup your CNAME
+    return true;
+  end
+  
+  return false;
+end
+
+
+-- this implements DNS64
+
+function nodata(dq)
+  if dq.qtype == pdns.AAAA
+  then
+    dq.followupFunction = "getFakeAAAARecords"
+    dq.followupName = dq.qname
+    dq.followupPrefix="fe80::"
+    return true
+  end
+
+  if dq.qtype == pdns.PTR
+  then
+    dq.followupFunction = "getFakePTRRecords"
+    dq.followupName = dq.qname
+    dq.followupPrefix = "fe80::"
+    return true
+  end
+  return false
 end
 
 -- postresolve runs after the packet has been answered, and can be used to change things
 -- or still drop
 function postresolve(dq)
-	pdnslog("postresolve called for "..dq.qname:toString())
-	local records = dq:getRecords()
-	for k,v in pairs(records) do
-		pdnslog(k, v.name:toString()..v:getContent())
-		if v.type == pdns.A and v:getContent() == "185.31.17.73"
-		then
-			pdnslog("Changing content!")
-			v:changeContent("130.161.252.29")
-			v.ttl=1
-		end
-	end
-	dq:setRecords(records)
-	return true
+  pdnslog("postresolve called for "..dq.qname:toString())
+  local records = dq:getRecords()
+  for k,v in pairs(records) do
+    pdnslog(k, v.name:toString()..v:getContent())
+    if v.type == pdns.A and v:getContent() == "185.31.17.73"
+    then
+      pdnslog("Changing content!")
+      v:changeContent("130.161.252.29")
+      v.ttl = 1
+    end
+  end
+  dq:setRecords(records)
+  return true
 end
 
-nxdomainsuffix=newDN("com")
+nxdomainsuffix = newDN("com")
 
 function nxdomain(dq)
-	pdnslog("Hooking: "..dq.qname:toString())
-	if dq.qname:isPartOf(nxdomainsuffix)
-	then
-		dq.rcode=0 -- make it a normal answer
-		dq:addAnswer(pdns.CNAME, "ourhelpfulservice.com")
-		dq:addAnswer(pdns.A, "1.2.3.4", 60, "ourhelpfulservice.com")
-		return true
-	end
-	return false
+  pdnslog("nxdomain called for: "..dq.qname:toString())
+  if dq.qname:isPartOf(nxdomainsuffix)
+  then
+    dq.rcode = 0 -- make it a normal answer
+    dq:addAnswer(pdns.CNAME, "ourhelpfulservice.com")
+    dq:addAnswer(pdns.A, "1.2.3.4", 60, "ourhelpfulservice.com")
+    return true
+  end
+  return false
 end

--- a/pdns/recursordist/contrib/powerdns-example-script.lua
+++ b/pdns/recursordist/contrib/powerdns-example-script.lua
@@ -3,7 +3,7 @@ pdnslog("pdns-recursor Lua script starting!", pdns.loglevels.Warning)
 blockset = newDS()
 blockset:add{"powerdns.org", "xxx"}
 
-dropset = newDS();
+dropset = newDS()
 dropset:add("123.cn")
 
 malwareset = newDS()
@@ -67,14 +67,15 @@ function preresolve(dq)
     if dq.qtype == pdns.A then
       dq:addAnswer(pdns.A, "1.2.3.4")
       dq:addAnswer(pdns.TXT, "\"Hello!\"", 3601) -- ttl
-      return true;
+      return true
     end
   end
 
   if dropset:check(dq.qname)
   then
-    dq.rcode = pdns.DROP
-   return true;
+   pdnslog("dopping query")
+   dq.appliedPolicy.policyKind = pdns.policykinds.Drop
+   return false -- recursor still needs to handle the policy
   end
 
   if malwareset:check(dq.qname)
@@ -82,10 +83,10 @@ function preresolve(dq)
     dq:addAnswer(pdns.CNAME, "blog.powerdns.com.")
     dq.rcode = 0
     dq.followupFunction = "followCNAMERecords"    -- this makes PowerDNS lookup your CNAME
-    return true;
+    return true
   end
 
-  return false;
+  return false
 end
 
 -- this implements DNS64

--- a/pdns/recursordist/contrib/powerdns-example-script.lua
+++ b/pdns/recursordist/contrib/powerdns-example-script.lua
@@ -79,7 +79,7 @@ function preresolve(dq)
 
   if malwareset:check(dq.qname)
   then
-    dq:addAnswer(pdns.CNAME, "xs.powerdns.com.")
+    dq:addAnswer(pdns.CNAME, "blog.powerdns.com.")
     dq.rcode = 0
     dq.followupFunction = "followCNAMERecords"    -- this makes PowerDNS lookup your CNAME
     return true;

--- a/pdns/recursordist/contrib/powerdns-example-script.lua
+++ b/pdns/recursordist/contrib/powerdns-example-script.lua
@@ -18,8 +18,8 @@ badips:addMask("127.1.0.0/16")
 
 -- this check is applied before any packet parsing is done
 function ipfilter(rem, loc, dh)
-  pdnslog("ipfilter called, rem: "..rem:toStringWithPort().."loc: "..loc:toStringWithPort().." match:"..tostring(badips:match(rem)))
-  pdnslog("id: "..dh:getID().."aa: "..tostring(dh:getAA()).."ad: "..tostring(dh:getAD()).." arcount: "..dh:getARCOUNT())
+  pdnslog("ipfilter called, rem: "..rem:toStringWithPort().." loc: "..loc:toStringWithPort().." match:"..tostring(badips:match(rem)))
+  pdnslog("id: "..dh:getID().." aa: "..tostring(dh:getAA()).." ad: "..tostring(dh:getAD()).." arcount: "..dh:getARCOUNT())
   pdnslog("ports: "..rem:getPort().." "..loc:getPort())
   return badips:match(rem)
 end
@@ -31,14 +31,12 @@ function preresolve(dq)
   pdnslog("Got question for "..dq.qname:toString().." from "..dq.remoteaddr:toString().." to "..dq.localaddr:toString())
 
   local ednssubnet = dq:getEDNSSubnet()
-  if ednssubnet
-  then
+  if ednssubnet then
     pdnslog("Packet EDNS subnet source: "..ednssubnet:toString()..", "..ednssubnet:getNetwork():toString())
   end
 
   local a = dq:getEDNSOption(3)
-  if a
-  then
+  if a then
     pdnslog("There is an EDNS option 3 present: "..a)
   end
 
@@ -48,21 +46,18 @@ function preresolve(dq)
   end
 
   -- note that the comparisons below are CaSe InSensiTivE and you don't have to worry about trailing dots
-  if dq.qname:equal("magic.com")
-  then
+  if dq.qname:equal("magic.com") then
     magicMetric:inc()
     pdnslog("Magic!")
   else
     pdnslog("not magic..")
   end
 
-  if dq.qname == magic2
-  then
+  if dq.qname == magic2 then
     pdnslog("Faster magic") -- compares against existing DNSName
   end
 
-  if blockset:check(dq.qname)
-  then
+  if blockset:check(dq.qname) then
     dq.variable = true      -- disable packet cache in any case
     if dq.qtype == pdns.A then
       dq:addAnswer(pdns.A, "1.2.3.4")
@@ -71,15 +66,13 @@ function preresolve(dq)
     end
   end
 
-  if dropset:check(dq.qname)
-  then
+  if dropset:check(dq.qname) then
    pdnslog("dopping query")
    dq.appliedPolicy.policyKind = pdns.policykinds.Drop
    return false -- recursor still needs to handle the policy
   end
 
-  if malwareset:check(dq.qname)
-  then
+  if malwareset:check(dq.qname) then
     dq:addAnswer(pdns.CNAME, "blog.powerdns.com.")
     dq.rcode = 0
     dq.followupFunction = "followCNAMERecords"    -- this makes PowerDNS lookup your CNAME
@@ -92,16 +85,14 @@ end
 -- this implements DNS64
 
 function nodata(dq)
-  if dq.qtype == pdns.AAAA
-  then
+  if dq.qtype == pdns.AAAA then
     dq.followupFunction = "getFakeAAAARecords"
     dq.followupName = dq.qname
     dq.followupPrefix="fe80::"
     return true
   end
 
-  if dq.qtype == pdns.PTR
-  then
+  if dq.qtype == pdns.PTR then
     dq.followupFunction = "getFakePTRRecords"
     dq.followupName = dq.qname
     dq.followupPrefix = "fe80::"
@@ -117,8 +108,7 @@ function postresolve(dq)
   local records = dq:getRecords()
   for k,v in pairs(records) do
     pdnslog(k.." "..v.name:toString().." "..v:getContent())
-    if v.type == pdns.A and v:getContent() == "185.31.17.73"
-    then
+    if v.type == pdns.A and v:getContent() == "185.31.17.73" then
       pdnslog("Changing content!")
       v:changeContent("130.161.252.29")
       v.ttl = 1
@@ -132,8 +122,7 @@ nxdomainsuffix = newDN("com")
 
 function nxdomain(dq)
   pdnslog("nxdomain called for: "..dq.qname:toString())
-  if dq.qname:isPartOf(nxdomainsuffix)
-  then
+  if dq.qname:isPartOf(nxdomainsuffix) then
     dq.rcode = 0 -- make it a normal answer
     dq:addAnswer(pdns.CNAME, "ourhelpfulservice.com")
     dq:addAnswer(pdns.A, "1.2.3.4", 60, "ourhelpfulservice.com")

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -39,8 +39,8 @@ The DNSQuestion object contains at least the following fields:
 
   .. attribute:: DNSQuestion.rcode
 
-      current DNS Result Code, which can be overridden, including to several magical values
-      The rcode can be set to ``pdns.DROP`` to drop the query.
+      current DNS Result Code, which can be overridden, including to several magical values.
+      Before 4.4.0, the rcode can be set to ``pdns.DROP`` to drop the query, for later versions refer to :ref:`hooksemantics`.
       Other statuses are normal DNS return codes, like ``pdns.NOERROR``, ``pdns.NXDOMAIN`` etc.
 
   .. attribute:: DNSQuestion.isTcp

--- a/pdns/recursordist/docs/lua-scripting/dq.rst
+++ b/pdns/recursordist/docs/lua-scripting/dq.rst
@@ -40,7 +40,7 @@ The DNSQuestion object contains at least the following fields:
   .. attribute:: DNSQuestion.rcode
 
       current DNS Result Code, which can be overridden, including to several magical values.
-      Before 4.4.0, the rcode can be set to ``pdns.DROP`` to drop the query, for later versions refer to :ref:`hooksemantics`.
+      Before 4.4.0, the rcode can be set to ``pdns.DROP`` to drop the query, for later versions refer to :ref:`hook-semantics`.
       Other statuses are normal DNS return codes, like ``pdns.NOERROR``, ``pdns.NXDOMAIN`` etc.
 
   .. attribute:: DNSQuestion.isTcp

--- a/pdns/recursordist/docs/lua-scripting/hooks.rst
+++ b/pdns/recursordist/docs/lua-scripting/hooks.rst
@@ -211,13 +211,15 @@ Interception Functions
 
   :param :class:`PolicyEvent` event: The event to handle
 
-Semantics
-^^^^^^^^^
-The `ipfilter` and `preresolve` must return ``true`` if they have taken over the query and wish that the nameserver should not proceed with its regular query-processing.
+ .. _hooksemantics:
+
+Callback Semantics
+^^^^^^^^^^^^^^^^^^
+The :func:`ipfilter` and :func:`preresolve` callbacks must return ``true`` if they have taken over the query and wish that the nameserver should not proceed with processing.
 When a function returns ``false``, the nameserver will process the query normally until a new function is called.
 
 If a function has taken over a request, it should set an rcode (usually 0), and specify a table with records to be put in the answer section of a packet.
-An interesting rcode is NXDOMAIN (3, or ``pdns.NXDOMAIN``), which specifies the non-existence of a domain.
+An interesting rcode is `NXDOMAIN` (3, or ``pdns.NXDOMAIN``), which specifies the non-existence of a domain.
 
 The :func:`ipfilter` and :func:`preoutquery` hooks are different, in that :func:`ipfilter` can only return a true of false value, and that :func:`preoutquery` can also set rcode -3 to signify that the whole query should be terminated.
 
@@ -241,8 +243,8 @@ A minimal sample script:
 **Warning**: Please do NOT use the above sample script in production!
 Responsible NXDomain redirection requires more attention to detail.
 
-Useful 'rcodes' include 0 for "no error" and ``pdns.NXDOMAIN`` for "NXDOMAIN". Before 4.4.0, ``pdns.DROP`` can also be used to drop the question without any further processing.
-Such a drop is accounted in the 'policy-drops' metric.
+Useful ``rcodes`` include 0 or ``pdns.NOERROR`` for no error and ``pdns.NXDOMAIN`` for ``NXDOMAIN``. Before 4.4.0, ``pdns.DROP`` can also be used to drop the question without any further processing.
+Such a drop is accounted in the ``policy-drops`` metric.
 
 Starting with recursor 4.4.0, the method to drop a request is to set the ``dq.appliedPolicy.policyKind`` to the value ``pdns.policykinds.Drop``.
 
@@ -257,7 +259,7 @@ Starting with recursor 4.4.0, the method to drop a request is to set the ``dq.ap
         return false
     end
 
-**Note**: to drop a query from ``preresolve``, set ``policyKind`` and return false, to indicate the Recursor should process the Drop action.
+**Note**: to drop a query set ``policyKind`` and return ``false``, to indicate the Recursor should process the ``Drop`` action.
 
 DNS64
 -----

--- a/pdns/recursordist/docs/lua-scripting/hooks.rst
+++ b/pdns/recursordist/docs/lua-scripting/hooks.rst
@@ -211,7 +211,7 @@ Interception Functions
 
   :param :class:`PolicyEvent` event: The event to handle
 
- .. _hooksemantics:
+ .. _hook-semantics:
 
 Callback Semantics
 ^^^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -117,7 +117,7 @@ See :ref:`rpz` for details. Additionally a new type of callback has been introdu
 Dropping queries from Lua callbacks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The method to drop a query from a Lua callback has been changed.
-Previously, you could set `rcode` to `pdns.DROP`. See :ref:`hooksemantics` for the new method.
+Previously, you could set `rcode` to `pdns.DROP`. See :ref:`hook-semantics` for the new method.
 
 Parsing of unknown record types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pdns/recursordist/docs/upgrade.rst
+++ b/pdns/recursordist/docs/upgrade.rst
@@ -114,6 +114,10 @@ To conform better to the standard, RPZ processing has been modified.
 This has consequences for the points in the resolving process where matches are checked and callbacks are called.
 See :ref:`rpz` for details. Additionally a new type of callback has been introduced: :func:`policyEventFilter`.
 
+Dropping queries from Lua callbacks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The method to drop a query from a Lua callback has been changed.
+Previously, you could set `rcode` to `pdns.DROP`. See :ref:`hooksemantics` for the new method.
 
 Parsing of unknown record types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Address documentation issues with the old `pdns.DROP` method and warn if `rcode` is set to it in Lua hooks.

Also fix a few other cases of inconsistent style (and errors) in the example script.

Fixes #11287

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
