### PR TITLE
rec: Use the Lua context stored in SyncRes when calling hooks.

### DIFF
--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -48,8 +48,8 @@
 //! used to send information to a newborn mthread
 struct DNSComboWriter
 {
-  DNSComboWriter(const std::string& query, const struct timeval& now) :
-    d_mdp(true, query), d_now(now), d_query(query)
+  DNSComboWriter(const std::string& query, const struct timeval& now, shared_ptr<RecursorLua4> luaContext) :
+    d_mdp(true, query), d_now(now), d_query(query), d_luaContext(luaContext)
   {
   }
 

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -53,8 +53,8 @@ struct DNSComboWriter
   {
   }
 
-  DNSComboWriter(const std::string& query, const struct timeval& now, std::unordered_set<std::string>&& policyTags, LuaContext::LuaObject&& data, std::vector<DNSRecord>&& records) :
-    d_mdp(true, query), d_now(now), d_query(query), d_policyTags(std::move(policyTags)), d_records(std::move(records)), d_data(std::move(data))
+  DNSComboWriter(const std::string& query, const struct timeval& now, std::unordered_set<std::string>&& policyTags, shared_ptr<RecursorLua4> luaContext, LuaContext::LuaObject&& data, std::vector<DNSRecord>&& records) :
+    d_mdp(true, query), d_now(now), d_query(query), d_policyTags(std::move(policyTags)), d_records(std::move(records)), d_luaContext(luaContext), d_data(std::move(data))
   {
   }
 
@@ -119,7 +119,11 @@ struct DNSComboWriter
   std::unordered_set<std::string> d_policyTags;
   std::string d_routingTag;
   std::vector<DNSRecord> d_records;
+
+  // d_data is tied to this LuaContext so we need to keep it alive and use it, not a newer one, as long as d_data exists
+  shared_ptr<RecursorLua4> d_luaContext;
   LuaContext::LuaObject d_data;
+
   EDNSSubnetOpts d_ednssubnet;
   shared_ptr<TCPConnection> d_tcpConnection;
   boost::optional<uint16_t> d_extendedErrorCode{boost::none};

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -329,7 +329,7 @@ static void handleRunningTCPQuestion(int fd, FDMultiplexer::funcparam_t& var)
       conn->state = TCPConnection::BYTE0;
       std::unique_ptr<DNSComboWriter> dc;
       try {
-        dc = std::make_unique<DNSComboWriter>(conn->data, g_now);
+        dc = std::make_unique<DNSComboWriter>(conn->data, g_now, t_pdl);
       }
       catch (const MOADNSException& mde) {
         g_stats.clientParseError++;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -687,6 +687,11 @@ public:
     d_pdl = pdl;
   }
 
+  shared_ptr<RecursorLua4> getLuaEngine()
+  {
+    return d_pdl;
+  }
+
   bool wasVariable() const
   {
     return d_wasVariable;

--- a/pdns/syncres.hh
+++ b/pdns/syncres.hh
@@ -687,11 +687,6 @@ public:
     d_pdl = pdl;
   }
 
-  shared_ptr<RecursorLua4> getLuaEngine()
-  {
-    return d_pdl;
-  }
-
   bool wasVariable() const
   {
     return d_wasVariable;


### PR DESCRIPTION
After the Lua context is recreated by a reload script, in-flight queries should still use the old one and not the new.

Fixes #11289

The Lua context used by the followCNAMERecords(), getFakeAAAARecords() and
getFakePTRRecords() functions should be validated. I have marked the spots
with XXX in this commit

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
