### PR TITLE
Document which version adds svc-autohints

### DIFF
--- a/docs/changelog/4.5.rst
+++ b/docs/changelog/4.5.rst
@@ -374,9 +374,15 @@ Changelogs for 4.5.x
 
   .. change::
     :tags: Bug Fixes
-    :pullreq: 9766, 9844, 9919, 10074
+    :pullreq: 9766, 9844, 9919
 
     Fixed bugs in the implementations of the ``SVCB``, ``HTTPS``, ``IPSECKEY`` and ``APL`` types.
+
+  .. change::
+    :tags: New Features
+    :pullreq: 10074
+
+    ``SVCB`` improvements, including a new ``svc-autohints`` setting
 
   .. change::
     :tags: New Features

--- a/docs/guides/svcb.rst
+++ b/docs/guides/svcb.rst
@@ -11,6 +11,9 @@ Automatic hints
 PowerDNS can automatically fill in ``ipv4hint`` and ``ipv6hint`` parameters in SVCB records based on A and AAAA records already present in the zone.
 This can be enabled by setting :ref:`setting-svc-autohints` to 'yes'.
 
+.. versionadded:: 4.5.0
+  The ``svc-autohints`` setting was added in 4.5.0
+
 Consider the following zone content::
 
   example.org      IN HTTPS 0 www.example.org

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1660,6 +1660,8 @@ Turn on supermaster support. See :ref:`supermaster-operation`.
 - Boolean
 - Default: no
 
+.. versionadded:: 4.5.0
+
 Whether or not to enable IPv4 and IPv6 :ref:`autohints <svc-autohints>`.
 
 .. _setting-tcp-control-address:


### PR DESCRIPTION
### Short description
I stumbled upon the [`svc-autohints` guide](https://doc.powerdns.com/authoritative/guides/svcb.html#svc-autohints) (probably via IRC) and went to test it out, but instead I got some error.

As it turns out, this isn't included in my version (4.4.1 from Debian 11) but is 4.5.0 as part of #10074, for which the changelog entry didn't mention this.

(Thanks Habbie for pointing out the version and PR before I could finish digging through the `git blame`)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)


