### PR TITLE
docs: fix rst syntax

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -983,8 +983,8 @@ Setting this to any value less than or equal to 0 will set no limit.
 ``master``
 ----------
 
-+.. deprecated:: 4.5.0
-+  Renamed to :ref:`setting-primary`.
+.. deprecated:: 4.5.0
+  Renamed to :ref:`setting-primary`.
  
 -  Boolean
 -  Default: no
@@ -1839,7 +1839,7 @@ Webserver/API access is only allowed from these subnets.
 
 ``webserver-hash-plaintext-credentials``
 ----------------------------------------
-..versionadded:: 4.6.0
+.. versionadded:: 4.6.0
 
 -  Boolean
 -  Default: no

--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -2264,7 +2264,7 @@ of /32 or /128.
 
 ``webserver-hash-plaintext-credentials``
 ----------------------------------------
-..versionadded:: 4.6.0
+.. versionadded:: 4.6.0
 
 -  Boolean
 -  Default: no


### PR DESCRIPTION
### Short description

Fix some reStructuredText syntax, seems it is picky about the space in `.. foobar::`, so it's just rendered as "..foobar::" in some places in the docs.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)

